### PR TITLE
fix: filter control chars in mac os key input

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -270,13 +270,31 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
 
+	// Only printable text input should flow through UnicodeKey. Control characters
+	// like Tab are handled as keys for focus/navigation and must not be inserted.
+	private static char? FilterTextInputCharacter(ushort unicode)
+	{
+		if (unicode == 0)
+		{
+			return null;
+		}
+
+		var character = (char)unicode;
+		if (char.IsControl(character) && character is not '\r' and not '\n')
+		{
+			return null;
+		}
+
+		return character;
+	}
+
 	private static KeyEventArgs CreateArgs(VirtualKey key, VirtualKeyModifiers mods, uint scanCode, ushort unicode)
 	{
 		var status = new CorePhysicalKeyStatus
 		{
 			ScanCode = scanCode,
 		};
-		return new KeyEventArgs("keyboard", key, mods, status, unicode == 0 ? null : (char)unicode);
+		return new KeyEventArgs("keyboard", key, mods, status, FilterTextInputCharacter(unicode));
 	}
 
 	[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -397,7 +397,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				TextWrapping = TextWrapping.Wrap,
 				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida dictum fusce ut placerat orci nulla. Luctus venenatis lectus magna fringilla urna porttitor rhoncus. Faucibus vitae aliquet nec ullamcorper. Sem fringilla ut morbi tincidunt. Imperdiet proin fermentum leo vel orci. Velit aliquet sagittis id consectetur. Faucibus et molestie ac feugiat sed lectus vestibulum. Morbi enim nunc faucibus a pellentesque sit amet porttitor. Elementum sagittis vitae et leo duis ut diam. Pulvinar pellentesque habitant morbi tristique senectus et netus et malesuada. Id porta nibh venenatis cras sed felis eget velit aliquet. Feugiat pretium nibh ipsum consequat nisl. Adipiscing diam donec adipiscing tristique risus nec feugiat. Consequat semper viverra nam libero justo laoreet sit. Non tellus orci ac auctor augue mauris augue neque. Dolor purus non enim praesent."
 			};
-
 			await UITestHelper.Load(SUT);
 
 			SUT.Focus(FocusState.Programmatic);
@@ -415,6 +414,76 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Task.Delay(1000); // Allow the ScrollViewer to update its offset
 
 			((ScrollViewer)SUT.ContentElement).VerticalOffset.Should().BeApproximately(((ScrollViewer)SUT.ContentElement).ScrollableHeight, 1.0);
+		}
+
+		[TestMethod]
+		public async Task When_Tab_Moves_Focus_TextBox_Does_Not_Insert_Tab()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var textBox = new TextBox();
+			var button = new Button
+			{
+				Content = "Next"
+			};
+			var stackPanel = new StackPanel
+			{
+				Children =
+				{
+					textBox,
+					button,
+				}
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(textBox);
+
+			textBox.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(textBox, FocusManager.GetFocusedElement(WindowHelper.XamlRoot));
+
+			await KeyboardHelper.Tab();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(string.Empty, textBox.Text);
+			Assert.AreEqual(button, FocusManager.GetFocusedElement(WindowHelper.XamlRoot));
+		}
+
+		[TestMethod]
+		public async Task When_Tab_Moves_Focus_PasswordBox_Does_Not_Insert_Tab()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var passwordBox = new PasswordBox();
+			var button = new Button
+			{
+				Content = "Next"
+			};
+			var stackPanel = new StackPanel
+			{
+				Children =
+				{
+					passwordBox,
+					button,
+				}
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(passwordBox);
+
+			passwordBox.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(passwordBox, FocusManager.GetFocusedElement(WindowHelper.XamlRoot));
+
+			await KeyboardHelper.Tab();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(string.Empty, passwordBox.Password);
+			Assert.AreEqual(button, FocusManager.GetFocusedElement(WindowHelper.XamlRoot));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -397,6 +397,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				TextWrapping = TextWrapping.Wrap,
 				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida dictum fusce ut placerat orci nulla. Luctus venenatis lectus magna fringilla urna porttitor rhoncus. Faucibus vitae aliquet nec ullamcorper. Sem fringilla ut morbi tincidunt. Imperdiet proin fermentum leo vel orci. Velit aliquet sagittis id consectetur. Faucibus et molestie ac feugiat sed lectus vestibulum. Morbi enim nunc faucibus a pellentesque sit amet porttitor. Elementum sagittis vitae et leo duis ut diam. Pulvinar pellentesque habitant morbi tristique senectus et netus et malesuada. Id porta nibh venenatis cras sed felis eget velit aliquet. Feugiat pretium nibh ipsum consequat nisl. Adipiscing diam donec adipiscing tristique risus nec feugiat. Consequat semper viverra nam libero justo laoreet sit. Non tellus orci ac auctor augue mauris augue neque. Dolor purus non enim praesent."
 			};
+
 			await UITestHelper.Load(SUT);
 
 			SUT.Focus(FocusState.Programmatic);


### PR DESCRIPTION
Fix macOS Skia to stop inserting Tab into `TextBox` and `PasswordBox` during focus navigation.

The issue was caused by Tab being forwarded as text input (UnicodeKey) in addition to being handled as a navigation key. The fix filters control characters at the macOS keyboard input source and adds runtime regression tests for both controls.

**GitHub Issue:** #22818

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
- 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On macOS Skia, pressing Tab in a focused TextBox or PasswordBox inserts a tab character and also moves focus to the next element.

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->
On macOS Skia, pressing Tab in a focused TextBox or PasswordBox only moves focus and no longer inserts a tab character.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->