### PR TITLE
fix: stabilize MCP DevServer startup, discovery, and diagnostics

### DIFF
--- a/.github/agents/devserver-agent.md
+++ b/.github/agents/devserver-agent.md
@@ -56,6 +56,11 @@ The CLI can also run in **MCP mode** (`--mcp-app`), acting as a Model Context Pr
 | `ToolListManager.cs` | Tool list management and caching |
 | `DevServerMonitor.cs` | DevServer process health monitoring and crash recovery |
 | `MonitorDecisions.cs` | Pure decision logic extracted from DevServerMonitor for testability |
+| `HealthService.cs` | Health reports (`uno_health` tool, `uno://health` resource) |
+| `HealthReport.cs` | Data models: `HealthReport`, `IssueCode`, `ValidationSeverity`, `ConnectionState` |
+| `DiscoveryIssueMapper.cs` | Static mapper: `DiscoveryInfo` → `ValidationIssue[]` |
+| `ConnectionState.cs` | Observational state machine for MCP bridge lifecycle |
+| `SolutionFileFinder.cs` | Recursive `.sln`/`.slnx` search with `.gitignore` awareness |
 | `RemoteControlServer.cs` | Host: WebSocket server, processor management |
 | `AddIns.cs` | Host: add-in discovery and assembly loading |
 
@@ -172,6 +177,38 @@ The MCP proxy (`McpStdioServer.cs` / `ProxyLifecycleManager.cs`) runs in STDIO m
 - Sends `tools/list_changed` notification when tools become available
 - Detects client capabilities (roots support) via `ClientCapabilities.Roots` to adapt behavior
 
+### MCP Roots (Two Modes)
+
+Only some MCP clients support roots natively (Claude Code, VS Code Copilot, Cursor). Others (Windsurf, JetBrains, Gemini CLI, Claude Desktop) do not.
+
+- **Default mode** (no `--force-roots-fallback`): DevServer starts immediately using `--solution-dir` or the current directory. If the client supports roots, they are requested but not required for startup.
+- **`--force-roots-fallback` mode**: DevServer startup is deferred until the client calls the `uno_app_set_roots` tool. Used for clients without native roots support that need to specify the workspace explicitly.
+
+The `StartOnceGuard` in `MonitorDecisions.cs` prevents duplicate DevServer starts when roots arrive after an immediate start.
+
+### Solution Discovery
+
+`SolutionFileFinder` performs recursive search for `.sln`/`.slnx` files:
+
+- Searches up to **3 levels deep** from the working directory
+- Respects `.gitignore` rules when inside a git repository (via `git check-ignore`)
+- Falls back to a hardcoded skip list (`node_modules`, `bin`, `obj`, `.vs`, `.idea`, `packages`) when git is unavailable
+- Discovered solutions are exposed as relative paths in `HealthReport.DiscoveredSolutions`
+
+### ConnectionState Lifecycle
+
+The `ConnectionState` enum tracks the MCP bridge lifecycle (see `Mcp/ConnectionState.cs` for the full state diagram):
+
+```
+Initializing → Discovering → Launching → Connecting → Connected
+                                                         ↓ (crash)
+                                                    Reconnecting → Discovering (cycle)
+                                                         ↓ (max retries)
+                                                      Degraded
+```
+
+Two separate retry counters: DevServerMonitor (3 startup attempts) and ProxyLifecycleManager (3 crash→restart cycles).
+
 ### Key Files
 
 | File | Role |
