### PR TITLE
Support for `BackgroundSizing`

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2166,6 +2166,7 @@
 		  <!-- END AutomationPeer API alignment -->
 
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="BackgroundSizing support" />
 	  </Methods>
 	</IgnoreSet>
 	<![CDATA[

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2526,7 +2526,9 @@
 		  <!-- END AutomationPeer API alignment -->
 
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="BackgroundSizing support" />
+		  <!-- Uno-specific extension point (not part of the WinUI surface) emitted by the DependencyProperty mixin generator.
+		       Control.BackgroundSizing now uses [GeneratedDependencyProperty], which does not emit a typed protected virtual. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="Intentional removal of Uno-only protected virtual; replaced by [GeneratedDependencyProperty] BackgroundSizing on Control" />
 
 		  <!-- Replaced generic App<TApplication>(Func<TApplication>) with non-generic App(Func<Application>)
 		       to prevent CoreCLR shared-generic policy from placing Func<TApp> instantiations in the default

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2526,6 +2526,7 @@
 		  <!-- END AutomationPeer API alignment -->
 
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="BackgroundSizing support" />
 
 		  <!-- Replaced generic App<TApplication>(Func<TApplication>) with non-generic App(Func<Application>)
 		       to prevent CoreCLR shared-generic policy from placing Func<TApp> instantiations in the default

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2913,7 +2913,9 @@
 		  <!-- END AutomationPeer API alignment -->
 
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="BackgroundSizing support" />
+		  <!-- Uno-specific extension point (not part of the WinUI surface) emitted by the DependencyProperty mixin generator.
+		       Control.BackgroundSizing now uses [GeneratedDependencyProperty], which does not emit a typed protected virtual. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="Intentional removal of Uno-only protected virtual; replaced by [GeneratedDependencyProperty] BackgroundSizing on Control" />
 
 		  <!-- Replaced generic App<TApplication>(Func<TApplication>) with non-generic App(Func<Application>)
 		       to prevent CoreCLR shared-generic policy from placing Func<TApp> instantiations in the default

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2913,6 +2913,7 @@
 		  <!-- END AutomationPeer API alignment -->
 
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundSizingChanged(Microsoft.UI.Xaml.Controls.BackgroundSizing oldBackgroundSizing, Microsoft.UI.Xaml.Controls.BackgroundSizing newBackgroundSizing)" reason="BackgroundSizing support" />
 
 		  <!-- Replaced generic App<TApplication>(Func<TApplication>) with non-generic App(Func<Application>)
 		       to prevent CoreCLR shared-generic policy from placing Func<TApp> instantiations in the default

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/DependencyPropertyMixinGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/DependencyPropertyMixinGenerator.cs
@@ -203,7 +203,6 @@ using View = Microsoft.UI.Xaml.FrameworkElement;
 		{
 			new ClassDefinition("Control", "true", "public", new[]
 			{
-				new PropertyDefinition("BackgroundSizing", "BackgroundSizing", "default"),
 				new PropertyDefinition("HorizontalContentAlignment", "HorizontalAlignment",
 					"(Uno.UI.FeatureConfiguration.Control.UseLegacyContentAlignment ? HorizontalAlignment.Left : HorizontalAlignment.Center)",
 					frameworkPropertyOption: "AffectsArrange"),

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/DependencyPropertyMixinGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/DependencyPropertyMixinGenerator.cs
@@ -203,7 +203,6 @@ using View = Microsoft.UI.Xaml.FrameworkElement;
 		{
 			new ClassDefinition("Control", "true", "public", new[]
 			{
-				new PropertyDefinition("BackgroundSizing", "BackgroundSizing", "default"),
 				new PropertyDefinition("HorizontalContentAlignment", "HorizontalAlignment",
 					"HorizontalAlignment.Center",
 					frameworkPropertyOption: "AffectsArrange"),

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_CompositionSpriteShape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_CompositionSpriteShape.cs
@@ -10,6 +10,7 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
+using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Microsoft.UI.Xaml.Markup;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using System.Numerics;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_CompositionSpriteShape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_CompositionSpriteShape.cs
@@ -12,7 +12,6 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Microsoft.UI.Xaml.Markup;
-using Path = Microsoft.UI.Xaml.Shapes.Path;
 using System.Numerics;
 using Windows.Foundation;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -1,0 +1,371 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
+using MUXControlsTestApp.Utilities;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_BackgroundSizing
+{
+	#region Property Default & Read/Write
+
+	[TestMethod]
+	public void When_Border_Default_BackgroundSizing()
+	{
+		var border = new Border();
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, border.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public void When_ContentPresenter_Default_BackgroundSizing()
+	{
+		var cp = new ContentPresenter();
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, cp.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public void When_Control_Default_BackgroundSizing()
+	{
+		var button = new Button();
+		// Raw default before style application
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, (BackgroundSizing)button.GetValue(Control.BackgroundSizingProperty));
+	}
+
+	[TestMethod]
+	public void When_Grid_Default_BackgroundSizing()
+	{
+		var grid = new Grid();
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, grid.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public void When_StackPanel_Default_BackgroundSizing()
+	{
+		var sp = new StackPanel();
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, sp.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public void When_RelativePanel_Default_BackgroundSizing()
+	{
+		var rp = new RelativePanel();
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, rp.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public void When_Control_BackgroundSizing_SetAndGet()
+	{
+		var button = new Button();
+		button.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, button.BackgroundSizing);
+
+		button.BackgroundSizing = BackgroundSizing.InnerBorderEdge;
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, button.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public async Task When_Button_Style_Sets_BackgroundSizing()
+	{
+		// The default Button style (AccentButtonStyle) sets BackgroundSizing=OuterBorderEdge,
+		// but the default XamlDefaultButton style does not. Let's test that
+		// setting via style works.
+		var button = new Button
+		{
+			Style = (Style)Application.Current.Resources["AccentButtonStyle"],
+			Content = "Test"
+		};
+
+		await UITestHelper.Load(button);
+
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, button.BackgroundSizing);
+	}
+
+	#endregion
+
+	#region TemplateBinding Propagation
+
+	[TestMethod]
+	public async Task When_Button_BackgroundSizing_Propagates_To_ContentPresenter()
+	{
+		var button = new Button
+		{
+			BackgroundSizing = BackgroundSizing.OuterBorderEdge,
+			Content = "Test"
+		};
+
+		await UITestHelper.Load(button);
+
+		var cp = button.FindVisualChildByType<ContentPresenter>();
+		Assert.IsNotNull(cp, "ContentPresenter should exist in Button template");
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, cp.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public async Task When_Button_BackgroundSizing_InnerBorderEdge_Propagates()
+	{
+		var button = new Button
+		{
+			BackgroundSizing = BackgroundSizing.InnerBorderEdge,
+			Content = "Test"
+		};
+
+		await UITestHelper.Load(button);
+
+		var cp = button.FindVisualChildByType<ContentPresenter>();
+		Assert.IsNotNull(cp, "ContentPresenter should exist in Button template");
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, cp.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public async Task When_ToggleButton_BackgroundSizing_Propagates_To_Grid()
+	{
+		var toggleButton = new ToggleButton
+		{
+			BackgroundSizing = BackgroundSizing.OuterBorderEdge,
+			Content = "Test"
+		};
+
+		await UITestHelper.Load(toggleButton);
+
+		var grid = toggleButton.FindVisualChildByType<Grid>();
+		Assert.IsNotNull(grid, "Grid should exist in ToggleButton template");
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, grid.BackgroundSizing);
+	}
+
+	[TestMethod]
+	public async Task When_BackgroundSizing_Changed_After_Load_Propagates()
+	{
+		var button = new Button
+		{
+			BackgroundSizing = BackgroundSizing.InnerBorderEdge,
+			Content = "Test"
+		};
+
+		await UITestHelper.Load(button);
+
+		var cp = button.FindVisualChildByType<ContentPresenter>();
+		Assert.IsNotNull(cp);
+		Assert.AreEqual(BackgroundSizing.InnerBorderEdge, cp.BackgroundSizing);
+
+		// Change at runtime
+		button.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, cp.BackgroundSizing);
+	}
+
+	#endregion
+
+	#region Visual Rendering
+
+#if HAS_RENDER_TARGET_BITMAP
+	[TestMethod]
+	public async Task When_Border_InnerBorderEdge_Background_Not_Under_Border()
+	{
+		var border = new Border
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
+			BorderThickness = new Thickness(20),
+			BackgroundSizing = BackgroundSizing.InnerBorderEdge
+		};
+
+		await UITestHelper.Load(border);
+
+		var screenshot = await UITestHelper.ScreenShot(border);
+
+		// Pixel at (5,50) is inside the border area — should be red, NOT green
+		ImageAssert.HasColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Green, tolerance: 20);
+	}
+
+	[TestMethod]
+	public async Task When_Border_OuterBorderEdge_Background_Under_Border()
+	{
+		var border = new Border
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
+			BorderThickness = new Thickness(20),
+			BackgroundSizing = BackgroundSizing.OuterBorderEdge
+		};
+
+		await UITestHelper.Load(border);
+
+		var screenshot = await UITestHelper.ScreenShot(border);
+
+		// Pixel at (5,50) is inside the border area — green should bleed through semi-transparent red
+		// So it should NOT be pure red (green is under it)
+		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+	}
+
+	[TestMethod]
+	public async Task When_ContentPresenter_OuterBorderEdge_Visual()
+	{
+		var cp = new ContentPresenter
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
+			BorderThickness = new Thickness(20),
+			BackgroundSizing = BackgroundSizing.OuterBorderEdge
+		};
+
+		await UITestHelper.Load(cp);
+
+		var screenshot = await UITestHelper.ScreenShot(cp);
+
+		// Green bleeds through semi-transparent red border when OuterBorderEdge
+		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+	}
+
+	[TestMethod]
+	public async Task When_Grid_BackgroundSizing_OuterBorderEdge_Visual()
+	{
+		var grid = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
+			BorderThickness = new Thickness(20),
+			BackgroundSizing = BackgroundSizing.OuterBorderEdge
+		};
+
+		await UITestHelper.Load(grid);
+
+		var screenshot = await UITestHelper.ScreenShot(grid);
+
+		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+	}
+
+	[TestMethod]
+	public async Task When_Border_BackgroundSizing_With_CornerRadius()
+	{
+		var border = new Border
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
+			BorderThickness = new Thickness(20),
+			CornerRadius = new CornerRadius(15),
+			BackgroundSizing = BackgroundSizing.InnerBorderEdge
+		};
+
+		await UITestHelper.Load(border);
+
+		var screenshot = await UITestHelper.ScreenShot(border);
+
+		// Center should be green (inner content area)
+		ImageAssert.HasColorAt(screenshot, 50, 50, Microsoft.UI.Colors.Green, tolerance: 20);
+	}
+
+	[TestMethod]
+	public async Task When_Border_BackgroundSizing_Dynamic_Change_Visual()
+	{
+		var border = new Border
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
+			BorderThickness = new Thickness(20),
+			BackgroundSizing = BackgroundSizing.InnerBorderEdge
+		};
+
+		await UITestHelper.Load(border);
+
+		var screenshotBefore = await UITestHelper.ScreenShot(border);
+
+		// Border area should be pure red (no green underneath)
+		ImageAssert.HasColorAt(screenshotBefore, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+
+		// Switch to OuterBorderEdge — now use semi-transparent border to see the difference
+		border.BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0));
+		border.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var screenshotAfter = await UITestHelper.ScreenShot(border);
+
+		// Green should now bleed through, so it should NOT be pure red anymore
+		ImageAssert.DoesNotHaveColorAt(screenshotAfter, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+	}
+#endif
+
+	#endregion
+
+	#region Issue #7192 Repro
+
+	[TestMethod]
+	public async Task When_ToggleButton_With_CornerRadius_And_Border()
+	{
+		var grid = new Grid
+		{
+			Width = 300,
+			ColumnDefinitions =
+			{
+				new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+				new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }
+			}
+		};
+
+		var toggle1 = new ToggleButton
+		{
+			Content = "RGB",
+			BorderThickness = new Thickness(1),
+			IsChecked = true,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			IsThreeState = false,
+			CornerRadius = new CornerRadius(2, 0, 0, 2)
+		};
+		Grid.SetColumn(toggle1, 0);
+
+		var toggle2 = new ToggleButton
+		{
+			Content = "HSV",
+			BorderThickness = new Thickness(1),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			IsThreeState = false,
+			CornerRadius = new CornerRadius(0, 2, 2, 0)
+		};
+		Grid.SetColumn(toggle2, 1);
+
+		grid.Children.Add(toggle1);
+		grid.Children.Add(toggle2);
+
+		await UITestHelper.Load(grid);
+
+		// Both ToggleButtons should render with valid dimensions
+		Assert.IsTrue(toggle1.ActualWidth > 0, "toggle1 ActualWidth should be > 0");
+		Assert.IsTrue(toggle1.ActualHeight > 0, "toggle1 ActualHeight should be > 0");
+		Assert.IsTrue(toggle2.ActualWidth > 0, "toggle2 ActualWidth should be > 0");
+		Assert.IsTrue(toggle2.ActualHeight > 0, "toggle2 ActualHeight should be > 0");
+
+		// Verify BackgroundSizing can be set on ToggleButton and propagates
+		toggle1.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var innerGrid = toggle1.FindVisualChildByType<Grid>();
+		Assert.IsNotNull(innerGrid, "Grid should exist in ToggleButton template");
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, innerGrid.BackgroundSizing,
+			"BackgroundSizing should propagate from ToggleButton to template Grid");
+	}
+
+	#endregion
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -125,7 +125,7 @@ public class Given_BackgroundSizing
 	}
 
 	[TestMethod]
-	public async Task When_ToggleButton_BackgroundSizing_Propagates_To_Grid()
+	public async Task When_ToggleButton_BackgroundSizing_Propagates_To_ContentPresenter()
 	{
 		var toggleButton = new ToggleButton
 		{
@@ -135,9 +135,10 @@ public class Given_BackgroundSizing
 
 		await UITestHelper.Load(toggleButton);
 
-		var grid = toggleButton.FindVisualChildByType<Grid>();
-		Assert.IsNotNull(grid, "Grid should exist in ToggleButton template");
-		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, grid.BackgroundSizing);
+		// WinUI ToggleButton template uses ContentPresenter with {TemplateBinding BackgroundSizing}
+		var cp = toggleButton.FindVisualChildByType<ContentPresenter>();
+		Assert.IsNotNull(cp, "ContentPresenter should exist in ToggleButton template");
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, cp.BackgroundSizing);
 	}
 
 	[TestMethod]
@@ -358,13 +359,14 @@ public class Given_BackgroundSizing
 		Assert.IsTrue(toggle2.ActualHeight > 0, "toggle2 ActualHeight should be > 0");
 
 		// Verify BackgroundSizing can be set on ToggleButton and propagates
+		// WinUI ToggleButton template uses ContentPresenter with {TemplateBinding BackgroundSizing}
 		toggle1.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
 		await TestServices.WindowHelper.WaitForIdle();
 
-		var innerGrid = toggle1.FindVisualChildByType<Grid>();
-		Assert.IsNotNull(innerGrid, "Grid should exist in ToggleButton template");
-		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, innerGrid.BackgroundSizing,
-			"BackgroundSizing should propagate from ToggleButton to template Grid");
+		var cp = toggle1.FindVisualChildByType<ContentPresenter>();
+		Assert.IsNotNull(cp, "ContentPresenter should exist in ToggleButton template");
+		Assert.AreEqual(BackgroundSizing.OuterBorderEdge, cp.BackgroundSizing,
+			"BackgroundSizing should propagate from ToggleButton to template ContentPresenter");
 	}
 
 	#endregion

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -174,7 +174,7 @@ public class Given_BackgroundSizing
 		{
 			Width = 100,
 			Height = 100,
-			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
 			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.InnerBorderEdge
@@ -205,7 +205,7 @@ public class Given_BackgroundSizing
 		{
 			Width = 100,
 			Height = 100,
-			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
 			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.OuterBorderEdge
@@ -236,7 +236,7 @@ public class Given_BackgroundSizing
 		{
 			Width = 100,
 			Height = 100,
-			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
 			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.OuterBorderEdge
@@ -267,7 +267,7 @@ public class Given_BackgroundSizing
 		{
 			Width = 100,
 			Height = 100,
-			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
 			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.OuterBorderEdge
@@ -298,7 +298,7 @@ public class Given_BackgroundSizing
 		{
 			Width = 100,
 			Height = 100,
-			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
 			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			CornerRadius = new CornerRadius(15),
@@ -310,7 +310,7 @@ public class Given_BackgroundSizing
 		var screenshot = await UITestHelper.ScreenShot(border);
 
 		// Center should be green (inner content area)
-		ImageAssert.HasColorAt(screenshot, 50, 50, Microsoft.UI.Colors.Green, tolerance: 20);
+		ImageAssert.HasColorAt(screenshot, 50, 50, Microsoft.UI.Colors.Lime, tolerance: 20);
 	}
 
 	[TestMethod]
@@ -320,7 +320,7 @@ public class Given_BackgroundSizing
 		{
 			Width = 100,
 			Height = 100,
-			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
 			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.InnerBorderEdge

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -74,9 +74,8 @@ public class Given_BackgroundSizing
 	[TestMethod]
 	public async Task When_Button_Style_Sets_BackgroundSizing()
 	{
-		// The default Button style (AccentButtonStyle) sets BackgroundSizing=OuterBorderEdge,
-		// but the default XamlDefaultButton style does not. Let's test that
-		// setting via style works.
+		// Verify that an explicitly applied style can set BackgroundSizing.
+		// AccentButtonStyle is used here as a concrete style that sets OuterBorderEdge.
 		var button = new Button
 		{
 			Style = (Style)Application.Current.Resources["AccentButtonStyle"],
@@ -176,18 +175,27 @@ public class Given_BackgroundSizing
 			Width = 100,
 			Height = 100,
 			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
-			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.InnerBorderEdge
 		};
 
-		await UITestHelper.Load(border);
+		var root = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Blue),
+			Children = { border }
+		};
 
-		var screenshot = await UITestHelper.ScreenShot(border);
+		await UITestHelper.Load(root);
 
-		// Pixel at (5,50) is inside the border area — should be red, NOT green
-		ImageAssert.HasColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
-		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Green, tolerance: 20);
+		var screenshot = await UITestHelper.ScreenShot(root);
+
+		// With InnerBorderEdge, the green background does not extend under the border.
+		// The semi-transparent red border blends with the blue parent background,
+		// producing a pixel with no green component: ~(255, 128, 0, 127).
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: 20);
 	}
 
 	[TestMethod]
@@ -203,13 +211,22 @@ public class Given_BackgroundSizing
 			BackgroundSizing = BackgroundSizing.OuterBorderEdge
 		};
 
-		await UITestHelper.Load(border);
+		var root = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Blue),
+			Children = { border }
+		};
 
-		var screenshot = await UITestHelper.ScreenShot(border);
+		await UITestHelper.Load(root);
 
-		// Pixel at (5,50) is inside the border area — green should bleed through semi-transparent red
-		// So it should NOT be pure red (green is under it)
-		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+		var screenshot = await UITestHelper.ScreenShot(root);
+
+		// With OuterBorderEdge, the green background extends under the border.
+		// The semi-transparent red border blends with the green background,
+		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
 	}
 
 	[TestMethod]
@@ -225,12 +242,22 @@ public class Given_BackgroundSizing
 			BackgroundSizing = BackgroundSizing.OuterBorderEdge
 		};
 
-		await UITestHelper.Load(cp);
+		var root = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Blue),
+			Children = { cp }
+		};
 
-		var screenshot = await UITestHelper.ScreenShot(cp);
+		await UITestHelper.Load(root);
 
-		// Green bleeds through semi-transparent red border when OuterBorderEdge
-		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+		var screenshot = await UITestHelper.ScreenShot(root);
+
+		// With OuterBorderEdge, the green background extends under the border.
+		// The semi-transparent red border blends with the green background,
+		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
 	}
 
 	[TestMethod]
