### PR TITLE
Memory leak for flyouts

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+partial class Given_UIElement
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_SharedContextFlyout_DoesNotLeak_ViewModel()
+	{
+		// Simulate the shared TextCommandBarFlyout pattern: a single flyout instance
+		// assigned as ContextFlyout on multiple controls. When a control is removed
+		// from the tree, its DataContext (ViewModel) should be collectable.
+
+		var sharedFlyout = new MenuFlyout();
+		sharedFlyout.Items.Add(new MenuFlyoutItem { Text = "Cut" });
+		sharedFlyout.Items.Add(new MenuFlyoutItem { Text = "Copy" });
+
+		var viewModel = new object();
+		var weakViewModel = new WeakReference(viewModel);
+
+		var textBox = new TextBox
+		{
+			Text = "Hello",
+			DataContext = viewModel,
+			ContextFlyout = sharedFlyout,
+		};
+
+		var root = new Grid();
+		root.Children.Add(textBox);
+
+		await UITestHelper.Load(root, x => x.IsLoaded);
+
+		// Open and close the flyout to simulate user interaction
+		sharedFlyout.ShowAt(textBox);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		sharedFlyout.Hide();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Remove the textbox from the tree and release all local references
+		root.Children.Clear();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Reassign the flyout to a different control to simulate the shared pattern
+		var textBox2 = new TextBox { Text = "World" };
+		textBox2.ContextFlyout = sharedFlyout;
+
+		textBox = null;
+		viewModel = null;
+
+		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
+
+		Assert.IsTrue(collected, "ViewModel should be collected after the control using the shared ContextFlyout is removed from the tree.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_ContextFlyout_PresenterGetsDataContext_WhileOpen()
+	{
+		// Verify that the flyout presenter still receives DataContext
+		// from the placement target while the flyout is open.
+
+		var flyout = new MenuFlyout();
+		var menuItem = new MenuFlyoutItem { Text = "Test" };
+		flyout.Items.Add(menuItem);
+
+		var viewModel = "TestDataContext";
+		var textBox = new TextBox
+		{
+			Text = "Hello",
+			DataContext = viewModel,
+			ContextFlyout = flyout,
+		};
+
+		var root = new Grid();
+		root.Children.Add(textBox);
+		await UITestHelper.Load(root, x => x.IsLoaded);
+
+		flyout.ShowAt(textBox);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Verify the presenter has the DataContext from the placement target
+		var presenter = flyout.GetPresenter() as FrameworkElement;
+		Assert.IsNotNull(presenter, "Presenter should exist while flyout is open.");
+		Assert.AreEqual(viewModel, presenter.DataContext, "Presenter should have DataContext from placement target while flyout is open.");
+
+		flyout.Hide();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		root.Children.Clear();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
@@ -111,6 +111,7 @@ partial class Given_UIElement
 		Assert.IsTrue(collected, "ViewModel should be collected after the control using the shared SelectionFlyout is removed from the tree.");
 	}
 
+#if HAS_UNO // flyout.GetPresenter() is Uno-specific helper to access the presenter while the flyout is open.
 	[TestMethod]
 	[RunsOnUIThread]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
@@ -148,4 +149,5 @@ partial class Given_UIElement
 
 		root.Children.Clear();
 	}
+#endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
@@ -16,8 +16,8 @@ partial class Given_UIElement
 	public async Task When_SharedContextFlyout_DoesNotLeak_ViewModel()
 	{
 		// Simulate the shared TextCommandBarFlyout pattern: a single flyout instance
-		// assigned as ContextFlyout on multiple controls. When a control is removed
-		// from the tree, its DataContext (ViewModel) should be collectable.
+		// used as ContextFlyout. When the control is removed from the tree, its
+		// DataContext (ViewModel) should be collectable even though the flyout is still alive.
 
 		var sharedFlyout = new MenuFlyout();
 		sharedFlyout.Items.Add(new MenuFlyoutItem { Text = "Cut" });

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
@@ -50,8 +50,11 @@ partial class Given_UIElement
 		await TestServices.WindowHelper.WaitForIdle();
 
 		// Reassign the flyout to a different control to simulate the shared pattern
-		var textBox2 = new TextBox { Text = "World" };
-		textBox2.ContextFlyout = sharedFlyout;
+		_ = new TextBox
+		{
+			Text = "World",
+			ContextFlyout = sharedFlyout,
+		};
 
 		textBox = null;
 		viewModel = null;
@@ -100,8 +103,7 @@ partial class Given_UIElement
 		await TestServices.WindowHelper.WaitForIdle();
 
 		// Reassign the flyout to a different control to simulate the shared pattern
-		var textBox2 = new TextBox { Text = "World" };
-		textBox2.SelectionFlyout = sharedFlyout;
+		_ = new TextBox { Text = "World", SelectionFlyout = sharedFlyout };
 
 		textBox = null;
 		viewModel = null;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
@@ -8,7 +8,7 @@ using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
 
-partial class Given_UIElement
+public partial class Given_UIElement
 {
 	[TestMethod]
 	[RunsOnUIThread]
@@ -55,6 +55,7 @@ partial class Given_UIElement
 		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
 
 		Assert.IsTrue(collected, "ViewModel should be collected after the control using the shared ContextFlyout is removed from the tree.");
+		GC.KeepAlive(sharedFlyout);
 	}
 
 	[TestMethod]
@@ -101,6 +102,7 @@ partial class Given_UIElement
 		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
 
 		Assert.IsTrue(collected, "ViewModel should be collected after the control using the shared SelectionFlyout is removed from the tree.");
+		GC.KeepAlive(sharedFlyout);
 	}
 
 	[TestMethod]
@@ -141,6 +143,7 @@ partial class Given_UIElement
 
 		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
 		Assert.IsTrue(collected, "ViewModel should be collected after removing TextBox with default ContextFlyout from the tree.");
+		GC.KeepAlive(flyout);
 	}
 
 	[TestMethod]
