### PR TITLE
chore(ci): Shard runtime tests and add heartbeat logging

### DIFF
--- a/build/ci/tests/.azure-devops-tests-android-native.yml
+++ b/build/ci/tests/.azure-devops-tests-android-native.yml
@@ -233,7 +233,9 @@ jobs:
   - task: PublishTestResults@2
     condition: always()
     inputs:
-      testResultsFiles: '$(build.sourcesdirectory)/build/RuntimeTestResults*.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/RuntimeTestResults*.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       testRunTitle: 'Android Native $(UITEST_TEST_MODE_DISPLAY_NAME)'
       testResultsFormat: 'NUnit'
       failTaskOnFailedTests: $(FAILBUILD_ON_FAILURE)

--- a/build/ci/tests/.azure-devops-tests-android-native.yml
+++ b/build/ci/tests/.azure-devops-tests-android-native.yml
@@ -18,6 +18,9 @@ parameters:
     - 2
     - 3
     - 4
+    - 5
+    - 6
+    - 7
 
 jobs:
 
@@ -112,6 +115,9 @@ jobs:
           ALLOW_RERUN: true
           UITEST_TEST_TIMEOUT: '270s'
 
+      # Runtime tests can re-run when a failure/timeout is detected; the script
+      # writes a marker to skip reruns after success.
+      # Use 8 groups to reduce per-job runtime and avoid 45-minute job timeouts.
       ${{ each testGroup in parameters.runtimeTestsGroups }}:
         'Runtime Tests ${{ testGroup }}':
           ANDROID_SIMULATOR_APILEVEL: 28
@@ -119,11 +125,11 @@ jobs:
           UITEST_TEST_MODE_NAME: RuntimeTests
           UNO_UITEST_BUCKET_ID: RuntimeTests
           UITEST_RUNTIME_TEST_GROUP: ${{ testGroup }}
-          UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+          UITEST_RUNTIME_TEST_GROUP_COUNT: 8
           SAMPLEAPP_ARTIFACT_NAME: uitests-android-netcoremobile-build
           TARGETPLATFORM_NAME: net9
           FAILBUILD_ON_FAILURE: true
-          ALLOW_RERUN: false
+          ALLOW_RERUN: true
           UITEST_TEST_TIMEOUT: '2600s'
 
       'Snapshot Tests':

--- a/build/ci/tests/.azure-devops-tests-android-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-skia.yml
@@ -24,12 +24,14 @@ jobs:
   strategy:
     matrix:
 
+      # Keep runtime sharding aligned with native to reduce long-tail runtimes.
+
       'Runtime Tests 0':
         ANDROID_SIMULATOR_APILEVEL: 34
         UITEST_TEST_MODE_NAME: RuntimeTests
         UNO_UITEST_BUCKET_ID: RuntimeTests
         UITEST_RUNTIME_TEST_GROUP: 0
-        UITEST_RUNTIME_TEST_GROUP_COUNT: 4
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
         TARGETPLATFORM_NAME: net9
         UITEST_TEST_TIMEOUT: '2600s'
 
@@ -38,7 +40,7 @@ jobs:
         UITEST_TEST_MODE_NAME: RuntimeTests
         UNO_UITEST_BUCKET_ID: RuntimeTests
         UITEST_RUNTIME_TEST_GROUP: 1
-        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
         TARGETPLATFORM_NAME: net9
         UITEST_TEST_TIMEOUT: '2600s'
 
@@ -47,7 +49,7 @@ jobs:
         UITEST_TEST_MODE_NAME: RuntimeTests
         UNO_UITEST_BUCKET_ID: RuntimeTests
         UITEST_RUNTIME_TEST_GROUP: 2
-        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
         TARGETPLATFORM_NAME: net9
         UITEST_TEST_TIMEOUT: '2600s'
 
@@ -56,7 +58,7 @@ jobs:
         UITEST_TEST_MODE_NAME: RuntimeTests
         UNO_UITEST_BUCKET_ID: RuntimeTests
         UITEST_RUNTIME_TEST_GROUP: 3
-        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
         TARGETPLATFORM_NAME: net9
         UITEST_TEST_TIMEOUT: '2600s'
 
@@ -65,7 +67,34 @@ jobs:
         UITEST_TEST_MODE_NAME: RuntimeTests
         UNO_UITEST_BUCKET_ID: RuntimeTests
         UITEST_RUNTIME_TEST_GROUP: 4
-        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
+        TARGETPLATFORM_NAME: net9
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 5':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 5
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
+        TARGETPLATFORM_NAME: net9
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 6':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 6
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
+        TARGETPLATFORM_NAME: net9
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 7':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 7
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 8
         TARGETPLATFORM_NAME: net9
         UITEST_TEST_TIMEOUT: '2600s'
 

