### PR TITLE
`ItemsPresenter` header and footer changes should affect layout

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -25,6 +25,31 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 public partial class Given_ContentPresenter
 {
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20966")]
+	public async Task When_Content_Cleared_Then_Space_Is_Reclaimed()
+	{
+		var SUT = new ContentPresenter { Content = "Some content" };
+		var host = new StackPanel { Width = 300 };
+		host.Children.Add(SUT);
+
+		await UITestHelper.Load(host);
+
+		Assert.IsTrue(SUT.ActualHeight > 0, "Text content should occupy a line");
+
+		SUT.Content = null;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// WinUI's ContentPresenter materializes no visuals at all while the content is null and no
+		// template is set, so the line of text height must go away with the content.
+		Assert.AreEqual(0d, SUT.ActualHeight, "Height should be reclaimed once the content is cleared");
+
+		SUT.Content = "Some other content";
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(SUT.ActualHeight > 0, "Text content should occupy a line again");
+	}
+
+	[TestMethod]
 	public async Task When_Padding_Set_In_SizeChanged()
 	{
 		var SUT = new ContentPresenter()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1200,6 +1200,7 @@ public class Given_ItemsPresenter
 		Assert.AreNotEqual(double.PositiveInfinity, availableSize.Width);
 	}
 
+#if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
 	public async Task When_Header_Set_To_Null_Layout_Space_Reclaimed()
@@ -1234,21 +1235,21 @@ public class Given_ItemsPresenter
 		lv.Header = null;
 		await WindowHelper.WaitForIdle();
 
-		Assert.AreEqual(Visibility.Collapsed, headerCC.Visibility, "Header should be collapsed when set to null");
+		Assert.AreEqual(0.0, headerCC.ActualHeight, "Header should have zero height when set to null");
 
 		// Set Footer to null and verify layout space is reclaimed
 		lv.Footer = null;
 		await WindowHelper.WaitForIdle();
 
-		Assert.AreEqual(Visibility.Collapsed, footerCC.Visibility, "Footer should be collapsed when set to null");
+		Assert.AreEqual(0.0, footerCC.ActualHeight, "Footer should have zero height when set to null");
 
 		// Set Header back and verify it becomes visible again
 		lv.Header = "New Header";
 		await WindowHelper.WaitForIdle();
 
-		Assert.AreEqual(Visibility.Visible, headerCC.Visibility, "Header should be visible again when re-set");
 		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height after being re-set");
 	}
+#endif
 
 	public record MyTextModel(string MyText);
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1200,5 +1200,55 @@ public class Given_ItemsPresenter
 		Assert.AreNotEqual(double.PositiveInfinity, availableSize.Width);
 	}
 
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Header_Set_To_Null_Layout_Space_Reclaimed()
+	{
+		var lv = new ListView
+		{
+			Width = 300,
+			Height = 300,
+			Header = "My Header",
+			Footer = "My Footer",
+			ItemsSource = new[] { "Item 1", "Item 2" }
+		};
+
+		await UITestHelper.Load(lv);
+
+		var sv = (ScrollViewer)((Border)VisualTreeHelper.GetChild(lv, 0)).Child;
+		var ip = (ItemsPresenter)sv.Content;
+		var headerCC = ip.HeaderContentControl;
+		var footerCC = ip.FooterContentControl;
+
+		Assert.IsNotNull(headerCC, "HeaderContentControl should exist");
+		Assert.IsNotNull(footerCC, "FooterContentControl should exist");
+		Assert.AreEqual(Visibility.Visible, headerCC.Visibility);
+		Assert.AreEqual(Visibility.Visible, footerCC.Visibility);
+
+		var headerHeightBefore = headerCC.ActualHeight;
+		var footerHeightBefore = footerCC.ActualHeight;
+		Assert.IsTrue(headerHeightBefore > 0, "Header should have non-zero height");
+		Assert.IsTrue(footerHeightBefore > 0, "Footer should have non-zero height");
+
+		// Set Header to null and verify layout space is reclaimed
+		lv.Header = null;
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(Visibility.Collapsed, headerCC.Visibility, "Header should be collapsed when set to null");
+
+		// Set Footer to null and verify layout space is reclaimed
+		lv.Footer = null;
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(Visibility.Collapsed, footerCC.Visibility, "Footer should be collapsed when set to null");
+
+		// Set Header back and verify it becomes visible again
+		lv.Header = "New Header";
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(Visibility.Visible, headerCC.Visibility, "Header should be visible again when re-set");
+		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height after being re-set");
+	}
+
 	public record MyTextModel(string MyText);
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1203,7 +1203,8 @@ public class Given_ItemsPresenter
 #if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
