### PR TITLE
chore: Enable iOS+NativeAOT builds by removing #9430 workaround

### DIFF
--- a/src/Uno.Sdk/targets/xamarin-ios-maccatalyst-workarounds.targets
+++ b/src/Uno.Sdk/targets/xamarin-ios-maccatalyst-workarounds.targets
@@ -4,8 +4,5 @@
 		<!-- Debugger workaround https://github.com/dotnet/maui-samples/blob/8aa6b8780b12e97b157514c3bdc54bb4a13001cd/HelloMacCatalyst/HelloMacCatalyst.csproj#L7 -->
 		<!-- <MtouchExtraArgs Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
 		<MtouchExtraArgs Condition="!$(MtouchExtraArgs.ToLowerInvariant().Contains('--setenv=mono_gc_params=')) and $(DisableXamarinDebug_Workaround) != 'true'">$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-
-		<!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
-		<MtouchExtraArgs Condition="!$(MtouchExtraArgs.ToLowerInvariant().Contains('--registrar:')) and $(DisableUno9430_Workaround) != 'true'">$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/issues/9430
Context: https://github.com/unoplatform/uno/commit/5a7634799bfb69a47e5ed29c6851f02620d24c9b / https://github.com/unoplatform/uno/pull/9626
Context: https://github.com/dotnet/macios/issues/15677
Context: https://learn.microsoft.com/en-us/dotnet/maui/deployment/nativeaot?view=net-maui-9.0

Suppose you want to build a Uno app for iOS+NativeAOT:

	dotnet new unoapp -n ios_naot
	cd ios_naot
	cat <<'EOF' >patch
	diff --git a/ios_naot/ios_naot.csproj b/ios_naot/ios_naot.csproj
	index 416d511..6f7b051 100644
	--- a/ios_naot/ios_naot.csproj
	+++ b/ios_naot/ios_naot.csproj
	@@ -20,6 +20,10 @@
	     <ImplicitUsings>enable</ImplicitUsings>
	     <Nullable>enable</Nullable>

	+    <IsAotCompatible>true</IsAotCompatible>
	+    <PublishAot Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">true</PublishAot>
	+    <PublishAot Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">true</PublishAot>
	+
	     <!--
	       UnoFeatures are used to quickly add and manage features enabled for your app.
	       https://aka.platform.uno/singleproject-features
	EOF
	git apply patch
	dotnet publish -f net10.0-ios -r ios-arm64 ios_naot/ios_naot.csproj

The patch is to [follow the documentation][0] around enabling Native AOT support in iOS projects.

Unexpectedly, the `dotnet publish` command *fails*:

	…/dotnet/packs/Microsoft.iOS.Sdk.net10.0_26.1/26.1.10494/targets/Xamarin.Shared.Sdk.targets(522,3):
	  error The only valid registrar when using NativeAOT is 'managed-static' (current value: 'static').
	  Please either delete the 'Registrar' property, or change it to be 'managed-static'.

The *cause* of the failure is twofold:

 1. iOS+NativeAOT [requires the `managed-static` registrar][1].
 2. Commit 5a763479/#9626 updates `$(MtouchExtraArgs)` to always contain `--registrar=static`, which is *not* `managed-static`.

    This behavior can be disabled via the `$(DisableUno9430_Workaround)` MSBuild property.

If we set the `$(DisableUno9430_Workaround)` MSBuild property, the app is able to build:

	dotnet publish -f net10.0-ios -r ios-arm64 ios_naot/ios_naot.csproj -p:DisableUno9430_Workaround=true
	# no errors

Given that commit 5a763479 exists to workaround dotnet/macios#15677, which was fixed 2022-October (as part of .NET 7), and Uno currently only supports .NET 9 and .NET 10, @jonpryor believes we can remove the setting of `--registrar:static` and `$(DisableUno9430_Workaround)` entirely.  This would allow iOS+NativeAOT to build without workarounds.

[0]: https://learn.microsoft.com/en-us/dotnet/maui/deployment/nativeaot?view=net-maui-9.0#publish-using-native-aot
[1]: https://github.com/dotnet/macios/blob/2a471e5a77b4ea69cecb9c9f5118f5419595d2fb/docs/managed-static-registrar.md

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->