### PR TITLE
fix: allow XAML HR when debugging with mono runtime

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/AssemblyDeltaReloadMessageTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/AssemblyDeltaReloadMessageTests.cs
@@ -1,0 +1,174 @@
+using System.Collections.Immutable;
+using Uno.UI.RemoteControl.HotReload.Messages;
+using Uno.UI.RemoteControl.Messaging.IdeChannel;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.HotReload;
+
+/// <summary>
+/// Tests for the <see cref="AssemblyDeltaReload"/> message shape emitted by the server
+/// for both the standard (non-debugger) path and the debugger path.
+/// </summary>
+/// <remarks>
+/// The server emits different frame shapes depending on whether the app is running
+/// with the mono debugger attached (VSCode extension with Uno Platform debugger):
+/// <list type="bullet">
+/// <item>
+///   <term>Non-debugger path</term>
+///   <description>
+///     The server sends a single <see cref="AssemblyDeltaReload"/> frame that contains
+///     all delta fields (MetadataDelta, ILDelta, PdbDelta, ModuleId, UpdatedTypes).
+///     This frame passes <see cref="AssemblyDeltaReload.IsValid"/> on the client side.
+///   </description>
+/// </item>
+/// <item>
+///   <term>Debugger path</term>
+///   <description>
+///     The server sends the metadata, IL and PDB deltas to the IDE via
+///     <see cref="HotReloadThruDebuggerIdeMessage"/>, and then sends a reduced
+///     <see cref="AssemblyDeltaReload"/> frame containing only ModuleId and UpdatedTypes
+///     (no delta bytes).  The client detects this case when running inside the VSCode
+///     extension and applies only the updated-types information (the debugger handles
+///     the actual metadata/IL application).
+///   </description>
+/// </item>
+/// </list>
+/// </remarks>
+[TestClass]
+public class AssemblyDeltaReloadMessageTests
+{
+	// Minimal base-64 placeholder values used by these tests; the actual content
+	// does not matter because we are testing structure, not content.
+	private const string SampleModuleId = "12345678-1234-1234-1234-123456789abc";
+	private const string SampleBase64 = "AQID"; // base-64 for [1, 2, 3]
+	private static readonly ImmutableHashSet<string> SampleFilePaths = ImmutableHashSet.Create("Sample.xaml");
+
+	// ---------------------------------------------------------------------------
+	// Non-debugger path
+	// ---------------------------------------------------------------------------
+
+	/// <summary>
+	/// In the non-debugger path the server populates all delta fields so the client
+	/// can apply the assembly update directly.
+	/// </summary>
+	[TestMethod]
+	public void NonDebuggerPath_AssemblyDeltaReload_IsValid()
+	{
+		// Arrange – simulate what the server produces for the non-debugger path
+		var message = new AssemblyDeltaReload
+		{
+			FilePaths = SampleFilePaths,
+			ModuleId = SampleModuleId,
+			MetadataDelta = SampleBase64,
+			ILDelta = SampleBase64,
+			PdbDelta = SampleBase64,
+			UpdatedTypes = SampleBase64,
+		};
+
+		// Act & Assert
+		message.IsValid().Should().BeTrue("the non-debugger path message must pass IsValid() so the client can apply the delta");
+	}
+
+	/// <summary>
+	/// The non-debugger path frame must carry all four required delta fields.
+	/// </summary>
+	[TestMethod]
+	public void NonDebuggerPath_AssemblyDeltaReload_ContainsAllDeltaFields()
+	{
+		// Arrange
+		var message = new AssemblyDeltaReload
+		{
+			FilePaths = SampleFilePaths,
+			ModuleId = SampleModuleId,
+			MetadataDelta = SampleBase64,
+			ILDelta = SampleBase64,
+			PdbDelta = SampleBase64,
+			UpdatedTypes = SampleBase64,
+		};
+
+		// Assert – every delta field must be present
+		message.ModuleId.Should().NotBeNullOrEmpty("ModuleId is required to identify the assembly");
+		message.MetadataDelta.Should().NotBeNullOrEmpty("MetadataDelta must be present in the non-debugger path");
+		message.ILDelta.Should().NotBeNullOrEmpty("ILDelta must be present in the non-debugger path");
+		message.PdbDelta.Should().NotBeNullOrEmpty("PdbDelta must be present in the non-debugger path");
+		message.UpdatedTypes.Should().NotBeNullOrEmpty("UpdatedTypes must be present so XAML hot reload can refresh the correct types");
+	}
+
+	// ---------------------------------------------------------------------------
+	// Debugger path – AssemblyDeltaReload (reduced frame sent to the app)
+	// ---------------------------------------------------------------------------
+
+	/// <summary>
+	/// In the debugger path the server intentionally omits the delta bytes from the
+	/// <see cref="AssemblyDeltaReload"/> frame because they are forwarded to the IDE.
+	/// The frame therefore fails <see cref="AssemblyDeltaReload.IsValid"/> on its own.
+	/// </summary>
+	[TestMethod]
+	public void DebuggerPath_ReducedAssemblyDeltaReload_IsNotValid()
+	{
+		// Arrange – simulate the reduced frame the server sends when the mono debugger is attached
+		var message = new AssemblyDeltaReload
+		{
+			FilePaths = SampleFilePaths,
+			ModuleId = SampleModuleId,
+			UpdatedTypes = SampleBase64,
+			// MetadataDelta, ILDelta and PdbDelta intentionally absent
+		};
+
+		// Act & Assert
+		message.IsValid().Should().BeFalse("delta bytes are absent in the debugger path; the mono debugger applies them via the IDE channel");
+	}
+
+	/// <summary>
+	/// Although the full <see cref="AssemblyDeltaReload.IsValid"/> check fails for the
+	/// debugger path frame, the client can still process updated types when
+	/// <c>_runningInsideVSCodeExtension</c> is true, using the relaxed check
+	/// <c>UpdatedTypes is not null &amp;&amp; ModuleId is not null</c>.
+	/// </summary>
+	[TestMethod]
+	public void DebuggerPath_ReducedAssemblyDeltaReload_HasRequiredFieldsForVSCodeExtension()
+	{
+		// Arrange – simulate the reduced frame the server sends when the mono debugger is attached
+		var message = new AssemblyDeltaReload
+		{
+			FilePaths = SampleFilePaths,
+			ModuleId = SampleModuleId,
+			UpdatedTypes = SampleBase64,
+			// MetadataDelta, ILDelta and PdbDelta intentionally absent
+		};
+
+		// Act – replicates the client-side check applied when _runningInsideVSCodeExtension is true
+		// (see ClientHotReloadProcessor.Agent.cs)
+		var validForVSCodeExtension = message.UpdatedTypes is not null && message.ModuleId is not null;
+
+		// Assert
+		validForVSCodeExtension.Should().BeTrue("the reduced frame must still carry ModuleId and UpdatedTypes so the client can refresh XAML after the debugger applies the deltas");
+		message.MetadataDelta.Should().BeNull("delta bytes must NOT be in the reduced frame; they go via the IDE channel instead");
+		message.ILDelta.Should().BeNull("delta bytes must NOT be in the reduced frame; they go via the IDE channel instead");
+		message.PdbDelta.Should().BeNull("delta bytes must NOT be in the reduced frame; they go via the IDE channel instead");
+	}
+
+	// ---------------------------------------------------------------------------
+	// Debugger path – HotReloadThruDebuggerIdeMessage (sent to the IDE)
+	// ---------------------------------------------------------------------------
+
+	/// <summary>
+	/// The <see cref="HotReloadThruDebuggerIdeMessage"/> sent via the IDE channel in the
+	/// debugger path must carry all three delta blobs and the module identifier.
+	/// </summary>
+	[TestMethod]
+	public void DebuggerPath_IdeMessage_ContainsAllDeltaFields()
+	{
+		// Arrange – simulate what the server constructs for TrySendMessageToIDEAsync
+		var ideMessage = new HotReloadThruDebuggerIdeMessage(
+			ModuleId: SampleModuleId,
+			MetadataDelta: SampleBase64,
+			IlDelta: SampleBase64,
+			PdbBytes: SampleBase64);
+
+		// Assert
+		ideMessage.ModuleId.Should().NotBeNullOrEmpty("the IDE needs the module GUID to target the correct assembly");
+		ideMessage.MetadataDelta.Should().NotBeNullOrEmpty("the IDE/debugger needs MetadataDelta to apply the update");
+		ideMessage.IlDelta.Should().NotBeNullOrEmpty("the IDE/debugger needs IlDelta to apply the update");
+		ideMessage.PdbBytes.Should().NotBeNullOrEmpty("the IDE/debugger needs PdbBytes for symbol information");
+	}
+}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -450,19 +451,13 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 			static byte[] GetLengthPrefixedArray(ImmutableArray<int> values)
 			{
-				if (values.Length == 0)
+				var result = new byte[sizeof(int) /* length */ + values.Length * sizeof(int)];
+				BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(0), values.Length);
+				for (var i = 0; i < values.Length; i++)
 				{
-					return [0, 0, 0, 0]; // length (empty)
+					BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan((i + 1) * sizeof(int)), values[i]);
 				}
-
-				var stream = new MemoryStream(sizeof(int) /* length */ + values.Length * sizeof(int));
-				var writer = new BinaryWriter(stream);
-				writer.Write(values.Length);
-				foreach (var value in values)
-				{
-					writer.Write(value);
-				}
-				return stream.ToArray();
+				return result;
 			}
 		}
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -179,12 +179,11 @@ namespace Uno.UI.RemoteControl.HotReload
 							this.Log().Error("Hot Reload is not supported when the debugger is attached.");
 						}
 						_status.ReportLocalStarting([]).ReportIgnored("Hot Reload is not supported when the debugger is attached");
+						return;
 					}
-
-					return;
 				}
 
-				if (assemblyDeltaReload.IsValid())
+				if (assemblyDeltaReload.IsValid(_runningInsideVSCodeExtension))
 				{
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
@@ -194,17 +193,23 @@ namespace Uno.UI.RemoteControl.HotReload
 					var changedTypesStreams = new MemoryStream(Convert.FromBase64String(assemblyDeltaReload.UpdatedTypes));
 					var changedTypesReader = new BinaryReader(changedTypesStreams);
 
+					// when executing in VSCode extension / mono runtime the MetadataDelta, ILDelta and PdbBytes are processed thru the debugger
+					// however we still need to apply the updated types (e.g. for XAML HR to work properly)
 					var delta = new UpdateDelta
 					{
-						MetadataDelta = Convert.FromBase64String(assemblyDeltaReload.MetadataDelta),
-						ILDelta = Convert.FromBase64String(assemblyDeltaReload.ILDelta),
-						PdbBytes = Convert.FromBase64String(assemblyDeltaReload.PdbDelta),
+						MetadataDelta = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.MetadataDelta),
+						ILDelta = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.ILDelta),
+						PdbBytes = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.PdbDelta),
 						ModuleId = Guid.Parse(assemblyDeltaReload.ModuleId),
 						UpdatedTypes = ReadIntArray(changedTypesReader)
 					};
 
 					_status.ConfigureSourceForNextOperation(HotReloadSource.DevServer);
-					_agent?.ApplyDeltas(new[] { delta });
+					if (!_runningInsideVSCodeExtension)
+					{
+						_agent?.ApplyDeltas([delta]);
+					}
+					_agent?.ApplyUpdatedTypes([delta]);
 
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -183,24 +183,31 @@ namespace Uno.UI.RemoteControl.HotReload
 					}
 				}
 
-				if (assemblyDeltaReload.IsValid(_runningInsideVSCodeExtension))
+				var valid = assemblyDeltaReload.IsValid();
+				if (!valid && _runningInsideVSCodeExtension)
+				{
+					// if we're running inside the VS Code extension, we can still apply the updated types even if the IL/Metadata/PDB deltas are not present (e.g. when launched with a debugger attached)
+					valid = assemblyDeltaReload.UpdatedTypes is not null && assemblyDeltaReload.ModuleId is not null;
+				}
+
+				if (valid)
 				{
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
 						this.Log().Trace($"Applying IL Delta after {string.Join(",", assemblyDeltaReload.FilePaths)}, Guid:{assemblyDeltaReload.ModuleId}");
 					}
 
-					var changedTypesStreams = new MemoryStream(Convert.FromBase64String(assemblyDeltaReload.UpdatedTypes));
+					var changedTypesStreams = new MemoryStream(Convert.FromBase64String(assemblyDeltaReload.UpdatedTypes!));
 					var changedTypesReader = new BinaryReader(changedTypesStreams);
 
 					// when executing in VSCode extension / mono runtime the MetadataDelta, ILDelta and PdbBytes are processed thru the debugger
 					// however we still need to apply the updated types (e.g. for XAML HR to work properly)
 					var delta = new UpdateDelta
 					{
-						MetadataDelta = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.MetadataDelta),
-						ILDelta = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.ILDelta),
-						PdbBytes = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.PdbDelta),
-						ModuleId = Guid.Parse(assemblyDeltaReload.ModuleId),
+						MetadataDelta = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.MetadataDelta!),
+						ILDelta = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.ILDelta!),
+						PdbBytes = _runningInsideVSCodeExtension ? Array.Empty<byte>() : Convert.FromBase64String(assemblyDeltaReload.PdbDelta!),
+						ModuleId = Guid.Parse(assemblyDeltaReload.ModuleId!),
 						UpdatedTypes = ReadIntArray(changedTypesReader)
 					};
 

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/AssemblyDeltaReload.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/AssemblyDeltaReload.cs
@@ -33,13 +33,13 @@ namespace Uno.UI.RemoteControl.HotReload.Messages
 		string IMessage.Name => Name;
 
 		[MemberNotNullWhen(true, nameof(UpdatedTypes), nameof(MetadataDelta), nameof(ILDelta), nameof(PdbDelta), nameof(ModuleId))]
