### PR TITLE
fix: `End` key shortcuts don't work at the start of `TextBox`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -222,6 +222,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_End_And_Shift_End_At_Position_Zero()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			await KeyboardHelper.InputText("hello world", SUT);
+
+			// Move cursor to position 0
+			await KeyboardHelper.PressKeySequence("$d$_home#$u$_home", SUT);
+			Assert.AreEqual(0, SUT.SelectionStart, "Cursor should be at position 0 after Home");
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			// Press End at position 0 - should move to end of line
+			await KeyboardHelper.PressKeySequence("$d$_end#$u$_end", SUT);
+			Assert.AreEqual(11, SUT.SelectionStart, "End key at position 0 should move cursor to end of text");
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			// Move back to position 0
+			await KeyboardHelper.PressKeySequence("$d$_home#$u$_home", SUT);
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			// Press Shift+End at position 0 - should select all text
+			await KeyboardHelper.PressKeySequence("$d$_shift#$d$_end#$u$_end#$u$_shift", SUT);
+			Assert.AreEqual(0, SUT.SelectionStart, "Shift+End at position 0 should keep SelectionStart at 0");
+			Assert.AreEqual(11, SUT.SelectionLength, "Shift+End at position 0 should select all text");
+		}
+
+		[TestMethod]
 		public async Task When_Home_Empty_TextBox()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
@@ -1244,7 +1244,7 @@ internal readonly partial struct UnicodeText : IParsedText
 	{
 		if (_text.Length == 0 || _lines.Count == 0)
 		{
-			return (0, 0, true, _lines.Count == 1 || (_lines.Count == 0 && _endingNewLineLineHeight is not null), 0);
+			return (0, 0, true, true, 0);
 		}
 		if (index >= _lines[^1].end)
 		{

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.skia.cs
@@ -1242,7 +1242,7 @@ internal readonly partial struct UnicodeText : IParsedText
 
 	public (int start, int length, bool firstLine, bool lastLine, int lineIndex) GetLineAt(int index)
 	{
-		if (index == 0 || _text.Length == 0 || _lines.Count == 0)
+		if (_text.Length == 0 || _lines.Count == 0)
 		{
 			return (0, 0, true, _lines.Count == 1 || (_lines.Count == 0 && _endingNewLineLineHeight is not null), 0);
 		}


### PR DESCRIPTION
## Summary
- Fix `GetLineAt` in `UnicodeText.skia.cs` returning an empty line when `index == 0`, which caused `End` and `Shift+End` key shortcuts to do nothing when the cursor was at position 0 in a `TextBox`
- Add runtime test covering `End` and `Shift+End` at position 0

## Test plan
- [x] Runtime test `When_End_And_Shift_End_At_Position_Zero` validates End moves cursor to end of text and Shift+End selects all text from position 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)