### PR TITLE
fix: WebView2 swallows arrow keys after losing focus on macOS

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4328,6 +4328,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView2_ArrowKeys.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView2_Fixed_Height.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -8617,6 +8621,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView2_Clipping.xaml.cs">
       <DependentUpon>WebView2_Clipping.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView2_ArrowKeys.xaml.cs">
+      <DependentUpon>WebView2_ArrowKeys.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView2_Fixed_Height.xaml.cs">
       <DependentUpon>WebView2_Fixed_Height.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView2_ArrowKeys.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView2_ArrowKeys.xaml
@@ -1,0 +1,27 @@
+<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.WebView.WebView2_ArrowKeys"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="12" Padding="20">
+		<TextBlock Text="1. Click on the WebView below to give it focus" />
+		<TextBlock Text="2. Click on the TextBox and type some text" />
+		<TextBlock Text="3. Use arrow keys to move the cursor in the TextBox" />
+		<TextBlock Text="Arrow keys should work normally in the TextBox after focusing the WebView" />
+
+		<WebView2 x:Name="TestWebView" Source="https://platform.uno/" Height="300" />
+
+		<TextBox x:Name="TestTextBox" PlaceholderText="Click WebView above, then type here and use arrow keys" />
+
+		<TextBox x:Name="TestMultilineTextBox"
+				 AcceptsReturn="True"
+				 TextWrapping="Wrap"
+				 Height="150"
+				 PlaceholderText="Multiline TextBox - test Up/Down arrow keys here"
+				 Text="Line 1&#x0a;Line 2&#x0a;Line 3&#x0a;Line 4&#x0a;Line 5" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView2_ArrowKeys.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView2_ArrowKeys.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.WebView;
+
+[Sample("WebView", IsManualTest = true, IgnoreInSnapshotTests = true,
+	Description = "WebView2 swallows arrow keys - Click WebView, then TextBox, and verify arrow keys work (issue #22819)")]
+public sealed partial class WebView2_ArrowKeys : Page
+{
+	public WebView2_ArrowKeys()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -297,6 +297,9 @@ internal static partial class NativeUno
 	[return: MarshalAs(UnmanagedType.I1)]
 	internal static partial bool uno_window_clip_svg(nint window, string? svg);
 
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_resign_native_first_responder(nint window);
+
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]
 	internal static partial string? /* const char* _Nullable */ uno_pick_single_folder(string? prompt, string? identifier, int suggestedStartLocation);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -304,8 +304,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 			var args = CreateArgs(key, mods, scanCode, unicode);
 			keyDown.Invoke(window!, args);
-			var root = window?._xamlRoot;
-			return root is null || FocusManager.GetFocusedElement(root) == null ? 0 : 1;
+			return args.Handled ? 1 : 0;
 		}
 		catch (Exception e)
 		{
@@ -332,7 +331,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 			var args = CreateArgs(key, mods, scanCode, unicode);
 			keyUp.Invoke(window!, args);
-			return 1;
+			return args.Handled ? 1 : 0;
 		}
 		catch (Exception e)
 		{

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -204,6 +204,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 	void IXamlRootHost.InvalidateRender() => NativeUno.uno_window_invalidate(_nativeWindow.Handle);
 
+	void IXamlRootHost.ResignNativeFocus() => NativeUno.uno_window_resign_native_first_responder(_nativeWindow.Handle);
+
 	public static void Register(nint handle, XamlRoot xamlRoot, MacOSWindowHost host)
 	{
 		XamlRootMap.Register(xamlRoot, host);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOSoftView.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOSoftView.m
@@ -8,6 +8,10 @@
 
 @implementation UNOSoftView
 
+- (BOOL)acceptsFirstResponder {
+    return YES;
+}
+
 - (void)drawRect:(NSRect)dirtyRect
 {
     double width = dirtyRect.origin.x + dirtyRect.size.width;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -81,6 +81,8 @@ void uno_window_restore(UNOWindow *window, bool activateWindow);
 
 bool uno_window_clip_svg(UNOWindow* window, const char* svg);
 
+void uno_window_resign_native_first_responder(UNOWindow* window);
+
 OverlappedPresenterState uno_window_get_overlapped_presenter_state(UNOWindow *window);
 
 void uno_window_set_always_on_top(NSWindow* window, bool isAlwaysOnTop);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -1038,6 +1038,19 @@ NSOperatingSystemVersion _osVersion;
 #if DEBUG_MOUSE // very noisy
             NSLog(@"NSEventTypeMouse*: %@ %g %g handled? %s", event, data.x, data.y, handled ? "true" : "false");
 #endif
+
+            // When a native element (e.g. WKWebView) holds first responder and the
+            // user clicks elsewhere, resign it so keyboard events stop going to the
+            // native element. Since mouse events always return handled=0 (see above),
+            // [super sendEvent:] runs next and will re-assign first responder to the
+            // native element if the click actually landed on it. (fixes #22819)
+            if (mouse == MouseEventsDown) {
+                NSResponder *fr = self.firstResponder;
+                NSView *cv = self.contentViewController.view;
+                if ([fr isKindOfClass:[NSView class]] && fr != cv && [(NSView *)fr isDescendantOf:cv]) {
+                    [self makeFirstResponder:cv];
+                }
+            }
         }
     }
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -95,6 +95,10 @@ NSWindow* uno_app_get_main_window(void)
     return YES;
 }
 
