### PR TITLE
chore: address trimmer warnings visible in downstream apps

### DIFF
--- a/src/Uno.Foundation/Metadata/ApiInformation.cs
+++ b/src/Uno.Foundation/Metadata/ApiInformation.cs
@@ -170,8 +170,16 @@ public partial class ApiInformation
 	{
 		lock (_assemblies)
 		{
-			if (_typeCache.TryGetValue(typeName, out var type))
+			var type = CacheGetType(typeName);
+			if (type != null)
 			{
+				return type;
+			}
+
+			type = TypeGetType(typeName);
+			if (type != null)
+			{
+				_typeCache[typeName] = type;
 				return type;
 			}
 
@@ -206,14 +214,35 @@ public partial class ApiInformation
 				}
 			}
 
-			[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "Assume that if Assembly.GetType() returns an assembly, it is un-trimmed, and thus has everything.")]
+			return null;
+
+			[UnconditionalSuppressMessage("Trimming", "IL2068", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` et al should ensure required members are preserved.")]
 			[return: DynamicallyAccessedMembers(PublicMembers)]
-			Type? AssemblyGetType(Assembly? assembly, string type)
+			static Type? CacheGetType(
+				[DynamicallyAccessedMembers(PublicMembers)]
+				string typeName)
+			{
+				if (_typeCache.TryGetValue(typeName, out var type))
+				{
+					return type;
+				}
+				return null;
+			}
+
+			[return: DynamicallyAccessedMembers(PublicMembers)]
+			static Type? TypeGetType(
+				[DynamicallyAccessedMembers(PublicMembers)]
+				string typeName)
+			{
+				return Type.GetType(typeName, throwOnError: false);
+			}
+
+			[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` et al should ensure required members are preserved.")]
+			[return: DynamicallyAccessedMembers(PublicMembers)]
+			static Type? AssemblyGetType(Assembly? assembly, string type)
 			{
 				return assembly?.GetType(type);
 			}
-
-			return null;
 		}
 	}
 

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -118,4 +118,9 @@
 	<ItemGroup>
 		<PackageReference Include="@(_UnoProjectSystemPackageReference)" Exclude="@(PackageReference)" />
 	</ItemGroup>
+
+	<ItemGroup Condition=" '$(PublishTrimmed)' == 'true' ">
+		<RuntimeHostConfigurationOption Include="Is_System_Dynamic_DynamicObject_Available" Value="false" Trim="true" />
+		<RuntimeHostConfigurationOption Include="Is_System_Dynamic_ExpandoObject_Available" Value="false" Trim="true" />
+	</ItemGroup>
 </Project>

--- a/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_X11Structs.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_X11Structs.cs
@@ -53,6 +53,7 @@
 // NOT COMPLETE
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -713,6 +714,68 @@ namespace Uno.WinUI.Runtime.Skia.X11
 			}
 		}
 
+		[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Output is for diagnostic purposes. If fields are removed, so be it.")]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(MotifWmHints))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XAnyEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XButtonEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XCirculateEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XCirculateRequestEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XClientMessageEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XColor))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XColormapEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XConfigureEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XConfigureRequestEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XCreateWindowEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XCrossingEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XcursorImage))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XcursorImages))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XDestroyWindowEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XErrorEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XEventPad))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XExposeEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XFocusChangeEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XGCValues))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XGenericEventCookie))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XGraphicsExposeEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XGravityEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XIconSize))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XImage))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XIMFeedbackStruct))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XIMPreeditCaretCallbackStruct))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XIMPreeditDrawCallbackStruct))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XIMStyles))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XIMText))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XKeyBoardState.AutoRepeats))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XKeyBoardState))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XKeyEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XKeymapEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XMapEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XMappingEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XMapRequestEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XModifierKeymap))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XMotionEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XNoExposeEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XPoint))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XPropertyEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XRectangle))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XReparentEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XResizeRequestEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XRRMonitorInfo))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XScreen))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XSelectionClearEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XSelectionEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XSelectionRequestEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XSetWindowAttributes))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XSizeHints))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XStandardColormap))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XTextProperty))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XUnmapEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XVisibilityEvent))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XVisualInfo))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XWindowAttributes))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XWindowChanges))]
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields, typeof(XWMHints))]
 		public static string ToString(object ev)
 		{
 			string result = string.Empty;

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.Properties.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml.Navigation;
 
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2111", Scope = "member",
+	Target = "M:Microsoft.UI.Xaml.Controls.Frame.#cctor()",
+	Justification = "From the `CurrentSourcePageTypeProperty`, `SourcePageTypeProperty` assignment; `typeof(Type)` triggers IL2111 regarding `Type.TypeInitializer`, but Uno doesn't use `Type.TypeInitializer`!")]
+
 namespace Microsoft.UI.Xaml.Controls;
 
 partial class Frame

--- a/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Properties.cs
@@ -9,6 +9,10 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Animation;
 using Uno.UI.Helpers;
 
+[assembly: UnconditionalSuppressMessage("Trimming", "IL2111", Scope = "member",
+	Target = "M:Microsoft.UI.Xaml.Navigation.PageStackEntry.#cctor()",
+	Justification = "From the `SourcePageTypeProperty` assignment; `typeof(Type)` triggers IL2111 regarding `Type.TypeInitializer`, but Uno doesn't use `Type.TypeInitializer`!")]
+
 namespace Microsoft.UI.Xaml.Navigation;
 
 partial class PageStackEntry

--- a/src/Uno.UWP/Storage/Helpers/StorageFileHelper.cs
+++ b/src/Uno.UWP/Storage/Helpers/StorageFileHelper.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Package = Windows.ApplicationModel.Package;
 using Uno;
 
 namespace Windows.Storage.Helpers;
@@ -26,15 +27,11 @@ internal partial class StorageFileHelper
 #if __SKIA__ || WINDOWS || WINAPPSDK || WINDOWS_UWP || WINUI
 	private static Task<bool> FileExistsInPackage(string fileName)
 	{
-		var executingPath = Assembly.GetExecutingAssembly().Location;
-		if (!string.IsNullOrEmpty(executingPath))
+		var installDir = Package.GetAppInstallDirectory(Assembly.GetExecutingAssembly());
+		if (installDir != null)
 		{
-			var path = Path.GetDirectoryName(executingPath);
-			if (!string.IsNullOrEmpty(path))
-			{
-				var fullPath = Path.Combine(path, fileName);
-				return Task.FromResult(File.Exists(fullPath));
-			}
+			var fullPath = Path.Combine(installDir, fileName);
+			return Task.FromResult(File.Exists(fullPath));
 		}
 
 		return Task.FromResult(false);


### PR DESCRIPTION
Context: 5d956f20e5490a31294891f6ebf5c3a4e56d8d15
Context: 71657498a2a9c11a986f82604215cf4edfcf858e
Context: 559b1f7866028a1d23f74ba43c3e8614a8e9f284

When *building* uno.chefs for NativeAOT with all warnings enabled:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Chefs/Chefs.csproj -p:UseSkiaRendering=true -p:SelfContained=true \
	  -p:PublishAot=true -p:IsAotCompatible=true -p:TrimmerSingleWarn=false -p:_ExtraTrimmerArgs=--verbose \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen

Address the following warning:

	ILC : Trim analysis warning IL2075:
	  Uno.WinUI.Runtime.Skia.X11.XEvent.ToString(Object): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.NonPublicFields' in call to 'System.Type.GetFields(BindingFlags)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Use `[DynamicDependency]` to preserve Reflection metadata for other
structs within the same file.  For anything else, use
`[UnconditionalSuppressMessage]` to suppress the IL2075 warning.
`XEvent.ToString(object)` is for diagnostic purposes, and if a field
is removed, so be it.

Address the following warning:

	ILC : Trim analysis warning IL2068:
	  Windows.Foundation.Metadata.ApiInformation.GetValidType(String): 'Windows.Foundation.Metadata.ApiInformation.GetValidType(String)' method return value does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.PublicEvents' requirements.
	  The parameter '#ILLink.Shared.TypeSystemProxy.ParameterIndex' of method 'System.Collections.Generic.Dictionary`2<String,Type>.TryGetValue(String,Type&)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Suppress this warning.  As with most everything else in that file,
required members should be preserved via `BindableTypeProviders`/etc.
Additionally, as we "know" that `typeName` should be an assembly-
qualified type name, also try `Type.GetType()` before consulting
`_assemblies`.

Address the following warnings:

	src/unoplatform/uno/src/Uno.UI/Helpers/TypeMappings.cs(91): Trim analysis warning IL2068: Uno.UI.Helpers.TypeMappings.GetOriginalType(Type): 'Uno.UI.Helpers.TypeMappings.GetOriginalType(Type)' method return value does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' requirements.
	  The parameter '#ILLink.Shared.TypeSystemProxy.ParameterIndex' of method 'System.Collections.Generic.IDictionary`2<Type,Type>.TryGetValue(Type,Type&)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/unoplatform/uno/src/Uno.UI/Helpers/TypeMappings.cs(85): Trim analysis warning IL2068: Uno.UI.Helpers.TypeMappings.GetMappedType(Type): 'Uno.UI.Helpers.TypeMappings.GetMappedType(Type)' method return value does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' requirements.
	  The parameter '#ILLink.Shared.TypeSystemProxy.ParameterIndex' of method 'System.Collections.Generic.IDictionary`2<Type,Type>.TryGetValue(Type,Type&)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Fix this by introducing a new `TypeMapCollection` type which has the
required annotations on the required members.  We *still* need
`[UnconditionalSuppressMessage]` in places, but logic is centralized.

Address the following warnings:

	ILC : warning IL3000: Windows.ApplicationModel.Package.GetInstalledPath():
	  'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded in a single-file app.
	  If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
	ILC : warning IL3000: Windows.Storage.Helpers.StorageFileHelper.FileExistsInPackage(String):
	  'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded in a single-file app.
	  If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.

`Package.GetInstalledPath()` was already using
`#pragma warning disable IL3000`.  The problem with the `#pragma` is
that it only silences the warning within the `src/Uno.UWP` build, not
by referenced assemblies.  "Upgrade" the `#pragma` to
`[UnconditionalSuppressMessage]`, so that the IL3000 is no longer
observed within uno.chefs.

Additionally, refactor `Package.GetInstalledPath()` and share it with
`StorageFileHelper.FileExistsInPackage()`, addressing the IL3000 from
there as well.

Address the following warnings:

	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'System.Type.TypeInitializer.get' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type,Object,NavigationTransitionInfo)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.SourcePageType.set' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type,Object,NavigationTransitionInfo)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.SourcePageType.set' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type,Object,NavigationTransitionInfo)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Navigation.PageStackEntry..cctor(): Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.SourcePageType.set' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Controls.Frame..cctor(): Method 'System.Type.TypeInitializer.get' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111:
	  Microsoft.UI.Xaml.Controls.Frame..cctor(): Method 'System.Type.TypeInitializer.get' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.

