### PR TITLE
fix(hr): Fix HR not working on iOS

### DIFF
--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -87,4 +87,26 @@
 		<WasmShellMonoEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>
 
+	<!-- Disable linking on iOS and Android to avoid stripping required reflection metadata -->
+	<Choose>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+			<PropertyGroup>
+				<AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">None</AndroidLinkMode>
+			</PropertyGroup>
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+			<PropertyGroup>
+				<MTouchLink Condition="'$(MTouchLink)' == ''">None</MTouchLink>
+			</PropertyGroup>
+		</When>
+	</Choose>
+
+	<Target Name="_UnoWarnAndroidLinkNotSetToNone" BeforeTargets="CoreCompile" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and '$(AndroidLinkMode)' != 'None'">
+		<Warning Code="UHR001" Text="Hot Reload won't work correctly when linker/trimming is enabled. Set AndroidLinkMode to 'None'." />
+	</Target>
+	
+	<Target Name="_UnoWarniOSLinkNotSetToNone" BeforeTargets="CoreCompile" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' and '$(MTouchLink)' != 'None'">
+		<Warning Code="UHR001" Text="Hot Reload won't work correctly when linker/trimming is enabled. Set MTouchLink to 'None'." />
+	</Target>
+
 </Project>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -89,23 +89,23 @@
 
 	<!-- Disable linking on iOS and Android to avoid stripping required reflection metadata -->
 	<Choose>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'android'">
 			<PropertyGroup>
 				<AndroidLinkMode Condition="'$(AndroidLinkMode)' == ''">None</AndroidLinkMode>
 			</PropertyGroup>
 		</When>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'ios'">
 			<PropertyGroup>
 				<MTouchLink Condition="'$(MTouchLink)' == ''">None</MTouchLink>
 			</PropertyGroup>
 		</When>
 	</Choose>
 
-	<Target Name="_UnoWarnAndroidLinkNotSetToNone" BeforeTargets="CoreCompile" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and '$(AndroidLinkMode)' != 'None'">
+	<Target Name="_UnoWarnAndroidLinkNotSetToNone" BeforeTargets="CoreCompile" Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'android' and '$(AndroidLinkMode)' != 'None'">
 		<Warning Code="UHR001" Text="Hot Reload won't work correctly when linker/trimming is enabled. Set AndroidLinkMode to 'None'." />
 	</Target>
 	
-	<Target Name="_UnoWarniOSLinkNotSetToNone" BeforeTargets="CoreCompile" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' and '$(MTouchLink)' != 'None'">
+	<Target Name="_UnoWarniOSLinkNotSetToNone" BeforeTargets="CoreCompile" Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'ios' and '$(MTouchLink)' != 'None'">
 		<Warning Code="UHR001" Text="Hot Reload won't work correctly when linker/trimming is enabled. Set MTouchLink to 'None'." />
 	</Target>
 


### PR DESCRIPTION
linked https://github.com/unoplatform/uno/issues/21857

## 🐞 Bugfix
Fix HR not working on iOS

## What is the current behavior? 🤔
* Trimmer/linker removes HR messages
* Timmer/Linker remove unused types and properties that might be used later when using HR to update app

## What is the new behavior? 🚀
Trimmer/linker disabled when RemoteControl package is referenced.

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
There is still an issue where HR is not working with debugger attached with VSCode: https://github.com/unoplatform/uno.vscode/issues/1226