-	public async Task When_Header_Set_To_Null_Layout_Space_Reclaimed()
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20966")]
+	public async Task When_Header_And_Footer_Set_To_Null_Layout_Space_Reclaimed()
 	{
 		var lv = new ListView
 		{
@@ -1226,10 +1227,8 @@ public class Given_ItemsPresenter
 		Assert.AreEqual(Visibility.Visible, headerCC.Visibility);
 		Assert.AreEqual(Visibility.Visible, footerCC.Visibility);
 
-		var headerHeightBefore = headerCC.ActualHeight;
-		var footerHeightBefore = footerCC.ActualHeight;
-		Assert.IsTrue(headerHeightBefore > 0, "Header should have non-zero height");
-		Assert.IsTrue(footerHeightBefore > 0, "Footer should have non-zero height");
+		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height");
+		Assert.IsTrue(footerCC.ActualHeight > 0, "Footer should have non-zero height");
 
 		// Set Header to null and verify layout space is reclaimed
 		lv.Header = null;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1196,6 +1196,7 @@ public class Given_ItemsPresenter
 		Assert.AreNotEqual(double.PositiveInfinity, availableSize.Width);
 	}
 
+#if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
 	public async Task When_Header_Set_To_Null_Layout_Space_Reclaimed()
@@ -1230,21 +1231,21 @@ public class Given_ItemsPresenter
 		lv.Header = null;
 		await WindowHelper.WaitForIdle();
 
-		Assert.AreEqual(Visibility.Collapsed, headerCC.Visibility, "Header should be collapsed when set to null");
+		Assert.AreEqual(0.0, headerCC.ActualHeight, "Header should have zero height when set to null");
 
 		// Set Footer to null and verify layout space is reclaimed
 		lv.Footer = null;
 		await WindowHelper.WaitForIdle();
 
-		Assert.AreEqual(Visibility.Collapsed, footerCC.Visibility, "Footer should be collapsed when set to null");
+		Assert.AreEqual(0.0, footerCC.ActualHeight, "Footer should have zero height when set to null");
 
 		// Set Header back and verify it becomes visible again
 		lv.Header = "New Header";
 		await WindowHelper.WaitForIdle();
 
-		Assert.AreEqual(Visibility.Visible, headerCC.Visibility, "Header should be visible again when re-set");
 		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height after being re-set");
 	}
+#endif
 
 	public record MyTextModel(string MyText);
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1196,5 +1196,55 @@ public class Given_ItemsPresenter
 		Assert.AreNotEqual(double.PositiveInfinity, availableSize.Width);
 	}
 
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Header_Set_To_Null_Layout_Space_Reclaimed()
+	{
+		var lv = new ListView
+		{
+			Width = 300,
+			Height = 300,
+			Header = "My Header",
+			Footer = "My Footer",
+			ItemsSource = new[] { "Item 1", "Item 2" }
+		};
+
+		await UITestHelper.Load(lv);
+
+		var sv = (ScrollViewer)((Border)VisualTreeHelper.GetChild(lv, 0)).Child;
+		var ip = (ItemsPresenter)sv.Content;
+		var headerCC = ip.HeaderContentControl;
+		var footerCC = ip.FooterContentControl;
+
+		Assert.IsNotNull(headerCC, "HeaderContentControl should exist");
+		Assert.IsNotNull(footerCC, "FooterContentControl should exist");
+		Assert.AreEqual(Visibility.Visible, headerCC.Visibility);
+		Assert.AreEqual(Visibility.Visible, footerCC.Visibility);
+
+		var headerHeightBefore = headerCC.ActualHeight;
+		var footerHeightBefore = footerCC.ActualHeight;
+		Assert.IsTrue(headerHeightBefore > 0, "Header should have non-zero height");
+		Assert.IsTrue(footerHeightBefore > 0, "Footer should have non-zero height");
+
+		// Set Header to null and verify layout space is reclaimed
+		lv.Header = null;
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(Visibility.Collapsed, headerCC.Visibility, "Header should be collapsed when set to null");
+
+		// Set Footer to null and verify layout space is reclaimed
+		lv.Footer = null;
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(Visibility.Collapsed, footerCC.Visibility, "Footer should be collapsed when set to null");
+
+		// Set Header back and verify it becomes visible again
+		lv.Header = "New Header";
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(Visibility.Visible, headerCC.Visibility, "Header should be visible again when re-set");
+		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height after being re-set");
+	}
+
 	public record MyTextModel(string MyText);
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1199,7 +1199,8 @@ public class Given_ItemsPresenter
 #if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
