### PR TITLE
chore(ci): scope docs pipeline

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -6,6 +6,10 @@ trigger:
       - release/stable/*
       - feature/*
       - legacy/*
+  paths:
+    include:
+      - doc/**
+      - '**/*.md'
 
 pr: 
   branches:
@@ -15,6 +19,10 @@ pr:
       - release/stable/*
       - feature/*
       - legacy/*
+  paths:
+    include:
+      - doc/**
+      - '**/*.md'
 
 variables:
   windowsScaledPool: 'Windows2022-20250720-1'


### PR DESCRIPTION
Scopes the Azure DevOps docs pipeline to run only when documentation files change, reducing unnecessary CI runs. This is needed to prevent the docs pipeline from running on non-doc changes. 
Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).