### PR TITLE
test: Verify FlipView with StackPanel ItemsPanel auto-sizes to content

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.StackPanelItemsPanel_13944.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.StackPanelItemsPanel_13944.cs
@@ -1,0 +1,70 @@
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_FlipView_StackPanelItemsPanel_13944
+	{
+		// Reproduction for https://github.com/unoplatform/uno/issues/13944
+		// Setting <FlipView.ItemsPanel> to a horizontal StackPanel was reported to:
+		//   - throw on iOS
+		//   - render with wrong layout on Android
+		//   - render nothing on Skia / WASM
+		// Each FlipViewItem has a fixed Height=500. WinUI auto-sizes the FlipView
+		// to that height; Uno renders nothing on Skia.
+		[TestMethod]
+		public async Task When_FlipView_Has_StackPanel_ItemsPanel_13944()
+		{
+			var template = (ItemsPanelTemplate)XamlReader.Load(
+				"""
+				<ItemsPanelTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+					<StackPanel Orientation="Horizontal" />
+				</ItemsPanelTemplate>
+				""");
+
+			var flipView = new FlipView
+			{
+				ItemsPanel = template,
+				HorizontalAlignment = HorizontalAlignment.Stretch,
+				VerticalAlignment = VerticalAlignment.Top,
+			};
+
+			for (var i = 0; i < 3; i++)
+			{
+				flipView.Items.Add(new FlipViewItem
+				{
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.LightBlue),
+						Height = 500,
+						Child = new TextBlock { Text = $"Item {i}" },
+					},
+				});
+			}
+
+			var host = new StackPanel { Children = { flipView } };
+
+			WindowHelper.WindowContent = host;
+			await WindowHelper.WaitForLoaded(host);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(
+				flipView.IsLoaded,
+				"FlipView should load when its ItemsPanel is a StackPanel.");
+
+			Assert.IsTrue(
+				flipView.ActualHeight > 0,
+				$"FlipView should auto-size to its content height (Item Border Height=500). Actual={flipView.ActualHeight}. " +
+				$"See https://github.com/unoplatform/uno/issues/13944");
+		}
+	}
+}


### PR DESCRIPTION
Closes #13944

## Summary

Issue #13944 reports that setting `<FlipView.ItemsPanel>` to a horizontal `StackPanel` throws on iOS, renders with broken layout on Android, and renders nothing on Skia/WASM (vs. WinUI which auto-sizes to the items' fixed Height=500).

The test wires up the same shape (FlipView with three FlipViewItems each containing a 500-px-tall Border, hosted in an outer StackPanel) and asserts the `FlipView.IsLoaded` and `FlipView.ActualHeight > 0`.

The test **passes on current master (Skia Desktop target)**.

### Test(s) added
- `src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.StackPanelItemsPanel_13944.cs` → `Given_FlipView_StackPanelItemsPanel_13944.When_FlipView_Has_StackPanel_ItemsPanel_13944`

### Notes
The issue was reported on **iOS**, **Android**, **Skia (GTK)**, and **WASM**. Runtime tests run on Skia only — verification of the iOS exception and Android layout still needs to happen on the native targets.