### PR TITLE
fix(text): erroneous logic when a text run ending in CRLF is moved to the next line due to line wrapping

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -764,6 +764,31 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+#if !HAS_RENDER_TARGET_BITMAP
+		[Ignore("Cannot take screenshot on this platform.")]
+#endif
+		public async Task When_Text_Wrapped_At_LineBreak()
+		{
+			var tb1 = new TextBlock()
+			{
+				TextWrapping = TextWrapping.Wrap,
+				Text = "Line1 Line2\r\nLine3",
+				Width = 40,
+				Foreground = new SolidColorBrush(Colors.Red)
+			};
+			var tb2 = new TextBlock()
+			{
+				TextWrapping = TextWrapping.Wrap,
+				Text = "Line1 Line2 Line3",
+				Width = 40,
+				Foreground = new SolidColorBrush(Colors.Red)
+			};
+
+			await UITestHelper.Load(new StackPanel { Children = { tb1, tb2 } });
+			Assert.AreEqual(tb1.ActualHeight, tb2.ActualHeight);
+		}
+
+		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Empty_TextBlock_Measure()
 		{

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
@@ -14,8 +14,10 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents.TextFormatting;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
+using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
+using Uno.UI.Xaml.Media;
 using Buffer = HarfBuzzSharp.Buffer;
 using GlyphInfo = HarfBuzzSharp.GlyphInfo;
 
@@ -384,12 +386,11 @@ internal readonly partial struct UnicodeText : IParsedText
 		var lastRun = logicallyOrderedRuns[endRunIndex - 1];
 		var start = firstRunIndex == endRunIndex - 1 ? startingIndexInFirstRun : lastRun.startInInline;
 		var glyphsWithoutTrailingSpaces = ShapeRun(lastRun.inline.Text[start..endIndexInLastRun], lastRun.rtl, lastRun.fontDetails, usedWidth, ignoreTrailingSpaces: true);
-		usedWidth += RunWidth(glyphsWithoutTrailingSpaces, lastRun.inline.FontDetails);
 
 		logicallyOrderedRuns[firstRunIndex] = backup1;
 		logicallyOrderedRuns[endRunIndex - 1] = backup2;
 
-		return usedWidth - currentLineWidth;
+		return usedWidth - currentLineWidth + RunWidth(glyphsWithoutTrailingSpaces, lastRun.inline.FontDetails);
 	}
 
 	private static IEnumerable<(int endRunIndex, int endIndexInLastRun)> SplitByLineBreakingOpportunities(List<BidiRun> logicallyOrderedRuns, List<(int indexInInline, ReadonlyInlineCopy inline)> logicallyOrderedLineBreakingOpportunities)
