### PR TITLE
Dev/xygu/20260305/clipboard

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/ClipboardTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/ClipboardTests.xaml
@@ -1,29 +1,55 @@
-﻿<Page
-    x:Class="UITests.Windows_ApplicationModel.ClipboardTests"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:UITests.Windows_ApplicationModel"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    mc:Ignorable="d">
+﻿<Page x:Class="UITests.Windows_ApplicationModel.ClipboardTests"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:UITests.Windows_ApplicationModel"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	  mc:Ignorable="d">
 
-    <StackPanel Padding="12" Spacing="8">
-        <TextBox Text="{x:Bind Model.Text, Mode=TwoWay}" AcceptsReturn="True" />
-        <Button Command="{x:Bind Model.CopyCommand}">Copy to clipboard</Button>
-        <Button Command="{x:Bind Model.CopyHtmlCommand}">Copy HTML to clipboard</Button>
-        <Button Command="{x:Bind Model.CopyImageCommand}">Copy sample image to clipboard</Button>
-        <Button Command="{x:Bind Model.PasteTextCommand}">Paste text from clipboard</Button>
-        <Button Command="{x:Bind Model.PasteHtmlCommand}">Paste HTML from clipboard</Button>
-        <Button Command="{x:Bind Model.PasteStorageItemsCommand}">Paste files from clipboard</Button>
-        <Button Command="{x:Bind Model.PasteImageCommand}">Paste image from clipboard</Button>
-        <Button Command="{x:Bind Model.ClearCommand}">Clear clipboard</Button>
-        <Button Command="{x:Bind Model.FlushCommand}">Flush clipboard</Button>
-        <ToggleButton Command="{x:Bind Model.ToggleContentChangedCommand}" IsChecked="{x:Bind Model.IsObservingContentChanged, Mode=OneWay}">Observe ContentChanged</ToggleButton>
-        <TextBlock>
-            <Run FontWeight="Bold">Last content change:</Run>
-            <Run Text="{x:Bind Model.LastContentChangedDate, Mode=OneWay}" />
-        </TextBlock>
-        <Image Source="{x:Bind Model.Bitmap, Mode=OneWay}" x:Name="image" />
-    </StackPanel>
+	<ScrollView HorizontalScrollMode="Disabled" VerticalScrollMode="Auto">
+		<StackPanel Padding="12" Spacing="20">
+			<TextBox Text="{x:Bind Model.Text, Mode=TwoWay}" AcceptsReturn="True" />
+
+			<!-- Copying -->
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<TextBlock Text="Copy to clipboard:" />
+				<Button Command="{x:Bind Model.CopyCommand}">Text</Button>
+				<Button Command="{x:Bind Model.CopyHtmlCommand}">HTML</Button>
+				<Button Command="{x:Bind Model.CopyImageCommand}">Sample image</Button>
+			</StackPanel>
+
+			<!-- Pasting -->
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<TextBlock Text="Paste from clipboard:" />
+				<Button Command="{x:Bind Model.PasteTextCommand}">Text</Button>
+				<Button Command="{x:Bind Model.PasteHtmlCommand}">HTML</Button>
+				<Button Command="{x:Bind Model.PasteStorageItemsCommand}">Files</Button>
+				<Button Command="{x:Bind Model.PasteImageCommand}">Image</Button>
+			</StackPanel>
+
+			<!-- Utils -->
+			<StackPanel Spacing="8">
+				<Button Command="{x:Bind Model.ListAvailableFormatsCommand}">List AvailableFormats</Button>
+				<Button Command="{x:Bind Model.ClearCommand}">Clear clipboard</Button>
+				<Button Command="{x:Bind Model.FlushCommand}">Flush clipboard</Button>
+				<ToggleButton Command="{x:Bind Model.ToggleContentChangedCommand}" IsChecked="{x:Bind Model.IsObservingContentChanged, Mode=OneWay}">Observe ContentChanged</ToggleButton>
+			</StackPanel>
+
+			<!-- Output -->
+			<StackPanel Spacing="8">
+				<TextBlock Text="Last observed change:" FontWeight="Bold" />
+				<TextBlock Text="{x:Bind Model.LastContentChangedDate, Mode=OneWay}" />
+
+				<TextBlock Text="Status:" FontWeight="Bold" />
+				<TextBlock Text="{x:Bind Model.StatusText, Mode=OneWay}" />
+
+				<TextBlock Text="Pasted Content:" FontWeight="Bold" />
+				<TextBlock Text="{x:Bind Model.PastedContent, Mode=OneWay}" />
+				<Image x:Name="image" Source="{x:Bind Model.Bitmap, Mode=OneWay}" />
+			</StackPanel>
+
+		</StackPanel>
+
+	</ScrollView>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/ClipboardTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/ClipboardTests.xaml.cs
@@ -47,6 +47,8 @@ namespace UITests.Windows_ApplicationModel
 		private bool _isObservingContentChanged = false;
 		private string _lastContentChangedDate = "";
 		private string _text = "";
+		private string _statusText = "";
+		private string _pastedContent = "";
 		private BitmapSource _bmp;
 
 		public ClipboardTestsViewModel(Private.Infrastructure.UnitTestDispatcherCompat dispatcher) : base(dispatcher)
@@ -90,6 +92,26 @@ namespace UITests.Windows_ApplicationModel
 			}
 		}
 
+		public string StatusText
+		{
+			get => _statusText;
+			set
+			{
+				_statusText = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string PastedContent
+		{
+			get => _pastedContent;
+			set
+			{
+				_pastedContent = value;
+				RaisePropertyChanged();
+			}
+		}
+
 		public BitmapSource Bitmap
 		{
 			get => _bmp;
@@ -100,8 +122,7 @@ namespace UITests.Windows_ApplicationModel
 			}
 		}
 
-		public ICommand ClearCommand => GetOrCreateCommand(Clear);
-
+		#region ICommands
 		public ICommand CopyCommand => GetOrCreateCommand(Copy);
 
 		public ICommand CopyHtmlCommand => GetOrCreateCommand(CopyHtml);
@@ -112,15 +133,18 @@ namespace UITests.Windows_ApplicationModel
 
 		public ICommand PasteHtmlCommand => GetOrCreateCommand(PasteHtml);
 
+		public ICommand PasteStorageItemsCommand => GetOrCreateCommand(PasteStorageItems);
+
 		public ICommand PasteImageCommand => GetOrCreateCommand(PasteImage);
 
-		public ICommand PasteStorageItemsCommand => GetOrCreateCommand(PasteStorageItems);
+		public ICommand ListAvailableFormatsCommand => GetOrCreateCommand(ListAvailableFormats);
+
+		public ICommand ClearCommand => GetOrCreateCommand(Clear);
 
 		public ICommand FlushCommand => GetOrCreateCommand(Flush);
 
 		public ICommand ToggleContentChangedCommand => GetOrCreateCommand(ToggleContentChange);
-
-		private void Clear() => Clipboard.Clear();
+		#endregion
 
 		private void Copy()
 		{
@@ -141,27 +165,106 @@ namespace UITests.Windows_ApplicationModel
 			Clipboard.SetContent(dataPackage);
 		}
 
+		private async void CopyImage()
+		{
+			var dataPackage = new DataPackage();
+			var imageUri = OperatingSystem.IsBrowser()
+				// for browser, the primary supported format is image/png
+				? new Uri("ms-appx:///Assets/Formats/uno-overalls.png")
+				: new Uri("ms-appx:///Assets/Formats/uno-overalls.bmp");
+			var imageFile = await StorageFile.GetFileFromApplicationUriAsync(imageUri);
+			dataPackage.SetBitmap(RandomAccessStreamReference.CreateFromFile(imageFile));
+			Clipboard.SetContent(dataPackage);
+		}
+
 		private async void PasteText()
 		{
-			var content = Clipboard.GetContent();
-			Text = await content.GetTextAsync();
+			var package = Clipboard.GetContent();
+			UpdateStatusAndClearOldContents(package);
+
+			PastedContent = await package.GetTextAsync();
 		}
 
 		private async void PasteHtml()
 		{
-			var content = Clipboard.GetContent();
-			if (content.Contains(StandardDataFormats.Html))
+			var package = Clipboard.GetContent();
+			UpdateStatusAndClearOldContents(package);
+
+			if (package.Contains(StandardDataFormats.Html))
 			{
-				var html = await content.GetHtmlFormatAsync();
+				var html = await package.GetHtmlFormatAsync();
 				// Truncate long HTML for better display
 				var displayHtml = html.Length > 200 ? html[..200] + "..." : html;
-				Text = $"HTML: {displayHtml}";
+
+				PastedContent = $"HTML: {displayHtml}";
 			}
 			else
 			{
-				Text = "No HTML content in clipboard";
+				PastedContent = "No HTML content in clipboard";
 			}
 		}
+
+		private async void PasteStorageItems()
+		{
+			var package = Clipboard.GetContent();
+			UpdateStatusAndClearOldContents(package);
+
+			if (package.Contains(StandardDataFormats.StorageItems))
+			{
+				PastedContent = string.Join("\n", (await package.GetStorageItemsAsync()).Select(si => si.Path));
+			}
+			else
+			{
+				PastedContent = "No StorageItems content in clipboard";
+			}
+		}
+
+		private async void PasteImage()
+		{
+			var package = Clipboard.GetContent();
+			UpdateStatusAndClearOldContents(package);
+
+			var formats = new[]
+			{
+				"image/png",
+				"image/jpeg"
+			};
+
+			foreach (var format in formats)
+			{
+				if (package.Contains(format))
+				{
+					if (await package.GetDataAsync(format) is byte[] bytes)
+					{
+						var fileName = Path.GetTempPath() + Guid.NewGuid() + "." + format.Split("/")[1];
+						await File.WriteAllBytesAsync(fileName, bytes);
+						var bitmapImage = new BitmapImage(new Uri(fileName));
+						Bitmap = bitmapImage;
+
+						return;
+					}
+				}
+			}
+
+			if (Bitmap is null && package.Contains(StandardDataFormats.Bitmap))
+			{
+				var bitmapReference = await package.GetBitmapAsync();
+				var bitmapStream = await bitmapReference.OpenReadAsync();
+
+				var bitmapImage = new BitmapImage();
+				bitmapImage.SetSource(bitmapStream);
+
+				Bitmap = bitmapImage;
+			}
+		}
+
+		private void ListAvailableFormats()
+		{
+			var package = Clipboard.GetContent();
+			UpdateStatusAndClearOldContents(package);
+		}
+
+		private void Clear() => Clipboard.Clear();
 
 		private void Flush() => Clipboard.Flush();
 
@@ -178,69 +281,15 @@ namespace UITests.Windows_ApplicationModel
 			}
 		}
 
