### PR TITLE
fix(uitests): Replace invalid asserts (follow-up to #22467)

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/TwoPaneViewTests/Given_TwoPaneView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/TwoPaneViewTests/Given_TwoPaneView.cs
@@ -49,7 +49,7 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 
 			// _app.Repl();
 
-			Assert.IsGreaterThan(641, controlWidthText.GetDependencyPropertyValue<int>("Text"), "The window size must be large enough for the control Width to be larger than 641");
+			Assert.Greater(controlWidthText.GetDependencyPropertyValue<int>("Text"), 641, "The window size must be large enough for the control Width to be larger than 641");
 		}
 
 		[Test]
@@ -330,15 +330,15 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 				case ViewMode.LeftRight:
 				case ViewMode.RightLeft:
 					Assert.AreEqual(paneContent1BoundingRectangle.Y, paneContent2BoundingRectangle.Y, "Assert panes are horizontally aligned");
-					if (mode == ViewMode.LeftRight) Assert.IsGreaterThanOrEqualTo(paneContent1BoundingRectangle.Right, paneContent2BoundingRectangle.X, "Assert left/right pane placement");
-					else Assert.IsGreaterThanOrEqualTo(-paneContent2BoundingRectangle.Right, paneContent1BoundingRectangle.X, "Assert right/left pane placement");
+					if (mode == ViewMode.LeftRight) Assert.GreaterOrEqual(paneContent1BoundingRectangle.Right, paneContent2BoundingRectangle.X, "Assert left/right pane placement");
+					else Assert.GreaterOrEqual(-paneContent2BoundingRectangle.Right, paneContent1BoundingRectangle.X, "Assert right/left pane placement");
 					break;
 
 				case ViewMode.TopBottom:
 				case ViewMode.BottomTop:
 					Assert.AreEqual(paneContent1BoundingRectangle.X, paneContent2BoundingRectangle.X, "Assert panes are vertically aligned");
-					if (mode == ViewMode.TopBottom) Assert.IsGreaterThanOrEqualTo(paneContent1BoundingRectangle.Bottom, paneContent2BoundingRectangle.Y, "Assert top/bottom pane placement");
-					else Assert.IsGreaterThanOrEqualTo(paneContent2BoundingRectangle.Bottom, paneContent1BoundingRectangle.Y, "Assert bottom/top pane placement");
+					if (mode == ViewMode.TopBottom) Assert.GreaterOrEqual(paneContent1BoundingRectangle.Bottom, paneContent2BoundingRectangle.Y, "Assert top/bottom pane placement");
+					else Assert.GreaterOrEqual(paneContent2BoundingRectangle.Bottom, paneContent1BoundingRectangle.Y, "Assert bottom/top pane placement");
 					break;
 			}
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -112,7 +112,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			var popupResult = _app.WaitForElement("PopupBorder").First();
 
-			Assert.IsLessThan(sampleControlResult.Rect.Width / 2, popupResult.Rect.Width, "The popup should not stretch to the width of the screen");
+			Assert.Greater(popupResult.Rect.Width, sampleControlResult.Rect.Width / 2, "The popup should not stretch to the width of the screen");
 		}
 
 		[Test]
@@ -134,7 +134,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			TakeScreenshot("Opened");
 
 			Assert.AreEqual(popupResult.Rect.Width, sampleControlResult.Rect.Width, "The popup must stretch horizontally");
-			Assert.IsLessThan(sampleControlResult.Rect.Height / 2, popupResult.Rect.Height, "The popup should not stretch to the height of the screen");
+			Assert.Greater(popupResult.Rect.Height, sampleControlResult.Rect.Height / 2, "The popup should not stretch to the height of the screen");
 
 			_app.TapCoordinates(sampleControlResult.Rect.Width / 2, popupResult.Rect.Bottom + 20);
 
@@ -162,7 +162,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			var popupResult = _app.WaitForElement("PopupBorder").First();
 
 			Assert.AreEqual(popupResult.Rect.Width, sampleControlResult.Rect.Width, "The popup must stretch horizontally");
