### PR TITLE
fix: prevent Tab key from inserting character in TextBox on Skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5717,6 +5717,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		#endregion
 
+		[TestMethod]
+		public async Task When_Tab_Pressed_Should_Not_Insert_Character()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+			var button = new Button { Content = "Next" };
+			var panel = new StackPanel
+			{
+				Children = { SUT, button }
+			};
+
+			WindowHelper.WindowContent = panel;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			// Simulate Tab key press with unicode '\t' (as macOS/FrameBuffer/Android backends do)
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Tab, VirtualKeyModifiers.None, unicodeKey: '\t'));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(string.Empty, SUT.Text, "Tab should not insert a character in TextBox");
+			Assert.IsFalse(SUT.Text.Contains('\t'), "TextBox.Text should not contain a tab character");
+		}
+
 		private class TextBoxFeatureConfigDisposable : IDisposable
 		{
 			private bool _useOverlay;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5743,6 +5743,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual(string.Empty, SUT.Text, "Tab should not insert a character in TextBox");
 			Assert.IsFalse(SUT.Text.Contains('\t'), "TextBox.Text should not contain a tab character");
+
+			// Ensure that Tab key still moves focus to the next control
+			var focusedElement = FocusManager.GetFocusedElement(SUT.XamlRoot) as Control;
+			Assert.AreEqual(button, focusedElement, "Tab should move focus to the next control (button)");
 		}
 
 		private class TextBoxFeatureConfigDisposable : IDisposable

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5718,6 +5718,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		#endregion
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22818")]
 		public async Task When_Tab_Pressed_Should_Not_Insert_Character()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -5742,7 +5743,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(string.Empty, SUT.Text, "Tab should not insert a character in TextBox");
-			Assert.IsFalse(SUT.Text.Contains('\t'), "TextBox.Text should not contain a tab character");
 
 			// Ensure that Tab key still moves focus to the next control
 			var focusedElement = FocusManager.GetFocusedElement(SUT.XamlRoot) as Control;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -8170,6 +8170,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		#endregion
 
+		[TestMethod]
+		public async Task When_Tab_Pressed_Should_Not_Insert_Character()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+			var button = new Button { Content = "Next" };
+			var panel = new StackPanel
+			{
+				Children = { SUT, button }
+			};
+
+			WindowHelper.WindowContent = panel;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			// Simulate Tab key press with unicode '\t' (as macOS/FrameBuffer/Android backends do)
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Tab, VirtualKeyModifiers.None, unicodeKey: '\t'));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(string.Empty, SUT.Text, "Tab should not insert a character in TextBox");
+			Assert.IsFalse(SUT.Text.Contains('\t'), "TextBox.Text should not contain a tab character");
+		}
+
 		private class TextBoxFeatureConfigDisposable : IDisposable
 		{
 			private bool _hideCaret;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -8196,6 +8196,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual(string.Empty, SUT.Text, "Tab should not insert a character in TextBox");
 			Assert.IsFalse(SUT.Text.Contains('\t'), "TextBox.Text should not contain a tab character");
+
+			// Ensure that Tab key still moves focus to the next control
+			var focusedElement = FocusManager.GetFocusedElement(SUT.XamlRoot) as Control;
+			Assert.AreEqual(button, focusedElement, "Tab should move focus to the next control (button)");
 		}
 
 		private class TextBoxFeatureConfigDisposable : IDisposable

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -8171,6 +8171,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		#endregion
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22818")]
 		public async Task When_Tab_Pressed_Should_Not_Insert_Character()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -8195,7 +8196,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(string.Empty, SUT.Text, "Tab should not insert a character in TextBox");
-			Assert.IsFalse(SUT.Text.Contains('\t'), "TextBox.Text should not contain a tab character");
 
 			// Ensure that Tab key still moves focus to the next control
 			var focusedElement = FocusManager.GetFocusedElement(SUT.XamlRoot) as Control;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1048,6 +1048,10 @@ public partial class TextBox : ITextSelectionGripperHost
 					selectionLength = text.Length;
 				}
 				break;
+			case VirtualKey.Tab:
+				// Tab is handled by UnoFocusInputHandler for focus navigation.
+				// Never insert a tab character in TextBox (no AcceptsTab property).
+				return;
 			default:
 				// During IME composition, skip normal character insertion.
 				// The IME extension handles text updates via OnImeCompositionUpdated → ProcessTextInput.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBoxCore/TextBoxCore.Input.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBoxCore/TextBoxCore.Input.cs
@@ -1016,6 +1016,10 @@ internal sealed partial class TextBoxCore : ITextSelectionGripperHost
 					selectionLength = text.Length;
 				}
 				break;
+			case VirtualKey.Tab:
+				// Tab is handled by UnoFocusInputHandler for focus navigation.
+				// Never insert a tab character in TextBox (no AcceptsTab property).
+				return;
 			default:
 				// During IME composition, skip normal character insertion.
 				// The IME extension handles text updates via OnImeCompositionUpdated → ProcessTextInput.


### PR DESCRIPTION
## Summary

Fixes #22818

On several Skia backends (macOS, FrameBuffer/Linux, Android), pressing **Tab** in a `TextBox` inserts a `\t` character into the text in addition to moving focus. The expected WinUI behavior is that Tab should **only** move focus and never insert a character — `TextBox` has no `AcceptsTab` property (only `RichEditBox` does).

### Root cause

In `TextBox.OnKeyDownSkia()`, there was no explicit `case VirtualKey.Tab:` in the second switch statement (text input/movement). When a backend passes the tab unicode character (`0x09`) through `KeyRoutedEventArgs.UnicodeKey`, the unhandled key fell into the `default` case which inserts any non-null `UnicodeKey` as text. Focus navigation happens later in `UnoFocusInputHandler` (on the root element's KeyDown), but by then the tab character was already inserted.

**Affected backends:** macOS, FrameBuffer (Linux), Android — all pass unicode `0x09` for Tab.
**Unaffected backends:** Win32, WPF, X11, and WebAssembly already filter it out at the platform layer.

### WinUI comparison

WinUI blocks Tab insertion through multiple layers:
1. Windows doesn't generate `WM_CHAR` for Tab, so no character input event exists
2. `KeyboardInputProcessor` triggers `UIElement_TabProcessing` for focus navigation before `CharacterReceived` fires
3. RichEdit single-line mode ignores Tab

In Uno/Skia, layer 1 is inconsistent across backends, layer 2 (`UnoFocusInputHandler`) runs after TextBox processes the key, and there's no RichEdit layer. This fix mirrors WinUI's intent by preventing Tab from reaching character insertion.

### Fix

Added `case VirtualKey.Tab:` with a `return;` before the `default` case in `TextBox.skia.cs`:

- **Tab does NOT insert a character** — we skip the default case entirely
- **The event is NOT marked as `Handled`** — we use `return` (not `break`), so the event bubbles up
- **Focus navigation still works** — `UnoFocusInputHandler.OnKeyDown()` handles Tab for focus navigation as before

Using `return` (not `break`) is important because `break` would fall through to `ProcessTextInput(text)`, whereas `return` exits the method immediately.

## Changes

- `src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs` — Add `case VirtualKey.Tab: return;` before the default case
- `src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs` — Add runtime test `When_Tab_Pressed_Should_Not_Insert_Character`

## Test plan

- [x] Compile validation: `Uno.UI.Skia.csproj` and `Uno.UI.RuntimeTests.Skia.csproj` build with 0 errors
- [ ] Runtime test: `When_Tab_Pressed_Should_Not_Insert_Character` — creates a TextBox, simulates Tab with unicode `\t`, asserts no tab character is inserted
- [ ] Manual: Open SamplesApp on macOS/Linux, focus a TextBox, press Tab — verify no `\t` character appears and focus moves to the next control

🤖 Generated with [Claude Code](https://claude.com/claude-code)