@@ -253,6 +290,8 @@ The Host accepts arguments via `ConfigurationBuilder.AddCommandLine()`. The `--a
 ## 11. References
 
 - [Dev Server documentation](../../doc/articles/dev-server.md)
+- [Health & Diagnostics](../../src/Uno.UI.DevServer.Cli/health-diagnostics.md)
+- [Add-in Discovery](../../src/Uno.UI.DevServer.Cli/addin-discovery.md)
 - [Specs](../../specs/001-fast-devserver-startup/)
 - [Integration test script](../../build/test-scripts/run-devserver-cli-tests.ps1)
 - [NuGet spec](../../build/nuget/Uno.WinUI.DevServer.nuspec)

--- a/doc/articles/features/using-the-uno-mcps.md
+++ b/doc/articles/features/using-the-uno-mcps.md
@@ -56,6 +56,10 @@ These tools give "eyes" and "hands" to Agents in order to validate their assumpt
 
 ### App MCP Tools
 
+The following diagnostic tool is always available, even before the app connects:
+
+- `uno_health`, used to get the health status of the DevServer MCP bridge, including connection state, tool count, discovered solutions, and any issues detected during startup
+
 The Community license MCP app tools are:
 
 - `uno_app_get_runtime_info`, used to get general information about the running app, such as its PID, OS, Platform, etc...
@@ -72,6 +76,22 @@ The Pro license App MCP app tools are:
 
 - `uno_app_element_peer_action`, used to invoke a specific element automation peer action
 - `uno_app_get_element_datacontext`, used to get a textual representation of the DataContext on a FrameworkElement
+
+### MCP Roots Compatibility
+
+The App MCP uses [MCP roots](https://modelcontextprotocol.io/docs/concepts/roots) to determine which workspace directory to scan for solutions. Not all agents support this capability:
+
+| Agent | Roots Support |
+|-------|:------------:|
+| Claude Code | Yes |
+| VS Code Copilot | Yes |
+| Cursor | Yes |
+| Google Antigravity | No |
+| Claude Desktop | No |
+| Windsurf | No |
+| JetBrains AI | No |
+
+For agents without roots support, the DevServer CLI uses the `--force-roots-fallback` flag to expose a `uno_app_set_roots` tool, allowing the agent to specify the workspace directory manually.
 
 ## Troubleshooting MCP Servers
 

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -382,7 +382,7 @@
 	},
 	{
 		"group": "AppMcp",
-		"version": "1.2.0-dev.30",
+		"version": "1.2.0-dev.31",
 		"packages": [
 			"Uno.UI.App.Mcp"
 		]

--- a/src/Uno.UI.DevServer.Cli.Tests/Uno.UI.DevServer.Cli.Tests.csproj
+++ b/src/Uno.UI.DevServer.Cli.Tests/Uno.UI.DevServer.Cli.Tests.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
-		<PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
+		<PackageReference Include="ModelContextProtocol" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
@@ -132,7 +132,8 @@ public sealed class ActiveServerInfo
 	public string? SolutionPath { get; init; }
 
 	/// <summary>
-	/// True when this server's solution matches the current working directory's solution.
+	/// True when this server's solution matches one of the working directory's
+	/// solutions, or when the solution resides within the working directory tree.
 	/// </summary>
-	public bool IsLocal { get; init; }
+	public bool IsInWorkspace { get; init; }
 }

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
@@ -129,4 +129,10 @@ public sealed class ActiveServerInfo
 	public int ParentProcessId { get; init; }
 	public DateTime StartTime { get; init; }
 	public string? IdeChannelId { get; init; }
+	public string? SolutionPath { get; init; }
+
+	/// <summary>
+	/// True when this server's solution matches the current working directory's solution.
+	/// </summary>
+	public bool IsLocal { get; init; }
 }

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryOutputFormatter.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryOutputFormatter.cs
@@ -61,9 +61,13 @@ internal static class DiscoveryOutputFormatter
 		{
 			foreach (var server in info.ActiveServers)
 			{
-				AddRow(table, "processId", server.ProcessId.ToString(CultureInfo.InvariantCulture));
+				var localTag = server.IsLocal ? " [green][local][/]" : " [grey][other][/]";
+				table.AddRow(
+					new Markup($"[white]processId[/]"),
+					new Markup($"[grey]{server.ProcessId}[/]{localTag}"));
 				AddRow(table, "port", server.Port.ToString(CultureInfo.InvariantCulture));
 				AddRow(table, "mcpEndpoint", server.McpEndpoint);
+				AddRow(table, "solution", server.SolutionPath);
 				AddRow(table, "parentProcessId", server.ParentProcessId.ToString(CultureInfo.InvariantCulture));
 				AddRow(table, "startTime", server.StartTime.ToString("yyyy-MM-dd HH:mm:ss UTC", CultureInfo.InvariantCulture));
 				AddRow(table, "ideChannelId", server.IdeChannelId);

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryOutputFormatter.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryOutputFormatter.cs
@@ -61,7 +61,7 @@ internal static class DiscoveryOutputFormatter
 		{
 			foreach (var server in info.ActiveServers)
 			{
-				var localTag = server.IsLocal ? " [green][local][/]" : " [grey][other][/]";
+				var localTag = server.IsInWorkspace ? " [green][workspace][/]" : " [grey][other][/]";
 				table.AddRow(
 					new Markup($"[white]processId[/]"),
 					new Markup($"[grey]{server.ProcessId}[/]{localTag}"));

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryOutputFormatter.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryOutputFormatter.cs
@@ -61,7 +61,7 @@ internal static class DiscoveryOutputFormatter
 		{
 			foreach (var server in info.ActiveServers)
 			{
-				var localTag = server.IsInWorkspace ? " [green][workspace][/]" : " [grey][other][/]";
+				var localTag = server.IsInWorkspace ? " [green][[workspace]][/]" : " [grey][[other]][/]";
 				table.AddRow(
 					new Markup($"[white]processId[/]"),
 					new Markup($"[grey]{server.ProcessId}[/]{localTag}"));

--- a/src/Uno.UI.DevServer.Cli/Helpers/SolutionFileFinder.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/SolutionFileFinder.cs
@@ -118,16 +118,9 @@ internal static class SolutionFileFinder
 				return null; // git not available
 			}
 
-			var ignored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-			while (process.StandardOutput.ReadLine() is { } line)
-			{
-				var trimmed = line.Trim();
-				if (trimmed.Length > 0 && relativeToAbsolute.TryGetValue(trimmed, out var absolutePath))
-				{
-					ignored.Add(absolutePath);
-				}
-			}
-
+			// Kill the process after a timeout to prevent hanging. This
+			// ensures that the subsequent synchronous ReadToEnd() will
+			// return promptly because killing closes the stdout pipe.
 			if (!process.WaitForExit(2000))
 			{
 				// git hung — kill it and fall back
@@ -140,6 +133,18 @@ internal static class SolutionFileFinder
 			if (process.ExitCode is not (0 or 1))
 			{
 				return null;
+			}
+
+			// Safe to read synchronously: the process has exited, so stdout is closed.
+			var output = process.StandardOutput.ReadToEnd();
+			var ignored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+			{
+				var trimmed = line.Trim();
+				if (trimmed.Length > 0 && relativeToAbsolute.TryGetValue(trimmed, out var absolutePath))
+				{
+					ignored.Add(absolutePath);
+				}
 			}
 
 			return ignored;

--- a/src/Uno.UI.DevServer.Cli/Helpers/SolutionFileFinder.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/SolutionFileFinder.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Uno.UI.DevServer.Cli.Helpers;
+
+// Directory filtering uses a two-layer strategy: a hardcoded skip list is
+// always applied, and `git check-ignore` is layered on top when available.
+// This ensures robust behavior across all environments:
+//
+// | # | `.git` exists | `git` installed | `.gitignore` | Result                                                                  |
+// |---|---------------|-----------------|--------------|-------------------------------------------------------------------------|
+// | 1 | no            | no              | no           | Hardcoded skip list only                                                |
+// | 2 | no            | no              | yes          | Hardcoded skip list only (`.gitignore` ignored without a repo)          |
+// | 3 | no            | yes             | no           | Hardcoded skip list only (not in a repo)                                |
+// | 4 | no            | yes             | yes          | Hardcoded skip list only (`.gitignore` ignored without `.git`)          |
+// | 5 | yes           | no              | no           | Hardcoded skip list only (`Process.Start` throws, caught gracefully)    |
+// | 6 | yes           | no              | yes          | Hardcoded skip list only (same as #5)                                   |
+// | 7 | yes (worktree)| no              | yes          | Hardcoded skip list only (worktree detected, but git missing)           |
+// | 8 | fake/corrupt  | yes             | no           | Hardcoded skip list only (`git check-ignore` exits 128 → null fallback) |
+// | 9 | yes           | yes             | no           | Hardcoded skip list only (`git check-ignore` returns empty set)         |
+// |10 | yes           | yes             | yes          | **Hardcoded skip list + `.gitignore` rules (union)**                    |
+// |11 | yes           | yes (hangs)     | yes          | Hardcoded skip list only (2s timeout → kill → null fallback)            |
+// |12 | yes (worktree)| yes             | yes          | Same as #10 — worktree detected correctly                              |
+//
+// No scenario can result in accidentally empty filtering.
+
+/// <summary>
+/// Searches for .sln/.slnx files recursively, respecting .gitignore rules
+/// when running inside a git repository.
+/// </summary>
+internal static class SolutionFileFinder
+{
+	/// <summary>
+	/// Default directories to skip when not inside a git repository.
+	/// </summary>
+	private static readonly string[] HardcodedSkipDirs =
+		["node_modules", "bin", "obj", ".vs", ".idea", "packages"];
+
+	/// <summary>
+	/// Finds solution files (.sln, .slnx) recursively up to <paramref name="maxDepth"/> levels.
+	/// When inside a git repo, uses <c>git check-ignore</c> to skip ignored directories.
+	/// Otherwise, uses a hardcoded skip list.
+	/// </summary>
+	public static string[] FindSolutionFiles(string directory, int maxDepth = 3)
+	{
+		var results = new List<string>();
+		var gitRoot = FindGitRoot(directory);
+		SearchDirectory(directory, 0, maxDepth, results, gitRoot);
+		return results.ToArray();
+	}
+
+	/// <summary>
+	/// Finds the root of the git repository containing <paramref name="directory"/>,
+	/// or returns <c>null</c> if the directory is not inside a git repo.
+	/// </summary>
+	public static string? FindGitRoot(string directory)
+	{
+		var current = directory;
+		while (current is not null)
+		{
+			var gitPath = Path.Combine(current, ".git");
+			// .git can be a directory (normal repo) or a file (worktree)
+			if (Directory.Exists(gitPath) || File.Exists(gitPath))
+			{
+				return current;
+			}
+			current = Path.GetDirectoryName(current);
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Uses <c>git check-ignore</c> to determine which of the given paths
+	/// are ignored by .gitignore rules. Returns the set of ignored paths,
+	/// or <c>null</c> if git is not available or fails (so the caller can
+	/// fall back to the hardcoded skip list).
+	/// </summary>
+	public static HashSet<string>? GetGitIgnoredPaths(List<string> paths, string gitRoot)
+	{
+		if (paths.Count == 0)
+		{
+			return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		}
+
+		try
+		{
+			// Build relative paths for git check-ignore (absolute Windows paths don't work)
+			var gitRootFull = Path.GetFullPath(gitRoot);
+			var relativeToAbsolute = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			var relativePaths = new List<string>();
+			foreach (var path in paths)
+			{
+				var relativePath = Path.GetRelativePath(gitRootFull, path).Replace('\\', '/');
+				relativeToAbsolute[relativePath] = path;
+				relativePaths.Add(relativePath);
+			}
+
+			// Pass paths as arguments (--stdin has issues on Windows via ProcessStartInfo)
+			var psi = new ProcessStartInfo("git")
+			{
+				WorkingDirectory = gitRoot,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				UseShellExecute = false,
+				CreateNoWindow = true,
+			};
+			psi.ArgumentList.Add("check-ignore");
+			foreach (var relativePath in relativePaths)
+			{
+				psi.ArgumentList.Add(relativePath);
+			}
+
+			using var process = Process.Start(psi);
+			if (process is null)
+			{
+				return null; // git not available
+			}
+
+			var ignored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			while (process.StandardOutput.ReadLine() is { } line)
+			{
+				var trimmed = line.Trim();
+				if (trimmed.Length > 0 && relativeToAbsolute.TryGetValue(trimmed, out var absolutePath))
+				{
+					ignored.Add(absolutePath);
+				}
+			}
+
+			if (!process.WaitForExit(2000))
+			{
+				// git hung — kill it and fall back
+				try { process.Kill(); } catch { /* best effort */ }
+				return null;
+			}
+
+			// Exit code 128 = not a git repo, other non-0/1 = unexpected error
+			// Exit code 0 = at least one path is ignored, 1 = none are ignored (both valid)
+			if (process.ExitCode is not (0 or 1))
+			{
+				return null;
+			}
+
+			return ignored;
+		}
+		catch
+		{
+			// git not found or other error — caller will use hardcoded skip list
+			return null;
+		}
+	}
+
+	private static void SearchDirectory(string directory, int currentDepth, int maxDepth,
+		List<string> results, string? gitRoot)
+	{
+		try
+		{
+			foreach (var file in Directory.EnumerateFiles(directory, "*.sln"))
+			{
+				results.Add(file);
+			}
+			foreach (var file in Directory.EnumerateFiles(directory, "*.slnx"))
+			{
+				results.Add(file);
+			}
+		}
+		catch (UnauthorizedAccessException)
+		{
+			// Skip directories we can't access
+		}
+
+		if (currentDepth >= maxDepth)
+		{
+			return;
+		}
+
+		try
+		{
+			var subDirs = Directory.EnumerateDirectories(directory).ToList();
+
+			// Always skip .git directory (contains git objects, never solutions)
+			subDirs.RemoveAll(d => string.Equals(Path.GetFileName(d), ".git", StringComparison.OrdinalIgnoreCase));
+
+			// Always apply hardcoded skip list (node_modules, bin, obj, etc.)
+			var ignored = subDirs
+				.Where(d => HardcodedSkipDirs.Contains(Path.GetFileName(d), StringComparer.OrdinalIgnoreCase))
+				.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+			// Additionally filter via git check-ignore when inside a git repo
+			if (gitRoot is not null)
+			{
+				var gitIgnored = GetGitIgnoredPaths(subDirs, gitRoot);
+				if (gitIgnored is not null)
+				{
+					ignored.UnionWith(gitIgnored);
+				}
+			}
+
+			foreach (var subDir in subDirs)
+			{
+				if (ignored.Contains(subDir))
+				{
+					continue;
+				}
+				SearchDirectory(subDir, currentDepth + 1, maxDepth, results, gitRoot);
+			}
+		}
+		catch (UnauthorizedAccessException)
+		{
+			// Skip directories we can't access
+		}
+	}
+}

--- a/src/Uno.UI.DevServer.Cli/Helpers/SolutionFileFinder.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/SolutionFileFinder.cs
@@ -170,9 +170,9 @@ internal static class SolutionFileFinder
 				results.Add(file);
 			}
 		}
-		catch (UnauthorizedAccessException)
+		catch (Exception ex) when (ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException)
 		{
-			// Skip directories we can't access
+			// Skip directories we can't access or that disappeared during scanning
 		}
 
 		if (currentDepth >= maxDepth)
@@ -211,9 +211,9 @@ internal static class SolutionFileFinder
 				SearchDirectory(subDir, currentDepth + 1, maxDepth, results, gitRoot);
 			}
 		}
-		catch (UnauthorizedAccessException)
+		catch (Exception ex) when (ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException)
 		{
-			// Skip directories we can't access
+			// Skip directories we can't access or that disappeared during scanning
 		}
 	}
 }

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -175,24 +175,23 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		}
 
 		// Lookup active DevServers via AmbientRegistry
+		// Show all servers on this machine, with IsLocal flag for matching solution or directory.
 		var activeServers = new List<ActiveServerInfo>();
 		try
 		{
-			var solutionFiles = Directory.EnumerateFiles(workDirectory, "*.sln")
+			var localSolutions = Directory.EnumerateFiles(workDirectory, "*.sln")
 				.Concat(Directory.EnumerateFiles(workDirectory, "*.slnx"))
-				.ToArray();
-			var solution = solutionFiles.FirstOrDefault();
-			if (solution is not null)
-			{
-				var solutionFull = Path.GetFullPath(solution);
-				var ambient = new AmbientRegistry(NullLogger.Instance);
-				activeServers = ambient.GetActiveDevServers()
-					.Where(s =>
-						!string.IsNullOrWhiteSpace(s.SolutionPath)
-						&& Path.GetFullPath(s.SolutionPath).Equals(solutionFull, StringComparison.OrdinalIgnoreCase)
-						&& s.MachineName == Environment.MachineName
-						&& s.UserName == Environment.UserName)
-					.Select(s => new ActiveServerInfo
+				.Select(f => Path.GetFullPath(f))
+				.ToHashSet(StringComparer.OrdinalIgnoreCase);
+			var workDirFull = Path.GetFullPath(workDirectory);
+
+			var ambient = new AmbientRegistry(NullLogger.Instance);
+			activeServers = ambient.GetActiveDevServers()
+				.Where(s => s.MachineName == Environment.MachineName && s.UserName == Environment.UserName)
+				.Select(s =>
+				{
+					var isLocal = IsServerLocal(s.SolutionPath, localSolutions, workDirFull);
+					return new ActiveServerInfo
 					{
 						ProcessId = s.ProcessId,
 						Port = s.Port,
@@ -200,9 +199,11 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 						ParentProcessId = s.ParentProcessId,
 						StartTime = s.StartTime,
 						IdeChannelId = s.IdeChannelId,
-					})
-					.ToList();
-			}
+						SolutionPath = s.SolutionPath,
+						IsLocal = isLocal,
+					};
+				})
+				.ToList();
 		}
 		catch (Exception ex)
 		{
@@ -409,6 +410,42 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		{
 			_logger.LogDebug("Package {SdkPackage} version {Version} installed successfully", packageId, version);
 		}
+	}
+
+	/// <summary>
+	/// Determines if a server is "local" to the working directory by matching
+	/// its solution against any solution in the directory, or by checking if
+	/// the solution resides within the working directory (for solution-less or
+	/// multi-solution repos).
+	/// </summary>
+	private static bool IsServerLocal(string? serverSolutionPath, HashSet<string> localSolutions, string workDirFull)
+	{
+		if (string.IsNullOrWhiteSpace(serverSolutionPath))
+		{
+			return false;
+		}
+
+		var serverSolutionFull = Path.GetFullPath(serverSolutionPath);
+
+		// Direct match: server's solution is one of the solutions in the working directory
+		if (localSolutions.Contains(serverSolutionFull))
+		{
+			return true;
+		}
+
+		// Directory match: server's solution is inside the working directory tree
+		var serverDir = Path.GetDirectoryName(serverSolutionFull);
+		if (serverDir is not null)
+		{
+			var normalizedServerDir = serverDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			var normalizedWorkDir = workDirFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			if (normalizedServerDir.StartsWith(normalizedWorkDir, StringComparison.OrdinalIgnoreCase))
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	internal static IReadOnlyList<string> GetNuGetCachePaths(string? workingDirectory = null)

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -439,7 +439,9 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		{
 			var normalizedServerDir = serverDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 			var normalizedWorkDir = workDirFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-			if (normalizedServerDir.StartsWith(normalizedWorkDir, StringComparison.OrdinalIgnoreCase))
+			if (normalizedServerDir.StartsWith(normalizedWorkDir, StringComparison.OrdinalIgnoreCase)
+				&& (normalizedServerDir.Length == normalizedWorkDir.Length
+					|| normalizedServerDir[normalizedWorkDir.Length] is '/' or '\\'))
 			{
 				return true;
 			}

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -425,7 +425,16 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			return false;
 		}
 
-		var serverSolutionFull = Path.GetFullPath(serverSolutionPath);
+		string serverSolutionFull;
+		try
+		{
+			serverSolutionFull = Path.GetFullPath(serverSolutionPath);
+		}
+		catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+		{
+			// Malformed path from AmbientRegistry — treat as non-workspace
+			return false;
+		}
 
 		// Direct match: server's solution is one of the solutions in the working directory
 		if (localSolutions.Contains(serverSolutionFull))

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -175,7 +175,7 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		}
 
 		// Lookup active DevServers via AmbientRegistry
-		// Show all servers on this machine, with IsLocal flag for matching solution or directory.
+		// Show all servers on this machine, with IsInWorkspace flag for matching solution or directory.
 		var activeServers = new List<ActiveServerInfo>();
 		try
 		{
@@ -190,7 +190,7 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 				.Where(s => s.MachineName == Environment.MachineName && s.UserName == Environment.UserName)
 				.Select(s =>
 				{
-					var isLocal = IsServerLocal(s.SolutionPath, localSolutions, workDirFull);
+					var isInWorkspace = IsServerLocal(s.SolutionPath, localSolutions, workDirFull);
 					return new ActiveServerInfo
 					{
 						ProcessId = s.ProcessId,
@@ -200,7 +200,7 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 						StartTime = s.StartTime,
 						IdeChannelId = s.IdeChannelId,
 						SolutionPath = s.SolutionPath,
-						IsLocal = isLocal,
+						IsInWorkspace = isInWorkspace,
 					};
 				})
 				.ToList();

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -42,6 +42,14 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 	/// </summary>
 	public bool SolutionNotFound { get; private set; }
 
+	/// <summary>
+	/// The list of solution files discovered during the last scan, stored as
+	/// paths relative to <see cref="_currentDirectory"/>. Exposed via
+	/// <see cref="HealthService"/> so the MCP agent can see which solutions
+	/// were found.
+	/// </summary>
+	public IReadOnlyList<string> DiscoveredSolutions { get; private set; } = [];
+
 	internal void StartMonitoring(string currentDirectory, int port, List<string> forwardedArgs)
 	{
 		if (_monitor is not null)
@@ -102,6 +110,9 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 					_currentDirectory);
 
 				SolutionNotFound = solutionFiles.Length == 0;
+				DiscoveredSolutions = solutionFiles
+					.Select(f => Path.GetRelativePath(_currentDirectory, f))
+					.ToArray();
 
 				if (solutionFiles.Length != 0)
 				{
@@ -531,11 +542,5 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 		tcp.Stop();
 		return port;
 	}
-
-	/// <summary>
-	/// Finds .sln and .slnx files in the given directory, searching recursively
-	/// up to <paramref name="maxDepth"/> levels deep. Results are sorted by depth
-	/// (shallowest first) so the closest solution to the root is preferred.
-	/// </summary>
 
 }

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -302,7 +302,7 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 				return true;
 			}
 
-			// Probe aggressively for the first 5 seconds (200ms), then slow to 1s
+			// Probe aggressively for the first ~2 seconds (10×200ms), then slow to 1s (~30s total budget)
 			var delay = i < 10 ? 200 : 1000;
 			await Task.Delay(delay, ct);
 		}

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -35,6 +35,13 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 	public long DiscoveryDurationMs => _discoveryDurationMs;
 	public DiscoveryInfo? LastDiscoveryInfo => _lastDiscoveryInfo;
 
+	/// <summary>
+	/// Set to true when the monitor has scanned for solutions and found none.
+	/// Reset to false when a solution is found. Used by HealthService to report
+	/// a clear message to the agent.
+	/// </summary>
+	public bool SolutionNotFound { get; private set; }
+
 	internal void StartMonitoring(string currentDirectory, int port, List<string> forwardedArgs)
 	{
 		if (_monitor is not null)
@@ -85,14 +92,16 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 			try
 			{
 				// If we don't have a solution, we can't start a DevServer yet.
-				var solutionFiles = Directory
-					.EnumerateFiles(_currentDirectory, "*.sln")
-					.Concat(Directory.EnumerateFiles(_currentDirectory, "*.slnx")).ToArray();
+				// Search recursively (up to 3 levels deep) so solutions in
+				// subdirectories like src/MyProject.slnx are found.
+				var solutionFiles = FindSolutionFiles(_currentDirectory);
 
 				_logger.LogTrace(
 					"DevServerMonitor scan found {Count} solution files in {Directory}",
 					solutionFiles.Length,
 					_currentDirectory);
+
+				SolutionNotFound = solutionFiles.Length == 0;
 
 				if (solutionFiles.Length != 0)
 				{
@@ -519,6 +528,60 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 		var port = ((IPEndPoint)tcp.LocalEndpoint).Port;
 		tcp.Stop();
 		return port;
+	}
+
+	/// <summary>
+	/// Finds .sln and .slnx files in the given directory, searching recursively
+	/// up to <paramref name="maxDepth"/> levels deep. Results are sorted by depth
+	/// (shallowest first) so the closest solution to the root is preferred.
+	/// </summary>
+	internal static string[] FindSolutionFiles(string directory, int maxDepth = 3)
+	{
+		var results = new List<string>();
+		SearchDirectory(directory, 0, maxDepth, results);
+		return results.ToArray();
+	}
+
+	private static void SearchDirectory(string directory, int currentDepth, int maxDepth, List<string> results)
+	{
+		try
+		{
+			foreach (var file in Directory.EnumerateFiles(directory, "*.sln"))
+			{
+				results.Add(file);
+			}
+			foreach (var file in Directory.EnumerateFiles(directory, "*.slnx"))
+			{
+				results.Add(file);
+			}
+		}
+		catch (UnauthorizedAccessException)
+		{
+			// Skip directories we can't access
+		}
+
+		if (currentDepth >= maxDepth)
+		{
+			return;
+		}
+
+		try
+		{
+			foreach (var subDir in Directory.EnumerateDirectories(directory))
+			{
+				// Skip common large directories that won't contain solutions
+				var dirName = Path.GetFileName(subDir);
+				if (dirName is "node_modules" or ".git" or "bin" or "obj" or ".vs" or ".idea" or "packages")
+				{
+					continue;
+				}
+				SearchDirectory(subDir, currentDepth + 1, maxDepth, results);
+			}
+		}
+		catch (UnauthorizedAccessException)
+		{
+			// Skip directories we can't access
+		}
 	}
 
 }

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -259,7 +259,7 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 			$"http://[::1]:{port}/mcp"
 		};
 
-		var maxAttempts = 40; // ~30 seconds total (fast probes then slower)
+		var maxAttempts = 40; // ~32s delay budget: 10×200ms + 30×1000ms (plus HTTP request time)
 
 		using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
 

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -94,7 +94,7 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 				// If we don't have a solution, we can't start a DevServer yet.
 				// Search recursively (up to 3 levels deep) so solutions in
 				// subdirectories like src/MyProject.slnx are found.
-				var solutionFiles = FindSolutionFiles(_currentDirectory);
+				var solutionFiles = SolutionFileFinder.FindSolutionFiles(_currentDirectory);
 
 				_logger.LogTrace(
 					"DevServerMonitor scan found {Count} solution files in {Directory}",
@@ -537,53 +537,5 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 	/// up to <paramref name="maxDepth"/> levels deep. Results are sorted by depth
 	/// (shallowest first) so the closest solution to the root is preferred.
 	/// </summary>
-	internal static string[] FindSolutionFiles(string directory, int maxDepth = 3)
-	{
-		var results = new List<string>();
-		SearchDirectory(directory, 0, maxDepth, results);
-		return results.ToArray();
-	}
-
-	private static void SearchDirectory(string directory, int currentDepth, int maxDepth, List<string> results)
-	{
-		try
-		{
-			foreach (var file in Directory.EnumerateFiles(directory, "*.sln"))
-			{
-				results.Add(file);
-			}
-			foreach (var file in Directory.EnumerateFiles(directory, "*.slnx"))
-			{
-				results.Add(file);
-			}
-		}
-		catch (UnauthorizedAccessException)
-		{
-			// Skip directories we can't access
-		}
-
-		if (currentDepth >= maxDepth)
-		{
-			return;
-		}
-
-		try
-		{
-			foreach (var subDir in Directory.EnumerateDirectories(directory))
-			{
-				// Skip common large directories that won't contain solutions
-				var dirName = Path.GetFileName(subDir);
-				if (dirName is "node_modules" or ".git" or "bin" or "obj" or ".vs" or ".idea" or "packages")
-				{
-					continue;
-				}
-				SearchDirectory(subDir, currentDepth + 1, maxDepth, results);
-			}
-		}
-		catch (UnauthorizedAccessException)
-		{
-			// Skip directories we can't access
-		}
-	}
 
 }

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -248,7 +248,7 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 			$"http://[::1]:{port}/mcp"
 		};
 
-		var maxAttempts = 30; // 30 seconds
+		var maxAttempts = 40; // ~30 seconds total (fast probes then slower)
 
 		using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
 
@@ -291,7 +291,9 @@ public class DevServerMonitor(IServiceProvider services, ILogger<DevServerMonito
 				return true;
 			}
 
-			await Task.Delay(1000, ct);
+			// Probe aggressively for the first 5 seconds (200ms), then slow to 1s
+			var delay = i < 10 ? 200 : 1000;
+			await Task.Delay(delay, ct);
 		}
 
 		_logger.LogError("DevServer did not become ready within timeout period on any of: {Endpoints}", string.Join(", ", endpoints));

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
@@ -41,7 +41,7 @@ internal sealed record ActiveServerSummary
 	public DateTime StartTime { get; init; }
 	public string? IdeChannelId { get; init; }
 	public string? SolutionPath { get; init; }
-	public bool IsLocal { get; init; }
+	public bool IsInWorkspace { get; init; }
 }
 
 internal sealed record AddInSummary

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
@@ -39,6 +39,8 @@ internal sealed record ActiveServerSummary
 	public int ParentProcessId { get; init; }
 	public DateTime StartTime { get; init; }
 	public string? IdeChannelId { get; init; }
+	public string? SolutionPath { get; init; }
+	public bool IsLocal { get; init; }
 }
 
 internal sealed record AddInSummary

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
@@ -91,4 +91,5 @@ internal enum IssueCode
 	AddInLoadFailed,
 	AddInDiscoveryFallback,
 	UpstreamError,
+	NoSolutionFound,
 }

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
@@ -15,6 +15,7 @@ internal sealed record HealthReport
 	public string? UnoSdkVersion { get; init; }
 	public long DiscoveryDurationMs { get; init; }
 	public ConnectionState? ConnectionState { get; init; }
+	public IReadOnlyList<string>? DiscoveredSolutions { get; init; }
 	public required IReadOnlyList<ValidationIssue> Issues { get; init; }
 	public DiscoverySummary? Discovery { get; init; }
 }

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
@@ -58,6 +58,17 @@ internal class HealthService(
 			});
 		}
 
+		if (devServerMonitor.SolutionNotFound)
+		{
+			issues.Add(new ValidationIssue
+			{
+				Code = IssueCode.NoSolutionFound,
+				Severity = ValidationSeverity.Warning,
+				Message = "No .sln or .slnx file found in the working directory or its subdirectories.",
+				Remediation = "Create an Uno Platform project first (e.g. 'dotnet new unoapp'), then tools will become available automatically.",
+			});
+		}
+
 		if (ConnectionState == ConnectionState.Reconnecting)
 		{
 			issues.Add(new ValidationIssue

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
@@ -173,7 +173,7 @@ internal class HealthService(
 					StartTime = s.StartTime,
 					IdeChannelId = s.IdeChannelId,
 					SolutionPath = s.SolutionPath,
-					IsLocal = s.IsLocal,
+					IsInWorkspace = s.IsInWorkspace,
 				}).ToList()
 				: null,
 		};

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
@@ -122,6 +122,10 @@ internal class HealthService(
 				? HealthStatus.Degraded
 				: HealthStatus.Healthy;
 
+		var discoveredSolutions = devServerMonitor.DiscoveredSolutions is { Count: > 0 }
+			? devServerMonitor.DiscoveredSolutions
+			: null;
+
 		return new HealthReport
 		{
 			Status = status,
@@ -131,6 +135,7 @@ internal class HealthService(
 			UnoSdkVersion = devServerMonitor.UnoSdkVersion,
 			DiscoveryDurationMs = devServerMonitor.DiscoveryDurationMs,
 			ConnectionState = ConnectionState,
+			DiscoveredSolutions = discoveredSolutions,
 			Issues = issues,
 			Discovery = MapDiscovery(devServerMonitor.LastDiscoveryInfo),
 		};

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
@@ -167,6 +167,8 @@ internal class HealthService(
 					ParentProcessId = s.ParentProcessId,
 					StartTime = s.StartTime,
 					IdeChannelId = s.IdeChannelId,
+					SolutionPath = s.SolutionPath,
+					IsLocal = s.IsLocal,
 				}).ToList()
 				: null,
 		};

--- a/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
@@ -157,11 +157,9 @@ internal class ProxyLifecycleManager
 	{
 		_logger.LogTrace("Processing MCP Client Roots: {Roots}", string.Join(", ", _roots));
 
-		if (_devServerStartGuard.IsStarted)
-		{
-			_logger.LogTrace("DevServer monitor already running; skipping additional root processing");
-			return;
-		}
+		// The StartOnceGuard inside StartDevServerMonitor() prevents concurrent starts.
+		// We don't early-return here so that roots from the MCP client can trigger
+		// the monitor when no --solution-dir was provided.
 
 		if (_roots.FirstOrDefault() is { } rootUri)
 		{
@@ -237,22 +235,21 @@ internal class ProxyLifecycleManager
 			return;
 		}
 
-		var directory = string.IsNullOrWhiteSpace(_solutionDirectory)
-			? _currentDirectory
-			: _solutionDirectory;
-
 		_logger.LogTrace(
 			"EnsureDevServerStartedFromSolutionDirectory (solutionDir: {SolutionDir}, currentDir: {CurrentDir})",
 			_solutionDirectory,
 			_currentDirectory);
 
-		if (string.IsNullOrWhiteSpace(directory))
+		if (string.IsNullOrWhiteSpace(_solutionDirectory))
 		{
-			_logger.LogTrace("No directory available to start the DevServer monitor; skipping initial start");
+			// No explicit --solution-dir was provided. Defer startup until we receive
+			// roots from the MCP client (in EnsureRootsInitialized). For clients that
+			// don't support roots, the fallback to currentDirectory happens there.
+			_logger.LogTrace("No explicit solution directory; deferring DevServer start until MCP roots are received");
 			return;
 		}
 
-		StartDevServerMonitor(directory);
+		StartDevServerMonitor(_solutionDirectory);
 	}
 
 	private void StartDevServerMonitor(string? directory)

--- a/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
@@ -174,9 +174,9 @@ internal class ProxyLifecycleManager
 				_logger.LogWarning("Unable to resolve MCP root '{RootUri}' to a local path", rootUri);
 			}
 		}
-		else if (!_forceRootsFallback)
+		else if (_forceRootsFallback)
 		{
-			_logger.LogWarning("No roots found and roots fallback is disabled; devserver was not started");
+			_logger.LogWarning("No roots provided via uno_app_set_roots; DevServer startup is deferred until roots are set");
 		}
 	}
 

--- a/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
@@ -240,16 +240,18 @@ internal class ProxyLifecycleManager
 			_solutionDirectory,
 			_currentDirectory);
 
-		if (string.IsNullOrWhiteSpace(_solutionDirectory))
+		if (!string.IsNullOrWhiteSpace(_solutionDirectory))
 		{
-			// No explicit --solution-dir was provided. Defer startup until we receive
-			// roots from the MCP client (in EnsureRootsInitialized). For clients that
-			// don't support roots, the fallback to currentDirectory happens there.
-			_logger.LogTrace("No explicit solution directory; deferring DevServer start until MCP roots are received");
+			StartDevServerMonitor(_solutionDirectory);
 			return;
 		}
 
-		StartDevServerMonitor(_solutionDirectory);
+		// No explicit --solution-dir was provided. Use the current directory
+		// so the monitor can scan for solutions immediately. MCP roots received
+		// later will be processed via ProcessRoots() which can trigger the
+		// monitor if it hasn't started yet (StartOnceGuard prevents duplicates).
+		_logger.LogTrace("No explicit solution directory; using current directory {Directory}", _currentDirectory);
+		StartDevServerMonitor(_currentDirectory);
 	}
 
 	private void StartDevServerMonitor(string? directory)

--- a/src/Uno.UI.DevServer.Cli/Mcp/ToolListManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ToolListManager.cs
@@ -25,7 +25,7 @@ internal class ToolListManager(
 	private const string ToolCacheFileName = "tools-cache.json";
 
 	/// <summary>Maximum time to wait for upstream list_tools before returning cached/empty result.</summary>
-	internal const int ListToolsTimeoutMs = 30_000;
+	internal const int ListToolsTimeoutMs = 60_000;
 
 	public string? WorkspaceHash { get; set; }
 

--- a/src/Uno.UI.DevServer.Cli/Uno.UI.DevServer.Cli.csproj
+++ b/src/Uno.UI.DevServer.Cli/Uno.UI.DevServer.Cli.csproj
@@ -30,8 +30,8 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
-		<PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
-		<PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
+		<PackageReference Include="ModelContextProtocol" Version="1.1.0" />
+		<PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
 		<PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
 		<PackageReference Include="Spectre.Console" Version="0.49.1" />
 	</ItemGroup>

--- a/src/Uno.UI.DevServer.Cli/health-diagnostics.md
+++ b/src/Uno.UI.DevServer.Cli/health-diagnostics.md
@@ -43,6 +43,7 @@ These are added directly by `HealthService.BuildHealthReport()`:
 | IssueCode | Severity | Trigger |
 |-----------|----------|---------|
 | `HostNotStarted` | Fatal | DevServer not yet started |
+| `NoSolutionFound` | Warning | No `.sln` or `.slnx` file found in working directory tree |
 | `HostCrashed` | Warning/Fatal | Connection state `Reconnecting` / `Degraded` |
 | `HostUnreachable` | Warning | Started but not yet connected |
 | `UpstreamError` | Fatal | Upstream task faulted |
@@ -54,6 +55,14 @@ Three codes exist in the `IssueCode` enum but are **not currently mapped** in CL
 - `DotNetVersionUnsupported`
 - `AddInLoadFailed`
 - `AddInBinaryNotFound`
+
+## Notable HealthReport Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `DiscoveredSolutions` | `string[]?` | Relative paths to `.sln`/`.slnx` files found by recursive search (null when none found) |
+| `ConnectionState` | `ConnectionState?` | Lifecycle state of the MCP bridge (see `Mcp/ConnectionState.cs` for state diagram) |
+| `Discovery` | `DiscoverySummary?` | Full discovery info including `ActiveServers[]` with `IsInWorkspace` flag |
 
 ## Health Status
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
@@ -6,7 +6,7 @@ namespace Uno.UI.RemoteControl.DevServer.Tests.Mcp;
 
 /// <summary>
 /// Tests for <see cref="DevServerMonitor"/> patterns: ambient registry lookup,
-/// direct launch arg building, and retry logic.
+/// direct launch arg building, retry logic, and <see cref="SolutionFileFinder"/>.
 /// <para>
 /// These tests simulate DevServerMonitor patterns rather than instantiating
 /// the real class because it requires a .sln on disk and a real Uno SDK
@@ -105,7 +105,7 @@ public class Given_DevServerMonitor
 
 	[TestMethod]
 	[Description("ServerFailed event fires after exhausting all retry attempts")]
-	public void DevServerMonitor_RetryLogic_FailsAfterMaxAttempts()
+	public void SolutionFileFinder_RetryLogic_FailsAfterMaxAttempts()
 	{
 		const int maxRetries = 3;
 		int retryCount = 0;
@@ -220,7 +220,7 @@ public class Given_DevServerMonitor
 	// -------------------------------------------------------------------
 
 	[TestMethod]
-	[Description("DiscoveryInfo fields map to the values DevServerMonitor exposes")]
+	[Description("DiscoveryInfo fields map to the values SolutionFileFinder exposes")]
 	public void DiscoveryInfo_WhenFullyPopulated_ExposesExpectedFields()
 	{
 		var discovery = new DiscoveryInfo
@@ -297,11 +297,255 @@ public class Given_DevServerMonitor
 	}
 
 	// -------------------------------------------------------------------
+	// FindGitRoot
+	// -------------------------------------------------------------------
+
+	[TestMethod]
+	public void FindGitRoot_ReturnsRoot_WhenInGitRepo()
+	{
+		// The test project itself is inside the uno2 git repo
+		var testDir = AppContext.BaseDirectory;
+		var gitRoot = SolutionFileFinder.FindGitRoot(testDir);
+
+		gitRoot.Should().NotBeNull();
+		// .git can be a directory (normal repo) or a file (worktree)
+		var gitPath = Path.Combine(gitRoot!, ".git");
+		(Directory.Exists(gitPath) || File.Exists(gitPath)).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void FindGitRoot_ReturnsNull_WhenNotInGitRepo()
+	{
+		// Use a temp directory that's not inside any git repo
+		var tempDir = Path.Combine(Path.GetTempPath(), $"no-git-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			// Temp root is unlikely inside a git repo; if it is, skip
+			if (SolutionFileFinder.FindGitRoot(Path.GetTempPath()) is not null)
+			{
+				Assert.Inconclusive("Temp directory is inside a git repo, cannot test non-git fallback.");
+			}
+
+			var result = SolutionFileFinder.FindGitRoot(tempDir);
+			result.Should().BeNull();
+		}
+		finally
+		{
+			Directory.Delete(tempDir, recursive: true);
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// FindSolutionFiles with .gitignore awareness
+	// -------------------------------------------------------------------
+
+	[TestMethod]
+	public void FindSolutionFiles_SkipsGitIgnoredDirectories()
+	{
+		var tempDir = Path.Combine(Path.GetTempPath(), $"git-ignore-test-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			// Init a git repo
+			RunGit(tempDir, "init");
+			RunGit(tempDir, "config user.email test@test.com");
+			RunGit(tempDir, "config user.name Test");
+
+			// Create .gitignore that ignores the "ignored" directory
+			File.WriteAllText(Path.Combine(tempDir, ".gitignore"), "ignored/\n");
+			RunGit(tempDir, "add .gitignore");
+			RunGit(tempDir, "commit -m init");
+
+			// Create two subdirectories with .sln files
+			var ignoredDir = Path.Combine(tempDir, "ignored");
+			var visibleDir = Path.Combine(tempDir, "visible");
+			Directory.CreateDirectory(ignoredDir);
+			Directory.CreateDirectory(visibleDir);
+			File.WriteAllText(Path.Combine(ignoredDir, "Hidden.sln"), "");
+			File.WriteAllText(Path.Combine(visibleDir, "Visible.sln"), "");
+
+			var solutions = SolutionFileFinder.FindSolutionFiles(tempDir);
+
+			solutions.Should().ContainSingle(s => s.Contains("Visible.sln"));
+			solutions.Should().NotContain(s => s.Contains("Hidden.sln"));
+		}
+		finally
+		{
+			// .git directories on Windows need special cleanup
+			ForceDeleteDirectory(tempDir);
+		}
+	}
+
+	[TestMethod]
+	public void FindSolutionFiles_FallsBackToHardcodedList_WhenNoGit()
+	{
+		var tempDir = Path.Combine(Path.GetTempPath(), $"no-git-test-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			// Skip if temp dir happens to be inside a git repo
+			if (SolutionFileFinder.FindGitRoot(Path.GetTempPath()) is not null)
+			{
+				Assert.Inconclusive("Temp directory is inside a git repo, cannot test non-git fallback.");
+			}
+
+			// Create node_modules (should be skipped by hardcoded list) and a visible dir
+			var nodeModules = Path.Combine(tempDir, "node_modules");
+			var src = Path.Combine(tempDir, "src");
+			Directory.CreateDirectory(nodeModules);
+			Directory.CreateDirectory(src);
+			File.WriteAllText(Path.Combine(nodeModules, "Bad.sln"), "");
+			File.WriteAllText(Path.Combine(src, "Good.sln"), "");
+
+			var solutions = SolutionFileFinder.FindSolutionFiles(tempDir);
+
+			solutions.Should().ContainSingle(s => s.Contains("Good.sln"));
+			solutions.Should().NotContain(s => s.Contains("Bad.sln"));
+		}
+		finally
+		{
+			Directory.Delete(tempDir, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public void GetGitIgnoredPaths_ReturnsEmpty_WhenNoPathsProvided()
+	{
+		var result = SolutionFileFinder.GetGitIgnoredPaths(new List<string>(), ".");
+		result.Should().NotBeNull();
+		result!.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public void GetGitIgnoredPaths_ReturnsNull_WhenGitNotAvailable()
+	{
+		// Use a directory that is NOT a git repo — git check-ignore will fail
+		var tempDir = Path.Combine(Path.GetTempPath(), $"no-git-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var subDir = Path.Combine(tempDir, "somedir");
+			Directory.CreateDirectory(subDir);
+
+			// git check-ignore will fail because tempDir is not a git repo
+			var result = SolutionFileFinder.GetGitIgnoredPaths([subDir], tempDir);
+
+			// Should return null (git failed) so caller can fall back to hardcoded list
+			result.Should().BeNull();
+		}
+		finally
+		{
+			Directory.Delete(tempDir, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public void FindSolutionFiles_UsesHardcodedSkipList_WhenGitFails()
+	{
+		// Even if a .git exists, if git executable is broken or not a real repo,
+		// the hardcoded skip list should kick in as fallback.
+		var tempDir = Path.Combine(Path.GetTempPath(), $"fake-git-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			// Create a fake .git file (not a real repo — git check-ignore will fail)
+			File.WriteAllText(Path.Combine(tempDir, ".git"), "not a real git repo");
+
+			// Create node_modules (should be skipped by hardcoded fallback) and src
+			var nodeModules = Path.Combine(tempDir, "node_modules");
+			var src = Path.Combine(tempDir, "src");
+			Directory.CreateDirectory(nodeModules);
+			Directory.CreateDirectory(src);
+			File.WriteAllText(Path.Combine(nodeModules, "Bad.sln"), "");
+			File.WriteAllText(Path.Combine(src, "Good.sln"), "");
+
+			var solutions = SolutionFileFinder.FindSolutionFiles(tempDir);
+
+			solutions.Should().ContainSingle(s => s.Contains("Good.sln"));
+			solutions.Should().NotContain(s => s.Contains("Bad.sln"));
+		}
+		finally
+		{
+			Directory.Delete(tempDir, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public void FindSolutionFiles_RespectsNestedGitignoreInSubdirectories()
+	{
+		var tempDir = Path.Combine(Path.GetTempPath(), $"nested-gi-test-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			// Init a git repo with a root .gitignore
+			RunGit(tempDir, "init");
+			RunGit(tempDir, "config user.email test@test.com");
+			RunGit(tempDir, "config user.name Test");
+			File.WriteAllText(Path.Combine(tempDir, ".gitignore"), "root-ignored/\n");
+			RunGit(tempDir, "add .gitignore");
+			RunGit(tempDir, "commit -m init");
+
+			// Create a nested .gitignore inside src/
+			var src = Path.Combine(tempDir, "src");
+			Directory.CreateDirectory(src);
+			File.WriteAllText(Path.Combine(src, ".gitignore"), "sub-ignored/\n");
+
+			// Create directories with .sln files at various levels
+			Directory.CreateDirectory(Path.Combine(tempDir, "root-ignored"));
+			File.WriteAllText(Path.Combine(tempDir, "root-ignored", "RootIgnored.sln"), "");
+
+			Directory.CreateDirectory(Path.Combine(src, "sub-ignored"));
+			File.WriteAllText(Path.Combine(src, "sub-ignored", "SubIgnored.sln"), "");
+
+			Directory.CreateDirectory(Path.Combine(src, "visible"));
+			File.WriteAllText(Path.Combine(src, "visible", "Visible.sln"), "");
+
+			var solutions = SolutionFileFinder.FindSolutionFiles(tempDir);
+
+			solutions.Should().ContainSingle(s => s.Contains("Visible.sln"));
+			solutions.Should().NotContain(s => s.Contains("RootIgnored.sln"),
+				"root .gitignore should exclude root-ignored/");
+			solutions.Should().NotContain(s => s.Contains("SubIgnored.sln"),
+				"nested src/.gitignore should exclude sub-ignored/");
+		}
+		finally
+		{
+			ForceDeleteDirectory(tempDir);
+		}
+	}
+
+	// -------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------
 
+	private static void RunGit(string workingDir, string args)
+	{
+		var psi = new System.Diagnostics.ProcessStartInfo("git", args)
+		{
+			WorkingDirectory = workingDir,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+			CreateNoWindow = true,
+		};
+		using var process = System.Diagnostics.Process.Start(psi)!;
+		process.WaitForExit(5000);
+	}
+
+	private static void ForceDeleteDirectory(string path)
+	{
+		// Remove read-only attributes on .git objects so delete works on Windows
+		foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+		{
+			File.SetAttributes(file, FileAttributes.Normal);
+		}
+		Directory.Delete(path, recursive: true);
+	}
+
+
 	/// <summary>
-	/// Mirrors the arg-building logic in <see cref="DevServerMonitor.StartProcess"/>
+	/// Mirrors the arg-building logic in <see cref="SolutionFileFinder.StartProcess"/>
 	/// to verify that the direct launch path produces the expected arguments.
 	/// </summary>
 	private static List<string> BuildDirectLaunchArgs(int port, string? solution, string? addins = null)

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
@@ -105,7 +105,7 @@ public class Given_DevServerMonitor
 
 	[TestMethod]
 	[Description("ServerFailed event fires after exhausting all retry attempts")]
-	public void SolutionFileFinder_RetryLogic_FailsAfterMaxAttempts()
+	public void DevServerMonitor_RetryLogic_FailsAfterMaxAttempts()
 	{
 		const int maxRetries = 3;
 		int retryCount = 0;
@@ -563,7 +563,7 @@ public class Given_DevServerMonitor
 
 
 	/// <summary>
-	/// Mirrors the arg-building logic in <see cref="SolutionFileFinder.StartProcess"/>
+	/// Mirrors the arg-building logic in DevServerMonitor.StartProcess
 	/// to verify that the direct launch path produces the expected arguments.
 	/// </summary>
 	private static List<string> BuildDirectLaunchArgs(int port, string? solution, string? addins = null)

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
@@ -220,7 +220,7 @@ public class Given_DevServerMonitor
 	// -------------------------------------------------------------------
 
 	[TestMethod]
-	[Description("DiscoveryInfo fields map to the values SolutionFileFinder exposes")]
+	[Description("DiscoveryInfo exposes the expected values when fully populated")]
 	public void DiscoveryInfo_WhenFullyPopulated_ExposesExpectedFields()
 	{
 		var discovery = new DiscoveryInfo

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_DevServerMonitor.cs
@@ -521,16 +521,34 @@ public class Given_DevServerMonitor
 
 	private static void RunGit(string workingDir, string args)
 	{
-		var psi = new System.Diagnostics.ProcessStartInfo("git", args)
+		System.Diagnostics.Process process;
+		try
 		{
-			WorkingDirectory = workingDir,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			UseShellExecute = false,
-			CreateNoWindow = true,
-		};
-		using var process = System.Diagnostics.Process.Start(psi)!;
-		process.WaitForExit(5000);
+			var psi = new System.Diagnostics.ProcessStartInfo("git", args)
+			{
+				WorkingDirectory = workingDir,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				UseShellExecute = false,
+				CreateNoWindow = true,
+			};
+			process = System.Diagnostics.Process.Start(psi)
+				?? throw new InvalidOperationException("Failed to start git process");
+		}
+		catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException)
+		{
+			Assert.Inconclusive($"git is not available: {ex.Message}");
+			return; // unreachable, but satisfies the compiler
+		}
+
+		using (process)
+		{
+			if (!process.WaitForExit(10000))
+			{
+				try { process.Kill(); } catch { /* best effort */ }
+				Assert.Inconclusive("git process timed out");
+			}
+		}
 	}
 
 	private static void ForceDeleteDirectory(string path)

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
 		<PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
 		<PackageReference Include="StreamJsonRpc" Version="2.17.11" />
-		<PackageReference Include="ModelContextProtocol" Version="0.8.0-preview.1" />
+		<PackageReference Include="ModelContextProtocol" Version="1.1.0" />
 		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.1.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -40,6 +40,7 @@
 		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\NuGetCacheHelper.cs" Link="Helpers\NuGetCacheHelper.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\ProjectAssetsParser.cs" Link="Helpers\ProjectAssetsParser.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\DiscoveryInfo.cs" Link="Helpers\DiscoveryInfo.cs" />
+		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\SolutionFileFinder.cs" Link="Helpers\SolutionFileFinder.cs" />
 
 		<!-- Link MCP sources for unit testing -->
 		<!-- TODO: MCP tests that only depend on CLI types should be migrated to Uno.UI.DevServer.Cli.Tests -->

--- a/src/Uno.UI.RemoteControl.Host/Mcp/HostHealthTool.cs
+++ b/src/Uno.UI.RemoteControl.Host/Mcp/HostHealthTool.cs
@@ -59,12 +59,28 @@ internal sealed class HostHealthTool
 		PropertyNameCaseInsensitive = true,
 	};
 
+	private static string GetAssemblyVersion()
+	{
+		var version = VersionHelper.GetVersion(typeof(HostHealthTool).Assembly);
+
+		// Strip the commit hash after '+' (e.g. "5.5.100-dev.1+abc123" → "5.5.100-dev.1")
+		var plusIndex = version.IndexOf('+');
+		return plusIndex >= 0 ? version[..plusIndex] : version;
+	}
+
 	/// <summary>
 	/// Registers the Host-level MCP health tool and resource on the given service collection.
 	/// </summary>
 	internal static void Configure(IServiceCollection services)
 	{
-		services.AddMcpServer()
+		services.AddMcpServer(options =>
+			{
+				options.ServerInfo = new Implementation
+				{
+					Name = "Uno Server",
+					Version = GetAssemblyVersion(),
+				};
+			})
 			.WithTools<HostHealthTool>()
 			.WithListResourcesHandler((ctx, ct) =>
 			{

--- a/src/Uno.UI.RemoteControl.Host/Program.Command.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.Command.cs
@@ -127,7 +127,14 @@ partial class Program
 			var ready = await WaitForDevServerReadyAsync(httpPort, timeoutMs);
 			if (!ready)
 			{
-				await Console.Error.WriteLineAsync($"DevServer did not become ready within {timeoutMs}ms");
+				if (process.HasExited)
+				{
+					await Console.Error.WriteLineAsync($"DevServer process died (exit code {process.ExitCode}) before becoming ready");
+				}
+				else
+				{
+					await Console.Error.WriteLineAsync($"DevServer did not become ready within {timeoutMs}ms");
+				}
 
 				await TerminateProcessAsync(process);
 				await DrainProcessOutputAsync(outputTask, errorTask);

--- a/src/Uno.UI.RemoteControl.Host/Program.Command.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.Command.cs
@@ -274,8 +274,10 @@ partial class Program
 
 		foreach (var s in servers)
 		{
-			await Console.Out.WriteLineAsync($"Process ID: {s.ProcessId}");
-			await Console.Out.WriteLineAsync($"  Parent PID: {s.ParentProcessId}");
+			var processName = TryGetProcessName(s.ProcessId);
+			var parentName = TryGetProcessName(s.ParentProcessId);
+			await Console.Out.WriteLineAsync($"Process ID: {s.ProcessId}{(processName is not null ? $" ({processName})" : "")}");
+			await Console.Out.WriteLineAsync($"  Parent PID: {s.ParentProcessId}{(parentName is not null ? $" ({parentName})" : "")}");
 			await Console.Out.WriteLineAsync($"  Port: {s.Port}");
 			await Console.Out.WriteLineAsync($"  Solution: {s.SolutionPath ?? "N/A"}");
 			await Console.Out.WriteLineAsync($"  Machine: {s.MachineName}");
@@ -356,6 +358,19 @@ partial class Program
 		}
 
 		return false;
+	}
+
+	private static string? TryGetProcessName(int pid)
+	{
+		try
+		{
+			using var process = Process.GetProcessById(pid);
+			return process.HasExited ? null : process.ProcessName;
+		}
+		catch
+		{
+			return null;
+		}
 	}
 
 	private static int EnsureTcpPort()

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -13,8 +13,8 @@
 	<Import Project="../targetframework-override-noplatform.props" />
 
 	<ItemGroup>
-		<PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.4" />
-		<PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.4" />
+		<PackageReference Include="ModelContextProtocol" Version="1.1.0" />
+		<PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
 		<PackageReference Include="Mono.Options" Version="6.6.0.161" />
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="System.Reactive" Version="6.0.0" />


### PR DESCRIPTION
## Summary

Addresses multiple issues affecting the MCP bridge experience for AI agents (Claude Code, Copilot, Cursor, Codex, etc.).

### Roots & solution discovery

- Defer DevServer startup until MCP client roots are received instead of starting immediately from `cwd`. This eliminates the need for `--solution-dir` when the client supports roots.
- Agents without roots support (Claude Desktop, Windsurf, Codex CLI) still work via `--force-roots-fallback` or `cwd` fallback — triggered at the right time now instead of racing with the handshake.
- Solution search is now recursive (up to 3 levels deep), so solutions in `src/MyApp.slnx` are found when the root is the repo.
- When no solution is found, `uno_health` reports a clear `NoSolutionFound` issue with remediation guidance. The monitor keeps polling so tools appear automatically once a project is created.

### `.gitignore`-aware directory filtering

- Recursive search uses `git check-ignore` to skip directories ignored by `.gitignore` (including nested `.gitignore` files in subdirectories).
- Two-layer strategy: hardcoded skip list (`node_modules`, `bin`, `obj`, `.vs`, `.idea`, `packages`) is **always** applied, `.gitignore` rules are layered on top when available.
- Graceful degradation: works without git installed, outside a git repo, with corrupted `.git`, or if git hangs (2s timeout + kill). Every scenario falls back to the hardcoded skip list.

### Startup reliability

- Readiness probe accelerated: 200ms intervals for the first 10 attempts (was 1s from the start), then 1s, up to 40 attempts total.
- Tool list timeout increased from 30s to 60s for first-time startup without cache.

### MCP SDK upgrade

- Both CLI (`Uno.UI.DevServer.Cli`) and Host (`Uno.UI.RemoteControl.Host`) upgraded from preview (0.8.0-preview.1 / 0.3.0-preview.4) to stable 1.1.0.
- Benefits: max reconnection attempts 2→5, fixed HTTP timeout issues, fixed stderr event loss.

### Host MCP version

- `ServerInfo` now reports the actual `InformationalVersion` (stripped after `+`) instead of `255.255.255.255` (the `FileVersion` default).
- Server name changed to `"Uno Server"`.

### `devserver list` & `disco` alignment

- `list` now resolves and displays process names next to PIDs (e.g., `1234 (dotnet)`).
- Both `list` and `disco` now show **all** active servers with a `[local]` / `[other]` indicator based on whether the server's solution is under the current working directory.
- Solution paths are displayed for each server so it's clear which project each server belongs to.

## Test plan

- [ ] `dotnet test` on `Uno.UI.RemoteControl.DevServer.Tests` (236 tests pass)
- [ ] Launch `uno.devserver --mcp-app` from a repo root without `--solution-dir` — verify it finds the solution via roots
- [ ] Launch from an empty directory — verify `uno_health` reports `NoSolutionFound`, then create a project and confirm auto-recovery
- [ ] `uno.devserver devserver list` — verify process names and solution paths are displayed
- [ ] `uno.devserver devserver disco` — verify `[local]`/`[other]` markers match expectations