### PR TITLE
chore: support attached properties in trimming environments

### DIFF
--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -130,8 +130,16 @@ namespace Uno.UI.Toolkit
 			=> obj.SetValue(PaddingMaskProperty, value);
 
 #pragma warning disable RS0030 // Do not used banned APIs, This can't be changed because it's built by UWP.
-		public static DependencyProperty PaddingMaskProperty { get; } =
-			DependencyProperty.RegisterAttached("PaddingMask", typeof(PaddingMask), typeof(_VisibleBoundsPadding), new PropertyMetadata(PaddingMask.None, OnIsPaddingMaskChanged));
+		public static DependencyProperty PaddingMaskProperty
+		{
+			[DynamicDependency(nameof(GetPaddingMask))]
+			[DynamicDependency(nameof(SetPaddingMask))]
+			get;
+		} = DependencyProperty.RegisterAttached(
+				"PaddingMask",
+				typeof(PaddingMask),
+				typeof(_VisibleBoundsPadding),
+				new PropertyMetadata(PaddingMask.None, OnIsPaddingMaskChanged));
 #pragma warning restore RS0030 // Do not used banned APIs
 
 		private static void OnIsPaddingMaskChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Uno.UI;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Automation.Peers;
@@ -22,8 +23,12 @@ namespace Microsoft.UI.Xaml.Automation
 			return (string)element.GetValue(NameProperty);
 		}
 
