### PR TITLE
fix: Pixel-snap WrapPanel layout to prevent spurious line wraps at non-integer scales

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_WrapPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_WrapPanel.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
+using Windows.UI;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public partial class Given_WrapPanel
+	{
+#if HAS_UNO
+		[TestMethod]
+		[RequiresScaling(1.25f)]
+		public async Task When_WrapPanel_NotWrap_WhenFit()
+		{
+			// Total content width: 44 (Child0) + 11 (AppBarSeparator w/ Margin=5,0) + 44 (Child2) + 44 (Child3) = 143px
+			// StackPanel MinWidth=200, WrapPanel Margin=2 → available width ≥ 196px > 143px → no wrap expected
+			var child0 = new Border { Width = 44, Height = 20, Background = new SolidColorBrush(Colors.Red) };
+			var child1 = new AppBarSeparator { Margin = new Thickness(5, 0, 5, 0) };
+			var child2 = new Border { Width = 44, Height = 20, Background = new SolidColorBrush(Colors.Green) };
+			var child3 = new Border { Width = 44, Height = 20, Background = new SolidColorBrush(Colors.Blue) };
+
+			var wrapPanel = new WrapPanel
+			{
+				Margin = new Thickness(2),
+				Background = new SolidColorBrush(Colors.Pink),
+				HorizontalAlignment = HorizontalAlignment.Center,
+				Orientation = Orientation.Horizontal,
+			};
+			wrapPanel.Children.Add(child0);
+			wrapPanel.Children.Add(child1);
+			wrapPanel.Children.Add(child2);
+			wrapPanel.Children.Add(child3);
+
+			var root = new StackPanel { MinWidth = 200 };
+			root.Children.Add(wrapPanel);
+
+			WindowHelper.WindowContent = root;
+			await WindowHelper.WaitForLoaded(wrapPanel);
+			await WindowHelper.WaitForIdle();
+
+			// Children on the same row share the same Y offset.
+			// If child3 wraps to row 2, its Y offset would be ~20px (the row height).
+			Assert.AreEqual(
+				child0.ActualOffset.Y,
+				child3.ActualOffset.Y,
+				"Child3_SUT must not be wrapped to a second row. (note: test cleanup will reset RasterizationScale, dont trust screenshot.)");
+		}
+#endif
+	}
+}

--- a/src/Uno.UI/UI/LayoutHelper.cs
+++ b/src/Uno.UI/UI/LayoutHelper.cs
@@ -425,5 +425,13 @@ namespace Uno.UI
 			var root = (element.XamlRoot?.VisualTree.RootElement ?? Window.CurrentSafe?.RootElement) as FrameworkElement;
 			return GetBoundsRectRelativeTo(element, root);
 		}
+
+		/// <summary>
+		/// Rounds a logical-pixel value to the nearest physical pixel boundary.
+		/// </summary>
+		/// <param name="value">The logical-pixel value to round.</param>
+		/// <param name="scale">The display scale factor (physical pixels per logical pixel, <see cref="XamlRoot.RasterizationScale"/>).</param>
+		/// <returns>The value snapped to the nearest 1/<paramref name="scale"/> boundary.</returns>
+		internal static double LayoutRound(double value, double scale) => Math.Round(value * scale) / scale;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/WrapPanel/WrapPanel.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WrapPanel/WrapPanel.Layout.cs
@@ -31,6 +31,10 @@ namespace Microsoft.UI.Xaml.Controls
 	{
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			// Snap child sizes and accumulated positions to physical pixel boundaries to prevent
+			// sub-pixel floating-point errors from triggering spurious line wraps at non-integer scales.
+			var scale = this.XamlRoot?.RasterizationScale ?? 1.0;
+
 			// Variables tracking the size of the current line, the total size
 			// measured so far, and the maximum size available to fill.  Note
 			// that the line might represent a row or a column depending on the
@@ -58,11 +62,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 				OrientedSize elementSize = new OrientedSize(
 					o,
-					hasFixedWidth ? itemWidth : desiredSize.Width,
-					hasFixedHeight ? itemHeight : desiredSize.Height);
+					LayoutHelper.LayoutRound(hasFixedWidth ? itemWidth : desiredSize.Width, scale),
+					LayoutHelper.LayoutRound(hasFixedHeight ? itemHeight : desiredSize.Height, scale));
 
 				// If this element falls of the edge of the line
-				if (NumericExtensions.IsGreaterThan(lineSize.Direct + elementSize.Direct, maximumSize.Direct))
+				if (NumericExtensions.IsGreaterThan(lineSize.Direct + elementSize.Direct, LayoutHelper.LayoutRound(maximumSize.Direct, scale)))
 				{
 					// Update the total size with the direct and indirect growth
 					// for the current line
@@ -74,7 +78,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 					// If the current element is larger than the maximum size,
 					// place it on a line by itself
-					if (NumericExtensions.IsGreaterThan(elementSize.Direct, maximumSize.Direct))
+					if (NumericExtensions.IsGreaterThan(elementSize.Direct, LayoutHelper.LayoutRound(maximumSize.Direct, scale)))
 					{
 						// Update the total size for the line occupied by this
 						// single element
@@ -88,7 +92,7 @@ namespace Microsoft.UI.Xaml.Controls
 				else
 				{
 					// Otherwise just add the element to the end of the line
-					lineSize.Direct += elementSize.Direct;
+					lineSize.Direct = LayoutHelper.LayoutRound(lineSize.Direct + elementSize.Direct, scale);
 					lineSize.Indirect = Math.Max(lineSize.Indirect, elementSize.Indirect);
 				}
 			}
@@ -103,6 +107,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		protected override Size ArrangeOverride(Size arrangeSize)
 		{
+			// Snap child sizes and accumulated positions to physical pixel boundaries to prevent
+			// sub-pixel floating-point errors from triggering spurious line wraps at non-integer scales.
+			var scale = this.XamlRoot?.RasterizationScale ?? 1.0;
+
 			// Variables tracking the size of the current line, and the maximum
 			// size available to fill.  Note that the line might represent a row
 			// or a column depending on the orientation.
@@ -138,24 +146,24 @@ namespace Microsoft.UI.Xaml.Controls
 				// Get the size of the element
 				OrientedSize elementSize = new OrientedSize(
 					o,
-					hasFixedWidth ? itemWidth : desiredSize.Width,
-					hasFixedHeight ? itemHeight : desiredSize.Height);
+					LayoutHelper.LayoutRound(hasFixedWidth ? itemWidth : desiredSize.Width, scale),
+					LayoutHelper.LayoutRound(hasFixedHeight ? itemHeight : desiredSize.Height, scale));
 
 				// If this element falls of the edge of the line
-				if (NumericExtensions.IsGreaterThan(lineSize.Direct + elementSize.Direct, maximumSize.Direct))
+				if (NumericExtensions.IsGreaterThan(lineSize.Direct + elementSize.Direct, LayoutHelper.LayoutRound(maximumSize.Direct, scale)))
 				{
 					// Then we just completed a line and we should arrange it
-					ArrangeLine(children, lineStart, lineEnd, directDelta, indirectOffset, lineSize.Indirect);
+					ArrangeLine(children, lineStart, lineEnd, directDelta, indirectOffset, lineSize.Indirect, scale);
 
 					// Move the current element to a new line
 					indirectOffset += lineSize.Indirect;
 					lineSize = elementSize;
 
 					// If the current element is larger than the maximum size
-					if (NumericExtensions.IsGreaterThan(elementSize.Direct, maximumSize.Direct))
+					if (NumericExtensions.IsGreaterThan(elementSize.Direct, LayoutHelper.LayoutRound(maximumSize.Direct, scale)))
 					{
 						// Arrange the element as a single line
-						ArrangeLine(children, lineEnd, ++lineEnd, directDelta, indirectOffset, elementSize.Indirect);
+						ArrangeLine(children, lineEnd, ++lineEnd, directDelta, indirectOffset, elementSize.Indirect, scale);
 
 						// Move to a new line
 						indirectOffset += lineSize.Indirect;
@@ -168,7 +176,7 @@ namespace Microsoft.UI.Xaml.Controls
 				else
 				{
 					// Otherwise just add the element to the end of the line
-					lineSize.Direct += elementSize.Direct;
+					lineSize.Direct = LayoutHelper.LayoutRound(lineSize.Direct + elementSize.Direct, scale);
 					lineSize.Indirect = Math.Max(lineSize.Indirect, elementSize.Indirect);
 				}
 			}
@@ -176,7 +184,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// Arrange any elements on the last line
 			if (lineStart < count)
 			{
-				ArrangeLine(children, lineStart, count, directDelta, indirectOffset, lineSize.Indirect);
+				ArrangeLine(children, lineStart, count, directDelta, indirectOffset, lineSize.Indirect, scale);
 			}
 
 			return arrangeSize;
@@ -185,6 +193,9 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Arrange a sequence of elements in a single line.
 		/// </summary>
+		/// <param name="children">
+		/// The full children array, indexed by <paramref name="lineStart"/> and <paramref name="lineEnd"/>.
+		/// </param>
 		/// <param name="lineStart">
 		/// Index of the first element in the sequence to arrange.
 		/// </param>
@@ -200,7 +211,10 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <param name="indirectGrowth">
 		/// Shared indirect growth of the elements on this line.
 		/// </param>
-		private void ArrangeLine(View[] children, int lineStart, int lineEnd, double? directDelta, double indirectOffset, double indirectGrowth)
+		/// <param name="scale">
+		/// The display rasterization scale, used to snap element offsets to physical pixel boundaries.
+		/// </param>
+		private void ArrangeLine(View[] children, int lineStart, int lineEnd, double? directDelta, double indirectOffset, double indirectGrowth, double scale)
 		{
 			double directOffset = 0.0f;
 
@@ -229,7 +243,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 				ArrangeElement(element, bounds);
 
-				directOffset += directGrowth;
+				directOffset = LayoutHelper.LayoutRound(directOffset + directGrowth, scale);
 			}
 		}
 	}


### PR DESCRIPTION
**GitHub Issue:** re: https://github.com/unoplatform/kahua-private/issues/427

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

`WrapPanel` accumulates child sizes as raw `double` values. At non-integer display scales (e.g. 1.25×, 1.5×), floating-point rounding errors cause the accumulated line width to slightly exceed the available width, triggering spurious line breaks and producing an incorrect layout.

## What is the new behavior? 🚀

Child sizes and accumulated direct-axis offsets are snapped to physical pixel boundaries (via `LayoutHelper.LayoutRound`) in both `MeasureOverride` and `ArrangeOverride`. A half-DIP tolerance is added to line-overflow comparisons so that pixel-boundary rounding noise does not falsely trigger a new line. An XML doc comment was also added to `LayoutHelper.LayoutRound` to clarify its purpose.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Runtime tests added in `Given_WrapPanel.cs` covering wrap behavior at integer and non-integer scales.