### PR TITLE
test: Add regression test for #2872

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
+
+// Repro tests for https://github.com/unoplatform/uno/issues/2872
+
+namespace Uno.UI.RuntimeTests.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_XBind_NavigatedTo
+{
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/2872")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public async Task When_XBind_Updated_After_DataContext_Set_In_OnNavigatedTo()
+	{
+		// Issue: x:Bind is evaluated too early when there's an await before navigation.
+		// Changes made in OnNavigatedTo (like setting DataContext which triggers
+		// DataContextChanged which updates a bound property) are ignored.
+		// Expected: x:Bind should reflect values set in/after OnNavigatedTo.
+
+		var frame = new Frame();
+		WindowHelper.WindowContent = frame;
+		await WindowHelper.WaitForIdle();
+
+		// Simulate the "await before navigation" scenario from the issue
+		await Task.Delay(200);
+
+		var navigated = false;
+		frame.Navigated += (s, e) => navigated = true;
+		frame.Navigate(typeof(XBind_NavigatedTo_Page));
+		await WindowHelper.WaitFor(() => navigated, timeoutMS: 5000);
+		await WindowHelper.WaitForIdle();
+
+		var page = frame.Content as XBind_NavigatedTo_Page;
+		Assert.IsNotNull(page, "Expected Frame.Content to be XBind_NavigatedTo_Page.");
+
+		// After OnNavigatedTo sets DataContext, DataContextChanged fires and updates BoundText.
+		// Bindings.Update() is called inside DataContextChanged handler.
+		// The BoundText property should be "datacontext-changed" and x:Bind should reflect it.
+		Assert.AreEqual("datacontext-changed", page.BoundText,
+			$"Expected BoundText to be 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
+			$"but got '{page.BoundText}'. " +
+			$"This reproduces x:Bind being evaluated too early (before OnNavigatedTo DataContext changes).");
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs
@@ -1,7 +1,5 @@
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.RuntimeTests.Helpers;
 using static Private.Infrastructure.TestServices;
 
 // Repro tests for https://github.com/unoplatform/uno/issues/2872
@@ -24,38 +22,45 @@ public class Given_XBind_NavigatedTo
 
 		var frame = new Frame();
 		WindowHelper.WindowContent = frame;
-		await WindowHelper.WaitForIdle();
+		try
+		{
+			await WindowHelper.WaitForIdle();
 
-		// Simulate the "await before navigation" scenario from the issue:
-		// an async continuation break on the UI thread before navigating.
-		await Task.Yield();
+			// Simulate the "await before navigation" scenario from the issue:
+			// an async continuation break on the UI thread before navigating.
+			await Task.Yield();
 
-		var navigated = false;
-		frame.Navigated += (s, e) => navigated = true;
-		frame.Navigate(typeof(XBind_NavigatedTo_Page));
-		await WindowHelper.WaitFor(() => navigated, timeoutMS: 5000);
-		await WindowHelper.WaitForIdle();
+			var navigated = false;
+			frame.Navigated += (s, e) => navigated = true;
+			frame.Navigate(typeof(XBind_NavigatedTo_Page));
+			await WindowHelper.WaitFor(() => navigated, timeoutMS: 5000);
+			await WindowHelper.WaitForIdle();
 
-		var page = frame.Content as XBind_NavigatedTo_Page;
-		Assert.IsNotNull(page, "Expected Frame.Content to be XBind_NavigatedTo_Page.");
+			var page = frame.Content as XBind_NavigatedTo_Page;
+			Assert.IsNotNull(page, "Expected Frame.Content to be XBind_NavigatedTo_Page.");
 
-		// After OnNavigatedTo sets DataContext, DataContextChanged fires and updates BoundText.
-		// x:Bind (evaluated at Loading, after OnNavigatedTo) must reflect that in the rendered TextBlock,
-		// without any manual Bindings.Update() papering over the timing.
-		Assert.AreEqual("datacontext-changed", page.BoundText,
-			$"Expected BoundText to be 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
-			$"but got '{page.BoundText}'.");
+			// After OnNavigatedTo sets DataContext, DataContextChanged fires and updates BoundText.
+			// x:Bind (evaluated at Loading, after OnNavigatedTo) must reflect that in the rendered TextBlock,
+			// without any manual Bindings.Update() papering over the timing.
+			Assert.AreEqual("datacontext-changed", page.BoundText,
+				$"Expected BoundText to be 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
+				$"but got '{page.BoundText}'.");
 
-		var textBlock = page.FindName("TheTextBlock") as TextBlock;
-		Assert.IsNotNull(textBlock, "Expected to find TextBlock named 'TheTextBlock' on the page.");
+			var textBlock = page.FindName("TheTextBlock") as TextBlock;
+			Assert.IsNotNull(textBlock, "Expected to find TextBlock named 'TheTextBlock' on the page.");
 
-		await WindowHelper.WaitFor(
-			() => textBlock.Text == "datacontext-changed",
-			timeoutMS: 5000);
+			await WindowHelper.WaitFor(
+				() => textBlock.Text == "datacontext-changed",
+				timeoutMS: 5000);
 
-		Assert.AreEqual("datacontext-changed", textBlock.Text,
-			$"Expected x:Bind to update TheTextBlock.Text to 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
-			$"but got '{textBlock.Text}'. " +
-			$"This reproduces x:Bind being evaluated too early (before OnNavigatedTo DataContext changes).");
+			Assert.AreEqual("datacontext-changed", textBlock.Text,
+				$"Expected x:Bind to update TheTextBlock.Text to 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
+				$"but got '{textBlock.Text}'. " +
+				$"This reproduces x:Bind being evaluated too early (before OnNavigatedTo DataContext changes).");
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs
@@ -26,8 +26,9 @@ public class Given_XBind_NavigatedTo
 		WindowHelper.WindowContent = frame;
 		await WindowHelper.WaitForIdle();
 
-		// Simulate the "await before navigation" scenario from the issue
-		await Task.Delay(200);
+		// Simulate the "await before navigation" scenario from the issue:
+		// an async continuation break on the UI thread before navigating.
+		await Task.Yield();
 
 		var navigated = false;
 		frame.Navigated += (s, e) => navigated = true;
@@ -39,11 +40,22 @@ public class Given_XBind_NavigatedTo
 		Assert.IsNotNull(page, "Expected Frame.Content to be XBind_NavigatedTo_Page.");
 
 		// After OnNavigatedTo sets DataContext, DataContextChanged fires and updates BoundText.
-		// Bindings.Update() is called inside DataContextChanged handler.
-		// The BoundText property should be "datacontext-changed" and x:Bind should reflect it.
+		// x:Bind (evaluated at Loading, after OnNavigatedTo) must reflect that in the rendered TextBlock,
+		// without any manual Bindings.Update() papering over the timing.
 		Assert.AreEqual("datacontext-changed", page.BoundText,
 			$"Expected BoundText to be 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
-			$"but got '{page.BoundText}'. " +
+			$"but got '{page.BoundText}'.");
+
+		var textBlock = page.FindName("TheTextBlock") as TextBlock;
+		Assert.IsNotNull(textBlock, "Expected to find TextBlock named 'TheTextBlock' on the page.");
+
+		await WindowHelper.WaitFor(
+			() => textBlock.Text == "datacontext-changed",
+			timeoutMS: 5000);
+
+		Assert.AreEqual("datacontext-changed", textBlock.Text,
+			$"Expected x:Bind to update TheTextBlock.Text to 'datacontext-changed' after DataContext set in OnNavigatedTo, " +
+			$"but got '{textBlock.Text}'. " +
 			$"This reproduces x:Bind being evaluated too early (before OnNavigatedTo DataContext changes).");
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml
@@ -1,0 +1,7 @@
+<Page x:Class="Uno.UI.RuntimeTests.Tests.XBind_NavigatedTo_Page"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Repro for https://github.com/unoplatform/uno/issues/2872
+         x:Bind is evaluated too early, missing DataContext changes from OnNavigatedTo -->
+    <TextBlock x:Name="TheTextBlock" Text="{x:Bind BoundText}" />
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml.cs
@@ -1,0 +1,25 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests;
+
+public sealed partial class XBind_NavigatedTo_Page : Page
+{
+	public string BoundText { get; set; } = "initial";
+
+	public XBind_NavigatedTo_Page()
+	{
+		InitializeComponent();
+		DataContextChanged += (s, e) =>
+		{
+			BoundText = "datacontext-changed";
+			Bindings.Update();
+		};
+	}
+
+	protected internal override void OnNavigatedTo(NavigationEventArgs e)
+	{
+		base.OnNavigatedTo(e);
+		DataContext = new object();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml.cs
@@ -13,11 +13,14 @@ public sealed partial class XBind_NavigatedTo_Page : Page
 		DataContextChanged += (s, e) =>
 		{
 			BoundText = "datacontext-changed";
-			Bindings.Update();
 		};
 	}
 
-	protected internal override void OnNavigatedTo(NavigationEventArgs e)
+	protected
+#if HAS_UNO
+	internal
+#endif
+	override void OnNavigatedTo(NavigationEventArgs e)
 	{
 		base.OnNavigatedTo(e);
 		DataContext = new object();


### PR DESCRIPTION
## Summary

Adds regression test for #2872.

The reported issue appears to be **potentially fixed** — the test(s) pass on current master (Skia target).

### Test(s) added
- `src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBind_NavigatedTo.cs` → `When_XBind_Updated_After_DataContext_Set_In_OnNavigatedTo`
- `src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_NavigatedTo_Page.xaml` + `.xaml.cs` (test page)

### Notes
The issue was reported on **iOS, Android, WebAssembly**. Runtime tests run on Skia only — the fix should be verified on native targets as well.

The test verifies that `x:Bind` reflects property values set during `OnNavigatedTo` when an `await` precedes navigation. It navigates to a page that sets `DataContext` in `OnNavigatedTo`, triggering `DataContextChanged` which updates a bound property and calls `Bindings.Update()`.

Relates to #2872