### PR TITLE
Support for stroke caps, stroke dash, stroke line join

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -5684,6 +5684,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Shape_StrokeCapJoin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\StretchPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -9306,6 +9310,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Shape_StrokeTest.xaml.cs">
       <DependentUpon>Shape_StrokeTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Shape_StrokeCapJoin.xaml.cs">
+      <DependentUpon>Shape_StrokeCapJoin.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\StretchPage.xaml.cs">
       <DependentUpon>StretchPage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
@@ -1,0 +1,133 @@
+<Page
+	x:Class="SamplesApp.Windows_UI_Xaml_Shapes.Shape_StrokeCapJoin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<ScrollViewer>
+		<StackPanel Spacing="16" Padding="16">
+
+			<!-- Line Caps -->
+			<TextBlock Text="StrokeStartLineCap / StrokeEndLineCap" FontWeight="Bold" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Flat (default)" />
+				<Line X1="20" Y1="20" X2="200" Y2="20"
+					  Stroke="Black" StrokeThickness="10"
+					  StrokeStartLineCap="Flat" StrokeEndLineCap="Flat" />
+
+				<TextBlock Text="Round" />
+				<Line X1="20" Y1="20" X2="200" Y2="20"
+					  Stroke="Blue" StrokeThickness="10"
+					  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+
+				<TextBlock Text="Square" />
+				<Line X1="20" Y1="20" X2="200" Y2="20"
+					  Stroke="Green" StrokeThickness="10"
+					  StrokeStartLineCap="Square" StrokeEndLineCap="Square" />
+
+				<TextBlock Text="Triangle" />
+				<Line X1="20" Y1="20" X2="200" Y2="20"
+					  Stroke="Red" StrokeThickness="10"
+					  StrokeStartLineCap="Triangle" StrokeEndLineCap="Triangle" />
+
+				<TextBlock Text="Different: Start=Round, End=Square" />
+				<Line X1="20" Y1="20" X2="200" Y2="20"
+					  Stroke="Purple" StrokeThickness="10"
+					  StrokeStartLineCap="Round" StrokeEndLineCap="Square" />
+			</StackPanel>
+
+			<!-- Line Joins -->
+			<TextBlock Text="StrokeLineJoin" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Miter (default)" />
+				<Polyline Points="20,50 60,10 100,50 140,10 180,50"
+						  Stroke="Black" StrokeThickness="8"
+						  StrokeLineJoin="Miter" Fill="Transparent" />
+
+				<TextBlock Text="Bevel" />
+				<Polyline Points="20,50 60,10 100,50 140,10 180,50"
+						  Stroke="Blue" StrokeThickness="8"
+						  StrokeLineJoin="Bevel" Fill="Transparent" />
+
+				<TextBlock Text="Round" />
+				<Polyline Points="20,50 60,10 100,50 140,10 180,50"
+						  Stroke="Green" StrokeThickness="8"
+						  StrokeLineJoin="Round" Fill="Transparent" />
+			</StackPanel>
+
+			<!-- Dash Caps -->
+			<TextBlock Text="StrokeDashCap" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Flat dash cap" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Black" StrokeThickness="8"
+					  StrokeDashArray="3 2"
+					  StrokeDashCap="Flat" />
+
+				<TextBlock Text="Round dash cap" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Blue" StrokeThickness="8"
+					  StrokeDashArray="3 2"
+					  StrokeDashCap="Round" />
+
+				<TextBlock Text="Square dash cap" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Green" StrokeThickness="8"
+					  StrokeDashArray="3 2"
+					  StrokeDashCap="Square" />
+			</StackPanel>
+
+			<!-- Dash Offset -->
+			<TextBlock Text="StrokeDashOffset" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Offset=0" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Black" StrokeThickness="6"
+					  StrokeDashArray="4 2"
+					  StrokeDashOffset="0" />
+
+				<TextBlock Text="Offset=2" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Black" StrokeThickness="6"
+					  StrokeDashArray="4 2"
+					  StrokeDashOffset="2" />
+
+				<TextBlock Text="Offset=4" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Black" StrokeThickness="6"
+					  StrokeDashArray="4 2"
+					  StrokeDashOffset="4" />
+			</StackPanel>
+
+			<!-- Issue #5426 repro: Path with round caps and joins -->
+			<TextBlock Text="Issue #5426 repro: Path with Round caps and joins" FontWeight="Bold" Margin="0,16,0,0" />
+			<Path Stroke="DarkBlue" StrokeThickness="8"
+				  StrokeStartLineCap="Round" StrokeEndLineCap="Round"
+				  StrokeLineJoin="Round"
+				  Data="M 20,80 L 80,20 L 140,80 L 200,20" />
+
+			<!-- StrokeMiterLimit -->
+			<TextBlock Text="StrokeMiterLimit" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="MiterLimit=10 (default)" />
+				<Polyline Points="20,50 50,10 80,50"
+						  Stroke="Black" StrokeThickness="10"
+						  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+
+				<TextBlock Text="MiterLimit=1 (bevel fallback)" />
+				<Polyline Points="20,50 50,10 80,50"
+						  Stroke="Black" StrokeThickness="10"
+						  StrokeLineJoin="Miter" StrokeMiterLimit="1" Fill="Transparent" />
+			</StackPanel>
+
+		</StackPanel>
+	</ScrollViewer>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
@@ -106,6 +106,62 @@
 					  StrokeDashOffset="4" />
 			</StackPanel>
 
+			<!-- Dashed Endpoint Caps: WinUI uses StartCap/EndCap at path endpoints, DashCap only at internal boundaries -->
+			<TextBlock Text="Dashed Endpoint Caps (DashCap vs StartCap/EndCap)" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="DashCap=Round, Start/EndCap=Flat (default) — endpoints should be FLAT" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="DarkRed" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round" />
+				</Grid>
+
+				<TextBlock Text="DashCap=Round, StartCap=Round, EndCap=Round — all caps round (reference)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="DarkBlue" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+				</Grid>
+
+				<TextBlock Text="DashCap=Round, StartCap=Square, EndCap=Flat — start=square, end=flat" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="DarkGreen" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeStartLineCap="Square" StrokeEndLineCap="Flat" />
+				</Grid>
+
+				<TextBlock Text="DashCap=Square, Start/EndCap=Flat — endpoints should be FLAT" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="Purple" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Square" />
+				</Grid>
+
+				<TextBlock Text="DashCap=Flat, StartCap=Round, EndCap=Round — endpoints round, internal flat" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="Teal" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Flat"
+						  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+				</Grid>
+
+				<TextBlock Text="Path: DashCap=Round, Start/EndCap=Flat — endpoints should be FLAT" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="Crimson" StrokeThickness="12"
+						  StrokeDashArray="2 1"
+						  StrokeDashCap="Round"
+						  Data="M 30,50 L 120,20 L 220,80" />
+				</Grid>
+			</StackPanel>
+
 			<!-- Issue #5426 repro: Path with round caps and joins -->
 			<TextBlock Text="Issue #5426 repro: Path with Round caps and joins" FontWeight="Bold" Margin="0,16,0,0" />
 			<Path Stroke="DarkBlue" StrokeThickness="8"
@@ -117,15 +173,253 @@
 			<TextBlock Text="StrokeMiterLimit" FontWeight="Bold" Margin="0,16,0,0" />
 
 			<StackPanel Spacing="8">
