### PR TITLE
fix(RefreshContainer): invalid pull states

### DIFF
--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTracker.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTracker.cs
@@ -44,6 +44,10 @@ public partial class InteractionTracker : CompositionObject
 
 	public int CurrentRequestId => _currentRequestId;
 
+#if HAS_UNO
+	internal InteractionTrackerState State => _state;
+#endif
+
 	public static InteractionTracker Create(Compositor compositor) => new InteractionTracker(compositor);
 
 	public static InteractionTracker CreateWithOwner(Compositor compositor, IInteractionTrackerOwner owner) => new InteractionTracker(compositor, owner);

--- a/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/RefreshContainer/RefreshContainer.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/RefreshContainer/RefreshContainer.mux.cs
@@ -266,6 +266,9 @@ public partial class RefreshContainer : ContentControl, IRefreshContainerPrivate
 					if (adaptFromTreeResult != null)
 					{
 						((IRefreshVisualizerPrivate)m_refreshVisualizer).InfoProvider = adaptFromTreeResult;
+#if HAS_UNO && !__ANDROID__ && !__IOS__
+						(m_refreshInfoProviderAdapter as ScrollViewerIRefreshInfoProviderAdapter)?.SetupVisualizer(m_refreshVisualizer);
+#endif
 						m_refreshInfoProviderAdapter.SetAnimations(m_refreshVisualizer);
 					}
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/RefreshVisualizer/RefreshVisualizer.Header.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/RefreshVisualizer/RefreshVisualizer.Header.cs
@@ -11,6 +11,7 @@ using Uno.Disposables;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Composition.Interactions;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -26,6 +27,9 @@ public partial class RefreshVisualizer
 
 	private SerialDisposable m_RefreshInfoProvider_InteractingForRefreshChangedToken = new SerialDisposable();
 	private SerialDisposable m_RefreshInfoProvider_InteractionRatioChangedToken = new SerialDisposable();
+#if HAS_UNO
+	private SerialDisposable m_RefreshInfoProvider_IdleEnteredToken = new SerialDisposable();
+#endif
 
 	///////////////////////////////////////////////
 	/////////	Internal Reference Vars   /////////
@@ -35,6 +39,11 @@ public partial class RefreshVisualizer
 	private double m_interactionRatio = 0.0;
 
 	private Compositor? m_compositor = null;
+
+#if HAS_UNO
+	internal ScrollViewer? ScrollViewer { get; set; }
+	internal InteractionTracker? InteractionTracker { get; set; }
+#endif
 
 	//private Panel? m_containerPanel = null;
 	private Panel? m_root = null;

--- a/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/RefreshInfoProviderImpl.Header.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/RefreshInfoProviderImpl.Header.cs
@@ -4,9 +4,10 @@
 
 #nullable enable
 
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.Interactions;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
-using Microsoft.UI.Composition;
 using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
 
 namespace Microsoft.UI.Private.Controls;
@@ -25,11 +26,12 @@ internal partial class RefreshInfoProviderImpl
 	private bool m_peeking = false;
 
 	public event TypedEventHandler<IRefreshInfoProvider, object> IsInteractingForRefreshChanged;
-
 #pragma warning disable CS0067 // The event 'RefreshInfoProviderImpl.InteractionRatioChanged' is never used
 	public event TypedEventHandler<IRefreshInfoProvider, RefreshInteractionRatioChangedEventArgs> InteractionRatioChanged;
 #pragma warning restore CS0067 // The event 'RefreshInfoProviderImpl.InteractionRatioChanged' is never used
-
 	public event TypedEventHandler<IRefreshInfoProvider, object> RefreshStarted;
 	public event TypedEventHandler<IRefreshInfoProvider, object> RefreshCompleted;
+#if HAS_UNO
+	internal event TypedEventHandler<IRefreshInfoProvider, InteractionTracker> IdleEntered;
+#endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/RefreshInfoProviderImpl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/RefreshInfoProviderImpl.cs
@@ -101,6 +101,10 @@ internal partial class RefreshInfoProviderImpl : IRefreshInfoProvider, IInteract
 	public void IdleStateEntered(InteractionTracker sender, InteractionTrackerIdleStateEnteredArgs args)
 	{
 		//PTR_TRACE_INFO(null, TRACE_MSG_METH_INT, METH_NAME, this, args.RequestId());
+
+#if HAS_UNO
+		IdleEntered?.Invoke(this, sender);
+#endif
 	}
 
 	public void CustomAnimationStateEntered(InteractionTracker sender, InteractionTrackerCustomAnimationStateEnteredArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.cs
@@ -301,6 +301,15 @@ internal partial class ScrollViewerIRefreshInfoProviderAdapter : IRefreshInfoPro
 	{
 		if (m_infoProvider is not null && m_infoProvider.IsInteractingForRefresh)
 		{
+#if HAS_UNO
+			// During overpan, any scroll back will trigger UpdateIsInteractingForRefresh which causes premature Refresh or Idle to occur.
+			// We should prevent that while the user still had the touch held down (read: in InteractionTrackerInteractingState).
+			if (m_interactionTracker?.State is InteractionTrackerInteractingState)
+			{
+				return;
+			}
+#endif
+
 			//PTR_TRACE_INFO(null, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, args.FinalView().HorizontalOffset(), args.FinalView().VerticalOffset());
 			if (!IsWithinOffsetThreshold())
 			{
@@ -426,5 +435,16 @@ internal partial class ScrollViewerIRefreshInfoProviderAdapter : IRefreshInfoPro
 	}
 
 	public void Dispose() { }
+
+#if HAS_UNO
+	internal void SetupVisualizer(RefreshVisualizer visualizer)
+	{
+		if (visualizer is { })
+		{
+			visualizer.ScrollViewer = m_scrollViewer;
+			visualizer.InteractionTracker = m_interactionTracker;
+		}
+	}
+#endif
 }
 #endif


### PR DESCRIPTION
**GitHub Issue:** 
closes #22453
re: unoplatform/dispatchscience-private#29

## PR Type: 🐞 Bugfix
## What is the current behavior? 🤔
RefreshContainer pull-to-refresh can often get stuck, especially when pull is started and a slight push (against pull direction) is performed.

## What is the new behavior? 🚀
^ should no longer happen.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
<!-- Please provide any additional information if necessary -->