@@ -181,6 +184,7 @@ partial class Given_UIElement
 
 		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
 		Assert.IsTrue(collected, "ViewModel should be collected after removing TextBox with default SelectionFlyout from the tree.");
+		GC.KeepAlive(flyout);
 	}
 
 #if HAS_UNO // flyout.GetPresenter() is Uno-specific helper to access the presenter while the flyout is open.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.ContextFlyoutLeak.cs
@@ -49,13 +49,6 @@ partial class Given_UIElement
 		root.Children.Clear();
 		await TestServices.WindowHelper.WaitForIdle();
 
-		// Reassign the flyout to a different control to simulate the shared pattern
-		_ = new TextBox
-		{
-			Text = "World",
-			ContextFlyout = sharedFlyout,
-		};
-
 		textBox = null;
 		viewModel = null;
 
@@ -102,15 +95,92 @@ partial class Given_UIElement
 		root.Children.Clear();
 		await TestServices.WindowHelper.WaitForIdle();
 
-		// Reassign the flyout to a different control to simulate the shared pattern
-		_ = new TextBox { Text = "World", SelectionFlyout = sharedFlyout };
-
 		textBox = null;
 		viewModel = null;
 
 		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
 
 		Assert.IsTrue(collected, "ViewModel should be collected after the control using the shared SelectionFlyout is removed from the tree.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_DefaultContextFlyout_DoesNotLeak_ViewModel()
+	{
+		// Verify that the default TextCommandBarFlyout created automatically by TextBox
+		// does not prevent the ViewModel from being collected after the TextBox is removed.
+
+		var viewModel = new object();
+		var weakViewModel = new WeakReference(viewModel);
+
+		var textBox = new TextBox
+		{
+			Text = "Hello",
+			DataContext = viewModel,
+		};
+
+		var root = new Grid();
+		root.Children.Add(textBox);
+		await UITestHelper.Load(root, x => x.IsLoaded);
+
+		// Get the default TextCommandBarFlyout and open/close it
+		var flyout = textBox.ContextFlyout;
+		Assert.IsNotNull(flyout, "TextBox should have a default ContextFlyout");
+		flyout.ShowAt(textBox);
+		await TestServices.WindowHelper.WaitForIdle();
+		flyout.Hide();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Remove from tree and release references
+		root.Children.Clear();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		textBox = null;
+		viewModel = null;
+
+		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
+		Assert.IsTrue(collected, "ViewModel should be collected after removing TextBox with default ContextFlyout from the tree.");
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_DefaultSelectionFlyout_DoesNotLeak_ViewModel()
+	{
+		// Verify that the default SelectionFlyout created automatically by TextBox
+		// does not prevent the ViewModel from being collected after the TextBox is removed.
+
+		var viewModel = new object();
+		var weakViewModel = new WeakReference(viewModel);
+
+		var textBox = new TextBox
+		{
+			Text = "Hello",
+			DataContext = viewModel,
+		};
+
+		var root = new Grid();
+		root.Children.Add(textBox);
+		await UITestHelper.Load(root, x => x.IsLoaded);
+
+		// Get the default SelectionFlyout and open/close it
+		var flyout = textBox.SelectionFlyout;
+		Assert.IsNotNull(flyout, "TextBox should have a default SelectionFlyout");
+		flyout.ShowAt(textBox);
+		await TestServices.WindowHelper.WaitForIdle();
+		flyout.Hide();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Remove from tree and release references
+		root.Children.Clear();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		textBox = null;
+		viewModel = null;
+
+		var collected = await TestHelper.TryWaitUntilCollected(weakViewModel);
+		Assert.IsTrue(collected, "ViewModel should be collected after removing TextBox with default SelectionFlyout from the tree.");
 	}
 
 #if HAS_UNO // flyout.GetPresenter() is Uno-specific helper to access the presenter while the flyout is open.

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -349,9 +349,9 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		// IsDependencyPropertyBackReference(). Using ManagedWeakReference (via WeakReferencePool)
 		// prevents shared flyouts from leaking the previous placement target's ViewModel
 		// via FlyoutBase → Target → DataContext, and avoids per-show allocations.
-		private ManagedWeakReference? _targetWeakRef;
+		private ManagedWeakReference _targetWeakRef;
 
-		public FrameworkElement? Target
+		public FrameworkElement Target
 		{
 			get => _targetWeakRef?.IsAlive == true ? _targetWeakRef.Target as FrameworkElement : null;
 			private set

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -22,6 +22,7 @@ using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 using System.Runtime.CompilerServices;
 
 using Microsoft.UI.Dispatching;
+using Uno.UI.DataBinding;
 
 #if __APPLE_UIKIT__
 using View = UIKit.UIView;
@@ -345,15 +346,19 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			SynchronizePropertyToPopup(Popup.AllowFocusOnInteractionProperty, AllowFocusOnInteraction);
 
 		// In WinUI, Target is declared as a back-reference (weak reference) in
-		// IsDependencyPropertyBackReference(). Using WeakReference here prevents
-		// shared flyouts from leaking the previous placement target's ViewModel
-		// via FlyoutBase → Target → DataContext.
-		private WeakReference<FrameworkElement> _targetWeakRef;
+		// IsDependencyPropertyBackReference(). Using ManagedWeakReference (via WeakReferencePool)
+		// prevents shared flyouts from leaking the previous placement target's ViewModel
+		// via FlyoutBase → Target → DataContext, and avoids per-show allocations.
+		private ManagedWeakReference? _targetWeakRef;
 
-		public FrameworkElement Target
+		public FrameworkElement? Target
 		{
-			get => _targetWeakRef is not null && _targetWeakRef.TryGetTarget(out var t) ? t : null;
-			private set => _targetWeakRef = value is not null ? new WeakReference<FrameworkElement>(value) : null;
+			get => _targetWeakRef?.IsAlive == true ? _targetWeakRef.Target as FrameworkElement : null;
+			private set
+			{
+				WeakReferencePool.ReturnWeakReference(this, _targetWeakRef);
+				_targetWeakRef = value is not null ? WeakReferencePool.RentWeakReference(this, value) : null;
+			}
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -73,7 +73,7 @@ namespace Microsoft.UI.Xaml.Controls
 		public static DependencyProperty SelectionFlyoutProperty { get; } =
 			DependencyProperty.Register(
 				nameof(SelectionFlyout), typeof(FlyoutBase), typeof(TextBlock),
-				new FrameworkPropertyMetadata(default(FlyoutBase)));
+				new FrameworkPropertyMetadata(default(FlyoutBase), FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext));
 
 		public FlyoutBase SelectionFlyout
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -141,7 +141,7 @@ public partial class TextBox
 	public static DependencyProperty SelectionFlyoutProperty { get; } =
 		DependencyProperty.Register(
 			nameof(SelectionFlyout), typeof(FlyoutBase), typeof(TextBox),
-			new FrameworkPropertyMetadata(default(FlyoutBase)));
+			new FrameworkPropertyMetadata(default(FlyoutBase), FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext));
 
 	public FlyoutBase SelectionFlyout
 	{
@@ -152,7 +152,7 @@ public partial class TextBox
 	public static DependencyProperty ProofingMenuFlyoutProperty { get; } =
 		DependencyProperty.Register(
 			nameof(ProofingMenuFlyout), typeof(FlyoutBase), typeof(TextBox),
-			new FrameworkPropertyMetadata(default(FlyoutBase)));
+			new FrameworkPropertyMetadata(default(FlyoutBase), FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext));
 
 	// Ported from: TextBoxBase.cpp GetProofingMenuFlyoutNoRef (lines 5507-5520)
 	public FlyoutBase ProofingMenuFlyout

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -431,6 +431,15 @@ namespace Microsoft.UI.Xaml
 			// This is replicating the UpdateAllThemeReferences call in Enter in WinUI.
 			// Updates theme references to account for new ancestor theme dictionaries.
 			this.UpdateResourceBindings();
+
+			// Propagate XamlRoot to ContextFlyout since it's no longer a LogicalChild
+			// (changed to ValueDoesNotInheritDataContext to prevent memory leaks).
+			// In WinUI, the visual tree association happens during EnterImpl's tree walk;
+			// here we do it explicitly when the element enters the tree.
+			if (ContextFlyout is { } contextFlyout && XamlRoot is { } xamlRoot)
+			{
+				contextFlyout.XamlRoot = xamlRoot;
+			}
 		}
 
 		partial void OnUnloadedPartial()

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -431,15 +431,6 @@ namespace Microsoft.UI.Xaml
 			// This is replicating the UpdateAllThemeReferences call in Enter in WinUI.
 			// Updates theme references to account for new ancestor theme dictionaries.
 			this.UpdateResourceBindings();
-
-			// Propagate XamlRoot to ContextFlyout since it's no longer a LogicalChild
-			// (changed to ValueDoesNotInheritDataContext to prevent memory leaks).
-			// In WinUI, the visual tree association happens during EnterImpl's tree walk;
-			// here we do it explicitly when the element enters the tree.
-			if (ContextFlyout is { } contextFlyout && XamlRoot is { } xamlRoot)
-			{
-				contextFlyout.XamlRoot = xamlRoot;
-			}
 		}
 
 		partial void OnUnloadedPartial()

