### PR TITLE
fix: Adjust MCP start and testing

### DIFF
--- a/build/test-scripts/run-devserver-cli-tests.ps1
+++ b/build/test-scripts/run-devserver-cli-tests.ps1
@@ -1,9 +1,54 @@
 # Set-PSDebug -Trace 1
 
+[CmdletBinding()]
+param(
+    [string]$DevServerCliDllPath
+)
+
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 function Write-Log([string]$Message){ Write-Host "[devserver-cli-test] $Message" }
+
+$script:DevServerHostExecutable = "dotnet"
+$script:DevServerCliEntryPoint = "uno-devserver"
+$script:DevServerCliDisplayName = "$script:DevServerHostExecutable $script:DevServerCliEntryPoint"
+$script:DevServerCliUsesDllPath = $false
+$script:DevServerCliResolvedDllPath = $null
+
+if (-not [string]::IsNullOrWhiteSpace($DevServerCliDllPath)) {
+    if (-not (Test-Path -LiteralPath $DevServerCliDllPath)) {
+        throw "Provided DevServerCliDllPath '$DevServerCliDllPath' was not found."
+    }
+
+    $script:DevServerCliResolvedDllPath = (Resolve-Path -LiteralPath $DevServerCliDllPath -ErrorAction Stop).Path
+    $script:DevServerCliEntryPoint = $script:DevServerCliResolvedDllPath
+    $script:DevServerCliDisplayName = "$script:DevServerHostExecutable $script:DevServerCliResolvedDllPath"
+    $script:DevServerCliUsesDllPath = $true
+}
+
+function Get-DevserverCliArguments {
+    param([string[]]$Arguments = @())
+
+    return @($script:DevServerCliEntryPoint) + $Arguments
+}
+
+function Get-DevserverExternalCommand {
+    param([string[]]$Arguments = @())
+
+    return @($script:DevServerHostExecutable) + (Get-DevserverCliArguments -Arguments $Arguments)
+}
+
+function Invoke-DevserverCli {
+    param([string[]]$Arguments = @())
+
+    $fullArgs = Get-DevserverCliArguments -Arguments $Arguments
+    & $script:DevServerHostExecutable @fullArgs
+}
+
+if ($script:DevServerCliUsesDllPath -and $script:DevServerCliResolvedDllPath) {
+    Write-Log "Using devserver CLI from $script:DevServerCliResolvedDllPath"
+}
 
 # Wait for a TCP port to be opened on localhost. Accepts a Path parameter (e.g. '/', 'subpath') and sets $Global:DevServerBaseUrl. Returns $true when the port is open, $false otherwise.
 function Wait-ForHttpPortOpen([int]$Port, [string]$Path = '/', [int]$MaxAttempts = 30, [int]$ConnectTimeoutMs = 2000, [string]$TargetHost = '127.0.0.1', [string]$Scheme = 'http') {
@@ -53,6 +98,43 @@ function Wait-ForHttpPortOpen([int]$Port, [string]$Path = '/', [int]$MaxAttempts
     $Global:DevServerBaseUrl = $url
 
     return $success
+}
+
+function Wait-ForDevserverListEntry([int]$Port, [string]$SolutionDirectory, [int]$MaxAttempts = 30, [int]$DelaySeconds = 2) {
+    $normalizedDirectory = $SolutionDirectory
+    try {
+        $normalizedDirectory = (Resolve-Path -LiteralPath $SolutionDirectory -ErrorAction Stop).Path
+    }
+    catch {
+        Write-Log "Unable to normalize solution directory '$SolutionDirectory' for list validation: $($_.Exception.Message)"
+    }
+
+    $escapedDirectory = [Regex]::Escape($normalizedDirectory)
+    $portPattern = "Port\s*:\s*$Port"
+    $endpointPattern = ":$Port(\b|/)"
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        Write-Log "Checking devserver list for directory $normalizedDirectory (attempt $attempt/$MaxAttempts)..."
+
+        $listOutput = ""
+        try {
+            $listOutput = Invoke-DevserverCli -Arguments @('list') 2>&1
+        }
+        catch {
+            $listOutput = $_.Exception.Message
+        }
+
+        $listText = ($listOutput | Out-String)
+
+        if ($LASTEXITCODE -eq 0 -and $listText -match $escapedDirectory -and ($listText -match $portPattern -or $listText -match $endpointPattern)) {
+            return $true
+        }
+
+        Start-Sleep -Seconds $DelaySeconds
+    }
+
+    Write-Log "Devserver list did not report directory $normalizedDirectory with port $Port after $MaxAttempts attempts."
+    return $false
 }
 
 # Helper: try to extract a port number from a .csproj.user XML file
