### PR TITLE
chore: fix TransformToVisual_Transform test-page

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/TransformToVisual_Transform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/TransformToVisual_Transform.xaml.cs
@@ -225,7 +225,7 @@ namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
 					{
 						(play = new Button
 						{
-							Content = "?",
+							Content = "▶",
 						}),
 						test.Output
 					}
@@ -299,7 +299,7 @@ namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
 				Output = new TextBlock
 				{
 					Name = Name + "_Result",
-					Text = "?? " + Name,
+					Text = "🟨 " + Name,
 					TextWrapping = TextWrapping.Wrap,
 					VerticalAlignment = VerticalAlignment.Center
 				};
@@ -326,19 +326,19 @@ namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
 					}
 
 					LastResult = TestResult.Success;
-					Output.Text = $"?? {_testMethod.Name}: SUCCESS";
+					Output.Text = $"🟩 {_testMethod.Name}: SUCCESS";
 				}
 				catch (TargetInvocationException e)
 				{
 					LastResult = TestResult.Failure;
-					Output.Text = $"?? {_testMethod.Name}: FAILED ({e.InnerException?.Message ?? e.Message})";
+					Output.Text = $"🟥 {_testMethod.Name}: FAILED ({e.InnerException?.Message ?? e.Message})";
 					Console.WriteLine($"{_testMethod.Name}: FAILED");
 					Console.WriteLine(e.InnerException ?? e);
 				}
 				catch (Exception e)
 				{
 					LastResult = TestResult.Failure;
-					Output.Text = $"?? {_testMethod.Name}: FAILED ({e.Message})";
+					Output.Text = $"🟥 {_testMethod.Name}: FAILED ({e.Message})";
 					Console.WriteLine($"{_testMethod.Name}: FAILED");
 					Console.WriteLine(e);
 				}


### PR DESCRIPTION
**GitHub Issue:** regression from #22334

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
TransformToVisual_Transform page got accidentally modified in a copilot pr:
<img width="313" height="54" alt="image" src="https://github.com/user-attachments/assets/5b412930-2da5-4e15-a0a0-e898a17dd946" />

## What is the new behavior? 🚀
restored TransformToVisual_Transform page to its original implementation/look
<img width="342" height="61" alt="image" src="https://github.com/user-attachments/assets/4e4e8d4a-5c28-48f6-9c4a-bff18d527c17" />

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes