### PR TITLE
fix(x11): avoid harfbuzz crashes after a WebView is loaded

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.Generic/Properties/launchSettings.json
+++ b/src/SamplesApp/SamplesApp.Skia.Generic/Properties/launchSettings.json
@@ -4,6 +4,7 @@
 			"commandName": "Project",
 			"nativeDebugging": false,
 			"environmentVariables": {
+				"GDK_BACKEND": "x11",
 				//"UNO_DISPLAY_SCALE_OVERRIDE": "2"
 				//"COREHOST_TRACE": "1",
 				//"COREHOST_TRACE_VERBOSITY": "4"

--- a/src/Uno.UI.Runtime.Skia.X11/Builder/X11HostBuilder.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Builder/X11HostBuilder.cs
@@ -12,6 +12,7 @@ public partial class X11HostBuilder : IPlatformHostBuilder
 
 	private int _renderFrameRate = 60;
 	private bool _preloadMediaPlayer;
+	private bool _useSystemHarfBuzz;
 
 	internal X11HostBuilder()
 	{
@@ -32,11 +33,20 @@ public partial class X11HostBuilder : IPlatformHostBuilder
 		return this;
 	}
 
+	/// <summary>
+	/// Uses the system HarfBuzz library for text shaping instead of libHarfBuzzSharp shipped with SkiaSharp.
+	/// </summary>
+	public X11HostBuilder UseSystemHarfBuzz(bool value)
+	{
+		_useSystemHarfBuzz = value;
+		return this;
+	}
+
 	bool IPlatformHostBuilder.IsSupported
 		=> OperatingSystem.IsLinux() &&
 			Environment.GetEnvironmentVariable("DISPLAY") is { } displayString &&
 			DisplayRegex().Match(displayString).Success;
 
 	UnoPlatformHost IPlatformHostBuilder.Create(Func<Microsoft.UI.Xaml.Application> appBuilder, Type appType)
-		=> new X11ApplicationHost(appBuilder, _renderFrameRate, preloadVlc: _preloadMediaPlayer);
+		=> new X11ApplicationHost(appBuilder, _renderFrameRate, _preloadMediaPlayer, _useSystemHarfBuzz);
 }

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
@@ -157,7 +157,7 @@ public partial class X11ApplicationHost : SkiaHost, ISkiaApplicationHost, IDispo
 
 				if (!success)
 				{
-					throw new FileNotFoundException($"Could not find libHarfBuzzSharp.so in NATIVE_DLL_SEARCH_DIRECTORIES. Searched directories: {search}");
+					throw new FileNotFoundException($"Could not find libHarfBuzzSharp.so in the configured native DLL search directories. Searched directories: {search}");
 				}
 			}
 			catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
@@ -157,7 +157,7 @@ public partial class X11ApplicationHost : SkiaHost, ISkiaApplicationHost, IDispo
 
 				if (!success)
 				{
-					throw new FileNotFoundException("Could not find libHarfBuzzSharp.so in NATIVE_DLL_SEARCH_DIRECTORIES.");
+					throw new FileNotFoundException($"Could not find libHarfBuzzSharp.so in NATIVE_DLL_SEARCH_DIRECTORIES. Searched directories: {search}");
 				}
 			}
 			catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