-	public async Task When_Header_Set_To_Null_Layout_Space_Reclaimed()
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20966")]
+	public async Task When_Header_And_Footer_Set_To_Null_Layout_Space_Reclaimed()
 	{
 		var lv = new ListView
 		{
@@ -1222,10 +1223,8 @@ public class Given_ItemsPresenter
 		Assert.AreEqual(Visibility.Visible, headerCC.Visibility);
 		Assert.AreEqual(Visibility.Visible, footerCC.Visibility);
 
-		var headerHeightBefore = headerCC.ActualHeight;
-		var footerHeightBefore = footerCC.ActualHeight;
-		Assert.IsTrue(headerHeightBefore > 0, "Header should have non-zero height");
-		Assert.IsTrue(footerHeightBefore > 0, "Footer should have non-zero height");
+		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height");
+		Assert.IsTrue(footerCC.ActualHeight > 0, "Footer should have non-zero height");
 
 		// Set Header to null and verify layout space is reclaimed
 		lv.Header = null;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1213,15 +1213,12 @@ public class Given_ItemsPresenter
 
 		await UITestHelper.Load(lv);
 
-		var sv = (ScrollViewer)((Border)VisualTreeHelper.GetChild(lv, 0)).Child;
-		var ip = (ItemsPresenter)sv.Content;
+		var ip = lv.FindVisualChildByType<ItemsPresenter>();
 		var headerCC = ip.HeaderContentControl;
 		var footerCC = ip.FooterContentControl;
 
 		Assert.IsNotNull(headerCC, "HeaderContentControl should exist");
 		Assert.IsNotNull(footerCC, "FooterContentControl should exist");
-		Assert.AreEqual(Visibility.Visible, headerCC.Visibility);
-		Assert.AreEqual(Visibility.Visible, footerCC.Visibility);
 
 		Assert.IsTrue(headerCC.ActualHeight > 0, "Header should have non-zero height");
 		Assert.IsTrue(footerCC.ActualHeight > 0, "Footer should have non-zero height");

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -727,6 +727,13 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 			// If setting Content to a new View, recreate the template
 			ContentTemplateRoot = null;
 		}
+		else if (newValue is null && ContentTemplateRoot is ImplicitTextBlock)
+		{
+			// WinUI only materializes the implicit text block while the content is non-null
+			// (CContentPresenter::ApplyTemplate), so drop it here as well: an emptied text block
+			// still reserves a line of height, so the space would never be reclaimed.
+			ContentTemplateRoot = null;
+		}
 
 		// We need to overrides the local value of DataContext with Content's value here.
 		// But if the content value is the result of a binding without explicit sources: TemplatedParent, ElementName...

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -445,9 +445,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			// Most of this is inspired by StackPanel's MeasureOverride
 
-			// Collapse header/footer when they have no content and no template (matching WinUI)
+			// Collapse header/footer when they have no content and no template (matching WinUI).
+			// In WinUI, ContentControl templates are applied when entering the visual tree,
+			// but in Uno, template application is deferred to the first measure. Since
+			// collapsed elements skip measure, we must ensure templates are applied first.
 			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
 			{
+				headerCC.ApplyTemplate();
 				headerCC.Visibility = (Header is null && HeaderTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;
@@ -455,6 +459,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
 			{
+				footerCC.ApplyTemplate();
 				footerCC.Visibility = (Footer is null && FooterTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static object GetHeaderDefaultValue() => null;
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty HeaderProperty { get; } = CreateHeaderProperty();
 
 		private void OnHeaderChanged(DependencyPropertyChangedEventArgs args)
@@ -72,7 +72,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static object GetFooterDefaultValue() => null;
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty FooterProperty { get; } = CreateFooterProperty();
 
 		private void OnFooterChanged(DependencyPropertyChangedEventArgs args)
@@ -91,7 +91,7 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetHeaderTemplateValue(value);
 		}
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty HeaderTemplateProperty { get; } = CreateHeaderTemplateProperty();
 
 		private void OnHeaderTemplateChanged(DependencyPropertyChangedEventArgs args)
@@ -110,7 +110,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static DataTemplate GetFooterTemplateDefaultValue() => null;
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty FooterTemplateProperty { get; } = CreateFooterTemplateProperty();
 
 		private void OnFooterTemplateChanged(DependencyPropertyChangedEventArgs args)
@@ -444,6 +444,21 @@ namespace Microsoft.UI.Xaml.Controls
 		protected override Size MeasureOverride(Size size)
 		{
 			// Most of this is inspired by StackPanel's MeasureOverride
+
+			// Collapse header/footer when they have no content and no template (matching WinUI)
+			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
+			{
+				headerCC.Visibility = (Header is null && HeaderTemplate is null)
+					? Visibility.Collapsed
+					: Visibility.Visible;
+			}
+
+			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
+			{
+				footerCC.Visibility = (Footer is null && FooterTemplate is null)
+					? Visibility.Collapsed
+					: Visibility.Visible;
+			}
 
 			var padding = AppliedPadding;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -451,7 +451,12 @@ namespace Microsoft.UI.Xaml.Controls
 			// collapsed elements skip measure, we must ensure templates are applied first.
 			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
 			{
-				headerCC.ApplyTemplate();
+				// Guarded: on the non-enhanced lifecycle, ApplyTemplate always invalidates measure.
+				if (headerCC.TemplatedRoot is null)
+				{
+					headerCC.ApplyTemplate();
+				}
+
 				headerCC.Visibility = (Header is null && HeaderTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;
@@ -459,7 +464,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
 			{
-				footerCC.ApplyTemplate();
+				if (footerCC.TemplatedRoot is null)
+				{
+					footerCC.ApplyTemplate();
+				}
+
 				footerCC.Visibility = (Footer is null && FooterTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -421,7 +421,12 @@ namespace Microsoft.UI.Xaml.Controls
 			// collapsed elements skip measure, we must ensure templates are applied first.
 			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
 			{
-				headerCC.ApplyTemplate();
+				// Guarded: on the non-enhanced lifecycle, ApplyTemplate always invalidates measure.
+				if (headerCC.TemplatedRoot is null)
+				{
+					headerCC.ApplyTemplate();
+				}
+
 				headerCC.Visibility = (Header is null && HeaderTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;
@@ -429,7 +434,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
 			{
-				footerCC.ApplyTemplate();
+				if (footerCC.TemplatedRoot is null)
+				{
+					footerCC.ApplyTemplate();
+				}
+
 				footerCC.Visibility = (Footer is null && FooterTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -415,9 +415,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			// Most of this is inspired by StackPanel's MeasureOverride
 
-			// Collapse header/footer when they have no content and no template (matching WinUI)
+			// Collapse header/footer when they have no content and no template (matching WinUI).
+			// In WinUI, ContentControl templates are applied when entering the visual tree,
+			// but in Uno, template application is deferred to the first measure. Since
+			// collapsed elements skip measure, we must ensure templates are applied first.
 			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
 			{
+				headerCC.ApplyTemplate();
 				headerCC.Visibility = (Header is null && HeaderTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;
@@ -425,6 +429,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
 			{
+				footerCC.ApplyTemplate();
 				footerCC.Visibility = (Footer is null && FooterTemplate is null)
 					? Visibility.Collapsed
 					: Visibility.Visible;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static object GetHeaderDefaultValue() => null;
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty HeaderProperty { get; } = CreateHeaderProperty();
 
 		private void OnHeaderChanged(DependencyPropertyChangedEventArgs args)
@@ -55,7 +55,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static object GetFooterDefaultValue() => null;
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty FooterProperty { get; } = CreateFooterProperty();
 
 		private void OnFooterChanged(DependencyPropertyChangedEventArgs args)
@@ -74,7 +74,7 @@ namespace Microsoft.UI.Xaml.Controls
 			set => SetHeaderTemplateValue(value);
 		}
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty HeaderTemplateProperty { get; } = CreateHeaderTemplateProperty();
 
 		private void OnHeaderTemplateChanged(DependencyPropertyChangedEventArgs args)
@@ -93,7 +93,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static DataTemplate GetFooterTemplateDefaultValue() => null;
 
-		[GeneratedDependencyProperty(ChangedCallback = true)]
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure)]
 		public static DependencyProperty FooterTemplateProperty { get; } = CreateFooterTemplateProperty();
 
 		private void OnFooterTemplateChanged(DependencyPropertyChangedEventArgs args)
@@ -414,6 +414,21 @@ namespace Microsoft.UI.Xaml.Controls
 		protected override Size MeasureOverride(Size size)
 		{
 			// Most of this is inspired by StackPanel's MeasureOverride
+
+			// Collapse header/footer when they have no content and no template (matching WinUI)
+			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
+			{
+				headerCC.Visibility = (Header is null && HeaderTemplate is null)
+					? Visibility.Collapsed
+					: Visibility.Visible;
+			}
+
+			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
+			{
+				footerCC.Visibility = (Footer is null && FooterTemplate is null)
+					? Visibility.Collapsed
+					: Visibility.Visible;
+			}
 
 			var padding = AppliedPadding;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -415,35 +415,6 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			// Most of this is inspired by StackPanel's MeasureOverride
 
-			// Collapse header/footer when they have no content and no template (matching WinUI).
-			// In WinUI, ContentControl templates are applied when entering the visual tree,
-			// but in Uno, template application is deferred to the first measure. Since
-			// collapsed elements skip measure, we must ensure templates are applied first.
-			if (HeaderFooterEnabled && HeaderContentControl is { } headerCC)
-			{
-				// Guarded: on the non-enhanced lifecycle, ApplyTemplate always invalidates measure.
-				if (headerCC.TemplatedRoot is null)
-				{
-					headerCC.ApplyTemplate();
-				}
-
-				headerCC.Visibility = (Header is null && HeaderTemplate is null)
-					? Visibility.Collapsed
-					: Visibility.Visible;
-			}
-
-			if (HeaderFooterEnabled && FooterContentControl is { } footerCC)
-			{
-				if (footerCC.TemplatedRoot is null)
-				{
-					footerCC.ApplyTemplate();
-				}
-
-				footerCC.Visibility = (Footer is null && FooterTemplate is null)
-					? Visibility.Collapsed
-					: Visibility.Visible;
-			}
-
 			var padding = AppliedPadding;
 
 			var unpaddedSize = new Size(


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20966

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔

Clearing a `ListView.Header` (or `Footer`) at runtime leaves the space it occupied behind. The same
`Header` cleared through Hot Reload *does* reclaim the space, which is what makes the bug look like a
layout-invalidation problem.

It isn't. The root cause is in `ContentPresenter`: once the implicit text block has been materialized
for non-`View` content, setting `Content` back to `null` only empties the text block's `Text` — the
`TextBlock` itself stays in the tree and keeps reserving a full line of height. So the header
`ContentControl` can never measure below one line, no matter how often the `ItemsPresenter` is
re-measured. WinUI materializes no visuals at all while the content is `null` and no template is set
(`CContentPresenter::ApplyTemplate`, `dxaml/xcp/core/core/elements/ContentPresenter.cpp`).

## What is the new behavior? 🚀

- `ContentPresenter` drops the implicit text block when `Content` goes back to `null`, matching WinUI.
  This fixes every `ContentControl`/`ContentPresenter` whose content is cleared, not just list headers.
- `ItemsPresenter.Header`/`Footer`/`HeaderTemplate`/`FooterTemplate` are now `AffectsMeasure`, so a
  change re-measures the presenter itself rather than relying on the child's invalidation reaching it.

An earlier revision of this PR collapsed the header/footer `ContentControl` inside `MeasureOverride`
(mirroring `ItemsPresenter::MeasureOverride` in WinUI). That has been dropped: it papered over the
`ContentPresenter` bug instead of fixing it, needed an `ApplyTemplate()` call inside `MeasureOverride`
to work at all, and regressed `LayoutInformation.GetLayoutSlot()` for the empty header/footer — Uno
never flags layout storage for a collapsed element, so the slot came back as a default rect instead of
the arrange rect WinUI reports. That broke
`Given_ItemsPresenter.When_Small_Elements_Horizontal_Many_Margins_No_Header`/`_No_Footer` on every
platform in CI.

## Tests

- `Given_ContentPresenter.When_Content_Cleared_Then_Space_Is_Reclaimed` — the root-cause regression test.
- `Given_ItemsPresenter.When_Header_And_Footer_Set_To_Null_Layout_Space_Reclaimed` — the reported scenario.

Validated at runtime on Skia Desktop (Win32, 100% scale): 303 tests across `Given_ItemsPresenter`,
`Given_ContentPresenter` and `Given_ContentControl` pass, including the two tests that were red in CI.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