-				<TextBlock Text="MiterLimit=10 (default)" />
-				<Polyline Points="20,50 50,10 80,50"
-						  Stroke="Black" StrokeThickness="10"
-						  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				<!-- Sharp angle (V shape ~53°) -->
+				<TextBlock Text="Sharp V (53°) — MiterLimit=10 (default)" />
+				<Grid Height="70" Background="LightGray">
+					<Polyline Points="20,60 50,10 80,60"
+							  Stroke="Black" StrokeThickness="10"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				</Grid>
 
-				<TextBlock Text="MiterLimit=1 (bevel fallback)" />
-				<Polyline Points="20,50 50,10 80,50"
-						  Stroke="Black" StrokeThickness="10"
-						  StrokeLineJoin="Miter" StrokeMiterLimit="1" Fill="Transparent" />
+				<TextBlock Text="Sharp V (53°) — MiterLimit=4" />
+				<Grid Height="70" Background="LightGray">
+					<Polyline Points="20,60 50,10 80,60"
+							  Stroke="Black" StrokeThickness="10"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="4" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Sharp V (53°) — MiterLimit=2" />
+				<Grid Height="70" Background="LightGray">
+					<Polyline Points="20,60 50,10 80,60"
+							  Stroke="Black" StrokeThickness="10"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="2" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Sharp V (53°) — MiterLimit=1 (bevel fallback)" />
+				<Grid Height="70" Background="LightGray">
+					<Polyline Points="20,60 50,10 80,60"
+							  Stroke="Black" StrokeThickness="10"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="1" Fill="Transparent" />
+				</Grid>
+
+				<!-- Very sharp angle (~15°) — miter extends far -->
+				<TextBlock Text="Very sharp (~15°) — MiterLimit=10 (default)" />
+				<Grid Height="90" Background="LightGray">
+					<Polyline Points="20,80 50,10 80,80"
+							  Stroke="Red" StrokeThickness="14"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Very sharp (~15°) — MiterLimit=4" />
+				<Grid Height="90" Background="LightGray">
+					<Polyline Points="20,80 50,10 80,80"
+							  Stroke="Red" StrokeThickness="14"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="4" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Very sharp (~15°) — MiterLimit=2" />
+				<Grid Height="90" Background="LightGray">
+					<Polyline Points="20,80 50,10 80,80"
+							  Stroke="Red" StrokeThickness="14"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="2" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Very sharp (~15°) — MiterLimit=1" />
+				<Grid Height="90" Background="LightGray">
+					<Polyline Points="20,80 50,10 80,80"
+							  Stroke="Red" StrokeThickness="14"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="1" Fill="Transparent" />
+				</Grid>
+
+				<!-- Wide angle (~120°) — miter is short -->
+				<TextBlock Text="Wide angle (~120°) — MiterLimit=10 (default)" />
+				<Grid Height="60" Background="LightGray">
+					<Polyline Points="20,20 100,50 180,20"
+							  Stroke="Blue" StrokeThickness="10"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Wide angle (~120°) — MiterLimit=1" />
+				<Grid Height="60" Background="LightGray">
+					<Polyline Points="20,20 100,50 180,20"
+							  Stroke="Blue" StrokeThickness="10"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="1" Fill="Transparent" />
+				</Grid>
+
+				<!-- Multiple joins with different angles -->
+				<TextBlock Text="Zigzag (mixed angles) — MiterLimit=10 (default)" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="10,60 40,10 70,60 100,10 130,60 160,10 190,60"
+							  Stroke="DarkGreen" StrokeThickness="8"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Zigzag (mixed angles) — MiterLimit=2" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="10,60 40,10 70,60 100,10 130,60 160,10 190,60"
+							  Stroke="DarkGreen" StrokeThickness="8"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="2" Fill="Transparent" />
+				</Grid>
+
+				<!-- Thick stroke to exaggerate miter differences -->
+				<TextBlock Text="Thick stroke (20px), sharp angle — MiterLimit=10" />
+				<Grid Height="100" Background="LightGray">
+					<Polyline Points="30,80 80,15 130,80"
+							  Stroke="Crimson" StrokeThickness="20"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Thick stroke (20px), sharp angle — MiterLimit=4" />
+				<Grid Height="100" Background="LightGray">
+					<Polyline Points="30,80 80,15 130,80"
+							  Stroke="Crimson" StrokeThickness="20"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="4" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Thick stroke (20px), sharp angle — MiterLimit=2" />
+				<Grid Height="100" Background="LightGray">
+					<Polyline Points="30,80 80,15 130,80"
+							  Stroke="Crimson" StrokeThickness="20"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="2" Fill="Transparent" />
+				</Grid>
+
+				<!-- Right angle (90°) -->
+				<TextBlock Text="Right angle (90°) — MiterLimit=10" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="20,20 20,60 80,60"
+							  Stroke="Teal" StrokeThickness="12"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="10" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Right angle (90°) — MiterLimit=1" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="20,20 20,60 80,60"
+							  Stroke="Teal" StrokeThickness="12"
+							  StrokeLineJoin="Miter" StrokeMiterLimit="1" Fill="Transparent" />
+				</Grid>
+
+				<!-- Path with MiterLimit -->
+				<TextBlock Text="Path zigzag — Miter, MiterLimit=10" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="DarkBlue" StrokeThickness="10"
+						  StrokeLineJoin="Miter" StrokeMiterLimit="10"
+						  Data="M 20,80 L 60,15 L 100,80 L 140,15 L 180,80" />
+				</Grid>
+
+				<TextBlock Text="Path zigzag — Miter, MiterLimit=2" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="DarkBlue" StrokeThickness="10"
+						  StrokeLineJoin="Miter" StrokeMiterLimit="2"
+						  Data="M 20,80 L 60,15 L 100,80 L 140,15 L 180,80" />
+				</Grid>
+			</StackPanel>
+
+			<!-- Round Join comparison -->
+			<TextBlock Text="StrokeLineJoin=Round (comparison)" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Sharp V (53°) — Round" />
+				<Grid Height="70" Background="LightGray">
+					<Polyline Points="20,60 50,10 80,60"
+							  Stroke="Black" StrokeThickness="10"
+							  StrokeLineJoin="Round" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Very sharp (~15°) — Round" />
+				<Grid Height="90" Background="LightGray">
+					<Polyline Points="20,80 50,10 80,80"
+							  Stroke="Red" StrokeThickness="14"
+							  StrokeLineJoin="Round" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Wide angle (~120°) — Round" />
+				<Grid Height="60" Background="LightGray">
+					<Polyline Points="20,20 100,50 180,20"
+							  Stroke="Blue" StrokeThickness="10"
+							  StrokeLineJoin="Round" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Zigzag — Round" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="10,60 40,10 70,60 100,10 130,60 160,10 190,60"
+							  Stroke="DarkGreen" StrokeThickness="8"
+							  StrokeLineJoin="Round" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Thick stroke (20px), sharp angle — Round" />
+				<Grid Height="100" Background="LightGray">
+					<Polyline Points="30,80 80,15 130,80"
+							  Stroke="Crimson" StrokeThickness="20"
+							  StrokeLineJoin="Round" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Right angle (90°) — Round" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="20,20 20,60 80,60"
+							  Stroke="Teal" StrokeThickness="12"
+							  StrokeLineJoin="Round" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Path zigzag — Round" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="DarkBlue" StrokeThickness="10"
+						  StrokeLineJoin="Round"
+						  Data="M 20,80 L 60,15 L 100,80 L 140,15 L 180,80" />
+				</Grid>
+			</StackPanel>
+
+			<!-- Bevel Join comparison -->
+			<TextBlock Text="StrokeLineJoin=Bevel (comparison)" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Sharp V (53°) — Bevel" />
+				<Grid Height="70" Background="LightGray">
+					<Polyline Points="20,60 50,10 80,60"
+							  Stroke="Black" StrokeThickness="10"
+							  StrokeLineJoin="Bevel" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Very sharp (~15°) — Bevel" />
+				<Grid Height="90" Background="LightGray">
+					<Polyline Points="20,80 50,10 80,80"
+							  Stroke="Red" StrokeThickness="14"
+							  StrokeLineJoin="Bevel" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Wide angle (~120°) — Bevel" />
+				<Grid Height="60" Background="LightGray">
+					<Polyline Points="20,20 100,50 180,20"
+							  Stroke="Blue" StrokeThickness="10"
+							  StrokeLineJoin="Bevel" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Zigzag — Bevel" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="10,60 40,10 70,60 100,10 130,60 160,10 190,60"
+							  Stroke="DarkGreen" StrokeThickness="8"
+							  StrokeLineJoin="Bevel" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Thick stroke (20px), sharp angle — Bevel" />
+				<Grid Height="100" Background="LightGray">
+					<Polyline Points="30,80 80,15 130,80"
+							  Stroke="Crimson" StrokeThickness="20"
+							  StrokeLineJoin="Bevel" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Right angle (90°) — Bevel" />
+				<Grid Height="80" Background="LightGray">
+					<Polyline Points="20,20 20,60 80,60"
+							  Stroke="Teal" StrokeThickness="12"
+							  StrokeLineJoin="Bevel" Fill="Transparent" />
+				</Grid>
+
+				<TextBlock Text="Path zigzag — Bevel" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="DarkBlue" StrokeThickness="10"
+						  StrokeLineJoin="Bevel"
+						  Data="M 20,80 L 60,15 L 100,80 L 140,15 L 180,80" />
+				</Grid>
 			</StackPanel>
 
 		</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