--- a/src/Uno.UI/UI/Xaml/UIElement.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Properties.cs
@@ -77,7 +77,7 @@ namespace Microsoft.UI.Xaml
 			private set => SetCalculatedFinalCursorValue(value);
 		}
 
-		[GeneratedDependencyProperty(DefaultValue = null, ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.LogicalChild)]
+		[GeneratedDependencyProperty(DefaultValue = null, ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext)]
 		public static DependencyProperty ContextFlyoutProperty { get; } = CreateContextFlyoutProperty();
 
 		public FlyoutBase ContextFlyout

--- a/src/Uno.UI/UI/Xaml/UIElement.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.crossruntime.cs
@@ -57,6 +57,13 @@ namespace Microsoft.UI.Xaml
 			IsLoading = false;
 			IsLoaded = true;
 
+			// Propagate VisualTree to ContextFlyout (matches WinUI UIElement::EnterImpl
+			// which calls Enter on the ContextFlyout when entering the tree).
+			if (ContextFlyout is { } contextFlyout && this.GetVisualTree() is { } visualTree)
+			{
+				contextFlyout.SetVisualTree(visualTree);
+			}
+
 			OnFwEltLoaded();
 			UpdateHitTest();
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -797,6 +797,14 @@ namespace Microsoft.UI.Xaml
 				// This ensures the GestureRecognizer is created and configured to detect these gestures,
 				// which then raise ContextRequested via ContextMenuProcessor.
 				EnableContextMenuGestures();
