### PR TITLE
fix(msbuild): stabilize override sync and incrementality

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -13,11 +13,13 @@
 	<!--
 		These core tasks always run through TaskHostFactory to avoid loading Uno.UI.Tasks.v0.dll
 		into long-lived MSBuild nodes directly.
+		Runtime/Architecture are pinned to Current* so TaskHostFactory uses the active dotnet host
+		instead of inferring a CLR4 task host path (MSBuild.exe), which is not present under dotnet SDK layouts.
 	-->
-	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerHintGeneratorTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerDefinitionMergerTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.BindableTypeLinkerGeneratorTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.EmbeddedResourceInjector.EmbeddedResourceInjectorTask_v0" TaskFactory="TaskHostFactory" />
+	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerHintGeneratorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerDefinitionMergerTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.BindableTypeLinkerGeneratorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.EmbeddedResourceInjector.EmbeddedResourceInjectorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
 
 	<!--
 		When consuming Uno from NuGet (outside the Uno repository), prefer default in-proc task loading.
@@ -35,15 +37,16 @@
 	<!--
 		Inside the Uno repo, run the remaining tasks out-of-proc as well so repeated local builds can
 		update Uno.UI.Tasks.v0.dll without requiring full build server shutdown between iterations.
+		Keep Runtime/Architecture explicit for the same host-selection reason as above.
 	-->
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" TaskFactory="TaskHostFactory"/>
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriFeaturesGeneratorTask_v0" TaskFactory="TaskHostFactory"/>
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriSubstitutionsGeneratorTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.Assets.RetargetAssets_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsSelector.RuntimeAssetsSelectorTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsValidator.RuntimeAssetsValidatorTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.HotReloadInfo.HotReloadInfoTask_v0" TaskFactory="TaskHostFactory" />
-	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="BatchMergeXaml" TaskFactory="TaskHostFactory" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriFeaturesGeneratorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriSubstitutionsGeneratorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.Assets.RetargetAssets_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsSelector.RuntimeAssetsSelectorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsValidator.RuntimeAssetsValidatorTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.HotReloadInfo.HotReloadInfoTask_v0" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="BatchMergeXaml" TaskFactory="TaskHostFactory" Runtime="CurrentRuntime" Architecture="CurrentArchitecture" />
 
 	<Target Name="_UnoLangSetup">
 		<!-- String resources -->

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -14,7 +14,6 @@
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerDefinitionMergerTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.BindableTypeLinkerGeneratorTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.EmbeddedResourceInjector.EmbeddedResourceInjectorTask_v0" TaskFactory="TaskHostFactory" />
-
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriFeaturesGeneratorTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriSubstitutionsGeneratorTask_v0" />
@@ -22,6 +21,7 @@
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsSelector.RuntimeAssetsSelectorTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsValidator.RuntimeAssetsValidatorTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.HotReloadInfo.HotReloadInfoTask_v0" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="BatchMergeXaml" />
 
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" TaskFactory="TaskHostFactory"/>
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriFeaturesGeneratorTask_v0" TaskFactory="TaskHostFactory"/>
@@ -30,6 +30,7 @@
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsSelector.RuntimeAssetsSelectorTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.RuntimeAssetsValidator.RuntimeAssetsValidatorTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.HotReloadInfo.HotReloadInfoTask_v0" TaskFactory="TaskHostFactory" />
+	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="BatchMergeXaml" TaskFactory="TaskHostFactory" />
 
 	<Target Name="_UnoLangSetup">
 		<!-- String resources -->

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -10,10 +10,19 @@
 
 	<Import Project="uno.ui.tasks.assets.targets"/>
 
+	<!--
+		These core tasks always run through TaskHostFactory to avoid loading Uno.UI.Tasks.v0.dll
+		into long-lived MSBuild nodes directly.
+	-->
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerHintGeneratorTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerDefinitionMergerTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.BindableTypeLinkerGeneratorTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.EmbeddedResourceInjector.EmbeddedResourceInjectorTask_v0" TaskFactory="TaskHostFactory" />
+
+	<!--
+		When consuming Uno from NuGet (outside the Uno repository), prefer default in-proc task loading.
+		The package payload is immutable during the build, so this keeps task startup overhead lower.
+	-->
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriFeaturesGeneratorTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriSubstitutionsGeneratorTask_v0" />
@@ -23,6 +32,10 @@
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.HotReloadInfo.HotReloadInfoTask_v0" />
 	<UsingTask Condition="'$(_IsUnoUISolution)'==''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="BatchMergeXaml" />
 
+	<!--
+		Inside the Uno repo, run the remaining tasks out-of-proc as well so repeated local builds can
+		update Uno.UI.Tasks.v0.dll without requiring full build server shutdown between iterations.
+	-->
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" TaskFactory="TaskHostFactory"/>
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriFeaturesGeneratorTask_v0" TaskFactory="TaskHostFactory"/>
 	<UsingTask Condition="'$(_IsUnoUISolution)'!=''" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.UpriSubstitutionsGeneratorTask_v0" TaskFactory="TaskHostFactory" />

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -6,11 +6,18 @@
 		AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll"
 		TaskName="Uno.UI.Tasks.Assets.ExpandPackageAssets_v0" />
 
+	<!--
+		When building Uno.UI itself, keep this task out-of-proc and explicitly pin Runtime/Architecture.
+		Without these attributes, TaskHostFactory can infer a CLR4 host and probe for MSBuild.exe
+		under the dotnet SDK folder, which causes task-host launch failures.
+	-->
 	<UsingTask
 		Condition="'$(_IsUnoUISolution)'!=''"
 		AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll"
 		TaskName="Uno.UI.Tasks.Assets.ExpandPackageAssets_v0"
