### PR TITLE
fix(ci): add Linux host disk cleanup for CI builds

### DIFF
--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -19,6 +19,7 @@ stages:
         README/**
         build/**
 
+    - template: templates/host-cleanup-linux.yml
     - template: templates/gitversion-run.yml
     - template: setup/.azure-devops-setup-commitsar.yml
     - template: setup/.azure-devops-setup-doc-validations.yml
@@ -35,6 +36,7 @@ stages:
       clean: false
       fetchDepth: 0
 
+    - template: templates/host-cleanup-linux.yml
     - task: PowerShell@2
       name: SetScope
       displayName: Evaluate native-impacting changes

--- a/build/ci/templates/host-cleanup-linux.yml
+++ b/build/ci/templates/host-cleanup-linux.yml
@@ -5,9 +5,9 @@
 # Use the `du` command to determine what can be uninstalled.
 steps:
   - bash: |
-      # Use sudo only when available (containers may not have it)
-      if command -v sudo >/dev/null 2>&1; then
-        SUDO="sudo"
+      # Use sudo only when available and non-interactive (no password prompt)
+      if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+        SUDO="sudo -n"
       else
         SUDO=""
       fi
@@ -15,7 +15,7 @@ steps:
       echo "Disk space before cleanup:"
       df -h /
 
-      rm -rf ~/.cargo ~/.rustup ~/.dotnet
+      rm -rf ~/.cargo ~/.rustup ~/.dotnet || true
 
       $SUDO rm -rf /usr/share/swift || true
       $SUDO rm -rf /opt/microsoft/msedge || true
@@ -25,9 +25,14 @@ steps:
       $SUDO rm -rf /opt/ghc || true
       $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
 
-      $SUDO snap remove lxd || true
-      $SUDO snap remove core20 || true
-      $SUDO apt-get purge -y snapd || true
+      if command -v snap >/dev/null 2>&1; then
+        timeout 60s $SUDO snap remove lxd || true
+        timeout 60s $SUDO snap remove core20 || true
+      fi
+
+      if command -v apt-get >/dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive timeout 120s $SUDO apt-get purge -y snapd || true
+      fi
 
       echo "Disk space after cleanup:"
       df -h /

--- a/build/ci/templates/host-cleanup-linux.yml
+++ b/build/ci/templates/host-cleanup-linux.yml
@@ -1,13 +1,35 @@
+# Reusable AzDO template: Cleanup unused dependencies on Linux CI agents.
+#
+# This list is based on what the base image contains and
+# may need to be adjusted as new software gets installed.
+# Use the `du` command to determine what can be uninstalled.
 steps:
-- bash: |
-    echo "=== Disk usage BEFORE cleanup ==="
-    df -h /
-    sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-    sudo snap remove lxd --purge || true
-    sudo snap remove core20 --purge || true
-    sudo snap remove snapd --purge || true
-    sudo apt-get purge -y snapd || true
-    echo "=== Disk usage AFTER cleanup ==="
-    df -h /
-  displayName: 'Free disk space (Linux)'
-  condition: eq(variables['Agent.OS'], 'Linux')
+  - bash: |
+      # Use sudo only when available (containers may not have it)
+      if command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+      else
+        SUDO=""
+      fi
+
+      echo "Disk space before cleanup:"
+      df -h /
+
+      rm -rf ~/.cargo ~/.rustup ~/.dotnet
+
+      $SUDO rm -rf /usr/share/swift || true
+      $SUDO rm -rf /opt/microsoft/msedge || true
+      $SUDO rm -rf /usr/local/.ghcup || true
+      $SUDO rm -rf /usr/lib/mono || true
+      $SUDO rm -rf /usr/local/lib/android || true
+      $SUDO rm -rf /opt/ghc || true
+      $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
+
+      $SUDO snap remove lxd || true
+      $SUDO snap remove core20 || true
+      $SUDO apt-get purge -y snapd || true
+
+      echo "Disk space after cleanup:"
+      df -h /
+    displayName: Cleanup unused host dependencies
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/ci/templates/host-cleanup-linux.yml
+++ b/build/ci/templates/host-cleanup-linux.yml
@@ -1,23 +1,13 @@
 steps:
 - bash: |
-    # This list is based on what the base image contains and
-    # may need to be adjusted as new software gets installed.
-    # Use the `du` command below to determine what can be
-    # uninstalled.
-    
-    rm -fR ~/.cargo
-    rm -fR ~/.rustup
-    rm -fR ~/.dotnet
-    sudo rm -fR /usr/share/swift
-    sudo rm -fR /opt/microsoft/msedge
-    sudo rm -fR /usr/local/.ghcup
-    sudo rm -fR /usr/lib/mono
-    sudo snap remove lxd
-    sudo snap remove core20
-    sudo apt remove snapd
-
-    df -h
-    # du -h -d 3 /
-
-  displayName: 'Cleanup unused image dependencies (Linux)'
+    echo "=== Disk usage BEFORE cleanup ==="
+    df -h /
+    sudo rm -rf ~/.cargo ~/.rustup ~/.dotnet /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+    sudo snap remove lxd --purge || true
+    sudo snap remove core20 --purge || true
+    sudo snap remove snapd --purge || true
+    sudo apt-get purge -y snapd || true
+    echo "=== Disk usage AFTER cleanup ==="
+    df -h /
+  displayName: 'Free disk space (Linux)'
   condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
@@ -24,6 +24,7 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-linux.yml
     parameters:

--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia.yml
@@ -73,6 +73,8 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
+
   - bash: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules

--- a/build/ci/tests/.azure-devops-tests-android-native.yml
+++ b/build/ci/tests/.azure-devops-tests-android-native.yml
@@ -146,6 +146,8 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
+
   - bash: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules

--- a/build/ci/tests/.azure-devops-tests-android-nativeaot-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-nativeaot-skia-build.yml
@@ -22,6 +22,7 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-linux.yml
     parameters:

--- a/build/ci/tests/.azure-devops-tests-android-nativeaot-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-nativeaot-skia.yml
@@ -73,6 +73,8 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
+
   - bash: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules

--- a/build/ci/tests/.azure-devops-tests-android-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-skia-build.yml
@@ -22,6 +22,7 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-linux.yml
     parameters:

--- a/build/ci/tests/.azure-devops-tests-android-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-skia.yml
@@ -73,6 +73,8 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: ../templates/host-cleanup-linux.yml
+
   - bash: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules

--- a/build/ci/tests/.azure-devops-tests-linux-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-linux-skia.yml
@@ -31,6 +31,8 @@ jobs:
   steps:
   - checkout: none
 
+  - template: ../templates/host-cleanup-linux.yml
+
   - task: DownloadPipelineArtifact@2
     displayName: Downloading $(SamplesAppArtifactName)
     inputs:
@@ -73,6 +75,8 @@ jobs:
     XAML_FLAVOR_BUILD: ${{ parameters.XAML_FLAVOR_BUILD }}
 
   steps:
+
+  - template: ../templates/host-cleanup-linux.yml
 
   - task: DownloadPipelineArtifact@2
     displayName: Downloading $(SamplesAppArtifactName)

--- a/build/ci/tests/.azure-devops-tests-webassembly-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-webassembly-skia-build.yml
@@ -29,6 +29,7 @@ jobs:
     clean: true
     fetchDepth: 1
 
+  - template: ../templates/host-cleanup-linux.yml
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-windows.yml
     parameters:

--- a/build/ci/tests/.azure-devops-tests-webassembly-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-webassembly-skia.yml
@@ -44,6 +44,8 @@ jobs:
 
   steps:
 
+  - template: ../templates/host-cleanup-linux.yml
+
   - task: DownloadPipelineArtifact@2
     displayName: Downloading $(SamplesAppArtifactName)
     inputs:


### PR DESCRIPTION
## What
Adds a Linux host disk cleanup step to all Linux CI jobs to reclaim disk space by removing unused pre-installed software.

## Why
Linux CI agents accumulate ~20–30 GB of pre-installed software (Cargo, Rust, Swift, Edge, GHC, Mono, Android SDK, CodeQL, snapd) that is not needed for builds. This cleanup step runs at the start of each Linux job to ensure sufficient disk space.

## Details
- Adds a reusable AzDO template (`host-cleanup-linux.yml`) with inline cleanup script
- Cleanup is conditional on Linux (`condition: eq(variables['Agent.OS'], 'Linux')`)
- Uses `sudo -n` (non-interactive) probe to work safely in both host and container environments
- All removals are best-effort (`|| true`) with `timeout` guards on snap/apt-get commands
- Uses `DEBIAN_FRONTEND=noninteractive` for apt-get to prevent dpkg prompts

Part of org-wide CI disk cleanup initiative.
Related to https://github.com/unoplatform/uno.rider/pull/480