@@ -246,11 +273,22 @@ public class Given_BackgroundSizing
 			BackgroundSizing = BackgroundSizing.OuterBorderEdge
 		};
 
-		await UITestHelper.Load(grid);
+		var root = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Blue),
+			Children = { grid }
+		};
 
-		var screenshot = await UITestHelper.ScreenShot(grid);
+		await UITestHelper.Load(root);
 
-		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+		var screenshot = await UITestHelper.ScreenShot(root);
+
+		// With OuterBorderEdge, the green background extends under the border.
+		// The semi-transparent red border blends with the green background,
+		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
 	}
 
 	[TestMethod]
@@ -283,27 +321,38 @@ public class Given_BackgroundSizing
 			Width = 100,
 			Height = 100,
 			Background = new SolidColorBrush(Microsoft.UI.Colors.Green),
-			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			BackgroundSizing = BackgroundSizing.InnerBorderEdge
 		};
 
-		await UITestHelper.Load(border);
+		var root = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Blue),
+			Children = { border }
+		};
 
-		var screenshotBefore = await UITestHelper.ScreenShot(border);
+		await UITestHelper.Load(root);
 
-		// Border area should be pure red (no green underneath)
-		ImageAssert.HasColorAt(screenshotBefore, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+		var screenshotBefore = await UITestHelper.ScreenShot(root);
 
-		// Switch to OuterBorderEdge — now use semi-transparent border to see the difference
-		border.BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0));
+		// With InnerBorderEdge, the green background does not extend under the border.
+		// The semi-transparent red border blends with the blue parent background,
+		// producing a pixel with no green component: ~(255, 128, 0, 127).
+		ImageAssert.HasColorAt(screenshotBefore, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: 20);
+
+		// Switch to OuterBorderEdge — green background now extends under the border
 		border.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
 		await TestServices.WindowHelper.WaitForIdle();
 
