### PR TITLE
Bump SamplesApp, adjust iOS Skia Runtime Tests and Android Native UI Tests

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -57,9 +57,9 @@ variables:
   linuxVMImage: 'ubuntu-24.04'
   linuxScaledPool: 'Ubuntu2404-20251016'
   macOSVMImage: 'macOS-15'
-  macOSVMImage_UITests: 'macOS-14'
-  xCodeRoot: '/Applications/Xcode_26.0.1.app'
-  xCodeRoot_iOS_UITests: '/Applications/Xcode_15.3.app'
+  macOSVMImage_UITests: 'macOS-15'
+  xCodeRoot: '/Applications/Xcode_26.2.app'
+  xCodeRoot_iOS_UITests: '/Applications/Xcode_26.2.app'
 
   # Offline validation to improve build performance
   NUGET_CERT_REVOCATION_MODE: offline

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -77,7 +77,8 @@ stages:
 
 - stage: packages_tests
   displayName: Tests - Templates
-  condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.TemplateTestsRequired'], 'true')))
+  # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - Setup
     - binaries_build_winui
@@ -104,7 +105,8 @@ stages:
 
 - stage: wasm_tests
   displayName: Tests - WebAssembly Native
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeWasm'], 'true')))
+  # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - Setup
 
@@ -129,7 +131,8 @@ stages:
 
 - stage: android_tests
   displayName: Tests - Android Native
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeAndroid'], 'true')))
+  # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - Setup
 
@@ -170,7 +173,8 @@ stages:
 - stage: test_finalization
   displayName: Tests - Screenshots
   # This stage only run screenshot comparison, which is not relevant for unit tests and also uap_tests.
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.ScreenshotsRequired'], 'true')))
+  # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - Setup
     - wasm_tests

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -144,7 +144,8 @@ stages:
 
 - stage: ios_tests
   displayName: Tests - iOS Native
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true')))
+  # TODO: Revert after verifying iOS CI fix - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - Setup
 

--- a/build/ci/publish/.azure-devops-publish-ios-testflight.yml
+++ b/build/ci/publish/.azure-devops-publish-ios-testflight.yml
@@ -6,7 +6,8 @@ parameters:
 jobs:
 - job: iOS_TestFlight
   displayName: 'Build Samples App - TestFlight'
-  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
+  # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+  condition: succeededOrFailed()
   cancelTimeoutInMinutes: 0
 
   strategy:

--- a/build/ci/publish/.azure-devops-publish-ios-testflight.yml
+++ b/build/ci/publish/.azure-devops-publish-ios-testflight.yml
@@ -62,7 +62,7 @@ jobs:
 
   - template: ../templates/dotnet-mobile-install-mac.yml
     parameters:
-      UnoCheckParameters: '--tfm net9.0-ios'
+      UnoCheckParameters: '--tfm net10.0-ios26.0'
 
   - template: ../templates/ios-build-select-version.yml
     parameters:
@@ -73,10 +73,10 @@ jobs:
   - bash: |
       cd $(_BuildFolder)
       dotnet publish \
-        -f net9.0-ios \
+        -f net10.0-ios26.0 \
         -c Release \
         -p:BuildForTestFlight=true \
-        -p:UnoTargetFrameworkOverride=net9.0-ios \
+        -p:UnoTargetFrameworkOverride=net10.0-ios26.0 \
         /bl:$(build.artifactstagingdirectory)/ios-netcoremobile-sampleapp-testflight.binlog
 
     displayName: Build for TestFlight
@@ -88,7 +88,7 @@ jobs:
 
   - task: CopyFiles@2
     inputs:
-      SourceFolder: $(_BuildFolder)/bin/Release/net9.0-ios/ios-arm64/publish
+      SourceFolder: $(_BuildFolder)/bin/Release/net10.0-ios26.0/ios-arm64/publish
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)/TestFlight
       CleanTargetFolder: false

