### PR TITLE
Revert "ci: bump Xcode to 26.2, update iOS 18.5, and fix macOS template tests"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -58,7 +58,7 @@ variables:
   linuxScaledPool: 'Ubuntu2404-20251016'
   macOSVMImage: 'macOS-15'
   macOSVMImage_UITests: 'macOS-14'
-  xCodeRoot: '/Applications/Xcode_26.2.app'
+  xCodeRoot: '/Applications/Xcode_26.0.1.app'
   xCodeRoot_iOS_UITests: '/Applications/Xcode_15.3.app'
 
   # Offline validation to improve build performance

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -105,16 +105,6 @@ jobs:
     parameters:
       xCodeRoot: ${{ parameters.xCodeRoot }}
 
-  - bash: |
-      set -euo pipefail
-      if xcrun simctl list runtimes | grep -q "iOS 26.2"; then
-        echo "iOS 26.2 runtime already installed"
-        exit 0
-      fi
-      echo "Downloading iOS 26.2 simulator runtime"
-      sudo xcodebuild -downloadPlatform iOS -buildVersion 26.2
-    displayName: Ensure iOS 26.2 simulator runtime
-
   - template: ../templates/dotnet-mobile-install-mac.yml
   - template: ../templates/dotnet-install-previous-wasmtools.yml
   - template: ../templates/uno-dev-feed.yml

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -110,7 +110,7 @@ export UNO_TESTS_LOCAL_TESTS_FILE=$BUILD_SOURCESDIRECTORY/src/SamplesApp/Samples
 export UNO_UITEST_BENCHMARKS_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/benchmarks/ios-automated
 export UNO_UITEST_RUNTIMETESTS_RESULTS_FILE_PATH=$BUILD_SOURCESDIRECTORY/build/RuntimeTestResults-ios-automated.xml
 
-export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-18-5"
+export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-17-5"
 export UNO_UITEST_SIMULATOR_NAME="iPad Pro (12.9-inch) (6th generation)"
 
 export UnoTargetFrameworkOverride="net9.0-ios18.0"

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -167,7 +167,7 @@ if ($IsWindows)
 }
 else
 {
-    $default = @('-v:m', '-p:AotAssemblies=false', '-p:ValidateXcodeVersion=false')
+    $default = @('-v:m', '-p:AotAssemblies=false')
 }
 
 $debug = $default + '-p:Configuration=Debug'


### PR DESCRIPTION
Reverts unoplatform/uno#22504

(As we are kind of blocked with https://github.com/unoplatform/uno/pull/22573 at the moment, and https://github.com/actions/runner-images/pull/13607 was made related to https://github.com/actions/runner-images/issues/13570)