### PR TITLE
ci: use token as env variable

### DIFF
--- a/.github/actions/docs-update/action.yml
+++ b/.github/actions/docs-update/action.yml
@@ -7,10 +7,6 @@ inputs:
     required: true
     default: 'master'
 
-  github_token:
-  description: 'GitHub token used for authenticated API calls'
-  required: false
-
 outputs:
   has_changes:
     description: 'Whether changes were detected'
@@ -27,7 +23,6 @@ runs:
     - name: Update external docs commit hashes
       shell: pwsh
       run: |
-        $env:GITHUB_TOKEN = '${{ inputs.github_token }}'
         ./doc/update_external_docs_hashes.ps1 -Branch '${{ inputs.branch }}'
 
     - name: Check for changes

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -16,7 +16,8 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   docs-update:
     runs-on: ubuntu-latest
@@ -32,7 +33,6 @@ jobs:
         uses: ./.github/actions/docs-update
         with:
           branch: ${{ inputs.branch || 'master' }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set target branch
         id: targetbranch


### PR DESCRIPTION
This pull request updates the way the GitHub token is provided to the docs update workflow, simplifying the configuration and improving consistency. The most important changes are grouped below:

**Workflow and Action Configuration Simplification:**

* Removed the `github_token` input from the `.github/actions/docs-update/action.yml` action definition, so the token is no longer passed as an explicit input to the action.
* Removed the use of the `github_token` input in the action's PowerShell script step, relying instead on environment variables.
* Added a global `env` section to `.github/workflows/docs-updater.yml` to set `GITHUB_TOKEN` from secrets for all jobs, centralizing token management.
* Removed the explicit passing of `github_token` to the action in the workflow, since it is now set via the environment.