-		var screenshotAfter = await UITestHelper.ScreenShot(border);
+		var screenshotAfter = await UITestHelper.ScreenShot(root);
 
-		// Green should now bleed through, so it should NOT be pure red anymore
-		ImageAssert.DoesNotHaveColorAt(screenshotAfter, 5, 50, Microsoft.UI.Colors.Red, tolerance: 20);
+		// With OuterBorderEdge, the green background extends under the border.
+		// The semi-transparent red border blends with the green background,
+		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
+		ImageAssert.HasColorAt(screenshotAfter, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
 	}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -167,6 +167,13 @@ public class Given_BackgroundSizing
 	#region Visual Rendering
 
 #if HAS_RENDER_TARGET_BITMAP
+	// The border-area samples below expect alpha-blend results (a 50% red border over the parent's
+	// blue or the element's green), whose 8-bit rounding differs slightly between rasterizers.
+	// The band is intentionally wider than the 1-5 used for flat colors: the two modes differ by
+	// ~127 counts in the green/blue channels, so it still cannot conflate InnerBorderEdge with
+	// OuterBorderEdge. Flat, unblended samples keep a tight tolerance.
+	private const int BlendedBorderTolerance = 20;
+
 	[TestMethod]
 	public async Task When_Border_InnerBorderEdge_Background_Not_Under_Border()
 	{
@@ -195,7 +202,7 @@ public class Given_BackgroundSizing
 		// With InnerBorderEdge, the green background does not extend under the border.
 		// The semi-transparent red border blends with the blue parent background,
 		// producing a pixel with no green component: ~(255, 128, 0, 127).
-		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: 20);
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: BlendedBorderTolerance);
 	}
 
 	[TestMethod]
