### PR TITLE
ci: ignore master health check for stable branch

### DIFF
--- a/build/ci/setup/.azure-devops-master-health.yml
+++ b/build/ci/setup/.azure-devops-master-health.yml
@@ -6,7 +6,7 @@ stages:
   displayName: Validate Master Health
   dependsOn:
     - Setup
-  condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable')))
+  condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable/')))
 
   jobs:
   - job: MasterHealth

--- a/build/ci/setup/.azure-devops-master-health.yml
+++ b/build/ci/setup/.azure-devops-master-health.yml
@@ -6,7 +6,10 @@ stages:
   displayName: Validate Master Health
   dependsOn:
     - Setup
-  condition: eq(variables['Build.Reason'], 'PullRequest')
+  condition: and(
+    eq(variables['Build.Reason'], 'PullRequest'),
+    not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable'))
+  )
 
   jobs:
   - job: MasterHealth

--- a/build/ci/setup/.azure-devops-master-health.yml
+++ b/build/ci/setup/.azure-devops-master-health.yml
@@ -6,10 +6,7 @@ stages:
   displayName: Validate Master Health
   dependsOn:
     - Setup
-  condition: and(
-    eq(variables['Build.Reason'], 'PullRequest'),
-    not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable'))
-  )
+  condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable'))
 
   jobs:
   - job: MasterHealth

--- a/build/ci/setup/.azure-devops-master-health.yml
+++ b/build/ci/setup/.azure-devops-master-health.yml
@@ -6,7 +6,7 @@ stages:
   displayName: Validate Master Health
   dependsOn:
     - Setup
-  condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable'))
+  condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(startsWith(variables['System.PullRequest.TargetBranch'], 'refs/heads/release/stable')))
 
   jobs:
   - job: MasterHealth


### PR DESCRIPTION
This pull request updates the pipeline trigger conditions for the "Validate Master Health" stage in the Azure DevOps configuration. The change ensures that the validation job only runs for pull requests that do not target branches starting with `refs/heads/release/stable`.

Pipeline condition update:

* Updated the `condition` in `build/ci/setup/.azure-devops-master-health.yml` to prevent the "Validate Master Health" job from running on pull requests targeting release/stable branches.