### PR TITLE
test: Verify OneWay x:Bind on ListView.ItemsSource preserves the source collection

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.XBindOneWayItemsSourceTests
+{
+	using Uno.UI.RuntimeTests.Tests;
+
+	[TestClass]
+	public class Given_XBindOneWayItemsSource_13433
+	{
+		// Reproduction for https://github.com/unoplatform/uno/issues/13433
+		// {x:Bind Items, Mode=OneWay} on ListView.ItemsSource was reported to
+		// reset/clear the source-side property if a setter is available, so the
+		// list ends up empty even though Items had data. Removing Mode=OneWay
+		// (the workaround) avoids the issue.
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_OneWay_xBind_To_ItemsSource_Items_Are_Visible_13433()
+		{
+			var page = new XBindOneWayItemsSourcePage_13433();
+			WindowHelper.WindowContent = page;
+			await WindowHelper.WaitForLoaded(page);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsNotNull(page.Items, "Page.Items should not have been reset to null by the OneWay binding.");
+			Assert.AreEqual(3, page.Items.Count, "Page.Items should still hold the 3 initial entries.");
+			Assert.AreEqual(
+				3,
+				page.ItemsListView.Items.Count,
+				"ListView should display the 3 items from the source. " +
+				"See https://github.com/unoplatform/uno/issues/13433");
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
@@ -7,11 +7,7 @@ namespace Uno.UI.RuntimeTests.Tests;
 [TestClass]
 public class Given_XBindOneWayItemsSource_13433
 {
-	// Reproduction for https://github.com/unoplatform/uno/issues/13433
-	// {x:Bind Items, Mode=OneWay} on ListView.ItemsSource was reported to
-	// reset/clear the source-side property if a setter is available, so the
-	// list ends up empty even though Items had data. Removing Mode=OneWay
-	// (the workaround) avoids the issue.
+	// Repro: Mode=OneWay x:Bind on ItemsSource was reported to clear the source property when it has a setter.
 	[TestMethod]
 	[RunsOnUIThread]
 	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/13433")]
@@ -19,6 +15,7 @@ public class Given_XBindOneWayItemsSource_13433
 	{
 		var page = new XBindOneWayItemsSourcePage_13433();
 		await UITestHelper.Load(page);
+		await UITestHelper.WaitForIdle();
 
 		Assert.IsNotNull(page.Items, "Page.Items should not have been reset to null by the OneWay binding.");
 		Assert.AreEqual(3, page.Items.Count, "Page.Items should still hold the 3 initial entries.");

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
@@ -15,7 +15,6 @@ public class Given_XBindOneWayItemsSource_13433
 	{
 		var page = new XBindOneWayItemsSourcePage_13433();
 		await UITestHelper.Load(page);
-		await UITestHelper.WaitForIdle();
 
 		Assert.IsNotNull(page.Items, "Page.Items should not have been reset to null by the OneWay binding.");
 		Assert.AreEqual(3, page.Items.Count, "Page.Items should still hold the 3 initial entries.");

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs
@@ -1,36 +1,31 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Helpers;
-using static Private.Infrastructure.TestServices;
 
-namespace Uno.UI.RuntimeTests.Tests.XBindOneWayItemsSourceTests
+namespace Uno.UI.RuntimeTests.Tests;
+
+[TestClass]
+public class Given_XBindOneWayItemsSource_13433
 {
-	using Uno.UI.RuntimeTests.Tests;
-
-	[TestClass]
-	public class Given_XBindOneWayItemsSource_13433
+	// Reproduction for https://github.com/unoplatform/uno/issues/13433
+	// {x:Bind Items, Mode=OneWay} on ListView.ItemsSource was reported to
+	// reset/clear the source-side property if a setter is available, so the
+	// list ends up empty even though Items had data. Removing Mode=OneWay
+	// (the workaround) avoids the issue.
+	[TestMethod]
+	[RunsOnUIThread]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/13433")]
+	public async Task When_OneWay_xBind_To_ItemsSource_Items_Are_Visible_13433()
 	{
-		// Reproduction for https://github.com/unoplatform/uno/issues/13433
-		// {x:Bind Items, Mode=OneWay} on ListView.ItemsSource was reported to
-		// reset/clear the source-side property if a setter is available, so the
-		// list ends up empty even though Items had data. Removing Mode=OneWay
-		// (the workaround) avoids the issue.
-		[TestMethod]
-		[RunsOnUIThread]
-		public async Task When_OneWay_xBind_To_ItemsSource_Items_Are_Visible_13433()
-		{
-			var page = new XBindOneWayItemsSourcePage_13433();
-			WindowHelper.WindowContent = page;
-			await WindowHelper.WaitForLoaded(page);
-			await WindowHelper.WaitForIdle();
+		var page = new XBindOneWayItemsSourcePage_13433();
+		await UITestHelper.Load(page);
 
-			Assert.IsNotNull(page.Items, "Page.Items should not have been reset to null by the OneWay binding.");
-			Assert.AreEqual(3, page.Items.Count, "Page.Items should still hold the 3 initial entries.");
-			Assert.AreEqual(
-				3,
-				page.ItemsListView.Items.Count,
-				"ListView should display the 3 items from the source. " +
-				"See https://github.com/unoplatform/uno/issues/13433");
-		}
+		Assert.IsNotNull(page.Items, "Page.Items should not have been reset to null by the OneWay binding.");
+		Assert.AreEqual(3, page.Items.Count, "Page.Items should still hold the 3 initial entries.");
+		Assert.AreEqual(
+			3,
+			page.ItemsListView.Items.Count,
+			"ListView should display the 3 items from the source. " +
+			"See https://github.com/unoplatform/uno/issues/13433");
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml
@@ -1,0 +1,11 @@
+<Page x:Class="Uno.UI.RuntimeTests.Tests.XBindOneWayItemsSourcePage_13433"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ListView x:Name="SUT" ItemsSource="{x:Bind Items, Mode=OneWay}">
+        <ListView.ItemTemplate>
+            <DataTemplate x:DataType="x:String">
+                <TextBlock Text="{x:Bind}" />
+            </DataTemplate>
+        </ListView.ItemTemplate>
+    </ListView>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml.cs
@@ -1,0 +1,17 @@
+using System.Collections.ObjectModel;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests
+{
+	public sealed partial class XBindOneWayItemsSourcePage_13433 : Page
+	{
+		public ObservableCollection<string> Items { get; set; } = new ObservableCollection<string> { "a", "b", "c" };
+
+		public XBindOneWayItemsSourcePage_13433()
+		{
+			this.InitializeComponent();
+		}
+
+		public ListView ItemsListView => SUT;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml.cs
@@ -1,17 +1,16 @@
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml.Controls;
 
-namespace Uno.UI.RuntimeTests.Tests
+namespace Uno.UI.RuntimeTests.Tests;
+
+public sealed partial class XBindOneWayItemsSourcePage_13433 : Page
 {
-	public sealed partial class XBindOneWayItemsSourcePage_13433 : Page
+	public ObservableCollection<string> Items { get; set; } = new ObservableCollection<string> { "a", "b", "c" };
+
+	public XBindOneWayItemsSourcePage_13433()
 	{
-		public ObservableCollection<string> Items { get; set; } = new ObservableCollection<string> { "a", "b", "c" };
-
-		public XBindOneWayItemsSourcePage_13433()
-		{
-			this.InitializeComponent();
-		}
-
-		public ListView ItemsListView => SUT;
+		this.InitializeComponent();
 	}
+
+	public ListView ItemsListView => SUT;
 }


### PR DESCRIPTION
Closes #13433

## Summary

Issue #13433 reports that `<ListView ItemsSource="{x:Bind Items, Mode=OneWay}">` on **Android (7.0) and WASM** results in an empty ListView even though the source `ObservableCollection<T> Items { get; set; }` was non-empty — apparently the OneWay binding ends up resetting the source-side property because it has a setter. Workaround was to drop `Mode=OneWay`.

This test reproduces the exact scenario (`x:Bind` OneWay on `ItemsSource`, source property has a setter, source initialised in constructor with 3 items) and asserts both that the source survives binding evaluation and that the `ListView` displays all 3 items.

The test **passes on current master (Skia Desktop target)**.

### Test(s) added
- `src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindOneWayItemsSourcePage_13433.xaml` (+ `.xaml.cs`)
- `src/Uno.UI.RuntimeTests/Tests/BindingTests/Given_XBindOneWayItemsSource_13433.cs` → `Given_XBindOneWayItemsSource_13433.When_OneWay_xBind_To_ItemsSource_Items_Are_Visible_13433`

### Notes
The issue was reported on **Android (7.0)** and **WASM (Firefox)**. Runtime tests run on Skia only — verification on native Android and WASM is still recommended.