### PR TITLE
fix(webview): prevent webview from being reset when detached then reattached

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_NativeEmbedding_Android_FillType.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_NativeEmbedding_Android_FillType.xaml
@@ -11,7 +11,7 @@
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
 	<Grid>
-		<WebView2 Source="https://google.com" />
+		<WebView2 Source="https://microsoft.com" />
 		<Rectangle Height="30" Width="30" VerticalAlignment="Center" Fill="Orange" />
 	</Grid>
 </UserControl>

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -45,6 +45,14 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		NativeMethods.ChangeNativeElementOpacity(((BrowserHtmlElement)content).ElementId, opacity);
 	}
 
+	public bool SupportsZIndex() => true;
+
+	public void SetZIndex(object content, int zIndex)
+	{
+		Debug.Assert(content is BrowserHtmlElement);
+		NativeMethods.SetZIndex(((BrowserHtmlElement)content).ElementId, zIndex);
+	}
+
 	public static void SetSvgClipPathForNativeElementHost(string path)
 	{
 		if (_lastSvgClipPath != path)
@@ -85,5 +93,8 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.setSvgClipPathForNativeElementHost")]
 		internal static partial string SetSvgClipPathForNativeElementHost(string path);
+
+		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.setZIndex")]
+		internal static partial void SetZIndex(string content, int zIndex);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -11,7 +11,7 @@ namespace Uno.UI.Runtime.Skia;
 internal partial class BrowserNativeElementHostingExtension : ContentPresenter.INativeElementHostingExtension
 {
 	private readonly ContentPresenter _presenter;
-	private static string? _lastSvgClipPath;
+	private static (string path, string fillType)? _lastSvgClipPath;
 
 	public BrowserNativeElementHostingExtension(ContentPresenter contentPresenter)
 	{
@@ -53,12 +53,12 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		NativeMethods.SetZIndex(((BrowserHtmlElement)content).ElementId, zIndex);
 	}
 
-	public static void SetSvgClipPathForNativeElementHost(string path)
+	public static void SetSvgClipPathForNativeElementHost(string path, string fillType)
 	{
-		if (_lastSvgClipPath != path)
+		if (_lastSvgClipPath != (path, fillType))
 		{
-			_lastSvgClipPath = path;
-			NativeMethods.SetSvgClipPathForNativeElementHost(path);
+			_lastSvgClipPath = (path, fillType);
+			NativeMethods.SetSvgClipPathForNativeElementHost(path, fillType);
 		}
 	}
 
@@ -77,22 +77,22 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		internal static partial bool IsNativeElement(string content);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.attachNativeElement")]
-		internal static partial bool AttachNativeElement(string content);
+		internal static partial void AttachNativeElement(string content);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.detachNativeElement")]
-		internal static partial bool DetachNativeElement(string content);
+		internal static partial void DetachNativeElement(string content);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.arrangeNativeElement")]
-		internal static partial bool ArrangeNativeElement(string content, double x, double y, double width, double height);
+		internal static partial void ArrangeNativeElement(string content, double x, double y, double width, double height);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.createSampleComponent")]
 		internal static partial void CreateSampleComponent(string parentId, string text);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.changeNativeElementOpacity")]
-		internal static partial string ChangeNativeElementOpacity(string content, double opacity);
+		internal static partial void ChangeNativeElementOpacity(string content, double opacity);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.setSvgClipPathForNativeElementHost")]
-		internal static partial string SetSvgClipPathForNativeElementHost(string path);
+		internal static partial void SetSvgClipPathForNativeElementHost(string path, string fillType);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.{nameof(BrowserHtmlElement)}.setZIndex")]
 		internal static partial void SetZIndex(string content, int zIndex);

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
@@ -115,7 +115,8 @@ internal partial class BrowserRenderer
 
 		_context.Flush();
 
-		BrowserNativeElementHostingExtension.SetSvgClipPathForNativeElementHost(!currentClipPath.IsEmpty ? currentClipPath.ToSvgPathData() : "");
+		var (path, fillType) = !currentClipPath.IsEmpty ? (currentClipPath.ToSvgPathData(), currentClipPath.FillType is SKPathFillType.EvenOdd ? "evenodd" : "nonzero") : ("", "nonzero");
+		BrowserNativeElementHostingExtension.SetSvgClipPathForNativeElementHost(path, fillType);
 
 		if (this.Log().IsEnabled(LogLevel.Trace))
 		{

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -32,7 +32,6 @@ namespace Uno.UI.NativeElementHosting {
 				defs.appendChild(clipPath);
 				svgContainer.appendChild(defs);
 				document.body.appendChild(svgContainer);
-				clipPath.appendChild(this.clipPath);
 			}
 			this.clipPath.setAttribute("d", path);
 			this.clipPath.setAttribute("clip-rule", fillType);

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -98,6 +98,11 @@ namespace Uno.UI.NativeElementHosting {
 			this.getElementOrThrow(id).remove();
 		}
 
+		public static setZIndex(id: string, zIndex: number) {
+			let element = this.getElementOrThrow(id);
+			element.style.zIndex = zIndex.toString();
+		}
+
 		public static createSampleComponent(parentId: string, text: string) {
 			let element = this.getElementOrThrow(parentId);
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -54,26 +54,8 @@ namespace Uno.UI.NativeElementHosting {
 			return nativeElementHost;
 		}
 
-		// We have a store to put elements in before they are loaded/unloaded as native elements.
-		// We have to put these elements somewhere we can access, so we do so in a hidden div.
-		// Only elements in the store are considered part of the "uno world" and can be
-		// embedded inside the uno canvas. Clients need to request html elements to be added
-		// to the store before any native hosting takes place.
-		private static getNativeElementStore(): HTMLElement {
-			let nativeElementStore = document.getElementById("uno-native-element-store");
-			if (!nativeElementStore) {
-				nativeElementStore = document.createElement("div");
-				nativeElementStore.id = "uno-native-element-store";
-				nativeElementStore.style.display = "none";
-				let unoBody = document.getElementById("uno-body");
-				unoBody.insertBefore(nativeElementStore, unoBody.firstChild);
-			}
-
-			return nativeElementStore;
-		}
-
 		public static isNativeElement(content: string): boolean {
-			for (let child of this.getNativeElementStore().children) {
+			for (let child of this.getNativeElementHost().children) {
 				if (child.id === content) {
 					return true;
 				}
@@ -83,14 +65,12 @@ namespace Uno.UI.NativeElementHosting {
 
 		public static attachNativeElement(content: string) {
 			let element = this.getElementOrThrow(content);
-			element.remove(); // remove from the store
-			this.getNativeElementHost().appendChild(element); // add to the native host
+			element.hidden = false;
 		}
 
 		public static detachNativeElement(content: string) {
 			let element = this.getElementOrThrow(content);
-			element.remove(); // remove from the native host
-			this.getNativeElementStore().appendChild(element); // add to the native host
+			element.hidden = true;
 		}
 
 		public static arrangeNativeElement(content: string, x: number, y: number, width: number, height: number) {
@@ -107,14 +87,11 @@ namespace Uno.UI.NativeElementHosting {
 			element.style.opacity = opacity.toString();
 		}
 
-		public static createHtmlElementAndAddToStore(id: string, tagName: string) {
+		public static createHtmlElement(id: string, tagName: string) {
 			let element = document.createElement(tagName);
 			element.id = id;
-			this.getNativeElementStore().appendChild(element);
-		}
-
-		public static addToStore(id: string) {
-			this.getNativeElementStore().appendChild(this.getElementOrThrow(id));
+			element.hidden = true;
+			this.getNativeElementHost().appendChild(element);
 		}
 
 		public static disposeHtmlElement(id: string) {

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -19,7 +19,7 @@ namespace Uno.UI.NativeElementHosting {
 			}
 		}
 
-		public static setSvgClipPathForNativeElementHost(path: string) {
+		public static setSvgClipPathForNativeElementHost(path: string, fillType: string) {
 			if (!document.getElementById("unoNativeElementHostClipPath")) {
 				const svgContainer = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 				svgContainer.setAttribute("width", "0");
@@ -34,7 +34,8 @@ namespace Uno.UI.NativeElementHosting {
 				document.body.appendChild(svgContainer);
 				clipPath.appendChild(this.clipPath);
 			}
-			this.clipPath.setAttributeNS(null, "d", path);
+			this.clipPath.setAttribute("d", path);
+			this.clipPath.setAttribute("clip-rule", fillType);
 		}
 
 		private static getNativeElementHost(): HTMLElement {

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
@@ -54,7 +54,6 @@ public sealed partial class BrowserHtmlElement : IDisposable
 		}
 
 		ElementId = elementId;
-		RegisterExistingElementNative(elementId);
 	}
 
 	/// <summary>

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.skia.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.skia.cs
@@ -23,11 +23,7 @@ public sealed partial class BrowserHtmlElement : IDisposable
 
 	private static void CreateHtmlElementNative(string id, nint unoElementId, string tagName)
 	{
-		NativeMethods.CreateHtmlElementAndAddToStore(id, tagName);
-	}
-
-	private static void RegisterExistingElementNative(string elementId)
-	{
+		NativeMethods.CreateHtmlElement(id, tagName);
 	}
 
 	private void SetCssStyleNative(string name, string value)
@@ -166,11 +162,8 @@ public sealed partial class BrowserHtmlElement : IDisposable
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.initialize")]
 		internal static partial void Initialize();
 
-		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.createHtmlElementAndAddToStore")]
-		internal static partial void CreateHtmlElementAndAddToStore(string id, string tagName);
-
-		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.addToStore")]
-		internal static partial void AddToStore(string id);
+		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.createHtmlElement")]
+		internal static partial void CreateHtmlElement(string id, string tagName);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.disposeHtmlElement")]
 		internal static partial bool DisposeHtmlElement(string id);

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -155,18 +155,33 @@ partial class ContentPresenter
 		{
 			var host = rentedArray[index].Item2;
 
-			if (index == -1 && host._nativeElementAttached)
+			if (host._nativeElementHostingExtension.Value.SupportsZIndex())
 			{
-				// We're detaching the native element as it's no longer in view, but conceptually, it's still in the tree, so IsNativeHost is still true
-				Debug.Assert(host.IsNativeHost);
-				host._nativeElementAttached = false;
-				host._nativeElementHostingExtension.Value!.DetachNativeElement(host.Content);
+				host._nativeElementHostingExtension.Value.SetZIndex(host.Content, index);
 			}
-			else if (host._nativeElementAttached)
+			else
 			{
-				host.DetachNativeElement(host.Content);
-				host.AttachNativeElement();
-				host.ArrangeNativeElement();
+				if (host._nativeElementAttached)
+				{
+					if (index == -1)
+					{
+						// We're detaching the native element as it's no longer in view, but conceptually, it's still in the tree, so IsNativeHost is still true
+						Debug.Assert(host.IsNativeHost);
+						host._nativeElementAttached = false;
+						host._nativeElementHostingExtension.Value!.DetachNativeElement(host.Content);
+					}
+					else
+					{
+						host.DetachNativeElement(host.Content);
+						host.AttachNativeElement();
+						host.ArrangeNativeElement();
+					}
+				}
+				else if (index != -1)
+				{
+					host.AttachNativeElement();
+					host.ArrangeNativeElement();
+				}
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -20,6 +20,7 @@ partial class ContentPresenter
 
 	private bool _nativeElementAttached;
 	private IDisposable _frameRenderedDisposable;
+	private Rect? _lastArrangeRect;
 
 	internal static bool HasNativeElements() => _nativeHosts.Count > 0;
 
@@ -96,6 +97,7 @@ partial class ContentPresenter
 		global::System.Diagnostics.Debug.Assert(IsNativeHost);
 #endif
 		_nativeHosts.Remove(this);
+		_lastArrangeRect = null;
 		if (_nativeElementAttached)
 		{
 			_frameRenderedDisposable.Dispose();
@@ -190,7 +192,11 @@ partial class ContentPresenter
 	private void ArrangeNativeElement()
 	{
 		var arrangeRect = this.GetAbsoluteBoundsRect();
-		_nativeElementHostingExtension.Value!.ArrangeNativeElement(Content, arrangeRect);
+		if (_lastArrangeRect != arrangeRect)
+		{
+			_lastArrangeRect = arrangeRect;
+			_nativeElementHostingExtension.Value!.ArrangeNativeElement(Content, arrangeRect);
+		}
 	}
 
 	internal object CreateSampleComponent(string text)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -154,6 +154,7 @@ partial class ContentPresenter
 		for (var index = 0; index < _nativeHosts.Count; index++)
 		{
 			var host = rentedArray[index].Item2;
+			var order = rentedArray[index].Item1;
 
 			if (host._nativeElementHostingExtension.Value.SupportsZIndex())
 			{
@@ -163,7 +164,7 @@ partial class ContentPresenter
 			{
 				if (host._nativeElementAttached)
 				{
-					if (index == -1)
+					if (order == -1)
 					{
 						// We're detaching the native element as it's no longer in view, but conceptually, it's still in the tree, so IsNativeHost is still true
 						Debug.Assert(host.IsNativeHost);
@@ -177,7 +178,7 @@ partial class ContentPresenter
 						host.ArrangeNativeElement();
 					}
 				}
-				else if (index != -1)
+				else if (order != -1)
 				{
 					host.AttachNativeElement();
 					host.ArrangeNativeElement();

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/INativeElementHostingExtension.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/INativeElementHostingExtension.cs
@@ -1,3 +1,4 @@
+using System;
 using Windows.Foundation;
 
 namespace Microsoft.UI.Xaml.Controls;
@@ -20,6 +21,16 @@ partial class ContentPresenter
 		object CreateSampleComponent(string text);
 
 		void ChangeNativeElementOpacity(object content, double opacity);
+
+		bool SupportsZIndex() => false;
+
+		void SetZIndex(object content, int zIndex)
+		{
+			if (SupportsZIndex())
+			{
+				throw new InvalidOperationException($"{nameof(SetZIndex)} should be implemented if {nameof(SupportsZIndex)}.");
+			}
+		}
 #endif
 	}
 }


### PR DESCRIPTION
Found this while working on https://github.com/unoplatform/uno/issues/22018.

It looks like the browser erases iframes whenever they're removed from the DOM, so we cannot rely on DOM reparenting either for removal from the visual tree or for Z ordering. Instead, all "alive" (i.e. not GC-collected) instances remain in the DOM and don't move but are hidden/unhidden as needed. For Z ordering, instead of doing the remove+insert trick, we use css for ordering.