### PR TITLE
fix(skia): improve subpixel clipping and rendering

### DIFF
--- a/src/Uno.UI.Composition/Composition/CompositionColorBrush.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionColorBrush.skia.cs
@@ -10,7 +10,7 @@ namespace Microsoft.UI.Composition
 	{
 		// We don't call SKPaint.Reset() after usage, so make sure
 		// that only SKPaint.Color is being set
-		private static readonly SKPaint _tempPaint = new();
+		private static readonly SKPaint _tempPaint = new() { IsAntialias = true };
 
 		internal override void Paint(SKCanvas canvas, float opacity, SKRect bounds)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ShapeVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ShapeVisual.cs
@@ -96,10 +96,10 @@ public class Given_ShapeVisual
 						await TestServices.WindowHelper.WaitFor(() => imageOpened);
 
 						var screenShot1 = await UITestHelper.ScreenShot(border);
+						var screenShot2 = await UITestHelper.ScreenShot(referenceImage);
 						// To generate the images
 						// await screenShot1.Save(filename);
 
-						var screenShot2 = await UITestHelper.ScreenShot(referenceImage);
 						// there can be a very small _bit_ difference when drawing with metal on some platforms
 						if (OperatingSystem.IsMacOS() || OperatingSystem.IsBrowser() || OperatingSystem.IsIOS() || OperatingSystem.IsAndroid())
 						{
@@ -107,7 +107,14 @@ public class Given_ShapeVisual
 						}
 						else
 						{
-							await ImageAssert.AreEqualAsync(screenShot1, screenShot2);
+							// with anti-aliasing in CompositionColorBrush, there can be some minor differences sometimes, but not always
+							// so here we first check for pixel equality, and only if that fails we check for similarity,
+							// to avoid the performance cost of the similarity check when not needed.
+							var pixelEqual = await ImageAssert.AreRenderTargetBitmapsEqualAsync(screenShot1.Bitmap, screenShot2.Bitmap);
+							if (!pixelEqual)
+							{
+								await ImageAssert.AreSimilarAsync(screenShot1, screenShot2);
+							}
 						}
 					}
 				}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
@@ -515,6 +515,7 @@ namespace Microsoft.UI.Xaml
 		}
 
 		private static bool IsLessThanAndNotCloseTo(double a, double b) => a < (b - SIZE_EPSILON);
+		private static bool IsCloseTo(double a, double b) => Math.Abs(a - b) < SIZE_EPSILON;
 
 		private void InnerArrangeCore(Rect finalRect)
 		{
@@ -576,7 +577,7 @@ namespace Microsoft.UI.Xaml
 				if (roundedMarginWidth != marginWidth && arrangeSizeWithoutMargin.Width != unclippedDesiredSize.Width)
 				{
 					double arrangeWidthWithoutRoundedMargin = Math.Max(arrangeSize.Width - roundedMarginWidth, 0);
-					if (arrangeWidthWithoutRoundedMargin == unclippedDesiredSize.Width)
+					if (IsCloseTo(arrangeWidthWithoutRoundedMargin, unclippedDesiredSize.Width))
 					{
 						// The rounding difference between arrangeSizeWithoutMargin.width and unclippedDesiredSize.width
 						// comes from the horizontal margin. The rounded value of that margin must be used so that this
@@ -597,7 +598,7 @@ namespace Microsoft.UI.Xaml
 				if (roundedMarginHeight != marginHeight && arrangeSizeWithoutMargin.Height != unclippedDesiredSize.Height)
 				{
 					double arrangeHeightWithoutRoundedMargin = Math.Max(arrangeSize.Height - roundedMarginHeight, 0);
-					if (arrangeHeightWithoutRoundedMargin == unclippedDesiredSize.Height)
+					if (IsCloseTo(arrangeHeightWithoutRoundedMargin, unclippedDesiredSize.Height))
 					{
 						// The rounding difference between arrangeSizeWithoutMargin.height and unclippedDesiredSize.height
 						// comes from the vertical margin. The rounded value of that margin must be used so that this


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#356

## PR Type: 🐞 Bugfix


## What is the current behavior? 🤔
With scaled display (XamlRoot.RasterizationScale, windows: Settings\Display\Scale and layout), eg: 125%, certain elements may fails to render on uno:
- something around the edges of its parent container may get clipped.
- something being rendered on a subpixel(between two pixels)

## What is the new behavior? 🚀
^ should render properly now.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
n/a