@@ -35,27 +35,6 @@ public partial class X11ApplicationHost : SkiaHost, ISkiaApplicationHost, IDispo
 
 	static X11ApplicationHost()
 	{
-		NativeLibrary.SetDllImportResolver(typeof(HarfBuzzSharp.Direction).Assembly, HarfBuzzResolver);
-		// libHarfBuzzSharp is, at the time of writing, practically identical to libharfbuzz.so.0 that ships with
-		// most Linux environments and, unlike libSkiaSharp, does not have any extra helper functions to help with marshalling, etc.
-		// Therefore, we prefer to use the system-wide libharfbuzz.so.0 if it exists over libHarfBuzzSharp.so. This avoids
-		// symbol clashes when other dependencies also depend on harfbuzz. Concretely, when a WebView is loaded,
-		// it loads libgtk-3 which in turn depends on libharfbuzz.so.0. Afterward, we can get crashes when SkiaSharp
-		// makes a HarfBuzz call to symbols that were first resolved by libgtk-3 to be in libharfbuzz.so.0. In this scenario,
-		// the call starts in libHarfBuzzSharp.so but then jumps to symbols in libharfbuzz.so.0 (the symbols are also in
-		// libHarfBuzzSharp.so, but libharfbuzz.so.0 resolved them first).
-		static IntPtr HarfBuzzResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
-		{
-			if (libraryName == "libHarfBuzzSharp" && NativeLibrary.TryLoad("libharfbuzz.so.0", assembly, searchPath, out var lib))
-			{
-				return lib;
-			}
-			else
-			{
-				return IntPtr.Zero;
-			}
-		}
-
 		// This seems to be necessary to run on WSL, but not necessary on the X.org implementation.
 		// We therefore wrap every x11 call with XLockDisplay and XUnlockDisplay
 		_ = X11Helper.XInitThreads();
@@ -125,7 +104,68 @@ public partial class X11ApplicationHost : SkiaHost, ISkiaApplicationHost, IDispo
 	}
 
 	public X11ApplicationHost(Func<Application> appBuilder, int renderFrameRate = 60, bool preloadVlc = false)
