### PR TITLE
fix: Win32 a11y provider to support automation peer resolution

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -300,6 +300,12 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 	{
 		if (_providers.TryGetValue(element, out var provider))
 		{
+			// A provider can briefly remain alive after removal (e.g. pending structure
+			// notifications or external UIA/COM references). Clear any cached peer lists
+			// first so a stale provider cannot keep the removed subtree alive.
+			provider.InvalidateChildrenCache();
+			_pendingStructureChanges.Remove(provider);
+
 			_providers.Remove(element);
 			if (provider.RepresentedPeer is { } representedPeer)
 			{

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -298,39 +298,46 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 
 	private void CleanupProviders(UIElement element)
 	{
-		if (_providers.TryGetValue(element, out var provider))
+		// Use an explicit stack instead of recursion to prevent StackOverflow
+		// on deep visual trees when subtrees are removed.
+		var stack = new Stack<UIElement>();
+		stack.Push(element);
+
+		while (stack.Count > 0)
 		{
-			// A provider can briefly remain alive after removal (e.g. pending structure
-			// notifications or external UIA/COM references). Clear any cached peer lists
-			// first so a stale provider cannot keep the removed subtree alive.
-			provider.InvalidateChildrenCache();
-			_pendingStructureChanges.Remove(provider);
+			var current = stack.Pop();
 
-			_providers.Remove(element);
-			if (provider.RepresentedPeer is { } representedPeer)
+			if (_providers.TryGetValue(current, out var provider))
 			{
-				_peerProviders.Remove(representedPeer);
-			}
+				// Clear cached peer lists so a stale provider cannot keep the
+				// removed subtree alive.
+				provider.InvalidateChildrenCache();
+				_pendingStructureChanges.Remove(provider);
 
-			// Disconnect the provider from UIA so stale COM references are released.
-			// This matches WinUI3's CUIAWrapper::Invalidate() which calls
-			// UiaDisconnectProvider(this) when the automation peer is destroyed.
-			try
-			{
-				_ = Win32UIAutomationInterop.UiaDisconnectProvider(provider);
-			}
-			catch (Exception ex)
-			{
-				if (this.Log().IsEnabled(LogLevel.Debug))
+				_providers.Remove(current);
+				if (provider.RepresentedPeer is { } representedPeer)
 				{
-					this.Log().Debug($"UiaDisconnectProvider failed for {provider.DescribeElement()}: {ex.Message}");
+					_peerProviders.Remove(representedPeer);
+				}
+
+				// Disconnect the provider from UIA so stale COM references are released.
+				try
+				{
+					_ = Win32UIAutomationInterop.UiaDisconnectProvider(provider);
+				}
+				catch (Exception ex)
+				{
+					if (this.Log().IsEnabled(LogLevel.Debug))
+					{
+						this.Log().Debug($"UiaDisconnectProvider failed for {provider.DescribeElement()}: {ex.Message}");
+					}
 				}
 			}
-		}
 
-		foreach (var child in element.GetChildren())
-		{
-			CleanupProviders(child);
+			foreach (var child in current.GetChildren())
+			{
+				stack.Push(child);
+			}
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -27,6 +27,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 	private bool _accessibilityTreeInitialized;
 	private Win32RawElementProvider? _rootProvider;
 	private readonly ConditionalWeakTable<UIElement, Win32RawElementProvider> _providers = new();
+	private readonly ConditionalWeakTable<AutomationPeer, Win32RawElementProvider> _peerProviders = new();
 	private DispatcherQueue? _dispatcherQueue;
 	private readonly HashSet<Win32RawElementProvider> _pendingStructureChanges = new();
 
@@ -100,12 +101,16 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 		}
 
 		// Create root provider only; child providers are created lazily during navigation.
-		_rootProvider = new Win32RawElementProvider(rootElement, _hwnd, isRoot: true, this);
+		var rootPeer = rootElement.GetOrCreateAutomationPeer()?.ResolveProviderPeer(resolveEventsSource: true);
+		_rootProvider = new Win32RawElementProvider(rootElement, _hwnd, isRoot: true, this, rootPeer);
 		_providers.AddOrUpdate(rootElement, _rootProvider);
+		if (rootPeer is not null)
+		{
+			_peerProviders.AddOrUpdate(rootPeer, _rootProvider);
+		}
 		_dispatcherQueue = rootElement.DispatcherQueue;
 		_accessibilityTreeInitialized = true;
 
-		var rootPeer = rootElement.GetOrCreateAutomationPeer();
 		if (this.Log().IsEnabled(LogLevel.Information))
 		{
 			this.Log().Info(
@@ -172,7 +177,6 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 			return null;
 		}
 
-		// Only create providers for elements with automation peers
 		var peer = element.GetOrCreateAutomationPeer();
 		if (peer is null)
 		{
@@ -183,15 +187,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 			return null;
 		}
 
-		var provider = new Win32RawElementProvider(element, _hwnd, isRoot: false, this);
-		_providers.AddOrUpdate(element, provider);
-
-		if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"[UIA] Created provider for {provider.DescribeElement()} (peer={peer.GetType().Name})");
-		}
-
-		return provider;
+		return GetOrCreateProviderForResolvedPeer(peer.ResolveProviderPeer(resolveEventsSource: true));
 	}
 
 	/// <summary>
@@ -202,32 +198,65 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 	/// </summary>
 	internal Win32RawElementProvider? GetProviderForPeer(AutomationPeer peer, bool resolveEventsSource = false)
 	{
-		var resolvedPeer = peer;
-
-		if (resolveEventsSource)
-		{
-			var eventsSource = peer.GetAPEventsSource();
-			if (eventsSource is not null)
-			{
-				resolvedPeer = eventsSource;
-			}
-		}
-
-		if (TryGetPeerOwner(resolvedPeer, out var element))
-		{
-			return GetOrCreateProvider(element);
-		}
-
-		if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"[UIA] GetProviderForPeer: Could not resolve owner for {resolvedPeer.GetType().Name}");
-		}
-		return null;
+		return GetOrCreateProviderForResolvedPeer(peer.ResolveProviderPeer(resolveEventsSource));
 	}
 
 	internal Win32RawElementProvider? GetProvider(UIElement element)
 	{
-		_providers.TryGetValue(element, out var provider);
+		if (_providers.TryGetValue(element, out var provider))
+		{
+			return provider;
+		}
+
+		var peer = element.GetOrCreateAutomationPeer();
+		return peer is null
+			? null
+			: GetOrCreateProviderForResolvedPeer(peer.ResolveProviderPeer(resolveEventsSource: true));
+	}
+
+	private Win32RawElementProvider? GetOrCreateProviderForResolvedPeer(AutomationPeer resolvedPeer)
+	{
+		if (!resolvedPeer.TryGetProviderOwner(out var element))
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"[UIA] GetProviderForPeer: Could not resolve owner for {resolvedPeer.GetType().Name}");
+			}
+			return null;
+		}
+
+		var canonicalPeer = element.GetOrCreateAutomationPeer()?.ResolveProviderPeer(resolveEventsSource: true) ?? resolvedPeer;
+		if (!canonicalPeer.TryGetProviderOwner(out element))
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"[UIA] GetProviderForPeer: Canonical owner resolution failed for {canonicalPeer.GetType().Name}");
+			}
+			return null;
+		}
+
+		if (_providers.TryGetValue(element, out var existingByElement)
+			&& existingByElement.RepresentsPeer(canonicalPeer))
+		{
+			_peerProviders.AddOrUpdate(canonicalPeer, existingByElement);
+			return existingByElement;
+		}
+
+		if (_peerProviders.TryGetValue(canonicalPeer, out var existingByPeer))
+		{
+			_providers.AddOrUpdate(element, existingByPeer);
+			return existingByPeer;
+		}
+
+		var provider = new Win32RawElementProvider(element, _hwnd, isRoot: false, this, canonicalPeer);
+		_providers.AddOrUpdate(element, provider);
+		_peerProviders.AddOrUpdate(canonicalPeer, provider);
+
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			this.Log().Debug($"[UIA] Created provider for {provider.DescribeElement()} (peer={canonicalPeer.GetType().Name})");
+		}
+
 		return provider;
 	}
 
