### PR TITLE
chore(ci): Install iOS platforms and enable tests again

### DIFF
--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -145,7 +145,7 @@ stages:
 - stage: ios_tests
   displayName: Tests - iOS Native
   # condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true')))
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
+  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true'), eq(variables['System.PullRequest.SourceBranch'], 'refs/heads/dev/agzi/enabling-ios-macos-tests'))) # Temporary: force-enable on this draft PR for CI timing.
   dependsOn:
     - Setup
 
@@ -189,7 +189,6 @@ stages:
 
 - stage: ios_testflight
   displayName: Publish - iOS Testflight
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   dependsOn:
     - Setup
 

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -144,8 +144,7 @@ stages:
 
 - stage: ios_tests
   displayName: Tests - iOS Native
-  # condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true')))
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true'), eq(variables['System.PullRequest.SourceBranch'], 'refs/heads/dev/agzi/enabling-ios-macos-tests'))) # Temporary: force-enable on this draft PR for CI timing.
+  # condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true'))) # Temporary: force-enable on this draft PR for CI timing.
   dependsOn:
     - Setup
 

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -77,7 +77,7 @@ stages:
 
 - stage: packages_tests
   displayName: Tests - Templates
-  condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.TemplateTestsRequired'], 'true')))
+  # condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.TemplateTestsRequired'], 'true'))) # Temporary: force-enable on this draft PR for CI timing.
   dependsOn:
     - Setup
     - binaries_build_winui

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -77,7 +77,7 @@ stages:
 
 - stage: packages_tests
   displayName: Tests - Templates
-  # condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.TemplateTestsRequired'], 'true'))) # Temporary: force-enable on this draft PR for CI timing.
+  condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.TemplateTestsRequired'], 'true')))
   dependsOn:
     - Setup
     - binaries_build_winui
@@ -144,7 +144,7 @@ stages:
 
 - stage: ios_tests
   displayName: Tests - iOS Native
-  # condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true'))) # Temporary: force-enable on this draft PR for CI timing.
+  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeIos'], 'true')))
   dependsOn:
     - Setup
 

--- a/build/ci/templates/ios-build-select-version.yml
+++ b/build/ci/templates/ios-build-select-version.yml
@@ -6,5 +6,7 @@ steps:
       echo 'xCode Root to ${{parameters.xCodeRoot}}'
       echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${{parameters.xCodeRoot}}
       sudo xcode-select --switch ${{parameters.xCodeRoot}}/Contents/Developer
+      sudo xcodebuild -runFirstLaunch
+      sudo xcodebuild -downloadPlatform iOS
 
     displayName: Select Xcode

--- a/build/ci/templates/ios-build-select-version.yml
+++ b/build/ci/templates/ios-build-select-version.yml
@@ -16,7 +16,7 @@ steps:
       if [ -n "$SDK_VERSION" ]; then
         echo "iOS simulator SDK version: $SDK_VERSION"
       fi
-      if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "$SDK_BUILD_VERSION"; then
+      if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
         echo "Required iOS simulator runtime already installed."
       elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
         echo "Required iOS simulator runtime already installed."
@@ -24,19 +24,22 @@ steps:
         echo "iOS simulator runtime already installed."
       else
         echo "iOS simulator runtime missing, downloading."
+        DOWNLOAD_SUCCESS=false
         for attempt in 1 2 3; do
           if sudo xcodebuild -downloadPlatform iOS; then
+            DOWNLOAD_SUCCESS=true
             break
           fi
           if [ "$attempt" -lt 3 ]; then
             echo "Download failed (attempt $attempt). Retrying in 30s..."
             sudo xcodebuild -runFirstLaunch
             sleep 30
-          else
-            echo "Download failed after $attempt attempts."
           fi
         done
-        if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "$SDK_BUILD_VERSION"; then
+        if [ "$DOWNLOAD_SUCCESS" != "true" ]; then
+          echo "Download failed after $attempt attempts."
+        fi
+        if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
           echo "Required iOS simulator runtime now installed."
         elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
           echo "Required iOS simulator runtime now installed."

