### PR TITLE
feat(skia): Per-platform render improvements (Android/macOS/X11/WASM)

### DIFF
--- a/src/Uno.UI.Dispatching/Dispatching/DispatcherQueue.cs
+++ b/src/Uno.UI.Dispatching/Dispatching/DispatcherQueue.cs
@@ -67,7 +67,13 @@ namespace Windows.System
 
 		public bool TryEnqueue(DispatcherQueuePriority priority, DispatcherQueueHandler callback)
 		{
-			NativeDispatcher.Main.Enqueue(Unsafe.As<Action>(callback), (NativeDispatcherPriority)(~((int)priority - 11) >> 3));
+			var native = priority switch
+			{
+				DispatcherQueuePriority.High => NativeDispatcherPriority.High,
+				DispatcherQueuePriority.Low => NativeDispatcherPriority.Low,
+				_ => NativeDispatcherPriority.Normal,
+			};
+			NativeDispatcher.Main.Enqueue(Unsafe.As<Action>(callback), native);
 
 			return true;
 		}

--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -1,4 +1,4 @@
-﻿// #define REPORT_FPS
+// #define REPORT_FPS
 
 #nullable enable
 
@@ -27,13 +27,12 @@ namespace Uno.UI.Dispatching
 		{
 			new Queue<Delegate>(), // High
 			new Queue<Delegate>(), // Normal
+			new Queue<Delegate>(), // Render
 			new Queue<Delegate>(), // Low
 			new Queue<Delegate>(), // Idle
 		};
 
 		private readonly object _gate = new();
-
-		private readonly Dictionary<object, (Action? renderAction, int normalItemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
 
 		private NativeDispatcherPriority _currentPriority;
 
@@ -49,9 +48,10 @@ namespace Uno.UI.Dispatching
 			Debug.Assert(
 				(int)NativeDispatcherPriority.High == 0 &&
 				(int)NativeDispatcherPriority.Normal == 1 &&
-				(int)NativeDispatcherPriority.Low == 2 &&
-				(int)NativeDispatcherPriority.Idle == 3 &&
-				Enum.GetValues<NativeDispatcherPriority>().Length == 4);
+				(int)NativeDispatcherPriority.Render == 2 &&
+				(int)NativeDispatcherPriority.Low == 3 &&
+				(int)NativeDispatcherPriority.Idle == 4 &&
+				Enum.GetValues<NativeDispatcherPriority>().Length == 5);
 
 			_currentPriority = NativeDispatcherPriority.Normal;
 
@@ -80,40 +80,27 @@ namespace Uno.UI.Dispatching
 			// We want DispatchItems to be static to avoid delegate allocations.
 			var @this = NativeDispatcher.Main;
 
-			Action? action = @this.TryGetRenderAction();
+			Action? action = null;
 
-			if (action is null)
+			for (var p = 0; p <= 4; p++)
 			{
-				for (var p = 0; p <= 3; p++)
+				var queue = @this._queues[p];
+
+				lock (@this._gate)
 				{
-					var queue = @this._queues[p];
-
-					lock (@this._gate)
+					if (queue.Count > 0)
 					{
-						if (queue.Count > 0)
+						action = Unsafe.As<Action>(queue.Dequeue());
+
+						@this._currentPriority = (NativeDispatcherPriority)p;
+
+						@this.LogTrace()?.Trace($"Running next job in dispatcher queue: priority: {@this._currentPriority} queue states=[{string.Join("] [", @this._queues.Select(q => q.Count))}]");
+						if (Interlocked.Decrement(ref @this._globalCount) > 0)
 						{
-							action = Unsafe.As<Action>(queue.Dequeue());
-
-							@this._currentPriority = (NativeDispatcherPriority)p;
-
-							@this.LogTrace()?.Trace($"Running next job in dispatcher queue: priority: {@this._currentPriority} queue states=[{string.Join("] [", @this._queues.Select(q => q.Count))}]");
-							if (Interlocked.Decrement(ref @this._globalCount) > 0)
-							{
-								@this.EnqueueNative(@this._currentPriority);
-							}
-
-							if (@this._currentPriority == NativeDispatcherPriority.Normal)
-							{
-								foreach (var (compositionTarget, details) in @this._compositionTargets)
-								{
-									if (details.normalItemsToProcessBeforeNextRenderAction > 0)
-									{
-										@this._compositionTargets[compositionTarget] = details with { normalItemsToProcessBeforeNextRenderAction = details.normalItemsToProcessBeforeNextRenderAction - 1 };
-									}
-								}
-							}
-							break;
+							@this.EnqueueNative(@this._currentPriority);
 						}
+
+						break;
 					}
 				}
 			}
@@ -151,65 +138,7 @@ namespace Uno.UI.Dispatching
 				dispatcher.Log().Error("Dispatch queue is empty.");
 			}
 		}
-
-		private Action? TryGetRenderAction()
-		{
-			lock (_gate)
-			{
-				foreach (var (compositionTarget, details) in _compositionTargets)
-				{
-					if (details.renderAction is not null)
-					{
-						if (details.normalItemsToProcessBeforeNextRenderAction == 0)
-						{
-							_compositionTargets[compositionTarget] = (renderAction: null, normalItemsToProcessBeforeNextRenderAction: _queues[(int)NativeDispatcherPriority.Normal].Count);
-
-							_currentPriority = NativeDispatcherPriority.High;
-
-							if (Interlocked.Decrement(ref _globalCount) > 0)
-							{
-								EnqueueNative(_currentPriority);
-							}
-
-							this.LogTrace()?.Trace($"Running render job from the dispatcher: queue states=[{string.Join("] [", _queues.Select(q => q.Count))}]");
-
-							return details.renderAction;
-						}
-					}
-				}
-			}
-
-			return null;
-		}
 #endif
-
-		public void EnqueueRender(object compositionTarget, Action handler)
-		{
-			bool shouldEnqueue = false;
-			lock (_gate)
-			{
-				if (!_compositionTargets.TryGetValue(compositionTarget, out var details))
-				{
-					details = _compositionTargets[compositionTarget] = (null, 0);
-				}
-
-				Debug.Assert(details.renderAction is null);
-				if (details.renderAction is null)
-				{
-					shouldEnqueue = Interlocked.Increment(ref _globalCount) == 1;
-				}
-				_compositionTargets[compositionTarget] = details with
-				{
-					renderAction = handler,
-				};
-			}
-
-			this.LogTrace()?.Trace($"{nameof(EnqueueRender)} : {nameof(shouldEnqueue)}={shouldEnqueue}");
-			if (shouldEnqueue)
-			{
-				EnqueueNative(NativeDispatcherPriority.High);
-			}
-		}
 
 		internal void Enqueue(Action handler, NativeDispatcherPriority priority = NativeDispatcherPriority.Normal)
 		{
@@ -426,7 +355,7 @@ namespace Uno.UI.Dispatching
 
 		private void EnqueueCore(Delegate handler, NativeDispatcherPriority priority)
 		{
-			Debug.Assert((int)priority >= 0 && (int)priority <= 3);
+			Debug.Assert((int)priority >= 0 && (int)priority <= 4);
 
 			bool shouldEnqueue;
 
@@ -485,6 +414,7 @@ namespace Uno.UI.Dispatching
 		internal bool HasThreadAccess => _hasThreadAccess ??= GetHasThreadAccess();
 
 		internal bool IsIdle => _queues[(int)NativeDispatcherPriority.High].Count +
+								_queues[(int)NativeDispatcherPriority.Render].Count +
 								_queues[(int)NativeDispatcherPriority.Normal].Count +
 								_queues[(int)NativeDispatcherPriority.Low].Count == 0;
 

--- a/src/Uno.UI.Dispatching/Native/NativeDispatcherPriority.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcherPriority.cs
@@ -1,10 +1,11 @@
-﻿namespace Uno.UI.Dispatching
+namespace Uno.UI.Dispatching
 {
 	internal enum NativeDispatcherPriority
 	{
 		High = 0,
 		Normal = 1,
-		Low = 2,
-		Idle = 3
+		Render = 2,   // Internal only — below Normal, matches WPF/Avalonia ordering
+		Low = 3,
+		Idle = 4
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -44,6 +44,12 @@ namespace Microsoft.UI.Xaml
 		private bool _isContentViewSet;
 
 		/// <summary>
+		/// Set by the GL thread after the first Skia frame has been rendered.
+		/// Used to keep the splash screen visible until pixels are ready.
+		/// </summary>
+		internal volatile bool FirstFrameRendered;
+
+		/// <summary>
 		/// The windows model implies only one managed activity.
 		/// </summary>
 		internal static ApplicationActivity Instance { get; private set; } = null!;

--- a/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Uno.Foundation.Extensibility;
@@ -16,10 +17,17 @@ internal class AndroidSkiaXamlRootHost : IXamlRootHost
 	private Action? _pendingVsyncAction;
 	private bool _vsyncPosted;
 
+	/// <summary>
+	/// The Choreographer's frameTimeNanos from the most recent VSync callback.
+	/// On .NET Android, this is nanoseconds from CLOCK_MONOTONIC — the same clock
+	/// as <see cref="Stopwatch.GetTimestamp"/> (Stopwatch.Frequency == 1_000_000_000).
+	/// </summary>
+	private long _lastFrameTimeNanos;
+
 	public AndroidSkiaXamlRootHost(XamlRoot xamlRoot)
 	{
 		_choreographer = Choreographer.Instance!;
-		_vsyncCallback = new VsyncCallback(OnVsyncFrame);
+		_vsyncCallback = new VsyncCallback(this);
 
 		XamlRootMap.Register(xamlRoot, this);
 	}
@@ -36,8 +44,15 @@ internal class AndroidSkiaXamlRootHost : IXamlRootHost
 
 	UIElement? IXamlRootHost.RootElement => Window.Current!.RootElement;
 
+	long IXamlRootHost.FrameVsyncTimestamp => _lastFrameTimeNanos;
+
 	void IXamlRootHost.ScheduleFrameCallback(Action callback)
 	{
+		Debug.Assert(
+			_pendingVsyncAction is null || _pendingVsyncAction == callback,
+			"ScheduleFrameCallback called with a different callback while one is already pending. " +
+			"Only one FrameTick should be scheduled per VSync interval.");
+
 		_pendingVsyncAction = callback;
 		if (!_vsyncPosted)
 		{
@@ -46,8 +61,9 @@ internal class AndroidSkiaXamlRootHost : IXamlRootHost
 		}
 	}
 
-	private void OnVsyncFrame()
+	private void OnVsyncFrame(long frameTimeNanos)
 	{
+		_lastFrameTimeNanos = frameTimeNanos;
 		_vsyncPosted = false;
 		var action = _pendingVsyncAction;
 		_pendingVsyncAction = null;
@@ -56,16 +72,16 @@ internal class AndroidSkiaXamlRootHost : IXamlRootHost
 
 	private sealed class VsyncCallback : Java.Lang.Object, Choreographer.IFrameCallback
 	{
-		private readonly Action _action;
+		private readonly AndroidSkiaXamlRootHost _host;
 
-		public VsyncCallback(Action action)
+		public VsyncCallback(AndroidSkiaXamlRootHost host)
 		{
-			_action = action;
+			_host = host;
 		}
 
 		public void DoFrame(long frameTimeNanos)
 		{
-			_action();
+			_host.OnVsyncFrame(frameTimeNanos);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
@@ -5,12 +5,22 @@ using Uno.Foundation.Extensibility;
 using Uno.UI.Hosting;
 using Uno.UI.Xaml.Controls;
 
+using Choreographer = Android.Views.Choreographer;
+
 namespace Uno.UI.Runtime.Skia.Android;
 
 internal class AndroidSkiaXamlRootHost : IXamlRootHost
 {
+	private readonly Choreographer _choreographer;
+	private readonly VsyncCallback _vsyncCallback;
+	private Action? _pendingVsyncAction;
+	private bool _vsyncPosted;
+
 	public AndroidSkiaXamlRootHost(XamlRoot xamlRoot)
 	{
+		_choreographer = Choreographer.Instance!;
+		_vsyncCallback = new VsyncCallback(OnVsyncFrame);
+
 		XamlRootMap.Register(xamlRoot, this);
 	}
 
@@ -19,5 +29,43 @@ internal class AndroidSkiaXamlRootHost : IXamlRootHost
 		ApplicationActivity.Instance?.InvalidateRender();
 	}
 
+	// Choreographer-based ScheduleFrameCallback already limits FrameTick to 1 per vsync,
+	// so the render throttle is unnecessary. Disabling it avoids an extra round-trip
+	// (OnFramePresented → ScheduleFrameTick) that halves the effective frame rate.
+	bool IXamlRootHost.SupportsRenderThrottle => false;
+
 	UIElement? IXamlRootHost.RootElement => Window.Current!.RootElement;
+
+	void IXamlRootHost.ScheduleFrameCallback(Action callback)
+	{
+		_pendingVsyncAction = callback;
+		if (!_vsyncPosted)
+		{
+			_vsyncPosted = true;
+			_choreographer.PostFrameCallback(_vsyncCallback);
+		}
+	}
+
+	private void OnVsyncFrame()
+	{
+		_vsyncPosted = false;
+		var action = _pendingVsyncAction;
+		_pendingVsyncAction = null;
+		action?.Invoke();
+	}
+
+	private sealed class VsyncCallback : Java.Lang.Object, Choreographer.IFrameCallback
+	{
+		private readonly Action _action;
+
+		public VsyncCallback(Action action)
+		{
+			_action = action;
+		}
+
+		public void DoFrame(long frameTimeNanos)
+		{
+			_action();
+		}
+	}
 }

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -16,7 +16,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
 using Uno.Foundation.Logging;
-using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
 using Windows.Graphics.Display;
 
@@ -216,6 +215,9 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 			// else : we already drew directly on the OpenGL-backed canvas
 
 			_context!.Flush();
+
+			// Render throttle is disabled on Android (Choreographer provides pacing),
+			// so OnFramePresented is not needed here. See AndroidSkiaXamlRootHost.
 		}
 
 		void IRenderer.OnSurfaceChanged(IGL10? gl, int width, int height)

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -216,6 +216,14 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 			_context!.Flush();
 
+			if (!ApplicationActivity.Instance.FirstFrameRendered)
+			{
+				ApplicationActivity.Instance.FirstFrameRendered = true;
+				// Post invalidation to trigger OnPreDraw re-evaluation so the splash can dismiss
+				ApplicationActivity.RelativeLayout?.Post(() =>
+					ApplicationActivity.RelativeLayout?.Invalidate());
+			}
+
 			// Render throttle is disabled on Android (Choreographer provides pacing),
 			// so OnFramePresented is not needed here. See AndroidSkiaXamlRootHost.
 		}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Rendering/UnoSKMetalView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Rendering/UnoSKMetalView.cs
@@ -183,6 +183,13 @@ namespace Uno.UI.Runtime.Skia.AppleUIKit
 					commandBuffer.PresentDrawable(drawable);
 					commandBuffer.Commit();
 				}
+
+				if (_owner?.RootElement?.Visual.CompositionTarget is CompositionTarget ct)
+				{
+					NativeDispatcher.Main.Enqueue(
+						ct.OnFramePresented,
+						NativeDispatcherPriority.Render);
+				}
 			}
 			finally
 			{

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
@@ -273,6 +273,8 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 		_skCanvasView?.QueueRender();
 	}
 
+	public bool SupportsRenderThrottle => true;
+
 	public UIElement? RootElement => _xamlRoot?.VisualTree.RootElement;
 
 	public UIView TextInputLayer => _textInputLayer!;

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -281,6 +281,13 @@ internal static partial class NativeUno
 	internal static partial void uno_window_get_metal_handles(nint window, out nint device, out nint queue);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	[return: MarshalAs(UnmanagedType.I1)]
+	internal static partial bool uno_window_acquire_next_frame(nint window, out nint texture, out double width, out double height);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_present_frame(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_move(nint window, double x, double y);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -133,17 +133,23 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			return surface.Canvas;
 		});
 
+		// Dispatch clip path update to the main thread — uno_window_clip_svg modifies
+		// AppKit view layers (view.layer.mask, subview frames) which must only be
+		// accessed from the main thread.
 		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
-		if (clip != _lastSvgClipPath)
+		if (clip != Volatile.Read(ref _lastSvgClipPath))
 		{
-			if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+			NativeDispatcher.Main.Enqueue(() =>
 			{
-				_lastSvgClipPath = clip;
-			}
+				if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				{
+					Volatile.Write(ref _lastSvgClipPath, clip);
+				}
+			}, NativeDispatcherPriority.Normal);
 		}
 
-		// Note: _context.Flush() is called by the render loop after this method returns,
-		// before presenting the drawable. No need to flush here.
+		// Note: _context.Flush(submit: true) is called by the render loop after this
+		// method returns, before presenting the drawable. No need to flush here.
 		target?.Dispose();
 		surface?.Dispose();
 	}
@@ -402,6 +408,21 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 			var args = CreateArgs(key, mods, scanCode, unicode);
 			keyDown.Invoke(window!, args);
+
+			// When a text-input control (TextBox, PasswordBox) has focus and a printable
+			// character key is pressed, report as handled even if the XAML KeyDown event
+			// didn't set Handled=true (WinUI doesn't either). This prevents [super sendEvent:]
+			// from dispatching to the NSResponder chain, which would play the system alert
+			// sound because no native text input client is present.
+			if (!args.Handled && unicode != 0 && window is not null)
+			{
+				var focused = FocusManager.GetFocusedElement(window._xamlRoot);
+				if (focused is Microsoft.UI.Xaml.Controls.TextBox or Microsoft.UI.Xaml.Controls.PasswordBox)
+				{
+					return 1;
+				}
+			}
+
 			return args.Handled ? 1 : 0;
 		}
 		catch (Exception e)
@@ -763,8 +784,10 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 						// Draw the recorded SKPicture to the Metal texture
 						_drawFrame(width, height, texture);
 
-						// Flush Skia GPU commands
-						_context.Flush();
+						// Flush and submit Skia GPU commands before presenting.
+						// submit: true ensures the Metal command buffer is submitted
+						// to the GPU before we present the drawable. Matches iOS path.
+						_context.Flush(submit: true);
 
 						// Present drawable and commit command buffer (may block for VSync)
 						NativeUno.uno_window_present_frame(_windowHandle);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
@@ -30,6 +31,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private readonly XamlRoot _xamlRoot;
 	private readonly DisplayInformation _displayInformation;
 	private readonly GRContext? _context;
+	private MacOSRenderThread? _metalRenderThread;
 	private SKBitmap? _bitmap;
 	private SKSurface? _surface;
 	private int _rowBytes;
@@ -57,6 +59,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					QueueHandle = queue,
 				};
 				_context = GRContext.CreateMetal(ctx);
+				InitializeMetalRenderThread();
 				break;
 			case RenderSurfaceType.Software:
 				break;
@@ -79,6 +82,76 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		SizeChanged?.Invoke(this, _nativeWindowSize);
 	}
 
+	private void InitializeMetalRenderThread()
+	{
+		if (_context is null)
+		{
+			return;
+		}
+
+		_metalRenderThread = new MacOSRenderThread(
+			_nativeWindow.Handle,
+			_context,
+			drawFrame: RenderThreadMetalDraw,
+			onFramePresented: () =>
+			{
+				NativeDispatcher.Main.Enqueue(
+					OnFramePresented,
+					NativeDispatcherPriority.Render);
+			});
+	}
+
+	private void OnFramePresented()
+	{
+		var ct = RootElement?.Visual.CompositionTarget as CompositionTarget;
+		ct?.OnFramePresented();
+	}
+
+	/// <summary>
+	/// Called on the render thread. Draws the recorded SKPicture to the Metal texture.
+	/// </summary>
+	private void RenderThreadMetalDraw(double nativeWidth, double nativeHeight, nint texture)
+	{
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace($"Window {_nativeWindow.Handle} render thread drawing {nativeWidth}x{nativeHeight} texture: {texture}");
+		}
+
+		var ct = RootElement?.Visual.CompositionTarget as CompositionTarget;
+		if (ct is null)
+		{
+			return;
+		}
+
+		// we can't cache anything since the texture will be different on next calls
+		GRBackendRenderTarget? target = null;
+		SKSurface? surface = null;
+		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
+		{
+			target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
+			surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
+			return surface.Canvas;
+		});
+
+		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+		if (clip != _lastSvgClipPath)
+		{
+			if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+			{
+				_lastSvgClipPath = clip;
+			}
+		}
+
+		// Note: _context.Flush() is called by the render loop after this method returns,
+		// before presenting the drawable. No need to flush here.
+		target?.Dispose();
+		surface?.Dispose();
+	}
+
+	/// <summary>
+	/// Legacy Metal draw callback from native MTKView delegate (drawInMTKView:).
+	/// Only called if the MTKView is not in paused mode (software fallback or legacy path).
+	/// </summary>
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
 	{
 		if (this.Log().IsEnabled(LogLevel.Trace))
@@ -176,6 +249,15 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			*size = (int)bitmapSize;
 			*rowBytes = _rowBytes;
 		}
+
+		// Post OnFramePresented for the software path (no render thread).
+		// This ensures render throttle consistency even without a dedicated render thread.
+		if (RootElement?.Visual.CompositionTarget is CompositionTarget ct)
+		{
+			NativeDispatcher.Main.Enqueue(
+				ct.OnFramePresented,
+				NativeDispatcherPriority.Render);
+		}
 	}
 
 	// Window management
@@ -202,7 +284,21 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 	public UIElement? RootElement => _winUIWindow.RootElement;
 
-	void IXamlRootHost.InvalidateRender() => NativeUno.uno_window_invalidate(_nativeWindow.Handle);
+	bool IXamlRootHost.SupportsRenderThrottle => _metalRenderThread is not null;
+
+	void IXamlRootHost.InvalidateRender()
+	{
+		if (_metalRenderThread is not null)
+		{
+			// Metal path: signal the dedicated render thread
+			_metalRenderThread.SignalNewFrame();
+		}
+		else
+		{
+			// Software path: use AppKit's display loop
+			NativeUno.uno_window_invalidate(_nativeWindow.Handle);
+		}
+	}
 
 	void IXamlRootHost.ResignNativeFocus() => NativeUno.uno_window_resign_native_first_responder(_nativeWindow.Handle);
 
@@ -547,6 +643,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			var window = GetWindowHost(handle);
 			if (window is not null)
 			{
+				window._metalRenderThread?.Dispose();
+				window._metalRenderThread = null;
 				Unregister(handle);
 				window._nativeWindow.Destroyed();
 				window.Closed?.Invoke(window, EventArgs.Empty);
@@ -599,6 +697,96 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		catch (Exception e)
 		{
 			Application.Current.RaiseRecoverableUnhandledException(e);
+		}
+	}
+
+	// --- Render Thread ---
+
+	/// <summary>
+	/// Dedicated render thread for macOS Metal rendering. Mirrors Win32's RenderThread
+	/// and iOS's CADisplayLink render thread patterns.
+	/// Acquires Metal drawables, draws SKPictures, and presents — all on a background thread
+	/// so the UI thread is never blocked by Metal present/VSync.
+	/// </summary>
+	private sealed class MacOSRenderThread : IDisposable
+	{
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _frameSignal = new(false);
+		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly nint _windowHandle;
+		private readonly GRContext _context;
+		private readonly Action<double, double, nint> _drawFrame;
+		private readonly Action _onFramePresented;
+		private volatile bool _disposed;
+
+		internal MacOSRenderThread(
+			nint windowHandle,
+			GRContext context,
+			Action<double, double, nint> drawFrame,
+			Action onFramePresented)
+		{
+			_windowHandle = windowHandle;
+			_context = context;
+			_drawFrame = drawFrame;
+			_onFramePresented = onFramePresented;
+			_thread = new Thread(RenderLoop) { Name = "Uno macOS Render Thread", IsBackground = true };
+			_thread.Start();
+		}
+
+		/// <summary>
+		/// Signals the render thread that a new frame is available for presentation.
+		/// Multiple calls while the thread is busy coalesce into a single wake-up.
+		/// </summary>
+		internal void SignalNewFrame() => _frameSignal.Set();
+
+		/// <summary>
+		/// Blocks the calling thread until the render thread finishes presenting a frame.
+		/// </summary>
+		internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+		private void RenderLoop()
+		{
+			while (!_disposed)
+			{
+				_frameSignal.WaitOne();
+				if (_disposed)
+				{
+					break;
+				}
+
+				_presentedEvent.Reset();
+				try
+				{
+					// Acquire drawable from native Metal layer
+					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
+					{
+						// Draw the recorded SKPicture to the Metal texture
+						_drawFrame(width, height, texture);
+
+						// Flush Skia GPU commands
+						_context.Flush();
+
+						// Present drawable and commit command buffer (may block for VSync)
+						NativeUno.uno_window_present_frame(_windowHandle);
+					}
+				}
+				catch (Exception ex)
+				{
+					typeof(MacOSRenderThread).LogError()?.Error($"macOS render thread error: {ex}");
+				}
+
+				_presentedEvent.Set();
+				_onFramePresented();
+			}
+		}
+
+		public void Dispose()
+		{
+			_disposed = true;
+			_frameSignal.Set(); // Unblock if waiting
+			_thread.Join(timeout: TimeSpan.FromSeconds(2));
+			_frameSignal.Dispose();
+			_presentedEvent.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
@@ -16,10 +16,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable) id<MTLCommandQueue> queue;
 
+/// Holds the drawable acquired by uno_window_acquire_next_frame until
+/// uno_window_present_frame is called. Only accessed from the render thread.
+@property (nullable) id<CAMetalDrawable> currentFrameDrawable;
+
 @end
 
 typedef void (*metal_draw_fn_ptr)(void* /* window */, double /* width */, double /* height */, void* _Nullable /* texture */);
 metal_draw_fn_ptr uno_get_metal_draw_callback(void);
 void uno_set_draw_callback(metal_draw_fn_ptr p);
+
+/// Acquires the next drawable from the MTKView and returns its texture handle and size.
+/// The drawable is held by the delegate until uno_window_present_frame is called.
+/// Returns false if no drawable is available.
+bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull texture, double* width, double* height);
+
+/// Presents the previously acquired drawable via a Metal command buffer.
+/// Must be called after uno_window_acquire_next_frame returned true.
+void uno_window_present_frame(NSWindow* window);
 
 NS_ASSUME_NONNULL_END

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -105,47 +105,65 @@
 @end
 
 // --- Render thread drawable lifecycle functions ---
+// These functions are called from the managed render thread (background thread).
+// They use CAMetalLayer directly instead of MTKView.currentDrawable because
+// MTKView.currentDrawable is only valid during drawInMTKView: callbacks on the
+// main thread. CAMetalLayer.nextDrawable is thread-safe and designed for this.
+// See: https://developer.apple.com/documentation/quartzcore/cametallayer
 
 bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* width, double* height)
 {
-    if (window == nil) return false;
+    @autoreleasepool {
+        if (window == nil) return false;
 
-    MTKView* view = (MTKView*)window.contentViewController.view;
-    if (view == nil || ![view isKindOfClass:[MTKView class]]) return false;
+        MTKView* view = (MTKView*)window.contentViewController.view;
+        if (view == nil || ![view isKindOfClass:[MTKView class]]) return false;
 
-    UNOWindow* unoWindow = (UNOWindow*)window;
-    UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
-    if (delegate == nil) return false;
+        UNOWindow* unoWindow = (UNOWindow*)window;
+        UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+        if (delegate == nil) return false;
 
-    id<CAMetalDrawable> drawable = view.currentDrawable;
-    if (drawable == nil) return false;
+        // Access the underlying CAMetalLayer directly — nextDrawable is thread-safe
+        // unlike MTKView.currentDrawable which must be called during draw callbacks.
+        // nextDrawable blocks up to 1s (default timeout) if all drawables are in use.
+        // With maximumDrawableCount=2 (set in uno_window_create), this only happens
+        // when the window is occluded or minimized. Returning nil is handled below.
+        CAMetalLayer* metalLayer = (CAMetalLayer*)view.layer;
 
-    // Hold drawable until present
-    delegate.currentFrameDrawable = drawable;
+        id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
+        if (drawable == nil) return false;
 
-    *texture = (__bridge void*)drawable.texture;
-    CGSize size = view.drawableSize;
-    *width = size.width;
-    *height = size.height;
-    return true;
+        // Hold drawable until present (strong property retains via ARC)
+        delegate.currentFrameDrawable = drawable;
+
+        *texture = (__bridge void*)drawable.texture;
+        // Use layer's drawableSize (thread-safe) rather than MTKView.drawableSize
+        CGSize size = metalLayer.drawableSize;
+        *width = size.width;
+        *height = size.height;
+        return true;
+    }
 }
 
 void uno_window_present_frame(NSWindow* window)
 {
-    if (window == nil) return;
+    @autoreleasepool {
+        if (window == nil) return;
 
-    UNOWindow* unoWindow = (UNOWindow*)window;
-    UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
-    if (delegate == nil) return;
+        UNOWindow* unoWindow = (UNOWindow*)window;
+        UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+        if (delegate == nil) return;
 
-    id<CAMetalDrawable> drawable = delegate.currentFrameDrawable;
-    if (drawable == nil) return;
+        id<CAMetalDrawable> drawable = delegate.currentFrameDrawable;
+        if (drawable == nil) return;
 
-    id<MTLCommandBuffer> commandBuffer = [delegate.queue commandBuffer];
-    [commandBuffer presentDrawable:drawable];
-    [commandBuffer commit];
+        id<MTLCommandBuffer> commandBuffer = [delegate.queue commandBuffer];
+        [commandBuffer presentDrawable:drawable];
+        [commandBuffer commit];
 
-    // Release the drawable as soon as possible
-    // See: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/Drawables.html
-    delegate.currentFrameDrawable = nil;
+        // Release the drawable as soon as possible after committing the command buffer.
+        // The command buffer retains the drawable internally for presentation.
+        // See: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/Drawables.html
+        delegate.currentFrameDrawable = nil;
+    }
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -18,7 +18,7 @@
     {
         _device = mtkView.device;
         self.queue = [_device newCommandQueue];
-        
+
         mtkView.colorPixelFormat = MTLPixelFormatRGBA8Unorm;
         mtkView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
         mtkView.sampleCount = 1;
@@ -28,12 +28,16 @@
         NSLog(@"initWithMetalKitView: paused %s enableSetNeedsDisplay %s", mtkView.paused ? "true" : "false", mtkView.enableSetNeedsDisplay ? "true" : "false");
 #endif
     }
-    
+
     return self;
 }
 
 - (void)drawInMTKView:(nonnull MTKView *)view
 {
+    // This delegate method is no longer called when the MTKView is paused
+    // (paused=YES, enableSetNeedsDisplay=NO). Frame drawing is now driven
+    // by the managed render thread via uno_window_acquire_next_frame /
+    // uno_window_present_frame. Kept for software fallback compatibility.
 #if DEBUG
     NSLog (@"drawInMTKView: %f %f", view.drawableSize.width, view.drawableSize.height);
 #endif
@@ -99,3 +103,49 @@
 }
 
 @end
+
+// --- Render thread drawable lifecycle functions ---
+
+bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* width, double* height)
+{
+    if (window == nil) return false;
+
+    MTKView* view = (MTKView*)window.contentViewController.view;
+    if (view == nil || ![view isKindOfClass:[MTKView class]]) return false;
+
+    UNOWindow* unoWindow = (UNOWindow*)window;
+    UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+    if (delegate == nil) return false;
+
+    id<CAMetalDrawable> drawable = view.currentDrawable;
+    if (drawable == nil) return false;
+
+    // Hold drawable until present
+    delegate.currentFrameDrawable = drawable;
+
+    *texture = (__bridge void*)drawable.texture;
+    CGSize size = view.drawableSize;
+    *width = size.width;
+    *height = size.height;
+    return true;
+}
+
+void uno_window_present_frame(NSWindow* window)
+{
+    if (window == nil) return;
+
+    UNOWindow* unoWindow = (UNOWindow*)window;
+    UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+    if (delegate == nil) return;
+
+    id<CAMetalDrawable> drawable = delegate.currentFrameDrawable;
+    if (drawable == nil) return;
+
+    id<MTLCommandBuffer> commandBuffer = [delegate.queue commandBuffer];
+    [commandBuffer presentDrawable:drawable];
+    [commandBuffer commit];
+
+    // Release the drawable as soon as possible
+    // See: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/Drawables.html
+    delegate.currentFrameDrawable = nil;
+}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -45,7 +45,6 @@ typedef NS_ENUM(sint32, OverlappedPresenterState) {
 @property OverlappedPresenterState overlappedPresenterState;
 
 - (void)sendEvent:(NSEvent *)event;
-- (BOOL)performKeyEquivalent:(NSEvent *)event;
 
 - (void)windowWillMiniaturize:(NSNotification *)notification;
 - (void)windowDidMiniaturize:(NSNotification *)notification;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -345,6 +345,14 @@ void uno_set_window_close_callbacks(window_should_close_fn_ptr shouldClose, wind
 
 void uno_window_get_metal_handles(UNOWindow* window, void*_Nonnull* _Nonnull device, void*_Nonnull* _Nonnull queue);
 
+/// Acquires the next drawable from the MTKView and returns its texture handle and size.
+/// Called from the managed render thread.
+bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull texture, double* width, double* height);
+
+/// Presents the previously acquired drawable via a Metal command buffer.
+/// Called from the managed render thread after drawing is complete.
+void uno_window_present_frame(NSWindow* window);
+
 typedef void (*window_did_change_screen_fn_ptr)(NSWindow* window, uint32 width, uint32 height, CGFloat backingScaleFactor);
 window_did_change_screen_fn_ptr uno_get_window_did_change_screen_callback(void);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -127,7 +127,10 @@ NSWindow* uno_window_create(double width, double height)
     id device = uno_application_get_metal_device();
     if (device) {
         UNOMetalFlippedView *v = [[UNOMetalFlippedView alloc] initWithFrame:size device:device];
-        v.enableSetNeedsDisplay = YES;
+        // Disable MTKView auto-draw. Frame rendering is driven by the managed
+        // render thread via uno_window_acquire_next_frame / uno_window_present_frame.
+        v.paused = YES;
+        v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];
         v.delegate = window.metalViewDelegate;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -100,11 +100,28 @@ NSWindow* uno_app_get_main_window(void)
     return YES;
 }
 
+// Safety net: suppress the system alert sound for printable character keys
+// that reach the view. The managed side (OnRawKeyDown) handles text-input
+// suppression for focused TextBox/PasswordBox controls, but if a character
+// key somehow reaches the view unhandled, we swallow it here to avoid the
+// NSResponder default keyDown: → interpretKeyEvents: → alert sound path.
+// Non-printable keys (function keys, arrows, etc.) are forwarded to super
+// so standard AppKit behavior (including the alert sound) is preserved.
+-(void) keyDown:(NSEvent *)event {
+    // Only suppress for events that produce printable characters.
+    // Non-character keys (function keys, etc.) get default handling.
+    if (event.characters.length > 0) {
+        unichar ch = [event.characters characterAtIndex:0];
+        // ASCII control characters (< 0x20) and DEL (0x7F) are non-printable
+        if (ch >= 0x20 && ch != 0x7F) {
+            return; // suppress sound for printable characters
+        }
+    }
+    [super keyDown:event];
+}
+
 -(instancetype) initWithFrame:(CGRect)frameRect device:(id<MTLDevice>)device {
     self = [super initWithFrame:frameRect device:device];
-    if (self) {
-        // TODO
-    }
     return self;
 }
 
@@ -132,6 +149,12 @@ NSWindow* uno_window_create(double width, double height)
         v.paused = YES;
         v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+        // Double-buffering (2 drawables) instead of the default triple-buffering (3).
+        // Reduces frame latency by one VSync interval while the render thread is
+        // already throttled by the UI thread's FrameTick scheduling.
+        CAMetalLayer* metalLayer = (CAMetalLayer*)v.layer;
+        metalLayer.maximumDrawableCount = 2;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];
         v.delegate = window.metalViewDelegate;
         window.renderingView = v;

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
@@ -115,6 +115,8 @@ internal partial class WebAssemblyBrowserHost : SkiaHost, ISkiaApplicationHost, 
 
 	internal void RemoveSplashScreen() => NativeMethods.RemoveLoading();
 
+	bool IXamlRootHost.SupportsRenderThrottle => true;
+
 	UIElement? IXamlRootHost.RootElement => Window.CurrentSafe!.RootElement;
 
 	private static partial class NativeMethods

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Hosting/WebAssemblyBrowserHost.cs
@@ -115,7 +115,19 @@ internal partial class WebAssemblyBrowserHost : SkiaHost, ISkiaApplicationHost, 
 
 	internal void RemoveSplashScreen() => NativeMethods.RemoveLoading();
 
-	bool IXamlRootHost.SupportsRenderThrottle => true;
+	// RAF provides natural frame pacing on single-threaded WASM — no need for
+	// the OnFramePresented throttle. When MT WASM adds a render worker, this
+	// should switch to true and ScheduleFrameCallback should use the default
+	// dispatcher-based scheduling (see plan for details).
+	bool IXamlRootHost.SupportsRenderThrottle => false;
+
+	/// <summary>
+	/// Aligns FrameTick (layout + render + record) to the browser's requestAnimationFrame,
+	/// matching Avalonia's BrowserRenderTimer and Flutter's scheduleFrame → RAF pattern.
+	/// Without this, FrameTick runs at arbitrary setImmediate timing, disconnected from vsync.
+	/// </summary>
+	void IXamlRootHost.ScheduleFrameCallback(Action callback)
+		=> BrowserRenderer.ScheduleOnAnimationFrame(callback);
 
 	UIElement? IXamlRootHost.RootElement => Window.CurrentSafe!.RootElement;
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices.JavaScript;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
 using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
 
 namespace Uno.UI.Runtime.Skia;
@@ -96,6 +97,10 @@ internal partial class BrowserRenderer
 			_canvas.Flush();
 			_renderer.Flush();
 		}
+
+		NativeDispatcher.Main.Enqueue(
+			compositionTarget.OnFramePresented,
+			NativeDispatcherPriority.Render);
 
 		var (path, fillType) = !currentClipPath.IsEmpty ? (currentClipPath.ToSvgPathData(), currentClipPath.FillType is SKPathFillType.EvenOdd ? "evenodd" : "nonzero") : ("", "nonzero");
 		BrowserNativeElementHostingExtension.SetSvgClipPathForNativeElementHost(path, fillType);

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
@@ -98,6 +98,8 @@ internal partial class BrowserRenderer
 			_renderer.Flush();
 		}
 
+		// Currently a no-op on single-threaded WASM (SupportsRenderThrottle = false),
+		// but kept for forward-compatibility with future MT WASM render worker.
 		NativeDispatcher.Main.Enqueue(
 			compositionTarget.OnFramePresented,
 			NativeDispatcherPriority.Render);
@@ -112,6 +114,13 @@ internal partial class BrowserRenderer
 	}
 
 