--- a/build/ci/tests/.azure-devops-tests-android-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-skia.yml
@@ -135,7 +135,9 @@ jobs:
     inputs:
       testRunTitle: 'Android Skia Runtime Tests $(UITEST_RUNTIME_TEST_GROUP)'
       testResultsFormat: 'NUnit'
-      testResultsFiles: '$(build.sourcesdirectory)/build/*TestResult*.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/*TestResult*.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       failTaskOnFailedTests: true
 
   - task: PublishBuildArtifacts@1

--- a/build/ci/tests/.azure-devops-tests-ios-runner.yml
+++ b/build/ci/tests/.azure-devops-tests-ios-runner.yml
@@ -151,7 +151,9 @@ jobs:
   - task: PublishTestResults@2
     condition: always()
     inputs:
-      testResultsFiles: '$(build.sourcesdirectory)/build/RuntimeTestResults*.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/RuntimeTestResults*.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       testRunTitle: ${{ parameters.TestRunName }}
       testResultsFormat: 'NUnit'
       failTaskOnFailedTests: true

--- a/build/ci/tests/.azure-devops-tests-linux-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-linux-skia.yml
@@ -104,7 +104,9 @@ jobs:
     inputs:
       testRunTitle: 'Linux Skia Runtime Tests'
       testResultsFormat: 'NUnit'
-      testResultsFiles: '$(build.sourcesdirectory)/build/skia-linux-runtime-tests-results.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/skia-linux-runtime-tests-results.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       failTaskOnFailedTests: true
       failTaskOnMissingResultsFile: true
 

--- a/build/ci/tests/.azure-devops-tests-macos-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-macos-skia.yml
@@ -58,7 +58,9 @@ jobs:
     inputs:
       testRunTitle: 'macOS Skia Runtime Tests'
       testResultsFormat: 'NUnit'
-      testResultsFiles: '$(build.sourcesdirectory)/build/skia-macos-runtime-tests-results.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/skia-macos-runtime-tests-results.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       failTaskOnFailedTests: true
       failTaskOnMissingResultsFile: true
 

--- a/build/ci/tests/.azure-devops-tests-webassembly-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-webassembly-skia.yml
@@ -80,7 +80,9 @@ jobs:
     inputs:
       testRunTitle: 'WebAssembly Skia Runtime Tests $(UITEST_RUNTIME_TEST_GROUP)'
       testResultsFormat: 'NUnit'
-      testResultsFiles: '$(build.sourcesdirectory)/build/skia-browserwasm-runtime-tests-results.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/skia-browserwasm-runtime-tests-results.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       failTaskOnFailedTests: true
       failTaskOnMissingResultsFile: true
 

--- a/build/ci/tests/.azure-devops-tests-windows-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-windows-skia.yml
@@ -112,7 +112,9 @@ jobs:
     inputs:
       testRunTitle: 'Windows Skia Runtime Tests'
       testResultsFormat: 'NUnit'
-      testResultsFiles: '$(build.sourcesdirectory)/build/skia-windows-runtime-tests-results.xml'
+      testResultsFiles: |
+        $(build.sourcesdirectory)/build/skia-windows-runtime-tests-results.xml
+        $(build.sourcesdirectory)/build/runtime-heartbeat-*.xml
       failTaskOnFailedTests: true
       failTaskOnMissingResultsFile: true
 

--- a/build/test-scripts/android-run-skia-runtime-tests.sh
+++ b/build/test-scripts/android-run-skia-runtime-tests.sh
@@ -190,7 +190,11 @@ $ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PA
 RUNTIME_CURRENT_TEST_LOCAL="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-skia-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.txt"
 $ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_CURRENT_TEST_DEVICE_PATH $RUNTIME_CURRENT_TEST_LOCAL || true
 if [ -f "$RUNTIME_CURRENT_TEST_LOCAL" ]; then
-	echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+	if command -v iconv >/dev/null 2>&1; then
+		echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$RUNTIME_CURRENT_TEST_LOCAL")"
+	else
+		echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+	fi
 else
 	echo "No runtime test heartbeat file found."
 fi

--- a/build/test-scripts/android-uitest-run.sh
+++ b/build/test-scripts/android-uitest-run.sh
@@ -5,6 +5,30 @@ IFS=$'\n\t'
 # echo commands
 set -x
 
+escape_for_xml() {
+	printf '%s' "$1" | tr '\r\n' ' ' | \
+		sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
+}
+
+write_heartbeat_xml() {
+	local output_path="$1"
+	local message="$2"
+	local escaped_message
+	escaped_message=$(escape_for_xml "$message")
+	cat > "$output_path" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="0" name="RuntimeHeartbeat" testcasecount="1" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+  <test-suite type="Assembly" name="RuntimeHeartbeat" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+    <test-case id="0-0" name="LastHeartbeat" result="Skipped" duration="0">
+      <reason>
+        <message>${escaped_message}</message>
+      </reason>
+    </test-case>
+  </test-suite>
+</test-run>
+EOF
+}
+
 export BUILDCONFIGURATION=Release
 
 if [ "$UITEST_TEST_MODE_NAME" == 'Snapshots' ];
@@ -261,15 +285,20 @@ then
 	
 	RUNTIME_CURRENT_TEST_LOCAL="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.txt"
 	$ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_CURRENT_TEST_FILE $RUNTIME_CURRENT_TEST_LOCAL || true
+	HEARTBEAT_MESSAGE="No runtime test heartbeat file found."
 	if [ -f "$RUNTIME_CURRENT_TEST_LOCAL" ]; then
 		if command -v iconv >/dev/null 2>&1; then
-			echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$RUNTIME_CURRENT_TEST_LOCAL")"
+			HEARTBEAT_MESSAGE="$(iconv -f utf-16 -t utf-8 "$RUNTIME_CURRENT_TEST_LOCAL")"
 		else
-			echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+			HEARTBEAT_MESSAGE="$(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
 		fi
+		echo "Last runtime test heartbeat: $HEARTBEAT_MESSAGE"
 	else
 		echo "No runtime test heartbeat file found."
 	fi
+
+	HEARTBEAT_XML_PATH="$BUILD_SOURCESDIRECTORY/build/runtime-heartbeat-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.xml"
+	write_heartbeat_xml "$HEARTBEAT_XML_PATH" "$HEARTBEAT_MESSAGE"
 
 else
 

--- a/build/test-scripts/android-uitest-run.sh
+++ b/build/test-scripts/android-uitest-run.sh
@@ -262,7 +262,11 @@ then
 	RUNTIME_CURRENT_TEST_LOCAL="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.txt"
 	$ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_CURRENT_TEST_FILE $RUNTIME_CURRENT_TEST_LOCAL || true
 	if [ -f "$RUNTIME_CURRENT_TEST_LOCAL" ]; then
-		echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+		if command -v iconv >/dev/null 2>&1; then
+			echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$RUNTIME_CURRENT_TEST_LOCAL")"
+		else
+			echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+		fi
 	else
 		echo "No runtime test heartbeat file found."
 	fi

--- a/build/test-scripts/android-uitest-run.sh
+++ b/build/test-scripts/android-uitest-run.sh
@@ -46,6 +46,8 @@ export UNO_TESTS_RESPONSE_FILE=$BUILD_SOURCESDIRECTORY/build/nunit.response
 export UNO_UITEST_RUNTIMETESTS_RESULTS_FILE_PATH=$BUILD_SOURCESDIRECTORY/build/RuntimeTestResults-android-automated-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME.xml
 
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
+# Always create the failed-results folder so artifact publishing does not fail on success.
+mkdir -p $BUILD_SOURCESDIRECTORY/build/uitests-failure-results
 
 if [ -f "$UNO_TESTS_FAILED_LIST" ] && [ `cat "$UNO_TESTS_FAILED_LIST"` = "invalid-test-for-retry" ];
 then
@@ -80,6 +82,16 @@ fi
 
 AVD_NAME=xamarin_android_emulator
 AVD_CONFIG_FILE="$ANDROID_AVD_HOME/$AVD_NAME.avd/config.ini"
+
+is_emulator_booted() {
+	if $ANDROID_HOME/platform-tools/adb devices | grep -q "emulator"; then
+		local boot_completed
+		boot_completed=$($ANDROID_HOME/platform-tools/adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)
+		[ "$boot_completed" = "1" ]
+	else
+		return 1
+	fi
+}
 
 if [[ ! -f $AVD_CONFIG_FILE ]];
 then
@@ -153,11 +165,16 @@ then
 	source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh 500
 
 else
-	# Restart the emulator to avoid running first-time tasks
-	$ANDROID_HOME/platform-tools/adb reboot
+	if is_emulator_booted; then
+		# Reuse the already-booted emulator during reruns to save startup time.
+		echo "Emulator already booted; skipping reboot."
+	else
+		# Restart the emulator to avoid running first-time tasks
+		$ANDROID_HOME/platform-tools/adb reboot
 
-	# Wait for the emulator to finish booting
-	source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh 500
+		# Wait for the emulator to finish booting
+		source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh 500
+	fi
 fi
 
 # list active devices
