### PR TITLE
fix: macos dispatch filepicker calls to main thread

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -54,19 +54,30 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 		}
 		else
 		{
-			var tcs = new TaskCompletionSource<IntPtr>();
+			var tcs = new TaskCompletionSource<IntPtr>(TaskCreationOptions.RunContinuationsAsynchronously);
+			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
+				if (token.IsCancellationRequested)
+				{
+					tcs.TrySetCanceled(token);
+					return;
+				}
 				try
 				{
-					tcs.SetResult(NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+					tcs.TrySetResult(NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
 				}
 				catch (Exception ex)
 				{
-					tcs.SetException(ex);
+					tcs.TrySetException(ex);
 				}
 			});
 			array = await tcs.Task;
+		}
+
+		if (array == IntPtr.Zero)
+		{
+			return Array.Empty<StorageFile>();
 		}
 
 		var files = new List<StorageFile>();
@@ -93,16 +104,22 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 		}
 		else
 		{
-			var tcs = new TaskCompletionSource<string?>();
+			var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
+				if (token.IsCancellationRequested)
+				{
+					tcs.TrySetCanceled(token);
+					return;
+				}
 				try
 				{
-					tcs.SetResult(NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+					tcs.TrySetResult(NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
 				}
 				catch (Exception ex)
 				{
-					tcs.SetException(ex);
+					tcs.TrySetException(ex);
 				}
 			});
 			file = await tcs.Task;

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -5,6 +5,7 @@ using Windows.Storage.Pickers;
 
 using Uno.Foundation.Extensibility;
 using Uno.Extensions.Storage.Pickers;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia.MacOS;
 
@@ -46,7 +47,28 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 
 	public async Task<IReadOnlyList<StorageFile>> PickMultipleFilesAsync(CancellationToken token)
 	{
-		var array = NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
+		IntPtr array;
+		if (NativeDispatcher.Main.HasThreadAccess)
+		{
+			array = NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
+		}
+		else
+		{
+			var tcs = new TaskCompletionSource<IntPtr>();
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				try
+				{
+					tcs.SetResult(NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+			array = await tcs.Task;
+		}
+
 		var files = new List<StorageFile>();
 		var ptr = Marshal.ReadIntPtr(array);
 		while (ptr != IntPtr.Zero)
@@ -64,7 +86,28 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 
 	public async Task<StorageFile?> PickSingleFileAsync(CancellationToken token)
 	{
-		var file = NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
+		string? file;
+		if (NativeDispatcher.Main.HasThreadAccess)
+		{
+			file = NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
+		}
+		else
+		{
+			var tcs = new TaskCompletionSource<string?>();
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				try
+				{
+					tcs.SetResult(NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+			file = await tcs.Task;
+		}
+
 		return file is null ? null : await StorageFile.GetFileFromPathAsync(file);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
@@ -3,6 +3,7 @@ using Windows.Storage.Pickers;
 
 using Uno.Extensions.Storage.Pickers;
 using Uno.Foundation.Extensibility;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia.MacOS;
 
@@ -60,7 +61,28 @@ internal class MacOSFileSavePickerExtension : IFileSavePickerExtension
 
 	public async Task<StorageFile?> PickSaveFileAsync(CancellationToken token)
 	{
-		var file = NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length);
+		string? file;
+		if (NativeDispatcher.Main.HasThreadAccess)
+		{
+			file = NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length);
+		}
+		else
+		{
+			var tcs = new TaskCompletionSource<string?>();
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				try
+				{
+					tcs.SetResult(NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length));
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+			file = await tcs.Task;
+		}
+
 		return file is null ? null : await StorageFile.GetFileFromPathAsync(file);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
@@ -68,16 +68,22 @@ internal class MacOSFileSavePickerExtension : IFileSavePickerExtension
 		}
 		else
 		{
-			var tcs = new TaskCompletionSource<string?>();
+			var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
+				if (token.IsCancellationRequested)
+				{
+					tcs.TrySetCanceled(token);
+					return;
+				}
 				try
 				{
-					tcs.SetResult(NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length));
+					tcs.TrySetResult(NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length));
 				}
 				catch (Exception ex)
 				{
-					tcs.SetException(ex);
+					tcs.TrySetException(ex);
 				}
 			});
 			file = await tcs.Task;

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
@@ -48,16 +48,22 @@ internal class MacOSFolderPickerExtension : IFolderPickerExtension
 		}
 		else
 		{
-			var tcs = new TaskCompletionSource<string?>();
+			var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
+				if (token.IsCancellationRequested)
+				{
+					tcs.TrySetCanceled(token);
+					return;
+				}
 				try
 				{
-					tcs.SetResult(NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation));
+					tcs.TrySetResult(NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation));
 				}
 				catch (Exception ex)
 				{
-					tcs.SetException(ex);
+					tcs.TrySetException(ex);
 				}
 			});
 			folder = await tcs.Task;

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
@@ -3,6 +3,7 @@ using Windows.Storage.Pickers;
 
 using Uno.Foundation.Extensibility;
 using Uno.Extensions.Storage.Pickers;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia.MacOS;
 
@@ -40,7 +41,28 @@ internal class MacOSFolderPickerExtension : IFolderPickerExtension
 
 	public async Task<StorageFolder?> PickSingleFolderAsync(CancellationToken token)
 	{
-		var folder = NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation);
+		string? folder;
+		if (NativeDispatcher.Main.HasThreadAccess)
+		{
+			folder = NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation);
+		}
+		else
+		{
+			var tcs = new TaskCompletionSource<string?>();
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				try
+				{
+					tcs.SetResult(NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation));
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+			folder = await tcs.Task;
+		}
+
 		return folder is null ? null : await StorageFolder.GetFolderFromPathAsync(folder);
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/studio.live/issues/812

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

On macOS Desktop, the app crashes with `NSInternalInconsistencyException: NSWindow should only be instantiated on the main thread!` when invoking any file or folder picker (`FileSavePicker`, `FileOpenPicker`, `FolderPicker`) from an async continuation that resumes on a threadpool thread.

This affects scenarios such as Export and Send Feedback in Studio Live.

Fixes https://github.com/nickmeinhold/studio.live/issues/812

## What is the new behavior? 🚀

All three macOS picker extensions (`MacOSFileSavePickerExtension`, `MacOSFileOpenPickerExtension`, `MacOSFolderPickerExtension`) now check `NativeDispatcher.Main.HasThreadAccess` before calling native P/Invoke functions. If the call is already on the main thread, it proceeds directly. Otherwise, it is dispatched to the main thread via `NativeDispatcher.Main.Enqueue()` with a `TaskCompletionSource` to bridge the result back to the async caller.

The implementation follows async best practices:
- `CancellationToken` is honored (checks before showing picker, cancels pending operations)
- `TaskCompletionSource` uses `RunContinuationsAsynchronously` to avoid blocking the UI thread
- `TrySet*` methods prevent race conditions with cancellation
- Null pointer handling for user cancellation in `PickMultipleFilesAsync`

This matches the existing pattern used by other macOS extensions in the same project (e.g., `MacOSClipboardExtension`, `MacOSMediaPlayerExtension`).

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Automated tests are not practical for this fix: the native P/Invoke calls target `libUnoNativeMac.dylib` (macOS-only), show blocking modal OS dialogs, and the threading bug is non-deterministic. Manual validation on macOS is required — trigger Export or Submit Feedback and confirm the save dialog appears without crashing.