+	/// <summary>
+	/// Schedules a callback to run on the next requestAnimationFrame.
+	/// Used by the WASM host to align FrameTick to vsync.
+	/// </summary>
+	internal static void ScheduleOnAnimationFrame(Action callback)
+		=> NativeMethods.ScheduleOnAnimationFrame(callback);
+
 	internal static partial class NativeMethods
 	{
 		[JSImport($"globalThis.Uno.UI.Runtime.Skia.{nameof(BrowserRenderer)}.createInstance")]
@@ -119,5 +128,8 @@ internal partial class BrowserRenderer
 
 		[JSImport($"globalThis.Uno.UI.Runtime.Skia.{nameof(BrowserRenderer)}.invalidate")]
 		internal static partial void Invalidate(JSObject nativeSwapChainPanel);
+
+		[JSImport($"globalThis.Uno.UI.Runtime.Skia.{nameof(BrowserRenderer)}.scheduleOnAnimationFrame")]
+		internal static partial void ScheduleOnAnimationFrame([JSMarshalAs<JSType.Function>] Action callback);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserRenderer.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserRenderer.ts
@@ -44,10 +44,18 @@ namespace Uno.UI.Runtime.Skia {
 			BrowserRenderer.invalidate(this);
 		}
 
+		// Schedules a callback to run on the next requestAnimationFrame.
+		// Used to align FrameTick (layout + render) to vsync.
+		static scheduleOnAnimationFrame(callback: () => void) {
+			window.requestAnimationFrame(() => callback());
+		}
+
 		static invalidate(instance: BrowserRenderer) {
-			window.requestAnimationFrame(() => {
-				instance.requestRender();
-			});
+			// Render synchronously — FrameTick already runs inside a RAF callback
+			// (via ScheduleFrameCallback → scheduleOnAnimationFrame), so the draw
+			// happens within the same animation frame. Using another RAF here would
+			// defer the draw to the next vsync, halving the effective frame rate.
+			instance.requestRender();
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -165,6 +165,7 @@ DwmIsCompositionEnabled
 DwmExtendFrameIntoClientArea
 DwmSetWindowAttribute
 DwmDefWindowProc
+DwmFlush
 EmptyClipboard
 EnableMouseInPointer
 EndPaint

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -49,13 +49,7 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 			_displayInformation?.NotifyDpiChanged();
 		}
 
-		if (_refreshRate != oldRefreshRate)
-		{
-			if (FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
-			{
-				_framePacer.UpdateTargetFps(_refreshRate);
-			}
-		}
+		// _refreshRate is still tracked for display information consumers.
 	}
 
 	private unsafe (DisplayInfo, float) GetDisplayInfo()

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading;
+using SkiaSharp;
+using Uno.Foundation.Logging;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal partial class Win32WindowWrapper
+{
+	/// <summary>
+	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt).
+	/// The UI thread records SKPictures and signals this thread to present them.
+	/// This mirrors the pattern used by WPF (milcore render thread), Avalonia
+	/// (ServerCompositor), and Uno Android (GLSurfaceView GL thread).
+	/// </summary>
+	private sealed class RenderThread : IDisposable
+	{
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _frameSignal = new(false);
+		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly IRenderer _renderer;
+		private readonly Func<(SKPath clipPath, int width, int height)?> _drawFrame;
+		private readonly Action<SKPath> _onClipPathUpdated;
+		private readonly Action _onFramePresented;
+		private volatile bool _disposed;
+
+		internal RenderThread(
+			IRenderer renderer,
+			Func<(SKPath, int, int)?> drawFrame,
+			Action<SKPath> onClipPathUpdated,
+			Action onFramePresented)
+		{
+			_renderer = renderer;
+			_drawFrame = drawFrame;
+			_onClipPathUpdated = onClipPathUpdated;
+			_onFramePresented = onFramePresented;
+			_thread = new Thread(RenderLoop) { Name = "Uno Render Thread", IsBackground = true };
+			_thread.Start();
+		}
+
+		/// <summary>
+		/// Signals the render thread that a new frame is available for presentation.
+		/// Multiple calls while the thread is busy coalesce into a single wake-up
+		/// (AutoResetEvent semantics).
+		/// </summary>
+		internal void SignalNewFrame() => _frameSignal.Set();
+
+		/// <summary>
+		/// Blocks the calling thread until the render thread finishes presenting a frame.
+		/// Used by ShowCore to ensure the first frame is painted before the window is shown.
+		/// </summary>
+		internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+		private void RenderLoop()
+		{
+			while (!_disposed)
+			{
+				_frameSignal.WaitOne();
+				if (_disposed)
+				{
+					break;
+				}
+
+				_presentedEvent.Reset();
+				_renderer.StartPaint();
+				try
+				{
+					var result = _drawFrame();
+					if (result is var (clipPath, width, height))
+					{
+						_onClipPathUpdated(clipPath);
+						_renderer.CopyPixels(width, height); // SwapBuffers/BitBlt — may block for VSync
+					}
+				}
+				catch (Exception ex)
+				{
+					typeof(RenderThread).LogError()?.Error($"Render thread error: {ex}");
+				}
+				finally
+				{
+					_renderer.EndPaint();
+				}
+
+				_presentedEvent.Set();
+				_onFramePresented();
+			}
+		}
+
+		public void Dispose()
+		{
+			_disposed = true;
+			_frameSignal.Set(); // Unblock if waiting
+			_thread.Join(timeout: TimeSpan.FromSeconds(2));
+			_frameSignal.Dispose();
+			_presentedEvent.Dispose();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -15,6 +15,9 @@ internal partial class Win32WindowWrapper
 {
 	private class GlRenderer : IRenderer
 	{
+		[UnmanagedFunctionPointer(CallingConvention.Winapi)]
+		private delegate int WglSwapIntervalEXT(int interval);
+
 		private readonly HWND _hwnd;
 		private readonly HDC _hdc;
 		private HGLRC _glContext; // recreated when window is extended into titlebar
@@ -103,6 +106,17 @@ internal partial class Win32WindowWrapper
 					version is null
 						? $"{nameof(PInvoke.glGetString)} failed with error code {PInvoke.glGetError().ToString("X", CultureInfo.InvariantCulture)}"
 						: $"OpenGL Version: {Marshal.PtrToStringUTF8((IntPtr)version)}");
+			}
+
+			// Enable VSync so SwapBuffers blocks until the next display refresh.
+			// Without this, some GPU drivers default to swap interval 0,
+			// causing SwapBuffers to return immediately and the render loop
+			// to spin at hundreds of fps.
+			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
+			if (wglSwapIntervalAddr != IntPtr.Zero)
+			{
+				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
+				wglSwapInterval(1);
 			}
 
 			var grGlInterface = GRGlInterface.Create();

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -82,6 +82,12 @@ internal partial class Win32WindowWrapper
 
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
+
+			// Block until the DWM compositor's next VSync to pace frames.
+			// Without this, BitBlt returns instantly (unlike GL's SwapBuffers
+			// which blocks for VSync), causing the render loop to spin at
+			// hundreds of fps — wasting CPU and reporting misleading frame rates.
+			PInvoke.DwmFlush();
 		}
 
 		bool IRenderer.IsSoftware() => true;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -1,38 +1,56 @@
 using System;
+using System.Drawing;
+using System.Threading;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
-using Uno.UI.Runtime.Skia.Hosting;
-using Windows.Win32;
-using Windows.Win32.Foundation;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
 internal partial class Win32WindowWrapper
 {
-	private readonly FramePacer _framePacer;
 	private int _renderCount;
 	private SKSurface? _surface;
 	private bool _rendering;
+	private bool _blitScheduled;
+	private bool _inSizeMove;
 
 	public event EventHandler<SKPath>? RenderingNegativePathReevaluated; // not necessarily changed
 
-	private FramePacer CreateFramePacer()
-	{
-		return new FramePacer(
-			_refreshRate,
-			() => NativeDispatcher.Main.Enqueue(Render, NativeDispatcherPriority.High));
-	}
-
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
-		var success = PInvoke.InvalidateRect(_hwnd, default(RECT*), true);
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}"); }
+		// Mark the window dirty for WM_PAINT. This handles external repaints (window
+		// uncovering, restore from minimized) where Windows generates WM_PAINT.
+		// Like WPF (InvalidateRect in HwndTarget) and Avalonia (InvalidateRect in WindowImpl).
+		PInvoke.InvalidateRect(_hwnd, default(RECT*), false);
 
-		_framePacer.RequestFrame();
+		// During the modal resize/move loop, rendering is driven synchronously from
+		// WM_SIZE. Don't schedule dispatcher-based blits — they would flood the modal
+		// loop's message queue and starve resize messages (each FrameTick posts the
+		// next via PostMessage, and GL's SwapBuffers blocks for VSync per blit).
+		if (_inSizeMove)
+		{
+			return;
+		}
+
+		// Schedule a single coalesced blit at Render priority. Neither WPF nor Avalonia
+		// rely on WM_PAINT for the primary blit — WM_PAINT is too low priority in the
+		// Windows message queue (starved by PostMessage'd dispatcher items during
+		// continuous animation). Like Avalonia's compositor-driven render loop, we
+		// schedule the blit as part of the render pass via the dispatcher.
+		if (!Interlocked.Exchange(ref _blitScheduled, true))
+		{
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				Interlocked.Exchange(ref _blitScheduled, false);
+				Render();
+			}, NativeDispatcherPriority.Render);
+		}
 	}
 
 	private void ReinitializeRenderer()
@@ -48,8 +66,6 @@ internal partial class Win32WindowWrapper
 		{
 			return;
 		}
-
-		_framePacer.OnFrameStart();
 
 		this.LogTrace()?.Trace($"Render {this._renderCount++}");
 

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Drawing;
-using System.Threading;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.OpenGL;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
-using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
@@ -14,13 +12,12 @@ namespace Uno.UI.Runtime.Skia.Win32;
 
 internal partial class Win32WindowWrapper
 {
-	private int _renderCount;
 	private SKSurface? _surface;
-	private bool _rendering;
-	private bool _blitScheduled;
-	private bool _inSizeMove;
+	private RenderThread? _renderThread;
 
 	public event EventHandler<SKPath>? RenderingNegativePathReevaluated; // not necessarily changed
+
+	bool IXamlRootHost.SupportsRenderThrottle => true;
 
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
@@ -29,28 +26,8 @@ internal partial class Win32WindowWrapper
 		// Like WPF (InvalidateRect in HwndTarget) and Avalonia (InvalidateRect in WindowImpl).
 		PInvoke.InvalidateRect(_hwnd, default(RECT*), false);
 
-		// During the modal resize/move loop, rendering is driven synchronously from
-		// WM_SIZE. Don't schedule dispatcher-based blits — they would flood the modal
-		// loop's message queue and starve resize messages (each FrameTick posts the
-		// next via PostMessage, and GL's SwapBuffers blocks for VSync per blit).
-		if (_inSizeMove)
-		{
-			return;
-		}
-
-		// Schedule a single coalesced blit at Render priority. Neither WPF nor Avalonia
-		// rely on WM_PAINT for the primary blit — WM_PAINT is too low priority in the
-		// Windows message queue (starved by PostMessage'd dispatcher items during
-		// continuous animation). Like Avalonia's compositor-driven render loop, we
-		// schedule the blit as part of the render pass via the dispatcher.
-		if (!Interlocked.Exchange(ref _blitScheduled, true))
-		{
-			NativeDispatcher.Main.Enqueue(() =>
-			{
-				Interlocked.Exchange(ref _blitScheduled, false);
-				Render();
-			}, NativeDispatcherPriority.Render);
-		}
+		// Signal the render thread to present the current frame.
+		_renderThread?.SignalNewFrame();
 	}
 
 	private void ReinitializeRenderer()
@@ -60,43 +37,65 @@ internal partial class Win32WindowWrapper
 		_surface = null;
 	}
 
-	private void Render()
+	private void InitializeRenderThread()
 	{
-		if (_rendererDisposed || _rendering)
-		{
-			return;
-		}
+		// TryCreateGlRenderer leaves the GL context current on the UI thread
+		// (WglCurrentContextDisposable doesn't restore to "no context" when there
+		// was none before). Detach it so the render thread can make it current.
+		// No-op for the software renderer (no GL context to detach).
+		PInvoke.wglMakeCurrent(default, HGLRC.Null);
 
-		this.LogTrace()?.Trace($"Render {this._renderCount++}");
-
-		_renderer.StartPaint();
-		using var paintDisposable = new DisposableStruct<IRenderer>(static r => r.EndPaint(), _renderer);
-
-		// In some cases, if a call to a synchronization method such as Monitor.Enter or Task.Wait()
-		// happens inside Paint(), the dotnet runtime can itself call WndProc, which can lead to
-		// Paint() becoming reentrant which can cause crashes.
-		_rendering = true;
-		try
-		{
-			var nativeElementClipPath = ((CompositionTarget)((IXamlRootHost)this).RootElement!.Visual.CompositionTarget!).OnNativePlatformFrameRequested(_surface?.Canvas, size =>
+		_renderThread = new RenderThread(
+			_renderer,
+			drawFrame: DrawFrame,
+			onClipPathUpdated: clipPath =>
 			{
-				_surface?.Dispose();
-				_surface = _renderer.UpdateSize((int)size.Width, (int)size.Height);
-				return _surface.Canvas;
+				NativeDispatcher.Main.Enqueue(() =>
+					RenderingNegativePathReevaluated?.Invoke(this, clipPath),
+					NativeDispatcherPriority.Normal);
+			},
+			onFramePresented: () =>
+			{
+				NativeDispatcher.Main.Enqueue(
+					OnFramePresented,
+					NativeDispatcherPriority.Render);
 			});
-			RenderingNegativePathReevaluated?.Invoke(this, nativeElementClipPath);
-		}
-		finally
+	}
+
+	/// <summary>
+	/// Called on the render thread. Replays the last recorded SKPicture to
+	/// the canvas and returns the clip path and client dimensions for CopyPixels.
+	/// </summary>
+	private unsafe (SKPath clipPath, int width, int height)? DrawFrame()
+	{
+		var ct = ((IXamlRootHost)this).RootElement?.Visual.CompositionTarget as CompositionTarget;
+		if (ct is null || _rendererDisposed)
 		{
-			_rendering = false;
+			return null;
 		}
+
+		var clipPath = ct.OnNativePlatformFrameRequested(_surface?.Canvas, size =>
+		{
+			_surface?.Dispose();
+			_surface = _renderer.UpdateSize((int)size.Width, (int)size.Height);
+			return _surface.Canvas;
+		});
 
 		if (!PInvoke.GetClientRect(_hwnd, out RECT clientRect))
 		{
-			this.LogError()?.Error($"{nameof(PInvoke.GetClientRect)} failed: {Win32Helper.GetErrorMessage()}");
-			return;
+			return null;
 		}
-		// this may call WM_ERASEBKGND
-		_renderer.CopyPixels(clientRect.Width, clientRect.Height);
+
+		return (clipPath, clientRect.Width, clientRect.Height);
+	}
+
+	/// <summary>
+	/// Posted to the UI thread by the render thread after a frame is presented.
+	/// Clears the throttle so the next FrameTick can be scheduled.
+	/// </summary>
+	private void OnFramePresented()
+	{
+		var ct = ((IXamlRootHost)this).RootElement?.Visual.CompositionTarget as CompositionTarget;
+		ct?.OnFramePresented();
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -112,6 +112,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				? (IRenderer?)GlRenderer.TryCreateGlRenderer(_hwnd) ?? new SoftwareRenderer(_hwnd)
 				: new SoftwareRenderer(_hwnd);
 
+		InitializeRenderThread();
+
 		RegisterForBackgroundColor();
 
 		PointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
@@ -241,16 +243,11 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		switch (msg)
 		{
-			case PInvoke.WM_ENTERSIZEMOVE:
-				_inSizeMove = true;
-				break;
-			case PInvoke.WM_EXITSIZEMOVE:
-				_inSizeMove = false;
-				break;
 			case PInvoke.WM_NCPAINT:
 				if (_forcePaintOnNextEraseBkgndOrNcPaint)
 				{
-					SynchronousRenderAndDraw(true);
+					(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.SynchronousRender(forceLayout: true);
+					_renderThread?.SignalNewFrame();
 				}
 				break;
 			case PInvoke.WM_ACTIVATE:
@@ -273,27 +270,24 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
 				UpdateWindowState(wParam);
-				// During the modal resize loop, dispatcher-based blits are suppressed
-				// (they would starve the resize messages). Render synchronously instead,
-				// like WPF does with CompleteRender() during user-initiated resize.
-				if (_inSizeMove)
-				{
-					SynchronousRenderAndDraw(true);
-				}
+				// Synchronous layout + record, then signal the render thread.
+				// The render thread presents at VSync independently of any modal loop.
+				(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.SynchronousRender(forceLayout: true);
+				_renderThread?.SignalNewFrame();
 				return new LRESULT(0);
 			case PInvoke.WM_MOVE:
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
 				// When the window moves and part of it was off-screen, Windows discards that part of
-				// the framebuffer. SynchronousRenderAndDraw re-blits so the exposed area is painted.
-				SynchronousRenderAndDraw(false);
+				// the framebuffer. Signal the render thread to re-blit the exposed area.
+				_renderThread?.SignalNewFrame();
 				return new LRESULT(0);
 			case PInvoke.WM_PAINT:
-				// Blit the current frame to screen. WM_PAINT is generated when the window is
-				// uncovered, restored, or otherwise needs repainting. We blit then let DefWindowProc
-				// call BeginPaint/EndPaint to validate the update region.
-				Render();
+				// Signal the render thread to re-blit the current frame. WM_PAINT is generated
+				// when the window is uncovered, restored, or otherwise needs repainting.
+				// DefWindowProc calls BeginPaint/EndPaint to validate the update region.
+				_renderThread?.SignalNewFrame();
 				break;
 			case PInvoke.WM_GETMINMAXINFO:
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_GETMINMAXINFO)} message.");
@@ -314,14 +308,14 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				if (_forcePaintOnNextEraseBkgndOrNcPaint)
 				{
 					_forcePaintOnNextEraseBkgndOrNcPaint = false;
-					// This call is necessary to avoid an initial blank frame during window startup.
-					// This follows from the SynchronousRenderAndDraw call in ShowCore.
-					Render();
+					// Signal the render thread to re-blit. The first frame was already painted
+					// by ShowCore (which waited for present), so the framebuffer has content.
+					_renderThread?.SignalNewFrame();
 					return new LRESULT(1);
 				}
 				else
 				{
-					// Paiting on WM_ERASEBKGND causes severe flickering in hosted native windows so we
+					// Painting on WM_ERASEBKGND causes severe flickering in hosted native windows so we
 					// only do it the first time when we really need to
 					return new LRESULT(0);
 				}
@@ -391,7 +385,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		// triggered by a Loaded handler), and FrameTick's RaiseLoadedEvent would corrupt the
 		// iteration of the loaded event list.
 		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.SynchronousRender(forceLayout: sizeChanged);
-		Render();
+		_renderThread?.SignalNewFrame();
+		_renderThread?.WaitForNextPresent(TimeSpan.FromMilliseconds(100));
 	}
 
 	private static System.Drawing.Point PointFromLParam(LPARAM lParam)
@@ -459,6 +454,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_DESTROY)} message.");
 		Win32SystemThemeHelperExtension.Instance.SystemThemeChanged -= OnSystemThemeChanged;
 		Win32Host.UnregisterWindow(_hwnd);
+		_renderThread?.Dispose();
+		_renderThread = null;
 		_renderer.Dispose();
 		_rendererDisposed = true;
 		_backgroundDisposable?.Dispose();
@@ -589,12 +586,10 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 					_ = PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_MINIMIZE);
 					break;
 				default:
-					// This SynchronousRenderAndDraw call avoids showing the window with a blank first frame.
-					// We call it here and not when handling WM_ERASEBKGND. The problem is that any minor delay
-					// will cause a split-second white flash, so we're keeping the "time to blit" to a minimum by rendering
-					// before the window is shown and then making a Render call on WM_ERASEBKGND.
-					// For other pending states, SynchronousRenderAndDraw will still be called but slightly later after
-					// the window has been resized (due to e.g. maximizing)
+					// Record the first frame synchronously, signal the render thread, and wait
+					// for presentation to complete before showing the window. This avoids a
+					// blank first-frame flash. For other pending states (maximized/minimized),
+					// the first frame is handled by WM_SIZE after the window is resized.
 					SynchronousRenderAndDraw(true);
 					PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWDEFAULT);
 					break;

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -103,7 +103,6 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		Win32Host.RegisterWindow(_hwnd);
 
-		_framePacer = CreateFramePacer();
 		_renderer = FeatureConfiguration.Rendering.UseVulkanOnWin32
 			? (IRenderer?)VulkanRenderer.TryCreateVulkanRenderer(_hwnd)
 				?? (FeatureConfiguration.Rendering.UseOpenGLOnWin32 ?? true
@@ -242,6 +241,12 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		switch (msg)
 		{
+			case PInvoke.WM_ENTERSIZEMOVE:
+				_inSizeMove = true;
+				break;
+			case PInvoke.WM_EXITSIZEMOVE:
+				_inSizeMove = false;
+				break;
 			case PInvoke.WM_NCPAINT:
 				if (_forcePaintOnNextEraseBkgndOrNcPaint)
 				{
@@ -268,18 +273,28 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
 				UpdateWindowState(wParam);
+				// During the modal resize loop, dispatcher-based blits are suppressed
+				// (they would starve the resize messages). Render synchronously instead,
+				// like WPF does with CompleteRender() during user-initiated resize.
+				if (_inSizeMove)
+				{
+					SynchronousRenderAndDraw(true);
+				}
 				return new LRESULT(0);
 			case PInvoke.WM_MOVE:
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// This call is necessary when part of the window is outside the bounds of the screen and is then moved inside.
-				// In that case, the part that was outside the screen will remain unpainted until the next Render call, probably
-				// since Windows discards that part of the framebuffer thinking that that part will be drawn again during the
-				// WM_PAINT message that follows the movement of the window. However, we ignore WM_PAINT and depend on InvalidateRender
-				// and our render timer.
+				// When the window moves and part of it was off-screen, Windows discards that part of
+				// the framebuffer. SynchronousRenderAndDraw re-blits so the exposed area is painted.
 				SynchronousRenderAndDraw(false);
 				return new LRESULT(0);
+			case PInvoke.WM_PAINT:
+				// Blit the current frame to screen. WM_PAINT is generated when the window is
+				// uncovered, restored, or otherwise needs repainting. We blit then let DefWindowProc
+				// call BeginPaint/EndPaint to validate the update region.
+				Render();
+				break;
 			case PInvoke.WM_GETMINMAXINFO:
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_GETMINMAXINFO)} message.");
 				if (Window?.AppWindow?.Presenter is OverlappedPresenter overlappedPresenter)
@@ -300,9 +315,7 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				{
 					_forcePaintOnNextEraseBkgndOrNcPaint = false;
 					// This call is necessary to avoid an initial blank frame during window startup.
-					// This follows from the SynchronousRenderAndDraw call in ShowCore
-					// The render timer might already be running. This is fine. The CompositionTarget
-					// contract allows calling OnNativePlatformFrameRequested multiple times.
+					// This follows from the SynchronousRenderAndDraw call in ShowCore.
 					Render();
 					return new LRESULT(1);
 				}
@@ -372,9 +385,12 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		if (sizeChanged)
 		{
 			OnWindowSizeOrLocationChanged(); // In case the window size has changed but WM_SIZE is not fired yet. This happens specifically if the window is starting maximized using _pendingState
-			XamlRoot!.VisualTree.RootElement.UpdateLayout(); // relayout in response to the new window size
 		}
-		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.OnRenderFrameOpportunity(); // force an early render
+		// Use SynchronousRender (layout + render) instead of full FrameTick to avoid re-entrancy:
+		// SynchronousRenderAndDraw can be called from within loaded event processing (Window.Show
+		// triggered by a Loaded handler), and FrameTick's RaiseLoadedEvent would corrupt the
+		// iteration of the loaded event list.
+		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.SynchronousRender(forceLayout: sizeChanged);
 		Render();
 	}
 
@@ -443,7 +459,6 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_DESTROY)} message.");
 		Win32SystemThemeHelperExtension.Instance.SystemThemeChanged -= OnSystemThemeChanged;
 		Win32Host.UnregisterWindow(_hwnd);
-		_framePacer.Dispose();
 		_renderer.Dispose();
 		_rendererDisposed = true;
 		_backgroundDisposable?.Dispose();

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -128,14 +128,15 @@ internal partial class X11XamlRootHost : IXamlRootHost
 
 		// only start listening to events after we're done setting everything up
 		InitializeX11EventsThread();
-		_framePacer = CreateFramePacer();
-		_renderThread = InitRenderThread();
+		InitializeRenderThread();
 
 		var windowBackgroundDisposable = _window.RegisterBackgroundChangedEvent((_, _) => UpdateRendererBackground());
 		UpdateRendererBackground();
 
 		Closed.ContinueWith(_ =>
 		{
+			_renderThread?.Dispose();
+			_renderThread = null;
 			using (X11Helper.XLock(RootX11Window.Display))
 			{
 				XamlRootMap.Unregister(xamlRoot);
@@ -143,8 +144,6 @@ internal partial class X11XamlRootHost : IXamlRootHost
 				CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBarChanged -= UpdateWindowPropertiesFromCoreApplication;
 				winUIWindow.AppWindow.TitleBar.ExtendsContentIntoTitleBarChanged -= ExtendContentIntoTitleBar;
 				windowBackgroundDisposable.Dispose();
-				_framePacer.Dispose();
-				_renderRequested.Dispose();
 				_renderer?.Dispose();
 			}
 		});
@@ -322,23 +321,20 @@ internal partial class X11XamlRootHost : IXamlRootHost
 	{
 		lock (_x11WindowToXamlRootHostMutex)
 		{
-			if (!_x11WindowToXamlRootHost.Remove(x11window, out var host))
+			if (_x11WindowToXamlRootHost.Remove(x11window, out var host))
+			{
+				using (X11Helper.XLock(x11window.Display))
+				{
+					host._closed.SetResult();
+				}
+			}
+			else
 			{
 				if (typeof(X11XamlRootHost).Log().IsEnabled(LogLevel.Error))
 				{
 					typeof(X11XamlRootHost).Log().Error($"{nameof(Close)} could not find X11Window {x11window}");
 				}
-				return;
 			}
-
-			// The rendering thread needs to be stopped before we destroy the window,
-			// otherwise we might end up in a situation where the render thread is
-			// trying to render on a destroyed window.
-			host._renderLoopRunning = false;
-			host._renderRequested.Set(); // wake up the render loop so it can see that it needs to exit
-			host._renderThread.Join();
-
-			host._closed.SetResult();
 		}
 	}
 
@@ -380,26 +376,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		IntPtr rootXWindow = XLib.XRootWindow(display, screen);
 		_x11Window = CreateSoftwareRenderWindow(display, screen, size, rootXWindow);
 		var topWindowDisplay = XLib.XOpenDisplay(IntPtr.Zero);
-		if (FeatureConfiguration.Rendering.UseVulkanOnX11)
-		{
-			try
-			{
-				_x11TopWindow = CreateSoftwareRenderWindow(topWindowDisplay, screen, size, RootX11Window.Window);
-				_renderer = X11VulkanRenderer.Create(this, TopX11Window);
-			}
-			catch (Exception e)
-			{
-				this.Log().Info($"Vulkan rendering not available: {e.Message}. Falling back to OpenGL.");
-				if (_x11TopWindow is not null)
-				{
-					_ = XLib.XDestroyWindow(_x11TopWindow.Value.Display, _x11TopWindow.Value.Window);
-					_x11TopWindow = null;
-				}
-				_renderer = null;
-			}
-		}
-
-		if (_renderer is null && (FeatureConfiguration.Rendering.UseOpenGLOnX11 ?? true))
+		if (FeatureConfiguration.Rendering.UseOpenGLOnX11 ?? true)
 		{
 			try
 			{
@@ -449,13 +426,10 @@ internal partial class X11XamlRootHost : IXamlRootHost
 				}
 			}
 		}
-		if (_renderer is null)
+		else
 		{
 			this.Log().Info($"Forcing software rendering.");
-			if (_x11TopWindow is null)
-			{
-				_x11TopWindow = CreateSoftwareRenderWindow(topWindowDisplay, screen, size, RootX11Window.Window);
-			}
+			_x11TopWindow = CreateSoftwareRenderWindow(topWindowDisplay, screen, size, RootX11Window.Window);
 			_renderer = new X11SoftwareRenderer(this, TopX11Window);
 		}
 

