### PR TITLE
fix: Load explicitly mentioned assemblies, don't probe

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/BindableTypeLinkerGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/BindableTypeLinkerGeneratorTask.cs
@@ -20,7 +20,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 	/// </summary>
 	public class BindableTypeLinkerGeneratorTask_v0 : Microsoft.Build.Utilities.Task
 	{
-		private const MessageImportance DefaultLogMessageLevel
+		internal const MessageImportance DefaultLogMessageLevel
 #if DEBUG
 			= MessageImportance.High;
 #else
@@ -49,7 +49,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				var typeCache = new TypeDefinitionCache();
 				var typesToProperties = FindReferencedPropertyTypes(bindableTypes, typeCache);
 
-				var typesWithProperties = typesToProperties.Count(kvp => kvp.Value.Count > 0);
+				var typesWithProperties = typesToProperties.GetTypeProperties().Count(kvp => kvp.Value.Count > 0);
 				if (typesWithProperties > 0)
 				{
 					GenerateLinkerDescriptor(typesToProperties);
@@ -70,9 +70,9 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			}
 		}
 
-		private DefaultAssemblyResolver BuildAssemblyResolver()
+		private ReferencePathAssemblyResolver BuildAssemblyResolver()
 		{
-			var resolver = new DefaultAssemblyResolver();
+			var resolver = new ReferencePathAssemblyResolver(BuildReferencePaths(), Log);
 
 			var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -107,9 +107,36 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			}
 		}
 
-		private HashSet<AssemblyDefinition> BuildAssemblyList(DefaultAssemblyResolver resolver)
+		private Dictionary<string, string> BuildReferencePaths()
 		{
-			var rootAssembly = resolver.Resolve(AssemblyNameReference.Parse(Path.GetFileNameWithoutExtension(AssemblyPath)));
+			var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+			AddPath(dict, AssemblyPath);
+
+			foreach (var item in ReferencePath ?? [])
+			{
+				AddPath(dict, item.ItemSpec);
+			}
+
+			return dict;
+
+			static void AddPath(Dictionary<string, string> dict, string path)
+			{
+				var fileName = Path.GetFileName(path);
+				if (!dict.ContainsKey(fileName))
+				{
+					dict[fileName] = path;
+				}
+			}
+		}
+
+		private HashSet<AssemblyDefinition> BuildAssemblyList(IAssemblyResolver resolver)
+		{
+			var readerParameters = new ReaderParameters
+			{
+				AssemblyResolver = resolver,
+			};
+			var rootAssembly = resolver.Resolve(AssemblyNameReference.Parse(Path.GetFileNameWithoutExtension(AssemblyPath)), readerParameters);
 			Log.LogMessage(DefaultLogMessageLevel, $"Resolved Root Assembly reference `{rootAssembly.FullName}`.");
 
 			var assemblies = new HashSet<AssemblyDefinition>()
@@ -139,11 +166,16 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			return assemblies;
 		}
 
-		private AssemblyDefinition? TryResolveAssembly(DefaultAssemblyResolver resolver, AssemblyNameReference assemblyName)
+		private AssemblyDefinition? TryResolveAssembly(IAssemblyResolver resolver, AssemblyNameReference assemblyName)
 		{
+			var readerParameters = new ReaderParameters
+			{
+				AssemblyResolver = resolver,
+			};
+
 			try
 			{
-				return resolver.Resolve(assemblyName);
+				return resolver.Resolve(assemblyName, readerParameters);
 			}
 			catch (Exception ex)
 			{
@@ -192,9 +224,9 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				attr.AttributeType.FullName.EndsWith(".BindableAttribute", StringComparison.Ordinal));
 		}
 
