### PR TITLE
fix(wasm): make sure the splash screen is removed only after fonts preloading is done and a new frame is generated

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
@@ -18,6 +18,7 @@ using Windows.Graphics.Display;
 using Windows.Media.Playback;
 using Microsoft.UI.Xaml.Documents.TextFormatting;
 using Microsoft.UI.Xaml.Media;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia.WebAssembly.Browser;
 
@@ -51,12 +52,6 @@ internal partial class WebAssemblyBrowserHost : SkiaHost, ISkiaApplicationHost, 
 	protected async override Task InitializeAsync()
 	{
 		NativeMethods.PersistBootstrapperLoader();
-		CompositionTarget.Rendering += OnCompositionTargetOnRendering;
-		void OnCompositionTargetOnRendering(object? sender, object o)
-		{
-			NativeMethods.RemoveLoading();
-			CompositionTarget.Rendering -= OnCompositionTargetOnRendering;
-		}
 
 		ApiExtensibility.Register(typeof(Uno.ApplicationModel.Core.ICoreApplicationExtension), o => _coreApplicationExtension!);
 		ApiExtensibility.Register(typeof(Windows.UI.Core.IUnoCorePointerInputSource), o => new BrowserPointerInputSource());
@@ -118,6 +113,8 @@ internal partial class WebAssemblyBrowserHost : SkiaHost, ISkiaApplicationHost, 
 		_renderer?.InvalidateRender();
 		Window.CurrentSafe!.RootElement?.XamlRoot?.InvalidateOverlays();
 	}
+
+	internal void RemoveSplashScreen() => NativeMethods.RemoveLoading();
 
 	UIElement? IXamlRootHost.RootElement => Window.CurrentSafe!.RootElement;
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
@@ -18,7 +18,6 @@ using Windows.Graphics.Display;
 using Windows.Media.Playback;
 using Microsoft.UI.Xaml.Documents.TextFormatting;
 using Microsoft.UI.Xaml.Media;
-using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia.WebAssembly.Browser;
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
@@ -102,19 +102,26 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 			{
 				NativeDispatcher.Main.Enqueue(() =>
 				{
-					// queue twice to ensure that a layout cycle happens after the fonts are loaded
-					NativeDispatcher.Main.Enqueue(() =>
+					if (XamlRoot?.Content is FrameworkElement content)
 					{
-						var compositionTarget = (CompositionTarget)XamlRoot?.Content?.Visual.CompositionTarget!;
-						var host = (WebAssemblyBrowserHost)XamlRootMap.GetHostForRoot(XamlRoot!)!;
-						compositionTarget.FrameRendered += CompositionTargetOnFrameRendered;
-						((IXamlRootHost)host).InvalidateRender();
-						void CompositionTargetOnFrameRendered()
+						content.InvalidateArrange();
+						content.LayoutUpdated += OnContentLayoutUpdated;
+
+						void OnContentLayoutUpdated(object? sender, object e)
 						{
-							compositionTarget.FrameRendered -= CompositionTargetOnFrameRendered;
-							host.RemoveSplashScreen();
+							content.LayoutUpdated -= OnContentLayoutUpdated;
+
+							var compositionTarget = (CompositionTarget)XamlRoot?.Content?.Visual.CompositionTarget!;
+							var host = (WebAssemblyBrowserHost)XamlRootMap.GetHostForRoot(XamlRoot!)!;
+							compositionTarget.FrameRendered += CompositionTargetOnFrameRendered;
+							((IXamlRootHost)host).InvalidateRender();
+							void CompositionTargetOnFrameRendered()
+							{
+								compositionTarget.FrameRendered -= CompositionTargetOnFrameRendered;
+								host.RemoveSplashScreen();
+							}
 						}
-					});
+					}
 				});
 			});
 		}

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -158,12 +158,12 @@ namespace Microsoft.UI.Xaml
 						textFontManifestSuccess = await FontFamilyHelper.PreloadAllFontsInManifest(uri);
 						if (!textFontManifestSuccess)
 						{
-							typeof(Application).LogDebug()?.Debug($"Failed to load ${nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a font manifest");
+							typeof(Application).LogDebug()?.Debug($"Failed to load {nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a font manifest");
 						}
 					}
 					catch (Exception e)
 					{
-						typeof(Application).LogError()?.Error($"Failed to load ${nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a font manifest", e);
+						typeof(Application).LogError()?.Error($"Failed to load {nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a font manifest", e);
 					}
 				}
 				if (!textFontManifestSuccess)
@@ -173,12 +173,12 @@ namespace Microsoft.UI.Xaml
 						textFontManifestSuccess = await FontFamilyHelper.PreloadAsync(new FontFamily(FeatureConfiguration.Font.DefaultTextFontFamily), FontWeights.Normal, FontStretch.Normal, FontStyle.Normal);
 						if (!textFontManifestSuccess)
 						{
-							typeof(Application).LogDebug()?.Debug($"Failed to load ${nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a non-manifest font");
+							typeof(Application).LogDebug()?.Debug($"Failed to load {nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a non-manifest font");
 						}
 					}
 					catch (Exception e)
 					{
-						typeof(Application).LogError()?.Error($"Failed to load ${nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a non-manifest font", e);
+						typeof(Application).LogError()?.Error($"Failed to load {nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a non-manifest font", e);
 					}
 				}
 
@@ -191,12 +191,12 @@ namespace Microsoft.UI.Xaml
 					}
 					else
 					{
-						typeof(Application).LogError()?.Error($"Failed to load ${nameof(FeatureConfiguration.Font.SymbolsFont)}=[{FeatureConfiguration.Font.SymbolsFont}]");
+						typeof(Application).LogError()?.Error($"Failed to load {nameof(FeatureConfiguration.Font.SymbolsFont)}=[{FeatureConfiguration.Font.SymbolsFont}]");
 					}
 				}
 				catch (Exception e)
 				{
-					typeof(Application).LogError()?.Error($"Failed to load ${nameof(FeatureConfiguration.Font.SymbolsFont)}=[{FeatureConfiguration.Font.SymbolsFont}]", e);
+					typeof(Application).LogError()?.Error($"Failed to load {nameof(FeatureConfiguration.Font.SymbolsFont)}=[{FeatureConfiguration.Font.SymbolsFont}]", e);
 				}
 			}
 			catch (Exception e)


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->