@@ -162,6 +162,152 @@
 				</Grid>
 			</StackPanel>
 
+			<!-- Zero-Length Dash at Endpoint Edge Cases -->
+			<!-- When a dashed line's endpoint falls in a gap (or at a gap/dash boundary), -->
+			<!-- WinUI creates a zero-length dash: DashCap facing backward + EndCap facing forward. -->
+			<!-- Line length=240, pattern [48,32] (StrokeDashArray="3 2", Thickness=16): -->
+			<!-- 240/80=3 exactly. Dashes at [0-48],[80-128],[160-208]. Gap ends at 240=endpoint. -->
+			<TextBlock Text="Zero-Length Dash at Endpoint (gap boundary)" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<!-- Case 1: All caps Round — endpoint at gap end -->
+				<!-- Previously broken: calling condition skipped when all caps matched -->
+				<TextBlock Text="All Round caps, endpoint in gap — full circle at end (backward+forward)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="DarkRed" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+				</Grid>
+
+				<!-- Case 2: DashCap=Round, EndCap=Flat — only backward semicircle at end -->
+				<TextBlock Text="DashCap=Round, EndCap=Flat, endpoint in gap — semicircle at end (backward only)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="DarkBlue" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round" />
+				</Grid>
+
+				<!-- Case 3: DashCap=Square, EndCap=Round — Square backward + Round forward -->
+				<TextBlock Text="DashCap=Square, EndCap=Round, endpoint in gap — square back + round fwd" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="DarkGreen" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Square"
+						  StrokeEndLineCap="Round" />
+				</Grid>
+
+				<!-- Case 4: DashCap=Flat, EndCap=Round — only forward semicircle at end -->
+				<TextBlock Text="DashCap=Flat, EndCap=Round, endpoint in gap — semicircle at end (forward only)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="Teal" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Flat"
+						  StrokeEndLineCap="Round" />
+				</Grid>
+
+				<!-- Case 5: All Flat — nothing extra at endpoint (optimization: skip entirely) -->
+				<TextBlock Text="All Flat caps, endpoint in gap — no protrusion at end" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="270" Y2="20"
+						  Stroke="Gray" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Flat" />
+				</Grid>
+			</StackPanel>
+
+			<!-- Endpoint at exact dash end — IsEndpointInRenderedDash should return true -->
+			<!-- Line length=208, pattern [48,32]: dashes at [0-48],[80-128],[160-208]. Endpoint at 208 = dash end. -->
+			<TextBlock Text="Endpoint at Exact Dash End (no zero-length dash)" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<!-- Case 6: Endpoint at dash end, DashCap=Round, EndCap=Flat — swap to Flat -->
+				<TextBlock Text="DashCap=Round, EndCap=Flat, endpoint at dash end — flat end (cap swap)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="238" Y2="20"
+						  Stroke="DarkRed" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round" />
+				</Grid>
+
+				<!-- Case 7: Endpoint at dash end, all Round — no swap needed, just Round -->
+				<TextBlock Text="All Round, endpoint at dash end — round end (no change needed)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="238" Y2="20"
+						  Stroke="DarkBlue" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+				</Grid>
+			</StackPanel>
+
+			<!-- Short line where endpoint lands in gap -->
+			<!-- Line length=60, pattern [48,32]: one dash [0-48], gap [48-60]. Endpoint in gap. -->
+			<TextBlock Text="Short Line — Endpoint in Gap" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Short line (60px), DashCap=Round — no extra at end (mid-gap)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="90" Y2="20"
+						  Stroke="Purple" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round" />
+				</Grid>
+
+				<TextBlock Text="Short line (60px), all Round — no extra at end (mid-gap)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="90" Y2="20"
+						  Stroke="Crimson" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeStartLineCap="Round" StrokeEndLineCap="Round" />
+				</Grid>
+			</StackPanel>
+
+			<!-- Dash offset shifting endpoint into gap -->
+			<!-- Line length=208, pattern [48,32], offset=1.5 (24px). -->
+			<!-- Shifted pattern starts at -24: dash[-24,24], gap[24,56], dash[56,104], gap[104,136], dash[136,184], gap[184,216]. -->
+			<!-- Endpoint 208 is in gap [184,216] — zero-length dash needed. -->
+			<TextBlock Text="Dash Offset Shifting Endpoint into Gap" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Length=208, offset=1.5 — endpoint in mid-gap (no extra at end)" />
+				<Grid Height="40" Background="LightGray">
+					<Line X1="30" Y1="20" X2="238" Y2="20"
+						  Stroke="DarkOrange" StrokeThickness="16"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeDashOffset="1.5" />
+				</Grid>
+			</StackPanel>
+
+			<!-- Multi-segment path endpoint in gap -->
+			<TextBlock Text="Path Endpoint in Gap" FontWeight="Bold" Margin="0,16,0,0" />
+
+			<StackPanel Spacing="8">
+				<TextBlock Text="Path, DashCap=Round — zero-length dash at path endpoint" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="DarkViolet" StrokeThickness="12"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Round"
+						  StrokeStartLineCap="Round" StrokeEndLineCap="Round"
+						  Data="M 30,50 L 150,20 L 270,50" />
+				</Grid>
+
+				<TextBlock Text="Path, DashCap=Square, EndCap=Round — square back + round fwd at end" />
+				<Grid Height="100" Background="LightGray">
+					<Path Stroke="Maroon" StrokeThickness="12"
+						  StrokeDashArray="3 2"
+						  StrokeDashCap="Square"
+						  StrokeEndLineCap="Round"
+						  Data="M 30,50 L 150,20 L 270,50" />
+				</Grid>
+			</StackPanel>
+
 			<!-- Issue #5426 repro: Path with round caps and joins -->
 			<TextBlock Text="Issue #5426 repro: Path with Round caps and joins" FontWeight="Bold" Margin="0,16,0,0" />
 			<Path Stroke="DarkBlue" StrokeThickness="8"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml
@@ -81,6 +81,12 @@
 					  Stroke="Green" StrokeThickness="8"
 					  StrokeDashArray="3 2"
 					  StrokeDashCap="Square" />
+
+				<TextBlock Text="Triangle dash cap" />
+				<Line X1="20" Y1="20" X2="280" Y2="20"
+					  Stroke="Red" StrokeThickness="8"
+					  StrokeDashArray="3 2"
+					  StrokeDashCap="Triangle" />
 			</StackPanel>
 
 			<!-- Dash Offset -->

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeCapJoin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Microsoft.UI.Xaml.Controls;
+
+namespace SamplesApp.Windows_UI_Xaml_Shapes
+{
+	[Sample("Shapes")]
+	public sealed partial class Shape_StrokeCapJoin : Page
+	{
+		public Shape_StrokeCapJoin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -13,6 +13,7 @@ namespace Microsoft.UI.Composition
 	{
 		private static readonly SKPaint _spareHitTestPaint = new();
 		private static readonly SKPath _spareHitTestPath = new();
+		private static readonly SKPoint[] _spareMiterPoints = new SKPoint[4];
 		// We don't call SKPaint.Reset() after usage, so make sure
 		// that only SKPaint.Color is being set
 		private static readonly SKPaint _spareColorPaint = new();
@@ -666,7 +667,7 @@ namespace Microsoft.UI.Composition
 			float hw = strokeWidth / 2;
 
 			using var iter = originalGeometry.CreateIterator(false);
-			var points = new SKPoint[4];
+			var points = _spareMiterPoints;
 
 			// Per-contour tracking
 			SKPoint contourStart = default;

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -102,7 +102,15 @@ namespace Microsoft.UI.Composition
 						{
 							dashValues[i] *= StrokeThickness;
 						}
-						strokePaint.PathEffect = SKPathEffect.CreateDash(dashValues, StrokeDashOffset * StrokeThickness);
+						var dashEffect = SKPathEffect.CreateDash(dashValues, StrokeDashOffset * StrokeThickness);
+						if (dashEffect is not null)
+						{
+							strokePaint.PathEffect = dashEffect;
+						}
+						else
+						{
+							dashValues = null;
+						}
 					}
 					else if (!needsCustomCaps)
 					{
@@ -261,7 +269,15 @@ namespace Microsoft.UI.Composition
 						{
 							dashValues[i] *= StrokeThickness;
 						}
-						strokePaint.PathEffect = SKPathEffect.CreateDash(dashValues, StrokeDashOffset * StrokeThickness);
+						var dashEffect = SKPathEffect.CreateDash(dashValues, StrokeDashOffset * StrokeThickness);
+						if (dashEffect is not null)
+						{
+							strokePaint.PathEffect = dashEffect;
+						}
+						else
+						{
+							dashValues = null;
+						}
 					}
 					else if (!needsCustomCaps)
 					{

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -94,7 +94,13 @@ namespace Microsoft.UI.Composition
 					if (StrokeDashArray is { Count: > 0 } strokeDashArray)
 					{
 						strokePaint.StrokeCap = ToSKStrokeCap(StrokeDashCap);
-						strokePaint.PathEffect = SKPathEffect.CreateDash(strokeDashArray.ToEvenArray(), StrokeDashOffset);
+						// WinUI dash values are in multiples of StrokeThickness; Skia expects pixels
+						var dashValues = strokeDashArray.ToEvenArray();
+						for (int i = 0; i < dashValues.Length; i++)
+						{
+							dashValues[i] *= StrokeThickness;
+						}
+						strokePaint.PathEffect = SKPathEffect.CreateDash(dashValues, StrokeDashOffset * StrokeThickness);
 					}
 					else if (!needsCustomCaps)
 					{
@@ -217,7 +223,13 @@ namespace Microsoft.UI.Composition
 					if (StrokeDashArray is { Count: > 0 } strokeDashArray)
 					{
 						strokePaint.StrokeCap = ToSKStrokeCap(StrokeDashCap);
-						strokePaint.PathEffect = SKPathEffect.CreateDash(strokeDashArray.ToEvenArray(), StrokeDashOffset);
+						// WinUI dash values are in multiples of StrokeThickness; Skia expects pixels
+						var dashValues = strokeDashArray.ToEvenArray();
+						for (int i = 0; i < dashValues.Length; i++)
+						{
+							dashValues[i] *= StrokeThickness;
+						}
+						strokePaint.PathEffect = SKPathEffect.CreateDash(dashValues, StrokeDashOffset * StrokeThickness);
 					}
 					else if (!needsCustomCaps)
 					{
@@ -325,7 +337,7 @@ namespace Microsoft.UI.Composition
 					position.Y - halfWidth,
 					position.X + halfWidth,
 					position.Y + halfWidth);
-				path.AddArc(rect, startAngle, 180);
+				path.AddArc(rect, startAngle, -180);
 				path.Close();
 				return path;
 			}

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using Windows.Foundation;
 using SkiaSharp;
 using Uno;
@@ -81,10 +82,27 @@ namespace Microsoft.UI.Composition
 
 					// Set stroke thickness
 					strokePaint.StrokeWidth = StrokeThickness;
+
+					// Set stroke join and miter limit
+					strokePaint.StrokeJoin = ToSKStrokeJoin(StrokeLineJoin);
+					strokePaint.StrokeMiter = StrokeMiterLimit;
+
+					// Determine if we need custom cap rendering (different start/end caps, or Triangle caps)
+					bool needsCustomCaps = StrokeStartCap != StrokeEndCap
+						|| StrokeStartCap == CompositionStrokeCap.Triangle;
+
 					if (StrokeDashArray is { Count: > 0 } strokeDashArray)
 					{
-						strokePaint.PathEffect = SKPathEffect.CreateDash(strokeDashArray.ToEvenArray(), 0);
+						strokePaint.StrokeCap = ToSKStrokeCap(StrokeDashCap);
+						strokePaint.PathEffect = SKPathEffect.CreateDash(strokeDashArray.ToEvenArray(), StrokeDashOffset);
 					}
+					else if (!needsCustomCaps)
+					{
+						// Fast path: same start/end cap, not Triangle - use native SKPaint.StrokeCap
+						strokePaint.StrokeCap = ToSKStrokeCap(StrokeEndCap);
+					}
+					// else: needsCustomCaps without dashes - keep Butt cap (default after Reset),
+					// custom caps are added as geometry below.
 
 					if (Geometry is not null && (Geometry.TrimStart != default || Geometry.TrimEnd != default))
 					{
@@ -117,6 +135,12 @@ namespace Microsoft.UI.Composition
 					strokeFillPath.Rewind();
 					// Get the stroke geometry, after scaling has been applied.
 					geometryWithTransformations.GetFillPath(strokePaint, strokeFillPath);
+
+					// Add custom cap geometry for Triangle caps or different start/end caps
+					if (needsCustomCaps && StrokeDashArray is not { Count: > 0 })
+					{
+						AddCustomCaps(strokeFillPath, geometryWithTransformations.Geometry, StrokeThickness, StrokeStartCap, StrokeEndCap);
+					}
 
 					session.Canvas.Save();
 					session.Canvas.ClipPath(strokeFillPath, antialias: true);
@@ -184,12 +208,33 @@ namespace Microsoft.UI.Composition
 					PrepareTempPaint(strokePaint, isStroke: true);
 
 					strokePaint.StrokeWidth = StrokeThickness;
+					strokePaint.StrokeJoin = ToSKStrokeJoin(StrokeLineJoin);
+					strokePaint.StrokeMiter = StrokeMiterLimit;
+
+					bool needsCustomCaps = StrokeStartCap != StrokeEndCap
+						|| StrokeStartCap == CompositionStrokeCap.Triangle;
+
+					if (StrokeDashArray is { Count: > 0 } strokeDashArray)
+					{
+						strokePaint.StrokeCap = ToSKStrokeCap(StrokeDashCap);
+						strokePaint.PathEffect = SKPathEffect.CreateDash(strokeDashArray.ToEvenArray(), StrokeDashOffset);
+					}
+					else if (!needsCustomCaps)
+					{
+						strokePaint.StrokeCap = ToSKStrokeCap(StrokeEndCap);
+					}
 
 					var hitTestStrokeFillPath = _spareHitTestPath;
 
 					hitTestStrokeFillPath.Rewind();
 
 					geometryWithTransformations.GetFillPath(strokePaint, hitTestStrokeFillPath);
+
+					if (needsCustomCaps && StrokeDashArray is not { Count: > 0 })
+					{
+						AddCustomCaps(hitTestStrokeFillPath, geometryWithTransformations.Geometry, StrokeThickness, StrokeStartCap, StrokeEndCap);
+					}
+
 					if (hitTestStrokeFillPath.Contains((float)point.X, (float)point.Y))
 					{
 						return true;
@@ -197,6 +242,116 @@ namespace Microsoft.UI.Composition
 				}
 			}
 			return false;
+		}
+
+		private static SKStrokeCap ToSKStrokeCap(CompositionStrokeCap cap) => cap switch
+		{
+			CompositionStrokeCap.Flat => SKStrokeCap.Butt,
+			CompositionStrokeCap.Square => SKStrokeCap.Square,
+			CompositionStrokeCap.Round => SKStrokeCap.Round,
+			CompositionStrokeCap.Triangle => SKStrokeCap.Butt, // Simulated via custom geometry
+			_ => SKStrokeCap.Butt,
+		};
+
+		private static SKStrokeJoin ToSKStrokeJoin(CompositionStrokeLineJoin join) => join switch
+		{
+			CompositionStrokeLineJoin.Miter => SKStrokeJoin.Miter,
+			CompositionStrokeLineJoin.Bevel => SKStrokeJoin.Bevel,
+			CompositionStrokeLineJoin.Round => SKStrokeJoin.Round,
+			CompositionStrokeLineJoin.MiterOrBevel => SKStrokeJoin.Miter, // Skia's miter limit provides bevel fallback
+			_ => SKStrokeJoin.Miter,
+		};
+
+		/// <summary>
+		/// Adds custom cap geometry to the stroke fill path for cases where native SKPaint.StrokeCap
+		/// is insufficient (different start/end caps, or Triangle cap type).
+		/// </summary>
+		private static void AddCustomCaps(SKPath fillPath, SKPath originalGeometry, float strokeWidth, CompositionStrokeCap startCap, CompositionStrokeCap endCap)
+		{
+			using var measure = new SKPathMeasure(originalGeometry, false);
+			do
+			{
+				if (measure.IsClosed)
+				{
+					continue;
+				}
+
+				var length = measure.Length;
+				if (length <= 0)
+				{
+					continue;
+				}
+
+				// Start cap: tangent direction is negated (cap extends backward from start)
+				if (startCap != CompositionStrokeCap.Flat
+					&& measure.GetPositionAndTangent(0, out var startPos, out var startTan))
+				{
+					using var capPath = BuildCapPath(startPos, new SKPoint(-startTan.X, -startTan.Y), strokeWidth, startCap);
+					if (capPath != null)
+					{
+						fillPath.AddPath(capPath);
+					}
+				}
+
+				// End cap: tangent direction as-is (cap extends forward from end)
+				if (endCap != CompositionStrokeCap.Flat
+					&& measure.GetPositionAndTangent(length, out var endPos, out var endTan))
+				{
+					using var capPath = BuildCapPath(endPos, endTan, strokeWidth, endCap);
+					if (capPath != null)
+					{
+						fillPath.AddPath(capPath);
+					}
+				}
+			} while (measure.NextContour());
+		}
+
+		/// <summary>
+		/// Builds a cap shape at the given position extending in the given direction.
+		/// </summary>
+		private static SKPath? BuildCapPath(SKPoint position, SKPoint direction, float strokeWidth, CompositionStrokeCap capType)
+		{
+			var halfWidth = strokeWidth / 2;
+			// Normal perpendicular to direction
+			var normal = new SKPoint(-direction.Y, direction.X);
+
+			if (capType == CompositionStrokeCap.Round)
+			{
+				var path = new SKPath();
+				// Build a semicircle oriented in the cap direction
+				var startAngle = (float)(Math.Atan2(normal.Y, normal.X) * 180 / Math.PI);
+				var rect = new SKRect(
+					position.X - halfWidth,
+					position.Y - halfWidth,
+					position.X + halfWidth,
+					position.Y + halfWidth);
+				path.AddArc(rect, startAngle, 180);
+				path.Close();
+				return path;
+			}
+			else if (capType == CompositionStrokeCap.Square)
+			{
+				var path = new SKPath();
+				// Rectangle extending halfWidth beyond endpoint in direction
+				var p1 = new SKPoint(position.X + normal.X * halfWidth, position.Y + normal.Y * halfWidth);
+				var p2 = new SKPoint(p1.X + direction.X * halfWidth, p1.Y + direction.Y * halfWidth);
+				var p3 = new SKPoint(p2.X - normal.X * strokeWidth, p2.Y - normal.Y * strokeWidth);
+				var p4 = new SKPoint(position.X - normal.X * halfWidth, position.Y - normal.Y * halfWidth);
+				path.AddPoly(new[] { p1, p2, p3, p4 }, close: true);
+				return path;
+			}
+			else if (capType == CompositionStrokeCap.Triangle)
+			{
+				var path = new SKPath();
+				// Isoceles triangle: base perpendicular to direction at endpoint, apex at halfWidth in direction
+				var base1 = new SKPoint(position.X + normal.X * halfWidth, position.Y + normal.Y * halfWidth);
+				var apex = new SKPoint(position.X + direction.X * halfWidth, position.Y + direction.Y * halfWidth);
+				var base2 = new SKPoint(position.X - normal.X * halfWidth, position.Y - normal.Y * halfWidth);
+				path.AddPoly(new[] { base1, apex, base2 }, close: true);
+				return path;
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using Windows.Foundation;
@@ -163,6 +163,13 @@ namespace Microsoft.UI.Composition
 							dashValues, StrokeDashOffset * StrokeThickness);
 					}
 
+					// Add Triangle cap geometry at internal dash boundaries.
+					if (dashValues is not null && StrokeDashCap == CompositionStrokeCap.Triangle)
+					{
+						AddInternalTriangleDashCaps(strokeFillPath, geometryWithTransformations.Geometry,
+							StrokeThickness, dashValues, StrokeDashOffset * StrokeThickness);
+					}
+
 					// WinUI's Miter join uses miter-clip (truncates the miter protrusion at
 					// the limit), while Skia's Miter uses miter-or-bevel (full bevel fallback).
 					// Add clipped miter trapezoids for vertices where Skia produced a bevel.
@@ -281,6 +288,13 @@ namespace Microsoft.UI.Composition
 						FixDashEndpointCaps(hitTestStrokeFillPath, geometryWithTransformations.Geometry,
 							StrokeThickness, StrokeDashCap, StrokeStartCap, StrokeEndCap,
 							dashValues, StrokeDashOffset * StrokeThickness);
+					}
+
+					// Add Triangle cap geometry at internal dash boundaries (mirror of Paint logic).
+					if (dashValues is not null && StrokeDashCap == CompositionStrokeCap.Triangle)
+					{
+						AddInternalTriangleDashCaps(hitTestStrokeFillPath, geometryWithTransformations.Geometry,
+							StrokeThickness, dashValues, StrokeDashOffset * StrokeThickness);
 					}
 
 					// WinUI's Miter join uses miter-clip (see Paint() comment).
@@ -474,6 +488,104 @@ namespace Microsoft.UI.Composition
 						}
 					}
 					// else: InGap — endpoint in middle of a gap, nothing to render
+				}
+			} while (measure.NextContour());
+		}
+
+		/// <summary>
+		/// Adds Triangle cap geometry at every internal dash boundary. Skia maps Triangle
+		/// to Butt (flat), so internal dash starts/ends need filled polygon caps added manually.
+		/// Path start/end boundaries are excluded for open contours (handled by FixDashEndpointCaps).
+		/// </summary>
+		private static void AddInternalTriangleDashCaps(
+			SKPath fillPath,
+			SKPath originalGeometry,
+			float strokeWidth,
+			float[] dashValues,
+			float dashOffset)
+		{
+			var totalPattern = 0f;
+			for (int i = 0; i < dashValues.Length; i++)
+			{
+				totalPattern += dashValues[i];
+			}
+
+			if (totalPattern <= 0)
+			{
+				return;
+			}
+
+			using var measure = new SKPathMeasure(originalGeometry, false);
+			do
+			{
+				var pathLength = measure.Length;
+				if (pathLength <= 0)
+				{
+					continue;
+				}
+
+				var isClosed = measure.IsClosed;
+
+				var patternStart = -(dashOffset % totalPattern);
+				if (patternStart > 0)
+				{
+					patternStart -= totalPattern;
+				}
+
+				var pos = patternStart;
+				var idx = 0;
+
+				while (pos < pathLength)
+				{
+					var segLen = dashValues[idx % dashValues.Length];
+
+					if (segLen <= 0)
+					{
+						idx++;
+						continue;
+					}
+
+					var segEnd = pos + segLen;
+					var isDash = (idx % 2) == 0;
+
+					if (isDash)
+					{
+						var dashStart = Math.Max(pos, 0f);
+						var dashEnd = Math.Min(segEnd, pathLength);
+
+						if (dashStart < dashEnd)
+						{
+							// Dash start boundary: triangle faces backward (-tangent).
+							// Skip for open path start (StrokeStartLineCap covers it).
+							var isPathStart = !isClosed && dashStart <= 0f;
+							if (!isPathStart
+								&& measure.GetPositionAndTangent(dashStart, out var startPos, out var startTan))
+							{
+								var backDir = new SKPoint(-startTan.X, -startTan.Y);
+								using var capPath = BuildCapPath(startPos, backDir, strokeWidth, CompositionStrokeCap.Triangle);
+								if (capPath != null)
+								{
+									fillPath.AddPath(capPath);
+								}
+							}
+
+							// Dash end boundary: triangle faces forward (+tangent).
+							// Skip for open path end (StrokeEndLineCap covers it).
+							var isPathEnd = !isClosed && dashEnd >= pathLength;
+							if (!isPathEnd
+								&& measure.GetPositionAndTangent(dashEnd, out var endPos, out var endTan))
+							{
+								using var capPath = BuildCapPath(endPos, endTan, strokeWidth, CompositionStrokeCap.Triangle);
+								if (capPath != null)
+								{
+									fillPath.AddPath(capPath);
+								}
+							}
+						}
+					}
+
+					pos = segEnd;
+					idx++;
 				}
 			} while (measure.NextContour());
 		}

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -579,6 +579,15 @@ namespace Microsoft.UI.Composition
 			while (pos < pathLength)
 			{
 				var segLen = dashValues[idx % dashValues.Length];
+
+				// Guard: skip zero/negative segments so pos always advances.
+				// The totalPattern <= 0 check above handles the all-zeros case.
+				if (segLen <= 0)
+				{
+					idx++;
+					continue;
+				}
+
 				var segEnd = pos + segLen;
 				var isDash = (idx % 2) == 0;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
@@ -264,9 +264,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Shapes
 			var screenshot = await UITestHelper.ScreenShot(container);
 
 			// With offset=4 (half pattern), the dash/gap pattern should be shifted.
-			// At the start of the line, one should have a dash and the other a gap.
-			// Verify both lines render (center point check)
+			// At x=100 (center), both lines are in a dash segment.
 			ImageAssert.HasColorAt(screenshot, 100, 15, Colors.Black, tolerance: 30);
+
+			// At x=12 (near start): line1 (offset=0) is in a dash, line2 (offset=4) is in a gap.
+			// Dash length = 4 * StrokeThickness = 32px, gap = 32px.
+			// line1 first dash: x=10–42  → x=12 is Black
+			// line2 offset=4 shifts 32px  → x=12 is in gap → White (container background)
+			ImageAssert.HasColorAt(screenshot, 12, 15, Colors.Black, tolerance: 30);
+			ImageAssert.HasColorAt(screenshot, 12, 45, Colors.White, tolerance: 30);
 		}
 
 		[TestMethod]
