### PR TITLE
fix(pt): Fix possible leak on iOS when removing a page from tree while finger down

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -230,7 +230,10 @@ namespace Microsoft.UI.Xaml
 			ClearPressed();
 			SetOver(null, false, ctx: BubblingContext.NoBubbling);
 			ClearDragOver();
+			ClearPointerStateNative();
 		}
+
+		partial void ClearPointerStateNative();
 
 		[ThreadStatic]
 		private static PointerEventDispatchResult _currentPointerEventDispatch;


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1563

##  🐞 Bugfix
Fix possible leak on iOS when removing a page from tree while finger down

## What is the current behavior? 🤔
When page is being removed, it does not release it lease to native pointer ID

## What is the new behavior? 🚀
Remove all lease on unload (or other operation that will prevent element to get the subsequent pointer events)

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