@@ -1322,11 +1323,6 @@ internal readonly partial struct UnicodeText : IParsedText
 	private static bool IsLineBreak(string text, int indexAfterLineBreakOpportunity)
 	{
 		// https://www.unicode.org/standard/reports/tr13/tr13-5.html
-
-		if (text is [.., '\r', '\n'])
-		{
-			return true;
-		}
 
 		switch (text[indexAfterLineBreakOpportunity - 1])
 		{

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
@@ -58,7 +58,7 @@ internal readonly partial struct UnicodeText : IParsedText
 
 		public ReadonlyInlineCopy(Inline inline, int startIndex, FlowDirection defaultFlowDirection, bool forceDefaultFlowDirection = false)
 		{
-			Debug.Assert(inline is Run or LineBreak);
+			CI.Assert(inline is Run or LineBreak);
 			Inline = inline;
 			Text = inline.GetText();
 			Foreground = inline.Foreground;
@@ -124,7 +124,7 @@ internal readonly partial struct UnicodeText : IParsedText
 		TextWrapping textWrapping,
 		out Size desiredSize)
 	{
-		Debug.Assert(maxLines >= 0);
+		CI.Assert(maxLines >= 0);
 		_size = availableSize;
 		_defaultFontDetails = defaultFontDetails;
 
@@ -132,7 +132,7 @@ internal readonly partial struct UnicodeText : IParsedText
 		if (textAlignment is null)
 		{
 			// TODO: can we make this cleaner instead of implicitly assuming that this is a code path coming from TextBox?
-			Debug.Assert(inlines.Length == 1);
+			CI.Assert(inlines.Length == 1);
 			var inline = (Run)inlines[0];
 			var inlineText = inline.GetText();
 			if (inlineText.Length == 0)
@@ -144,7 +144,7 @@ internal readonly partial struct UnicodeText : IParsedText
 				var firstInlineText = inlines[0].GetText();
 				using var _1 = ICU.CreateBiDiAndSetPara(firstInlineText, 0, firstInlineText.Length, UBIDI_DEFAULT_LTR, out var bidi);
 				ICU.GetMethod<ICU.ubidi_getLogicalRun>()(bidi, 0, out _, out var level);
-				Debug.Assert(level is UBIDI_LTR or UBIDI_RTL);
+				CI.Assert(level is UBIDI_LTR or UBIDI_RTL);
 				flowDirection = level is UBIDI_RTL ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
 			}
 			textAlignment = flowDirection is FlowDirection.LeftToRight ? TextAlignment.Left : TextAlignment.Right;
@@ -229,7 +229,7 @@ internal readonly partial struct UnicodeText : IParsedText
 			if (line.Count == 0)
 			{
 				// Only the last line can be empty, otherwise it will have at least one piece of text or a line break.
-				Debug.Assert(lineIndex == linesWithLogicallyOrderedRuns.Count - 1);
+				CI.Assert(lineIndex == linesWithLogicallyOrderedRuns.Count - 1);
 				if (lineIndex == 0)
 				{
 					shapedLines.Add((new(), 0, 0));
@@ -255,7 +255,7 @@ internal readonly partial struct UnicodeText : IParsedText
 				for (var runIndex = 0; runIndex < runCount; runIndex++)
 				{
 					var level = ICU.GetMethod<ICU.ubidi_getVisualRun>()(bidi, runIndex, out var logicalStart, out var length);
-					Debug.Assert(level is UBIDI_LTR or UBIDI_RTL);
+					CI.Assert(level is UBIDI_LTR or UBIDI_RTL);
 
 					var sameInlineRunsLengthBeforeFontSplitting = sameInlineRuns.Count;
 					var currentFontDetails = inline.FontDetails;
@@ -456,7 +456,7 @@ internal readonly partial struct UnicodeText : IParsedText
 			if (widthWithoutTrailingSpaces > lineWidth)
 			{
 				// If there was no text wrapping, then everything would fit on the same line
-				Debug.Assert(textWrapping is TextWrapping.Wrap or TextWrapping.WrapWholeWords);
+				CI.Assert(textWrapping is TextWrapping.Wrap or TextWrapping.WrapWholeWords);
 
 				if (prevInSameLine is not null)
 				{
@@ -541,11 +541,11 @@ internal readonly partial struct UnicodeText : IParsedText
 		}
 
 #if DEBUG
-		Debug.Assert(lines.Count > 0);
+		CI.Assert(lines.Count > 0);
 		// all the lines have content except possibly the last line, because we only move to a new line when we hit a line break
 		foreach (var line in lines)
 		{
-			Debug.Assert(line.Count > 0 || line == lines[^1]);
+			CI.Assert(line.Count > 0 || line == lines[^1]);
 		}
 #endif
 
@@ -674,7 +674,7 @@ internal readonly partial struct UnicodeText : IParsedText
 		{
 			// using bidi.GetLogicalRun instead returned weird results especially in rtl text.
 			var level = ICU.GetMethod<ICU.ubidi_getVisualRun>()(bidi, runIndex, out var logicalStart, out var length);
-			Debug.Assert(level is UBIDI_LTR or UBIDI_RTL);
+			CI.Assert(level is UBIDI_LTR or UBIDI_RTL);
 
 			var currentFontDetails = inline.FontDetails;
 			var currentFontSplitStart = logicalStart;
@@ -716,12 +716,12 @@ internal readonly partial struct UnicodeText : IParsedText
 		logicallyOrderedRuns.Sort((run, bidiRun) => run.startInInline - bidiRun.startInInline);
 
 #if DEBUG
-		Debug.Assert(logicallyOrderedRuns[0].startInInline == 0);
+		CI.Assert(logicallyOrderedRuns[0].startInInline == 0);
 		for (var i = 0; i < runCount - 1; i++)
 		{
-			Debug.Assert(logicallyOrderedRuns[i].endInInline != logicallyOrderedRuns[i].startInInline && logicallyOrderedRuns[i].endInInline == logicallyOrderedRuns[i + 1].startInInline);
+			CI.Assert(logicallyOrderedRuns[i].endInInline != logicallyOrderedRuns[i].startInInline && logicallyOrderedRuns[i].endInInline == logicallyOrderedRuns[i + 1].startInInline);
 		}
-		Debug.Assert(logicallyOrderedRuns[^1].endInInline != logicallyOrderedRuns[^1].startInInline && logicallyOrderedRuns[^1].endInInline == inline.Text.Length);
+		CI.Assert(logicallyOrderedRuns[^1].endInInline != logicallyOrderedRuns[^1].startInInline && logicallyOrderedRuns[^1].endInInline == inline.Text.Length);
 #endif
 
 		return logicallyOrderedRuns;
@@ -735,7 +735,7 @@ internal readonly partial struct UnicodeText : IParsedText
 			textRun = textRun[..^TrailingSpaceCount(textRun, 0, textRun.Length)];
 		}
 
-		Debug.Assert(textRun.Length < 2 || !textRun[..^2].Contains("\r\n"));
+		CI.Assert(textRun.Length < 2 || !textRun[..^2].Contains("\r\n"));
 		using var buffer = new Buffer();
 		buffer.AddUtf16(textRun, 0, textRun is [.., '\r', '\n'] ? textRun.Length - 1 : textRun.Length);
 		buffer.GuessSegmentProperties();
@@ -786,7 +786,7 @@ internal readonly partial struct UnicodeText : IParsedText
 			if (lineRuns.Count == 0)
 			{
 				// Only the last line can be empty. All other lines either have a line break character or actual content since you can't wrap to a new line without having any content on the initial line.
-				Debug.Assert(lineIndex == lines.Count - 1 && lineIndex != 0);
+				CI.Assert(lineIndex == lines.Count - 1 && lineIndex != 0);
 				var (currentLineHeight, baselineOffset) = GetLineHeightAndBaselineOffset(lineStackingStrategy, lineHeight, defaultFontDetails, false, true);
 				layoutedLine = new LayoutedLine(currentLineHeight, baselineOffset, lineIndex, 0, currentLineY, line.startInText, line.endInText, new());
 			}
@@ -873,7 +873,7 @@ internal readonly partial struct UnicodeText : IParsedText
 					}
 				}
 
-				Debug.Assert(run.glyphs.All(g => g.cluster is not null));
+				CI.Assert(run.glyphs.All(g => g.cluster is not null));
 			}
 		}
 	}
@@ -1158,7 +1158,7 @@ internal readonly partial struct UnicodeText : IParsedText
 
 			if (line.runs.Count == 0)
 			{
-				Debug.Assert(line == _lines[^1]);
+				CI.Assert(line == _lines[^1]);
 				return extendedSelection ? (0, _lines[^2].runs.MaxBy(r => r.indexInLine + r.inline.StartIndex)) : (-1, null);
 			}
 
@@ -1217,7 +1217,7 @@ internal readonly partial struct UnicodeText : IParsedText
 			}
 		}
 