-		TaskFactory="TaskHostFactory" />
+		TaskFactory="TaskHostFactory"
+		Runtime="CurrentRuntime"
+		Architecture="CurrentArchitecture" />
 
 	<PropertyGroup>
 		<_UnoDirectorySeparator Condition="'$(OS)' == 'Unix'">/</_UnoDirectorySeparator>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -44,14 +44,15 @@
 			<_UnoTasksShadowOutputPath>$([System.IO.Path]::GetFullPath('$(_UnoTasksBuildOutputPath)\..\$(Configuration)_Shadow'))</_UnoTasksShadowOutputPath>
 		</PropertyGroup>
 		<ItemGroup>
+			<!-- Use the task project output as the source of truth for the local shadow copy. -->
 			<_UnoTasksSourceFiles Include="$(_UnoTasksBuildOutputPath)\*.*" />
 			<_UnoTasksShadowDestinationFiles Include="@(_UnoTasksSourceFiles->'$(_UnoTasksShadowOutputPath)\%(Filename)%(Extension)')" />
 			<_UnoTasksExistingShadowFiles Include="$(_UnoTasksShadowOutputPath)\*.*" />
 			<_UnoTasksStaleShadowFiles Include="@(_UnoTasksExistingShadowFiles)" Exclude="@(_UnoTasksShadowDestinationFiles)" />
 		</ItemGroup>
 		<!--
-		Copy the files to an alternal location, using deterministic build.
-		Don't fail the build if the file is locked
+		Copy the files to an alternate location using deterministic source/destination mapping.
+		Skip unchanged files and tolerate transient lock contention from external hosts.
 		-->
 		<MakeDir Directories="$(_UnoTasksShadowOutputPath)" />
 		<Delete Files="@(_UnoTasksStaleShadowFiles)" ContinueOnError="true" />
@@ -73,6 +74,7 @@
 		</ItemGroup>
 		<MakeDir Directories="$(_TargetNugetFolder)" />
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
+		<!-- Keep override cache consistent with current output and incremental for repeated local builds. -->
 		<Delete Files="@(_StaleTargetFiles)" ContinueOnError="true" />
 		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputDestinationFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 	</Target>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -37,24 +37,25 @@
 		<Compile Include="..\..\Uno.UI.RemoteControl\HotReload\HotReloadInfoHelper.cs" Link="HotReloadInfo/%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<PropertyGroup>
-		<_UnoTasksShadowOutputPath>$(OutputPath)\..\$(Configuration)_Shadow</_UnoTasksShadowOutputPath>
-		<_UnoTasksShadowCopyStamp>$(_UnoTasksShadowOutputPath)\Uno.UI.Tasks.copy.stamp</_UnoTasksShadowCopyStamp>
-	</PropertyGroup>
-
 	<Target Name="_copyUnoTasksBuildTime"
-			AfterTargets="Build"
-			Inputs="$(TargetPath);$(TargetPath).pdb;$(TargetPath).config;$(TargetDir)$(TargetFileName).deps.json;@(ReferenceCopyLocalPaths)"
-			Outputs="$(_UnoTasksShadowCopyStamp)">
+			AfterTargets="Build">
+		<PropertyGroup>
+			<_UnoTasksBuildOutputPath>$([System.IO.Path]::GetFullPath('$(TargetDir)'))</_UnoTasksBuildOutputPath>
+			<_UnoTasksShadowOutputPath>$([System.IO.Path]::GetFullPath('$(_UnoTasksBuildOutputPath)\..\$(Configuration)_Shadow'))</_UnoTasksShadowOutputPath>
+		</PropertyGroup>
 		<ItemGroup>
-			<_unoTasksFiles Include="$(OutputPath)\*.*" />
+			<_UnoTasksSourceFiles Include="$(_UnoTasksBuildOutputPath)\*.*" />
+			<_UnoTasksShadowDestinationFiles Include="@(_UnoTasksSourceFiles->'$(_UnoTasksShadowOutputPath)\%(Filename)%(Extension)')" />
+			<_UnoTasksExistingShadowFiles Include="$(_UnoTasksShadowOutputPath)\*.*" />
+			<_UnoTasksStaleShadowFiles Include="@(_UnoTasksExistingShadowFiles)" Exclude="@(_UnoTasksShadowDestinationFiles)" />
 		</ItemGroup>
 		<!--
 		Copy the files to an alternal location, using deterministic build.
 		Don't fail the build if the file is locked
 		-->
-		<Copy SkipUnchangedFiles="true" SourceFiles="@(_unoTasksFiles)" DestinationFolder="$(_UnoTasksShadowOutputPath)" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
-		<Touch Files="$(_UnoTasksShadowCopyStamp)" AlwaysCreate="true" />
+		<MakeDir Directories="$(_UnoTasksShadowOutputPath)" />
+		<Delete Files="@(_UnoTasksStaleShadowFiles)" ContinueOnError="true" />
+		<Copy SkipUnchangedFiles="true" SourceFiles="@(_UnoTasksSourceFiles)" DestinationFiles="@(_UnoTasksShadowDestinationFiles)" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 	</Target>
 
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
@@ -65,11 +66,14 @@
 			<_TargetNugetFolder>$(NuGetPackageRoot)\$(_PackageId)\$(UnoNugetOverrideVersion)\buildTransitive\Uno.UI.Tasks</_TargetNugetFolder>
 		</PropertyGroup>
 		<ItemGroup>
-			<_OutputFiles Include="$(TargetDir)**" />
+			<_OutputFiles Include="$(TargetDir)**\*.*" />
+			<_OutputDestinationFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<_ExistingTargetFiles Include="$(_TargetNugetFolder)\**\*.*" />
+			<_StaleTargetFiles Include="@(_ExistingTargetFiles)" Exclude="@(_OutputDestinationFiles)" />
 		</ItemGroup>
 		<MakeDir Directories="$(_TargetNugetFolder)" />
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
-		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
+		<Delete Files="@(_StaleTargetFiles)" ContinueOnError="true" />
+		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputDestinationFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 	</Target>
 </Project>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -37,7 +37,15 @@
 		<Compile Include="..\..\Uno.UI.RemoteControl\HotReload\HotReloadInfoHelper.cs" Link="HotReloadInfo/%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<Target Name="_copyUnoTasksBuildTime" AfterTargets="Build">
+	<PropertyGroup>
+		<_UnoTasksShadowOutputPath>$(OutputPath)\..\$(Configuration)_Shadow</_UnoTasksShadowOutputPath>
+		<_UnoTasksShadowCopyStamp>$(_UnoTasksShadowOutputPath)\Uno.UI.Tasks.copy.stamp</_UnoTasksShadowCopyStamp>
+	</PropertyGroup>
+
+	<Target Name="_copyUnoTasksBuildTime"
+			AfterTargets="Build"
+			Inputs="$(TargetPath);$(TargetPath).pdb;$(TargetPath).config;$(TargetDir)$(TargetFileName).deps.json;@(ReferenceCopyLocalPaths)"
+			Outputs="$(_UnoTasksShadowCopyStamp)">
 		<ItemGroup>
 			<_unoTasksFiles Include="$(OutputPath)\*.*" />
 		</ItemGroup>
@@ -45,7 +53,8 @@
 		Copy the files to an alternal location, using deterministic build.
 		Don't fail the build if the file is locked
 		-->
-		<Copy SkipUnchangedFiles="true" SourceFiles="@(_unoTasksFiles)" DestinationFolder="$(OutputPath)\..\$(Configuration)_Shadow" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
+		<Copy SkipUnchangedFiles="true" SourceFiles="@(_unoTasksFiles)" DestinationFolder="$(_UnoTasksShadowOutputPath)" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
+		<Touch Files="$(_UnoTasksShadowCopyStamp)" AlwaysCreate="true" />
 	</Target>
 
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -188,7 +188,7 @@
 			<_StaleOwnedTargetFiles Include="@(_PreviouslyOwnedTargetFiles)" Exclude="@(_OutputTargetFiles)" />
 			<_StaleOwnedTargetRefFiles Include="@(_PreviouslyOwnedTargetRefFiles)" Exclude="@(_OutputTargetRefFiles)" />
 		</ItemGroup>
-		<Delete Files="@(_StaleOwnedTargetFiles);@(_StaleOwnedTargetRefFiles)" />
+		<Delete Files="@(_StaleOwnedTargetFiles);@(_StaleOwnedTargetRefFiles)" ContinueOnError="true" />
 
 		<Copy SourceFiles="@(_OutputFiles)"
 			  DestinationFiles="@(_OutputTargetFiles)"
@@ -247,7 +247,7 @@
 			<_CommonOverrideCurrentOwnedFiles Include="@(_CommonOverrideTargetFiles);@(_CommonOverrideTargetDebugFiles)" />
 			<_CommonOverrideStaleOwnedFiles Include="@(_PreviouslyOwnedCommonFiles)" Exclude="@(_CommonOverrideCurrentOwnedFiles)" />
 		</ItemGroup>
-		<Delete Files="@(_CommonOverrideStaleOwnedFiles)" />
+		<Delete Files="@(_CommonOverrideStaleOwnedFiles)" ContinueOnError="true" />
 
 		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_CommonOverrideTargetFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" />
 		<Copy SourceFiles="@(_OutputDebugSymbols)" DestinationFiles="@(_CommonOverrideTargetDebugFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" />

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -161,19 +161,35 @@
 		<ItemGroup>
 			<_OutputFiles Include="$(TargetDir)\*.*" />
 			<_OutputRefFiles Include="$(TargetDir)\ref\*.*" />
+			<_OutputTargetFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<_OutputTargetRefFiles Include="@(_OutputRefFiles->'$(_TargetNugetRefFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<_ExistingTargetFiles Include="$(_TargetNugetFolder)\*.*" />
+			<_ExistingTargetRefFiles Include="$(_TargetNugetRefFolder)\*.*" />
+			<_StaleTargetFiles Include="@(_ExistingTargetFiles)" Exclude="@(_OutputTargetFiles);$(_TargetNugetFolder)\.packageoverride" />
+			<_StaleTargetRefFiles Include="@(_ExistingTargetRefFiles)" Exclude="@(_OutputTargetRefFiles)" />
 		</ItemGroup>
-		<MakeDir Directories="$(_TargetNugetFolder)" />
+		<MakeDir Directories="$(_TargetNugetFolder);$(_TargetNugetRefFolder)" />
 
 		<!-- Add override file to notify a developer that the used package is modified -->
 		<WriteLinestoFile File="$(_TargetNugetFolder)\.packageoverride"
-				 Lines="$([System.DateTime]::Now.ToString('yyyyMMddTHHmmss')) from $(MSBuildThisFileDirectory)"
-				 Overwrite="True" />
+				 Lines="override from $(MSBuildThisFileDirectory)"
+				 Overwrite="True"
+				 WriteOnlyWhenDifferent="true" />
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder) and $(_TargetNugetRefFolder)" />
 
+		<Delete Files="@(_StaleTargetFiles);@(_StaleTargetRefFiles)" ContinueOnError="true" />
 		<Copy SourceFiles="@(_OutputFiles)"
-			  DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			  DestinationFiles="@(_OutputTargetFiles)"
+			  SkipUnchangedFiles="true"
+			  Retries="1"
+			  RetryDelayMilliseconds="500"
+			  ContinueOnError="true" />
 		<Copy SourceFiles="@(_OutputRefFiles)"
-			  DestinationFiles="@(_OutputRefFiles->'$(_TargetNugetRefFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			  DestinationFiles="@(_OutputTargetRefFiles)"
+			  SkipUnchangedFiles="true"
+			  Retries="1"
+			  RetryDelayMilliseconds="500"
+			  ContinueOnError="true" />
 	</Target>
 
 
@@ -193,13 +209,19 @@
 
 		<ItemGroup>
 			<_OutputFiles Include="@(TargetPathWithTargetPlatformMoniker)" />
+			<_OutputDebugSymbols Include="@(_DebugSymbolsIntermediatePath)" />
+			<_CommonOverrideTargetFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<_CommonOverrideTargetDebugFiles Include="@(_OutputDebugSymbols->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<_CommonOverrideExistingFiles Include="$(_TargetNugetFolder)\*.*" />
+			<_CommonOverrideStaleFiles Include="@(_CommonOverrideExistingFiles)" Exclude="@(_CommonOverrideTargetFiles);@(_CommonOverrideTargetDebugFiles)" />
 		</ItemGroup>
 
 		<MakeDir Directories="$(_TargetNugetFolder)" />
 
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
 
-		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-		<Copy SourceFiles="@(_DebugSymbolsIntermediatePath)" DestinationFiles="@(_DebugSymbolsIntermediatePath->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+		<Delete Files="@(_CommonOverrideStaleFiles)" ContinueOnError="true" />
+		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_CommonOverrideTargetFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
+		<Copy SourceFiles="@(_OutputDebugSymbols)" DestinationFiles="@(_CommonOverrideTargetDebugFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 	</Target>
 </Project>

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -157,18 +157,16 @@
 			<_overridePackageId Condition="'$(UNO_UWP_BUILD)'=='false'">$(_overridePackageId.Replace('uno.ui','uno.winui'))</_overridePackageId>
 			<_TargetNugetFolder>$(NuGetPackageRoot)\$(_overridePackageId)\$(UnoNugetOverrideVersion)\lib\$(_OverrideTargetFramework)</_TargetNugetFolder>
 			<_TargetNugetRefFolder>$(NuGetPackageRoot)\$(_overridePackageId)\$(UnoNugetOverrideVersion)\ref\$(_OverrideTargetFramework)</_TargetNugetRefFolder>
+			<!-- Track ownership so cleanup only touches files produced by this project/TFM. -->
+			<_OwnedOutputManifest>$(_TargetNugetFolder)\.$(MSBuildProjectName).$(_OverrideTargetFramework).owned-files.txt</_OwnedOutputManifest>
+			<_OwnedRefOutputManifest>$(_TargetNugetRefFolder)\.$(MSBuildProjectName).$(_OverrideTargetFramework).owned-files.txt</_OwnedRefOutputManifest>
 		</PropertyGroup>
 		<ItemGroup>
 			<_OutputFiles Include="$(TargetDir)\*.*" />
 			<_OutputRefFiles Include="$(TargetDir)\ref\*.*" />
-			<!-- Precompute destination paths so stale-file detection and copy use the same mapping. -->
+			<!-- Precompute destination paths so cleanup and copy use the same mapping. -->
 			<_OutputTargetFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 			<_OutputTargetRefFiles Include="@(_OutputRefFiles->'$(_TargetNugetRefFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-			<_ExistingTargetFiles Include="$(_TargetNugetFolder)\*.*" />
-			<_ExistingTargetRefFiles Include="$(_TargetNugetRefFolder)\*.*" />
-			<!-- Keep .packageoverride and remove any payload that is no longer produced by this build. -->
-			<_StaleTargetFiles Include="@(_ExistingTargetFiles)" Exclude="@(_OutputTargetFiles);$(_TargetNugetFolder)\.packageoverride" />
-			<_StaleTargetRefFiles Include="@(_ExistingTargetRefFiles)" Exclude="@(_OutputTargetRefFiles)" />
 		</ItemGroup>
 		<MakeDir Directories="$(_TargetNugetFolder);$(_TargetNugetRefFolder)" />
 
@@ -179,20 +177,37 @@
 				 WriteOnlyWhenDifferent="true" />
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder) and $(_TargetNugetRefFolder)" />
 