-		public static DependencyProperty NameProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty NameProperty
+		{
+			[DynamicDependency(nameof(GetName))]
+			[DynamicDependency(nameof(SetName))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"Name",
 				typeof(string),
 				typeof(AutomationProperties),
@@ -57,8 +62,12 @@ namespace Microsoft.UI.Xaml.Automation
 			element.SetValue(AccessibilityViewProperty, value);
 		}
 
-		public static DependencyProperty AccessibilityViewProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty AccessibilityViewProperty
+		{
+			[DynamicDependency(nameof(GetAccessibilityView))]
+			[DynamicDependency(nameof(SetAccessibilityView))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"AccessibilityView",
 				typeof(AccessibilityView),
 				typeof(AutomationProperties),
@@ -79,8 +88,12 @@ namespace Microsoft.UI.Xaml.Automation
 			element.SetValue(LabeledByProperty, value);
 		}
 
-		public static DependencyProperty LabeledByProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty LabeledByProperty
+		{
+			[DynamicDependency(nameof(GetLabeledBy))]
+			[DynamicDependency(nameof(SetLabeledBy))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"LabeledBy", typeof(UIElement),
 				typeof(AutomationProperties),
 				new FrameworkPropertyMetadata(default(UIElement))
@@ -100,8 +113,12 @@ namespace Microsoft.UI.Xaml.Automation
 			element.SetValue(LocalizedControlTypeProperty, value);
 		}
 
-		public static DependencyProperty LocalizedControlTypeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty LocalizedControlTypeProperty
+		{
+			[DynamicDependency(nameof(GetLocalizedControlType))]
+			[DynamicDependency(nameof(SetLocalizedControlType))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"LocalizedControlType", typeof(string),
 				typeof(AutomationProperties),
 				new FrameworkPropertyMetadata(default(string))
@@ -116,8 +133,11 @@ namespace Microsoft.UI.Xaml.Automation
 			return (IList<DependencyObject>)element.GetValue(DescribedByProperty);
 		}
 
-		public static DependencyProperty DescribedByProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty DescribedByProperty
+		{
+			[DynamicDependency(nameof(GetDescribedBy))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"DescribedBy", typeof(IList<DependencyObject>),
 				typeof(AutomationProperties),
 				new FrameworkPropertyMetadata(default(IList<DependencyObject>)) // TODO: Empty list?
@@ -127,8 +147,12 @@ namespace Microsoft.UI.Xaml.Automation
 
 		#region AutomationId
 
-		public static DependencyProperty AutomationIdProperty { get; } =
-		DependencyProperty.RegisterAttached(
+		public static DependencyProperty AutomationIdProperty
+		{
+			[DynamicDependency(nameof(GetAutomationId))]
+			[DynamicDependency(nameof(SetAutomationId))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			name: "AutomationId",
 			propertyType: typeof(string),
 			ownerType: typeof(AutomationProperties),
@@ -179,8 +203,12 @@ namespace Microsoft.UI.Xaml.Automation
 
 		public static void SetPositionInSet(DependencyObject element, int value) => element.SetValue(PositionInSetProperty, value);
 
-		public static DependencyProperty PositionInSetProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty PositionInSetProperty
+		{
+			[DynamicDependency(nameof(GetPositionInSet))]
+			[DynamicDependency(nameof(SetPositionInSet))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"PositionInSet", typeof(int),
 				typeof(AutomationProperties),
 				new FrameworkPropertyMetadata(-1)); //TODO:MZ: Validate this default value
@@ -189,8 +217,12 @@ namespace Microsoft.UI.Xaml.Automation
 
 		public static void SetSizeOfSet(DependencyObject element, int value) => element.SetValue(SizeOfSetProperty, value);
 
-		public static DependencyProperty SizeOfSetProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty SizeOfSetProperty
+		{
+			[DynamicDependency(nameof(GetSizeOfSet))]
+			[DynamicDependency(nameof(SetSizeOfSet))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"SizeOfSet", typeof(int),
 				typeof(AutomationProperties),
 				new FrameworkPropertyMetadata(-1)); //TODO:MZ: Validate this default value
@@ -199,8 +231,12 @@ namespace Microsoft.UI.Xaml.Automation
 
 		public static void SetLandmarkType(DependencyObject element, AutomationLandmarkType value) => element.SetValue(LandmarkTypeProperty, value);
 
-		public static DependencyProperty LandmarkTypeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty LandmarkTypeProperty
+		{
+			[DynamicDependency(nameof(GetLandmarkType))]
+			[DynamicDependency(nameof(SetLandmarkType))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"LandmarkType", typeof(AutomationLandmarkType),
 				typeof(AutomationProperties),
 				new FrameworkPropertyMetadata(default(AutomationLandmarkType)));

--- a/src/Uno.UI/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.Properties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference AnimatedIcon.properties.cpp, commit f4d781d
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 
 namespace Microsoft.UI.Xaml.Controls
@@ -45,8 +46,16 @@ namespace Microsoft.UI.Xaml.Controls
 			@object.SetValue(StateProperty, value);
 		}
 
-		public static DependencyProperty StateProperty { get; } =
-			DependencyProperty.RegisterAttached("State", typeof(string), typeof(AnimatedIcon), new FrameworkPropertyMetadata(string.Empty, OnAnimatedIconStatePropertyChanged));
+		public static DependencyProperty StateProperty
+		{
+			[DynamicDependency(nameof(GetState))]
+			[DynamicDependency(nameof(SetState))]
+			get;
+		} = DependencyProperty.RegisterAttached(
+				"State",
+				typeof(string),
+				typeof(AnimatedIcon),
+				new FrameworkPropertyMetadata(string.Empty, OnAnimatedIconStatePropertyChanged));
 
 		private static void OnFallbackIconSourcePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.Uno.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.UI.Xaml;
 
@@ -45,7 +46,12 @@ public static class ComboBox
 	/// This is only the preferred placement, the combo will still ensure to keep its drop down in the visual bounds of the window
 	/// (When content cannot be rendered out of the current window ...)
 	/// </remarks>
-	public static DependencyProperty DropDownPreferredPlacementProperty { get; } = DependencyProperty.RegisterAttached(
+	public static DependencyProperty DropDownPreferredPlacementProperty
+	{
+		[DynamicDependency(nameof(GetDropDownPreferredPlacement))]
+		[DynamicDependency(nameof(SetDropDownPreferredPlacement))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 		"DropDownPreferredPlacement",
 		typeof(DropDownPlacement),
 		typeof(Microsoft.UI.Xaml.Controls.ComboBox),

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/CommandBarFlyoutCommandBarAutomationProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/CommandBarFlyoutCommandBarAutomationProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference controls\dev\Generated\CommandBarFlyoutCommandBarAutomationProperties.properties.cpp, tag winui3/release/1.7.3, commit 65718e2813a90fc900e8775d2ddc580b268fcc2f
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 
@@ -31,8 +32,12 @@ public static partial class CommandBarFlyoutCommandBarAutomationProperties
 	/// <summary>
 	/// Identifies the ControlType dependency property.
 	/// </summary>
-	public static DependencyProperty ControlTypeProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	public static DependencyProperty ControlTypeProperty
+	{
+		[DynamicDependency(nameof(GetControlType))]
+		[DynamicDependency(nameof(SetControlType))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"ControlType",
 			typeof(AutomationControlType),
 			typeof(CommandBarFlyoutCommandBarAutomationProperties),

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
@@ -624,8 +625,12 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			element.SetValue(AttachedFlyoutProperty, value);
 		}
 
-		public static DependencyProperty AttachedFlyoutProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty AttachedFlyoutProperty
+		{
+			[DynamicDependency(nameof(GetAttachedFlyout))]
+			[DynamicDependency(nameof(SetAttachedFlyout))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"AttachedFlyout",
 				typeof(FlyoutBase),
 				typeof(FlyoutBase),

--- a/src/Uno.UI/UI/Xaml/Controls/InfoBar/InfoBarPanel.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/InfoBar/InfoBarPanel.Properties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX reference InfoBarPanel.properties.cpp, tag winui3/release/1.4.2
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 
 namespace Microsoft.UI.Xaml.Controls.Primitives;
@@ -25,8 +26,16 @@ public partial class InfoBarPanel
 	/// <summary>
 	/// Gets the identifier for the HorizontalOrientationMargin dependency property.
 	/// </summary>
-	public static DependencyProperty HorizontalOrientationMarginProperty { get; } =
-		DependencyProperty.RegisterAttached("HorizontalOrientationMargin", typeof(Thickness), typeof(InfoBarPanel), new FrameworkPropertyMetadata(default(Thickness)));
+	public static DependencyProperty HorizontalOrientationMarginProperty
+	{
+		[DynamicDependency(nameof(GetHorizontalOrientationMargin))]
+		[DynamicDependency(nameof(SetHorizontalOrientationMargin))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"HorizontalOrientationMargin",
+			typeof(Thickness),
+			typeof(InfoBarPanel),
+			new FrameworkPropertyMetadata(default(Thickness)));
 
 	/// <summary>
 	/// Gets and sets the distance between the edges of the InfoBarPanel
@@ -61,8 +70,16 @@ public partial class InfoBarPanel
 	/// <summary>
 	/// Gets the identifier for the VerticalOrientationMargin dependency property.
 	/// </summary>
-	public static DependencyProperty VerticalOrientationMarginProperty { get; } =
-		DependencyProperty.RegisterAttached("VerticalOrientationMargin", typeof(Thickness), typeof(InfoBarPanel), new FrameworkPropertyMetadata(default(Thickness)));
+	public static DependencyProperty VerticalOrientationMarginProperty
+	{
+		[DynamicDependency(nameof(GetVerticalOrientationMargin))]
+		[DynamicDependency(nameof(SetVerticalOrientationMargin))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"VerticalOrientationMargin",
+			typeof(Thickness),
+			typeof(InfoBarPanel),
+			new FrameworkPropertyMetadata(default(Thickness)));
 
 	/// <summary>
 	/// Gets and sets the distance between the edges of the InfoBarPanel

--- a/src/Uno.UI/UI/Xaml/Controls/Materials/Backdrop/BackdropMaterial.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Materials/Backdrop/BackdropMaterial.Properties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference BackdropMaterial.properties.cpp, commit 0db5d03
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -28,8 +29,12 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Applies the backdrop material to the root or background of the XAML content.
 		/// </summary>
-		public static DependencyProperty ApplyToRootOrPageBackgroundProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty ApplyToRootOrPageBackgroundProperty
+		{
+			[DynamicDependency(nameof(GetApplyToRootOrPageBackground))]
+			[DynamicDependency(nameof(SetApplyToRootOrPageBackground))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"ApplyToRootOrPageBackground",
 				typeof(bool),
 				typeof(BackdropMaterial),

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElementExtensions.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElementExtensions.wasm.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.UI.Xaml.Controls;
 
 public static class MediaPlayerElementExtensions
 {
-	public static DependencyProperty AnonymousCORSProperty { get; } =
-	DependencyProperty.RegisterAttached(
+	public static DependencyProperty AnonymousCORSProperty
+	{
+		[DynamicDependency(nameof(SetAnonymousCORS))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 		"AnonymousCORS",
 		typeof(bool),
 		typeof(MediaPlayerElementExtensions),

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControlsHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControlsHelper.cs
@@ -1,9 +1,15 @@
-﻿namespace Microsoft.UI.Xaml.Controls
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class MediaTransportControlsHelper
 	{
-		public static DependencyProperty DropoutOrderProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty DropoutOrderProperty
+		{
+			[DynamicDependency(nameof(GetDropoutOrder))]
+			[DynamicDependency(nameof(SetDropoutOrder))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"DropoutOrder",
 				typeof(int?),
 				typeof(MediaTransportControlsHelper),

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/PickerFlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/PickerFlyoutBase.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Microsoft.UI.Xaml.Controls.Primitives
 {
 	public partial class PickerFlyoutBase : FlyoutBase
 	{
-		public static DependencyProperty TitleProperty { get; } =
-			Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
+		public static DependencyProperty TitleProperty
+		{
+			[DynamicDependency(nameof(GetTitle))]
+			[DynamicDependency(nameof(SetTitle))]
+			get;
+		} = Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
 				"Title", typeof(string),
 				typeof(PickerFlyoutBase),
 				new FrameworkPropertyMetadata(default(string)));

--- a/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.Properties.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference RadioMenuFlyoutItem.properties.cpp, commit d6634d1bb82697c9b700fff5adf4e9484e0952c5
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -11,8 +12,16 @@ namespace Microsoft.UI.Xaml.Controls
 		public static bool GetAreCheckStatesEnabled(DependencyObject obj) => (bool)obj.GetValue(AreCheckStatesEnabledProperty);
 		public static void SetAreCheckStatesEnabled(DependencyObject obj, bool value) => obj.SetValue(AreCheckStatesEnabledProperty, value);
 
-		public static DependencyProperty AreCheckStatesEnabledProperty { get; } =
-			DependencyProperty.RegisterAttached("AreCheckStatesEnabled", typeof(bool), typeof(RadioMenuFlyoutItem), new FrameworkPropertyMetadata(false, OnAreCheckStatesEnabledPropertyChanged));
+		public static DependencyProperty AreCheckStatesEnabledProperty
+		{
+			[DynamicDependency(nameof(GetAreCheckStatesEnabled))]
+			[DynamicDependency(nameof(SetAreCheckStatesEnabled))]
+			get;
+		} = DependencyProperty.RegisterAttached(
+				"AreCheckStatesEnabled",
+				typeof(bool),
+				typeof(RadioMenuFlyoutItem),
+				new FrameworkPropertyMetadata(false, OnAreCheckStatesEnabledPropertyChanged));
 
 		public string GroupName
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/RelativePanel/RelativePanel.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/RelativePanel/RelativePanel.Properties.cs
@@ -1,4 +1,5 @@
-﻿using Uno.UI.Xaml;
+﻿using System.Diagnostics.CodeAnalysis;
+using Uno.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.UI.Xaml.Controls;
@@ -134,8 +135,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignBottomWithPanelProperty XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignBottomWithPanelProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignBottomWithPanel", typeof(bool), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignBottomWithPanelProperty
+	{
+		[DynamicDependency(nameof(GetAlignBottomWithPanel))]
+		[DynamicDependency(nameof(SetAlignBottomWithPanel))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignBottomWithPanel",
+			typeof(bool),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignLeftWithPanel XAML attached property for the target element.
@@ -154,8 +163,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignLeftWithPanelProperty XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignLeftWithPanelProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignLeftWithPanel", typeof(bool), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignLeftWithPanelProperty
+	{
+		[DynamicDependency(nameof(GetAlignLeftWithPanel))]
+		[DynamicDependency(nameof(SetAlignLeftWithPanel))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignLeftWithPanel",
+			typeof(bool),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignRightWithPanel XAML attached property for the target element.
@@ -174,8 +191,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignRightWithPanelProperty XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignRightWithPanelProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignRightWithPanel", typeof(bool), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignRightWithPanelProperty
+	{
+		[DynamicDependency(nameof(GetAlignRightWithPanel))]
+		[DynamicDependency(nameof(SetAlignRightWithPanel))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignRightWithPanel",
+			typeof(bool),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignTopWithPanel XAML attached property for the target element.
@@ -194,8 +219,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignTopWithPanelProperty XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignTopWithPanelProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignTopWithPanel", typeof(bool), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignTopWithPanelProperty
+	{
+		[DynamicDependency(nameof(GetAlignTopWithPanel))]
+		[DynamicDependency(nameof(SetAlignTopWithPanel))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignTopWithPanel",
+			typeof(bool),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignHorizontalCenterWithPanel XAML attached property for the target element.
@@ -214,8 +247,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignHorizontalCenterWithPanel XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignHorizontalCenterWithPanelProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignHorizontalCenterWithPanel", typeof(bool), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignHorizontalCenterWithPanelProperty
+	{
+		[DynamicDependency(nameof(GetAlignHorizontalCenterWithPanel))]
+		[DynamicDependency(nameof(SetAlignHorizontalCenterWithPanel))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignHorizontalCenterWithPanel",
+			typeof(bool),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignVerticalCenterWithPanel XAML attached property for the target element.
@@ -234,8 +275,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignVerticalCenterWithPanel XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignVerticalCenterWithPanelProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignVerticalCenterWithPanel", typeof(bool), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignVerticalCenterWithPanelProperty
+	{
+		[DynamicDependency(nameof(GetAlignVerticalCenterWithPanel))]
+		[DynamicDependency(nameof(SetAlignVerticalCenterWithPanel))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignVerticalCenterWithPanel",
+			typeof(bool),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: false, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	#endregion
 
@@ -258,8 +307,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignBottomWith XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignBottomWithProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignBottomWith", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignBottomWithProperty
+	{
+		[DynamicDependency(nameof(GetAlignBottomWith))]
+		[DynamicDependency(nameof(SetAlignBottomWith))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignBottomWith",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignLeftWith XAML attached property for the target element.
@@ -278,8 +335,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignLeftWith XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignLeftWithProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignLeftWith", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignLeftWithProperty
+	{
+		[DynamicDependency(nameof(GetAlignLeftWith))]
+		[DynamicDependency(nameof(SetAlignLeftWith))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignLeftWith",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignRightWith XAML attached property for the target element.
@@ -298,8 +363,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignRightWith XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignRightWithProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignRightWith", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignRightWithProperty
+	{
+		[DynamicDependency(nameof(GetAlignRightWith))]
+		[DynamicDependency(nameof(SetAlignRightWith))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignRightWith",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignTopWith XAML attached property for the target element.
@@ -318,8 +391,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignTopWith XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignTopWithProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignTopWith", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignTopWithProperty
+	{
+		[DynamicDependency(nameof(GetAlignTopWith))]
+		[DynamicDependency(nameof(SetAlignTopWith))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignTopWith",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignHorizontalCenterWith XAML attached property for the target element.
@@ -338,8 +419,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignHorizontalCenterWith XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignHorizontalCenterWithProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignHorizontalCenterWith", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignHorizontalCenterWithProperty
+	{
+		[DynamicDependency(nameof(GetAlignHorizontalCenterWith))]
+		[DynamicDependency(nameof(SetAlignHorizontalCenterWith))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignHorizontalCenterWith",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.AlignVerticalCenterWith XAML attached property for the target element.
@@ -358,8 +447,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.AlignVerticalCenterWith XAML attached property.
 	/// </summary>
-	public static DependencyProperty AlignVerticalCenterWithProperty { get; } =
-		DependencyProperty.RegisterAttached("AlignVerticalCenterWith", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AlignVerticalCenterWithProperty
+	{
+		[DynamicDependency(nameof(GetAlignVerticalCenterWith))]
+		[DynamicDependency(nameof(SetAlignVerticalCenterWith))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"AlignVerticalCenterWith",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	#endregion
 
@@ -382,8 +479,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.Above XAML attached property.
 	/// </summary>
-	public static DependencyProperty AboveProperty { get; } =
-		DependencyProperty.RegisterAttached("Above", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty AboveProperty
+	{
+		[DynamicDependency(nameof(GetAbove))]
+		[DynamicDependency(nameof(SetAbove))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"Above",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.Below XAML attached property for the target element.
@@ -402,8 +507,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.Below XAML attached property.
 	/// </summary>
-	public static DependencyProperty BelowProperty { get; } =
-		DependencyProperty.RegisterAttached("Below", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty BelowProperty
+	{
+		[DynamicDependency(nameof(GetBelow))]
+		[DynamicDependency(nameof(SetBelow))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"Below",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.LeftOf XAML attached property for the target element.
@@ -422,8 +535,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.LeftOf XAML attached property.
 	/// </summary>
-	public static DependencyProperty LeftOfProperty { get; } =
-		DependencyProperty.RegisterAttached("LeftOf", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty LeftOfProperty
+	{
+		[DynamicDependency(nameof(GetLeftOf))]
+		[DynamicDependency(nameof(SetLeftOf))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"LeftOf",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	/// <summary>
 	/// Gets the value of the RelativePanel.RightOf XAML attached property for the target element.
@@ -442,8 +563,16 @@ public partial class RelativePanel
 	/// <summary>
 	/// Identifies the RelativePanel.RightOf XAML attached property.
 	/// </summary>
-	public static DependencyProperty RightOfProperty { get; } =
-		DependencyProperty.RegisterAttached("RightOf", typeof(object), typeof(RelativePanel), new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
+	public static DependencyProperty RightOfProperty
+	{
+		[DynamicDependency(nameof(GetRightOf))]
+		[DynamicDependency(nameof(SetRightOf))]
+		get;
+	} = DependencyProperty.RegisterAttached(
+			"RightOf",
+			typeof(object),
+			typeof(RelativePanel),
+			new FrameworkPropertyMetadata(defaultValue: null, options: FrameworkPropertyMetadataOptions.AffectsMeasure, propertyChangedCallback: (s, e) => OnPositioningChanged(s)));
 
 	#endregion
 

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.Properties.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.UI.Xaml;
 
@@ -6,7 +7,12 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	partial class RecyclePool
 	{
-		public static DependencyProperty PoolInstanceProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty PoolInstanceProperty
+		{
+			[DynamicDependency(nameof(GetPoolInstance))]
+			[DynamicDependency(nameof(SetPoolInstance))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"PoolInstance", typeof(RecyclePool), typeof(RecyclePool), new FrameworkPropertyMetadata(default(RecyclePool)));
 
 		public static RecyclePool GetPoolInstance(DataTemplate dataTemplate)

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePoolFactory.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePoolFactory.cs
@@ -1,13 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 
 namespace Microsoft.UI.Xaml.Controls
 {
 	partial class RecyclePool
 	{
-		internal static DependencyProperty ReuseKeyProperty { get; } = DependencyProperty.RegisterAttached(
+		internal static DependencyProperty ReuseKeyProperty
+		{
+			[DynamicDependency(nameof(GetReuseKey))]
+			[DynamicDependency(nameof(SetReuseKey))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"ReuseKey",
 			typeof(string),
 			typeof(RecyclePool),

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.uno.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,6 +13,8 @@ namespace Uno.UI.Xaml.Controls
 		/// <summary>
 		/// Backing property for the IsPointerWheelReversed attached property.
 		/// </summary>
+		[DynamicDependency(nameof(GetIsPointerWheelReversed))]
+		[DynamicDependency(nameof(SetIsPointerWheelReversed))]
 		public static readonly DependencyProperty IsPointerWheelReversedProperty = DependencyProperty.RegisterAttached(
 			"IsPointerWheelReversed",
 			typeof(bool),

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
@@ -3,6 +3,7 @@
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -31,8 +32,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(IsScrollInertiaEnabledProperty, value);
 		}
 
-		public static DependencyProperty IsScrollInertiaEnabledProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsScrollInertiaEnabledProperty
+		{
+			[DynamicDependency(nameof(GetIsScrollInertiaEnabled))]
+			[DynamicDependency(nameof(SetIsScrollInertiaEnabled))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				nameof(IsScrollInertiaEnabled),
 				typeof(bool),
 				typeof(ScrollViewer),
@@ -52,8 +57,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(IsHorizontalScrollChainingEnabledProperty, value);
 		}
 
-		public static DependencyProperty IsHorizontalScrollChainingEnabledProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsHorizontalScrollChainingEnabledProperty
+		{
+			[DynamicDependency(nameof(GetIsHorizontalScrollChainingEnabled))]
+			[DynamicDependency(nameof(SetIsHorizontalScrollChainingEnabled))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"IsHorizontalScrollChainingEnabled",
 				typeof(bool),
 				typeof(ScrollViewer),
@@ -73,8 +82,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(IsHorizontalRailEnabledProperty, value);
 		}
 
-		public static DependencyProperty IsHorizontalRailEnabledProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsHorizontalRailEnabledProperty
+		{
+			[DynamicDependency(nameof(GetIsHorizontalRailEnabled))]
+			[DynamicDependency(nameof(SetIsHorizontalRailEnabled))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"IsHorizontalRailEnabled",
 				typeof(bool),
 				typeof(ScrollViewer),
@@ -94,8 +107,13 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(IsVerticalScrollChainingEnabledProperty, value);
 		}
 
-		public static DependencyProperty IsVerticalScrollChainingEnabledProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsVerticalScrollChainingEnabledProperty
+		{
+
+			[DynamicDependency(nameof(GetIsVerticalScrollChainingEnabled))]
+			[DynamicDependency(nameof(SetIsVerticalScrollChainingEnabled))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"IsVerticalScrollChainingEnabled",
 				typeof(bool),
 				typeof(ScrollViewer),
@@ -115,8 +133,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(IsVerticalRailEnabledProperty, value);
 		}
 
-		public static DependencyProperty IsVerticalRailEnabledProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsVerticalRailEnabledProperty
+		{
+			[DynamicDependency(nameof(GetIsVerticalRailEnabled))]
+			[DynamicDependency(nameof(SetIsVerticalRailEnabled))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"IsVerticalRailEnabled",
 				typeof(bool),
 				typeof(ScrollViewer),

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Uno.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.UI.Xaml;
 
@@ -35,7 +36,12 @@ namespace Uno.UI.Xaml.Controls
 		/// <summary>
 		/// Backing property for the <see cref="ScrollViewerUpdatesMode"/> of a ScrollViewer.
 		/// </summary>
-		public static DependencyProperty UpdatesModeProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty UpdatesModeProperty
+		{
+			[DynamicDependency(nameof(GetUpdatesMode))]
+			[DynamicDependency(nameof(SetUpdatesMode))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"UpdatesMode",
 			typeof(ScrollViewerUpdatesMode),
 			typeof(ScrollViewer),
@@ -81,6 +87,8 @@ namespace Uno.UI.Xaml.Controls
 			scrollViewer.SetValue(ShouldFallBackToNativeScrollBarsProperty, value);
 		}
 
+		[DynamicDependency(nameof(GetShouldFallBackToNativeScrollBars))]
+		[DynamicDependency(nameof(SetShouldFallBackToNativeScrollBars))]
 		public static readonly DependencyProperty ShouldFallBackToNativeScrollBarsProperty =
 			DependencyProperty.RegisterAttached("ShouldFallBackToNativeScrollBars", typeof(bool), typeof(ScrollViewer), new FrameworkPropertyMetadata(true));
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -169,8 +169,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => this.SetValue(HorizontalScrollBarVisibilityProperty, value);
 		}
 
-		public static DependencyProperty HorizontalScrollBarVisibilityProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty HorizontalScrollBarVisibilityProperty
+		{
+			[DynamicDependency(nameof(GetHorizontalScrollBarVisibility))]
+			[DynamicDependency(nameof(SetHorizontalScrollBarVisibility))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"HorizontalScrollBarVisibility",
 				typeof(ScrollBarVisibility),
 				typeof(ScrollViewer),
@@ -194,8 +198,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => this.SetValue(VerticalScrollBarVisibilityProperty, value);
 		}
 
-		public static DependencyProperty VerticalScrollBarVisibilityProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty VerticalScrollBarVisibilityProperty
+		{
+			[DynamicDependency(nameof(GetVerticalScrollBarVisibility))]
+			[DynamicDependency(nameof(SetVerticalScrollBarVisibility))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"VerticalScrollBarVisibility",
 				typeof(ScrollBarVisibility),
 				typeof(ScrollViewer),
@@ -219,8 +227,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => this.SetValue(HorizontalScrollModeProperty, value);
 		}
 
-		public static DependencyProperty HorizontalScrollModeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty HorizontalScrollModeProperty
+		{
+			[DynamicDependency(nameof(GetHorizontalScrollMode))]
+			[DynamicDependency(nameof(SetHorizontalScrollMode))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"HorizontalScrollMode",
 				typeof(ScrollMode),
 				typeof(ScrollViewer),
@@ -246,8 +258,12 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		// Using a DependencyProperty as the backing store for VerticalScrollMode.  This enables animation, styling, binding, etc...
-		public static DependencyProperty VerticalScrollModeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty VerticalScrollModeProperty
+		{
+			[DynamicDependency(nameof(GetVerticalScrollMode))]
+			[DynamicDependency(nameof(SetVerticalScrollMode))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"VerticalScrollMode",
 				typeof(ScrollMode),
 				typeof(ScrollViewer),
@@ -280,8 +296,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(BringIntoViewOnFocusChangeProperty, value);
 		}
 
-		public static DependencyProperty BringIntoViewOnFocusChangeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty BringIntoViewOnFocusChangeProperty
+		{
+			[DynamicDependency(nameof(GetBringIntoViewOnFocusChange))]
+			[DynamicDependency(nameof(SetBringIntoViewOnFocusChange))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"BringIntoViewOnFocusChange",
 				typeof(bool),
 				typeof(ScrollViewer),
@@ -312,8 +332,12 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetValue(ZoomModeProperty, value);
 		}
 
-		public static DependencyProperty ZoomModeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty ZoomModeProperty
+		{
+			[DynamicDependency(nameof(GetZoomMode))]
+			[DynamicDependency(nameof(SetZoomMode))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"ZoomMode",
 				typeof(ZoomMode),
 				typeof(ScrollViewer),

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Attached.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Attached.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,6 +15,8 @@ public class TextBoxExtensions
 
 	public static void SetInputReturnType(DependencyObject obj, InputReturnType value) => obj.SetValue(InputReturnTypeProperty, value);
 
+	[DynamicDependency(nameof(GetInputReturnType))]
+	[DynamicDependency(nameof(SetInputReturnType))]
 	public static readonly DependencyProperty InputReturnTypeProperty =
 		DependencyProperty.RegisterAttached(
 			nameof(InputReturnType),

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.Properties.cs
@@ -1,11 +1,16 @@
-﻿using Microsoft.UI.Xaml.Controls.Primitives;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml.Controls.Primitives;
 
 namespace Microsoft.UI.Xaml.Controls;
 
 public partial class ToolTipService
 {
-	public static DependencyProperty ToolTipProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	public static DependencyProperty ToolTipProperty
+	{
+		[DynamicDependency(nameof(GetToolTip))]
+		[DynamicDependency(nameof(SetToolTip))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"ToolTip",
 			typeof(object),
 			typeof(ToolTipService),
@@ -15,8 +20,12 @@ public partial class ToolTipService
 
 	public static void SetToolTip(DependencyObject element, object value) => element.SetValue(ToolTipProperty, value);
 
-	public static DependencyProperty PlacementProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	public static DependencyProperty PlacementProperty
+	{
+		[DynamicDependency(nameof(GetPlacement))]
+		[DynamicDependency(nameof(SetPlacement))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"Placement",
 			typeof(PlacementMode),
 			typeof(ToolTipService),
@@ -29,8 +38,12 @@ public partial class ToolTipService
 	/// <summary>
 	/// Gets or sets the object relative to which the tooltip is positioned.
 	/// </summary>
-	public static DependencyProperty PlacementTargetProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	public static DependencyProperty PlacementTargetProperty
+	{
+		[DynamicDependency(nameof(GetPlacementTarget))]
+		[DynamicDependency(nameof(SetPlacementTarget))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"PlacementTarget",
 			typeof(UIElement),
 			typeof(ToolTipService),
@@ -50,8 +63,12 @@ public partial class ToolTipService
 	/// <param name="value">The visual element that should be the placement target for the tooltip.</param>
 	public static void SetPlacementTarget(DependencyObject element, UIElement value) => element.SetValue(PlacementTargetProperty, value);
 
-	internal static DependencyProperty ToolTipReferenceProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	internal static DependencyProperty ToolTipReferenceProperty
+	{
+		[DynamicDependency(nameof(GetToolTipReference))]
+		[DynamicDependency(nameof(SetToolTipReference))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"ToolTipReference",
 			typeof(ToolTip),
 			typeof(ToolTipService),
@@ -61,8 +78,12 @@ public partial class ToolTipService
 
 	internal static void SetToolTipReference(DependencyObject element, ToolTip value) => element.SetValue(ToolTipReferenceProperty, value);
 
-	internal static DependencyProperty KeyboardAcceleratorToolTipProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	internal static DependencyProperty KeyboardAcceleratorToolTipProperty
+	{
+		[DynamicDependency(nameof(GetKeyboardAcceleratorToolTip))]
+		[DynamicDependency(nameof(SetKeyboardAcceleratorToolTip))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"KeyboardAcceleratorToolTip",
 			typeof(object),
 			typeof(ToolTipService),
@@ -72,8 +93,12 @@ public partial class ToolTipService
 
 	internal static void SetKeyboardAcceleratorToolTip(DependencyObject element, object value) => element.SetValue(KeyboardAcceleratorToolTipProperty, value);
 
-	internal static DependencyProperty KeyboardAcceleratorToolTipObjectProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	internal static DependencyProperty KeyboardAcceleratorToolTipObjectProperty
+	{
+		[DynamicDependency(nameof(GetKeyboardAcceleratorToolTipObject))]
+		[DynamicDependency(nameof(SetKeyboardAcceleratorToolTipObject))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"KeyboardAcceleratorToolTipObject",
 			typeof(ToolTip),
 			typeof(ToolTipService),

--- a/src/Uno.UI/UI/Xaml/Controls/VariableSizedWrapGrid/VariableSizedWrapGrid.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/VariableSizedWrapGrid/VariableSizedWrapGrid.Properties.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -7,8 +8,12 @@ partial class VariableSizedWrapGrid
 	/// <summary>
 	/// Identifies the VariableSizedWrapGrid.ColumnSpan XAML attached property.
 	/// </summary>
-	public static DependencyProperty ColumnSpanProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	public static DependencyProperty ColumnSpanProperty
+	{
+		[DynamicDependency(nameof(GetColumnSpan))]
+		[DynamicDependency(nameof(SetColumnSpan))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"ColumnSpan",
 			typeof(int),
 			typeof(VariableSizedWrapGrid),
@@ -128,8 +133,12 @@ partial class VariableSizedWrapGrid
 	/// <summary>
 	/// Identifies the VariableSizedWrapGrid.RowSpan XAML attached property.
 	/// </summary>
-	public static DependencyProperty RowSpanProperty { get; } =
-		DependencyProperty.RegisterAttached(
+	public static DependencyProperty RowSpanProperty
+	{
+		[DynamicDependency(nameof(GetRowSpan))]
+		[DynamicDependency(nameof(SetRowSpan))]
+		get;
+	} = DependencyProperty.RegisterAttached(
 			"RowSpan",
 			typeof(int),
 			typeof(VariableSizedWrapGrid),

--- a/src/Uno.UI/UI/Xaml/Maps/MapControl.cs
+++ b/src/Uno.UI/UI/Xaml/Maps/MapControl.cs
@@ -3,6 +3,7 @@
 #pragma warning disable 114 // new keyword hiding
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 using Uno;
 using Uno.Extensions;
@@ -236,8 +237,12 @@ namespace Microsoft.UI.Xaml.Controls.Maps
 			"LandmarksVisible", typeof(bool),
 			typeof(MapControl),
 			new FrameworkPropertyMetadata(default(bool)));
-		public static DependencyProperty LocationProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
+		public static DependencyProperty LocationProperty
+		{
+			[DynamicDependency(nameof(GetLocation))]
+			[DynamicDependency(nameof(SetLocation))]
+			get;
+		} = Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
 			"Location", typeof(Geopoint),
 			typeof(MapControl),
 			new FrameworkPropertyMetadata(default(Geopoint)));
@@ -251,8 +256,12 @@ namespace Microsoft.UI.Xaml.Controls.Maps
 			"MapServiceToken", typeof(string),
 			typeof(MapControl),
 			new FrameworkPropertyMetadata(default(string)));
-		public static DependencyProperty NormalizedAnchorPointProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
+		public static DependencyProperty NormalizedAnchorPointProperty
+		{
+			[DynamicDependency(nameof(GetNormalizedAnchorPoint))]
+			[DynamicDependency(nameof(SetNormalizedAnchorPoint))]
+			get;
+		} = Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
 			"NormalizedAnchorPoint", typeof(global::Windows.Foundation.Point),
 			typeof(MapControl),
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));

--- a/src/Uno.UI/UI/Xaml/Media/Animation/CommonNavigationTransitionInfo.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/CommonNavigationTransitionInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.UI.Xaml.Media.Animation
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.UI.Xaml.Media.Animation
 {
 	public partial class CommonNavigationTransitionInfo : NavigationTransitionInfo
 	{
@@ -33,8 +35,12 @@
 			element.SetValue(IsStaggerElementProperty, value);
 		}
 
-		public static DependencyProperty IsStaggerElementProperty { get; } =
-		DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsStaggerElementProperty
+		{
+			[DynamicDependency(nameof(GetIsStaggerElement))]
+			[DynamicDependency(nameof(SetIsStaggerElement))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"IsStaggerElement", typeof(bool),
 			typeof(CommonNavigationTransitionInfo),
 			new FrameworkPropertyMetadata(default(bool))

--- a/src/Uno.UI/UI/Xaml/Media/Animation/EntranceNavigationTransitionInfo.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/EntranceNavigationTransitionInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.UI.Xaml.Media.Animation
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.UI.Xaml.Media.Animation
 {
 	public partial class EntranceNavigationTransitionInfo : NavigationTransitionInfo
 	{
@@ -16,8 +18,12 @@
 			element.SetValue(IsTargetElementProperty, value);
 		}
 
-		public static DependencyProperty IsTargetElementProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty IsTargetElementProperty
+		{
+			[DynamicDependency(nameof(GetIsTargetElement))]
+			[DynamicDependency(nameof(SetIsTargetElement))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 			"IsTargetElement", typeof(bool),
 			typeof(EntranceNavigationTransitionInfo),
 			new FrameworkPropertyMetadata(default(bool))

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -1,6 +1,7 @@
 ﻿using Uno.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Collections.Specialized;
 using System.Linq;
@@ -51,8 +52,16 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		public static void SetTargetName(Timeline element, string name) => element.SetValue(TargetNameProperty, name);
 
 		// Using a DependencyProperty as the backing store for TargetName.  This enables animation, styling, binding, etc...
-		public static DependencyProperty TargetNameProperty { get; } =
-			DependencyProperty.RegisterAttached("TargetName", typeof(string), typeof(Storyboard), new FrameworkPropertyMetadata(string.Empty));
+		public static DependencyProperty TargetNameProperty
+		{
+			[DynamicDependency(nameof(GetTargetName))]
+			[DynamicDependency(nameof(SetTargetName))]
+			get;
+		} = DependencyProperty.RegisterAttached(
+				"TargetName",
+				typeof(string),
+				typeof(Storyboard),
+				new FrameworkPropertyMetadata(string.Empty));
 		#endregion
 
 		#region TargetProperty Attached Property
@@ -61,8 +70,16 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		public static void SetTargetProperty(Timeline element, string path) => element.SetValue(TargetPropertyProperty, path);
 
 		// Using a DependencyProperty as the backing store for TargetProperty.  This enables animation, styling, binding, etc...
-		public static DependencyProperty TargetPropertyProperty { get; } =
-			DependencyProperty.RegisterAttached("TargetProperty", typeof(string), typeof(Storyboard), new FrameworkPropertyMetadata(string.Empty));
+		public static DependencyProperty TargetPropertyProperty
+		{
+			[DynamicDependency(nameof(GetTargetProperty))]
+			[DynamicDependency(nameof(SetTargetProperty))]
+			get;
+		} = DependencyProperty.RegisterAttached(
+				"TargetProperty",
+				typeof(string),
+				typeof(Storyboard),
+				new FrameworkPropertyMetadata(string.Empty));
 		#endregion
 
 		public static void SetTarget(Timeline timeline, DependencyObject target) => timeline.Target = target;

--- a/src/Uno.UI/UI/Xaml/NameScope.cs
+++ b/src/Uno.UI/UI/Xaml/NameScope.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
@@ -80,8 +81,12 @@ namespace Microsoft.UI.Xaml
 		/// <summary>
 		/// Identifies the NameScope attached property.
 		/// </summary>
-		public static DependencyProperty NameScopeProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty NameScopeProperty
+		{
+			[DynamicDependency(nameof(GetNameScope))]
+			[DynamicDependency(nameof(SetNameScope))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"NameScope",
 				typeof(INameScope),
 				typeof(NameScope),

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.debugging.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.debugging.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Uno.UI;
 using Uno.Extensions;
@@ -58,6 +59,8 @@ namespace Microsoft.UI.Xaml
 		}
 
 		// Using a DependencyProperty as the backing store for ResourceSource.  This enables animation, styling, binding, etc...
+		[DynamicDependency(nameof(GetResourceSource))]
+		[DynamicDependency(nameof(SetResourceSource))]
 		internal static readonly DependencyProperty ResourceSourceProperty =
 			DependencyProperty.RegisterAttached("ResourceSource", typeof(DebugResourceSource), typeof(ResourceDictionary), new FrameworkPropertyMetadata(null));
 

--- a/src/Uno.UI/UI/Xaml/VisualStateManager.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
@@ -40,8 +41,12 @@ namespace Microsoft.UI.Xaml
 			obj.SetValue(VisualStateGroupsProperty, value);
 		}
 
-		public static DependencyProperty VisualStateGroupsProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty VisualStateGroupsProperty
+		{
+			[DynamicDependency(nameof(GetVisualStateGroups))]
+			[DynamicDependency(nameof(SetVisualStateGroups))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"VisualStateGroups",
 				typeof(IList<VisualStateGroup>),
 				typeof(VisualStateManager),
@@ -94,13 +99,26 @@ namespace Microsoft.UI.Xaml
 			obj.SetValue(VisualStateManagerProperty, value);
 		}
 
-		internal static DependencyProperty VisualStateManagerProperty { get; } =
-			DependencyProperty.RegisterAttached("VisualStateManager", typeof(VisualStateManager), typeof(VisualStateManager), new FrameworkPropertyMetadata(null));
+		internal static DependencyProperty VisualStateManagerProperty
+		{
+			[DynamicDependency(nameof(GetVisualStateManager))]
+			[DynamicDependency(nameof(SetVisualStateManager))]
+			get;
+		} = DependencyProperty.RegisterAttached(
+				"VisualStateManager",
+				typeof(VisualStateManager),
+				typeof(VisualStateManager),
+				new FrameworkPropertyMetadata(null));
 
 		#endregion
 
 		#region CustomVisualStateManager Attached Property
-		public static DependencyProperty CustomVisualStateManagerProperty { get; } = DependencyProperty.RegisterAttached(
+		public static DependencyProperty CustomVisualStateManagerProperty
+		{
+			[DynamicDependency(nameof(GetCustomVisualStateManager))]
+			[DynamicDependency(nameof(SetCustomVisualStateManager))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				"CustomVisualStateManager", typeof(VisualStateManager),
 				typeof(VisualStateManager),
 				new FrameworkPropertyMetadata(default(VisualStateManager)));

--- a/src/Uno.UI/UI/Xaml/XamlInfo.cs
+++ b/src/Uno.UI/UI/Xaml/XamlInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -38,8 +39,12 @@ namespace Uno.UI.Xaml
 		public static void SetXamlInfo(DependencyObject obj, XamlInfo owner)
 			=> obj.SetValue(XamlInfoProperty, owner);
 
-		public static DependencyProperty XamlInfoProperty { get; } =
-			DependencyProperty.RegisterAttached(
+		public static DependencyProperty XamlInfoProperty
+		{
+			[DynamicDependency(nameof(GetXamlInfo))]
+			[DynamicDependency(nameof(SetXamlInfo))]
+			get;
+		} = DependencyProperty.RegisterAttached(
 				name: nameof(XamlInfo),
 				propertyType: typeof(XamlInfo),
 				ownerType: typeof(XamlInfo),


### PR DESCRIPTION
(Let's say it with me…)

While running the uno.chefs app on macOS under NativeAOT:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:UseSkiaRendering=true \
	  -p:TrimmerSingleWarn=false -p:IsTrimmable=true -p:IsAotCompatible=true -p:_ExtraTrimmerArgs=--verbose \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

when using recent versions of Uno, the app log (stdout) would contain:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Microsoft.UI.Xaml.Controls:ToolTipService.Placement] property getter does not exist on type [Microsoft.UI.Xaml.Controls.Button]

The `Microsoft.UI.Xaml.Controls:ToolTipService.Placement` property is an *attached* property, from `ToolTipService.Placement`:

	partial class ToolTipService {
	  public static DependencyProperty PlacementProperty { get; } =
	    DependencyProperty.RegisterAttached(
	      "Placement",
	      typeof(PlacementMode),
	      typeof(ToolTipService),
	      new FrameworkPropertyMetadata(PlacementMode.Top, OnPlacementChanged));
	  public static PlacementMode GetPlacement(DependencyObject element) => …;
	  public static void SetPlacement(DependencyObject element, PlacementMode value) => …;
	}

Attached properties work by using Reflection to look for methods with `Get` and `Set` prefixes before the property name, in this case `GetPlacement()` and `SetPlacement()`.

NativeAOT cannot statically determine that `GetPlacement()` and `SetPlacement()` are used, and thus doesn't emit any reflection metadata for these members.  This can be verified by consulting the generated `Chefs.metadata.csv` file, which only contains these entries for `GetPlacement` and `SetPlacement`:

	3432be02, ConstantStringValue, "GetPlacement", ""
	3432be1b, ConstantStringValue, "SetPlacement", ""

The [`[DynamicDependency]`][0] custom attribute can be used to inform NativeAOT of this dependency, by listing the names of members which should be preserved:

	partial class ToolTipService {
	  public static DependencyProperty PlacementProperty
	  {
	    [DynamicDependency(nameof(GetPlacement))]
	    [DynamicDependency(nameof(SetPlacement))]
	    get;
	  } = DependencyProperty.RegisterAttached(
	      "Placement",
	      typeof(PlacementMode),
	      typeof(ToolTipService),
	      new FrameworkPropertyMetadata(PlacementMode.Top, OnPlacementChanged));
	  public static PlacementMode GetPlacement(DependencyObject element) => …;
	  public static void SetPlacement(DependencyObject element, PlacementMode value) => …;
	}

With this change in place, the originating failure message is no longer emitted, and `Chefs.metadata.csv` contains:

	5009ff1e, Method, "Microsoft.UI.Xaml.Controls.Primitives.PlacementMode GetPlacement(Microsoft.UI.Xaml.DependencyObject)", "3412dd90 5612dd9d 620c0f74"
	5009ff2d, Method, "System.Void SetPlacement(Microsoft.UI.Xaml.DependencyObject, Microsoft.UI.Xaml.Controls.Primitives.PlacementMode)", "3412dda9 5612ddb6 620c0f74 620671d0"
	3412dd90, ConstantStringValue, "GetPlacement", ""
	3412dda9, ConstantStringValue, "SetPlacement", ""

Note the addition of the `Method` lines.

Review all usage of `DependencyProperty.RegisterAttached()` within `src/Uno.UI` and add `[DynamicDependency]` attributes as appropriate.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->