### PR TITLE
Add Uno TechBite video guide to documentation

### DIFF
--- a/doc/articles/get-started-ai-cursor.md
+++ b/doc/articles/get-started-ai-cursor.md
@@ -19,6 +19,10 @@ Install [Cursor](https://cursor.com/docs).
 
 There is nothing specific to set up for Cursor. You can proceed to the next section to create your first app and use the Uno MCPs.
 
+## Uno TechBite
+Getting Started with Uno Platform & Cursor IDE - Complete Setup Guide:
+<iframe width="560" height="315" src="https://www.youtube.com/embed/H-7WcTKAY3s?si=WXtHrE_W49HbDeNr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Next Steps
 
 Now that you are set up, let's [create your first app](xref:Uno.GettingStarted.CreateAnApp.AI.Cursor).

--- a/doc/articles/get-started-ai-cursor.md
+++ b/doc/articles/get-started-ai-cursor.md
@@ -21,6 +21,7 @@ There is nothing specific to set up for Cursor. You can proceed to the next sect
 
 ## Uno TechBite
 Getting Started with Uno Platform & Cursor IDE - Complete Setup Guide:
+
 > [!Video https://www.youtube-nocookie.com/embed/H-7WcTKAY3s]
 
 ## Next Steps

--- a/doc/articles/get-started-ai-cursor.md
+++ b/doc/articles/get-started-ai-cursor.md
@@ -21,7 +21,7 @@ There is nothing specific to set up for Cursor. You can proceed to the next sect
 
 ## Uno TechBite
 Getting Started with Uno Platform & Cursor IDE - Complete Setup Guide:
-[!Video https://www.youtube-nocookie.com/embed/H-7WcTKAY3s]
+> [!Video https://www.youtube-nocookie.com/embed/H-7WcTKAY3s]
 
 ## Next Steps
 

--- a/doc/articles/get-started-ai-cursor.md
+++ b/doc/articles/get-started-ai-cursor.md
@@ -21,7 +21,7 @@ There is nothing specific to set up for Cursor. You can proceed to the next sect
 
 ## Uno TechBite
 Getting Started with Uno Platform & Cursor IDE - Complete Setup Guide:
-<iframe width="560" height="315" src="https://www.youtube.com/embed/H-7WcTKAY3s?si=WXtHrE_W49HbDeNr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+[!Video https://www.youtube-nocookie.com/embed/H-7WcTKAY3s]
 
 ## Next Steps
 


### PR DESCRIPTION
Added a section for the Uno TechBite video guide on setting up the Uno Platform with Cursor IDE.

## PR Type:
- 📚 Documentation content changes

## What is the current behavior? 🤔
- Docs don't show video walkthrough

## What is the new behavior? 🚀
- Docs show embedded video

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ❗ Contains **NO** breaking changes

