### PR TITLE
fix(win32): avoid flickering when attaching windows

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -69,6 +69,7 @@ partial class ContentPresenter
 			{
 				//If in visual tree, attach immediately. If not, don't attach since Enter will attach later.
 				AttachNativeElement();
+				ArrangeNativeElement();
 			}
 		}
 		else
@@ -87,8 +88,16 @@ partial class ContentPresenter
 		_nativeElementHostingExtension.Value!.AttachNativeElement(Content);
 		_nativeHosts.Add(this);
 		var ct = ((CompositionTarget)Visual.CompositionTarget)!;
-		ct.FrameRendered += ArrangeNativeElement;
-		_frameRenderedDisposable = Disposable.Create(() => ct.FrameRendered -= ArrangeNativeElement);
+		ct.FrameRendered += OnFrameRendered;
+		_frameRenderedDisposable = Disposable.Create(() => ct.FrameRendered -= OnFrameRendered);
+	}
+
+	private void OnFrameRendered()
+	{
+		if (_nativeElementAttached)
+		{
+			ArrangeNativeElement();
+		}
 	}
 
 	partial void DetachNativeElement(object content)
@@ -171,6 +180,7 @@ partial class ContentPresenter
 						// We're detaching the native element as it's no longer in view, but conceptually, it's still in the tree, so IsNativeHost is still true
 						Debug.Assert(host.IsNativeHost);
 						host._nativeElementAttached = false;
+						host._lastArrangeRect = null;
 						host._nativeElementHostingExtension.Value!.DetachNativeElement(host.Content);
 					}
 					else


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/22694

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->