@@ -179,6 +196,7 @@ cd $UNO_UITEST_SCREENSHOT_PATH
 if [ "$UITEST_TEST_MODE_NAME" == 'RuntimeTests' ];
 then
 	UITEST_RUNTIME_AUTOSTART_RESULT_FILE="/sdcard/TestResult-`date +"%Y%m%d%H%M%S"`.xml"
+	UITEST_RUNTIME_CURRENT_TEST_FILE="/sdcard/RuntimeCurrentTest-$UITEST_RUNTIME_TEST_GROUP.txt"
 
 	# Install the app
 	$ANDROID_HOME/platform-tools/adb install $UNO_UITEST_ANDROIDAPK_PATH
@@ -186,7 +204,9 @@ then
 	# Create the environment file for the app to read
 	echo "UITEST_RUNTIME_TEST_GROUP=$UITEST_RUNTIME_TEST_GROUP" > samplesapp-environment.txt
 	echo "UITEST_RUNTIME_TEST_GROUP_COUNT=$UITEST_RUNTIME_TEST_GROUP_COUNT" >> samplesapp-environment.txt
-	echo "UITEST_RUNTIME_AUTOSTART_RESULT_FILE=$UITEST_RUNTIME_AUTOSTART_RESULT_FILE" >> samplesapp-environment.txt
+		echo "UITEST_RUNTIME_AUTOSTART_RESULT_FILE=$UITEST_RUNTIME_AUTOSTART_RESULT_FILE" >> samplesapp-environment.txt
+		# CI uses this file to report the last started test when a shard hangs.
+		echo "UITEST_RUNTIME_CURRENT_TEST_FILE=$UITEST_RUNTIME_CURRENT_TEST_FILE" >> samplesapp-environment.txt
 
 	if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
 		export UITEST_RUNTIME_TESTS_FILTER=`cat $UNO_TESTS_FAILED_LIST | base64 -w 0`
@@ -228,7 +248,24 @@ then
 		fi
 	done
 
+	if ! $ANDROID_HOME/platform-tools/adb shell test -e "$UITEST_RUNTIME_AUTOSTART_RESULT_FILE" > /dev/null; then
+		if [ $SECONDS -ge $END_TIME ]; then
+			# Capture a timeout marker so CI artifacts explain why the run ended early.
+			echo "Runtime tests timed out after ${TIMEOUT}s (group=$UITEST_RUNTIME_TEST_GROUP)." > $BUILD_SOURCESDIRECTORY/build/uitests-failure-results/runtime-tests-timeout-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.txt
+		else
+			echo "Runtime tests ended without results (app exited early)." > $BUILD_SOURCESDIRECTORY/build/uitests-failure-results/runtime-tests-no-results-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.txt
+		fi
+	fi
+
 	$ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_AUTOSTART_RESULT_FILE $UNO_ORIGINAL_TEST_RESULTS || true
+	
+	RUNTIME_CURRENT_TEST_LOCAL="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-android-$ANDROID_SIMULATOR_APILEVEL-$TARGETPLATFORM_NAME-$UITEST_RUNTIME_TEST_GROUP.txt"
+	$ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_CURRENT_TEST_FILE $RUNTIME_CURRENT_TEST_LOCAL || true
+	if [ -f "$RUNTIME_CURRENT_TEST_LOCAL" ]; then
+		echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+	else
+		echo "No runtime test heartbeat file found."
+	fi
 
 else
 
@@ -276,6 +313,11 @@ dotnet run fail-empty $UNO_ORIGINAL_TEST_RESULTS
 
 if [ $? -eq 0 ]; then
 	dotnet run list-failed $UNO_ORIGINAL_TEST_RESULTS $UNO_TESTS_FAILED_LIST
+
+	if [ "$UITEST_TEST_MODE_NAME" == 'RuntimeTests' ] && [ -f "$UNO_TESTS_FAILED_LIST" ] && [ ! -s "$UNO_TESTS_FAILED_LIST" ]; then
+		# Mark successful runtime runs so reruns are skipped when ALLOW_RERUN is enabled.
+		echo "invalid-test-for-retry" > "$UNO_TESTS_FAILED_LIST"
+	fi
 fi
 
 popd

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -220,6 +220,7 @@ then
 	export SIMCTL_CHILD_UITEST_RUNTIME_TEST_GROUP=$UITEST_RUNTIME_TEST_GROUP
 	export SIMCTL_CHILD_UITEST_RUNTIME_TEST_GROUP_COUNT=$UITEST_RUNTIME_TEST_GROUP_COUNT
 	export SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE=/tmp/TestResult-`date +"%Y%m%d%H%M%S"`.xml