@@ -226,7 +233,7 @@ public class Given_BackgroundSizing
 		// With OuterBorderEdge, the green background extends under the border.
 		// The semi-transparent red border blends with the green background,
 		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
-		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: BlendedBorderTolerance);
 	}
 
 	[TestMethod]
@@ -257,7 +264,7 @@ public class Given_BackgroundSizing
 		// With OuterBorderEdge, the green background extends under the border.
 		// The semi-transparent red border blends with the green background,
 		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
-		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: BlendedBorderTolerance);
 	}
 
 	[TestMethod]
@@ -288,7 +295,7 @@ public class Given_BackgroundSizing
 		// With OuterBorderEdge, the green background extends under the border.
 		// The semi-transparent red border blends with the green background,
 		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
-		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: BlendedBorderTolerance);
 	}
 
 	[TestMethod]
@@ -322,7 +329,7 @@ public class Given_BackgroundSizing
 		// inner edge, leaving the semi-transparent red border blended with the blue parent:
 		// ~(255, 128, 0, 127). Under OuterBorderEdge it would blend with green instead
 		// (~(255, 128, 127, 0)), so this assertion discriminates between the two modes.
-		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: 20);
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: BlendedBorderTolerance);
 
 		// Inner content area stays green (flat, unblended color).
 		ImageAssert.HasColorAt(screenshot, 50, 50, Microsoft.UI.Colors.Lime, tolerance: 5);
