### PR TITLE
fix: native clipping never cleared on AppleUIKit

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
@@ -140,13 +140,6 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 				}
 				else
 				{
-					// svgPath is null meaning the clip path became empty (all native areas
-					// are covered by Skia content). Clear the CAShapeLayer mask so that
-					// NativeOverlayLayer.HitTest returns nil and touches pass through to
-					// the TopViewLayer for Skia input handling.
-					// NOTE: Previously this checked `_lastSvgClipPath is not null`, but
-					// _lastSvgClipPath was already set to null before the lambda ran,
-					// so ClearNativeClipping was never called.
 					ClearNativeClipping();
 				}
 			});

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
@@ -130,7 +130,6 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 
 		if (svgPath != _lastSvgClipPath)
 		{
-			var oldPath = _lastSvgClipPath;
 			_lastSvgClipPath = svgPath;
 
 			NativeDispatcher.Main.Enqueue(() =>
@@ -139,8 +138,15 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 				{
 					ClipBySvgPath(svgPath);
 				}
-				else if (_lastSvgClipPath is not null)
+				else
 				{
+					// svgPath is null meaning the clip path became empty (all native areas
+					// are covered by Skia content). Clear the CAShapeLayer mask so that
+					// NativeOverlayLayer.HitTest returns nil and touches pass through to
+					// the TopViewLayer for Skia input handling.
+					// NOTE: Previously this checked `_lastSvgClipPath is not null`, but
+					// _lastSvgClipPath was already set to null before the lambda ran,
+					// so ClearNativeClipping was never called.
 					ClearNativeClipping();
 				}
 			});


### PR DESCRIPTION
related to https://github.com/unoplatform/dispatchscience-private/issues/71

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

In `RootViewController.cs` on AppleUIKit (Skia iOS), when the SVG clip path becomes `null` (meaning all native areas are covered by Skia content), `ClearNativeClipping()` is never called. This happens because `_lastSvgClipPath` is set to `null` *before* the `NativeDispatcher.Main.Enqueue` lambda executes. The lambda then checks `_lastSvgClipPath is not null`, which is always `false`, so the `ClearNativeClipping()` branch is dead code.

As a result, the `CAShapeLayer` mask on `NativeOverlayLayer` is never removed, causing `HitTest` to continue returning non-nil values. This prevents touches from passing through to the `TopViewLayer` for Skia input handling (e.g., MAUI Picker popups fail to receive touch input).

## What is the new behavior? 🚀

The fix removes the captured `oldPath` variable and changes the `else if (_lastSvgClipPath is not null)` guard to a plain `else`. Now when `svgPath` is `null`, `ClearNativeClipping()` is always called, correctly removing the `CAShapeLayer` mask so touches pass through to Skia.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

The bug was a classic closure-over-mutable-state issue: `_lastSvgClipPath` was assigned `null` synchronously, then the async lambda captured the field (not a snapshot), so by the time the lambda ran the guard `_lastSvgClipPath is not null` was always false.
