### PR TITLE
Revert "chore(ci): Pause iOS/macOS simulator tests during runner rollout"

### DIFF
--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -144,8 +144,7 @@ stages:
 
 - stage: ios_tests
   displayName: Tests - iOS Native
-  # condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true')))
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
+  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true')))
   dependsOn:
     - Setup
 
@@ -189,7 +188,6 @@ stages:
 
 - stage: ios_testflight
   displayName: Publish - iOS Testflight
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   dependsOn:
     - Setup
 

--- a/build/ci/tests/.azure-devops-tests-skia-stages.yml
+++ b/build/ci/tests/.azure-devops-tests-skia-stages.yml
@@ -94,7 +94,6 @@ stages:
 
 - stage: runtime_tests_skia_ios
   displayName: Tests - iOS Skia
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   dependsOn:
     - binaries_build_native_macos
 
@@ -146,7 +145,6 @@ stages:
 
 - stage: runtime_tests_skia_macos
   displayName: Tests - Desktop Skia macOS
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   dependsOn:
     - Setup
     - runtime_tests_skia_build

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -68,7 +68,6 @@ jobs:
 
 - job: Dotnet_Template_Tests_NetCoreMobile_macos
   displayName: 'macOS Tests'
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
 


### PR DESCRIPTION
Reverts unoplatform/uno#22608