### PR TITLE
Dev/xygu/20251216/hotreload-fwktemplate-leak

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/TestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/TestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Uno.UI.RuntimeTests.Helpers
@@ -49,6 +50,25 @@ namespace Uno.UI.RuntimeTests.Helpers
 					await Task.Delay(10);
 				}
 			}
+		}
+
+		public static async Task<bool> TryWaitUntilCollected(WeakReference reference)
+		{
+			var sw = Stopwatch.StartNew();
+			while (sw.Elapsed < TimeSpan.FromSeconds(3))
+			{
+				GC.Collect(2);
+				GC.WaitForPendingFinalizers();
+
+				if (!reference.IsAlive)
+				{
+					return true;
+				}
+
+				await Task.Delay(100);
+			}
+
+			return false;
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
@@ -92,11 +92,30 @@ partial class Given_FrameworkTemplate // tests
 		// Assert
 		Assert.IsNull(setupWR.Target);
 	}
+
+	[TestMethod]
+	public async Task LambdaFactory_ShouldNotBeCollected()
+	{
+		// Arrange
+		var context = new object();
+		Func<View?>? builder = () => new ContentPresenter { Content = context };
+		Assert.IsNotNull(builder.Target, "The delegate is expected to have a capture here");
+
+		var template = new DataTemplate(builder);
+		var targetWR = new WeakReference(builder.Target);
+
+		// Act
+		builder = null;
+		await TestHelper.TryWaitUntilCollected(targetWR);
+
+		// Assert
+		Assert.IsNotNull(targetWR.Target);
+	}
 }
 
 partial class Given_FrameworkTemplate
 {
-	public class XamlPageSetup
+	public class XamlPageSetup : Page
 	{
 		public DataTemplate GetTemplate(string name)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
@@ -1,0 +1,121 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.RuntimeTests.Helpers;
+
+#if __ANDROID__
+using View = Android.Views.View;
+#elif __APPLE_UIKIT__
+using View = UIKit.UIView;
+#else
+using View = Microsoft.UI.Xaml.UIElement;
+#endif
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+[TestClass]
+[RunsOnUIThread]
+public partial class Given_FrameworkTemplate;
+
+#if HAS_UNO
+partial class Given_FrameworkTemplate // tests
+{
+	[TestMethod]
+	public void When_TemplatesHaveSameFactoryTarget_Then_AreEqual()
+	{
+		// Arrange
+		Func<UIElement?> factory = () => new Border();
+		var template1 = new FrameworkTemplate(factory);
+		var template2 = new FrameworkTemplate(factory);
+
+		// Act & Assert
+		Assert.AreEqual(template1, template2);
+		Assert.AreEqual(template1.GetHashCode(), template2.GetHashCode());
+	}
+
+	[TestMethod]
+	public void When_TemplatesHaveSameStaticFactoryTarget_Then_AreEqual()
+	{
+		// Arrange
+		static UIElement StaticLocalMethodFactory() => new Border();
+		var template1 = new FrameworkTemplate(StaticLocalMethodFactory);
+		var template2 = new FrameworkTemplate(StaticLocalMethodFactory);
+
+		// Act & Assert
+		Assert.AreEqual(template1, template2);
+		Assert.AreEqual(template1.GetHashCode(), template2.GetHashCode());
+	}
+
+	[TestMethod]
+	public void When_TemplatesHaveDifferentFactories_Then_AreNotEqual()
+	{
+		// Arrange
+		var template1 = new FrameworkTemplate(() => new Border());
+		var template2 = new FrameworkTemplate(() => new TextBlock());
+
+		// Act & Assert
+		Assert.AreNotEqual(template1, template2);
+	}
+
+	[TestMethod]
+	public async Task InstancedFactory_ShouldNotLeak()
+	{
+		// Arrange
+		var setup = new XamlPageSetup();
+		var template = setup.GetTemplate(nameof(setup.InstancedBuilder));
+		var setupWR = new WeakReference(setup);
+
+		// Act
+		setup = null;
+		await TestHelper.TryWaitUntilCollected(setupWR);
+
+		// Assert
+		Assert.IsNull(setupWR.Target);
+	}
+
+	[TestMethod]
+	public async Task InstancedLegacyFactory_ShouldNotLeak()
+	{
+		// Arrange
+		var setup = new XamlPageSetup();
+		var template = setup.GetTemplate(nameof(setup.InstancedLegacyBuilder));
+		var setupWR = new WeakReference(setup);
+
+		// Act
+		setup = null;
+		await TestHelper.TryWaitUntilCollected(setupWR);
+
+		// Assert
+		Assert.IsNull(setupWR.Target);
+	}
+}
+
+partial class Given_FrameworkTemplate
+{
+	public class XamlPageSetup
+	{
+		public DataTemplate GetTemplate(string name)
+		{
+			return name switch
+			{
+				"InstancedBuilder" => new DataTemplate(owner: null, factory: InstancedBuilder),
+				"StaticBuilder" => new DataTemplate(owner: null, factory: StaticBuilder),
+				"InstancedLegacyBuilder" => new DataTemplate(factory: InstancedLegacyBuilder),
+				"StaticLegacyBuilder" => new DataTemplate(factory: StaticLegacyBuilder),
+
+				_ => throw new KeyNotFoundException(nameof(name)),
+			};
+		}
+
+		public View? InstancedBuilder(object? owner, TemplateMaterializationSettings settings) => new Border();
+		public static View? StaticBuilder(object? owner, TemplateMaterializationSettings settings) => new Border();
+
+		public View? InstancedLegacyBuilder() => new Border();
+		public static View? StaticLegacyBuilder() => new Border();
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
@@ -229,4 +229,22 @@ public class Given_FrameworkTemplatePool
 			AssertEditorContents();
 		}
 	}
+
+#if HAS_UNO
+	[TestMethod]
+	public async Task When_PoolingIsDisabled_NoEntriesAreAdded()
+	{
+		using (FeatureConfigurationHelper.UseTemplatePooling())
+		{
+			FrameworkTemplatePool.InternalIsPoolingEnabled = false;
+
+			var capture = new object();
+			var template = new DataTemplate(() => new ContentPresenter { Content = capture });
+
+			Assert.IsFalse(FrameworkTemplatePool.Instance.ContainsKey(template));
+			template.LoadContentCached();
+			Assert.IsFalse(FrameworkTemplatePool.Instance.ContainsKey(template));
+		}
+	}
+#endif
 }

--- a/src/Uno.UI/Helpers/WeakDelegate.cs
+++ b/src/Uno.UI/Helpers/WeakDelegate.cs
@@ -1,0 +1,67 @@
+﻿#nullable enable
+
+using System;
+using System.Reflection;
+
+namespace Uno.UI.Helpers;
+
+internal class WeakDelegate
+{
+	public static WeakDelegate<TDelegate>? Create<TDelegate>(TDelegate? d)
+		where TDelegate : Delegate
+	{
+		return d is { } ? new(d) : null;
+	}
+}
+
+/// <summary>
+/// Represents a delegate that references its <see cref="Delegate.Target"/> weakly, allowing the target to be eventually garbage collected.
+/// </summary>
+/// <remarks>Use <see cref="WeakDelegate{TDelegate}"/> to hold a reference to a delegate without preventing its
+/// target object from being collected by the garbage collector. This is useful for scenarios where you want to
+/// avoid memory leaks caused by strong references. Only delegates with a single target are supported;
+/// multicast delegates are not allowed.</remarks>
+/// <typeparam name="TDelegate">The type of delegate to be referenced. Must derive from <see cref="Delegate"/>.</typeparam>
+internal class WeakDelegate<TDelegate> where TDelegate : Delegate
+{
+	public WeakReference? Instance { get; init; }
+	public MethodInfo Method { get; init; }
+
+	// static method delegate doesn't capture any target instance, so we can just reuse it
+	private TDelegate? _staticDelegate;
+
+	public WeakDelegate(TDelegate d)
+	{
+		if (!d.HasSingleTarget)
+		{
+			throw new NotImplementedException("Multi-cast delegate not supported");
+		}
+
+		if (d.Target is { } t)
+		{
+			Instance = new WeakReference(t);
+			Method = d.Method;
+		}
+		else
+		{
+			_staticDelegate = d;
+			Method = d.Method; // still used outside of this class for logging
+		}
+	}
+
+	public object? Target => Instance?.Target;
+
+	/// <summary>
+	/// Gets the delegate instance that targets the referenced object and method,
+	/// may be null if the target is no longer available.
+	/// </summary>
+	/// <remarks>
+	/// DO NOT store/cache the returned delegate, as it keeps a strong reference to the target just like the original delegate.
+	/// </remarks>
+	public TDelegate? Delegate =>
+		_staticDelegate ??
+		// for instanced method delegate, only try to create if the instance reference is still alive
+		(Instance!.Target is { } t
+			? System.Delegate.CreateDelegate(typeof(TDelegate), t, Method) as TDelegate
+			: null);
+}

--- a/src/Uno.UI/Helpers/WeakDelegate.cs
+++ b/src/Uno.UI/Helpers/WeakDelegate.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace Uno.UI.Helpers;
 
-internal interface IDelegate<TDelegate> where TDelegate : Delegate
+internal interface IDelegate<out TDelegate> where TDelegate : Delegate
 {
 	public object? Target { get; }
 	public MethodInfo Method { get; }

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -56,7 +56,14 @@ namespace Microsoft.UI.Xaml.Controls
 		/// FrameworkTemplate pooling to function properly when an ItemTemplateSelector has been
 		/// specified.
 		/// </summary>
-		private readonly static DataTemplate InnerContentPresenterTemplate = new DataTemplate(() => new ContentPresenter());
+		private readonly static DataTemplate InnerContentPresenterTemplate =
+			new DataTemplate(owner: null, factory: InnerContentPresenterTemplateImpl);
+
+		// note: Lambda functions even with `static` and none of variable captures
+		// still captures an instance of `ItemsControl+c<>` into `Delegate.Target` for no reason.
+		// This instance tends to be GC'd pretty soon, if the delegate was converted into a WeakDelegate by FrameworkTemplate.
+		// Using a regular static method avoids that capture.
+		private static _View InnerContentPresenterTemplateImpl(object o, TemplateMaterializationSettings s) => new ContentPresenter();
 
 		public static ItemsControl GetItemsOwner(DependencyObject element)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -56,14 +56,7 @@ namespace Microsoft.UI.Xaml.Controls
 		/// FrameworkTemplate pooling to function properly when an ItemTemplateSelector has been
 		/// specified.
 		/// </summary>
-		private readonly static DataTemplate InnerContentPresenterTemplate =
-			new DataTemplate(owner: null, factory: InnerContentPresenterTemplateImpl);
-
-		// note: Lambda functions even with `static` and none of variable captures
-		// still captures an instance of `ItemsControl+c<>` into `Delegate.Target` for no reason.
-		// This instance tends to be GC'd pretty soon, if the delegate was converted into a WeakDelegate by FrameworkTemplate.
-		// Using a regular static method avoids that capture.
-		private static _View InnerContentPresenterTemplateImpl(object o, TemplateMaterializationSettings s) => new ContentPresenter();
+		private readonly static DataTemplate InnerContentPresenterTemplate = new DataTemplate(() => new ContentPresenter());
 
 		public static ItemsControl GetItemsOwner(DependencyObject element)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -262,10 +262,8 @@ namespace Microsoft.UI.Xaml
 				// Same target method (instance or static) (possible if the delegate was created from a
 				// method group, which are *not* cached by the C# compiler (required by
 				// the C# spec as of version 6.0)
-				|| (
-					ReferenceEquals(left?._viewFactory?.Target, right?._viewFactory?.Target)
-					&& left?.RawFactoryMethodInfo == right?.RawFactoryMethodInfo
-				);
+				|| (left?._hashCode == right?._hashCode)
+				;
 
 			public int GetHashCode(FrameworkTemplate obj) => obj._hashCode;
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -250,7 +250,7 @@ namespace Microsoft.UI.Xaml
 			{
 				if (_trace.IsEnabled)
 				{
-					_trace.WriteEventActivity(TraceProvider.CreateTemplate, EventOpcode.Send, new[] { template._viewFactory?.Method.DeclaringType?.FullName });
+					_trace.WriteEventActivity(TraceProvider.CreateTemplate, EventOpcode.Send, new[] { template.RawFactoryMethodInfo?.DeclaringType?.FullName });
 				}
 
 				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
@@ -524,10 +524,10 @@ namespace Microsoft.UI.Xaml
 		private string GetTemplateDebugId(FrameworkTemplate? template)
 		{
 			// Grossly inefficient, should only be used for debug logging
-			if (template?._viewFactory is { } func &&
+			if (template?.RawFactoryMethodInfo is { } method &&
 				_templates.Keys.IndexOf(template) is { } index && index != -1)
 			{
-				return $"{index}({func.Method.DeclaringType}.{func.Method.Name})";
+				return $"{index}({method.DeclaringType}.{method.Name})";
 			}
 
 			return "Unknown";

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -250,7 +250,7 @@ namespace Microsoft.UI.Xaml
 			{
 				if (_trace.IsEnabled)
 				{
-					_trace.WriteEventActivity(TraceProvider.CreateTemplate, EventOpcode.Send, new[] { template.RawFactoryMethodInfo?.DeclaringType?.FullName });
+					_trace.WriteEventActivity(TraceProvider.CreateTemplate, EventOpcode.Send, new[] { template.ViewFactoryInner?.Method.DeclaringType?.FullName });
 				}
 
 				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
@@ -524,7 +524,7 @@ namespace Microsoft.UI.Xaml
 		private string GetTemplateDebugId(FrameworkTemplate? template)
 		{
 			// Grossly inefficient, should only be used for debug logging
-			if (template?.RawFactoryMethodInfo is { } method &&
+			if (template?.ViewFactoryInner?.Method is { } method &&
 				_templates.Keys.IndexOf(template) is { } index && index != -1)
 			{
 				return $"{index}({method.DeclaringType}.{method.Name})";

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -533,6 +533,8 @@ namespace Microsoft.UI.Xaml
 			return "Unknown";
 		}
 
+		internal bool ContainsKey(FrameworkTemplate template) => _templates.ContainsKey(template);
+
 		private record TemplateInfo(List<MaterializedEntry> MaterializedInstance, List<TemplateEntry> PooledInstances);
 
 		private class TemplateEntry

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -131,14 +131,15 @@ namespace Uno.UI
 		/// <returns>
 		/// True if the template was updated successfully.
 		/// </returns>
-		public static bool UpdateDataTemplate(DataTemplate currentTemplate, Func<View?> newViewfactory)
+		public static bool UpdateDataTemplate(DataTemplate currentTemplate, Func<View?> newViewFactory)
 		{
 			if (IsDataTemplateDynamicUpdateEnabled)
 			{
 				ArgumentNullException.ThrowIfNull(currentTemplate);
-				ArgumentNullException.ThrowIfNull(newViewfactory);
+				ArgumentNullException.ThrowIfNull(newViewFactory);
 
-				return currentTemplate.UpdateFactory(_ => (NewFrameworkTemplateBuilder)((_, _) => newViewfactory()));
+				// Update and notify
+				return currentTemplate.UpdateFactory(newViewFactory);
 			}
 
 			return false;


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno-private#1670

## PR Type:
- 🐞 Bugfix
- 🔄 Refactoring (no functional changes, no api changes)

## What is the current behavior? 🤔
1. FrameworkTemplate can leak if its view-factory method isn't static
2. FrameworkTemplatePool still creates an entry for every data-template even if it is disabled

## What is the new behavior? 🚀
1. FrameworkTemplate nows holds its view-factory with the new weak-delegate
2. FrameworkTemplatePool wont create any entry when disabled

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
view-factory method are usually generated with `static` modifier, except when hot-reload is enable (which implies in DEBUG only)