### PR TITLE
fix: Sync Themes.Active with resolved app theme during initialization

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_AppBrushes.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_AppBrushes.xaml
@@ -1,0 +1,46 @@
+<ResourceDictionary x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.MergedAppResources_ThemeResource_Test_AppBrushes"
+					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					mc:Ignorable="d">
+
+	<!--
+		A single ResourceDictionary intended to be merged into Application.Resources
+		that contains BOTH ThemeDictionaries-scoped entries and top-level (non-theme)
+		entries, consumed via {ThemeResource} from both direct property assignments
+		and Style Setters living in a separate merged dictionary.
+	-->
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<SolidColorBrush x:Key="MergedRegression_ThemedBrush"
+							 Color="#FFFFFF" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Dark">
+			<SolidColorBrush x:Key="MergedRegression_ThemedBrush"
+							 Color="#16181A" />
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+
+	<!-- Root-level (non-themed) resources, same dictionary file as the ThemeDictionaries above -->
+	<LinearGradientBrush x:Key="MergedRegression_RootGradientBrush"
+						 StartPoint="0,0.5"
+						 EndPoint="1,0.5">
+		<GradientStop Color="#FF7A67F8"
+					  Offset="0" />
+		<GradientStop Color="#FF159BFF"
+					  Offset="1" />
+	</LinearGradientBrush>
+
+	<!-- Style whose Setters reference the ThemeResources above -->
+	<Style x:Key="MergedRegression_ButtonStyle"
+		   TargetType="Button">
+		<Setter Property="Background"
+				Value="{ThemeResource MergedRegression_ThemedBrush}" />
+		<Setter Property="BorderBrush"
+				Value="{ThemeResource MergedRegression_RootGradientBrush}" />
+		<Setter Property="BorderThickness"
+				Value="1" />
+	</Style>
+</ResourceDictionary>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_AppBrushes.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_AppBrushes.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+
+public sealed partial class MergedAppResources_ThemeResource_Test_AppBrushes : ResourceDictionary
+{
+	public MergedAppResources_ThemeResource_Test_AppBrushes()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_ButtonStyles.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_ButtonStyles.xaml
@@ -1,0 +1,32 @@
+<ResourceDictionary x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.MergedAppResources_ThemeResource_Test_ButtonStyles"
+					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+					mc:Ignorable="d">
+
+	<!--
+		Separate merged dictionary for the Style so that Setters in this dictionary
+		reference ThemeResources defined in a SIBLING merged dictionary
+		(MergedAppResources_ThemeResource_Test_AppBrushes), exercising the shape
+		where a Style file and a brushes file are two sibling entries in
+		Application.Resources.MergedDictionaries.
+	-->
+	<Style x:Key="MergedRegression_BaseButtonStyle"
+		   TargetType="Button">
+		<Setter Property="BorderThickness"
+				Value="1" />
+		<Setter Property="Height"
+				Value="40" />
+	</Style>
+
+	<Style x:Key="MergedRegression_ButtonStyleCrossDict"
+		   TargetType="Button"
+		   BasedOn="{StaticResource MergedRegression_BaseButtonStyle}">
+		<Setter Property="Background"
+				Value="{ThemeResource MergedRegression_ThemedBrush}" />
+		<Setter Property="BorderBrush"
+				Value="{ThemeResource MergedRegression_RootGradientBrush}" />
+	</Style>
+</ResourceDictionary>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_ButtonStyles.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_ButtonStyles.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+
+public sealed partial class MergedAppResources_ThemeResource_Test_ButtonStyles : ResourceDictionary
+{
+	public MergedAppResources_ThemeResource_Test_ButtonStyles()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_View.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_View.xaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.MergedAppResources_ThemeResource_Test_View"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+	<StackPanel Spacing="8">
+		<!-- Direct property consumers, matching ChatInputBox.xaml:70,88 -->
+		<Border x:Name="DirectBorder"
+				Width="200"
+				Height="50"
+				Background="{ThemeResource MergedRegression_ThemedBrush}"
+				BorderBrush="{ThemeResource MergedRegression_RootGradientBrush}"
+				BorderThickness="1" />
+
+		<!-- Style Setter consumers, matching Button.xaml SuggestionButtonStyle -->
+		<Button x:Name="StyledButton"
+				Style="{StaticResource MergedRegression_ButtonStyle}"
+				Width="200"
+				Height="50"
+				Content="Styled" />
+
+		<!-- Same pattern, but the Style lives in a DIFFERENT merged dictionary than the brushes -->
+		<Button x:Name="CrossDictStyledButton"
+				Style="{StaticResource MergedRegression_ButtonStyleCrossDict}"
+				Width="200"
+				Height="50"
+				Content="Cross-dict styled" />
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_View.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/MergedAppResources_ThemeResource_Test_View.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+
+public sealed partial class MergedAppResources_ThemeResource_Test_View : UserControl
+{
+	public MergedAppResources_ThemeResource_Test_View()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_MergedAppResources_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_MergedAppResources_ThemeResource.cs
@@ -1,0 +1,77 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_MergedAppResources_ThemeResource
+{
+	[TestMethod]
+	public async Task When_MergedAppResource_ThemeResource_On_Direct_Property_And_Setter()
+	{
+		using (StyleHelper.UseAppLevelResources(new MergedAppResources_ThemeResource_Test_AppBrushes()))
+		using (StyleHelper.UseAppLevelResources(new MergedAppResources_ThemeResource_Test_ButtonStyles()))
+		{
+			var view = new MergedAppResources_ThemeResource_Test_View
+			{
+				RequestedTheme = ElementTheme.Dark
+			};
+
+			WindowHelper.WindowContent = view;
+			await WindowHelper.WaitForLoaded(view);
+			await WindowHelper.WaitForIdle();
+
+			var directBorder = (Border)view.FindName("DirectBorder");
+			var styledButton = (Button)view.FindName("StyledButton");
+			var crossDictButton = (Button)view.FindName("CrossDictStyledButton");
+
+			Assert.IsNotNull(directBorder.Background);
+			Assert.IsNotNull(directBorder.BorderBrush);
+			Assert.IsInstanceOfType(directBorder.BorderBrush, typeof(LinearGradientBrush));
+
+			Assert.IsNotNull(styledButton.Background);
+			Assert.IsNotNull(styledButton.BorderBrush);
+			Assert.IsInstanceOfType(styledButton.BorderBrush, typeof(LinearGradientBrush));
+
+			Assert.IsNotNull(crossDictButton.Background);
+			Assert.IsNotNull(crossDictButton.BorderBrush);
+			Assert.IsInstanceOfType(crossDictButton.BorderBrush, typeof(LinearGradientBrush));
+		}
+	}
+
+	[TestMethod]
+	public async Task When_MergedAppResource_ThemeResource_Tracks_Theme_Change()
+	{
+		using (StyleHelper.UseAppLevelResources(new MergedAppResources_ThemeResource_Test_AppBrushes()))
+		{
+			var view = new MergedAppResources_ThemeResource_Test_View
+			{
+				RequestedTheme = ElementTheme.Light
+			};
+
+			WindowHelper.WindowContent = view;
+			await WindowHelper.WaitForLoaded(view);
+			await WindowHelper.WaitForIdle();
+
+			var directBorder = (Border)view.FindName("DirectBorder");
+
+			var lightBrush = directBorder.Background as SolidColorBrush;
+			Assert.IsNotNull(lightBrush);
+			Assert.AreEqual(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF), lightBrush.Color);
+
+			view.RequestedTheme = ElementTheme.Dark;
+			await WindowHelper.WaitForIdle();
+
+			var darkBrush = directBorder.Background as SolidColorBrush;
+			Assert.IsNotNull(darkBrush);
+			Assert.AreEqual(Color.FromArgb(0xFF, 0x16, 0x18, 0x1A), darkBrush.Color);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_MergedAppResources_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_MergedAppResources_ThemeResource.cs
@@ -47,6 +47,7 @@ public class Given_MergedAppResources_ThemeResource
 	}
 
 	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 	public async Task When_MergedAppResource_ThemeResource_Tracks_Theme_Change()
 	{
 		using (StyleHelper.UseAppLevelResources(new MergedAppResources_ThemeResource_Test_AppBrushes()))

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -301,6 +301,85 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			Assert.AreEqual(Colors.DarkSlateBlue, (rd["Blu"] as SolidColorBrush).Color);
 		}
 
+#if !NETFX_CORE
+		// Application's _requestedTheme field defaults to ApplicationTheme.Dark. When
+		// App.xaml declares RequestedTheme="Dark", the equality check in SetRequestedTheme
+		// turns the call into a no-op — which also skips UpdateRequestedThemesForResources,
+		// the only path that syncs ResourceDictionary's Themes.Active. Without the
+		// unconditional sync in InitializeSystemTheme, Themes.Active would stay at its
+		// static initial "Default" while Application.Current.RequestedTheme reports "Dark",
+		// and ThemeDictionary lookups on dicts with only "Light"/"Dark" sub-dictionaries
+		// would resolve against the wrong theme.
+		[TestMethod]
+		public void When_App_RequestedTheme_Matches_Default_InternalRequestedTheme_ThemesActive_Syncs()
+		{
+			UnitTestsApp.App.EnsureApplication();
+
+			var app = Application.Current;
+			var priorActive = ResourceDictionary.GetActiveTheme();
+			var priorRequested = app.RequestedTheme;
+			var priorExplicit = app.IsThemeSetExplicitly;
+
+			try
+			{
+				// Force _requestedTheme back to its default (Dark) to mimic the moment
+				// before App.xaml's RequestedTheme="Dark" is processed.
+				var field = typeof(Application).GetField(
+					"_requestedTheme",
+					System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+				Assert.IsNotNull(field);
+				field.SetValue(app, ApplicationTheme.Dark);
+
+				// Reset IsThemeSetExplicitly via SetExplicitRequestedTheme(null).
+				app.SetExplicitRequestedTheme(null);
+				app.SetExplicitRequestedTheme(null); // ensure IsThemeSetExplicitly=false
+
+				// App.xaml RequestedTheme="Dark" path. Because _requestedTheme is already
+				// Dark, SetRequestedTheme short-circuits and Themes.Active is not synced.
+				app.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+				Assert.IsTrue(app.IsThemeSetExplicitly);
+
+				// Force Themes.Active back to "Default" to mimic the static initial value.
+				ResourceDictionary.SetActiveTheme(new SpecializedResourceDictionary.ResourceKey("Default"));
+
+				// InvokeOnLaunched → InitializeSystemTheme. The fix calls
+				// UpdateRequestedThemesForResources unconditionally so Themes.Active
+				// matches InternalRequestedTheme even on the IsThemeSetExplicitly=true path.
+				app.InitializeSystemTheme();
+
+				Assert.AreEqual("Dark", ResourceDictionary.GetActiveTheme().Key,
+					"InitializeSystemTheme must sync Themes.Active with Application.RequestedTheme. "
+					+ "Regression: SetExplicitRequestedTheme(Dark) is a no-op when "
+					+ "_requestedTheme already defaults to Dark, leaving Themes.Active stale.");
+
+				// End-to-end check: a ThemeDictionary lookup with only Light+Dark entries
+				// must return the Dark sub-dictionary's value under app theme Dark.
+				var rd = new ResourceDictionary();
+				var light = new ResourceDictionary();
+				light["Brushie"] = new SolidColorBrush(Colors.White);
+				var dark = new ResourceDictionary();
+				dark["Brushie"] = new SolidColorBrush(Colors.Black);
+				rd.ThemeDictionaries["Light"] = light;
+				rd.ThemeDictionaries["Dark"] = dark;
+
+				Assert.AreEqual(Colors.Black, ((SolidColorBrush)rd["Brushie"]).Color,
+					"ThemeDictionary lookup should return the Dark entry when Application.RequestedTheme=Dark.");
+			}
+			finally
+			{
+				ResourceDictionary.SetActiveTheme(priorActive);
+				if (priorExplicit)
+				{
+					app.SetExplicitRequestedTheme(priorRequested);
+				}
+				else
+				{
+					app.SetExplicitRequestedTheme(null);
+				}
+			}
+		}
+#endif
+
 		[TestMethod]
 		public void When_Has_Custom_Theme()
 		{

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -151,13 +151,40 @@ namespace Microsoft.UI.Xaml
 
 		internal bool IsSuspended { get; set; }
 
-		private void InitializeSystemTheme()
+		internal void InitializeSystemTheme()
 		{
 			if (!IsThemeSetExplicitly)
 			{
 				// just cache the theme, but do not notify about a change unnecessarily
 				InternalRequestedTheme = GetSystemTheme();
 			}
+
+			// Force-sync ResourceDictionary's static Themes.Active with the application's
+			// resolved theme before any resource lookup can happen at startup.
+			//
+			// Themes.Active is normally updated as a side-effect of the InternalRequestedTheme
+			// setter (via UpdateRequestedThemesForResources). However, there are two startup
+			// paths that can leave Themes.Active at its static default ("Default") while
+			// Application.RequestedTheme reports a real theme:
+			//
+			//   1. App.xaml declares RequestedTheme="Dark" before this method runs.
+			//      SetExplicitRequestedTheme(Dark) -> SetRequestedTheme(Dark) sees that the
+			//      backing field already equals Dark (because _requestedTheme's field default
+			//      is ApplicationTheme.Dark) and short-circuits as a no-op, never invoking
+			//      the InternalRequestedTheme setter.
+			//
+			//   2. IsThemeSetExplicitly was already true when this method is reached, so the
+			//      `if (!IsThemeSetExplicitly)` block above is skipped and the setter never runs.
+			//
+			// In both cases, ThemeDictionary lookups performed while loading Application.Resources
+			// (and the first frames that reference ThemeResource keys) would hit GetActiveTheme()
+			// returning "Default", resolving against the wrong sub-dictionary. For a dictionary
+			// that only defines "Light" and "Dark" sub-dicts, this means the lookup misses
+			// entirely (and potentially poisons KeyNotFoundCache).
+			//
+			// This unconditional call guarantees Themes.Active is coherent with
+			// InternalRequestedTheme by the time the runtime starts consuming resources.
+			UpdateRequestedThemesForResources();
 		}
 
 		private ApplicationTheme InternalRequestedTheme


### PR DESCRIPTION
## Summary

Ensures `ResourceDictionary.Themes.Active` stays in sync with `Application.RequestedTheme` at startup, so `ThemeDictionary` lookups in the first frames after launch resolve against the correct theme.

## The problem

`Application._requestedTheme` has a C# field initializer of `ApplicationTheme.Dark`. When an app declares `<Application RequestedTheme="Dark">` in its XAML, the path is:

```
RequestedTheme setter
  → SetExplicitRequestedTheme(Dark)       // marks IsThemeSetExplicitly = true
     → SetRequestedTheme(Dark)
        → if (Dark != InternalRequestedTheme)  // false — backing field is already Dark
              InternalRequestedTheme = Dark;    //   ← skipped
              OnRequestedThemeChanged();        //   ← skipped
```

The `InternalRequestedTheme` setter is the only code path that calls `UpdateRequestedThemesForResources()`, which in turn updates `ResourceDictionary.Themes.Active`. Skipping it leaves `Themes.Active` at its static initial `"Default"` value.

`InitializeSystemTheme()` would normally cover this case via `if (!IsThemeSetExplicitly) InternalRequestedTheme = GetSystemTheme();`, but when the app has already called `SetExplicitRequestedTheme(...)` earlier during parsing of `App.xaml`, `IsThemeSetExplicitly` is already `true`, so the body is skipped and `Themes.Active` is never touched by either path.

The symptom this produces: resource lookups like `{ThemeResource SomeBrush}` on a dictionary that only defines `"Light"` and `"Dark"` sub-dictionaries resolve to `GetActiveThemeDictionary("Default")` → `null` (no `"Default"` key, no fallback). The brush comes back as the property's default (e.g. transparent for `Background`), and the failed lookup is added to `KeyNotFoundCache`, which can shadow subsequent successful lookups until the cache is invalidated.

## The fix

Call `UpdateRequestedThemesForResources()` unconditionally at the end of `InitializeSystemTheme()`. This guarantees `Themes.Active` matches the resolved theme regardless of which of the two no-op paths was hit — so after startup it's always `"Light"`, `"Dark"`, or a user-provided custom theme key, never the static `"Default"` initial value.

## Test plan

- [x] New unit test `Given_ResourceDictionary.When_App_RequestedTheme_Matches_Default_InternalRequestedTheme_ThemesActive_Syncs` (in `Uno.UI.Tests`) reproduces the regression deterministically on plain .NET — forces the no-op path (`IsThemeSetExplicitly=true`, `_requestedTheme=Dark`, `Themes.Active="Default"`) and asserts `InitializeSystemTheme()` now syncs `Themes.Active` to `"Dark"` plus validates a full `ThemeDictionary` lookup returns the Dark sub-dict. Fails on `master`, passes with the fix.
- [x] Two additional runtime tests in `Given_MergedAppResources_ThemeResource` exercise the shape end-to-end (merged `ResourceDictionary` with `ThemeDictionaries` + root-level brushes, consumed via `{ThemeResource}` on direct properties and via `Style` `Setter`s, with and without theme toggles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)