### PR TITLE
chore: fix local SKIA projects (netcoremobile, generic, etc)

### DIFF
--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.netcoremobile.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.netcoremobile.csproj
@@ -8,8 +8,10 @@
 
 	<PropertyGroup>
 		<!-- When building for the generic net target (e.g., via UnoTargetFrameworkOverride=net10.0),
-		     use the Skia runtime identifier so that NativeDispatcher.skia.cs is included. -->
-		<UnoRuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == ''">Skia</UnoRuntimeIdentifier>
+		     use the Skia runtime identifier so that NativeDispatcher.skia.cs is included.
+		     Use GetTargetPlatformIdentifier() instead of $(TargetPlatformIdentifier) because the latter
+		     is set in Sdk.targets (after project file evaluation) and would always be empty here. -->
+		<UnoRuntimeIdentifier Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == ''">Skia</UnoRuntimeIdentifier>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.netcoremobile.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.netcoremobile.csproj
@@ -7,6 +7,12 @@
 	<Import Project="../targetframework-override.props" />
 
 	<PropertyGroup>
+		<!-- When building for the generic net target (e.g., via UnoTargetFrameworkOverride=net10.0),
+		     use the Skia runtime identifier so that NativeDispatcher.skia.cs is included. -->
+		<UnoRuntimeIdentifier Condition="'$(TargetPlatformIdentifier)' == ''">Skia</UnoRuntimeIdentifier>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<AssemblyName>Uno.UI.Dispatching</AssemblyName>
 		<RootNamespace>Uno.UI.Dispatching</RootNamespace>
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;IS_UNO_UI_DISPATCHING_PROJECT</DefineConstants>


### PR DESCRIPTION
**GitHub Issue:** closes #

Building either Skia.Generic or Skia.netcoremobile locally is failing with:

```
uno/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs(485,57): error CS0103: The name
  'GetHasThreadAccess' does not exist in the current context
```

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->