@@ -787,8 +793,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Shapes
 			var screenshot = await UITestHelper.ScreenShot(container);
 
 			// At 90 degrees, the miter tip extends about halfWidth/sin(45) ~ 14.14px
-			// above the vertex in the bisector direction. The full miter point at
-			// (100, ~16) should be colored.
+			// above the vertex in the bisector direction. The mitered stroke should
+			// be visible around (100, 20).
 			ImageAssert.HasColorAt(screenshot, 100, 20, Colors.Red, tolerance: 30);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
@@ -792,9 +792,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Shapes
 			await UITestHelper.Load(container);
 			var screenshot = await UITestHelper.ScreenShot(container);
 
-			// At 90 degrees, the miter tip extends about halfWidth/sin(45) ~ 14.14px
-			// above the vertex in the bisector direction. The mitered stroke should
-			// be visible around (100, 20).
+			// The miter tip extends above the vertex along the bisector direction.
+			// The mitered stroke should be visible at (100, 20), which is within
+			// the miter protrusion.
 			ImageAssert.HasColorAt(screenshot, 100, 20, Colors.Red, tolerance: 30);
 		}
 

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Shapes/Shape.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Shapes/Shape.cs
@@ -9,90 +9,12 @@ namespace Microsoft.UI.Xaml.Shapes
 	public partial class Shape : global::Microsoft.UI.Xaml.FrameworkElement
 	{
 		// Skipping already declared property StrokeThickness
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.PenLineCap StrokeStartLineCap
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.PenLineCap)this.GetValue(StrokeStartLineCapProperty);
-			}
-			set
-			{
-				this.SetValue(StrokeStartLineCapProperty, value);
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public double StrokeMiterLimit
-		{
-			get
-			{
-				return (double)this.GetValue(StrokeMiterLimitProperty);
-			}
-			set
-			{
-				this.SetValue(StrokeMiterLimitProperty, value);
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.PenLineJoin StrokeLineJoin
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.PenLineJoin)this.GetValue(StrokeLineJoinProperty);
-			}
-			set
-			{
-				this.SetValue(StrokeLineJoinProperty, value);
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.PenLineCap StrokeEndLineCap
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.PenLineCap)this.GetValue(StrokeEndLineCapProperty);
-			}
-			set
-			{
-				this.SetValue(StrokeEndLineCapProperty, value);
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public double StrokeDashOffset
-		{
-			get
-			{
-				return (double)this.GetValue(StrokeDashOffsetProperty);
-			}
-			set
-			{
-				this.SetValue(StrokeDashOffsetProperty, value);
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.PenLineCap StrokeDashCap
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.PenLineCap)this.GetValue(StrokeDashCapProperty);
-			}
-			set
-			{
-				this.SetValue(StrokeDashCapProperty, value);
-			}
-		}
-#endif
+		// Skipping already declared property StrokeStartLineCap
+		// Skipping already declared property StrokeMiterLimit
+		// Skipping already declared property StrokeLineJoin
+		// Skipping already declared property StrokeEndLineCap
+		// Skipping already declared property StrokeDashOffset
+		// Skipping already declared property StrokeDashCap
 		// Skipping already declared property StrokeDashArray
 		// Skipping already declared property Stroke
 		// Skipping already declared property Stretch
