### PR TITLE
feat: Initial a11y implementation for Win32

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -1,0 +1,675 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Media;
+using Uno.Foundation.Logging;
+using Uno.Helpers;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+/// <summary>
+/// Manages the Win32 UIAutomation provider tree for Skia-rendered Uno applications.
+/// Creates UIA providers lazily for elements that have automation peers, enabling
+/// Narrator and other screen readers. The UIA tree follows the automation peer tree
+/// (which flattens layout-only elements) rather than the raw visual tree.
+/// </summary>
+internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
+{
+	private static Win32Accessibility? _instance;
+
+	private nint _hwnd;
+	private bool _accessibilityTreeInitialized;
+	private Win32RawElementProvider? _rootProvider;
+	private readonly Dictionary<UIElement, Win32RawElementProvider> _providers = new();
+	private DispatcherQueue? _dispatcherQueue;
+	private readonly HashSet<Win32RawElementProvider> _pendingStructureChanges = new();
+
+	internal static Win32Accessibility Instance => _instance ??= new Win32Accessibility();
+
+	internal Win32RawElementProvider? RootProvider => _rootProvider;
+
+	private Win32Accessibility()
+	{
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace($"Initializing {nameof(Win32Accessibility)}");
+		}
+
+		AccessibilityAnnouncer.AccessibilityImpl = this;
+		UIElementAccessibilityHelper.ExternalOnChildAdded = OnChildAdded;
+		UIElementAccessibilityHelper.ExternalOnChildRemoved = OnChildRemoved;
+		VisualAccessibilityHelper.ExternalOnVisualOffsetOrSizeChanged = OnSizeOrOffsetChanged;
+		AutomationPeer.AutomationPeerListener = this;
+	}
+
+	internal static void Register()
+	{
+		// Force singleton creation, which registers all callbacks
+		_ = Instance;
+	}
+
+	// IUnoAccessibility
+
+	public bool IsAccessibilityEnabled => _hwnd != nint.Zero;
+
+	public void AnnouncePolite(string text)
+	{
+		if (!IsAccessibilityEnabled || _rootProvider is null)
+		{
+			return;
+		}
+
+		_ = Win32UIAutomationInterop.UiaRaiseNotificationEvent(
+			_rootProvider,
+			Win32UIAutomationInterop.AutomationNotificationKind_Other,
+			Win32UIAutomationInterop.AutomationNotificationProcessing_CurrentThenMostRecent,
+			text,
+			"UnoAnnouncement");
+	}
+
+	public void AnnounceAssertive(string text)
+	{
+		if (!IsAccessibilityEnabled || _rootProvider is null)
+		{
+			return;
+		}
+
+		_ = Win32UIAutomationInterop.UiaRaiseNotificationEvent(
+			_rootProvider,
+			Win32UIAutomationInterop.AutomationNotificationKind_Other,
+			Win32UIAutomationInterop.AutomationNotificationProcessing_ImportantMostRecent,
+			text,
+			"UnoAnnouncement");
+	}
+
+	// Initialization
+
+	internal void Initialize(nint hwnd, UIElement rootElement)
+	{
+		_hwnd = hwnd;
+
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			this.Log().Debug($"[UIA] Win32Accessibility initialized for window 0x{hwnd:X}");
+		}
+
+		// Create root provider only; child providers are created lazily during navigation.
+		_rootProvider = new Win32RawElementProvider(rootElement, _hwnd, isRoot: true, this);
+		_providers[rootElement] = _rootProvider;
+		_dispatcherQueue = rootElement.DispatcherQueue;
+		_accessibilityTreeInitialized = true;
+
+		var rootPeer = rootElement.GetOrCreateAutomationPeer();
+		if (this.Log().IsEnabled(LogLevel.Information))
+		{
+			this.Log().Info(
+				$"[UIA] Root provider created: element={rootElement.GetType().Name}, " +
+				$"peer={rootPeer?.GetType().Name ?? "NULL"}, " +
+				$"children count={rootElement.GetChildren().Count}, " +
+				$"window=0x{_hwnd:X}");
+		}
+
+		// Dump the initial automation tree at Info level for diagnostics
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			DumpAutomationTree(rootElement, 0);
+		}
+	}
+
+	private void DumpAutomationTree(UIElement element, int depth)
+	{
+		if (depth > 6)
+		{
+			return;
+		}
+
+		var indent = new string(' ', depth * 2);
+		var peer = element.GetOrCreateAutomationPeer();
+		var peerType = peer?.GetType().Name ?? "no-peer";
+		string peerName;
+		try { peerName = peer?.GetName() ?? ""; }
+		catch { peerName = "<error>"; }
+		var controlType = peer != null ? peer.GetAutomationControlType().ToString() : "none";
+		var automationId = AutomationProperties.GetAutomationId(element);
+		var automationName = AutomationProperties.GetName(element);
+
+		this.Log().Debug(
+			$"[UIA] {indent}{element.GetType().Name}" +
+			$" peer={peerType}" +
+			$" name=\"{peerName}\"" +
+			$" type={controlType}" +
+			$" a11yId={automationId}" +
+			$" a11yName={automationName}" +
+			$" vis={element.Visibility}");
+
+		foreach (var child in element.GetChildren())
+		{
+			DumpAutomationTree(child, depth + 1);
+		}
+	}
+
+	// Provider management
+
+	/// <summary>
+	/// Gets or lazily creates a UIA provider for the given element.
+	/// Only creates providers for elements that have automation peers.
+	/// </summary>
+	internal Win32RawElementProvider? GetOrCreateProvider(UIElement element)
+	{
+		if (_providers.TryGetValue(element, out var existing))
+		{
+			return existing;
+		}
+
+		if (!_accessibilityTreeInitialized || !IsAccessibilityEnabled)
+		{
+			return null;
+		}
+
+		// Only create providers for elements with automation peers
+		var peer = element.GetOrCreateAutomationPeer();
+		if (peer is null)
+		{
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				this.Log().Trace($"[UIA] GetOrCreateProvider: No automation peer for {element.GetType().Name}");
+			}
+			return null;
+		}
+
+		var provider = new Win32RawElementProvider(element, _hwnd, isRoot: false, this);
+		_providers[element] = provider;
+
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			this.Log().Debug($"[UIA] Created provider for {provider.DescribeElement()} (peer={peer.GetType().Name}, total providers={_providers.Count})");
+		}
+
+		return provider;
+	}
+
+	/// <summary>
+	/// Resolves an <see cref="AutomationPeer"/> to its corresponding UIA provider.
+	/// When <paramref name="resolveEventsSource"/> is true, the peer's EventsSource
+	/// is resolved first (matching WinUI3 CUIAWrapper behavior where navigation
+	/// substitutes the EventsSource peer before creating a wrapper).
+	/// </summary>
+	internal Win32RawElementProvider? GetProviderForPeer(AutomationPeer peer, bool resolveEventsSource = false)
+	{
+		var resolvedPeer = peer;
+
+		if (resolveEventsSource)
+		{
+			var eventsSource = peer.GetAPEventsSource();
+			if (eventsSource is not null)
+			{
+				resolvedPeer = eventsSource;
+			}
+		}
+
+		if (TryGetPeerOwner(resolvedPeer, out var element))
+		{
+			return GetOrCreateProvider(element);
+		}
+
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			this.Log().Debug($"[UIA] GetProviderForPeer: Could not resolve owner for {resolvedPeer.GetType().Name}");
+		}
+		return null;
+	}
+
+	internal Win32RawElementProvider? GetProvider(UIElement element)
+	{
+		_providers.TryGetValue(element, out var provider);
+		return provider;
+	}
+
+	// Callbacks from UIElementAccessibilityHelper
+
+	private void OnChildAdded(UIElement parent, UIElement child, int? index)
+	{
+		if (!IsAccessibilityEnabled || !_accessibilityTreeInitialized)
+		{
+			return;
+		}
+
+		// Raise structure changed event on the nearest ancestor that has a provider.
+		// Child providers will be lazily created when UIA navigates to them.
+		var ancestorProvider = FindNearestAncestorProvider(parent);
+		if (ancestorProvider is not null)
+		{
+			RaiseStructureChanged(ancestorProvider);
+		}
+	}
+
+	private void OnChildRemoved(UIElement parent, UIElement child)
+	{
+		if (!IsAccessibilityEnabled || !_accessibilityTreeInitialized)
+		{
+			return;
+		}
+
+		// Clean up cached providers for the removed subtree
+		CleanupProviders(child);
+
+		// Raise structure changed event on the nearest ancestor
+		var ancestorProvider = FindNearestAncestorProvider(parent);
+		if (ancestorProvider is not null)
+		{
+			RaiseStructureChanged(ancestorProvider);
+		}
+	}
+
+	private void CleanupProviders(UIElement element)
+	{
+		if (_providers.Remove(element, out var provider))
+		{
+			// Disconnect the provider from UIA so stale COM references are released.
+			// This matches WinUI3's CUIAWrapper::Invalidate() which calls
+			// UiaDisconnectProvider(this) when the automation peer is destroyed.
+			try
+			{
+				_ = Win32UIAutomationInterop.UiaDisconnectProvider(provider);
+			}
+			catch (Exception ex)
+			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"UiaDisconnectProvider failed for {provider.DescribeElement()}: {ex.Message}");
+				}
+			}
+		}
+
+		foreach (var child in element.GetChildren())
+		{
+			CleanupProviders(child);
+		}
+	}
+
+	private Win32RawElementProvider? FindNearestAncestorProvider(UIElement element)
+	{
+		UIElement? current = element;
+		while (current is not null)
+		{
+			if (_providers.TryGetValue(current, out var provider))
+			{
+				return provider;
+			}
+			current = VisualTreeHelper.GetParent(current) as UIElement;
+		}
+		return _rootProvider;
+	}
+
+	private void RaiseStructureChanged(Win32RawElementProvider provider)
+	{
+		// Invalidate the children cache so the next navigation rebuilds the list
+		provider.InvalidateChildrenCache();
+
+		// Coalesce rapid StructureChanged events into a single deferred dispatch.
+		// Each affected provider is tracked so we fire per-subtree events rather
+		// than always invalidating the entire root, which reduces the scope of
+		// UIA re-validation during steady-state interaction. During startup the
+		// batch still avoids hundreds of synchronous round-trips.
+		if (_dispatcherQueue is not null)
+		{
+			var wasEmpty = _pendingStructureChanges.Count == 0;
+			_pendingStructureChanges.Add(provider);
+
+			if (wasEmpty)
+			{
+				_dispatcherQueue.TryEnqueue(() =>
+				{
+					foreach (var pending in _pendingStructureChanges)
+					{
+						RaiseStructureChangedCore(pending);
+					}
+					_pendingStructureChanges.Clear();
+				});
+			}
+			return;
+		}
+
+		RaiseStructureChangedCore(provider);
+	}
+
+	private void RaiseStructureChangedCore(Win32RawElementProvider provider)
+	{
+		try
+		{
+			_ = Win32UIAutomationInterop.UiaRaiseStructureChangedEvent(
+				provider,
+				StructureChangeType.ChildrenInvalidated,
+				provider.GetRuntimeId());
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"RaiseStructureChanged failed: {ex.Message}");
+			}
+		}
+	}
+
+	// Callback from VisualAccessibilityHelper
+
+	private void OnSizeOrOffsetChanged(Visual visual)
+	{
+		if (!IsAccessibilityEnabled || !_accessibilityTreeInitialized)
+		{
+			return;
+		}
+
+		// UIA pulls BoundingRectangle on demand, so we only need to notify
+		// clients that the property has changed so they re-query it.
+		if (visual is ContainerVisual containerVisual
+			&& containerVisual.Owner?.Target is UIElement owner
+			&& _providers.TryGetValue(owner, out var provider))
+		{
+			try
+			{
+				_ = Win32UIAutomationInterop.UiaRaiseAutomationPropertyChangedEvent(
+					provider,
+					Win32UIAutomationInterop.UIA_BoundingRectanglePropertyId,
+					null,
+					null);
+			}
+			catch (Exception ex)
+			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"Failed to raise BoundingRectangle changed event: {ex.Message}");
+				}
+			}
+		}
+	}
+
+	// Helpers
+
+	internal static bool TryGetPeerOwner(AutomationPeer peer, [NotNullWhen(true)] out UIElement? owner)
+	{
+		if (peer is FrameworkElementAutomationPeer { Owner: { } element })
+		{
+			owner = element;
+			return true;
+		}
+
+		if (peer is ItemAutomationPeer itemPeer)
+		{
+			var parent = itemPeer.GetParent();
+			if (parent is FrameworkElementAutomationPeer { Owner: { } parentElement })
+			{
+				owner = parentElement;
+				return true;
+			}
+		}
+
+		owner = null;
+		return false;
+	}
+
+	// IAutomationPeerListener
+
+	public void NotifyPropertyChangedEvent(AutomationPeer peer, AutomationProperty automationProperty, object oldValue, object newValue)
+	{
+		if (!IsAccessibilityEnabled || !TryGetPeerOwner(peer, out var owner))
+		{
+			return;
+		}
+
+		if (!_providers.TryGetValue(owner, out var provider))
+		{
+			return;
+		}
+
+		var propertyId = MapAutomationPropertyToUia(automationProperty);
+		if (propertyId is null)
+		{
+			return;
+		}
+
+		try
+		{
+			_ = Win32UIAutomationInterop.UiaRaiseAutomationPropertyChangedEvent(
+				provider, propertyId.Value, oldValue, newValue);
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"NotifyPropertyChangedEvent failed for {automationProperty}: {ex.Message}");
+			}
+		}
+	}
+
+	public void NotifyAutomationEvent(AutomationPeer peer, AutomationEvents eventId)
+	{
+		if (!IsAccessibilityEnabled || !TryGetPeerOwner(peer, out var owner))
+		{
+			return;
+		}
+
+		// For focus and live region changes, ensure a provider exists so Narrator
+		// can track focus or announce the live region content. Non-focusable
+		// elements like TextBlocks won't have a provider created until needed.
+		if (!_providers.TryGetValue(owner, out var provider))
+		{
+			if (eventId is AutomationEvents.AutomationFocusChanged or AutomationEvents.LiveRegionChanged)
+			{
+				provider = GetOrCreateProvider(owner);
+			}
+
+			if (provider is null)
+			{
+				return;
+			}
+		}
+
+		try
+		{
+			switch (eventId)
+			{
+				case AutomationEvents.AutomationFocusChanged:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_AutomationFocusChangedEventId);
+					break;
+				case AutomationEvents.InvokePatternOnInvoked:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_Invoke_InvokedEventId);
+					break;
+				case AutomationEvents.SelectionPatternOnInvalidated:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_Selection_InvalidatedEventId);
+					break;
+				case AutomationEvents.SelectionItemPatternOnElementSelected:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_SelectionItem_ElementSelectedEventId);
+					break;
+				case AutomationEvents.SelectionItemPatternOnElementAddedToSelection:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_SelectionItem_ElementAddedToSelectionEventId);
+					break;
+				case AutomationEvents.SelectionItemPatternOnElementRemovedFromSelection:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_SelectionItem_ElementRemovedFromSelectionEventId);
+					break;
+				case AutomationEvents.TextPatternOnTextChanged:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_Text_TextChangedEventId);
+					break;
+				case AutomationEvents.TextPatternOnTextSelectionChanged:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_Text_TextSelectionChangedEventId);
+					break;
+				case AutomationEvents.StructureChanged:
+					_ = Win32UIAutomationInterop.UiaRaiseStructureChangedEvent(
+						provider, StructureChangeType.ChildrenInvalidated, provider.GetRuntimeId());
+					break;
+				case AutomationEvents.MenuOpened:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_MenuOpenedEventId);
+					break;
+				case AutomationEvents.MenuClosed:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_MenuClosedEventId);
+					break;
+				case AutomationEvents.ToolTipOpened:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_ToolTipOpenedEventId);
+					break;
+				case AutomationEvents.ToolTipClosed:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_ToolTipClosedEventId);
+					break;
+				case AutomationEvents.LiveRegionChanged:
+					_ = Win32UIAutomationInterop.UiaRaiseAutomationEvent(
+						provider, Win32UIAutomationInterop.UIA_LiveRegionChangedEventId);
+					// Also announce the live region text for reliable Narrator delivery
+					var label = peer.GetName();
+					if (!string.IsNullOrEmpty(label))
+					{
+						var liveSetting = AutomationProperties.GetLiveSetting(owner);
+						if (liveSetting == AutomationLiveSetting.Assertive)
+						{
+							AnnounceAssertive(label);
+						}
+						else
+						{
+							AnnouncePolite(label);
+						}
+					}
+					break;
+			}
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"NotifyAutomationEvent failed for {eventId}: {ex.Message}");
+			}
+		}
+	}
+
+	public void NotifyNotificationEvent(AutomationPeer peer, AutomationNotificationKind notificationKind, AutomationNotificationProcessing notificationProcessing, string displayString, string activityId)
+	{
+		if (!IsAccessibilityEnabled || string.IsNullOrEmpty(displayString))
+		{
+			return;
+		}
+
+		// Use specific provider if available, otherwise fall back to root
+		IRawElementProviderSimple? target = _rootProvider;
+		if (TryGetPeerOwner(peer, out var owner) && _providers.TryGetValue(owner, out var elementProvider))
+		{
+			target = elementProvider;
+		}
+
+		if (target is null)
+		{
+			return;
+		}
+
+		try
+		{
+			// Uno enum values match UIA values exactly, so cast directly
+			_ = Win32UIAutomationInterop.UiaRaiseNotificationEvent(
+				target,
+				(int)notificationKind,
+				(int)notificationProcessing,
+				displayString,
+				activityId);
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"NotifyNotificationEvent failed: {ex.Message}");
+			}
+		}
+	}
+
+	public void OnAutomationEvent(AutomationPeer peer, AutomationEvents eventId)
+	{
+		NotifyAutomationEvent(peer, eventId);
+	}
+
+	public bool ListenerExistsHelper(AutomationEvents eventId)
+		=> IsAccessibilityEnabled;
+
+	// Property mapping
+
+	private static int? MapAutomationPropertyToUia(AutomationProperty property)
+	{
+		if (ReferenceEquals(property, AutomationElementIdentifiers.NameProperty))
+		{
+			return Win32UIAutomationInterop.UIA_NamePropertyId;
+		}
+		if (ReferenceEquals(property, TogglePatternIdentifiers.ToggleStateProperty))
+		{
+			return Win32UIAutomationInterop.UIA_ToggleToggleStatePropertyId;
+		}
+		if (ReferenceEquals(property, RangeValuePatternIdentifiers.ValueProperty))
+		{
+			return Win32UIAutomationInterop.UIA_RangeValueValuePropertyId;
+		}
+		if (ReferenceEquals(property, ValuePatternIdentifiers.ValueProperty))
+		{
+			return Win32UIAutomationInterop.UIA_ValueValuePropertyId;
+		}
+		if (ReferenceEquals(property, ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty))
+		{
+			return Win32UIAutomationInterop.UIA_ExpandCollapseExpandCollapseStatePropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.IsEnabledProperty))
+		{
+			return Win32UIAutomationInterop.UIA_IsEnabledPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.HelpTextProperty))
+		{
+			return Win32UIAutomationInterop.UIA_HelpTextPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.HeadingLevelProperty))
+		{
+			return Win32UIAutomationInterop.UIA_HeadingLevelPropertyId;
+		}
+		if (ReferenceEquals(property, SelectionItemPatternIdentifiers.IsSelectedProperty))
+		{
+			return Win32UIAutomationInterop.UIA_SelectionItemIsSelectedPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.LandmarkTypeProperty))
+		{
+			return Win32UIAutomationInterop.UIA_LandmarkTypePropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.LiveSettingProperty))
+		{
+			return Win32UIAutomationInterop.UIA_LiveSettingPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.IsOffscreenProperty))
+		{
+			return Win32UIAutomationInterop.UIA_IsOffscreenPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.AcceleratorKeyProperty))
+		{
+			return Win32UIAutomationInterop.UIA_AcceleratorKeyPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.AccessKeyProperty))
+		{
+			return Win32UIAutomationInterop.UIA_AccessKeyPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.ItemStatusProperty))
+		{
+			return Win32UIAutomationInterop.UIA_ItemStatusPropertyId;
+		}
+		if (ReferenceEquals(property, AutomationElementIdentifiers.ItemTypeProperty))
+		{
+			return Win32UIAutomationInterop.UIA_ItemTypePropertyId;
+		}
+
+		return null;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -25,7 +26,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 	private nint _hwnd;
 	private bool _accessibilityTreeInitialized;
 	private Win32RawElementProvider? _rootProvider;
-	private readonly Dictionary<UIElement, Win32RawElementProvider> _providers = new();
+	private readonly ConditionalWeakTable<UIElement, Win32RawElementProvider> _providers = new();
 	private DispatcherQueue? _dispatcherQueue;
 	private readonly HashSet<Win32RawElementProvider> _pendingStructureChanges = new();
 
@@ -100,7 +101,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 
 		// Create root provider only; child providers are created lazily during navigation.
 		_rootProvider = new Win32RawElementProvider(rootElement, _hwnd, isRoot: true, this);
-		_providers[rootElement] = _rootProvider;
+		_providers.AddOrUpdate(rootElement, _rootProvider);
 		_dispatcherQueue = rootElement.DispatcherQueue;
 		_accessibilityTreeInitialized = true;
 
@@ -183,11 +184,11 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 		}
 
 		var provider = new Win32RawElementProvider(element, _hwnd, isRoot: false, this);
-		_providers[element] = provider;
+		_providers.AddOrUpdate(element, provider);
 
 		if (this.Log().IsEnabled(LogLevel.Debug))
 		{
-			this.Log().Debug($"[UIA] Created provider for {provider.DescribeElement()} (peer={peer.GetType().Name}, total providers={_providers.Count})");
+			this.Log().Debug($"[UIA] Created provider for {provider.DescribeElement()} (peer={peer.GetType().Name})");
 		}
 
 		return provider;
@@ -268,8 +269,10 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 
 	private void CleanupProviders(UIElement element)
 	{
-		if (_providers.Remove(element, out var provider))
+		if (_providers.TryGetValue(element, out var provider))
 		{
+			_providers.Remove(element);
+
 			// Disconnect the provider from UIA so stale COM references are released.
 			// This matches WinUI3's CUIAWrapper::Invalidate() which calls
 			// UiaDisconnectProvider(this) when the automation peer is destroyed.

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32AccessibilityPatterns.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32AccessibilityPatterns.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+// UIA COM Pattern Interfaces
+// Method ordering must match the COM vtable layout exactly (from UIAutomationCore.idl).
+
+[ComImport, Guid("54fcb24b-e18e-47a2-b4d3-eccbe77599a2"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaInvokeProvider
+{
+	void Invoke();
+}
+
+[ComImport, Guid("56d00bd0-c4f4-433c-a836-1a52a57e0892"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaToggleProvider
+{
+	void Toggle();
+	ToggleState ToggleState { get; }
+}
+
+[ComImport, Guid("c7935180-6fb3-4201-b174-7df73adbf64a"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaValueProvider
+{
+	void SetValue([MarshalAs(UnmanagedType.LPWStr)] string val);
+	string Value { get; }
+	bool IsReadOnly { get; }
+}
+
+[ComImport, Guid("36dc7aef-33e6-4691-afe1-2be7274b3d33"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaRangeValueProvider
+{
+	void SetValue(double val);
+	double Value { get; }
+	bool IsReadOnly { get; }
+	double Maximum { get; }
+	double Minimum { get; }
+	double LargeChange { get; }
+	double SmallChange { get; }
+}
+
+[ComImport, Guid("d847d3a5-cab0-4a98-8c32-ecb45c59ad24"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaExpandCollapseProvider
+{
+	void Expand();
+	void Collapse();
+	ExpandCollapseState ExpandCollapseState { get; }
+}
+
+[ComImport, Guid("fb8b03af-3bdf-48d4-bd36-1a65793be168"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaSelectionProvider
+{
+	[return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
+	object[]? GetSelection();
+	bool CanSelectMultiple { get; }
+	bool IsSelectionRequired { get; }
+}
+
+[ComImport, Guid("2acad808-b2d4-452d-a407-91ff1ad167b2"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaSelectionItemProvider
+{
+	void Select();
+	void AddToSelection();
+	void RemoveFromSelection();
+	bool IsSelected { get; }
+	IRawElementProviderSimple? SelectionContainer { get; }
+}
+
+[ComImport, Guid("b38b8077-1fc3-42a5-8cae-d40c2215055a"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaScrollProvider
+{
+	void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount);
+	void SetScrollPercent(double horizontalPercent, double verticalPercent);
+	double HorizontalScrollPercent { get; }
+	double VerticalScrollPercent { get; }
+	double HorizontalViewSize { get; }
+	double VerticalViewSize { get; }
+	bool HorizontallyScrollable { get; }
+	bool VerticallyScrollable { get; }
+}
+
+[ComImport, Guid("b17d6187-0907-464b-a168-0ef17a1572b1"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaGridProvider
+{
+	IRawElementProviderSimple? GetItem(int row, int column);
+	int RowCount { get; }
+	int ColumnCount { get; }
+}
+
+[ComImport, Guid("d02541f1-fb81-4d64-ae32-f520f8a6dbd1"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaGridItemProvider
+{
+	int Row { get; }
+	int Column { get; }
+	int RowSpan { get; }
+	int ColumnSpan { get; }
+	IRawElementProviderSimple? ContainingGrid { get; }
+}
+
+[ComImport, Guid("9c860395-97b3-490a-b52a-858cc22af166"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaTableProvider
+{
+	[return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
+	object[]? GetRowHeaders();
+	[return: MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_UNKNOWN)]
+	object[]? GetColumnHeaders();
+	RowOrColumnMajor RowOrColumnMajor { get; }
+}
+
+[ComImport, Guid("2360c714-4bf1-4b26-ba65-9b21316127eb"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IUiaScrollItemProvider
+{
+	void ScrollIntoView();
+}
+
+// Wrapper classes that bridge Uno AutomationPeer patterns to UIA COM pattern interfaces.
+// Each wrapper is [ComVisible(true)] so the CLR creates a COM Callable Wrapper (CCW)
+// that UIA can consume directly.
+
+[ComVisible(true)]
+internal sealed class UiaInvokeProviderWrapper : IUiaInvokeProvider
+{
+	private readonly IInvokeProvider _inner;
+	internal UiaInvokeProviderWrapper(IInvokeProvider inner) => _inner = inner;
+	public void Invoke() => _inner.Invoke();
+}
+
+[ComVisible(true)]
+internal sealed class UiaToggleProviderWrapper : IUiaToggleProvider
+{
+	private readonly IToggleProvider _inner;
+	internal UiaToggleProviderWrapper(IToggleProvider inner) => _inner = inner;
+	public void Toggle() => _inner.Toggle();
+	public ToggleState ToggleState => _inner.ToggleState;
+}
+
+[ComVisible(true)]
+internal sealed class UiaValueProviderWrapper : IUiaValueProvider
+{
+	private readonly IValueProvider _inner;
+	internal UiaValueProviderWrapper(IValueProvider inner) => _inner = inner;
+	public void SetValue(string val) => _inner.SetValue(val);
+	public string Value => _inner.Value ?? string.Empty;
+	public bool IsReadOnly => _inner.IsReadOnly;
+}
+
+[ComVisible(true)]
+internal sealed class UiaRangeValueProviderWrapper : IUiaRangeValueProvider
+{
+	private readonly IRangeValueProvider _inner;
+	internal UiaRangeValueProviderWrapper(IRangeValueProvider inner) => _inner = inner;
+	public void SetValue(double val) => _inner.SetValue(val);
+	public double Value => _inner.Value;
+	public bool IsReadOnly => _inner.IsReadOnly;
+	public double Maximum => _inner.Maximum;
+	public double Minimum => _inner.Minimum;
+	public double LargeChange => _inner.LargeChange;
+	public double SmallChange => _inner.SmallChange;
+}
+
+[ComVisible(true)]
+internal sealed class UiaExpandCollapseProviderWrapper : IUiaExpandCollapseProvider
+{
+	private readonly IExpandCollapseProvider _inner;
+	internal UiaExpandCollapseProviderWrapper(IExpandCollapseProvider inner) => _inner = inner;
+	public void Expand() => _inner.Expand();
+	public void Collapse() => _inner.Collapse();
+	public ExpandCollapseState ExpandCollapseState => _inner.ExpandCollapseState;
+}
+
+[ComVisible(true)]
+internal sealed class UiaSelectionProviderWrapper : IUiaSelectionProvider
+{
+	private readonly Microsoft.UI.Xaml.Automation.Provider.ISelectionProvider _inner;
+	private readonly Win32Accessibility _accessibility;
+
+	internal UiaSelectionProviderWrapper(
+		Microsoft.UI.Xaml.Automation.Provider.ISelectionProvider inner,
+		Win32Accessibility accessibility)
+	{
+		_inner = inner;
+		_accessibility = accessibility;
+	}
+
+	public object[]? GetSelection()
+	{
+		var selected = _inner.GetSelection();
+		if (selected is null || selected.Length == 0)
+		{
+			return null;
+		}
+
+		var result = new object[selected.Length];
+		var count = 0;
+		foreach (var rep in selected)
+		{
+			// In Uno, IRawElementProviderSimple wraps an AutomationPeer
+			if (rep?.AutomationPeer is { } automationPeer)
+			{
+				var provider = _accessibility.GetProviderForPeer(automationPeer);
+				if (provider is not null)
+				{
+					result[count++] = provider;
+				}
+			}
+		}
+
+		if (count == 0)
+		{
+			return null;
+		}
+
+		if (count < result.Length)
+		{
+			Array.Resize(ref result, count);
+		}
+
+		return result;
+	}
+
+	public bool CanSelectMultiple => _inner.CanSelectMultiple;
+	public bool IsSelectionRequired => _inner.IsSelectionRequired;
+}
+
+[ComVisible(true)]
+internal sealed class UiaSelectionItemProviderWrapper : IUiaSelectionItemProvider
+{
+	private readonly ISelectionItemProvider _inner;
+	private readonly Win32Accessibility _accessibility;
+
+	internal UiaSelectionItemProviderWrapper(
+		ISelectionItemProvider inner,
+		Win32Accessibility accessibility)
+	{
+		_inner = inner;
+		_accessibility = accessibility;
+	}
+
+	public void Select() => _inner.Select();
+	public void AddToSelection() => _inner.AddToSelection();
+	public void RemoveFromSelection() => _inner.RemoveFromSelection();
+	public bool IsSelected => _inner.IsSelected;
+
+	public IRawElementProviderSimple? SelectionContainer
+	{
+		get
+		{
+			var container = _inner.SelectionContainer;
+			if (container?.AutomationPeer is { } peer)
+			{
+				return _accessibility.GetProviderForPeer(peer);
+			}
+			return null;
+		}
+	}
+}
+
+[ComVisible(true)]
+internal sealed class UiaScrollProviderWrapper : IUiaScrollProvider
+{
+	private readonly IScrollProvider _inner;
+	internal UiaScrollProviderWrapper(IScrollProvider inner) => _inner = inner;
+	public void Scroll(ScrollAmount horizontalAmount, ScrollAmount verticalAmount) => _inner.Scroll(horizontalAmount, verticalAmount);
+	public void SetScrollPercent(double horizontalPercent, double verticalPercent) => _inner.SetScrollPercent(horizontalPercent, verticalPercent);
+	public double HorizontalScrollPercent => _inner.HorizontalScrollPercent;
+	public double VerticalScrollPercent => _inner.VerticalScrollPercent;
+	public double HorizontalViewSize => _inner.HorizontalViewSize;
+	public double VerticalViewSize => _inner.VerticalViewSize;
+	public bool HorizontallyScrollable => _inner.HorizontallyScrollable;
+	public bool VerticallyScrollable => _inner.VerticallyScrollable;
+}
+
+[ComVisible(true)]
+internal sealed class UiaGridProviderWrapper : IUiaGridProvider
+{
+	private readonly IGridProvider _inner;
+	private readonly Win32Accessibility _accessibility;
+
+	internal UiaGridProviderWrapper(IGridProvider inner, Win32Accessibility accessibility)
+	{
+		_inner = inner;
+		_accessibility = accessibility;
+	}
+
+	public IRawElementProviderSimple? GetItem(int row, int column)
+	{
+		var item = _inner.GetItem(row, column);
+		if (item?.AutomationPeer is { } peer)
+		{
+			return _accessibility.GetProviderForPeer(peer);
+		}
+		return null;
+	}
+
+	public int RowCount => _inner.RowCount;
+	public int ColumnCount => _inner.ColumnCount;
+}
+
+[ComVisible(true)]
+internal sealed class UiaGridItemProviderWrapper : IUiaGridItemProvider
+{
+	private readonly IGridItemProvider _inner;
+	private readonly Win32Accessibility _accessibility;
+
+	internal UiaGridItemProviderWrapper(IGridItemProvider inner, Win32Accessibility accessibility)
+	{
+		_inner = inner;
+		_accessibility = accessibility;
+	}
+
+	public int Row => _inner.Row;
+	public int Column => _inner.Column;
+	public int RowSpan => _inner.RowSpan;
+	public int ColumnSpan => _inner.ColumnSpan;
+
+	public IRawElementProviderSimple? ContainingGrid
+	{
+		get
+		{
+			var grid = _inner.ContainingGrid;
+			if (grid?.AutomationPeer is { } peer)
+			{
+				return _accessibility.GetProviderForPeer(peer);
+			}
+			return null;
+		}
+	}
+}
+
+[ComVisible(true)]
+internal sealed class UiaTableProviderWrapper : IUiaTableProvider
+{
+	private readonly ITableProvider _inner;
+	private readonly Win32Accessibility _accessibility;
+
+	internal UiaTableProviderWrapper(ITableProvider inner, Win32Accessibility accessibility)
+	{
+		_inner = inner;
+		_accessibility = accessibility;
+	}
+
+	public object[]? GetRowHeaders()
+	{
+		var headers = _inner.GetRowHeaders();
+		return ResolveProviders(headers);
+	}
+
+	public object[]? GetColumnHeaders()
+	{
+		var headers = _inner.GetColumnHeaders();
+		return ResolveProviders(headers);
+	}
+
+	public RowOrColumnMajor RowOrColumnMajor => _inner.RowOrColumnMajor;
+
+	private object[]? ResolveProviders(Microsoft.UI.Xaml.Automation.Provider.IRawElementProviderSimple[]? elements)
+	{
+		if (elements is null || elements.Length == 0)
+		{
+			return null;
+		}
+
+		var result = new object[elements.Length];
+		var count = 0;
+		foreach (var rep in elements)
+		{
+			if (rep?.AutomationPeer is { } peer)
+			{
+				var provider = _accessibility.GetProviderForPeer(peer);
+				if (provider is not null)
+				{
+					result[count++] = provider;
+				}
+			}
+		}
+
+		if (count == 0)
+		{
+			return null;
+		}
+
+		if (count < result.Length)
+		{
+			Array.Resize(ref result, count);
+		}
+
+		return result;
+	}
+}
+
+[ComVisible(true)]
+internal sealed class UiaScrollItemProviderWrapper : IUiaScrollItemProvider
+{
+	private readonly IScrollItemProvider _inner;
+	internal UiaScrollItemProviderWrapper(IScrollItemProvider inner) => _inner = inner;
+	public void ScrollIntoView() => _inner.ScrollIntoView();
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -1,0 +1,1034 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Uno.Extensions;
+using Uno.Foundation.Logging;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+/// <summary>
+/// UIA provider for a single UIElement in the accessibility tree.
+/// Implements IRawElementProviderSimple and IRawElementProviderFragment.
+/// The root element additionally implements IRawElementProviderFragmentRoot.
+///
+/// Navigation uses the automation peer tree (which flattens layout-only elements)
+/// rather than the raw visual tree, matching WinUI3 behavior.
+/// </summary>
+[ComVisible(true)]
+internal class Win32RawElementProvider :
+	IRawElementProviderSimple,
+	IRawElementProviderFragment,
+	IRawElementProviderFragmentRoot
+{
+	private static int _nextRuntimeId = 1;
+
+	private readonly UIElement _owner;
+	private readonly nint _hwnd;
+	private readonly int _runtimeId;
+	private readonly bool _isRoot;
+	private readonly Win32Accessibility _accessibility;
+	private IList<AutomationPeer>? _cachedAutomationChildren;
+
+	internal UIElement Owner => _owner;
+
+	internal Win32RawElementProvider(
+		UIElement owner,
+		nint hwnd,
+		bool isRoot,
+		Win32Accessibility accessibility)
+	{
+		_owner = owner;
+		_hwnd = hwnd;
+		_isRoot = isRoot;
+		_accessibility = accessibility;
+		_runtimeId = _nextRuntimeId++;
+	}
+
+	// IRawElementProviderSimple
+
+	public ProviderOptions ProviderOptions =>
+		ProviderOptions.ServerSideProvider | ProviderOptions.UseComThreading;
+
+	public object? GetPatternProvider(int patternId)
+	{
+		try
+		{
+			var peer = _owner.GetOrCreateAutomationPeer();
+			if (peer is null)
+			{
+				return null;
+			}
+
+			object? result = patternId switch
+			{
+				Win32UIAutomationInterop.UIA_InvokePatternId
+					when peer.GetPattern(PatternInterface.Invoke) is IInvokeProvider invoke
+					=> new UiaInvokeProviderWrapper(invoke),
+				Win32UIAutomationInterop.UIA_TogglePatternId
+					when peer.GetPattern(PatternInterface.Toggle) is IToggleProvider toggle
+					=> new UiaToggleProviderWrapper(toggle),
+				Win32UIAutomationInterop.UIA_ValuePatternId
+					when peer.GetPattern(PatternInterface.Value) is IValueProvider value
+					=> new UiaValueProviderWrapper(value),
+				Win32UIAutomationInterop.UIA_RangeValuePatternId
+					when peer.GetPattern(PatternInterface.RangeValue) is IRangeValueProvider rangeValue
+					=> new UiaRangeValueProviderWrapper(rangeValue),
+				Win32UIAutomationInterop.UIA_ExpandCollapsePatternId
+					when peer.GetPattern(PatternInterface.ExpandCollapse) is IExpandCollapseProvider expandCollapse
+					=> new UiaExpandCollapseProviderWrapper(expandCollapse),
+				Win32UIAutomationInterop.UIA_SelectionPatternId
+					when peer.GetPattern(PatternInterface.Selection) is Microsoft.UI.Xaml.Automation.Provider.ISelectionProvider selection
+					=> new UiaSelectionProviderWrapper(selection, _accessibility),
+				Win32UIAutomationInterop.UIA_SelectionItemPatternId
+					when peer.GetPattern(PatternInterface.SelectionItem) is ISelectionItemProvider selectionItem
+					=> new UiaSelectionItemProviderWrapper(selectionItem, _accessibility),
+				Win32UIAutomationInterop.UIA_ScrollPatternId
+					when peer.GetPattern(PatternInterface.Scroll) is IScrollProvider scroll
+					=> new UiaScrollProviderWrapper(scroll),
+				Win32UIAutomationInterop.UIA_ScrollItemPatternId
+					when peer.GetPattern(PatternInterface.ScrollItem) is IScrollItemProvider scrollItem
+					=> new UiaScrollItemProviderWrapper(scrollItem),
+				Win32UIAutomationInterop.UIA_GridPatternId
+					when peer.GetPattern(PatternInterface.Grid) is IGridProvider grid
+					=> new UiaGridProviderWrapper(grid, _accessibility),
+				Win32UIAutomationInterop.UIA_GridItemPatternId
+					when peer.GetPattern(PatternInterface.GridItem) is IGridItemProvider gridItem
+					=> new UiaGridItemProviderWrapper(gridItem, _accessibility),
+				Win32UIAutomationInterop.UIA_TablePatternId
+					when peer.GetPattern(PatternInterface.Table) is ITableProvider table
+					=> new UiaTableProviderWrapper(table, _accessibility),
+				_ => null,
+			};
+
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				var patternName = GetPatternName(patternId);
+				this.Log().Trace($"[UIA] GetPatternProvider({patternName}) on {DescribeElement()} → {(result is not null ? result.GetType().Name : "(null)")}");
+			}
+
+			return result;
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"GetPatternProvider({patternId}) failed: {ex.Message}");
+			}
+			return null;
+		}
+	}
+
+	public object? GetPropertyValue(int propertyId)
+	{
+		try
+		{
+			var peer = _owner.GetOrCreateAutomationPeer();
+
+			object? result = propertyId switch
+			{
+				// Identity & structure
+				Win32UIAutomationInterop.UIA_NamePropertyId => GetName(peer),
+				Win32UIAutomationInterop.UIA_AutomationIdPropertyId => GetAutomationId(peer),
+				Win32UIAutomationInterop.UIA_ClassNamePropertyId => peer?.GetClassName(),
+				Win32UIAutomationInterop.UIA_ControlTypePropertyId => GetControlTypeId(peer),
+				Win32UIAutomationInterop.UIA_LocalizedControlTypePropertyId => peer?.GetLocalizedControlType(),
+				Win32UIAutomationInterop.UIA_FrameworkIdPropertyId => "Uno",
+				Win32UIAutomationInterop.UIA_ProviderDescriptionPropertyId => "Uno Platform UIA Provider",
+				Win32UIAutomationInterop.UIA_ProcessIdPropertyId => GetProcessId(),
+				Win32UIAutomationInterop.UIA_NativeWindowHandlePropertyId => _isRoot ? (int)_hwnd : 0,
+
+				// State
+				Win32UIAutomationInterop.UIA_IsEnabledPropertyId => peer?.IsEnabled() ?? (_owner is Control c ? c.IsEnabled : true),
+				Win32UIAutomationInterop.UIA_IsKeyboardFocusablePropertyId => peer?.IsKeyboardFocusable() ?? false,
+				Win32UIAutomationInterop.UIA_HasKeyboardFocusPropertyId => peer?.HasKeyboardFocus() ?? false,
+				Win32UIAutomationInterop.UIA_IsOffscreenPropertyId => peer?.IsOffscreen() ?? false,
+				Win32UIAutomationInterop.UIA_IsPasswordPropertyId => peer?.IsPassword() ?? false,
+				Win32UIAutomationInterop.UIA_IsRequiredForFormPropertyId => peer?.IsRequiredForForm() ?? false,
+
+				// Tree view membership
+				Win32UIAutomationInterop.UIA_IsControlElementPropertyId => GetIsControlElement(peer),
+				Win32UIAutomationInterop.UIA_IsContentElementPropertyId => GetIsContentElement(peer),
+
+				// Description & labels
+				Win32UIAutomationInterop.UIA_HelpTextPropertyId => peer?.GetHelpText(),
+				Win32UIAutomationInterop.UIA_AcceleratorKeyPropertyId => GetNonEmpty(peer?.GetAcceleratorKey()),
+				Win32UIAutomationInterop.UIA_AccessKeyPropertyId => GetNonEmpty(peer?.GetAccessKey()),
+				Win32UIAutomationInterop.UIA_ItemTypePropertyId => GetNonEmpty(peer?.GetItemType()),
+				Win32UIAutomationInterop.UIA_ItemStatusPropertyId => GetNonEmpty(peer?.GetItemStatus()),
+				Win32UIAutomationInterop.UIA_FullDescriptionPropertyId => GetNonEmpty(AutomationProperties.GetFullDescription(_owner)),
+
+				// Semantics
+				Win32UIAutomationInterop.UIA_HeadingLevelPropertyId => MapHeadingLevel(AutomationProperties.GetHeadingLevel(_owner)),
+				Win32UIAutomationInterop.UIA_LandmarkTypePropertyId => MapLandmarkType(AutomationProperties.GetLandmarkType(_owner)),
+				Win32UIAutomationInterop.UIA_LocalizedLandmarkTypePropertyId => GetNonEmpty(AutomationProperties.GetLocalizedLandmarkType(_owner)),
+				Win32UIAutomationInterop.UIA_LiveSettingPropertyId => (int)AutomationProperties.GetLiveSetting(_owner),
+				Win32UIAutomationInterop.UIA_OrientationPropertyId => MapOrientation(peer),
+
+				// Position in group
+				Win32UIAutomationInterop.UIA_PositionInSetPropertyId => GetPositiveOrNull(peer?.GetPositionInSet() ?? AutomationProperties.GetPositionInSet(_owner)),
+				Win32UIAutomationInterop.UIA_SizeOfSetPropertyId => GetPositiveOrNull(peer?.GetSizeOfSet() ?? AutomationProperties.GetSizeOfSet(_owner)),
+				Win32UIAutomationInterop.UIA_LevelPropertyId => GetPositiveOrNull(peer?.GetLevel() ?? AutomationProperties.GetLevel(_owner)),
+
+				// Form validation
+				Win32UIAutomationInterop.UIA_IsDataValidForFormPropertyId => peer?.IsDataValidForForm() ?? true,
+
+				// Dialog
+				Win32UIAutomationInterop.UIA_IsDialogPropertyId => peer?.IsDialog() ?? false,
+
+				// Relation properties
+				Win32UIAutomationInterop.UIA_LabeledByPropertyId => GetLabeledByProvider(peer),
+				Win32UIAutomationInterop.UIA_DescribedByPropertyId => null,
+				Win32UIAutomationInterop.UIA_ControllerForPropertyId => null,
+				Win32UIAutomationInterop.UIA_FlowsToPropertyId => null,
+				Win32UIAutomationInterop.UIA_FlowsFromPropertyId => null,
+
+				// ARIA properties - not applicable for non-web frameworks
+				Win32UIAutomationInterop.UIA_AriaRolePropertyId => null,
+				Win32UIAutomationInterop.UIA_AriaPropertiesPropertyId => null,
+
+				// Culture / peripheral / other
+				Win32UIAutomationInterop.UIA_CulturePropertyId => null,
+				Win32UIAutomationInterop.UIA_IsPeripheralPropertyId => null,
+
+				_ => null,
+			};
+
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				var propName = GetPropertyName(propertyId);
+				this.Log().Trace($"[UIA] GetPropertyValue({propName}) on {DescribeElement()} → {result ?? "(null)"}");
+			}
+
+			return result;
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"GetPropertyValue({propertyId}) failed: {ex.Message}");
+			}
+			return null;
+		}
+	}
+
+	public IRawElementProviderSimple? HostRawElementProvider
+	{
+		get
+		{
+			if (_isRoot)
+			{
+				var hr = Win32UIAutomationInterop.UiaHostProviderFromHwnd(_hwnd, out var hostProvider);
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"[UIA] HostRawElementProvider: hwnd=0x{_hwnd:X}, hr=0x{hr:X}, hostProvider={(hostProvider is not null ? "present" : "NULL")}");
+				}
+
+				return hostProvider;
+			}
+			return null;
+		}
+	}
+
+	// IRawElementProviderFragment
+
+	public IRawElementProviderFragment? Navigate(NavigateDirection direction)
+	{
+		try
+		{
+			var result = direction switch
+			{
+				NavigateDirection.Parent => FindParentProvider(),
+				NavigateDirection.FirstChild => GetFirstChild(),
+				NavigateDirection.LastChild => GetLastChild(),
+				NavigateDirection.NextSibling => GetNextSibling(),
+				NavigateDirection.PreviousSibling => GetPreviousSibling(),
+				_ => null,
+			};
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				var targetDesc = result is Win32RawElementProvider targetProvider
+					? targetProvider.DescribeElement()
+					: "(null)";
+				this.Log().Debug($"[UIA] Navigate({direction}) on {DescribeElement()} → {targetDesc}");
+			}
+
+			return result;
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"Navigate({direction}) on {DescribeElement()} failed: {ex.Message}");
+			}
+			return null;
+		}
+	}
+
+	public int[]? GetRuntimeId()
+	{
+		return [Win32UIAutomationInterop.UiaAppendRuntimeId, _runtimeId];
+	}
+
+	public UiaRect BoundingRectangle
+	{
+		get
+		{
+			try
+			{
+				var visual = _owner.Visual;
+				var size = visual.Size;
+
+				// Compute the full element-to-root transform, then transform the
+				// local rect to get the axis-aligned bounding box in window coords.
+				// This correctly handles rotation, scale, and skew transforms.
+				var transform = UIElement.GetTransform(from: _owner, to: null);
+				var localRect = new Windows.Foundation.Rect(0, 0, size.X, size.Y);
+				var logicalRect = transform.Transform(localRect);
+
+				// Convert logical pixels to physical screen coordinates
+				float dpiScale = Win32UIAutomationInterop.GetDpiForWindow(_hwnd)
+					/ (float)Win32UIAutomationInterop.USER_DEFAULT_SCREEN_DPI;
+				if (dpiScale <= 0)
+				{
+					dpiScale = 1.0f;
+				}
+
+				var clientOrigin = new System.Drawing.Point(0, 0);
+				Win32UIAutomationInterop.ClientToScreen(_hwnd, ref clientOrigin);
+
+				return new UiaRect
+				{
+					Left = clientOrigin.X + logicalRect.X * dpiScale,
+					Top = clientOrigin.Y + logicalRect.Y * dpiScale,
+					Width = logicalRect.Width * dpiScale,
+					Height = logicalRect.Height * dpiScale,
+				};
+			}
+			catch (Exception ex)
+			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"BoundingRectangle failed: {ex.Message}");
+				}
+				return default;
+			}
+		}
+	}
+
+	public IRawElementProviderFragment[]? GetEmbeddedFragmentRoots() => null;
+
+	public void SetFocus()
+	{
+		if (_owner is Control control)
+		{
+			control.Focus(FocusState.Programmatic);
+		}
+		else
+		{
+			// For non-Control elements, try to set focus via the automation peer
+			_owner.GetOrCreateAutomationPeer()?.SetFocus();
+		}
+	}
+
+	public IRawElementProviderFragmentRoot? FragmentRoot
+		=> _accessibility.RootProvider;
+
+	// IRawElementProviderFragmentRoot (only meaningful on root element)
+
+	public IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
+	{
+		try
+		{
+			var result = FindDeepestProviderAtPoint(x, y) ?? this;
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				var desc = result is Win32RawElementProvider p ? p.DescribeElement() : "self";
+				this.Log().Debug($"[UIA] ElementProviderFromPoint({x:F0}, {y:F0}) → {desc}");
+			}
+
+			return result;
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"ElementProviderFromPoint({x}, {y}) failed: {ex.Message}");
+			}
+			return this;
+		}
+	}
+
+	public IRawElementProviderFragment? GetFocus()
+	{
+		try
+		{
+			var xamlRoot = _owner.XamlRoot;
+			if (xamlRoot is null)
+			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"[UIA] GetFocus: XamlRoot is null on {DescribeElement()}");
+				}
+				return null;
+			}
+
+			var focusedElement = FocusManager.GetFocusedElement(xamlRoot);
+			if (focusedElement is UIElement uiElement)
+			{
+				// Return the provider for the focused element, or its nearest ancestor
+				// that has an automation peer
+				var result = _accessibility.GetOrCreateProvider(uiElement)
+					?? FindNearestProviderAncestor(uiElement);
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					var desc = result is Win32RawElementProvider p ? p.DescribeElement() : "(null)";
+					this.Log().Debug($"[UIA] GetFocus → focused={uiElement.GetType().Name}, provider={desc}");
+				}
+
+				return result;
+			}
+			else
+			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"[UIA] GetFocus → no focused UIElement (focusedElement={focusedElement?.GetType().Name ?? "null"})");
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"GetFocus failed: {ex.Message}");
+			}
+		}
+		return null;
+	}
+
+	// Navigation helpers - use automation peer tree, not visual tree
+
+	/// <summary>
+	/// Gets the automation peer children for this element. If the element has an
+	/// automation peer, its <see cref="AutomationPeer.GetChildren"/> provides the
+	/// filtered/flattened list. Otherwise we walk the visual tree to collect peers,
+	/// mimicking <see cref="FrameworkElementAutomationPeer.GetChildrenCore"/>.
+	/// </summary>
+	internal void InvalidateChildrenCache() => _cachedAutomationChildren = null;
+
+	private IList<AutomationPeer>? GetAutomationChildren()
+	{
+		if (_cachedAutomationChildren is not null)
+		{
+			return _cachedAutomationChildren;
+		}
+
+		var peer = _owner.GetOrCreateAutomationPeer();
+		IList<AutomationPeer>? result;
+
+		if (peer is not null)
+		{
+			result = peer.GetChildren();
+		}
+		else
+		{
+			// Fallback for elements without automation peers (e.g. root if it's a raw panel):
+			// Walk visual tree and collect automation peers from descendants.
+			var children = new List<AutomationPeer>();
+			CollectAutomationPeers(_owner, children);
+			result = children.Count > 0 ? children : null;
+		}
+
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			var count = result?.Count ?? 0;
+			var peerDesc = peer?.GetType().Name ?? "none";
+			var childNames = "";
+			if (result is not null && count <= 10)
+			{
+				var names = new List<string>();
+				foreach (var child in result)
+				{
+					var childType = child?.GetType().Name ?? "null";
+					string childName;
+					try { childName = child?.GetName() ?? ""; }
+					catch { childName = "<error>"; }
+					names.Add($"{childType}({childName})");
+				}
+				childNames = $" [{string.Join(", ", names)}]";
+			}
+			this.Log().Debug($"[UIA] GetAutomationChildren on {DescribeElement()} (peer={peerDesc}) → {count} children{childNames}");
+		}
+
+		_cachedAutomationChildren = result;
+		return result;
+	}
+
+	private static void CollectAutomationPeers(UIElement element, List<AutomationPeer> result)
+	{
+		foreach (var child in element.GetChildren())
+		{
+			if (child.Visibility == Visibility.Collapsed)
+			{
+				continue;
+			}
+
+			var peer = child.GetOrCreateAutomationPeer();
+			if (peer is not null)
+			{
+				result.Add(peer);
+			}
+			else
+			{
+				// No peer on this element - flatten by recursing into its children
+				CollectAutomationPeers(child, result);
+			}
+		}
+	}
+
+	private IRawElementProviderFragment? GetFirstChild()
+	{
+		var children = GetAutomationChildren();
+		if (children is null || children.Count == 0)
+		{
+			return null;
+		}
+
+		for (var i = 0; i < children.Count; i++)
+		{
+			var provider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
+			if (provider is not null)
+			{
+				return provider;
+			}
+		}
+		return null;
+	}
+
+	private IRawElementProviderFragment? GetLastChild()
+	{
+		var children = GetAutomationChildren();
+		if (children is null || children.Count == 0)
+		{
+			return null;
+		}
+
+		for (var i = children.Count - 1; i >= 0; i--)
+		{
+			var provider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
+			if (provider is not null)
+			{
+				return provider;
+			}
+		}
+		return null;
+	}
+
+	private IRawElementProviderFragment? GetNextSibling()
+	{
+		var parentProvider = FindParentProvider();
+		if (parentProvider is null)
+		{
+			return null;
+		}
+
+		var siblings = parentProvider.GetAutomationChildren();
+		if (siblings is null)
+		{
+			return null;
+		}
+
+		var myPeer = _owner.GetOrCreateAutomationPeer();
+		var foundSelf = false;
+
+		for (var i = 0; i < siblings.Count; i++)
+		{
+			if (foundSelf)
+			{
+				var provider = _accessibility.GetProviderForPeer(siblings[i], resolveEventsSource: true);
+				if (provider is not null)
+				{
+					return provider;
+				}
+			}
+			else if (IsSamePeer(siblings[i], myPeer))
+			{
+				foundSelf = true;
+			}
+		}
+		return null;
+	}
+
+	private IRawElementProviderFragment? GetPreviousSibling()
+	{
+		var parentProvider = FindParentProvider();
+		if (parentProvider is null)
+		{
+			return null;
+		}
+
+		var siblings = parentProvider.GetAutomationChildren();
+		if (siblings is null)
+		{
+			return null;
+		}
+
+		var myPeer = _owner.GetOrCreateAutomationPeer();
+		Win32RawElementProvider? previous = null;
+
+		for (var i = 0; i < siblings.Count; i++)
+		{
+			if (IsSamePeer(siblings[i], myPeer))
+			{
+				return previous;
+			}
+			var provider = _accessibility.GetProviderForPeer(siblings[i], resolveEventsSource: true);
+			if (provider is not null)
+			{
+				previous = provider;
+			}
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Finds the parent UIA provider for this element. Prefers the automation
+	/// peer tree (via <see cref="AutomationPeer.GetParent"/>) since it may
+	/// differ from the visual tree — e.g. <see cref="ItemAutomationPeer"/>'s
+	/// parent is the <see cref="ItemsControlAutomationPeer"/>, not the visual
+	/// parent. Falls back to walking the visual tree if the peer tree doesn't
+	/// resolve to a provider.
+	/// </summary>
+	private Win32RawElementProvider? FindParentProvider()
+	{
+		if (_isRoot)
+		{
+			return null;
+		}
+
+		// First, try the automation peer tree. This is the correct path for
+		// ItemAutomationPeer and other peers whose logical parent differs
+		// from the visual parent.
+		var myPeer = _owner.GetOrCreateAutomationPeer();
+		if (myPeer?.GetParent() is { } parentPeer)
+		{
+			var parentProvider = _accessibility.GetProviderForPeer(parentPeer);
+			if (parentProvider is not null)
+			{
+				return parentProvider;
+			}
+		}
+
+		// Fall back to the visual tree when the peer tree doesn't yield a
+		// provider (e.g. the parent peer has no owner element yet).
+		var current = VisualTreeHelper.GetParent(_owner) as UIElement;
+		while (current is not null)
+		{
+			// Check if this is the root element
+			if (_accessibility.RootProvider is { } root && ReferenceEquals(root.Owner, current))
+			{
+				return root;
+			}
+
+			// Check if this ancestor has an automation peer
+			if (current.GetOrCreateAutomationPeer() is not null)
+			{
+				return _accessibility.GetOrCreateProvider(current);
+			}
+
+			current = VisualTreeHelper.GetParent(current) as UIElement;
+		}
+
+		// If no ancestor with a peer was found, return the root
+		return _accessibility.RootProvider;
+	}
+
+	/// <summary>
+	/// Finds the nearest ancestor with a UIA provider, for elements that
+	/// might not have a direct provider themselves.
+	/// </summary>
+	private Win32RawElementProvider? FindNearestProviderAncestor(UIElement element)
+	{
+		var current = VisualTreeHelper.GetParent(element) as UIElement;
+		while (current is not null)
+		{
+			// Use GetOrCreateProvider so that ancestor providers are lazily created —
+			// GetProvider only looks in the already-created cache and would fall back to
+			// root when no providers have been created yet (e.g. on first GetFocus call).
+			var provider = _accessibility.GetOrCreateProvider(current);
+			if (provider is not null)
+			{
+				return provider;
+			}
+			current = VisualTreeHelper.GetParent(current) as UIElement;
+		}
+		return _accessibility.RootProvider;
+	}
+
+	/// <summary>
+	/// Compares two automation peers for identity. Uses reference equality first,
+	/// then falls back to checking if they wrap the same UIElement.
+	/// </summary>
+	private static bool IsSamePeer(AutomationPeer? a, AutomationPeer? b)
+	{
+		if (a is null || b is null)
+		{
+			return false;
+		}
+
+		if (ReferenceEquals(a, b))
+		{
+			return true;
+		}
+
+		// Fall back to comparing owner UIElements
+		if (a is FrameworkElementAutomationPeer feapA
+			&& b is FrameworkElementAutomationPeer feapB)
+		{
+			return ReferenceEquals(feapA.Owner, feapB.Owner);
+		}
+
+		return false;
+	}
+
+	// Hit testing helper
+
+	private Win32RawElementProvider? FindDeepestProviderAtPoint(double screenX, double screenY)
+	{
+		// Use the automation children (filtered tree) for hit testing
+		var children = GetAutomationChildren();
+		if (children is not null)
+		{
+			// Search in reverse order (topmost Z-index first)
+			for (var i = children.Count - 1; i >= 0; i--)
+			{
+				var childProvider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
+				if (childProvider is not null)
+				{
+					var found = childProvider.FindDeepestProviderAtPoint(screenX, screenY);
+					if (found is not null)
+					{
+						return found;
+					}
+				}
+			}
+		}
+
+		// Check if point is within this element's bounds
+		var bounds = BoundingRectangle;
+		if (screenX >= bounds.Left && screenX < bounds.Left + bounds.Width &&
+			screenY >= bounds.Top && screenY < bounds.Top + bounds.Height)
+		{
+			return this;
+		}
+
+		return null;
+	}
+
+	// Property helpers
+
+	private IRawElementProviderSimple? GetLabeledByProvider(AutomationPeer? peer)
+	{
+		// Check AutomationProperties.LabeledBy attached property first
+		var labeledByElement = AutomationProperties.GetLabeledBy(_owner);
+		if (labeledByElement is UIElement labelElement)
+		{
+			return _accessibility.GetOrCreateProvider(labelElement);
+		}
+
+		// Fall back to peer's GetLabeledBy()
+		if (peer?.GetLabeledBy() is { } labeledByPeer)
+		{
+			return _accessibility.GetProviderForPeer(labeledByPeer);
+		}
+
+		return null;
+	}
+
+	private string? GetName(AutomationPeer? peer)
+	{
+		if (_isRoot && peer is null)
+		{
+			// Root without a peer returns the window title
+			return GetWindowTitle();
+		}
+		// Return null instead of empty string so UIA knows the name is unset
+		// and can fall back to other name computation strategies.
+		return GetNonEmpty(peer?.GetName());
+	}
+
+	private string? GetAutomationId(AutomationPeer? peer)
+	{
+		// Prefer the attached property, fall back to the peer
+		var id = AutomationProperties.GetAutomationId(_owner);
+		if (!string.IsNullOrEmpty(id))
+		{
+			return id;
+		}
+		return GetNonEmpty(peer?.GetAutomationId());
+	}
+
+	private int GetControlTypeId(AutomationPeer? peer)
+	{
+		if (peer is null)
+		{
+			return _isRoot
+				? Win32UIAutomationInterop.UIA_PaneControlTypeId
+				: Win32UIAutomationInterop.UIA_CustomControlTypeId;
+		}
+
+		return MapControlType(peer.GetAutomationControlType());
+	}
+
+	private bool GetIsControlElement(AutomationPeer? peer)
+	{
+		if (_isRoot)
+		{
+			return true;
+		}
+
+		// Elements without automation peers are not control elements
+		return peer?.IsControlElement() ?? false;
+	}
+
+	private bool GetIsContentElement(AutomationPeer? peer)
+	{
+		if (_isRoot)
+		{
+			return true;
+		}
+
+		return peer?.IsContentElement() ?? false;
+	}
+
+	private int GetProcessId()
+	{
+		_ = Win32UIAutomationInterop.GetWindowThreadProcessId(_hwnd, out var processId);
+		return processId;
+	}
+
+	private string? GetWindowTitle()
+	{
+		if (!_isRoot)
+		{
+			return null;
+		}
+
+		// Try to get the window title from the HWND
+		try
+		{
+			var titleLength = GetWindowTextLength(_hwnd);
+			if (titleLength > 0)
+			{
+				var buffer = new char[titleLength + 1];
+				unsafe
+				{
+					fixed (char* pBuffer = buffer)
+					{
+						var charsRead = GetWindowText(_hwnd, pBuffer, buffer.Length);
+						if (charsRead > 0)
+						{
+							return new string(buffer, 0, charsRead);
+						}
+					}
+				}
+			}
+		}
+		catch
+		{
+			// Fall through
+		}
+
+		return "Uno Platform";
+	}
+
+	[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+	private static extern int GetWindowTextLength(nint hWnd);
+
+	[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+	private static extern unsafe int GetWindowText(nint hWnd, char* lpString, int nMaxCount);
+
+	private static string? GetNonEmpty(string? value)
+		=> string.IsNullOrEmpty(value) ? null : value;
+
+	private static int? GetPositiveOrNull(int value)
+		=> value > 0 ? value : null;
+
+	private static int? MapOrientation(AutomationPeer? peer)
+	{
+		if (peer is null)
+		{
+			return null;
+		}
+		return peer.GetOrientation() switch
+		{
+			AutomationOrientation.Horizontal => Win32UIAutomationInterop.OrientationType_Horizontal,
+			AutomationOrientation.Vertical => Win32UIAutomationInterop.OrientationType_Vertical,
+			_ => Win32UIAutomationInterop.OrientationType_None,
+		};
+	}
+
+	internal static int MapHeadingLevel(AutomationHeadingLevel level) => level switch
+	{
+		AutomationHeadingLevel.None => Win32UIAutomationInterop.HeadingLevel_None,
+		AutomationHeadingLevel.Level1 => Win32UIAutomationInterop.HeadingLevel1,
+		AutomationHeadingLevel.Level2 => Win32UIAutomationInterop.HeadingLevel2,
+		AutomationHeadingLevel.Level3 => Win32UIAutomationInterop.HeadingLevel3,
+		AutomationHeadingLevel.Level4 => Win32UIAutomationInterop.HeadingLevel4,
+		AutomationHeadingLevel.Level5 => Win32UIAutomationInterop.HeadingLevel5,
+		AutomationHeadingLevel.Level6 => Win32UIAutomationInterop.HeadingLevel6,
+		AutomationHeadingLevel.Level7 => Win32UIAutomationInterop.HeadingLevel7,
+		AutomationHeadingLevel.Level8 => Win32UIAutomationInterop.HeadingLevel8,
+		AutomationHeadingLevel.Level9 => Win32UIAutomationInterop.HeadingLevel9,
+		_ => Win32UIAutomationInterop.HeadingLevel_None,
+	};
+
+	internal static int? MapLandmarkType(AutomationLandmarkType type) => type switch
+	{
+		AutomationLandmarkType.None => null,
+		AutomationLandmarkType.Custom => Win32UIAutomationInterop.UIA_CustomLandmarkTypeId,
+		AutomationLandmarkType.Form => Win32UIAutomationInterop.UIA_FormLandmarkTypeId,
+		AutomationLandmarkType.Main => Win32UIAutomationInterop.UIA_MainLandmarkTypeId,
+		AutomationLandmarkType.Navigation => Win32UIAutomationInterop.UIA_NavigationLandmarkTypeId,
+		AutomationLandmarkType.Search => Win32UIAutomationInterop.UIA_SearchLandmarkTypeId,
+		_ => null,
+	};
+
+	internal static int MapControlType(AutomationControlType controlType) => controlType switch
+	{
+		AutomationControlType.Button => Win32UIAutomationInterop.UIA_ButtonControlTypeId,
+		AutomationControlType.Calendar => Win32UIAutomationInterop.UIA_CalendarControlTypeId,
+		AutomationControlType.CheckBox => Win32UIAutomationInterop.UIA_CheckBoxControlTypeId,
+		AutomationControlType.ComboBox => Win32UIAutomationInterop.UIA_ComboBoxControlTypeId,
+		AutomationControlType.Edit => Win32UIAutomationInterop.UIA_EditControlTypeId,
+		AutomationControlType.Hyperlink => Win32UIAutomationInterop.UIA_HyperlinkControlTypeId,
+		AutomationControlType.Image => Win32UIAutomationInterop.UIA_ImageControlTypeId,
+		AutomationControlType.ListItem => Win32UIAutomationInterop.UIA_ListItemControlTypeId,
+		AutomationControlType.List => Win32UIAutomationInterop.UIA_ListControlTypeId,
+		AutomationControlType.Menu => Win32UIAutomationInterop.UIA_MenuControlTypeId,
+		AutomationControlType.MenuBar => Win32UIAutomationInterop.UIA_MenuBarControlTypeId,
+		AutomationControlType.MenuItem => Win32UIAutomationInterop.UIA_MenuItemControlTypeId,
+		AutomationControlType.ProgressBar => Win32UIAutomationInterop.UIA_ProgressBarControlTypeId,
+		AutomationControlType.RadioButton => Win32UIAutomationInterop.UIA_RadioButtonControlTypeId,
+		AutomationControlType.ScrollBar => Win32UIAutomationInterop.UIA_ScrollBarControlTypeId,
+		AutomationControlType.Slider => Win32UIAutomationInterop.UIA_SliderControlTypeId,
+		AutomationControlType.Spinner => Win32UIAutomationInterop.UIA_SpinnerControlTypeId,
+		AutomationControlType.StatusBar => Win32UIAutomationInterop.UIA_StatusBarControlTypeId,
+		AutomationControlType.Tab => Win32UIAutomationInterop.UIA_TabControlTypeId,
+		AutomationControlType.TabItem => Win32UIAutomationInterop.UIA_TabItemControlTypeId,
+		AutomationControlType.Text => Win32UIAutomationInterop.UIA_TextControlTypeId,
+		AutomationControlType.ToolBar => Win32UIAutomationInterop.UIA_ToolBarControlTypeId,
+		AutomationControlType.ToolTip => Win32UIAutomationInterop.UIA_ToolTipControlTypeId,
+		AutomationControlType.Tree => Win32UIAutomationInterop.UIA_TreeControlTypeId,
+		AutomationControlType.TreeItem => Win32UIAutomationInterop.UIA_TreeItemControlTypeId,
+		AutomationControlType.Custom => Win32UIAutomationInterop.UIA_CustomControlTypeId,
+		AutomationControlType.Group => Win32UIAutomationInterop.UIA_GroupControlTypeId,
+		AutomationControlType.Thumb => Win32UIAutomationInterop.UIA_ThumbControlTypeId,
+		AutomationControlType.DataGrid => Win32UIAutomationInterop.UIA_DataGridControlTypeId,
+		AutomationControlType.DataItem => Win32UIAutomationInterop.UIA_DataItemControlTypeId,
+		AutomationControlType.Document => Win32UIAutomationInterop.UIA_DocumentControlTypeId,
+		AutomationControlType.SplitButton => Win32UIAutomationInterop.UIA_SplitButtonControlTypeId,
+		AutomationControlType.Window => Win32UIAutomationInterop.UIA_WindowControlTypeId,
+		AutomationControlType.Pane => Win32UIAutomationInterop.UIA_PaneControlTypeId,
+		AutomationControlType.Header => Win32UIAutomationInterop.UIA_HeaderControlTypeId,
+		AutomationControlType.HeaderItem => Win32UIAutomationInterop.UIA_HeaderItemControlTypeId,
+		AutomationControlType.Table => Win32UIAutomationInterop.UIA_TableControlTypeId,
+		AutomationControlType.Separator => Win32UIAutomationInterop.UIA_SeparatorControlTypeId,
+		AutomationControlType.SemanticZoom => Win32UIAutomationInterop.UIA_SemanticZoomControlTypeId,
+		AutomationControlType.AppBar => Win32UIAutomationInterop.UIA_AppBarControlTypeId,
+		AutomationControlType.FlipView => Win32UIAutomationInterop.UIA_FlipViewControlTypeId,
+		_ => Win32UIAutomationInterop.UIA_CustomControlTypeId,
+	};
+
+	// Diagnostic helpers
+
+	internal string DescribeElement()
+	{
+		var typeName = _owner.GetType().Name;
+		var automationId = AutomationProperties.GetAutomationId(_owner);
+		var name = AutomationProperties.GetName(_owner);
+		var details = !string.IsNullOrEmpty(automationId) ? automationId
+			: !string.IsNullOrEmpty(name) ? $"\"{name}\""
+			: $"rid={_runtimeId}";
+		return $"{typeName}({details}){(_isRoot ? " [ROOT]" : "")}";
+	}
+
+	private static string GetPropertyName(int propertyId) => propertyId switch
+	{
+		Win32UIAutomationInterop.UIA_NamePropertyId => "Name",
+		Win32UIAutomationInterop.UIA_AutomationIdPropertyId => "AutomationId",
+		Win32UIAutomationInterop.UIA_ClassNamePropertyId => "ClassName",
+		Win32UIAutomationInterop.UIA_ControlTypePropertyId => "ControlType",
+		Win32UIAutomationInterop.UIA_LocalizedControlTypePropertyId => "LocalizedControlType",
+		Win32UIAutomationInterop.UIA_FrameworkIdPropertyId => "FrameworkId",
+		Win32UIAutomationInterop.UIA_ProviderDescriptionPropertyId => "ProviderDescription",
+		Win32UIAutomationInterop.UIA_ProcessIdPropertyId => "ProcessId",
+		Win32UIAutomationInterop.UIA_NativeWindowHandlePropertyId => "NativeWindowHandle",
+		Win32UIAutomationInterop.UIA_IsEnabledPropertyId => "IsEnabled",
+		Win32UIAutomationInterop.UIA_IsKeyboardFocusablePropertyId => "IsKeyboardFocusable",
+		Win32UIAutomationInterop.UIA_HasKeyboardFocusPropertyId => "HasKeyboardFocus",
+		Win32UIAutomationInterop.UIA_IsOffscreenPropertyId => "IsOffscreen",
+		Win32UIAutomationInterop.UIA_IsPasswordPropertyId => "IsPassword",
+		Win32UIAutomationInterop.UIA_IsRequiredForFormPropertyId => "IsRequiredForForm",
+		Win32UIAutomationInterop.UIA_IsControlElementPropertyId => "IsControlElement",
+		Win32UIAutomationInterop.UIA_IsContentElementPropertyId => "IsContentElement",
+		Win32UIAutomationInterop.UIA_HelpTextPropertyId => "HelpText",
+		Win32UIAutomationInterop.UIA_AcceleratorKeyPropertyId => "AcceleratorKey",
+		Win32UIAutomationInterop.UIA_AccessKeyPropertyId => "AccessKey",
+		Win32UIAutomationInterop.UIA_ItemTypePropertyId => "ItemType",
+		Win32UIAutomationInterop.UIA_ItemStatusPropertyId => "ItemStatus",
+		Win32UIAutomationInterop.UIA_FullDescriptionPropertyId => "FullDescription",
+		Win32UIAutomationInterop.UIA_HeadingLevelPropertyId => "HeadingLevel",
+		Win32UIAutomationInterop.UIA_LandmarkTypePropertyId => "LandmarkType",
+		Win32UIAutomationInterop.UIA_LocalizedLandmarkTypePropertyId => "LocalizedLandmarkType",
+		Win32UIAutomationInterop.UIA_LiveSettingPropertyId => "LiveSetting",
+		Win32UIAutomationInterop.UIA_OrientationPropertyId => "Orientation",
+		Win32UIAutomationInterop.UIA_PositionInSetPropertyId => "PositionInSet",
+		Win32UIAutomationInterop.UIA_SizeOfSetPropertyId => "SizeOfSet",
+		Win32UIAutomationInterop.UIA_LevelPropertyId => "Level",
+		Win32UIAutomationInterop.UIA_BoundingRectanglePropertyId => "BoundingRectangle",
+		Win32UIAutomationInterop.UIA_RuntimeIdPropertyId => "RuntimeId",
+		Win32UIAutomationInterop.UIA_ClickablePointPropertyId => "ClickablePoint",
+		Win32UIAutomationInterop.UIA_CulturePropertyId => "Culture",
+		Win32UIAutomationInterop.UIA_LabeledByPropertyId => "LabeledBy",
+		Win32UIAutomationInterop.UIA_DescribedByPropertyId => "DescribedBy",
+		Win32UIAutomationInterop.UIA_FlowsToPropertyId => "FlowsTo",
+		Win32UIAutomationInterop.UIA_FlowsFromPropertyId => "FlowsFrom",
+		Win32UIAutomationInterop.UIA_AriaRolePropertyId => "AriaRole",
+		Win32UIAutomationInterop.UIA_AriaPropertiesPropertyId => "AriaProperties",
+		Win32UIAutomationInterop.UIA_IsDataValidForFormPropertyId => "IsDataValidForForm",
+		Win32UIAutomationInterop.UIA_ControllerForPropertyId => "ControllerFor",
+		Win32UIAutomationInterop.UIA_IsPeripheralPropertyId => "IsPeripheral",
+		Win32UIAutomationInterop.UIA_IsDialogPropertyId => "IsDialog",
+		Win32UIAutomationInterop.UIA_OptimizeForVisualContentPropertyId => "OptimizeForVisualContent",
+		_ => $"Unknown({propertyId})",
+	};
+
+	private static string GetPatternName(int patternId) => patternId switch
+	{
+		Win32UIAutomationInterop.UIA_InvokePatternId => "Invoke",
+		Win32UIAutomationInterop.UIA_TogglePatternId => "Toggle",
+		Win32UIAutomationInterop.UIA_ValuePatternId => "Value",
+		Win32UIAutomationInterop.UIA_RangeValuePatternId => "RangeValue",
+		Win32UIAutomationInterop.UIA_ExpandCollapsePatternId => "ExpandCollapse",
+		Win32UIAutomationInterop.UIA_SelectionPatternId => "Selection",
+		Win32UIAutomationInterop.UIA_SelectionItemPatternId => "SelectionItem",
+		Win32UIAutomationInterop.UIA_ScrollPatternId => "Scroll",
+		Win32UIAutomationInterop.UIA_ScrollItemPatternId => "ScrollItem",
+		Win32UIAutomationInterop.UIA_GridPatternId => "Grid",
+		Win32UIAutomationInterop.UIA_GridItemPatternId => "GridItem",
+		Win32UIAutomationInterop.UIA_TablePatternId => "Table",
+		_ => $"Unknown({patternId})",
+	};
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32UIAutomationInterop.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32UIAutomationInterop.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Runtime.InteropServices;
+using Uno.Foundation.Logging;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+// UIA COM Interfaces
+// These are the raw COM interfaces that UIA uses to communicate with providers.
+// Method ordering must match the COM vtable layout exactly.
+
+[ComImport, Guid("d6dd68d1-86fd-4332-8666-9abedea2d24c"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IRawElementProviderSimple
+{
+	ProviderOptions ProviderOptions { get; }
+
+	[return: MarshalAs(UnmanagedType.IUnknown)]
+	object? GetPatternProvider(int patternId);
+
+	object? GetPropertyValue(int propertyId);
+
+	IRawElementProviderSimple? HostRawElementProvider { get; }
+}
+
+[ComImport, Guid("f7063da8-8359-439c-9297-bbc5299a7d87"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IRawElementProviderFragment
+{
+	IRawElementProviderFragment? Navigate(NavigateDirection direction);
+
+	int[]? GetRuntimeId();
+
+	UiaRect BoundingRectangle { get; }
+
+	IRawElementProviderFragment[]? GetEmbeddedFragmentRoots();
+
+	void SetFocus();
+
+	IRawElementProviderFragmentRoot? FragmentRoot { get; }
+}
+
+[ComImport, Guid("620ce2a5-ab8f-40a9-86cb-de3c75599b58"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IRawElementProviderFragmentRoot
+{
+	IRawElementProviderFragment? ElementProviderFromPoint(double x, double y);
+
+	IRawElementProviderFragment? GetFocus();
+}
+
+// Enums
+
+[Flags]
+internal enum ProviderOptions
+{
+	ClientSideProvider = 0x1,
+	ServerSideProvider = 0x2,
+	NonClientAreaProvider = 0x4,
+	OverrideProvider = 0x8,
+	ProviderOwnsSetFocus = 0x10,
+	UseComThreading = 0x20,
+	RefuseNonClientSupport = 0x40,
+	HasNativeIAccessible = 0x80,
+	UseClientCoordinates = 0x100,
+}
+
+internal enum NavigateDirection
+{
+	Parent = 0,
+	NextSibling = 1,
+	PreviousSibling = 2,
+	FirstChild = 3,
+	LastChild = 4,
+}
+
+internal enum StructureChangeType
+{
+	ChildAdded = 0,
+	ChildRemoved = 1,
+	ChildrenInvalidated = 2,
+	ChildrenBulkAdded = 3,
+	ChildrenBulkRemoved = 4,
+	ChildrenReordered = 5,
+}
+
+// UIA rect structure returned by BoundingRectangle
+[StructLayout(LayoutKind.Sequential)]
+internal struct UiaRect
+{
+	public double Left;
+	public double Top;
+	public double Width;
+	public double Height;
+}
+
+// P/Invoke declarations for UIAutomation Core API
+internal static class Win32UIAutomationInterop
+{
+	internal const int UiaRootObjectId = -25;
+	internal const int UiaAppendRuntimeId = 3;
+
+	// WM_GETOBJECT message constant
+	internal const uint WM_GETOBJECT = 0x003D;
+
+	// UIA Property IDs
+	internal const int UIA_RuntimeIdPropertyId = 30000;
+	internal const int UIA_BoundingRectanglePropertyId = 30001;
+	internal const int UIA_ProcessIdPropertyId = 30002;
+	internal const int UIA_ControlTypePropertyId = 30003;
+	internal const int UIA_LocalizedControlTypePropertyId = 30004;
+	internal const int UIA_NamePropertyId = 30005;
+	internal const int UIA_AcceleratorKeyPropertyId = 30006;
+	internal const int UIA_AccessKeyPropertyId = 30007;
+	internal const int UIA_HasKeyboardFocusPropertyId = 30008;
+	internal const int UIA_IsKeyboardFocusablePropertyId = 30009;
+	internal const int UIA_IsEnabledPropertyId = 30010;
+	internal const int UIA_AutomationIdPropertyId = 30011;
+	internal const int UIA_ClassNamePropertyId = 30012;
+	internal const int UIA_HelpTextPropertyId = 30013;
+	internal const int UIA_ClickablePointPropertyId = 30014;
+	internal const int UIA_CulturePropertyId = 30015;
+	internal const int UIA_IsControlElementPropertyId = 30016;
+	internal const int UIA_IsContentElementPropertyId = 30017;
+	internal const int UIA_LabeledByPropertyId = 30018;
+	internal const int UIA_IsPasswordPropertyId = 30019;
+	internal const int UIA_NativeWindowHandlePropertyId = 30020;
+	internal const int UIA_ItemTypePropertyId = 30021;
+	internal const int UIA_IsOffscreenPropertyId = 30022;
+	internal const int UIA_OrientationPropertyId = 30023;
+	internal const int UIA_FrameworkIdPropertyId = 30024;
+	internal const int UIA_IsRequiredForFormPropertyId = 30025;
+	internal const int UIA_ItemStatusPropertyId = 30026;
+	internal const int UIA_AriaRolePropertyId = 30101;
+	internal const int UIA_AriaPropertiesPropertyId = 30102;
+	internal const int UIA_IsDataValidForFormPropertyId = 30103;
+	internal const int UIA_ControllerForPropertyId = 30104;
+	internal const int UIA_DescribedByPropertyId = 30105;
+	internal const int UIA_HeadingLevelPropertyId = 30114;
+	internal const int UIA_LiveSettingPropertyId = 30135;
+	internal const int UIA_FlowsToPropertyId = 30147;
+	internal const int UIA_FlowsFromPropertyId = 30148;
+	internal const int UIA_OptimizeForVisualContentPropertyId = 30149;
+	internal const int UIA_IsPeripheralPropertyId = 30150;
+	internal const int UIA_ProviderDescriptionPropertyId = 30107;
+	internal const int UIA_IsDialogPropertyId = 30174;
+	internal const int UIA_PositionInSetPropertyId = 30152;
+	internal const int UIA_SizeOfSetPropertyId = 30153;
+	internal const int UIA_LevelPropertyId = 30154;
+	internal const int UIA_LandmarkTypePropertyId = 30157;
+	internal const int UIA_LocalizedLandmarkTypePropertyId = 30158;
+	internal const int UIA_FullDescriptionPropertyId = 30159;
+
+	// UIA Control Type IDs
+	internal const int UIA_ButtonControlTypeId = 50000;
+	internal const int UIA_CalendarControlTypeId = 50001;
+	internal const int UIA_CheckBoxControlTypeId = 50002;
+	internal const int UIA_ComboBoxControlTypeId = 50003;
+	internal const int UIA_EditControlTypeId = 50004;
+	internal const int UIA_HyperlinkControlTypeId = 50005;
+	internal const int UIA_ImageControlTypeId = 50006;
+	internal const int UIA_ListItemControlTypeId = 50007;
+	internal const int UIA_ListControlTypeId = 50008;
+	internal const int UIA_MenuControlTypeId = 50009;
+	internal const int UIA_MenuBarControlTypeId = 50010;
+	internal const int UIA_MenuItemControlTypeId = 50011;
+	internal const int UIA_ProgressBarControlTypeId = 50012;
+	internal const int UIA_RadioButtonControlTypeId = 50013;
+	internal const int UIA_ScrollBarControlTypeId = 50014;
+	internal const int UIA_SliderControlTypeId = 50015;
+	internal const int UIA_SpinnerControlTypeId = 50016;
+	internal const int UIA_StatusBarControlTypeId = 50017;
+	internal const int UIA_TabControlTypeId = 50018;
+	internal const int UIA_TabItemControlTypeId = 50019;
+	internal const int UIA_TextControlTypeId = 50020;
+	internal const int UIA_ToolBarControlTypeId = 50021;
+	internal const int UIA_ToolTipControlTypeId = 50022;
+	internal const int UIA_TreeControlTypeId = 50023;
+	internal const int UIA_TreeItemControlTypeId = 50024;
+	internal const int UIA_CustomControlTypeId = 50025;
+	internal const int UIA_GroupControlTypeId = 50026;
+	internal const int UIA_ThumbControlTypeId = 50027;
+	internal const int UIA_DataGridControlTypeId = 50028;
+	internal const int UIA_DataItemControlTypeId = 50029;
+	internal const int UIA_DocumentControlTypeId = 50030;
+	internal const int UIA_SplitButtonControlTypeId = 50031;
+	internal const int UIA_WindowControlTypeId = 50032;
+	internal const int UIA_PaneControlTypeId = 50033;
+	internal const int UIA_HeaderControlTypeId = 50034;
+	internal const int UIA_HeaderItemControlTypeId = 50035;
+	internal const int UIA_TableControlTypeId = 50036;
+	internal const int UIA_SeparatorControlTypeId = 50038;
+	internal const int UIA_SemanticZoomControlTypeId = 50039;
+	internal const int UIA_AppBarControlTypeId = 50040;
+	internal const int UIA_FlipViewControlTypeId = 50041;
+
+	// UIA Pattern IDs
+	internal const int UIA_InvokePatternId = 10000;
+	internal const int UIA_SelectionPatternId = 10001;
+	internal const int UIA_ValuePatternId = 10002;
+	internal const int UIA_RangeValuePatternId = 10003;
+	internal const int UIA_ScrollPatternId = 10004;
+	internal const int UIA_ExpandCollapsePatternId = 10005;
+	internal const int UIA_GridPatternId = 10006;
+	internal const int UIA_GridItemPatternId = 10007;
+	internal const int UIA_MultipleViewPatternId = 10008;
+	internal const int UIA_WindowPatternId = 10009;
+	internal const int UIA_SelectionItemPatternId = 10010;
+	internal const int UIA_DockPatternId = 10011;
+	internal const int UIA_TablePatternId = 10012;
+	internal const int UIA_TableItemPatternId = 10013;
+	internal const int UIA_TextPatternId = 10014;
+	internal const int UIA_TogglePatternId = 10015;
+	internal const int UIA_TransformPatternId = 10016;
+	internal const int UIA_ScrollItemPatternId = 10017;
+
+	// UIA Event IDs
+	internal const int UIA_ToolTipOpenedEventId = 20000;
+	internal const int UIA_ToolTipClosedEventId = 20001;
+	internal const int UIA_StructureChangedEventId = 20002;
+	internal const int UIA_MenuOpenedEventId = 20003;
+	internal const int UIA_MenuClosedEventId = 20004;
+	internal const int UIA_AutomationFocusChangedEventId = 20005;
+	internal const int UIA_AutomationPropertyChangedEventId = 20006;
+	internal const int UIA_Invoke_InvokedEventId = 20009;
+	internal const int UIA_SelectionItem_ElementAddedToSelectionEventId = 20010;
+	internal const int UIA_SelectionItem_ElementRemovedFromSelectionEventId = 20011;
+	internal const int UIA_SelectionItem_ElementSelectedEventId = 20012;
+	internal const int UIA_Selection_InvalidatedEventId = 20013;
+	internal const int UIA_Text_TextSelectionChangedEventId = 20014;
+	internal const int UIA_Text_TextChangedEventId = 20015;
+	internal const int UIA_Window_WindowOpenedEventId = 20016;
+	internal const int UIA_Window_WindowClosedEventId = 20017;
+	internal const int UIA_LiveRegionChangedEventId = 20024;
+
+	// UIA Property Changed Event IDs (for UiaRaiseAutomationPropertyChangedEvent)
+	internal const int UIA_ExpandCollapseExpandCollapseStatePropertyId = 30070;
+	internal const int UIA_RangeValueValuePropertyId = 30047;
+	internal const int UIA_SelectionItemIsSelectedPropertyId = 30079;
+	internal const int UIA_ToggleToggleStatePropertyId = 30086;
+	internal const int UIA_ValueValuePropertyId = 30045;
+
+	// UIA Heading Level IDs
+	internal const int HeadingLevel_None = 80050;
+	internal const int HeadingLevel1 = 80051;
+	internal const int HeadingLevel2 = 80052;
+	internal const int HeadingLevel3 = 80053;
+	internal const int HeadingLevel4 = 80054;
+	internal const int HeadingLevel5 = 80055;
+	internal const int HeadingLevel6 = 80056;
+	internal const int HeadingLevel7 = 80057;
+	internal const int HeadingLevel8 = 80058;
+	internal const int HeadingLevel9 = 80059;
+
+	// UIA Landmark Type IDs
+	internal const int UIA_CustomLandmarkTypeId = 80000;
+	internal const int UIA_FormLandmarkTypeId = 80001;
+	internal const int UIA_MainLandmarkTypeId = 80002;
+	internal const int UIA_NavigationLandmarkTypeId = 80003;
+	internal const int UIA_SearchLandmarkTypeId = 80004;
+
+	// UIA Live Setting values
+	internal const int Off = 0;
+	internal const int Polite = 1;
+	internal const int Assertive = 2;
+
+	// UIA Notification kinds
+	internal const int AutomationNotificationKind_ItemAdded = 0;
+	internal const int AutomationNotificationKind_ItemRemoved = 1;
+	internal const int AutomationNotificationKind_ActionCompleted = 2;
+	internal const int AutomationNotificationKind_ActionAborted = 3;
+	internal const int AutomationNotificationKind_Other = 4;
+
+	// UIA Notification processing
+	internal const int AutomationNotificationProcessing_ImportantAll = 0;
+	internal const int AutomationNotificationProcessing_ImportantMostRecent = 1;
+	internal const int AutomationNotificationProcessing_All = 2;
+	internal const int AutomationNotificationProcessing_MostRecent = 3;
+	internal const int AutomationNotificationProcessing_CurrentThenMostRecent = 4;
+
+	// UIA Orientation IDs
+	internal const int OrientationType_None = 0;
+	internal const int OrientationType_Horizontal = 1;
+	internal const int OrientationType_Vertical = 2;
+
+	// Win32 helpers for coordinate conversion
+
+	internal const uint USER_DEFAULT_SCREEN_DPI = 96;
+
+	[DllImport("user32.dll")]
+	internal static extern bool ClientToScreen(nint hWnd, ref System.Drawing.Point lpPoint);
+
+	[DllImport("user32.dll")]
+	internal static extern bool ScreenToClient(nint hWnd, ref System.Drawing.Point lpPoint);
+
+	[DllImport("user32.dll")]
+	internal static extern uint GetDpiForWindow(nint hwnd);
+
+	[DllImport("user32.dll")]
+	internal static extern int GetWindowThreadProcessId(nint hWnd, out int lpdwProcessId);
+
+	// Core UIA functions
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern nint UiaReturnRawElementProvider(
+		nint hwnd,
+		nint wParam,
+		nint lParam,
+		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple? el);
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern int UiaHostProviderFromHwnd(
+		nint hwnd,
+		[MarshalAs(UnmanagedType.Interface)] out IRawElementProviderSimple? provider);
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern int UiaRaiseAutomationPropertyChangedEvent(
+		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,
+		int propertyId,
+		[MarshalAs(UnmanagedType.Struct)] object? oldValue,
+		[MarshalAs(UnmanagedType.Struct)] object? newValue);
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern int UiaRaiseAutomationEvent(
+		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,
+		int eventId);
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern int UiaRaiseStructureChangedEvent(
+		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,
+		StructureChangeType structureChangeType,
+		[MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)] int[]? runtimeId);
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern int UiaRaiseNotificationEvent(
+		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,
+		int notificationKind,
+		int notificationProcessing,
+		[MarshalAs(UnmanagedType.BStr)] string? displayString,
+		[MarshalAs(UnmanagedType.BStr)] string? activityId);
+
+	[DllImport("uiautomationcore.dll")]
+	internal static extern int UiaDisconnectProvider(
+		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider);
+
+	/// <summary>
+	/// Handles WM_GETOBJECT by returning the root UIA provider to the automation framework.
+	/// </summary>
+	internal static LRESULT HandleGetObject(HWND hwnd, WPARAM wParam, LPARAM lParam, Win32RawElementProvider? rootProvider)
+	{
+		if (typeof(Win32UIAutomationInterop).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Information))
+		{
+			typeof(Win32UIAutomationInterop).Log().Info(
+				$"[UIA] WM_GETOBJECT received: hwnd=0x{hwnd.Value:X}, lParam={lParam.Value}, rootProvider={(rootProvider is not null ? "present" : "NULL")}");
+		}
+
+		if (rootProvider is null)
+		{
+			return PInvoke.DefWindowProc(hwnd, WM_GETOBJECT, wParam, lParam);
+		}
+
+		var result = UiaReturnRawElementProvider(hwnd.Value, (nint)wParam.Value, lParam.Value, rootProvider);
+
+		if (typeof(Win32UIAutomationInterop).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Information))
+		{
+			typeof(Win32UIAutomationInterop).Log().Info(
+				$"[UIA] UiaReturnRawElementProvider returned: 0x{result:X}");
+		}
+
+		return new LRESULT(result);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Hosting/Win32Host.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Hosting/Win32Host.cs
@@ -99,6 +99,8 @@ public class Win32Host : SkiaHost, ISkiaApplicationHost
 		}
 		ApiExtensibility.Register(typeof(ITextBoxNotificationsProviderSingleton), _ => Win32TextBoxNotificationsProviderSingleton.Instance);
 		ApiExtensibility.Register<XamlRoot>(typeof(INativeOpenGLWrapper), xamlRoot => new Win32NativeOpenGLWrapper(xamlRoot));
+
+		Win32Accessibility.Register();
 	}
 
 	public Win32Host(Func<Application> appBuilder) : this(appBuilder, false)

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -53,6 +53,7 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 	private readonly HWND _hwnd;
 	private readonly IRenderer _renderer;
 
+	private Win32Accessibility? _accessibility;
 	private bool _rendererDisposed;
 	private IDisposable? _backgroundDisposable;
 	private SKColor _background;
@@ -117,6 +118,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		window.AppWindow.TitleBar.Changed += OnAppWindowTitleBarChanged;
 		UpdateClientAreaExtension();
+
+		InitializeAccessibility();
 	}
 
 	private void OnAppWindowTitleBarChanged(object? sender, EventArgs e)
@@ -214,6 +217,13 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 	private unsafe LRESULT WndProcInner(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
 	{
 		Debug.Assert(_hwnd == HWND.Null || hwnd == _hwnd); // the null check is for when this method gets called inside CreateWindow before setting _hwnd
+
+		if (msg == Win32UIAutomationInterop.WM_GETOBJECT
+			&& (int)lParam.Value == Win32UIAutomationInterop.UiaRootObjectId)
+		{
+			return Win32UIAutomationInterop.HandleGetObject(
+				hwnd, wParam, lParam, _accessibility?.RootProvider);
+		}
 
 		if (TryHandleCustomCaptionMessage(hwnd, msg, wParam, lParam, out var customCaptionResult))
 		{
@@ -665,6 +675,35 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		PInvoke.SendMessage(_hwnd, PInvoke.WM_SETICON, PInvoke.ICON_SMALL, hIcon.Value);
 		PInvoke.SendMessage(_hwnd, PInvoke.WM_SETICON, PInvoke.ICON_BIG, hIcon.Value);
+	}
+
+	private void InitializeAccessibility()
+	{
+		_accessibility = Win32Accessibility.Instance;
+
+		// Defer tree initialization until the root element is available.
+		// The root element may not be set yet at construction time.
+		if (Window?.RootElement is { } rootElement)
+		{
+			_accessibility.Initialize(_hwnd.Value, rootElement);
+		}
+		else if (Window is not null)
+		{
+			// Wait for the content to be set, then initialize
+			Window.Activated += OnWindowActivatedForAccessibility;
+		}
+	}
+
+	private void OnWindowActivatedForAccessibility(object sender, Microsoft.UI.Xaml.WindowActivatedEventArgs args)
+	{
+		if (Window is not null)
+		{
+			Window.Activated -= OnWindowActivatedForAccessibility;
+			if (Window.RootElement is { } rootElement)
+			{
+				_accessibility?.Initialize(_hwnd.Value, rootElement);
+			}
+		}
 	}
 
 	UIElement? IXamlRootHost.RootElement => Window?.RootElement;

--- a/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
@@ -149,7 +149,7 @@ public partial class AutomationProperties
 			"IsDataValidForForm",
 			typeof(bool),
 			typeof(AutomationProperties),
-			new FrameworkPropertyMetadata(default(bool)));
+			new FrameworkPropertyMetadata(true));
 
 	/// <summary>
 	/// Identifies the IsDialog attached property, which indicates whether the element represents a dialog.

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/PasswordBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/PasswordBoxAutomationPeer.cs
@@ -25,6 +25,33 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 			return true;
 		}
 
+		protected override string GetNameCore()
+		{
+			var baseName = base.GetNameCore();
+			if (!string.IsNullOrEmpty(baseName))
+			{
+				return baseName;
+			}
+
+			// WinUI3 uses the Header as the accessible name for PasswordBox
+			if (Owner is PasswordBox { Header: { } header })
+			{
+				var headerText = header.ToString();
+				if (!string.IsNullOrEmpty(headerText))
+				{
+					return headerText;
+				}
+			}
+
+			// Fall back to PlaceholderText
+			if (Owner is PasswordBox { PlaceholderText: { } placeholder } && !string.IsNullOrEmpty(placeholder))
+			{
+				return placeholder;
+			}
+
+			return string.Empty;
+		}
+
 		protected override IEnumerable<AutomationPeer> GetDescribedByCore()
 		{
 			if (Owner is PasswordBox owner)

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/TextBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/TextBoxAutomationPeer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.UI.Xaml.Automation.Peers;
 /// <summary>
 /// Exposes TextBox types to Microsoft UI Automation.
 /// </summary>
-public partial class TextBoxAutomationPeer : FrameworkElementAutomationPeer, IValueProvider
+public partial class TextBoxAutomationPeer : FrameworkElementAutomationPeer, Provider.IValueProvider
 {
 	public TextBoxAutomationPeer(TextBox owner) : base(owner)
 	{
@@ -32,35 +32,20 @@ public partial class TextBoxAutomationPeer : FrameworkElementAutomationPeer, IVa
 		return base.GetPatternCore(patternInterface);
 	}
 
-	/// <summary>
-	/// Gets the text value of the TextBox.
-	/// </summary>
-	public string Value => (Owner as TextBox)?.Text ?? string.Empty;
+	// IValueProvider
 
-	/// <summary>
-	/// Gets whether the TextBox is read-only.
-	/// </summary>
-	public bool IsReadOnly => (Owner as TextBox)?.IsReadOnly ?? false;
+	public string Value => ((TextBox)Owner).Text ?? string.Empty;
 
-	/// <summary>
-	/// Sets the text value of the TextBox.
-	/// </summary>
+	public bool IsReadOnly => ((TextBox)Owner).IsReadOnly;
+
 	public void SetValue(string value)
 	{
-		if (!IsEnabled())
-		{
-			throw new InvalidOperationException("Element not enabled");
-		}
-
 		if (IsReadOnly)
 		{
-			throw new InvalidOperationException("Element is read-only");
+			throw new System.InvalidOperationException("Cannot set value on a read-only TextBox.");
 		}
 
-		if (Owner is TextBox textBox)
-		{
-			textBox.Text = value;
-		}
+		((TextBox)Owner).Text = value;
 	}
 
 	/// <summary>
@@ -73,6 +58,54 @@ public partial class TextBoxAutomationPeer : FrameworkElementAutomationPeer, IVa
 		{
 			RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, oldValue, newValue);
 		}
+	}
+
+	protected override string GetNameCore()
+	{
+		var baseName = base.GetNameCore();
+		if (!string.IsNullOrEmpty(baseName))
+		{
+			return baseName;
+		}
+
+		// WinUI3 uses the Header as the accessible name for TextBox when no
+		// explicit Name or LabeledBy is set.
+		if (Owner is TextBox { Header: { } header })
+		{
+			var headerText = header.ToString();
+			if (!string.IsNullOrEmpty(headerText))
+			{
+				return headerText;
+			}
+		}
+
+		// Fall back to PlaceholderText when no Header is available.
+		if (Owner is TextBox { PlaceholderText: { } placeholder } && !string.IsNullOrEmpty(placeholder))
+		{
+			return placeholder;
+		}
+
+		return string.Empty;
+	}
+
+	protected override string GetHelpTextCore()
+	{
+		var baseHelp = base.GetHelpTextCore();
+		if (!string.IsNullOrEmpty(baseHelp))
+		{
+			return baseHelp;
+		}
+
+		// When Header provides the name, PlaceholderText serves as help text
+		// (shown as the Narrator hint). This matches WinUI3 behavior.
+		if (Owner is TextBox { Header: { } header, PlaceholderText: { } placeholder }
+			&& !string.IsNullOrEmpty(header.ToString())
+			&& !string.IsNullOrEmpty(placeholder))
+		{
+			return placeholder;
+		}
+
+		return string.Empty;
 	}
 
 	protected override IEnumerable<AutomationPeer> GetDescribedByCore()

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleButtonAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleButtonAutomationPeer.cs
@@ -20,6 +20,16 @@ public partial class ToggleButtonAutomationPeer : ButtonBaseAutomationPeer, Prov
 	protected override AutomationControlType GetAutomationControlTypeCore()
 		=> AutomationControlType.Button;
 
+	protected override object GetPatternCore(PatternInterface patternInterface)
+	{
+		if (patternInterface == PatternInterface.Toggle)
+		{
+			return this;
+		}
+
+		return base.GetPatternCore(patternInterface);
+	}
+
 	/// <summary>
 	/// Gets the toggle state of the control.
 	/// </summary>

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleSwitchAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleSwitchAutomationPeer.cs
@@ -63,11 +63,11 @@ public partial class ToggleSwitchAutomationPeer : FrameworkElementAutomationPeer
 			if (owner.IsOn)
 			{
 				// We only want to include the OnContent if custom content has been provided.
-				// The default value of OnContent is the string "On", but including this in the UIA Name adds no value, since this information is
-				// already included in the ToggleState. Narrator reads out both the ToggleState and the Name (We don't want it to read "On On ToggleSwitch").
-				// WinUI uses IsPropertyDefaultByIndex to detect custom vs default content.
-				var hasCustomOnContent = owner.GetCurrentHighestValuePrecedence(Controls.ToggleSwitch.OnContentProperty) != DependencyPropertyValuePrecedences.DefaultValue;
-				if (hasCustomOnContent && owner.OnContent is { } onContent)
+				// The default value of OnContent is the localized string "On", but including
+				// this in the UIA Name adds no value, since this information is already
+				// included in the ToggleState. Narrator reads both the ToggleState and the
+				// Name (We don't want it to read "On On ToggleSwitch").
+				if (owner.OnContent is { } onContent && !IsDefaultOnOffContent(onContent, isOn: true))
 				{
 					onOffContentText = onContent.ToString() ?? string.Empty;
 				}
@@ -75,8 +75,7 @@ public partial class ToggleSwitchAutomationPeer : FrameworkElementAutomationPeer
 			else
 			{
 				// As above, we only include custom OffContent.
-				var hasCustomOffContent = owner.GetCurrentHighestValuePrecedence(Controls.ToggleSwitch.OffContentProperty) != DependencyPropertyValuePrecedences.DefaultValue;
-				if (hasCustomOffContent && owner.OffContent is { } offContent)
+				if (owner.OffContent is { } offContent && !IsDefaultOnOffContent(offContent, isOn: false))
 				{
 					onOffContentText = offContent.ToString() ?? string.Empty;
 				}
@@ -131,5 +130,31 @@ public partial class ToggleSwitchAutomationPeer : FrameworkElementAutomationPeer
 		{
 			RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, oldValue, newValue);
 		}
+	}
+
+	/// <summary>
+	/// Checks whether the given On/Off content is the default localized string
+	/// ("On" or "Off") rather than custom content provided by the developer.
+	/// Default content should not be included in the accessible name because
+	/// Narrator already announces the ToggleState.
+	/// </summary>
+	private static bool IsDefaultOnOffContent(object content, bool isOn)
+	{
+		if (content is not string text)
+		{
+			return false;
+		}
+
+		var core = DXamlCore.GetCurrentNoCreate();
+		if (core is null)
+		{
+			return false;
+		}
+
+		var defaultText = isOn
+			? core.GetLocalizedResourceString("TEXT_TOGGLESWITCH_ON")
+			: core.GetLocalizedResourceString("TEXT_TOGGLESWITCH_OFF");
+
+		return string.Equals(text, defaultText, System.StringComparison.Ordinal);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -654,12 +654,12 @@ namespace Microsoft.UI.Xaml
 			((IDependencyObjectStoreProvider)this).Store.SetLastUsedTheme(Application.Current?.RequestedThemeForResources);
 		}
 
-		[NotImplemented]
-		protected virtual AutomationPeer OnCreateAutomationPeer() => new AutomationPeer();
-
-		internal AutomationPeer OnCreateAutomationPeerInternal() => OnCreateAutomationPeer();
-
 #nullable enable
+		protected virtual AutomationPeer? OnCreateAutomationPeer() => null;
+
+		internal AutomationPeer? OnCreateAutomationPeerInternal() => OnCreateAutomationPeer();
+
+
 		internal static Matrix3x2 GetTransform(UIElement from, UIElement? to)
 		{
 			if (from == to || !from.IsInLiveTree || (to is { IsVisualTreeRoot: false, IsInLiveTree: false }))

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -31,7 +31,7 @@ namespace Microsoft.UI.Xaml
 		// Cached automation peer, mirrors WinUI's m_tpAP field.
 		// Ensures peer identity is stable across calls so that reference
 		// comparisons (e.g. HasKeyboardFocusImpl, SetFocusHelper) work correctly.
-		private AutomationPeer? _cachedAutomationPeer;
+		private AutomationPeer? _uiElementAutomationPeer;
 
 		/// <summary>
 		/// Set to True when the imminent Focus(FocusState) call needs to use an animation if bringing the focused
@@ -140,16 +140,11 @@ namespace Microsoft.UI.Xaml
 			// identity-based checks (HasKeyboardFocusImpl, SetFocusHelper) work correctly.
 			if (Visibility != Visibility.Collapsed && isPopupOpen)
 			{
-				if (_cachedAutomationPeer is null)
-				{
-					_cachedAutomationPeer = OnCreateAutomationPeerInternal();
-				}
-
-				return _cachedAutomationPeer;
+				return _uiElementAutomationPeer ??= OnCreateAutomationPeerInternal();
 			}
 			else
 			{
-				_cachedAutomationPeer = null;
+				_uiElementAutomationPeer = null;
 				return null;
 			}
 		}
@@ -488,10 +483,9 @@ namespace Microsoft.UI.Xaml
 			//return pParent;
 		}
 
-		//UNO TODO: Implement GetUIElementParentInternal on UIElement
 		internal DependencyObject GetAccessKeyScopeOwner()
 		{
-			throw new NotImplementedException("GetUIElementParentInternal is not implemented on UIElement");
+			return (DependencyObject)GetValue(AccessKeyScopeOwnerProperty);
 		}
 
 		/// <summary>


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- ✨ Feature

## What is the new behavior? 🚀

Implement complete Win32 UI Automation support for Skia-rendered Uno applications, enabling Narrator and other screen readers.

Key components:
- Win32RawElementProvider: IRawElementProviderSimple/Fragment/FragmentRoot per UIElement, with lazy provider creation and automation peer tree navigation
- Win32Accessibility: orchestrator connecting AutomationPeer events to UIA, with debounced structure change notifications
- Win32AccessibilityPatterns: COM wrappers bridging 12 UIA patterns (Invoke, Toggle, Value, RangeValue, ExpandCollapse, Selection, SelectionItem, Scroll, ScrollItem, Grid, GridItem, Table)
- Win32UIAutomationInterop: P/Invoke declarations and WM_GETOBJECT handling

Review fixes applied:
- Resolve EventsSource during navigation/hit-testing (WinUI3 parity)
- Delegate table GetRowHeaders/GetColumnHeaders to inner provider
- Call UiaDisconnectProvider on element removal to prevent stale COM refs
- Reduce GetPropertyValue logging from Debug to Trace

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes