### PR TITLE
docs: Add WPF to WinUI XAML equivalents reference

### DIFF
--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -290,6 +290,8 @@
         items:
           - name: Migrating WPF Apps to Web
             href: wpf-migration.md
+          - name: WPF to WinUI XAML Equivalents
+            href: wpf-winui-equivalents.md
       - name: UWP-only code
         items:
           - name: Overview

--- a/doc/articles/wpf-migration.md
+++ b/doc/articles/wpf-migration.md
@@ -69,3 +69,7 @@ Full support for WCF and WCF Data Services are not included in modern .NET versi
 ### Desktop Integration
 
 If your app relies on heavy access to Windows-specific constructs such as the registry, you should rethink your approach to fit the Web's platform agnostic app model.
+
+## XAML and API Equivalents
+
+For a comprehensive reference of WPF-to-WinUI namespace, control, event, and syntax mappings, see the [WPF to WinUI XAML Equivalents Reference](wpf-winui-equivalents.md).

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -19,7 +19,7 @@ This reference provides a comprehensive mapping of WPF namespaces, controls, XAM
 | `System.Windows.Media` | `Microsoft.UI.Xaml.Media` | Brushes, transforms |
 | `System.Windows.Media.Animation` | `Microsoft.UI.Xaml.Media.Animation` | Storyboard, animations |
 | `System.Windows.Media.Imaging` | `Microsoft.UI.Xaml.Media.Imaging` | BitmapImage, WriteableBitmap |
-| `System.Windows.Media.Media3D` | `Microsoft.UI.Xaml.Media.Media3D` (partial equivalent) | Supports 3D transforms/projection (for example `CompositeTransform3D`, `Matrix3D`, `PerspectiveTransform3D`), but not WPF-style `Viewport3D` / 3D scenegraph APIs |
+| `System.Windows.Media.Media3D` | `Microsoft.UI.Xaml.Media.Media3D` (partial equivalent) | Supports 3D transforms/projection (for example `CompositeTransform3D`, `Matrix3D`, `PerspectiveTransform3D`), but not WPF-style `Viewport3D` / 3D scene graph APIs |
 | `System.Windows.Shapes` | `Microsoft.UI.Xaml.Shapes` | Rectangle, Ellipse, Path |
 | `System.Windows.Data` | `Microsoft.UI.Xaml.Data` | Binding, IValueConverter |
 | `System.Windows.Input` | `Microsoft.UI.Xaml.Input` | Pointer, keyboard, focus |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -1,0 +1,368 @@
+---
+uid: Uno.Development.WpfWinUiEquivalents
+---
+
+# WPF to WinUI XAML Equivalents Reference
+
+This reference provides a comprehensive mapping of WPF namespaces, controls, XAML syntax, events, and patterns to their WinUI 3 / Uno Platform equivalents. Use it as a lookup when migrating WPF applications.
+
+> [!TIP]
+> For architectural migration guidance (MVVM, navigation, data access), see [Migrating WPF Apps to Web](wpf-migration.md).
+
+## Namespace Mapping
+
+| WPF Namespace | WinUI 3 Namespace | Notes |
+|---|---|---|
+| `System.Windows` | `Microsoft.UI.Xaml` | Root namespace |
+| `System.Windows.Controls` | `Microsoft.UI.Xaml.Controls` | Core controls |
+| `System.Windows.Controls.Primitives` | `Microsoft.UI.Xaml.Controls.Primitives` | Low-level primitives |
+| `System.Windows.Media` | `Microsoft.UI.Xaml.Media` | Brushes, transforms |
+| `System.Windows.Media.Animation` | `Microsoft.UI.Xaml.Media.Animation` | Storyboard, animations |
+| `System.Windows.Media.Imaging` | `Microsoft.UI.Xaml.Media.Imaging` | BitmapImage, WriteableBitmap |
+| `System.Windows.Media.Media3D` | No equivalent | Use Win2D or Composition APIs |
+| `System.Windows.Shapes` | `Microsoft.UI.Xaml.Shapes` | Rectangle, Ellipse, Path |
+| `System.Windows.Data` | `Microsoft.UI.Xaml.Data` | Binding, IValueConverter |
+| `System.Windows.Input` | `Microsoft.UI.Xaml.Input` | Pointer, keyboard, focus |
+| `System.Windows.Navigation` | No direct equivalent | Use `Frame.Navigate()` |
+| `System.Windows.Documents` | Limited | `RichTextBlock` + `Paragraph` |
+| `System.Windows.Markup` | `Microsoft.UI.Xaml.Markup` | XAML parsing, markup extensions |
+| `System.Windows.Automation` | `Microsoft.UI.Xaml.Automation` | Accessibility / UI Automation |
+| `System.Windows.Interop` | `Microsoft.UI.Xaml.Hosting` | Interop / XAML Islands |
+| `System.Windows.Threading` | `Microsoft.UI.Dispatching` | `Dispatcher` becomes `DispatcherQueue` |
+
+### XAML Declaration Syntax
+
+| WPF | WinUI |
+|---|---|
+| `xmlns:local="clr-namespace:MyApp"` | `xmlns:local="using:MyApp"` |
+| `xmlns:local="clr-namespace:MyApp;assembly=MyLib"` | `xmlns:local="using:MyApp"` (assembly inferred) |
+
+## Control Mappings
+
+### Controls That Transfer Directly
+
+These controls require only a namespace change:
+
+Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, GridView, Grid, StackPanel, Border, ScrollViewer, Canvas, Image, Slider, ProgressBar, ProgressRing, ToggleSwitch, HyperlinkButton, ToolTip/ToolTipService, NavigationView, NumberBox, InfoBar, Expander, TreeView.
+
+### Controls Requiring Replacement
+
+| WPF Control | WinUI / Uno Replacement | Notes |
+|---|---|---|
+| `DataGrid` | Community Toolkit `DataGrid` | Similar API, not identical. Requires `CommunityToolkit.WinUI.UI.Controls`. |
+| `Ribbon` | `CommandBar` or `NavigationView` | No Ribbon in WinUI |
+| `Menu` / `MenuItem` | `MenuBar` / `MenuBarItem` / `MenuFlyoutItem` | `MenuBar` for top-level menus; `MenuFlyout` for context menus |
+| `ContextMenu` | `MenuFlyout` via `ContextFlyout` property | Assign to `ContextFlyout` on any `UIElement` |
+| `ToolBar` / `ToolBarTray` | `CommandBar` + `AppBarButton` | |
+| `StatusBar` | Custom `Grid` / `StackPanel` or `InfoBar` | No StatusBar control in WinUI |
+| `TabControl` | `TabView` or `NavigationView` (Top mode) | `TabView` supports closeable tabs |
+| `DocumentViewer` | `WebView2` | Render PDFs/XPS inside WebView2 |
+| `FlowDocument` | `RichTextBlock` | Partial replacement only |
+| `RichTextBox` | `RichEditBox` | Rich text editing |
+| `WrapPanel` | Community Toolkit `WrapPanel` | Not in WinUI by default |
+| `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default |
+| `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default |
+| `GroupBox` | `Expander` or custom `HeaderedContentControl` | No GroupBox in WinUI |
+| `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
+| `MediaElement` | `MediaPlayerElement` | Different API surface |
+| `Window` (standalone) | `Page` (navigable) | Or `ContentDialog` for modal windows |
+
+### Useful NuGet Packages
+
+| Package | Purpose |
+|---|---|
+| `CommunityToolkit.WinUI.UI.Controls` | DataGrid, WrapPanel, DockPanel, UniformGrid |
+| `CommunityToolkit.Mvvm` | RelayCommand, ObservableObject, source generators |
+| `Uno.Themes.WinUI` | Material, Cupertino, or Fluent theme support |
+| `Uno.Toolkit.WinUI` | Additional cross-platform controls and helpers |
+
+## Property and Value Mappings
+
+| WPF Property / Value | WinUI Equivalent | Context |
+|---|---|---|
+| `Visibility.Hidden` | Not available | Use `Opacity="0"` for invisible-but-layout-occupying |
+| `TextWrapping.WrapWithOverflow` | `TextWrapping.Wrap` | WinUI does not distinguish |
+| `Focusable="True"` | `IsTabStop="True"` | Different property name, same behavior |
+
+## Event Mappings
+
+### Pointer Events (Replacing Mouse Events)
+
+| WPF Event | WinUI Event | Args Type |
+|---|---|---|
+| `MouseLeftButtonDown` | `PointerPressed` | `PointerRoutedEventArgs` |
+| `MouseLeftButtonUp` | `PointerReleased` | `PointerRoutedEventArgs` |
+| `MouseMove` | `PointerMoved` | `PointerRoutedEventArgs` |
+| `MouseEnter` | `PointerEntered` | `PointerRoutedEventArgs` |
+| `MouseLeave` | `PointerExited` | `PointerRoutedEventArgs` |
+| `MouseWheel` | `PointerWheelChanged` | `PointerRoutedEventArgs` |
+| `MouseDoubleClick` | `DoubleTapped` | `DoubleTappedRoutedEventArgs` |
+| `PreviewMouseDown` | `PointerPressed` | No tunneling/preview events in WinUI |
+| `PreviewKeyDown` | `KeyDown` | No tunneling/preview events in WinUI |
+
+> [!NOTE]
+> WinUI does not support tunneling (preview) events. If you relied on tunneling to intercept events, use the `Handled` property or `AddHandler` with `handledEventsToo: true`.
+
+### Mouse Capture
+
+| WPF | WinUI |
+|---|---|
+| `element.CaptureMouse()` | `element.CapturePointer(e.Pointer)` |
+| `element.ReleaseMouseCapture()` | `element.ReleasePointerCapture(e.Pointer)` |
+| `Mouse.GetPosition(element)` | `e.GetCurrentPoint(element).Position` |
+
+## XAML Syntax Translations
+
+### Resource and Binding Markup
+
+| WPF | WinUI | Notes |
+|---|---|---|
+| `{StaticResource Key}` | `{StaticResource Key}` | Identical - resolved once at load |
+| `{DynamicResource Key}` | `{ThemeResource Key}` | Re-evaluated on theme changes (Light/Dark) |
+| `{x:Static ns:Type.Member}` | `{x:Bind ns:Type.Member}` | Static member references |
+| `{Binding Path=X}` | `{x:Bind ViewModel.X, Mode=OneWay}` | See [binding comparison](#binding-technology-comparison) below |
+
+### Binding Technology Comparison
+
+| Feature | `{Binding}` | `{x:Bind}` |
+|---|---|---|
+| Compile-time validation | No | Yes |
+| Default mode | OneWay | **OneTime** |
+| Default source | DataContext | Page / UserControl code-behind |
+| Function binding | No | Yes |
+| Performance | Reflection-based | Compiled, no reflection |
+| MultiBinding | Not in WinUI | Use function binding |
+
+> [!IMPORTANT]
+> `{x:Bind}` defaults to **OneTime**, not OneWay. Always specify `Mode=OneWay` for properties that should update.
+
+## Patterns Without Direct WinUI Equivalents
+
+### Style.Triggers and DataTriggers
+
+WinUI does not support `Style.Triggers`, `DataTrigger`, `EventTrigger`, or `MultiDataTrigger`. Replace with `VisualStateManager`:
+
+**WPF:**
+
+```xml
+<Style TargetType="Border">
+  <Style.Triggers>
+    <DataTrigger Binding="{Binding IsActive}" Value="True">
+      <Setter Property="Background" Value="Green" />
+    </DataTrigger>
+  </Style.Triggers>
+</Style>
+```
+
+**WinUI equivalent:**
+
+```xml
+<Border x:Name="MyBorder">
+  <VisualStateManager.VisualStateGroups>
+    <VisualStateGroup>
+      <VisualState x:Name="Active">
+        <VisualState.StateTriggers>
+          <StateTrigger IsActive="{x:Bind ViewModel.IsActive, Mode=OneWay}" />
+        </VisualState.StateTriggers>
+        <VisualState.Setters>
+          <Setter Target="MyBorder.Background" Value="Green" />
+        </VisualState.Setters>
+      </VisualState>
+    </VisualStateGroup>
+  </VisualStateManager.VisualStateGroups>
+</Border>
+```
+
+### MultiBinding
+
+WinUI does not support `MultiBinding`. Use `x:Bind` with function binding:
+
+```xml
+<TextBlock Text="{x:Bind local:Converters.FormatFullName(ViewModel.FirstName, ViewModel.LastName), Mode=OneWay}" />
+```
+
+```csharp
+public static class Converters
+{
+    public static string FormatFullName(string first, string last)
+        => $"{first} {last}";
+}
+```
+
+### RoutedUICommand
+
+Replace `RoutedUICommand` and `CommandBinding` with `ICommand` implementations. Using CommunityToolkit.Mvvm:
+
+```csharp
+[RelayCommand(CanExecute = nameof(CanSave))]
+private void Save() { /* save logic */ }
+
+private bool CanSave() => IsDirty;
+```
+
+WinUI 3 also offers `StandardUICommand` and `XamlUICommand` for predefined operations (Cut, Copy, Paste) with built-in icons and keyboard accelerators.
+
+### Adorners
+
+WinUI does not have an Adorner layer. Use these alternatives:
+
+| Adorner Use Case | WinUI Replacement |
+|---|---|
+| Validation indicators | `TeachingTip`, `InfoBar`, or input validation templates |
+| Resize handles | `Popup` positioned relative to target |
+| Drag preview | `DragItemsStarting` event with custom DragUI |
+| Overlay decorations | Canvas overlay or `Popup` layer |
+| Watermark / Placeholder | `TextBox.PlaceholderText` (built-in) |
+
+## Resource Dictionaries
+
+```xml
+<Application.Resources>
+  <ResourceDictionary>
+    <ResourceDictionary.MergedDictionaries>
+      <!-- Required: default Fluent styles -->
+      <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+      <!-- Your custom resources -->
+      <ResourceDictionary Source="ms-appx:///Styles/Colors.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+  </ResourceDictionary>
+</Application.Resources>
+```
+
+Key differences from WPF:
+
+- `XamlControlsResources` must be the **first** merged dictionary to provide default styles. Omitting it leaves controls with no visual appearance.
+- Resource paths use `ms-appx:///` protocol instead of relative paths.
+- `Window.Resources` does not exist in WinUI. Place window-level resources on root layout containers or `Page`.
+
+### Implicit Styles and BasedOn
+
+Always use `BasedOn` when overriding default control styles. Without it, your style **replaces** the entire default style rather than extending it:
+
+```xml
+<Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+  <Setter Property="Background" Value="Red" />
+</Style>
+```
+
+## Common API Replacements
+
+| WPF Code | WinUI Replacement | Notes |
+|---|---|---|
+| `Application.Current.Dispatcher.Invoke(...)` | `App.Window.DispatcherQueue.TryEnqueue(...)` | Async only; no synchronous `Invoke` |
+| `Window.Current` | Custom `App.Window` static | Not supported in Windows App SDK |
+| `Clipboard` (System.Windows) | `Windows.ApplicationModel.DataTransfer.Clipboard` | Different API surface |
+| `MessageBox.Show()` | `ContentDialog` with `XamlRoot` | No MessageBox in WinUI |
+
+## Find-and-Replace Quick Reference
+
+### XAML Attribute Replacements
+
+| Find | Replace With |
+|---|---|
+| `ContextMenu=` | `ContextFlyout=` |
+| `{DynamicResource` | `{ThemeResource` |
+| `{x:Static` | `{x:Bind` |
+| `Visibility="Hidden"` | `Visibility="Collapsed"` (or `Opacity="0"`) |
+| `MouseLeftButtonDown` | `PointerPressed` |
+| `MouseLeftButtonUp` | `PointerReleased` |
+| `MouseEnter` | `PointerEntered` |
+| `MouseLeave` | `PointerExited` |
+| `MouseMove` | `PointerMoved` |
+| `MouseWheel` | `PointerWheelChanged` |
+| `Focusable="True"` | `IsTabStop="True"` |
+| `TextWrapping="WrapWithOverflow"` | `TextWrapping="Wrap"` |
+| `MediaElement` | `MediaPlayerElement` |
+
+### Code-Behind Replacements
+
+| Find | Replace With |
+|---|---|
+| `using System.Windows;` | `using Microsoft.UI.Xaml;` |
+| `using System.Windows.Controls;` | `using Microsoft.UI.Xaml.Controls;` |
+| `using System.Windows.Media;` | `using Microsoft.UI.Xaml.Media;` |
+| `using System.Windows.Data;` | `using Microsoft.UI.Xaml.Data;` |
+| `using System.Windows.Input;` | `using Microsoft.UI.Xaml.Input;` |
+| `Dispatcher.Invoke(` | `DispatcherQueue.TryEnqueue(` |
+| `MouseEventArgs` | `PointerRoutedEventArgs` |
+| `KeyEventArgs` | `KeyRoutedEventArgs` |
+| `RoutedUICommand` | `RelayCommand` (CommunityToolkit.Mvvm) |
+| `CommandBinding` | Remove; bind `ICommand` directly |
+
+## AI Prompt Template
+
+Use this prompt with an AI coding assistant to automate the mechanical translation of WPF XAML files:
+
+````text
+You are a WPF-to-WinUI XAML migration assistant. Translate the following WPF XAML
+file to WinUI 3 XAML compatible with Uno Platform.
+
+Apply ALL of the following rules:
+
+NAMESPACE RULES:
+- Keep the default xmlns as-is
+- Replace clr-namespace references with "using:" syntax
+- Replace System.Windows.* with Microsoft.UI.Xaml.*
+
+RESOURCE RULES:
+- Replace {DynamicResource X} with {ThemeResource X}
+- Replace {x:Static X} with {x:Bind X}
+- Keep {StaticResource X} as-is
+
+CONTROL REPLACEMENTS:
+- Menu/MenuItem -> MenuBar/MenuBarItem/MenuFlyoutItem
+- ContextMenu -> ContextFlyout with MenuFlyout
+- ToolBar -> CommandBar with AppBarButton
+- StatusBar -> Grid at bottom of layout
+- TabControl -> TabView or NavigationView (Top mode)
+- DataGrid -> CommunityToolkit DataGrid
+- Label -> TextBlock
+- MediaElement -> MediaPlayerElement
+
+PROPERTY REPLACEMENTS:
+- Visibility="Hidden" -> Visibility="Collapsed"
+- TextWrapping="WrapWithOverflow" -> TextWrapping="Wrap"
+- Focusable -> IsTabStop
+
+EVENT REPLACEMENTS:
+- Mouse* events -> Pointer* equivalents
+- Remove Preview* tunneling events
+
+TRIGGER REPLACEMENTS:
+- Remove Style.Triggers, DataTrigger, EventTrigger
+- Create VisualStateManager.VisualStateGroups with StateTrigger
+
+BINDING UPGRADES:
+- Convert {Binding Path=X} to {x:Bind ViewModel.X, Mode=OneWay}
+- Replace MultiBinding with x:Bind function binding
+
+OUTPUT: Complete translated XAML with a list of manual follow-up items.
+
+WPF XAML to translate:
+````
+
+## FAQ
+
+**Do I need to rewrite all my XAML from scratch?**
+
+No. The majority of WPF XAML transfers with namespace changes and minor property fixes. The heavy lifting is in triggers, MultiBinding, and controls that don't exist in WinUI.
+
+**Can I keep using {Binding} or must I switch to {x:Bind}?**
+
+`{Binding}` still works and is not mandatory to replace. However, `{x:Bind}` provides compile-time validation, better performance, and function binding (which replaces MultiBinding). For new or migrated code, `{x:Bind}` is recommended.
+
+**What replaces Visibility.Hidden?**
+
+WinUI only has `Visible` and `Collapsed`. For invisible-but-layout-occupying behavior, set `Opacity="0"` while keeping `Visibility="Visible"`.
+
+**How do I handle preview/tunneling events?**
+
+WinUI does not support tunneling events. Replace `PreviewMouseDown`, `PreviewKeyDown`, etc. with their bubbling equivalents. Use the `Handled` property or `AddHandler` with `handledEventsToo: true` if you need to intercept events.
+
+**How do I migrate the Dispatcher pattern?**
+
+Replace `Application.Current.Dispatcher.Invoke(...)` with `App.Window.DispatcherQueue.TryEnqueue(...)`. The `DispatcherQueue` API is asynchronous by default and has no synchronous `Invoke` method.
+
+**Does Uno Platform add controls beyond WinUI?**
+
+Yes. The [Uno Toolkit](xref:Toolkit.GettingStarted) includes NavigationBar, TabBar, DrawerControl, SafeArea, and more. The [Community Toolkit](uno-community-toolkit.md) controls (DataGrid, WrapPanel, DockPanel) also work across all Uno Platform targets.

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -87,7 +87,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 |---|---|---|
 | `Visibility.Hidden` | Not available | Use `Opacity="0"` together with `IsHitTestVisible="False"` (and, for focusable controls, `IsTabStop="False"`) to be invisible, non-interactive, but still layout-occupying. |
 | `TextWrapping.WrapWithOverflow` | `TextWrapping.Wrap` | WinUI does not distinguish |
