### PR TITLE
perf: on macOS and Windows, load CLDR data from a shared icudt.dat instead of dynamically linking the data

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -214,7 +214,7 @@ namespace SamplesApp
 			// This is done by the IcuDataInitializerGenerator for external projects
 			var icuType = typeof(UnicodeText)?.GetNestedType("ICU", BindingFlags.NonPublic | BindingFlags.Static);
 			var setMethod = icuType?.GetMethod("SetDataAssembly", BindingFlags.Public | BindingFlags.Static);
-			var assembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name?.StartsWith("SamplesApp.Skia.", StringComparison.Ordinal) ?? false);
+			var assembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name is { } name && name.StartsWith("SamplesApp", StringComparison.Ordinal) && !name.Equals("SamplesApp.Skia", StringComparison.Ordinal));
 			setMethod?.Invoke(null, [assembly]);
 		}
 #endif

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -26,6 +26,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.UI.Xaml.Documents;
 using Private.Infrastructure;
 
 #if !HAS_UNO
@@ -78,6 +79,9 @@ namespace SamplesApp
 		static App()
 		{
 			ConfigureLogging();
+#if __SKIA__
+			InitializeIcuData();
+#endif
 		}
 
 		/// <summary>
@@ -202,6 +206,15 @@ namespace SamplesApp
 #endif
 			Private.Infrastructure.TestServices.WindowHelper.CurrentTestWindow =
 				_mainWindow;
+		}
+
+		private static void InitializeIcuData()
+		{
+			// This is done by the IcuDataInitializerGenerator for external projects
+			var icuType = typeof(UnicodeText)?.GetNestedType("ICU", BindingFlags.NonPublic | BindingFlags.Static);
+			var setMethod = icuType?.GetMethod("SetDataAssembly", BindingFlags.Public | BindingFlags.Static);
+			var assembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name?.StartsWith("SamplesApp.Skia.", StringComparison.Ordinal) ?? false);
+			setMethod?.Invoke(null, [assembly]);
 		}
 
 		private void SetupAndroidEnvironment()

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -212,7 +212,7 @@ namespace SamplesApp
 		private static void InitializeIcuData()
 		{
 			// This is done by the IcuDataInitializerGenerator for external projects
-			var icuType = typeof(UnicodeText)?.GetNestedType("ICU", BindingFlags.NonPublic | BindingFlags.Static);
+			var icuType = Type.GetType("Microsoft.UI.Xaml.Documents.UnicodeText+ICU, Uno.UI");
 			var setMethod = icuType?.GetMethod("SetDataAssembly", BindingFlags.Public | BindingFlags.Static);
 			var assembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name is { } name && name.StartsWith("SamplesApp", StringComparison.Ordinal) && !name.Equals("SamplesApp.Skia", StringComparison.Ordinal));
 			setMethod?.Invoke(null, [assembly]);

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -208,6 +208,7 @@ namespace SamplesApp
 				_mainWindow;
 		}
 
+#if __SKIA__
 		private static void InitializeIcuData()
 		{
 			// This is done by the IcuDataInitializerGenerator for external projects
@@ -216,6 +217,7 @@ namespace SamplesApp
 			var assembly = AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name?.StartsWith("SamplesApp.Skia.", StringComparison.Ordinal) ?? false);
 			setMethod?.Invoke(null, [assembly]);
 		}
+#endif
 
 		private void SetupAndroidEnvironment()
 		{

--- a/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
+++ b/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
@@ -18,6 +18,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<SkipIcuDataInitializerGenerator>true</SkipIcuDataInitializerGenerator>
+	</PropertyGroup>
+	<ItemGroup>
+		<CompilerVisibleProperty Include="SkipIcuDataInitializerGenerator" />
+	</ItemGroup>
+
+	<PropertyGroup>
 		<!-- Workaround for https://github.com/unoplatform/uno/discussions/5007 -->
 		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 		<CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Uno.UI.SourceGenerators;
+
+[Generator]
+public class IcuDataInitializerGenerator : IIncrementalGenerator
+{
+	public void Initialize(IncrementalGeneratorInitializationContext context)
+	{
+		var shouldGenerateProvider = context.AnalyzerConfigOptionsProvider.Select(static (provider, ct) =>
+		{
+			provider.GlobalOptions.TryGetValue("build_property.IsUnoHead", out var isUnoHead);
+			provider.GlobalOptions.TryGetValue("build_property.SkipIcuDataInitializerGenerator", out var skipIcuDataInitializerGenerator);
+			return isUnoHead?.Equals("true", StringComparison.InvariantCultureIgnoreCase) == true && (skipIcuDataInitializerGenerator?.Equals("false", StringComparison.InvariantCultureIgnoreCase) ?? true);
+		});
+
+		context.RegisterSourceOutput(shouldGenerateProvider, (productionContext, shouldGenerate) =>
+		{
+			if (!shouldGenerate)
+			{
+				return;
+			}
+			var code = """
+						internal static class __IcuDataInitializer
+						{
+							[global::System.Runtime.CompilerServices.ModuleInitializerAttribute]
+							internal static void Initialize()
+							{
+								var unoAssembly = typeof(Microsoft.UI.Xaml.UIElement).Assembly;
+								var unicodeTextType = unoAssembly.GetType("Microsoft.UI.Xaml.Documents.UnicodeText");
+								var icuType = unicodeTextType?.GetNestedType("ICU",
+									System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+								var setMethod = icuType?.GetMethod("SetDataAssembly",
+									System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+								setMethod?.Invoke(null, new object[] { typeof(__IcuDataInitializer).Assembly });
+							}
+						}
+						""";
+
+			productionContext.AddSource("IcuDataInitializer.g.cs", code);
+		});
+	}
+}
+

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
@@ -25,13 +25,9 @@ public class IcuDataInitializerGenerator : IIncrementalGenerator
 						internal static class __IcuDataInitializer
 						{
 							[global::System.Runtime.CompilerServices.ModuleInitializerAttribute]
-							[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "UnicodeText.ICU is already preserved.")]
 							internal static void Initialize()
 							{
-								var unoAssembly = typeof(Microsoft.UI.Xaml.UIElement).Assembly;
-								var unicodeTextType = unoAssembly.GetType("Microsoft.UI.Xaml.Documents.UnicodeText");
-								var icuType = unicodeTextType?.GetNestedType("ICU",
-									System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+								var icuType = Type.GetType("Microsoft.UI.Xaml.Documents.UnicodeText+ICU, Uno.UI");
 								var setMethod = icuType?.GetMethod("SetDataAssembly",
 									System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
 								setMethod?.Invoke(null, new object[] { typeof(__IcuDataInitializer).Assembly });

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
@@ -21,13 +21,14 @@ public class IcuDataInitializerGenerator : IIncrementalGenerator
 			{
 				return;
 			}
+			var icuType = Type.GetType("Microsoft.UI.Xaml.Documents.UnicodeText+ICU, Uno.UI");
 			var code = """
 						internal static class __IcuDataInitializer
 						{
 							[global::System.Runtime.CompilerServices.ModuleInitializerAttribute]
 							internal static void Initialize()
 							{
-								var icuType = Type.GetType("Microsoft.UI.Xaml.Documents.UnicodeText+ICU, Uno.UI");
+								var icuType = System.Type.GetType("Microsoft.UI.Xaml.Documents.UnicodeText+ICU, Uno.UI");
 								var setMethod = icuType?.GetMethod("SetDataAssembly",
 									System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
 								setMethod?.Invoke(null, new object[] { typeof(__IcuDataInitializer).Assembly });

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/IcuDataInitializerGenerator.cs
@@ -25,6 +25,7 @@ public class IcuDataInitializerGenerator : IIncrementalGenerator
 						internal static class __IcuDataInitializer
 						{
 							[global::System.Runtime.CompilerServices.ModuleInitializerAttribute]
+							[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "UnicodeText.ICU is already preserved.")]
 							internal static void Initialize()
 							{
 								var unoAssembly = typeof(Microsoft.UI.Xaml.UIElement).Assembly;
@@ -42,4 +43,3 @@ public class IcuDataInitializerGenerator : IIncrementalGenerator
 		});
 	}
 }
-

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -4,6 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
+		<IsUnoHead>true</IsUnoHead>
 
 		<!-- in-solution build -->
 		<_UnoBaseReferenceBinPath Condition="exists('$(MSBuildThisFileDirectory)../../../../../SamplesApp')">$(MSBuildThisFileDirectory)../../../../../SamplesApp/SamplesApp.Skia.Generic/bin/$(Configuration)/$(TargetFramework)</_UnoBaseReferenceBinPath>
@@ -44,7 +45,7 @@
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.7.1" />
-		<PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+		<PackageReference Include="Uno.icu-win" Version="77.1.2" />
 
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -14,10 +14,12 @@ internal readonly partial struct UnicodeText
 {
 	private static class ICU
 	{
+		private static Assembly? _dataAssembly;
+
 		// The version number of ICU is important because the exported symbols have their names appended by
 		// the version number. For example, there's a ubrk_open_74 in ICU v74, but not a ubrk_open.
-		private static readonly int _icuVersion;
-		private static readonly IntPtr _libicuuc;
+		private static int _icuVersion;
+		private static IntPtr _libicuuc;
 		private static readonly Dictionary<Type, object> _lookupCache = new();
 
 		private const DllImportSearchPath NativeLibrarySearchDirectories =
@@ -26,7 +28,13 @@ internal readonly partial struct UnicodeText
 			| DllImportSearchPath.UserDirectories
 			;
 
-		static unsafe ICU()
+		public static void SetDataAssembly(Assembly assembly)
+		{
+			_dataAssembly = assembly;
+			Init();
+		}
+
+		private static unsafe void Init()
 		{
 			IntPtr libicuuc;
 			if (OperatingSystem.IsWindows())
@@ -108,16 +116,14 @@ internal readonly partial struct UnicodeText
 
 			if (OperatingSystem.IsBrowser() || OperatingSystem.IsMacOS() || OperatingSystem.IsWindows())
 			{
-				var stream = AppDomain.CurrentDomain
-					.GetAssemblies()
-					.Select(a => (a, a.GetManifestResourceNames().FirstOrDefault(name => name.EndsWith("icudt.dat", StringComparison.InvariantCulture))))
-					.Where(t => t.Item2 != null)
-					.Select(t => t.a.GetManifestResourceStream(t.Item2!))
-					.FirstOrDefault();
-
-				if (stream is null)
+				if (_dataAssembly is null)
 				{
-					throw new InvalidOperationException("Failed to find icudt.dat resource in any loaded assembly. Ensure the Uno.ICU package is properly referenced.");
+					throw new InvalidOperationException("Failed to find the assembly containing icudt.dat resource in the entry assembly.");
+				}
+				var resourceName = _dataAssembly.GetManifestResourceNames().FirstOrDefault(name => name.EndsWith("icudt.dat", StringComparison.InvariantCulture));
+				if (resourceName is null || _dataAssembly.GetManifestResourceStream(resourceName) is not { } stream)
+				{
+					throw new InvalidOperationException($"Failed to find icudt.dat resource in {_dataAssembly.FullName}.");
 				}
 				// udata_setCommonData does not copy the buffer, so it needs to be pinned.
 				// For alignment, the ICU docs require 16-byte alignment. https://unicode-org.github.io/icu/userguide/icu_data/#alignment

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -124,11 +124,7 @@ internal readonly partial struct UnicodeText
 				var data = NativeMemory.AlignedAlloc((UIntPtr)stream.Length, 16);
 				stream.ReadExactly(new Span<byte>(data, (int)stream.Length));
 				GetMethod<udata_setCommonData>()((IntPtr)data, out var errorCode);
-				if (errorCode > 0)
-				{
-					var errorString = Marshal.PtrToStringUTF8(GetMethod<u_errorName>()(errorCode));
-					throw new InvalidOperationException($"{nameof(udata_setCommonData)} failed: {errorString}");
-				}
+				CheckErrorCode<udata_setCommonData>(errorCode);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -113,7 +113,12 @@ internal readonly partial struct UnicodeText
 					.Select(a => (a, a.GetManifestResourceNames().FirstOrDefault(name => name.EndsWith("icudt.dat", StringComparison.InvariantCulture))))
 					.Where(t => t.Item2 != null)
 					.Select(t => t.a.GetManifestResourceStream(t.Item2!))
-					.First()!;
+					.FirstOrDefault();
+
+				if (stream is null)
+				{
+					throw new InvalidOperationException("Failed to find icudt.dat resource in any loaded assembly. Ensure the Uno.ICU package is properly referenced.");
+				}
 				// udata_setCommonData does not copy the buffer, so it needs to be pinned.
 				// For alignment, the ICU docs require 16-byte alignment. https://unicode-org.github.io/icu/userguide/icu_data/#alignment
 				var data = NativeMemory.AlignedAlloc((UIntPtr)stream.Length, 16);

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -184,8 +184,9 @@ internal readonly partial struct UnicodeText
 			}
 			else if (status < 0)
 			{
-				// ICU has a very low bar for what it considers a "warning", so this can be very spammy. 
-				typeof(ICU).LogTrace()?.Warn($"{typeof(T).Name} raised a warning code {status.ToString("X", CultureInfo.InvariantCulture)}");
+				// ICU has a very low bar for what it considers a "warning", so this can be very spammy.
+				var errorString = Marshal.PtrToStringUTF8(GetMethod<u_errorName>()(status));
+				typeof(ICU).LogTrace()?.Trace($"{typeof(T).Name} raised a warning code: {errorString}");
 			}
 		}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/22349

~~On top of https://github.com/unoplatform/uno/pull/22203's branch~~

~~Blocked until a new Uno.icu version with https://github.com/unoplatform/uno.icu/pull/12 is published.~~