-		<!-- Delete stale files first, then copy only files that changed to keep override builds incremental. -->
-		<Delete Files="@(_StaleTargetFiles);@(_StaleTargetRefFiles)" ContinueOnError="true" />
+		<!-- Delete only files previously owned by this project/TFM. Shared package folders may also contain outputs from other projects. -->
+		<ReadLinesFromFile File="$(_OwnedOutputManifest)" Condition="Exists('$(_OwnedOutputManifest)')">
+			<Output TaskParameter="Lines" ItemName="_PreviouslyOwnedTargetFiles" />
+		</ReadLinesFromFile>
+		<ReadLinesFromFile File="$(_OwnedRefOutputManifest)" Condition="Exists('$(_OwnedRefOutputManifest)')">
+			<Output TaskParameter="Lines" ItemName="_PreviouslyOwnedTargetRefFiles" />
+		</ReadLinesFromFile>
+		<ItemGroup>
+			<_StaleOwnedTargetFiles Include="@(_PreviouslyOwnedTargetFiles)" Exclude="@(_OutputTargetFiles)" />
+			<_StaleOwnedTargetRefFiles Include="@(_PreviouslyOwnedTargetRefFiles)" Exclude="@(_OutputTargetRefFiles)" />
+		</ItemGroup>
+		<Delete Files="@(_StaleOwnedTargetFiles);@(_StaleOwnedTargetRefFiles)" />
+
 		<Copy SourceFiles="@(_OutputFiles)"
 			  DestinationFiles="@(_OutputTargetFiles)"
 			  SkipUnchangedFiles="true"
 			  Retries="1"
-			  RetryDelayMilliseconds="500"
-			  ContinueOnError="true" />
+			  RetryDelayMilliseconds="500" />
 		<Copy SourceFiles="@(_OutputRefFiles)"
 			  DestinationFiles="@(_OutputTargetRefFiles)"
 			  SkipUnchangedFiles="true"
 			  Retries="1"
-			  RetryDelayMilliseconds="500"
-			  ContinueOnError="true" />
+			  RetryDelayMilliseconds="500" />
+		<WriteLinestoFile File="$(_OwnedOutputManifest)"
+				 Lines="@(_OutputTargetFiles)"
+				 Overwrite="True"
+				 WriteOnlyWhenDifferent="true" />
+		<WriteLinestoFile File="$(_OwnedRefOutputManifest)"
+				 Lines="@(_OutputTargetRefFiles)"
+				 Overwrite="True"
+				 WriteOnlyWhenDifferent="true" />
 	</Target>
 
 
@@ -208,25 +223,37 @@
 			<CommonOverridePackageId Condition="'$(UNO_UWP_BUILD)'=='false'">$(CommonOverridePackageId.Replace('uno.ui','uno.winui'))</CommonOverridePackageId>
 			<_TargetNugetFolder Condition="'$(UnoRuntimeIdentifier)'=='' or '$(UnoRuntimeIdentifier)'=='Reference'">$(NuGetPackageRoot)\$(CommonOverridePackageId)\$(UnoNugetOverrideVersion)\lib\$(_OverrideTargetFramework)</_TargetNugetFolder>
 			<_TargetNugetFolder Condition="'$(UnoRuntimeIdentifier)'!='' and '$(UnoRuntimeIdentifier)'!='Reference'">$(NuGetPackageRoot)\$(CommonOverridePackageId)\$(UnoNugetOverrideVersion)\uno-runtime\$(TargetFramework)\$(UnoRuntimeIdentifier.ToLower())</_TargetNugetFolder>
+			<!-- Track ownership so shared package folders are cleaned safely. -->
+			<_OwnedCommonOverrideManifest>$(_TargetNugetFolder)\.$(MSBuildProjectName).$(_OverrideTargetFramework).owned-files.txt</_OwnedCommonOverrideManifest>
 		</PropertyGroup>
 
 		<ItemGroup>
 			<_OutputFiles Include="@(TargetPathWithTargetPlatformMoniker)" />
 			<_OutputDebugSymbols Include="@(_DebugSymbolsIntermediatePath)" />
-			<!-- Precompute destinations so copy+cleanup stay deterministic across target frameworks/runtimes. -->
+			<!-- Precompute destinations so cleanup+copy stay deterministic across target frameworks/runtimes. -->
 			<_CommonOverrideTargetFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 			<_CommonOverrideTargetDebugFiles Include="@(_OutputDebugSymbols->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-			<_CommonOverrideExistingFiles Include="$(_TargetNugetFolder)\*.*" />
-			<_CommonOverrideStaleFiles Include="@(_CommonOverrideExistingFiles)" Exclude="@(_CommonOverrideTargetFiles);@(_CommonOverrideTargetDebugFiles)" />
 		</ItemGroup>
 
 		<MakeDir Directories="$(_TargetNugetFolder)" />
 
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
 
-		<!-- Remove obsolete files and avoid rewriting unchanged artifacts in the package override cache. -->
-		<Delete Files="@(_CommonOverrideStaleFiles)" ContinueOnError="true" />
-		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_CommonOverrideTargetFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
-		<Copy SourceFiles="@(_OutputDebugSymbols)" DestinationFiles="@(_CommonOverrideTargetDebugFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
+		<!-- Remove obsolete files owned by this project/TFM only. -->
+		<ReadLinesFromFile File="$(_OwnedCommonOverrideManifest)" Condition="Exists('$(_OwnedCommonOverrideManifest)')">
+			<Output TaskParameter="Lines" ItemName="_PreviouslyOwnedCommonFiles" />
+		</ReadLinesFromFile>
+		<ItemGroup>
+			<_CommonOverrideCurrentOwnedFiles Include="@(_CommonOverrideTargetFiles);@(_CommonOverrideTargetDebugFiles)" />
+			<_CommonOverrideStaleOwnedFiles Include="@(_PreviouslyOwnedCommonFiles)" Exclude="@(_CommonOverrideCurrentOwnedFiles)" />
+		</ItemGroup>
+		<Delete Files="@(_CommonOverrideStaleOwnedFiles)" />
+
+		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_CommonOverrideTargetFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" />
+		<Copy SourceFiles="@(_OutputDebugSymbols)" DestinationFiles="@(_CommonOverrideTargetDebugFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" />
+		<WriteLinestoFile File="$(_OwnedCommonOverrideManifest)"
+				 Lines="@(_CommonOverrideCurrentOwnedFiles)"
+				 Overwrite="True"
+				 WriteOnlyWhenDifferent="true" />
 	</Target>
 </Project>

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -161,10 +161,12 @@
 		<ItemGroup>
 			<_OutputFiles Include="$(TargetDir)\*.*" />
 			<_OutputRefFiles Include="$(TargetDir)\ref\*.*" />
