### PR TITLE
fix: Time selection reliability

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
@@ -424,10 +424,24 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			// to prevent incorrect re-selection.
 			if (pEventArgs.IsIntermediate)
 			{
-				// For intermediate events, balance immediately to keep items visible during fast scrolling
+				// For intermediate events, balance immediately to keep items visible during fast scrolling.
+				// Suppress selection changes so that SelectionChanged only fires on the final
+				// ViewChanged event. Without this, keyboard-driven animated scrolls can raise
+				// SelectionChanged from an intermediate scroll position, causing callers that
+				// react to SelectionChanged (e.g., LoopingSelectorHelper.SelectItemByIndex) to
+				// proceed before the animation settles, leading to accumulated scroll drift.
 				if (!_isWithinScrollChange && !_isWithinArrangeOverride)
 				{
-					Balance(false);
+					var prevSkip = _skipSelectionChangeUntilFinalViewChanged;
+					_skipSelectionChangeUntilFinalViewChanged = true;
+					try
+					{
+						Balance(false);
+					}
+					finally
+					{
+						_skipSelectionChangeUntilFinalViewChanged = prevSkip;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
…croll events

Intermediate ViewChanged Balance calls (added for fast-scrolling virtualization) were firing SelectionChanged before scroll animations settled. This caused keyboard-driven selection (e.g. SelectItemByIndex) to proceed from stale scroll positions, accumulating drift over many key presses and making SelectingTimeSetsSelectedTime flaky on Android Skia.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->