-| `Focusable="True"` | `IsTabStop="True"` | Different property name, same behavior |
+| `Focusable` | `IsTabStop` and, when preventing interaction focus, `AllowFocusOnInteraction` | `IsTabStop` controls keyboard tab navigation; to also prevent focus via pointer interaction in WinUI/Uno, typically use `AllowFocusOnInteraction="False"` as well (and `IsTabStop="False"` where applicable). |
 
 ## Event Mappings
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -1,5 +1,5 @@
 ---
-uid: Uno.Development.WpfWinUiEquivalents
+uid: Uno.Development.WPFWinUIEquivalents
 ---
 
 # WPF to WinUI XAML Equivalents Reference

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -62,7 +62,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `ToolBar` / `ToolBarTray` | `CommandBar` + `AppBarButton` | |
 | `StatusBar` | Custom `Grid` / `StackPanel` or `InfoBar` | No StatusBar control in WinUI |
 | `TabControl` | `TabView` or `NavigationView` (Top mode) | `TabView` supports closable tabs |
-| `DocumentViewer` | `WebView2` | Render PDFs/XPS inside WebView2 |
+| `DocumentViewer` | `WebView2` | Can display PDFs in WebView2; XPS requires conversion or a dedicated/third-party viewer |
 | `FlowDocument` | `RichTextBlock` | Partial replacement only |
 | `RichTextBox` | `RichEditBox` | Rich text editing |
 | `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; otherwise see package guidance below. |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -80,7 +80,7 @@ Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, 
 
 | WPF Property / Value | WinUI Equivalent | Context |
 |---|---|---|
-| `Visibility.Hidden` | Not available | Use `Opacity="0"` for invisible-but-layout-occupying |
+| `Visibility.Hidden` | Not available | Use `Opacity="0"` together with `IsHitTestVisible="False"` (and, for focusable controls, `IsTabStop="False"`) to be invisible, non-interactive, but still layout-occupying. |
 | `TextWrapping.WrapWithOverflow` | `TextWrapping.Wrap` | WinUI does not distinguish |
 | `Focusable="True"` | `IsTabStop="True"` | Different property name, same behavior |
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -150,7 +150,7 @@ Package guidance for Community Toolkit controls in this table: in WinUI 3 (Windo
 | Feature | `{Binding}` | `{x:Bind}` |
 |---|---|---|
 | Compile-time validation | No | Yes |
-| Default mode | OneWay | **OneTime** |
+| Default mode | Depends on target property metadata (often OneWay; some are TwoWay) | **OneTime** |
 | Default source | DataContext | Page / UserControl code-behind |
 | Function binding | No | Yes |
 | Performance | Reflection-based | Compiled, no reflection |
@@ -305,24 +305,24 @@ await tcs.Task;
 
 ### XAML Attribute Replacements
 
-| Find | Replace With |
-|---|---|
-| `ContextMenu=` | `ContextFlyout=` |
-| `{DynamicResource` | `{ThemeResource` |
-| `{x:Static` | `{x:Bind` |
+| Find | Replace With | Notes |
+|---|---|---|
+| `ContextMenu=` | `ContextFlyout=` | |
+| `{DynamicResource` | `{ThemeResource` | |
+| `{x:Static` | `{x:Bind` | |
 | `Visibility="Hidden"` (layout-preserving) | `Opacity="0"` with `IsHitTestVisible="False"` | Keeps layout space; combine with `IsTabStop="False"` for focusable controls |
 | `Visibility="Hidden"` (remove from layout) | `Visibility="Collapsed"` | Collapses space like WPF `Visibility="Collapsed"` |
-| `MouseLeftButtonDown` | `PointerPressed` |
-| `MouseLeftButtonUp` | `PointerReleased` |
-| `MouseEnter` | `PointerEntered` |
-| `MouseLeave` | `PointerExited` |
-| `MouseMove` | `PointerMoved` |
-| `MouseWheel` | `PointerWheelChanged` |
-| `Focusable="True"` | `IsTabStop="True"` |
-| `TextWrapping="WrapWithOverflow"` | `TextWrapping="Wrap"` |
-| `MediaElement` | `MediaPlayerElement` |
-| `InputBindings` | `KeyboardAccelerators` |
-| `KeyBinding` | `KeyboardAccelerator` |
+| `MouseLeftButtonDown` | `PointerPressed` | |
+| `MouseLeftButtonUp` | `PointerReleased` | |
+| `MouseEnter` | `PointerEntered` | |
+| `MouseLeave` | `PointerExited` | |
+| `MouseMove` | `PointerMoved` | |
+| `MouseWheel` | `PointerWheelChanged` | |
+| `Focusable="True"` | `IsTabStop="True"` | |
+| `TextWrapping="WrapWithOverflow"` | `TextWrapping="Wrap"` | |
+| `MediaElement` | `MediaPlayerElement` | |
+| `InputBindings` | `KeyboardAccelerators` | |
+| `KeyBinding` | `KeyboardAccelerator` | |
 
 ### Code-Behind Replacements
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -41,10 +41,15 @@ This reference provides a comprehensive mapping of WPF namespaces, controls, XAM
 
 ### Controls That Transfer Directly
 
-These controls require only a namespace change:
+These controls exist in both WPF and WinUI and typically require only a namespace change:
 
-Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, GridView, Grid, StackPanel, Border, ScrollViewer, Canvas, Image, Slider, ProgressBar, ProgressRing, ToggleSwitch, HyperlinkButton, ToolTip/ToolTipService, NavigationView, NumberBox, InfoBar, Expander, TreeView.
+Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, Grid, StackPanel, Border, ScrollViewer, Canvas, Image, Slider, ProgressBar, ToolTip/ToolTipService, Expander, TreeView.
 
+### WinUI-Only Additions You May Want to Adopt
+
+The following controls do not have direct equivalents in WPF but are often valuable to introduce when modernizing your UI with WinUI / Uno Platform:
+
+NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton, GridView.
 ### Controls Requiring Replacement
 
 | WPF Control | WinUI / Uno Replacement | Notes |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -64,13 +64,16 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `DocumentViewer` | `WebView2` | Render PDFs/XPS inside WebView2 |
 | `FlowDocument` | `RichTextBlock` | Partial replacement only |
 | `RichTextBox` | `RichEditBox` | Rich text editing |
-| `WrapPanel` | Community Toolkit `WrapPanel` | Not in WinUI by default |
+| `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; in WinUI 3 (Windows App SDK only), use `CommunityToolkit.WinUI.UI.Controls` |
 | `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default |
 | `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default |
 | `GroupBox` | `Expander` or custom `HeaderedContentControl` | No GroupBox in WinUI |
 | `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
 | `MediaElement` | `MediaPlayerElement` | Different API surface |
 | `Window` (standalone) | `Window` | Window host; content is typically a `Page`/root `UIElement`. Use `ContentDialog` for modal windows. |
+| `GridSplitter` | Community Toolkit `GridSplitter` | Requires `CommunityToolkit.WinUI.UI.Controls` |
+| `Calendar` | `CalendarView` | Similar functionality with updated API |
+| `ListBox` | `ListView` | `ListView` is the WinUI equivalent |
 
 ### Useful NuGet Packages
 
@@ -102,11 +105,22 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `MouseLeave` | `PointerExited` | `PointerRoutedEventArgs` |
 | `MouseWheel` | `PointerWheelChanged` | `PointerRoutedEventArgs` |
 | `MouseDoubleClick` | `DoubleTapped` | `DoubleTappedRoutedEventArgs` |
-| `PreviewMouseDown` | `PointerPressed` | No tunneling/preview events in WinUI |
-| `PreviewKeyDown` | `KeyDown` | No tunneling/preview events in WinUI |
+| `PreviewMouseDown` | `PointerPressed` | No direct WPF-style tunneling/preview pointer event in WinUI |
 
 > [!NOTE]
-> WinUI does not support tunneling (preview) events. Routed events are bubbling-only, so if you need to listen for an event even after a child marks it handled, use `AddHandler` with `handledEventsToo: true`. This does not reproduce WPF-style preview ordering (parent before child).
+> WinUI does not provide WPF-style `PreviewMouse*` tunneling events for pointer/mouse input. If you need to listen for a bubbling event even after a child marks it handled, use `AddHandler` with `handledEventsToo: true`. This does not reproduce WPF-style preview ordering (parent before child).
+
+### Keyboard Events
+
+| WPF Event | WinUI Event | Args Type |
+|---|---|---|
+| `KeyDown` | `KeyDown` | `KeyRoutedEventArgs` |
+| `KeyUp` | `KeyUp` | `KeyRoutedEventArgs` |
+| `PreviewKeyDown` | `PreviewKeyDown` | `KeyRoutedEventArgs` |
+| `PreviewKeyUp` | `PreviewKeyUp` | `KeyRoutedEventArgs` |
+
+> [!NOTE]
+> Unlike pointer/mouse input, WinUI/Uno supports preview keyboard events via `PreviewKeyDown` and `PreviewKeyUp` on `UIElement`. If you are migrating from WPF, use those events for keyboard tunneling scenarios. Platform-specific behavior can still vary, so validate event ordering on your target platforms when the distinction matters.
 
 ### Mouse Capture
 
@@ -126,6 +140,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `{DynamicResource Key}` | `{ThemeResource Key}` | Re-evaluated on theme changes (Light/Dark) |
 | `{x:Static ns:Type.Member}` | `{x:Bind ns:Type.Member}` | Common option for static member references; enums/values can often use direct `ns:Type.Member` or literals |
 | `{Binding Path=X}` | `{x:Bind ViewModel.X, Mode=OneWay}` | See [binding comparison](#binding-technology-comparison) below |
+| `{Binding RelativeSource={RelativeSource AncestorType=...}}` | Uno Toolkit `AncestorSource` | See [Ancestor/ItemsControl binding](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/helpers/ancestor-itemscontrol-binding.md) |
 
 ### Binding Technology Comparison
 
@@ -254,7 +269,7 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 
 | WPF Code | WinUI Replacement | Notes |
 |---|---|---|
-| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Async only; no synchronous `Invoke` |
+| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Fire-and-forget; no synchronous `Invoke`. For awaitable dispatch, wrap with a `TaskCompletionSource`: `var tcs = new TaskCompletionSource(); App.MainWindow.DispatcherQueue.TryEnqueue(() => { /* work */ tcs.SetResult(); }); await tcs.Task;` |
 | `Window.Current` | `App.MainWindow` (captured at startup) | Not supported in Windows App SDK |
 | `Clipboard` (System.Windows) | `Windows.ApplicationModel.DataTransfer.Clipboard` | Different API surface |
 | `MessageBox.Show()` | `ContentDialog` with `XamlRoot` | No MessageBox in WinUI |
@@ -268,7 +283,8 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 | `ContextMenu=` | `ContextFlyout=` |
 | `{DynamicResource` | `{ThemeResource` |
 | `{x:Static` | `{x:Bind` |
-| `Visibility="Hidden"` | `Visibility="Collapsed"` (or `Opacity="0"`) |
+| `Visibility="Hidden"` (layout-preserving) | `Opacity="0"` with `IsHitTestVisible="False"` | Keeps layout space; combine with `IsTabStop="False"` for focusable controls |
+| `Visibility="Hidden"` (remove from layout) | `Visibility="Collapsed"` | Collapses space like WPF `Visibility="Collapsed"` |
 | `MouseLeftButtonDown` | `PointerPressed` |
 | `MouseLeftButtonUp` | `PointerReleased` |
 | `MouseEnter` | `PointerEntered` |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -366,7 +366,7 @@ WinUI does not support tunneling events. Replace `PreviewMouseDown`, `PreviewKey
 
 **How do I migrate the Dispatcher pattern?**
 
-Replace `Application.Current.Dispatcher.Invoke(...)` with `App.Window.DispatcherQueue.TryEnqueue(...)`. The `DispatcherQueue` API is asynchronous by default and has no synchronous `Invoke` method.
+Replace `Application.Current.Dispatcher.Invoke(...)` with `App.MainWindow.DispatcherQueue.TryEnqueue(...)`. The `DispatcherQueue` API is asynchronous by default and has no synchronous `Invoke` method.
 
 **Does Uno Platform add controls beyond WinUI?**
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -337,7 +337,6 @@ RESOURCE RULES:
 
 CONTROL REPLACEMENTS:
 - Menu/MenuItem -> MenuBar/MenuBarItem/MenuFlyoutItem
-````
 - ContextMenu -> ContextFlyout with MenuFlyout
 - ToolBar -> CommandBar with AppBarButton
 - StatusBar -> Grid at bottom of layout

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -61,7 +61,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `ContextMenu` | `MenuFlyout` via `ContextFlyout` property | Assign to `ContextFlyout` on any `UIElement` |
 | `ToolBar` / `ToolBarTray` | `CommandBar` + `AppBarButton` | |
 | `StatusBar` | Custom `Grid` / `StackPanel` or `InfoBar` | No StatusBar control in WinUI |
-| `TabControl` | `TabView` or `NavigationView` (Top mode) | `TabView` supports closeable tabs |
+| `TabControl` | `TabView` or `NavigationView` (Top mode) | `TabView` supports closable tabs |
 | `DocumentViewer` | `WebView2` | Render PDFs/XPS inside WebView2 |
 | `FlowDocument` | `RichTextBlock` | Partial replacement only |
 | `RichTextBox` | `RichEditBox` | Rich text editing |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -127,11 +127,11 @@ Package guidance for Community Toolkit controls in this table: in WinUI 3 (Windo
 
 ### Mouse Capture
 
-| WPF | WinUI |
-|---|---|
-| `element.CaptureMouse()` | `element.CapturePointer(e.Pointer)` |
-| `element.ReleaseMouseCapture()` | `element.ReleasePointerCapture(e.Pointer)` |
-| `Mouse.GetPosition(element)` | `e.GetCurrentPoint(element).Position` |
+| WPF | WinUI | Notes |
+|---|---|---|
+| `element.CaptureMouse()` | `element.CapturePointer(e.Pointer)` | Typically used inside a pointer event where `e.Pointer` is available |
+| `element.ReleaseMouseCapture()` | `element.ReleasePointerCaptures()` | General equivalent when you do not have the original `Pointer`; if you need to release a specific pointer later, store it and call `element.ReleasePointerCapture(pointer)` |
+| `Mouse.GetPosition(element)` | `e.GetCurrentPoint(element).Position` | Use within pointer event handling |
 
 ## XAML Syntax Translations
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -273,7 +273,7 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 | WPF Code | WinUI Replacement | Notes |
 |---|---|---|
 | `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Fire-and-forget; no synchronous `Invoke`. See awaitable example below. |
-| `Window.Current` | `App.MainWindow` (captured at startup) | Not supported in Windows App SDK |
+| `Application.Current.MainWindow` | `App.MainWindow` (captured at startup) | Use the app's main window reference in WinUI/Uno. |
 | `Clipboard` (System.Windows) | `Windows.ApplicationModel.DataTransfer.Clipboard` | Different API surface |
 | `MessageBox.Show()` | `ContentDialog` with `XamlRoot` | No MessageBox in WinUI |
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -55,7 +55,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 
 | WPF Control | WinUI / Uno Replacement | Notes |
 |---|---|---|
-| `DataGrid` | Community Toolkit `DataGrid` | Similar API, not identical. Requires `CommunityToolkit.WinUI.UI.Controls`. |
+| `DataGrid` | Community Toolkit `DataGrid` | Similar API, not identical. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
 | `Ribbon` | `CommandBar` or `NavigationView` | No Ribbon in WinUI |
 | `Menu` / `MenuItem` | `MenuBar` / `MenuBarItem` / `MenuFlyoutItem` | `MenuBar` for top-level menus; `MenuFlyout` for context menus |
 | `ContextMenu` | `MenuFlyout` via `ContextFlyout` property | Assign to `ContextFlyout` on any `UIElement` |
@@ -65,14 +65,14 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `DocumentViewer` | `WebView2` | Render PDFs/XPS inside WebView2 |
 | `FlowDocument` | `RichTextBlock` | Partial replacement only |
 | `RichTextBox` | `RichEditBox` | Rich text editing |
-| `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; in WinUI 3 (Windows App SDK only), use `CommunityToolkit.WinUI.UI.Controls` |
-| `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default |
-| `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default |
+| `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; in WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
+| `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
+| `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
 | `GroupBox` | `Expander` or custom `HeaderedContentControl` | No GroupBox in WinUI |
 | `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
 | `MediaElement` | `MediaPlayerElement` | Different API surface |
 | `Window` (standalone) | `Window` | Window host; content is typically a `Page`/root `UIElement`. Use `ContentDialog` for modal windows. |
-| `GridSplitter` | Community Toolkit `GridSplitter` | Requires `CommunityToolkit.WinUI.UI.Controls` |
+| `GridSplitter` | Community Toolkit `GridSplitter` | In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
 | `Calendar` | `CalendarView` | Similar functionality with updated API |
 | `ListBox` | `ListView` | `ListView` is the WinUI equivalent |
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -278,7 +278,8 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 | `Focusable="True"` | `IsTabStop="True"` |
 | `TextWrapping="WrapWithOverflow"` | `TextWrapping="Wrap"` |
 | `MediaElement` | `MediaPlayerElement` |
-
+| `InputBindings` | `KeyboardAccelerators` |
+| `KeyBinding` | `KeyboardAccelerator` |
 ### Code-Behind Replacements
 
 | Find | Replace With |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -325,7 +325,7 @@ CONTROL REPLACEMENTS:
 - MediaElement -> MediaPlayerElement
 
 PROPERTY REPLACEMENTS:
-- Visibility="Hidden" -> Visibility="Collapsed"
+- Visibility="Hidden" -> use `Opacity="0"` with `Visibility="Visible"` when layout must be preserved; use `Visibility="Collapsed"` only when removing the element from layout is acceptable
 - TextWrapping="WrapWithOverflow" -> TextWrapping="Wrap"
 - Focusable -> IsTabStop
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -362,7 +362,7 @@ WinUI only has `Visible` and `Collapsed`. For invisible-but-layout-occupying beh
 
 **How do I handle preview/tunneling events?**
 
-WinUI does not support tunneling events. Replace `PreviewMouseDown`, `PreviewKeyDown`, etc. with their bubbling equivalents. Use the `Handled` property or `AddHandler` with `handledEventsToo: true` if you need to intercept events.
+WinUI/Uno supports some preview/tunneling events for keyboard input, including `PreviewKeyDown` and `PreviewKeyUp`, so you do not need to replace those with `KeyDown`/`KeyUp`. However, WPF-style preview mouse/pointer events such as `PreviewMouseDown` do not generally have direct equivalents. In those cases, use the corresponding bubbling event (for example, `PointerPressed`) and, if you need to observe events that were already marked handled, register with `AddHandler(..., handledEventsToo: true)`.
 
 **How do I migrate the Dispatcher pattern?**
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -76,7 +76,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `Calendar` | `CalendarView` | Similar functionality with updated API |
 | `ListBox` | `ListBox` or `ListView` | `ListBox` exists in WinUI/Uno; prefer `ListView` when you need richer built-in list item presentation or interaction features |
 
-Package guidance for Community Toolkit controls in this table: in WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`).
+Package guidance for Community Toolkit controls in this table: in WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, install the matching Uno package for the control you use, such as `Uno.CommunityToolkit.WinUI.UI.Controls` for controls like `DockPanel` and `GridSplitter`, or `Uno.CommunityToolkit.WinUI.UI.Controls.DataGrid` for `DataGrid`. See [Uno Community Toolkit packages](uno-community-toolkit.md) for the authoritative package list and version guidance.
 
 ### Useful NuGet Packages
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -337,6 +337,8 @@ RESOURCE RULES:
 
 CONTROL REPLACEMENTS:
 - Menu/MenuItem -> MenuBar/MenuBarItem/MenuFlyoutItem
+
+````
 - ContextMenu -> ContextFlyout with MenuFlyout
 - ToolBar -> CommandBar with AppBarButton
 - StatusBar -> Grid at bottom of layout

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -117,11 +117,11 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 |---|---|---|
 | `KeyDown` | `KeyDown` | `KeyRoutedEventArgs` |
 | `KeyUp` | `KeyUp` | `KeyRoutedEventArgs` |
-| `PreviewKeyDown` | `PreviewKeyDown` | `KeyRoutedEventArgs` |
-| `PreviewKeyUp` | `PreviewKeyUp` | `KeyRoutedEventArgs` |
+| `PreviewKeyDown` | `Uno only (WASM/SKIA): PreviewKeyDown` | `KeyRoutedEventArgs` |
+| `PreviewKeyUp` | `Uno only (WASM/SKIA): PreviewKeyUp` | `KeyRoutedEventArgs` |
 
 > [!NOTE]
-> Unlike pointer/mouse input, WinUI/Uno supports preview keyboard events via `PreviewKeyDown` and `PreviewKeyUp` on `UIElement`. If you are migrating from WPF, use those events for keyboard tunneling scenarios. Platform-specific behavior can still vary, so validate event ordering on your target platforms when the distinction matters.
+> Standard WinUI 3 does not expose WPF-style preview keyboard events. On Uno, `PreviewKeyDown` and `PreviewKeyUp` are available only on some targets (for example, WASM/SKIA), so treat them as platform-specific rather than general WinUI equivalents. When you need a cross-target or WinUI 3-compatible alternative, use `KeyDown` and `KeyUp`, and validate event ordering on your target platforms when the distinction matters.
 
 ### Mouse Capture
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -371,7 +371,7 @@ CONTROL REPLACEMENTS:
 - MediaElement -> MediaPlayerElement
 
 PROPERTY REPLACEMENTS:
-- Visibility="Hidden" -> use `Opacity="0"` with `Visibility="Visible"` when layout must be preserved; use `Visibility="Collapsed"` only when removing the element from layout is acceptable
+- Visibility="Hidden" -> WinUI has no direct `Hidden` state; when layout must be preserved, use `Opacity="0"` with `Visibility="Visible"` and also set `IsHitTestVisible="False"`; for focusable controls also set `IsTabStop="False"` and `AllowFocusOnInteraction="False"` so the element is not invisible-but-interactive; use `Visibility="Collapsed"` only when removing the element from layout is acceptable
 - TextWrapping="WrapWithOverflow" -> TextWrapping="Wrap"
 - Focusable -> IsTabStop
 
@@ -408,7 +408,7 @@ No. The majority of WPF XAML transfers with namespace changes and minor property
 
 **What replaces Visibility.Hidden?**
 
-WinUI only has `Visible` and `Collapsed`. For invisible-but-layout-occupying behavior, set `Opacity="0"` while keeping `Visibility="Visible"`.
+WinUI only has `Visible` and `Collapsed`. For invisible-but-layout-occupying behavior, set `Opacity="0"` while keeping `Visibility="Visible"`, and also set `IsHitTestVisible="False"`. If the control can receive focus, also set `IsTabStop="False"` and `AllowFocusOnInteraction="False"` so it does not remain invisible but interactive.
 
 **How do I handle preview/tunneling events?**
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -119,7 +119,7 @@ Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, 
 |---|---|---|
 | `{StaticResource Key}` | `{StaticResource Key}` | Identical - resolved once at load |
 | `{DynamicResource Key}` | `{ThemeResource Key}` | Re-evaluated on theme changes (Light/Dark) |
-| `{x:Static ns:Type.Member}` | `{x:Bind ns:Type.Member}` | Static member references |
+| `{x:Static ns:Type.Member}` | `{x:Bind ns:Type.Member}` | Common option for static member references; enums/values can often use direct `ns:Type.Member` or literals |
 | `{Binding Path=X}` | `{x:Bind ViewModel.X, Mode=OneWay}` | See [binding comparison](#binding-technology-comparison) below |
 
 ### Binding Technology Comparison

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -65,7 +65,7 @@ Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, 
 | `GroupBox` | `Expander` or custom `HeaderedContentControl` | No GroupBox in WinUI |
 | `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
 | `MediaElement` | `MediaPlayerElement` | Different API surface |
-| `Window` (standalone) | `Page` (navigable) | Or `ContentDialog` for modal windows |
+| `Window` (standalone) | `Window` | Window host; content is typically a `Page`/root `UIElement`. Use `ContentDialog` for modal windows. |
 
 ### Useful NuGet Packages
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -284,8 +284,15 @@ var tcs = new TaskCompletionSource<bool>();
 
 if (!App.MainWindow.DispatcherQueue.TryEnqueue(() =>
 {
-    /* work */
-    tcs.SetResult(true);
+    try
+    {
+        /* work */
+        tcs.SetResult(true);
+    }
+    catch (Exception ex)
+    {
+        tcs.SetException(ex);
+    }
 }))
 {
     tcs.SetException(new InvalidOperationException("Failed to enqueue work on the DispatcherQueue."));
@@ -369,7 +376,6 @@ PROPERTY REPLACEMENTS:
 - Focusable -> IsTabStop
 
 EVENT REPLACEMENTS:
-````
 - Mouse* events -> Pointer* equivalents
 - Remove Preview* tunneling events
 
@@ -388,6 +394,7 @@ WPF XAML to translate:
 <!-- Paste WPF XAML here -->
 <PASTE WPF XAML HERE>
 ```
+````
 
 ## FAQ
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -76,7 +76,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 
 | Package | Purpose |
 |---|---|
-| `CommunityToolkit.WinUI.UI.Controls` | DataGrid, WrapPanel, DockPanel, UniformGrid |
+| `CommunityToolkit.WinUI.UI.Controls` | DataGrid, WrapPanel, DockPanel, UniformGrid. Note: `DataGrid` and some related controls are available in Windows Community Toolkit 7.x; they were removed from 8.x. |
 | `CommunityToolkit.Mvvm` | RelayCommand, ObservableObject, source generators |
 | `Uno.Themes.WinUI` | Material, Cupertino, or Fluent theme support |
 | `Uno.Toolkit.WinUI` | Additional cross-platform controls and helpers |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -254,8 +254,8 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 
 | WPF Code | WinUI Replacement | Notes |
 |---|---|---|
-| `Application.Current.Dispatcher.Invoke(...)` | `App.Window.DispatcherQueue.TryEnqueue(...)` | Async only; no synchronous `Invoke` |
-| `Window.Current` | Custom `App.Window` static | Not supported in Windows App SDK |
+| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Async only; no synchronous `Invoke` |
+| `Window.Current` | `App.MainWindow` (captured at startup) | Not supported in Windows App SDK |
 | `Clipboard` (System.Windows) | `Windows.ApplicationModel.DataTransfer.Clipboard` | Different API surface |
 | `MessageBox.Show()` | `ContentDialog` with `XamlRoot` | No MessageBox in WinUI |
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -337,6 +337,7 @@ RESOURCE RULES:
 
 CONTROL REPLACEMENTS:
 - Menu/MenuItem -> MenuBar/MenuBarItem/MenuFlyoutItem
+````
 - ContextMenu -> ContextFlyout with MenuFlyout
 - ToolBar -> CommandBar with AppBarButton
 - StatusBar -> Grid at bottom of layout

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -65,16 +65,18 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `DocumentViewer` | `WebView2` | Render PDFs/XPS inside WebView2 |
 | `FlowDocument` | `RichTextBlock` | Partial replacement only |
 | `RichTextBox` | `RichEditBox` | Rich text editing |
-| `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; in WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
-| `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
-| `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
+| `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; otherwise see package guidance below. |
+| `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default; see package guidance below. |
+| `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default; see package guidance below. |
 | `GroupBox` | `Expander` or a custom `UserControl`/templated `ContentControl` | No built-in GroupBox in WinUI; use a custom header + border presentation when needed |
 | `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
 | `MediaElement` | `MediaPlayerElement` | Different API surface |
 | `Window` (standalone) | `Window` | Window host; content is typically a `Page`/root `UIElement`. Use `ContentDialog` for modal windows. |
-| `GridSplitter` | Community Toolkit `GridSplitter` | In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
+| `GridSplitter` | Community Toolkit `GridSplitter` | See package guidance below. |
 | `Calendar` | `CalendarView` | Similar functionality with updated API |
-| `ListBox` | `ListView` | `ListView` is the WinUI equivalent |
+| `ListBox` | `ListBox` or `ListView` | `ListBox` exists in WinUI/Uno; prefer `ListView` when you need richer built-in list item presentation or interaction features |
+
+Package guidance for Community Toolkit controls in this table: in WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`).
 
 ### Useful NuGet Packages
 
@@ -270,7 +272,7 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 
 | WPF Code | WinUI Replacement | Notes |
 |---|---|---|
-| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Fire-and-forget; no synchronous `Invoke`. For awaitable dispatch, wrap with a `TaskCompletionSource`: `var tcs = new TaskCompletionSource(); App.MainWindow.DispatcherQueue.TryEnqueue(() => { /* work */ tcs.SetResult(); }); await tcs.Task;` |
+| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Fire-and-forget; no synchronous `Invoke`. For awaitable dispatch, wrap with a `TaskCompletionSource`: `var tcs = new TaskCompletionSource<bool>(); if (!App.MainWindow.DispatcherQueue.TryEnqueue(() => { /* work */ tcs.SetResult(true); })) { tcs.SetException(new InvalidOperationException("Failed to enqueue work on the DispatcherQueue.")); } await tcs.Task;` |
 | `Window.Current` | `App.MainWindow` (captured at startup) | Not supported in Windows App SDK |
 | `Clipboard` (System.Windows) | `Windows.ApplicationModel.DataTransfer.Clipboard` | Different API surface |
 | `MessageBox.Show()` | `ContentDialog` with `XamlRoot` | No MessageBox in WinUI |
@@ -363,6 +365,11 @@ BINDING UPGRADES:
 OUTPUT: Complete translated XAML with a list of manual follow-up items.
 
 WPF XAML to translate:
+```xml
+<!-- Paste WPF XAML here -->
+```
+````
+<PASTE WPF XAML HERE>
 ````
 
 ## FAQ
@@ -381,7 +388,7 @@ WinUI only has `Visible` and `Collapsed`. For invisible-but-layout-occupying beh
 
 **How do I handle preview/tunneling events?**
 
-WinUI/Uno supports some preview/tunneling events for keyboard input, including `PreviewKeyDown` and `PreviewKeyUp`, so you do not need to replace those with `KeyDown`/`KeyUp`. However, WPF-style preview mouse/pointer events such as `PreviewMouseDown` do not generally have direct equivalents. In those cases, use the corresponding bubbling event (for example, `PointerPressed`) and, if you need to observe events that were already marked handled, register with `AddHandler(..., handledEventsToo: true)`.
+WinUI 3 does not generally provide WPF-style preview/tunneling events. In Uno Platform, some preview keyboard events such as `PreviewKeyDown` and `PreviewKeyUp` are available on specific targets only, so they should not be treated as a general WinUI 3 migration equivalent. For cross-target and WinUI 3-compatible code, use `KeyDown`/`KeyUp` instead. WPF-style preview mouse/pointer events such as `PreviewMouseDown` do not generally have direct equivalents; use the corresponding bubbling event (for example, `PointerPressed`) and, if you need to observe events that were already marked handled, register with `AddHandler(..., handledEventsToo: true)`.
 
 **How do I migrate the Dispatcher pattern?**
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -272,10 +272,27 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 
 | WPF Code | WinUI Replacement | Notes |
 |---|---|---|
-| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Fire-and-forget; no synchronous `Invoke`. For awaitable dispatch, wrap with a `TaskCompletionSource`: `var tcs = new TaskCompletionSource<bool>(); if (!App.MainWindow.DispatcherQueue.TryEnqueue(() => { /* work */ tcs.SetResult(true); })) { tcs.SetException(new InvalidOperationException("Failed to enqueue work on the DispatcherQueue.")); } await tcs.Task;` |
+| `Application.Current.Dispatcher.Invoke(...)` | `App.MainWindow.DispatcherQueue.TryEnqueue(...)` | Fire-and-forget; no synchronous `Invoke`. See awaitable example below. |
 | `Window.Current` | `App.MainWindow` (captured at startup) | Not supported in Windows App SDK |
 | `Clipboard` (System.Windows) | `Windows.ApplicationModel.DataTransfer.Clipboard` | Different API surface |
 | `MessageBox.Show()` | `ContentDialog` with `XamlRoot` | No MessageBox in WinUI |
+
+For awaitable dispatch, wrap `DispatcherQueue.TryEnqueue(...)` with a `TaskCompletionSource`:
+
+```csharp
+var tcs = new TaskCompletionSource<bool>();
+
+if (!App.MainWindow.DispatcherQueue.TryEnqueue(() =>
+{
+    /* work */
+    tcs.SetResult(true);
+}))
+{
+    tcs.SetException(new InvalidOperationException("Failed to enqueue work on the DispatcherQueue."));
+}
+
+await tcs.Task;
+```
 
 ## Find-and-Replace Quick Reference
 
@@ -338,7 +355,6 @@ RESOURCE RULES:
 CONTROL REPLACEMENTS:
 - Menu/MenuItem -> MenuBar/MenuBarItem/MenuFlyoutItem
 
-````
 - ContextMenu -> ContextFlyout with MenuFlyout
 - ToolBar -> CommandBar with AppBarButton
 - StatusBar -> Grid at bottom of layout
@@ -353,6 +369,7 @@ PROPERTY REPLACEMENTS:
 - Focusable -> IsTabStop
 
 EVENT REPLACEMENTS:
+````
 - Mouse* events -> Pointer* equivalents
 - Remove Preview* tunneling events
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -280,22 +280,22 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 For awaitable dispatch, wrap `DispatcherQueue.TryEnqueue(...)` with a `TaskCompletionSource`:
 
 ```csharp
-var tcs = new TaskCompletionSource<bool>();
+var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 if (!App.MainWindow.DispatcherQueue.TryEnqueue(() =>
 {
     try
     {
         /* work */
-        tcs.SetResult(true);
+        tcs.TrySetResult(true);
     }
     catch (Exception ex)
     {
-        tcs.SetException(ex);
+        tcs.TrySetException(ex);
     }
 }))
 {
-    tcs.SetException(new InvalidOperationException("Failed to enqueue work on the DispatcherQueue."));
+    tcs.TrySetException(new InvalidOperationException("Failed to enqueue work on the DispatcherQueue."));
 }
 
 await tcs.Task;

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -50,6 +50,7 @@ Button, TextBox, TextBlock, CheckBox, RadioButton, ComboBox, ListBox, ListView, 
 The following controls do not have direct equivalents in WPF but are often valuable to introduce when modernizing your UI with WinUI / Uno Platform:
 
 NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton, GridView.
+
 ### Controls Requiring Replacement
 
 | WPF Control | WinUI / Uno Replacement | Notes |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -68,7 +68,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `WrapPanel` | `WrapPanel` (built-in on Uno Platform) or Community Toolkit `WrapPanel` | Built-in on Uno Platform; in WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
 | `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
 | `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default. In WinUI 3 (Windows App SDK), use `CommunityToolkit.WinUI.UI.Controls`; for Uno Platform non-Windows targets, use the Uno-ported toolkit packages (`Uno.CommunityToolkit.WinUI.*`). |
-| `GroupBox` | `Expander` or custom `HeaderedContentControl` | No GroupBox in WinUI |
+| `GroupBox` | `Expander` or a custom `UserControl`/templated `ContentControl` | No built-in GroupBox in WinUI; use a custom header + border presentation when needed |
 | `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
 | `MediaElement` | `MediaPlayerElement` | Different API surface |
 | `Window` (standalone) | `Window` | Window host; content is typically a `Page`/root `UIElement`. Use `ContentDialog` for modal windows. |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -69,7 +69,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `UniformGrid` | Community Toolkit `UniformGrid` | Not in WinUI by default; see package guidance below. |
 | `DockPanel` | Community Toolkit `DockPanel` | Not in WinUI by default; see package guidance below. |
 | `GroupBox` | `Expander` or a custom `UserControl`/templated `ContentControl` | No built-in GroupBox in WinUI; use a custom header + border presentation when needed |
-| `Label` | `TextBlock` | Use `TextBlock` + `AccessKey` property |
+| `Label` | `TextBlock` | Use `TextBlock` for the visual label; for WPF `Label.Target`-style association, use `AutomationProperties.LabeledBy` on the labeled control. `AccessKey` can be added separately for keyboard access. |
 | `MediaElement` | `MediaPlayerElement` | Different API surface |
 | `Window` (standalone) | `Window` | Window host; content is typically a `Page`/root `UIElement`. Use `ContentDialog` for modal windows. |
 | `GridSplitter` | Community Toolkit `GridSplitter` | See package guidance below. |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -84,7 +84,7 @@ Package guidance for Community Toolkit controls in this table: in WinUI 3 (Windo
 |---|---|
 | `CommunityToolkit.WinUI.UI.Controls` | DataGrid, WrapPanel, DockPanel, UniformGrid. Note: `DataGrid` and some related controls are available in Windows Community Toolkit 7.x; they were removed from 8.x. |
 | `CommunityToolkit.Mvvm` | RelayCommand, ObservableObject, source generators |
-| `Uno.Themes.WinUI` | Material, Cupertino, or Fluent theme support |
+| `Uno.Material.WinUI`, `Uno.Cupertino.WinUI`, `Uno.Simple.WinUI` | Material, Cupertino, or simple theme support |
 | `Uno.Toolkit.WinUI` | Additional cross-platform controls and helpers |
 
 ## Property and Value Mappings
@@ -367,10 +367,8 @@ OUTPUT: Complete translated XAML with a list of manual follow-up items.
 WPF XAML to translate:
 ```xml
 <!-- Paste WPF XAML here -->
-```
-````
 <PASTE WPF XAML HERE>
-````
+```
 
 ## FAQ
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -106,7 +106,7 @@ NavigationView, NumberBox, InfoBar, ProgressRing, ToggleSwitch, HyperlinkButton,
 | `PreviewKeyDown` | `KeyDown` | No tunneling/preview events in WinUI |
 
 > [!NOTE]
-> WinUI does not support tunneling (preview) events. If you relied on tunneling to intercept events, use the `Handled` property or `AddHandler` with `handledEventsToo: true`.
+> WinUI does not support tunneling (preview) events. Routed events are bubbling-only, so if you need to listen for an event even after a child marks it handled, use `AddHandler` with `handledEventsToo: true`. This does not reproduce WPF-style preview ordering (parent before child).
 
 ### Mouse Capture
 

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -297,6 +297,7 @@ Always use `BasedOn` when overriding default control styles. Without it, your st
 | `MediaElement` | `MediaPlayerElement` |
 | `InputBindings` | `KeyboardAccelerators` |
 | `KeyBinding` | `KeyboardAccelerator` |
+
 ### Code-Behind Replacements
 
 | Find | Replace With |

--- a/doc/articles/wpf-winui-equivalents.md
+++ b/doc/articles/wpf-winui-equivalents.md
@@ -19,7 +19,7 @@ This reference provides a comprehensive mapping of WPF namespaces, controls, XAM
 | `System.Windows.Media` | `Microsoft.UI.Xaml.Media` | Brushes, transforms |
 | `System.Windows.Media.Animation` | `Microsoft.UI.Xaml.Media.Animation` | Storyboard, animations |
 | `System.Windows.Media.Imaging` | `Microsoft.UI.Xaml.Media.Imaging` | BitmapImage, WriteableBitmap |
-| `System.Windows.Media.Media3D` | No equivalent | Use Win2D or Composition APIs |
+| `System.Windows.Media.Media3D` | `Microsoft.UI.Xaml.Media.Media3D` (partial equivalent) | Supports 3D transforms/projection (for example `CompositeTransform3D`, `Matrix3D`, `PerspectiveTransform3D`), but not WPF-style `Viewport3D` / 3D scenegraph APIs |
 | `System.Windows.Shapes` | `Microsoft.UI.Xaml.Shapes` | Rectangle, Ellipse, Path |
 | `System.Windows.Data` | `Microsoft.UI.Xaml.Data` | Binding, IValueConverter |
 | `System.Windows.Input` | `Microsoft.UI.Xaml.Input` | Pointer, keyboard, focus |


### PR DESCRIPTION
## Summary

- Adds a new documentation page: **WPF to WinUI XAML Equivalents Reference** (`doc/articles/wpf-winui-equivalents.md`)
- Nested under **Migrating > WPF** in the docs navigation (toc.yml)
- Adds a cross-reference link from the existing `wpf-migration.md` page

## What's in the new page

A comprehensive, searchable reference covering every major WPF-to-WinUI translation:

- **Namespace mapping** — All `System.Windows.*` to `Microsoft.UI.Xaml.*` translations
- **Control mappings** — 1:1 transfers, replacements (DataGrid, Menu, ToolBar, TabControl, etc.), and Community Toolkit alternatives
- **Property/value changes** — `Visibility.Hidden`, `TextWrapping.WrapWithOverflow`, `Focusable`, etc.
- **Event translations** — Full Mouse-to-Pointer event table with args types, plus mouse capture equivalents
- **XAML syntax** — `{DynamicResource}` → `{ThemeResource}`, `{Binding}` → `{x:Bind}`, binding comparison table
- **Patterns without equivalents** — Style.Triggers → VisualStateManager (with before/after code), MultiBinding → function binding, RoutedUICommand → ICommand, Adorner alternatives
- **Resource dictionaries** — `XamlControlsResources`, `ms-appx:///` paths, `BasedOn` requirements
- **Common API replacements** — Dispatcher, Clipboard, MessageBox, Window.Current
- **Find-and-replace tables** — Ready-to-use XAML attribute and code-behind replacement lists
- **AI prompt template** — Copy-paste prompt for automated WPF XAML translation with AI agents
- **FAQ** — Answers to the 6 most common WPF migration questions

## Motivation

WPF developers migrating to WinUI / Uno Platform currently have no single reference page for equivalents. This information is scattered across Microsoft Learn, blog posts, and Stack Overflow. This page consolidates it into one authoritative location within the Uno Platform docs.

The content is derived from real migration work (porting [Text-Grab](https://github.com/TheJoeFin/Text-Grab) from WPF to Uno Platform) and the companion blog article [WPF to WinUI XAML: The Complete Namespace and Control Map](https://platform.uno/articles/wpf-to-winui-xaml-the-complete-namespace-and-control-map/).

## Test plan

- [ ] Verify `wpf-winui-equivalents.md` renders correctly in DocFX
- [ ] Verify TOC entry appears under Migrating > WPF > "WPF to WinUI XAML Equivalents"
- [ ] Verify cross-reference link in `wpf-migration.md` resolves correctly
- [ ] Verify all internal xref links (`xref:Toolkit.GettingStarted`, `uno-community-toolkit.md`) resolve
- [ ] Verify anchor link `#binding-technology-comparison` works within the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)