-		private void Clipboard_ContentChanged(object sender, object e)
+		private void Clipboard_ContentChanged(object sender, object e) => LastContentChangedDate = Timestamp;
+
+		private void UpdateStatusAndClearOldContents(DataPackageView package)
 		{
-			LastContentChangedDate = DateTime.UtcNow.ToLongTimeString();
+			StatusText = $"{Timestamp} available formats: {string.Join(", ", package.AvailableFormats)}";
+			PastedContent = null;
+			Bitmap = null;
 		}
 
-		private async void PasteImage()
-		{
-			var dataPackageView = Clipboard.GetContent();
-
-			if (dataPackageView is null)
-			{
-				return;
-			}
-
-			var formats = new[]
-			{
-				"image/png",
-				"image/jpeg"
-			};
-
-			foreach (var format in formats)
-			{
-				if (dataPackageView.Contains(format))
-				{
-					if (await dataPackageView.GetDataAsync("image/png") is byte[] bytes)
-					{
-						var fileName = Path.GetTempPath() + Guid.NewGuid() + "." + format.Split("/")[1];
-						await File.WriteAllBytesAsync(fileName, bytes);
-						var bitmapImage = new BitmapImage(new Uri(fileName));
-						Bitmap = bitmapImage;
-					}
-				}
-			}
-
-			if (Bitmap is null && dataPackageView.Contains(StandardDataFormats.Bitmap))
-			{
-				var bitmapReference = await dataPackageView.GetBitmapAsync();
-				var bitmapImage = new BitmapImage();
-				bitmapImage.SetSource(await bitmapReference.OpenReadAsync());
-				Bitmap = bitmapImage;
-			}
-		}
-
-		private void CopyImage()
-		{
-			var dataPackage = new DataPackage();
-			dataPackage.SetBitmap(RandomAccessStreamReference.CreateFromUri(new Uri("ms-appx:///Assets/Formats/uno-overalls.bmp")));
-			Clipboard.SetContent(dataPackage);
-		}
-
-		private async void PasteStorageItems()
-		{
-			var dataPackageView = Clipboard.GetContent();
-
-			if (dataPackageView is null)
-			{
-				return;
-			}
-
-			if (dataPackageView.Contains(StandardDataFormats.StorageItems))
-			{
-				Text = string.Join("\n", (await dataPackageView.GetStorageItemsAsync()).Select(si => si.Path));
-			}
-		}
+		private static string Timestamp => DateTime.Now.ToString("HH\\:mm\\:ss");
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
@@ -21,15 +21,18 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using SkiaSharp;
 using Uno.ApplicationModel.DataTransfer;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
 using Windows.Storage;
 using Windows.Storage.Streams;
 using Windows.Win32;
@@ -47,25 +50,31 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 {
 	public static Win32ClipboardExtension Instance { get; } = new();
 
-	private static readonly Dictionary<string, Func<nint, string?>> _knownTextBasedClipboardFormats = new()
+
+	private static readonly Dictionary<string, (PointerToString FromPointer, StringToPointer ToPointer)> _knownTextBasedClipboardFormats = new()
 	{
-		["HTML Format"] = Marshal.PtrToStringUTF8, // HTML fragment with header metadata
-		["Rich Text Format"] = Marshal.PtrToStringAnsi, // RTF document
-		["Rich Text Format Without Objects"] = Marshal.PtrToStringAnsi, // RTF without embedded objects
-		["Rich Text & Unicode"] = Marshal.PtrToStringUni, // RTF with Unicode support
-		["XML Spreadsheet"] = Marshal.PtrToStringUTF8, // Excel XML format
-		["CSV"] = Marshal.PtrToStringAnsi, // Comma-separated values
-		["Csv"] = Marshal.PtrToStringAnsi, // Alternate CSV registration (Excel)
-		["MIME:text/plain"] = Marshal.PtrToStringUTF8, // Plain text via MIME
-		["MIME:text/html"] = Marshal.PtrToStringUTF8, // HTML via MIME
-		["text/html"] = Marshal.PtrToStringUTF8, // Raw HTML (Chromium/browsers)
-		["text/plain"] = Marshal.PtrToStringUTF8, // Raw plain text (Chromium/browsers)
-		["text/uri-list"] = Marshal.PtrToStringUTF8, // Newline-separated URIs
-		["UniformResourceLocator"] = Marshal.PtrToStringAnsi, // Single URL
-		["UniformResourceLocatorW"] = Marshal.PtrToStringUni, // Single URL (wide)
-		["FileName"] = Marshal.PtrToStringAnsi, // File path
-		["FileNameW"] = Marshal.PtrToStringUni, // File path (wide)
+		["HTML Format"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // HTML fragment with header metadata
+		["Rich Text Format"] = (Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi), // RTF document
+		["Rich Text & Unicode"] = (Marshal.PtrToStringUni, Marshal.StringToCoTaskMemUni), // RTF with Unicode support
+		["Rich Text Format Without Objects"] = (Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi), // RTF without embedded objects
+		["XML Spreadsheet"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // Excel XML format
+		["CSV"] = (Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi), // Comma-separated values
+		["Csv"] = (Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi), // Alternate CSV registration (Excel)
+		["MIME:text/plain"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // Plain text via MIME
+		["MIME:text/html"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // HTML via MIME
+		["text/html"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // Raw HTML (Chromium/browsers)
+		["text/plain"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // Raw plain text (Chromium/browsers)
+		["text/uri-list"] = (Marshal.PtrToStringUTF8, Marshal.StringToCoTaskMemUTF8), // Newline-separated URIs
+		["UniformResourceLocator"] = (Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi), // Single URL
+		["UniformResourceLocatorW"] = (Marshal.PtrToStringUni, Marshal.StringToCoTaskMemUni), // Single URL (wide)
+		["FileName"] = (Marshal.PtrToStringAnsi, Marshal.StringToCoTaskMemAnsi), // File path
+		["FileNameW"] = (Marshal.PtrToStringUni, Marshal.StringToCoTaskMemUni), // File path (wide)
 	};
+	private static readonly Lazy<Encoding> _oemEncoding = new(() =>
+	{
+		Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+		return Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+	});
 
 	// _windowClass must be statically stored, otherwise lpfnWndProc will get collected and the CLR will throw some weird exceptions
 	// ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
@@ -191,6 +200,8 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 			}
 		}
 	}
+	private delegate string? PointerToString(nint p);
+	private delegate nint StringToPointer(string s);
 }
 
 partial class Win32ClipboardExtension // from clipboard
@@ -286,14 +297,12 @@ partial class Win32ClipboardExtension // from clipboard
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
 		if (lockDisposable is null) return;
 
-		package.SetData(GetClipboardFormatName(format), Marshal.PtrToStringUTF8((IntPtr)ptr)!);
-	}
-	private static unsafe void GetString(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
-	{
-		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
-		if (lockDisposable is null) return;
+		var length = (int)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
+		var text = length > 1
+			? _oemEncoding.Value.GetString((byte*)ptr, length - 1)
+			: string.Empty;
 
-		package.SetData(GetClipboardFormatName(format), Marshal.PtrToStringAnsi((IntPtr)ptr)!);
+		package.SetData(GetClipboardFormatName(format), text);
 	}
 #if false // this would require System.Drawing.Common
 	private static void GetBitmap(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle) => package
@@ -388,9 +397,9 @@ partial class Win32ClipboardExtension // from clipboard
 
 			// note: WinUI Clipboard seem to detect certain named format as string, it is unknown by which mechanism.
 			// since HGlobal itself doesnt carry any type metadata, presumably this is done with a white list.
-			if (_knownTextBasedClipboardFormats.TryGetValue(name, out var ptr2str))
+			if (_knownTextBasedClipboardFormats.TryGetValue(name, out var marshaler))
 			{
-				var text = ptr2str.Invoke((IntPtr)ptr) ?? string.Empty;
+				var text = marshaler.FromPointer.Invoke((IntPtr)ptr) ?? string.Empty;
 
 				return Task.FromResult<object>(text);
 			}
@@ -430,7 +439,6 @@ partial class Win32ClipboardExtension // from clipboard
 			}
 		}
 	}
-
 	private static unsafe void GetText(HGLOBAL handle, DataPackage package)
 	{
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var bytes);
@@ -441,7 +449,6 @@ partial class Win32ClipboardExtension // from clipboard
 
 		package.SetText(Marshal.PtrToStringUni((IntPtr)bytes)!);
 	}
-
 	private static unsafe void GetBitmap(HGLOBAL handle, DataPackage package)
 	{
 		package.SetDataProvider(StandardDataFormats.Bitmap, _ =>
@@ -490,7 +497,6 @@ partial class Win32ClipboardExtension // from clipboard
 			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream()));
 		});
 	}
-
 	internal static unsafe List<IStorageItem>? GetFileDropList(HGLOBAL handle)
 	{
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var firstByte);
@@ -613,15 +619,15 @@ partial class Win32ClipboardExtension // to clipboard
 		Debug.Assert(stream.CanRead);
 		stream.Seek(0);
 
-#if false // this would require System.Drawing.Common
+#if false
+		// this would require System.Drawing.Common
 		var readStream = stream.AsStreamForRead();
 
 		var bitmap = new Bitmap(readStream);
 		var handle = (HBITMAP)bitmap.GetHbitmap();
 
-		SetClipboardData(CLIPBOARD_FORMAT.CF_BITMAP, handle);
-#endif
-
+		SetClipboardHBitmapData(CLIPBOARD_FORMAT.CF_BITMAP, handle);
+#else
 		// since we couldn't create a HBITMAP here, we will just write CF_DIB data directly to the clipboard,
 		// which Windows will synthesize CF_BITMAP for us.
 
@@ -643,69 +649,65 @@ partial class Win32ClipboardExtension // to clipboard
 		else
 		{
 			// Unknown image format — decode via SkiaSharp and convert to CF_DIB
-			SetBitmapViaSKBitmap(bytes);
-		}
-	}
+			using var skBitmap = SKBitmap.Decode(bytes);
+			if (skBitmap is null)
+			{
+				typeof(Win32ClipboardExtension).LogError()?.Error("SetBitmap: SkiaSharp failed to decode image.");
+				return;
+			}
 
