### PR TITLE
fix: Prevent crash on macOS when opening File Pickers

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -46,6 +46,7 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 
 	public async Task<IReadOnlyList<StorageFile>> PickMultipleFilesAsync(CancellationToken token)
 	{
+		await Task.Yield();
 		var array = NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
 		var files = new List<StorageFile>();
 		var ptr = Marshal.ReadIntPtr(array);
@@ -64,6 +65,7 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 
 	public async Task<StorageFile?> PickSingleFileAsync(CancellationToken token)
 	{
+		await Task.Yield();
 		var file = NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
 		return file is null ? null : await StorageFile.GetFileFromPathAsync(file);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -10,16 +10,14 @@ namespace Uno.UI.Runtime.Skia.MacOS;
 
 internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 {
-	private static readonly MacOSFileOpenPickerExtension _instance = new();
-
 	private static readonly string[] _asteriskArray = new string[] { "*" };
 
-	private MacOSFileOpenPickerExtension()
+	public MacOSFileOpenPickerExtension()
 	{
 		_filters = Array.Empty<string>();
 	}
 
-	public static void Register() => ApiExtensibility.Register<FileOpenPicker>(typeof(IFileOpenPickerExtension), _ => _instance);
+	public static void Register() => ApiExtensibility.Register<FileOpenPicker>(typeof(IFileOpenPickerExtension), _ => new MacOSFileOpenPickerExtension());
 
 	// Mapping
 	// WinUI                            AppKit (NSOpenPanel)

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
@@ -60,6 +60,7 @@ internal class MacOSFileSavePickerExtension : IFileSavePickerExtension
 
 	public async Task<StorageFile?> PickSaveFileAsync(CancellationToken token)
 	{
+		await Task.Yield();
 		var file = NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length);
 		return file is null ? null : await StorageFile.GetFileFromPathAsync(file);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
@@ -8,14 +8,12 @@ namespace Uno.UI.Runtime.Skia.MacOS;
 
 internal class MacOSFileSavePickerExtension : IFileSavePickerExtension
 {
-	private static readonly MacOSFileSavePickerExtension _instance = new();
-
-	private MacOSFileSavePickerExtension()
+	public MacOSFileSavePickerExtension()
 	{
 		_filters = Array.Empty<string>();
 	}
 
-	public static void Register() => ApiExtensibility.Register<FileSavePicker>(typeof(IFileSavePickerExtension), _ => _instance);
+	public static void Register() => ApiExtensibility.Register<FileSavePicker>(typeof(IFileSavePickerExtension), _ => new MacOSFileSavePickerExtension());
 
 	// Mapping
 	// WinUI                            AppKit (NSSavePanel)

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
@@ -8,13 +8,11 @@ namespace Uno.UI.Runtime.Skia.MacOS;
 
 internal class MacOSFolderPickerExtension : IFolderPickerExtension
 {
-	private static readonly MacOSFolderPickerExtension _instance = new();
-
-	private MacOSFolderPickerExtension()
+	public MacOSFolderPickerExtension()
 	{
 	}
 
-	public static void Register() => ApiExtensibility.Register<FolderPicker>(typeof(IFolderPickerExtension), _ => _instance);
+	public static void Register() => ApiExtensibility.Register<FolderPicker>(typeof(IFolderPickerExtension), _ => new MacOSFolderPickerExtension());
 
 	// Mapping
 	// WinUI                            AppKit (NSOpenPanel)

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
@@ -40,6 +40,7 @@ internal class MacOSFolderPickerExtension : IFolderPickerExtension
 
 	public async Task<StorageFolder?> PickSingleFolderAsync(CancellationToken token)
 	{
+		await Task.Yield();
 		var folder = NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation);
 		return folder is null ? null : await StorageFolder.GetFolderFromPathAsync(folder);
 	}


### PR DESCRIPTION
**GitHub Issue:** closes #22307

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

Crashes.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

Added await Task.Yield() before invoking native pickers (MacOSFileOpenPickerExtension, MacOSFolderPickerExtension, MacOSFileSavePickerExtension) to ensure the current pointer event completes before the native dialog opens.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