-		private Dictionary<PreserveTypeDefinition, HashSet<PreservePropertyInfo>> FindReferencedPropertyTypes(IEnumerable<TypeDefinition> bindableTypes, TypeDefinitionCache typeCache)
+		private PreservePropertyInfoMap FindReferencedPropertyTypes(IEnumerable<TypeDefinition> bindableTypes, TypeDefinitionCache typeCache)
 		{
-			var typesToProperties = new Dictionary<PreserveTypeDefinition, HashSet<PreservePropertyInfo>>();
+			var typesToProperties = new PreservePropertyInfoMap();
 
 			foreach (var bindableType in bindableTypes)
 			{
@@ -206,22 +238,23 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				// Iterate over all public properties
 				foreach (var property in bindableType.Properties.Where(ShouldProcessPropertyType))
 				{
-					AddDeclaredPropertyTypes(typeCache, property.PropertyType, typesToProperties);
+					AddDeclaredPropertyTypes(typeCache, property.PropertyType, typesToProperties)
+						?.AddContext($"From Property `{property.Name} : {property.PropertyType.FullName}` on bindable type `{bindableType.FullName}`");
 				}
 			}
 
-			Log.LogMessage(DefaultLogMessageLevel, $"Found {typesToProperties.Values.Count(v => v.Count > 0)} implicitly referenced types.");
+			Log.LogMessage(DefaultLogMessageLevel, $"Found {typesToProperties.GetTypeProperties().Count(kvp => kvp.Value.Count > 0)} implicitly referenced types.");
 			return typesToProperties;
 		}
 
 		static readonly HashSet<PreservePropertyInfo> EmptyPreservedPropertyInfo = [];
 
-		private void AddDeclaredPropertyTypes(TypeDefinitionCache typeCache, TypeReference typeReference, Dictionary<PreserveTypeDefinition, HashSet<PreservePropertyInfo>> typesToProperties)
+		private PreserveTypeDefinition? AddDeclaredPropertyTypes(TypeDefinitionCache typeCache, TypeReference typeReference, PreservePropertyInfoMap typesToProperties)
 		{
 			var typeDefinition = TryResolveTypeDefinition(typeCache, typeReference);
 			if (typeDefinition == null)
 			{
-				return;
+				return null;
 			}
 
 			// Process generic arguments (e.g., List<Entity> should also process Entity)
@@ -229,27 +262,34 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			{
 				foreach (var genericArg in genericType.GenericArguments)
 				{
-					AddDeclaredPropertyTypes(typeCache, genericArg, typesToProperties);
+					AddDeclaredPropertyTypes(typeCache, genericArg, typesToProperties)
+						?.AddContext($"Generic type parameter from {typeReference.FullName}");
 				}
 			}
 
-			if (typeDefinition.BaseType != null)
+			if (typesToProperties.TryGetPreserveType(typeDefinition.FullName, out var existingType))
 			{
-				AddDeclaredPropertyTypes(typeCache, typeDefinition.BaseType, typesToProperties);
+				// Already processed; return the *existing* key, so that callers can call `.AddContext()`
+				return existingType;
 			}
 
 			var key = new PreserveTypeDefinition(typeDefinition.FullName, typeDefinition);
 
-			if (typesToProperties.ContainsKey(key) ||
-					HasBindableAttribute(typeDefinition))
+			if (HasBindableAttribute(typeDefinition))
 			{
-				return;
+				return null;
+			}
+
+			if (typeDefinition.BaseType != null)
+			{
+				AddDeclaredPropertyTypes(typeCache, typeDefinition.BaseType, typesToProperties)
+					?.AddContext($"Base type of {typeDefinition.FullName}");
 			}
 
 			if (!typeDefinition.HasProperties)
 			{
 				typesToProperties[key] = EmptyPreservedPropertyInfo;
-				return;
+				return key;
 			}
 
 			var declaredProperties = new HashSet<PreservePropertyInfo>();
@@ -262,8 +302,10 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 
 			foreach (var property in declaredProperties)
 			{
-				AddDeclaredPropertyTypes(typeCache, property.PropertyType, typesToProperties);
+				AddDeclaredPropertyTypes(typeCache, property.PropertyType, typesToProperties)
+					?.AddContext($"From Property `{property.PropertyName} : {property.PropertyType.FullName}` on type `{typeDefinition.FullName}`");
 			}
+			return key;
 		}
 
 		static bool ShouldProcessPropertyType(PropertyDefinition property)
@@ -290,10 +332,11 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			}
 		}
 
-		private void GenerateLinkerDescriptor(Dictionary<PreserveTypeDefinition, HashSet<PreservePropertyInfo>> referencedTypes)
+		private void GenerateLinkerDescriptor(PreservePropertyInfoMap referencedTypes)
 		{
 			// Group types by assembly
 			var typesByAssembly = referencedTypes
+				.GetTypeProperties()
 				.GroupBy(kvp => kvp.Key.TypeDefinition.Module.Assembly.Name.Name)
 				.OrderBy(g => g.Key);
 
@@ -325,24 +368,40 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				return new XElement("assembly",
 					new XAttribute("fullname", assemblyName),
 					types.OrderBy(t => t.Key.FullName).Select(typeEntry =>
-						CreateTypeElement(typeEntry.Key.FullName, typeEntry.Value)));
+						CreateTypeElement(typeEntry.Key, typeEntry.Value)));
 			}
 
-			static XElement? CreateTypeElement(string typeFullName, HashSet<PreservePropertyInfo> properties)
+			static IEnumerable<XNode> CreateTypeElement(PreserveTypeDefinition preserveTypeDefinition, HashSet<PreservePropertyInfo> properties)
 			{
 				if (properties.Count == 0)
 				{
-					return null; // Skip types with no public properties
+					yield break; // Skip types with no public properties
 				}
 
-				return new XElement("type",
-					new XAttribute("fullname", typeFullName),
+				yield return new XElement("type",
+					new XAttribute("fullname", preserveTypeDefinition.FullName),
 					new XAttribute("required", "false"),
+					OrderedDistinct(preserveTypeDefinition.Context).Select(c => new XComment(c)),
 					properties.OrderBy(p => p.PropertyName)
 						.Select(p =>
 							new XElement("property",
 								new XAttribute("name", p.PropertyName),
 								new XComment($" {p.PropertyType.FullName} {p.PropertyName} {{get;}} "))));
+			}
+		}
+
+		// *Implementation-wise*, `Enumerable.Distinct()` preserves order.
+		// However, that isn't documented behavior, so "appease" Copilot by implementing our version
+		// in which the order is preserved.
+		private static IEnumerable<T> OrderedDistinct<T>(IEnumerable<T> sequence)
+		{
+			var seen = new HashSet<T>();
+			foreach (var item in sequence)
+			{
+				if (seen.Add(item))
+				{
+					yield return item;
+				}
 			}
 		}
 	}
@@ -351,6 +410,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 	{
 		public string FullName { get; }
 		public TypeDefinition TypeDefinition { get; }
+		public List<string> Context { get; } = new List<string>();
 
 		public PreserveTypeDefinition(string fullName, TypeDefinition typeDefinition)
 		{
@@ -372,6 +432,11 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 		public override int GetHashCode()
 		{
 			return FullName.GetHashCode();
+		}
+
+		public void AddContext(string context)
+		{
+			Context.Add(context);
 		}
 	}
 
@@ -429,6 +494,107 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			if (methods.TryGetValue(method, out var methodDefinition))
 				return methodDefinition;
 			return methods[method] = method.Resolve();
+		}
+	}
+
+	internal class PreservePropertyInfoMap
+	{
+		private Dictionary<string, PreserveTypeDefinition> typeMap = new();
+		private Dictionary<PreserveTypeDefinition, HashSet<PreservePropertyInfo>> propertiesMap = new();
+
+		public bool TryGetPreserveType(string fullName, out PreserveTypeDefinition? preserveTypeDefinition)
+		{
+			return typeMap.TryGetValue(fullName, out preserveTypeDefinition!);
+		}
+
+		public HashSet<PreservePropertyInfo>? this[PreserveTypeDefinition preserveType]
+		{
+			get
+			{
+				if (propertiesMap.TryGetValue(preserveType, out var properties))
+				{
+					return properties;
+				}
+				return null;
+			}
+			set
+			{
+				if (value == null)
+				{
+					propertiesMap.Remove(preserveType);
+					return;
+				}
+				typeMap[preserveType.FullName] = preserveType;
+				propertiesMap[preserveType] = value;
+			}
+		}
+
+		public IEnumerable<KeyValuePair<PreserveTypeDefinition, HashSet<PreservePropertyInfo>>> GetTypeProperties()
+		{
+			return propertiesMap;
+		}
+	}
+
+	internal class ReferencePathAssemblyResolver : BaseAssemblyResolver
+	{
+		private Dictionary<string, string> referencePaths;
+		private TaskLoggingHelper log;
+		private Dictionary<string, AssemblyDefinition> cache = new();
+
+		public ReferencePathAssemblyResolver(Dictionary<string, string> referencePaths, TaskLoggingHelper log)
+		{
+			this.referencePaths = referencePaths;
+			this.log = log;
+		}
+
+		public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+		{
+			if (cache.TryGetValue(name.FullName, out var assembly))
+			{
+				return assembly;
+			}
+
+			assembly = base.Resolve(name, parameters);
+			cache[name.FullName] = assembly;
+
+			return assembly;
+		}
+
+		protected override AssemblyDefinition SearchDirectory(AssemblyNameReference name, IEnumerable<string> directories, ReaderParameters parameters)
+		{
+			// Modified from: https://github.com/jbevain/cecil/blob/882ca5eedda1e62eb41bd5869aeb15d8f1538e51/Mono.Cecil/BaseAssemblyResolver.cs#L210-L227
+			var extensions = name.IsWindowsRuntime
+				? new[] { ".winmd", ".dll" }
+				: new[] { ".dll", ".exe" };
+			foreach (var extension in extensions)
+			{
+				var fileName = name.Name + extension;
+				if (referencePaths.TryGetValue(fileName, out var path))
+				{
+					return ReadAssembly(path, name.Name, parameters);
+				}
+			}
+
+			log.LogMessage(MessageImportance.High, $"Assembly name `{name.FullName}` was not in @(ReferencePath); falling back to arbitrary directories…");
+			return base.SearchDirectory(name, directories, parameters);
+		}
+
+		private AssemblyDefinition ReadAssembly(string path, string assemblyName, ReaderParameters parameters)
+		{
+			return AssemblyDefinition.ReadAssembly(path, parameters);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			// Copied from: https://github.com/jbevain/cecil/blob/882ca5eedda1e62eb41bd5869aeb15d8f1538e51/Mono.Cecil/DefaultAssemblyResolver.cs#L53-L58
+			foreach (var assembly in cache.Values)
+			{
+				assembly.Dispose();
+			}
+
+			cache.Clear();
+
+			base.Dispose(disposing);
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/uno/issues/22832

Context: https://github.com/unoplatform/Uno.Gallery/pull/1233
Context: https://github.com/unoplatform/uno/pull/22676

Build unoplatform/Uno.Gallery#1233 for Android + Native AOT with Uno.Sdk 6.6.0-dev.92 or later:

	git clone https://github.com/unoplatform/Uno.Gallery.git
	cd Uno.Gallery
	git checkout dev/jonpryor/jonp-naot-support
	sed -i '' 's/"Uno.Sdk": ".*"/"Uno.Sdk": "6.6.0-dev.127"/g' global.json
	dotnet publish -m:1 -r android-x64 -f net10.0-android -p:TargetFrameworkOverride=net10.0-android \
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:UseSkiaRendering=true -p:SkiaPublishAot=true \
	  "-p:ApplicationTitleVendorSuffix= (NAOT)" -p:ApplicationIdVendorSuffix=.naot \
	  -p:TrimmerSingleWarn=false -p:IsTrimmable=true -p:IsAotCompatible=true -p:_ExtraTrimmerArgs=--verbose \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	adb logcat > log.txt &
	adb install Uno.Gallery/bin/Release/net10.0-android/android-x64/publish/com.nventive.uno.ui.demo.naot-Signed.apk
	adb shell am start com.nventive.uno.ui.demo.naot/crc64a57a145253f0f267.MainActivity

The app crashes at startup; `log.txt` contains:

	E JavaInteropRuntime: JavaInteropRuntime.init: error: System.IO.FileNotFoundException: IO_FileNotFound_FileName, Uno.UI.BindingHelper.Android
	E JavaInteropRuntime: IO_FileName_Name, Uno.UI.BindingHelper.Android
	E JavaInteropRuntime:    at Internal.Runtime.TypeLoaderExceptionHelper.CreateFileNotFoundException(ExceptionStringID, String) + 0x4a
	E JavaInteropRuntime:    at Microsoft.Android.Runtime.ManagedTypeMapping.GetTypeByJniNameHashIndex(Int32) + 0x12
	E JavaInteropRuntime:    at Microsoft.Android.Runtime.ManagedTypeMapping.TryGetType(String, Type&) + 0x85
	E JavaInteropRuntime:    at Microsoft.Android.Runtime.ManagedTypeManager.<GetTypesForSimpleReference>d__6.MoveNext() + 0xd1
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniTypeManager.<CreateGetTypesEnumerator>d__28.MoveNext() + 0x103
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniValueManager.<CreatePeerInstance>g__GetTypeAssignableTo|28_0(JniTypeSignature, Type) + 0x54
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniValueManager.CreatePeerInstance(JniObjectReference&, Type, JniObjectReference&, JniObjectReferenceOptions) + 0x69
	E JavaInteropRuntime:    at Java.Interop.JniRuntime.JniValueManager.CreatePeer(JniObjectReference&, JniObjectReferenceOpti
	E DOTNET  : Unhandled exception.
	E DOTNET  : System.IO.FileNotFoundException: IO_FileNotFound_FileName, Uno.UI.BindingHelper.Android
	E DOTNET  : IO_FileName_Name, Uno.UI.BindingHelper.Android
	E DOTNET  :    at Internal.Runtime.TypeLoaderExceptionHelper.CreateFileNotFoundException(ExceptionStringID, String) + 0x4a
	E DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeMapping.GetTypeByJniNameHashIndex(Int32) + 0x12
	E DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeMapping.TryGetType(String, Type&) + 0x85
	E DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeManager.<GetTypesForSimpleReference>d__6.MoveNext() + 0xd1
	E DOTNET  :    at Java.Interop.JniRuntime.JniTypeManager.<CreateGetTypesEnumerator>d__28.MoveNext() + 0x103
	E DOTNET  :    at System.Linq.Enumerable.TryGetFirstNonIterator[TSource](IEnumerable`1, Boolean&) + 0x53
	E DOTNET  :    at Java.Interop.ManagedPeer.GetTypeFromSignature(JniRuntime.JniTypeManager, JniTypeSignature, String) + 0x6a
	E DOTNET  :    at Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr jnienv, IntPtr klass, IntPtr n_nativeClass, IntPtr n_methods) + 0x11d
	E DOTNET  : --- End of stack trace from previous location ---
	E DOTNET  :    at Java.Interop.
	E DOTNET  :
	--------- beginning of crash
	F libc    : Fatal signal 6 (SIGABRT), code -6 (SI_TKILL) in tid 8165 (no.ui.demo.naot), pid 8165 (no.ui.demo.naot)
	F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
	F DEBUG   : Build fingerprint: 'google/sdk_gphone_x86_64/generic_x86_64:9/PSR1.180720.075/5124027:user/release-keys'
	F DEBUG   : Revision: '0'
	F DEBUG   : ABI: 'x86_64'
	F DEBUG   : pid: 8165, tid: 8165, name: no.ui.demo.naot  >>> com.nventive.uno.ui.demo.naot <<<
	F DEBUG   : signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
	F DEBUG   :     rax 0000000000000000  rbx 0000000000001fe5  rcx 00007bee94d69b98  rdx 0000000000000006
	F DEBUG   :     r8  00007ffe68c985b0  r9  00007ffe68c985b0  r10 00007ffe68c985b0  r11 0000000000000246
	F DEBUG   :     r12 00007bedf85be38c  r13 0000000000000000  r14 0000000000001fe5  r15 00007ffe68c986e8
	F DEBUG   :     rdi 0000000000001fe5  rsi 0000000000001fe5
	F DEBUG   :     rbp 00007ffe68c98730  rsp 00007ffe68c986d8  rip 00007bee94d69b98
	F DEBUG   :
	F DEBUG   : backtrace:
	F DEBUG   :     #00 pc 0000000000026b98  /system/lib64/libc.so (syscall+24)
	F DEBUG   :     #01 pc 0000000000029775  /system/lib64/libc.so (abort+101)
	F DEBUG   :     #02 pc 0000000002dfc298  /data/app/com.nventive.uno.ui.demo.naot-G-PdZd4xCgJDY9vLPv4UWA==/lib/x86_64/libUno.Gallery.so (offset 0x2d0f000)
	F DEBUG   :     #03 pc 000000000363e5db  /data/app/com.nventive.uno.ui.demo.naot-G-PdZd4xCgJDY9vLPv4UWA==/lib/x86_64/libUno.Gallery.so (offset 0x2d0f000)
	F DEBUG   :     #04 pc 0000000000dc1aff  [anon:.bss:00007bedfaaab000]

*This used to work*, i.e. the app would launch *without* crashing. The crash was introduced in Uno.Sdk 6.6.0-dev.92, specifically by unoplatform/uno#22676.

The cause of the crash is inconsistencies in the build environment:

When the `<BindableTypeLinkerGeneratorTask_v0/>` task is executed, it would eventually resolve the *Android* variant of `Uno.UI.dll`, which can be inferred from diagnostic messages such as:

	Resolved Assembly reference `System.Runtime.InteropServices.JavaScript, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a` via `…/uno.winui/6.6.0-dev.464/lib/net10.0-android36.0/Uno.UI.dll`.

Note the `net10.0-android36.0` in the path.

*Beacuse* `<BindableTypeLinkerGeneratorTask_v0/>` processes `net10.0-android36.0/Uno.UI.dll`, it also resolves it's assembly depenendencies, which includes `Uno.UI.BindingHelper.Android.dll`, resulting in this fragment within `Uno.Bindable.Descriptor.xml`:

	<assembly fullname="Uno.UI.BindingHelper.Android">
	  <type fullname="Uno.UI.UnoViewGroup" required="false">
	    <!-- … -->
	  </type>
	</assembly>

This in turn causes the dotnet/android "managed type map" to contain types from `Uno.UI.BindingHelper.Android.dll`.

Meanwhile, when the `IlcCompile` target executes -- which is the target responsible for compiling assemblies into native code under Native AOT -- the diagnostic log contains:

	Added Item(s):
	    _IlcRootedAssembliesRaw=
	        …
	        Uno.UI
	                AssetType=runtime
	                CopyLocal=true
	                CopyToPublishDirectory=true
	                DestinationSubPath=Uno.UI.dll
	                NuGetPackageId=Uno.WinUI
	                PathInPackage=uno-runtime/net10.0/skia/Uno.UI.dll
	                TrimMode=All

which states that it's not using the `net10.0-android36.0` variant, but instead the Skia variant!

The `IlcCompile` target *never receives* the `net10.0-android36.0` assembly, and thus cannot retain types within it.

Here's the fun bit: `…/uno.winui/6.6.0-dev.464/lib/net10.0-android36.0/Uno.UI.dll` never should have been processed by
`<BindableTypeLinkerGeneratorTask_v0/>` in the first place, because the `ReferencePath` parameters specify a different one!

	Task "BindableTypeLinkerGeneratorTask_v0" (TaskId:287)
	  Task Parameter:AssemblyPath=obj/Release/net10.0-android/android-x64/Uno.Gallery.dll (TaskId:287)
	  Task Parameter:OutputDescriptorPath=obj/Release/net10.0-android/android-x64/Uno.Bindable.Descriptor.xml (TaskId:287)
	  Task Parameter:
	      ReferencePath=
	          …
	          …/Uno.Gallery-packages/uno.winui/6.6.0-dev.464/lib/net10.0/Uno.UI.dll
	                  CopyLocal=false
	                  ExternallyResolved=true
	                  FusionName=Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null
	                  HintPath=…/Uno.Gallery-packages/uno.winui/6.6.0-dev.464/buildTransitive/../uno-runtime/../lib/net10.0/Uno.UI.dll
	                  NuGetPackageId=Uno.WinUI
	                  NuGetPackageVersion=6.6.0-dev.464
	                  NuGetSourceType=Package
	                  OriginalItemSpec=…/Uno.Gallery-packages/uno.winui/6.6.0-dev.464/buildTransitive/../uno-runtime/../lib/net10.0/Uno.UI.dll
	                  PathInPackage=lib/net10.0/Uno.UI.dll
	                  Private=false
	                  ReferenceAssembly=…/Uno.Gallery-packages/uno.winui/6.6.0-dev.464/lib/net10.0/Uno.UI.dll
	                  ReferenceSourceTarget=ResolveAssemblyReference
	                  ResolvedFrom={HintPathFromItem}
	                  Version=

The crux of the issue is that `<BindableTypeLinkerGeneratorTask_v0/>` was trying to "probe" for assemblies in a list of *directories* controlled by `BindableTypeLinkerGeneratorTask_v0.ReferencePath`, but *it didn't need to probe*, nor should it have probed.

Fix this by introducing a new `ReferencePathAssemblyResolver` type which looks for *exact* matches within `ReferencePath` when resolving assemblies.  This results in log messages such as:

	Resolving assembly name `Uno.UI` to path `…/uno.winui/6.6.0-dev.464/lib/net10.0/Uno.UI.dll`.
	…
	Resolved Assembly reference `System.Runtime.InteropServices.JavaScript, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a` via `…/uno.winui/6.6.0-dev.464/lib/net10.0/Uno.UI.dll`.

This in turn means that `Uno.Bindable.Descriptor.xml` *no longer* mentions `Uno.UI.BindingHelper.Android`, and thus the app no longer crashes at startup.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->