### PR TITLE
fix: Default Button style has incorrect padding

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -465,5 +465,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		public class NoopCommand() : DelegateCommand(null, null) { }
+
+		[TestMethod]
+		public async Task When_AccentButtonStyle_Has_Same_Height_As_Default()
+		{
+			var defaultButton = new Button { Content = "Default" };
+			var accentButton = (Button)XamlReader.Load("""
+				<Button xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+						Content="Accent"
+						Style="{StaticResource AccentButtonStyle}" />
+				""");
+
+			var panel = new StackPanel
+			{
+				Children =
+				{
+					defaultButton,
+					accentButton,
+				}
+			};
+
+			await UITestHelper.Load(panel);
+
+			Assert.AreEqual(defaultButton.Padding, accentButton.Padding, "Padding should match between default and AccentButtonStyle buttons");
+			Assert.AreEqual(defaultButton.ActualHeight, accentButton.ActualHeight, "ActualHeight should match between default and AccentButtonStyle buttons");
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -227,7 +227,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 				var fg = SUT.PrimaryButton.Foreground as SolidColorBrush;
 				Assert.IsNotNull(fg);
-				Assert.AreEqual(Colors.Black, fg.Color);
+				Assert.AreEqual(Color.FromArgb(0xE4, 0x00, 0x00, 0x00), fg.Color);
 			}
 			finally
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SKCanvasElement.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SKCanvasElement.skia.cs
@@ -46,6 +46,7 @@ public class Given_SKCanvasElement
 
 	[TestMethod]
 	[GitHubWorkItem("https://github.com/unoplatform/brain-products-private/issues/14")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Android)] // https://github.com/unoplatform/uno/issues/22665
 	public async Task When_Waiting_For_Another_Thread()
 	{
 		if (OperatingSystem.IsBrowser())
@@ -60,6 +61,7 @@ public class Given_SKCanvasElement
 
 	[TestMethod]
 	[GitHubWorkItem("https://github.com/unoplatform/brain-products-private/issues/14")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Android)] // https://github.com/unoplatform/uno/issues/22665
 	public async Task When_Waiting_For_Another_Thread2()
 	{
 		if (OperatingSystem.IsBrowser())

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Explicit_Style.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Explicit_Style.cs
@@ -17,12 +17,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 	[TestClass]
 	public class Given_Explicit_Style
 	{
-#if NETFX_CORE
-		internal static readonly Thickness DefaultButtonPadding = new Thickness(8, 4, 8, 4);
-#else
-		// TODO: adjust this when Uno retargets newer version of the SDK
-		internal static readonly Thickness DefaultButtonPadding = new Thickness(8, 4, 8, 4);
-#endif
+		internal static readonly Thickness DefaultButtonPadding = new Thickness(8, 4, 8, 5);
 		[TestInitialize]
 		public void Init()
 		{

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -2898,15 +2898,17 @@
 	<Style x:Key="XamlDefaultButton"
 				   TargetType="Button">
 		<Setter Property="Background"
-				Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+				Value="{ThemeResource ButtonBackground}" />
+		<Setter Property="BackgroundSizing"
+				Value="OuterBorderEdge" />
 		<Setter Property="Foreground"
-				Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+				Value="{ThemeResource ButtonForeground}" />
 		<Setter Property="BorderBrush"
-				Value="{ThemeResource SystemControlForegroundTransparentBrush}" />
+				Value="{ThemeResource ButtonBorderBrush}" />
 		<Setter Property="BorderThickness"
 				Value="{ThemeResource ButtonBorderThemeThickness}" />
 		<Setter Property="Padding"
-				Value="8,4,8,4" />
+				Value="{StaticResource ButtonPadding}" />
 		<Setter Property="HorizontalAlignment"
 				Value="Left" />
 		<Setter Property="VerticalAlignment"
@@ -2918,89 +2920,87 @@
 		<Setter Property="FontSize"
 				Value="{ThemeResource ControlContentThemeFontSize}" />
 		<Setter Property="UseSystemFocusVisuals"
-				Value="True" />
+				Value="{StaticResource UseSystemFocusVisuals}" />
+		<Setter Property="FocusVisualMargin"
+				Value="-3" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="Button">
-					<Grid x:Name="RootGrid"
-						  Background="{TemplateBinding Background}"
-						  CornerRadius="{TemplateBinding CornerRadius}">
+					<ContentPresenter x:Name="ContentPresenter"
+							Background="{TemplateBinding Background}"
+							BackgroundSizing="{TemplateBinding BackgroundSizing}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							Content="{TemplateBinding Content}"
+							ContentTemplate="{TemplateBinding ContentTemplate}"
+							ContentTransitions="{TemplateBinding ContentTransitions}"
+							CornerRadius="{TemplateBinding CornerRadius}"
+							Padding="{TemplateBinding Padding}"
+							HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+							VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+							AutomationProperties.AccessibilityView="Raw">
+
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal">
-									<!--<Storyboard>
-										<PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
-									</Storyboard>-->
-								</VisualState>
-								<VisualState x:Name="PointerOver">
+
 									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																	   Storyboard.TargetProperty="BorderBrush">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+										<PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
+									</Storyboard>
+								</VisualState>
+
+								<VisualState x:Name="PointerOver">
+
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPointerOver}" />
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																	   Storyboard.TargetProperty="Foreground">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPointerOver}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundPointerOver}" />
 										</ObjectAnimationUsingKeyFrames>
 										<!--<PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />-->
 									</Storyboard>
 								</VisualState>
+
 								<VisualState x:Name="Pressed">
+
 									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
-																	   Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPressed}" />
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																	   Storyboard.TargetProperty="BorderBrush">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPressed}" />
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																	   Storyboard.TargetProperty="Foreground">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlHighlightBaseHighBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundPressed}" />
 										</ObjectAnimationUsingKeyFrames>
 										<!--<PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />-->
 									</Storyboard>
 								</VisualState>
+
 								<VisualState x:Name="Disabled">
+
 									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid"
-																	   Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundDisabled}" />
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																	   Storyboard.TargetProperty="Foreground">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushDisabled}" />
 										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																	   Storyboard.TargetProperty="BorderBrush">
-											<DiscreteObjectKeyFrame KeyTime="0"
-																	Value="{ThemeResource SystemControlDisabledTransparentBrush}" />
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundDisabled}" />
 										</ObjectAnimationUsingKeyFrames>
 									</Storyboard>
 								</VisualState>
+
 							</VisualStateGroup>
+
 						</VisualStateManager.VisualStateGroups>
-						<ContentPresenter x:Name="ContentPresenter"
-										  BorderBrush="{TemplateBinding BorderBrush}"
-										  BorderThickness="{TemplateBinding BorderThickness}"
-										  Content="{TemplateBinding Content}"
-										  ContentTransitions="{TemplateBinding ContentTransitions}"
-										  ContentTemplate="{TemplateBinding ContentTemplate}"
-										  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-										  CornerRadius="{TemplateBinding CornerRadius}"
-										  Padding="{TemplateBinding Padding}"
-										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-										  AutomationProperties.AccessibilityView="Raw" />
-					</Grid>
+					</ContentPresenter>
+
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/22647

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`AccentButtonStyle` has incorrect height, because it inherits default UWP style padding from Generic.xaml.

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

Updated the `Generic.xaml` "UWP" style to correctly use padding theme resource, so that the `AccentButtonStyle` inherits the fluent padding correctly.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes