### PR TITLE
fix(hr): HR builds all targets

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/RemoteControlExtensions.cs
+++ b/src/Uno.UI.RemoteControl.Host/RemoteControlExtensions.cs
@@ -104,8 +104,7 @@ namespace Uno.UI.RemoteControl.Host
 						throw new InvalidOperationException("IIdeChannel is required"),
 						context.RequestServices);
 
-					await server.RunAsync(await context.WebSockets.AcceptWebSocketAsync(),
-						CancellationToken.None);
+					await server.RunAsync(await context.WebSockets.AcceptWebSocketAsync(), context.RequestAborted);
 				}
 				else
 				{

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 			Dictionary<string, string> properties,
 			CancellationToken ct)
 		{
-			if (properties.TryGetValue("UnoHotReloadDiagnosticsLogPath", out var logPath))
+			if (properties.TryGetValue("UnoHotReloadDiagnosticsLogPath", out var logPath) && logPath is { Length: > 0 })
 			{
 				// Sets Roslyn's environment variable for troubleshooting HR, see:
 				// https://github.com/dotnet/roslyn/blob/fc6e0c25277ff440ca7ded842ac60278ee6c9695/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs#L72

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -21,7 +21,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 	{
 		private static string MSBuildBasePath = "";
 
-		public static async Task<(Solution, WatchHotReloadService)> CreateWorkspaceAsync(
+		public static async Task<(Workspace, WatchHotReloadService)> CreateWorkspaceAsync(
 			string projectPath,
 			IReporter reporter,
 			string[] metadataUpdateCapabilities,
@@ -102,7 +102,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 				await project.GetCompilationAsync(ct);
 			}
 
-			return (currentSolution, hotReloadService);
+			return (workspace, hotReloadService);
 		}
 
 		public static void InitializeRoslyn(string? workDir)

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -179,6 +179,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			if (properties.Remove("TargetFramework", out var targetFramework))
 			{
 				properties["UnoHotReloadTargetFramework"] = targetFramework;
+				properties["TargetFrameworks"] = targetFramework;
 			}
 
 			var (workspace, watch) = await CompilationWorkspaceProvider.CreateWorkspaceAsync(

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -198,7 +198,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			return new HotReloadWorkspace(workspace, watch, [Trim(outputPath), Trim(intermediateOutputPath)]);
 
 			// We make sure to trim the output path from any TFM / RID / Configuration suffixes
-			// This is to make sure that is we have multiple active HR workspace (like an old Android emulator reconnecting while a desktop app is running),
+			// This is to make sure that if we have multiple active HR workspace (like an old Android emulator reconnecting while a desktop app is running),
 			// we will not consider the files of the other targets.
 			string? Trim(string? outDir)
 			{

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -75,6 +75,12 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 		{
 			try
 			{
+				if (_workspace is not null)
+				{
+					_reporter.Warn("Hot-reload workspace is already initialized.");
+					return;
+				}
+
 				if (Assembly.Load("Microsoft.CodeAnalysis.Workspaces") is { } wsAsm)
 				{
 					// If this assembly was loaded from a stream, it will not have a location.

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -203,7 +203,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			string? Trim(string? outDir)
 			{
 				var result = outDir;
-				while(!string.IsNullOrWhiteSpace(result))
+				while (!string.IsNullOrWhiteSpace(result))
 				{
 					var updated = result
 						.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -854,10 +854,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 		#endregion
 
 		public void Dispose()
-		{
-			_solutionSubscriptions?.Dispose();
-			_hotReloadService?.EndSession();
-		}
+			=> _workspace?.Ct.Cancel();
 
 		#region Helpers
 		private class BufferGate

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Uno.Foundation.Logging;
@@ -93,7 +94,7 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 					_status.ReportInvalidRuntime();
 				}
 
-				var hrDebug = Environment.GetEnvironmentVariable("__UNO_SUPPORT_DEBUG_HOT_RELOAD__") == "true";
+				var hrDebug = Debugger.IsAttached && Environment.GetEnvironmentVariable("__UNO_SUPPORT_DEBUG_HOT_RELOAD__") == "true";
 				var message = new ConfigureServer(
 					_projectPath,
 					GetMetadataUpdateCapabilities(),


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.rider/issues/443
closes https://github.com/unoplatform/uno.rider/issues/445
closes https://github.com/unoplatform/uno.hotdesign/issues/5820

## 🐞 Bugfix
HR builds all targets

## What is the current behavior? 🤔
* We select the target TFM using a set of properties that we expect to be converted by the `WinUI.DevServer.props` file to the `TargetFramework` property, unfortunately the `WinUI.DevServer.props` is imported in MSBuild only for the effective target but not other targets ... driving HR workspace to build all targets!
* As it builds all targets it may fall in loop where it tries to validate files from intermediate paths of targets that are not ignored (since we ignore only the intermediate and output path only of the current target)
* The consumed memory grows really fast as for each new detected files we are instantiating temporary workspace to validate if and how is should be included in HR workspace ... but those are not disposed.

## What is the new behavior? 🚀
* We filter built targets using the property `TargetFrameworks` that does not flow on dependency projects but which make sure to be considered during MSBuild evaluation
* We now ignore the whole `bin` and `obj` folders, ignoring sub-folders like `Configuration` and `TFM`.
* We are now keep a reference on the root workspace instance and make sure to dispose it.

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
