### PR TITLE
ci: Add auto-assignment of PRs to their authors

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,3 +13,38 @@ jobs:
     - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Assign PR to its author
+      uses: actions/github-script@v6
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        script: |
+          const pr = context.payload.pull_request;
+          if (!pr) {
+            core.info('No pull_request payload available, skipping.');
+            return;
+          }
+          // If the PR already has any assignees, skip auto-assignment
+          if (pr.assignees && pr.assignees.length > 0) {
+            core.info(`PR #${pr.number} already has assignees; skipping auto-assignment.`);
+            return;
+          }
+          const author = pr.user && pr.user.login;
+          if (!author) {
+            core.info('PR has no author, skipping assignment.');
+            return;
+          }
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const pull_number = pr.number;
+          core.info(`Attempting to assign PR #${pull_number} to ${author}`);
+          try {
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: pull_number,
+              assignees: [author]
+            });
+            core.info(`Assigned PR #${pull_number} to ${author}`);
+          } catch (err) {
+            core.info(`Could not assign PR #${pull_number} to ${author}: ${err.message}`);
+          }


### PR DESCRIPTION
**GitHub Issue:** closes none

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🤖 Project automation

## What is the new behavior? 🚀

Since there is an increasing number of Copilot assisted PRs, I think auto assigning the authors for all PRs would be nice for better filtering. It should be handled by assigning PRs that the user/copilot didn't assign "manually" when creating the PR.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