-	private static unsafe void SetBitmapViaSKBitmap(byte[] bytes)
+			// Ensure BGRA8888 so pixel layout matches what CF_DIB BI_RGB 32bpp expects (BGRX, alpha ignored)
+			using var bgra = skBitmap.ColorType == SKColorType.Bgra8888
+				? null
+				: skBitmap.Copy(SKColorType.Bgra8888);
+			var src = bgra ?? skBitmap;
+
+			var width = src.Width;
+			var height = src.Height;
+			var stride = width * 4;
+			var headerSize = Marshal.SizeOf<BITMAPINFOHEADER>();
+			var pixelDataSize = stride * height;
+			var dib = new byte[headerSize + pixelDataSize];
+
+			fixed (byte* pDib = dib)
+			{
+				var header = (BITMAPINFOHEADER*)pDib;
+				header->biSize = (uint)headerSize;
+				header->biWidth = width;
+				header->biHeight = height; // positive = bottom-up storage
+				header->biPlanes = 1;
+				header->biBitCount = 32;
+				header->biCompression = 0; // BI_RGB
+				header->biSizeImage = (uint)pixelDataSize;
+
+				// SkiaSharp rows are top-down; CF_DIB with positive biHeight expects bottom-up
+				var pixelSrc = (byte*)src.GetPixels();
+				var pixelDst = pDib + headerSize;
+				for (var row = 0; row < height; row++)
+				{
+					Buffer.MemoryCopy(
+						pixelSrc + (long)(height - 1 - row) * stride,
+						pixelDst + (long)row * stride,
+						stride, stride);
+				}
+			}
+
+			SetClipboardData(CLIPBOARD_FORMAT.CF_DIB, dib);
+		}
+#endif
+	}
+	private static void SetUnknownData(DataPackageView view, string format)
 	{
-		using var skBitmap = SKBitmap.Decode(bytes);
-		if (skBitmap is null)
+		if (!WaitForAsyncOperation(view.GetDataAsync(format), out var task))
 		{
-			typeof(Win32ClipboardExtension).LogError()?.Error("SetBitmap: SkiaSharp failed to decode image.");
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(view.GetDataAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception!);
 			return;
 		}
 
-		// Ensure BGRA8888 so pixel layout matches what CF_DIB BI_RGB 32bpp expects (BGRX, alpha ignored)
-		using var bgra = skBitmap.ColorType == SKColorType.Bgra8888
-			? null
-			: skBitmap.Copy(SKColorType.Bgra8888);
-		var src = bgra ?? skBitmap;
-
-		var width = src.Width;
-		var height = src.Height;
-		var stride = width * 4;
-		var headerSize = Marshal.SizeOf<BITMAPINFOHEADER>();
-		var pixelDataSize = stride * height;
-		var dib = new byte[headerSize + pixelDataSize];
-
-		fixed (byte* pDib = dib)
+		var cfid = (CLIPBOARD_FORMAT)PInvoke.RegisterClipboardFormat(format);
+		if (cfid == 0)
 		{
-			var header = (BITMAPINFOHEADER*)pDib;
-			header->biSize = (uint)headerSize;
-			header->biWidth = width;
-			header->biHeight = height; // positive = bottom-up storage
-			header->biPlanes = 1;
-			header->biBitCount = 32;
-			header->biCompression = 0; // BI_RGB
-			header->biSizeImage = (uint)pixelDataSize;
-
-			// SkiaSharp rows are top-down; CF_DIB with positive biHeight expects bottom-up
-			var pixelSrc = (byte*)src.GetPixels();
-			var pixelDst = pDib + headerSize;
-			for (var row = 0; row < height; row++)
-			{
-				Buffer.MemoryCopy(
-					pixelSrc + (long)(height - 1 - row) * stride,
-					pixelDst + (long)row * stride,
-					stride, stride);
-			}
-		}
-
-		SetClipboardData(CLIPBOARD_FORMAT.CF_DIB, dib);
-	}
-
-	private static void SetUnknownData(DataPackageView view, string format)
-	{
-		var task = view.GetDataAsync(format).AsTask();
-		while (!task.IsCompleted)
-		{
-			Win32EventLoop.RunOnce();
-		}
-
-		if (!task.IsCompletedSuccessfully)
-		{
-			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(view.GetDataAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.RegisterClipboardFormat)} failed: {Win32Helper.GetErrorMessage()}");
 			return;
 		}
 
@@ -722,27 +724,18 @@ partial class Win32ClipboardExtension // to clipboard
 			var bytes = new byte[checked((int)size)];
 			ras.AsStreamForRead().ReadExactly(bytes);
 
-			SetClipboardData(format, bytes);
+			SetClipboardData(cfid, bytes);
 		}
 		else if (task.Result is string str)
 		{
-			var bytes = new byte[(str.Length + 1) * sizeof(char)]; // +1 char: last 2 bytes remain 0 as null terminator
-			MemoryMarshal.Cast<char, byte>(str.AsSpan()).CopyTo(bytes);
-			SetClipboardData(format, bytes);
+			var p = _knownTextBasedClipboardFormats.TryGetValue(format, out var marshaler)
+				? marshaler.ToPointer(str)
+				: Marshal.StringToCoTaskMemUni(str);
+
+			SetClipboardCoTaskMemData(cfid, p);
 		}
 	}
 
-	private static void SetClipboardData(string formatName, ReadOnlySpan<byte> data)
-	{
-		var format = PInvoke.RegisterClipboardFormat(formatName);
-		if (format == 0)
-		{
-			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.RegisterClipboardFormat)} failed: {Win32Helper.GetErrorMessage()}");
-			return;
-		}
-
-		SetClipboardData((CLIPBOARD_FORMAT)format, data);
-	}
 	private static unsafe void SetClipboardData(CLIPBOARD_FORMAT format, ReadOnlySpan<byte> data)
 	{
 		// If the hMem parameter identifies a memory object, the object must have been allocated using the function with the GMEM_MOVEABLE flag
@@ -757,12 +750,6 @@ partial class Win32ClipboardExtension // to clipboard
 		if (allocDisposable is null) return;
 
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var dst);
-		if (lockDisposable is null || dst == null)
-		{
-			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(Win32Helper.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}");
-			return;
-		}
-
 		fixed (byte* src = &MemoryMarshal.GetReference(data))
 		{
 			Buffer.MemoryCopy(src, dst, data.Length, data.Length);
@@ -780,7 +767,7 @@ partial class Win32ClipboardExtension // to clipboard
 			shouldFree = false;
 		}
 	}
-	private static void SetClipboardData(CLIPBOARD_FORMAT format, HBITMAP hbitmap)
+	private static void SetClipboardHBitmapData(CLIPBOARD_FORMAT format, HBITMAP hbitmap)
 	{
 		var result = PInvoke.SetClipboardData((uint)format, new HANDLE(hbitmap));
 		if (result == HANDLE.Null)
@@ -794,6 +781,32 @@ partial class Win32ClipboardExtension // to clipboard
 		{
 			// On success the system owns the HBITMAP; do not delete it
 		}
+	}
+	private static void SetClipboardCoTaskMemData(CLIPBOARD_FORMAT format, IntPtr p)
+	{
+		var result = PInvoke.SetClipboardData((uint)format, new HANDLE(p));
+		if (result == HANDLE.Null)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.SetClipboardData)} failed: {Win32Helper.GetErrorMessage()}");
+
+			Marshal.FreeCoTaskMem(p);
+		}
+		else
+		{
+			// If SetClipboardData succeeds, the system owns the object identified by the hMem parameter.
+			// The application may not write to or free the data once ownership has been transferred to the system
+		}
+	}
+
+	private static bool WaitForAsyncOperation<T>(IAsyncOperation<T> operation, out Task<T> task)
+	{
+		task = operation.AsTask();
+		while (!task.IsCompleted)
+		{
+			Win32EventLoop.RunOnce();
+		}
+
+		return task.IsCompletedSuccessfully;
 	}
 }
 

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
@@ -25,6 +25,10 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using SkiaSharp;
+using Uno.ApplicationModel.DataTransfer;
+using Uno.Disposables;
+using Uno.Foundation.Logging;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Windows.Storage.Streams;
@@ -35,15 +39,34 @@ using Windows.Win32.System.Memory;
 using Windows.Win32.System.Ole;
 using Windows.Win32.UI.Shell;
 using Windows.Win32.UI.WindowsAndMessaging;
-using Uno.ApplicationModel.DataTransfer;
-using Uno.Disposables;
-using Uno.Foundation.Logging;
 using Buffer = System.Buffer;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
-internal class Win32ClipboardExtension : IClipboardExtension
+internal partial class Win32ClipboardExtension : IClipboardExtension
 {
+	public static Win32ClipboardExtension Instance { get; } = new();
+
+	private static readonly Dictionary<string, Func<nint, string?>> _knownTextBasedClipboardFormats = new()
+	{
+		["HTML Format"] = Marshal.PtrToStringUTF8, // HTML fragment with header metadata
+		["Rich Text Format"] = Marshal.PtrToStringAnsi, // RTF document
+		["Rich Text Format Without Objects"] = Marshal.PtrToStringAnsi, // RTF without embedded objects
+		["Rich Text & Unicode"] = Marshal.PtrToStringUni, // RTF with Unicode support
+		["XML Spreadsheet"] = Marshal.PtrToStringUTF8, // Excel XML format
+		["CSV"] = Marshal.PtrToStringAnsi, // Comma-separated values
+		["Csv"] = Marshal.PtrToStringAnsi, // Alternate CSV registration (Excel)
+		["MIME:text/plain"] = Marshal.PtrToStringUTF8, // Plain text via MIME
+		["MIME:text/html"] = Marshal.PtrToStringUTF8, // HTML via MIME
+		["text/html"] = Marshal.PtrToStringUTF8, // Raw HTML (Chromium/browsers)
+		["text/plain"] = Marshal.PtrToStringUTF8, // Raw plain text (Chromium/browsers)
+		["text/uri-list"] = Marshal.PtrToStringUTF8, // Newline-separated URIs
+		["UniformResourceLocator"] = Marshal.PtrToStringAnsi, // Single URL
+		["UniformResourceLocatorW"] = Marshal.PtrToStringUni, // Single URL (wide)
+		["FileName"] = Marshal.PtrToStringAnsi, // File path
+		["FileNameW"] = Marshal.PtrToStringUni, // File path (wide)
+	};
+
 	// _windowClass must be statically stored, otherwise lpfnWndProc will get collected and the CLR will throw some weird exceptions
 	// ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
 	private readonly WNDCLASSEXW _windowClass;
@@ -51,8 +74,6 @@ internal class Win32ClipboardExtension : IClipboardExtension
 
 	private bool _observeContentChanged;
 	private DataPackage? _currentPackage;
-
-	public static Win32ClipboardExtension Instance { get; } = new();
 
 	private unsafe Win32ClipboardExtension()
 	{
@@ -125,41 +146,262 @@ internal class Win32ClipboardExtension : IClipboardExtension
 
 	public void Flush() { }
 
+	private static string GetClipboardFormatName(CLIPBOARD_FORMAT format) =>
+		Enum.GetName(format) ?? // cant call GetClipboardFormatName on these
+		GetClipboardFormatNameCore(format) ??
+		format.ToString();
+
+	private static unsafe string? GetClipboardFormatNameCore(CLIPBOARD_FORMAT format)
+	{
+		const int MAX_PATH = 260;
+		const int BufferSize = MAX_PATH + 1;
+
+		var buffer = Marshal.AllocHGlobal((IntPtr)(BufferSize * Unsafe.SizeOf<char>()));
+		using var bufferDisposable = new DisposableStruct<IntPtr>(Marshal.FreeHGlobal, buffer);
+		var length = PInvoke.GetClipboardFormatName((uint)format, new PWSTR((char*)buffer), BufferSize);
+		if (length == 0)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GetClipboardFormatName)} failed (format={format}): {Win32Helper.GetErrorMessage()} ");
+			return null;
+		}
+
+		return Marshal.PtrToStringUni(buffer);
+	}
+
+	private readonly ref struct ClipboardDisposable
+	{
+		private readonly bool _shouldClose;
+		public ClipboardDisposable(HWND hwnd, bool ownClipboard)
+		{
+			_shouldClose = PInvoke.OpenClipboard(hwnd);
+			if (!_shouldClose) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.OpenClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
+			if (ownClipboard)
+			{
+				var success = PInvoke.EmptyClipboard();
+				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.EmptyClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
+			}
+		}
+
+		public void Dispose()
+		{
+			if (_shouldClose)
+			{
+				var success = PInvoke.CloseClipboard();
+				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.CloseClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
+			}
+		}
+	}
+}
+
+partial class Win32ClipboardExtension // from clipboard
+{
 	public DataPackageView GetContent()
 	{
 		if (_currentPackage is null)
 		{
-			_currentPackage = new DataPackage();
+			_currentPackage = GetContentPackage();
+		}
 
-			using var clipboardDisposable = new ClipboardDisposable(_hwnd, false);
+		return _currentPackage.GetView();
+	}
 
-			var formats = new List<CLIPBOARD_FORMAT>();
-			uint lastFormat = 0;
-			while ((lastFormat = PInvoke.EnumClipboardFormats(lastFormat)) != 0)
-			{
-				formats.Add((CLIPBOARD_FORMAT)lastFormat);
-			}
+	private static DataPackage GetContentPackage()
+	{
+		var package = new DataPackage();
 
-			if (Marshal.GetLastWin32Error() != (int)WIN32_ERROR.ERROR_SUCCESS)
+		using var clipboardDisposable = new ClipboardDisposable(Instance._hwnd, false);
+
+		var formats = new List<CLIPBOARD_FORMAT>();
+		for (uint lastFormat = 0; (lastFormat = PInvoke.EnumClipboardFormats(lastFormat)) != 0;)
+		{
+			formats.Add((CLIPBOARD_FORMAT)lastFormat);
+		}
+
+		if (Marshal.GetLastWin32Error() != (int)WIN32_ERROR.ERROR_SUCCESS)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.EnumClipboardFormats)} failed: {Win32Helper.GetErrorMessage()}");
+			return package;
+		}
+
+		foreach (var format in formats)
+		{
+			var loader = (Action<DataPackage, CLIPBOARD_FORMAT, HGLOBAL>?)(format switch
 			{
-				this.LogError()?.Error($"{nameof(PInvoke.EnumClipboardFormats)} failed: {Win32Helper.GetErrorMessage()}");
-			}
-			else
+				// https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats#constants
+				// https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#synthesized-clipboard-formats
+
+				// synthesized text formats
+				CLIPBOARD_FORMAT.CF_TEXT => null,
+				CLIPBOARD_FORMAT.CF_LOCALE => GetUnknownData, // 4 bytes CultureInfo.LCID
+				CLIPBOARD_FORMAT.CF_UNICODETEXT => GetText,
+				CLIPBOARD_FORMAT.CF_OEMTEXT => GetOmeText,
+
+				// synthesized image formats
+				CLIPBOARD_FORMAT.CF_BITMAP => null, // Windows synthesizes CF_DIB from CF_BITMAP; handled below
+				CLIPBOARD_FORMAT.CF_DIB => GetDib,
+				CLIPBOARD_FORMAT.CF_DIBV5 => null,
+				CLIPBOARD_FORMAT.CF_PALETTE => null,
+
+				// synthesized meta-file formats
+				CLIPBOARD_FORMAT.CF_METAFILEPICT => null,
+				CLIPBOARD_FORMAT.CF_ENHMETAFILE => null,
+
+				CLIPBOARD_FORMAT.CF_HDROP => null,
+
+				CLIPBOARD_FORMAT.CF_SYLK => null,
+				CLIPBOARD_FORMAT.CF_DIF => null,
+				CLIPBOARD_FORMAT.CF_TIFF => null,
+				CLIPBOARD_FORMAT.CF_PENDATA => null,
+				CLIPBOARD_FORMAT.CF_RIFF => null,
+				CLIPBOARD_FORMAT.CF_WAVE => null,
+
+				_ => GetUnknownData,
+			});
+			if (loader is { })
 			{
-				ReadContentIntoPackage(_currentPackage, formats, static format =>
+				// GetClipboardData must be called here, and not within async-func of SetDataProvider,
+				// or it will throw: Thread does not have a clipboard open
+				var handle = PInvoke.GetClipboardData((uint)format);
+				if (handle == default)
 				{
-					var handle = (HGLOBAL)(IntPtr)PInvoke.GetClipboardData((uint)format);
-					if (handle == IntPtr.Zero)
-					{
-						typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GetClipboardData)} failed: {Win32Helper.GetErrorMessage()}");
-						return null;
-					}
+					typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GetClipboardData)} failed: {Win32Helper.GetErrorMessage()}");
+					continue;
+				}
 
-					return handle;
-				});
+				loader.Invoke(package, format, (HGLOBAL)(IntPtr)handle);
 			}
 		}
-		return _currentPackage.GetView();
+
+		return package;
+	}
+	private static unsafe void GetText(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	{
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
+		if (lockDisposable is null) return;
+
+		package.SetText(Marshal.PtrToStringUni((IntPtr)ptr)!);
+	}
+	private static unsafe void GetOmeText(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	{
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
+		if (lockDisposable is null) return;
+
+		package.SetData(GetClipboardFormatName(format), Marshal.PtrToStringUTF8((IntPtr)ptr)!);
+	}
+	private static unsafe void GetString(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	{
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
+		if (lockDisposable is null) return;
+
+		package.SetData(GetClipboardFormatName(format), Marshal.PtrToStringAnsi((IntPtr)ptr)!);
+	}
+#if false // this would require System.Drawing.Common
+	private static void GetBitmap(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle) => package
+		.SetDataProvider(StandardDataFormats.Bitmap, _ =>
+		{
+			// CF_BITMAP handle is an HBITMAP, not an HGLOBAL — GlobalLock must not be called on it.
+
+			var image = Image.FromHbitmap(handle);
+
+			var ras = new InMemoryRandomAccessStream();
+			var stream = ras.AsStreamForWrite(); // dont dispose
+			{
+				image.Save(stream, System.Drawing.Imaging.ImageFormat.Bmp);
+				stream.Flush(); // without this, only the file header is written
+				stream.Position = 0;
+			}
+
+			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(ras));
+		});
+#endif
+	private static unsafe void GetDib(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	{
+		// we are remapping CF_DIB to bitmap, since there is no good way to load from CF_BITMAP which contains an HBITMAP
+		var name =
+			//"DeviceIndependentBitmap";
+			StandardDataFormats.Bitmap;
+
+		package.SetDataProvider(name, _ =>
+		{
+			using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr, logLastError: false);
+			if (lockDisposable is null)
+			{
+				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}"));
+			}
+
+			var memSize = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
+			if (memSize <= Marshal.SizeOf<BITMAPINFOHEADER>())
+			{
+				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {memSize}: {Win32Helper.GetErrorMessage()}"));
+			}
+
+			var srcBitmapInfo = (BITMAPINFO*)ptr;
+
+			// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
+			int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
+			{
+				// BI_RGB
+				0 when srcBitmapInfo->bmiHeader.biBitCount <= 8 => Marshal.SizeOf<RGBQUAD>() * (srcBitmapInfo->bmiHeader.biClrUsed == 0 ? 1 << srcBitmapInfo->bmiHeader.biBitCount : (int)srcBitmapInfo->bmiHeader.biClrUsed),
+				0 => 0,
+				// BI_BITFIELDS
+				3 => 3 * Marshal.SizeOf<uint>(),
+				// FOURCC
+				_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
+			};
+
+			BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
+			{
+				bfType = /* BM */ 0x4d42,
+				bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
+				bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
+			};
+
+			var bmpSize = Marshal.SizeOf<BITMAPFILEHEADER>() + (int)memSize;
+			var arr = new byte[bmpSize];
+			fixed (byte* bmp = arr)
+			{
+				Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
+				Buffer.MemoryCopy(ptr, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), memSize, memSize);
+			}
+
+			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream()));
+		});
+	}
+	private static unsafe void GetUnknownData(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	{
+		var name = GetClipboardFormatName(format);
+
+		package.SetDataProvider(name, _ =>
+		{
+			using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr, logLastError: false);
+			if (lockDisposable is null)
+			{
+				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}"));
+			}
+
+			var size = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
+			if (size <= 0)
+			{
+				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {size}: {Win32Helper.GetErrorMessage()}"));
+			}
+
+			// note: WinUI Clipboard seem to detect certain named format as string, it is unknown by which mechanism.
+			// since HGlobal itself doesnt carry any type metadata, presumably this is done with a white list.
+			if (_knownTextBasedClipboardFormats.TryGetValue(name, out var ptr2str))
+			{
+				var text = ptr2str.Invoke((IntPtr)ptr) ?? string.Empty;
+
+				return Task.FromResult<object>(text);
+			}
+
+			var buffer = new byte[size];
+			fixed (byte* pBuffer = buffer)
+			{
+				System.Buffer.MemoryCopy(ptr, pBuffer, size, size);
+			}
+
+			return Task.FromResult<object>(new MemoryStream(buffer).AsRandomAccessStream());
+		});
 	}
 
 	internal static void ReadContentIntoPackage(DataPackage package, IEnumerable<CLIPBOARD_FORMAT> formats, Func<CLIPBOARD_FORMAT, HGLOBAL?> dataGetter)
