### PR TITLE
fix(devserver): prevent MCP handlers from blocking indefinitely

### DIFF
--- a/build/test-scripts/run-devserver-compat-tests.ps1
+++ b/build/test-scripts/run-devserver-compat-tests.ps1
@@ -50,7 +50,7 @@ function Get-DevserverCliArguments {
 
 function Invoke-DevserverCli {
     param([string[]]$Arguments = @())
-    $fullArgs = Get-DevserverCliArguments -Arguments $Arguments
+    [string[]]$fullArgs = @(Get-DevserverCliArguments -Arguments $Arguments)
     & $script:DevServerHostExecutable @fullArgs
 }
 

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -382,7 +382,7 @@
 	},
 	{
 		"group": "AppMcp",
-		"version": "1.2.0-dev.31",
+		"version": "1.2.0-dev.41",
 		"packages": [
 			"Uno.UI.App.Mcp"
 		]

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -512,8 +512,11 @@ internal class DevServerMonitor(IServiceProvider services, ILogger<DevServerMoni
 
 		args.AddRange(_forwardedArgs);
 
+		// CRITICAL: redirectInput MUST be true when the CLI runs as an MCP stdio bridge.
+		// Without it, the child process inherits our stdin — the MCP message pipe from
+		// the AI agent — and steals incoming JSON-RPC messages, causing random hangs.
 		var startInfo =
-			DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput: true);
+			DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput: true, redirectInput: true);
 
 		_logger.LogDebug("Starting server process: {File} {Args}", startInfo.FileName,
 			startInfo.Arguments);
@@ -550,6 +553,13 @@ internal class DevServerMonitor(IServiceProvider services, ILogger<DevServerMoni
 
 		try
 		{
+			// Close the redirected stdin immediately — the host doesn't read from it,
+			// and leaving it open can prevent the process from exiting cleanly.
+			if (startInfo.RedirectStandardInput)
+			{
+				process.StandardInput.Close();
+			}
+
 			if (startInfo.RedirectStandardOutput)
 			{
 				process.BeginOutputReadLine();

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReportFactory.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReportFactory.cs
@@ -41,12 +41,18 @@ internal static class HealthReportFactory
 		}
 		else if (connectionState == ConnectionState.Degraded && devServerStarted)
 		{
+			var hostInfo = discovery?.HostPath is not null
+				? $" Host: {discovery.HostPath}. SDK: {discovery.UnoSdkVersion ?? "unknown"}."
+				: "";
+			var addInInfo = discovery?.AddIns is { Count: > 0 }
+				? $" Add-ins: {string.Join(", ", discovery.AddIns.Select(a => $"{a.PackageName} {a.PackageVersion}"))}."
+				: "";
 			issues.Add(new ValidationIssue
 			{
 				Code = IssueCode.HostCrashed,
 				Severity = ValidationSeverity.Fatal,
-				Message = "The DevServer host process crashed repeatedly and could not be restarted.",
-				Remediation = "Check the DevServer logs for errors. You may need to restart the MCP proxy manually.",
+				Message = $"The DevServer host process crashed repeatedly and could not be restarted.{hostInfo}{addInInfo}",
+				Remediation = "Check the 'discovery' section of this health report for details. Common causes: incompatible add-in versions, missing SDK, or host binary not found.",
 			});
 		}
 

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
@@ -46,7 +46,7 @@ internal class HealthService(
 		var upstreamTask = mcpUpstreamClient.UpstreamClient;
 		var upstreamConnected = upstreamTask.IsCompletedSuccessfully;
 
-		var toolCount = toolListManager.GetCachedTools().Length;
+		var toolCount = toolListManager.SnapshotToolCount;
 
 		var discoveredSolutions = devServerMonitor.DiscoveredSolutions is { Count: > 0 }
 			? devServerMonitor.DiscoveredSolutions

--- a/src/Uno.UI.DevServer.Cli/Mcp/McpStdioServer.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/McpStdioServer.cs
@@ -20,6 +20,9 @@ internal class McpStdioServer(
 	HealthService healthService,
 	McpUpstreamClient mcpUpstreamClient)
 {
+	/// <summary>Maximum time to wait for an upstream tool call before returning a timeout error.</summary>
+	internal const int UpstreamCallToolTimeoutMs = 5 * 60 * 1000; // 5 minutes — tool calls can involve builds
+
 	private static void LogTimeline(ILogger logger, string stage, long elapsedMilliseconds, string details)
 	{
 		logger.LogDebug("TIMELINE|mcp-stdio|{Stage}|{ElapsedMs}|{Details}", stage, elapsedMilliseconds, details);
@@ -56,6 +59,7 @@ internal class McpStdioServer(
 			{
 				var toolName = ctx.Params?.Name ?? "unknown";
 				var toolStopwatch = Stopwatch.StartNew();
+				logger.LogTrace("RECV call_tool {Tool}", toolName);
 
 				if (forceRootsFallback && toolName == addRootsTool.Name)
 				{
@@ -133,21 +137,43 @@ internal class McpStdioServer(
 				var args = ctx.Params.Arguments ?? new Dictionary<string, JsonElement>();
 				var adjustedArguments = args.ToDictionary(v => v.Key, v => (object?)v.Value);
 
-				var result = await upstreamClient.CallToolAsync(
-					name,
-					adjustedArguments,
-					cancellationToken: ct
-				);
+				try
+				{
+					using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+					timeoutCts.CancelAfter(UpstreamCallToolTimeoutMs);
 
-				toolStopwatch.Stop();
-				LogTimeline(logger, "tool.forwarded-upstream.complete", toolStopwatch.ElapsedMilliseconds, toolName);
-				logger.LogDebug("Forwarded MCP tool {Tool} to upstream in {ElapsedMs} ms", toolName,
-					toolStopwatch.ElapsedMilliseconds);
-				return result;
+					var result = await upstreamClient.CallToolAsync(
+						name,
+						adjustedArguments,
+						cancellationToken: timeoutCts.Token
+					);
+
+					toolStopwatch.Stop();
+					LogTimeline(logger, "tool.forwarded-upstream.complete", toolStopwatch.ElapsedMilliseconds, toolName);
+					logger.LogDebug("Forwarded MCP tool {Tool} to upstream in {ElapsedMs} ms", toolName,
+						toolStopwatch.ElapsedMilliseconds);
+					return result;
+				}
+				catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+				{
+					toolStopwatch.Stop();
+					var message = $"Tool '{toolName}' timed out after {UpstreamCallToolTimeoutMs / 1000}s waiting for the DevServer host to respond. " +
+						"The host may be busy (building, restoring packages) or unresponsive. " +
+						"Call uno_health for diagnostics, then retry.";
+					logger.LogWarning("Tool {Tool} timed out after {ElapsedMs} ms", toolName,
+						toolStopwatch.ElapsedMilliseconds);
+					LogTimeline(logger, "tool.forwarded-upstream.timeout", toolStopwatch.ElapsedMilliseconds, toolName);
+					return new CallToolResult()
+					{
+						Content = [new TextContentBlock() { Text = message }],
+						IsError = true,
+					};
+				}
 			})
 			.WithListToolsHandler(async (ctx, ct) =>
 			{
 				var listToolsStopwatch = Stopwatch.StartNew();
+				logger.LogTrace("RECV list_tools");
 				await ensureRootsInitialized(ctx, tcs, ct);
 
 				if (forceRootsFallback && getRoots().Length == 0)

--- a/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
@@ -517,6 +517,7 @@ internal class ProxyLifecycleManager
 
 		var fileName = Path.GetFileName(path);
 		return string.Equals(fileName, "global.json", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(fileName, "project.assets.json", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(Path.GetExtension(path), ".sln", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(Path.GetExtension(path), ".slnx", StringComparison.OrdinalIgnoreCase);
 	}
@@ -1164,20 +1165,16 @@ internal class ProxyLifecycleManager
 
 		_devServerMonitor.ServerFailed += () =>
 		{
-			_logger.LogError("DevServer failed to start, stopping stdio server");
+			var discovery = _devServerMonitor.LastDiscoveryInfo;
+			_logger.LogError(
+				"DevServer host failed to start after retries; bridge stays alive for diagnostics via uno_health. " +
+				"Host={HostPath}, SDK={SdkVersion}, Solution={Solution}, AddIns={AddInCount}",
+				discovery?.HostPath ?? "<not resolved>",
+				discovery?.UnoSdkVersion ?? "<unknown>",
+				_workspaceResolution?.SelectedSolutionPath ?? "<none>",
+				discovery?.AddIns?.Count ?? 0);
 			SetConnectionState(ConnectionState.Degraded);
 			FailToolCachePriming();
-			_ = Task.Run(async () =>
-			{
-				try
-				{
-					await host.StopAsync().ConfigureAwait(false);
-				}
-				catch (Exception ex)
-				{
-					_logger.LogError(ex, "Error while stopping stdio server host after DevServer failure.");
-				}
-			});
 		};
 
 		try

--- a/src/Uno.UI.DevServer.Cli/Mcp/ToolListManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ToolListManager.cs
@@ -21,11 +21,15 @@ internal class ToolListManager(
 	private bool _toolCacheLoaded;
 	private bool _shouldRefreshToolCache = true;
 	private readonly object _toolCacheLock = new();
+	private volatile int _snapshotToolCount;
 
 	private const string ToolCacheFileName = "tools-cache.json";
 
 	/// <summary>Maximum time to wait for upstream list_tools before returning cached/empty result.</summary>
 	internal const int ListToolsTimeoutMs = 60_000;
+
+	/// <summary>Maximum time to wait for a single upstream ListToolsAsync call.</summary>
+	internal const int UpstreamCallTimeoutMs = 30_000;
 
 	public string? WorkspaceHash { get; set; }
 
@@ -35,6 +39,9 @@ internal class ToolListManager(
 	{
 		get { lock (_toolCacheLock) { return _toolCache.Length; } }
 	}
+
+	/// <summary>Lock-free snapshot of tool count, safe to read from any thread without blocking.</summary>
+	public int SnapshotToolCount => _snapshotToolCount;
 
 	public bool HasCachedTools => GetCachedTools().Length > 0;
 
@@ -97,6 +104,7 @@ internal class ToolListManager(
 				_toolCache = [];
 			}
 
+			_snapshotToolCount = _toolCache.Length;
 			return _toolCache;
 		}
 	}
@@ -140,6 +148,7 @@ internal class ToolListManager(
 				File.Move(tempPath, _toolCachePath, overwrite: true);
 
 				_toolCache = entry.Tools;
+				_snapshotToolCount = entry.Tools.Length;
 				_toolCacheLoaded = true;
 				_shouldRefreshToolCache = false;
 
@@ -180,10 +189,17 @@ internal class ToolListManager(
 		{
 			var upstreamClient = await mcpUpstreamClient.UpstreamClient;
 
-			var list = await upstreamClient.ListToolsAsync();
+			using var cts = new CancellationTokenSource(UpstreamCallTimeoutMs);
+			var list = await upstreamClient.ListToolsAsync(cancellationToken: cts.Token);
 			Tool[] protocolTools = [.. list.Select(t => t.ProtocolTool).DistinctBy(t => t.Name)];
 
 			PersistToolCacheIfNeeded(protocolTools);
+		}
+		catch (OperationCanceledException)
+		{
+			logger.LogWarning(
+				"Timed out refreshing cached tools from upstream after {Timeout}ms",
+				UpstreamCallTimeoutMs);
 		}
 		catch (Exception ex)
 		{
@@ -236,7 +252,10 @@ internal class ToolListManager(
 	{
 		logger.LogTrace("Client requested tools list update");
 
-		var list = await upstreamClient.ListToolsAsync(cancellationToken: ct);
+		using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+		timeoutCts.CancelAfter(UpstreamCallTimeoutMs);
+
+		var list = await upstreamClient.ListToolsAsync(cancellationToken: timeoutCts.Token);
 		Tool[] protocolTools = [.. list.Select(t => t.ProtocolTool).DistinctBy(t => t.Name)];
 
 		logger.LogDebug("Reporting {Count} tools", protocolTools.Length);

--- a/src/Uno.UI.DevServer.Cli/Mcp/ToolListManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ToolListManager.cs
@@ -214,7 +214,15 @@ internal class ToolListManager(
 		// If the upstream client is already available, use it directly
 		if (upstreamTask.IsCompletedSuccessfully)
 		{
-			return await FetchToolsFromUpstreamAsync(upstreamTask.Result, ct);
+			try
+			{
+				return await FetchToolsFromUpstreamAsync(upstreamTask.Result, ct);
+			}
+			catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+			{
+				logger.LogWarning("Timed out fetching tools from upstream after {Timeout}ms, returning empty tool list", UpstreamCallTimeoutMs);
+				return new() { Tools = [] };
+			}
 		}
 
 		// If we have cached tools, return them immediately without waiting

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_StdinIsolation.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_StdinIsolation.cs
@@ -1,0 +1,50 @@
+using AwesomeAssertions;
+using Uno.UI.DevServer.Cli.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Mcp;
+
+/// <summary>
+/// Regression tests for the stdin-theft bug: when the MCP CLI bridge launches
+/// the DevServer host process, it must redirect the child's stdin so that it
+/// does not inherit the parent's stdin pipe (the JSON-RPC MCP channel).
+/// Without this, the child process reads (and discards) incoming MCP messages,
+/// producing random hangs where every other tool call blocks indefinitely.
+/// </summary>
+[TestClass]
+public class Given_StdinIsolation
+{
+	[TestMethod]
+	[Description("ProcessStartInfo for the host must redirect stdin to prevent MCP message theft")]
+	public void ProcessStartInfo_RedirectsStdin_WhenRedirectInputIsTrue()
+	{
+		// Mirrors the CreateDotnetProcessStartInfo call in DevServerMonitor.StartProcess.
+		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
+			hostPath: "C:\\fake\\host.exe",
+			arguments: ["--httpPort", "12345"],
+			workingDirectory: "C:\\fake",
+			redirectOutput: true,
+			redirectInput: true);
+
+		psi.RedirectStandardInput.Should().BeTrue(
+			"the host process must NOT inherit the parent's stdin when running as an MCP stdio bridge");
+		psi.RedirectStandardOutput.Should().BeTrue();
+		psi.RedirectStandardError.Should().BeTrue();
+		psi.UseShellExecute.Should().BeFalse(
+			"UseShellExecute=false is required for stream redirection");
+	}
+
+	[TestMethod]
+	[Description("CreateDotnetProcessStartInfo defaults to not redirecting stdin")]
+	public void ProcessStartInfo_DoesNotRedirectStdin_ByDefault()
+	{
+		// Non-MCP callers (e.g. IDE integration) should keep the default behavior.
+		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
+			hostPath: "C:\\fake\\host.exe",
+			arguments: ["--httpPort", "12345"],
+			workingDirectory: "C:\\fake",
+			redirectOutput: true);
+
+		psi.RedirectStandardInput.Should().BeFalse(
+			"non-MCP callers should not redirect stdin by default");
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_ToolListManager.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_ToolListManager.cs
@@ -22,13 +22,13 @@ public class Given_ToolListManager
 		await using var fixture = await SlowMcpFixture.CreateAsync();
 
 		// Call without CT — simulates the bug
-		var listTask = fixture.Client.ListToolsAsync();
+		var listTaskInstance = fixture.Client.ListToolsAsync().AsTask();
 
 		// Should hang (not complete within 3s), proving the bug exists
-		var winner = await Task.WhenAny(listTask.AsTask(), Task.Delay(3_000));
+		var winner = await Task.WhenAny(listTaskInstance, Task.Delay(3_000));
 
 		winner.Should().NotBeSameAs(
-			listTask.AsTask(),
+			listTaskInstance,
 			"ListToolsAsync without CT hangs on a slow server");
 	}
 
@@ -59,15 +59,15 @@ public class Given_ToolListManager
 		await using var fixture = await SlowMcpFixture.CreateAsync();
 
 		// Call a tool — upstream accepts but never responds
-		var callTask = fixture.Client.CallToolAsync(
+		var callTaskInstance = fixture.Client.CallToolAsync(
 			"uno_app_start",
-			new Dictionary<string, object?>());
+			new Dictionary<string, object?>()).AsTask();
 
 		// Should hang (not complete within 3s), proving the bug exists
-		var winner = await Task.WhenAny(callTask.AsTask(), Task.Delay(3_000));
+		var winner = await Task.WhenAny(callTaskInstance, Task.Delay(3_000));
 
 		winner.Should().NotBeSameAs(
-			callTask.AsTask(),
+			callTaskInstance,
 			"CallToolAsync without timeout hangs on a slow server");
 	}
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_ToolListManager.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_ToolListManager.cs
@@ -1,0 +1,164 @@
+using System.IO.Pipelines;
+using AwesomeAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Mcp;
+
+// Reproduces the uno_health freeze: ToolListManager calls ListToolsAsync
+// without a bounded timeout, blocking the entire MCP pipeline when the
+// upstream DevServer is slow to respond.
+[TestClass]
+public class Given_ToolListManager
+{
+	// Proves ListToolsAsync without CT hangs forever on a slow server.
+	// This is the exact pattern at ToolListManager.RefreshCachedToolsFromUpstreamAsync:183
+	//   var list = await upstreamClient.ListToolsAsync();
+	[TestMethod]
+	[Timeout(15_000)]
+	public async Task ListToolsAsync_WithoutCT_HangsOnSlowServer()
+	{
+		await using var fixture = await SlowMcpFixture.CreateAsync();
+
+		// Call without CT — simulates the bug
+		var listTask = fixture.Client.ListToolsAsync();
+
+		// Should hang (not complete within 3s), proving the bug exists
+		var winner = await Task.WhenAny(listTask.AsTask(), Task.Delay(3_000));
+
+		winner.Should().NotBeSameAs(
+			listTask.AsTask(),
+			"ListToolsAsync without CT hangs on a slow server");
+	}
+
+	// Proves ListToolsAsync WITH a timeout CT cancels properly.
+	// This is the pattern the fix should use.
+	[TestMethod]
+	[Timeout(15_000)]
+	public async Task ListToolsAsync_WithTimeout_CancelsOnSlowServer()
+	{
+		await using var fixture = await SlowMcpFixture.CreateAsync();
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+		var act = async () =>
+		{
+			var unused = await fixture.Client.ListToolsAsync(cancellationToken: cts.Token);
+		};
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	// Proves CallToolAsync without timeout hangs forever on a slow server.
+	// This is the pattern at McpStdioServer.cs:136 where call_tool is forwarded:
+	//   var result = await upstreamClient.CallToolAsync(name, args, ct);
+	[TestMethod]
+	[Timeout(15_000)]
+	public async Task CallToolAsync_WithoutTimeout_HangsOnSlowServer()
+	{
+		await using var fixture = await SlowMcpFixture.CreateAsync();
+
+		// Call a tool — upstream accepts but never responds
+		var callTask = fixture.Client.CallToolAsync(
+			"uno_app_start",
+			new Dictionary<string, object?>());
+
+		// Should hang (not complete within 3s), proving the bug exists
+		var winner = await Task.WhenAny(callTask.AsTask(), Task.Delay(3_000));
+
+		winner.Should().NotBeSameAs(
+			callTask.AsTask(),
+			"CallToolAsync without timeout hangs on a slow server");
+	}
+
+	// Proves CallToolAsync WITH a timeout CT cancels properly.
+	[TestMethod]
+	[Timeout(15_000)]
+	public async Task CallToolAsync_WithTimeout_CancelsOnSlowServer()
+	{
+		await using var fixture = await SlowMcpFixture.CreateAsync();
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+		var act = async () =>
+		{
+			var unused = await fixture.Client.CallToolAsync(
+				"uno_app_start",
+				new Dictionary<string, object?>(),
+				cancellationToken: cts.Token);
+		};
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	// In-memory MCP client/server pair where tools/list and tools/call never respond.
+	private sealed class SlowMcpFixture : IAsyncDisposable
+	{
+		private readonly McpServer _server;
+
+		public McpClient Client { get; }
+
+		private SlowMcpFixture(McpServer server, McpClient client)
+		{
+			_server = server;
+			Client = client;
+		}
+
+		public static async Task<SlowMcpFixture> CreateAsync()
+		{
+			Pipe clientToServer = new(), serverToClient = new();
+
+			var server = McpServer.Create(
+				new StreamServerTransport(
+					clientToServer.Reader.AsStream(),
+					serverToClient.Writer.AsStream()),
+				new McpServerOptions
+				{
+					ServerInfo = new Implementation
+					{
+						Name = "slow-test",
+						Version = "1.0.0"
+					},
+					Capabilities = new ServerCapabilities
+					{
+						Tools = new()
+					},
+					Handlers =
+					{
+						ListToolsHandler = async (_, ct) =>
+						{
+							await Task.Delay(Timeout.Infinite, ct);
+							return new ListToolsResult();
+						},
+						CallToolHandler = async (_, ct) =>
+						{
+							await Task.Delay(Timeout.Infinite, ct);
+							return new CallToolResult();
+						}
+					}
+				});
+
+			_ = server.RunAsync();
+
+			var client = await McpClient.CreateAsync(
+				new StreamClientTransport(
+					clientToServer.Writer.AsStream(),
+					serverToClient.Reader.AsStream()),
+				new McpClientOptions
+				{
+					ClientInfo = new Implementation
+					{
+						Name = "test-client",
+						Version = "1.0.0"
+					}
+				});
+
+			return new SlowMcpFixture(server, client);
+		}
+
+		public async ValueTask DisposeAsync()
+		{
+			await Client.DisposeAsync();
+			await _server.DisposeAsync();
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -48,6 +48,7 @@
 		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\WorkspaceResolver.cs" Link="Helpers\WorkspaceResolver.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\HealthReportFormatter.cs" Link="Helpers\HealthReportFormatter.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\AssemblyVersionHelper.cs" Link="Helpers\AssemblyVersionHelper.cs" />
+		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\DevServerProcessHelper.cs" Link="Helpers\DevServerProcessHelper.cs" />
 
 		<!-- Link MCP sources for unit testing -->
 		<!-- TODO: MCP tests that only depend on CLI types should be migrated to Uno.UI.DevServer.Cli.Tests -->


### PR DESCRIPTION
Fixes #22850

## Summary

- **Root cause fix**: The DevServer host process inherited the MCP bridge's stdin pipe, stealing incoming JSON-RPC messages from the AI agent and causing random tool call hangs where every other request would block indefinitely
- Bounded all upstream MCP calls with timeouts so no handler can block forever, even in degraded scenarios
- The MCP bridge now stays alive when the host fails to start, allowing `uno_health` to report diagnostics instead of silently dying

## Problem

When the MCP CLI bridge (`--mcp-app`) launched the DevServer host process, it used `RedirectStandardInput = false`. With `UseShellExecute = false`, this caused the child to inherit the parent's stdin — which **is** the JSON-RPC message pipe from the AI agent.

Once the host process started (~5-10s after launch), it would race with the MCP server to read from the same stdin pipe. The host consumed roughly every other message, producing a pattern where tool calls alternated between instant responses and indefinite hangs.

This was reproduced with an automated timing test: 8 sequential `uno_health` calls at 5s intervals showed calls #3, #5, #7 hanging for 30+ seconds while #4, #6, #8 returned in <1ms.

## Changes

### Root cause fix (`DevServerMonitor.cs`)
- Pass `redirectInput: true` when launching the host process, giving it its own stdin pipe instead of inheriting the MCP message channel
- Close the redirected stdin immediately after `Process.Start()` since the host doesn't read from it

### Defense-in-depth: bounded timeouts
- `ToolListManager`: 30s timeout on all upstream `ListToolsAsync` calls (previously: no cancellation token at all)
- `McpStdioServer`: 5-minute timeout on forwarded `CallToolAsync` calls; returns a descriptive `IsError` result on timeout instead of hanging
- `HealthService`: use lock-free `SnapshotToolCount` instead of acquiring the tool cache lock

### Resilience improvements
- `ProxyLifecycleManager`: bridge stays alive in `Degraded` state when host fails (previously called `host.StopAsync()`, killing the entire MCP server)
- `ProxyLifecycleManager`: watch `project.assets.json` for changes to trigger re-discovery after `dotnet restore`
- `HealthReportFactory`: enriched `HostCrashed` issue message with host path, SDK version, and add-in list for faster troubleshooting

## Test plan

- [x] Automated timing test: 8 `uno_health` calls at 5s intervals — **0 hangs** after fix (was 3/8 before)
- [x] `Given_StdinIsolation` regression test verifies `ProcessStartInfo.RedirectStandardInput = true`
- [x] `Given_ToolListManager` tests prove `ListToolsAsync`/`CallToolAsync` without timeout hangs on slow servers, and with timeout cancels properly (4 tests)
- [x] Full test suite: 274 tests, 0 failures