### PR TITLE
fix: Handle unrecognized language tags in resource qualifier parsing

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
@@ -51,25 +51,29 @@ public partial class ResourceQualifier
 	#region Language helpers
 
 	private static HashSet<string> _languageTags;
+	private static readonly object _languageTagsLock = new();
 	private static HashSet<string> LanguageTags
 	{
 		get
 		{
-			if (_languageTags == null)
+			lock (_languageTagsLock)
 			{
-				var cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
-				var ietfLanguageTags = cultures.Select(c => c.IetfLanguageTag);
-				var ietfLanguageParentTags = cultures.Select(c => c.Parent.IetfLanguageTag);
-				var twoLetterLanguageTags = cultures.Select(c => c.TwoLetterISOLanguageName);
+				if (_languageTags == null)
+				{
+					var cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+					var ietfLanguageTags = cultures.Select(c => c.IetfLanguageTag);
+					var ietfLanguageParentTags = cultures.Select(c => c.Parent.IetfLanguageTag);
+					var twoLetterLanguageTags = cultures.Select(c => c.TwoLetterISOLanguageName);
 
-				var allCulture = Enumerable.Concat(
-					ietfLanguageTags,
-					twoLetterLanguageTags.Concat(ietfLanguageParentTags));
+					var allCulture = Enumerable.Concat(
+						ietfLanguageTags,
+						twoLetterLanguageTags.Concat(ietfLanguageParentTags));
 
-				_languageTags = new HashSet<string>(allCulture.Distinct(), StringComparer.InvariantCultureIgnoreCase);
+					_languageTags = new HashSet<string>(allCulture.Distinct(), StringComparer.InvariantCultureIgnoreCase);
+				}
+
+				return _languageTags;
 			}
-
-			return _languageTags;
 		}
 	}
 
@@ -87,7 +91,12 @@ public partial class ResourceQualifier
 		try
 		{
 			_ = CultureInfo.GetCultureInfo(str);
-			_languageTags.Add(str);
+
+			lock (_languageTagsLock)
+			{
+				LanguageTags.Add(str);
+			}
+
 			return true;
 		}
 		catch (CultureNotFoundException)

--- a/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
@@ -75,7 +75,25 @@ public partial class ResourceQualifier
 
 	private static bool IsLanguageTag(string str)
 	{
-		return LanguageTags.Contains(str);
+		if (LanguageTags.Contains(str))
+		{
+			return true;
+		}
+
+		// Fallback: CultureInfo.GetCultures may not enumerate all valid cultures
+		// on all platforms (e.g., macOS/Linux ICU may use different IETF tags like
+		// zh-Hans-CN instead of zh-CN, or may omit cultures like kok-IN, quz-PE).
+		// Try to create the culture directly as a fallback.
+		try
+		{
+			_ = CultureInfo.GetCultureInfo(str);
+			_languageTags.Add(str);
+			return true;
+		}
+		catch (CultureNotFoundException)
+		{
+			return false;
+		}
 	}
 
 	#endregion


### PR DESCRIPTION
CultureInfo.GetCultures() does not enumerate all valid cultures on every platform. Add fallback using CultureInfo.GetCultureInfo() to resolve UNOB0003 warnings for kok-IN, zh-CN, zh-TW, and others.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 💬 Other... (Please describe)

## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->