--- a/build/ci/publish/.azure-devops-publish-ios-testflight.yml
+++ b/build/ci/publish/.azure-devops-publish-ios-testflight.yml
@@ -63,7 +63,7 @@ jobs:
 
   - template: ../templates/dotnet-mobile-install-mac.yml
     parameters:
-      UnoCheckParameters: '--tfm net10.0-ios26.0'
+      UnoCheckParameters: '--tfm net10.0-ios'
 
   - template: ../templates/ios-build-select-version.yml
     parameters:

--- a/build/ci/tests/.azure-devops-tests-ios-native.yml
+++ b/build/ci/tests/.azure-devops-tests-ios-native.yml
@@ -90,7 +90,7 @@ jobs:
 
   - task: CopyFiles@2
     inputs:
-      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.netcoremobile/bin/Release/net9.0-ios/iossimulator-x64/SamplesApp.app
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.netcoremobile/bin/Release/net10.0-ios26.0/iossimulator-x64/SamplesApp.app
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)/bin/SamplesApp.app
       CleanTargetFolder: false

--- a/build/ci/tests/.azure-devops-tests-ios-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-ios-skia-build.yml
@@ -56,7 +56,7 @@ jobs:
 
   - task: CopyFiles@2
     inputs:
-      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Skia.netcoremobile/bin/Release/net9.0-ios18.0/iossimulator-x64/SamplesApp.app
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Skia.netcoremobile/bin/Release/net10.0-ios26.0/iossimulator-x64/SamplesApp.app
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)/bin/SamplesApp.app
       CleanTargetFolder: false

--- a/build/ci/tests/.azure-devops-tests-linux-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-linux-skia.yml
@@ -26,7 +26,8 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmLinuxImage }}
 
-    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['SetScope.SkiaScreenshots'], 'true')))
+    # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+    condition: succeededOrFailed()
 
     variables:
       SamplesAppArtifactName: skia-generic-samples-app-WinUI

--- a/build/ci/tests/.azure-devops-tests-skia-stages.yml
+++ b/build/ci/tests/.azure-devops-tests-skia-stages.yml
@@ -96,6 +96,8 @@ stages:
 
 - stage: runtime_tests_skia_ios
   displayName: Tests - iOS Skia
+  # TODO: Revert after verifying iOS/macOS CI health - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - binaries_build_native_macos
 
@@ -172,6 +174,8 @@ stages:
 
 - stage: runtime_tests_skia_macos
   displayName: Tests - Desktop Skia macOS
+  # TODO: Revert after verifying iOS/macOS CI health - temporarily enabled for all builds
+  condition: succeededOrFailed()
   dependsOn:
     - Setup
     - runtime_tests_skia_build

--- a/build/ci/tests/.azure-devops-tests-webassembly-native.yml
+++ b/build/ci/tests/.azure-devops-tests-webassembly-native.yml
@@ -63,7 +63,8 @@ jobs:
   cancelTimeoutInMinutes: 0
   dependsOn:
   - Wasm_UITests_Build
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['SetScope.RequireNativeWasm'], 'true')))
+  # TODO: Revert after verifying PR CI coverage - temporarily enabled for all builds
+  condition: succeededOrFailed()
 
   container: nv-bionic-wasm
 

--- a/build/test-scripts/ios-uitest-build.sh
+++ b/build/test-scripts/ios-uitest-build.sh
@@ -1,7 +1,7 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.netcoremobile
 
-dotnet build -f net9.0-ios -c Release -p:UnoTargetFrameworkOverride=net9.0-ios /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/logs/ios-netcoremobile-sampleapp.binlog
+dotnet build -f net10.0-ios26.0 -c Release -p:UnoTargetFrameworkOverride=net10.0-ios26.0 /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/logs/ios-netcoremobile-sampleapp.binlog

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -127,6 +127,13 @@ fi
 echo "Current system date"
 date
 
