### PR TITLE
docs: add root-cause debugging protocol for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,85 @@ Auto-generated stubs marked with `[Uno.NotImplemented]` allow compilation but wa
 
 ## Development Workflow
 
+### Root-Cause First Debugging Protocol (MANDATORY)
+
+When fixing crashes, rendering issues, or selection/indexing bugs,
+agents must follow this order:
+
+1. **Reproduce first**
+   - Capture exact repro steps and expected vs actual behavior.
+   - Keep one known-good repro path and rerun it after each meaningful change.
+
+2. **Identify the broken invariant**
+   - Prefer state/lifecycle invariants over symptom-level checks.
+   - For pipelines that derive secondary state, verify those derived
+      structures (for example: maps, indices, caches, or metadata)
+      are rebuilt from final post-mutation state.
+
+3. **Fix root cause before adding guards**
+    - Do not lead with null/index guards as the primary fix if
+       ownership/lifecycle is incorrect.
+    - Defensive guards are allowed only after root-cause correction,
+       and only as secondary hardening.
+
+4. **Prove correctness with targeted tests**
+   - Add/extend tests that fail before and pass after the root fix.
+   - Cover both the triggering scenario and one adjacent regression scenario.
+
+5. **Validate with runtime behavior, not compile only**
+   - Run the closest runtime or integration path available for the changed area.
+   - If full runtime execution is not possible in the environment,
+       state that explicitly and provide the exact command(s) for
+       maintainers to run.
+
+6. **Communicate confidence accurately**
+   - Separate: (a) code review assessment,
+       (b) compile validation, (c) runtime validation.
+   - Never present guard-only mitigation as a complete root-cause fix.
+
+**Anti-pattern to avoid:**
+
+- Symptom-driven patching that accumulates bounds checks while
+   stale or invalid intermediate state remains possible.
+
+### Validation Evidence Protocol (MANDATORY)
+
+For bug fixes and PR reviews, agents must report validation evidence
+with explicit labels:
+
+- **Code review assessment**: What logic appears correct by inspection.
+- **Compile validation**: Which project/solution was built, and result.
+- **Runtime validation**: Which app/test path was executed, and result.
+
+Rules:
+
+1. Do not present compile-only checks as runtime validation.
+2. If runtime execution is skipped or blocked, state that explicitly
+   and provide exact commands to run.
+3. When reviewing another PR, distinguish between confidence from
+   diff inspection vs. confidence from local execution.
+
+### Diagnosis Bias Checks (MANDATORY)
+
+Before proposing a crash fix, agents must run these checks to avoid
+choosing symptom-level guards over the real fix:
+
+1. **Invariant checkpoint before patching**
+    - Name the invariant likely broken (ownership, lifecycle,
+       index/map coherence, post-mutation consistency).
+   - If no invariant is identified, do not claim a root-cause fix.
+
+2. **Mutation-point review**
+    - Inspect where state is created/trimmed/reordered and verify all
+       dependent structures are refreshed there.
+    - Prefer correcting the mutation point over adding protections in
+       downstream consumers.
+
+3. **Guard classification**
+    - Explicitly label each proposed change as either
+       `root-cause fix` or `defensive hardening`.
+   - Guard-only changes must not be presented as complete resolution.
+
 ### Validation Checklist
 
 Run these after making changes:


### PR DESCRIPTION
This updates AGENTS guidance to steer agents toward root-cause-first debugging for crash and indexing issues, instead of symptom-first guard patching. It adds mandatory diagnosis and validation evidence protocols so confidence and verification claims are explicit and reproducible.

> [!NOTE]
> We are keeping this guidance in AGENTS.md for now. We can refactor it into an Uno-core-specific skill later if AGENTS.md grows too large after syncing with @jeromelaban 

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).