### PR TITLE
fix: data-context propagation around non-FE DO

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.DataContext.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.DataContext.cs
@@ -1,7 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
@@ -65,4 +70,165 @@ partial class Given_UIElement
 		Assert.AreEqual(DC, nested3.DataContext, "3. when reattached, DC (nested3) should still be inherited&unaffected");
 		Assert.AreEqual(DC, nested4.DataContext, "3. when reattached, DC (nested4) should still be inherited&unaffected");
 	}
+
+#if HAS_UNO // there is no DC on non-FE DO for winui, not directly*
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task SingleParentNonFE_Direct_DataContext_Propagation_Works()
+	{
+		var dc = new { Data = "Context" };
+
+		var run = new Run();
+		run.SetBinding(Run.TextProperty, new Binding { Path = new(nameof(dc.Data)) });
+		var tblock = new TextBlock();
+		tblock.Inlines.Add(run);
+		tblock.DataContext = dc;
+
+		await UITestHelper.Load(tblock, x => x.IsLoaded);
+
+		Assert.AreEqual(dc, run.DataContext);
+		Assert.AreEqual(dc.Data, run.Text);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task MultiParentNonFE_Direct_DataContext_Propagation_WorksOnlyOnce1()
+	{
+		var brush = new SolidColorBrush(Colors.SkyBlue);
+
+#if DEBUG
+		using var disp = brush.RegisterDisposablePropertyChangedCallback(
+			SolidColorBrush.DataContextProperty,
+			(s, e) => { /* breakpoint here to investigate */ });
+#endif
+
+		// variant: assignment order: foreground > dc
+
+		var setup0 = new Control();
+		setup0.Foreground = brush;
+		setup0.DataContext = new { Data = "Context 0" };
+		Assert.IsNotNull(brush.DataContext, "0. until it is attached to multiple \"parent\", dc propagate should work");
+
+		var setup1 = new Control();
+		setup1.Foreground = brush;
+		setup1.DataContext = new { Data = "Context 1" };
+		Assert.IsNull(brush.DataContext, "1. once it is attached to multiple \"parent\", dc should no longer propagate");
+
+		setup0.Foreground = null;
+		setup1.Foreground = null;
+		var setup2 = new Control();
+		setup2.Foreground = brush;
+		setup2.DataContext = new { Data = "Context 2" };
+		Assert.IsNull(brush.DataContext, "2. once it has been attached to multiple \"parent\", dc shouldn't propagate anymore even if we only have a single parent now");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task MultiParentNonFE_Direct_DataContext_Propagation_WorksOnlyOnce2()
+	{
+		var brush = new SolidColorBrush(Colors.SkyBlue);
+
+#if DEBUG
+		using var disp = brush.RegisterDisposablePropertyChangedCallback(
+			SolidColorBrush.DataContextProperty,
+			(s, e) => { /* breakpoint here to investigate */ });
+#endif
+
+		// variant: assignment order: dc > foreground
+
+		var setup0 = new Control();
+		setup0.DataContext = new { Data = "Context 0" };
+		setup0.Foreground = brush;
+		Assert.IsNotNull(brush.DataContext, "0. until it is attached to multiple \"parent\", dc propagate should work");
+
+		var setup1 = new Control();
+		setup1.DataContext = new { Data = "Context 1" };
+		setup1.Foreground = brush;
+		Assert.IsNull(brush.DataContext, "1. once it is attached to multiple \"parent\", dc should no longer propagate");
+
+		setup0.Foreground = null;
+		setup1.Foreground = null;
+		var setup2 = new Control();
+		setup2.DataContext = new { Data = "Context 2" };
+		setup2.Foreground = brush;
+		Assert.IsNull(brush.DataContext, "2. once it has been attached to multiple \"parent\", dc shouldn't propagate anymore even if we only have a single parent now");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task MultiParentNonFE_Inherited_DataContext_Propagation_WorksOnlyOnce()
+	{
+		// all permutations just in case
+		var variants = """
+			A. child.fg > host.dc > host.child
+			B. child.fg > host.child > host.dc
+			C. host.dc > child.fg > host.child
+			D. host.dc > host.child > child.fg
+			E. host.child > host.dc > child.fg
+			F. host.child > child.fg > host.dc
+		""".Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+			.Where(x => !x.StartsWith("//"))
+			.Select(x => new
+			{
+				Label = x[0..1],
+				Instructions = x[3..].Split(" > "),
+			})
+			.ToArray();
+		var instructionMap = new Dictionary<string, Action<Border, Control, object, Brush>>
+		{
+			["child.fg"] = (host, child, dc, brush) => child.Foreground = brush,
+			["host.dc"] = (host, child, dc, brush) => host.DataContext = dc,
+			["host.child"] = (host, child, dc, brush) => host.Child = child,
+		};
+
+		foreach (var variant in variants)
+		{
+			var brush = new SolidColorBrush(Colors.SkyBlue);
+#if DEBUG
+			using var disp = brush.RegisterDisposablePropertyChangedCallback(
+				SolidColorBrush.DataContextProperty,
+				(s, e) => { /* breakpoint here to investigate */ });
+#endif
+
+			var setup0 = new
+			{
+				Host = new Border(),
+				Child = new Control(),
+				DC = new { Data = $"Context {variant.Label}0" },
+			};
+			instructionMap[variant.Instructions[0]](setup0.Host, setup0.Child, setup0.DC, brush);
+			instructionMap[variant.Instructions[1]](setup0.Host, setup0.Child, setup0.DC, brush);
+			instructionMap[variant.Instructions[2]](setup0.Host, setup0.Child, setup0.DC, brush);
+			Assert.IsNotNull(brush.DataContext, $"{variant.Label}0. until it is attached to multiple \"parent\", dc propagate should work");
+
+			var setup1 = new
+			{
+				Host = new Border(),
+				Child = new Control(),
+				DC = new { Data = $"Context {variant.Label}1" },
+			};
+			instructionMap[variant.Instructions[0]](setup1.Host, setup1.Child, setup1.DC, brush);
+			instructionMap[variant.Instructions[1]](setup1.Host, setup1.Child, setup1.DC, brush);
+			instructionMap[variant.Instructions[2]](setup1.Host, setup1.Child, setup1.DC, brush);
+			Assert.IsNull(brush.DataContext, $"{variant.Label}1. once it is attached to multiple \"parent\", dc should no longer propagate");
+
+			setup0.Child.Foreground = null;
+			setup1.Child.Foreground = null;
+			var setup2 = new
+			{
+				Host = new Border(),
+				Child = new Control(),
+				DC = new { Data = $"Context {variant.Label}2" },
+			};
+			instructionMap[variant.Instructions[0]](setup2.Host, setup2.Child, setup2.DC, brush);
+			instructionMap[variant.Instructions[1]](setup2.Host, setup2.Child, setup2.DC, brush);
+			instructionMap[variant.Instructions[2]](setup2.Host, setup2.Child, setup2.DC, brush);
+			Assert.IsNull(brush.DataContext, $"{variant.Label}2. once it has been attached to multiple \"parent\", dc shouldn't propagate anymore even if we only have a single parent now");
+		}
+	}
+#endif
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -532,6 +532,11 @@ namespace Microsoft.UI.Xaml
 						TryClearBinding(value, propertyDetails);
 					}
 
+					if (!_inheritanceContextEnabled && precedence == DependencyPropertyValuePrecedences.Inheritance)
+					{
+						value = DependencyProperty.UnsetValue;
+					}
+
 					var previousValue = GetValue(propertyDetails);
 					var previousPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
 

--- a/src/Uno.UI/UI/Xaml/IMultiParentShareableDependencyObject.cs
+++ b/src/Uno.UI/UI/Xaml/IMultiParentShareableDependencyObject.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.UI.Xaml;
+
+internal interface IMultiParentShareableDependencyObject;
+
+/* This interface is used to mark DependencyObjects that can be shared across multiple "parents".
+ * While they CAN participate in data-context inheritance/propagation,
+ * this only works until they are shared by more than one parent.
+ * And, once multiple parents are detected, the DC inheritance/propagation is forever disabled on this object.
+ */

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Transition.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Transition.cs
@@ -15,7 +15,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 	/// Transition : Based on WinRT Transition
 	/// (https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.media.animation.transition.Aspx)
 	/// </summary>
-	public partial class Transition : DependencyObject
+	public partial class Transition : DependencyObject, IMultiParentShareableDependencyObject
 	{
 		private Transform _elementTransform;
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.cs
@@ -14,7 +14,7 @@ using Windows.UI;
 namespace Microsoft.UI.Xaml.Media
 {
 	[TypeConverter(typeof(BrushConverter))]
-	public partial class Brush : DependencyObject
+	public partial class Brush : DependencyObject, IMultiParentShareableDependencyObject
 	{
 		private WeakEventHelper.WeakEventCollection? _invalidateRenderHandlers;
 

--- a/src/Uno.UI/UI/Xaml/Media/GeneralTransform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeneralTransform.cs
@@ -5,7 +5,7 @@ using Windows.Foundation;
 
 namespace Microsoft.UI.Xaml.Media
 {
-	public partial class GeneralTransform : DependencyObject
+	public partial class GeneralTransform : DependencyObject, IMultiParentShareableDependencyObject
 	{
 		protected GeneralTransform() { }
 

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
@@ -18,7 +18,7 @@ using Uno.UI.Xaml.Media;
 namespace Microsoft.UI.Xaml.Media
 {
 	[TypeConverter(typeof(ImageSourceConverter))]
-	public partial class ImageSource : DependencyObject, IDisposable
+	public partial class ImageSource : DependencyObject, IMultiParentShareableDependencyObject, IDisposable
 	{
 		private protected ImageData _imageData = ImageData.Empty;
 

--- a/src/Uno.UI/UI/Xaml/Media/Projection.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Projection.cs
@@ -8,7 +8,7 @@ namespace Microsoft.UI.Xaml.Media;
 /// <summary>
 /// Provides a base class for projections, which describe how to transform an object in 3-D space using perspective transforms.
 /// </summary>
-public partial class Projection : DependencyObject
+public partial class Projection : DependencyObject, IMultiParentShareableDependencyObject
 {
 	private WeakReference<UIElement> _owner;
 

--- a/src/Uno.UI/UI/Xaml/Media/Shadow.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Shadow.cs
@@ -1,9 +1,6 @@
-﻿namespace Microsoft.UI.Xaml.Media
-{
-	/// <summary>
-	/// The base class for shadow effects that can be applied to a XAML element.
-	/// </summary>
-	public partial class Shadow : DependencyObject
-	{
-	}
-}
+﻿namespace Microsoft.UI.Xaml.Media;
+
+/// <summary>
+/// The base class for shadow effects that can be applied to a XAML element.
+/// </summary>
+public partial class Shadow : DependencyObject, IMultiParentShareableDependencyObject;

--- a/src/Uno.UI/UI/Xaml/Media/SystemBackdrop.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SystemBackdrop.cs
@@ -1,6 +1,6 @@
 namespace Microsoft.UI.Xaml.Media;
 
-public partial class SystemBackdrop : global::Microsoft.UI.Xaml.DependencyObject
+public partial class SystemBackdrop : DependencyObject, IMultiParentShareableDependencyObject
 {
 	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	protected SystemBackdrop()

--- a/src/Uno.UI/UI/Xaml/SetterBase.cs
+++ b/src/Uno.UI/UI/Xaml/SetterBase.cs
@@ -6,7 +6,7 @@ using Uno.Foundation.Logging;
 
 namespace Microsoft.UI.Xaml
 {
-	public abstract partial class SetterBase
+	public abstract partial class SetterBase : DependencyObject, IMultiParentShareableDependencyObject
 	{
 		internal SetterBase()
 		{

--- a/src/Uno.UI/UI/Xaml/StateTriggerBase.cs
+++ b/src/Uno.UI/UI/Xaml/StateTriggerBase.cs
@@ -7,7 +7,7 @@ using Windows.Foundation.Metadata;
 
 namespace Microsoft.UI.Xaml
 {
-	public partial class StateTriggerBase : DependencyObject
+	public partial class StateTriggerBase : DependencyObject, IMultiParentShareableDependencyObject
 	{
 		protected StateTriggerBase()
 		{

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -14,7 +14,7 @@ using Uno.UI;
 namespace Microsoft.UI.Xaml
 {
 	[Markup.ContentProperty(Name = "Setters")]
-	public partial class Style
+	public partial class Style : IMultiParentShareableDependencyObject
 	{
 		private static Logger _logger = typeof(Style).Log();
 


### PR DESCRIPTION
**GitHub Issue**: re: #22610, re: unoplatform/add-private#44

## PR Type: 🐞 Bugfix
## What is the current behavior? 🤔
Rooted reusable non-`FrameworkElement` `DependencyObject`s like `Brush`es could keep inherited `DataContext` alive indefinitely, causing memory leak.

## What is the new behavior? 🚀
This PR fixes `DataContext` propagation for non-`FrameworkElement` `DependencyObject` instances when they are used as bindable child values. It introduces a marker for multi-parent shareable objects and updates binder parent-association logic so `DataContext` inheritance is disabled once an object is shared across multiple parents, matching expected WinUI behavior.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
<!-- Please provide any additional information if necessary -->