### PR TITLE
fix: guard AbsoluteUri in GetSvgImageDataAsync before URI fetch

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.skia.cs
@@ -79,7 +79,13 @@ partial class SvgImageSource
 	{
 		try
 		{
-			ImageData imageData = await ImageSourceHelpers.GetImageDataFromUriAsBytes(AbsoluteUri, ct);
+			ImageData imageData = ImageData.Empty;
+
+			if (AbsoluteUri is { } uri)
+			{
+				imageData = await ImageSourceHelpers.GetImageDataFromUriAsBytes(uri, ct);
+			}
+
 			if (!imageData.HasData && _stream is not null)
 			{
 				imageData = await ImageSourceHelpers.ReadFromStreamAsBytesAsync(_stream.AsStream(), ct);


### PR DESCRIPTION
## Summary
This PR fixes issue #22839 by preventing an unnecessary URI fetch attempt in the Skia SVG loading path when AbsoluteUri is null.

## Problem
When SVG content is provided through SetSourceAsync (stream-based source), AbsoluteUri can be null. The previous implementation always called GetImageDataFromUriAsBytes(AbsoluteUri, ct) first, which could throw before falling back to the stream path. The exception was caught, but this introduced debugger noise and unnecessary overhead.

## Fix
Updated GetSvgImageDataAsync in SvgImageSource.skia.cs to:
- Initialize imageData with ImageData.Empty
- Call GetImageDataFromUriAsBytes only when AbsoluteUri is non-null
- Preserve existing stream fallback (_stream) when URI data is unavailable

## Why this is safe
- Behavior is unchanged for URI-based SVG sources.
- Stream-based SVG sources now follow the intended non-exceptional path.
- Error handling remains in place for actual exceptional conditions.

## Validation
- Verified the change is isolated to the Skia method.
- Confirmed no diagnostics for the edited file.

## Issue
Closes #22839