--- a/src/Uno.UI.Runtime.Skia.X11/Rendering/X11RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Rendering/X11RenderThread.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using Uno.Foundation.Logging;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+/// <summary>
+/// Dedicated render thread for X11. The UI thread records SKPictures and signals
+/// this thread to present them. Mirrors Win32's RenderThread and iOS's CADisplayLink
+/// render thread patterns.
+///
+/// Key improvements over the previous timer-based approach:
+/// - GL context stays on a single dedicated thread (required by GLX/EGL)
+/// - glXSwapBuffers/eglSwapBuffers blocking for VSync correctly blocks this thread
+/// - AutoResetEvent coalesces multiple invalidation signals
+/// - OnFramePresented posted to UI thread enables render throttling
+/// </summary>
+internal sealed class X11RenderThread : IDisposable
+{
+	private readonly Thread _thread;
+	private readonly AutoResetEvent _frameSignal = new(false);
+	private readonly ManualResetEventSlim _presentedEvent = new(false);
+	private readonly X11Renderer _renderer;
+	private readonly Action _onFramePresented;
+	private volatile bool _disposed;
+
+	internal X11RenderThread(X11Renderer renderer, Action onFramePresented)
+	{
+		_renderer = renderer;
+		_onFramePresented = onFramePresented;
+		_thread = new Thread(RenderLoop) { Name = "Uno X11 Render Thread", IsBackground = true };
+		_thread.Start();
+	}
+
+	/// <summary>
+	/// Signals the render thread that a new frame is available for presentation.
+	/// Multiple calls while the thread is busy coalesce into a single wake-up
+	/// (AutoResetEvent semantics).
+	/// </summary>
+	internal void SignalNewFrame() => _frameSignal.Set();
+
+	/// <summary>
+	/// Blocks the calling thread until the render thread finishes presenting a frame.
+	/// Used to ensure the first frame is painted before the window is shown.
+	/// </summary>
+	internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+	private void RenderLoop()
+	{
+		while (!_disposed)
+		{
+			_frameSignal.WaitOne();
+			if (_disposed)
+			{
+				break;
+			}
+
+			_presentedEvent.Reset();
+			try
+			{
+				_renderer.Render();
+			}
+			catch (Exception ex)
+			{
+				typeof(X11RenderThread).LogError()?.Error($"Render thread error: {ex}");
+			}
+
+			_presentedEvent.Set();
+			_onFramePresented();
+		}
+	}
+
+	public void Dispose()
+	{
+		_disposed = true;
+		_frameSignal.Set(); // Unblock if waiting
+		_thread.Join(timeout: TimeSpan.FromSeconds(2));
+		_frameSignal.Dispose();
+		_presentedEvent.Dispose();
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.X11/Rendering/X11XamlRootHost.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Rendering/X11XamlRootHost.Rendering.cs
@@ -1,60 +1,53 @@
-using System.Threading;
-using Uno.UI;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
-using Uno.UI.Runtime.Skia.Hosting;
 
 namespace Uno.WinUI.Runtime.Skia.X11;
 
 internal partial class X11XamlRootHost
 {
-	private readonly AutoResetEvent _renderRequested = new(false);
-	private volatile bool _renderLoopRunning = true;
-	private readonly Thread _renderThread;
-	private readonly FramePacer _framePacer;
+	private X11RenderThread? _renderThread;
 
-	private FramePacer CreateFramePacer()
-	{
-		return new FramePacer(
-			FeatureConfiguration.CompositionTarget.FrameRate,
-			() => _renderRequested.Set());
-	}
+	bool IXamlRootHost.SupportsRenderThrottle => true;
 
-	private Thread InitRenderThread()
+	private void InitializeRenderThread()
 	{
-		var thread = new Thread(RenderLoop)
+		if (_renderer is null)
 		{
-			IsBackground = true,
-			Name = "X11RenderThread",
-			Priority = ThreadPriority.AboveNormal
-		};
-		thread.Start();
-		return thread;
-	}
-
-	private void RenderLoop()
-	{
-		while (_renderLoopRunning)
-		{
-			_renderRequested.WaitOne();
-
-			_framePacer.OnFrameStart();
-			_renderer?.Render();
+			return;
 		}
+
+		_renderThread = new X11RenderThread(
+			_renderer,
+			onFramePresented: () =>
+			{
+				NativeDispatcher.Main.Enqueue(
+					OnFramePresented,
+					NativeDispatcherPriority.Render);
+			});
 	}
 
+	/// <summary>
+	/// No-op. Previously updated the timer interval based on screen refresh rate.
+	/// With the render thread, VSync pacing comes from glXSwapBuffers/eglSwapBuffers
+	/// blocking, so explicit frame rate configuration is no longer needed.
+	/// </summary>
 	internal void UpdateRenderTimerFps(double fps)
 	{
-		if (FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
-		{
-			_framePacer.UpdateTargetFps(fps);
-		}
+		// Render thread is paced by VSync (SwapBuffers blocking).
+	}
+
+	private void OnFramePresented()
+	{
+		var ct = ((IXamlRootHost)this).RootElement?.Visual.CompositionTarget as CompositionTarget;
+		ct?.OnFramePresented();
 	}
 
 	void IXamlRootHost.InvalidateRender()
 	{
 		if (!_closed.Task.IsCompleted)
 		{
-			_framePacer.RequestFrame();
+			_renderThread?.SignalNewFrame();
 		}
 	}
 }

--- a/src/Uno.UI/Hosting/IXamlRootHost.cs
+++ b/src/Uno.UI/Hosting/IXamlRootHost.cs
@@ -14,4 +14,11 @@ internal interface IXamlRootHost
 	/// Resigns native first responder
 	/// </summary>
 	void ResignNativeFocus() { }
+
+	/// <summary>
+	/// When true, CompositionTarget throttles FrameTick scheduling until the host
+	/// signals that the previous frame has been presented (via OnFramePresented).
+	/// Only Win32 returns true (it has a dedicated render thread for presentation).
+	/// </summary>
+	bool SupportsRenderThrottle => false;
 }

--- a/src/Uno.UI/Hosting/IXamlRootHost.cs
+++ b/src/Uno.UI/Hosting/IXamlRootHost.cs
@@ -21,4 +21,14 @@ internal interface IXamlRootHost
 	/// Only Win32 returns true (it has a dedicated render thread for presentation).
 	/// </summary>
 	bool SupportsRenderThrottle => false;
+
+	/// <summary>
+	/// Returns the <see cref="System.Diagnostics.Stopwatch"/>-compatible timestamp of the
+	/// most recent VSync that triggered the current frame callback, or 0 if unavailable.
+	/// Used by <see cref="Microsoft.UI.Xaml.Media.CompositionTarget"/> to provide accurate
+	/// animation timing even when the frame tick is delayed by GC or heavy layout.
+	/// On Android, this is the <c>frameTimeNanos</c> from Choreographer which shares the
+	/// same CLOCK_MONOTONIC source as <see cref="System.Diagnostics.Stopwatch.GetTimestamp"/>.
+	/// </summary>
+	long FrameVsyncTimestamp => 0;
 }

--- a/src/Uno.UI/Hosting/IXamlRootHost.cs
+++ b/src/Uno.UI/Hosting/IXamlRootHost.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 
+using System;
 using Microsoft.UI.Xaml;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Hosting;
 
@@ -18,7 +20,7 @@ internal interface IXamlRootHost
 	/// <summary>
 	/// When true, CompositionTarget throttles FrameTick scheduling until the host
 	/// signals that the previous frame has been presented (via OnFramePresented).
-	/// Only Win32 returns true (it has a dedicated render thread for presentation).
+	/// Platforms that return true post OnFramePresented after each present.
 	/// </summary>
 	bool SupportsRenderThrottle => false;
 
@@ -31,4 +33,12 @@ internal interface IXamlRootHost
 	/// same CLOCK_MONOTONIC source as <see cref="System.Diagnostics.Stopwatch.GetTimestamp"/>.
 	/// </summary>
 	long FrameVsyncTimestamp => 0;
+
+	/// <summary>
+	/// Schedules a callback for the next frame. Platforms can override to provide
+	/// vsync-aligned scheduling (e.g. Android Choreographer). The default dispatches
+	/// at Render priority on the main dispatcher.
+	/// </summary>
+	void ScheduleFrameCallback(Action callback)
+		=> NativeDispatcher.Main.Enqueue(callback, NativeDispatcherPriority.Render);
 }

--- a/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
@@ -58,7 +58,7 @@ namespace Uno.UI.Xaml.Core
 				Interlocked.CompareExchange(ref _isAdditionalFrameRequested, 1, 0) == 0)
 			{
 				// This lambda is intentionally static. It shouldn't capture anything to avoid allocations.
-				NativeDispatcher.Main.Enqueue(static () => OnTick(), NativeDispatcherPriority.Normal);
+				NativeDispatcher.Main.Enqueue(static () => OnTick(), NativeDispatcherPriority.Render);
 			}
 		}
 
@@ -66,22 +66,26 @@ namespace Uno.UI.Xaml.Core
 		{
 			_isAdditionalFrameRequested = 0;
 
-			// NOTE: The below code should really be replaced with just this:
-			// ----------------------------
-			//if (GetXamlRoot()?.VisualTree?.RootElement is { } root)
-			//{
-			//	root.UpdateLayout();
-			//
-			//	if (CoreServices.Instance.EventManager.ShouldRaiseLoadedEvent)
-			//	{
-			//		CoreServices.Instance.EventManager.RaiseLoadedEvent();
-			//		root.UpdateLayout();
-			//	}
-			//}
-			// -----------------------------
-			// However, as we don't yet have XamlIslandRootCollection, we will need to enumerate the windows through ApplicationHelper.Windows.
+			// Schedule a FrameTick for each CompositionTarget. FrameTick batches
+			// layout, loaded events, CompositionTarget.Rendering, and render into
+			// a single dispatcher item at Render priority.
 
-			// This happens for Islands.
+#if __SKIA__
+			// Islands
+			if (GetXamlRoot() is { HostWindow: null, VisualTree.RootElement: { } xamlIsland })
+			{
+				(xamlIsland.XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.ScheduleFrameTick();
+			}
+
+			foreach (var window in ApplicationHelper.WindowsInternal)
+			{
+				if (window.RootElement?.XamlRoot?.Content?.Visual.CompositionTarget is CompositionTarget ct)
+				{
+					ct.ScheduleFrameTick();
+				}
+			}
+#else
+			// Non-Skia platforms: keep the existing layout-only behavior.
 			if (GetXamlRoot() is { HostWindow: null, VisualTree.RootElement: { } xamlIsland })
 			{
 				xamlIsland.UpdateLayout();
@@ -107,11 +111,8 @@ namespace Uno.UI.Xaml.Core
 					CoreServices.Instance.EventManager.RaiseLoadedEvent();
 					root.UpdateLayout();
 				}
-
-#if __SKIA__
-				(root.XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.OnRenderFrameOpportunity();
-#endif
 			}
+#endif
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Diagnostics;
 using System.Threading;
 using SkiaSharp;
 using Windows.Foundation;
@@ -61,14 +62,23 @@ public partial class CompositionTarget
 	/// Throttle flag: when true, ScheduleFrameTick defers until OnFramePresented clears it.
 	/// Only set on hosts with a render thread (SupportsRenderThrottle == true).
 	/// Prevents the UI thread from recording frames faster than the render thread presents.
+	/// Volatile: written on UI thread (FrameTick / OnFramePresented), read in ScheduleFrameTick
+	/// which may be called from a non-UI thread via RequestNewFrame.
 	/// </summary>
-	private bool _waitingForPresent;
+	private volatile bool _waitingForPresent;
 
 	/// <summary>
 	/// Set when ScheduleFrameTick is called while throttled. OnFramePresented schedules
 	/// the deferred FrameTick when it clears the throttle.
+	/// Volatile: written in ScheduleFrameTick (any thread), read in OnFramePresented (UI thread).
 	/// </summary>
-	private bool _pendingFrameRequest;
+	private volatile bool _pendingFrameRequest;
+
+	/// <summary>
+	/// Set when FrameTick is called re-entrantly (e.g. loaded event → Window.Show → SynchronousRenderAndDraw).
+	/// The outer FrameTick schedules another tick after completing if this is set.
+	/// </summary>
+	private bool _reentrantFrameRequested;
 
 	void ICompositionTarget.RequestNewFrame()
 	{
@@ -128,7 +138,9 @@ public partial class CompositionTarget
 		if (_inFrameTick)
 		{
 			// Re-entrant call (e.g. loaded event handler → Window.Show → SynchronousRenderAndDraw).
-			// Skip to avoid corrupting the loaded event list iteration.
+			// Skip to avoid corrupting the loaded event list iteration. The outer FrameTick
+			// will schedule another tick after completing.
+			_reentrantFrameRequested = true;
 			return;
 		}
 
@@ -140,6 +152,11 @@ public partial class CompositionTarget
 		_inFrameTick = true;
 		try
 		{
+			// Resolve the host once for this tick (used for throttle + VSync timestamp).
+			var host = ContentRoot.XamlRoot is { } xr
+				? XamlRootMap.GetHostForRoot(xr)
+				: null;
+
 			// 1. Layout pass
 			rootElement.UpdateLayout();
 
@@ -150,29 +167,46 @@ public partial class CompositionTarget
 				rootElement.UpdateLayout();
 			}
 
-			// 3. CompositionTarget.Rendering event (may dirty layout)
-			InvokeRendering();
+			// 3. CompositionTarget.Rendering event (may dirty layout).
+			//    Use the host's VSync timestamp when available (e.g. Android Choreographer)
+			//    for accurate animation timing; fall back to wall clock otherwise.
+			var vsync = host?.FrameVsyncTimestamp ?? 0;
+			InvokeRendering(vsync != 0
+				? Stopwatch.GetElapsedTime(_start, vsync)
+				: Stopwatch.GetElapsedTime(_start));
 
 			// 4. Re-layout after Rendering callbacks (matches WinUI NWDrawTree which runs
 			//    UpdateLayout after CallPerFrameCallback). Without this, Rendering handlers
 			//    that modify layout-affecting properties would render with stale layout.
 			rootElement.UpdateLayout();
+
+			// 5. Record SKPicture from visual tree
 			if (SkiaRenderHelper.CanRecordPicture(rootElement))
 			{
-				Render();
-
-				// Throttle: don't schedule next FrameTick until render thread presents.
-				// Only set on hosts with a render thread that calls OnFramePresented.
-				if (ContentRoot.XamlRoot is { } xamlRoot
-					&& XamlRootMap.GetHostForRoot(xamlRoot) is { SupportsRenderThrottle: true })
+				// Set throttle BEFORE Render() to prevent RequestNewFrame() inside Render()
+				// (called when CompositionTarget.Rendering has subscribers) from scheduling
+				// another FrameTick immediately. Without this, one extra FrameTick fires per
+				// displayed frame during continuous animations, doubling CPU work.
+				if (host is { SupportsRenderThrottle: true })
 				{
 					_waitingForPresent = true;
 				}
+
+				Render();
 			}
 		}
 		finally
 		{
 			_inFrameTick = false;
+
+			// If a re-entrant call was suppressed, schedule another tick to process
+			// the deferred state change. This prevents lost frames when loaded event
+			// handlers indirectly trigger RequestNewFrame.
+			if (_reentrantFrameRequested)
+			{
+				_reentrantFrameRequested = false;
+				ScheduleFrameTick();
+			}
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
@@ -118,8 +118,8 @@ public partial class CompositionTarget
 
 	/// <summary>
 	/// Single batched frame tick, posted to the dispatcher as one operation at Render priority.
-	/// Sequences: Layout -> Loaded events -> Layout -> CompositionTarget.Rendering -> Render.
-	/// Matches WPF MediaContext.RenderMessageHandlerCore / WinUI OnTick pattern.
+	/// Sequences: Layout -> Loaded events -> Layout -> CompositionTarget.Rendering -> Layout -> Render.
+	/// Matches WPF MediaContext.RenderMessageHandlerCore / WinUI NWDrawTree OnTick pattern.
 	/// </summary>
 	internal void FrameTick()
 	{
@@ -150,10 +150,13 @@ public partial class CompositionTarget
 				rootElement.UpdateLayout();
 			}
 
-			// 3. CompositionTarget.Rendering event
+			// 3. CompositionTarget.Rendering event (may dirty layout)
 			InvokeRendering();
 
-			// 4. Record SKPicture from visual tree
+			// 4. Re-layout after Rendering callbacks (matches WinUI NWDrawTree which runs
+			//    UpdateLayout after CallPerFrameCallback). Without this, Rendering handlers
+			//    that modify layout-affecting properties would render with stale layout.
+			rootElement.UpdateLayout();
 			if (SkiaRenderHelper.CanRecordPicture(rootElement))
 			{
 				Render();

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
@@ -53,6 +53,11 @@ public partial class CompositionTarget
 	private bool _frameTickScheduled;
 
 	/// <summary>
+	/// Cached delegate for FrameTick scheduling to avoid per-call lambda allocation.
+	/// </summary>
+	private Action? _frameTickCallback;
+
+	/// <summary>
 	/// Re-entrancy guard for FrameTick. FrameTick can be called re-entrantly when loaded
 	/// event handlers trigger SynchronousRenderAndDraw (e.g., during Window.Show on Win32).
 	/// </summary>
@@ -118,11 +123,21 @@ public partial class CompositionTarget
 
 		if (!Interlocked.Exchange(ref _frameTickScheduled, true))
 		{
-			NativeDispatcher.Main.Enqueue(() =>
+			_frameTickCallback ??= () =>
 			{
 				Interlocked.Exchange(ref _frameTickScheduled, false);
 				FrameTick();
-			}, NativeDispatcherPriority.Render);
+			};
+
+			if (ContentRoot.XamlRoot is { } xamlRoot
+				&& XamlRootMap.GetHostForRoot(xamlRoot) is { } host)
+			{
+				host.ScheduleFrameCallback(_frameTickCallback);
+			}
+			else
+			{
+				NativeDispatcher.Main.Enqueue(_frameTickCallback, NativeDispatcherPriority.Render);
+			}
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
@@ -1,230 +1,172 @@
 #nullable enable
 using System;
-using System.Diagnostics;
 using System.Threading;
-using Windows.Foundation;
 using SkiaSharp;
+using Windows.Foundation;
 using Uno.Foundation.Logging;
 using Uno.UI.Composition;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
 using Uno.UI.Hosting;
+using Uno.UI.Xaml.Core;
 
 namespace Microsoft.UI.Xaml.Media;
 
 public partial class CompositionTarget
 {
-	//                      +---------+            +-------------------------------------------+                                                                                   +---------------+ +-----------------------------+        +-------------------+
-	//                      | Visual  |            | CompositionTargetNotNecessarilyOnUIThread |                                                                                   | IXamlRootHost | | CompositionTargetOnUIThread |        | NativeDispatcher  |
-	//                      +---------+            +-------------------------------------------+                                                                                   +---------------+ +-----------------------------+        +-------------------+
-	// ------------------------\ |                                       |                                                                                                                 |                        |                                 |
-	// | some property changes |-|                                       |                                                                                                                 |                        |                                 |
-	// |-----------------------| |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           | RequestNewFrame                       |                                                                                                                 |                        |                                 |
-	//                           |-------------------------------------->|                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       | InvalidateRender (the native platform will later call us back likely on the next monitor VSync)                 |                        |                                 |
-	//                           |                                       |---------------------------------------------------------------------------------------------------------------->|                        |                                 |
-	// ------------------------\ |                                       |                                                                                                                 |                        |                                 |
-	// | some property changes |-|                                       |                                                                                                                 |                        |                                 |
-	// |-----------------------| |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           | RequestNewFrame                       |                                                                                                                 |                        |                                 |
-	//                           |-------------------------------------->|                                                                                                                 |                        |                                 |
-	//                           |        -----------------------------\ |                                                                                                                 |                        |                                 |
-	//                           |        | RequestNewFrame is ignored |-|                                                                                                                 |                        |                                 |
-	//                           |        |----------------------------| |                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           | RequestNewFrame                       |                                                                                                                 |                        |                                 |
-	//                           |-------------------------------------->|                                                                                                                 |                        |                                 |
-	//                           |        -----------------------------\ |                                                                                                                 |                        |                                 |
-	//                           |        | RequestNewFrame is ignored |-|                                                                                                                 |                        |                                 |
-	//                           |        |----------------------------| |                                                                                                                 |                        |                                 |
-	//                           |                                       |                           ------------------------------------------------------------------------------------\ |                        |                                 |
-	//                           |                                       |                           | native platform render callback in response to the previous InvalidateRender call |-|                        |                                 |
-	//                           |                                       |                           |-----------------------------------------------------------------------------------| |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                  OnNativePlatformFrameRequested |                        |                                 |
-	//                           |                                       |<----------------------------------------------------------------------------------------------------------------|                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       | Draw the pixels from the last SKPicture and returns native element clip path pair generated in Render()         |                        |                                 |
-	//                           |                                       |---------------------------------------------------------------------------------------------------------------->|                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       | EnqueueRender (the NativeDispatcher will call us back when it thinks it's the best time to do so)               |                        |                                 |
-	//                           |                                       |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------->|
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |           EnqueueRenderCallback |
-	//                           |                                       |                                                                                                                 |                        |<--------------------------------|
-	//                           |                                       |                                                                                                                 |           -----------\ |                                 |
-	//                           |                                       |                                                                                                                 |           | Render() |-|                                 |
-	//                           |                                       |                                                                                                                 |           |----------| |                                 |
-	// ------------------------\ |                                       |                                                                                                                 |                        |                                 |
-	// | some property changes |-|                                       |                                                                                                                 |                        |                                 |
-	// |-----------------------| |                                       |                                                                                                                 |                        |                                 |
-	//             ------------\ |                                       |                                                                                                                 |                        |                                 |
-	//             | Repeat... |-|                                       |                                                                                                                 |                        |                                 |
-	//             |-----------| |                                       |                                                                                                                 |                        |                                 |
-	//                           |                                       |                                                                                                                 |                        |                                 |
-	private readonly object _renderingStateGate = new();
+	//                      +---------+            +-------------------------------------------+
+	//                      | Visual  |            |    CompositionTarget (batched FrameTick)   |
+	//                      +---------+            +-------------------------------------------+
+	// ------------------------\ |                                       |
+	// | some property changes |-|                                       |
+	// |-----------------------| |                                       |
+	//                           |                                       |
+	//                           | RequestNewFrame                       |
+	//                           |-------------------------------------->|
+	//                           |                                       |
+	//                           |                                       | ScheduleFrameTick (at Render priority)
+	//                           |                                       |----.
+	//                           |                                       |    |
+	//                           |                                       |<---'
+	//                           |                                       |
+	//                           |                                       | FrameTick: Layout -> Loaded -> InvokeRendering -> Render
+	//                           |                                       |----.
+	//                           |                                       |    |
+	//                           |                                       |<---'
+	//                           |                                       |
+	//                           |                                       | InvalidateRender (native platform draws on next VSync)
+	//                           |                                       |----.
+	//                           |                                       |    |
+	//                           |                                       |<---'
+	//                           |                                       |
+	//                           |                                       | OnNativePlatformFrameRequested -> Draw (previous SKPicture)
+	//                           |                                       |
+	//             ------------\ |                                       |
+	//             | Repeat... |-|                                       |
+	//             |-----------| |                                       |
+	//                           |                                       |
 
-	private bool _renderRequested; // only set or read under _renderingStateGate
-	private bool _renderedAheadOfTime; // only set or read under _renderingStateGate
-	private bool _renderRequestedAfterAheadOfTimePaint; // only set or read under _renderingStateGate
-	private bool _shouldEnqueueRenderOnNextNativePlatformFrameRequested = true; // only set from the UI thread, only reset from the rendering/gpu thread
+	/// <summary>
+	/// Guards against scheduling duplicate frame ticks. Thread-safe via Interlocked.
+	/// </summary>
+	private bool _frameTickScheduled;
 
-	private bool RenderRequested
-	{
-		get => _renderRequested;
-		set
-		{
-			_renderRequested = value;
-			this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()} {nameof(_renderRequested)} = {_renderRequested}");
-		}
-	}
+	/// <summary>
+	/// Re-entrancy guard for FrameTick. FrameTick can be called re-entrantly when loaded
+	/// event handlers trigger SynchronousRenderAndDraw (e.g., during Window.Show on Win32).
+	/// </summary>
+	private bool _inFrameTick;
 
 	void ICompositionTarget.RequestNewFrame()
 	{
-		var shouldEnqueue = false;
-		lock (_renderingStateGate)
-		{
-			LogRenderState();
-			AssertRenderStateMachine();
-			if (!_renderedAheadOfTime && !RenderRequested)
-			{
-				RenderRequested = true;
-				shouldEnqueue = true;
-			}
-			else if (_renderedAheadOfTime)
-			{
-				_renderRequestedAfterAheadOfTimePaint = true;
-			}
-			AssertRenderStateMachine();
-			LogRenderState();
-		}
+		ScheduleFrameTick();
 
-		if (shouldEnqueue)
+		if (ContentRoot.XamlRoot is { } xamlRoot && XamlRootMap.GetHostForRoot(xamlRoot) is { } host)
 		{
-			if (ContentRoot.XamlRoot is { } xamlRoot && XamlRootMap.GetHostForRoot(xamlRoot) is { } host)
-			{
-				host.InvalidateRender();
-			}
-			this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(ICompositionTarget.RequestNewFrame)} invalidated render");
-		}
-		else
-		{
-			this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(ICompositionTarget.RequestNewFrame)} found no need to invalidate render.");
-		}
-	}
-
-	private void EnqueueRenderCallback()
-	{
-		this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(EnqueueRenderCallback)}");
-		NativeDispatcher.CheckThreadAccess();
-
-		Interlocked.Exchange(ref _shouldEnqueueRenderOnNextNativePlatformFrameRequested, true);
-
-		lock (_renderingStateGate)
-		{
-			LogRenderState();
-			AssertRenderStateMachine();
-			if (_renderedAheadOfTime)
-			{
-				_renderedAheadOfTime = false;
-				if (_renderRequestedAfterAheadOfTimePaint)
-				{
-					_renderRequestedAfterAheadOfTimePaint = false;
-					this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(EnqueueRenderCallback)}: rendered ahead of time and got a new frame request since. Doing nothing this tick and rescheduling another tick");
-					((ICompositionTarget)this).RequestNewFrame();
-				}
-				else
-				{
-					this.LogTrace()?.Trace($"{nameof(EnqueueRenderCallback)}: rendered ahead of time and no new frame was requested since.");
-				}
-			}
-			else if (RenderRequested)
-			{
-				lock (_renderingStateGate)
-				{
-					RenderRequested = false;
-				}
-				this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(Draw)} fired from {nameof(EnqueueRenderCallback)}");
-				Render();
-			}
-			AssertRenderStateMachine();
-			LogRenderState();
+			host.InvalidateRender();
 		}
 	}
 
 	/// <summary>
