### PR TITLE
fix: block DataContext propagation into non-FrameworkElement properties

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -993,7 +993,9 @@ namespace Uno.UI
 			/// When false, restricts DataContext propagation to FrameworkElement instances only.
 			/// </summary>
 			[EditorBrowsable(EditorBrowsableState.Never)]
-			public static bool LegacyDataContextPropagation { get; set; } = true;
+			public static bool LegacyDataContextPropagation { get; set; } = false;
+			// ^ just turning this off for now, to check runtime test results with this settings
+			// todo@xy: restore value back to true
 		}
 
 		/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -986,6 +987,13 @@ namespace Uno.UI
 #else
 				global::System.Diagnostics.Debugger.IsAttached;
 #endif
+
+			/// <summary>
+			/// When true (default), DataContext propagates to all properties where the type implements IDependencyObjectStoreProvider.
+			/// When false, restricts DataContext propagation to FrameworkElement instances only.
+			/// </summary>
+			[EditorBrowsable(EditorBrowsableState.Never)]
+			public static bool LegacyDataContextPropagation { get; set; } = true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
**GitHub Issue:** re: #22610, re: unoplatform/add-private#44

## PR Type: 🐞 Bugfix


## What is the current behavior? 🤔
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior? 🚀
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->