### PR TITLE
fix(droid): statusbar inset after deeplinking 2

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -70,11 +70,6 @@ namespace Microsoft.UI.Xaml
 			_inputPane.Showing += OnInputPaneVisibilityChanged;
 			_inputPane.Hiding += OnInputPaneVisibilityChanged;
 			Uno.UI.Extensions.PermissionsHelper.Initialize();
-
-			// Note: Deep-linking will cause a new instance of this Activity and its DecorView to be created.
-			// This means any event handlers or listeners attached to these objects in previous instances will not be present.
-			// Therefore, it is important to rewire or update any event/listener on these two here to ensure correct behavior.
-			StatusBar.GetForCurrentView().ResetListener();
 		}
 
 		internal void EnsureContentView()
@@ -96,6 +91,11 @@ namespace Microsoft.UI.Xaml
 			// https://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview#10603714
 			RaiseConfigurationChanges();
 			SimpleOrientationSensor.GetDefault()!.OrientationChanged += OnSensorOrientationChanged;
+
+			// Note: Deep-linking will cause a new instance of this Activity and its DecorView to be created.
+			// This means any event handlers or listeners attached to these objects in previous instances will not be present.
+			// Therefore, it is important to rewire or update any event/listener on these two here to ensure correct behavior.
+			StatusBar.GetForCurrentView().ResetListener();
 		}
 
 		private void OnSensorOrientationChanged(SimpleOrientationSensor sender, SimpleOrientationSensorOrientationChangedEventArgs args)

--- a/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.Android.cs
+++ b/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.Android.cs
@@ -25,13 +25,17 @@ namespace Windows.UI.ViewManagement
 
 		internal void ResetListener()
 		{
+			if (_backgroundColor is null) return;
+
 			// used to reset the stale instance of the insets listener
 			// when the activity&decor-view is recreated, eg: on deep-linking
 			if (_insetsListener is { })
 			{
 				_insetsListener = null;
-				SetStatusBarBackgroundColor(_backgroundColor);
 			}
+
+			// using background as a proxy, to trigger an insets update (InsetsListener::OnApplyWindowInsets)
+			SetStatusBarBackgroundColor(_backgroundColor);
 		}
 
 		private void SetStatusBarForegroundType(StatusBarForegroundType? foregroundType)


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#416

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
An application with a status-bar background set, when deep-linked, will have incorrect hitbox due to the insets not being updated.

note: previous fix #22095 made an attempt to fix this, but it was calling ResetListener too early before the activity::window was set, so it had no effect.

## What is the new behavior? 🚀
StatusBar insets are properly updated when deeplinked.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes