### PR TITLE
fix: nested MenuFlyout closing on hover

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
@@ -3,21 +3,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.Appointments;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.RuntimeTests.Extensions;
-using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.VisualTreeHelperPages;
-using Windows.Foundation;
-using Windows.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Disposables;
 using Uno.Extensions;
+using Uno.UI.Extensions;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
-using static Private.Infrastructure.TestServices;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Data;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.VisualTreeHelperPages;
 using Uno.UI.Toolkit.DevTools.Input;
+using Windows.Foundation;
+using Windows.UI;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 {
@@ -63,6 +65,80 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			CollectionAssert.Contains(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).ToArray(), popup);
 			popup.IsOpen = false;
 		}
+
+#if HAS_UNO
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+		[RunsOnUIThread]
+		public async Task OpenPopups_MenuFlyout_HitTest()
+		{
+			// setup a button with menu flyout
+			var nestedItem1 = new MenuFlyoutItem() { Text = "QweQweQwe QweQweQwe" };
+			var nestedItem2 = new MenuFlyoutItem() { Text = "ZxcZxcZxc ZxcZxcZxc" };
+			var menu = new MenuFlyout() { Items = { nestedItem1, nestedItem2 } };
+			var sut = new Button() { Flyout = menu };
+			await UITestHelper.Load(sut);
+
+			// force open the menu, via button click
+			using var cleanup = Disposable.Create(() =>
+			{
+				menu.Hide();
+				UITestHelper.CloseAllPopups();
+			});
+			sut.ProgrammaticClick();
+			await UITestHelper.WaitForIdle();
+
+			// check if the flyout is opened
+			var popup = VisualTreeHelper
+				.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)
+				.FirstOrDefault(x => x.Child is MenuFlyoutPresenter);
+			Assert.IsNotNull(popup, "Expected to find the MenuFlyout's Popup in the visual tree");
+
+			// hit-test for MenuFlyoutPresenter
+			var rect = nestedItem1.GetAbsoluteBounds();
+			var center = rect.GetCenter();
+			var matches = VisualTreeHelper.FindElementsInHostCoordinates(center, popup.Child, includeAllElements: true).ToArray();
+			Assert.IsTrue(matches.Contains(popup.Child), "Expected to find the element in the FindElementsInHostCoordinates results");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Nested_Setup_HitTest()
+		{
+			var sut = new Border
+			{
+				Name = "sut",
+				Width = 10,
+				Height = 10,
+				Background = new SolidColorBrush(Colors.Blue),
+			};
+			var wrapper = new Border
+			{
+				Name = "wrapper",
+				Width = 10,
+				Height = 10,
+				HorizontalAlignment = HorizontalAlignment.Right,
+				VerticalAlignment = VerticalAlignment.Bottom,
+				Child = sut,
+				Background = new SolidColorBrush(Colors.Green),
+			};
+			var setup = new Border
+			{
+				Name = "setup",
+				Width = 100,
+				Height = 100,
+				Background = new SolidColorBrush(Colors.Red),
+				Child = wrapper,
+			};
+			await UITestHelper.Load(setup);
+
+			var rect = sut.GetAbsoluteBounds();
+			var center = rect.GetCenter();
+			var matches = VisualTreeHelper.FindElementsInHostCoordinates(center, setup, includeAllElements: true).ToArray();
+
+			Assert.IsTrue(matches.Contains(sut), "Expected to find the element in the FindElementsInHostCoordinates results");
+		}
+#endif
 
 #if !WINAPPSDK // Testing internal Uno methods
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -98,9 +98,13 @@ namespace Microsoft.UI.Xaml.Media
 
 		private static bool IsElementIntersecting(Point intersectingPoint, UIElement uiElement)
 		{
-			GeneralTransform transformToRoot = uiElement.TransformToVisual(null);
-			var target = transformToRoot.TransformBounds(LayoutInformation.GetLayoutSlot(uiElement));
-			return target.Contains(intersectingPoint);
+			// offset from GetLayoutSlot is dropped, since it is already included in TransformToVisual
+			var transform = uiElement.TransformToVisual(null);
+			var rect = LayoutInformation.GetLayoutSlot(uiElement) with { Location = default };
+			var absRect = transform.TransformBounds(rect);
+			var result = absRect.Contains(intersectingPoint);
+
+			return result;
 		}
 
 		[Uno.NotImplemented]


### PR DESCRIPTION
**GitHub Issue:** re: unoplatform/kahua-private#436

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

`VisualTreeHelper.FindElementsInHostCoordinates` performs incorrect hit-testing for elements that are offset from the root (e.g. nested `MenuFlyout` popups). This causes nested sub-menus to close unexpectedly when hovering over them, because the hit-test fails to find the sub-menu's presenter at the cursor position.

## What is the new behavior? 🚀

`IsElementIntersecting` now correctly drops the `Location` from the layout slot before applying `TransformToVisual(null)`, since the transform already encodes the element's absolute position. Hit-testing now returns accurate results for offset elements.

## PR Checklist ✅

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Two new runtime tests added to `Given_VisualTreeHelper`:
- `OpenPopups_MenuFlyout_HitTest` — verifies a `MenuFlyoutItem` is found by `FindElementsInHostCoordinates` at its correct screen coordinates
- `Nested_Setup_HitTest` — verifies hit-testing for a nested `Border` at a non-trivial offset within its parent