-	/// This method is called from each platform's rendering logic in response to the native windowing/composition
-	/// engine's signal requesting the Uno app to draw something _right now_, usually synced to the refresh rate
-	/// of the screen (e.g. Android's IRenderer.OnDrawFrame). This class does not assume that this method will only
-	/// be called once per <see cref="IXamlRootHost.InvalidateRender"/> call, but the contract allows any number
-	/// of repeated calls, even if no new invalidations are requested.
+	/// Schedules a single batched frame tick at Render priority if one is not already scheduled.
+	/// Thread-safe: can be called from the UI thread or the native render thread.
+	/// </summary>
+	internal void ScheduleFrameTick()
+	{
+		if (!Interlocked.Exchange(ref _frameTickScheduled, true))
+		{
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				Interlocked.Exchange(ref _frameTickScheduled, false);
+				FrameTick();
+			}, NativeDispatcherPriority.Render);
+		}
+	}
+
+	/// <summary>
+	/// Single batched frame tick, posted to the dispatcher as one operation at Render priority.
+	/// Sequences: Layout -> Loaded events -> Layout -> CompositionTarget.Rendering -> Render.
+	/// Matches WPF MediaContext.RenderMessageHandlerCore / WinUI OnTick pattern.
+	/// </summary>
+	internal void FrameTick()
+	{
+		NativeDispatcher.CheckThreadAccess();
+
+		if (_inFrameTick)
+		{
+			// Re-entrant call (e.g. loaded event handler → Window.Show → SynchronousRenderAndDraw).
+			// Skip to avoid corrupting the loaded event list iteration.
+			return;
+		}
+
+		if (ContentRoot.VisualTree.RootElement is not { } rootElement)
+		{
+			return;
+		}
+
+		_inFrameTick = true;
+		try
+		{
+			// 1. Layout pass
+			rootElement.UpdateLayout();
+
+			// 2. Loaded events (may dirty layout again)
+			if (CoreServices.Instance.EventManager.ShouldRaiseLoadedEvent)
+			{
+				CoreServices.Instance.EventManager.RaiseLoadedEvent();
+				rootElement.UpdateLayout();
+			}
+
+			// 3. CompositionTarget.Rendering event
+			InvokeRendering();
+
+			// 4. Record SKPicture from visual tree
+			if (SkiaRenderHelper.CanRecordPicture(rootElement))
+			{
+				Render();
+			}
+		}
+		finally
+		{
+			_inFrameTick = false;
+		}
+	}
+
+	/// <summary>
+	/// Synchronous layout + render without processing loaded events.
+	/// Used by Win32's SynchronousRenderAndDraw which may be called during loaded event
+	/// processing (re-entrant with FrameTick). This matches the original OnRenderFrameOpportunity behavior.
+	/// </summary>
+	internal void SynchronousRender(bool forceLayout)
+	{
+		NativeDispatcher.CheckThreadAccess();
+
+		if (ContentRoot.VisualTree.RootElement is not { } rootElement)
+		{
+			return;
+		}
+
+		if (forceLayout)
+		{
+			rootElement.UpdateLayout();
+		}
+
+		if (SkiaRenderHelper.CanRecordPicture(rootElement))
+		{
+			Render();
+		}
+	}
+
+	/// <summary>
+	/// Called from each platform's rendering logic in response to the native windowing/composition
+	/// engine's signal requesting the Uno app to draw something _right now_, usually synced to the
+	/// refresh rate of the screen (e.g. Android's IRenderer.OnDrawFrame).
 	/// </summary>
 	internal SKPath OnNativePlatformFrameRequested(SKCanvas? canvas, Func<Size, SKCanvas> resizeFunc)
 	{
 		this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(OnNativePlatformFrameRequested)}");
 
-		if (Interlocked.Exchange(ref _shouldEnqueueRenderOnNextNativePlatformFrameRequested, false))
-		{
-			NativeDispatcher.Main.EnqueueRender(this, EnqueueRenderCallback);
-		}
-
+		// Draw previous frame's SKPicture on render/GL thread
 		return Draw(canvas, resizeFunc);
-	}
-
-	internal void OnRenderFrameOpportunity()
-	{
-		// If we get an opportunity to get call Render earlier than EnqueuePaintCallback, then we do that
-		// but skip the Render call in the next EnqueuePaintCallback so that overall we're still keeping
-		// the rate of Render calls the same.
-		NativeDispatcher.CheckThreadAccess();
-
-		if (SkiaRenderHelper.CanRecordPicture(ContentRoot.VisualTree.RootElement))
-		{
-			var shouldRender = false;
-			lock (_renderingStateGate)
-			{
-				LogRenderState();
-				AssertRenderStateMachine();
-				if (RenderRequested && !_renderedAheadOfTime)
-				{
-					RenderRequested = false;
-					_renderedAheadOfTime = true;
-					shouldRender = true;
-				}
-				AssertRenderStateMachine();
-				LogRenderState();
-			}
-
-			if (shouldRender)
-			{
-				this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(OnRenderFrameOpportunity)}: Calling {nameof(Draw)} early ");
-				Render();
-			}
-		}
-	}
-
-	[Conditional("DEBUG")]
-	private void AssertRenderStateMachine()
-	{
-		lock (_renderingStateGate)
-		{
-			Debug.Assert(!_renderRequestedAfterAheadOfTimePaint || _renderedAheadOfTime);
-			Debug.Assert(!_renderedAheadOfTime || !RenderRequested);
-		}
-	}
-
-	private void LogRenderState()
-	{
-		if (this.Log().IsEnabled(LogLevel.Trace))
-		{
-			lock (_renderingStateGate)
-			{
-				this.Log().Trace($"CompositionTarget#{GetHashCode()}: Render state machine: {nameof(_renderRequested)} = {_renderRequested}, {nameof(_renderedAheadOfTime)} = {_renderedAheadOfTime}, {nameof(_renderRequestedAfterAheadOfTimePaint)}={_renderRequestedAfterAheadOfTimePaint}");
-			}
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
@@ -57,13 +57,38 @@ public partial class CompositionTarget
 	/// </summary>
 	private bool _inFrameTick;
 
+	/// <summary>
+	/// Throttle flag: when true, ScheduleFrameTick defers until OnFramePresented clears it.
+	/// Only set on hosts with a render thread (SupportsRenderThrottle == true).
+	/// Prevents the UI thread from recording frames faster than the render thread presents.
+	/// </summary>
+	private bool _waitingForPresent;
+
+	/// <summary>
+	/// Set when ScheduleFrameTick is called while throttled. OnFramePresented schedules
+	/// the deferred FrameTick when it clears the throttle.
+	/// </summary>
+	private bool _pendingFrameRequest;
+
 	void ICompositionTarget.RequestNewFrame()
 	{
+		// Only schedule the next FrameTick. Don't call host.InvalidateRender() here —
+		// the render thread is signaled from Render() after a new frame is recorded.
 		ScheduleFrameTick();
+	}
 
-		if (ContentRoot.XamlRoot is { } xamlRoot && XamlRootMap.GetHostForRoot(xamlRoot) is { } host)
+	/// <summary>
+	/// Called by the host's render thread (posted to UI thread) after a frame is presented.
+	/// Clears the throttle and schedules the next FrameTick if one was deferred.
+	/// </summary>
+	internal void OnFramePresented()
+	{
+		NativeDispatcher.CheckThreadAccess();
+		_waitingForPresent = false;
+		if (_pendingFrameRequest)
 		{
-			host.InvalidateRender();
+			_pendingFrameRequest = false;
+			ScheduleFrameTick();
 		}
 	}
 
@@ -73,6 +98,14 @@ public partial class CompositionTarget
 	/// </summary>
 	internal void ScheduleFrameTick()
 	{
+		if (_waitingForPresent)
+		{
+			// Render thread hasn't finished presenting the previous frame.
+			// Remember the request — it will be scheduled when OnFramePresented fires.
+			_pendingFrameRequest = true;
+			return;
+		}
+
 		if (!Interlocked.Exchange(ref _frameTickScheduled, true))
 		{
 			NativeDispatcher.Main.Enqueue(() =>
@@ -124,6 +157,14 @@ public partial class CompositionTarget
 			if (SkiaRenderHelper.CanRecordPicture(rootElement))
 			{
 				Render();
+
+				// Throttle: don't schedule next FrameTick until render thread presents.
+				// Only set on hosts with a render thread that calls OnFramePresented.
+				if (ContentRoot.XamlRoot is { } xamlRoot
+					&& XamlRootMap.GetHostForRoot(xamlRoot) is { SupportsRenderThrottle: true })
+				{
+					_waitingForPresent = true;
+				}
 			}
 		}
 		finally

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -192,8 +192,6 @@ public partial class CompositionTarget
 
 			ReturnFrame(lastRenderedFrame);
 
-			InvokeRendering();
-
 			if (FrameRenderingOptions.applyScalingToNativeElementClipPath && rasterizationScale != 1)
 			{
 				if (_lastNativeClipPath != lastRenderedFrame.nativeElementClipPath || _lastScaledNativeClipPath == null)
@@ -240,16 +238,7 @@ public partial class CompositionTarget
 
 	internal static void InvokeRendering()
 	{
-		if (NativeDispatcher.Main.HasThreadAccess)
-		{
-			_rendering?.Invoke(null, new RenderingEventArgs(Stopwatch.GetElapsedTime(_start)));
-		}
-		else
-		{
-			NativeDispatcher.Main.Enqueue(() =>
-			{
-				_rendering?.Invoke(null, new RenderingEventArgs(Stopwatch.GetElapsedTime(_start)));
-			}, NativeDispatcherPriority.High);
-		}
+		NativeDispatcher.CheckThreadAccess();
+		_rendering?.Invoke(null, new RenderingEventArgs(Stopwatch.GetElapsedTime(_start)));
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -28,6 +28,7 @@ public partial class CompositionTarget
 	private readonly SkiaRenderHelper.FpsHelper _fpsHelper = new();
 	private readonly Lock _frameGate = new();
 	private readonly Lock _xamlRootBoundsGate = new();
+	private static readonly SKPath _emptyPath = new();
 
 	// Only read and set from the native rendering thread in OnNativePlatformFrameRequested
 	private Size _lastCanvasSize = Size.Empty;
@@ -151,7 +152,7 @@ public partial class CompositionTarget
 
 		if (lastRenderedFrameNullable is not { } lastRenderedFrame)
 		{
-			return new SKPath();
+			return _emptyPath;
 		}
 		else
 		{

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -236,9 +236,17 @@ public partial class CompositionTarget
 		}
 	}
 
-	internal static void InvokeRendering()
+	/// <summary>
+	/// Fires the <see cref="Rendering"/> event.
+	/// </summary>
+	/// <param name="renderingTime">
+	/// Elapsed time since application start. When a VSync-aligned timestamp is available
+	/// (e.g. Android Choreographer), this reflects the VSync time rather than wall clock,
+	/// giving animations a stable time base even if the tick is delayed by GC or layout.
+	/// </param>
+	internal static void InvokeRendering(TimeSpan renderingTime)
 	{
 		NativeDispatcher.CheckThreadAccess();
-		_rendering?.Invoke(null, new RenderingEventArgs(Stopwatch.GetElapsedTime(_start)));
+		_rendering?.Invoke(null, new RenderingEventArgs(renderingTime));
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml;
 using Windows.UI.ViewManagement;
 using Uno.Helpers.Theming;
 using Uno.UI.Core;
+using Uno.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Uno.Disposables;
 
@@ -364,7 +365,12 @@ internal abstract partial class BaseWindowImplementation : IWindowImplementation
 	{
 		_contentLoaded = true;
 
-		TryActivate();
+		// Defer activation to the next dispatcher cycle. NotifyContentLoaded is called
+		// from FrameworkElement.Loaded (which fires inside the frame tick during loaded
+		// event processing). Synchronous activation would trigger SynchronousRenderAndDraw
+		// and re-enter the frame tick — WinUI treats tick re-entry as fatal (XAML_FAIL_FAST).
+		// Window activation is async in WinUI; deferring matches that behavior.
+		NativeDispatcher.Main.Enqueue(TryActivate);
 	}
 
 	private void TryActivate()

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -345,7 +345,8 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 		public bool OnPreDraw()
 		{
-			if (_windowWrapper._contentViewAttachedToWindow)
+			if (_windowWrapper._contentViewAttachedToWindow
+				&& MUX.ApplicationActivity.Instance?.FirstFrameRendered == true)
 			{
 				_windowWrapper.RemovePreDrawListener();
 				return true;


### PR DESCRIPTION
## Summary

Second slice of the split from `dev/mazi/rendering-fixes`. Builds on #23047 (render-loop core) and adopts the new render loop / throttle / VSync-timestamp machinery per platform.

- **Android**: Choreographer-based frame scheduling via `ScheduleFrameCallback`; exposes `frameTimeNanos` as `FrameVsyncTimestamp` so `CompositionTarget.Rendering` gets a stable VSync time base instead of wall clock. Fixes white flash during startup.
- **macOS**: Render improvements in `MacOSWindowHost` and the native `UNOMetalViewDelegate` / `UNOWindow` pair. Follow-up perf pass on the Metal view delegate.
- **Linux X11**: Dedicated `X11RenderThread` with the same UI-thread/render-thread split.
- **WASM / browser**: `BrowserRenderer` timing tweaks on the JS and C# sides.

**⚠️ This PR is stacked on #23047.** The base branch is `dev/mazi/render-loop-core`; GitHub will rebase this PR onto `master` automatically once #23047 merges.

Split out of the original bundled branch `dev/mazi/rendering-fixes`.

## Test plan

- [ ] Depends on #23047 merging first (or rebase once A lands)
- [ ] `dotnet build src/Uno.UI-Skia-only.slnf`
- [ ] Android emulator: `SamplesApp.Skia` startup — no white flash, smooth scroll
- [ ] macOS: `SamplesApp.Skia` renders smoothly under the Metal pipeline
- [ ] Linux/X11: render thread runs, no regressions
- [ ] WASM: `cd src/SamplesApp/SamplesApp.Wasm && dotnet run` — verify renderer timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)