### PR TITLE
test: temporarily disable flaky SelectingTimeSetsSelectedTime

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TimePicker/TimePickerIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TimePicker/TimePickerIntegrationTests.cs
@@ -260,11 +260,7 @@ public class TimePickerIntegrationTests
 	}
 
 	[TestMethod]
-#if __ANDROID__ || __APPLE_UIKIT__
-	[Ignore("This is only relevant for managed implementation")]
-#elif __WASM__
-	[Ignore("https://github.com/unoplatform/uno/issues/16167")]
-#endif
+	[Ignore("Temporarily disabled - flaky in CI, tracked by https://github.com/unoplatform/uno/issues/16167; re-enable once this issue is resolved")]
 	public async Task SelectingTimeSetsSelectedTime()
 	{
 		var timePicker = await SetupTimePickerTestAsync();


### PR DESCRIPTION
Temporarily disables the `SelectingTimeSetsSelectedTime` runtime test which is flaky in CI, blocking master merges.

The test was already `[Ignore]`'d on Android native, iOS, and WASM with platform-specific `#if` directives, but it was still running on Skia desktop, where it consistently fails in the `Android+NativeAOT Skia Runtime Tests 3` CI bucket.

PR https://github.com/unoplatform/uno/pull/22854 attempted to fix the root cause (intermediate `LoopingSelector` scroll events firing `SelectionChanged` too early), but the test continues to fail on master.

This replaces the platform-specific ignores with a universal `[Ignore]` so master can go green and PRs can merge again.

Related to https://github.com/unoplatform/uno/issues/16167