+# Workaround for Xcode 26 simulator platform availability (see #13570).
+# Preload simulator runtimes and ensure iOS platform is downloaded.
+echo ""
+echo "=== Xcode Platform Warmup ==="
+xcrun simctl list >/dev/null 2>&1 || echo "Warning: simctl list failed during warmup"
+xcodebuild -downloadPlatform iOS -architectureVariant universal || echo "Warning: xcodebuild platform download failed"
+
 # Output the available simulator/runtime/device list
 echo ""
 echo "=== Simulator Configuration ==="

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -240,6 +240,11 @@ fi
 ##
 ## Pre-install the application to avoid https://github.com/microsoft/appcenter/issues/2389
 ##
+# Ensure a clean simulator to reduce transient XcodeService/socket bind failures.
+echo "Cleaning simulator state: [$UITEST_IOSDEVICE_ID]"
+xcrun simctl shutdown "$UITEST_IOSDEVICE_ID" || true
+xcrun simctl erase "$UITEST_IOSDEVICE_ID" || true
+
 echo "Starting simulator: [$UITEST_IOSDEVICE_ID] ($UNO_UITEST_SIMULATOR_VERSION / $UNO_UITEST_SIMULATOR_NAME)"
 xcrun simctl boot "$UITEST_IOSDEVICE_ID" || true
 

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -152,24 +152,27 @@ while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
 	ATTEMPT=$((ATTEMPT + 1))
 
 	# Try the specified device first
-	export UITEST_IOSDEVICE_ID=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$UNO_UITEST_SIMULATOR_NAME" '.devices[$sim] // [] | .[] | select(.name==$name) | .udid'`
+	# Cache simulator JSON once per attempt to avoid redundant xcrun calls
+	SIMCTL_JSON="$(xcrun simctl list -j)"
+
+	export UITEST_IOSDEVICE_ID=`echo "$SIMCTL_JSON" | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$UNO_UITEST_SIMULATOR_NAME" '.devices[$sim] // [] | .[] | select(.name==$name) | .udid'`
 	SELECTED_DEVICE="$UNO_UITEST_SIMULATOR_NAME"
 
 	# Fallback to any iPad Pro 13-inch
 	if [ -z "$UITEST_IOSDEVICE_ID" ]; then
-		FALLBACK_DEVICE=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" '.devices[$sim] // [] | .[].name' | grep -i "iPad Pro" | grep -i "13-inch" | head -1 || true`
+		FALLBACK_DEVICE=`echo "$SIMCTL_JSON" | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" '.devices[$sim] // [] | .[].name' | grep -i "iPad Pro" | grep -i "13-inch" | head -1 || true`
 		if [ -n "$FALLBACK_DEVICE" ]; then
 			SELECTED_DEVICE="$FALLBACK_DEVICE"
-			export UITEST_IOSDEVICE_ID=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$SELECTED_DEVICE" '.devices[$sim] // [] | .[] | select(.name==$name) | .udid'`
+			export UITEST_IOSDEVICE_ID=`echo "$SIMCTL_JSON" | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$SELECTED_DEVICE" '.devices[$sim] // [] | .[] | select(.name==$name) | .udid'`
 		fi
 	fi
 
 	# Fallback to any iPad Pro
 	if [ -z "$UITEST_IOSDEVICE_ID" ]; then
-		FALLBACK_DEVICE=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" '.devices[$sim] // [] | .[].name' | grep -i "iPad Pro" | head -1 || true`
+		FALLBACK_DEVICE=`echo "$SIMCTL_JSON" | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" '.devices[$sim] // [] | .[].name' | grep -i "iPad Pro" | head -1 || true`
 		if [ -n "$FALLBACK_DEVICE" ]; then
 			SELECTED_DEVICE="$FALLBACK_DEVICE"
-			export UITEST_IOSDEVICE_ID=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$SELECTED_DEVICE" '.devices[$sim] // [] | .[] | select(.name==$name) | .udid'`
+			export UITEST_IOSDEVICE_ID=`echo "$SIMCTL_JSON" | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$SELECTED_DEVICE" '.devices[$sim] // [] | .[] | select(.name==$name) | .udid'`
 		fi
 	fi
 

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -127,13 +127,6 @@ fi
 echo "Current system date"
 date
 
-# Workaround for Xcode 26 simulator platform availability (see #13570).
-# Preload simulator runtimes and ensure iOS platform is downloaded.
-echo ""
-echo "=== Xcode Platform Warmup ==="
-xcrun simctl list >/dev/null 2>&1 || echo "Warning: simctl list failed during warmup"
-xcodebuild -downloadPlatform iOS -architectureVariant universal || echo "Warning: xcodebuild platform download failed"
-
 # Output the available simulator/runtime/device list
 echo ""
 echo "=== Simulator Configuration ==="

--- a/build/test-scripts/skia-ios-uitest-build.sh
+++ b/build/test-scripts/skia-ios-uitest-build.sh
@@ -1,7 +1,7 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Skia.netcoremobile
 
-dotnet build -f net9.0-ios18.0 -c Release -p:UnoTargetFrameworkOverride=net9.0-ios18.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog
+dotnet build -f net10.0-ios26.0 -c Release -p:UnoTargetFrameworkOverride=net10.0-ios26.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog

--- a/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetSkiaPreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrent)</TargetFrameworks>
 		<RollForward>Major</RollForward>
 	</PropertyGroup>
-
 	<Import Project="../../targetframework-override-noplatform.props" />
 
 	<PropertyGroup>

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetMobilePreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrentNetCoreMobile)</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -22,7 +22,7 @@
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tvos'">tvossimulator-x64</RuntimeIdentifier>
 
 		<!-- Override RuntimeIdentifir specifically for smaller builds -->
-		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))!=''">$(UnoSampleAppRuntimeIdentifiers)</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(UnoSampleAppRuntimeIdentifiers)' != '' and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))!=''">$(UnoSampleAppRuntimeIdentifiers)</RuntimeIdentifier>
 
 		<InvariantGlobalization Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">true</InvariantGlobalization>
 
@@ -276,8 +276,7 @@
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="Uno.Resizetizer" />

--- a/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
+++ b/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetPrevious)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrent)</TargetFrameworks>
 	</PropertyGroup>
-
 	<Import Project="../../targetframework-override.props" />
 
 	<PropertyGroup>

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -285,7 +285,17 @@ namespace SamplesApp.UITests
 				{
 					lastError = ex;
 					Console.WriteLine($"Cold start attempt {attempt}/{maxAttempts} failed: {ex.Message}");
-					ResetSimulator();
+
+					// ResetSimulator internally calls ColdStartApp after erasing the sim.
+					// Wrap in try/catch so a failure inside reset doesn't abort the retry loop.
+					try
+					{
+						ResetSimulator();
+					}
+					catch (Exception resetEx)
+					{
+						Console.WriteLine($"Simulator reset failed: {resetEx.Message}");
+					}
 
 					if (attempt < maxAttempts)
 					{

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Devices.Input;
 using NUnit.Framework;
@@ -94,7 +95,8 @@ namespace SamplesApp.UITests
 			}
 			catch
 			{
-				ResetSimulator();
+				// ColdStartWithRetry already performs resets inside its retry loop for iOS.
+				// For non-iOS, ResetSimulator is a no-op. Avoid a redundant reset here.
 				throw;
 			}
 
@@ -284,7 +286,7 @@ namespace SamplesApp.UITests
 				catch (Exception ex)
 				{
 					lastError = ex;
-					Console.WriteLine($"Cold start attempt {attempt}/{maxAttempts} failed: {ex.Message}");
+					Console.WriteLine($"Cold start attempt {attempt}/{maxAttempts} failed: {ex}");
 
 					// ResetSimulator internally calls ColdStartApp after erasing the sim.
 					// Wrap in try/catch so a failure inside reset doesn't abort the retry loop.
@@ -294,12 +296,12 @@ namespace SamplesApp.UITests
 					}
 					catch (Exception resetEx)
 					{
-						Console.WriteLine($"Simulator reset failed: {resetEx.Message}");
+						Console.WriteLine($"Simulator reset failed: {resetEx}");
 					}
 
 					if (attempt < maxAttempts)
 					{
-						Task.Delay(retryDelay).Wait();
+						Thread.Sleep(retryDelay);
 					}
 				}
 			}

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- We keep TFM as NetPrevious to allow local build to work with "Previous" SDK -->
 		<!-- However, in CI, we run with "Current" SDK and so "Previous" .NET runtime may not be installed, so we set RollForward -->
