### PR TITLE
fix: Map FileAccessMode to appropriate FileMode in StorageFile.OpenStreamAsync

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -294,7 +294,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_OpenStreamForReadAsync_Stream_Is_ReadOnly()
 		{
-			StorageFile createdFile = null;
+			StorageFile? createdFile = null;
 			try
 			{
 				var rootFolder = await GetRootFolderAsync();
@@ -316,7 +316,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_OpenStreamForWriteAsync_Stream_CanWrite()
 		{
-			StorageFile createdFile = null;
+			StorageFile? createdFile = null;
 			try
 			{
 				var rootFolder = await GetRootFolderAsync();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -291,6 +291,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 			}
 		}
 
+		[TestMethod]
+		public async Task When_OpenStreamForWriteAsync_On_New_File()
+		{
+			var rootFolder = await GetRootFolderAsync();
+			var fileName = GetRandomTextFileName();
+			var filePath = Path.Combine(rootFolder.Path, fileName);
+			
+			try
+			{
+				// Ensure the file does not exist
+				if (File.Exists(filePath))
+				{
+					File.Delete(filePath);
+				}
+
+				// Get a reference to a file that doesn't exist yet
+				var storageFile = await StorageFile.GetFileFromPathAsync(filePath);
+
+				// This should not throw FileNotFoundException
+				using var stream = await storageFile.OpenStreamForWriteAsync();
+				using var writer = new StreamWriter(stream);
+				await writer.WriteAsync("Test content");
+				await writer.FlushAsync();
+
+				// Verify the file was created and contains the expected content
+				Assert.IsTrue(File.Exists(filePath), "File should have been created");
+				var content = await FileIO.ReadTextAsync(storageFile);
+				Assert.AreEqual("Test content", content);
+			}
+			finally
+			{
+				if (File.Exists(filePath))
+				{
+					File.Delete(filePath);
+				}
+				await CleanupRootFolderAsync();
+			}
+		}
+
 		private string GetRandomFolderName() => Guid.NewGuid().ToString();
 
 		private string GetRandomTextFileName() => Guid.NewGuid().ToString() + ".txt";

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -297,7 +297,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 			var rootFolder = await GetRootFolderAsync();
 			var fileName = GetRandomTextFileName();
 			var filePath = Path.Combine(rootFolder.Path, fileName);
-			
+
 			try
 			{
 				// Ensure the file does not exist

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -399,7 +399,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 				var fileRef = createdFile;
 				createdFile = null;
 
-				await Assert.ThrowsExceptionAsync<FileNotFoundException>(
+				await Assert.ThrowsAsync<FileNotFoundException>(
 					async () =>
 					{
 						using var _ = await fileRef.OpenStreamForReadAsync();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -342,6 +342,76 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 			}
 		}
 
+		[TestMethod]
+#if WINAPPSDK
+		[Ignore("Exercises Uno's StorageFile.OpenStreamAsync FileMode mapping; native WinUI's StorageFile isn't subject to this fix.")]
+#endif
+		public async Task When_OpenStreamForWriteAsync_FileDoesNotExist_Stream_CreatesFile()
+		{
+			StorageFile? createdFile = null;
+			try
+			{
+				var rootFolder = await GetRootFolderAsync();
+				var fileName = GetRandomTextFileName();
+
+				// Hold a StorageFile reference, then delete the backing file to reproduce
+				// the regression: OpenStreamForWriteAsync used to hard-code FileMode.Open
+				// and threw FileNotFoundException when the file was missing. With the fix
+				// it maps ReadWrite → FileMode.OpenOrCreate and re-creates the file.
+				createdFile = await rootFolder.CreateFileAsync(fileName);
+				File.Delete(createdFile.Path);
+				Assert.IsFalse(File.Exists(createdFile.Path), "Pre-condition: backing file should be deleted");
+
+				using (var stream = await createdFile.OpenStreamForWriteAsync())
+				{
+					using var writer = new StreamWriter(stream);
+					await writer.WriteAsync("Recreated content");
+					await writer.FlushAsync();
+				}
+
+				Assert.IsTrue(File.Exists(createdFile.Path), "OpenStreamForWriteAsync should have recreated the file");
+				var content = await FileIO.ReadTextAsync(createdFile);
+				Assert.AreEqual("Recreated content", content);
+			}
+			finally
+			{
+				await DeleteIfNotNullAsync(createdFile);
+				await CleanupRootFolderAsync();
+			}
+		}
+
+		[TestMethod]
+#if WINAPPSDK
+		[Ignore("Exercises Uno's StorageFile.OpenStreamAsync FileMode mapping; native WinUI's StorageFile isn't subject to this fix.")]
+#endif
+		public async Task When_OpenStreamForReadAsync_FileDoesNotExist_Throws()
+		{
+			StorageFile? createdFile = null;
+			try
+			{
+				var rootFolder = await GetRootFolderAsync();
+				var fileName = GetRandomTextFileName();
+
+				createdFile = await rootFolder.CreateFileAsync(fileName);
+				File.Delete(createdFile.Path);
+				Assert.IsFalse(File.Exists(createdFile.Path), "Pre-condition: backing file should be deleted");
+
+				var fileRef = createdFile;
+				createdFile = null;
+
+				await Assert.ThrowsExceptionAsync<FileNotFoundException>(
+					async () =>
+					{
+						using var _ = await fileRef.OpenStreamForReadAsync();
+					});
+			}
+			finally
+			{
+				await DeleteIfNotNullAsync(createdFile);
+				await CleanupRootFolderAsync();
+			}
+		}
+
 		private string GetRandomFolderName() => Guid.NewGuid().ToString();
 
 		private string GetRandomTextFileName() => Guid.NewGuid().ToString() + ".txt";

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -292,40 +292,52 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		}
 
 		[TestMethod]
-		public async Task When_OpenStreamForWriteAsync_On_New_File()
+		public async Task When_OpenStreamForReadAsync_Stream_Is_ReadOnly()
 		{
-			var rootFolder = await GetRootFolderAsync();
-			var fileName = GetRandomTextFileName();
-			var filePath = Path.Combine(rootFolder.Path, fileName);
-
+			StorageFile createdFile = null;
 			try
 			{
-				// Ensure the file does not exist
-				if (File.Exists(filePath))
+				var rootFolder = await GetRootFolderAsync();
+				var fileName = GetRandomTextFileName();
+				createdFile = await rootFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
+				await FileIO.WriteTextAsync(createdFile, "Some content");
+
+				using var stream = await createdFile.OpenStreamForReadAsync();
+				Assert.IsTrue(stream.CanRead, "Read stream should be readable");
+				Assert.IsFalse(stream.CanWrite, "Read stream should not be writable");
+			}
+			finally
+			{
+				await DeleteIfNotNullAsync(createdFile);
+				await CleanupRootFolderAsync();
+			}
+		}
+
+		[TestMethod]
+		public async Task When_OpenStreamForWriteAsync_Stream_CanWrite()
+		{
+			StorageFile createdFile = null;
+			try
+			{
+				var rootFolder = await GetRootFolderAsync();
+				var fileName = GetRandomTextFileName();
+				createdFile = await rootFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
+
+				using (var stream = await createdFile.OpenStreamForWriteAsync())
 				{
-					File.Delete(filePath);
+					Assert.IsTrue(stream.CanWrite, "Write stream should be writable");
+
+					using var writer = new StreamWriter(stream);
+					await writer.WriteAsync("Test content");
+					await writer.FlushAsync();
 				}
 
-				// Get a reference to a file that doesn't exist yet
-				var storageFile = await StorageFile.GetFileFromPathAsync(filePath);
-
-				// This should not throw FileNotFoundException
-				using var stream = await storageFile.OpenStreamForWriteAsync();
-				using var writer = new StreamWriter(stream);
-				await writer.WriteAsync("Test content");
-				await writer.FlushAsync();
-
-				// Verify the file was created and contains the expected content
-				Assert.IsTrue(File.Exists(filePath), "File should have been created");
-				var content = await FileIO.ReadTextAsync(storageFile);
+				var content = await FileIO.ReadTextAsync(createdFile);
 				Assert.AreEqual("Test content", content);
 			}
 			finally
 			{
-				if (File.Exists(filePath))
-				{
-					File.Delete(filePath);
-				}
+				await DeleteIfNotNullAsync(createdFile);
 				await CleanupRootFolderAsync();
 			}
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -14,6 +14,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 
 		protected virtual Task CleanupRootFolderAsync() => Task.CompletedTask;
 
+		/// <summary>
+		/// True when the provider's <see cref="StorageFile.Path"/> is a real filesystem path, so a test may
+		/// manipulate the backing file directly through <see cref="File"/>. Virtual providers (browser OPFS,
+		/// Android SAF) expose a synthetic path and must opt out.
+		/// </summary>
+		protected virtual bool HasFileSystemBackedPath => false;
+
 		[TestMethod]
 		public async Task When_CreateFile_Name_Matches()
 		{
@@ -343,11 +350,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		}
 
 		[TestMethod]
-#if WINAPPSDK
-		[Ignore("Exercises Uno's StorageFile.OpenStreamAsync FileMode mapping; native WinUI's StorageFile isn't subject to this fix.")]
-#endif
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21311")]
+		// Exercises Uno's StorageFile.OpenStreamAsync FileMode mapping; native WinUI's StorageFile isn't subject to it.
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public async Task When_OpenStreamForWriteAsync_FileDoesNotExist_Stream_CreatesFile()
 		{
+			if (!HasFileSystemBackedPath)
+			{
+				Assert.Inconclusive("Provider's StorageFile.Path is not a real filesystem path.");
+			}
+
 			StorageFile? createdFile = null;
 			try
 			{
@@ -381,11 +393,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		}
 
 		[TestMethod]
-#if WINAPPSDK
-		[Ignore("Exercises Uno's StorageFile.OpenStreamAsync FileMode mapping; native WinUI's StorageFile isn't subject to this fix.")]
-#endif
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21311")]
+		// Exercises Uno's StorageFile.OpenStreamAsync FileMode mapping; native WinUI's StorageFile isn't subject to it.
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public async Task When_OpenStreamForReadAsync_FileDoesNotExist_Throws()
 		{
+			if (!HasFileSystemBackedPath)
+			{
+				Assert.Inconclusive("Provider's StorageFile.Path is not a real filesystem path.");
+			}
+
 			StorageFile? createdFile = null;
 			try
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.iOS.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.iOS.cs
@@ -11,6 +11,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 	[TestClass]
 	public class Given_StorageFile_Native : Given_StorageFile_Native_Base
 	{
+		// Security-scoped URLs still resolve to a real filesystem path.
+		protected override bool HasFileSystemBackedPath => true;
+
 		protected override Task<StorageFolder> GetRootFolderAsync()
 		{
 			var path = ApplicationData.Current.LocalCacheFolder.Path;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.local.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.local.cs
@@ -14,6 +14,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 	{
 		private StorageFolder? _rootFolder;
 
+		protected override bool HasFileSystemBackedPath => true;
+
 		protected override async Task<StorageFolder> GetRootFolderAsync()
 		{
 			var testFolderName = Guid.NewGuid().ToString();

--- a/src/Uno.UWP/Storage/StorageFile.Local.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Local.cs
@@ -40,7 +40,7 @@ namespace Windows.Storage
 				=> Task.FromResult<IRandomAccessStreamWithContentType>(new RandomAccessStreamWithContentType(FileRandomAccessStream.CreateLocal(Path, ToFileAccess(accessMode), ToFileShare(options)), ContentType));
 
 			public override Task<Stream> OpenStreamAsync(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
-				=> Task.FromResult<Stream>(File.Open(Path, FileMode.Open, ToFileAccess(accessMode), ToFileShare(options)));
+				=> Task.FromResult<Stream>(File.Open(Path, ToFileMode(accessMode), ToFileAccess(accessMode), ToFileShare(options)));
 
 			public override Task<StorageStreamTransaction> OpenTransactedWriteAsync(CancellationToken ct, StorageOpenOptions option)
 				=> Task.FromResult(new StorageStreamTransaction(Owner, ToFileShare(option)));

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -216,6 +216,14 @@ namespace Windows.Storage
 				_ => throw new ArgumentOutOfRangeException(nameof(accessMode))
 			};
 
+		/// <summary>
+		/// Maps FileAccessMode to the appropriate FileMode for file operations.
+		/// </summary>
+		/// <param name="accessMode">The access mode requested for the file.</param>
+		/// <returns>
+		/// FileMode.Open for Read access (requires file to exist),
+		/// FileMode.OpenOrCreate for ReadWrite access (creates file if it doesn't exist).
+		/// </returns>
 		private static FileMode ToFileMode(FileAccessMode accessMode)
 			=> accessMode switch
 			{

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -216,6 +216,14 @@ namespace Windows.Storage
 				_ => throw new ArgumentOutOfRangeException(nameof(accessMode))
 			};
 
+		private static FileMode ToFileMode(FileAccessMode accessMode)
+			=> accessMode switch
+			{
+				FileAccessMode.Read => FileMode.Open,
+				FileAccessMode.ReadWrite => FileMode.OpenOrCreate,
+				_ => throw new ArgumentOutOfRangeException(nameof(accessMode))
+			};
+
 		private static FileShare ToFileShare(StorageOpenOptions options)
 			=> options switch
 			{

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -217,13 +217,9 @@ namespace Windows.Storage
 			};
 
 		/// <summary>
-		/// Maps FileAccessMode to the appropriate FileMode for file operations.
+		/// Maps <see cref="FileAccessMode"/> to the <see cref="FileMode"/> used to open the stream:
+		/// a ReadWrite open creates the file when it is missing, a Read open requires it to exist.
 		/// </summary>
-		/// <param name="accessMode">The access mode requested for the file.</param>
-		/// <returns>
-		/// FileMode.Open for Read access (requires file to exist),
-		/// FileMode.OpenOrCreate for ReadWrite access (creates file if it doesn't exist).
-		/// </returns>
 		private static FileMode ToFileMode(FileAccessMode accessMode)
 			=> accessMode switch
 			{

--- a/src/Uno.UWP/Storage/StorageFile.iOS.cs
+++ b/src/Uno.UWP/Storage/StorageFile.iOS.cs
@@ -84,7 +84,7 @@ namespace Windows.Storage
 
 			public override Task<Stream> OpenStreamAsync(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
 			{
-				Func<Stream> streamBuilder = () => File.Open(Path, FileMode.Open, ToFileAccess(accessMode), ToFileShare(options));
+				Func<Stream> streamBuilder = () => File.Open(Path, ToFileMode(accessMode), ToFileAccess(accessMode), ToFileShare(options));
 				var streamWrapper = new SecurityScopeStreamWrapper(_nsUrl, streamBuilder);
 				return Task.FromResult<Stream>(streamWrapper);
 			}


### PR DESCRIPTION
closes unoplatform/uno#21311

- [x] Understand the issue: `StorageFile.Local.OpenStreamAsync` uses `FileMode.Open` instead of mapping `FileAccessMode` to appropriate `FileMode`
- [x] Add a helper method `ToFileMode` to convert `FileAccessMode` to `FileMode`
- [x] Update `OpenStreamAsync` to use the correct `FileMode` based on `FileAccessMode`
  - [x] Fixed in `StorageFile.Local.cs` (Skia, Desktop, etc.)
  - [x] Fixed in `StorageFile.iOS.cs` (iOS security-scoped files)
- [x] Create a test to verify the fix
- [x] Build the changes successfully
- [x] Run tests to verify the fix works
  - ✓ Writing to non-existent file works (uses FileMode.OpenOrCreate)
  - ✓ Reading from non-existent file throws FileNotFoundException (uses FileMode.Open)
- [x] Add XML documentation to ToFileMode method
- [x] Fix formatting issues (remove trailing whitespace)

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>


----

*This section details on the original issue you should resolve*

<issue_title>`StorageFile.Local.OpenStreamAsync` always use `File.Open` instead of the `FileAccessMode` argument</issue_title>
<issue_description>### Current behavior 🐛

`FileNotFoundException` thrown when trying to write new StorageFile in a Skia.Desktop Mac app. 

<img width="1041" height="385" alt="Image" src="https://github.com/user-attachments/assets/5b2b2c45-1bb3-4052-a409-c8298375651c" />

 

### Expected behavior 🎯

No exception thrown with correct entitlements or choice of output folder

### How to reproduce it (as minimally and precisely as possible) 🔬

Demo project: https://github.com/baskren/MacDesktop_StorageFile_Write

Relevant configurations:

<details><summary>entitlements.plist [CLICK HERE TO EXPAND]</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
	<dict>
		<key>com.apple.security.cs.allow-jit</key>
		<true/>
		<key>com.apple.security.files.user-selected.read-write</key>
		<true/>
		<key>com.apple.security.files.downloads</key>
		<true/>
		<key>com.apple.security.files.documents</key>
		<true/>
	</dict>
</plist>
```
</details>

- Tried adding either/or/both of the following to the project's `.csproj`, in the `<Properties>` group:

```xml

<CodesignEntitlements Condition=" $(TargetFramework.Contains('desktop')) " >Platforms/Desktop/MacOS/entitlements.plist</CodesignEntitlements>

```

```xml

<UnoMacOSEntitlements Condition=" $(TargetFramework.Contains('desktop')) " >Platforms/Desktop/MacOS/entitlements.plist</UnoMacOSEntitlements>

```


### Workaround 🛠️

None known at this time

### Renderer 🎨

- [x] Skia
- [ ] Native

### Affected platforms 📱💻🖥️

Desktop (macOS)

### Uno.Sdk version (and other relevant versions) 📦

Uno.Sdk: 6.1.23

UnoFeatures: 
- CSharpMarkup;
- Lottie;
- Hosting;
- Toolkit;
- Configuration;
- Localization;
- ThemeService;
- SkiaRenderer;


### IDE version 🧑‍💻

<details><summary>Click to expand [Mac Dev Environment]</summary>

### JetBrains Rider

JetBrains Rider 2025.2
Build #RD-252.23892.524, built on August 12, 2025
Source revision: 18364647ddbb4
Licensed to Ben Askren
Subscription is active until July 10, 2026.
Runtime version: 21.0.7+6-b1038.58 aarch64 (JCEF 122.1.9)
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Toolkit: sun.lwawt.macosx.LWCToolkit
macOS 15.6
.NET Core v8.0.11 ARM64 (Server GC)
GC: G1 Young Generation, G1 Concurrent GC, G1 Old Generation
Memory: 4096M
Cores: 12
Metal Rendering is ON
Registry:
  ide.lookup.shrink=true
  ide.experimental.ui=true
  llm.show.ai.promotion.window.on.start=false
Non-Bundled Plugins:
  org.antlr.intellij.plugin (1.24)
  com.intellij.resharper.HeapAllocationsViewer (2025.1.0)
  com.intellij.copyright (252.23892.464)
  com.redhat.devtools.lsp4ij (0.14.2)
  lermitage.intellij.iconviewer (1.31.3)
  com.github.camork.fileExpander (2.5)
  com.wakatime.intellij.plugin (15.0.4)
  com.cppcxy.Intellij-SumnekoLua (3.15.0.46-IDEA243)
  com.jetbrains.rider.android (252.23892.524)
  unoplatform (1.5.19)
  Karma (252.25204.0)
  me.rafaelldi.aspire (1.8.8)
  com.intellij.resharper.azure (4.5.3)

</details>



### Anything else we need to know? 💬

_No response_</issue_description>

## Comments on the Issue (you are @copilot in this section)

<comments>
<comment_new><author>@spouliot</author><body>
https://github.com/baskren/MacDesktop_StorageFile_Write is a 404. Is it public ?</body></comment_new>
<comment_new><author>@spouliot</author><body>
Your `entitlements.plist` above does not match the one inside the repo.

However that's not the problem. Entitlements are only needed if/when the app is packaged as an app bundle (and in the case of this entitlement the app would have to be sandboxed to need this).

For a dotnet app the file system is accessible with the same permission that the current user (launching the app) has.


The full exception is:

```
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
   at Windows.Storage.StorageFile.Local.OpenStreamAsync(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options) in C:\a\1\s\src\Uno.UWP\Storage\StorageFile.Local.cs:line 43
   at Windows.Storage.StorageFile.OpenStream(CancellationToken ct, FileAccessMode accessMode, StorageOpenOption...

</details>

Fixes unoplatform/uno#21311

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 We'd love your input! Share your thoughts on Copilot coding agent in our [2 minute survey](https://survey3.medallia.com/?EAHeSx-AP01bZqG0Ld9QLQ).