In commit 559b1f78 `[UnconditionalSuppressMessage]` was added to
various static properties that also included assignment:

	partial class Frame {
	  [UnconditionalSuppressMessage(…)]
	  public static DependencyProperty CurrentSourcePageTypeProperty { get; } =
	    DependencyProperty.Register(
	        nameof(CurrentSourcePageType),
	        typeof(Type),
	        typeof(Frame),
	        new FrameworkPropertyMetadata(null));
	}

The "funny" thing is that, due to the assignment, a static constructor
is synthesized to perform the actual assignment:

	partial class Frame {
	  // compiler-generated
	  static Frame()
	  {
	    var v = DependencyProperty.Register(…);
	    CurrentSourcePageTypeProperty = v;
	  }
	}

It's the static constructor which is the source of the IL2111 warnings!

Furthermore, it's difficultt o suppress warnings in a method which
doesn't exist within C# (as it's synthesized/generated).

Use `[assembly: UnconditionalSuppressMessage]` to silence warnings
coming from these static constructors.

*Note*: `UnconditionalSuppressMessageAttribute.Target` is a C#
doc string value, and `#` is used to "escape" `.`, hence
`Frame.#cctor` *and not* `Frame..cctor`.  The latter doesn't work.

Address the following set of warnings:

	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.Bind(DynamicMetaObject,DynamicMetaObject[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.FallbackGetMember(DynamicMetaObject,DynamicMetaObject)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.GetMemberBinder(String,Boolean)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.IgnoreCase.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.IsStandardBinder.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.Name.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Dynamic.GetMemberBinder.ReturnType.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'System.Runtime.CompilerServices.CallSiteBinder.BindCore<T>(CallSite`1<T>,Object[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating arrays at runtime requires dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'Uno.UI.DataBinding.BindingPropertyHelper.UnoGetMemberBinder.FallbackGetMember(DynamicMetaObject,DynamicMetaObject)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  `System.Dynamic` use requires dynamic code.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass38_0.<InternalGetValueGetter>b__14(Object): Using member 'Uno.UI.DataBinding.BindingPropertyHelper.UnoGetMemberBinder.UnoGetMemberBinder(String,Boolean)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  `System.Dynamic` use requires dynamic code.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.Bind(DynamicMetaObject,DynamicMetaObject[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.FallbackSetMember(DynamicMetaObject,DynamicMetaObject,DynamicMetaObject)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.IgnoreCase.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.IsStandardBinder.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.Name.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.ReturnType.get' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'System.Dynamic.SetMemberBinder.SetMemberBinder(String,Boolean)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'Uno.UI.DataBinding.BindingPropertyHelper.UnoSetMemberBinder.FallbackSetMember(DynamicMetaObject,DynamicMetaObject,DynamicMetaObject)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  `System.Dynamic` use requires dynamic code.
	ILC : AOT analysis warning IL3050:
	  Uno.UI.DataBinding.BindingPropertyHelper.<>c__DisplayClass40_0.<InternalGetValueSetter>b__19(Object,Object): Using member 'Uno.UI.DataBinding.BindingPropertyHelper.UnoSetMemberBinder.UnoSetMemberBinder(String,Boolean)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  `System.Dynamic` use requires dynamic code.

(plus 39 other very similar warnings)

What's "interesting" is that parts of this codepath are "wrapped" in
`__LinkerHints.Is_System_Dynamic_DynamicObject_Available` checks,
e.g. from `BindingPropertyHelper.cs`:

	if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
	    && type.Is(typeof(System.Dynamic.DynamicObject))) {
	  return […](instance) => /* code which uses UnoGetMemberBinder */ ;
	}

Further interesting is how `__LinkerHints` *works*: 5d956f20, 71657498.
The `DependencyObjectAvailabilityGenerator` checks for use of
`[assembly: AdditionalLinkerHint(HINT)]`, then does two things:

 1. Creates a `__LinkerHints` class, containing a property named
    `Is_HINT_Available`.

 2. Creates an `ILLink.Substitutions.xml` for each `HINT`.

For example, given the *already existing* attributes:

	[assembly: AdditionalLinkerHint("System.Dynamic.ExpandoObject")]
	[assembly: AdditionalLinkerHint("System.Dynamic.DynamicObject")]

Then `__LinkerHints` has:

	partial class __LinkerHints {
	  internal static bool Is_System_Dynamic_DynamicObject_Available => true;
	  internal static bool Is_System_Dynamic_ExpandoObject_Available => true;
	}

`ILLink.Substitutions.xml` contains:

	<assembly fullname="Uno.UI">
	  <type fullname="Uno.UI.__LinkerHints">
	    <method signature="System.Boolean get_Is_System_Dynamic_DynamicObject_Available()" body="stub" value="false" feature="Is_System_Dynamic_DynamicObject_Available" featurevalue="false" />
	    <method signature="System.Boolean get_Is_System_Dynamic_ExpandoObject_Available()" body="stub" value="false" feature="Is_System_Dynamic_ExpandoObject_Available" featurevalue="false" />
	  </type>
	</assembly>

What's *very useful* is the interaction between linker substutution
files such as `ILLink.Substitutions.xml`, and [feature switches][0].

We can use the `@(RuntimeHostConfigurationOption)` item group to
selectively enable these features.

Consider:

	<ItemGroup>
	  <RuntimeHostConfigurationOption Include="Is_System_Dynamic_DynamicObject_Available" Value="false" Trim="true" />
	  <RuntimeHostConfigurationOption Include="Is_System_Dynamic_ExpandoObject_Available" Value="false" Trim="true" />
	</ItemGroup>

When:

  * `%(RuntimeHostConfigurationOption.Identity)` matches the
    `//method/@feature` attribute within linker substitution XML, and
  * `%(RuntimeHostConfigurationOption.Trime)`=true, and
  * `%(RuntimeHostConfigurationOption.Value)` matches the
    ``//method/@featurevalue` attribute within linker substitution XML

Then `//method/@value` is *inlined*.  This *alters* the trimmed
version of `__LinkerHints` to be:

	partial class __LinkerHints {
	  internal static bool Is_System_Dynamic_DynamicObject_Available => false;
	  internal static bool Is_System_Dynamic_ExpandoObject_Available => false;
	}

Additionally, this is behavior known by the trimmer, allowing the
trimmer to *remove* unreachable code.

This *fixes* (removes) the 53 IL3050 warnings mentioned above.

*Codify* this by updating `Uno.Implicit.Packages.ProjectSystem.targets`
so that when `$(PublishTrimmed)`=true, the
`@(RuntimeHostConfigurationOption)` item group is updated as above.

[0]: https://github.com/dotnet/designs/blob/75e598244648a66ac579c0d5537467d4fa02cde2/accepted/2020/feature-switch.md

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->