### PR TITLE
chore: add automerge for docs pr updates

### DIFF
--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -70,3 +70,10 @@ jobs:
             This is an automated update created by the external docs updater workflow.
           labels: docs-update
           draft: false
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
This pull request adds automation to the documentation update workflow by enabling automatic merging of pull requests created by the external docs updater.

Automation improvements:

* [`.github/workflows/docs-updater.yml`](diffhunk://#diff-611ad9b6bf62b5a0ceb5e5275ebd0d92d723b440dedc0d2c63f2650e1a850ef3R73-R79): Added a step to automatically enable pull request automerge for documentation update PRs when they are created, using the `peter-evans/enable-pull-request-automerge` GitHub Action.