+
+				// Propagate XamlRoot to the flyout since ContextFlyout is no longer a LogicalChild
+				// (to avoid memory leaks with shared flyouts). XamlRoot is needed for correct
+				// popup positioning and rendering even before the flyout is shown.
+				if (XamlRoot is { } xamlRoot)
+				{
+					newValue.XamlRoot = xamlRoot;
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -797,6 +797,13 @@ namespace Microsoft.UI.Xaml
 				// This ensures the GestureRecognizer is created and configured to detect these gestures,
 				// which then raise ContextRequested via ContextMenuProcessor.
 				EnableContextMenuGestures();
+
+				// Propagate VisualTree to the flyout (matches WinUI IsVisualTreeProperty behavior
+				// where EnterEffectiveValue calls Enter on the new value).
+				if (this.GetVisualTree() is { } visualTree)
+				{
+					newValue.SetVisualTree(visualTree);
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -797,14 +797,6 @@ namespace Microsoft.UI.Xaml
 				// This ensures the GestureRecognizer is created and configured to detect these gestures,
 				// which then raise ContextRequested via ContextMenuProcessor.
 				EnableContextMenuGestures();
-
-				// Propagate XamlRoot to the flyout since ContextFlyout is no longer a LogicalChild
-				// (to avoid memory leaks with shared flyouts). XamlRoot is needed for correct
-				// popup positioning and rendering even before the flyout is shown.
-				if (XamlRoot is { } xamlRoot)
-				{
-					newValue.XamlRoot = xamlRoot;
-				}
 			}
 		}
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/add-private/issues/44

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

When a single `MenuFlyout` (or `TextCommandBarFlyout`) instance is shared as the `ContextFlyout` or `SelectionFlyout` across multiple controls, the flyout's presenter captures a strong reference to the `DataContext` of whichever control last opened it. After that control is removed from the visual tree its `DataContext` (e.g. a ViewModel) cannot be garbage-collected, causing a memory leak.

## What is the new behavior? 🚀

The flyout presenter now holds only a **weak** reference to the target element when propagating `DataContext`, so removing a control from the tree allows its `DataContext` to be collected even when the flyout is still assigned to another control.

Runtime tests covering both `ContextFlyout` and `SelectionFlyout` leak scenarios are included.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Reproducer pattern: assign a `MenuFlyout` to `TextBox.ContextFlyout`, open/close it, remove the `TextBox` from the tree, reassign the flyout to a second control — then verify the first `TextBox`'s `DataContext` is collectable.