+			<!-- Precompute destination paths so stale-file detection and copy use the same mapping. -->
 			<_OutputTargetFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 			<_OutputTargetRefFiles Include="@(_OutputRefFiles->'$(_TargetNugetRefFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 			<_ExistingTargetFiles Include="$(_TargetNugetFolder)\*.*" />
 			<_ExistingTargetRefFiles Include="$(_TargetNugetRefFolder)\*.*" />
+			<!-- Keep .packageoverride and remove any payload that is no longer produced by this build. -->
 			<_StaleTargetFiles Include="@(_ExistingTargetFiles)" Exclude="@(_OutputTargetFiles);$(_TargetNugetFolder)\.packageoverride" />
 			<_StaleTargetRefFiles Include="@(_ExistingTargetRefFiles)" Exclude="@(_OutputTargetRefFiles)" />
 		</ItemGroup>
@@ -177,6 +179,7 @@
 				 WriteOnlyWhenDifferent="true" />
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder) and $(_TargetNugetRefFolder)" />
 
+		<!-- Delete stale files first, then copy only files that changed to keep override builds incremental. -->
 		<Delete Files="@(_StaleTargetFiles);@(_StaleTargetRefFiles)" ContinueOnError="true" />
 		<Copy SourceFiles="@(_OutputFiles)"
 			  DestinationFiles="@(_OutputTargetFiles)"
@@ -210,6 +213,7 @@
 		<ItemGroup>
 			<_OutputFiles Include="@(TargetPathWithTargetPlatformMoniker)" />
 			<_OutputDebugSymbols Include="@(_DebugSymbolsIntermediatePath)" />
+			<!-- Precompute destinations so copy+cleanup stay deterministic across target frameworks/runtimes. -->
 			<_CommonOverrideTargetFiles Include="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 			<_CommonOverrideTargetDebugFiles Include="@(_OutputDebugSymbols->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 			<_CommonOverrideExistingFiles Include="$(_TargetNugetFolder)\*.*" />
@@ -220,6 +224,7 @@
 
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
 
+		<!-- Remove obsolete files and avoid rewriting unchanged artifacts in the package override cache. -->
 		<Delete Files="@(_CommonOverrideStaleFiles)" ContinueOnError="true" />
 		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_CommonOverrideTargetFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 		<Copy SourceFiles="@(_OutputDebugSymbols)" DestinationFiles="@(_CommonOverrideTargetDebugFiles)" SkipUnchangedFiles="true" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />

--- a/src/Uno.UI.FluentTheme.v1/FluentMerge.targets
+++ b/src/Uno.UI.FluentTheme.v1/FluentMerge.targets
@@ -4,8 +4,19 @@
 	<PageExclusions>$(MSBuildThisFileDirectory)Resources\**\*.xaml</PageExclusions>
   </PropertyGroup>
 
+  <ItemGroup>
+	<!-- Expand merge inputs at evaluation time so target incremental checks can compare timestamps. -->
+	<ThemeResourceV1MergeInput Include="$(MSBuildThisFileDirectory)Resources\Version1\**\*.xaml" />
+	<ThemeResourceV1MergeInput Include="$(MSBuildThisFileFullPath)" />
+  </ItemGroup>
+
   <!-- This task is temporarily placed in debug configuration to avoid parallel build concurrency issues -->
-  <Target Name="GenerateThemeResourceV1File" DependsOnTargets="ResolveProjectReferences" BeforeTargets="BeforeBuild" Outputs="themeresources_v1.xaml" Condition="'$(Configuration)'=='Debug'">
+  <Target Name="GenerateThemeResourceV1File"
+          DependsOnTargets="ResolveProjectReferences"
+          BeforeTargets="BeforeBuild"
+          Inputs="@(ThemeResourceV1MergeInput)"
+          Outputs="$(IntermediateOutputPath)\Version1\GenerateThemeResourceFile.write.1u.tlog"
+          Condition="'$(Configuration)'=='Debug'">
 	<ItemGroup>
 	  <WinUIStylePage
 		  Include="$(MSBuildThisFileDirectory)Resources\Version1\**\*.xaml" />
@@ -15,7 +26,7 @@
 	<MakeDir Directories="$(IntermediateOutputPath)\Version1" />
 	<BatchMergeXaml
 	  Pages="@(WinUIStylePage)"
-	  MergedXamlFile="themeresources_v1.xaml"
+	  MergedXamlFile="$(MSBuildThisFileDirectory)themeresources_v1.xaml"
 	  TlogReadFilesOutputPath="$(IntermediateOutputPath)\Version1\GenerateThemeResourceFile.read.1u.tlog"
 	  TlogWriteFilesOutputPath="$(IntermediateOutputPath)\Version1\GenerateThemeResourceFile.write.1u.tlog" />
 	<Message Text="Theme resources XAML file was generated" />

--- a/src/Uno.UI.FluentTheme.v1/FluentMerge.targets
+++ b/src/Uno.UI.FluentTheme.v1/FluentMerge.targets
@@ -4,8 +4,6 @@
 	<PageExclusions>$(MSBuildThisFileDirectory)Resources\**\*.xaml</PageExclusions>
   </PropertyGroup>
 
-  <UsingTask TaskName="BatchMergeXaml" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" />
-
   <!-- This task is temporarily placed in debug configuration to avoid parallel build concurrency issues -->
   <Target Name="GenerateThemeResourceV1File" DependsOnTargets="ResolveProjectReferences" BeforeTargets="BeforeBuild" Outputs="themeresources_v1.xaml" Condition="'$(Configuration)'=='Debug'">
 	<ItemGroup>

--- a/src/Uno.UI.FluentTheme.v2/FluentMerge.targets
+++ b/src/Uno.UI.FluentTheme.v2/FluentMerge.targets
@@ -4,8 +4,19 @@
 	<PageExclusions>$(MSBuildThisFileDirectory)Resources\**\*.xaml</PageExclusions>
   </PropertyGroup>
 
+  <ItemGroup>
+	<!-- Expand merge inputs at evaluation time so target incremental checks can compare timestamps. -->
+	<ThemeResourceV2MergeInput Include="$(MSBuildThisFileDirectory)Resources\Version2\**\*.xaml" />
+	<ThemeResourceV2MergeInput Include="$(MSBuildThisFileFullPath)" />
+  </ItemGroup>
+
   <!-- This task is temporarily placed in debug configuration to avoid parallel build concurrency issues -->
-  <Target Name="GenerateThemeResourceV2File" DependsOnTargets="ResolveProjectReferences" BeforeTargets="BeforeBuild" Outputs="themeresources_v2.xaml" Condition="'$(Configuration)'=='Debug'">
+  <Target Name="GenerateThemeResourceV2File"
+          DependsOnTargets="ResolveProjectReferences"
+          BeforeTargets="BeforeBuild"
+          Inputs="@(ThemeResourceV2MergeInput)"
+          Outputs="$(IntermediateOutputPath)\Version2\GenerateThemeResourceFile.write.1u.tlog"
+          Condition="'$(Configuration)'=='Debug'">
     <ItemGroup>
       <ExcludedTemplatesV2 Include="$(MSBuildThisFileDirectory)Resources\Version2\PriorityDefault\RadioMenuFlyoutItem_themeresources.xaml" />      
       <ExcludedTemplatesV2 Include="$(MSBuildThisFileDirectory)Resources\Version2\PriorityDefault\ProgressRing.xaml" />
@@ -23,7 +34,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)\Version2" />
     <BatchMergeXaml
 	  Pages="@(WinUIStylePageV2)"