--- a/build/ci/templates/ios-build-select-version.yml
+++ b/build/ci/templates/ios-build-select-version.yml
@@ -7,6 +7,46 @@ steps:
       echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${{parameters.xCodeRoot}}
       sudo xcode-select --switch ${{parameters.xCodeRoot}}/Contents/Developer
       sudo xcodebuild -runFirstLaunch
-      sudo xcodebuild -downloadPlatform iOS
+      # Verify expected iOS simulator runtime; download only if missing.
+      SDK_BUILD_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-build-version 2>/dev/null || true)
+      SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version 2>/dev/null || true)
+      if [ -n "$SDK_BUILD_VERSION" ]; then
+        echo "iOS simulator SDK build version: $SDK_BUILD_VERSION"
+      fi
+      if [ -n "$SDK_VERSION" ]; then
+        echo "iOS simulator SDK version: $SDK_VERSION"
+      fi
+      if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "$SDK_BUILD_VERSION"; then
+        echo "Required iOS simulator runtime already installed."
+      elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
+        echo "Required iOS simulator runtime already installed."
+      elif xcrun simctl list runtimes | grep -q "iOS"; then
+        echo "iOS simulator runtime already installed."
+      else
+        echo "iOS simulator runtime missing, downloading."
+        for attempt in 1 2 3; do
+          if sudo xcodebuild -downloadPlatform iOS; then
+            break
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Download failed (attempt $attempt). Retrying in 30s..."
+            sudo xcodebuild -runFirstLaunch
+            sleep 30
+          else
+            echo "Download failed after $attempt attempts."
+          fi
+        done
+        if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "$SDK_BUILD_VERSION"; then
+          echo "Required iOS simulator runtime now installed."
+        elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
+          echo "Required iOS simulator runtime now installed."
+        elif xcrun simctl list runtimes | grep -q "iOS"; then
+          echo "iOS simulator runtime now installed."
+        else
+          echo "iOS simulator runtime still missing after download attempts."
+          xcrun simctl list runtimes
+          exit 1
+        fi
+      fi
 
     displayName: Select Xcode

--- a/build/ci/templates/ios-build-select-version.yml
+++ b/build/ci/templates/ios-build-select-version.yml
@@ -16,13 +16,23 @@ steps:
       if [ -n "$SDK_VERSION" ]; then
         echo "iOS simulator SDK version: $SDK_VERSION"
       fi
-      if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
-        echo "Required iOS simulator runtime already installed."
-      elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
-        echo "Required iOS simulator runtime already installed."
+      if [ -n "$SDK_BUILD_VERSION" ]; then
+        if xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
+          echo "Required iOS simulator runtime already installed."
+          exit 0
+        fi
+      elif [ -n "$SDK_VERSION" ]; then
+        if xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
+          echo "Required iOS simulator runtime already installed."
+          exit 0
+        fi
       elif xcrun simctl list runtimes | grep -q "iOS"; then
         echo "iOS simulator runtime already installed."
-      else
+        exit 0
+      fi
+
+      # Required runtime missing, attempt download.
+      {
         echo "iOS simulator runtime missing, downloading."
         DOWNLOAD_SUCCESS=false
         for attempt in 1 2 3; do
@@ -43,13 +53,13 @@ steps:
           echo "Required iOS simulator runtime now installed."
         elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
           echo "Required iOS simulator runtime now installed."
-        elif xcrun simctl list runtimes | grep -q "iOS"; then
+        elif [ -z "$SDK_BUILD_VERSION" ] && [ -z "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS"; then
           echo "iOS simulator runtime now installed."
         else
           echo "iOS simulator runtime still missing after download attempts."
           xcrun simctl list runtimes
           exit 1
         fi
-      fi
+      }
 
     displayName: Select Xcode

--- a/build/ci/templates/ios-build-select-version.yml
+++ b/build/ci/templates/ios-build-select-version.yml
@@ -3,6 +3,7 @@ parameters:
 
 steps:
   - bash: |
+      set -e
       echo 'xCode Root to ${{parameters.xCodeRoot}}'
       echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${{parameters.xCodeRoot}}
       sudo xcode-select --switch ${{parameters.xCodeRoot}}/Contents/Developer
@@ -22,7 +23,7 @@ steps:
           exit 0
         fi
       elif [ -n "$SDK_VERSION" ]; then
-        if xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
+        if xcrun simctl list runtimes | grep -Fq "iOS $SDK_VERSION"; then
           echo "Required iOS simulator runtime already installed."
           exit 0
         fi
@@ -51,7 +52,7 @@ steps:
         fi
         if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
           echo "Required iOS simulator runtime now installed."
-        elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS $SDK_VERSION"; then
+        elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -Fq "iOS $SDK_VERSION"; then
           echo "Required iOS simulator runtime now installed."
         elif [ -z "$SDK_BUILD_VERSION" ] && [ -z "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS"; then
           echo "iOS simulator runtime now installed."

--- a/build/ci/templates/ios-build-select-version.yml
+++ b/build/ci/templates/ios-build-select-version.yml
@@ -18,7 +18,7 @@ steps:
         echo "iOS simulator SDK version: $SDK_VERSION"
       fi
       if [ -n "$SDK_BUILD_VERSION" ]; then
-        if xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
+        if xcrun simctl list runtimes | grep -Fq "iOS $SDK_BUILD_VERSION"; then
           echo "Required iOS simulator runtime already installed."
           exit 0
         fi
@@ -49,8 +49,11 @@ steps:
         done
         if [ "$DOWNLOAD_SUCCESS" != "true" ]; then
           echo "Download failed after $attempt attempts."
+          echo "iOS simulator runtime download did not complete successfully."
+          xcrun simctl list runtimes || true
+          exit 1
         fi
-        if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -q "iOS.*$SDK_BUILD_VERSION"; then
+        if [ -n "$SDK_BUILD_VERSION" ] && xcrun simctl list runtimes | grep -Fq "iOS $SDK_BUILD_VERSION"; then
           echo "Required iOS simulator runtime now installed."
         elif [ -n "$SDK_VERSION" ] && xcrun simctl list runtimes | grep -Fq "iOS $SDK_VERSION"; then
           echo "Required iOS simulator runtime now installed."

--- a/build/ci/tests/.azure-devops-tests-skia-stages.yml
+++ b/build/ci/tests/.azure-devops-tests-skia-stages.yml
@@ -94,7 +94,6 @@ stages:
 
 - stage: runtime_tests_skia_ios
   displayName: Tests - iOS Skia
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   dependsOn:
     - binaries_build_native_macos
 
@@ -146,7 +145,6 @@ stages:
 
 - stage: runtime_tests_skia_macos
   displayName: Tests - Desktop Skia macOS
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   dependsOn:
     - Setup
     - runtime_tests_skia_build

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -68,7 +68,6 @@ jobs:
 
 - job: Dotnet_Template_Tests_NetCoreMobile_macos
   displayName: 'macOS Tests'
-  condition: and(succeededOrFailed(), false) # Temporarily disabled: runner image propagation not done yet (https://github.com/actions/runner-images/pull/13607)
   timeoutInMinutes: 120
   cancelTimeoutInMinutes: 0
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -245,10 +245,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 #if HAS_UNO
 		[TestMethod]
-#if __ANDROID__ || __APPLE_UIKIT__
-		[Ignore("Fails")]
-#endif
 		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.IOS | RuntimeTestPlatforms.Android)]
 		public async Task When_Path_Contains_Space()
 		{
 			var img = new Image { Source = "ms-appx:///Assets/image with space in path.png" };


### PR DESCRIPTION
This installs iOS platform components after selecting Xcode to avoid missing simulator runtimes on macOS runners. 

It also re-enables the iOS/macOS tests previously disabled in https://github.com/unoplatform/uno/pull/22608
(Ref: https://github.com/actions/runner-images/pull/13607#issuecomment-3883879136 / https://github.com/actions/runner-images/blob/main/README.md#available-images)

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).