### PR TITLE
Stdio MCP fixes

### DIFF
--- a/doc/articles/dev-server.md
+++ b/doc/articles/dev-server.md
@@ -43,6 +43,8 @@ You can manage the Dev Server from the command line using the dotnet tool `Uno.D
 - `--port | -p <int>`: Optional port value for MCP proxy mode
 - `--mcp-wait-tools-list`: Wait for the upstream Uno App tools to become available before responding to clients. Use this when working with MCP agents that do not react to `tool_list_changed` (for example, Codex or Claude Code).
 - `--force-roots-fallback`: Skip the MCP `roots` handshake and expose the `uno_app_set_roots` tool so agents that cannot send workspace roots can still initialize (required for Google Antigravity).
+- `--force-generate-tool-cache`: Immediately request the Uno App tool list once the Dev Server is online and persist it to the local cache. Use this to prime CI environments or agents that expect a tools cache before they can call `list_tools`.
+- `--solution-dir <path>`: Explicit solution directory Uno.DevServer should monitor. Useful when starting the DevServer manually (e.g., CI agents) or when priming tools via `--force-generate-tool-cache`. Defaults to the current working directory when omitted.
 
 ## Hot Reload
 

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
@@ -26,19 +27,31 @@ internal class CliManager
 	{
 		try
 		{
+			var solutionDirParseResult = ExtractSolutionDirectory(originalArgs);
+			if (!solutionDirParseResult.Success)
+			{
+				return 1;
+			}
+
+			originalArgs = solutionDirParseResult.FilteredArgs;
+			var workingDirectory = solutionDirParseResult.SolutionDirectory ?? Environment.CurrentDirectory;
+
 			if (originalArgs.Contains("--mcp-app"))
 			{
-				return await RunMcpProxyAsync(originalArgs.Where(a => a != "--mcp-app").ToArray());
+				return await RunMcpProxyAsync(
+					originalArgs.Where(a => a != "--mcp-app").ToArray(),
+					workingDirectory,
+					solutionDirParseResult.SolutionDirectory);
 			}
 
 			ShowBanner();
 
 			if (originalArgs is { Length: > 0 } && string.Equals(originalArgs[0], "login", StringComparison.OrdinalIgnoreCase))
 			{
-				return await OpenSettings(originalArgs);
+				return await OpenSettings(originalArgs, workingDirectory);
 			}
 
-			var hostPath = await _unoToolsLocator.ResolveHostExecutableAsync(Environment.CurrentDirectory);
+			var hostPath = await _unoToolsLocator.ResolveHostExecutableAsync(workingDirectory);
 
 			if (hostPath is null)
 			{
@@ -50,7 +63,7 @@ internal class CliManager
 				string.Equals(originalArgs[0], "cleanup", StringComparison.OrdinalIgnoreCase)
 			);
 
-			var startInfo = BuildHostArgs(hostPath, originalArgs, Environment.CurrentDirectory, redirectOutput: !isDirectOutputCommand);
+			var startInfo = BuildHostArgs(hostPath, originalArgs, workingDirectory, redirectOutput: !isDirectOutputCommand);
 
 			var result = await DevServerProcessHelper.RunConsoleProcessAsync(startInfo, _logger);
 			return result.ExitCode;
@@ -80,16 +93,16 @@ internal class CliManager
 		}
 	}
 
-	private async Task<int> OpenSettings(string[] originalArgs)
+	private async Task<int> OpenSettings(string[] originalArgs, string workingDirectory)
 	{
-		var studioExecutable = await _unoToolsLocator.ResolveSettingsExecutableAsync(Environment.CurrentDirectory);
+		var studioExecutable = await _unoToolsLocator.ResolveSettingsExecutableAsync(workingDirectory);
 
 		if (studioExecutable is null)
 		{
 			return 1; // errors already logged
 		}
 
-		var startInfo = DevServerProcessHelper.CreateDotnetProcessStartInfo(studioExecutable, originalArgs, Environment.CurrentDirectory, redirectOutput: true);
+		var startInfo = DevServerProcessHelper.CreateDotnetProcessStartInfo(studioExecutable, originalArgs, workingDirectory, redirectOutput: true);
 
 		var (exitCode, stdOut, stdErr) = await DevServerProcessHelper.RunGuiProcessAsync(startInfo, _logger, TimeSpan.FromSeconds(3));
 
@@ -116,7 +129,7 @@ internal class CliManager
 		}
 	}
 
-	private async Task<int> RunMcpProxyAsync(string[] args)
+	private async Task<int> RunMcpProxyAsync(string[] args, string workingDirectory, string? solutionDirectory)
 	{
 		try
 		{
@@ -125,6 +138,7 @@ internal class CliManager
 			int requestedPort = 0;
 			bool mcpWaitToolsList = false;
 			bool forceRootsFallback = false;
+			bool forceGenerateToolCache = false;
 			var forwardedArgs = new List<string>();
 
 			for (int i = 0; i < args.Length; i++)
@@ -155,17 +169,73 @@ internal class CliManager
 					forceRootsFallback = true;
 					continue; // do not forward mcp-specific arguments to controller
 				}
+				else if (a == "--force-generate-tool-cache")
+				{
+					forceGenerateToolCache = true;
+					continue; // do not forward mcp-specific arguments to controller
+				}
 				forwardedArgs.Add(a);
 			}
 
+			var normalizedSolutionDirectory = solutionDirectory ?? (forceGenerateToolCache ? workingDirectory : null);
+
 			var waitForTools = mcpWaitToolsList;
-			return await _services.GetRequiredService<McpProxy>().RunAsync(Environment.CurrentDirectory, requestedPort, forwardedArgs, waitForTools, forceRootsFallback, CancellationToken.None);
+			return await _services.GetRequiredService<McpProxy>().RunAsync(
+				workingDirectory,
+				requestedPort,
+				forwardedArgs,
+				waitForTools,
+				forceRootsFallback,
+				forceGenerateToolCache,
+				normalizedSolutionDirectory,
+				CancellationToken.None);
 		}
 		catch (Exception ex)
 		{
 			_logger.LogError($"MCP proxy error: {ex.Message}");
 			return 1;
 		}
+	}
+
+	private (bool Success, string[] FilteredArgs, string? SolutionDirectory) ExtractSolutionDirectory(string[] args)
+	{
+		string? rawSolutionDirectory = null;
+		var filteredArgs = new List<string>(args.Length);
+
+		for (int i = 0; i < args.Length; i++)
+		{
+			var arg = args[i];
+			if (arg == "--solution-dir")
+			{
+				if (i + 1 >= args.Length)
+				{
+					_logger.LogError("Missing value for --solution-dir");
+					return (false, Array.Empty<string>(), null);
+				}
+
+				rawSolutionDirectory = args[i + 1];
+				i++; // skip value
+				continue;
+			}
+
+			filteredArgs.Add(arg);
+		}
+
+		string? normalizedSolutionDirectory = null;
+		if (!string.IsNullOrWhiteSpace(rawSolutionDirectory))
+		{
+			try
+			{
+				normalizedSolutionDirectory = Path.GetFullPath(rawSolutionDirectory);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, "Invalid solution directory '{Directory}'", rawSolutionDirectory);
+				return (false, Array.Empty<string>(), null);
+			}
+		}
+
+		return (true, filteredArgs.ToArray(), normalizedSolutionDirectory);
 	}
 
 	private ProcessStartInfo BuildHostArgs(string hostPath, string[] originalArgs, string workingDirectory, bool redirectOutput = true)

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -28,6 +28,9 @@ internal class CliManager
 		try
 		{
 			var solutionDirParseResult = ExtractSolutionDirectory(originalArgs);
+			// --solution-dir is applied uniformly so automation and CI environments can run any
+			// command (start, stop, list, login, MCP) against a target solution even when the
+			// current working directory differs from the solution root.
 			if (!solutionDirParseResult.Success)
 			{
 				return 1;

--- a/src/Uno.UI.DevServer.Cli/Program.cs
+++ b/src/Uno.UI.DevServer.Cli/Program.cs
@@ -126,7 +126,7 @@ internal class Program
 
 	private static void WriteOption(string option, string description)
 	{
-		const int optionWidth = 28;
+		const int optionWidth = 32;
 		Console.WriteLine($"  {option,-optionWidth} {description}");
 	}
 

--- a/src/Uno.UI.DevServer.Cli/Program.cs
+++ b/src/Uno.UI.DevServer.Cli/Program.cs
@@ -18,17 +18,19 @@ internal class Program
 			Console.WriteLine("Usage: dnx -y uno.devserver [options] [command]");
 			Console.WriteLine();
 			Console.WriteLine("Options:");
-			Console.WriteLine("  --help, -h                 Show this help message and exit");
-			Console.WriteLine("  --log-level, -l <level>    Set the log level (Trace, Debug, Information, Warning, Error, Critical, None). Default is Information.");
-			Console.WriteLine("  --file-log, -fl <path>     Enable file logging to the provided file path (supports {Date} token). Required path argument.");
-			Console.WriteLine("  --mcp-app                  Start in App MCP STDIO mode");
-			Console.WriteLine("  --mcp-wait-tools-list      Wait for upstream server tools before responding to list_tools (MCP mode only)");
-			Console.WriteLine("  --force-roots-fallback     This mode can be used when the MCP client does not support the roots feature");
+			WriteOption("--help, -h", "Show this help message and exit");
+			WriteOption("--log-level, -l <level>", "Set the log level (Trace, Debug, Information, Warning, Error, Critical, None). Default is Information.");
+			WriteOption("--file-log, -fl <path>", "Enable file logging to the provided file path (supports {Date} token). Required path argument.");
+			WriteOption("--mcp-app", "Start in App MCP STDIO mode");
+			WriteOption("--mcp-wait-tools-list", "Wait for upstream server tools before responding to list_tools (MCP mode only)");
+			WriteOption("--force-roots-fallback", "This mode can be used when the MCP client does not support the roots feature");
+			WriteOption("--force-generate-tool-cache", "Force tool discovery and persist the cache immediately (MCP mode only)");
+			WriteOption("--solution-dir <path>", "Explicit solution root when priming tools without client-provided roots");
 			Console.WriteLine();
 			Console.WriteLine("Commands:");
-			Console.WriteLine("  start                      Start the DevServer for the current folder");
-			Console.WriteLine("  stop                       Stop the DevServer for the current folder");
-			Console.WriteLine("  list                       List active DevServer instances");
+			WriteCommand("start", "Start the DevServer for the current folder");
+			WriteCommand("stop", "Stop the DevServer for the current folder");
+			WriteCommand("list", "List active DevServer instances");
 			Console.WriteLine();
 			return 0;
 		}
@@ -120,5 +122,17 @@ internal class Program
 			}
 		}
 		return null;
+	}
+
+	private static void WriteOption(string option, string description)
+	{
+		const int optionWidth = 28;
+		Console.WriteLine($"  {option,-optionWidth} {description}");
+	}
+
+	private static void WriteCommand(string command, string description)
+	{
+		const int commandWidth = 10;
+		Console.WriteLine($"  {command,-commandWidth} {description}");
 	}
 }


### PR DESCRIPTION
- Fixes invalid roots path parsing on Windows
- Adds the ability to generate the tools cache explicitly for CI priming
- Adds the ability to use an arbitrary solution path different from the working directory