@@ -110,55 +32,13 @@ namespace Microsoft.UI.Xaml.Shapes
 		// Skipping already declared property FillProperty
 		// Skipping already declared property StretchProperty
 		// Skipping already declared property StrokeDashArrayProperty
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StrokeDashCapProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(StrokeDashCap), typeof(global::Microsoft.UI.Xaml.Media.PenLineCap),
-			typeof(global::Microsoft.UI.Xaml.Shapes.Shape),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.PenLineCap)));
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StrokeDashOffsetProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(StrokeDashOffset), typeof(double),
-			typeof(global::Microsoft.UI.Xaml.Shapes.Shape),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(double)));
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StrokeEndLineCapProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(StrokeEndLineCap), typeof(global::Microsoft.UI.Xaml.Media.PenLineCap),
-			typeof(global::Microsoft.UI.Xaml.Shapes.Shape),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.PenLineCap)));
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StrokeLineJoinProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(StrokeLineJoin), typeof(global::Microsoft.UI.Xaml.Media.PenLineJoin),
-			typeof(global::Microsoft.UI.Xaml.Shapes.Shape),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.PenLineJoin)));
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StrokeMiterLimitProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(StrokeMiterLimit), typeof(double),
-			typeof(global::Microsoft.UI.Xaml.Shapes.Shape),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(double)));
-#endif
+		// Skipping already declared property StrokeDashCapProperty
+		// Skipping already declared property StrokeDashOffsetProperty
+		// Skipping already declared property StrokeEndLineCapProperty
+		// Skipping already declared property StrokeLineJoinProperty
+		// Skipping already declared property StrokeMiterLimitProperty
 		// Skipping already declared property StrokeProperty
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StrokeStartLineCapProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(StrokeStartLineCap), typeof(global::Microsoft.UI.Xaml.Media.PenLineCap),
-			typeof(global::Microsoft.UI.Xaml.Shapes.Shape),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.PenLineCap)));
-#endif
+		// Skipping already declared property StrokeStartLineCapProperty
 		// Skipping already declared property StrokeThicknessProperty
 		// Skipping already declared method Microsoft.UI.Xaml.Shapes.Shape.Shape()
 		// Forced skipping of method Microsoft.UI.Xaml.Shapes.Shape.Shape()

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -171,6 +171,114 @@ namespace Microsoft.UI.Xaml.Shapes
 		);
 		#endregion
 
+		#region StrokeStartLineCap Dependency Property
+		public Media.PenLineCap StrokeStartLineCap
+		{
+			get => (Media.PenLineCap)this.GetValue(StrokeStartLineCapProperty);
+			set => this.SetValue(StrokeStartLineCapProperty, value);
+		}
+
+		public static DependencyProperty StrokeStartLineCapProperty { get; } = DependencyProperty.Register(
+			nameof(StrokeStartLineCap),
+			typeof(Media.PenLineCap),
+			typeof(Shape),
+			new FrameworkPropertyMetadata(
+				defaultValue: Media.PenLineCap.Flat,
+				options: FrameworkPropertyMetadataOptions.AffectsArrange
+			)
+		);
+		#endregion
+
+		#region StrokeEndLineCap Dependency Property
+		public Media.PenLineCap StrokeEndLineCap
+		{
+			get => (Media.PenLineCap)this.GetValue(StrokeEndLineCapProperty);
+			set => this.SetValue(StrokeEndLineCapProperty, value);
+		}
+
+		public static DependencyProperty StrokeEndLineCapProperty { get; } = DependencyProperty.Register(
+			nameof(StrokeEndLineCap),
+			typeof(Media.PenLineCap),
+			typeof(Shape),
+			new FrameworkPropertyMetadata(
+				defaultValue: Media.PenLineCap.Flat,
+				options: FrameworkPropertyMetadataOptions.AffectsArrange
+			)
+		);
+		#endregion
+
+		#region StrokeLineJoin Dependency Property
+		public Media.PenLineJoin StrokeLineJoin
+		{
+			get => (Media.PenLineJoin)this.GetValue(StrokeLineJoinProperty);
+			set => this.SetValue(StrokeLineJoinProperty, value);
+		}
+
+		public static DependencyProperty StrokeLineJoinProperty { get; } = DependencyProperty.Register(
+			nameof(StrokeLineJoin),
+			typeof(Media.PenLineJoin),
+			typeof(Shape),
+			new FrameworkPropertyMetadata(
+				defaultValue: Media.PenLineJoin.Miter,
+				options: FrameworkPropertyMetadataOptions.AffectsArrange
+			)
+		);
+		#endregion
+
+		#region StrokeMiterLimit Dependency Property
+		public double StrokeMiterLimit
+		{
+			get => (double)this.GetValue(StrokeMiterLimitProperty);
+			set => this.SetValue(StrokeMiterLimitProperty, value);
+		}
+
+		public static DependencyProperty StrokeMiterLimitProperty { get; } = DependencyProperty.Register(
+			nameof(StrokeMiterLimit),
+			typeof(double),
+			typeof(Shape),
+			new FrameworkPropertyMetadata(
+				defaultValue: 10.0,
+				options: FrameworkPropertyMetadataOptions.AffectsArrange
+			)
+		);
+		#endregion
+
+		#region StrokeDashCap Dependency Property
+		public Media.PenLineCap StrokeDashCap
+		{
+			get => (Media.PenLineCap)this.GetValue(StrokeDashCapProperty);
+			set => this.SetValue(StrokeDashCapProperty, value);
+		}
+
+		public static DependencyProperty StrokeDashCapProperty { get; } = DependencyProperty.Register(
+			nameof(StrokeDashCap),
+			typeof(Media.PenLineCap),
+			typeof(Shape),
+			new FrameworkPropertyMetadata(
+				defaultValue: Media.PenLineCap.Flat,
+				options: FrameworkPropertyMetadataOptions.AffectsArrange
+			)
+		);
+		#endregion
+
+		#region StrokeDashOffset Dependency Property
+		public double StrokeDashOffset
+		{
+			get => (double)this.GetValue(StrokeDashOffsetProperty);
+			set => this.SetValue(StrokeDashOffsetProperty, value);
+		}
+
+		public static DependencyProperty StrokeDashOffsetProperty { get; } = DependencyProperty.Register(
+			nameof(StrokeDashOffset),
+			typeof(double),
+			typeof(Shape),
+			new FrameworkPropertyMetadata(
+				defaultValue: 0.0,
+				options: FrameworkPropertyMetadataOptions.AffectsArrange
+			)
+		);
+		#endregion
+
 		// Do not invoke base.IsViewHit(): We don't have to have de FrameworkElement.Background to be hit testable!
 		internal override bool IsViewHit()
 			=> Fill != null

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -172,54 +172,54 @@ namespace Microsoft.UI.Xaml.Shapes
 		#endregion
 
 		#region StrokeStartLineCap Dependency Property
