### PR TITLE
fix(RangeBase): re-coerce Value after Minimum/Maximum is fully committed

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/RangeBase/RangeBaseTests.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/RangeBase/RangeBaseTests.cs
@@ -154,6 +154,49 @@ public class RangeBaseTests
 		valueChangedEvent = false;
 	}
 
+	// Reproduces https://github.com/unoplatform/uno/issues/22884
+	// When Value is set before Maximum (as happens when Maximum comes from a style),
+	// Value is incorrectly coerced against the stale Maximum because SetValue(ValueProperty)
+	// inside SetRangeBaseValue(MaximumProperty) reads the not-yet-committed Maximum.
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22884")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public async Task When_Value_Set_Before_Maximum_Value_Is_Correctly_Recoerced()
+	{
+		// Simulates the case where Maximum comes from a style (applied after local Value):
+		// 1. ProgressBar created, Value=25 set as local value → clamped to default Maximum=1
+		// 2. Style applies Maximum=100 → SetRangeBaseValue(MaximumProperty) tries to re-coerce Value
+		//    but reads stale Maximum=1 inside ValueProperty coercion → Value stays at 1
+		await RunOnUIThread(() =>
+		{
+			var progressBar = new ProgressBar();
+			progressBar.Value = 25.0; // Clamped to 1.0 (default Maximum=1)
+			progressBar.Maximum = 100.0; // Should re-coerce Value to 25.0
+
+			// Bug: Value is 1.0 because coercion inside MaximumProperty setter reads stale Maximum=1
+			Assert.AreEqual(25.0, progressBar.Value,
+				"Value should be correctly coerced to 25 after Maximum is expanded to 100");
+		});
+	}
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22884")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public async Task When_Value_Set_Before_Maximum_Slider_Value_Is_Correctly_Recoerced()
+	{
+		// Note: this test passes on Skia Desktop (Slider behavior differs from ProgressBar in this scenario)
+		await RunOnUIThread(() =>
+		{
+			var slider = new Slider();
+			slider.Value = 50.0;
+			slider.Maximum = 100.0;
+
+			Assert.AreEqual(50.0, slider.Value,
+				"Slider Value should be correctly coerced to 50 after Maximum is expanded to 100");
+		});
+	}
+
 	[TestMethod]
 	public async Task MinMaxValueSetThroughMarkupWork()
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/RangeBase/RangeBaseTests.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/RangeBase/RangeBaseTests.cs
@@ -160,41 +160,49 @@ public class RangeBaseTests
 	// inside SetRangeBaseValue(MaximumProperty) reads the not-yet-committed Maximum.
 
 	[TestMethod]
+	[RunsOnUIThread]
 	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22884")]
 	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public async Task When_Value_Set_Before_Maximum_Value_Is_Correctly_Recoerced()
+	public async Task When_ValueSet_BeforeMaximum_WillBe_Recoerced_ProgressBar()
 	{
 		// Simulates the case where Maximum comes from a style (applied after local Value):
 		// 1. ProgressBar created, Value=25 set as local value → clamped to default Maximum=1
 		// 2. Style applies Maximum=100 → SetRangeBaseValue(MaximumProperty) tries to re-coerce Value
 		//    but reads stale Maximum=1 inside ValueProperty coercion → Value stays at 1
-		await RunOnUIThread(() =>
-		{
-			var progressBar = new ProgressBar();
-			progressBar.Value = 25.0; // Clamped to 1.0 (default Maximum=1)
-			progressBar.Maximum = 100.0; // Should re-coerce Value to 25.0
+		var sut = new ProgressBar();
 
-			// Bug: Value is 1.0 because coercion inside MaximumProperty setter reads stale Maximum=1
-			Assert.AreEqual(25.0, progressBar.Value,
-				"Value should be correctly coerced to 25 after Maximum is expanded to 100");
-		});
+		// reset
+		sut.Minimum = 0;
+		sut.Maximum = 1;
+		sut.Value = 0;
+
+		// actual test
+		sut.Value = 25.0; // Clamped to 1.0 (default Maximum=1)
+		sut.Maximum = 100.0; // Should re-coerce Value to 25.0
+
+		// Bug: Value is 1.0 because coercion inside MaximumProperty setter reads stale Maximum=1
+		Assert.AreEqual(25.0, sut.Value, "Value should be correctly coerced to 25 after Maximum is expanded to 100");
 	}
 
 	[TestMethod]
+	[RunsOnUIThread]
 	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22884")]
 	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public async Task When_Value_Set_Before_Maximum_Slider_Value_Is_Correctly_Recoerced()
+	public async Task When_ValueSet_BeforeMaximum_WillBe_Recoerced_Slider()
 	{
-		// Note: this test passes on Skia Desktop (Slider behavior differs from ProgressBar in this scenario)
-		await RunOnUIThread(() =>
-		{
-			var slider = new Slider();
-			slider.Value = 50.0;
-			slider.Maximum = 100.0;
+		var sut = new Slider();
 
-			Assert.AreEqual(50.0, slider.Value,
-				"Slider Value should be correctly coerced to 50 after Maximum is expanded to 100");
-		});
+		// reset
+		sut.Minimum = 0;
+		sut.Maximum = 1;
+		sut.Value = 0;
+
+		// actual test
+		sut.Value = 25.0; // Clamped to 1.0 (default Maximum=1)
+		sut.Maximum = 100.0; // Should re-coerce Value to 25.0
+
+		// Bug: Value is 1.0 because coercion inside MaximumProperty setter reads stale Maximum=1
+		Assert.AreEqual(25.0, sut.Value, "Value should be correctly coerced to 25 after Maximum is expanded to 100");
 	}
 
 	[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.Properties.cs
@@ -48,7 +48,7 @@ public partial class RangeBase
 			nameof(Maximum),
 			typeof(double),
 			typeof(RangeBase),
-			new FrameworkPropertyMetadata(1.0, null, CoerceMaximum));
+			new FrameworkPropertyMetadata(1.0, OnRangeChanged, CoerceMaximum));
 
 	/// <summary>
 	/// Gets or sets the Minimum possible Value of the range element.
@@ -71,7 +71,7 @@ public partial class RangeBase
 			nameof(Minimum),
 			typeof(double),
 			typeof(RangeBase),
-			new FrameworkPropertyMetadata(0.0, null, CoerceMinimum));
+			new FrameworkPropertyMetadata(0.0, OnRangeChanged, CoerceMinimum));
 
 	/// <summary>
 	/// Gets or sets a Value to be added to or subtracted from the Value of a RangeBase control.

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.cs
@@ -32,4 +32,22 @@ public partial class RangeBase : Control
 	{
 		return ((RangeBase)dependencyObject).SetRangeBaseValue(MaximumProperty, baseValue);
 	}
+
+	// Uno specific: coercion workaround
+
+	private static void OnRangeChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+	{
+		if (sender is not RangeBase control) return;
+
+		if (e.Property == MinimumProperty || e.Property == MaximumProperty)
+		{
+			var clampedValue = control.CoerceValueBetween(control.m_uncoercedValue, control.Minimum, control.Maximum);
+			var currentValue = control.Value;
+
+			if (clampedValue != currentValue)
+			{
+				control.CoerceValue(ValueProperty);
+			}
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.mux.core.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.mux.core.cs
@@ -34,7 +34,15 @@ public partial class RangeBase : Control
 		{
 			return null;
 		}
+
+		// winui: used to control fall through, unhandled ones (not Value,Min,Max) goes to parent handler CControl::SetValue, and so on...
 		//bool wasHandled = false;
+
+		// Uno: the coercion `Value`(ValueProperty) in the set `Minimum` and set `Maximum` is commented out,
+		// because when it occurs we are still within the DOS::ApplyCoercion and the actual value of min/max
+		// is NOT YET committed. This means that the SetValue(ValueProperty,...) will hit
+		// this `SetRangeBaseValue` coerce impl again and clamp the value within [oldMin, oldMax].
+		// As a workaround, we will re-apply the value coercion in RangeBase::OnRangeChanged when min/max updates are fully committed.
 
 		if (property == ValueProperty)
 		{
@@ -63,11 +71,11 @@ public partial class RangeBase : Control
 				// CControl::SetValue(args));
 
 				// update value
-				var newValue = CoerceValueBetween(m_uncoercedValue, newMin, max);
-				if (newValue != Value)
-				{
-					SetValue(ValueProperty, newValue);
-				}
+				//var newValue = CoerceValueBetween(m_uncoercedValue, newMin, max);
+				//if (newValue != Value)
+				//{
+				//	SetValue(ValueProperty, newValue);
+				//}
 			}
 			else
 			{
@@ -81,11 +89,11 @@ public partial class RangeBase : Control
 				}
 
 				// set value
-				var newValue = CoerceValueBetween(m_uncoercedValue, newMin, max);
-				if (newValue != Value)
-				{
-					SetValue(ValueProperty, newValue);
-				}
+				//var newValue = CoerceValueBetween(m_uncoercedValue, newMin, max);
+				//if (newValue != Value)
+				//{
+				//	SetValue(ValueProperty, newValue);
+				//}
 
 				// set minimum
 				// CControl::SetValue(args));
@@ -108,11 +116,11 @@ public partial class RangeBase : Control
 				// CControl::SetValue(args));
 
 				// set value
-				var newValue = CoerceValueBetween(m_uncoercedValue, min, newMax);
-				if (newValue != Value)
-				{
-					SetValue(ValueProperty, newValue);
-				}
+				//var newValue = CoerceValueBetween(m_uncoercedValue, min, newMax);
+				//if (newValue != Value)
+				//{
+				//	SetValue(ValueProperty, newValue);
+				//}
 			}
 			else
 			{
@@ -122,11 +130,11 @@ public partial class RangeBase : Control
 				newMax = Math.Max(newMax, min);
 
 				// coerce and set value
-				var newValue = CoerceValueBetween(m_uncoercedValue, min, newMax);
-				if (newValue != Value)
-				{
-					SetValue(ValueProperty, newValue);
-				}
+				//var newValue = CoerceValueBetween(m_uncoercedValue, min, newMax);
+				//if (newValue != Value)
+				//{
+				//	SetValue(ValueProperty, newValue);
+				//}
 
 				// set maximum
 				// SetMaximum(newMax);


### PR DESCRIPTION
**GitHub Issue:** closes #22884

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

When `Value` is set before `Maximum` (e.g. when `Maximum` comes from a Style applied after the local `Value`), `Value` is incorrectly coerced against the stale `Maximum`.

Root cause: inside `SetRangeBaseValue(MaximumProperty)`, calling `SetValue(ValueProperty, newValue)` triggers Value's coercion callback again — but at that point the new `Maximum` is not yet committed (we are still inside `ApplyCoercion`). So `Value` gets clamped to the old `[min, oldMax]` range and stays stale.

## What is the new behavior? 🚀

The `SetValue(ValueProperty, …)` calls inside `SetRangeBaseValue` for the `Minimum`/`Maximum` cases are removed. Instead, `OnRangeChanged` is registered as the property-changed callback for both `MinimumProperty` and `MaximumProperty`. It fires **after** the new bound is fully committed, reads the current `m_uncoercedValue`, compares the correctly-clamped result against the current `Value`, and triggers `CoerceValue(ValueProperty)` only when a correction is needed.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Two runtime tests cover the regression (`When_ValueSet_BeforeMaximum_WillBe_Recoerced_ProgressBar` and `When_ValueSet_BeforeMaximum_WillBe_Recoerced_Slider`). Both are excluded from `NativeWinUI` since the fix is Uno-specific (WinUI does not have this timing issue).