@@ -356,7 +363,7 @@ public class Given_BackgroundSizing
 		// With InnerBorderEdge, the green background does not extend under the border.
 		// The semi-transparent red border blends with the blue parent background,
 		// producing a pixel with no green component: ~(255, 128, 0, 127).
-		ImageAssert.HasColorAt(screenshotBefore, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: 20);
+		ImageAssert.HasColorAt(screenshotBefore, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: BlendedBorderTolerance);
 
 		// Switch to OuterBorderEdge — green background now extends under the border
 		border.BackgroundSizing = BackgroundSizing.OuterBorderEdge;
@@ -367,7 +374,7 @@ public class Given_BackgroundSizing
 		// With OuterBorderEdge, the green background extends under the border.
 		// The semi-transparent red border blends with the green background,
 		// producing a pixel with a meaningful green component: ~(255, 128, 127, 0).
-		ImageAssert.HasColorAt(screenshotAfter, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: 20);
+		ImageAssert.HasColorAt(screenshotAfter, 5, 50, Color.FromArgb(255, 128, 127, 0), tolerance: BlendedBorderTolerance);
 	}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -361,6 +361,7 @@ public class Given_BackgroundSizing
 	#region Issue #7192 Repro
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/7192")]
 	public async Task When_ToggleButton_With_CornerRadius_And_Border()
 	{
 		var grid = new Grid

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_BackgroundSizing.cs
@@ -299,18 +299,33 @@ public class Given_BackgroundSizing
 			Width = 100,
 			Height = 100,
 			Background = new SolidColorBrush(Microsoft.UI.Colors.Lime),
-			BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0)),
+			BorderBrush = new SolidColorBrush(Color.FromArgb(128, 255, 0, 0)),
 			BorderThickness = new Thickness(20),
 			CornerRadius = new CornerRadius(15),
 			BackgroundSizing = BackgroundSizing.InnerBorderEdge
 		};
 
