### PR TITLE
fix: include ThemeResource reason in HR resource binding updates

### DIFF
--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -458,7 +458,7 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		internal void UpdateResourceBindingsForHotReload() => OnResourcesChanged(ResourceUpdateReason.HotReload);
+		internal void UpdateResourceBindingsForHotReload() => OnResourcesChanged(ResourceUpdateReason.HotReload | ResourceUpdateReason.ThemeResource);
 
 		internal void OnRequestedThemeChanged()
 		{


### PR DESCRIPTION
**GitHub Issue:** closes  unoplatform/Uno.Themes#1580


## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

When an app uses library-provided theme dictionaries (e.g., Material Toolkit) and overrides theme resources at the app level via `ColorPaletteOverride`, Hot Reload does not propagate the updated resource values to controls whose templates were compiled from library NuGet packages.

This happens because library templates are compiled in Release mode with `isHotReloadSupported: false`, so their `{ThemeResource}` bindings are registered with only the `ResourceUpdateReason.ThemeResource` flag. When `UpdateResourceBindingsForHotReload()` fires, it passes only `ResourceUpdateReason.HotReload`, and the bitwise filter in `DependencyObjectStore.InnerUpdateResourceBindingsUnsafe` skips all library bindings since `(ThemeResource & HotReload) == None`.


## What is the new behavior? 🚀

`UpdateResourceBindingsForHotReload()` now passes `ResourceUpdateReason.HotReload | ResourceUpdateReason.ThemeResource`, ensuring that resource bindings registered with either flag are refreshed during Hot Reload. This allows library-compiled controls (like Material Chip, Button, etc.) to correctly pick up theme resource changes made during a Hot Reload session.


## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes