### PR TITLE
fix(webview2): add explicit dispose teardown

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -46,7 +46,7 @@ internal class Win32NativeWebViewProvider(CoreWebView2 owner) : INativeWebViewPr
 	}
 }
 
-internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHostMapping, ISupportsWebResourceRequested
+internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHostMapping, ISupportsWebResourceRequested, IDisposable
 {
 	private const string WindowClassName = "UnoPlatformWebViewWindow";
 	private const uint SC_MASK = 0xFFF0; // Mask to extract system command from wParam
@@ -69,6 +69,14 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 	private Dictionary<ulong, string> _navigationIdToUriMap = new();
 	private string _documentTitle = string.Empty;
 	private readonly NativeWebView.CoreWebView2Controller _controller;
+	private readonly EventHandler<NativeWebView.CoreWebView2NavigationCompletedEventArgs> _navigationCompletedHandler;
+	private readonly EventHandler<NativeWebView.CoreWebView2NewWindowRequestedEventArgs> _newWindowRequestedHandler;
+	private readonly EventHandler<NativeWebView.CoreWebView2SourceChangedEventArgs> _sourceChangedHandler;
+	private readonly EventHandler<NativeWebView.CoreWebView2WebMessageReceivedEventArgs> _webMessageReceivedHandler;
+	private readonly EventHandler<NativeWebView.CoreWebView2NavigationStartingEventArgs> _navigationStartingHandler;
+	private readonly EventHandler<object> _historyChangedHandler;
+	private readonly EventHandler<object> _documentTitleChangedHandler;
+	private int _disposeState;
 
 	private HWND ParentHwnd => (_presenter.XamlRoot?.HostWindow?.NativeWindow as Win32NativeWindow)?.Hwnd is IntPtr hwnd ? (HWND)hwnd : HWND.Null;
 
@@ -176,13 +184,21 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 		// This dance with weak refs is necessary because there seems like _nativeWebView when it has a ref back
 		// to this.
-		_nativeWebView.NavigationCompleted += EventHandlerBuilder<NativeWebView.CoreWebView2NavigationCompletedEventArgs>(static (@this, o, a) => @this.NativeWebView_NavigationCompleted(o, a));
-		_nativeWebView.NewWindowRequested += EventHandlerBuilder<NativeWebView.CoreWebView2NewWindowRequestedEventArgs>(static (@this, o, a) => @this.NativeWebView_NewWindowRequested(o, a));
-		_nativeWebView.SourceChanged += EventHandlerBuilder<NativeWebView.CoreWebView2SourceChangedEventArgs>(static (@this, o, a) => @this.NativeWebView_SourceChanged(o, a));
-		_nativeWebView.WebMessageReceived += EventHandlerBuilder<NativeWebView.CoreWebView2WebMessageReceivedEventArgs>(static (@this, o, a) => @this.NativeWebView_WebMessageReceived(o, a));
-		_nativeWebView.NavigationStarting += EventHandlerBuilder<NativeWebView.CoreWebView2NavigationStartingEventArgs>(static (@this, o, a) => @this.NativeWebView_NavigationStarting(o, a));
-		_nativeWebView.HistoryChanged += EventHandlerBuilder<object>(static (@this, o, a) => @this.CoreWebView2_HistoryChanged(o, a));
-		_nativeWebView.DocumentTitleChanged += EventHandlerBuilder<object>(static (@this, o, a) => @this.OnNativeTitleChanged(o, a));
+		_navigationCompletedHandler = EventHandlerBuilder<NativeWebView.CoreWebView2NavigationCompletedEventArgs>(static (@this, o, a) => @this.NativeWebView_NavigationCompleted(o, a));
+		_newWindowRequestedHandler = EventHandlerBuilder<NativeWebView.CoreWebView2NewWindowRequestedEventArgs>(static (@this, o, a) => @this.NativeWebView_NewWindowRequested(o, a));
+		_sourceChangedHandler = EventHandlerBuilder<NativeWebView.CoreWebView2SourceChangedEventArgs>(static (@this, o, a) => @this.NativeWebView_SourceChanged(o, a));
+		_webMessageReceivedHandler = EventHandlerBuilder<NativeWebView.CoreWebView2WebMessageReceivedEventArgs>(static (@this, o, a) => @this.NativeWebView_WebMessageReceived(o, a));
+		_navigationStartingHandler = EventHandlerBuilder<NativeWebView.CoreWebView2NavigationStartingEventArgs>(static (@this, o, a) => @this.NativeWebView_NavigationStarting(o, a));
+		_historyChangedHandler = EventHandlerBuilder<object>(static (@this, o, a) => @this.CoreWebView2_HistoryChanged(o, a));
+		_documentTitleChangedHandler = EventHandlerBuilder<object>(static (@this, o, a) => @this.OnNativeTitleChanged(o, a));
+
+		_nativeWebView.NavigationCompleted += _navigationCompletedHandler;
+		_nativeWebView.NewWindowRequested += _newWindowRequestedHandler;
+		_nativeWebView.SourceChanged += _sourceChangedHandler;
+		_nativeWebView.WebMessageReceived += _webMessageReceivedHandler;
+		_nativeWebView.NavigationStarting += _navigationStartingHandler;
+		_nativeWebView.HistoryChanged += _historyChangedHandler;
+		_nativeWebView.DocumentTitleChanged += _documentTitleChangedHandler;
 		_nativeWebView.WebResourceRequested += NativeWebView2_WebResourceRequested;
 		UpdateDocumentTitle();
 
@@ -208,21 +224,89 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		};
 	}
 
+	public void Dispose()
+	{
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
 	~Win32NativeWebView()
 	{
-		_presenter.DispatcherQueue.TryEnqueue(() =>
+		Dispose(disposing: false);
+	}
+
+	private void Dispose(bool disposing)
+	{
+		if (Interlocked.Exchange(ref _disposeState, 1) != 0)
 		{
+			return;
+		}
+
+		this.LogTrace()?.Trace($"Disposing child hwnd={_hwnd.Value} disposing={disposing} parent={ParentHwnd.Value}");
+
+		void Cleanup()
+		{
+			// All COM-bound WebView2 teardown must happen on the UI thread.
+			// This includes event unsubscription and controller close.
+			try
+			{
+				_nativeWebView.NavigationCompleted -= _navigationCompletedHandler;
+				_nativeWebView.NewWindowRequested -= _newWindowRequestedHandler;
+				_nativeWebView.SourceChanged -= _sourceChangedHandler;
+				_nativeWebView.WebMessageReceived -= _webMessageReceivedHandler;
+				_nativeWebView.NavigationStarting -= _navigationStartingHandler;
+				_nativeWebView.HistoryChanged -= _historyChangedHandler;
+				_nativeWebView.DocumentTitleChanged -= _documentTitleChangedHandler;
+				_nativeWebView.WebResourceRequested -= NativeWebView2_WebResourceRequested;
+			}
+			catch
+			{
+				// Ignore; object is shutting down.
+			}
+
+			try
+			{
+				_controller.Close();
+			}
+			catch
+			{
+				// Ignore; object is shutting down.
+			}
+
+			_ = PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_HIDE);
 			var success = PInvoke.DestroyWindow(_hwnd);
 			if (!success && this.Log().IsEnabled(LogLevel.Error))
 			{
 				this.Log().Error($"{nameof(PInvoke.DestroyWindow)} failed: {Win32Helper.GetErrorMessage()}");
+			}
+			else
+			{
+				this.LogTrace()?.Trace($"Destroyed child hwnd={_hwnd.Value} parent={ParentHwnd.Value}");
 			}
 
 			lock (_hwndToWebView)
 			{
 				_hwndToWebView.Remove(_hwnd);
 			}
-		});
+		}
+
+		var dispatcherQueue = _presenter.DispatcherQueue;
+
+		if (dispatcherQueue.HasThreadAccess)
+		{
+			Cleanup();
+			return;
+		}
+
+		if (dispatcherQueue.TryEnqueue(Cleanup))
+		{
+			return;
+		}
+
+		// During process shutdown the dispatcher queue can reject enqueues.
+		// Keep the hwnd mapping untouched here: removing it without destroying the HWND can route late window
+		// messages through the "missing map entry" path while the native window still exists.
+		this.LogTrace()?.Trace($"Dispatcher queue rejected cleanup enqueue for child hwnd={_hwnd.Value}; skipping late teardown.");
 	}
 
 	[UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
@@ -250,6 +334,11 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 	private LRESULT WndProcInner(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
 	{
+		if (Volatile.Read(ref _disposeState) != 0)
+		{
+			return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+		}
+
 		Debug.Assert(_hwnd == HWND.Null || hwnd == _hwnd); // the null check is for when this method gets called inside CreateWindow before setting _hwnd
 		LogVerboseWin32Trace(() => $"WndProc {GetTrackedWndProcMessageName(msg)} hwnd={hwnd.Value} presenterParent={ParentHwnd.Value} wParam={wParam.Value} lParam={lParam.Value}{TryGetWindowPosPayload(msg, lParam)} active={PInvoke.GetActiveWindow().Value} childRect={GetWindowRectSnapshot(hwnd)} parentRect={GetWindowRectSnapshot(ParentHwnd)}");
 
@@ -475,13 +564,25 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 	}
 
 	public Task<string?> ExecuteScriptAsync(string script, CancellationToken token)
-		=> _nativeWebView.ExecuteScriptAsync(script);
+		=> Volatile.Read(ref _disposeState) == 0
+			? _nativeWebView.ExecuteScriptAsync(script)
+			: Task.FromResult<string?>(null);
 
 	public void GoBack()
-		=> _nativeWebView.GoBack();
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.GoBack();
+		}
+	}
 
 	public void GoForward()
-		=> _nativeWebView.GoForward();
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.GoForward();
+		}
+	}
 
 	public Task<string?> InvokeScriptAsync(string script, string[]? arguments, CancellationToken token)
 	{
@@ -509,11 +610,29 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		return ExecuteScriptAsync(adjustedScript.ToString(), token);
 	}
 
-	public void ProcessNavigation(Uri uri) => _nativeWebView.Navigate(uri.ToString());
+	public void ProcessNavigation(Uri uri)
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.Navigate(uri.ToString());
+		}
+	}
 
-	public void ProcessNavigation(string html) => _nativeWebView.NavigateToString(html);
+	public void ProcessNavigation(string html)
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.NavigateToString(html);
+		}
+	}
 
-	public void ProcessNavigation(HttpRequestMessage httpRequestMessage) => ProcessNavigationCore(httpRequestMessage);
+	public void ProcessNavigation(HttpRequestMessage httpRequestMessage)
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			ProcessNavigationCore(httpRequestMessage);
+		}
+	}
 
 	private void ProcessNavigationCore(HttpRequestMessage httpRequestMessage)
 	{
@@ -533,24 +652,54 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 	}
 
 	public void Reload()
-		=> _nativeWebView.Reload();
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.Reload();
+		}
+	}
 
 	public void SetScrollingEnabled(bool isScrollingEnabled)
 	{
 	}
 
 	public void Stop()
-		=> _nativeWebView.Stop();
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.Stop();
+		}
+	}
 
 	public void ClearVirtualHostNameToFolderMapping(string hostName)
-		=> _nativeWebView.ClearVirtualHostNameToFolderMapping(hostName);
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.ClearVirtualHostNameToFolderMapping(hostName);
+		}
+	}
 
 	public void SetVirtualHostNameToFolderMapping(string hostName, string folderPath, CoreWebView2HostResourceAccessKind accessKind)
