### PR TITLE
chore: Address "downstream" trimmer warnings in Uno.Xaml.dll

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml.Schema/XamlTypeName.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml.Schema/XamlTypeName.cs
@@ -202,7 +202,7 @@ namespace Uno.Xaml.Schema
 			Name = xamlType.Name;
 			if (xamlType.TypeArguments != null && xamlType.TypeArguments.Count > 0) {
 				var l = new List<XamlTypeName> ();
-				l.AddRange (from x in xamlType.TypeArguments.AsQueryable () select new XamlTypeName (x));
+				l.AddRange (xamlType.TypeArguments.Select (x => new XamlTypeName (x)));
 				TypeArguments = l;
 			}
 		}

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
@@ -390,6 +390,7 @@ namespace Uno.Xaml
 		static readonly int clr_ns_len = "clr-namespace:".Length;
 		static readonly int clr_ass_len = "assembly=".Length;
 
+		[UnconditionalSuppressMessage("Trimming", "IL3050", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the type exists.")]
 		Type ResolveXamlTypeName (string xmlNamespace, string xmlLocalName, IList<XamlType> typeArguments)
 		{
 			string ns = xmlNamespace;


### PR DESCRIPTION
When *building* uno.chefs for NativeAOT with all warnings enabled:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Chefs/Chefs.csproj -p:UseSkiaRendering=true -p:SelfContained=true \
	  -p:PublishAot=true -p:IsAotCompatible=true -p:TrimmerSingleWarn=false -p:_ExtraTrimmerArgs=--verbose \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen

We observe the following warnings (among others):

	AOT analysis warning IL3050:
	  Uno.Xaml.Schema.XamlTypeName.XamlTypeName(XamlType): Using member 'System.Linq.Queryable.AsQueryable<XamlType>(IEnumerable`1<XamlType>)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Enumerating in-memory collections as IQueryable can require creating new generic types or methods, which requires creating code at runtime.
	  This may not work when AOT compiling.
	AOT analysis warning IL3050: Uno.Xaml.XamlSchemaContext.ResolveXamlTypeName(String,String,IList`1<XamlType>): Using member 'System.Type.MakeGenericType(Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.

At a glance, `XamlTypeName` is an easy enough fix: don't use
`.AsQueryable()`.  @jonpryor doesn't see any need for it here.

`XamlSchemaContext.ResolveXamlTypeName()` looks similarly easy:
just add `[UnconditionalSuppressMessage]`, as is already done
elsewhere within `Uno.Xaml.dll`.

Additional thinking occurs: shouldn't this assembly be marked
as `$(IsAotCompatible)`=true?  Try that, and:

	/usr/local/share/dotnet/sdk/10.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(120,5): warning NETSDK1210:
	  IsAotCompatible and EnableAotAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable ahead-of-time compilation analysis, and set IsAotCompatible only for the supported frameworks. For example:
	  <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>

At which point everything becomes much more complicated:
`Uno.Xaml.csproj` targets `netstandard2.0`. When we multitarget *both*
netstandard2.0 and net10.0, everything breaks.
Because The World Has Moved On:

	src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs(78,24): error CS0672: Member 'XamlException.GetObjectData(SerializationInfo, StreamingContext)' overrides obsolete member 'Exception.GetObjectData(SerializationInfo, StreamingContext)'. …
	src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs(66,4): error SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.'
	src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs(153,31): error CA1865: Use 'string.StartsWith(char)' instead of 'string.StartsWith(string)' when you have a string with a single char
	…

Explore this a bit, but ultimately come to the conclusion that it
isn't worthwhile:

 1. `Uno.Xaml.dll` needs to maintain netstandard2.0 compatibility,
    as it's refernced by source generators.

 2. Multitargeting .NET 10 just adds "noise".

 3. Attempting to fix warnings introduced by `$(IsAotCompatible)`=true
    is a fools errand: *everything* eventually hits various forms
    of Reflection such as `Type.MakeGenericType()` and/or
    `TypeDescriptor.GetConverter()`, meaning *everything* needs to be
    marked with `[RequiresDynamicCode]` and
    `[RequiresUnreferencedCode]`.  *Other than* introducing lots of
    warnings in referencing code, how does this *benefit* us?

    (It doesn't.)

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->