### PR TITLE
fix(text): Harden UnicodeText malformed-text surrogate, indexing, and ICU bidi fallback

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -740,6 +740,66 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_TextBlock_With_Unpaired_Surrogate_Renders()
+		{
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
+			{
+				Assert.Inconclusive();
+			}
+
+			var text = "LTR \uD800 RTL שלום";
+			var sut = new TextBlock
+			{
+				Text = text,
+				TextWrapping = TextWrapping.Wrap
+			};
+			sut.TextHighlighters.Add(new TextHighlighter
+			{
+				Ranges =
+				{
+					new TextRange { StartIndex = 0, Length = text.Length }
+				}
+			});
+
+			var root = new Border
+			{
+				Width = 240,
+				Height = 120,
+				Child = sut
+			};
+
+			await UITestHelper.Load(root);
+			await UITestHelper.ScreenShot(root);
+		}
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_TextBlock_With_Unpaired_Surrogate_And_No_Highlighter_Renders()
+		{
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
+			{
+				Assert.Inconclusive();
+			}
+
+			var sut = new TextBlock
+			{
+				Text = "LTR \uD800 RTL שלום",
+				TextWrapping = TextWrapping.Wrap
+			};
+
+			var root = new Border
+			{
+				Width = 240,
+				Height = 120,
+				Child = sut
+			};
+
+			await UITestHelper.Load(root);
+			await UITestHelper.ScreenShot(root);
+		}
+
+		[TestMethod]
 #if !__ANDROID__
 		[Ignore("Android-only test for AndroidAssets backward compatibility")]
 #endif

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBlockTests/Given_TextBlock.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBlockTests/Given_TextBlock.cs
@@ -7,8 +7,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Controls;
-using System.Drawing;
 using Microsoft.UI.Xaml.Media;
+using Windows.Foundation;
 
 namespace Uno.UI.Tests.Windows_UI_XAML_Controls.TextBlockTests
 {
@@ -50,6 +50,55 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.TextBlockTests
 			Assert.AreEqual(SolidColorBrushHelper.AliceBlue.Color, ((SolidColorBrush)tb.Foreground).Color);
 		}
 #endif
+
+		[TestMethod]
+		public void When_Text_Has_Unpaired_Surrogate_Does_Not_Throw()
+		{
+			var tb = new TextBlock
+			{
+				Text = "A\uD800B\uDC00"
+			};
+
+			tb.Measure(new Size(300, 80));
+		}
+
+		[TestMethod]
+		public void When_Text_Has_Unpaired_Surrogate_With_Highlighter_Does_Not_Throw()
+		{
+			var tb = new TextBlock
+			{
+				Text = "A\uD800B\uDC00"
+			};
+
+			tb.TextHighlighters.Add(new TextHighlighter
+			{
+				Ranges =
+				{
+					new TextRange { StartIndex = 0, Length = tb.Text.Length }
+				}
+			});
+
+			tb.Measure(new Size(300, 80));
+		}
+
+		[TestMethod]
+		public void When_Highlighter_Range_Exceeds_Text_Does_Not_Throw()
+		{
+			var tb = new TextBlock
+			{
+				Text = "abc"
+			};
+
+			tb.TextHighlighters.Add(new TextHighlighter
+			{
+				Ranges =
+				{
+					new TextRange { StartIndex = 0, Length = 999 }
+				}
+			});
+
+			tb.Measure(new Size(300, 80));
+		}
 
 		[TestMethod]
 		public void When_LineBreak_SurroundingWhiteSpace()


### PR DESCRIPTION
Related to https://github.com/unoplatform/kahua-private/issues/426

## Summary
This PR hardens the Skia `UnicodeText` crash path for malformed-text scenarios, focusing on draw-time indexing, surrogate handling, and ICU/bidi setup. The goal is fail-safe rendering (no runtime exceptions) for the reported repro family.

## Why
The [repro1](https://github.com/unoplatform/kahua-private/issues/426#issuecomment-3930074957) and [repro2](https://github.com/unoplatform/kahua-private/issues/426#issuecomment-3935800282) hit `ArgumentOutOfRangeException` in `UnicodeText.Draw` with malformed surrogate/highlighter combinations. While fixing that path, related edge cases in bidi setup and draw-time index access were hardened to prevent equivalent crash outcomes.

## What changed
- Added draw-time bounds guards for:
  - highlighter slices traversal,
  - run-break traversal,
  - word-boundary/correction indexing,
  - line and line-metric index access.
- Adjusted highlighter foreground/background fallback behavior to keep foreground optional and correctly fall back to run/default brushes.
- Sanitized malformed surrogate code units to `U+FFFD` before shaping while preserving inline boundary behavior.
- Added bidi fallback/retry behavior: if `ubidi_setPara` fails with embedding levels, retry without embedding levels.
- Ensured bidi handle cleanup when `ubidi_setPara` fails in ICU interop.
- Included ICU/bidi block formatting cleanup in the touched path.
- Added targeted tests:
  - Unit tests for unpaired surrogate and oversized highlighter-range scenarios.
  - Skia runtime tests for unpaired surrogate rendering (with and without highlighter).

## Local Validation
- `dotnet build src/Uno.UI/Uno.UI.Tests.csproj -c Debug -f net9.0`
- `dotnet build src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Skia.csproj -c Debug`
- `dotnet test src/Uno.UI.Tests/Uno.UI.Tests.csproj -c Debug -f net9.0 --filter "FullyQualifiedName~When_Text_Has_Unpaired_Surrogate|FullyQualifiedName~When_Highlighter_Range_Exceeds_Text"`
- Desktop and WASM repro smoke scans no longer match the original `UnicodeText` crash signatures. 
  (With [repro1](https://github.com/unoplatform/kahua-private/issues/426#issuecomment-3930074957) and [repro2](https://github.com/unoplatform/kahua-private/issues/426#issuecomment-3935800282))