-		Debug.Assert(false, "This should be unreachable");
+		CI.Assert(false, "This should be unreachable");
 		return (-1, null);
 	}
 

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
@@ -14,10 +14,8 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents.TextFormatting;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
-using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
-using Uno.UI.Xaml.Media;
 using Buffer = HarfBuzzSharp.Buffer;
 using GlyphInfo = HarfBuzzSharp.GlyphInfo;
 
@@ -386,11 +384,12 @@ internal readonly partial struct UnicodeText : IParsedText
 		var lastRun = logicallyOrderedRuns[endRunIndex - 1];
 		var start = firstRunIndex == endRunIndex - 1 ? startingIndexInFirstRun : lastRun.startInInline;
 		var glyphsWithoutTrailingSpaces = ShapeRun(lastRun.inline.Text[start..endIndexInLastRun], lastRun.rtl, lastRun.fontDetails, usedWidth, ignoreTrailingSpaces: true);
+		usedWidth += RunWidth(glyphsWithoutTrailingSpaces, lastRun.inline.FontDetails);
 
 		logicallyOrderedRuns[firstRunIndex] = backup1;
 		logicallyOrderedRuns[endRunIndex - 1] = backup2;
 
-		return usedWidth - currentLineWidth + RunWidth(glyphsWithoutTrailingSpaces, lastRun.inline.FontDetails);
+		return usedWidth - currentLineWidth;
 	}
 
 	private static IEnumerable<(int endRunIndex, int endIndexInLastRun)> SplitByLineBreakingOpportunities(List<BidiRun> logicallyOrderedRuns, List<(int indexInInline, ReadonlyInlineCopy inline)> logicallyOrderedLineBreakingOpportunities)
@@ -468,7 +467,8 @@ internal readonly partial struct UnicodeText : IParsedText
 					line[^1] = line[^1] with { endInInline = prevInSameLine.Value.endIndexInLastRun };
 					lines.Add(line);
 					(firstRunIndex, startingIndexInFirstRun) = (prevInSameLine.Value.endRunIndex - 1, prevInSameLine.Value.endIndexInLastRun);
-					prevInSameLine = lineBreakingOpporunity;
+					prevInSameLine = null;
+					lineBreakingOpportunityIndex--; // retry the line breaking opportunity
 				}
 				else
 				{


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->