### PR TITLE
fix: replace TargetFrameworkVersion with GetTargetFrameworkVersion

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
@@ -33,7 +33,7 @@
 
 		<UnoEnableDefaultCompressedItems Condition=" '$(UnoEnableDefaultCompressedItems)' == '' ">true</UnoEnableDefaultCompressedItems>
 		<!-- based on https://github.com/dotnet/sdk/blob/be30c95a22d25aaedaed184ee4d188c5e31218c8/src/StaticWebAssetsSdk/Targets/Microsoft.NET.Sdk.StaticWebAssets.Compression.targets#L25 -->
-		<CompressionIncludePatterns Condition="'$(UnoEnableDefaultCompressedItems)' == 'true' AND '$(TargetFrameworkVersion)'!='' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '9.0'))">
+		<CompressionIncludePatterns Condition="'$(UnoEnableDefaultCompressedItems)' == 'true' AND '$(TargetFramework)' != '' AND $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) != '' AND $([MSBuild]::VersionGreaterThanOrEquals($([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')), '9.0'))">
 			$(CompressionIncludePatterns);
 			**/*.ttf;
 			**/*.woff;


### PR DESCRIPTION
**GitHub Issue:** closes #22506

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

`$(TargetFrameworkVersion)` is not set when Uno SDK targets are evaluated — Uno imports its targets before `Microsoft.NET.TargetFrameworkInference.targets` (by design, so Uno targets run first). As a result, any condition that references `$(TargetFrameworkVersion)` evaluates against an empty string.

Affected files and their impact:
- `Uno.SingleProject.Wasm.targets`: TTF/WOFF/WOFF2 font files are never added to `CompressionIncludePatterns`, so they are never compressed in WASM builds (fixes #22506).

## What is the new behavior? 🚀

Replace `$(TargetFrameworkVersion)` with `$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))`, which derives the version directly from the `$(TargetFramework)` moniker (e.g. `net10.0`). This property is always available at evaluation time, matching the pattern already used correctly in `Uno.Common.MacCatalyst.targets`.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

The fix is a pure MSBuild expression substitution — no behavioral change when targeting .NET 9+. The `GetTargetFrameworkVersion` function is a built-in MSBuild intrinsic available in all supported MSBuild versions.