-		<TargetFramework>$(NetPrevious)</TargetFramework>
+		<TargetFramework>$(NetCurrent)</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RollForward>Major</RollForward>
 
@@ -14,7 +14,6 @@
 		<!-- Use 'GeneratedRegexAttribute' to generate the regular expression -->
 		<NoWarn>$(NoWarn);SYSLIB1045;CS1998</NoWarn>
 	</PropertyGroup>
-
 	<ItemGroup Label="GlobalUsings">
 		<Using Include="AwesomeAssertions" />
 	</ItemGroup>

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<!-- We keep TFM as NetPrevious to allow local build to work with "Previous" SDK -->
-		<!-- However, in CI, we run with "Current" SDK and so "Previous" .NET runtime may not be installed, so we set RollForward -->
+		<!-- RollForward is set to Major so tests can run even if only a newer .NET runtime is available (e.g. in CI) -->
 		<TargetFramework>$(NetCurrent)</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<RollForward>Major</RollForward>

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" />
 		<PackageReference Include="Uno.Core.Extensions" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.0.0-rc" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>$(NetPreviousWinAppSDK)</TargetFramework>
+		<TargetFramework>$(NetCurrentWinAppSDK)</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>SamplesApp.Windows</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
@@ -21,6 +21,7 @@
 		<AppxAutoIncrementPackageRevision>false</AppxAutoIncrementPackageRevision>
 		<GenerateAppxPackageOnBuild>false</GenerateAppxPackageOnBuild>
 	</PropertyGroup>
+	<Import Project="../../targetframework-override.props" />
 
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -20,7 +20,7 @@
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
 
 		<!-- Override RuntimeIdentifir specifically for smaller builds -->
-		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))!=''">$(UnoSampleAppRuntimeIdentifiers)</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(UnoSampleAppRuntimeIdentifiers)' != '' and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))!=''">$(UnoSampleAppRuntimeIdentifiers)</RuntimeIdentifier>
 
 		<InvariantGlobalization Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tvos'">true</InvariantGlobalization>
 		<InvariantGlobalization Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">true</InvariantGlobalization>
@@ -238,7 +238,7 @@
 
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="Uno.Resizetizer" />

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetMobilePreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrentNetCoreMobile)</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -256,7 +256,8 @@
 		<ProjectReference Include="..\..\Uno.UI.Toolkit\Uno.UI.Toolkit.netcoremobile.csproj" />
 		<ProjectReference Include="..\..\AddIns\Uno.UI.Svg\Uno.UI.Svg.netcoremobile.csproj" />
 		<ProjectReference Include="..\..\AddIns\Uno.UI.Lottie\Uno.UI.Lottie.netcoremobile.csproj" />
-		<ProjectReference Include="..\..\Uno.UI.RuntimeTests\Uno.UI.RuntimeTests.netcoremobile.csproj" />
+		<!-- Exclude RuntimeTests from TestFlight builds to avoid trimmer IL20xx errors in release packaging. -->
+		<ProjectReference Include="..\..\Uno.UI.RuntimeTests\Uno.UI.RuntimeTests.netcoremobile.csproj" Condition="'$(BuildForTestFlight)'!='true'" />
 		<ProjectReference Include="..\..\Uno.UI.FluentTheme\Uno.UI.FluentTheme.netcoremobile.csproj" />
 		<ProjectReference Include="..\..\AddIns\Uno.UI.MSAL\Uno.UI.MSAL.netcoremobile.csproj" />
 		<ProjectReference Include="..\..\Uno.UI.Adapter.Microsoft.Extensions.Logging\Uno.UI.Adapter.Microsoft.Extensions.Logging.csproj" />

--- a/src/SamplesApp/UnoIslands.Skia.Wpf/UnoIslands.Skia.Wpf.csproj
+++ b/src/SamplesApp/UnoIslands.Skia.Wpf/UnoIslands.Skia.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetWpfPreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrentWpf)</TargetFrameworks>
 
 		<!--
 		Enable implicit dotnet runtime forward rolling, as a net5
@@ -10,7 +10,6 @@
 
 		<PreBuildUnoUITasks>true</PreBuildUnoUITasks>
 	</PropertyGroup>
-
 	<Import Project="../../targetframework-override-windows.props" />
 
 	<PropertyGroup>

--- a/src/SamplesApp/UnoIslands.Skia/UnoIslands.Skia.csproj
+++ b/src/SamplesApp/UnoIslands.Skia/UnoIslands.Skia.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetSkiaPreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrent)</TargetFrameworks>
 	</PropertyGroup>
-
 	<Import Project="../../targetframework-override.props" />
 
 	<PropertyGroup>

--- a/src/SamplesApp/UnoIslands.WinForms/UnoIslands.WinForms.csproj
+++ b/src/SamplesApp/UnoIslands.WinForms/UnoIslands.WinForms.csproj
@@ -2,10 +2,9 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>$(NetPreviousWpf)</TargetFramework>
+		<TargetFramework>$(NetCurrentWpf)</TargetFramework>
 		<Nullable>enable</Nullable>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
-
 </Project>

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/UnoIslandsSamplesApp.Skia.Wpf.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/UnoIslandsSamplesApp.Skia.Wpf.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetWpfPreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrentWpf)</TargetFrameworks>
 
 		<!--
 		Enable implicit dotnet runtime forward rolling, as the specifed target framework
@@ -15,7 +15,6 @@
 		<!-- Keep full exception strings in release -->
 		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 	</PropertyGroup>
-
 	<Import Project="../../targetframework-override-windows.props" />
 
 	<PropertyGroup>

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>$(NetSkiaPreviousAndCurrent)</TargetFrameworks>
+		<TargetFrameworks>$(NetCurrent)</TargetFrameworks>
 	</PropertyGroup>
-
 	<Import Project="../../targetframework-override.props" />
 
 	<PropertyGroup>

--- a/src/Uno.UI.Tests.ViewLibrary/Uno.UI.Tests.ViewLibrary.csproj
+++ b/src/Uno.UI.Tests.ViewLibrary/Uno.UI.Tests.ViewLibrary.csproj
@@ -21,8 +21,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 	</ItemGroup>
 
 

--- a/src/Uno.UI.Tests.ViewLibraryProps/Uno.UI.Tests.ViewLibraryProps.csproj
+++ b/src/Uno.UI.Tests.ViewLibraryProps/Uno.UI.Tests.ViewLibraryProps.csproj
@@ -21,8 +21,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 	</ItemGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
## Summary

Bump SamplesApp/UnoIslands targets to **net10** 
(Follow up changes after [uno/pull/22504](https://github.com/unoplatform/uno/pull/22504), [uno/pull/22521](https://github.com/unoplatform/uno/pull/22521#top). [uno/pull/22608](https://github.com/unoplatform/uno/pull/22608), [uno/pull/22636](https://github.com/unoplatform/uno/pull/22636#top), [uno/pull/22590](https://github.com/unoplatform/uno/pull/22590))
-  Update iOS/macOS CI tooling and simulator defaults
- Force iOS/macOS Skia stages on PRs **temporarily** to validate full CI validation