### PR TITLE
fix: Fix invalid TFMs used to init project

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -53,6 +53,16 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 					return false;
 				}
 
+				if (property.Equals("TargetFrameworks", StringComparison.OrdinalIgnoreCase))
+				{
+					// Don't set TargetFrameworks globally since it propagates to all referenced projects.
+					// Library projects may target different TFMs (e.g. net9.0) than the head project
+					// (e.g. net10.0-desktop). The head project's TFM is already passed via
+					// UnoHotReloadTargetFramework which is promoted back to TargetFramework only on
+					// the head project via the DevServer targets.
+					return false;
+				}
+
 				if (property.StartsWith("MSBuild", StringComparison.OrdinalIgnoreCase))
 				{
 					// Noticeably, don't set the "MSBuildVersion" (Forbidden, will fail workspace).

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -186,7 +186,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			if (properties.Remove("TargetFramework", out var targetFramework))
 			{
 				properties["UnoHotReloadTargetFramework"] = targetFramework;
-				properties["TargetFrameworks"] = targetFramework;
 			}
 
 			var (workspace, watch) = await CompilationWorkspaceProvider.CreateWorkspaceAsync(


### PR DESCRIPTION
## 🐞 Bugfix
Fix invalid TFMs used to init project

## What is the current behavior? 🤔
When we init the HR workspace, we are setting the TFMs which flows on all projects

## What is the new behavior? 🚀
Remove the property and let the project defines it's TFM (except the root one where TFM is configured using the `UnoHotReloadTargetFramework`)

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
Linked to https://github.com/unoplatform/private/issues/926 and https://github.com/unoplatform/uno.toolkit.ui/pull/1565