### PR TITLE
test: fix japanese CalendarView tests

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/calendarview/CalendarViewIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/calendarview/CalendarViewIntegrationTests.cs
@@ -5543,6 +5543,9 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 			{
 				cv.CalendarIdentifier = "JapaneseCalendar";
 				cv.DisplayMode = CalendarViewDisplayMode.Month;
+				// by default, CalendarView uses today +- 100years for min/max date
+				// we need enough wiggle room for previous-Decade/Year/Month button to work correctly
+				cv.MinDate = ConvertToDateTime(1, 1926, 12 - 1 * 2, 25);
 				rootPanel.Children.Add(cv);
 			});
 
@@ -5582,6 +5585,9 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 			{
 				cv.CalendarIdentifier = "JapaneseCalendar";
 				cv.DisplayMode = CalendarViewDisplayMode.Year;
+				// by default, CalendarView uses today +- 100years for min/max date
+				// we need enough wiggle room for previous-Decade/Year/Month button to work correctly
+				cv.MinDate = ConvertToDateTime(1, 1926 - 1 * 2, 12, 25);
 				rootPanel.Children.Add(cv);
 			});
 
@@ -5619,6 +5625,9 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 			{
 				cv.CalendarIdentifier = "JapaneseCalendar";
 				cv.DisplayMode = CalendarViewDisplayMode.Decade;
+				// by default, CalendarView uses today +- 100years for min/max date
+				// we need enough wiggle room for previous-Decade/Year/Month button to work correctly
+				cv.MinDate = ConvertToDateTime(1, 1926 - 10 * 2, 12, 25);
 				rootPanel.Children.Add(cv);
 			});
 


### PR DESCRIPTION
**GitHub Issue:** closes #22260

## PR Type: - 💬 Other..: tests


## What is the current behavior? 🤔
## What is the new behavior? 🚀
fixed CanScrollAcrossJapaneseEraOnYearView test

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
CanScrollAcrossJapaneseEraOnYearView performs previous/next-year scrolling (via button) around certain keys japanese calendar eras. One of them being 1926-12-25 marking the start of Showa era, which happens to be exactly 100year from now as of written.
By default, CalendarView limits the usage range between Today +- 100years. So as we enter 2026, that test stops passing.