### PR TITLE
fix: UIElement Event Registration under NativeAOT

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacOSDispatcher.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacOSDispatcher.cs
@@ -35,7 +35,7 @@ internal static class MacOSDispatcher
 	{
 		if (typeof(MacOSDispatcher).Log().IsEnabled(LogLevel.Trace))
 		{
-			typeof(MacOSDispatcher).Log().Trace($"Dispatching {d}");
+			typeof(MacOSDispatcher).Log().Trace($"Dispatching {d} on {d.Method.DeclaringType?.FullName ?? "[no-type]"}.{d.Method.Name} with target {d.Target}");
 		}
 
 		NativeMac.dispatch_async_f(_mainQueue, (nint)GCHandle.Alloc(d), &NativeToManaged);

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -330,23 +330,21 @@ namespace Microsoft.UI.Xaml.Controls
 #endif
 
 #if !__NETSTD_REFERENCE__
-		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
 		private void SubscribeToPostKeyDown()
 		{
-			if (GetIsEventOverrideImplemented(GetType(), nameof(OnPostKeyDown), _keyArgsType))
+			if (GetIsEventOverrideImplemented(OnPostKeyDown))
 			{
 				PostKeyDown += OnPostKeyDownHandler;
 			}
 		}
 
-		[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
 		private void SubscribeToOverridenRoutedEvents()
 		{
 			// Overridden Events are registered from constructor to ensure they are
 			// registered first in event handlers.
 			// https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.onpointerpressed#remarks
 
-			var implementedEvents = GetImplementedRoutedEventsForType(GetType());
+			var implementedEvents = GetImplementedRoutedEvents();
 
 			if (HasFlag(implementedEvents, RoutedEventFlag.PointerPressed))
 			{
@@ -1182,157 +1180,141 @@ namespace Microsoft.UI.Xaml.Controls
 		private static readonly RoutedEventHandler OnLostFocusHandler =
 			(object sender, RoutedEventArgs args) => ((Control)sender).OnLostFocus(args);
 
-		private static readonly Type[] _pointerArgsType = new[] { typeof(PointerRoutedEventArgs) };
-		private static readonly Type[] _tappedArgsType = new[] { typeof(TappedRoutedEventArgs) };
-		private static readonly Type[] _doubleTappedArgsType = new[] { typeof(DoubleTappedRoutedEventArgs) };
-		private static readonly Type[] _rightTappedArgsType = new[] { typeof(RightTappedRoutedEventArgs) };
-		private static readonly Type[] _holdingArgsType = new[] { typeof(HoldingRoutedEventArgs) };
-		private static readonly Type[] _dragArgsType = new[] { typeof(global::Microsoft.UI.Xaml.DragEventArgs) };
-		private static readonly Type[] _keyArgsType = new[] { typeof(KeyRoutedEventArgs) };
-		private static readonly Type[] _routedArgsType = new[] { typeof(RoutedEventArgs) };
-		private static readonly Type[] _manipStartingArgsType = new[] { typeof(ManipulationStartingRoutedEventArgs) };
-		private static readonly Type[] _manipStartedArgsType = new[] { typeof(ManipulationStartedRoutedEventArgs) };
-		private static readonly Type[] _manipDeltaArgsType = new[] { typeof(ManipulationDeltaRoutedEventArgs) };
-		private static readonly Type[] _manipInertiaArgsType = new[] { typeof(ManipulationInertiaStartingRoutedEventArgs) };
-		private static readonly Type[] _manipCompletedArgsType = new[] { typeof(ManipulationCompletedRoutedEventArgs) };
-
-		internal static RoutedEventFlag EvaluateImplementedControlRoutedEvents(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
-			Type type)
+		internal RoutedEventFlag EvaluateImplementedControlRoutedEvents()
 		{
 			var result = RoutedEventFlag.None;
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerPressed), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerPressed))
 			{
 				result |= RoutedEventFlag.PointerPressed;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerReleased), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerReleased))
 			{
 				result |= RoutedEventFlag.PointerReleased;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerEntered), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerEntered))
 			{
 				result |= RoutedEventFlag.PointerEntered;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerExited), _pointerArgsType))
+			if (GetIsEventOverrideImplemented<PointerRoutedEventArgs>(OnPointerExited))
 			{
 				result |= RoutedEventFlag.PointerExited;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerMoved), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerMoved))
 			{
 				result |= RoutedEventFlag.PointerMoved;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerCanceled), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerCanceled))
 			{
 				result |= RoutedEventFlag.PointerCanceled;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerCaptureLost), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerCaptureLost))
 			{
 				result |= RoutedEventFlag.PointerCaptureLost;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPointerWheelChanged), _pointerArgsType))