-		=> _nativeWebView.SetVirtualHostNameToFolderMapping(hostName, folderPath, (NativeWebView.CoreWebView2HostResourceAccessKind)accessKind);
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.SetVirtualHostNameToFolderMapping(hostName, folderPath, (NativeWebView.CoreWebView2HostResourceAccessKind)accessKind);
+		}
+	}
 
 	public void AddWebResourceRequestedFilter(string uri, CoreWebView2WebResourceContext resourceContext, CoreWebView2WebResourceRequestSourceKinds requestSourceKinds)
-		=> _nativeWebView.AddWebResourceRequestedFilter(uri, (NativeWebView.CoreWebView2WebResourceContext)resourceContext, (NativeWebView.CoreWebView2WebResourceRequestSourceKinds)requestSourceKinds);
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.AddWebResourceRequestedFilter(uri, (NativeWebView.CoreWebView2WebResourceContext)resourceContext, (NativeWebView.CoreWebView2WebResourceRequestSourceKinds)requestSourceKinds);
+		}
+	}
 
 	public void RemoveWebResourceRequestedFilter(string uri, CoreWebView2WebResourceContext resourceContext, CoreWebView2WebResourceRequestSourceKinds requestSourceKinds)
-		=> _nativeWebView.RemoveWebResourceRequestedFilter(uri, (NativeWebView.CoreWebView2WebResourceContext)resourceContext, (NativeWebView.CoreWebView2WebResourceRequestSourceKinds)requestSourceKinds);
+	{
+		if (Volatile.Read(ref _disposeState) == 0)
+		{
+			_nativeWebView.RemoveWebResourceRequestedFilter(uri, (NativeWebView.CoreWebView2WebResourceContext)resourceContext, (NativeWebView.CoreWebView2WebResourceRequestSourceKinds)requestSourceKinds);
+		}
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.SkiaWin32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.SkiaWin32.cs
@@ -146,6 +146,50 @@ public sealed class Given_WebView2_SkiaWin32
 	}
 
 	[TestMethod]
+	public async Task When_Disposed_Before_Load_Then_EnsureCoreWebView2Async_FailsFast()
+	{
+		var webView = new WebView2();
+		webView.Dispose();
+
+		await AssertEnsureCoreWebView2FailsFastAfterDisposeAsync(webView);
+	}
+
+	[TestMethod]
+	public async Task When_Disposed_After_Initialization_Then_EnsureCoreWebView2Async_RemainsTerminal()
+	{
+		const int loadTimeoutMs = 5000;
+		var initialRoot = new Grid();
+		var reloadedRoot = new Grid();
+		var webView = new WebView2();
+		initialRoot.Children.Add(webView);
+
+		try
+		{
+			TestServices.WindowHelper.WindowContent = initialRoot;
+			await TestServices.WindowHelper.WaitForLoaded(initialRoot, timeoutMS: loadTimeoutMs);
+			await TestServices.WindowHelper.WaitForLoaded(webView, timeoutMS: loadTimeoutMs);
+			await webView.EnsureCoreWebView2Async();
+
+			webView.Dispose();
+
+			TestServices.WindowHelper.WindowContent = null;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			reloadedRoot.Children.Add(webView);
+			TestServices.WindowHelper.WindowContent = reloadedRoot;
+			await TestServices.WindowHelper.WaitForLoaded(reloadedRoot, timeoutMS: loadTimeoutMs);
+			await TestServices.WindowHelper.WaitForLoaded(webView, timeoutMS: loadTimeoutMs);
+
+			await AssertEnsureCoreWebView2FailsFastAfterDisposeAsync(webView);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+			await TestServices.WindowHelper.WaitForIdle();
+		}
+	}
+
+	[TestMethod]
 	public void When_SuccessArtifacts_Are_Not_Explicitly_Enabled_Then_OutputRoot_Is_Null()
 	{
 		using var _ = new EnvironmentVariableScope("UNO_WEBVIEW2_RUNTIME_TEST_ARTIFACTS", null);
@@ -197,6 +241,22 @@ public sealed class Given_WebView2_SkiaWin32
 		}
 
 		Assert.Fail($"WebView2 content remained blank in phase '{phase}'. Last summary: {lastSummary}");