+		export SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE=/tmp/RuntimeCurrentTest-$UITEST_RUNTIME_TEST_GROUP.txt
 
 	# $UNO_TESTS_RUNTIMETESTS_FAILED_LIST file exists
 	if [ -f "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST" ]; then
@@ -275,8 +276,21 @@ then
 
 		# Copy the results to the build directory
 		cp -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
+		
+		RUNTIME_CURRENT_TEST_LOCAL="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-ios-$UITEST_RUNTIME_TEST_GROUP.txt"
+		if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
+			cp -f "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE" "$RUNTIME_CURRENT_TEST_LOCAL"
+			echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+		else
+			echo "No runtime test heartbeat file found."
+		fi
 	else
 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, the test run has timed out."
+		if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
+			echo "Last runtime test heartbeat: $(cat "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE")"
+		else
+			echo "No runtime test heartbeat file found."
+		fi
 	fi
 
 else

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -280,14 +280,22 @@ then
 		RUNTIME_CURRENT_TEST_LOCAL="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-ios-$UITEST_RUNTIME_TEST_GROUP.txt"
 		if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
 			cp -f "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE" "$RUNTIME_CURRENT_TEST_LOCAL"
-			echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+			if command -v iconv >/dev/null 2>&1; then
+				echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$RUNTIME_CURRENT_TEST_LOCAL")"
+			else
+				echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_LOCAL")"
+			fi
 		else
 			echo "No runtime test heartbeat file found."
 		fi
 	else
 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, the test run has timed out."
 		if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
-			echo "Last runtime test heartbeat: $(cat "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE")"
+			if command -v iconv >/dev/null 2>&1; then
+				echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE")"
+			else
+				echo "Last runtime test heartbeat: $(cat "$SIMCTL_CHILD_UITEST_RUNTIME_CURRENT_TEST_FILE")"
+			fi
 		else
 			echo "No runtime test heartbeat file found."
 		fi

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -25,7 +25,11 @@ cd $SamplesAppArtifactPath
 xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE' || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
 
 if [ -f "$UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
-	echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+	if command -v iconv >/dev/null 2>&1; then
+		echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+	else
+		echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+	fi
 else
 	echo "No runtime test heartbeat file found."
 fi

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -7,6 +7,10 @@ export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP:-}
 
 export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-skia-linux-runtimetests-$UITEST_RUNTIME_TEST_GROUP.txt
 export TEST_RESULTS_FILE=$BUILD_SOURCESDIRECTORY/build/skia-linux-runtime-tests-results.xml
+export UITEST_RUNTIME_CURRENT_TEST_FILE=$BUILD_SOURCESDIRECTORY/build/runtime-current-test-linux-$UITEST_RUNTIME_TEST_GROUP.txt
+
+# CI uses this file to report the last started test when a shard hangs.
+export UITEST_RUNTIME_CURRENT_TEST_FILE
 
 if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
 	export UITEST_RUNTIME_TESTS_FILTER=`cat $UNO_TESTS_FAILED_LIST | base64 -w 0`
@@ -19,6 +23,12 @@ fi
 
 cd $SamplesAppArtifactPath
 xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE' || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
+
+if [ -f "$UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
+	echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+else
+	echo "No runtime test heartbeat file found."
+fi
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -3,6 +3,30 @@ set -x #echo on
 set -euo pipefail
 IFS=$'\n\t'
 
+escape_for_xml() {
+	printf '%s' "$1" | tr '\r\n' ' ' | \
+		sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
+}
+
+write_heartbeat_xml() {
+	local output_path="$1"
+	local message="$2"
+	local escaped_message
+	escaped_message=$(escape_for_xml "$message")
+	cat > "$output_path" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="0" name="RuntimeHeartbeat" testcasecount="1" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+  <test-suite type="Assembly" name="RuntimeHeartbeat" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+    <test-case id="0-0" name="LastHeartbeat" result="Skipped" duration="0">
+      <reason>
+        <message>${escaped_message}</message>
+      </reason>
+    </test-case>
+  </test-suite>
+</test-run>
+EOF
+}
+
 export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP:-}
 
 export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-skia-linux-runtimetests-$UITEST_RUNTIME_TEST_GROUP.txt
@@ -24,15 +48,20 @@ fi
 cd $SamplesAppArtifactPath
 xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE' || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
 
+HEARTBEAT_MESSAGE="No runtime test heartbeat file found."
 if [ -f "$UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
 	if command -v iconv >/dev/null 2>&1; then
-		echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+		HEARTBEAT_MESSAGE="$(iconv -f utf-16 -t utf-8 "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
 	else
-		echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+		HEARTBEAT_MESSAGE="$(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
 	fi
+	echo "Last runtime test heartbeat: $HEARTBEAT_MESSAGE"
 else
 	echo "No runtime test heartbeat file found."
 fi
+
+HEARTBEAT_XML_PATH="$BUILD_SOURCESDIRECTORY/build/runtime-heartbeat-linux-$UITEST_RUNTIME_TEST_GROUP.xml"
+write_heartbeat_xml "$HEARTBEAT_XML_PATH" "$HEARTBEAT_MESSAGE"
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -3,6 +3,30 @@ set -x #echo on
 set -euo pipefail
 IFS=$'\n\t'
 
+escape_for_xml() {
+	printf '%s' "$1" | tr '\r\n' ' ' | \
+		sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
+}
+
+write_heartbeat_xml() {
+	local output_path="$1"
+	local message="$2"
+	local escaped_message
+	escaped_message=$(escape_for_xml "$message")
+	cat > "$output_path" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="0" name="RuntimeHeartbeat" testcasecount="1" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+  <test-suite type="Assembly" name="RuntimeHeartbeat" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+    <test-case id="0-0" name="LastHeartbeat" result="Skipped" duration="0">
+      <reason>
+        <message>${escaped_message}</message>
+      </reason>
+    </test-case>
+  </test-suite>
+</test-run>
+EOF
+}
+
 export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP:-}
 
 export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-skia-macos-runtimetests-$UITEST_RUNTIME_TEST_GROUP.txt
@@ -24,15 +48,20 @@ fi
 cd $SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
 
+HEARTBEAT_MESSAGE="No runtime test heartbeat file found."
 if [ -f "$UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
 	if command -v iconv >/dev/null 2>&1; then
-		echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+		HEARTBEAT_MESSAGE="$(iconv -f utf-16 -t utf-8 "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
 	else
-		echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+		HEARTBEAT_MESSAGE="$(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
 	fi
+	echo "Last runtime test heartbeat: $HEARTBEAT_MESSAGE"
 else
 	echo "No runtime test heartbeat file found."
 fi
+
+HEARTBEAT_XML_PATH="$BUILD_SOURCESDIRECTORY/build/runtime-heartbeat-macos-$UITEST_RUNTIME_TEST_GROUP.xml"
+write_heartbeat_xml "$HEARTBEAT_XML_PATH" "$HEARTBEAT_MESSAGE"
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -7,6 +7,10 @@ export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP:-}
 
 export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-skia-macos-runtimetests-$UITEST_RUNTIME_TEST_GROUP.txt
 export TEST_RESULTS_FILE=$BUILD_SOURCESDIRECTORY/build/skia-macos-runtime-tests-results.xml
+export UITEST_RUNTIME_CURRENT_TEST_FILE=$BUILD_SOURCESDIRECTORY/build/runtime-current-test-macos-$UITEST_RUNTIME_TEST_GROUP.txt
+
+# CI uses this file to report the last started test when a shard hangs.
+export UITEST_RUNTIME_CURRENT_TEST_FILE
 
 if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
 	export UITEST_RUNTIME_TESTS_FILTER=`cat $UNO_TESTS_FAILED_LIST | base64 -b 0`
@@ -19,6 +23,12 @@ fi
 
 cd $SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
+
+if [ -f "$UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
+	echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+else
+	echo "No runtime test heartbeat file found."
+fi
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -25,7 +25,11 @@ cd $SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
 
 if [ -f "$UITEST_RUNTIME_CURRENT_TEST_FILE" ]; then
-	echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+	if command -v iconv >/dev/null 2>&1; then
+		echo "Last runtime test heartbeat: $(iconv -f utf-16 -t utf-8 "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+	else
+		echo "Last runtime test heartbeat: $(cat "$UITEST_RUNTIME_CURRENT_TEST_FILE")"
+	fi
 else
 	echo "No runtime test heartbeat file found."
 fi

--- a/build/test-scripts/run-windows-skia-runtime-tests.ps1
+++ b/build/test-scripts/run-windows-skia-runtime-tests.ps1
@@ -10,6 +10,25 @@ function Assert-ExitCodeIsZero()
 	}
 }
 