+			if (GetIsEventOverrideImplemented(OnPointerWheelChanged))
 			{
 				result |= RoutedEventFlag.PointerWheelChanged;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationStarting), _manipStartingArgsType))
+			if (GetIsEventOverrideImplemented(OnManipulationStarting))
 			{
 				result |= RoutedEventFlag.ManipulationStarting;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationStarted), _manipStartedArgsType))
+			if (GetIsEventOverrideImplemented(OnManipulationStarted))
 			{
 				result |= RoutedEventFlag.ManipulationStarted;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationDelta), _manipDeltaArgsType))
+			if (GetIsEventOverrideImplemented(OnManipulationDelta))
 			{
 				result |= RoutedEventFlag.ManipulationDelta;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationInertiaStarting), _manipInertiaArgsType))
+			if (GetIsEventOverrideImplemented(OnManipulationInertiaStarting))
 			{
 				result |= RoutedEventFlag.ManipulationInertiaStarting;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationCompleted), _manipCompletedArgsType))
+			if (GetIsEventOverrideImplemented(OnManipulationCompleted))
 			{
 				result |= RoutedEventFlag.ManipulationCompleted;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnTapped), _tappedArgsType))
+			if (GetIsEventOverrideImplemented(OnTapped))
 			{
 				result |= RoutedEventFlag.Tapped;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnDoubleTapped), _doubleTappedArgsType))
+			if (GetIsEventOverrideImplemented(OnDoubleTapped))
 			{
 				result |= RoutedEventFlag.DoubleTapped;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnRightTapped), _rightTappedArgsType))
+			if (GetIsEventOverrideImplemented(OnRightTapped))
 			{
 				result |= RoutedEventFlag.RightTapped;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnHolding), _holdingArgsType))
+			if (GetIsEventOverrideImplemented(OnHolding))
 			{
 				result |= RoutedEventFlag.Holding;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnDragEnter), _dragArgsType))
+			if (GetIsEventOverrideImplemented(OnDragEnter))
 			{
 				result |= RoutedEventFlag.DragEnter;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnDragOver), _dragArgsType))
+			if (GetIsEventOverrideImplemented(OnDragOver))
 			{
 				result |= RoutedEventFlag.DragOver;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnDragLeave), _dragArgsType))
+			if (GetIsEventOverrideImplemented(OnDragLeave))
 			{
 				result |= RoutedEventFlag.DragLeave;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnDrop), _dragArgsType))
+			if (GetIsEventOverrideImplemented(OnDrop))
 			{
 				result |= RoutedEventFlag.Drop;
 			}
 #if __WASM__ || __SKIA__
-			if (GetIsEventOverrideImplemented(type, nameof(OnPreviewKeyDown), _keyArgsType))
+			if (GetIsEventOverrideImplemented(OnPreviewKeyDown))
 			{
 				result |= RoutedEventFlag.PreviewKeyDown;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnPreviewKeyUp), _keyArgsType))
+			if (GetIsEventOverrideImplemented(OnPreviewKeyUp))
 			{
 				result |= RoutedEventFlag.PreviewKeyUp;
 			}
 #endif
-			if (GetIsEventOverrideImplemented(type, nameof(OnKeyDown), _keyArgsType))
+			if (GetIsEventOverrideImplemented<KeyRoutedEventArgs>(OnKeyDown))
 			{
 				result |= RoutedEventFlag.KeyDown;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnKeyUp), _keyArgsType))
+			if (GetIsEventOverrideImplemented<KeyRoutedEventArgs>(OnKeyUp))
 			{
 				result |= RoutedEventFlag.KeyUp;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnLostFocus), _routedArgsType))
+			if (GetIsEventOverrideImplemented(OnLostFocus))
 			{
 				result |= RoutedEventFlag.LostFocus;
 			}
 
-			if (GetIsEventOverrideImplemented(type, nameof(OnGotFocus), _routedArgsType))
+			if (GetIsEventOverrideImplemented(OnGotFocus))
 			{
 				result |= RoutedEventFlag.GotFocus;
 			}


### PR DESCRIPTION
Context: 559b1f7866028a1d23f74ba43c3e8614a8e9f284
Context: https://github.com/unoplatform/uno-private/issues/1697#issuecomment-3752449412

(Repetition is fun!)

While running the uno.chefs app on macOS under NativeAOT:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Chefs/Chefs.csproj -p:SelfContained=true -p:UseSkiaRendering=true\
	  -p:PublishAot=true -p:IsAotCompatible=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

while using Uno 6.5.0-dev.104 (and later), the Login page doesn't work properly.  Specifically, after launching the app, click **Skip** to get to the Login page, and:

  * The `Username` field can be selected, but text cannot be entered.
  * The `Password` field cannot be selected via the mouse, but you can tab to it from the `Password` field.
  * You cannot enter text into the `Password` field.
  * You cannot check the `[ ] Remember me` checkbox.

You *can* click the **Sign in with Apple** and **Sign in with Google** buttons.

Why don't the `<TextBox/>` or `<PasswordBox/>` controls work?

Given that this is only under NativeAOT, the obvious answer is "Reflection!", but from where?

The less obvious answer is *event registration*, specifically the interaction between `Control.SubscribeToPostKeyDown()` and `UIElement.GetIsEventOverrideImplemented(Type, string, Type[])`:

	partial class Control {
	  [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
	  private void SubscribeToPostKeyDown() {
	    if (GetIsEventOverrideImplemented(GetType(), nameof(OnPostKeyDown), _keyArgsType))
	      PostKeyDown += OnPostKeyDownHandler;
	  }
	}
	partial class UIElement {
	  private protected static bool GetIsEventOverrideImplemented(
	    [DynamicallyAccessedMembers(…)] Type type, string name, Type[] args)
	  {
	    var method = type.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance, null, args, null);
	    return method != null && method.IsVirtual
	      && method.DeclaringType != typeof(UIElement)
	      && method.DeclaringType != typeof(Control);
	  }
	}

In order for text input to work, the type must subscribe to the `PostKeyDown` event.  In order for e.g. `<TextBox/>` to subscribe to the `PostKeyDown` event, it must override the `OnPostKeyDown()` method, *and* `Control` must *determine* that `OnPostKeyDown()` was overridden.  This override check involves Reflection by way of `Type.GetMethod()`, which in turn requires that `OnPostKeyDown` be included in "reflection metadata."

It was not:

	% grep OnPostKeyDown Chefs/obj/Release/net10.0-desktop/osx-x64/native/Chefs.metadata.csv
	3432e2bf, ConstantStringValue, "OnPostKeyDown", ""

We need *more* than `ConstantStringValue` for it be useful. For example, if we add `[DynamicDependency]` to `OnPostKeyDown()`:

	partial class TextBox {
	  [DynamicDependency(nameof(OnPostKeyDown))]
	  private protected override void OnPostKeyDown(KeyRoutedEventArgs args) => …;
	}

that *fixes* the "keyboard input doesn't work" problem, and `Chefs.metadata.csv` contains:

	% grep OnPostKeyDown Chefs/obj/Release/net10.0-desktop/osx-x64/native/Chefs.metadata.csv
	5009119c, Method, "[HasThis]  System.Void OnPostKeyDown(Microsoft.UI.Xaml.Input.KeyRoutedEventArgs)", "34117ead 56117ebb 6202258a 42117ec7"
	34117ead, ConstantStringValue, "OnPostKeyDown", ""
	42117ec7, CustomAttribute, "System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute.[HasThis]  System.Void .ctor(System.String)(\"OnPostKeyDown\")(ctor: Internal.Metadata.NativeFormat.Handle", "6c0aa81f 34117ead"

However, this is not a scalable answer.  *Lots* of codepaths touch `GetIsEventOverrideImplemented()`, notably
`Control.EvaluateImplementedControlRoutedEvents(Type)`.

Do we really want (or need?) to add every `Control` method to reflection metadata?

It also doesn't fix the inabilty to interract with the checkbox.

Additionally, some parts of System.Reflection *do not require* "reflection metadata".  In particular, it is possible to obtain `MethodInfo` instances *without* using `Type.GetMethod()`, by using *delegates*:

	Action a = () => {};
	MethodInfo method = a.Method;

This does not require "reflection metadata", and works under NativeAOT.

Rework `Control.EvaluateImplementedControlRoutedEvents()` et al to use *delegates* instead of `Type.GetMethod()`:

	partial class UIElement {
	  private protected static bool GetIsEventOverrideImplemented<T>(Action<T> a) =>
	    GetIsEventOverrideImplemented((Delegate)a);
	  private protected static bool GetIsEventOverrideImplemented(Delegate d) =>
	    d.Method.IsVirtual && d.Method.DeclaringType != typeof(UIElement) && d.Method.DeclaringType != typeof(Control);
	}
	partial class Control {
	  private void SubscribeToPostKeyDown() {
	    if (GetIsEventOverrideImplemented(OnPostKeyDown))
	      PostKeyDown += OnPostKeyDownHandler;
	  }
	}

This works because delegates know about method overrides.

This not only works under NativeAOT, but also allows us to remove many `[UnconditionalSuppressMessage]` annotations.

However, in order for this to work, many methods which were previously `static` must now be instance methods, such as
`Control.EvaluateImplementedControlRoutedEvents()`.

For backward compatibility/migration purposes, preserve the previous `static` methods and `[Obsolete]` them, directing code to use the instance method alternatives.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->