### PR TITLE
fix(droid): statusbar inset after deeplinking

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -69,8 +69,11 @@ namespace Microsoft.UI.Xaml
 			_inputPane = InputPane.GetForCurrentView();
 			_inputPane.Showing += OnInputPaneVisibilityChanged;
 			_inputPane.Hiding += OnInputPaneVisibilityChanged;
-
 			Uno.UI.Extensions.PermissionsHelper.Initialize();
+
+			// note: Deep-Link will causes a new instance of this Activity and DecorView to be created.
+			// So, it will be important to rewire/update any event/listener on these two, here.
+			StatusBar.GetForCurrentView().ResetListener();
 		}
 
 		internal void EnsureContentView()

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -71,8 +71,9 @@ namespace Microsoft.UI.Xaml
 			_inputPane.Hiding += OnInputPaneVisibilityChanged;
 			Uno.UI.Extensions.PermissionsHelper.Initialize();
 
-			// note: Deep-Link will causes a new instance of this Activity and DecorView to be created.
-			// So, it will be important to rewire/update any event/listener on these two, here.
+			// Note: Deep-linking will cause a new instance of this Activity and its DecorView to be created.
+			// This means any event handlers or listeners attached to these objects in previous instances will not be present.
+			// Therefore, it is important to rewire or update any event/listener on these two here to ensure correct behavior.
 			StatusBar.GetForCurrentView().ResetListener();
 		}
 

--- a/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.Android.cs
+++ b/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.Android.cs
@@ -23,6 +23,17 @@ namespace Windows.UI.ViewManagement
 		private IOnApplyWindowInsetsListener _insetsListener;
 		private DisplayInformation _displayInformation;
 
+		internal void ResetListener()
+		{
+			// used to reset the stale instance of the insets listener
+			// when the activity&decor-view is recreated, eg: on deep-linking
+			if (_insetsListener is { })
+			{
+				_insetsListener = null;
+				SetStatusBarBackgroundColor(_backgroundColor);
+			}
+		}
+
 		private void SetStatusBarForegroundType(StatusBarForegroundType? foregroundType)
 		{
 			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.M)
@@ -261,9 +272,12 @@ namespace Windows.UI.ViewManagement
 
 			public WindowInsetsCompat OnApplyWindowInsets(View view, WindowInsetsCompat insets)
 			{
-				var statusBarInsets = insets.GetInsets(WindowInsets.Type.StatusBars());
-				view.SetBackgroundColor((Android.Graphics.Color)_statusBar._backgroundColor);
-				view.SetPadding(0, statusBarInsets.Top, 0, 0); // adjust padding to avoid overlap
+				if (_statusBar._insetsListener == this)
+				{
+					var statusBarInsets = insets.GetInsets(WindowInsets.Type.StatusBars());
+					view.SetBackgroundColor((Android.Graphics.Color)(_statusBar._backgroundColor ?? Colors.Transparent));
+					view.SetPadding(0, statusBarInsets.Top, 0, 0); // adjust padding to avoid overlap
+				}
 				return insets;
 			}
 		}


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#387

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
An application with a status-bar background set, when deep-linked, will have incorrect hitbox due to the insets not being updated.

## What is the new behavior? 🚀
StatusBar insets are properly update when deeplinked.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
n/a