### PR TITLE
ci(docs): move docs deployment to main CI stages

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -10,6 +10,8 @@ trigger:
     include:
       - doc/**
       - '**/*.md'
+      - build/ci/.azure-devops-stages-docs.yml
+      - build/ci/docs/**
 
 pr: 
   branches:
@@ -23,6 +25,8 @@ pr:
     include:
       - doc/**
       - '**/*.md'
+      - build/ci/.azure-devops-stages-docs.yml
+      - build/ci/docs/**
 
 variables:
   windowsScaledPool: 'Windows2022-20250720-1'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,6 +19,9 @@ trigger:
     - '*.md'
     - 'build/cSpell.json'
     - 'build/.markdownlint.json'
+    - '.vsts-ci-docs.yml'
+    - 'build/ci/.azure-devops-stages-docs.yml'
+    - 'build/ci/docs/**'
     
 pr: 
   branches:
@@ -41,6 +44,9 @@ pr:
     - '*.md'
     - 'build/cSpell.json'
     - 'build/.markdownlint.json'
+    - '.vsts-ci-docs.yml'
+    - 'build/ci/.azure-devops-stages-docs.yml'
+    - 'build/ci/docs/**'
 
 resources:
   containers:

--- a/build/ci/.azure-devops-stages-docs.yml
+++ b/build/ci/.azure-devops-stages-docs.yml
@@ -53,7 +53,7 @@ stages:
       deploymentName: Docs_Deploy_Staging
       displayName: Deploy Docs Staging
       environmentName: Uno UI Docs Staging
-      azureSubscription: Uno Platform - Operations (platformuno.onmicrosoft.com)
+      azureSubscription: Uno Platform - Operations (uno-platform-operations @ platformuno.onmicrosoft.com)
       storageAccountName: unoplatformdocstaging
 
 - stage: docs_deploy_prod
@@ -67,5 +67,5 @@ stages:
       deploymentName: Docs_Deploy_Prod
       displayName: Deploy Docs Prod
       environmentName: Uno UI Docs Production
-      azureSubscription: Uno Platform - Operations (platformuno.onmicrosoft.com)
+      azureSubscription: Uno Platform - Operations (uno-platform-operations @ platformuno.onmicrosoft.com)
       storageAccountName: unoplatformdocsprod

--- a/build/ci/.azure-devops-stages-docs.yml
+++ b/build/ci/.azure-devops-stages-docs.yml
@@ -27,3 +27,45 @@ stages:
   - template: docs/.azure-devops-docs.yml
     parameters:
       poolName: '$(windowsScaledPool)'
+
+- stage: docs_deploy_dev
+  displayName: Docs Deploy - Dev
+  dependsOn: docs_generation
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), not(eq(variables['Build.Reason'], 'PullRequest')))
+  jobs:
+  - template: docs/.azure-devops-docs-deploy.yml
+    parameters:
+      poolName: '$(windowsScaledPool)'
+      deploymentName: Docs_Deploy_Dev
+      displayName: Deploy Docs Dev
+      environmentName: Uno UI Docs Development
+      azureSubscription: Uno Platform - Dev Operations (uno-staticapps-dev)
+      storageAccountName: unoplatformdocsdev
+
+- stage: docs_deploy_staging
+  displayName: Docs Deploy - Staging
+  dependsOn: docs_generation
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/'), not(eq(variables['Build.Reason'], 'PullRequest')))
+  jobs:
+  - template: docs/.azure-devops-docs-deploy.yml
+    parameters:
+      poolName: '$(windowsScaledPool)'
+      deploymentName: Docs_Deploy_Staging
+      displayName: Deploy Docs Staging
+      environmentName: Uno UI Docs Staging
+      azureSubscription: Uno Platform - Operations (platformuno.onmicrosoft.com)
+      storageAccountName: unoplatformdocstaging
+
+- stage: docs_deploy_prod
+  displayName: Docs Deploy - Prod
+  dependsOn: docs_deploy_staging
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/'), not(eq(variables['Build.Reason'], 'PullRequest')))
+  jobs:
+  - template: docs/.azure-devops-docs-deploy.yml
+    parameters:
+      poolName: '$(windowsScaledPool)'
+      deploymentName: Docs_Deploy_Prod
+      displayName: Deploy Docs Prod
+      environmentName: Uno UI Docs Production
+      azureSubscription: Uno Platform - Operations (platformuno.onmicrosoft.com)
+      storageAccountName: unoplatformdocsprod

--- a/build/ci/docs/.azure-devops-docs-deploy.yml
+++ b/build/ci/docs/.azure-devops-docs-deploy.yml
@@ -1,0 +1,36 @@
+parameters:
+  poolName: ''
+  deploymentName: ''
+  displayName: ''
+  environmentName: ''
+  azureSubscription: ''
+  storageAccountName: ''
+
+jobs:
+- deployment: ${{ parameters.deploymentName }}
+  displayName: ${{ parameters.displayName }}
+  cancelTimeoutInMinutes: 0
+  environment: ${{ parameters.environmentName }}
+
+  pool: ${{ parameters.poolName }}
+
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - download: none
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download Docs Artifacts
+          inputs:
+            artifactName: DocumentationArtifacts
+            targetPath: $(Pipeline.Workspace)/DocumentationArtifacts
+
+        - task: AzureCLI@2
+          displayName: Upload site files
+          inputs:
+            azureSubscription: ${{ parameters.azureSubscription }}
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              az storage blob upload-batch --account-name ${{ parameters.storageAccountName }} -s "$(Pipeline.Workspace)/DocumentationArtifacts/doc/_site" -d '$web' --overwrite

--- a/build/ci/docs/.azure-devops-docs-deploy.yml
+++ b/build/ci/docs/.azure-devops-docs-deploy.yml
@@ -22,15 +22,17 @@ jobs:
 
         - task: DownloadPipelineArtifact@2
           displayName: Download Docs Artifacts
+          retryCountOnTaskFailure: 3
           inputs:
             artifactName: DocumentationArtifacts
             targetPath: $(Pipeline.Workspace)/DocumentationArtifacts
 
         - task: AzureCLI@2
           displayName: Upload site files
+          retryCountOnTaskFailure: 3
           inputs:
             azureSubscription: ${{ parameters.azureSubscription }}
             scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
-              az storage blob upload-batch --account-name ${{ parameters.storageAccountName }} -s "$(Pipeline.Workspace)/DocumentationArtifacts/doc/_site" -d '$web' --overwrite
+              az storage blob upload-batch --account-name ${{ parameters.storageAccountName }} -s "$(Pipeline.Workspace)/DocumentationArtifacts/doc/_site" -d '$web' --overwrite --auth-mode login


### PR DESCRIPTION
This updates the docs pipeline to deploy through the main Uno docs CI using staged deployment environments (Development, Staging, Production), replacing reliance on the old classic release flow.

It keeps the validated deployment behavior and approval gates while removing temporary test-only queue-time overrides used during migration validation.

Related to https://github.com/unoplatform/private/issues/#882