### PR TITLE
fix: inherited dc lifecycle

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.DataContext.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.DataContext.cs
@@ -1,0 +1,68 @@
+﻿using System.Threading.Tasks;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+partial class Given_UIElement
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_Subtree_SeveredFromDataContextSource()
+	{
+		const int DC = 312;
+
+		var nested2 = new Border() { Name = "nested2" };
+		var nested1 = new Border() { Name = "nested1", Child = nested2 };
+		var host = new Border() { Name = "host", Child = nested1 };
+		await UITestHelper.Load(host, x => x.IsLoaded);
+
+		host.DataContext = DC;
+		Assert.AreEqual(DC, nested1.DataContext, "1. initially, DC (nested1) should be inherited");
+		Assert.AreEqual(DC, nested2.DataContext, "1. initially, DC (nested2) should be inherited");
+
+		host.Child = null;
+		Assert.IsNull(nested1.DataContext, "2. when detached, inherited DC(nested1) should be cleared");
+		Assert.IsNull(nested2.DataContext, "2. when detached, inherited DC(nested2) should be cleared");
+
+		host.Child = nested1;
+		Assert.AreEqual(DC, nested1.DataContext, "3. when reattached, DC (nested1) should be inherited again");
+		Assert.AreEqual(DC, nested2.DataContext, "3. when reattached, DC (nested2) should be inherited again");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_SeveredSubtree_ContainsDataContextSource()
+	{
+		const int DC = 312;
+
+		//   v detachment point
+		// H > N1 > N2 > N3 > N4
+		//          ^ DC owner, and propagation source
+		//               ^  + ^ inherited DC
+		var nested4 = new Border() { Name = "nested4", };
+		var nested3 = new Border() { Name = "nested3", Child = nested4 };
+		var nested2 = new Border() { Name = "nested2", Child = nested3 };
+		var nested1 = new Border() { Name = "nested1", Child = nested2 };
+		var host = new Border() { Name = "host", Child = nested1 };
+		await UITestHelper.Load(host, x => x.IsLoaded);
+
+		nested2.DataContext = DC;
+		Assert.AreEqual(DC, nested3.DataContext, "1. initially, DC (nested3) should be inherited");
+		Assert.AreEqual(DC, nested4.DataContext, "1. initially, DC (nested4) should be inherited");
+
+		host.Child = null;
+		Assert.AreEqual(DC, nested3.DataContext, "2. when detached, DC (nested3) should still be inherited&unaffected");
+		Assert.AreEqual(DC, nested4.DataContext, "2. when detached, DC (nested4) should still be inherited&unaffected");
+
+		host.Child = nested1;
+		Assert.AreEqual(DC, nested3.DataContext, "3. when reattached, DC (nested3) should still be inherited&unaffected");
+		Assert.AreEqual(DC, nested4.DataContext, "3. when reattached, DC (nested4) should still be inherited&unaffected");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -644,7 +644,7 @@ namespace Microsoft.UI.Xaml
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private void ClearInheritedDataContext()
+		internal void ClearInheritedDataContext()
 		{
 			ClearValue(_dataContextProperty, DependencyPropertyValuePrecedences.Inheritance);
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.crossruntime.cs
@@ -102,6 +102,7 @@ namespace Microsoft.UI.Xaml
 		private void OnChildRemoved(UIElement child)
 		{
 			child.Shutdown();
+			(child as IDependencyObjectStoreProvider)?.Store.ClearInheritedDataContext();
 
 #if UNO_HAS_ENHANCED_LIFECYCLE
 			var leaveParams = new LeaveParams(IsActiveInVisualTree);


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/add-private#44

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
Orphaned visual-tree nodes can still hold inherited data-context alive causing memory leak, even if it was disconnected from the source of data-context.

## What is the new behavior? 🚀
Inherited data-context will be cleared when a node is removed from its parent.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
<!-- Please provide any additional information if necessary -->