-		public Media.PenLineCap StrokeStartLineCap
+		public PenLineCap StrokeStartLineCap
 		{
-			get => (Media.PenLineCap)this.GetValue(StrokeStartLineCapProperty);
+			get => (PenLineCap)this.GetValue(StrokeStartLineCapProperty);
 			set => this.SetValue(StrokeStartLineCapProperty, value);
 		}
 
 		public static DependencyProperty StrokeStartLineCapProperty { get; } = DependencyProperty.Register(
 			nameof(StrokeStartLineCap),
-			typeof(Media.PenLineCap),
+			typeof(PenLineCap),
 			typeof(Shape),
 			new FrameworkPropertyMetadata(
-				defaultValue: Media.PenLineCap.Flat,
+				defaultValue: PenLineCap.Flat,
 				options: FrameworkPropertyMetadataOptions.AffectsArrange
 			)
 		);
 		#endregion
 
 		#region StrokeEndLineCap Dependency Property
-		public Media.PenLineCap StrokeEndLineCap
+		public PenLineCap StrokeEndLineCap
 		{
-			get => (Media.PenLineCap)this.GetValue(StrokeEndLineCapProperty);
+			get => (PenLineCap)this.GetValue(StrokeEndLineCapProperty);
 			set => this.SetValue(StrokeEndLineCapProperty, value);
 		}
 
 		public static DependencyProperty StrokeEndLineCapProperty { get; } = DependencyProperty.Register(
 			nameof(StrokeEndLineCap),
-			typeof(Media.PenLineCap),
+			typeof(PenLineCap),
 			typeof(Shape),
 			new FrameworkPropertyMetadata(
-				defaultValue: Media.PenLineCap.Flat,
+				defaultValue: PenLineCap.Flat,
 				options: FrameworkPropertyMetadataOptions.AffectsArrange
 			)
 		);
 		#endregion
 
 		#region StrokeLineJoin Dependency Property
-		public Media.PenLineJoin StrokeLineJoin
+		public PenLineJoin StrokeLineJoin
 		{
-			get => (Media.PenLineJoin)this.GetValue(StrokeLineJoinProperty);
+			get => (PenLineJoin)this.GetValue(StrokeLineJoinProperty);
 			set => this.SetValue(StrokeLineJoinProperty, value);
 		}
 
 		public static DependencyProperty StrokeLineJoinProperty { get; } = DependencyProperty.Register(
 			nameof(StrokeLineJoin),
-			typeof(Media.PenLineJoin),
+			typeof(PenLineJoin),
 			typeof(Shape),
 			new FrameworkPropertyMetadata(
-				defaultValue: Media.PenLineJoin.Miter,
+				defaultValue: PenLineJoin.Miter,
 				options: FrameworkPropertyMetadataOptions.AffectsArrange
 			)
 		);
@@ -244,18 +244,18 @@ namespace Microsoft.UI.Xaml.Shapes
 		#endregion
 
 		#region StrokeDashCap Dependency Property
-		public Media.PenLineCap StrokeDashCap
+		public PenLineCap StrokeDashCap
 		{
-			get => (Media.PenLineCap)this.GetValue(StrokeDashCapProperty);
+			get => (PenLineCap)this.GetValue(StrokeDashCapProperty);
 			set => this.SetValue(StrokeDashCapProperty, value);
 		}
 
 		public static DependencyProperty StrokeDashCapProperty { get; } = DependencyProperty.Register(
 			nameof(StrokeDashCap),
-			typeof(Media.PenLineCap),
+			typeof(PenLineCap),
 			typeof(Shape),
 			new FrameworkPropertyMetadata(
-				defaultValue: Media.PenLineCap.Flat,
+				defaultValue: PenLineCap.Flat,
 				options: FrameworkPropertyMetadataOptions.AffectsArrange
 			)
 		);

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.skia.cs
@@ -55,6 +55,10 @@ namespace Microsoft.UI.Xaml.Shapes
 			OnStrokeBrushChanged();
 			UpdateStrokeThickness();
 			UpdateStrokeDashArray();
+			UpdateStrokeCaps();
+			UpdateStrokeLineJoin();
+			UpdateStrokeMiterLimit();
+			UpdateStrokeDashOffset();
 		}
 
 		private void OnFillBrushChanged()
@@ -88,6 +92,28 @@ namespace Microsoft.UI.Xaml.Shapes
 		private void OnStrokeBrushChanged()
 		{
 			_shape.StrokeBrush = Stroke?.GetOrCreateCompositionBrush(Visual.Compositor);
+		}
+
+		private void UpdateStrokeCaps()
+		{
+			_shape.StrokeStartCap = (Composition.CompositionStrokeCap)StrokeStartLineCap;
+			_shape.StrokeEndCap = (Composition.CompositionStrokeCap)StrokeEndLineCap;
+			_shape.StrokeDashCap = (Composition.CompositionStrokeCap)StrokeDashCap;
+		}
+
+		private void UpdateStrokeLineJoin()
+		{
+			_shape.StrokeLineJoin = (Composition.CompositionStrokeLineJoin)StrokeLineJoin;
+		}
+
+		private void UpdateStrokeMiterLimit()
+		{
+			_shape.StrokeMiterLimit = (float)StrokeMiterLimit;
+		}
+
+		private void UpdateStrokeDashOffset()
+		{
+			_shape.StrokeDashOffset = (float)StrokeDashOffset;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.skia.cs
@@ -96,14 +96,14 @@ namespace Microsoft.UI.Xaml.Shapes
 
 		private void UpdateStrokeCaps()
 		{
-			_shape.StrokeStartCap = (Composition.CompositionStrokeCap)StrokeStartLineCap;
-			_shape.StrokeEndCap = (Composition.CompositionStrokeCap)StrokeEndLineCap;
-			_shape.StrokeDashCap = (Composition.CompositionStrokeCap)StrokeDashCap;
+			_shape.StrokeStartCap = (CompositionStrokeCap)StrokeStartLineCap;
+			_shape.StrokeEndCap = (CompositionStrokeCap)StrokeEndLineCap;
+			_shape.StrokeDashCap = (CompositionStrokeCap)StrokeDashCap;
 		}
 
 		private void UpdateStrokeLineJoin()
 		{
-			_shape.StrokeLineJoin = (Composition.CompositionStrokeLineJoin)StrokeLineJoin;
+			_shape.StrokeLineJoin = (CompositionStrokeLineJoin)StrokeLineJoin;
 		}
 
 		private void UpdateStrokeMiterLimit()


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/5426, closes https://github.com/unoplatform/uno/issues/16686

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Many shape stroke features are missing.


## What is the new behavior? 🚀

Before:

<img width="821" height="1677" alt="image" src="https://github.com/user-attachments/assets/222cbbab-61fc-4662-845c-e3ff2dd6e783" />

After:

<img width="523" height="1541" alt="image" src="https://github.com/user-attachments/assets/24e6094f-c4fa-4e88-bd52-f1f1bb52c084" />


## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->