+-(BOOL) acceptsFirstResponder {
+    return YES;
+}
+
 -(instancetype) initWithFrame:(CGRect)frameRect device:(id<MTLDevice>)device {
     self = [super initWithFrame:frameRect device:device];
     if (self) {

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -821,6 +821,15 @@ bool uno_window_clip_svg(UNOWindow* window, const char* svg)
     return true;
 }
 
+void uno_window_resign_native_first_responder(UNOWindow* window)
+{
+    NSView *cv = window.contentViewController.view;
+    NSResponder *fr = window.firstResponder;
+    if ([fr isKindOfClass:[NSView class]] && fr != cv && [(NSView *)fr isDescendantOf:cv]) {
+        [window makeFirstResponder:cv];
+    }
+}
+
 @implementation UNOWindow : NSWindow
 
 NSEventModifierFlags _previousFlags;
@@ -1042,24 +1051,6 @@ NSOperatingSystemVersion _osVersion;
 #if DEBUG_MOUSE // very noisy
             NSLog(@"NSEventTypeMouse*: %@ %g %g handled? %s", event, data.x, data.y, handled ? "true" : "false");
 #endif
-
-            // When a native element (e.g. WKWebView) holds first responder and the
-            // user clicks outside it, resign first responder so keyboard events stop
-            // going to the native element. Hit-test the click location to avoid
-            // resigning when the click is inside the native element. (fixes #22819)
-            if (mouse == MouseEventsDown) {
-                NSResponder *fr = self.firstResponder;
-                NSView *cv = self.contentViewController.view;
-                if ([fr isKindOfClass:[NSView class]] && fr != cv && [(NSView *)fr isDescendantOf:cv]) {
-                    NSPoint loc = [cv convertPoint:event.locationInWindow fromView:nil];
-                    NSView *hitView = [cv hitTest:loc];
-                    // hitView lands on cv (Skia layer) when the click is outside any
-                    // native subview — only then do we resign first responder.
-                    if (hitView == cv || hitView == nil) {
-                        [self makeFirstResponder:cv];
-                    }
-                }
-            }
         }
     }
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -1044,15 +1044,20 @@ NSOperatingSystemVersion _osVersion;
 #endif
 
             // When a native element (e.g. WKWebView) holds first responder and the
-            // user clicks elsewhere, resign it so keyboard events stop going to the
-            // native element. Since mouse events always return handled=0 (see above),
-            // [super sendEvent:] runs next and will re-assign first responder to the
-            // native element if the click actually landed on it. (fixes #22819)
+            // user clicks outside it, resign first responder so keyboard events stop
+            // going to the native element. Hit-test the click location to avoid
+            // resigning when the click is inside the native element. (fixes #22819)
             if (mouse == MouseEventsDown) {
                 NSResponder *fr = self.firstResponder;
                 NSView *cv = self.contentViewController.view;
                 if ([fr isKindOfClass:[NSView class]] && fr != cv && [(NSView *)fr isDescendantOf:cv]) {
-                    [self makeFirstResponder:cv];
+                    NSPoint loc = [cv convertPoint:event.locationInWindow fromView:nil];
+                    NSView *hitView = [cv hitTest:loc];
+                    // hitView lands on cv (Skia layer) when the click is outside any
+                    // native subview — only then do we resign first responder.
+                    if (hitView == cv || hitView == nil) {
+                        [self makeFirstResponder:cv];
+                    }
                 }
             }
         }

--- a/src/Uno.UI/Hosting/IXamlRootHost.cs
+++ b/src/Uno.UI/Hosting/IXamlRootHost.cs
@@ -9,4 +9,9 @@ internal interface IXamlRootHost
 	UIElement? RootElement { get; }
 
 	void InvalidateRender();
+
+	/// <summary>
+	/// Resigns native first responder
+	/// </summary>
+	void ResignNativeFocus() { }
 }

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.skia.cs
@@ -3,13 +3,20 @@
 using System;
 using System.Runtime.InteropServices.JavaScript;
 using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Hosting;
 
 namespace Microsoft.UI.Xaml.Input;
 
 public partial class FocusManager
 {
-	private static void FocusNative(UIElement? control)
+	private void FocusNative(UIElement? control)
 	{
+		// Resign native first responder so keyboard events return to the managed layer and are properly processed by the focused element.
+		if (_contentRoot.XamlRoot is { } xamlRoot)
+		{
+			XamlRootMap.GetHostForRoot(xamlRoot)?.ResignNativeFocus();
+		}
+
 		if (OperatingSystem.IsBrowser() && control is not null && (control as Control)?.IsDelegatingFocusToTemplateChild() != true)
 		{
 			NativeMethods.FocusSemanticElement(control.Visual.Handle);


### PR DESCRIPTION
Resign native first responder from embedded elements (e.g. WKWebView) on mouse-down outside them, and return args.Handled from key event callbacks instead of unconditionally claiming handled.

**GitHub Issue:** closes #22819

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->