@@ -272,6 +301,10 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 		if (_providers.TryGetValue(element, out var provider))
 		{
 			_providers.Remove(element);
+			if (provider.RepresentedPeer is { } representedPeer)
+			{
+				_peerProviders.Remove(representedPeer);
+			}
 
 			// Disconnect the provider from UIA so stale COM references are released.
 			// This matches WinUI3's CUIAWrapper::Invalidate() which calls
@@ -395,37 +428,19 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 	// Helpers
 
 	internal static bool TryGetPeerOwner(AutomationPeer peer, [NotNullWhen(true)] out UIElement? owner)
-	{
-		if (peer is FrameworkElementAutomationPeer { Owner: { } element })
-		{
-			owner = element;
-			return true;
-		}
-
-		if (peer is ItemAutomationPeer itemPeer)
-		{
-			var parent = itemPeer.GetParent();
-			if (parent is FrameworkElementAutomationPeer { Owner: { } parentElement })
-			{
-				owner = parentElement;
-				return true;
-			}
-		}
-
-		owner = null;
-		return false;
-	}
+		=> peer.TryGetProviderOwner(out owner);
 
 	// IAutomationPeerListener
 
 	public void NotifyPropertyChangedEvent(AutomationPeer peer, AutomationProperty automationProperty, object oldValue, object newValue)
 	{
-		if (!IsAccessibilityEnabled || !TryGetPeerOwner(peer, out var owner))
+		if (!IsAccessibilityEnabled)
 		{
 			return;
 		}
 
-		if (!_providers.TryGetValue(owner, out var provider))
+		var provider = GetProviderForPeer(peer, resolveEventsSource: true);
+		if (provider is null)
 		{
 			return;
 		}
@@ -452,25 +467,15 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 
 	public void NotifyAutomationEvent(AutomationPeer peer, AutomationEvents eventId)
 	{
-		if (!IsAccessibilityEnabled || !TryGetPeerOwner(peer, out var owner))
+		if (!IsAccessibilityEnabled)
 		{
 			return;
 		}
 
-		// For focus and live region changes, ensure a provider exists so Narrator
-		// can track focus or announce the live region content. Non-focusable
-		// elements like TextBlocks won't have a provider created until needed.
-		if (!_providers.TryGetValue(owner, out var provider))
+		var provider = GetProviderForPeer(peer, resolveEventsSource: true);
+		if (provider is null)
 		{
-			if (eventId is AutomationEvents.AutomationFocusChanged or AutomationEvents.LiveRegionChanged)
-			{
-				provider = GetOrCreateProvider(owner);
-			}
-
-			if (provider is null)
-			{
-				return;
-			}
+			return;
 		}
 
 		try
@@ -536,7 +541,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 					var label = peer.GetName();
 					if (!string.IsNullOrEmpty(label))
 					{
-						var liveSetting = AutomationProperties.GetLiveSetting(owner);
+						var liveSetting = AutomationProperties.GetLiveSetting(provider.Owner);
 						if (liveSetting == AutomationLiveSetting.Assertive)
 						{
 							AnnounceAssertive(label);
@@ -567,7 +572,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 
 		// Use specific provider if available, otherwise fall back to root
 		IRawElementProviderSimple? target = _rootProvider;
-		if (TryGetPeerOwner(peer, out var owner) && _providers.TryGetValue(owner, out var elementProvider))
+		if (GetProviderForPeer(peer, resolveEventsSource: true) is { } elementProvider)
 		{
 			target = elementProvider;
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -436,6 +436,30 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 	internal static bool TryGetPeerOwner(AutomationPeer peer, [NotNullWhen(true)] out UIElement? owner)
 		=> peer.TryGetProviderOwner(out owner);
 
+	/// <summary>
+	/// Looks up an existing provider for the given peer without creating one.
+	/// Used by event notification methods to avoid eagerly creating providers
+	/// for elements that UIA hasn't navigated to yet — creating providers in
+	/// event paths registers COM callable wrappers with UIA, which hold strong
+	/// references and prevent GC of the underlying UIElements.
+	/// </summary>
+	private Win32RawElementProvider? FindExistingProviderForPeer(AutomationPeer peer, bool resolveEventsSource = false)
+	{
+		var resolvedPeer = peer.ResolveProviderPeer(resolveEventsSource);
+
+		if (_peerProviders.TryGetValue(resolvedPeer, out var providerByPeer))
+		{
+			return providerByPeer;
+		}
+
+		if (resolvedPeer.TryGetProviderOwner(out var element) && _providers.TryGetValue(element, out var providerByElement))
+		{
+			return providerByElement;
+		}
+
+		return null;
+	}
+
 	// IAutomationPeerListener
 
 	public void NotifyPropertyChangedEvent(AutomationPeer peer, AutomationProperty automationProperty, object oldValue, object newValue)
@@ -445,7 +469,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 			return;
 		}
 
-		var provider = GetProviderForPeer(peer, resolveEventsSource: true);
+		var provider = FindExistingProviderForPeer(peer, resolveEventsSource: true);
 		if (provider is null)
 		{
 			return;
@@ -478,10 +502,22 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 			return;
 		}
 
-		var provider = GetProviderForPeer(peer, resolveEventsSource: true);
+		// Only look up existing providers for most events — eagerly creating
+		// providers registers COM callable wrappers with UIA that prevent GC.
+		// For focus and live region changes, create a provider so Narrator
+		// can track focus or announce live region content.
+		var provider = FindExistingProviderForPeer(peer, resolveEventsSource: true);
 		if (provider is null)
 		{
-			return;
+			if (eventId is AutomationEvents.AutomationFocusChanged or AutomationEvents.LiveRegionChanged)
+			{
+				provider = GetProviderForPeer(peer, resolveEventsSource: true);
+			}
+
+			if (provider is null)
+			{
+				return;
+			}
 		}
 
 		try
@@ -578,7 +614,7 @@ internal class Win32Accessibility : IUnoAccessibility, IAutomationPeerListener
 
 		// Use specific provider if available, otherwise fall back to root
 		IRawElementProviderSimple? target = _rootProvider;
-		if (GetProviderForPeer(peer, resolveEventsSource: true) is { } elementProvider)
+		if (FindExistingProviderForPeer(peer, resolveEventsSource: true) is { } elementProvider)
 		{
 			target = elementProvider;
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -35,12 +35,12 @@ internal class Win32RawElementProvider :
 	private readonly int _runtimeId;
 	private readonly bool _isRoot;
 	private readonly Win32Accessibility _accessibility;
-	private readonly AutomationPeer? _representedPeer;
+	private readonly WeakReference<AutomationPeer>? _representedPeer;
 	private IList<AutomationPeer>? _cachedAutomationChildren;
 	private const int MaxHitTestDepth = 1024;
 
 	internal UIElement Owner => _owner;
-	internal AutomationPeer? RepresentedPeer => _representedPeer;
+	internal AutomationPeer? RepresentedPeer => _representedPeer is not null && _representedPeer.TryGetTarget(out var peer) ? peer : null;
 
 	internal Win32RawElementProvider(
 		UIElement owner,
@@ -53,7 +53,7 @@ internal class Win32RawElementProvider :
 		_hwnd = hwnd;
 		_isRoot = isRoot;
 		_accessibility = accessibility;
-		_representedPeer = representedPeer;
+		_representedPeer = representedPeer is not null ? new WeakReference<AutomationPeer>(representedPeer) : null;
 		_runtimeId = _nextRuntimeId++;
 	}
 
@@ -995,8 +995,9 @@ internal class Win32RawElementProvider :
 
 	internal string DescribeElement()
 	{
-		var typeName = _representedPeer is not null && _representedPeer is not FrameworkElementAutomationPeer
-			? $"{_representedPeer.GetType().Name}->{_owner.GetType().Name}"
+		var resolvedPeer = _representedPeer is not null && _representedPeer.TryGetTarget(out var rp) ? rp : null;
+		var typeName = resolvedPeer is not null && resolvedPeer is not FrameworkElementAutomationPeer
+			? $"{resolvedPeer.GetType().Name}->{_owner.GetType().Name}"
 			: _owner.GetType().Name;
 		var automationId = AutomationProperties.GetAutomationId(_owner);
 		var name = AutomationProperties.GetName(_owner);
@@ -1111,7 +1112,8 @@ internal class Win32RawElementProvider :
 	}
 
 	private AutomationPeer? GetAutomationPeer()
-		=> _representedPeer ?? _owner.GetOrCreateAutomationPeer();
+		=> (_representedPeer is not null && _representedPeer.TryGetTarget(out var peer) ? peer : null)
+			?? _owner.GetOrCreateAutomationPeer();
 
 	private bool ContainsPoint(double screenX, double screenY)
 	{

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -498,6 +498,16 @@ internal class Win32RawElementProvider :
 
 	private static void CollectAutomationPeers(UIElement element, List<AutomationPeer> result)
 	{
+		CollectAutomationPeers(element, result, 0);
+	}
+
+	private static void CollectAutomationPeers(UIElement element, List<AutomationPeer> result, int depth)
+	{
+		if (depth > MaxHitTestDepth)
+		{
+			return;
+		}
+
 		foreach (var child in element.GetChildren())
 		{
 			if (child.Visibility == Visibility.Collapsed)
@@ -513,7 +523,7 @@ internal class Win32RawElementProvider :
 			else
 			{
 				// No peer on this element - flatten by recursing into its children
-				CollectAutomationPeers(child, result);
+				CollectAutomationPeers(child, result, depth + 1);
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -35,22 +35,30 @@ internal class Win32RawElementProvider :
 	private readonly int _runtimeId;
 	private readonly bool _isRoot;
 	private readonly Win32Accessibility _accessibility;
+	private readonly AutomationPeer? _representedPeer;
 	private IList<AutomationPeer>? _cachedAutomationChildren;
+	private const int MaxHitTestDepth = 1024;
 
 	internal UIElement Owner => _owner;
+	internal AutomationPeer? RepresentedPeer => _representedPeer;
 
 	internal Win32RawElementProvider(
 		UIElement owner,
 		nint hwnd,
 		bool isRoot,
-		Win32Accessibility accessibility)
+		Win32Accessibility accessibility,
+		AutomationPeer? representedPeer = null)
 	{
 		_owner = owner;
 		_hwnd = hwnd;
 		_isRoot = isRoot;
 		_accessibility = accessibility;
+		_representedPeer = representedPeer;
 		_runtimeId = _nextRuntimeId++;
 	}
+
+	internal bool RepresentsPeer(AutomationPeer peer)
+		=> ReferenceEquals(GetAutomationPeer(), peer);
 
 	// IRawElementProviderSimple
 
@@ -61,7 +69,7 @@ internal class Win32RawElementProvider :
 	{
 		try
 		{
-			var peer = _owner.GetOrCreateAutomationPeer();
+			var peer = GetAutomationPeer();
 			if (peer is null)
 			{
 				return null;
@@ -130,7 +138,7 @@ internal class Win32RawElementProvider :
 	{
 		try
 		{
-			var peer = _owner.GetOrCreateAutomationPeer();
+			var peer = GetAutomationPeer();
 
 			object? result = propertyId switch
 			{
@@ -345,7 +353,7 @@ internal class Win32RawElementProvider :
 		else
 		{
 			// For non-Control elements, try to set focus via the automation peer
-			_owner.GetOrCreateAutomationPeer()?.SetFocus();
+			GetAutomationPeer()?.SetFocus();
 		}
 	}
 
@@ -395,10 +403,14 @@ internal class Win32RawElementProvider :
 			var focusedElement = FocusManager.GetFocusedElement(xamlRoot);
 			if (focusedElement is UIElement uiElement)
 			{
-				// Return the provider for the focused element, or its nearest ancestor
-				// that has an automation peer
-				var result = _accessibility.GetOrCreateProvider(uiElement)
-					?? FindNearestProviderAncestor(uiElement);
+				var focusedPeer = uiElement.GetOrCreateAutomationPeer();
+
+				// Return the provider for the focused element's effective automation peer,
+				// or its nearest ancestor that has an automation peer.
+				var result = focusedPeer is not null
+					? _accessibility.GetProviderForPeer(focusedPeer, resolveEventsSource: true)
+						?? FindNearestProviderAncestor(uiElement)
+					: FindNearestProviderAncestor(uiElement);
 
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
@@ -443,7 +455,7 @@ internal class Win32RawElementProvider :
 			return _cachedAutomationChildren;
 		}
 
-		var peer = _owner.GetOrCreateAutomationPeer();
+		var peer = GetAutomationPeer();
 		IList<AutomationPeer>? result;
 
 		if (peer is not null)
@@ -517,7 +529,7 @@ internal class Win32RawElementProvider :
 		for (var i = 0; i < children.Count; i++)
 		{
 			var provider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
-			if (provider is not null)
+			if (provider is not null && !ReferenceEquals(provider, this))
 			{
 				return provider;
 			}
@@ -536,7 +548,7 @@ internal class Win32RawElementProvider :
 		for (var i = children.Count - 1; i >= 0; i--)
 		{
 			var provider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
-			if (provider is not null)
+			if (provider is not null && !ReferenceEquals(provider, this))
 			{
 				return provider;
 			}
@@ -558,7 +570,7 @@ internal class Win32RawElementProvider :
 			return null;
 		}
 
-		var myPeer = _owner.GetOrCreateAutomationPeer();
+		var myPeer = GetAutomationPeer();
 		var foundSelf = false;
 
 		for (var i = 0; i < siblings.Count; i++)
@@ -566,7 +578,7 @@ internal class Win32RawElementProvider :
 			if (foundSelf)
 			{
 				var provider = _accessibility.GetProviderForPeer(siblings[i], resolveEventsSource: true);
-				if (provider is not null)
+				if (provider is not null && !ReferenceEquals(provider, this))
 				{
 					return provider;
 				}
@@ -593,7 +605,7 @@ internal class Win32RawElementProvider :
 			return null;
 		}
 
-		var myPeer = _owner.GetOrCreateAutomationPeer();
+		var myPeer = GetAutomationPeer();
 		Win32RawElementProvider? previous = null;
 
 		for (var i = 0; i < siblings.Count; i++)
@@ -603,7 +615,7 @@ internal class Win32RawElementProvider :
 				return previous;
 			}
 			var provider = _accessibility.GetProviderForPeer(siblings[i], resolveEventsSource: true);
-			if (provider is not null)
+			if (provider is not null && !ReferenceEquals(provider, this))
 			{
 				previous = provider;
 			}
@@ -629,7 +641,7 @@ internal class Win32RawElementProvider :
 		// First, try the automation peer tree. This is the correct path for
 		// ItemAutomationPeer and other peers whose logical parent differs
 		// from the visual parent.
-		var myPeer = _owner.GetOrCreateAutomationPeer();
+		var myPeer = GetAutomationPeer();
 		if (myPeer?.GetParent() is { } parentPeer)
 		{
 			var parentProvider = _accessibility.GetProviderForPeer(parentPeer);
@@ -714,7 +726,28 @@ internal class Win32RawElementProvider :
 	// Hit testing helper
 
 	private Win32RawElementProvider? FindDeepestProviderAtPoint(double screenX, double screenY)
+		=> FindDeepestProviderAtPoint(screenX, screenY, new HashSet<Win32RawElementProvider>(), 0);
+
+	private Win32RawElementProvider? FindDeepestProviderAtPoint(double screenX, double screenY, HashSet<Win32RawElementProvider> visited, int depth)
 	{
+		if (!visited.Add(this))
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"[UIA] Hit-test cycle detected at {DescribeElement()}");
+			}
+			return null;
+		}
+
+		if (depth > MaxHitTestDepth)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"[UIA] Hit-test depth limit exceeded at {DescribeElement()}");
+			}
+			return null;
+		}
+
 		// Use the automation children (filtered tree) for hit testing
 		var children = GetAutomationChildren();
 		if (children is not null)
@@ -723,9 +756,9 @@ internal class Win32RawElementProvider :
 			for (var i = children.Count - 1; i >= 0; i--)
 			{
 				var childProvider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
-				if (childProvider is not null)
+				if (childProvider is not null && !ReferenceEquals(childProvider, this))
 				{
-					var found = childProvider.FindDeepestProviderAtPoint(screenX, screenY);
+					var found = childProvider.FindDeepestProviderAtPoint(screenX, screenY, visited, depth + 1);
 					if (found is not null)
 					{
 						return found;
@@ -735,9 +768,7 @@ internal class Win32RawElementProvider :
 		}
 
 		// Check if point is within this element's bounds
-		var bounds = BoundingRectangle;
-		if (screenX >= bounds.Left && screenX < bounds.Left + bounds.Width &&
-			screenY >= bounds.Top && screenY < bounds.Top + bounds.Height)
+		if (ContainsPoint(screenX, screenY))
 		{
 			return this;
 		}
@@ -964,7 +995,9 @@ internal class Win32RawElementProvider :
 
 	internal string DescribeElement()
 	{
-		var typeName = _owner.GetType().Name;
+		var typeName = _representedPeer is not null && _representedPeer is not FrameworkElementAutomationPeer
+			? $"{_representedPeer.GetType().Name}->{_owner.GetType().Name}"
+			: _owner.GetType().Name;
 		var automationId = AutomationProperties.GetAutomationId(_owner);
 		var name = AutomationProperties.GetName(_owner);
 		var details = !string.IsNullOrEmpty(automationId) ? automationId
@@ -1075,5 +1108,17 @@ internal class Win32RawElementProvider :
 			ancestor = ancestor.GetParent() as UIElement;
 		}
 		return rect;
+	}
+
+	private AutomationPeer? GetAutomationPeer()
+		=> _representedPeer ?? _owner.GetOrCreateAutomationPeer();
+
+	private bool ContainsPoint(double screenX, double screenY)
+	{
+		var bounds = BoundingRectangle;
+		return screenX >= bounds.Left
+			&& screenX < bounds.Left + bounds.Width
+			&& screenY >= bounds.Top
+			&& screenY < bounds.Top + bounds.Height;
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Automation/Given_AutomationPeerProviderTargets.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Automation/Given_AutomationPeerProviderTargets.cs
@@ -1,0 +1,85 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Helpers;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Automation;
+
+[TestClass]
+public class Given_AutomationPeerProviderTargets
+{
+	[TestInitialize]
+	public void Init() => UnitTestsApp.App.EnsureApplication();
+
+	[TestMethod]
+	public void When_ListViewItem_EventsSource_Resolved_Then_ItemPeer_Is_Preserved()
+	{
+		var listView = CreateListView("One");
+		var container = (ListViewItem)listView.ContainerFromIndex(0);
+		var containerPeer = FrameworkElementAutomationPeer.CreatePeerForElement(container);
+
+		Assert.IsNotNull(containerPeer, "Container peer should exist for the realized ListViewItem.");
+
+		var resolvedPeer = containerPeer.ResolveProviderPeer(resolveEventsSource: true);
+
+		Assert.AreNotSame(containerPeer, resolvedPeer, "List item containers should resolve to their data/item automation peer.");
+		Assert.IsInstanceOfType(resolvedPeer, typeof(ItemAutomationPeer));
+		Assert.IsTrue(resolvedPeer.TryGetProviderOwner(out var owner));
+		Assert.AreSame(container, owner, "The resolved item peer should stay anchored to its realized container.");
+	}
+
+	[TestMethod]
+	public void When_ListViewChildren_Are_Resolved_Then_ProviderOwners_Are_DistinctContainers()
+	{
+		var listView = CreateListView("One", "Two");
+		var listPeer = FrameworkElementAutomationPeer.CreatePeerForElement(listView);
+
+		Assert.IsNotNull(listPeer, "ListView peer should exist after loading the control.");
+
+		var children = listPeer.GetChildren();
+		Assert.IsNotNull(children, "ListView should expose item peers in its automation children.");
+		Assert.AreEqual(2, children.Count);
+
+		var firstResolvedPeer = children[0].ResolveProviderPeer(resolveEventsSource: true);
+		var secondResolvedPeer = children[1].ResolveProviderPeer(resolveEventsSource: true);
+
+		Assert.IsTrue(firstResolvedPeer.TryGetProviderOwner(out var firstOwner));
+		Assert.IsTrue(secondResolvedPeer.TryGetProviderOwner(out var secondOwner));
+
+		Assert.AreSame(listView.ContainerFromIndex(0), firstOwner);
+		Assert.AreSame(listView.ContainerFromIndex(1), secondOwner);
+		Assert.AreNotSame(firstOwner, secondOwner, "Distinct item peers must resolve to distinct container anchors.");
+	}
+
+	private static ListView CreateListView(params string[] items)
+	{
+		var listView = new ListView
+		{
+			Template = new ControlTemplate(() => new ItemsPresenter()),
+			ItemsPanel = new ItemsPanelTemplate(() => new StackPanel()),
+			ItemContainerStyle = BuildBasicContainerStyle(),
+			ItemsSource = items,
+		};
+
+		listView.ForceLoaded();
+		return listView;
+	}
+
+	private static Style BuildBasicContainerStyle() => XamlHelper.LoadXaml<Style>("""
+		<Style TargetType="ListViewItem">
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate>
+						<Grid>
+							<ContentPresenter
+								ContentTemplate="{Binding Path=ContentTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+								Content="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}}"
+								/>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+		""");
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Automation/Given_AutomationPeerProviderTargets.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Automation/Given_AutomationPeerProviderTargets.cs
@@ -17,6 +17,12 @@ public class Given_AutomationPeerProviderTargets
 	{
 		var listView = CreateListView("One");
 		var container = (ListViewItem)listView.ContainerFromIndex(0);
+
+		// Drive the automation tree so EventsSource is wired on container peers.
+		// ListView lacks an OnCreateAutomationPeer override, so construct directly.
+		var listPeer = new ListViewAutomationPeer(listView);
+		listPeer.GetChildren();
+
 		var containerPeer = FrameworkElementAutomationPeer.CreatePeerForElement(container);
 
 		Assert.IsNotNull(containerPeer, "Container peer should exist for the realized ListViewItem.");
@@ -33,7 +39,9 @@ public class Given_AutomationPeerProviderTargets
 	public void When_ListViewChildren_Are_Resolved_Then_ProviderOwners_Are_DistinctContainers()
 	{
 		var listView = CreateListView("One", "Two");
-		var listPeer = FrameworkElementAutomationPeer.CreatePeerForElement(listView);
+
+		// ListView lacks an OnCreateAutomationPeer override, so construct directly.
+		var listPeer = new ListViewAutomationPeer(listView);
 
 		Assert.IsNotNull(listPeer, "ListView peer should exist after loading the control.");
 

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.ProviderTargets.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.ProviderTargets.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Xaml.Automation.Peers;
+
+partial class AutomationPeer
+{
+	internal AutomationPeer ResolveProviderPeer(bool resolveEventsSource)
+	{
+		if (resolveEventsSource && GetAPEventsSource() is { } eventsSource)
+		{
+			return eventsSource;
+		}
+
+		return this;
+	}
+
+	internal bool TryGetProviderOwner([NotNullWhen(true)] out UIElement? owner)
+	{
+		switch (this)
+		{
+			case FrameworkElementAutomationPeer { Owner: { } element }:
+				owner = element;
+				return true;
+
+			case ItemAutomationPeer itemPeer when itemPeer.GetContainer() is { } container:
+				owner = container;
+				return true;
+
+			default:
+				owner = null;
+				return false;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.mux.cs
@@ -19,6 +19,10 @@ partial class AutomationPeer
 	// Cached events source for ListItem/TabItem/TreeItem control types
 	private AutomationPeer? _eventsSource;
 
+	// Re-entrancy guard for GetAPEventsSource. Prevents StackOverflow when
+	// Navigate(Parent) triggers peer creation that calls GetAPEventsSource again.
+	private bool _isResolvingEventsSource;
+
 	//------------------------------------------------------------------------
 	//
 	//  Method:   GetAPEventsSource
@@ -32,6 +36,13 @@ partial class AutomationPeer
 	//------------------------------------------------------------------------
 	internal AutomationPeer? GetAPEventsSource()
 	{
+		// Guard against re-entrancy: Navigate(Parent) may trigger peer creation
+		// that calls GetAPEventsSource again on the same peer.
+		if (_isResolvingEventsSource)
+		{
+			return _eventsSource ?? EventsSource;
+		}
+
 		var controlType = GetAutomationControlType();
 
 		// Only generate EventsSource for ListItem, TabItem, and TreeItem control types
@@ -39,29 +50,37 @@ partial class AutomationPeer
 			controlType == AutomationControlType.TabItem ||
 			controlType == AutomationControlType.TreeItem)
 		{
-			// Navigate to parent to generate EventsSource
-			var parent = Navigate(AutomationNavigationDirection.Parent) as AutomationPeer;
-
-			if (parent is not null && this is FrameworkElementAutomationPeer)
+			_isResolvingEventsSource = true;
+			try
 			{
-				// Generate the events source using the parent
-				GenerateAutomationPeerEventsSource(parent);
+				// Navigate to parent to generate EventsSource
+				var parent = Navigate(AutomationNavigationDirection.Parent) as AutomationPeer;
 
-				if (_eventsSource is not null)
+				if (parent is not null && this is FrameworkElementAutomationPeer)
 				{
-					// This code path exists for one reason: for ListViewItems we need to make sure that
-					// their DataAutomationPeers, which are the EventsSource for the actual FrameworkElement
-					// derived AutomationPeers, return the correct parent. In List/ListItem peer implementations
-					// we hide all the controls between the ListViewItem and the ListView control.
-					//
-					// We make sure here that if m_pAPParent is already set, we leave it alone and don't override it.
-					// That indicates external code is trying to set the parent on a data automation peer.
-					// If not we perform this call, which does the same thing, but for internal automation peers.
-					if (!_eventsSource.HasParent())
+					// Generate the events source using the parent
+					GenerateAutomationPeerEventsSource(parent);
+
+					if (_eventsSource is not null)
 					{
-						_eventsSource.SetParent(parent);
+						// This code path exists for one reason: for ListViewItems we need to make sure that
+						// their DataAutomationPeers, which are the EventsSource for the actual FrameworkElement
+						// derived AutomationPeers, return the correct parent. In List/ListItem peer implementations
+						// we hide all the controls between the ListViewItem and the ListView control.
+						//
+						// We make sure here that if m_pAPParent is already set, we leave it alone and don't override it.
+						// That indicates external code is trying to set the parent on a data automation peer.
+						// If not we perform this call, which does the same thing, but for internal automation peers.
+						if (!_eventsSource.HasParent())
+						{
+							_eventsSource.SetParent(parent);
+						}
 					}
 				}
+			}
+			finally
+			{
+				_isResolvingEventsSource = false;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/FrameworkElementAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/FrameworkElementAutomationPeer.cs
@@ -34,6 +34,13 @@ public partial class FrameworkElementAutomationPeer : AutomationPeer
 
 	private AutomationControlType m_ControlType;
 
+	// Recursion guard for GetNameCore → GetLabeledBy → GetName cycle.
+	// Prevents StackOverflowException when elements have circular LabeledBy references.
+	[ThreadStatic]
+	private static HashSet<AutomationPeer> t_peersResolvingName;
+
+	private const int MaxAutomationTreeDepth = 512;
+
 	public UIElement Owner { get; }
 
 	public FrameworkElementAutomationPeer() { }
@@ -155,10 +162,20 @@ public partial class FrameworkElementAutomationPeer : AutomationPeer
 
 	private void GetAutomationPeerChildren(UIElement element, List<AutomationPeer> children)
 	{
+		GetAutomationPeerChildren(element, children, 0);
+	}
+
+	private void GetAutomationPeerChildren(UIElement element, List<AutomationPeer> children, int depth)
+	{
 		//UNO TODO: Properly implement GetAutomationPeerChildren on FrameworkElementAutomationPeer
 		//Temporarily disabled as android, ios, macos doesn't use UIElement
 
 #if !__ANDROID__ && !__APPLE_UIKIT__
+		if (depth > MaxAutomationTreeDepth)
+		{
+			return;
+		}
+
 		var childCount = element.GetChildren().Count;
 		if (childCount > 0)
 		{
@@ -177,7 +194,7 @@ public partial class FrameworkElementAutomationPeer : AutomationPeer
 					}
 					else
 					{
-						GetAutomationPeerChildren(spChild, children);
+						GetAutomationPeerChildren(spChild, children, depth + 1);
 					}
 				}
 			}
@@ -264,9 +281,23 @@ public partial class FrameworkElementAutomationPeer : AutomationPeer
 			return name;
 		}
 
-		if (GetLabeledBy() is AutomationPeer labelAutomationPeer && labelAutomationPeer.GetName() is string label && !string.IsNullOrEmpty(label))
+		// Guard against circular LabeledBy references (A→B→A) which would cause
+		// StackOverflowException. Track which peers are currently resolving their
+		// name so we can break cycles.
+		var resolving = t_peersResolvingName ??= new HashSet<AutomationPeer>(ReferenceEqualityComparer.Instance);
+		if (resolving.Add(this))
 		{
-			return label;
+			try
+			{
+				if (GetLabeledBy() is AutomationPeer labelAutomationPeer && labelAutomationPeer.GetName() is string label && !string.IsNullOrEmpty(label))
+				{
+					return label;
+				}
+			}
+			finally
+			{
+				resolving.Remove(this);
+			}
 		}
 
 		if ((Owner as FrameworkElement)?.GetPlainText() is string plainText && !string.IsNullOrEmpty(plainText))

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/FrameworkElementAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/FrameworkElementAutomationPeer.cs
@@ -39,7 +39,9 @@ public partial class FrameworkElementAutomationPeer : AutomationPeer
 	[ThreadStatic]
 	private static HashSet<AutomationPeer> t_peersResolvingName;
 
+#if !__ANDROID__ && !__APPLE_UIKIT__
 	private const int MaxAutomationTreeDepth = 512;
+#endif
 
 	public UIElement Owner { get; }
 


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

This pull request significantly refactors and improves the accessibility infrastructure in the Win32 backend, focusing on more robust mapping and management between UI elements, automation peers, and their providers. The changes introduce a dual-mapping system to handle edge cases, improve provider creation and lookup, and enhance hit-testing reliability.

**Key improvements and refactoring:**

### Provider and Peer Management Enhancements

* Introduced a `ConditionalWeakTable` (`_peerProviders`) to map `AutomationPeer` instances to their corresponding `Win32RawElementProvider`, enabling more reliable and efficient provider lookups and preventing duplicate providers for the same peer. 
* Refactored provider creation and lookup logic to always resolve the canonical automation peer and ensure consistent provider reuse, including in cases involving event sources or peer ownership resolution.
* Updated provider cleanup to remove entries from both element and peer maps, preventing stale references.
* Made `Win32RawElementProvider` aware of its represented peer and added a `RepresentsPeer` method for accurate identity checks.

### Event Notification and Property Change Handling

* Centralized and simplified event notification logic to always resolve the correct provider for a peer, ensuring events are dispatched to the appropriate target and supporting cases where the provider may not yet exist.

### Provider and Peer Relationship Consistency

* Replaced direct peer-owner resolution logic with a unified `TryGetProviderOwner` helper, improving code clarity and correctness.
* Ensured that all provider lookups and creations use the resolved peer, reducing inconsistencies and bugs related to event sources or indirect peer relationships.

### Hit-Testing and Navigation Robustness

* Enhanced hit-testing logic to prevent cycles and stack overflows by tracking visited providers and enforcing a maximum recursion depth.
* Improved navigation among providers to avoid returning self-references and ensure correct traversal of the accessibility tree.

### Diagnostics and Debugging

* Improved logging and diagnostics for provider creation, peer resolution, and hit-testing, making it easier to trace and debug accessibility infrastructure issues.

These changes collectively make the accessibility layer more robust, maintainable, and correct, especially for complex UI structures and advanced automation scenarios.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->