### PR TITLE
test: Verify DateTimeFormatter tolerates unsupported preferred-language codes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
@@ -136,4 +136,21 @@ public class Given_DateTimeFormatter
 			Assert.AreEqual(expected, formattedTime, $"Mismatch for template: {template}");
 		}
 	}
+
+	// Reproduction for https://github.com/unoplatform/uno/issues/12423
+	// On iOS, when the device's preferred languages list combines a language
+	// with a region that isn't a real culture (e.g. preferred language "it"
+	// with region "US" can surface as "it-US"), CalendarDatePicker fails to
+	// construct because DateTimeFormatter eagerly calls `new CultureInfo(...)`
+	// on each language string and throws CultureNotFoundException. This is
+	// exercised cross-platform via the (language-list) constructor overload.
+	[TestMethod]
+	public void When_Languages_Contains_Unsupported_Culture_Should_Not_Throw_12423()
+	{
+		var formatter = new DateTimeFormatter("longdate", new[] { "it-US", "en-US" });
+
+		Assert.IsNotNull(formatter);
+		var formatted = formatter.Format(new DateTimeOffset(2024, 1, 15, 0, 0, 0, TimeSpan.Zero));
+		Assert.IsFalse(string.IsNullOrEmpty(formatted), "Formatter should produce a non-empty string even when the preferred language is unsupported.");
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
@@ -145,6 +145,7 @@ public class Given_DateTimeFormatter
 	// on each language string and throws CultureNotFoundException. This is
 	// exercised cross-platform via the (language-list) constructor overload.
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/12423")]
 	public void When_Languages_Contains_Unsupported_Culture_Should_Not_Throw_12423()
 	{
 		var formatter = new DateTimeFormatter("longdate", new[] { "it-US", "en-US" });

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
@@ -228,6 +228,7 @@ public class Given_DateTimeFormatter
 	// on each language string and throws CultureNotFoundException. This is
 	// exercised cross-platform via the (language-list) constructor overload.
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/12423")]
 	public void When_Languages_Contains_Unsupported_Culture_Should_Not_Throw_12423()
 	{
 		var formatter = new DateTimeFormatter("longdate", new[] { "it-US", "en-US" });

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
@@ -219,4 +219,21 @@ public class Given_DateTimeFormatter
 
 		Assert.AreEqual("longtime", formatter.Template);
 	}
+
+	// Reproduction for https://github.com/unoplatform/uno/issues/12423
+	// On iOS, when the device's preferred languages list combines a language
+	// with a region that isn't a real culture (e.g. preferred language "it"
+	// with region "US" can surface as "it-US"), CalendarDatePicker fails to
+	// construct because DateTimeFormatter eagerly calls `new CultureInfo(...)`
+	// on each language string and throws CultureNotFoundException. This is
+	// exercised cross-platform via the (language-list) constructor overload.
+	[TestMethod]
+	public void When_Languages_Contains_Unsupported_Culture_Should_Not_Throw_12423()
+	{
+		var formatter = new DateTimeFormatter("longdate", new[] { "it-US", "en-US" });
+
+		Assert.IsNotNull(formatter);
+		var formatted = formatter.Format(new DateTimeOffset(2024, 1, 15, 0, 0, 0, TimeSpan.Zero));
+		Assert.IsFalse(string.IsNullOrEmpty(formatted), "Formatter should produce a non-empty string even when the preferred language is unsupported.");
+	}
 }


### PR DESCRIPTION
Closes #12423

## Summary

Issue #12423 reports that `CalendarDatePicker` crashes on iOS when the device's Preferred Languages list combines a language with a region whose product isn't a real culture (e.g. preferred "Italian" + region "United States" surfaced as `it-US`). The reported stack goes through `DateTimeFormatter`'s internal `new CultureInfo(Languages[0])` which threw `CultureNotFoundException`.

This test exercises the cross-platform language-list constructor with `"it-US"` in the list and asserts that the formatter constructs and produces a non-empty formatted string.

The test **passes on current master (Skia Desktop target)**.

### Test(s) added
- `src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs` → `Given_DateTimeFormatter.When_Languages_Contains_Unsupported_Culture_Should_Not_Throw_12423`

### Notes
The issue was reported on **iOS** (Xamarin.iOS, Uno 4.8.39). The crash path depends on the iOS mono runtime's stricter `CultureInfo` handling. Validation on native iOS with the exact language configuration is still recommended.