### PR TITLE
Revert "fix(ci): Stabilize iOS builds on macOS-15"

### DIFF
--- a/build/test-scripts/ios-uitest-build.sh
+++ b/build/test-scripts/ios-uitest-build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.netcoremobile
 
-dotnet build -f net9.0-ios -c Release -p:UnoTargetFrameworkOverride=net9.0-ios -p:ValidateXcodeVersion=false /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/logs/ios-netcoremobile-sampleapp.binlog
+dotnet build -f net9.0-ios -c Release -p:UnoTargetFrameworkOverride=net9.0-ios /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/logs/ios-netcoremobile-sampleapp.binlog

--- a/build/test-scripts/skia-ios-uitest-build.sh
+++ b/build/test-scripts/skia-ios-uitest-build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Skia.netcoremobile
 
-dotnet build -f net9.0-ios18.0 -c Release -p:UnoTargetFrameworkOverride=net9.0-ios18.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true -p:ValidateXcodeVersion=false /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog
+dotnet build -f net9.0-ios18.0 -c Release -p:UnoTargetFrameworkOverride=net9.0-ios18.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog


### PR DESCRIPTION
Reverts unoplatform/uno#22521
(As we are kind of blocked with https://github.com/unoplatform/uno/pull/22573 at the moment and https://github.com/actions/runner-images/pull/13607 was made related to https://github.com/actions/runner-images/issues/13570)