### PR TITLE
fix(iOS): FileOpenPicker not returning video files

### DIFF
--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.iOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.iOS.cs
@@ -100,9 +100,9 @@ namespace Windows.Storage.Pickers
 
 				case PickerLocationId.PicturesLibrary when multiple is true && iOS14AndAbove is true:
 					var hasImages = FileTypeFilter.Count == 0 || FileTypeFilter.Contains("*") ||
-					                FilterHasImage(FileTypeFilter);
+					FilterHasImage(FileTypeFilter);
 					var hasVideos = FileTypeFilter.Count == 0 || FileTypeFilter.Contains("*") ||
-					                FilterHasVideo(FileTypeFilter);
+					FilterHasVideo(FileTypeFilter);
 
 					PHPickerFilter? pickerFilter = null;
 					if (hasImages && hasVideos)
@@ -123,7 +123,8 @@ namespace Windows.Storage.Pickers
 
 					var imageConfiguration = new PHPickerConfiguration
 					{
-						Filter = pickerFilter, SelectionLimit = limit
+						Filter = pickerFilter,
+						SelectionLimit = limit
 					};
 					return new PHPickerViewController(imageConfiguration)
 					{
@@ -200,12 +201,12 @@ namespace Windows.Storage.Pickers
 			{
 				NSUrl? nSUrl = null;
 
-				//Video URL
+				// Video URL
 				if (info.ValueForKey(new NSString("UIImagePickerControllerMediaURL")) is NSUrl videoUrl)
 				{
 					nSUrl = videoUrl;
 				}
-				//Image URL
+				// Image URL
 				else if (info.ValueForKey(new NSString("UIImagePickerControllerImageURL")) is NSUrl imageUrl)
 				{
 					nSUrl = imageUrl;


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/ziidms-private/issues/106

Previously only checked for image URLs, causing video selections to return null.


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->