### PR TITLE
ci: Skip mcp tests for forks

### DIFF
--- a/build/test-scripts/run-devserver-cli-tests.ps1
+++ b/build/test-scripts/run-devserver-cli-tests.ps1
@@ -403,7 +403,12 @@ try {
     & dotnet uno-devserver stop -l trace
 
     $CodexAPIKey = $env:CODEX_API_KEY
-    if ([string]::IsNullOrWhiteSpace($CodexAPIKey)) {
+    $isForkPr = $env:SYSTEM_PULLREQUEST_ISFORK -eq 'True'
+
+    if ($isForkPr) {
+        Write-Log "Forked pull request detected. Skipping Codex MCP integration test for security."
+    }
+    elseif ([string]::IsNullOrWhiteSpace($CodexAPIKey)) {
         Write-Log "CODEX_API_KEY not provided. Skipping Codex MCP integration test."
     }
     else {


### PR DESCRIPTION
Don't run mcp tests for fork builds