@@ -153,7 +235,7 @@ function Register-UnoCodexMcps {
             }
         }
 
-        $unoAppArguments += @("--", "dotnet", "uno-devserver", "--mcp-app", "-l", "trace")
+        $unoAppArguments += @("--") + (Get-DevserverExternalCommand -Arguments @("--mcp-app", "-l", "trace"))
 
         Invoke-CodexMcpAdd -Name "uno-app" -Arguments $unoAppArguments
     }
@@ -216,7 +298,6 @@ Begin now.
     $env:RUST_LOG = 'debug'
     try {
         $process = Start-Process -FilePath $codexExecutable -ArgumentList $codexArguments -WorkingDirectory $WorkingDirectory -RedirectStandardOutput $stdOutFile -RedirectStandardError $stdErrFile -RedirectStandardInput $instructionsFile -PassThru
-
         $timeoutMs = 180000 # 180 seconds
         if (-not $process.WaitForExit($timeoutMs)) {
             try { $process.Kill() } catch {}
@@ -334,14 +415,293 @@ function Setup-UnoStudioLicenses {
     return $unoDir
 }
 
+function Test-DevserverStartStop {
+    param(
+        [string]$SlnDir,
+        [string]$CsprojDir,
+        [string]$CsprojPath,
+        [int]$DefaultPort,
+        [int]$MaxAttempts
+    )
+
+    $port = $DefaultPort
+
+    Invoke-DevserverCli -Arguments @('start', '--httpPort', $port.ToString([System.Globalization.CultureInfo]::InvariantCulture), '-l', 'trace')
+
+    $csprojUserPath = Join-Path $CsprojDir ((Split-Path $CsprojPath -Leaf) + '.user')
+
+    $userPort = Get-PortFromCsprojUser -UserFilePath $csprojUserPath
+    if ($userPort) {
+        Write-Log "Port extracted from .csproj.user (UnoRemoteControlPort): $userPort"
+
+        if ($userPort -lt 1 -or $userPort -gt 65535) {
+            throw "Port number in $csprojUserPath is out of range: $userPort"
+        }
+
+        $port = $userPort
+    }
+    else {
+        if (Test-Path $csprojUserPath) {
+            throw "Could not find a valid UnoRemoteControlPort in $csprojUserPath"
+        }
+        else {
+            Write-Log "No .csproj.user file found. Using default port $DefaultPort"
+        }
+    }
+
+    $success = Wait-ForHttpPortOpen -Port $port -Path '/' -MaxAttempts $MaxAttempts -ConnectTimeoutMs 2000
+
+    if (-not $success) {
+        throw "Devserver did not open HTTP port $port after $MaxAttempts attempts."
+    }
+
+    Write-Log "Devserver HTTP port $port is open at $DevServerBaseUrl"
+
+    Invoke-DevserverCli -Arguments @('stop', '-l', 'trace')
+
+    return $port
+}
+
+function Test-DevserverSolutionDirSupport {
+    param(
+        [string]$SlnDir,
+        [int]$DefaultPort,
+        [int]$BaselinePort,
+        [int]$MaxAttempts
+    )
+
+    Write-Log "Validating --solution-dir support from outside the solution root"
+
+    $solutionDirTestPort = if ($BaselinePort -ge 65535) { $DefaultPort + 1 } else { $BaselinePort + 1 }
+    $outerDirectory = Split-Path $SlnDir -Parent
+    if ([string]::IsNullOrWhiteSpace($outerDirectory)) {
+        $outerDirectory = [System.IO.Path]::GetTempPath()
+    }
+
+    Push-Location $outerDirectory
+    try {
+        Invoke-DevserverCli -Arguments @('start', '--solution-dir', $SlnDir, '--httpPort', $solutionDirTestPort.ToString([System.Globalization.CultureInfo]::InvariantCulture), '-l', 'trace')
+
+        $solutionDirSuccess = Wait-ForHttpPortOpen -Port $solutionDirTestPort -Path '/' -MaxAttempts $MaxAttempts -ConnectTimeoutMs 2000
+        if (-not $solutionDirSuccess) {
+            throw "Devserver did not open HTTP port $solutionDirTestPort via --solution-dir after $MaxAttempts attempts."
+        }
+
+        Write-Log "Devserver started successfully using --solution-dir at $DevServerBaseUrl"
+
+        Invoke-DevserverCli -Arguments @('stop', '--solution-dir', $SlnDir, '-l', 'trace')
+    }
+    finally {
+        Pop-Location
+        Set-Location $SlnDir
+    }
+
+    return $solutionDirTestPort
+}
+
+function Stop-DevserverProcessCapture {
+    param($Context)
+
+    if (-not $Context) {
+        return
+    }
+
+    $process = $Context.Process
+
+    if ($Context.HasStarted -and $process -and -not $process.HasExited) {
+        try {
+            Stop-Process -Id $process.Id -ErrorAction Stop
+        }
+        catch {
+            Write-Log "Graceful devserver termination failed: $($_.Exception.Message)"
+        }
+
+        if (-not $process.WaitForExit(5000)) {
+            try {
+                Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            }
+            catch {
+                Write-Log "Failed to force-terminate devserver process: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    if ($Context.HasStarted -and $process) {
+        try { $process.WaitForExit(2000) | Out-Null } catch {}
+    }
+
+    if ($Context.CancellationSource) {
+        try { $Context.CancellationSource.Cancel() } catch {}
+        try { $Context.CancellationSource.Dispose() } catch {}
+        $Context.CancellationSource = $null
+    }
+
+    foreach ($task in @($Context.StdoutTask, $Context.StderrTask)) {
+        if ($task) {
+            try {
+                if (-not $task.Wait(5000)) {
+                    Write-Log "Background log capture task did not complete within timeout."
+                }
+            }
+            catch {
+                # swallow cancellation/aggregate errors
+            }
+        }
+    }
+
+    foreach ($stream in @($Context.StdoutStream, $Context.StderrStream)) {
+        if ($stream) {
+            try { $stream.Flush() } catch {}
+            $stream.Dispose()
+        }
+    }
+
+    $Context.HasStarted = $false
+}
+
+function Start-DevserverProcessCapture {
+    param(
+        [string]$WorkingDirectory,
+        [string]$Executable,
+        [string[]]$Arguments
+    )
+
+    $stdoutLogPath = [System.IO.Path]::GetTempFileName()
+    $stderrLogPath = [System.IO.Path]::GetTempFileName()
+
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = $Executable
+    foreach ($arg in $Arguments) {
+        [void]$startInfo.ArgumentList.Add($arg)
+    }
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $startInfo.StandardErrorEncoding = [System.Text.Encoding]::UTF8
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+
+    $context = [pscustomobject]@{
+        Process = $process
+        StdoutStream = $null
+        StderrStream = $null
+        StdoutTask = $null
+        StderrTask = $null
+        CancellationSource = $null
+        StdoutLogPath = $stdoutLogPath
+        StderrLogPath = $stderrLogPath
+        HasStarted = $false
+    }
+
+    try {
+        $context.StdoutStream = New-Object System.IO.FileStream($stdoutLogPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+        $context.StderrStream = New-Object System.IO.FileStream($stderrLogPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+
+        if (-not $process.Start()) {
+            throw "Failed to start devserver process for MCP validation."
+        }
+
+        $context.HasStarted = $true
+
+        $context.CancellationSource = New-Object System.Threading.CancellationTokenSource
+        $token = $context.CancellationSource.Token
+
+        $context.StdoutTask = $process.StandardOutput.BaseStream.CopyToAsync($context.StdoutStream, 81920, $token)
+        $context.StderrTask = $process.StandardError.BaseStream.CopyToAsync($context.StderrStream, 81920, $token)
+    }
+    catch {
+        Stop-DevserverProcessCapture -Context $context
+        throw
+    }
+
+    return $context
+}
+
+function Test-McpModeWithoutSolutionDir {
+    param(
+        [string]$SlnDir,
+        [int]$DefaultPort,
+        [int]$PrimaryPort,
+        [int]$SolutionDirPort,
+        [int]$MaxAttempts
+    )
+
+    Write-Log "Validating MCP mode from solution root without --solution-dir"
+
+    $maxAllocatedPort = [Math]::Max($PrimaryPort, $SolutionDirPort)
+    $mcpTestPort = if ($maxAllocatedPort -ge 65534) { $DefaultPort + 2 } else { $maxAllocatedPort + 1 }
+
+    $processContext = $null
+
+    $mcpArguments = Get-DevserverCliArguments -Arguments @("--mcp-app", "--port", $mcpTestPort.ToString([System.Globalization.CultureInfo]::InvariantCulture), "-l", "trace")
+    $processContext = Start-DevserverProcessCapture -WorkingDirectory $SlnDir -Executable $script:DevServerHostExecutable -Arguments $mcpArguments
+
+    try {
+        $mcpStarted = Wait-ForDevserverListEntry -Port $mcpTestPort -SolutionDirectory $SlnDir -MaxAttempts $MaxAttempts -DelaySeconds 2
+        if (-not $mcpStarted) {
+            $stdoutLog = if ($processContext -and (Test-Path $processContext.StdoutLogPath)) { Get-Content $processContext.StdoutLogPath -Raw -ErrorAction SilentlyContinue } else { "" }
+            $stderrLog = if ($processContext -and (Test-Path $processContext.StderrLogPath)) { Get-Content $processContext.StderrLogPath -Raw -ErrorAction SilentlyContinue } else { "" }
+            throw "Devserver MCP mode (no --solution-dir) did not appear in 'uno-devserver list' output after $MaxAttempts attempts.`nSTDOUT:`n$stdoutLog`nSTDERR:`n$stderrLog"
+        }
+
+        Write-Log "Devserver MCP mode without --solution-dir registered successfully in 'uno-devserver list'"
+    }
+    finally {
+        Stop-DevserverProcessCapture -Context $processContext
+
+        if ($processContext) {
+            foreach ($logPath in @($processContext.StdoutLogPath, $processContext.StderrLogPath)) {
+                if ($logPath -and (Test-Path $logPath)) {
+                    Remove-Item $logPath -ErrorAction SilentlyContinue
+                }
+            }
+        }
+    }
+}
+
+function Test-CodexIntegration {
+    param([string]$SlnDir)
+
+    $CodexAPIKey = $env:CODEX_API_KEY
+    $isForkPr = $env:SYSTEM_PULLREQUEST_ISFORK -eq 'True'
+
+    if ($isForkPr) {
+        Write-Log "Forked pull request detected. Skipping Codex MCP integration test for security."
+        return
+    }
+    elseif ([string]::IsNullOrWhiteSpace($CodexAPIKey)) {
+        Write-Log "CODEX_API_KEY not provided. Skipping Codex MCP integration test."
+        return
+    }
+
+    Write-Log "CODEX_API_KEY detected. Starting Codex MCP integration test."
+    if (Ensure-CodexCli) {
+        Register-UnoCodexMcps -WorkingDirectory $SlnDir
+        Invoke-CodexToolEnumerationTest -WorkingDirectory $SlnDir
+    }
+    else {
+        throw "Codex CLI unavailable after installation attempt."
+    }
+}
+
 try {
     cd $env:BUILD_SOURCESDIRECTORY/src/SolutionTemplate
     & $env:BUILD_SOURCESDIRECTORY/build/test-scripts/update-uno-sdk-globaljson.ps1
 
     Write-Log "Starting devserver CLI test"
 
-    Write-Log "Installing devserver CLI tool: uno.devserver";
-    dotnet tool install uno.devserver --version $env:NBGV_SemVer2
+    if (-not $script:DevServerCliUsesDllPath) {
+        Write-Log "Installing devserver CLI tool: uno.devserver"
+        dotnet tool install uno.devserver --version $env:NBGV_SemVer2
+    }
+    else {
+        Write-Log "Using provided devserver CLI at $script:DevServerCliResolvedDllPath. Skipping tool installation."
+    }
 
     # Use the project path (project directory) so we can look for the .csproj.user file
     $csprojPath = "$env:BUILD_SOURCESDIRECTORY/src/SolutionTemplate/5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj"
@@ -360,93 +720,13 @@ try {
     # Force a restore to prime the dependencies
     & dotnet restore
 
-    # Default port
     $defaultPort = 5042
-    $port = $defaultPort
+    $maxAttempts = 30
 
-    # Start the devserver in the current directory
-    & dotnet uno-devserver start --httpPort $port -l trace
-
-    # Look for a .csproj.user file next to the project file (e.g. 'uno56netcurrent.csproj.user')
-    $csprojUserPath = Join-Path $csprojDir ((Split-Path $csprojPath -Leaf) + '.user')
-
-    $userPort = Get-PortFromCsprojUser -UserFilePath $csprojUserPath
-    if ($userPort) {
-        Write-Log "Port extracted from .csproj.user (UnoRemoteControlPort): $userPort"
-
-        if ($userPort -lt 1 -or $userPort -gt 65535) {
-            throw "Port number in $csprojUserPath is out of range: $userPort"
-        }
-
-        $port = $userPort
-    }
-    else {
-        if (Test-Path $csprojUserPath) {
-            throw "Could not find a valid UnoRemoteControlPort in $csprojUserPath"
-        }
-        else {
-            Write-Log "No .csproj.user file found. Using default port $defaultPort"
-        }
-    }
-
-    $maxAttempts=30
-
-    # Validate that the HTTP port is open by attempting to connect to it with a TCP client.
-    $success = Wait-ForHttpPortOpen -Port $port -Path '/' -MaxAttempts $maxAttempts -ConnectTimeoutMs 2000
-
-    if (-not $success) {
-        throw "Devserver did not open HTTP port $port after $maxAttempts attempts."
-    }
-
-    Write-Log "Devserver HTTP port $port is open at $DevServerBaseUrl"
-
-    & dotnet uno-devserver stop -l trace
-
-    Write-Log "Validating --solution-dir support from outside the solution root"
-
-    $solutionDirTestPort = if ($port -ge 65535) { $defaultPort + 1 } else { $port + 1 }
-    $outerDirectory = Split-Path $slnDir -Parent
-    if ([string]::IsNullOrWhiteSpace($outerDirectory)) {
-        $outerDirectory = [System.IO.Path]::GetTempPath()
-    }
-
-    Push-Location $outerDirectory
-    try {
-        & dotnet uno-devserver start --solution-dir $slnDir --httpPort $solutionDirTestPort -l trace
-
-        $solutionDirSuccess = Wait-ForHttpPortOpen -Port $solutionDirTestPort -Path '/' -MaxAttempts $maxAttempts -ConnectTimeoutMs 2000
-        if (-not $solutionDirSuccess) {
-            throw "Devserver did not open HTTP port $solutionDirTestPort via --solution-dir after $maxAttempts attempts."
-        }
-
-        Write-Log "Devserver started successfully using --solution-dir at $DevServerBaseUrl"
-
-        & dotnet uno-devserver stop --solution-dir $slnDir -l trace
-    }
-    finally {
-        Pop-Location
-        Set-Location $slnDir
-    }
-
-    $CodexAPIKey = $env:CODEX_API_KEY
-    $isForkPr = $env:SYSTEM_PULLREQUEST_ISFORK -eq 'True'
-
-    if ($isForkPr) {
-        Write-Log "Forked pull request detected. Skipping Codex MCP integration test for security."
-    }
-    elseif ([string]::IsNullOrWhiteSpace($CodexAPIKey)) {
-        Write-Log "CODEX_API_KEY not provided. Skipping Codex MCP integration test."
-    }
-    else {
-        Write-Log "CODEX_API_KEY detected. Starting Codex MCP integration test."
-        if (Ensure-CodexCli) {
-            Register-UnoCodexMcps -WorkingDirectory $slnDir
-            Invoke-CodexToolEnumerationTest -WorkingDirectory $slnDir
-        }
-        else {
-            throw "Codex CLI unavailable after installation attempt."
-        }
-    }
+    $primaryPort = Test-DevserverStartStop -SlnDir $slnDir -CsprojDir $csprojDir -CsprojPath $csprojPath -DefaultPort $defaultPort -MaxAttempts $maxAttempts
+    $solutionDirTestPort = Test-DevserverSolutionDirSupport -SlnDir $slnDir -DefaultPort $defaultPort -BaselinePort $primaryPort -MaxAttempts $maxAttempts
+    Test-McpModeWithoutSolutionDir -SlnDir $slnDir -DefaultPort $defaultPort -PrimaryPort $primaryPort -SolutionDirPort $solutionDirTestPort -MaxAttempts $maxAttempts
+    Test-CodexIntegration -SlnDir $slnDir
 
     exit 0
 }

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -61,14 +61,14 @@ internal class CliManager
 				return 1; // errors already logged
 			}
 
-			var isDirectOutputCommand = originalArgs.Length > 0 && (
+			var requiresHostOutputPassthrough = originalArgs.Length > 0 && (
 				string.Equals(originalArgs[0], "list", StringComparison.OrdinalIgnoreCase) ||
 				string.Equals(originalArgs[0], "cleanup", StringComparison.OrdinalIgnoreCase)
 			);
 
-			var startInfo = BuildHostArgs(hostPath, originalArgs, workingDirectory, redirectOutput: !isDirectOutputCommand);
+			var startInfo = BuildHostArgs(hostPath, originalArgs, workingDirectory, redirectOutput: true);
 
-			var result = await DevServerProcessHelper.RunConsoleProcessAsync(startInfo, _logger);
+			var result = await DevServerProcessHelper.RunConsoleProcessAsync(startInfo, _logger, forwardOutputToConsole: requiresHostOutputPassthrough);
 			return result.ExitCode;
 		}
 		catch (Exception ex)

--- a/src/Uno.UI.DevServer.Cli/Mcp/McpProxy.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/McpProxy.cs
@@ -92,12 +92,9 @@ internal class McpProxy
 	[Description("This tool MUST be called before other uno app tools to initialize properly")]
 	private async Task SetRoots([Description("Fully qualified root folder path for the workspace")] string[] roots)
 	{
-		if (!IsToolCacheEnabled)
-		{
-			return;
-		}
-
-		_roots = roots;
+		var normalizedRoots = roots ?? Array.Empty<string>();
+		_logger.LogTrace("SetRoots invoked with {Count} roots: {Roots}", normalizedRoots.Length, string.Join(", ", normalizedRoots));
+		_roots = normalizedRoots;
 
 		await ProcessRoots();
 	}
@@ -115,7 +112,7 @@ internal class McpProxy
 
 	private async Task ProcessRoots()
 	{
-		_logger.LogTrace("MCP Client Roots: {Roots}", string.Join(", ", _roots));
+		_logger.LogTrace("Processing MCP Client Roots: {Roots}", string.Join(", ", _roots));
 
 		if (_devServerStarted)
 		{
@@ -128,7 +125,12 @@ internal class McpProxy
 			var rootPath = GetRootPath(rootUri);
 			if (!string.IsNullOrWhiteSpace(rootPath))
 			{
+				_logger.LogTrace("Resolved MCP root '{RootUri}' into path '{RootPath}'", rootUri, rootPath);
 				StartDevServerMonitor(rootPath);
+			}
+			else
+			{
+				_logger.LogWarning("Unable to resolve MCP root '{RootUri}' to a local path", rootUri);
 			}
 		}
 		else if (!_forceRootsFallback)
@@ -139,6 +141,8 @@ internal class McpProxy
 
 	private string? GetRootPath(string rootUri)
 	{
+		_logger.LogTrace("Attempting to resolve root URI '{RootUri}' using current directory '{CurrentDirectory}'", rootUri, _currentDirectory);
+
 		if (Uri.TryCreate(rootUri, UriKind.Absolute, out var absoluteUri) && absoluteUri.IsFile)
 		{
 			var normalizedPath = NormalizeLocalFilePath(absoluteUri.LocalPath);
@@ -183,22 +187,30 @@ internal class McpProxy
 	}
 
 	private void EnsureDevServerStartedFromSolutionDirectory()
-		=> EnsureDevServerStartedFromSolutionDirectory(_forceGenerateToolCache, _solutionDirectory);
-
-	internal void EnsureDevServerStartedFromSolutionDirectory(bool forceGenerateToolCache, string? solutionDirectory)
 	{
-		if (!forceGenerateToolCache || string.IsNullOrWhiteSpace(solutionDirectory))
+		var directory = string.IsNullOrWhiteSpace(_solutionDirectory)
+			? _currentDirectory
+			: _solutionDirectory;
+
+		_logger.LogTrace(
+			"EnsureDevServerStartedFromSolutionDirectory (solutionDir: {SolutionDir}, currentDir: {CurrentDir})",
+			_solutionDirectory,
+			_currentDirectory);
+
+		if (string.IsNullOrWhiteSpace(directory))
 		{
+			_logger.LogTrace("No directory available to start the DevServer monitor; skipping initial start");
 			return;
 		}
 
-		StartDevServerMonitor(solutionDirectory);
+		StartDevServerMonitor(directory);
 	}
 
-	protected virtual void StartDevServerMonitor(string? directory)
+	private void StartDevServerMonitor(string? directory)
 	{
 		if (_devServerStarted)
 		{
+			_logger.LogTrace("StartDevServerMonitor called but monitor already running");
 			return;
 		}
 
@@ -215,6 +227,7 @@ internal class McpProxy
 		{
 			_devServerMonitor.StartMonitoring(normalized, _devServerPort, _forwardedArgs);
 			_devServerStarted = true;
+			_logger.LogTrace("DevServer monitor started for {Directory} (port: {Port}, forwardedArgs: {Args})", normalized, _devServerPort, string.Join(" ", _forwardedArgs));
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Fixes incorrect startup from current working directory, following the addition of `--solution-dir`.