+function Write-HeartbeatXml([string]$OutputPath, [string]$Message)
+{
+	$singleLine = ($Message -replace "[\r\n]+", " ").Trim()
+	$escaped = [System.Security.SecurityElement]::Escape($singleLine)
+	$xml = @"
+<?xml version="1.0" encoding="utf-8"?>
+<test-run id="0" name="RuntimeHeartbeat" testcasecount="1" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+    <test-suite type="Assembly" name="RuntimeHeartbeat" result="Skipped" total="1" passed="0" failed="0" skipped="1" inconclusive="0" duration="0">
+        <test-case id="0-0" name="LastHeartbeat" result="Skipped" duration="0">
+            <reason>
+                <message>$escaped</message>
+            </reason>
+        </test-case>
+    </test-suite>
+</test-run>
+"@
+	$xml | Set-Content -Path $OutputPath -Encoding UTF8
+}
+
 
 $UNO_TESTS_FAILED_LIST="$env:BUILD_SOURCESDIRECTORY\build\uitests-failure-results\failed-tests-windows-runtimetests-windows-$env:UITEST_RUNTIME_TEST_GROUP.txt"
 $TEST_RESULTS_FILE="$env:build_sourcesdirectory\build\skia-windows-runtime-tests-results.xml"
@@ -28,10 +47,15 @@ cd $env:SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
 
 if (Test-Path $RUNTIME_CURRENT_TEST_FILE) {
-    Write-Host "Last runtime test heartbeat: $(Get-Content $RUNTIME_CURRENT_TEST_FILE)"
+    $heartbeatMessage = (Get-Content $RUNTIME_CURRENT_TEST_FILE -Raw -Encoding Unicode).Trim()
+    Write-Host "Last runtime test heartbeat: $heartbeatMessage"
 } else {
+    $heartbeatMessage = "No runtime test heartbeat file found."
     Write-Host "No runtime test heartbeat file found."
 }
+
+$heartbeatXmlPath = "$env:build_sourcesdirectory\build\runtime-heartbeat-windows-$env:UITEST_RUNTIME_TEST_GROUP.xml"
+Write-HeartbeatXml -OutputPath $heartbeatXmlPath -Message $heartbeatMessage
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $env:BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/run-windows-skia-runtime-tests.ps1
+++ b/build/test-scripts/run-windows-skia-runtime-tests.ps1
@@ -13,6 +13,10 @@ function Assert-ExitCodeIsZero()
 
 $UNO_TESTS_FAILED_LIST="$env:BUILD_SOURCESDIRECTORY\build\uitests-failure-results\failed-tests-windows-runtimetests-windows-$env:UITEST_RUNTIME_TEST_GROUP.txt"
 $TEST_RESULTS_FILE="$env:build_sourcesdirectory\build\skia-windows-runtime-tests-results.xml"
+$RUNTIME_CURRENT_TEST_FILE="$env:build_sourcesdirectory\build\runtime-current-test-windows-$env:UITEST_RUNTIME_TEST_GROUP.txt"
+
+# CI uses this file to report the last started test when a shard hangs.
+$env:UITEST_RUNTIME_CURRENT_TEST_FILE = $RUNTIME_CURRENT_TEST_FILE
 
 # convert the content of the file UNO_TESTS_FAILED_LIST to base64 and set it to UITEST_RUNTIME_TESTS_FILTER, if the file exists
 if (Test-Path $UNO_TESTS_FAILED_LIST) {
@@ -22,6 +26,12 @@ if (Test-Path $UNO_TESTS_FAILED_LIST) {
 
 cd $env:SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
+
+if (Test-Path $RUNTIME_CURRENT_TEST_FILE) {
+    Write-Host "Last runtime test heartbeat: $(Get-Content $RUNTIME_CURRENT_TEST_FILE)"
+} else {
+    Write-Host "No runtime test heartbeat file found."
+}
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $env:BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/wasm-run-skia-runtime-tests.sh
+++ b/build/test-scripts/wasm-run-skia-runtime-tests.sh
@@ -30,6 +30,7 @@ sleep 10
 
 export RESULTS_FILE="$BUILD_SOURCESDIRECTORY/build/skia-browserwasm-runtime-tests-results.xml"
 export RESULTS_CANARY_FILE="$RESULTS_FILE.canary"
+export RUNTIME_CURRENT_TEST_FILE="$BUILD_SOURCESDIRECTORY/build/runtime-current-test-wasm-$UITEST_RUNTIME_TEST_GROUP.txt"
 export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP:-}
 export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-skia-wasm-runtimetests-$UITEST_RUNTIME_TEST_GROUP-chromium.txt
 
@@ -50,10 +51,14 @@ fi
 rawurlencode "$RESULTS_FILE"
 RESULTS_FILE_ENCODED=$ENCODED_RESULT
 
+rawurlencode "$RUNTIME_CURRENT_TEST_FILE"
+RUNTIME_CURRENT_TEST_FILE_ENCODED=$ENCODED_RESULT
+
 rawurlencode "$UITEST_RUNTIME_TESTS_FILTER"
 UITEST_RUNTIME_TESTS_FILTER_ENCODED=$ENCODED_RESULT
 
 RUNTIME_TESTS_URL="http://localhost:8000/?--runtime-tests=${RESULTS_FILE_ENCODED}&--runtime-tests-group=${UITEST_RUNTIME_TEST_GROUP}&--runtime-tests-group-count=${UITEST_RUNTIME_TEST_GROUP_COUNT}&--runtime-test-filter=${UITEST_RUNTIME_TESTS_FILTER_ENCODED}"
+RUNTIME_TESTS_URL+="&--runtime-current-test-file=${RUNTIME_CURRENT_TEST_FILE_ENCODED}"
 
 TRY_COUNT=0
 
@@ -95,6 +100,12 @@ fi
 while ! test -f "$RESULTS_FILE"; do
     sleep 10
 done
+
+if test -f "$RUNTIME_CURRENT_TEST_FILE"; then
+    echo "Last runtime test heartbeat: $(cat "$RUNTIME_CURRENT_TEST_FILE")"
+else
+    echo "No runtime test heartbeat file found."
+fi
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -70,11 +70,18 @@ partial class App
 			Environment.SetEnvironmentVariable("UITEST_RUNTIME_TESTS_FILTER", runtimeTestFilter);
 		}
 
+		if (argsPairs.TryGetValue("--runtime-current-test-file", out var runtimeCurrentTestFile))
+		{
+			// CI uses this file to report the last started test when a shard hangs.
+			Environment.SetEnvironmentVariable("UITEST_RUNTIME_CURRENT_TEST_FILE", runtimeCurrentTestFile);
+		}
+
 		Console.WriteLine(
 			$"Automated runtime tests output file: {runtimeTestResultFilePath} (" +
 			$"UITEST_RUNTIME_TEST_GROUP: {Environment.GetEnvironmentVariable("UITEST_RUNTIME_TEST_GROUP")}, " +
 			$"UITEST_RUNTIME_TEST_GROUP_COUNT: {Environment.GetEnvironmentVariable("UITEST_RUNTIME_TEST_GROUP_COUNT")}, " +
-			$"UITEST_RUNTIME_TESTS_FILTER: {Environment.GetEnvironmentVariable("UITEST_RUNTIME_TESTS_FILTER")}" +
+			$"UITEST_RUNTIME_TESTS_FILTER: {Environment.GetEnvironmentVariable("UITEST_RUNTIME_TESTS_FILTER")}, " +
+			$"UITEST_RUNTIME_CURRENT_TEST_FILE: {Environment.GetEnvironmentVariable("UITEST_RUNTIME_CURRENT_TEST_FILE")}" +
 			$")");
 
 		if (!string.IsNullOrEmpty(runtimeTestResultFilePath))

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -53,6 +53,7 @@ namespace Uno.UI.Samples.Tests
 
 		private const StringComparison StrComp = StringComparison.InvariantCultureIgnoreCase;
 		private const string RuntimeCurrentTestFilePathVariable = "UITEST_RUNTIME_CURRENT_TEST_FILE";
+		private string _runtimeCurrentTestFilePath;
 		private Task _runner;
 		private CancellationTokenSource _cts = new CancellationTokenSource();
 #if DEBUG
@@ -1101,7 +1102,7 @@ namespace Uno.UI.Samples.Tests
 
 			async Task UpdateRuntimeTestHeartbeatAsync(string testName)
 			{
-				var heartbeatPath = Environment.GetEnvironmentVariable(RuntimeCurrentTestFilePathVariable);
+				var heartbeatPath = _runtimeCurrentTestFilePath ??= Environment.GetEnvironmentVariable(RuntimeCurrentTestFilePathVariable);
 				if (string.IsNullOrWhiteSpace(heartbeatPath))
 				{
 					return;
@@ -1332,7 +1333,7 @@ namespace Uno.UI.Samples.Tests
 
 			if (_ciTestsGroupCountCache != -1)
 			{
-				var activeGroupCount = groupedArray.SelectMany(t => t.Tests).Count();
+				var activeGroupCount = groupedArray.Sum(group => group.Tests.Count());
 				// CI uses these counts to spot slow shards and rebalance groups.
 				Console.WriteLine($"Active test group #{_ciTestGroupCache} contains {activeGroupCount} tests");
 			}


### PR DESCRIPTION
This updates runtime test sharding (Android native/Skia) and adds heartbeat logging across Android, iOS, Windows, Linux, macOS, and WASM so CI can surface the last started test during hangs and reduce long-running job timeouts. 

It also adds rerun markers and timeout/no-results artifacts to improve diagnostics and rerun behavior.

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).