@@ -301,69 +543,47 @@ internal class Win32ClipboardExtension : IClipboardExtension
 
 		return files;
 	}
+}
 
+partial class Win32ClipboardExtension // to clipboard
+{
 	public void SetContent(DataPackage content)
 	{
 		using var clipboardDisposable = new ClipboardDisposable(_hwnd, true);
 
-		TrySetText(content);
-		TrySetImage(content);
-	}
-
-	private unsafe void TrySetText(DataPackage content)
-	{
 		var view = content.GetView();
-		if (content.Contains(StandardDataFormats.Text))
+		foreach (var format in view.AvailableFormats)
 		{
-			var task = view.GetTextAsync().AsTask();
-			while (!task.IsCompleted)
+			var setter = (Action<DataPackageView, string>?)(format switch
 			{
-				Win32EventLoop.RunOnce();
-			}
-
-			if (!task.IsCompletedSuccessfully)
-			{
-				this.LogError()?.Error($"{nameof(view.GetTextAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
-				return;
-			}
-
-			var str = task.Result;
-			fixed (void* srcBytes = &str.GetPinnableReference())
-			{
-				// If the hMem parameter identifies a memory object, the object must have been allocated using the function with the GMEM_MOVEABLE flag
-				var bufferLength = (str.Length + 1) * sizeof(char); // + 1 for \0
-				var shouldFree = true;
-				using var allocDisposable = Win32Helper.GlobalAlloc(
-					GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE,
-					(UIntPtr)bufferLength,
-					out var handle,
-					// ReSharper disable once AccessToModifiedClosure
-					() => shouldFree);
-
-				if (allocDisposable is null)
-				{
-					return;
-				}
-
-				using var lockDisposable = Win32Helper.GlobalLock(handle, out var dstBytes);
-				Buffer.MemoryCopy(srcBytes, dstBytes, bufferLength, bufferLength);
-				var success = PInvoke.SetClipboardData((uint)CLIPBOARD_FORMAT.CF_UNICODETEXT, new HANDLE(handle)) != HANDLE.Null;
-				if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SetClipboardData)} failed: {Win32Helper.GetErrorMessage()}"); }
-
-				// "If SetClipboardData succeeds, the system owns the object identified by the hMem parameter. The application may not write to or free the data once ownership has been transferred to the system"
-				shouldFree = !success;
-			}
+				_ when format == StandardDataFormats.Text => SetText,
+				_ when format == StandardDataFormats.Bitmap => SetBitmap,
+				_ => SetUnknownData,
+			});
+			setter?.Invoke(view, format);
 		}
 	}
-
-	private unsafe void TrySetImage(DataPackage content)
+	private static void SetText(DataPackageView view, string format)
 	{
-		if (!content.Contains(StandardDataFormats.Bitmap))
+		var task = view.GetTextAsync().AsTask();
+		while (!task.IsCompleted)
 		{
+			Win32EventLoop.RunOnce();
+		}
+
+		if (!task.IsCompletedSuccessfully)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(view.GetTextAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
 			return;
 		}
 
-		var view = content.GetView();
+		var str = task.Result;
+		var bytes = new byte[(str.Length + 1) * sizeof(char)]; // +1 char: last 2 bytes remain 0 as null terminator
+		MemoryMarshal.Cast<char, byte>(str.AsSpan()).CopyTo(bytes);
+		SetClipboardData(CLIPBOARD_FORMAT.CF_UNICODETEXT, bytes);
+	}
+	private static unsafe void SetBitmap(DataPackageView view, string format)
+	{
 		var task = view.GetBitmapAsync().AsTask();
 		while (!task.IsCompleted)
 		{
@@ -372,7 +592,7 @@ internal class Win32ClipboardExtension : IClipboardExtension
 
 		if (!task.IsCompletedSuccessfully)
 		{
-			this.LogError()?.Error($"{nameof(view.GetBitmapAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(view.GetBitmapAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
 			return;
 		}
 
@@ -384,7 +604,7 @@ internal class Win32ClipboardExtension : IClipboardExtension
 
 		if (!task2.IsCompletedSuccessfully)
 		{
-			this.LogError()?.Error($"{nameof(RandomAccessStreamReference.OpenReadAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(RandomAccessStreamReference.OpenReadAsync)} failed to fetch data to be copied to the clipboard: {task2.Status}", task2.Exception);
 			return;
 		}
 
@@ -392,54 +612,168 @@ internal class Win32ClipboardExtension : IClipboardExtension
 		Debug.Assert(stream.CanRead);
 		stream.Seek(0);
 
+#if false // this would require System.Drawing.Common
 		var readStream = stream.AsStreamForRead();
-		if (readStream.ReadByte() != 0x42 || readStream.ReadByte() != 0x4D)
+
+		var bitmap = new Bitmap(readStream);
+		var handle = (HBITMAP)bitmap.GetHbitmap();
+
+		SetClipboardData(CLIPBOARD_FORMAT.CF_BITMAP, handle);
+#endif
+
+		// since we couldn't create a HBITMAP here, we will just write CF_DIB data directly to the clipboard,
+		// which Windows will synthesize CF_BITMAP for us.
+
+		var bytes = new byte[stream.Size];
+		stream.AsStreamForRead().ReadExactly(bytes);
+
+		// check for 'BM' file signature, if we got a bitmap image, we can just strip the header and send the pixel data (in DIB format)
+		if (bytes.Length > Marshal.SizeOf<BITMAPFILEHEADER>() &&
+			bytes[0] == 'B' && bytes[1] == 'M')
 		{
-			this.LogError()?.Error("Failed to copy BMP image to clipboard: invalid BMP format.");
+			SetClipboardData(CLIPBOARD_FORMAT.CF_DIB, bytes.AsSpan(/* start after: */ Marshal.SizeOf<BITMAPFILEHEADER>()));
+		}
+		else
+		{
+			// Unknown image format — decode via SkiaSharp and convert to CF_DIB
+			SetBitmapViaSKBitmap(bytes);
+		}
+	}
+
+	private static unsafe void SetBitmapViaSKBitmap(byte[] bytes)
+	{
+		using var skBitmap = SKBitmap.Decode(bytes);
+		if (skBitmap is null)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error("SetBitmap: SkiaSharp failed to decode image.");
 			return;
 		}
 
+		// Ensure BGRA8888 so pixel layout matches what CF_DIB BI_RGB 32bpp expects (BGRX, alpha ignored)
+		using var bgra = skBitmap.ColorType == SKColorType.Bgra8888
+			? null
+			: skBitmap.Copy(SKColorType.Bgra8888);
+		var src = bgra ?? skBitmap;
+
+		var width = src.Width;
+		var height = src.Height;
+		var stride = width * 4;
+		var headerSize = Marshal.SizeOf<BITMAPINFOHEADER>();
+		var pixelDataSize = stride * height;
+		var dib = new byte[headerSize + pixelDataSize];
+
+		fixed (byte* pDib = dib)
+		{
+			var header = (BITMAPINFOHEADER*)pDib;
+			header->biSize = (uint)headerSize;
+			header->biWidth = width;
+			header->biHeight = height; // positive = bottom-up storage
+			header->biPlanes = 1;
+			header->biBitCount = 32;
+			header->biCompression = 0; // BI_RGB
+			header->biSizeImage = (uint)pixelDataSize;
+
+			// SkiaSharp rows are top-down; CF_DIB with positive biHeight expects bottom-up
+			var pixelSrc = (byte*)src.GetPixels();
+			var pixelDst = pDib + headerSize;
+			for (var row = 0; row < height; row++)
+			{
+				Buffer.MemoryCopy(
+					pixelSrc + (long)(height - 1 - row) * stride,
+					pixelDst + (long)row * stride,
+					stride, stride);
+			}
+		}
+
+		SetClipboardData(CLIPBOARD_FORMAT.CF_DIB, dib);
+	}
+
+	private static void SetUnknownData(DataPackageView view, string format)
+	{
+		var task = view.GetDataAsync(format).AsTask();
+		while (!task.IsCompleted)
+		{
+			Win32EventLoop.RunOnce();
+		}
+
+		if (!task.IsCompletedSuccessfully)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(view.GetDataAsync)} failed to fetch data to be copied to the clipboard: {task.Status}", task.Exception);
+			return;
+		}
+
+		if (task.Result is IRandomAccessStream ras)
+		{
+			ras.Seek(0);
+			var bytes = new byte[ras.Size];
+			ras.AsStreamForRead().ReadExactly(bytes);
+
+			SetClipboardData(format, bytes);
+		}
+		else if (task.Result is string str)
+		{
+			var bytes = new byte[(str.Length + 1) * sizeof(char)]; // +1 char: last 2 bytes remain 0 as null terminator
+			MemoryMarshal.Cast<char, byte>(str.AsSpan()).CopyTo(bytes);
+			SetClipboardData(format, bytes);
+		}
+	}
+
+	private static void SetClipboardData(string formatName, ReadOnlySpan<byte> data)
+	{
+		var format = PInvoke.RegisterClipboardFormat(formatName);
+		if (format == 0)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.RegisterClipboardFormat)} failed: {Win32Helper.GetErrorMessage()}");
+			return;
+		}
+
+		SetClipboardData((CLIPBOARD_FORMAT)format, data);
+	}
+	private static unsafe void SetClipboardData(CLIPBOARD_FORMAT format, ReadOnlySpan<byte> data)
+	{
 		// If the hMem parameter identifies a memory object, the object must have been allocated using the function with the GMEM_MOVEABLE flag
 		var shouldFree = true;
 		using var allocDisposable = Win32Helper.GlobalAlloc(
 			GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE,
-			(UIntPtr)(stream.Size - (ulong)sizeof(BITMAPFILEHEADER)),
+			(UIntPtr)data.Length,
 			out var handle,
 			// ReSharper disable once AccessToModifiedClosure
 			() => shouldFree);
 
-		using var lockDisposable = Win32Helper.GlobalLock(handle, out var bmp);
+		if (allocDisposable is null) return;
 
-		readStream.Seek(sizeof(BITMAPFILEHEADER), SeekOrigin.Begin);
-		readStream.ReadExactly(new Span<byte>(bmp, (int)stream.Size - sizeof(BITMAPFILEHEADER)));
-
-		var success = PInvoke.SetClipboardData((uint)CLIPBOARD_FORMAT.CF_DIB, new HANDLE(handle)) != HANDLE.Null;
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SetClipboardData)} failed: {Win32Helper.GetErrorMessage()}"); }
-		// "If SetClipboardData succeeds, the system owns the object identified by the hMem parameter. The application may not write to or free the data once ownership has been transferred to the system"
-		shouldFree = !success;
-	}
-
-	private readonly ref struct ClipboardDisposable
-	{
-		private readonly bool _shouldClose;
-		public ClipboardDisposable(HWND hwnd, bool ownClipboard)
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var dst);
+		fixed (byte* src = &MemoryMarshal.GetReference(data))
 		{
-			_shouldClose = PInvoke.OpenClipboard(hwnd);
-			if (!_shouldClose) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.OpenClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
-			if (ownClipboard)
-			{
-				var success = PInvoke.EmptyClipboard();
-				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.EmptyClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
-			}
+			Buffer.MemoryCopy(src, dst, data.Length, data.Length);
 		}
 
-		public void Dispose()
+		var result = PInvoke.SetClipboardData((uint)format, new HANDLE(handle));
+		if (result == HANDLE.Null)
 		{
-			if (_shouldClose)
-			{
-				var success = PInvoke.CloseClipboard();
-				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.CloseClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
-			}
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.SetClipboardData)} failed: {Win32Helper.GetErrorMessage()}");
+		}
+		else
+		{
+			// If SetClipboardData succeeds, the system owns the object identified by the hMem parameter.
+			// The application may not write to or free the data once ownership has been transferred to the system
+			shouldFree = false;
+		}
+	}
+	private static void SetClipboardData(CLIPBOARD_FORMAT format, HBITMAP hbitmap)
+	{
+		var result = PInvoke.SetClipboardData((uint)format, new HANDLE(hbitmap));
+		if (result == HANDLE.Null)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.SetClipboardData)} failed: {Win32Helper.GetErrorMessage()}");
+
+			// System did not take ownership — free the HBITMAP ourselves
+			PInvoke.DeleteObject(hbitmap);
+		}
+		else
+		{
+			// On success the system owns the HBITMAP; do not delete it
 		}
 	}
 }
+

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
@@ -175,7 +175,7 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 		{
 			_shouldClose = PInvoke.OpenClipboard(hwnd);
 			if (!_shouldClose) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.OpenClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
-			if (ownClipboard)
+			if (ownClipboard && _shouldClose)
 			{
 				var success = PInvoke.EmptyClipboard();
 				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.EmptyClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
@@ -234,7 +234,7 @@ partial class Win32ClipboardExtension // from clipboard
 				CLIPBOARD_FORMAT.CF_TEXT => null,
 				CLIPBOARD_FORMAT.CF_LOCALE => GetUnknownData, // 4 bytes CultureInfo.LCID
 				CLIPBOARD_FORMAT.CF_UNICODETEXT => GetText,
-				CLIPBOARD_FORMAT.CF_OEMTEXT => GetOmeText,
+				CLIPBOARD_FORMAT.CF_OEMTEXT => GetOemText,
 
 				// synthesized image formats
 				CLIPBOARD_FORMAT.CF_BITMAP => null, // Windows synthesizes CF_DIB from CF_BITMAP; handled below
@@ -281,7 +281,7 @@ partial class Win32ClipboardExtension // from clipboard
 
 		package.SetText(Marshal.PtrToStringUni((IntPtr)ptr)!);
 	}
-	private static unsafe void GetOmeText(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	private static unsafe void GetOemText(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
 	{
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
 		if (lockDisposable is null) return;
@@ -317,9 +317,8 @@ partial class Win32ClipboardExtension // from clipboard
 	private static unsafe void GetDib(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
 	{
 		// we are remapping CF_DIB to bitmap, since there is no good way to load from CF_BITMAP which contains an HBITMAP
-		var name =
-			//"DeviceIndependentBitmap";
-			StandardDataFormats.Bitmap;
+		// normally, this would've been mapped to "DeviceIndependentBitmap"
+		var name = StandardDataFormats.Bitmap;
 
 		package.SetDataProvider(name, _ =>
 		{
@@ -380,10 +379,12 @@ partial class Win32ClipboardExtension // from clipboard
 			}
 
 			var size = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
-			if (size <= 0)
+			if (size == 0 || size > int.MaxValue)
 			{
 				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {size}: {Win32Helper.GetErrorMessage()}"));
 			}
+
+			var bufferLength = checked((int)size);
 
 			// note: WinUI Clipboard seem to detect certain named format as string, it is unknown by which mechanism.
 			// since HGlobal itself doesnt carry any type metadata, presumably this is done with a white list.
@@ -394,10 +395,10 @@ partial class Win32ClipboardExtension // from clipboard
 				return Task.FromResult<object>(text);
 			}
 
-			var buffer = new byte[size];
+			var buffer = new byte[bufferLength];
 			fixed (byte* pBuffer = buffer)
 			{
-				System.Buffer.MemoryCopy(ptr, pBuffer, size, size);
+				System.Buffer.MemoryCopy(ptr, pBuffer, bufferLength, bufferLength);
 			}
 
 			return Task.FromResult<object>(new MemoryStream(buffer).AsRandomAccessStream());
@@ -624,7 +625,13 @@ partial class Win32ClipboardExtension // to clipboard
 		// since we couldn't create a HBITMAP here, we will just write CF_DIB data directly to the clipboard,
 		// which Windows will synthesize CF_BITMAP for us.
 
-		var bytes = new byte[stream.Size];
+		var size = stream.Size;
+		if (size > int.MaxValue)
+		{
+			throw new InvalidOperationException("Clipboard bitmap data is too large to be processed.");
+		}
+
+		var bytes = new byte[(int)size];
 		stream.AsStreamForRead().ReadExactly(bytes);
 
 		// check for 'BM' file signature, if we got a bitmap image, we can just strip the header and send the pixel data (in DIB format)
@@ -705,7 +712,14 @@ partial class Win32ClipboardExtension // to clipboard
 		if (task.Result is IRandomAccessStream ras)
 		{
 			ras.Seek(0);
-			var bytes = new byte[ras.Size];
+			var size = ras.Size;
+			if (size > int.MaxValue)
+			{
+				typeof(Win32ClipboardExtension).LogError()?.Error($"Clipboard data for format '{format}' is too large to copy (size={size} bytes).");
+				return;
+			}
+
+			var bytes = new byte[checked((int)size)];
 			ras.AsStreamForRead().ReadExactly(bytes);
 
 			SetClipboardData(format, bytes);
@@ -743,6 +757,12 @@ partial class Win32ClipboardExtension // to clipboard
 		if (allocDisposable is null) return;
 
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var dst);
+		if (lockDisposable is null || dst == null)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(Win32Helper.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}");
+			return;
+		}
+
 		fixed (byte* src = &MemoryMarshal.GetReference(data))
 		{
 			Buffer.MemoryCopy(src, dst, data.Length, data.Length);

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32Helper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32Helper.cs
@@ -72,12 +72,15 @@ internal static class Win32Helper
 		public void Dispose() => Marshal.FreeHGlobal(Handle);
 	}
 
-	public static unsafe GlobalLockDisposable? GlobalLock(HGLOBAL handle, out void* firstByte)
+	public static unsafe GlobalLockDisposable? GlobalLock(HGLOBAL handle, out void* firstByte, bool logLastError = true)
 	{
 		firstByte = PInvoke.GlobalLock(handle);
 		if (firstByte is null)
 		{
-			typeof(Win32Helper).LogError()?.Error($"{nameof(PInvoke.GlobalLock)} failed: {GetErrorMessage()}");
+			if (logLastError) // note: this consumes GetLastError
+			{
+				typeof(Win32Helper).LogError()?.Error($"{nameof(PInvoke.GlobalLock)} failed: {GetErrorMessage()}");
+			}
 			return null;
 		}
 

--- a/src/Uno.UI.RuntimeTests/Helpers/SkiaImageAssert.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/SkiaImageAssert.cs
@@ -1,0 +1,29 @@
+﻿#if __SKIA__
+using SkiaSharp;
+
+namespace Uno.UI.RuntimeTests.Helpers;
+
+public static class SkiaImageAssert
+{
+	public static void ArePixelsEqual(byte[] expected, byte[] actual)
+	{
+		using var expectedBitmap = SKBitmap.Decode(expected);
+		using var actualBitmap = SKBitmap.Decode(actual);
+
+		Assert.IsNotNull(expectedBitmap, "Expected image could not be decoded by Skia");
+		Assert.IsNotNull(actualBitmap, "Actual image could not be decoded by Skia");
+		Assert.AreEqual(expectedBitmap.Width, actualBitmap.Width, "Image width mismatch");
+		Assert.AreEqual(expectedBitmap.Height, actualBitmap.Height, "Image height mismatch");
+
+		for (var y = 0; y < expectedBitmap.Height; y++)
+		{
+			for (var x = 0; x < expectedBitmap.Width; x++)
+			{
+				var expectedPixel = expectedBitmap.GetPixel(x, y);
+				var actualPixel = actualBitmap.GetPixel(x, y);
+				Assert.AreEqual(expectedPixel, actualPixel, $"Pixel mismatch at ({x}, {y}): expected {expectedPixel}, got {actualPixel}");
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
@@ -23,7 +23,7 @@ namespace Uno.UI.RuntimeTests.Tests;
 public partial class Given_Clipboard;
 partial class Given_Clipboard // setup and cleanup
 {
-	// limit cross contamination, and (external polution while running manually)
+	// limit cross contamination, and (external pollution while running manually)
 	[TestInitialize]
 	public void Setup() => Clipboard.Clear();
 
@@ -52,6 +52,8 @@ partial class Given_Clipboard
 		package.SetText(TestString);
 
 		Clipboard.SetContent(package);
+
+		await DelayForClipboard();
 
 		var view = Clipboard.GetContent();
 		var text = await view.GetTextAsync();
@@ -131,9 +133,19 @@ partial class Given_Clipboard
 	}
 #endif
 
+	private static async Task DelayForClipboard()
+	{
+		// on some platforms, clipboard operations are not immediately available,
+		// so we need to wait a bit before trying to read the content
+		if (RuntimeTestsPlatformHelper.CurrentPlatform is RuntimeTestPlatforms.SkiaWasm)
+		{
+			await Task.Delay(1000);
+		}
+	}
+
 	// for winui at least: use ToRASTream for SetData, use ToRAReferenceAsync for SetBitmap
-	public static IRandomAccessStream ToRAStream(byte[] buffer) => new MemoryStream(buffer).AsRandomAccessStream();
-	public static async Task<RandomAccessStreamReference> ToRAReferenceAsync(byte[] buffer)
+	private static IRandomAccessStream ToRAStream(byte[] buffer) => new MemoryStream(buffer).AsRandomAccessStream();
+	private static async Task<RandomAccessStreamReference> ToRAReferenceAsync(byte[] buffer)
 	{
 		var stream = new InMemoryRandomAccessStream();
 		await stream.WriteAsync(buffer.AsBuffer());
@@ -142,7 +154,7 @@ partial class Given_Clipboard
 		return RandomAccessStreamReference.CreateFromStream(stream);
 	}
 
-	public static byte[] ToBytes(IRandomAccessStream ras)
+	private static byte[] ToBytes(IRandomAccessStream ras)
 	{
 		using var stream = ras.AsStreamForRead();
 		using var buffer = new MemoryStream((int)ras.Size);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
@@ -1,78 +1,153 @@
-#if __ANDROID__ || __IOS__
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.Resources;
 using Windows.ApplicationModel.Resources.Core;
+using Windows.Storage.Streams;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.ConditionMode;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.RuntimeTestPlatforms;
+
+namespace Uno.UI.RuntimeTests.Tests;
 
 // Testing Append, Write and Read in one test method
 
-namespace Uno.UI.RuntimeTests.Tests
+[TestClass]
+public partial class Given_Clipboard;
+partial class Given_Clipboard // setup and cleanup
 {
-	[TestClass]
-	public class Given_Clipboard
-	{
-		[TestMethod]
-		[RunsOnUIThread]
-		public async Task When_Put_And_Get()
-		{
-			try
-			{
-				var text = "some text which should be intact";
+	// limit cross contamination, and (external polution while running manually)
+	[TestInitialize]
+	public void Setup() => Clipboard.Clear();
 
-				var package = new DataPackage();
-				package.SetText(text);
-#if WINAPPSDK
-				Clipboard.SetContent(package);
-#else
-				await Clipboard.SetContentAsync(package);
+#if !DEBUG // when running in debug, we want to still be able to inspect the clipboard content after a test failure
+	[TestCleanup]
+	public void Cleanup() => Clipboard.Clear();
 #endif
-
-				var clipboardView = Clipboard.GetContent();
-				var textFromClipboard = await clipboardView.GetTextAsync();
-
-				Assert.AreEqual(text, textFromClipboard, false);
-			}
-			finally
-			{
-				Clipboard.Clear();
-			}
-		}
-
-#if __ANDROID__
-		[TestMethod]
-		[RunsOnUIThread]
-		public async Task When_Uri_Content()
-		{
-			try
-			{
-				var uri = new Uri("https://platform.uno");
-				var package = new DataPackage();
-				package.SetUri(uri);
-#if WINAPPSDK
-				Clipboard.SetContent(package);
-#else
-				await Clipboard.SetContentAsync(package);
-#endif
-
-				var clipboardView = Clipboard.GetContent();
-				var uriFromClipboard = await clipboardView.GetUriAsync();
-
-				Assert.AreEqual(uri, uriFromClipboard);
-			}
-			finally
-			{
-				Clipboard.Clear();
-			}
-		}
-#endif
-	}
 }
 
+partial class Given_Clipboard
+{
+	private const string TestString = "test-string-raw";
+	private const string UriAddress = "https://platform.uno";
+	private readonly byte[] TestByteArray = [3, 1, 2];
+	private const string TestBmpBase64 = "Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAAAAADEDgAAxA4AAAAAAAAAAAAA686HAA==";
+	private const string TestPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWJiZmT6DwAAAP//EKnFGgAAAAZJREFUAwABIQEIIJGZrwAAAABJRU5ErkJggg==";
+
+	private const string OctetStreamFormat = "application/octet-stream";
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(Include, NativeIOS | NativeAndroid | SkiaWin32 | SkiaWasm)]
+	public async Task When_GetSet_Clipboard_Text()
+	{
+		var package = new DataPackage();
+		package.SetText(TestString);
+
+		Clipboard.SetContent(package);
+
+		var view = Clipboard.GetContent();
+		var text = await view.GetTextAsync();
+
+		Assert.AreEqual(TestString, text);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(Include, NativeAndroid)]
+	public async Task When_GetSet_Clipboard_Uri()
+	{
+		var package = new DataPackage();
+		var uri = new Uri(UriAddress);
+		package.SetUri(uri);
+		Clipboard.SetContent(package);
+
+		var view = Clipboard.GetContent();
+		var result = await view.GetUriAsync();
+		Assert.AreEqual(uri, result);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(Include, SkiaWin32)]
+	public async Task When_GetSet_Clipboard_ByteArray()
+	{
+		var package = new DataPackage();
+		package.SetData(OctetStreamFormat, ToRAStream(TestByteArray));
+
+		Clipboard.SetContent(package);
+
+		var view = Clipboard.GetContent();
+		var stream = await view.GetDataAsync(OctetStreamFormat) as IRandomAccessStream;
+		var bytes = ToBytes(stream);
+
+		CollectionAssert.AreEqual(TestByteArray, bytes);
+	}
+
+#if __SKIA__
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(Include, SkiaWin32)]
+	public async Task When_GetSet_Clipboard_Bitmap_With_Png()
+	{
+		var package = new DataPackage();
+		var bytes = Convert.FromBase64String(TestPngBase64);
+		package.SetBitmap(await ToRAReferenceAsync(bytes));
+
+		Clipboard.SetContent(package);
+
+		var view = Clipboard.GetContent();
+		var reference = await view.GetBitmapAsync();
+		using var stream = await reference.OpenReadAsync();
+		var results = ToBytes(stream);
+
+		SkiaImageAssert.ArePixelsEqual(bytes, results);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(Include, SkiaWin32)]
+	public async Task When_GetSet_Clipboard_Bitmap_With_Bmp()
+	{
+		var package = new DataPackage();
+		var bytes = Convert.FromBase64String(TestBmpBase64);
+		package.SetBitmap(await ToRAReferenceAsync(bytes));
+
+		Clipboard.SetContent(package);
+
+		var view = Clipboard.GetContent();
+		var reference = await view.GetBitmapAsync();
+		using var stream = await reference.OpenReadAsync();
+		var results = ToBytes(stream);
+
+		SkiaImageAssert.ArePixelsEqual(bytes, results);
+	}
 #endif
+
+	// for winui at least: use ToRASTream for SetData, use ToRAReferenceAsync for SetBitmap
+	public static IRandomAccessStream ToRAStream(byte[] buffer) => new MemoryStream(buffer).AsRandomAccessStream();
+	public static async Task<RandomAccessStreamReference> ToRAReferenceAsync(byte[] buffer)
+	{
+		var stream = new InMemoryRandomAccessStream();
+		await stream.WriteAsync(buffer.AsBuffer());
+		stream.Seek(0);
+
+		return RandomAccessStreamReference.CreateFromStream(stream);
+	}
+
+	public static byte[] ToBytes(IRandomAccessStream ras)
+	{
+		using var stream = ras.AsStreamForRead();
+		using var buffer = new MemoryStream((int)ras.Size);
+		stream.CopyTo(buffer);
+
+		return buffer.ToArray();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
@@ -45,7 +45,8 @@ partial class Given_Clipboard
 
 	[TestMethod]
 	[RunsOnUIThread]
-	[PlatformCondition(Include, NativeIOS | NativeAndroid | SkiaWin32 | SkiaWasm)]
+	// note: do not enable this for wasm, without adjust default clipboard permission
+	[PlatformCondition(Include, NativeIOS | NativeAndroid | SkiaWin32)]
 	public async Task When_GetSet_Clipboard_Text()
 	{
 		var package = new DataPackage();

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Interop.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Interop.wasm.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
 
 namespace __Windows.ApplicationModel.DataTransfer
@@ -20,6 +20,12 @@ namespace __Windows.ApplicationModel.DataTransfer
 
 			[JSImport($"{JsType}.setHtml")]
 			internal static partial Task SetHtmlAsync(string html, string text);
+
+			[JSImport($"{JsType}.getImage")]
+			internal static partial Task<string> GetImageAsync();
+
+			[JSImport($"{JsType}.setImage")]
+			internal static partial Task SetImageAsync(string base64, string mimeType);
 
 			[JSImport($"{JsType}.startContentChanged")]
 			internal static partial void StartContentChanged();

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -137,7 +137,9 @@ namespace Windows.ApplicationModel.DataTransfer
 
 			if (data == null || data.Length == 0)
 			{
-				return "application/octet-stream";
+				// Even if data is empty, return a generic image MIME type so JS clipboard logic
+				// (which filters on "image/") can handle the entry consistently.
+				return "image/png";
 			}
 
 			// PNG signature: 89 50 4E 47 0D 0A 1A 0A
@@ -177,8 +179,9 @@ namespace Windows.ApplicationModel.DataTransfer
 				return "image/webp";
 			}
 
-			// Fallback when the format is unknown
-			return "application/octet-stream";
+			// Fallback when the format is unknown: use a generic image MIME type so that
+			// the JS clipboard side (which only accepts "image/*") can still consume it.
+			return "image/png";
 		}
 
 		private static void StartContentChanged()

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -113,13 +113,72 @@ namespace Windows.ApplicationModel.DataTransfer
 			using var ras = await reference.OpenReadAsync();
 			using var stream = ras.AsStreamForRead();
 
+			if (ras.Size > int.MaxValue)
+			{
+				throw new NotSupportedException("Clipboard image is too large.");
+			}
+
 			var buffer = new MemoryStream((int)ras.Size);
 			stream.CopyTo(buffer);
 
-			var base64 = Convert.ToBase64String(buffer.ToArray());
-			var mimeType = string.IsNullOrEmpty(ras.ContentType) ? "image/png" : ras.ContentType;
+			var data = buffer.ToArray();
+			var base64 = Convert.ToBase64String(data);
+			var mimeType = GetImageMimeType(ras, data);
 
 			await NativeMethods.SetImageAsync(base64, mimeType);
+		}
+
+		private static string GetImageMimeType(IRandomAccessStreamWithContentType ras, byte[] data)
+		{
+			if (!string.IsNullOrEmpty(ras.ContentType))
+			{
+				return ras.ContentType;
+			}
+
+			if (data == null || data.Length == 0)
+			{
+				return "application/octet-stream";
+			}
+
+			// PNG signature: 89 50 4E 47 0D 0A 1A 0A
+			if (data.Length >= 8 &&
+				data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 &&
+				data[4] == 0x0D && data[5] == 0x0A && data[6] == 0x1A && data[7] == 0x0A)
+			{
+				return "image/png";
+			}
+
+			// JPEG signature: FF D8 FF
+			if (data.Length >= 3 &&
+				data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF)
+			{
+				return "image/jpeg";
+			}
+
+			// BMP signature: 42 4D
+			if (data.Length >= 2 &&
+				data[0] == 0x42 && data[1] == 0x4D)
+			{
+				return "image/bmp";
+			}
+
+			// GIF signature: 47 49 46 38 ("GIF8")
+			if (data.Length >= 4 &&
+				data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x38)
+			{
+				return "image/gif";
+			}
+
+			// WebP signature: "RIFF"...."WEBP"
+			if (data.Length >= 12 &&
+				data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 && // "RIFF"
+				data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50)   // "WEBP"
+			{
+				return "image/webp";
+			}
+
+			// Fallback when the format is unknown
+			return "application/octet-stream";
 		}
 
 		private static void StartContentChanged()

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -1,9 +1,11 @@
-﻿#nullable disable // Not supported by WinUI yet
+#nullable disable // Not supported by WinUI yet
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
+using Windows.Storage.Streams;
 using Windows.UI.Core;
 using Uno.Extensions.Specialized;
 using Uno.Foundation;
@@ -28,11 +30,16 @@ namespace Windows.ApplicationModel.DataTransfer
 		{
 			var data = content?.GetView(); // Freezes the DataPackage
 
-			// Handle both HTML and text formats - both should be written if present
+			var hasBitmap = data?.Contains(StandardDataFormats.Bitmap) ?? false;
 			var hasHtml = data?.Contains(StandardDataFormats.Html) ?? false;
 			var hasText = data?.Contains(StandardDataFormats.Text) ?? false;
 
-			if (hasHtml)
+			if (hasBitmap)
+			{
+				var bitmapRef = await data.GetBitmapAsync();
+				await SetClipboardBitmap(bitmapRef);
+			}
+			else if (hasHtml)
 			{
 				var html = await data.GetHtmlFormatAsync();
 				// Get text for fallback - either from explicit text or extract from HTML
@@ -55,6 +62,7 @@ namespace Windows.ApplicationModel.DataTransfer
 
 			dataPackage.SetDataProvider(StandardDataFormats.Text, async ct => await GetClipboardText(ct));
 			dataPackage.SetDataProvider(StandardDataFormats.Html, async ct => await GetClipboardHtml(ct));
+			dataPackage.SetDataProvider(StandardDataFormats.Bitmap, async ct => await GetClipboardBitmap(ct));
 
 			return dataPackage.GetView();
 		}
@@ -69,6 +77,27 @@ namespace Windows.ApplicationModel.DataTransfer
 			return await NativeMethods.GetHtmlAsync();
 		}
 
+		private static async Task<RandomAccessStreamReference> GetClipboardBitmap(CancellationToken ct)
+		{
+			var base64 = await NativeMethods.GetImageAsync();
+			if (string.IsNullOrEmpty(base64))
+			{
+				return null;
+			}
+
+			var bytes = Convert.FromBase64String(base64);
+			var ras = new InMemoryRandomAccessStream();
+			var stream = ras.AsStreamForWrite();
+			{
+				stream.Write(bytes, 0, bytes.Length);
+				stream.Flush();
+
+				stream.Position = 0;
+			}
+
+			return RandomAccessStreamReference.CreateFromStream(ras);
+		}
+
 		private static void SetClipboardText(string text)
 		{
 			NativeMethods.SetText(text);
@@ -77,6 +106,20 @@ namespace Windows.ApplicationModel.DataTransfer
 		private static async Task SetClipboardHtml(string html, string text)
 		{
 			await NativeMethods.SetHtmlAsync(html, text);
+		}
+
+		private static async Task SetClipboardBitmap(RandomAccessStreamReference reference)
+		{
+			using var ras = await reference.OpenReadAsync();
+			using var stream = ras.AsStreamForRead();
+
+			var buffer = new MemoryStream((int)ras.Size);
+			stream.CopyTo(buffer);
+
+			var base64 = Convert.ToBase64String(buffer.ToArray());
+			var mimeType = string.IsNullOrEmpty(ras.ContentType) ? "image/png" : ras.ContentType;
+
+			await NativeMethods.SetImageAsync(base64, mimeType);
 		}
 
 		private static void StartContentChanged()

--- a/src/Uno.UWP/js/Uno.Wasm.d.ts
+++ b/src/Uno.UWP/js/Uno.Wasm.d.ts
@@ -66,6 +66,8 @@ declare namespace Uno.Utils {
         static setText(text: string): string;
         static getText(): Promise<string>;
         static getHtml(): Promise<string>;
+        static getImage(): Promise<string>;
+        static setImage(base64: string, mimeType: string): Promise<void>;
         static setHtml(html: string, text: string): Promise<void>;
         private static onClipboardChanged;
     }

--- a/src/Uno.UWP/ts/Windows/ApplicationModel/DataTransfer/Clipboard.ts
+++ b/src/Uno.UWP/ts/Windows/ApplicationModel/DataTransfer/Clipboard.ts
@@ -101,6 +101,50 @@ namespace Uno.Utils {
 			return Promise.resolve("");
 		}
 
+		public static async getImage(): Promise<string> {
+			// we return "" on failure instead of null to avoid crashing with an NRE if there
+			// are no try blocks in the stack frames above.
+			const nav = navigator as NavigatorClipboard;
+			if (nav.clipboard && nav.clipboard.read) {
+				try {
+					const items = await nav.clipboard.read();
+					for (const item of items) {
+						const imageType = item.types.find(t => t.startsWith('image/'));
+						if (imageType) {
+							const blob = await item.getType(imageType);
+							const arrayBuffer = await blob.arrayBuffer();
+							const bytes = new Uint8Array(arrayBuffer);
+							let binary = '';
+							for (let i = 0; i < bytes.length; i++) {
+								binary += String.fromCharCode(bytes[i]);
+							}
+							return btoa(binary);
+						}
+					}
+					return "";
+				} catch (reason) {
+					console.error(`Failed to read image from clipboard: ${reason}`);
+					return "";
+				}
+			}
+			return Promise.resolve("");
+		}
+
+		public static async setImage(base64: string, mimeType: string): Promise<void> {
+			const nav = navigator as any;
+			if (nav.clipboard && nav.clipboard.write && typeof ClipboardItem !== 'undefined') {
+				try {
+					const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+					const blob = new Blob([bytes], { type: mimeType });
+					const item = new ClipboardItem({ [mimeType]: blob });
+					await nav.clipboard.write([item]);
+					Clipboard.onClipboardChanged();
+				} catch (reason) {
+					console.error(`Failed to write image to clipboard: ${reason}`);
+				}
+			}
+		}
+
 		public static async setHtml(html: string, text: string): Promise<void> {
 			const nav = navigator as any;
 			if (nav.clipboard && nav.clipboard.write && typeof ClipboardItem !== 'undefined') {

--- a/src/Uno.UWP/ts/Windows/ApplicationModel/DataTransfer/Clipboard.ts
+++ b/src/Uno.UWP/ts/Windows/ApplicationModel/DataTransfer/Clipboard.ts
@@ -112,13 +112,24 @@ namespace Uno.Utils {
 						const imageType = item.types.find(t => t.startsWith('image/'));
 						if (imageType) {
 							const blob = await item.getType(imageType);
-							const arrayBuffer = await blob.arrayBuffer();
-							const bytes = new Uint8Array(arrayBuffer);
-							let binary = '';
-							for (let i = 0; i < bytes.length; i++) {
-								binary += String.fromCharCode(bytes[i]);
-							}
-							return btoa(binary);
+							const dataUrl = await new Promise<string>((resolve, reject) => {
+								const reader = new FileReader();
+								reader.onload = () => {
+									if (typeof reader.result === "string") {
+										resolve(reader.result);
+									} else {
+										reject(new Error("Unexpected FileReader result type when reading image from clipboard."));
+									}
+								};
+								reader.onerror = () => {
+									reject(reader.error ?? new Error("Failed to read image from clipboard using FileReader."));
+								};
+								reader.readAsDataURL(blob);
+							});
+
+							const commaIndex = dataUrl.indexOf(",");
+							const base64 = commaIndex >= 0 ? dataUrl.substring(commaIndex + 1) : dataUrl;
+							return base64;
 						}
 					}
 					return "";


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/studio.live#411

## PR Type: ✨ Feature

## What is the current behavior? 🤔
## What is the new behavior? 🚀
- wasm: `Clipboard` now supports `image/png` content thought G/SetBitmap
- desktop.win32: `Clipboard` now supports full range of clipboard format above `CF_MAX`(18), and G/SetBitmap is extended to support a broader range of image, rather than just `BM` bitmap format.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes