### PR TITLE
fix(hr): Fix HR messages lost by JsonRPC due to buffer limitations

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServer.cs
+++ b/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServer.cs
@@ -118,7 +118,9 @@ internal class IdeChannelServer : IIdeChannel, IDisposable
 				direction: PipeDirection.InOut,
 				maxNumberOfServerInstances: 1,
 				transmissionMode: PipeTransmissionMode.Byte,
-				options: PipeOptions.Asynchronous | PipeOptions.WriteThrough);
+				options: PipeOptions.Asynchronous | PipeOptions.WriteThrough,
+				inBufferSize: 8 * 1024 * 1024,
+				outBufferSize: 8 * 1024 * 1024);
 
 			await _pipeServer.WaitForConnectionAsync();
 


### PR DESCRIPTION
linked https://github.com/unoplatform/uno.vscode/issues/1226

## 🐞 Bugfix
Fix HR messages lost by JsonRPC due to buffer limitations

## What is the current behavior? 🤔
Large messages are (dropped / chunked / ????) causing HR messages to not reach the IDE without any exception

## What is the new behavior? 🚀
Much bigger buffer to avoid loose

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
This is only a first step, we need:
1. Find a way to get informed when messages are dropped
2. Handle chunked messages in VS Code extension