+	}
+
+	private static async Task AssertEnsureCoreWebView2FailsFastAfterDisposeAsync(WebView2 webView)
+	{
+		var ensureTask = webView.EnsureCoreWebView2Async().AsTask();
+		var completedTask = await Task.WhenAny(ensureTask, Task.Delay(TimeSpan.FromSeconds(5)));
+
+		Assert.AreSame(ensureTask, completedTask, "EnsureCoreWebView2Async() should fail quickly after disposal instead of hanging.");
+		try
+		{
+			await ensureTask;
+			Assert.Fail("EnsureCoreWebView2Async() should throw ObjectDisposedException after disposal.");
+		}
+		catch (ObjectDisposedException)
+		{
+		}
 	}
 
 	private static unsafe ScreenCaptureBuffer CaptureClientAreaPixels()

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
@@ -30,6 +30,7 @@ public partial class CoreWebView2
 	private readonly List<WebResourceRequestedFilter> _webResourceRequestedFilters = new();
 	internal long _navigationId;
 	private object? _processedSource;
+	private bool _isClosed;
 
 	internal CoreWebView2(IWebView owner)
 	{
@@ -139,6 +140,19 @@ public partial class CoreWebView2
 
 	public void Reload() => _nativeWebView?.Reload();
 
+	// Explicit teardown entrypoint used by WebView2.Dispose().
+	// Destruction is intentionally decoupled from visual-tree unload transitions.
+	internal void Close()
+	{
+		if (_isClosed)
+		{
+			return;
+		}
+
+		_isClosed = true;
+		ReleaseNativeWebView();
+	}
+
 	public IAsyncOperation<string?> ExecuteScriptAsync(string javaScript) =>
 		AsyncOperation.FromTask(ct =>
 		{
@@ -163,6 +177,12 @@ public partial class CoreWebView2
 	internal void OnOwnerApplyTemplate()
 	{
 		var nativeWebView = GetNativeWebViewFromTemplate();
+		if (_isClosed)
+		{
+			DisposeNativeWebView(nativeWebView);
+			return;
+		}
+
 		SetNativeWebView(nativeWebView);
 		if (_nativeWebView is not null)
 		{
@@ -294,13 +314,28 @@ public partial class CoreWebView2
 		WebResourceRequested?.Invoke(this, eventArgs);
 	}
 	private TaskCompletionSource<bool> _nativeWebViewInitializedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-	internal Task EnsureNativeWebViewAsync() => _nativeWebViewInitializedTcs.Task;
+	internal Task EnsureNativeWebViewAsync()
+	{
+		if (_isClosed)
+		{
+			MarkClosedForFutureEnsures();
+		}
+
+		return _nativeWebViewInitializedTcs.Task;
+	}
 	internal static bool GetIsHistoryEntryValid(string url) =>
 		!url.IsNullOrWhiteSpace() &&
 		!url.Equals(BlankUrl, StringComparison.OrdinalIgnoreCase);
 
 	private void SetNativeWebView(INativeWebView? nativeWebView)
 	{
+		if (_isClosed)
+		{
+			DisposeNativeWebView(nativeWebView);
+			MarkClosedForFutureEnsures();
+			return;
+		}
+
 		// Template re-application can happen many times during a page lifetime (reload, visual tree churn,
 		// style/template updates). This method is the single swap point for the platform-native view instance.
 		if (ReferenceEquals(_nativeWebView, nativeWebView))
@@ -346,6 +381,11 @@ public partial class CoreWebView2
 		DisposeNativeWebView(_nativeWebView);
 
 		_nativeWebView = null;
+		if (_isClosed)
+		{
+			MarkClosedForFutureEnsures();
+			return;
+		}
 
 		if (_nativeWebViewInitializedTcs.Task.IsCompleted)
 		{
@@ -366,6 +406,24 @@ public partial class CoreWebView2
 		{
 			disposable.Dispose();
 		}
+	}
+
+	private void MarkClosedForFutureEnsures()
+	{
+		if (!_nativeWebViewInitializedTcs.Task.IsCompleted)
+		{
+			_nativeWebViewInitializedTcs.TrySetException(new ObjectDisposedException(nameof(CoreWebView2)));
+		}
+
+		if (_nativeWebViewInitializedTcs.Task.IsFaulted &&
+			_nativeWebViewInitializedTcs.Task.Exception?.InnerException is ObjectDisposedException)
+		{
+			return;
+		}
+
+		var closedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		closedTcs.TrySetException(new ObjectDisposedException(nameof(CoreWebView2)));
+		_nativeWebViewInitializedTcs = closedTcs;
 	}
 
 	private void ApplyNativeWebViewState()

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView2/WebView2.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView2/WebView2.cs
@@ -15,10 +15,11 @@ namespace Microsoft.UI.Xaml.Controls;
 #if IS_UNIT_TESTS || __SKIA__ || __NETSTD_REFERENCE__
 [Uno.NotImplemented("IS_UNIT_TESTS", "__SKIA__", "__NETSTD_REFERENCE__")]
 #endif
-public partial class WebView2 : Control, IWebView
+public partial class WebView2 : Control, IWebView, IDisposable
 {
 	private bool _sourceChangeFromCore;
 	private bool _coreWebView2Initialized;
+	private bool _isDisposed;
 
 	/// <summary>
 	/// Initializes a new instance of the WebView2 class.
@@ -48,10 +49,23 @@ public partial class WebView2 : Control, IWebView
 
 	CoreDispatcher IWebView.Dispatcher => Dispatcher;
 
-	protected override void OnApplyTemplate() => CoreWebView2.OnOwnerApplyTemplate();
+	protected override void OnApplyTemplate()
+	{
+		if (_isDisposed)
+		{
+			return;
+		}
+
+		CoreWebView2.OnOwnerApplyTemplate();
+	}
 
 	private void WebView2_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
 	{
+		if (_isDisposed)
+		{
+			return;
+		}
+
 		if (!_coreWebView2Initialized)
 		{
 			EnsureCoreWebView2();
@@ -69,6 +83,11 @@ public partial class WebView2 : Control, IWebView
 	public IAsyncAction EnsureCoreWebView2Async() =>
 		AsyncAction.FromTask(async ct =>
 		{
+			if (_isDisposed)
+			{
+				throw new ObjectDisposedException(nameof(WebView2));
+			}
+
 			if (!_coreWebView2Initialized)
 			{
 				EnsureCoreWebView2();
@@ -88,8 +107,27 @@ public partial class WebView2 : Control, IWebView
 
 	public void NavigateToString(string htmlContent) => CoreWebView2.NavigateToString(htmlContent);
 
+	// FrameworkElement already exposes a non-virtual Dispose(), so WebView2 intentionally hides it
+	// to provide meaningful WebView2 cleanup semantics.
+	// Loaded/Unloaded only drives visual hosting (show/hide), not resource destruction.
+	public new void Dispose()
+	{
+		if (_isDisposed)
+		{
+			return;
+		}
+
+		_isDisposed = true;
+		CoreWebView2.Close();
+	}
+
 	private void EnsureCoreWebView2()
 	{
+		if (_isDisposed)
+		{
+			return;
+		}
+
 		if (!_coreWebView2Initialized)
 		{
 			CoreWebView2Initialized?.Invoke(this, new());


### PR DESCRIPTION
## Summary\n- add explicit WebView2/Win32 native teardown via IDisposable-related changes\n- close and dispose native WebView instances after explicit disposal\n- add runtime coverage for EnsureCoreWebView2Async after disposal\n\n## Stack\n- base PR: #22735\n\n## Validation\n- not run in PR creation step