### PR TITLE
docs: Update instructions for starting uno MCP

### DIFF
--- a/doc/articles/create-an-app-vscode.md
+++ b/doc/articles/create-an-app-vscode.md
@@ -85,7 +85,7 @@ Next, open the project using Visual Studio Code.
    }
    ```
 
-1. On top of the registration for the uno MCP, click the **start** button.
+1. Save the file, then on top of the registration for the uno MCP, click the **start** button.
 
     ![start MCP](Assets/vscode-start-mcp.png)
 


### PR DESCRIPTION
Clarified instructions by adding 'Save the file' before starting the uno MCP.

Closes https://github.com/unoplatform/private/issues/981