### PR TITLE
fix(ci): Stabilize iOS builds on macOS-15

### DIFF
--- a/build/test-scripts/ios-uitest-build.sh
+++ b/build/test-scripts/ios-uitest-build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.netcoremobile
 
-dotnet build -f net9.0-ios -c Release -p:UnoTargetFrameworkOverride=net9.0-ios /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/logs/ios-netcoremobile-sampleapp.binlog
+dotnet build -f net9.0-ios -c Release -p:UnoTargetFrameworkOverride=net9.0-ios -p:ValidateXcodeVersion=false /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/logs/ios-netcoremobile-sampleapp.binlog

--- a/build/test-scripts/skia-ios-uitest-build.sh
+++ b/build/test-scripts/skia-ios-uitest-build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Skia.netcoremobile
 
-dotnet build -f net9.0-ios18.0 -c Release -p:UnoTargetFrameworkOverride=net9.0-ios18.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog
+dotnet build -f net9.0-ios18.0 -c Release -p:UnoTargetFrameworkOverride=net9.0-ios18.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true -p:ValidateXcodeVersion=false /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog


### PR DESCRIPTION
## Changes

More adjustments after  https://github.com/unoplatform/uno/pull/22504

- Disable strict Xcode version validation for iOS SamplesApp builds.
## Why

macOS‑15 runners ship Xcode 26.2, which fails strict .NET iOS validation and has removed older runtimes, causing the SamplesApp build to fail.
 
 ### Ref
 
 - https://github.com/actions/runner-images/issues/13570