-			Assert.IsLessThan(sampleControlResult.Rect.Height / 2, popupResult.Rect.Height, "The popup should not stretch to the height of the screen");
+			Assert.Greater(popupResult.Rect.Height, sampleControlResult.Rect.Height / 2, "The popup should not stretch to the height of the screen");
 
 			_app.TapCoordinates(sampleControlResult.Rect.Width / 2, popupResult.Rect.Y - 20);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -160,19 +160,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 			TakeScreenshot("Default");
 
 			var innerTextBoxResult = _app.Query(innerTextBox).First();
-			Assert.IsLessThanOrEqualTo(myCommandBarResult.Rect.Width / 2, innerTextBoxResult.Rect.Width, "TextBox Width is too large");
+			Assert.LessOrEqual(myCommandBarResult.Rect.Width / 2, innerTextBoxResult.Rect.Width, "TextBox Width is too large");
 
 			horizontalValue.SetDependencyPropertyValue("SelectedItem", "Stretch");
 
 			TakeScreenshot("Stretch");
 
 			innerTextBoxResult = _app.Query(innerTextBox).First();
-			Assert.IsGreaterThan(myCommandBarResult.Rect.Width * .75, innerTextBoxResult.Rect.Width, "TextBox Width is not large enough");
+			Assert.Less(innerTextBoxResult.Rect.Width, myCommandBarResult.Rect.Width * .75, "TextBox Width is too large");
 
 			horizontalValue.SetDependencyPropertyValue("SelectedItem", "Left");
 
 			innerTextBoxResult = _app.Query(innerTextBox).First();
-			Assert.IsLessThanOrEqualTo(myCommandBarResult.Rect.Width / 2, innerTextBoxResult.Rect.Width, "TextBox Width is too large");
+			Assert.LessOrEqual(myCommandBarResult.Rect.Width / 2, innerTextBoxResult.Rect.Width, "TextBox Width is too large");
 
 			TakeScreenshot("Left");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -81,8 +81,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 				var innerContentResult = _app.WaitForElement(innerContent, timeoutMessage: $"Timed out waiting for element {nameof(innerContent)} after tapping target1").First();
 
-				Assert.IsLessThanOrEqualTo(innerContentResult.Rect.X, target1Result.Rect.X);
-				Assert.IsGreaterThan(innerContentResult.Rect.Width, target1Result.Rect.Width);
+				Assert.LessOrEqual(innerContentResult.Rect.X, target1Result.Rect.X);
+				Assert.Greater(innerContentResult.Rect.Width, target1Result.Rect.Width);
 
 				_app.TapCoordinates(50, 100);
 			}
@@ -94,8 +94,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 				var innerContentResult = _app.WaitForElement(innerContent, timeoutMessage: $"Timed out waiting for element {nameof(innerContent)} after tapping target2").First();
 
-				Assert.IsLessThanOrEqualTo(innerContentResult.Rect.X, target2Result.Rect.X);
-				Assert.IsGreaterThan(innerContentResult.Rect.Width, target2Result.Rect.Width);
+				Assert.LessOrEqual(innerContentResult.Rect.X, target2Result.Rect.X);
+				Assert.Greater(innerContentResult.Rect.Width, target2Result.Rect.Width);
 
 				_app.TapCoordinates(50, 100);
 			}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ItemsControl/ItemsControlTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ItemsControl/ItemsControlTests.cs
@@ -72,7 +72,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ItemsControl
 
 
 			// This check validates that the native collection is properly manipulated
-			Assert.IsLessThan(item02.Rect.CenterY, item01.Rect.CenterY);
+			Assert.Less(item02.Rect.CenterY, item01.Rect.CenterY);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -173,7 +173,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 				var keys = match.Groups["key"].Captures;
 				var values = match.Groups["value"].Captures;
-				Assert.HasCount(keys.Count, values);
+				Assert.AreEqual(keys.Count, values.Count);
 
 				for (var i = 0; i < keys.Count; i++)
 				{


### PR DESCRIPTION
Replaces non-NUnit Assert helpers in SamplesApp.UITests to restore compilation.

This follows up on the assertion helper changes from PR #22467 that introduced compile failures.

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).