### PR TITLE
fix: Ensure ASB popup overlaps header when opening upward

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -1066,6 +1066,79 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			});
 		}
 
+#if !WINAPPSDK // GetTemplateChild is protected in UWP while public in Uno.
+		[TestMethod]
+		[RequiresFullWindow]
+#if RUNTIME_NATIVE_AOT
+        [Ignore("TODO: figure out why this fails, how to fix")]
+#endif  // RUNTIME_NATIVE_AOT
+		public async Task When_Popup_Above_With_Header_Should_Overlap_Header()
+		{
+			var SUT = new AutoSuggestBox
+			{
+				Header = "Test Header",
+				VerticalAlignment = VerticalAlignment.Bottom
+			};
+
+			Button button = null;
+			try
+			{
+				button = new Button();
+				var rootGrid = new Grid();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					},
+					VerticalAlignment = VerticalAlignment.Bottom
+				};
+
+				SUT.ItemsSource = Enumerable.Range(0, 10).ToArray();
+				rootGrid.Children.Add(stack);
+				WindowHelper.WindowContent = rootGrid;
+				await WindowHelper.WaitForIdle();
+
+				var textBox = (TextBox)SUT.GetTemplateChild("TextBox");
+				var headerPresenter = textBox.GetTemplateChild("HeaderContentPresenter") as FrameworkElement;
+				Assert.IsNotNull(headerPresenter);
+				Assert.IsTrue(headerPresenter.ActualHeight > 0);
+
+				SUT.Focus(FocusState.Programmatic);
+				SUT.Text = "1";
+				await WindowHelper.WaitForIdle();
+
+				var popups = VisualTreeHelper.GetOpenPopupsForXamlRoot(SUT.XamlRoot);
+				Assert.AreEqual(1, popups.Count);
+				var popup = popups[0];
+
+				Assert.IsNotNull(popup.Child);
+				await WindowHelper.WaitFor(() => popup.Child.ActualSize.Y > 0);
+
+				// Get positions relative to window content
+				var popupChild = popup.Child as FrameworkElement;
+				var popupPoint = popupChild.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+				var popupBottom = popupPoint.Y + popupChild.ActualHeight;
+
+				var textBoxPoint = textBox.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+				var headerPoint = headerPresenter.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+
+				var gapBetweenPopupAndTextBox = textBoxPoint.Y - popupBottom;
+
+				Assert.IsTrue(
+					gapBetweenPopupAndTextBox < headerPresenter.ActualHeight / 2,
+					$"Popup should overlap header area. Gap: {gapBetweenPopupAndTextBox}px, Header height: {headerPresenter.ActualHeight}px. " +
+					$"PopupBottom: {popupBottom}, TextBoxTop: {textBoxPoint.Y}, HeaderTop: {headerPoint.Y}");
+			}
+			finally
+			{
+				button?.Focus(FocusState.Programmatic);
+				await WindowHelper.WaitForIdle();
+			}
+		}
+#endif
+
 		[TestMethod]
 		[RequiresFullWindow]
 		public async Task When_Popup_Below()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -1070,7 +1070,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RequiresFullWindow]
 #if RUNTIME_NATIVE_AOT
-        [Ignore("TODO: figure out why this fails, how to fix")]
+		[Ignore("TODO: figure out why this fails, how to fix")]
 #endif  // RUNTIME_NATIVE_AOT
 		public async Task When_Popup_Above_With_Header_Should_Overlap_Header()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -208,6 +208,17 @@ namespace Microsoft.UI.Xaml.Controls
 				popup.VerticalOffset = 0;
 				popup.HorizontalOffset = 0;
 
+				// Get header height to account for positioning when opening upward.
+				// The Header is rendered inside the TextBox template (via HeaderContentPresenter),
+				// so when positioning the popup above the control, we need to ensure the popup
+				// overlaps the header area to match WinUI behavior.
+				double headerHeight = 0;
+
+				if (_textBox?.GetTemplateChild("HeaderContentPresenter") is FrameworkElement headerPresenter)
+				{
+					headerHeight = headerPresenter.ActualHeight;
+				}
+
 				// Inject layouting constraints
 				popupChild.MinHeight = _layoutRoot.ActualHeight;
 				popupChild.MinWidth = _layoutRoot.ActualWidth;
@@ -273,7 +284,8 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 				else if (availableHeightAbove >= popupChild.DesiredSize.Height)
 				{
-					targetY = containerRect.Top - popupChild.DesiredSize.Height;
+					// Position popup so it overlaps header area like on WinUI
+					targetY = containerRect.Top + headerHeight - popupChild.DesiredSize.Height;
 				}
 				else if (availableHeightBelow > availableHeightAbove)
 				{
@@ -282,7 +294,8 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 				else
 				{
-					targetY = containerRect.Top - availableHeightAbove;
+					// Position popup so it overlaps header area like on WinUI
+					targetY = containerRect.Top + headerHeight - availableHeightAbove;
 					targetHeight = availableHeightAbove;
 				}
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/ziidms-private/issues/112

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
- 🐞 Bugfix

Fixes AutoSuggestBox popup positioning when a Header is set and the dropdown opens upward. Previously, the popup would stop above the header, leaving a visible gap. Now the popup correctly overlaps the header area to match WinUI behavior.


<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔
<img width="406" height="201" alt="image" src="https://github.com/user-attachments/assets/48138f55-bc9f-4e50-a8fc-a49656e0e64e" />

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀
<img width="436" height="205" alt="image" src="https://github.com/user-attachments/assets/4a9db2ca-fb00-4e1d-8487-f3a4046f520d" />

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->