-	  MergedXamlFile="themeresources_v2.xaml"
+	  MergedXamlFile="$(MSBuildThisFileDirectory)themeresources_v2.xaml"
 	  TlogReadFilesOutputPath="$(IntermediateOutputPath)\Version2\GenerateThemeResourceFile.read.1u.tlog"
 	  TlogWriteFilesOutputPath="$(IntermediateOutputPath)\Version2\GenerateThemeResourceFile.write.1u.tlog" />
     <Message Text="Theme resources XAML file was generated" />

--- a/src/Uno.UI.FluentTheme.v2/FluentMerge.targets
+++ b/src/Uno.UI.FluentTheme.v2/FluentMerge.targets
@@ -4,8 +4,6 @@
 	<PageExclusions>$(MSBuildThisFileDirectory)Resources\**\*.xaml</PageExclusions>
   </PropertyGroup>
 
-  <UsingTask TaskName="BatchMergeXaml" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" />
-
   <!-- This task is temporarily placed in debug configuration to avoid parallel build concurrency issues -->
   <Target Name="GenerateThemeResourceV2File" DependsOnTargets="ResolveProjectReferences" BeforeTargets="BeforeBuild" Outputs="themeresources_v2.xaml" Condition="'$(Configuration)'=='Debug'">
     <ItemGroup>

--- a/src/Uno.UI.FluentTheme/FluentMerge.targets
+++ b/src/Uno.UI.FluentTheme/FluentMerge.targets
@@ -4,9 +4,6 @@
 	<PageExclusions>$(MSBuildThisFileDirectory)Resources\**\*.xaml</PageExclusions>
   </PropertyGroup>
 
-  <UsingTask TaskName="BatchMergeXaml" AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" />
-
-
   <PropertyGroup Condition="'$(UnoRuntimeIdentifier)'=='Reference'">
 	<EnableAutomaticXamlPageInclusion>false</EnableAutomaticXamlPageInclusion>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

This PR improves local Uno framework build stability and incremental behavior by fixing task-host configuration consistency, override-cache synchronization, and Fluent theme merge target up-to-date checks.

Fixes #22765

## Problem

Local Uno framework development uses override targets that copy outputs into local NuGet cache locations so downstream projects consume current framework bits. In that flow, repeated builds must be both correct and fast.

Before this PR:
1. Immediate second builds could fail with lock errors in override-cache destinations.
2. Incremental behavior existed in parts of the graph, but key override and merge paths still did unnecessary work.
3. Some Uno task declarations were split across separate imported targets files with inconsistent out-of-proc/runtime-pinning behavior.

