### PR TITLE
test: Verify custom Dictionary subclass compiles when used in XAML resources

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs
@@ -185,4 +185,60 @@ public class Given_ResourceDictionary
 
 		await Verify.AssertXamlGenerator(test);
 	}
+
+	// Reproduction for https://github.com/unoplatform/uno/issues/13373
+	// Custom Dictionary subclass declared in XAML produces invalid Add(...) calls
+	// because the generator picks the IDictionary base method that requires
+	// (key, value) but emits only the value, surfacing as CS7036.
+	[TestMethod]
+	public async Task When_Custom_Dictionary_Class_Used_In_XAML_13373()
+	{
+		var xamlFile = new XamlFile(
+			"MainPage.xaml",
+			"""
+			<Page
+				x:Class="TestRepro.MainPage"
+				xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="using:TestRepro">
+
+				<Page.Resources>
+					<local:MyDictionary x:Key="MyDict">
+						<x:String x:Key="One">One</x:String>
+						<x:String x:Key="Two">Two</x:String>
+					</local:MyDictionary>
+				</Page.Resources>
+			</Page>
+			""");
+
+		var test = new Verify.Test(xamlFile)
+		{
+			TestState =
+			{
+				Sources =
+				{
+					"""
+					using System.Collections.Generic;
+					using Microsoft.UI.Xaml.Controls;
+
+					namespace TestRepro
+					{
+						public sealed partial class MainPage : Page
+						{
+							public MainPage()
+							{
+								this.InitializeComponent();
+							}
+						}
+
+						public class MyDictionary : Dictionary<string, string> { }
+					}
+					"""
+				}
+			}
+		};
+		test.TestBehaviors |= TestBehaviors.SkipGeneratedSourcesCheck;
+
+		await test.RunAsync();
+	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs
@@ -259,4 +259,60 @@ public class Given_ResourceDictionary
 
 		await Verify.AssertXamlGenerator(test);
 	}
+
+	// Reproduction for https://github.com/unoplatform/uno/issues/13373
+	// Custom Dictionary subclass declared in XAML produces invalid Add(...) calls
+	// because the generator picks the IDictionary base method that requires
+	// (key, value) but emits only the value, surfacing as CS7036.
+	[TestMethod]
+	public async Task When_Custom_Dictionary_Class_Used_In_XAML_13373()
+	{
+		var xamlFile = new XamlFile(
+			"MainPage.xaml",
+			"""
+			<Page
+				x:Class="TestRepro.MainPage"
+				xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				xmlns:local="using:TestRepro">
+
+				<Page.Resources>
+					<local:MyDictionary x:Key="MyDict">
+						<x:String x:Key="One">One</x:String>
+						<x:String x:Key="Two">Two</x:String>
+					</local:MyDictionary>
+				</Page.Resources>
+			</Page>
+			""");
+
+		var test = new Verify.Test(xamlFile)
+		{
+			TestState =
+			{
+				Sources =
+				{
+					"""
+					using System.Collections.Generic;
+					using Microsoft.UI.Xaml.Controls;
+
+					namespace TestRepro
+					{
+						public sealed partial class MainPage : Page
+						{
+							public MainPage()
+							{
+								this.InitializeComponent();
+							}
+						}
+
+						public class MyDictionary : Dictionary<string, string> { }
+					}
+					"""
+				}
+			}
+		};
+		test.TestBehaviors |= TestBehaviors.SkipGeneratedSourcesCheck;
+
+		await test.RunAsync();
+	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs
@@ -262,8 +262,8 @@ public class Given_ResourceDictionary
 
 	// Reproduction for https://github.com/unoplatform/uno/issues/13373
 	// Custom Dictionary subclass declared in XAML produces invalid Add(...) calls
-	// because the generator picks the IDictionary base method that requires
-	// (key, value) but emits only the value, surfacing as CS7036.
+	// because the generator targets the IDictionary Add that requires (key, value)
+	// but omits the key, emitting a single-argument Add(value) call, surfacing as CS7036.
 	[TestMethod]
 	public async Task When_Custom_Dictionary_Class_Used_In_XAML_13373()
 	{


### PR DESCRIPTION
Closes #13373

## Summary

Issue #13373 reports that a custom `Dictionary<string, string>` subclass used as a XAML resource produced `error CS7036: There is no argument given that corresponds to the required parameter 'value' of 'Dictionary<string, string>.Add(string, string)'` from the generated code.

The test sets up exactly that scenario (`MyDictionary : Dictionary<string, string>` filled with `<x:String x:Key="...">` entries) and asserts the XAML generator produces compiling code.

The test **passes on current master** — the generator now emits a valid `Add(key, value)` call for custom dictionary subclasses.

### Test(s) added
- `src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_ResourceDictionary.cs` → `Given_ResourceDictionary.When_Custom_Dictionary_Class_Used_In_XAML_13373`