### PR TITLE
ci: fix ci build error

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Uno.Extensions;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.Toolkit.DevTools.Input;
 using static Private.Infrastructure.TestServices;
@@ -404,7 +405,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			var it = rv.InteractionTracker ?? throw new InvalidOperationException("InteractionTracker");
 
 			var lv = setup.Content as ListView ?? throw new InvalidOperationException("ListView");
-			var sv = lv.FindFirstChild<ScrollViewer>() ?? throw new InvalidOperationException("ScrollViewer");
+			var sv = lv.FindFirstDescendant<ScrollViewer>() ?? throw new InvalidOperationException("ScrollViewer");
 			var presenter = sv.Content as ItemsPresenter ?? throw new InvalidOperationException("ItemsPresenter");
 
 			// Make sure to abort any pending direct manip


### PR DESCRIPTION
**GitHub Issue:** n/a

## PR Type: 🏗️ Build or CI related changes

## What is the current behavior? 🤔
native skia build fails with:
```
/Users/runner/work/1/s/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs(407,16): 
error CS1061: 'ListView' does not contain a definition for 'FindFirstChild' and no accessible extension method 'FindFirstChild' accepting a first argument of type 'ListView' could be found (are you missing a using directive or an assembly reference?) 
[/Users/runner/work/1/s/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.netcoremobile.csproj::TargetFramework=net9.0-ios18.0]
```

## What is the new behavior? 🚀
^no more

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
regression from: #22392