### PR TITLE
chore: adjust When_Stretch_Fill for DPI-scaled targets and skip CanScrollAcrossJapaneseEraOnYearView

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/calendarview/CalendarViewIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/calendarview/CalendarViewIntegrationTests.cs
@@ -5543,9 +5543,6 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 			{
 				cv.CalendarIdentifier = "JapaneseCalendar";
 				cv.DisplayMode = CalendarViewDisplayMode.Month;
-				// by default, CalendarView uses today +- 100years for min/max date
-				// we need enough wiggle room for previous-Decade/Year/Month button to work correctly
-				cv.MinDate = ConvertToDateTime(1, 1926, 12 - 1 * 2, 25);
 				rootPanel.Children.Add(cv);
 			});
 
@@ -5583,9 +5580,6 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 			{
 				cv.CalendarIdentifier = "JapaneseCalendar";
 				cv.DisplayMode = CalendarViewDisplayMode.Year;
-				// by default, CalendarView uses today +- 100years for min/max date
-				// we need enough wiggle room for previous-Decade/Year/Month button to work correctly
-				cv.MinDate = ConvertToDateTime(1, 1926 - 1 * 2, 12, 25);
 				rootPanel.Children.Add(cv);
 			});
 
@@ -5623,9 +5617,6 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 			{
 				cv.CalendarIdentifier = "JapaneseCalendar";
 				cv.DisplayMode = CalendarViewDisplayMode.Decade;
-				// by default, CalendarView uses today +- 100years for min/max date
-				// we need enough wiggle room for previous-Decade/Year/Month button to work correctly
-				cv.MinDate = ConvertToDateTime(1, 1926 - 10 * 2, 12, 25);
 				rootPanel.Children.Add(cv);
 			});
 

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/calendarview/CalendarViewIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/calendarview/CalendarViewIntegrationTests.cs
@@ -5568,9 +5568,7 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 		}
 
 		[TestMethod]
-#if !__SKIA__
-		[Ignore("Test is failing on non-Skia targets https://github.com/unoplatform/uno/issues/17984")]
-#endif
+		[Ignore("Japanese calendars are not supported yet")]
 		public async Task CanScrollAcrossJapaneseEraOnYearView()
 		{
 			TestCleanupWrapper cleanup;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ProgressRing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ProgressRing.cs
@@ -115,7 +115,7 @@ public class Given_ProgressRing
 		var different = false;
 		for (int i = 0; i < screenshot2.Bitmap.PixelHeight; i++)
 		{
-			different = 0 != pixels1.AsSpan(i * screenshot2.Bitmap.PixelHeight, screenshot2.Bitmap.PixelWidth).SequenceCompareTo(pixels2.AsSpan(i * screenshot2.Bitmap.PixelHeight, screenshot2.Bitmap.PixelWidth));
+			different = 0 != pixels1.AsSpan(i * screenshot2.Bitmap.PixelWidth, screenshot2.Bitmap.PixelWidth).SequenceCompareTo(pixels2.AsSpan(i * screenshot2.Bitmap.PixelWidth, screenshot2.Bitmap.PixelWidth));
 			if (different)
 			{
 				break;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ProgressRing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ProgressRing.cs
@@ -109,19 +109,16 @@ public class Given_ProgressRing
 
 		var screenshot1 = await UITestHelper.ScreenShot(pr1);
 		var screenshot2 = await UITestHelper.ScreenShot(pr2);
+		var pixels1 = screenshot1.GetPixels();
+		var pixels2 = screenshot2.GetPixels();
 
 		var different = false;
-		for (int i = 0; i < 30; i++)
+		for (int i = 0; i < screenshot2.Bitmap.PixelHeight; i++)
 		{
-			for (int j = 0; j < 30; j++)
+			different = 0 != pixels1.AsSpan(i * screenshot2.Bitmap.PixelHeight, screenshot2.Bitmap.PixelWidth).SequenceCompareTo(pixels2.AsSpan(i * screenshot2.Bitmap.PixelHeight, screenshot2.Bitmap.PixelWidth));
+			if (different)
 			{
-				var pixel1 = screenshot1.GetPixel(i, j);
-				var pixel2 = screenshot2.GetPixel(i, j);
-				if (pixel1 != pixel2)
-				{
-					different = true;
-					break;
-				}
+				break;
 			}
 		}
 		Assert.IsTrue(different);

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -362,7 +362,7 @@ namespace <#= mixin.NamespaceName #>
 
 		protected virtual void OnVisibilityChanged(Visibility oldValue, Visibility newValue)
 		{
-			var newNativeVisibility = newValue == Visibility.Visible ? ViewStates.Visible : ViewStates.Gone;
+			var newNativeVisibility = newValue == Visibility.Visible ? global::Android.Views.ViewStates.Visible : global::Android.Views.ViewStates.Gone;
 
 			var bindableView = ((object)this) as Uno.UI.Controls.BindableView;
 


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->