## Changes

### 1) Standardize Uno task loading policy for repo builds

Commits: `3f28389ad2`, `b6292fe00a`

Files:
1. `src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets`
2. `src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets`

What changed:
1. `BatchMergeXaml` was added to the same dual-mode loading model as other Uno tasks.
2. In Uno repo builds (`'$(_IsUnoUISolution)'!=''`), Uno tasks are loaded via `TaskHostFactory`.
3. `TaskHostFactory` entries now explicitly set `Runtime="CurrentRuntime"` and `Architecture="CurrentArchitecture"`.
4. `ExpandPackageAssets_v0` in `uno.ui.tasks.assets.targets` was aligned to the same out-of-proc pinned-runtime model.

Why this change:
1. Repo inner-loop builds often rebuild task assemblies; out-of-proc loading avoids long-lived in-proc task assembly lifetime problems.
2. `ExpandPackageAssets_v0` is declared in a separate imported file; keeping it on a different loading model creates inconsistent host behavior.
3. Explicit runtime/architecture pinning makes task-host selection deterministic. It was picking CLR4 (MSBuild.exe) before when built with dotnet build due to internal checks of the target framework of the tasks lib (.NET Standard 2.0 doesn't map to .NET Core).

How this addresses the issue:
1. Task-host behavior is now coherent across the Uno task surface used during repo builds.
2. Host/runtime selection is explicit instead of inferred.

### 2) Make Uno task shadow-copy and task package override sync incremental

Commit: `0565029bc6`

File:
1. `src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj`

What changed:
1. `_copyUnoTasksBuildTime` now computes explicit source/destination file mappings.
2. The shadow destination removes stale files and copies with `SkipUnchangedFiles=true`.
3. `_UnoToolkitOverrideNuget` now computes destination files, removes stale files, and copies with `SkipUnchangedFiles=true`.

Why this change:
1. Destination folders must exactly match current outputs.
2. Rewriting unchanged files increases churn and lock windows.
3. Leaving stale files in override destinations can expose obsolete artifacts.

How this addresses the issue:
1. Shadow and override destinations converge to current outputs with minimal rewrites.
2. Repeated builds do less unnecessary work.

### 3) Optimize cross-targeting override copy behavior

Commit: `9e7f0c5878`

File:
1. `src/Uno.CrossTargetting.targets`

What changed:
1. `_UnoOverrideNuget` and `CommonOverrideNuget` now use deterministic destination mapping.
2. Added stale-file delete + `SkipUnchangedFiles=true` copy behavior.
3. `.packageoverride` content was stabilized with `WriteOnlyWhenDifferent=true`.

Why this change:
1. Override synchronization needs to be incremental in repeated builds.
2. Cleanup and copy must operate from the same mapping for deterministic behavior.

How this addresses the issue:
1. Unchanged files are not rewritten.
2. Override cache synchronization is deterministic and lower-churn.

### 4) Replace broad shared-folder cleanup with owner-scoped cleanup

Commit: `23dd9cdb06`

File:
1. `src/Uno.CrossTargetting.targets`

What changed:
1. Added per-project/per-TFM ownership manifests for outputs copied into override destinations.
2. Cleanup now deletes only files that were previously owned by that same project/TFM and are no longer produced by that same project/TFM.
3. Removed broad folder-scan cleanup logic that treated shared destination contents as a single ownership set.

Why this change:
1. Override destinations are shared.
2. Broad cleanup in shared folders can interfere with files written by other projects.
3. Output sets can change between normal incremental builds, so cleanup must run during normal build flow, not only during `Clean`.

How this addresses the issue:
1. Each project removes only its own obsolete files.
2. Shared-folder interference is eliminated.
3. Immediate second-build lock failures from cleanup contention are removed in the validated repro sequence.

### 5) Make Fluent theme merge targets explicitly incremental

Commit: `b7586a349f`

Files:
1. `src/Uno.UI.FluentTheme.v1/FluentMerge.targets`
2. `src/Uno.UI.FluentTheme.v2/FluentMerge.targets`

What changed:
1. Added explicit merge input item sets.
2. Added target `Inputs=...`.
3. Set target `Outputs` to the merge tlog write file under `$(IntermediateOutputPath)`.
4. Set `MergedXamlFile` with explicit `$(MSBuildThisFileDirectory)` path.

Why this change:
1. MSBuild up-to-date checks require explicit, accurate inputs/outputs to skip safely.
2. Explicit pathing avoids invocation-context ambiguity.

How this addresses the issue:
1. Merge targets are skipped when inputs are unchanged.
2. Repeated builds avoid unnecessary merge work.

## Incrementality and Reliability: Before vs After

Before:
1. Build 1: `13m35.9s`
2. Build 2 immediately after: failed (lock error)
3. Build 2 after build-server shutdown: `7m13.5s`

After:
1. Build 1: `10m10.3s`
2. Build 2 immediately after: `4m39.8s` and succeeds

Meaningful deltas:
1. Immediate second build changed from failure to success.
2. Build time improved from `10m10.3s` to `4m39.8s` (`5m30.5s`, ~54% faster).

## Notes

1. Cleanup remains part of normal override synchronization because output sets change during ordinary incremental builds; limiting cleanup to `Clean` would allow obsolete artifacts to persist between normal builds.
2. Ownership manifests are stored in destination override folders so cleanup decisions are based on what each project/TFM actually wrote to that destination.
3. Deterministic destination mapping is used consistently by both cleanup and copy paths.