-		await UITestHelper.Load(border);
+		var root = new Grid
+		{
+			Width = 100,
+			Height = 100,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.Blue),
+			Children = { border }
+		};
 
-		var screenshot = await UITestHelper.ScreenShot(border);
+		await UITestHelper.Load(root);
 
-		// Center should be green (inner content area)
-		ImageAssert.HasColorAt(screenshot, 50, 50, Microsoft.UI.Colors.Lime, tolerance: 20);
+		var screenshot = await UITestHelper.ScreenShot(root);
+
+		// At mid-height the left border is straight (the 15px corner arcs do not reach y=50),
+		// so this samples the border area. With InnerBorderEdge the green background stops at the
+		// inner edge, leaving the semi-transparent red border blended with the blue parent:
+		// ~(255, 128, 0, 127). Under OuterBorderEdge it would blend with green instead
+		// (~(255, 128, 127, 0)), so this assertion discriminates between the two modes.
+		ImageAssert.HasColorAt(screenshot, 5, 50, Color.FromArgb(255, 128, 0, 127), tolerance: 20);
+
+		// Inner content area stays green (flat, unblended color).
+		ImageAssert.HasColorAt(screenshot, 50, 50, Microsoft.UI.Colors.Lime, tolerance: 5);
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_PathIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_PathIcon.cs
@@ -2,6 +2,7 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using Path = Microsoft.UI.Xaml.Shapes.Path;
 using MUXControlsTestApp.Utilities;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Private.Infrastructure;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_PathIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_PathIcon.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using MUXControlsTestApp.Utilities;
-using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
@@ -8,7 +8,6 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using SamplesApp.UITests;
-using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Uno.UI.RuntimeTests.Helpers;
 using System.Threading;
 using static Private.Infrastructure.TestServices;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
+using Path = Microsoft.UI.Xaml.Shapes.Path;
 using SamplesApp.UITests;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Uno.UI.RuntimeTests.Helpers;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml.Shapes;
 #if !WINAPPSDK
 using Uno.Media;
 #endif
+using Path = Microsoft.UI.Xaml.Shapes.Path;
 using SamplesApp.UITests;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Uno.UI.RuntimeTests.Helpers;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Path.cs
@@ -11,7 +11,6 @@ using Uno.Media;
 #endif
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using SamplesApp.UITests;
-using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Uno.UI.RuntimeTests.Helpers;
 using System.Threading;
 using static Private.Infrastructure.TestServices;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
@@ -11,7 +11,6 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 using Uno.UI.RuntimeTests.Helpers;
-using Path = Microsoft.UI.Xaml.Shapes.Path;
 
 #if HAS_UNO
 using Uno.UI.Controls.Legacy;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
@@ -9,6 +9,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using Path = Microsoft.UI.Xaml.Shapes.Path;
+using Uno.UI.Controls.Legacy;
 using Uno.UI.RuntimeTests.Helpers;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Shape.cs
@@ -10,7 +10,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
-using Uno.UI.Controls.Legacy;
 using Uno.UI.RuntimeTests.Helpers;
 using Path = Microsoft.UI.Xaml.Shapes.Path;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -822,6 +822,24 @@ namespace Microsoft.UI.Xaml.Controls
 
 		#endregion
 
+		#region BackgroundSizing DependencyProperty
+
+		[GeneratedDependencyProperty(DefaultValue = default(BackgroundSizing), ChangedCallback = true)]
+		public static DependencyProperty BackgroundSizingProperty { get; } = CreateBackgroundSizingProperty();
+
+		public BackgroundSizing BackgroundSizing
+		{
+			get => GetBackgroundSizingValue();
+			set => SetBackgroundSizingValue(value);
+		}
+
+		private void OnBackgroundSizingChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnBackgroundSizingChangedInner(e);
+		}
+
+		#endregion
+
 		private protected override void OnIsTabStopChanged(bool oldValue, bool newValue)
 		{
 			OnIsFocusableChanged();

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -853,6 +853,24 @@ namespace Microsoft.UI.Xaml.Controls
 
 		#endregion
 
+		#region BackgroundSizing DependencyProperty
+
+		[GeneratedDependencyProperty(DefaultValue = default(BackgroundSizing), ChangedCallback = true)]
+		public static DependencyProperty BackgroundSizingProperty { get; } = CreateBackgroundSizingProperty();
+
+		public BackgroundSizing BackgroundSizing
+		{
+			get => GetBackgroundSizingValue();
+			set => SetBackgroundSizingValue(value);
+		}
+
+		private void OnBackgroundSizingChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnBackgroundSizingChangedInner(e);
+		}
+
+		#endregion
+
 		private protected override void OnIsTabStopChanged(bool oldValue, bool newValue)
 		{
 			OnIsFocusableChanged();

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -761,6 +761,24 @@ namespace Microsoft.UI.Xaml.Controls
 
 		#endregion
 
+		#region BackgroundSizing DependencyProperty
+
+		[GeneratedDependencyProperty(DefaultValue = default(BackgroundSizing), ChangedCallback = true)]
+		public static DependencyProperty BackgroundSizingProperty { get; } = CreateBackgroundSizingProperty();
+
+		public BackgroundSizing BackgroundSizing
+		{
+			get => GetBackgroundSizingValue();
+			set => SetBackgroundSizingValue(value);
+		}
+
+		private void OnBackgroundSizingChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnBackgroundSizingChangedInner(e);
+		}
+
+		#endregion
+
 		private protected override void OnIsTabStopChanged(bool oldValue, bool newValue)
 		{
 			OnIsFocusableChanged();

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3239,6 +3239,7 @@
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 						<ContentPresenter x:Name="ContentPresenter"
+										  BackgroundSizing="{TemplateBinding BackgroundSizing}"
 										  BorderBrush="{TemplateBinding BorderBrush}"
 										  BorderThickness="{TemplateBinding BorderThickness}"
 										  Content="{TemplateBinding Content}"

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3029,6 +3029,7 @@
 				<ControlTemplate TargetType="ToggleButton">
 					<Grid x:Name="RootGrid"
 						  Background="{TemplateBinding Background}"
+						  BackgroundSizing="{TemplateBinding BackgroundSizing}"
 						  CornerRadius="{TemplateBinding CornerRadius}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3027,6 +3027,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ToggleButton">
+					<!--  BackgroundSizing is bound for propagation, but has no visual effect in this legacy template: RootGrid owns the Background while ContentPresenter owns the border. The Fluent (v2) ToggleButton style carries Background and border together on its ContentPresenter, which is where BackgroundSizing takes effect. Aligning this template with the WinUI single-ContentPresenter root is a follow-up.  -->
 					<Grid x:Name="RootGrid"
 						  Background="{TemplateBinding Background}"
 						  BackgroundSizing="{TemplateBinding BackgroundSizing}"

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3011,6 +3011,7 @@
 				<ControlTemplate TargetType="ToggleButton">
 					<Grid x:Name="RootGrid"
 						  Background="{TemplateBinding Background}"
+						  BackgroundSizing="{TemplateBinding BackgroundSizing}"
 						  CornerRadius="{TemplateBinding CornerRadius}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3009,6 +3009,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ToggleButton">
+					<!--  BackgroundSizing is bound for propagation, but has no visual effect in this legacy template: RootGrid owns the Background while ContentPresenter owns the border. The Fluent (v2) ToggleButton style carries Background and border together on its ContentPresenter, which is where BackgroundSizing takes effect. Aligning this template with the WinUI single-ContentPresenter root is a follow-up.  -->
 					<Grid x:Name="RootGrid"
 						  Background="{TemplateBinding Background}"
 						  BackgroundSizing="{TemplateBinding BackgroundSizing}"

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3221,6 +3221,7 @@
 							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 						<ContentPresenter x:Name="ContentPresenter"
+										  BackgroundSizing="{TemplateBinding BackgroundSizing}"
 										  BorderBrush="{TemplateBinding BorderBrush}"
 										  BorderThickness="{TemplateBinding BorderThickness}"
 										  Content="{TemplateBinding Content}"


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/7192

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

`BackgroundSizing` is not fully supported on `Control`


## What is the new behavior? 🚀

Supported

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes