### PR TITLE
fix(RadioButtons): selection reset on unload for android-native

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioButton.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioButton.cs
@@ -363,7 +363,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid)]
 		public async Task When_RadioButtons_Unload_SelectedIndex()
 		{
 			var vm = new When_RadioButtons_Unload_VM
@@ -439,7 +438,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid)]
 		public async Task When_RadioButtons_Unload_SelectedItem()
 		{
 			var vm = new When_RadioButtons_Unload_VM();

--- a/src/Uno.UI/UI/Xaml/Controls/RadioButtons/RadioButtons.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/RadioButtons/RadioButtons.cs
@@ -340,7 +340,7 @@ namespace Microsoft.UI.Xaml.Controls
 						// Only reset selection if the item was actually removed from the source.
 						// When the repeater unloads, Uno sends a fake Reset to mark containers as recyclable,
 						// but the source is unchanged and selection should be preserved.
-						if (IsInLiveTree)
+						if (IsLoaded && IsInLiveTree)
 #endif
 						{
 							Select(-1);


### PR DESCRIPTION
**GitHub Issue:** re: https://github.com/unoplatform/uno/issues/9080#issuecomment-4224043555

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
recently introduced When_RadioButtons_Unload_SelectedIndex and ..._SelectedItem tests from #22964 are failing on android-native

## What is the new behavior? 🚀
^ no more

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes