### PR TITLE
fix(devserver): debounce FSW error handler to prevent infinite git processes

### DIFF
--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_ProxyLifecycleManager.cs
@@ -1395,12 +1395,13 @@ public class Given_ProxyLifecycleManager
 	public async Task When_WatcherReportsRapidErrors_FindSolutionFiles_IsBounded()
 	{
 		var root = CreateTempDirectory();
+		ProxyLifecycleManager? subject = null;
 
 		try
 		{
 			var finder = new CountingSolutionFileFinder([]);
 			var created = CreateSubject(solutionFileFinder: finder);
-			var subject = created.Subject;
+			subject = created.Subject;
 			SetPrivateField(subject, "_currentDirectory", root);
 
 			var method = typeof(ProxyLifecycleManager)
@@ -1413,8 +1414,10 @@ public class Given_ProxyLifecycleManager
 				method!.Invoke(subject, [subject, new ErrorEventArgs(new InternalBufferOverflowException("simulated overflow"))]);
 			}
 
-			// Wait well beyond the 250 ms debounce window.
-			await Task.Delay(700);
+			// Wait for at least one scan to complete (adaptive, up to 5s), then allow 300ms for
+			// any concurrent calls to land so the count stabilizes before asserting.
+			await WaitUntilAsync(() => finder.CallCount >= 1, timeoutMs: 5000);
+			await Task.Delay(300);
 
 			// With the fix, only the final debounced task runs the workspace scan → ≤ 2 calls.
 			// (≤ 2 instead of 1 to tolerate a single timing edge case where two tasks slip through.)
@@ -1423,6 +1426,11 @@ public class Given_ProxyLifecycleManager
 		}
 		finally
 		{
+			if (subject is not null)
+			{
+				await StopWatcherAndMonitorAsync(subject);
+			}
+
 			await DeleteDirectoryWithRetriesAsync(root);
 		}
 	}

--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_ProxyLifecycleManager.cs
@@ -1390,6 +1390,44 @@ public class Given_ProxyLifecycleManager
 	}
 
 	[TestMethod]
+	[Timeout(15_000)]
+	[Description("Rapid FSW buffer-overflow errors must be debounced; without the fix each error spawns a separate workspace scan (issue #22828)")]
+	public async Task When_WatcherReportsRapidErrors_FindSolutionFiles_IsBounded()
+	{
+		var root = CreateTempDirectory();
+
+		try
+		{
+			var finder = new CountingSolutionFileFinder([]);
+			var created = CreateSubject(solutionFileFinder: finder);
+			var subject = created.Subject;
+			SetPrivateField(subject, "_currentDirectory", root);
+
+			var method = typeof(ProxyLifecycleManager)
+				.GetMethod("OnWorkspaceMutationWatcherError", BindingFlags.Instance | BindingFlags.NonPublic);
+			method.Should().NotBeNull();
+
+			// Simulate 10 rapid buffer-overflow events (the bug causes 10 separate workspace scans).
+			for (var i = 0; i < 10; i++)
+			{
+				method!.Invoke(subject, [subject, new ErrorEventArgs(new InternalBufferOverflowException("simulated overflow"))]);
+			}
+
+			// Wait well beyond the 250 ms debounce window.
+			await Task.Delay(700);
+
+			// With the fix, only the final debounced task runs the workspace scan → ≤ 2 calls.
+			// (≤ 2 instead of 1 to tolerate a single timing edge case where two tasks slip through.)
+			finder.CallCount.Should().BeLessThanOrEqualTo(2,
+				"rapid FSW errors must be debounced; without the fix each error spawns a separate workspace scan");
+		}
+		finally
+		{
+			await DeleteDirectoryWithRetriesAsync(root);
+		}
+	}
+
+	[TestMethod]
 	[Description("Replacing the workspace debounce source installs the newest token source and cancels the previous one without disposing the superseded source yet")]
 	public void ReplaceWorkspaceMutationDebounceSource_WhenCalled_ReplacesAndCancelsPrevious()
 	{
@@ -1668,12 +1706,13 @@ public class Given_ProxyLifecycleManager
 	private sealed class CountingSolutionFileFinder(string[] solutions) : ISolutionFileFinder
 	{
 		private readonly string[] _solutions = solutions;
+		private int _callCount;
 
-		public int CallCount { get; private set; }
+		public int CallCount => Volatile.Read(ref _callCount);
 
 		public string[] FindSolutionFiles(string directory, int maxDepth = 3)
 		{
-			CallCount++;
+			Interlocked.Increment(ref _callCount);
 			return [.. _solutions];
 		}
 	}

--- a/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/ProxyLifecycleManager.cs
@@ -896,17 +896,40 @@ internal class ProxyLifecycleManager
 		_logger.LogWarning(args.GetException(),
 			"Workspace mutation watcher failed; restarting watcher and reevaluating the workspace");
 
+		var debounceCts = ReplaceWorkspaceMutationDebounceSource(ref _workspaceMutationDebounceCts);
+
 		_ = Task.Run(async () =>
 		{
 			try
 			{
+				await Task.Delay(TimeSpan.FromMilliseconds(250), debounceCts.Token);
+
+				// StopWorkspaceMutationWatcherAsync cancels _workspaceMutationDebounceCts (which may be
+				// debounceCts itself). Use CancellationToken.None for the reevaluation to avoid being
+				// cancelled by that cleanup.
 				await StopWorkspaceMutationWatcherAsync();
 				StartWorkspaceMutationWatcher();
 				await ReevaluateWorkspaceAsync(WorkspaceTransitionTrigger.FileSystem);
 			}
+			catch (OperationCanceledException)
+			{
+				// Superseded by a newer error event — expected.
+			}
 			catch (Exception ex)
 			{
 				_logger.LogWarning(ex, "Workspace reevaluation failed after watcher error");
+			}
+			finally
+			{
+				var clearedCurrent = ClearCompletedWorkspaceMutationDebounceSource(
+					ref _workspaceMutationDebounceCts,
+					debounceCts);
+				if (clearedCurrent)
+				{
+					TryCancel(debounceCts);
+				}
+
+				TryDispose(debounceCts);
 			}
 		}, CancellationToken.None);
 	}


### PR DESCRIPTION
## Summary

`OnWorkspaceMutationWatcherError` had no debouncing. On large git repositories,
the `FileSystemWatcher` internal buffer overflows rapidly, firing the error event
dozens of times in quick succession. Each event spawned an unbounded `Task.Run`
that restarted the watcher and called `ReevaluateWorkspaceAsync` → `FindSolutionFiles`
→ `git check-ignore`, accumulating hundreds of git processes until Windows froze.

This applies the same debounce pattern already used by `OnWorkspaceMutation`:
replace the shared `CancellationTokenSource` on each event so that only the last
error event in a burst actually triggers the workspace scan.

One subtlety: `ReevaluateWorkspaceAsync` is called with `CancellationToken.None`
(not `debounceCts.Token`) because `StopWorkspaceMutationWatcherAsync` cancels
`_workspaceMutationDebounceCts` — which may be the same `debounceCts` — before
the reevaluation runs.

## Changes

- `ProxyLifecycleManager.cs` — debounce `OnWorkspaceMutationWatcherError` via
  `ReplaceWorkspaceMutationDebounceSource` + 250 ms `Task.Delay`
- `Given_ProxyLifecycleManager.cs` — regression test: 10 rapid error events must
  produce ≤ 2 `FindSolutionFiles` calls (thread-safe counter via `Interlocked.Increment`)

## Test plan

- [x] New test `When_WatcherReportsRapidErrors_FindSolutionFiles_IsBounded` is RED
  without the fix (`CallCount = 10 > 2`) and GREEN with it (`CallCount = 1 ≤ 2`)

Closes https://github.com/unoplatform/uno/issues/22828
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/unoplatform/uno/pull/22853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