-		public bool IsValid(bool runningInsideVSCodeExtension)
+		public bool IsValid()
 		{
 			return FilePaths is { IsEmpty: false }
 				&& UpdatedTypes is not null
-				&& (MetadataDelta is not null || runningInsideVSCodeExtension)
-				&& (ILDelta is not null || runningInsideVSCodeExtension)
-				&& (PdbDelta is not null || runningInsideVSCodeExtension)
+				&& MetadataDelta is not null
+				&& ILDelta is not null
+				&& PdbDelta is not null
 				&& ModuleId is not null;
 		}
 	}

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/AssemblyDeltaReload.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/AssemblyDeltaReload.cs
@@ -33,13 +33,13 @@ namespace Uno.UI.RemoteControl.HotReload.Messages
 		string IMessage.Name => Name;
 
 		[MemberNotNullWhen(true, nameof(UpdatedTypes), nameof(MetadataDelta), nameof(ILDelta), nameof(PdbDelta), nameof(ModuleId))]
-		public bool IsValid()
+		public bool IsValid(bool runningInsideVSCodeExtension)
 		{
 			return FilePaths is { IsEmpty: false }
 				&& UpdatedTypes is not null
-				&& MetadataDelta is not null
-				&& ILDelta is not null
-				&& PdbDelta is not null
+				&& (MetadataDelta is not null || runningInsideVSCodeExtension)
+				&& (ILDelta is not null || runningInsideVSCodeExtension)
+				&& (PdbDelta is not null || runningInsideVSCodeExtension)
 				&& ModuleId is not null;
 		}
 	}

--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
@@ -225,7 +225,10 @@ internal sealed class HotReloadAgent : IDisposable
 			var cachedDeltas = _deltas.GetOrAdd(item.ModuleId, static _ => new());
 			cachedDeltas.Add(item);
 		}
+	}
 
+	public void ApplyUpdatedTypes(IReadOnlyList<UpdateDelta> deltas)
+	{
 		try
 		{
 			// Defer discovering metadata update handlers until after hot reload deltas have been applied.

--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
@@ -233,8 +233,7 @@ internal sealed class HotReloadAgent : IDisposable
 		{
 			// Defer discovering metadata update handlers until after hot reload deltas have been applied.
 			// This should give enough opportunity for AppDomain.GetAssemblies() to be sufficiently populated.
-			_handlerActions ??= GetMetadataUpdateHandlerActions();
-			var handlerActions = _handlerActions;
+			var handlerActions = _handlerActions ??= GetMetadataUpdateHandlerActions();
 
 			Type[]? updatedTypes = GetMetadataUpdateTypes(deltas);
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.vscode/issues/1240

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

When debugging with the mono runtime (e.g. iOS  and Android) Hot Reload might not always work, e.g. modifying XAML.

## What is the new behavior? 🚀

Hot Reload should always work, when debugging or not, whatever the runtime.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

- use `AsSpan` instead of `ToArray` to reduce memory allocations
- skip the creation of a `MemoryStream` and a `BinaryWriter` when the array is empty
- needs more testing so it's a draft for the moment