### PR TITLE
Enable Dev Server startup on partial solution build

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Build.targets
+++ b/src/Uno.Sdk/targets/Uno.Build.targets
@@ -181,6 +181,16 @@
 			Encoding="Unicode"/>
 	</Target>
 
+	<Target Name="_UnoGetDevServerConfig">
+		<Message Text="UnoVersion=$(UnoVersion)" Importance="High" />
+		<WriteLinesToFile
+			Condition="$(UnoDumpDevServerConfigTargetFile) != ''"
+			File="$(UnoDumpDevServerConfigTargetFile)"
+			Lines="UnoVersion=$(UnoVersion)"
+			Overwrite="true"
+			Encoding="Unicode"/>
+	</Target>
+
 	<Import Project="Uno.SingleProject.VS.Build.targets"
 			Condition=" '$(UnoSingleProject)' == 'true' AND '$(BuildingInsideVisualStudio)' == 'true' " />
 


### PR DESCRIPTION
**GitHub Issue:** closes #21888 

## PR Type:
- ✨ Feature

## Description:

- Current behavior 🐛

Currently, the Uno Dev Server cannot be started if one or more projects in the solution do not compile. This limitation restricts developers from running and testing Uno targets independent of other failing projects, which is particularly hindering during incremental migrations or large refactors.

- Expected behavior 🎯

Tooling should be able to detect the required Uno Dev Server version and launch it as long as the specific Uno project is valid, even if the rest of the solution fails to build.

## Changes:

- Modified src/Uno.Sdk/targets/Uno.Build.targets to add a new MSBuild target: _UnoGetDevServerConfig.
- This target outputs the UnoVersion property (and potentially other config in the future) either to the console or to a file specified by the UnoDumpDevServerConfigTargetFile property.
- This enables IDE extensions and CLI tools to query the project for the correct Dev Server version without triggering a full solution restore or build.

## Impact 💥

- Productivity: Allows developers to continue working on UI and testing with the Dev Server even when the solution is in a partially broken state.
- Tooling: Provides a lightweight mechanism for external tools to retrieve Uno configuration.

## Testing 🧪

- Verified that running dotnet build <Project.csproj> -t:_UnoGetDevServerConfig correctly outputs the UnoVersion.
- Verified that defining UnoDumpDevServerConfigTargetFile writes the configuration to the specified file.


Hope this resolves the issue and allows user to run partial builds! 
If any changes need to be make please let me Know.