+		: this(appBuilder, renderFrameRate, preloadVlc, useSystemHarfBuzz: false)
 	{
+	}
+
+	public X11ApplicationHost(Func<Application> appBuilder, int renderFrameRate = 60, bool preloadVlc = false, bool useSystemHarfBuzz = false)
+	{
+		// libHarfBuzzSharp is, at the time of writing, almost but not exactly identical to libharfbuzz.so.0 that ships with
+		// most Linux environments and, unlike libSkiaSharp, does not have any extra helper functions to help with marshalling, etc.
+		// However, we need to avoid symbol clashes when other dependencies also depend on harfbuzz. Concretely, when a
+		// WebView is loaded, it loads libgtk-3 which in turn depends on libharfbuzz.so.0. Afterward, we can get crashes
+		// when SkiaSharp makes a HarfBuzz call to symbols that were first resolved by libgtk-3 to be in libharfbuzz.so.0.
+		// In this scenario, the call starts in libHarfBuzzSharp.so but then jumps to symbols in libharfbuzz.so.0
+		// (the symbols are also in libHarfBuzzSharp.so, but libharfbuzz.so.0 resolved them first).
+		if (useSystemHarfBuzz)
+		{
+			// We can choose to ignore libHarfBuzzSharp entirely by redirecting all calls to libharfbuzz.so.0.
+			NativeLibrary.SetDllImportResolver(typeof(HarfBuzzSharp.Direction).Assembly, HarfBuzzResolver);
+			static IntPtr HarfBuzzResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+			{
+				if (libraryName == "libHarfBuzzSharp" && NativeLibrary.TryLoad("libharfbuzz.so.0", assembly, searchPath, out var lib))
+				{
+					return lib;
+				}
+				else
+				{
+					return IntPtr.Zero;
+				}
+			}
+		}
+		else
+		{
+			// Alternatively, we can preload libHarfBuzzSharp with RTLD_DEEPBIND to ensure its symbols are used
+			try
+			{
+				var search = AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")?.ToString() ?? "";
+
+				var success = false;
+				foreach (var path in search.Split(Path.PathSeparator))
+				{
+					var libPath = Path.Combine(path, "libHarfBuzzSharp.so");
+
+					if (File.Exists(libPath))
+					{
+						if (LibDl.dlopen(libPath, false) != IntPtr.Zero)
+						{
+							success = true;
+							break;
+						}
+					}
+				}
+
+				if (!success)
+				{
+					throw new FileNotFoundException("Could not find libHarfBuzzSharp.so in NATIVE_DLL_SEARCH_DIRECTORIES.");
+				}
+			}
+			catch (Exception ex)
+			{
+				typeof(X11ApplicationHost).LogError()?.Error($"Could not preload HarfBuzz with RTLD_DEEPBIND: {ex.Message}");
+			}
+		}
+
 		if (preloadVlc && Type.GetType("Uno.UI.MediaPlayer.Skia.X11.SharedMediaPlayerExtension, Uno.UI.MediaPlayer.Skia.X11") is { } mediaExtensionType)
 		{
 			mediaExtensionType.GetMethod("PreloadVlc", BindingFlags.Static | BindingFlags.Public)?.Invoke(null, null);


### PR DESCRIPTION
Scenario:
1. Open an Uno app on Linux (XWayland vs X11 shouldn't matter here)
2. Make sure not to include any Arabic text in any pages you open
3. Open any page with a WebView2 in it
4. Open any page with Arabic text (in a TextBox/TextBlock) in it.
5. Watch it segfault.

After some investigations, the segfault turned out to be in this HarfBuzz call to `AddUtf16`.
```csharp
		using var buffer = new Buffer();
		buffer.AddUtf16(textRun);
```

To get symbols from libHarfBuzzSharp, the latest (at the time of writing) preview version of HarfBuzzSharp is needed, which is 8.3.1.3-preview.1. Earlier versions have the symbols stripped out.

After moving to that version and moving SkiaSharp to the corresponding 3.119.2-preview.1 version, GDB spit out this stack trace:
```
#0  0x00007feba3678d30 in ??? ()
#1  0x00007feb8c35aaab in hb_face_reference_table () at /lib/x86_64-linux-gnu/libharfbuzz.so.0
#2  0x00007feb8c3ad3ab in ??? () at /lib/x86_64-linux-gnu/libharfbuzz.so.0
#3  0x00007feb8c39ece3 in ??? () at /lib/x86_64-linux-gnu/libharfbuzz.so.0
#4  0x00007feb8c39ff00 in hb_ot_layout_language_find_feature () at /lib/x86_64-linux-gnu/libharfbuzz.so.0
#5  0x00007feb7d4441a3 in collect_features_arabic(hb_ot_shape_planner_t*) ()
    at /home/ramez/Downloads/uno/src/SamplesApp/SamplesApp.Skia.Generic/bin/Debug/net10.0/runtimes/linux-x64/native/libHarfBuzzSharp.so
#6  0x00007feb7d43e7bc in hb_ot_shape_plan_t::init0(hb_face_t*, hb_shape_plan_key_t const*) ()
    at /home/ramez/Downloads/uno/src/SamplesApp/SamplesApp.Skia.Generic/bin/Debug/net10.0/runtimes/linux-x64/native/libHarfBuzzSharp.so
#7  0x00007feb7d452137 in hb_shape_plan_create2 ()
    at /home/ramez/Downloads/uno/src/SamplesApp/SamplesApp.Skia.Generic/bin/Debug/net10.0/runtimes/linux-x64/native/libHarfBuzzSharp.so
#8  0x00007feb7d452630 in hb_shape_plan_create_cached2 ()
    at /home/ramez/Downloads/uno/src/SamplesApp/SamplesApp.Skia.Generic/bin/Debug/net10.0/runtimes/linux-x64/native/libHarfBuzzSharp.so
#9  0x00007feb7d4528c7 in hb_shape_full ()
    at /home/ramez/Downloads/uno/src/SamplesApp/SamplesApp.Skia.Generic/bin/Debug/net10.0/runtimes/linux-x64/native/libHarfBuzzSharp.so
#10 0x00007fff7de54afc in ??? ()
#11 0x00007febffa28b88 in ??? ()
#12 0x00007febffa28b68 in ??? ()
#13 0x00007febffa276d8 in ??? ()
#14 0x00007fff7d0723d8 in ??? ()
#15 0x0000000000000001 in ??? ()
#16 0x00007febbd9fdd30 in ??? ()
#17 0x00007fff7bb4f7d0 in ??? ()
#18 0x00007febbd9f44d0 in ??? ()
#19 0x00007fff7de54afc in ??? ()
#20 0x00007febbd9f4560 in ??? ()
#21 0x00007fff7de547ae in ??? ()
#22 0x00007febbd9f4560 in ??? ()
```

The relevant part is this:
```
#4  0x00007feb8c39ff00 in hb_ot_layout_language_find_feature () at /lib/x86_64-linux-gnu/libharfbuzz.so.0
#5  0x00007feb7d4441a3 in collect_features_arabic(hb_ot_shape_planner_t*) ()
    at /home/ramez/Downloads/uno/src/SamplesApp/SamplesApp.Skia.Generic/bin/Debug/net10.0/runtimes/linux-x64/native/libHarfBuzzSharp.so
```
Note how `collect_features_arabic` in libHarfBuzzSharp.so suddenly jumps to `hb_ot_layout_language_find_feature` in the libharfbuzz provided by the system (libharfbuzz.so.0) instead of staying within libHarfBuzzSharp.so, which has the symbol. This indicates that at some point when loading WebView2 (which we implement using GTk and WebKit2GTK) makes a call to `collect_features_arabic`. Apparently, further symbol lookups to `collect_features_arabic` by HarfBuzzSharp are now resolved to the one is libharfbuzz.so.0 and not the one in libHarfBuzzSharp.so. Further checks with `LD_DEBUG` and `lld` confirm this hypothesis.

Interestingly, if we try to replicate the same scenario out of dotnet, using libdl instead of P/Invoke, this fails to replicate:

```c
// libA.c -> libA.so
// char* func_call_level2(void) { return "libA"; }
// char* func_call_level1(void) { return func_call_level2(); }

// libB.c -> libA.so
// char* func_call_level2(void) { return "libB"; }
// char* func_call_level1(void) { return func_call_level2(); }

// libLinkedToB.c -lB -> libLinkedToB.so
// char* func_call_level1(void);
// char* func_call_level0(void) { return func_call_level1(); }

// $ ldd libLinkedToB.so libA.so libB.so
// libLinkedToB.so:
//         linux-vdso.so.1 (0x00007f38a55d9000)
//         libB.so => ./libB.so (0x00007f38a55c9000)
// libA.so:
//         statically linked
// libB.so:
//         statically linked


#include <stdio.h>
#include <dlfcn.h>

typedef char* (*my_func_t)(void);

int main(void) {
    char *error;

    void *libA = dlopen("./libA.so", RTLD_LAZY);
    void *libLinkedToB = dlopen("./libLinkedToB.so", RTLD_LAZY);
    printf("func_call_level0 from libLinkedToB returned %s\n", ((my_func_t)dlsym(libLinkedToB, "func_call_level0"))());
    printf("func_call_level1 from libA returned %s\n", ((my_func_t)dlsym(libA, "func_call_level1"))());
    return 0;
}
```

```c
$ LD_LIBRARY_PATH=. ./main 
func_call_level0 from libLinkedToB returned libB
func_call_level1 from libA returned libA
```


Now, there's the question of why `libHarfBuzzSharp.so` even exists. When diffing the symbols with `nm` between `libharfbuzz.so.0` and `libHarfBuzzSharp.so`, the two are practically identical, barring the fact the two aren't based on the same version of the HarfBuzz sources, so there are a few discrepancies, but for the purposes of P/Invoking from dotnet, they're just as good.

This leaves us with (at least) two choices:
1. Load _all_ symbols from libHarfBuzzSharp.so early on, so they "win" over the ones from libharfbuzz.so.0. We used to do something similar way back when we had a GTK backend. This seems to work, but there's the concern of a similar crash due to the same reason of symbols clashing, but in GTK instead (this team, symbols intended to be read from libharfbuzz.so.0 would be read from libHarfBuzzSharp.so). This doesn't seem to happen in my testing, but remains a concern.

2. Since libHarfBuzzSharp.so doesn't seem to be offering anything special over the system-provided libharfbuzz.so.0, we can rig P/Invoke's symbol lookup to go to libharfbuzz.so.0 instead of libHarfBuzzSharp.so whenever it's looking for a symbol in "libHarfBuzzSharp". This also works.

After discussions, we decided to default to the former solution and put the later under an option in `X11HostBuilder`.