### PR TITLE
feat: Scroll and inertial scrolling smoothness

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidCorePointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidCorePointerInputSource.cs
@@ -226,7 +226,7 @@ internal sealed class AndroidCorePointerInputSource : IUnoCorePointerInputSource
 		var x = nativeArgs.GetX(pointerIndex);
 		var y = nativeArgs.GetY(pointerIndex);
 
-		var position = new Point((int)x - correction[0], (int)y - correction[1]).PhysicalToLogicalPixels();
+		var position = new Point(x - correction[0], y - correction[1]).PhysicalToLogicalPixels();
 		var properties = PointerHelpers.GetProperties(nativeArgs, pointerIndex, nativePointerType, nativePointerAction, nativePointerButtons, isInRange, isInContact);
 		var point = new PointerPoint(frameId, ts, pointerDevice, pointerId, position, position, isInContact, new PointerPointProperties(properties));
 		var args = new PointerEventArgs(point, keyModifiers)

--- a/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Pointers.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Pointers.cs
@@ -88,7 +88,10 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 
 	public void ReleasePointerCapture(PointerIdentifier pointer) => ReleasePointerCapture();
 
-	private ushort ReadCommonWParamInfo(WPARAM wParam, out POINTER_INFO pointerInfo, out POINTER_INPUT_TYPE pointerType, out System.Drawing.Point position, out System.Drawing.Point rawPosition)
+	// 1 logical px = 1/96 inch; 1 inch = 2540 HIMETRIC (0.01 mm) units.
+	private const double HimetricPerLogicalPx = 2540.0 / 96.0;
+
+	private ushort ReadCommonWParamInfo(WPARAM wParam, out POINTER_INFO pointerInfo, out POINTER_INPUT_TYPE pointerType, out Point position, out Point rawPosition)
 	{
 		var pointerId = Win32Helper.GET_POINTERID_WPARAM(wParam);
 
@@ -102,17 +105,38 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 			throw new InvalidOperationException($"{nameof(PInvoke.GetPointerInfo)} failed: {Win32Helper.GetErrorMessage()}");
 		}
 
-		position = pointerInfo.ptPixelLocation;
-		rawPosition = pointerInfo.ptPixelLocationRaw;
-		var success = PInvoke.ScreenToClient(_hwnd, ref position);
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ScreenToClient)} failed: {Win32Helper.GetErrorMessage()}"); }
-		var success2 = PInvoke.ScreenToClient(_hwnd, ref rawPosition);
-		if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.ScreenToClient)} failed: {Win32Helper.GetErrorMessage()}"); }
-
 		var scale = XamlRoot!.RasterizationScale;
-		position = new System.Drawing.Point((int)(position.X / scale), (int)(position.Y / scale));
-		rawPosition = new System.Drawing.Point((int)(rawPosition.X / scale), (int)(rawPosition.Y / scale));
+
+		// Touch and pen go through ptHimetricLocation*: HIMETRIC (0.01 mm) is ~26× finer than
+		// the pointer's logical pixel grid, so slow drags advance in sub-pixel increments
+		// instead of stair-stepping. Mouse stays on ptPixelLocation* — Win32 delivers mouse
+		// coordinates in integer screen pixels and HIMETRIC adds nothing there.
+		var useHimetric = pointerType is POINTER_INPUT_TYPE.PT_TOUCH or POINTER_INPUT_TYPE.PT_PEN;
+
+		position = ToClientLogical(pointerInfo.ptPixelLocation, pointerInfo.ptHimetricLocation, useHimetric, scale);
+		rawPosition = ToClientLogical(pointerInfo.ptPixelLocationRaw, pointerInfo.ptHimetricLocationRaw, useHimetric, scale);
 		return pointerId;
+	}
+
+	private Point ToClientLogical(System.Drawing.Point screenPx, System.Drawing.Point screenHimetric, bool useHimetric, double scale)
+	{
+		var clientPx = screenPx;
+		var success = PInvoke.ScreenToClient(_hwnd, ref clientPx);
+		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ScreenToClient)} failed: {Win32Helper.GetErrorMessage()}"); }
+
+		if (!useHimetric)
+		{
+			return new Point(clientPx.X / scale, clientPx.Y / scale);
+		}
+
+		// HIMETRIC is DPI-independent: logicalPx = himetric / HimetricPerLogicalPx regardless of monitor DPI.
+		// The screen → client translation is integer-pixel; subtract that integer offset (converted to
+		// logical px) so the HIMETRIC-derived sub-pixel precision is preserved in the client-relative result.
+		var screenLogicalX = screenHimetric.X / HimetricPerLogicalPx;
+		var screenLogicalY = screenHimetric.Y / HimetricPerLogicalPx;
+		var clientOriginLogicalX = (screenPx.X - clientPx.X) / scale;
+		var clientOriginLogicalY = (screenPx.Y - clientPx.Y) / scale;
+		return new Point(screenLogicalX - clientOriginLogicalX, screenLogicalY - clientOriginLogicalY);
 	}
 
 	private void OnPointerCaptureChanged(WPARAM wParam)
@@ -129,8 +153,8 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 				_ => PointerDeviceType.Mouse
 			}),
 			pointerId: pointerId,
-			rawPosition: new Point(rawPosition.X, rawPosition.Y),
-			position: new Point(position.X, position.Y),
+			rawPosition: rawPosition,
+			position: position,
 			isInContact: false,
 			properties: null);
 		PointerCaptureLost?.Invoke(this, new PointerEventArgs(point, Win32Helper.GetKeyModifiers()));
@@ -232,8 +256,8 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 				_ => PointerDeviceType.Mouse
 			}),
 			pointerId: pointerId,
-			rawPosition: new Point(rawPosition.X, rawPosition.Y),
-			position: new Point(position.X, position.Y),
+			rawPosition: rawPosition,
+			position: position,
 			isInContact: msg is not (PInvoke.WM_POINTERWHEEL or PInvoke.WM_POINTERHWHEEL) && Win32Helper.IS_POINTER_INCONTACT_WPARAM(wParam),
 			properties: properties
 		);

--- a/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Pointers.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Pointers.cs
@@ -90,7 +90,10 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 
 	public void ReleasePointerCapture(PointerIdentifier pointer) => ReleasePointerCapture();
 
-	private ushort ReadCommonWParamInfo(WPARAM wParam, out POINTER_INFO pointerInfo, out POINTER_INPUT_TYPE pointerType, out System.Drawing.Point position, out System.Drawing.Point rawPosition)
+	// 1 logical px = 1/96 inch; 1 inch = 2540 HIMETRIC (0.01 mm) units.
+	private const double HimetricPerLogicalPx = 2540.0 / 96.0;
+
+	private ushort ReadCommonWParamInfo(WPARAM wParam, out POINTER_INFO pointerInfo, out POINTER_INPUT_TYPE pointerType, out Point position, out Point rawPosition)
 	{
 		var pointerId = Win32Helper.GET_POINTERID_WPARAM(wParam);
 
@@ -104,17 +107,38 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 			throw new InvalidOperationException($"{nameof(PInvoke.GetPointerInfo)} failed: {Win32Helper.GetErrorMessage()}");
 		}
 
-		position = pointerInfo.ptPixelLocation;
-		rawPosition = pointerInfo.ptPixelLocationRaw;
-		var success = PInvoke.ScreenToClient(_hwnd, ref position);
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ScreenToClient)} failed: {Win32Helper.GetErrorMessage()}"); }
-		var success2 = PInvoke.ScreenToClient(_hwnd, ref rawPosition);
-		if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.ScreenToClient)} failed: {Win32Helper.GetErrorMessage()}"); }
-
 		var scale = XamlRoot!.RasterizationScale;
-		position = new System.Drawing.Point((int)(position.X / scale), (int)(position.Y / scale));
-		rawPosition = new System.Drawing.Point((int)(rawPosition.X / scale), (int)(rawPosition.Y / scale));
+
+		// Touch and pen go through ptHimetricLocation*: HIMETRIC (0.01 mm) is ~26× finer than
+		// the pointer's logical pixel grid, so slow drags advance in sub-pixel increments
+		// instead of stair-stepping. Mouse stays on ptPixelLocation* — Win32 delivers mouse
+		// coordinates in integer screen pixels and HIMETRIC adds nothing there.
+		var useHimetric = pointerType is POINTER_INPUT_TYPE.PT_TOUCH or POINTER_INPUT_TYPE.PT_PEN;
+
+		position = ToClientLogical(pointerInfo.ptPixelLocation, pointerInfo.ptHimetricLocation, useHimetric, scale);
+		rawPosition = ToClientLogical(pointerInfo.ptPixelLocationRaw, pointerInfo.ptHimetricLocationRaw, useHimetric, scale);
 		return pointerId;
+	}
+
+	private Point ToClientLogical(System.Drawing.Point screenPx, System.Drawing.Point screenHimetric, bool useHimetric, double scale)
+	{
+		var clientPx = screenPx;
+		var success = PInvoke.ScreenToClient(_hwnd, ref clientPx);
+		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ScreenToClient)} failed: {Win32Helper.GetErrorMessage()}"); }
+
+		if (!useHimetric)
+		{
+			return new Point(clientPx.X / scale, clientPx.Y / scale);
+		}
+
+		// HIMETRIC is DPI-independent: logicalPx = himetric / HimetricPerLogicalPx regardless of monitor DPI.
+		// The screen → client translation is integer-pixel; subtract that integer offset (converted to
+		// logical px) so the HIMETRIC-derived sub-pixel precision is preserved in the client-relative result.
+		var screenLogicalX = screenHimetric.X / HimetricPerLogicalPx;
+		var screenLogicalY = screenHimetric.Y / HimetricPerLogicalPx;
+		var clientOriginLogicalX = (screenPx.X - clientPx.X) / scale;
+		var clientOriginLogicalY = (screenPx.Y - clientPx.Y) / scale;
+		return new Point(screenLogicalX - clientOriginLogicalX, screenLogicalY - clientOriginLogicalY);
 	}
 
 	private void OnPointerCaptureChanged(WPARAM wParam)
@@ -131,8 +155,8 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 				_ => PointerDeviceType.Mouse
 			}),
 			pointerId: pointerId,
-			rawPosition: new Point(rawPosition.X, rawPosition.Y),
-			position: new Point(position.X, position.Y),
+			rawPosition: rawPosition,
+			position: position,
 			isInContact: false,
 			properties: null);
 		PointerCaptureLost?.Invoke(this, new PointerEventArgs(point, Win32Helper.GetKeyModifiers()));
@@ -234,8 +258,8 @@ internal partial class Win32WindowWrapper : IUnoCorePointerInputSource
 				_ => PointerDeviceType.Mouse
 			}),
 			pointerId: pointerId,
-			rawPosition: new Point(rawPosition.X, rawPosition.Y),
-			position: new Point(position.X, position.Y),
+			rawPosition: rawPosition,
+			position: position,
 			isInContact: msg is not (PInvoke.WM_POINTERWHEEL or PInvoke.WM_POINTERHWHEEL) && Win32Helper.IS_POINTER_INCONTACT_WPARAM(wParam),
 			properties: properties
 		);

--- a/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
@@ -305,7 +305,16 @@ internal partial class X11PointerInputSource
 			? XamlRoot.GetDisplayInformation(root).RawPixelsPerViewPixel
 			: 1;
 
-		_ = XLib.XTranslateCoordinates(display, data.EventWindow, _host!.TopX11Window.Window, (int)data.event_x, (int)data.event_y, out var dataEventX, out var dataEventY, out _);
+		// XTranslateCoordinates only accepts integer screen pixels. Translate using the floor of
+		// the XInput2 sub-pixel position, then re-add the fractional part so the sub-pixel
+		// precision survives the source-window → uno-window translation (which is integer-only).
+		var srcIntX = (int)Math.Floor(data.event_x);
+		var srcIntY = (int)Math.Floor(data.event_y);
+		var fracX = data.event_x - srcIntX;
+		var fracY = data.event_y - srcIntY;
+		_ = XLib.XTranslateCoordinates(display, data.EventWindow, _host!.TopX11Window.Window, srcIntX, srcIntY, out var dataEventX, out var dataEventY, out _);
+		var clientX = dataEventX + fracX;
+		var clientY = dataEventY + fracY;
 
 		var timeInMicroseconds = (ulong)(data.time * 1000); // Time is given in milliseconds since system boot. See also: https://github.com/unoplatform/uno/issues/14535
 		var deviceType = data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? PointerDeviceType.Touch : PointerDeviceType.Mouse;
@@ -315,8 +324,8 @@ internal partial class X11PointerInputSource
 			timestamp: timeInMicroseconds,
 			PointerDevice.For(deviceType),
 			pointerId,
-			new Point(dataEventX / scale, dataEventY / scale),
-			new Point(dataEventX / scale, dataEventY / scale),
+			new Point(clientX / scale, clientY / scale),
+			new Point(clientX / scale, clientY / scale),
 			properties.HasPressedButton,
 			properties // We don't SetUpdateKind here. We already did that above
 		);

--- a/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
@@ -306,7 +306,16 @@ internal partial class X11PointerInputSource
 			? XamlRoot.GetDisplayInformation(root).RawPixelsPerViewPixel
 			: 1;
 
-		_ = XLib.XTranslateCoordinates(display, data.EventWindow, _host!.TopX11Window.Window, (int)data.event_x, (int)data.event_y, out var dataEventX, out var dataEventY, out _);
+		// XTranslateCoordinates only accepts integer screen pixels. Translate using the floor of
+		// the XInput2 sub-pixel position, then re-add the fractional part so the sub-pixel
+		// precision survives the source-window → uno-window translation (which is integer-only).
+		var srcIntX = (int)Math.Floor(data.event_x);
+		var srcIntY = (int)Math.Floor(data.event_y);
+		var fracX = data.event_x - srcIntX;
+		var fracY = data.event_y - srcIntY;
+		_ = XLib.XTranslateCoordinates(display, data.EventWindow, _host!.TopX11Window.Window, srcIntX, srcIntY, out var dataEventX, out var dataEventY, out _);
+		var clientX = dataEventX + fracX;
+		var clientY = dataEventY + fracY;
 
 		var timeInMicroseconds = (ulong)(data.time * 1000); // Time is given in milliseconds since system boot. See also: https://github.com/unoplatform/uno/issues/14535
 		var deviceType = data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? PointerDeviceType.Touch : PointerDeviceType.Mouse;
@@ -322,8 +331,8 @@ internal partial class X11PointerInputSource
 			timestamp: timeInMicroseconds,
 			PointerDevice.For(deviceType),
 			pointerId,
-			new Point(dataEventX / scale, dataEventY / scale),
-			new Point(dataEventX / scale, dataEventY / scale),
+			new Point(clientX / scale, clientY / scale),
+			new Point(clientX / scale, clientY / scale),
 			properties.HasPressedButton,
 			properties // We don't SetUpdateKind here. We already did that above
 		);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -2069,5 +2069,201 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// The scroll offset should remain 0 — there's nothing to scroll
 			Assert.AreEqual(0d, sut.VerticalOffset, "Should not have scrolled");
 		}
+
+		#region Skia intermediate scrolling mode
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_SingleViewChangedEvent()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			var viewChangedCount = 0;
+			sut.ViewChanged += (s, e) => viewChangedCount++;
+
+			sut.ChangeView(null, 100, null, disableAnimation: true);
+
+			// On both WinUI and Skia, ChangeView stores offsets and defers DP updates to the arrange pass.
+			// ViewChanged fires during the layout pass. Exactly one event should be raised.
+			await WindowHelper.WaitFor(() => viewChangedCount >= 1);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, viewChangedCount, "Exactly one ViewChanged event should be raised for ChangeView with disableAnimation.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_ViewChangedIsNotIntermediate()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			var records = new List<bool>();
+			sut.ViewChanged += (s, e) => records.Add(e.IsIntermediate);
+
+			sut.ChangeView(null, 100, null, disableAnimation: true);
+
+			// On both WinUI and Skia, ViewChanged fires during the layout pass.
+			// Exactly one non-intermediate event should be raised.
+			await WindowHelper.WaitFor(() => records.Count >= 1);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, records.Count, "Exactly one ViewChanged event should be raised.");
+			Assert.IsFalse(records[0], "The ViewChanged event from ChangeView should have IsIntermediate=false.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_OffsetUpdatedAfterArrange()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			Assert.AreEqual(0d, sut.VerticalOffset, "Initial vertical offset should be 0.");
+
+			sut.ChangeView(null, 150, null, disableAnimation: true);
+
+			// On both WinUI and Skia, offsets are updated during the arrange pass
+			// (WinUI: ArrangeOverride → VerifyScrollData → put_VerticalOffset;
+			//  Skia: ArrangeOverride → OnPresenterArranged → set VerticalOffset DP).
+			await WindowHelper.WaitFor(() => sut.VerticalOffset == 150d);
+
+			Assert.AreEqual(150d, sut.VerticalOffset, "VerticalOffset should be updated after arrange.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("This test validates Skia-specific intermediate scrolling mode.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TouchScroll_Then_IntermediateEventsFollowedByFinal()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+				IsScrollInertiaEnabled = false,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var records = new List<bool>();
+			sut.ViewChanged += (s, e) => records.Add(e.IsIntermediate);
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+
+			finger.Press(bounds.GetCenter());
+			finger.MoveBy(0, -100, steps: 10);
+
+			// Flush the arrange pass so intermediate offset updates are applied and
+			// intermediate ViewChanged events fire before the finger is released.
+			// This is needed because offset DPs are deferred to ArrangeOverride,
+			// matching WinUI behavior where rapid scroll events are batched per layout pass.
+			await WindowHelper.WaitForIdle();
+
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+
+			// We should have at least 2 events: some intermediate + one final
+			Assert.IsTrue(records.Count >= 2, $"Expected at least 2 ViewChanged events, got {records.Count}.");
+
+			// All events except the last should be IsIntermediate=true
+			for (int i = 0; i < records.Count - 1; i++)
+			{
+				Assert.IsTrue(records[i], $"ViewChanged event #{i} during drag should have IsIntermediate=true.");
+			}
+
+			// The last event should be IsIntermediate=false (from LeaveIntermediateViewChangedMode)
+			Assert.IsFalse(records[records.Count - 1], "The final ViewChanged event after finger release should have IsIntermediate=false.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("This test validates Skia-specific intermediate scrolling mode.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TouchPressReleaseWithoutScroll_Then_NoViewChangedEvents()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+				IsScrollInertiaEnabled = false,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var viewChangedCount = 0;
+			sut.ViewChanged += (s, e) => viewChangedCount++;
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+
+			// Press and release without moving — enters and leaves intermediate mode
+			// but no scroll happened, so no final event should be raised.
+			finger.Press(bounds.GetCenter());
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, viewChangedCount, "No ViewChanged events should be raised when touch press-release occurs without scrolling.");
+		}
+
+		#endregion
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -2087,5 +2087,201 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// The scroll offset should remain 0 — there's nothing to scroll
 			Assert.AreEqual(0d, sut.VerticalOffset, "Should not have scrolled");
 		}
+
+		#region Skia intermediate scrolling mode
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_SingleViewChangedEvent()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			var viewChangedCount = 0;
+			sut.ViewChanged += (s, e) => viewChangedCount++;
+
+			sut.ChangeView(null, 100, null, disableAnimation: true);
+
+			// On both WinUI and Skia, ChangeView stores offsets and defers DP updates to the arrange pass.
+			// ViewChanged fires during the layout pass. Exactly one event should be raised.
+			await WindowHelper.WaitFor(() => viewChangedCount >= 1);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, viewChangedCount, "Exactly one ViewChanged event should be raised for ChangeView with disableAnimation.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_ViewChangedIsNotIntermediate()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			var records = new List<bool>();
+			sut.ViewChanged += (s, e) => records.Add(e.IsIntermediate);
+
+			sut.ChangeView(null, 100, null, disableAnimation: true);
+
+			// On both WinUI and Skia, ViewChanged fires during the layout pass.
+			// Exactly one non-intermediate event should be raised.
+			await WindowHelper.WaitFor(() => records.Count >= 1);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, records.Count, "Exactly one ViewChanged event should be raised.");
+			Assert.IsFalse(records[0], "The ViewChanged event from ChangeView should have IsIntermediate=false.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_OffsetUpdatedAfterArrange()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			Assert.AreEqual(0d, sut.VerticalOffset, "Initial vertical offset should be 0.");
+
+			sut.ChangeView(null, 150, null, disableAnimation: true);
+
+			// On both WinUI and Skia, offsets are updated during the arrange pass
+			// (WinUI: ArrangeOverride → VerifyScrollData → put_VerticalOffset;
+			//  Skia: ArrangeOverride → OnPresenterArranged → set VerticalOffset DP).
+			await WindowHelper.WaitFor(() => sut.VerticalOffset == 150d);
+
+			Assert.AreEqual(150d, sut.VerticalOffset, "VerticalOffset should be updated after arrange.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("This test validates Skia-specific intermediate scrolling mode.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TouchScroll_Then_IntermediateEventsFollowedByFinal()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+				IsScrollInertiaEnabled = false,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var records = new List<bool>();
+			sut.ViewChanged += (s, e) => records.Add(e.IsIntermediate);
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+
+			finger.Press(bounds.GetCenter());
+			finger.MoveBy(0, -100, steps: 10);
+
+			// Flush the arrange pass so intermediate offset updates are applied and
+			// intermediate ViewChanged events fire before the finger is released.
+			// This is needed because offset DPs are deferred to ArrangeOverride,
+			// matching WinUI behavior where rapid scroll events are batched per layout pass.
+			await WindowHelper.WaitForIdle();
+
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+
+			// We should have at least 2 events: some intermediate + one final
+			Assert.IsTrue(records.Count >= 2, $"Expected at least 2 ViewChanged events, got {records.Count}.");
+
+			// All events except the last should be IsIntermediate=true
+			for (int i = 0; i < records.Count - 1; i++)
+			{
+				Assert.IsTrue(records[i], $"ViewChanged event #{i} during drag should have IsIntermediate=true.");
+			}
+
+			// The last event should be IsIntermediate=false (from LeaveIntermediateViewChangedMode)
+			Assert.IsFalse(records[records.Count - 1], "The final ViewChanged event after finger release should have IsIntermediate=false.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("This test validates Skia-specific intermediate scrolling mode.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TouchPressReleaseWithoutScroll_Then_NoViewChangedEvents()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+				IsScrollInertiaEnabled = false,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var viewChangedCount = 0;
+			sut.ViewChanged += (s, e) => viewChangedCount++;
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+
+			// Press and release without moving — enters and leaves intermediate mode
+			// but no scroll happened, so no final event should be raised.
+			finger.Press(bounds.GetCenter());
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, viewChangedCount, "No ViewChanged events should be raised when touch press-release occurs without scrolling.");
+		}
+
+		#endregion
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -1554,13 +1554,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			mouse.WheelUp();
 
+			// Wheel inertia ticks via CompositionTarget.Rendering, not a tracked CompositionAnimation,
+			// so Compositor.IsAnimating doesn't gate the wait — sleep until the coast settles.
 			await UITestHelper.WaitForIdle(waitForCompositionAnimations: true);
+			await Task.Delay(1500);
+			await WindowHelper.WaitForIdle();
 
 			sut.VerticalOffset.Should().BeGreaterThan(0);
 
 			mouse.WheelDown();
 
 			await UITestHelper.WaitForIdle(waitForCompositionAnimations: true);
+			await Task.Delay(1500);
+			await WindowHelper.WaitForIdle();
 
 			sut.VerticalOffset.Should().BeApproximately(0, 0.5);
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -736,6 +736,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// poll for the converged state instead of relying on a single idle/animation check.
 			await WindowHelper.WaitFor(() => inner.VerticalOffset > 0, message: "Inner Vertical Offset is not greater than 0");
 			await UITestHelper.WaitForIdle(waitForCompositionAnimations: true);
+			await Task.Delay(1500);
+			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(0, outer.VerticalOffset);
 			Assert.IsGreaterThan(0d, inner.VerticalOffset, "Inner Vertical Offset is not greater than 0");
@@ -749,6 +751,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var expectedOffset = outer.ScrollableHeight / 2;
 			await WindowHelper.WaitFor(() => outer.VerticalOffset > expectedOffset, message: $"Outer Vertical Offset ({outer.VerticalOffset}) did not exceed outer.ScrollableHeight/2 ({expectedOffset})");
 			await UITestHelper.WaitForIdle(waitForCompositionAnimations: true);
+			await Task.Delay(1500);
+			await WindowHelper.WaitForIdle();
 
 			Assert.IsGreaterThan(expectedOffset, outer.VerticalOffset, $"Outer Vertical Offset ({outer.VerticalOffset}) is not greater than outer.ScrollableHeight/2 ({expectedOffset})");
 			Assert.AreEqual(inner.ScrollableHeight, inner.VerticalOffset);
@@ -822,54 +826,64 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #elif !HAS_INPUT_INJECTOR
 		[Ignore("InputInjector is not supported on this platform.")]
 #endif
-		// Both iOS and macOS animation were disabled and will be fixed under uno-private#1788
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.IOS | RuntimeTestPlatforms.SkiaMacOS)] // uno-private#1740 changed the way mouse wheel events are processed on iOS and macOS: Not using animations
-		public async Task When_LotOfWheelEvents_Then_IgnoreIrrelevant()
+		// iOS/macOS use the immediate per-event trackpad path, not the velocity-based wheel inertia.
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.IOS | RuntimeTestPlatforms.SkiaMacOS)]
+		public async Task When_Wheel_Then_VelocityAccumulatesAndReverses()
 		{
-			// This test make sure than when using a "free wheel" mouse or a touch-pad (which both produces a lot of events),
-			// we don't end up to invoke ScrollContentPresenter.Set again and again (preventing the ScrollContentPresenter.Update methohd to properly process its animation)
+			// Velocity-based wheel inertia: each wheel notch adds a velocity impulse to a per-VSync
+			// integration loop with exponential decay. Rapid same-direction notches accumulate into
+			// higher peak velocity (longer scroll); opposite-direction notches reverse the motion.
+			// This test validates the user-visible end state after each phase rather than the
+			// internal animation primitive (which is composition-driven and frame-by-frame).
 
-			FrameworkElement content;
 			var sut = new ScrollViewer
 			{
 				Height = 100,
 				Width = 100,
-				Content = content = new Border
+				Content = new Border
 				{
-					Height = 200,
+					Height = 1000,
 					Background = new SolidColorBrush(Colors.Chartreuse)
 				},
 			};
 
 			var bounds = await UITestHelper.Load(sut);
 
-			var visual = ElementCompositionPreview.GetElementVisual(content);
-
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var mouse = injector.GetMouse();
 
-			var initialAnimation = visual.GetKeyFrameAnimation(nameof(Visual.AnchorPoint));
-			initialAnimation.Should().BeNull(because: "we have not scrolled yet");
+			Assert.AreEqual(0d, sut.VerticalOffset, "Initial offset should be 0.");
 
 			mouse.MoveTo(bounds.GetCenter());
-			mouse.Wheel(-400, steps: 1);
+			mouse.Wheel(-120, steps: 1);
+			await WaitForInertiaToSettle();
+			var offsetAfterOneNotch = sut.VerticalOffset;
+			Assert.IsGreaterThan(0d, offsetAfterOneNotch, "One wheel notch should produce visible scroll.");
 
-			// Here we assume that ScrollContentPresenter is using KeyFrameAnimation. If no longer the case, the test can be updated!
-			var scrollAnimation1 = visual.GetKeyFrameAnimation(nameof(Visual.AnchorPoint));
-			scrollAnimation1.Should().NotBeNull(because: "we have requested scroll");
+			// Reset and wheel two notches in quick succession — velocity coalesces.
+			sut.ChangeView(null, 0, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
 
-			// Scroll again in the same direction
-			mouse.Wheel(-200, steps: 1);
+			mouse.Wheel(-120, steps: 1);
+			mouse.Wheel(-120, steps: 1);
+			await WaitForInertiaToSettle();
+			var offsetAfterTwoNotches = sut.VerticalOffset;
+			Assert.IsGreaterThan(offsetAfterOneNotch, offsetAfterTwoNotches,
+				"Two same-direction wheel notches should scroll farther than one (velocity accumulation).");
 
-			var scrollAnimation2 = visual.GetKeyFrameAnimation(nameof(Visual.AnchorPoint));
-			scrollAnimation2.Should().Be(scrollAnimation1, because: "the wheel event has no effect");
+			// Wheel the opposite direction — motion reverses.
+			mouse.Wheel(+120, steps: 1);
+			await WaitForInertiaToSettle();
+			Assert.IsLessThan(offsetAfterTwoNotches, sut.VerticalOffset,
+				"Opposite-direction wheel should reverse the scroll position.");
 
-			// But if we scroll in the opposite direction, the animation should be stopped and replaced
-			// (this basically confirm that the test is working -i.e the animation is not being re-used)
-			mouse.Wheel(+200, steps: 1);
-
-			var scrollAnimation3 = visual.GetKeyFrameAnimation(nameof(Visual.AnchorPoint));
-			scrollAnimation3.Should().NotBe(scrollAnimation1, because: "the wheel event should scroll in the opposite direction");
+			// Local helper: wait for wheel inertia to finish coasting.
+			static async Task WaitForInertiaToSettle()
+			{
+				await WindowHelper.WaitForIdle();
+				await Task.Delay(1500);
+				await WindowHelper.WaitForIdle();
+			}
 		}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -877,12 +877,28 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsLessThan(offsetAfterTwoNotches, sut.VerticalOffset,
 				"Opposite-direction wheel should reverse the scroll position.");
 
-			// Local helper: wait for wheel inertia to finish coasting.
-			static async Task WaitForInertiaToSettle()
+			// Local helper: wait for wheel inertia to finish coasting. Rather than sleeping for a
+			// fixed duration, poll the offset and return as soon as it has stopped moving for a
+			// few consecutive samples, with a hard ceiling so a stuck coast still reaches the asserts.
+			async Task WaitForInertiaToSettle()
 			{
+				const int SampleIntervalMs = 50;
+				const int StableSamplesRequired = 5;
+				const int TimeoutMs = 3000;
+
 				await WindowHelper.WaitForIdle();
-				await Task.Delay(1500);
-				await WindowHelper.WaitForIdle();
+
+				var lastOffset = double.NaN;
+				var stableSamples = 0;
+				for (var elapsed = 0; elapsed < TimeoutMs && stableSamples < StableSamplesRequired; elapsed += SampleIntervalMs)
+				{
+					await Task.Delay(SampleIntervalMs);
+					await WindowHelper.WaitForIdle();
+
+					var offset = sut.VerticalOffset;
+					stableSamples = offset == lastOffset ? stableSamples + 1 : 0;
+					lastOffset = offset;
+				}
 			}
 		}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -2154,5 +2154,201 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// The scroll offset should remain 0 — there's nothing to scroll
 			Assert.AreEqual(0d, sut.VerticalOffset, "Should not have scrolled");
 		}
+
+		#region Skia intermediate scrolling mode
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_SingleViewChangedEvent()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			var viewChangedCount = 0;
+			sut.ViewChanged += (s, e) => viewChangedCount++;
+
+			sut.ChangeView(null, 100, null, disableAnimation: true);
+
+			// On both WinUI and Skia, ChangeView stores offsets and defers DP updates to the arrange pass.
+			// ViewChanged fires during the layout pass. Exactly one event should be raised.
+			await WindowHelper.WaitFor(() => viewChangedCount >= 1);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, viewChangedCount, "Exactly one ViewChanged event should be raised for ChangeView with disableAnimation.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_ViewChangedIsNotIntermediate()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			var records = new List<bool>();
+			sut.ViewChanged += (s, e) => records.Add(e.IsIntermediate);
+
+			sut.ChangeView(null, 100, null, disableAnimation: true);
+
+			// On both WinUI and Skia, ViewChanged fires during the layout pass.
+			// Exactly one non-intermediate event should be raised.
+			await WindowHelper.WaitFor(() => records.Count >= 1);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, records.Count, "Exactly one ViewChanged event should be raised.");
+			Assert.IsFalse(records[0], "The ViewChanged event from ChangeView should have IsIntermediate=false.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ChangeView_DisableAnimation_Then_OffsetUpdatedAfterArrange()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+			};
+
+			await UITestHelper.Load(sut);
+
+			Assert.AreEqual(0d, sut.VerticalOffset, "Initial vertical offset should be 0.");
+
+			sut.ChangeView(null, 150, null, disableAnimation: true);
+
+			// On both WinUI and Skia, offsets are updated during the arrange pass
+			// (WinUI: ArrangeOverride → VerifyScrollData → put_VerticalOffset;
+			//  Skia: ArrangeOverride → OnPresenterArranged → set VerticalOffset DP).
+			await WindowHelper.WaitFor(() => sut.VerticalOffset == 150d);
+
+			Assert.AreEqual(150d, sut.VerticalOffset, "VerticalOffset should be updated after arrange.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("This test validates Skia-specific intermediate scrolling mode.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TouchScroll_Then_IntermediateEventsFollowedByFinal()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+				IsScrollInertiaEnabled = false,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var records = new List<bool>();
+			sut.ViewChanged += (s, e) => records.Add(e.IsIntermediate);
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+
+			finger.Press(bounds.GetCenter());
+			finger.MoveBy(0, -100, steps: 10);
+
+			// Flush the arrange pass so intermediate offset updates are applied and
+			// intermediate ViewChanged events fire before the finger is released.
+			// This is needed because offset DPs are deferred to ArrangeOverride,
+			// matching WinUI behavior where rapid scroll events are batched per layout pass.
+			await WindowHelper.WaitForIdle();
+
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+
+			// We should have at least 2 events: some intermediate + one final
+			Assert.IsTrue(records.Count >= 2, $"Expected at least 2 ViewChanged events, got {records.Count}.");
+
+			// All events except the last should be IsIntermediate=true
+			for (int i = 0; i < records.Count - 1; i++)
+			{
+				Assert.IsTrue(records[i], $"ViewChanged event #{i} during drag should have IsIntermediate=true.");
+			}
+
+			// The last event should be IsIntermediate=false (from LeaveIntermediateViewChangedMode)
+			Assert.IsFalse(records[records.Count - 1], "The final ViewChanged event after finger release should have IsIntermediate=false.");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("This test validates Skia-specific intermediate scrolling mode.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TouchPressReleaseWithoutScroll_Then_NoViewChangedEvents()
+		{
+			var content = new Border
+			{
+				Height = 2000,
+				Background = new SolidColorBrush(Colors.DeepPink)
+			};
+			var sut = new ScrollViewer
+			{
+				Height = 200,
+				Width = 200,
+				Content = content,
+				IsScrollInertiaEnabled = false,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var viewChangedCount = 0;
+			sut.ViewChanged += (s, e) => viewChangedCount++;
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+
+			// Press and release without moving — enters and leaves intermediate mode
+			// but no scroll happened, so no final event should be raised.
+			finger.Press(bounds.GetCenter());
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, viewChangedCount, "No ViewChanged events should be raised when touch press-release occurs without scrolling.");
+		}
+
+		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.InertiaProcessor.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.InertiaProcessor.cs
@@ -26,8 +26,6 @@ public partial class GestureRecognizer
 	{
 		internal class InertiaProcessor : IDisposable
 		{
-			private const double _defaultDurationMs = 1000;
-
 			private delegate double Get(in ManipulationDelta delta);
 			private delegate void Set(ref ManipulationDelta delta, double value);
 			private record struct ManipulationDeltaProperty(Get Get, Set Set);
@@ -62,9 +60,18 @@ public partial class GestureRecognizer
 			private bool _isRotateInertiaEnabled;
 			private bool _isScaleInertiaEnabled;
 
-			internal const double DefaultDesiredDisplacementDeceleration = .001;
-			internal const double DefaultDesiredRotationDeceleration = .0001;
-			internal const double DefaultDesiredExpansionDeceleration = .001;
+			/// <summary>
+			/// Velocity threshold (in units/ms) below which inertia is considered complete.
+			/// At 60fps this is ~0.6 units/frame — sub-pixel, so movement is imperceptible.
+			/// </summary>
+			internal const double VelocityThreshold = 0.01;
+
+			// Default decay constants (1/ms). These control how fast inertia decelerates.
+			// The exponential model: velocity(t) = v0 * e^(-k*t), position(t) = v0 * (1 - e^(-k*t)) / k
+			// A value of 0.003 corresponds to WinUI's InteractionTracker default of 0.95 decay per 16.67ms frame.
+			internal const double DefaultDesiredDisplacementDeceleration = .003;
+			internal const double DefaultDesiredRotationDeceleration = .003;
+			internal const double DefaultDesiredExpansionDeceleration = .003;
 
 			// Those values can be customized by the application through the ManipInertiaStartingArgs.Inertia<Tr|Rot|Exp>Behavior
 			public double DesiredDisplacement = NaN;
@@ -155,18 +162,17 @@ public partial class GestureRecognizer
 				if (!IsNaN(DesiredDisplacement))
 				{
 					var v0 = (Math.Abs(_velocities0.Linear.X) + Math.Abs(_velocities0.Linear.Y)) / 2;
-					DesiredDisplacementDeceleration = GetDecelerationFromDesiredDisplacement(v0, DesiredDisplacement);
+					DesiredDisplacementDeceleration = GetDecayRateFromDesiredDisplacement(v0, DesiredDisplacement);
 				}
 				if (!IsNaN(DesiredRotation))
 				{
-					DesiredRotationDeceleration = GetDecelerationFromDesiredDisplacement(_velocities0.Angular, DesiredRotation);
+					DesiredRotationDeceleration = GetDecayRateFromDesiredDisplacement(_velocities0.Angular, DesiredRotation);
 				}
 				if (!IsNaN(DesiredExpansion))
 				{
-					DesiredExpansionDeceleration = GetDecelerationFromDesiredDisplacement(_velocities0.Expansion, DesiredExpansion);
+					DesiredExpansionDeceleration = GetDecayRateFromDesiredDisplacement(_velocities0.Expansion, DesiredExpansion);
 				}
 
-				// Default values are **inspired** by https://docs.microsoft.com/en-us/windows/win32/wintouch/inertia-mechanics#smooth-object-animation-using-the-velocity-and-deceleration-properties
 				if (IsNaN(DesiredDisplacementDeceleration))
 				{
 					DesiredDisplacementDeceleration = DefaultDesiredDisplacementDeceleration;
@@ -264,23 +270,68 @@ public partial class GestureRecognizer
 				return true;
 			}
 
-			// https://docs.microsoft.com/en-us/windows/win32/wintouch/inertia-mechanics#inertia-physics-overview
-			internal static double GetValue(double v0, double d, double t)
-				=> v0 >= 0
-					? v0 * t - d * Math.Pow(t, 2)
-					: -(-v0 * t - d * Math.Pow(t, 2));
+			// Exponential decay model matching WinUI InteractionTracker, Flutter FrictionSimulation,
+			// and Avalonia ScrollGestureRecognizer. This produces smooth, natural-feeling deceleration
+			// where velocity decays as v(t) = v0 * e^(-k*t) and position follows the integral.
+			// The parameter 'k' is the decay rate constant (1/ms): higher values = faster deceleration.
 
-			private static bool IsCompleted(double v0, double d, double t)
-				=> Math.Abs(v0) - d * 2 * t <= 0; // The derivative of the GetValue function
+			/// <summary>
+			/// Computes the cumulative displacement at time <paramref name="t"/> (ms)
+			/// using exponential decay: position(t) = v0 * (1 - e^(-k*t)) / k.
+			/// </summary>
+			internal static double GetValue(double v0, double k, double t)
+			{
+				if (k <= 0)
+				{
+					return v0 * t; // No deceleration — constant velocity fallback
+				}
 
-			internal static double GetCompletionTime(double v0, double d)
-				=> Math.Abs(v0) / (2 * d);
+				var decay = Math.Exp(-k * t);
+				return v0 * (1 - decay) / k;
+			}
 
+			private static bool IsCompleted(double v0, double k, double t)
+				=> Math.Abs(v0) * Math.Exp(-k * t) <= VelocityThreshold;
+
+			internal static double GetCompletionTime(double v0, double k)
+			{
+				var absV0 = Math.Abs(v0);
+				if (absV0 <= VelocityThreshold || k <= 0)
+				{
+					return 0;
+				}
+
+				return Math.Log(absV0 / VelocityThreshold) / k;
+			}
+
+			/// <summary>
+			/// Computes the decay rate constant that causes inertia to complete in <paramref name="durationMs"/> ms.
+			/// </summary>
 			internal static double GetDecelerationFromDesiredDuration(double v0, double durationMs)
-				=> Math.Abs(v0) / (2 * durationMs);
+			{
+				var absV0 = Math.Abs(v0);
+				if (absV0 <= VelocityThreshold || durationMs <= 0)
+				{
+					return DefaultDesiredDisplacementDeceleration;
+				}
 
-			private static double GetDecelerationFromDesiredDisplacement(double v0, double displacement, double durationMs = _defaultDurationMs)
-				=> (v0 * durationMs - displacement) / Math.Pow(_defaultDurationMs, 2);
+				return Math.Log(absV0 / VelocityThreshold) / durationMs;
+			}
+
+			/// <summary>
+			/// Computes the decay rate constant that produces approximately <paramref name="displacement"/> total displacement.
+			/// From the exponential model: total ≈ |v0| / k, so k ≈ |v0| / displacement.
+			/// </summary>
+			private static double GetDecayRateFromDesiredDisplacement(double v0, double displacement)
+			{
+				var absV0 = Math.Abs(v0);
+				if (absV0 <= VelocityThreshold || displacement <= 0)
+				{
+					return DefaultDesiredDisplacementDeceleration;
+				}
+
+				return absV0 / Math.Abs(displacement);
+			}
 
 			/// <inheritdoc />
 			public void Dispose()
@@ -315,7 +366,7 @@ public partial class GestureRecognizer
 		{
 			private readonly DispatcherQueueTimer _timer;
 
-			public const double DefaultFramePerSeconds = 30d;
+			public const double DefaultFramePerSeconds = 60d;
 
 			public DispatcherInertiaProcessorTimer(Action<TimeSpan> OnTick, double framePerSeconds = DefaultFramePerSeconds)
 			{
@@ -335,7 +386,8 @@ public partial class GestureRecognizer
 		private sealed class CompositionInertiaProcessorTimer(Action<TimeSpan> onTick) : IInertiaProcessorTimer
 		{
 			private EventHandler<object>? _handler;
-			private Stopwatch? _time;
+			private TimeSpan? _t0; // First VSync timestamp — used as the inertia time origin
+			private Stopwatch? _fallbackTime; // Fallback for platforms that don't provide RenderingEventArgs
 
 			public bool IsRunning => _handler is not null;
 
@@ -343,11 +395,34 @@ public partial class GestureRecognizer
 			{
 				Stop();
 
-				_time = Stopwatch.StartNew();
+				_t0 = null;
+				_fallbackTime = null;
 				_handler = (_, args) =>
 				{
-					// Note: We are not using the ((Microsoft.UI.Xaml.Media.RenderingEventArgs)args).RenderingTime as we are not able to have the value at t0
-					onTick(_time.Elapsed);
+					// Prefer the VSync-aligned RenderingTime when available (Skia hosts provide this
+					// from the platform's VSync signal, e.g. Android Choreographer). Using VSync time
+					// ensures the physics position matches the actual display moment, eliminating
+					// micro-stutters caused by wall-clock / display-clock divergence.
+					if (args is Microsoft.UI.Xaml.Media.RenderingEventArgs rea)
+					{
+						if (_t0 is null)
+						{
+							_t0 = rea.RenderingTime;
+							return; // First frame just records t0; processing starts on the next frame.
+						}
+
+						onTick(rea.RenderingTime - _t0.Value);
+					}
+					else
+					{
+						if (_fallbackTime is null)
+						{
+							_fallbackTime = Stopwatch.StartNew();
+							return; // First frame just starts the clock; processing starts on the next frame.
+						}
+
+						onTick(_fallbackTime.Elapsed);
+					}
 				};
 
 				CompositionTarget.Rendering += _handler;

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.InertiaProcessor.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.InertiaProcessor.cs
@@ -26,8 +26,6 @@ public partial class GestureRecognizer
 	{
 		internal class InertiaProcessor : IDisposable
 		{
-			private const double _defaultDurationMs = 1000;
-
 			private delegate double Get(in ManipulationDelta delta);
 			private delegate void Set(ref ManipulationDelta delta, double value);
 			private record struct ManipulationDeltaProperty(Get Get, Set Set);
@@ -62,9 +60,18 @@ public partial class GestureRecognizer
 			private bool _isRotateInertiaEnabled;
 			private bool _isScaleInertiaEnabled;
 
-			internal const double DefaultDesiredDisplacementDeceleration = .001;
-			internal const double DefaultDesiredRotationDeceleration = .0001;
-			internal const double DefaultDesiredExpansionDeceleration = .001;
+			/// <summary>
+			/// Velocity threshold (in units/ms) below which inertia is considered complete.
+			/// At 60fps this is ~0.6 units/frame — sub-pixel, so movement is imperceptible.
+			/// </summary>
+			internal const double VelocityThreshold = 0.01;
+
+			// Default decay constants (1/ms). These control how fast inertia decelerates.
+			// The exponential model: velocity(t) = v0 * e^(-k*t), position(t) = v0 * (1 - e^(-k*t)) / k
+			// A value of 0.003 corresponds to WinUI's InteractionTracker default of 0.95 decay per 16.67ms frame.
+			internal const double DefaultDesiredDisplacementDeceleration = .003;
+			internal const double DefaultDesiredRotationDeceleration = .003;
+			internal const double DefaultDesiredExpansionDeceleration = .003;
 
 			// Those values can be customized by the application through the ManipInertiaStartingArgs.Inertia<Tr|Rot|Exp>Behavior
 			public double DesiredDisplacement = NaN;
@@ -155,18 +162,17 @@ public partial class GestureRecognizer
 				if (!IsNaN(DesiredDisplacement))
 				{
 					var v0 = (Math.Abs(_velocities0.Linear.X) + Math.Abs(_velocities0.Linear.Y)) / 2;
-					DesiredDisplacementDeceleration = GetDecelerationFromDesiredDisplacement(v0, DesiredDisplacement);
+					DesiredDisplacementDeceleration = GetDecayRateFromDesiredDisplacement(v0, DesiredDisplacement);
 				}
 				if (!IsNaN(DesiredRotation))
 				{
-					DesiredRotationDeceleration = GetDecelerationFromDesiredDisplacement(_velocities0.Angular, DesiredRotation);
+					DesiredRotationDeceleration = GetDecayRateFromDesiredDisplacement(_velocities0.Angular, DesiredRotation);
 				}
 				if (!IsNaN(DesiredExpansion))
 				{
-					DesiredExpansionDeceleration = GetDecelerationFromDesiredDisplacement(_velocities0.Expansion, DesiredExpansion);
+					DesiredExpansionDeceleration = GetDecayRateFromDesiredDisplacement(_velocities0.Expansion, DesiredExpansion);
 				}
 
-				// Default values are **inspired** by https://docs.microsoft.com/en-us/windows/win32/wintouch/inertia-mechanics#smooth-object-animation-using-the-velocity-and-deceleration-properties
 				if (IsNaN(DesiredDisplacementDeceleration))
 				{
 					DesiredDisplacementDeceleration = DefaultDesiredDisplacementDeceleration;
@@ -264,23 +270,68 @@ public partial class GestureRecognizer
 				return true;
 			}
 
-			// https://docs.microsoft.com/en-us/windows/win32/wintouch/inertia-mechanics#inertia-physics-overview
-			internal static double GetValue(double v0, double d, double t)
-				=> v0 >= 0
-					? v0 * t - d * Math.Pow(t, 2)
-					: -(-v0 * t - d * Math.Pow(t, 2));
+			// Exponential decay model matching WinUI InteractionTracker, Flutter FrictionSimulation,
+			// and Avalonia ScrollGestureRecognizer. This produces smooth, natural-feeling deceleration
+			// where velocity decays as v(t) = v0 * e^(-k*t) and position follows the integral.
+			// The parameter 'k' is the decay rate constant (1/ms): higher values = faster deceleration.
 
-			private static bool IsCompleted(double v0, double d, double t)
-				=> Math.Abs(v0) - d * 2 * t <= 0; // The derivative of the GetValue function
+			/// <summary>
+			/// Computes the cumulative displacement at time <paramref name="t"/> (ms)
+			/// using exponential decay: position(t) = v0 * (1 - e^(-k*t)) / k.
+			/// </summary>
+			internal static double GetValue(double v0, double k, double t)
+			{
+				if (k <= 0)
+				{
+					return v0 * t; // No deceleration — constant velocity fallback
+				}
 
-			internal static double GetCompletionTime(double v0, double d)
-				=> Math.Abs(v0) / (2 * d);
+				var decay = Math.Exp(-k * t);
+				return v0 * (1 - decay) / k;
+			}
 
+			private static bool IsCompleted(double v0, double k, double t)
+				=> Math.Abs(v0) * Math.Exp(-k * t) <= VelocityThreshold;
+
+			internal static double GetCompletionTime(double v0, double k)
+			{
+				var absV0 = Math.Abs(v0);
+				if (absV0 <= VelocityThreshold || k <= 0)
+				{
+					return 0;
+				}
+
+				return Math.Log(absV0 / VelocityThreshold) / k;
+			}
+
+			/// <summary>
+			/// Computes the decay rate constant that causes inertia to complete in <paramref name="durationMs"/> ms.
+			/// </summary>
 			internal static double GetDecelerationFromDesiredDuration(double v0, double durationMs)
-				=> Math.Abs(v0) / (2 * durationMs);
+			{
+				var absV0 = Math.Abs(v0);
+				if (absV0 <= VelocityThreshold || durationMs <= 0)
+				{
+					return DefaultDesiredDisplacementDeceleration;
+				}
 
-			private static double GetDecelerationFromDesiredDisplacement(double v0, double displacement, double durationMs = _defaultDurationMs)
-				=> (v0 * durationMs - displacement) / Math.Pow(_defaultDurationMs, 2);
+				return Math.Log(absV0 / VelocityThreshold) / durationMs;
+			}
+
+			/// <summary>
+			/// Computes the decay rate constant that produces approximately <paramref name="displacement"/> total displacement.
+			/// From the exponential model: total ≈ |v0| / k, so k ≈ |v0| / displacement.
+			/// </summary>
+			private static double GetDecayRateFromDesiredDisplacement(double v0, double displacement)
+			{
+				var absV0 = Math.Abs(v0);
+				if (absV0 <= VelocityThreshold || displacement <= 0)
+				{
+					return DefaultDesiredDisplacementDeceleration;
+				}
+
+				return absV0 / Math.Abs(displacement);
+			}
 
 			/// <inheritdoc />
 			public void Dispose()
@@ -313,7 +364,7 @@ public partial class GestureRecognizer
 		{
 			private readonly DispatcherQueueTimer _timer;
 
-			public const double DefaultFramePerSeconds = 30d;
+			public const double DefaultFramePerSeconds = 60d;
 
 			public DispatcherInertiaProcessorTimer(Action<TimeSpan> OnTick, double framePerSeconds = DefaultFramePerSeconds)
 			{
@@ -333,7 +384,8 @@ public partial class GestureRecognizer
 		private sealed class CompositionInertiaProcessorTimer(Action<TimeSpan> onTick) : IInertiaProcessorTimer
 		{
 			private EventHandler<object>? _handler;
-			private Stopwatch? _time;
+			private TimeSpan? _t0; // First VSync timestamp — used as the inertia time origin
+			private Stopwatch? _fallbackTime; // Fallback for platforms that don't provide RenderingEventArgs
 
 			public bool IsRunning => _handler is not null;
 
@@ -341,11 +393,34 @@ public partial class GestureRecognizer
 			{
 				Stop();
 
-				_time = Stopwatch.StartNew();
+				_t0 = null;
+				_fallbackTime = null;
 				_handler = (_, args) =>
 				{
-					// Note: We are not using the ((Microsoft.UI.Xaml.Media.RenderingEventArgs)args).RenderingTime as we are not able to have the value at t0
-					onTick(_time.Elapsed);
+					// Prefer the VSync-aligned RenderingTime when available (Skia hosts provide this
+					// from the platform's VSync signal, e.g. Android Choreographer). Using VSync time
+					// ensures the physics position matches the actual display moment, eliminating
+					// micro-stutters caused by wall-clock / display-clock divergence.
+					if (args is Microsoft.UI.Xaml.Media.RenderingEventArgs rea)
+					{
+						if (_t0 is null)
+						{
+							_t0 = rea.RenderingTime;
+							return; // First frame just records t0; processing starts on the next frame.
+						}
+
+						onTick(rea.RenderingTime - _t0.Value);
+					}
+					else
+					{
+						if (_fallbackTime is null)
+						{
+							_fallbackTime = Stopwatch.StartNew();
+							return; // First frame just starts the clock; processing starts on the next frame.
+						}
+
+						onTick(_fallbackTime.Elapsed);
+					}
 				};
 
 				CompositionTarget.Rendering += _handler;

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.InertiaProcessor.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.InertiaProcessor.cs
@@ -62,7 +62,7 @@ public partial class GestureRecognizer
 
 			/// <summary>
 			/// Velocity threshold (in units/ms) below which inertia is considered complete.
-			/// At 60fps this is ~0.6 units/frame — sub-pixel, so movement is imperceptible.
+			/// At 60fps this is ~0.17 units/frame — sub-pixel, so movement is imperceptible.
 			/// </summary>
 			internal const double VelocityThreshold = 0.01;
 

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -75,6 +75,9 @@ namespace Windows.UI.Input
 
 			private ManipulationVelocities _lastRelevantVelocities;
 			private InertiaProcessor? _inertia;
+#if IS_UNO_UI_PROJECT
+			private readonly VelocityTracker _velocityTracker = new();
+#endif
 
 			/// <summary>
 			/// Type of the pointers handled by this manipulation.
@@ -134,6 +137,11 @@ namespace Windows.UI.Input
 
 				_origins = _currents = pointer1;
 				_contacts = (0, 1);
+
+#if IS_UNO_UI_PROJECT
+				// Seed the velocity tracker with the initial pointer position.
+				_velocityTracker.AddPosition(pointer1.Timestamp, pointer1.Position.X, pointer1.Position.Y);
+#endif
 
 				switch (_deviceType)
 				{
@@ -241,7 +249,16 @@ namespace Windows.UI.Input
 				{
 					if (_deviceType == (PointerDeviceType)point.PointerDevice.PointerDeviceType)
 					{
-						hasUpdate |= _currents.TryUpdate(point);
+						if (_currents.TryUpdate(point))
+						{
+							hasUpdate = true;
+#if IS_UNO_UI_PROJECT
+							// Feed the least-squares velocity tracker with each pointer position.
+							// The tracker accumulates samples and uses polynomial fitting for
+							// a smoother velocity estimate than simple delta/time.
+							_velocityTracker.AddPosition(point.Timestamp, point.Position.X, point.Position.Y);
+#endif
+						}
 					}
 				}
 
@@ -268,6 +285,11 @@ namespace Windows.UI.Input
 
 				if (_currents.TryUpdate(removed))
 				{
+#if IS_UNO_UI_PROJECT
+					// Feed the release position to the velocity tracker so it has
+					// the most up-to-date data for the inertia velocity estimate.
+					_velocityTracker.AddPosition(removed.Timestamp, removed.Position.X, removed.Position.Y);
+#endif
 					_contacts.current--;
 
 					NotifyUpdate();
@@ -463,11 +485,31 @@ namespace Windows.UI.Input
 				ManipulationVelocities? velocities;
 				if (useHistory && _inertia is null && !_currents.StateHistory.IsDefault) // Cannot use history when inertia is running: pointer points are no longer updated!
 				{
-					var velocitiesPoints = _currents.StateHistory.GetBoundaries(static p => p.Timestamp);
-					var velocitiesElapsedMicroseconds = velocitiesPoints.to.Timestamp - velocitiesPoints.from.Timestamp;
-					var velocitiesDelta = ComputeDelta(velocitiesPoints.from, velocitiesPoints.to, parentCommit.SumOfDelta);
-
-					velocities = ComputeVelocities(velocitiesDelta, velocitiesElapsedMicroseconds);
+#if IS_UNO_UI_PROJECT
+					// Try the least-squares velocity tracker first — it provides a much smoother
+					// estimate by fitting a polynomial to all recent samples, rather than using
+					// just the boundary points. This significantly reduces fling velocity noise.
+					var lsEstimate = _velocityTracker.GetVelocityEstimate();
+					if (lsEstimate is var (vx, vy))
+					{
+						// VelocityTracker returns units/ms (position delta / ms), which matches
+						// Uno's ManipulationVelocities.Linear convention (units per millisecond).
+						velocities = new ManipulationVelocities
+						{
+							Linear = new Point(vx, vy),
+							Angular = 0,
+							Expansion = 0
+						};
+					}
+					else
+#endif
+					{
+						// Fallback: use the boundary-based linear velocity from the rolling history.
+						var velocitiesPoints = _currents.StateHistory.GetBoundaries(static p => p.Timestamp);
+						var velocitiesElapsedMicroseconds = velocitiesPoints.to.Timestamp - velocitiesPoints.from.Timestamp;
+						var velocitiesDelta = ComputeDelta(velocitiesPoints.from, velocitiesPoints.to, parentCommit.SumOfDelta);
+						velocities = ComputeVelocities(velocitiesDelta, velocitiesElapsedMicroseconds);
+					}
 				}
 				else
 				{

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -30,9 +30,15 @@ namespace Windows.UI.Input
 			internal static readonly Thresholds StartPen = new() { TranslateX = 15, TranslateY = 15, Rotate = 5, Expansion = 15 };
 			internal static readonly Thresholds StartMouse = new() { TranslateX = 1, TranslateY = 1, Rotate = .1, Expansion = 1 };
 
-			internal static readonly Thresholds DeltaTouch = new() { TranslateX = 2, TranslateY = 2, Rotate = .1, Expansion = 1 };
-			internal static readonly Thresholds DeltaPen = new() { TranslateX = 2, TranslateY = 2, Rotate = .1, Expansion = 1 };
-			internal static readonly Thresholds DeltaMouse = new() { TranslateX = 1, TranslateY = 1, Rotate = .1, Expansion = 1 };
+			// Translation thresholds are zero so every sub-pixel position delta flows through to
+			// ScrollViewer (matches WinUI: IInteractionContext fires INTERACTION_ID_MANIPULATION on
+			// every meaningful input change with no displacement gate). HIMETRIC touch on Win32 has
+			// ~0.038 logical px precision, MotionEvent floats on Android similar — any positive
+			// threshold would re-introduce stair-stepping. Rotate/Expansion stay non-zero because
+			// rotation/scale degrees-per-pixel is much noisier than translation.
+			internal static readonly Thresholds DeltaTouch = new() { TranslateX = 0, TranslateY = 0, Rotate = .1, Expansion = 1 };
+			internal static readonly Thresholds DeltaPen = new() { TranslateX = 0, TranslateY = 0, Rotate = .1, Expansion = 1 };
+			internal static readonly Thresholds DeltaMouse = new() { TranslateX = 0, TranslateY = 0, Rotate = .1, Expansion = 1 };
 
 			// Inertia thresholds are expressed in 'unit / millisecond' (unit being either 'logical px' or 'degree')
 			internal static readonly Thresholds InertiaTouch = new() { TranslateX = 15d / 1000, TranslateY = 15d / 1000, Rotate = 5d / 1000, Expansion = 15d / 1000 };

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -75,6 +75,9 @@ namespace Windows.UI.Input
 
 			private ManipulationVelocities _lastRelevantVelocities;
 			private InertiaProcessor? _inertia;
+#if IS_UNO_UI_PROJECT
+			private readonly VelocityTracker _velocityTracker = new();
+#endif
 
 			/// <summary>
 			/// Type of the pointers handled by this manipulation.
@@ -134,6 +137,11 @@ namespace Windows.UI.Input
 
 				_origins = _currents = pointer1;
 				_contacts = (0, 1);
+
+#if IS_UNO_UI_PROJECT
+				// Seed the velocity tracker with the initial pointer position.
+				_velocityTracker.AddPosition(pointer1.Timestamp, pointer1.Position.X, pointer1.Position.Y);
+#endif
 
 				switch (_deviceType)
 				{
@@ -241,7 +249,16 @@ namespace Windows.UI.Input
 				{
 					if (_deviceType == (PointerDeviceType)point.PointerDevice.PointerDeviceType)
 					{
-						hasUpdate |= _currents.TryUpdate(point);
+						if (_currents.TryUpdate(point))
+						{
+							hasUpdate = true;
+#if IS_UNO_UI_PROJECT
+							// Feed the least-squares velocity tracker with each pointer position.
+							// The tracker accumulates samples and uses polynomial fitting for
+							// a smoother velocity estimate than simple delta/time.
+							_velocityTracker.AddPosition(point.Timestamp, point.Position.X, point.Position.Y);
+#endif
+						}
 					}
 				}
 
@@ -268,6 +285,11 @@ namespace Windows.UI.Input
 
 				if (_currents.TryUpdate(removed))
 				{
+#if IS_UNO_UI_PROJECT
+					// Feed the release position to the velocity tracker so it has
+					// the most up-to-date data for the inertia velocity estimate.
+					_velocityTracker.AddPosition(removed.Timestamp, removed.Position.X, removed.Position.Y);
+#endif
 					_contacts.current--;
 
 					NotifyUpdate();
@@ -461,11 +483,31 @@ namespace Windows.UI.Input
 				ManipulationVelocities? velocities;
 				if (useHistory && _inertia is null && !_currents.StateHistory.IsDefault) // Cannot use history when inertia is running: pointer points are no longer updated!
 				{
-					var velocitiesPoints = _currents.StateHistory.GetBoundaries(static p => p.Timestamp);
-					var velocitiesElapsedMicroseconds = velocitiesPoints.to.Timestamp - velocitiesPoints.from.Timestamp;
-					var velocitiesDelta = ComputeDelta(velocitiesPoints.from, velocitiesPoints.to, parentCommit.SumOfDelta);
-
-					velocities = ComputeVelocities(velocitiesDelta, velocitiesElapsedMicroseconds);
+#if IS_UNO_UI_PROJECT
+					// Try the least-squares velocity tracker first — it provides a much smoother
+					// estimate by fitting a polynomial to all recent samples, rather than using
+					// just the boundary points. This significantly reduces fling velocity noise.
+					var lsEstimate = _velocityTracker.GetVelocityEstimate();
+					if (lsEstimate is var (vx, vy))
+					{
+						// VelocityTracker returns units/ms (position delta / ms), which matches
+						// Uno's ManipulationVelocities.Linear convention (units per millisecond).
+						velocities = new ManipulationVelocities
+						{
+							Linear = new Point(vx, vy),
+							Angular = 0,
+							Expansion = 0
+						};
+					}
+					else
+#endif
+					{
+						// Fallback: use the boundary-based linear velocity from the rolling history.
+						var velocitiesPoints = _currents.StateHistory.GetBoundaries(static p => p.Timestamp);
+						var velocitiesElapsedMicroseconds = velocitiesPoints.to.Timestamp - velocitiesPoints.from.Timestamp;
+						var velocitiesDelta = ComputeDelta(velocitiesPoints.from, velocitiesPoints.to, parentCommit.SumOfDelta);
+						velocities = ComputeVelocities(velocitiesDelta, velocitiesElapsedMicroseconds);
+					}
 				}
 				else
 				{

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -494,7 +494,7 @@ namespace Windows.UI.Input
 					// estimate by fitting a polynomial to all recent samples, rather than using
 					// just the boundary points. This significantly reduces fling velocity noise.
 					var lsEstimate = _velocityTracker.GetVelocityEstimate();
-					if (lsEstimate is var (vx, vy))
+					if (lsEstimate is (double vx, double vy))
 					{
 						// VelocityTracker returns units/ms (position delta / ms), which matches
 						// Uno's ManipulationVelocities.Linear convention (units per millisecond).

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -35,9 +35,15 @@ namespace Windows.UI.Input
 			internal static readonly Thresholds StartPen = new() { TranslateX = 10, TranslateY = 10, Rotate = 5, Expansion = 10 };
 			internal static readonly Thresholds StartMouse = new() { TranslateX = 4, TranslateY = 4, Rotate = 1, Expansion = 4 };
 
-			internal static readonly Thresholds DeltaTouch = new() { TranslateX = 2, TranslateY = 2, Rotate = .1, Expansion = 1 };
-			internal static readonly Thresholds DeltaPen = new() { TranslateX = 2, TranslateY = 2, Rotate = .1, Expansion = 1 };
-			internal static readonly Thresholds DeltaMouse = new() { TranslateX = 1, TranslateY = 1, Rotate = .1, Expansion = 1 };
+			// Translation thresholds are zero so every sub-pixel position delta flows through to
+			// ScrollViewer (matches WinUI: IInteractionContext fires INTERACTION_ID_MANIPULATION on
+			// every meaningful input change with no displacement gate). HIMETRIC touch on Win32 has
+			// ~0.038 logical px precision, MotionEvent floats on Android similar — any positive
+			// threshold would re-introduce stair-stepping. Rotate/Expansion stay non-zero because
+			// rotation/scale degrees-per-pixel is much noisier than translation.
+			internal static readonly Thresholds DeltaTouch = new() { TranslateX = 0, TranslateY = 0, Rotate = .1, Expansion = 1 };
+			internal static readonly Thresholds DeltaPen = new() { TranslateX = 0, TranslateY = 0, Rotate = .1, Expansion = 1 };
+			internal static readonly Thresholds DeltaMouse = new() { TranslateX = 0, TranslateY = 0, Rotate = .1, Expansion = 1 };
 
 			// Inertia thresholds are expressed in 'unit / millisecond' (unit being either 'logical px' or 'degree')
 			internal static readonly Thresholds InertiaTouch = new() { TranslateX = 15d / 1000, TranslateY = 15d / 1000, Rotate = 5d / 1000, Expansion = 15d / 1000 };

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -80,6 +80,9 @@ namespace Windows.UI.Input
 
 			private ManipulationVelocities _lastRelevantVelocities;
 			private InertiaProcessor? _inertia;
+#if IS_UNO_UI_PROJECT
+			private readonly VelocityTracker _velocityTracker = new();
+#endif
 
 			/// <summary>
 			/// Type of the pointers handled by this manipulation.
@@ -139,6 +142,11 @@ namespace Windows.UI.Input
 
 				_origins = _currents = pointer1;
 				_contacts = (0, 1);
+
+#if IS_UNO_UI_PROJECT
+				// Seed the velocity tracker with the initial pointer position.
+				_velocityTracker.AddPosition(pointer1.Timestamp, pointer1.Position.X, pointer1.Position.Y);
+#endif
 
 				switch (_deviceType)
 				{
@@ -246,7 +254,16 @@ namespace Windows.UI.Input
 				{
 					if (_deviceType == (PointerDeviceType)point.PointerDevice.PointerDeviceType)
 					{
-						hasUpdate |= _currents.TryUpdate(point);
+						if (_currents.TryUpdate(point))
+						{
+							hasUpdate = true;
+#if IS_UNO_UI_PROJECT
+							// Feed the least-squares velocity tracker with each pointer position.
+							// The tracker accumulates samples and uses polynomial fitting for
+							// a smoother velocity estimate than simple delta/time.
+							_velocityTracker.AddPosition(point.Timestamp, point.Position.X, point.Position.Y);
+#endif
+						}
 					}
 				}
 
@@ -273,6 +290,11 @@ namespace Windows.UI.Input
 
 				if (_currents.TryUpdate(removed))
 				{
+#if IS_UNO_UI_PROJECT
+					// Feed the release position to the velocity tracker so it has
+					// the most up-to-date data for the inertia velocity estimate.
+					_velocityTracker.AddPosition(removed.Timestamp, removed.Position.X, removed.Position.Y);
+#endif
 					_contacts.current--;
 
 					NotifyUpdate();
@@ -462,11 +484,31 @@ namespace Windows.UI.Input
 				ManipulationVelocities? velocities;
 				if (useHistory && _inertia is null && !_currents.StateHistory.IsDefault) // Cannot use history when inertia is running: pointer points are no longer updated!
 				{
-					var velocitiesPoints = _currents.StateHistory.GetBoundaries(static p => p.Timestamp);
-					var velocitiesElapsedMicroseconds = velocitiesPoints.to.Timestamp - velocitiesPoints.from.Timestamp;
-					var velocitiesDelta = ComputeDelta(velocitiesPoints.from, velocitiesPoints.to, parentCommit.SumOfDelta);
-
-					velocities = ComputeVelocities(velocitiesDelta, velocitiesElapsedMicroseconds);
+#if IS_UNO_UI_PROJECT
+					// Try the least-squares velocity tracker first — it provides a much smoother
+					// estimate by fitting a polynomial to all recent samples, rather than using
+					// just the boundary points. This significantly reduces fling velocity noise.
+					var lsEstimate = _velocityTracker.GetVelocityEstimate();
+					if (lsEstimate is var (vx, vy))
+					{
+						// VelocityTracker returns units/ms (position delta / ms), which matches
+						// Uno's ManipulationVelocities.Linear convention (units per millisecond).
+						velocities = new ManipulationVelocities
+						{
+							Linear = new Point(vx, vy),
+							Angular = 0,
+							Expansion = 0
+						};
+					}
+					else
+#endif
+					{
+						// Fallback: use the boundary-based linear velocity from the rolling history.
+						var velocitiesPoints = _currents.StateHistory.GetBoundaries(static p => p.Timestamp);
+						var velocitiesElapsedMicroseconds = velocitiesPoints.to.Timestamp - velocitiesPoints.from.Timestamp;
+						var velocitiesDelta = ComputeDelta(velocitiesPoints.from, velocitiesPoints.to, parentCommit.SumOfDelta);
+						velocities = ComputeVelocities(velocitiesDelta, velocitiesElapsedMicroseconds);
+					}
 				}
 				else
 				{

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -495,7 +495,7 @@ namespace Windows.UI.Input
 					// estimate by fitting a polynomial to all recent samples, rather than using
 					// just the boundary points. This significantly reduces fling velocity noise.
 					var lsEstimate = _velocityTracker.GetVelocityEstimate();
-					if (lsEstimate is var (vx, vy))
+					if (lsEstimate is (double vx, double vy))
 					{
 						// VelocityTracker returns units/ms (position delta / ms), which matches
 						// Uno's ManipulationVelocities.Linear convention (units per millisecond).

--- a/src/Uno.UI/UI/Input/WinRT/VelocityTracker.cs
+++ b/src/Uno.UI/UI/Input/WinRT/VelocityTracker.cs
@@ -1,0 +1,221 @@
+// Least-squares polynomial velocity tracker.
+// Ported from Flutter (velocity_tracker.dart) via Avalonia (VelocityTracker.cs).
+// Provides much smoother fling velocity estimates than simple delta/time,
+// especially when pointer events arrive at irregular intervals.
+
+using System;
+using System.Numerics;
+
+namespace Microsoft.UI.Input;
+
+/// <summary>
+/// Computes pointer velocity using a 2nd-degree least-squares polynomial fit
+/// over recent position history. This produces smoother and more accurate
+/// fling velocity estimates than simple Δposition/Δtime.
+/// </summary>
+internal sealed class VelocityTracker
+{
+	private const int AssumePointerMoveStoppedMicroseconds = 40_000; // 40 ms
+	private const int HistorySize = 20;
+	private const int HorizonMicroseconds = 100_000; // 100 ms
+	private const int MinSampleSize = 3;
+
+	private readonly Sample[] _samples = new Sample[HistorySize];
+	private int _index;
+
+	public void AddPosition(ulong timestampMicroseconds, double x, double y)
+	{
+		_index = (_index + 1) % HistorySize;
+		_samples[_index] = new Sample(true, timestampMicroseconds, x, y);
+	}
+
+	public void Reset()
+	{
+		Array.Clear(_samples, 0, HistorySize);
+		_index = 0;
+	}
+
+	/// <summary>
+	/// Estimates velocity in units per millisecond (matching Uno's ManipulationVelocities convention).
+	/// Returns null if insufficient data.
+	/// </summary>
+	public (double VelocityX, double VelocityY)? GetVelocityEstimate()
+	{
+		Span<double> x = stackalloc double[HistorySize];
+		Span<double> y = stackalloc double[HistorySize];
+		Span<double> w = stackalloc double[HistorySize];
+		Span<double> time = stackalloc double[HistorySize];
+		int sampleCount = 0;
+		int index = _index;
+
+		ref readonly var newest = ref _samples[index];
+		if (!newest.Valid)
+		{
+			return null;
+		}
+
+		var previousTs = newest.Timestamp;
+
+		// Walk backwards from newest, collecting samples within the horizon.
+		do
+		{
+			ref readonly var sample = ref _samples[index];
+			if (!sample.Valid)
+			{
+				break;
+			}
+
+			var age = newest.Timestamp - sample.Timestamp;
+			var delta = previousTs > sample.Timestamp ? previousTs - sample.Timestamp : sample.Timestamp - previousTs;
+			previousTs = sample.Timestamp;
+
+			if (age > HorizonMicroseconds || delta > AssumePointerMoveStoppedMicroseconds)
+			{
+				break;
+			}
+
+			x[sampleCount] = sample.X;
+			y[sampleCount] = sample.Y;
+			w[sampleCount] = 1.0;
+			time[sampleCount] = -(double)age / 1000.0; // Convert to milliseconds (negative = in the past)
+
+			index = index == 0 ? HistorySize - 1 : index - 1;
+			sampleCount++;
+		}
+		while (sampleCount < HistorySize);
+
+		if (sampleCount >= MinSampleSize)
+		{
+			var xSlice = time[..sampleCount];
+			var xFit = LeastSquaresSolve(2, xSlice, x[..sampleCount], w[..sampleCount]);
+			if (xFit is not null)
+			{
+				var yFit = LeastSquaresSolve(2, xSlice, y[..sampleCount], w[..sampleCount]);
+				if (yFit is not null)
+				{
+					// Coefficients[1] is the first derivative (velocity) in units/ms
+					return (xFit.Value.C1, yFit.Value.C1);
+				}
+			}
+		}
+
+		if (sampleCount >= 2)
+		{
+			// Fallback: linear velocity from oldest to newest
+			ref readonly var oldest = ref _samples[(index + 1) % HistorySize];
+			var elapsed = (double)(newest.Timestamp - oldest.Timestamp) / 1000.0; // ms
+			if (elapsed > 0)
+			{
+				return ((newest.X - oldest.X) / elapsed, (newest.Y - oldest.Y) / elapsed);
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Fits a polynomial of the given degree to weighted data using QR decomposition.
+	/// Returns the polynomial coefficients, or null if the system is under-determined.
+	/// </summary>
+	private static PolyResult? LeastSquaresSolve(int degree, ReadOnlySpan<double> xData, ReadOnlySpan<double> yData, ReadOnlySpan<double> wData)
+	{
+		int m = xData.Length;
+		int n = degree + 1;
+
+		if (n > m)
+		{
+			return null;
+		}
+
+		// Expand X to matrix A, pre-multiplied by weights.
+		// Using stackalloc for small matrices (max 20 samples × 3 columns = 60 doubles)
+		Span<double> aData = stackalloc double[n * m];
+		for (int h = 0; h < m; h++)
+		{
+			aData[h] = wData[h]; // a[0, h]
+			for (int i = 1; i < n; i++)
+			{
+				aData[i * m + h] = aData[(i - 1) * m + h] * xData[h]; // a[i, h] = a[i-1, h] * x[h]
+			}
+		}
+
+		// QR decomposition via Gram-Schmidt
+		Span<double> qData = stackalloc double[n * m];
+		Span<double> rData = stackalloc double[n * n];
+
+		for (int j = 0; j < n; j++)
+		{
+			// Copy column j of A into Q
+			for (int h = 0; h < m; h++)
+			{
+				qData[j * m + h] = aData[j * m + h];
+			}
+
+			// Orthogonalize against previous columns
+			for (int i = 0; i < j; i++)
+			{
+				double dot = Dot(qData.Slice(j * m, m), qData.Slice(i * m, m));
+				for (int h = 0; h < m; h++)
+				{
+					qData[j * m + h] -= dot * qData[i * m + h];
+				}
+			}
+
+			// Normalize
+			double norm = Math.Sqrt(Dot(qData.Slice(j * m, m), qData.Slice(j * m, m)));
+			if (norm < 1e-10)
+			{
+				return null; // Linearly dependent
+			}
+
+			double invNorm = 1.0 / norm;
+			for (int h = 0; h < m; h++)
+			{
+				qData[j * m + h] *= invNorm;
+			}
+
+			// Compute R
+			for (int i = 0; i < n; i++)
+			{
+				rData[j * n + i] = i < j ? 0.0 : Dot(qData.Slice(j * m, m), aData.Slice(i * m, m));
+			}
+		}
+
+		// Solve R * B = Q^T * W * Y via back-substitution
+		Span<double> wy = stackalloc double[m];
+		for (int h = 0; h < m; h++)
+		{
+			wy[h] = yData[h] * wData[h];
+		}
+
+		Span<double> coefficients = stackalloc double[n];
+		for (int i = n - 1; i >= 0; i--)
+		{
+			coefficients[i] = Dot(qData.Slice(i * m, m), wy);
+			for (int j = n - 1; j > i; j--)
+			{
+				coefficients[i] -= rData[i * n + j] * coefficients[j];
+			}
+			coefficients[i] /= rData[i * n + i];
+		}
+
+		return new PolyResult(coefficients[0], n > 1 ? coefficients[1] : 0);
+	}
+
+	private static double Dot(ReadOnlySpan<double> a, ReadOnlySpan<double> b)
+	{
+		double result = 0;
+		for (int i = 0; i < a.Length; i++)
+		{
+			result += a[i] * b[i];
+		}
+		return result;
+	}
+
+	private record struct Sample(bool Valid, ulong Timestamp, double X, double Y);
+
+	/// <summary>
+	/// Polynomial fit result. C0 = constant, C1 = first derivative (velocity).
+	/// </summary>
+	private record struct PolyResult(double C0, double C1);
+}

--- a/src/Uno.UI/UI/Input/WinRT/VelocityTracker.cs
+++ b/src/Uno.UI/UI/Input/WinRT/VelocityTracker.cs
@@ -1,5 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without modification,
+// 	are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright
+// 	notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following
+// disclaimer in the documentation and/or other materials provided
+// 	with the distribution.
+// * Neither the name of Google Inc. nor the names of its
+// 	contributors may be used to endorse or promote products derived
+// 	from this software without specific prior written permission.
+//
+// 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// 	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// 	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// 	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// 	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// 	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Based on the Avalonia project (MIT License, Copyright (c) AvaloniaUI OÜ).
+
 // Least-squares polynomial velocity tracker.
-// Ported from Flutter (velocity_tracker.dart) via Avalonia (VelocityTracker.cs).
+// Ported from Flutter's velocity_tracker.dart via Avalonia's VelocityTracker.cs.
 // Provides much smoother fling velocity estimates than simple delta/time,
 // especially when pointer events arrive at irregular intervals.
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
@@ -36,6 +37,16 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private GestureRecognizer.Manipulation? _touchInertia;
 		private (double hOffset, double vOffset, bool isIntermediate) _lastScrolledEvent;
+
+		// Batching: during active touch scrolling, we set AnchorPoint immediately (cheap) but
+		// defer the expensive Updated() call (OnPresenterScrolled + InvalidateViewport + EVP propagation)
+		// to once per frame via CompositionTarget.Rendering. This collapses N pointer moves
+		// per frame into 1 Updated() call while keeping the visual perfectly in sync.
+		private bool _hasPendingTouchUpdate;
+		private double _pendingTouchHOffset;
+		private double _pendingTouchVOffset;
+		private bool _pendingTouchIsIntermediate;
+		private EventHandler<object>? _touchUpdateHandler;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -128,6 +139,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				UnhookScrollEvents(sv);
 			}
+			FlushPendingTouchUpdate();
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -324,8 +336,22 @@ namespace Microsoft.UI.Xaml.Controls
 					visual.StopAnimation(nameof(Visual.AnchorPoint));
 				}
 
+				// Always set AnchorPoint immediately — this is cheap (just a field write + RequestNewFrame).
+				// Multiple writes per frame are fine; only the last value is used at render time.
 				visual.AnchorPoint = target;
-				Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+
+				if (options.IsTouch && options.IsIntermediate)
+				{
+					// During active touch scrolling (finger on screen or inertia), defer the expensive
+					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
+					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
+				else
+				{
+					// Non-intermediate (final) or non-touch: flush immediately for correct event sequencing.
+					FlushPendingTouchUpdate();
+					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
 			}
 			else
 			{
@@ -347,6 +373,36 @@ namespace Microsoft.UI.Xaml.Controls
 				animation.Stopped += OnStopped;
 
 				visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
+			}
+		}
+
+		private void ScheduleDeferredTouchUpdate(double hOffset, double vOffset, bool isIntermediate)
+		{
+			_pendingTouchHOffset = hOffset;
+			_pendingTouchVOffset = vOffset;
+			_pendingTouchIsIntermediate = isIntermediate;
+
+			if (!_hasPendingTouchUpdate)
+			{
+				_hasPendingTouchUpdate = true;
+				_touchUpdateHandler ??= OnRenderingFlushTouchUpdate;
+				CompositionTarget.Rendering += _touchUpdateHandler;
+			}
+		}
+
+		private void OnRenderingFlushTouchUpdate(object? sender, object e)
+		{
+			// Unsubscribe immediately — we re-subscribe on next touch move if needed.
+			CompositionTarget.Rendering -= _touchUpdateHandler;
+			FlushPendingTouchUpdate();
+		}
+
+		private void FlushPendingTouchUpdate()
+		{
+			if (_hasPendingTouchUpdate)
+			{
+				_hasPendingTouchUpdate = false;
+				Updated(_pendingTouchHOffset, _pendingTouchVOffset, _pendingTouchIsIntermediate);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -462,11 +462,12 @@ namespace Microsoft.UI.Xaml.Controls
 			var animation = compositor.CreateVector2KeyFrameAnimation();
 			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
 
-			// Sample the exponential decay curve at regular intervals as keyframes.
-			// The composition system linearly interpolates between them, which closely
-			// approximates the smooth exponential curve.
-			const int keyframeInterval = 32; // ms between keyframes (~30fps sampling)
-			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeInterval));
+			// Sample the exponential decay curve at frame-rate-matched intervals.
+			// Using 16ms (60fps) ensures each displayed frame has its own keyframe,
+			// eliminating velocity discontinuities from inter-keyframe linear interpolation
+			// that would otherwise cause subtle visual "shaking" or "tearing" effects.
+			const int keyframeIntervalMs = 16;
+			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeIntervalMs));
 
 			for (var i = 0; i <= numKeyframes; i++)
 			{
@@ -483,24 +484,31 @@ namespace Microsoft.UI.Xaml.Controls
 				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
 			}
 
-			// Throttled offset updates: only call Updated() every Nth frame to reduce
-			// the cost of OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
-			// The visual is still smooth at 60fps because the composition animation drives AnchorPoint.
+			// During the animation, update only the ScrollViewer offset DPs (for scrollbar movement).
+			// CRITICAL: Do NOT call InvalidateViewport() / PropagateEffectiveViewportChange() here.
+			// That triggers layout invalidation (item recycling, re-arrangement) which causes visible
+			// "tearing" — content appears at the animation position while layout elements shift around.
+			// Viewport propagation is deferred to OnInertiaAnimationCompleted for a single clean pass.
 			var frameCount = 0;
 			void OnFrame(CompositionAnimation? _)
 			{
-				// Update scrollbar position and viewport every 2nd frame (~30fps).
-				// This keeps the scrollbar visually smooth while halving the cost of
-				// OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
-				// The content itself is smooth at 60fps because the composition animation
-				// drives AnchorPoint directly.
+				// Update scrollbar position every 2nd frame (~30fps) for smooth scrollbar movement.
+				// Only updates the DP offsets — no layout invalidation, no viewport propagation.
 				if (++frameCount % 2 == 0)
 				{
 					var currentH = Math.Round(-visual.AnchorPoint.X);
 					var currentV = Math.Round(-visual.AnchorPoint.Y);
 					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
 					VerticalOffset = Math.Clamp(currentV, 0, maxV);
-					Updated(HorizontalOffset, VerticalOffset, isIntermediate: true);
+
+					// Update ScrollViewer DPs for scrollbar visuals, but skip full Updated()
+					// which would trigger InvalidateViewport → layout changes → tearing.
+					if (_lastScrolledEvent != (HorizontalOffset, VerticalOffset, true))
+					{
+						_lastScrolledEvent = (HorizontalOffset, VerticalOffset, true);
+						Scroller?.OnPresenterScrolled(HorizontalOffset, VerticalOffset, isIntermediate: true);
+					}
+					ScrollOffsets = new Point(HorizontalOffset, VerticalOffset);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -404,6 +404,9 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			Debug.Assert(_touchInertia is null || isResuming, "Inertia should already be null instead if we are resuming from a previous manipulation.");
 			_touchInertia = null;
+#if __SKIA__
+			Scroller?.EnterIntermediateViewChangedMode();
+#endif
 		}
 
 		/// <inheritdoc />
@@ -598,6 +601,9 @@ namespace Microsoft.UI.Xaml.Controls
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
+#if __SKIA__
+				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);
+#endif
 				return;
 			}
 
@@ -605,6 +611,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 			//Set(disableAnimation: true, isIntermediate: false);
 			Set(options: new ScrollOptions(DisableAnimation: true, IsTouch: true, IsIntermediate: false));
+#if __SKIA__
+			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
+#endif
 		}
 
 		private ScrollDirection GetDirection(ManipulationVelocities velocities)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -48,11 +48,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
 
-		// Composition-driven inertia: instead of running managed code every frame (inertia processor
-		// → gesture recognizer → event → Set → Update → viewport propagation), we pre-compute the
-		// exponential decay curve as keyframes and let the composition animation system drive the
-		// Visual.AnchorPoint directly. This makes inertia as smooth as any other composition animation.
-		private bool _isInertiaAnimationRunning;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -146,7 +141,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UnhookScrollEvents(sv);
 			}
 			FlushPendingTouchUpdate();
-			StopInertiaAnimation();
+
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -261,9 +256,8 @@ namespace Microsoft.UI.Xaml.Controls
 			if (!options.IsTouch)
 			{
 				// If we get a request to scroll to a specific offset **that is not flagged as IsInertial** (i.e. not coming from the inertia processing),
-				// we stop the pending inertia processor and any running inertia animation.
+				// we stop the pending inertia processor.
 				_touchInertia?.Complete();
-				StopInertiaAnimation();
 			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
@@ -348,15 +342,18 @@ namespace Microsoft.UI.Xaml.Controls
 				// Multiple writes per frame are fine; only the last value is used at render time.
 				visual.AnchorPoint = target;
 
-				if (options.IsTouch && options.IsIntermediate)
+				if (options.IsTouch && options.IsIntermediate && _touchInertia is null)
 				{
-					// During active touch scrolling (finger on screen or inertia), defer the expensive
+					// During active touch scrolling (finger on screen, NOT inertia), defer the expensive
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
+					// We DON'T defer during inertia because the inertia processor fires exactly once per
+					// frame during CompositionTarget.Rendering (BEFORE layout), and we need layout to
+					// process the new scroll position in the SAME frame to avoid tearing.
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
 				else
 				{
-					// Non-intermediate (final) or non-touch: flush immediately for correct event sequencing.
+					// Inertia, non-intermediate (final), or non-touch: flush immediately.
 					FlushPendingTouchUpdate();
 					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
@@ -414,161 +411,6 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		/// <summary>
-		/// Starts a composition-animation-driven inertia scroll.
-		/// Pre-computes the exponential decay curve as keyframes so the composition system
-		/// drives the Visual.AnchorPoint directly — no managed code per frame.
-		/// </summary>
-		private void StartInertiaAnimation(
-			ManipulationVelocities velocities,
-			double deceleration,
-			ScrollableOffsets scrollable)
-		{
-			if (Content is not UIElement contentElt)
-			{
-				return;
-			}
-
-			// Flush any pending touch updates before starting the animation
-			FlushPendingTouchUpdate();
-
-			// Velocities are in pointer-position space (px/ms). Negate to get scroll-offset velocity.
-			// When pointer moves right (positive velocity), content scrolls left (offset decreases).
-			var v0H = -velocities.Linear.X;
-			var v0V = -velocities.Linear.Y;
-			var k = deceleration;
-
-			// Compute duration: time until velocity drops below threshold
-			var maxAbsV = Math.Max(Math.Abs(v0H), Math.Abs(v0V));
-			if (maxAbsV <= GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold)
-			{
-				// Velocity too low for visible inertia
-				OnInertiaAnimationCompleted(contentElt);
-				return;
-			}
-
-			var durationMs = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(maxAbsV, k);
-
-			// Clamp to reasonable max (avoid extremely long animations from very fast flings)
-			durationMs = Math.Min(durationMs, 5000);
-
-			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
-			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
-			var startH = HorizontalOffset;
-			var startV = VerticalOffset;
-
-			var visual = contentElt.Visual;
-			var compositor = visual.Compositor;
-			var animation = compositor.CreateVector2KeyFrameAnimation();
-			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
-
-			// Sample the exponential decay curve at frame-rate-matched intervals.
-			// Using 16ms (60fps) ensures each displayed frame has its own keyframe,
-			// eliminating velocity discontinuities from inter-keyframe linear interpolation
-			// that would otherwise cause subtle visual "shaking" or "tearing" effects.
-			const int keyframeIntervalMs = 16;
-			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeIntervalMs));
-
-			for (var i = 0; i <= numKeyframes; i++)
-			{
-				var progress = (float)i / numKeyframes;
-				var tMs = progress * durationMs;
-
-				var hPos = startH + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0H, k, tMs);
-				var vPos = startV + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0V, k, tMs);
-
-				// Clamp to scrollable bounds
-				hPos = Math.Clamp(hPos, 0, maxH);
-				vPos = Math.Clamp(vPos, 0, maxV);
-
-				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
-			}
-
-			// During the animation, update only the ScrollViewer offset DPs (for scrollbar movement).
-			// CRITICAL: Do NOT call InvalidateViewport() / PropagateEffectiveViewportChange() here.
-			// That triggers layout invalidation (item recycling, re-arrangement) which causes visible
-			// "tearing" — content appears at the animation position while layout elements shift around.
-			// Viewport propagation is deferred to OnInertiaAnimationCompleted for a single clean pass.
-			var frameCount = 0;
-			void OnFrame(CompositionAnimation? _)
-			{
-				// Update scrollbar position every 2nd frame (~30fps) for smooth scrollbar movement.
-				// Only updates the DP offsets — no layout invalidation, no viewport propagation.
-				if (++frameCount % 2 == 0)
-				{
-					var currentH = Math.Round(-visual.AnchorPoint.X);
-					var currentV = Math.Round(-visual.AnchorPoint.Y);
-					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
-					VerticalOffset = Math.Clamp(currentV, 0, maxV);
-
-					// Update ScrollViewer DPs for scrollbar visuals, but skip full Updated()
-					// which would trigger InvalidateViewport → layout changes → tearing.
-					if (_lastScrolledEvent != (HorizontalOffset, VerticalOffset, true))
-					{
-						_lastScrolledEvent = (HorizontalOffset, VerticalOffset, true);
-						Scroller?.OnPresenterScrolled(HorizontalOffset, VerticalOffset, isIntermediate: true);
-					}
-					ScrollOffsets = new Point(HorizontalOffset, VerticalOffset);
-				}
-			}
-
-			void OnStopped(object? _, EventArgs __)
-			{
-				animation.AnimationFrame -= OnFrame;
-				animation.Stopped -= OnStopped;
-				OnInertiaAnimationCompleted(contentElt);
-			}
-
-			animation.AnimationFrame += OnFrame;
-			animation.Stopped += OnStopped;
-
-			// Stop any existing animation and start the inertia animation
-			if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
-			{
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
-			}
-
-			_isInertiaAnimationRunning = true;
-			visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
-		}
-
-		private void OnInertiaAnimationCompleted(UIElement contentElt)
-		{
-			_isInertiaAnimationRunning = false;
-
-			// Read the final position from the visual
-			var visual = contentElt.Visual;
-			var finalH = Math.Round(-visual.AnchorPoint.X);
-			var finalV = Math.Round(-visual.AnchorPoint.Y);
-
-			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
-			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
-
-			HorizontalOffset = Math.Clamp(finalH, 0, maxH);
-			VerticalOffset = Math.Clamp(finalV, 0, maxV);
-
-			// Fire final non-intermediate Updated
-			Updated(HorizontalOffset, VerticalOffset, isIntermediate: false);
-
-#if __SKIA__
-			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
-#endif
-		}
-
-		/// <summary>
-		/// Stops a running inertia animation (e.g. when user touches during fling)
-		/// and synchronizes the scroll offset to the current visual position.
-		/// </summary>
-		private void StopInertiaAnimation()
-		{
-			if (_isInertiaAnimationRunning && Content is UIElement contentElt)
-			{
-				var visual = contentElt.Visual;
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
-				// StopAnimation triggers the Stopped callback which calls OnInertiaAnimationCompleted
-			}
-		}
-
 		private void TryEnableDirectManipulation(object sender, PointerRoutedEventArgs args)
 		{
 			if (args.Pointer.PointerDeviceType is not (_PointerDeviceType.Pen or _PointerDeviceType.Touch))
@@ -589,7 +431,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_touchInertia = null;
 
 			// Stop any running composition-driven inertia animation (user touched during fling).
-			StopInertiaAnimation();
+
 
 			var mode = ManipulationModes.None;
 			var scrollable = GetScrollableOffsets();
@@ -809,21 +651,17 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				// Instead of letting the inertia processor tick managed code every frame
-				// (physics → gesture recognizer → events → Set → viewport propagation),
-				// we pre-compute the exponential decay curve as a composition animation.
-				// This makes inertia as smooth as any other composition animation (e.g. RedirectVisual).
-				_touchInertia = null; // Don't allow inertia processor ticks in OnUpdated
+				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
+				_touchInertia = args.Manipulation;
 
-				// Complete the gesture to stop the inertia processor from ticking.
-				// OnCompleted will see _touchInertia == null && IsInertial, so it early-returns
-				// without touching intermediate mode.
-				recognizer.CompleteGesture();
+				// Even if usually empty, make sure to apply the delta
+				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);
+				var deltaY = Math.Clamp(-args.Delta.Translation.Y, scrollable.Up, scrollable.Down);
 
-				StartInertiaAnimation(
-					args.Velocities,
-					inertia.DesiredDisplacementDeceleration,
-					scrollable);
+				Set(
+					horizontalOffset: HorizontalOffset + deltaX,
+					verticalOffset: VerticalOffset + deltaY,
+					options: new(DisableAnimation: true, IsTouch: true, IsIntermediate: true));
 			}
 
 			return true;
@@ -834,13 +672,6 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
-				if (_isInertiaAnimationRunning)
-				{
-					// The inertia is now driven by a composition animation, not the processor.
-					// Don't touch intermediate mode — the animation's Stopped callback handles it.
-					return;
-				}
-
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 #if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -47,6 +47,12 @@ namespace Microsoft.UI.Xaml.Controls
 		private double _pendingTouchVOffset;
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
+
+		// Composition-driven inertia: instead of running managed code every frame (inertia processor
+		// → gesture recognizer → event → Set → Update → viewport propagation), we pre-compute the
+		// exponential decay curve as keyframes and let the composition animation system drive the
+		// Visual.AnchorPoint directly. This makes inertia as smooth as any other composition animation.
+		private bool _isInertiaAnimationRunning;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -140,6 +146,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UnhookScrollEvents(sv);
 			}
 			FlushPendingTouchUpdate();
+			StopInertiaAnimation();
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -254,8 +261,9 @@ namespace Microsoft.UI.Xaml.Controls
 			if (!options.IsTouch)
 			{
 				// If we get a request to scroll to a specific offset **that is not flagged as IsInertial** (i.e. not coming from the inertia processing),
-				// we stop the pending inertia processor.
+				// we stop the pending inertia processor and any running inertia animation.
 				_touchInertia?.Complete();
+				StopInertiaAnimation();
 			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
@@ -406,6 +414,152 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		/// <summary>
+		/// Starts a composition-animation-driven inertia scroll.
+		/// Pre-computes the exponential decay curve as keyframes so the composition system
+		/// drives the Visual.AnchorPoint directly — no managed code per frame.
+		/// </summary>
+		private void StartInertiaAnimation(
+			ManipulationVelocities velocities,
+			double deceleration,
+			ScrollableOffsets scrollable)
+		{
+			if (Content is not UIElement contentElt)
+			{
+				return;
+			}
+
+			// Flush any pending touch updates before starting the animation
+			FlushPendingTouchUpdate();
+
+			// Velocities are in pointer-position space (px/ms). Negate to get scroll-offset velocity.
+			// When pointer moves right (positive velocity), content scrolls left (offset decreases).
+			var v0H = -velocities.Linear.X;
+			var v0V = -velocities.Linear.Y;
+			var k = deceleration;
+
+			// Compute duration: time until velocity drops below threshold
+			var maxAbsV = Math.Max(Math.Abs(v0H), Math.Abs(v0V));
+			if (maxAbsV <= GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold)
+			{
+				// Velocity too low for visible inertia
+				OnInertiaAnimationCompleted(contentElt);
+				return;
+			}
+
+			var durationMs = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(maxAbsV, k);
+
+			// Clamp to reasonable max (avoid extremely long animations from very fast flings)
+			durationMs = Math.Min(durationMs, 5000);
+
+			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
+			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
+			var startH = HorizontalOffset;
+			var startV = VerticalOffset;
+
+			var visual = contentElt.Visual;
+			var compositor = visual.Compositor;
+			var animation = compositor.CreateVector2KeyFrameAnimation();
+			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
+
+			// Sample the exponential decay curve at regular intervals as keyframes.
+			// The composition system linearly interpolates between them, which closely
+			// approximates the smooth exponential curve.
+			const int keyframeInterval = 32; // ms between keyframes (~30fps sampling)
+			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeInterval));
+
+			for (var i = 0; i <= numKeyframes; i++)
+			{
+				var progress = (float)i / numKeyframes;
+				var tMs = progress * durationMs;
+
+				var hPos = startH + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0H, k, tMs);
+				var vPos = startV + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0V, k, tMs);
+
+				// Clamp to scrollable bounds
+				hPos = Math.Clamp(hPos, 0, maxH);
+				vPos = Math.Clamp(vPos, 0, maxV);
+
+				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
+			}
+
+			// Throttled offset updates: only call Updated() every Nth frame to reduce
+			// the cost of OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
+			// The visual is still smooth at 60fps because the composition animation drives AnchorPoint.
+			var frameCount = 0;
+			void OnFrame(CompositionAnimation? _)
+			{
+				// Update scrollbar position and viewport every 2nd frame (~30fps).
+				// This keeps the scrollbar visually smooth while halving the cost of
+				// OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
+				// The content itself is smooth at 60fps because the composition animation
+				// drives AnchorPoint directly.
+				if (++frameCount % 2 == 0)
+				{
+					var currentH = Math.Round(-visual.AnchorPoint.X);
+					var currentV = Math.Round(-visual.AnchorPoint.Y);
+					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
+					VerticalOffset = Math.Clamp(currentV, 0, maxV);
+					Updated(HorizontalOffset, VerticalOffset, isIntermediate: true);
+				}
+			}
+
+			void OnStopped(object? _, EventArgs __)
+			{
+				animation.AnimationFrame -= OnFrame;
+				animation.Stopped -= OnStopped;
+				OnInertiaAnimationCompleted(contentElt);
+			}
+
+			animation.AnimationFrame += OnFrame;
+			animation.Stopped += OnStopped;
+
+			// Stop any existing animation and start the inertia animation
+			if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
+			{
+				visual.StopAnimation(nameof(Visual.AnchorPoint));
+			}
+
+			_isInertiaAnimationRunning = true;
+			visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
+		}
+
+		private void OnInertiaAnimationCompleted(UIElement contentElt)
+		{
+			_isInertiaAnimationRunning = false;
+
+			// Read the final position from the visual
+			var visual = contentElt.Visual;
+			var finalH = Math.Round(-visual.AnchorPoint.X);
+			var finalV = Math.Round(-visual.AnchorPoint.Y);
+
+			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
+			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
+
+			HorizontalOffset = Math.Clamp(finalH, 0, maxH);
+			VerticalOffset = Math.Clamp(finalV, 0, maxV);
+
+			// Fire final non-intermediate Updated
+			Updated(HorizontalOffset, VerticalOffset, isIntermediate: false);
+
+#if __SKIA__
+			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
+#endif
+		}
+
+		/// <summary>
+		/// Stops a running inertia animation (e.g. when user touches during fling)
+		/// and synchronizes the scroll offset to the current visual position.
+		/// </summary>
+		private void StopInertiaAnimation()
+		{
+			if (_isInertiaAnimationRunning && Content is UIElement contentElt)
+			{
+				var visual = contentElt.Visual;
+				visual.StopAnimation(nameof(Visual.AnchorPoint));
+				// StopAnimation triggers the Stopped callback which calls OnInertiaAnimationCompleted
+			}
+		}
 
 		private void TryEnableDirectManipulation(object sender, PointerRoutedEventArgs args)
 		{
@@ -425,6 +579,9 @@ namespace Microsoft.UI.Xaml.Controls
 			// If a previous inertia is still tracked, clear it immediately so old inertial deltas
 			// cannot fight with the new manipulation's direction.
 			_touchInertia = null;
+
+			// Stop any running composition-driven inertia animation (user touched during fling).
+			StopInertiaAnimation();
 
 			var mode = ManipulationModes.None;
 			var scrollable = GetScrollableOffsets();
@@ -644,17 +801,21 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
-				_touchInertia = args.Manipulation;
+				// Instead of letting the inertia processor tick managed code every frame
+				// (physics → gesture recognizer → events → Set → viewport propagation),
+				// we pre-compute the exponential decay curve as a composition animation.
+				// This makes inertia as smooth as any other composition animation (e.g. RedirectVisual).
+				_touchInertia = null; // Don't allow inertia processor ticks in OnUpdated
 
-				// Even if usually empty, make sure to apply the delta
-				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);
-				var deltaY = Math.Clamp(-args.Delta.Translation.Y, scrollable.Up, scrollable.Down);
+				// Complete the gesture to stop the inertia processor from ticking.
+				// OnCompleted will see _touchInertia == null && IsInertial, so it early-returns
+				// without touching intermediate mode.
+				recognizer.CompleteGesture();
 
-				Set(
-					horizontalOffset: HorizontalOffset + deltaX,
-					verticalOffset: VerticalOffset + deltaY,
-					options: new(DisableAnimation: true, IsTouch: true, IsIntermediate: true));
+				StartInertiaAnimation(
+					args.Velocities,
+					inertia.DesiredDisplacementDeceleration,
+					scrollable);
 			}
 
 			return true;
@@ -665,6 +826,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
+				if (_isInertiaAnimationRunning)
+				{
+					// The inertia is now driven by a composition animation, not the processor.
+					// Don't touch intermediate mode — the animation's Stopped callback handles it.
+					return;
+				}
+
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 #if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -48,6 +48,15 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
 
+		// Inertia viewport throttle: PropagateEffectiveViewportChange() can trigger
+		// heavy layout (ItemsRepeater measure, item recycling). If that layout doesn't
+		// fully resolve in one UpdateLayout() pass, CanRecordPicture returns false and
+		// the frame is SKIPPED, causing visible ghosting. By throttling EVP to every Nth
+		// inertia frame, most frames are lightweight (just AnchorPoint + scroll offset DPs)
+		// and always render. Items still materialize at ~20fps which is imperceptible.
+		private int _inertiaFrameCount;
+		private const int InertiaViewportUpdateInterval = 3;
+
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -340,20 +349,46 @@ namespace Microsoft.UI.Xaml.Controls
 
 				// Always set AnchorPoint immediately — this is cheap (just a field write + RequestNewFrame).
 				// Multiple writes per frame are fine; only the last value is used at render time.
-				visual.AnchorPoint = target;
+				// Pixel-snap to integer values to avoid subpixel text rendering artifacts
+				// (shimmer/ghosting from fractional offsets during inertia decay).
+				visual.AnchorPoint = new Vector2(MathF.Round(target.X), MathF.Round(target.Y));
 
 				if (options.IsTouch && options.IsIntermediate && _touchInertia is null)
 				{
 					// During active touch scrolling (finger on screen, NOT inertia), defer the expensive
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
-					// We DON'T defer during inertia because the inertia processor fires exactly once per
-					// frame during CompositionTarget.Rendering (BEFORE layout), and we need layout to
-					// process the new scroll position in the SAME frame to avoid tearing.
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
+				else if (options.IsTouch && options.IsIntermediate && _touchInertia is not null)
+				{
+					// Inertia: update immediately but throttle viewport propagation.
+					// PropagateEffectiveViewportChange() can trigger heavy layout (ItemsRepeater
+					// measure, item recycling). If layout doesn't fully resolve in one pass,
+					// CanRecordPicture returns false → frame skipped → visible ghosting.
+					// By only doing the full EVP every Nth frame, most frames are guaranteed
+					// to render. Items materialize at ~20fps which is imperceptible.
+					FlushPendingTouchUpdate();
+					_inertiaFrameCount++;
+					if (_inertiaFrameCount % InertiaViewportUpdateInterval == 0)
+					{
+						// Full update: scroll offsets + OnPresenterScrolled + InvalidateViewport
+						Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+					}
+					else
+					{
+						// Lightweight update: scroll offsets + scrollbar DPs only (no EVP tree walk).
+						// AnchorPoint was already set above, so the visual moves at 60fps.
+						if (_lastScrolledEvent != (horizontalOffset, verticalOffset, true))
+						{
+							_lastScrolledEvent = (horizontalOffset, verticalOffset, true);
+							Scroller?.OnPresenterScrolled(horizontalOffset, verticalOffset, isIntermediate: true);
+						}
+						ScrollOffsets = new Point(horizontalOffset, verticalOffset);
+					}
 				}
 				else
 				{
-					// Inertia, non-intermediate (final), or non-touch: flush immediately.
+					// Non-intermediate (final) or non-touch: flush immediately with full update.
 					FlushPendingTouchUpdate();
 					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
@@ -653,6 +688,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
 				_touchInertia = args.Manipulation;
+				_inertiaFrameCount = 0;
 
 				// Even if usually empty, make sure to apply the delta
 				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -317,7 +317,13 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (options is { DisableAnimation: true } or { IsTouch: true })
 			{
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
+				// Only stop a running animation — during inertia no animation is active,
+				// so calling StopAnimation every tick wastes time on dictionary lookups.
+				if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
+				{
+					visual.StopAnimation(nameof(Visual.AnchorPoint));
+				}
+
 				visual.AnchorPoint = target;
 				Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 			}
@@ -519,8 +525,8 @@ namespace Microsoft.UI.Xaml.Controls
 					_ => 0
 				};
 
-				// calculate the duration based on PKScrollView.prototype.stepThroughDecelerationAnimation from https://github.com/jimeh/PastryKit
-				// momentum should decay by 5% each frame, at 60fps, until the minimum threshold is reached.
+				// PastryKit-inspired iOS scroll physics: 0.95 friction factor per frame at 60fps.
+				// This maps directly to the exponential decay model: k = -ln(0.95)/16.67 ≈ 0.003
 				const double PKScrollViewDecelerationFrictionFactor = 0.95;
 				const double PKScrollViewDesiredAnimationFrameRate = 1000 / 60.0;
 				const double PKScrollViewMinimumVelocity = 0.01;
@@ -531,10 +537,13 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else if (OperatingSystem.IsAndroid())
 			{
-				inertia.DesiredDisplacementDeceleration = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration / 2;
+				// Gentler decay for Android, matching the longer fling feel of native Android OverScroller.
+				// 0.0025 ≈ 0.96 decay per 16.67ms frame (vs WinUI's 0.95).
+				inertia.DesiredDisplacementDeceleration = 0.0025;
 			}
 			else
 			{
+				// Desktop/other: match WinUI InteractionTracker default (0.95 decay per frame).
 				inertia.DesiredDisplacementDeceleration = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -438,6 +438,9 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			Debug.Assert(_touchInertia is null || isResuming, "Inertia should already be null instead if we are resuming from a previous manipulation.");
 			_touchInertia = null;
+#if __SKIA__
+			Scroller?.EnterIntermediateViewChangedMode();
+#endif
 		}
 
 		/// <inheritdoc />
@@ -632,6 +635,9 @@ namespace Microsoft.UI.Xaml.Controls
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
+#if __SKIA__
+				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);
+#endif
 				return;
 			}
 
@@ -639,6 +645,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 			//Set(disableAnimation: true, isIntermediate: false);
 			Set(options: new ScrollOptions(DisableAnimation: true, IsTouch: true, IsIntermediate: false));
+#if __SKIA__
+			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
+#endif
 		}
 
 		private ScrollDirection GetDirection(ManipulationVelocities velocities)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -48,11 +48,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
 
-		// Composition-driven inertia: instead of running managed code every frame (inertia processor
-		// → gesture recognizer → event → Set → Update → viewport propagation), we pre-compute the
-		// exponential decay curve as keyframes and let the composition animation system drive the
-		// Visual.AnchorPoint directly. This makes inertia as smooth as any other composition animation.
-		private bool _isInertiaAnimationRunning;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -167,7 +162,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UnhookScrollEvents(sv);
 			}
 			FlushPendingTouchUpdate();
-			StopInertiaAnimation();
+
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -282,9 +277,8 @@ namespace Microsoft.UI.Xaml.Controls
 			if (!options.IsTouch)
 			{
 				// If we get a request to scroll to a specific offset **that is not flagged as IsInertial** (i.e. not coming from the inertia processing),
-				// we stop the pending inertia processor and any running inertia animation.
+				// we stop the pending inertia processor.
 				_touchInertia?.Complete();
-				StopInertiaAnimation();
 			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
@@ -369,15 +363,18 @@ namespace Microsoft.UI.Xaml.Controls
 				// Multiple writes per frame are fine; only the last value is used at render time.
 				visual.AnchorPoint = target;
 
-				if (options.IsTouch && options.IsIntermediate)
+				if (options.IsTouch && options.IsIntermediate && _touchInertia is null)
 				{
-					// During active touch scrolling (finger on screen or inertia), defer the expensive
+					// During active touch scrolling (finger on screen, NOT inertia), defer the expensive
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
+					// We DON'T defer during inertia because the inertia processor fires exactly once per
+					// frame during CompositionTarget.Rendering (BEFORE layout), and we need layout to
+					// process the new scroll position in the SAME frame to avoid tearing.
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
 				else
 				{
-					// Non-intermediate (final) or non-touch: flush immediately for correct event sequencing.
+					// Inertia, non-intermediate (final), or non-touch: flush immediately.
 					FlushPendingTouchUpdate();
 					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
@@ -435,161 +432,6 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		/// <summary>
-		/// Starts a composition-animation-driven inertia scroll.
-		/// Pre-computes the exponential decay curve as keyframes so the composition system
-		/// drives the Visual.AnchorPoint directly — no managed code per frame.
-		/// </summary>
-		private void StartInertiaAnimation(
-			ManipulationVelocities velocities,
-			double deceleration,
-			ScrollableOffsets scrollable)
-		{
-			if (Content is not UIElement contentElt)
-			{
-				return;
-			}
-
-			// Flush any pending touch updates before starting the animation
-			FlushPendingTouchUpdate();
-
-			// Velocities are in pointer-position space (px/ms). Negate to get scroll-offset velocity.
-			// When pointer moves right (positive velocity), content scrolls left (offset decreases).
-			var v0H = -velocities.Linear.X;
-			var v0V = -velocities.Linear.Y;
-			var k = deceleration;
-
-			// Compute duration: time until velocity drops below threshold
-			var maxAbsV = Math.Max(Math.Abs(v0H), Math.Abs(v0V));
-			if (maxAbsV <= GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold)
-			{
-				// Velocity too low for visible inertia
-				OnInertiaAnimationCompleted(contentElt);
-				return;
-			}
-
-			var durationMs = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(maxAbsV, k);
-
-			// Clamp to reasonable max (avoid extremely long animations from very fast flings)
-			durationMs = Math.Min(durationMs, 5000);
-
-			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
-			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
-			var startH = HorizontalOffset;
-			var startV = VerticalOffset;
-
-			var visual = contentElt.Visual;
-			var compositor = visual.Compositor;
-			var animation = compositor.CreateVector2KeyFrameAnimation();
-			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
-
-			// Sample the exponential decay curve at frame-rate-matched intervals.
-			// Using 16ms (60fps) ensures each displayed frame has its own keyframe,
-			// eliminating velocity discontinuities from inter-keyframe linear interpolation
-			// that would otherwise cause subtle visual "shaking" or "tearing" effects.
-			const int keyframeIntervalMs = 16;
-			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeIntervalMs));
-
-			for (var i = 0; i <= numKeyframes; i++)
-			{
-				var progress = (float)i / numKeyframes;
-				var tMs = progress * durationMs;
-
-				var hPos = startH + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0H, k, tMs);
-				var vPos = startV + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0V, k, tMs);
-
-				// Clamp to scrollable bounds
-				hPos = Math.Clamp(hPos, 0, maxH);
-				vPos = Math.Clamp(vPos, 0, maxV);
-
-				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
-			}
-
-			// During the animation, update only the ScrollViewer offset DPs (for scrollbar movement).
-			// CRITICAL: Do NOT call InvalidateViewport() / PropagateEffectiveViewportChange() here.
-			// That triggers layout invalidation (item recycling, re-arrangement) which causes visible
-			// "tearing" — content appears at the animation position while layout elements shift around.
-			// Viewport propagation is deferred to OnInertiaAnimationCompleted for a single clean pass.
-			var frameCount = 0;
-			void OnFrame(CompositionAnimation? _)
-			{
-				// Update scrollbar position every 2nd frame (~30fps) for smooth scrollbar movement.
-				// Only updates the DP offsets — no layout invalidation, no viewport propagation.
-				if (++frameCount % 2 == 0)
-				{
-					var currentH = Math.Round(-visual.AnchorPoint.X);
-					var currentV = Math.Round(-visual.AnchorPoint.Y);
-					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
-					VerticalOffset = Math.Clamp(currentV, 0, maxV);
-
-					// Update ScrollViewer DPs for scrollbar visuals, but skip full Updated()
-					// which would trigger InvalidateViewport → layout changes → tearing.
-					if (_lastScrolledEvent != (HorizontalOffset, VerticalOffset, true))
-					{
-						_lastScrolledEvent = (HorizontalOffset, VerticalOffset, true);
-						Scroller?.OnPresenterScrolled(HorizontalOffset, VerticalOffset, isIntermediate: true);
-					}
-					ScrollOffsets = new Point(HorizontalOffset, VerticalOffset);
-				}
-			}
-
-			void OnStopped(object? _, EventArgs __)
-			{
-				animation.AnimationFrame -= OnFrame;
-				animation.Stopped -= OnStopped;
-				OnInertiaAnimationCompleted(contentElt);
-			}
-
-			animation.AnimationFrame += OnFrame;
-			animation.Stopped += OnStopped;
-
-			// Stop any existing animation and start the inertia animation
-			if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
-			{
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
-			}
-
-			_isInertiaAnimationRunning = true;
-			visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
-		}
-
-		private void OnInertiaAnimationCompleted(UIElement contentElt)
-		{
-			_isInertiaAnimationRunning = false;
-
-			// Read the final position from the visual
-			var visual = contentElt.Visual;
-			var finalH = Math.Round(-visual.AnchorPoint.X);
-			var finalV = Math.Round(-visual.AnchorPoint.Y);
-
-			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
-			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
-
-			HorizontalOffset = Math.Clamp(finalH, 0, maxH);
-			VerticalOffset = Math.Clamp(finalV, 0, maxV);
-
-			// Fire final non-intermediate Updated
-			Updated(HorizontalOffset, VerticalOffset, isIntermediate: false);
-
-#if __SKIA__
-			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
-#endif
-		}
-
-		/// <summary>
-		/// Stops a running inertia animation (e.g. when user touches during fling)
-		/// and synchronizes the scroll offset to the current visual position.
-		/// </summary>
-		private void StopInertiaAnimation()
-		{
-			if (_isInertiaAnimationRunning && Content is UIElement contentElt)
-			{
-				var visual = contentElt.Visual;
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
-				// StopAnimation triggers the Stopped callback which calls OnInertiaAnimationCompleted
-			}
-		}
-
 		private void TryEnableDirectManipulation(object sender, PointerRoutedEventArgs args)
 		{
 			if (args.Pointer.PointerDeviceType is not (_PointerDeviceType.Pen or _PointerDeviceType.Touch))
@@ -614,7 +456,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_touchInertia = null;
 
 			// Stop any running composition-driven inertia animation (user touched during fling).
-			StopInertiaAnimation();
+
 
 			return ComputeAcceptedManipulationModes();
 		}
@@ -843,21 +685,17 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				// Instead of letting the inertia processor tick managed code every frame
-				// (physics → gesture recognizer → events → Set → viewport propagation),
-				// we pre-compute the exponential decay curve as a composition animation.
-				// This makes inertia as smooth as any other composition animation (e.g. RedirectVisual).
-				_touchInertia = null; // Don't allow inertia processor ticks in OnUpdated
+				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
+				_touchInertia = args.Manipulation;
 
-				// Complete the gesture to stop the inertia processor from ticking.
-				// OnCompleted will see _touchInertia == null && IsInertial, so it early-returns
-				// without touching intermediate mode.
-				recognizer.CompleteGesture();
+				// Even if usually empty, make sure to apply the delta
+				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);
+				var deltaY = Math.Clamp(-args.Delta.Translation.Y, scrollable.Up, scrollable.Down);
 
-				StartInertiaAnimation(
-					args.Velocities,
-					inertia.DesiredDisplacementDeceleration,
-					scrollable);
+				Set(
+					horizontalOffset: HorizontalOffset + deltaX,
+					verticalOffset: VerticalOffset + deltaY,
+					options: new(DisableAnimation: true, IsTouch: true, IsIntermediate: true));
 			}
 
 			return true;
@@ -868,13 +706,6 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
-				if (_isInertiaAnimationRunning)
-				{
-					// The inertia is now driven by a composition animation, not the processor.
-					// Don't touch intermediate mode — the animation's Stopped callback handles it.
-					return;
-				}
-
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 #if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -483,11 +483,12 @@ namespace Microsoft.UI.Xaml.Controls
 			var animation = compositor.CreateVector2KeyFrameAnimation();
 			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
 
-			// Sample the exponential decay curve at regular intervals as keyframes.
-			// The composition system linearly interpolates between them, which closely
-			// approximates the smooth exponential curve.
-			const int keyframeInterval = 32; // ms between keyframes (~30fps sampling)
-			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeInterval));
+			// Sample the exponential decay curve at frame-rate-matched intervals.
+			// Using 16ms (60fps) ensures each displayed frame has its own keyframe,
+			// eliminating velocity discontinuities from inter-keyframe linear interpolation
+			// that would otherwise cause subtle visual "shaking" or "tearing" effects.
+			const int keyframeIntervalMs = 16;
+			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeIntervalMs));
 
 			for (var i = 0; i <= numKeyframes; i++)
 			{
@@ -504,24 +505,31 @@ namespace Microsoft.UI.Xaml.Controls
 				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
 			}
 
-			// Throttled offset updates: only call Updated() every Nth frame to reduce
-			// the cost of OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
-			// The visual is still smooth at 60fps because the composition animation drives AnchorPoint.
+			// During the animation, update only the ScrollViewer offset DPs (for scrollbar movement).
+			// CRITICAL: Do NOT call InvalidateViewport() / PropagateEffectiveViewportChange() here.
+			// That triggers layout invalidation (item recycling, re-arrangement) which causes visible
+			// "tearing" — content appears at the animation position while layout elements shift around.
+			// Viewport propagation is deferred to OnInertiaAnimationCompleted for a single clean pass.
 			var frameCount = 0;
 			void OnFrame(CompositionAnimation? _)
 			{
-				// Update scrollbar position and viewport every 2nd frame (~30fps).
-				// This keeps the scrollbar visually smooth while halving the cost of
-				// OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
-				// The content itself is smooth at 60fps because the composition animation
-				// drives AnchorPoint directly.
+				// Update scrollbar position every 2nd frame (~30fps) for smooth scrollbar movement.
+				// Only updates the DP offsets — no layout invalidation, no viewport propagation.
 				if (++frameCount % 2 == 0)
 				{
 					var currentH = Math.Round(-visual.AnchorPoint.X);
 					var currentV = Math.Round(-visual.AnchorPoint.Y);
 					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
 					VerticalOffset = Math.Clamp(currentV, 0, maxV);
-					Updated(HorizontalOffset, VerticalOffset, isIntermediate: true);
+
+					// Update ScrollViewer DPs for scrollbar visuals, but skip full Updated()
+					// which would trigger InvalidateViewport → layout changes → tearing.
+					if (_lastScrolledEvent != (HorizontalOffset, VerticalOffset, true))
+					{
+						_lastScrolledEvent = (HorizontalOffset, VerticalOffset, true);
+						Scroller?.OnPresenterScrolled(HorizontalOffset, VerticalOffset, isIntermediate: true);
+					}
+					ScrollOffsets = new Point(HorizontalOffset, VerticalOffset);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -48,6 +48,15 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
 
+		// Inertia viewport throttle: PropagateEffectiveViewportChange() can trigger
+		// heavy layout (ItemsRepeater measure, item recycling). If that layout doesn't
+		// fully resolve in one UpdateLayout() pass, CanRecordPicture returns false and
+		// the frame is SKIPPED, causing visible ghosting. By throttling EVP to every Nth
+		// inertia frame, most frames are lightweight (just AnchorPoint + scroll offset DPs)
+		// and always render. Items still materialize at ~20fps which is imperceptible.
+		private int _inertiaFrameCount;
+		private const int InertiaViewportUpdateInterval = 3;
+
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -361,20 +370,46 @@ namespace Microsoft.UI.Xaml.Controls
 
 				// Always set AnchorPoint immediately — this is cheap (just a field write + RequestNewFrame).
 				// Multiple writes per frame are fine; only the last value is used at render time.
-				visual.AnchorPoint = target;
+				// Pixel-snap to integer values to avoid subpixel text rendering artifacts
+				// (shimmer/ghosting from fractional offsets during inertia decay).
+				visual.AnchorPoint = new Vector2(MathF.Round(target.X), MathF.Round(target.Y));
 
 				if (options.IsTouch && options.IsIntermediate && _touchInertia is null)
 				{
 					// During active touch scrolling (finger on screen, NOT inertia), defer the expensive
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
-					// We DON'T defer during inertia because the inertia processor fires exactly once per
-					// frame during CompositionTarget.Rendering (BEFORE layout), and we need layout to
-					// process the new scroll position in the SAME frame to avoid tearing.
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
+				else if (options.IsTouch && options.IsIntermediate && _touchInertia is not null)
+				{
+					// Inertia: update immediately but throttle viewport propagation.
+					// PropagateEffectiveViewportChange() can trigger heavy layout (ItemsRepeater
+					// measure, item recycling). If layout doesn't fully resolve in one pass,
+					// CanRecordPicture returns false → frame skipped → visible ghosting.
+					// By only doing the full EVP every Nth frame, most frames are guaranteed
+					// to render. Items materialize at ~20fps which is imperceptible.
+					FlushPendingTouchUpdate();
+					_inertiaFrameCount++;
+					if (_inertiaFrameCount % InertiaViewportUpdateInterval == 0)
+					{
+						// Full update: scroll offsets + OnPresenterScrolled + InvalidateViewport
+						Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+					}
+					else
+					{
+						// Lightweight update: scroll offsets + scrollbar DPs only (no EVP tree walk).
+						// AnchorPoint was already set above, so the visual moves at 60fps.
+						if (_lastScrolledEvent != (horizontalOffset, verticalOffset, true))
+						{
+							_lastScrolledEvent = (horizontalOffset, verticalOffset, true);
+							Scroller?.OnPresenterScrolled(horizontalOffset, verticalOffset, isIntermediate: true);
+						}
+						ScrollOffsets = new Point(horizontalOffset, verticalOffset);
+					}
 				}
 				else
 				{
-					// Inertia, non-intermediate (final), or non-touch: flush immediately.
+					// Non-intermediate (final) or non-touch: flush immediately with full update.
 					FlushPendingTouchUpdate();
 					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
@@ -687,6 +722,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
 				_touchInertia = args.Manipulation;
+				_inertiaFrameCount = 0;
 
 				// Even if usually empty, make sure to apply the delta
 				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
@@ -36,6 +37,16 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private GestureRecognizer.Manipulation? _touchInertia;
 		private (double hOffset, double vOffset, bool isIntermediate) _lastScrolledEvent;
+
+		// Batching: during active touch scrolling, we set AnchorPoint immediately (cheap) but
+		// defer the expensive Updated() call (OnPresenterScrolled + InvalidateViewport + EVP propagation)
+		// to once per frame via CompositionTarget.Rendering. This collapses N pointer moves
+		// per frame into 1 Updated() call while keeping the visual perfectly in sync.
+		private bool _hasPendingTouchUpdate;
+		private double _pendingTouchHOffset;
+		private double _pendingTouchVOffset;
+		private bool _pendingTouchIsIntermediate;
+		private EventHandler<object>? _touchUpdateHandler;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -149,6 +160,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				UnhookScrollEvents(sv);
 			}
+			FlushPendingTouchUpdate();
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -345,8 +357,22 @@ namespace Microsoft.UI.Xaml.Controls
 					visual.StopAnimation(nameof(Visual.AnchorPoint));
 				}
 
+				// Always set AnchorPoint immediately — this is cheap (just a field write + RequestNewFrame).
+				// Multiple writes per frame are fine; only the last value is used at render time.
 				visual.AnchorPoint = target;
-				Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+
+				if (options.IsTouch && options.IsIntermediate)
+				{
+					// During active touch scrolling (finger on screen or inertia), defer the expensive
+					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
+					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
+				else
+				{
+					// Non-intermediate (final) or non-touch: flush immediately for correct event sequencing.
+					FlushPendingTouchUpdate();
+					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
 			}
 			else
 			{
@@ -368,6 +394,36 @@ namespace Microsoft.UI.Xaml.Controls
 				animation.Stopped += OnStopped;
 
 				visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
+			}
+		}
+
+		private void ScheduleDeferredTouchUpdate(double hOffset, double vOffset, bool isIntermediate)
+		{
+			_pendingTouchHOffset = hOffset;
+			_pendingTouchVOffset = vOffset;
+			_pendingTouchIsIntermediate = isIntermediate;
+
+			if (!_hasPendingTouchUpdate)
+			{
+				_hasPendingTouchUpdate = true;
+				_touchUpdateHandler ??= OnRenderingFlushTouchUpdate;
+				CompositionTarget.Rendering += _touchUpdateHandler;
+			}
+		}
+
+		private void OnRenderingFlushTouchUpdate(object? sender, object e)
+		{
+			// Unsubscribe immediately — we re-subscribe on next touch move if needed.
+			CompositionTarget.Rendering -= _touchUpdateHandler;
+			FlushPendingTouchUpdate();
+		}
+
+		private void FlushPendingTouchUpdate()
+		{
+			if (_hasPendingTouchUpdate)
+			{
+				_hasPendingTouchUpdate = false;
+				Updated(_pendingTouchHOffset, _pendingTouchVOffset, _pendingTouchIsIntermediate);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -474,8 +474,11 @@ namespace Microsoft.UI.Xaml.Controls
 			var maxV = Scroller?.ScrollableHeight ?? Math.Max(0, ExtentHeight - ViewportHeight);
 
 			// Where ongoing inertia (if any) would coast to, otherwise the current offset.
-			var prevProjH = _wheelInertia is { IsRunning: true } projH ? projH.ProjectedFinalH : HorizontalOffset;
-			var prevProjV = _wheelInertia is { IsRunning: true } projV ? projV.ProjectedFinalV : VerticalOffset;
+			// The projection is unbounded (offset + v/k), so it must be clamped to the scrollable
+			// range before being compared: an over-the-bound baseline would otherwise always differ
+			// from the clamped new projection and wrongly absorb wheel events at the bound.
+			var prevProjH = _wheelInertia is { IsRunning: true } projH ? Math.Clamp(projH.ProjectedFinalH, 0, maxH) : HorizontalOffset;
+			var prevProjV = _wheelInertia is { IsRunning: true } projV ? Math.Clamp(projV.ProjectedFinalV, 0, maxV) : VerticalOffset;
 			var newProjH = Math.Clamp(prevProjH + dxPx, 0, maxH);
 			var newProjV = Math.Clamp(prevProjV + dyPx, 0, maxV);
 
@@ -509,16 +512,16 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		private void OnRenderingFlushTouchUpdate(object? sender, object e)
-		{
-			// Unsubscribe immediately — we re-subscribe on next touch move if needed.
-			CompositionTarget.Rendering -= _touchUpdateHandler;
-			FlushPendingTouchUpdate();
-		}
+			=> FlushPendingTouchUpdate();
 
 		private void FlushPendingTouchUpdate()
 		{
 			if (_hasPendingTouchUpdate)
 			{
+				// Unsubscribe here (and not only from the Rendering callback) so that flushing from
+				// OnUnloaded also detaches from the static event, instead of leaving the presenter
+				// rooted until a tick that may never come.
+				CompositionTarget.Rendering -= _touchUpdateHandler;
 				_hasPendingTouchUpdate = false;
 				Updated(_pendingTouchHOffset, _pendingTouchVOffset, _pendingTouchIsIntermediate);
 			}
@@ -547,8 +550,9 @@ namespace Microsoft.UI.Xaml.Controls
 			// cannot fight with the new manipulation's direction.
 			_touchInertia = null;
 
-			// Stop any running composition-driven inertia animation (user touched during fling).
-
+			// Stop any running composition-driven inertia animation (user touched during fling),
+			// otherwise the wheel coast keeps issuing Set() calls that fight the new manipulation.
+			_wheelInertia?.Stop();
 
 			return ComputeAcceptedManipulationModes();
 		}
@@ -864,7 +868,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// this as an explicit, named multiplier so it can be tuned independently of the base decay.
 			private const double VelocityBoost = 1.15;
 
-			// Stop the loop when both axes have less than ~0.6 px/frame remaining velocity.
+			// Stop the loop when both axes have less than ~0.17 px/frame remaining velocity.
 			private const double VelocityThreshold = GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold;
 
 			private readonly ScrollContentPresenter _owner;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -849,8 +849,21 @@ namespace Microsoft.UI.Xaml.Controls
 		/// </summary>
 		private sealed class WheelInertia : IDisposable
 		{
-			// k = 0.003/ms ⇔ 0.95 decay per 16.67 ms frame, matching WinUI's InteractionTracker default.
-			private const double DecayPerMs = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
+			// Wheel-specific decay rate, tuned to match the legacy WinUI ScrollViewer feel
+			// (which is driven by DirectManipulation, not InteractionTracker). Empirically DManip's
+			// wheel coast settles in ~300–400 ms for a typical notch — much snappier than the
+			// 0.95-per-frame InteractionTracker default that ScrollPresenter uses for fling.
+			//
+			// k = 0.010/ms ⇔ 0.846 per 16.67 ms frame ⇒ 90-px notch settles in ~330 ms.
+			// Increase to scroll faster / less far; decrease to feel slower / coast longer.
+			private const double DecayPerMs = 0.010;
+
+			// Velocity boost relative to the per-notch displacement formula. WinUI legacy ScrollViewer
+			// feels like it scrolls slightly farther per notch than the bare GetVerticalScrollWheelDelta
+			// formula suggests — DManip seems to overshoot the discrete-notch math by ~15-20%. Keeping
+			// this as an explicit, named multiplier so it can be tuned independently of the base decay.
+			private const double VelocityBoost = 1.15;
+
 			// Stop the loop when both axes have less than ~0.6 px/frame remaining velocity.
 			private const double VelocityThreshold = GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold;
 
@@ -903,8 +916,10 @@ namespace Microsoft.UI.Xaml.Controls
 					_owner._inertiaFrameCount = 0;
 				}
 
-				_vx += dxPx * DecayPerMs;
-				_vy += dyPx * DecayPerMs;
+				// v₀ = displacement · k yields ∫₀^∞ v·e^(-k·t) dt = displacement;
+				// the boost factor inflates the final coast distance to match WinUI's per-notch feel.
+				_vx += dxPx * DecayPerMs * VelocityBoost;
+				_vy += dyPx * DecayPerMs * VelocityBoost;
 			}
 
 			private void OnFrame(object? sender, object e)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -47,6 +47,12 @@ namespace Microsoft.UI.Xaml.Controls
 		private double _pendingTouchVOffset;
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
+
+		// Composition-driven inertia: instead of running managed code every frame (inertia processor
+		// → gesture recognizer → event → Set → Update → viewport propagation), we pre-compute the
+		// exponential decay curve as keyframes and let the composition animation system drive the
+		// Visual.AnchorPoint directly. This makes inertia as smooth as any other composition animation.
+		private bool _isInertiaAnimationRunning;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -161,6 +167,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UnhookScrollEvents(sv);
 			}
 			FlushPendingTouchUpdate();
+			StopInertiaAnimation();
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -275,8 +282,9 @@ namespace Microsoft.UI.Xaml.Controls
 			if (!options.IsTouch)
 			{
 				// If we get a request to scroll to a specific offset **that is not flagged as IsInertial** (i.e. not coming from the inertia processing),
-				// we stop the pending inertia processor.
+				// we stop the pending inertia processor and any running inertia animation.
 				_touchInertia?.Complete();
+				StopInertiaAnimation();
 			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
@@ -427,6 +435,152 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		/// <summary>
+		/// Starts a composition-animation-driven inertia scroll.
+		/// Pre-computes the exponential decay curve as keyframes so the composition system
+		/// drives the Visual.AnchorPoint directly — no managed code per frame.
+		/// </summary>
+		private void StartInertiaAnimation(
+			ManipulationVelocities velocities,
+			double deceleration,
+			ScrollableOffsets scrollable)
+		{
+			if (Content is not UIElement contentElt)
+			{
+				return;
+			}
+
+			// Flush any pending touch updates before starting the animation
+			FlushPendingTouchUpdate();
+
+			// Velocities are in pointer-position space (px/ms). Negate to get scroll-offset velocity.
+			// When pointer moves right (positive velocity), content scrolls left (offset decreases).
+			var v0H = -velocities.Linear.X;
+			var v0V = -velocities.Linear.Y;
+			var k = deceleration;
+
+			// Compute duration: time until velocity drops below threshold
+			var maxAbsV = Math.Max(Math.Abs(v0H), Math.Abs(v0V));
+			if (maxAbsV <= GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold)
+			{
+				// Velocity too low for visible inertia
+				OnInertiaAnimationCompleted(contentElt);
+				return;
+			}
+
+			var durationMs = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(maxAbsV, k);
+
+			// Clamp to reasonable max (avoid extremely long animations from very fast flings)
+			durationMs = Math.Min(durationMs, 5000);
+
+			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
+			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
+			var startH = HorizontalOffset;
+			var startV = VerticalOffset;
+
+			var visual = contentElt.Visual;
+			var compositor = visual.Compositor;
+			var animation = compositor.CreateVector2KeyFrameAnimation();
+			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
+
+			// Sample the exponential decay curve at regular intervals as keyframes.
+			// The composition system linearly interpolates between them, which closely
+			// approximates the smooth exponential curve.
+			const int keyframeInterval = 32; // ms between keyframes (~30fps sampling)
+			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeInterval));
+
+			for (var i = 0; i <= numKeyframes; i++)
+			{
+				var progress = (float)i / numKeyframes;
+				var tMs = progress * durationMs;
+
+				var hPos = startH + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0H, k, tMs);
+				var vPos = startV + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0V, k, tMs);
+
+				// Clamp to scrollable bounds
+				hPos = Math.Clamp(hPos, 0, maxH);
+				vPos = Math.Clamp(vPos, 0, maxV);
+
+				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
+			}
+
+			// Throttled offset updates: only call Updated() every Nth frame to reduce
+			// the cost of OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
+			// The visual is still smooth at 60fps because the composition animation drives AnchorPoint.
+			var frameCount = 0;
+			void OnFrame(CompositionAnimation? _)
+			{
+				// Update scrollbar position and viewport every 2nd frame (~30fps).
+				// This keeps the scrollbar visually smooth while halving the cost of
+				// OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
+				// The content itself is smooth at 60fps because the composition animation
+				// drives AnchorPoint directly.
+				if (++frameCount % 2 == 0)
+				{
+					var currentH = Math.Round(-visual.AnchorPoint.X);
+					var currentV = Math.Round(-visual.AnchorPoint.Y);
+					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
+					VerticalOffset = Math.Clamp(currentV, 0, maxV);
+					Updated(HorizontalOffset, VerticalOffset, isIntermediate: true);
+				}
+			}
+
+			void OnStopped(object? _, EventArgs __)
+			{
+				animation.AnimationFrame -= OnFrame;
+				animation.Stopped -= OnStopped;
+				OnInertiaAnimationCompleted(contentElt);
+			}
+
+			animation.AnimationFrame += OnFrame;
+			animation.Stopped += OnStopped;
+
+			// Stop any existing animation and start the inertia animation
+			if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
+			{
+				visual.StopAnimation(nameof(Visual.AnchorPoint));
+			}
+
+			_isInertiaAnimationRunning = true;
+			visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
+		}
+
+		private void OnInertiaAnimationCompleted(UIElement contentElt)
+		{
+			_isInertiaAnimationRunning = false;
+
+			// Read the final position from the visual
+			var visual = contentElt.Visual;
+			var finalH = Math.Round(-visual.AnchorPoint.X);
+			var finalV = Math.Round(-visual.AnchorPoint.Y);
+
+			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
+			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
+
+			HorizontalOffset = Math.Clamp(finalH, 0, maxH);
+			VerticalOffset = Math.Clamp(finalV, 0, maxV);
+
+			// Fire final non-intermediate Updated
+			Updated(HorizontalOffset, VerticalOffset, isIntermediate: false);
+
+#if __SKIA__
+			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
+#endif
+		}
+
+		/// <summary>
+		/// Stops a running inertia animation (e.g. when user touches during fling)
+		/// and synchronizes the scroll offset to the current visual position.
+		/// </summary>
+		private void StopInertiaAnimation()
+		{
+			if (_isInertiaAnimationRunning && Content is UIElement contentElt)
+			{
+				var visual = contentElt.Visual;
+				visual.StopAnimation(nameof(Visual.AnchorPoint));
+				// StopAnimation triggers the Stopped callback which calls OnInertiaAnimationCompleted
+			}
+		}
 
 		private void TryEnableDirectManipulation(object sender, PointerRoutedEventArgs args)
 		{
@@ -450,6 +604,9 @@ namespace Microsoft.UI.Xaml.Controls
 			// If a previous inertia is still tracked, clear it immediately so old inertial deltas
 			// cannot fight with the new manipulation's direction.
 			_touchInertia = null;
+
+			// Stop any running composition-driven inertia animation (user touched during fling).
+			StopInertiaAnimation();
 
 			return ComputeAcceptedManipulationModes();
 		}
@@ -678,17 +835,21 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
-				_touchInertia = args.Manipulation;
+				// Instead of letting the inertia processor tick managed code every frame
+				// (physics → gesture recognizer → events → Set → viewport propagation),
+				// we pre-compute the exponential decay curve as a composition animation.
+				// This makes inertia as smooth as any other composition animation (e.g. RedirectVisual).
+				_touchInertia = null; // Don't allow inertia processor ticks in OnUpdated
 
-				// Even if usually empty, make sure to apply the delta
-				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);
-				var deltaY = Math.Clamp(-args.Delta.Translation.Y, scrollable.Up, scrollable.Down);
+				// Complete the gesture to stop the inertia processor from ticking.
+				// OnCompleted will see _touchInertia == null && IsInertial, so it early-returns
+				// without touching intermediate mode.
+				recognizer.CompleteGesture();
 
-				Set(
-					horizontalOffset: HorizontalOffset + deltaX,
-					verticalOffset: VerticalOffset + deltaY,
-					options: new(DisableAnimation: true, IsTouch: true, IsIntermediate: true));
+				StartInertiaAnimation(
+					args.Velocities,
+					inertia.DesiredDisplacementDeceleration,
+					scrollable);
 			}
 
 			return true;
@@ -699,6 +860,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
+				if (_isInertiaAnimationRunning)
+				{
+					// The inertia is now driven by a composition animation, not the processor.
+					// Don't touch intermediate mode — the animation's Stopped callback handles it.
+					return;
+				}
+
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 #if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -338,7 +338,13 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (options is { DisableAnimation: true } or { IsTouch: true })
 			{
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
+				// Only stop a running animation — during inertia no animation is active,
+				// so calling StopAnimation every tick wastes time on dictionary lookups.
+				if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
+				{
+					visual.StopAnimation(nameof(Visual.AnchorPoint));
+				}
+
 				visual.AnchorPoint = target;
 				Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 			}
@@ -553,8 +559,8 @@ namespace Microsoft.UI.Xaml.Controls
 					_ => 0
 				};
 
-				// calculate the duration based on PKScrollView.prototype.stepThroughDecelerationAnimation from https://github.com/jimeh/PastryKit
-				// momentum should decay by 5% each frame, at 60fps, until the minimum threshold is reached.
+				// PastryKit-inspired iOS scroll physics: 0.95 friction factor per frame at 60fps.
+				// This maps directly to the exponential decay model: k = -ln(0.95)/16.67 ≈ 0.003
 				const double PKScrollViewDecelerationFrictionFactor = 0.95;
 				const double PKScrollViewDesiredAnimationFrameRate = 1000 / 60.0;
 				const double PKScrollViewMinimumVelocity = 0.01;
@@ -565,10 +571,13 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else if (OperatingSystem.IsAndroid())
 			{
-				inertia.DesiredDisplacementDeceleration = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration / 2;
+				// Gentler decay for Android, matching the longer fling feel of native Android OverScroller.
+				// 0.0025 ≈ 0.96 decay per 16.67ms frame (vs WinUI's 0.95).
+				inertia.DesiredDisplacementDeceleration = 0.0025;
 			}
 			else
 			{
+				// Desktop/other: match WinUI InteractionTracker default (0.95 decay per frame).
 				inertia.DesiredDisplacementDeceleration = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -36,6 +36,7 @@ namespace Microsoft.UI.Xaml.Controls
 			: null;
 
 		private GestureRecognizer.Manipulation? _touchInertia;
+		private WheelInertia? _wheelInertia;
 		private (double hOffset, double vOffset, bool isIntermediate) _lastScrolledEvent;
 
 		// Batching: during active touch scrolling, we set AnchorPoint immediately (cheap) but
@@ -174,6 +175,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 			_touchInertia?.Complete();
 			_touchInertia = null;
+
+			_wheelInertia?.Dispose();
+			_wheelInertia = null;
 		}
 
 		/// <inheritdoc />
@@ -289,6 +293,12 @@ namespace Microsoft.UI.Xaml.Controls
 				// we stop the pending inertia processor.
 				_touchInertia?.Complete();
 			}
+			if (!options.IsWheelInertia)
+			{
+				// Programmatic/keyboard/touch updates cancel any in-flight wheel coast,
+				// so the new request wins (mirrors the touch-inertia cancel above).
+				_wheelInertia?.Stop();
+			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
 			var updatedVerticalOffset = VerticalOffset;
@@ -380,9 +390,9 @@ namespace Microsoft.UI.Xaml.Controls
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
-				else if (options.IsTouch && options.IsIntermediate && _touchInertia is not null)
+				else if (options.IsIntermediate && (options.IsWheelInertia || (options.IsTouch && _touchInertia is not null)))
 				{
-					// Inertia: update immediately but throttle viewport propagation.
+					// Inertia (touch fling OR wheel coast): update immediately but throttle viewport propagation.
 					// PropagateEffectiveViewportChange() can trigger heavy layout (ItemsRepeater
 					// measure, item recycling). If layout doesn't fully resolve in one pass,
 					// CanRecordPicture returns false → frame skipped → visible ghosting.
@@ -435,6 +445,53 @@ namespace Microsoft.UI.Xaml.Controls
 
 				visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
 			}
+		}
+
+		/// <summary>
+		/// Routes a desktop mouse-wheel notch with intended displacement (dxPx, dyPx) into the
+		/// velocity-based wheel inertia. When IsScrollInertiaEnabled is false on the Scroller,
+		/// falls back to the legacy 1 s eased animation. Returns true iff the full displacement
+		/// fit within scrollable bounds (matches the success semantic of the legacy Set() path).
+		/// </summary>
+		/// <remarks>
+		/// Bounds checking is done against the **projected** post-coast offset, not the current
+		/// instantaneous offset. This is what makes nested-ScrollViewer chaining work with rapid
+		/// wheel events: when the inner SV's accumulated trajectory is already at its bound, new
+		/// wheel events are reported as not-handled and bubble to the parent SV.
+		/// </remarks>
+		private bool TryStartWheelInertia(double dxPx, double dyPx)
+		{
+			if (Scroller is not { IsScrollInertiaEnabled: true })
+			{
+				// Legacy fallback: 1 s power-10 easing toward the new target offset.
+				return Set(
+					horizontalOffset: dxPx != 0 ? TargetHorizontalOffset + dxPx : null,
+					verticalOffset: dyPx != 0 ? TargetVerticalOffset + dyPx : null,
+					disableAnimation: false);
+			}
+
+			var maxH = Scroller?.ScrollableWidth ?? Math.Max(0, ExtentWidth - ViewportWidth);
+			var maxV = Scroller?.ScrollableHeight ?? Math.Max(0, ExtentHeight - ViewportHeight);
+
+			// Where ongoing inertia (if any) would coast to, otherwise the current offset.
+			var prevProjH = _wheelInertia is { IsRunning: true } projH ? projH.ProjectedFinalH : HorizontalOffset;
+			var prevProjV = _wheelInertia is { IsRunning: true } projV ? projV.ProjectedFinalV : VerticalOffset;
+			var newProjH = Math.Clamp(prevProjH + dxPx, 0, maxH);
+			var newProjV = Math.Clamp(prevProjV + dyPx, 0, maxV);
+
+			// If the impulse can move the projected target on at least one requested axis, absorb it.
+			// Otherwise the trajectory is already at the bound — let the event bubble to a parent SV.
+			var canAbsorb = (dxPx != 0 && newProjH != prevProjH) || (dyPx != 0 && newProjV != prevProjV);
+			if (!canAbsorb)
+			{
+				return false;
+			}
+
+			_wheelInertia ??= new WheelInertia(this);
+			_wheelInertia.AddImpulse(dxPx, dyPx);
+
+			// Match legacy semantic: success=true iff the full requested displacement fit.
+			return (dxPx == 0 || newProjH == prevProjH + dxPx) && (dyPx == 0 || newProjV == prevProjV + dyPx);
 		}
 
 		private void ScheduleDeferredTouchUpdate(double hOffset, double vOffset, bool isIntermediate)
@@ -783,6 +840,155 @@ namespace Microsoft.UI.Xaml.Controls
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => true; // force scrollviewer to always clip
 #endif
 
+		/// <summary>
+		/// Velocity-based mouse-wheel inertia. Each wheel notch injects a velocity impulse;
+		/// a per-VSync tick integrates position with exponential decay (v(t)=v0·e^(-k·t)),
+		/// matching the model used by WinUI's DirectManipulation/InteractionTracker for
+		/// wheel input. New notches arriving mid-flight ADD velocity (coalesce), so spinning
+		/// faster scrolls farther — instead of restarting a fixed-duration animation per notch.
+		/// </summary>
+		private sealed class WheelInertia : IDisposable
+		{
+			// k = 0.003/ms ⇔ 0.95 decay per 16.67 ms frame, matching WinUI's InteractionTracker default.
+			private const double DecayPerMs = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
+			// Stop the loop when both axes have less than ~0.6 px/frame remaining velocity.
+			private const double VelocityThreshold = GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold;
+
+			private readonly ScrollContentPresenter _owner;
+			private double _vx, _vy; // px/ms
+			private double _hOffset, _vOffset;
+			private TimeSpan? _t0;
+			private TimeSpan _lastTick;
+			private Stopwatch? _fallbackTime;
+			private EventHandler<object>? _frameHandler;
+			private bool _running;
+
+			public WheelInertia(ScrollContentPresenter owner)
+			{
+				_owner = owner;
+			}
+
+			public bool IsRunning => _running;
+
+			/// <summary>
+			/// Where the current trajectory would settle if no further impulse is added
+			/// (∫₀^∞ v·e^(-k·t) dt = v/k). Used by <see cref="TryStartWheelInertia"/> to
+			/// chain wheel events to a parent ScrollViewer once the projected target is at
+			/// the bound, instead of stacking them onto a saturated trajectory.
+			/// </summary>
+			public double ProjectedFinalH => _hOffset + _vx / DecayPerMs;
+
+			/// <inheritdoc cref="ProjectedFinalH"/>
+			public double ProjectedFinalV => _vOffset + _vy / DecayPerMs;
+
+			/// <summary>
+			/// Adds a velocity impulse equivalent to scrolling by the given displacement
+			/// in isolation. Total displacement of v0/k means v0 = displacement·k.
+			/// Multiple impulses arriving in quick succession sum into a higher peak velocity.
+			/// </summary>
+			public void AddImpulse(double dxPx, double dyPx)
+			{
+				if (!_running)
+				{
+					_hOffset = _owner.HorizontalOffset;
+					_vOffset = _owner.VerticalOffset;
+					_vx = 0;
+					_vy = 0;
+					_t0 = null;
+					_lastTick = TimeSpan.Zero;
+					_fallbackTime = null;
+					_frameHandler = OnFrame;
+					CompositionTarget.Rendering += _frameHandler;
+					_running = true;
+					_owner._inertiaFrameCount = 0;
+				}
+
+				_vx += dxPx * DecayPerMs;
+				_vy += dyPx * DecayPerMs;
+			}
+
+			private void OnFrame(object? sender, object e)
+			{
+				TimeSpan elapsed;
+				if (e is RenderingEventArgs rea)
+				{
+					if (_t0 is null)
+					{
+						_t0 = rea.RenderingTime;
+						_lastTick = TimeSpan.Zero;
+						return; // First frame just records t0; integration starts on the next frame.
+					}
+					elapsed = rea.RenderingTime - _t0.Value;
+				}
+				else
+				{
+					if (_fallbackTime is null)
+					{
+						_fallbackTime = Stopwatch.StartNew();
+						_lastTick = TimeSpan.Zero;
+						return;
+					}
+					elapsed = _fallbackTime.Elapsed;
+				}
+
+				var dt = (elapsed - _lastTick).TotalMilliseconds;
+				_lastTick = elapsed;
+
+				if (dt <= 0)
+				{
+					return;
+				}
+
+				// Closed-form exact integration: pos += v·(1-e^(-k·dt))/k; v *= e^(-k·dt).
+				var decay = Math.Exp(-DecayPerMs * dt);
+				var posStep = (1 - decay) / DecayPerMs;
+
+				var maxH = _owner.Scroller?.ScrollableWidth ?? Math.Max(0, _owner.ExtentWidth - _owner.ViewportWidth);
+				var maxV = _owner.Scroller?.ScrollableHeight ?? Math.Max(0, _owner.ExtentHeight - _owner.ViewportHeight);
+
+				_hOffset = Math.Clamp(_hOffset + _vx * posStep, 0, maxH);
+				_vOffset = Math.Clamp(_vOffset + _vy * posStep, 0, maxV);
+				_vx *= decay;
+				_vy *= decay;
+
+				// Pinning at a bound kills velocity on that axis so the loop can complete.
+				if ((_hOffset <= 0 && _vx < 0) || (_hOffset >= maxH && _vx > 0))
+				{
+					_vx = 0;
+				}
+				if ((_vOffset <= 0 && _vy < 0) || (_vOffset >= maxV && _vy > 0))
+				{
+					_vy = 0;
+				}
+
+				var stillMoving = Math.Abs(_vx) > VelocityThreshold || Math.Abs(_vy) > VelocityThreshold;
+
+				_owner.Set(
+					horizontalOffset: _hOffset,
+					verticalOffset: _vOffset,
+					options: new(DisableAnimation: true, IsIntermediate: stillMoving, IsWheelInertia: true));
+
+				if (!stillMoving)
+				{
+					Stop();
+				}
+			}
+
+			public void Stop()
+			{
+				if (_frameHandler is not null)
+				{
+					CompositionTarget.Rendering -= _frameHandler;
+					_frameHandler = null;
+				}
+				_running = false;
+				_vx = 0;
+				_vy = 0;
+			}
+
+			public void Dispose() => Stop();
+		}
+
 		/// <param name="Up">Offset that can be scrolled up. THIS IS ALWAYS NEGATIVE.</param>
 		/// <param name="Down">Offset that can be scrolled down. This is always positive.</param>
 		/// <param name="Left">Offset that can be scrolled left. THIS IS ALWAYS NEGATIVE.</param>
@@ -839,6 +1045,11 @@ namespace Microsoft.UI.Xaml.Controls
 	/// Indicates that the scroll is an intermediate value, not the final one
 	/// (i.e. active touch scrolling, touch scroll inertia or scroll animation).
 	/// </param>
-	internal record struct ScrollOptions(bool DisableAnimation = false, bool IsTouch = false, bool IsIntermediate = false);
+	/// <param name="IsWheelInertia">
+	/// Indicates that the scroll is a per-frame tick from the mouse-wheel inertia controller.
+	/// Routes through the same EVP-throttling branch as touch inertia and prevents the call
+	/// from cancelling itself.
+	/// </param>
+	internal record struct ScrollOptions(bool DisableAnimation = false, bool IsTouch = false, bool IsIntermediate = false, bool IsWheelInertia = false);
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -623,11 +623,12 @@ namespace Microsoft.UI.Xaml.Controls
 			var animation = compositor.CreateVector2KeyFrameAnimation();
 			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
 
-			// Sample the exponential decay curve at regular intervals as keyframes.
-			// The composition system linearly interpolates between them, which closely
-			// approximates the smooth exponential curve.
-			const int keyframeInterval = 32; // ms between keyframes (~30fps sampling)
-			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeInterval));
+			// Sample the exponential decay curve at frame-rate-matched intervals.
+			// Using 16ms (60fps) ensures each displayed frame has its own keyframe,
+			// eliminating velocity discontinuities from inter-keyframe linear interpolation
+			// that would otherwise cause subtle visual "shaking" or "tearing" effects.
+			const int keyframeIntervalMs = 16;
+			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeIntervalMs));
 
 			for (var i = 0; i <= numKeyframes; i++)
 			{
@@ -644,24 +645,31 @@ namespace Microsoft.UI.Xaml.Controls
 				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
 			}
 
-			// Throttled offset updates: only call Updated() every Nth frame to reduce
-			// the cost of OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
-			// The visual is still smooth at 60fps because the composition animation drives AnchorPoint.
+			// During the animation, update only the ScrollViewer offset DPs (for scrollbar movement).
+			// CRITICAL: Do NOT call InvalidateViewport() / PropagateEffectiveViewportChange() here.
+			// That triggers layout invalidation (item recycling, re-arrangement) which causes visible
+			// "tearing" — content appears at the animation position while layout elements shift around.
+			// Viewport propagation is deferred to OnInertiaAnimationCompleted for a single clean pass.
 			var frameCount = 0;
 			void OnFrame(CompositionAnimation? _)
 			{
-				// Update scrollbar position and viewport every 2nd frame (~30fps).
-				// This keeps the scrollbar visually smooth while halving the cost of
-				// OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
-				// The content itself is smooth at 60fps because the composition animation
-				// drives AnchorPoint directly.
+				// Update scrollbar position every 2nd frame (~30fps) for smooth scrollbar movement.
+				// Only updates the DP offsets — no layout invalidation, no viewport propagation.
 				if (++frameCount % 2 == 0)
 				{
 					var currentH = Math.Round(-visual.AnchorPoint.X);
 					var currentV = Math.Round(-visual.AnchorPoint.Y);
 					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
 					VerticalOffset = Math.Clamp(currentV, 0, maxV);
-					Updated(HorizontalOffset, VerticalOffset, isIntermediate: true);
+
+					// Update ScrollViewer DPs for scrollbar visuals, but skip full Updated()
+					// which would trigger InvalidateViewport → layout changes → tearing.
+					if (_lastScrolledEvent != (HorizontalOffset, VerticalOffset, true))
+					{
+						_lastScrolledEvent = (HorizontalOffset, VerticalOffset, true);
+						Scroller?.OnPresenterScrolled(HorizontalOffset, VerticalOffset, isIntermediate: true);
+					}
+					ScrollOffsets = new Point(HorizontalOffset, VerticalOffset);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
@@ -35,6 +36,16 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private GestureRecognizer.Manipulation? _touchInertia;
 		private (double hOffset, double vOffset, bool isIntermediate) _lastScrolledEvent;
+
+		// Batching: during active touch scrolling, we set AnchorPoint immediately (cheap) but
+		// defer the expensive Updated() call (OnPresenterScrolled + InvalidateViewport + EVP propagation)
+		// to once per frame via CompositionTarget.Rendering. This collapses N pointer moves
+		// per frame into 1 Updated() call while keeping the visual perfectly in sync.
+		private bool _hasPendingTouchUpdate;
+		private double _pendingTouchHOffset;
+		private double _pendingTouchVOffset;
+		private bool _pendingTouchIsIntermediate;
+		private EventHandler<object>? _touchUpdateHandler;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -158,6 +169,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				UnhookScrollEvents(sv);
 			}
+			FlushPendingTouchUpdate();
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -469,9 +481,23 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 				visual.StopAnimation(nameof(Visual.Scale));
 
+				// Always set AnchorPoint immediately — this is cheap (just a field write + RequestNewFrame).
+				// Multiple writes per frame are fine; only the last value is used at render time.
 				visual.AnchorPoint = target;
 				visual.Scale = targetScale;
-				Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+
+				if (options.IsTouch && options.IsIntermediate)
+				{
+					// During active touch scrolling (finger on screen or inertia), defer the expensive
+					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
+					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
+				else
+				{
+					// Non-intermediate (final) or non-touch: flush immediately for correct event sequencing.
+					FlushPendingTouchUpdate();
+					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
 			}
 			else
 			{
@@ -508,6 +534,36 @@ namespace Microsoft.UI.Xaml.Controls
 					zoomAnimation.Duration = TimeSpan.FromMilliseconds(300); // Shorter duration for zoom per WinUI style
 					visual.StartAnimation(nameof(Visual.Scale), zoomAnimation);
 				}
+			}
+		}
+
+		private void ScheduleDeferredTouchUpdate(double hOffset, double vOffset, bool isIntermediate)
+		{
+			_pendingTouchHOffset = hOffset;
+			_pendingTouchVOffset = vOffset;
+			_pendingTouchIsIntermediate = isIntermediate;
+
+			if (!_hasPendingTouchUpdate)
+			{
+				_hasPendingTouchUpdate = true;
+				_touchUpdateHandler ??= OnRenderingFlushTouchUpdate;
+				CompositionTarget.Rendering += _touchUpdateHandler;
+			}
+		}
+
+		private void OnRenderingFlushTouchUpdate(object? sender, object e)
+		{
+			// Unsubscribe immediately — we re-subscribe on next touch move if needed.
+			CompositionTarget.Rendering -= _touchUpdateHandler;
+			FlushPendingTouchUpdate();
+		}
+
+		private void FlushPendingTouchUpdate()
+		{
+			if (_hasPendingTouchUpdate)
+			{
+				_hasPendingTouchUpdate = false;
+				Updated(_pendingTouchHOffset, _pendingTouchVOffset, _pendingTouchIsIntermediate);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -461,8 +461,14 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (options is { DisableAnimation: true } or { IsTouch: true })
 			{
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
+				// Only stop a running animation — during inertia no animation is active,
+				// so calling StopAnimation every tick wastes time on dictionary lookups.
+				if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
+				{
+					visual.StopAnimation(nameof(Visual.AnchorPoint));
+				}
 				visual.StopAnimation(nameof(Visual.Scale));
+
 				visual.AnchorPoint = target;
 				visual.Scale = targetScale;
 				Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
@@ -726,8 +732,8 @@ namespace Microsoft.UI.Xaml.Controls
 					_ => 0
 				};
 
-				// calculate the duration based on PKScrollView.prototype.stepThroughDecelerationAnimation from https://github.com/jimeh/PastryKit
-				// momentum should decay by 5% each frame, at 60fps, until the minimum threshold is reached.
+				// PastryKit-inspired iOS scroll physics: 0.95 friction factor per frame at 60fps.
+				// This maps directly to the exponential decay model: k = -ln(0.95)/16.67 ≈ 0.003
 				const double PKScrollViewDecelerationFrictionFactor = 0.95;
 				const double PKScrollViewDesiredAnimationFrameRate = 1000 / 60.0;
 				const double PKScrollViewMinimumVelocity = 0.01;
@@ -738,10 +744,13 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else if (OperatingSystem.IsAndroid())
 			{
-				inertia.DesiredDisplacementDeceleration = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration / 2;
+				// Gentler decay for Android, matching the longer fling feel of native Android OverScroller.
+				// 0.0025 ≈ 0.96 decay per 16.67ms frame (vs WinUI's 0.95).
+				inertia.DesiredDisplacementDeceleration = 0.0025;
 			}
 			else
 			{
+				// Desktop/other: match WinUI InteractionTracker default (0.95 decay per frame).
 				inertia.DesiredDisplacementDeceleration = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -47,6 +47,15 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
 
+		// Inertia viewport throttle: PropagateEffectiveViewportChange() can trigger
+		// heavy layout (ItemsRepeater measure, item recycling). If that layout doesn't
+		// fully resolve in one UpdateLayout() pass, CanRecordPicture returns false and
+		// the frame is SKIPPED, causing visible ghosting. By throttling EVP to every Nth
+		// inertia frame, most frames are lightweight (just AnchorPoint + scroll offset DPs)
+		// and always render. Items still materialize at ~20fps which is imperceptible.
+		private int _inertiaFrameCount;
+		private const int InertiaViewportUpdateInterval = 3;
+
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -485,21 +494,47 @@ namespace Microsoft.UI.Xaml.Controls
 
 				// Always set AnchorPoint immediately — this is cheap (just a field write + RequestNewFrame).
 				// Multiple writes per frame are fine; only the last value is used at render time.
-				visual.AnchorPoint = target;
+				// Pixel-snap to integer values to avoid subpixel text rendering artifacts
+				// (shimmer/ghosting from fractional offsets during inertia decay).
+				visual.AnchorPoint = new Vector2(MathF.Round(target.X), MathF.Round(target.Y));
 				visual.Scale = targetScale;
 
 				if (options.IsTouch && options.IsIntermediate && _touchInertia is null)
 				{
 					// During active touch scrolling (finger on screen, NOT inertia), defer the expensive
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
-					// We DON'T defer during inertia because the inertia processor fires exactly once per
-					// frame during CompositionTarget.Rendering (BEFORE layout), and we need layout to
-					// process the new scroll position in the SAME frame to avoid tearing.
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
+				}
+				else if (options.IsTouch && options.IsIntermediate && _touchInertia is not null)
+				{
+					// Inertia: update immediately but throttle viewport propagation.
+					// PropagateEffectiveViewportChange() can trigger heavy layout (ItemsRepeater
+					// measure, item recycling). If layout doesn't fully resolve in one pass,
+					// CanRecordPicture returns false → frame skipped → visible ghosting.
+					// By only doing the full EVP every Nth frame, most frames are guaranteed
+					// to render. Items materialize at ~20fps which is imperceptible.
+					FlushPendingTouchUpdate();
+					_inertiaFrameCount++;
+					if (_inertiaFrameCount % InertiaViewportUpdateInterval == 0)
+					{
+						// Full update: scroll offsets + OnPresenterScrolled + InvalidateViewport
+						Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
+					}
+					else
+					{
+						// Lightweight update: scroll offsets + scrollbar DPs only (no EVP tree walk).
+						// AnchorPoint was already set above, so the visual moves at 60fps.
+						if (_lastScrolledEvent != (horizontalOffset, verticalOffset, true))
+						{
+							_lastScrolledEvent = (horizontalOffset, verticalOffset, true);
+							Scroller?.OnPresenterScrolled(horizontalOffset, verticalOffset, isIntermediate: true);
+						}
+						ScrollOffsets = new Point(horizontalOffset, verticalOffset);
+					}
 				}
 				else
 				{
-					// Inertia, non-intermediate (final), or non-touch: flush immediately.
+					// Non-intermediate (final) or non-touch: flush immediately with full update.
 					FlushPendingTouchUpdate();
 					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
@@ -859,6 +894,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
 				_touchInertia = args.Manipulation;
+				_inertiaFrameCount = 0;
 
 				// Even if usually empty, make sure to apply the delta
 				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -46,6 +46,12 @@ namespace Microsoft.UI.Xaml.Controls
 		private double _pendingTouchVOffset;
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
+
+		// Composition-driven inertia: instead of running managed code every frame (inertia processor
+		// → gesture recognizer → event → Set → Update → viewport propagation), we pre-compute the
+		// exponential decay curve as keyframes and let the composition animation system drive the
+		// Visual.AnchorPoint directly. This makes inertia as smooth as any other composition animation.
+		private bool _isInertiaAnimationRunning;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -170,6 +176,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UnhookScrollEvents(sv);
 			}
 			FlushPendingTouchUpdate();
+			StopInertiaAnimation();
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -360,8 +367,9 @@ namespace Microsoft.UI.Xaml.Controls
 			if (!options.IsTouch)
 			{
 				// If we get a request to scroll to a specific offset **that is not flagged as IsInertial** (i.e. not coming from the inertia processing),
-				// we stop the pending inertia processor.
+				// we stop the pending inertia processor and any running inertia animation.
 				_touchInertia?.Complete();
+				StopInertiaAnimation();
 			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
@@ -567,6 +575,152 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		/// <summary>
+		/// Starts a composition-animation-driven inertia scroll.
+		/// Pre-computes the exponential decay curve as keyframes so the composition system
+		/// drives the Visual.AnchorPoint directly — no managed code per frame.
+		/// </summary>
+		private void StartInertiaAnimation(
+			ManipulationVelocities velocities,
+			double deceleration,
+			ScrollableOffsets scrollable)
+		{
+			if (Content is not UIElement contentElt)
+			{
+				return;
+			}
+
+			// Flush any pending touch updates before starting the animation
+			FlushPendingTouchUpdate();
+
+			// Velocities are in pointer-position space (px/ms). Negate to get scroll-offset velocity.
+			// When pointer moves right (positive velocity), content scrolls left (offset decreases).
+			var v0H = -velocities.Linear.X;
+			var v0V = -velocities.Linear.Y;
+			var k = deceleration;
+
+			// Compute duration: time until velocity drops below threshold
+			var maxAbsV = Math.Max(Math.Abs(v0H), Math.Abs(v0V));
+			if (maxAbsV <= GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold)
+			{
+				// Velocity too low for visible inertia
+				OnInertiaAnimationCompleted(contentElt);
+				return;
+			}
+
+			var durationMs = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(maxAbsV, k);
+
+			// Clamp to reasonable max (avoid extremely long animations from very fast flings)
+			durationMs = Math.Min(durationMs, 5000);
+
+			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
+			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
+			var startH = HorizontalOffset;
+			var startV = VerticalOffset;
+
+			var visual = contentElt.Visual;
+			var compositor = visual.Compositor;
+			var animation = compositor.CreateVector2KeyFrameAnimation();
+			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
+
+			// Sample the exponential decay curve at regular intervals as keyframes.
+			// The composition system linearly interpolates between them, which closely
+			// approximates the smooth exponential curve.
+			const int keyframeInterval = 32; // ms between keyframes (~30fps sampling)
+			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeInterval));
+
+			for (var i = 0; i <= numKeyframes; i++)
+			{
+				var progress = (float)i / numKeyframes;
+				var tMs = progress * durationMs;
+
+				var hPos = startH + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0H, k, tMs);
+				var vPos = startV + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0V, k, tMs);
+
+				// Clamp to scrollable bounds
+				hPos = Math.Clamp(hPos, 0, maxH);
+				vPos = Math.Clamp(vPos, 0, maxV);
+
+				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
+			}
+
+			// Throttled offset updates: only call Updated() every Nth frame to reduce
+			// the cost of OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
+			// The visual is still smooth at 60fps because the composition animation drives AnchorPoint.
+			var frameCount = 0;
+			void OnFrame(CompositionAnimation? _)
+			{
+				// Update scrollbar position and viewport every 2nd frame (~30fps).
+				// This keeps the scrollbar visually smooth while halving the cost of
+				// OnPresenterScrolled + InvalidateViewport + PropagateEffectiveViewportChange.
+				// The content itself is smooth at 60fps because the composition animation
+				// drives AnchorPoint directly.
+				if (++frameCount % 2 == 0)
+				{
+					var currentH = Math.Round(-visual.AnchorPoint.X);
+					var currentV = Math.Round(-visual.AnchorPoint.Y);
+					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
+					VerticalOffset = Math.Clamp(currentV, 0, maxV);
+					Updated(HorizontalOffset, VerticalOffset, isIntermediate: true);
+				}
+			}
+
+			void OnStopped(object? _, EventArgs __)
+			{
+				animation.AnimationFrame -= OnFrame;
+				animation.Stopped -= OnStopped;
+				OnInertiaAnimationCompleted(contentElt);
+			}
+
+			animation.AnimationFrame += OnFrame;
+			animation.Stopped += OnStopped;
+
+			// Stop any existing animation and start the inertia animation
+			if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
+			{
+				visual.StopAnimation(nameof(Visual.AnchorPoint));
+			}
+
+			_isInertiaAnimationRunning = true;
+			visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
+		}
+
+		private void OnInertiaAnimationCompleted(UIElement contentElt)
+		{
+			_isInertiaAnimationRunning = false;
+
+			// Read the final position from the visual
+			var visual = contentElt.Visual;
+			var finalH = Math.Round(-visual.AnchorPoint.X);
+			var finalV = Math.Round(-visual.AnchorPoint.Y);
+
+			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
+			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
+
+			HorizontalOffset = Math.Clamp(finalH, 0, maxH);
+			VerticalOffset = Math.Clamp(finalV, 0, maxV);
+
+			// Fire final non-intermediate Updated
+			Updated(HorizontalOffset, VerticalOffset, isIntermediate: false);
+
+#if __SKIA__
+			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
+#endif
+		}
+
+		/// <summary>
+		/// Stops a running inertia animation (e.g. when user touches during fling)
+		/// and synchronizes the scroll offset to the current visual position.
+		/// </summary>
+		private void StopInertiaAnimation()
+		{
+			if (_isInertiaAnimationRunning && Content is UIElement contentElt)
+			{
+				var visual = contentElt.Visual;
+				visual.StopAnimation(nameof(Visual.AnchorPoint));
+				// StopAnimation triggers the Stopped callback which calls OnInertiaAnimationCompleted
+			}
+		}
 
 		private void TryEnableDirectManipulation(object sender, PointerRoutedEventArgs args)
 		{
@@ -590,6 +744,9 @@ namespace Microsoft.UI.Xaml.Controls
 			// If a previous inertia is still tracked, clear it immediately so old inertial deltas
 			// cannot fight with the new manipulation's direction.
 			_touchInertia = null;
+
+			// Stop any running composition-driven inertia animation (user touched during fling).
+			StopInertiaAnimation();
 
 			return ComputeAcceptedManipulationModes();
 		}
@@ -850,17 +1007,21 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
-				_touchInertia = args.Manipulation;
+				// Instead of letting the inertia processor tick managed code every frame
+				// (physics → gesture recognizer → events → Set → viewport propagation),
+				// we pre-compute the exponential decay curve as a composition animation.
+				// This makes inertia as smooth as any other composition animation (e.g. RedirectVisual).
+				_touchInertia = null; // Don't allow inertia processor ticks in OnUpdated
 
-				// Even if usually empty, make sure to apply the delta
-				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);
-				var deltaY = Math.Clamp(-args.Delta.Translation.Y, scrollable.Up, scrollable.Down);
+				// Complete the gesture to stop the inertia processor from ticking.
+				// OnCompleted will see _touchInertia == null && IsInertial, so it early-returns
+				// without touching intermediate mode.
+				recognizer.CompleteGesture();
 
-				Set(
-					horizontalOffset: HorizontalOffset + deltaX,
-					verticalOffset: VerticalOffset + deltaY,
-					options: new(DisableAnimation: true, IsTouch: true, IsIntermediate: true));
+				StartInertiaAnimation(
+					args.Velocities,
+					inertia.DesiredDisplacementDeceleration,
+					scrollable);
 			}
 
 			return true;
@@ -871,6 +1032,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
+				if (_isInertiaAnimationRunning)
+				{
+					// The inertia is now driven by a composition animation, not the processor.
+					// Don't touch intermediate mode — the animation's Stopped callback handles it.
+					return;
+				}
+
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 #if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -584,6 +584,9 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			Debug.Assert(_touchInertia is null || isResuming, "Inertia should already be null instead if we are resuming from a previous manipulation.");
 			_touchInertia = null;
+#if __SKIA__
+			Scroller?.EnterIntermediateViewChangedMode();
+#endif
 		}
 
 		/// <inheritdoc />
@@ -804,6 +807,9 @@ namespace Microsoft.UI.Xaml.Controls
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
+#if __SKIA__
+				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);
+#endif
 				return;
 			}
 
@@ -811,6 +817,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 			//Set(disableAnimation: true, isIntermediate: false);
 			Set(options: new ScrollOptions(DisableAnimation: true, IsTouch: true, IsIntermediate: false));
+#if __SKIA__
+			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
+#endif
 		}
 
 		private ScrollDirection GetDirection(ManipulationVelocities velocities)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -35,6 +35,7 @@ namespace Microsoft.UI.Xaml.Controls
 			: null;
 
 		private GestureRecognizer.Manipulation? _touchInertia;
+		private WheelInertia? _wheelInertia;
 		private (double hOffset, double vOffset, bool isIntermediate) _lastScrolledEvent;
 
 		// Batching: during active touch scrolling, we set AnchorPoint immediately (cheap) but
@@ -183,6 +184,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 			_touchInertia?.Complete();
 			_touchInertia = null;
+
+			_wheelInertia?.Dispose();
+			_wheelInertia = null;
 		}
 
 		/// <inheritdoc />
@@ -374,6 +378,12 @@ namespace Microsoft.UI.Xaml.Controls
 				// we stop the pending inertia processor.
 				_touchInertia?.Complete();
 			}
+			if (!options.IsWheelInertia)
+			{
+				// Programmatic/keyboard/touch updates cancel any in-flight wheel coast,
+				// so the new request wins (mirrors the touch-inertia cancel above).
+				_wheelInertia?.Stop();
+			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
 			var updatedVerticalOffset = VerticalOffset;
@@ -505,9 +515,9 @@ namespace Microsoft.UI.Xaml.Controls
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
-				else if (options.IsTouch && options.IsIntermediate && _touchInertia is not null)
+				else if (options.IsIntermediate && (options.IsWheelInertia || (options.IsTouch && _touchInertia is not null)))
 				{
-					// Inertia: update immediately but throttle viewport propagation.
+					// Inertia (touch fling OR wheel coast): update immediately but throttle viewport propagation.
 					// PropagateEffectiveViewportChange() can trigger heavy layout (ItemsRepeater
 					// measure, item recycling). If layout doesn't fully resolve in one pass,
 					// CanRecordPicture returns false → frame skipped → visible ghosting.
@@ -575,6 +585,53 @@ namespace Microsoft.UI.Xaml.Controls
 					visual.StartAnimation(nameof(Visual.Scale), zoomAnimation);
 				}
 			}
+		}
+
+		/// <summary>
+		/// Routes a desktop mouse-wheel notch with intended displacement (dxPx, dyPx) into the
+		/// velocity-based wheel inertia. When IsScrollInertiaEnabled is false on the Scroller,
+		/// falls back to the legacy 1 s eased animation. Returns true iff the full displacement
+		/// fit within scrollable bounds (matches the success semantic of the legacy Set() path).
+		/// </summary>
+		/// <remarks>
+		/// Bounds checking is done against the **projected** post-coast offset, not the current
+		/// instantaneous offset. This is what makes nested-ScrollViewer chaining work with rapid
+		/// wheel events: when the inner SV's accumulated trajectory is already at its bound, new
+		/// wheel events are reported as not-handled and bubble to the parent SV.
+		/// </remarks>
+		private bool TryStartWheelInertia(double dxPx, double dyPx)
+		{
+			if (Scroller is not { IsScrollInertiaEnabled: true })
+			{
+				// Legacy fallback: 1 s power-10 easing toward the new target offset.
+				return Set(
+					horizontalOffset: dxPx != 0 ? TargetHorizontalOffset + dxPx : null,
+					verticalOffset: dyPx != 0 ? TargetVerticalOffset + dyPx : null,
+					disableAnimation: false);
+			}
+
+			var maxH = Scroller?.ScrollableWidth ?? Math.Max(0, ExtentWidth - ViewportWidth);
+			var maxV = Scroller?.ScrollableHeight ?? Math.Max(0, ExtentHeight - ViewportHeight);
+
+			// Where ongoing inertia (if any) would coast to, otherwise the current offset.
+			var prevProjH = _wheelInertia is { IsRunning: true } projH ? projH.ProjectedFinalH : HorizontalOffset;
+			var prevProjV = _wheelInertia is { IsRunning: true } projV ? projV.ProjectedFinalV : VerticalOffset;
+			var newProjH = Math.Clamp(prevProjH + dxPx, 0, maxH);
+			var newProjV = Math.Clamp(prevProjV + dyPx, 0, maxV);
+
+			// If the impulse can move the projected target on at least one requested axis, absorb it.
+			// Otherwise the trajectory is already at the bound — let the event bubble to a parent SV.
+			var canAbsorb = (dxPx != 0 && newProjH != prevProjH) || (dyPx != 0 && newProjV != prevProjV);
+			if (!canAbsorb)
+			{
+				return false;
+			}
+
+			_wheelInertia ??= new WheelInertia(this);
+			_wheelInertia.AddImpulse(dxPx, dyPx);
+
+			// Match legacy semantic: success=true iff the full requested displacement fit.
+			return (dxPx == 0 || newProjH == prevProjH + dxPx) && (dyPx == 0 || newProjV == prevProjV + dyPx);
 		}
 
 		private void ScheduleDeferredTouchUpdate(double hOffset, double vOffset, bool isIntermediate)
@@ -955,6 +1012,155 @@ namespace Microsoft.UI.Xaml.Controls
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => true; // force scrollviewer to always clip
 #endif
 
+		/// <summary>
+		/// Velocity-based mouse-wheel inertia. Each wheel notch injects a velocity impulse;
+		/// a per-VSync tick integrates position with exponential decay (v(t)=v0·e^(-k·t)),
+		/// matching the model used by WinUI's DirectManipulation/InteractionTracker for
+		/// wheel input. New notches arriving mid-flight ADD velocity (coalesce), so spinning
+		/// faster scrolls farther — instead of restarting a fixed-duration animation per notch.
+		/// </summary>
+		private sealed class WheelInertia : IDisposable
+		{
+			// k = 0.003/ms ⇔ 0.95 decay per 16.67 ms frame, matching WinUI's InteractionTracker default.
+			private const double DecayPerMs = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
+			// Stop the loop when both axes have less than ~0.6 px/frame remaining velocity.
+			private const double VelocityThreshold = GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold;
+
+			private readonly ScrollContentPresenter _owner;
+			private double _vx, _vy; // px/ms
+			private double _hOffset, _vOffset;
+			private TimeSpan? _t0;
+			private TimeSpan _lastTick;
+			private Stopwatch? _fallbackTime;
+			private EventHandler<object>? _frameHandler;
+			private bool _running;
+
+			public WheelInertia(ScrollContentPresenter owner)
+			{
+				_owner = owner;
+			}
+
+			public bool IsRunning => _running;
+
+			/// <summary>
+			/// Where the current trajectory would settle if no further impulse is added
+			/// (∫₀^∞ v·e^(-k·t) dt = v/k). Used by <see cref="TryStartWheelInertia"/> to
+			/// chain wheel events to a parent ScrollViewer once the projected target is at
+			/// the bound, instead of stacking them onto a saturated trajectory.
+			/// </summary>
+			public double ProjectedFinalH => _hOffset + _vx / DecayPerMs;
+
+			/// <inheritdoc cref="ProjectedFinalH"/>
+			public double ProjectedFinalV => _vOffset + _vy / DecayPerMs;
+
+			/// <summary>
+			/// Adds a velocity impulse equivalent to scrolling by the given displacement
+			/// in isolation. Total displacement of v0/k means v0 = displacement·k.
+			/// Multiple impulses arriving in quick succession sum into a higher peak velocity.
+			/// </summary>
+			public void AddImpulse(double dxPx, double dyPx)
+			{
+				if (!_running)
+				{
+					_hOffset = _owner.HorizontalOffset;
+					_vOffset = _owner.VerticalOffset;
+					_vx = 0;
+					_vy = 0;
+					_t0 = null;
+					_lastTick = TimeSpan.Zero;
+					_fallbackTime = null;
+					_frameHandler = OnFrame;
+					CompositionTarget.Rendering += _frameHandler;
+					_running = true;
+					_owner._inertiaFrameCount = 0;
+				}
+
+				_vx += dxPx * DecayPerMs;
+				_vy += dyPx * DecayPerMs;
+			}
+
+			private void OnFrame(object? sender, object e)
+			{
+				TimeSpan elapsed;
+				if (e is RenderingEventArgs rea)
+				{
+					if (_t0 is null)
+					{
+						_t0 = rea.RenderingTime;
+						_lastTick = TimeSpan.Zero;
+						return; // First frame just records t0; integration starts on the next frame.
+					}
+					elapsed = rea.RenderingTime - _t0.Value;
+				}
+				else
+				{
+					if (_fallbackTime is null)
+					{
+						_fallbackTime = Stopwatch.StartNew();
+						_lastTick = TimeSpan.Zero;
+						return;
+					}
+					elapsed = _fallbackTime.Elapsed;
+				}
+
+				var dt = (elapsed - _lastTick).TotalMilliseconds;
+				_lastTick = elapsed;
+
+				if (dt <= 0)
+				{
+					return;
+				}
+
+				// Closed-form exact integration: pos += v·(1-e^(-k·dt))/k; v *= e^(-k·dt).
+				var decay = Math.Exp(-DecayPerMs * dt);
+				var posStep = (1 - decay) / DecayPerMs;
+
+				var maxH = _owner.Scroller?.ScrollableWidth ?? Math.Max(0, _owner.ExtentWidth - _owner.ViewportWidth);
+				var maxV = _owner.Scroller?.ScrollableHeight ?? Math.Max(0, _owner.ExtentHeight - _owner.ViewportHeight);
+
+				_hOffset = Math.Clamp(_hOffset + _vx * posStep, 0, maxH);
+				_vOffset = Math.Clamp(_vOffset + _vy * posStep, 0, maxV);
+				_vx *= decay;
+				_vy *= decay;
+
+				// Pinning at a bound kills velocity on that axis so the loop can complete.
+				if ((_hOffset <= 0 && _vx < 0) || (_hOffset >= maxH && _vx > 0))
+				{
+					_vx = 0;
+				}
+				if ((_vOffset <= 0 && _vy < 0) || (_vOffset >= maxV && _vy > 0))
+				{
+					_vy = 0;
+				}
+
+				var stillMoving = Math.Abs(_vx) > VelocityThreshold || Math.Abs(_vy) > VelocityThreshold;
+
+				_owner.Set(
+					horizontalOffset: _hOffset,
+					verticalOffset: _vOffset,
+					options: new(DisableAnimation: true, IsIntermediate: stillMoving, IsWheelInertia: true));
+
+				if (!stillMoving)
+				{
+					Stop();
+				}
+			}
+
+			public void Stop()
+			{
+				if (_frameHandler is not null)
+				{
+					CompositionTarget.Rendering -= _frameHandler;
+					_frameHandler = null;
+				}
+				_running = false;
+				_vx = 0;
+				_vy = 0;
+			}
+
+			public void Dispose() => Stop();
+		}
+
 		/// <param name="Up">Offset that can be scrolled up. THIS IS ALWAYS NEGATIVE.</param>
 		/// <param name="Down">Offset that can be scrolled down. This is always positive.</param>
 		/// <param name="Left">Offset that can be scrolled left. THIS IS ALWAYS NEGATIVE.</param>
@@ -1011,5 +1217,10 @@ namespace Microsoft.UI.Xaml.Controls
 	/// Indicates that the scroll is an intermediate value, not the final one
 	/// (i.e. active touch scrolling, touch scroll inertia or scroll animation).
 	/// </param>
-	internal record struct ScrollOptions(bool DisableAnimation = false, bool IsTouch = false, bool IsIntermediate = false);
+	/// <param name="IsWheelInertia">
+	/// Indicates that the scroll is a per-frame tick from the mouse-wheel inertia controller.
+	/// Routes through the same EVP-throttling branch as touch inertia and prevents the call
+	/// from cancelling itself.
+	/// </param>
+	internal record struct ScrollOptions(bool DisableAnimation = false, bool IsTouch = false, bool IsIntermediate = false, bool IsWheelInertia = false);
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -749,9 +749,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			Debug.Assert(_touchInertia is null || isResuming, "Inertia should already be null instead if we are resuming from a previous manipulation.");
 			_touchInertia = null;
-#if __SKIA__
 			Scroller?.EnterIntermediateViewChangedMode();
-#endif
 		}
 
 		/// <inheritdoc />
@@ -976,9 +974,7 @@ namespace Microsoft.UI.Xaml.Controls
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
-#if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);
-#endif
 				return;
 			}
 
@@ -986,9 +982,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			//Set(disableAnimation: true, isIntermediate: false);
 			Set(options: new ScrollOptions(DisableAnimation: true, IsTouch: true, IsIntermediate: false));
-#if __SKIA__
 			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
-#endif
 		}
 
 		private ScrollDirection GetDirection(ManipulationVelocities velocities)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -1021,8 +1021,21 @@ namespace Microsoft.UI.Xaml.Controls
 		/// </summary>
 		private sealed class WheelInertia : IDisposable
 		{
-			// k = 0.003/ms ⇔ 0.95 decay per 16.67 ms frame, matching WinUI's InteractionTracker default.
-			private const double DecayPerMs = GestureRecognizer.Manipulation.InertiaProcessor.DefaultDesiredDisplacementDeceleration;
+			// Wheel-specific decay rate, tuned to match the legacy WinUI ScrollViewer feel
+			// (which is driven by DirectManipulation, not InteractionTracker). Empirically DManip's
+			// wheel coast settles in ~300–400 ms for a typical notch — much snappier than the
+			// 0.95-per-frame InteractionTracker default that ScrollPresenter uses for fling.
+			//
+			// k = 0.010/ms ⇔ 0.846 per 16.67 ms frame ⇒ 90-px notch settles in ~330 ms.
+			// Increase to scroll faster / less far; decrease to feel slower / coast longer.
+			private const double DecayPerMs = 0.010;
+
+			// Velocity boost relative to the per-notch displacement formula. WinUI legacy ScrollViewer
+			// feels like it scrolls slightly farther per notch than the bare GetVerticalScrollWheelDelta
+			// formula suggests — DManip seems to overshoot the discrete-notch math by ~15-20%. Keeping
+			// this as an explicit, named multiplier so it can be tuned independently of the base decay.
+			private const double VelocityBoost = 1.15;
+
 			// Stop the loop when both axes have less than ~0.6 px/frame remaining velocity.
 			private const double VelocityThreshold = GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold;
 
@@ -1075,8 +1088,10 @@ namespace Microsoft.UI.Xaml.Controls
 					_owner._inertiaFrameCount = 0;
 				}
 
-				_vx += dxPx * DecayPerMs;
-				_vy += dyPx * DecayPerMs;
+				// v₀ = displacement · k yields ∫₀^∞ v·e^(-k·t) dt = displacement;
+				// the boost factor inflates the final coast distance to match WinUI's per-notch feel.
+				_vx += dxPx * DecayPerMs * VelocityBoost;
+				_vy += dyPx * DecayPerMs * VelocityBoost;
 			}
 
 			private void OnFrame(object? sender, object e)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -47,11 +47,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingTouchIsIntermediate;
 		private EventHandler<object>? _touchUpdateHandler;
 
-		// Composition-driven inertia: instead of running managed code every frame (inertia processor
-		// → gesture recognizer → event → Set → Update → viewport propagation), we pre-compute the
-		// exponential decay curve as keyframes and let the composition animation system drive the
-		// Visual.AnchorPoint directly. This makes inertia as smooth as any other composition animation.
-		private bool _isInertiaAnimationRunning;
 #nullable restore
 
 		private bool _canHorizontallyScroll;
@@ -176,7 +171,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UnhookScrollEvents(sv);
 			}
 			FlushPendingTouchUpdate();
-			StopInertiaAnimation();
+
 			_touchInertia?.Complete();
 			_touchInertia = null;
 		}
@@ -367,9 +362,8 @@ namespace Microsoft.UI.Xaml.Controls
 			if (!options.IsTouch)
 			{
 				// If we get a request to scroll to a specific offset **that is not flagged as IsInertial** (i.e. not coming from the inertia processing),
-				// we stop the pending inertia processor and any running inertia animation.
+				// we stop the pending inertia processor.
 				_touchInertia?.Complete();
-				StopInertiaAnimation();
 			}
 
 			var updatedHorizontalOffset = HorizontalOffset;
@@ -494,15 +488,18 @@ namespace Microsoft.UI.Xaml.Controls
 				visual.AnchorPoint = target;
 				visual.Scale = targetScale;
 
-				if (options.IsTouch && options.IsIntermediate)
+				if (options.IsTouch && options.IsIntermediate && _touchInertia is null)
 				{
-					// During active touch scrolling (finger on screen or inertia), defer the expensive
+					// During active touch scrolling (finger on screen, NOT inertia), defer the expensive
 					// Updated() call to once per frame. This batches N pointer moves into 1 Updated().
+					// We DON'T defer during inertia because the inertia processor fires exactly once per
+					// frame during CompositionTarget.Rendering (BEFORE layout), and we need layout to
+					// process the new scroll position in the SAME frame to avoid tearing.
 					ScheduleDeferredTouchUpdate(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
 				else
 				{
-					// Non-intermediate (final) or non-touch: flush immediately for correct event sequencing.
+					// Inertia, non-intermediate (final), or non-touch: flush immediately.
 					FlushPendingTouchUpdate();
 					Updated(horizontalOffset, verticalOffset, options.IsIntermediate);
 				}
@@ -575,161 +572,6 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		/// <summary>
-		/// Starts a composition-animation-driven inertia scroll.
-		/// Pre-computes the exponential decay curve as keyframes so the composition system
-		/// drives the Visual.AnchorPoint directly — no managed code per frame.
-		/// </summary>
-		private void StartInertiaAnimation(
-			ManipulationVelocities velocities,
-			double deceleration,
-			ScrollableOffsets scrollable)
-		{
-			if (Content is not UIElement contentElt)
-			{
-				return;
-			}
-
-			// Flush any pending touch updates before starting the animation
-			FlushPendingTouchUpdate();
-
-			// Velocities are in pointer-position space (px/ms). Negate to get scroll-offset velocity.
-			// When pointer moves right (positive velocity), content scrolls left (offset decreases).
-			var v0H = -velocities.Linear.X;
-			var v0V = -velocities.Linear.Y;
-			var k = deceleration;
-
-			// Compute duration: time until velocity drops below threshold
-			var maxAbsV = Math.Max(Math.Abs(v0H), Math.Abs(v0V));
-			if (maxAbsV <= GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold)
-			{
-				// Velocity too low for visible inertia
-				OnInertiaAnimationCompleted(contentElt);
-				return;
-			}
-
-			var durationMs = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(maxAbsV, k);
-
-			// Clamp to reasonable max (avoid extremely long animations from very fast flings)
-			durationMs = Math.Min(durationMs, 5000);
-
-			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
-			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
-			var startH = HorizontalOffset;
-			var startV = VerticalOffset;
-
-			var visual = contentElt.Visual;
-			var compositor = visual.Compositor;
-			var animation = compositor.CreateVector2KeyFrameAnimation();
-			animation.Duration = TimeSpan.FromMilliseconds(durationMs);
-
-			// Sample the exponential decay curve at frame-rate-matched intervals.
-			// Using 16ms (60fps) ensures each displayed frame has its own keyframe,
-			// eliminating velocity discontinuities from inter-keyframe linear interpolation
-			// that would otherwise cause subtle visual "shaking" or "tearing" effects.
-			const int keyframeIntervalMs = 16;
-			var numKeyframes = Math.Max(2, (int)(durationMs / keyframeIntervalMs));
-
-			for (var i = 0; i <= numKeyframes; i++)
-			{
-				var progress = (float)i / numKeyframes;
-				var tMs = progress * durationMs;
-
-				var hPos = startH + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0H, k, tMs);
-				var vPos = startV + GestureRecognizer.Manipulation.InertiaProcessor.GetValue(v0V, k, tMs);
-
-				// Clamp to scrollable bounds
-				hPos = Math.Clamp(hPos, 0, maxH);
-				vPos = Math.Clamp(vPos, 0, maxV);
-
-				animation.InsertKeyFrame(progress, new Vector2((float)-hPos, (float)-vPos));
-			}
-
-			// During the animation, update only the ScrollViewer offset DPs (for scrollbar movement).
-			// CRITICAL: Do NOT call InvalidateViewport() / PropagateEffectiveViewportChange() here.
-			// That triggers layout invalidation (item recycling, re-arrangement) which causes visible
-			// "tearing" — content appears at the animation position while layout elements shift around.
-			// Viewport propagation is deferred to OnInertiaAnimationCompleted for a single clean pass.
-			var frameCount = 0;
-			void OnFrame(CompositionAnimation? _)
-			{
-				// Update scrollbar position every 2nd frame (~30fps) for smooth scrollbar movement.
-				// Only updates the DP offsets — no layout invalidation, no viewport propagation.
-				if (++frameCount % 2 == 0)
-				{
-					var currentH = Math.Round(-visual.AnchorPoint.X);
-					var currentV = Math.Round(-visual.AnchorPoint.Y);
-					HorizontalOffset = Math.Clamp(currentH, 0, maxH);
-					VerticalOffset = Math.Clamp(currentV, 0, maxV);
-
-					// Update ScrollViewer DPs for scrollbar visuals, but skip full Updated()
-					// which would trigger InvalidateViewport → layout changes → tearing.
-					if (_lastScrolledEvent != (HorizontalOffset, VerticalOffset, true))
-					{
-						_lastScrolledEvent = (HorizontalOffset, VerticalOffset, true);
-						Scroller?.OnPresenterScrolled(HorizontalOffset, VerticalOffset, isIntermediate: true);
-					}
-					ScrollOffsets = new Point(HorizontalOffset, VerticalOffset);
-				}
-			}
-
-			void OnStopped(object? _, EventArgs __)
-			{
-				animation.AnimationFrame -= OnFrame;
-				animation.Stopped -= OnStopped;
-				OnInertiaAnimationCompleted(contentElt);
-			}
-
-			animation.AnimationFrame += OnFrame;
-			animation.Stopped += OnStopped;
-
-			// Stop any existing animation and start the inertia animation
-			if (visual.TryGetAnimationController(nameof(Visual.AnchorPoint)) is not null)
-			{
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
-			}
-
-			_isInertiaAnimationRunning = true;
-			visual.StartAnimation(nameof(Visual.AnchorPoint), animation);
-		}
-
-		private void OnInertiaAnimationCompleted(UIElement contentElt)
-		{
-			_isInertiaAnimationRunning = false;
-
-			// Read the final position from the visual
-			var visual = contentElt.Visual;
-			var finalH = Math.Round(-visual.AnchorPoint.X);
-			var finalV = Math.Round(-visual.AnchorPoint.Y);
-
-			var maxH = Math.Max(0, Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth);
-			var maxV = Math.Max(0, Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight);
-
-			HorizontalOffset = Math.Clamp(finalH, 0, maxH);
-			VerticalOffset = Math.Clamp(finalV, 0, maxV);
-
-			// Fire final non-intermediate Updated
-			Updated(HorizontalOffset, VerticalOffset, isIntermediate: false);
-
-#if __SKIA__
-			Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: true);
-#endif
-		}
-
-		/// <summary>
-		/// Stops a running inertia animation (e.g. when user touches during fling)
-		/// and synchronizes the scroll offset to the current visual position.
-		/// </summary>
-		private void StopInertiaAnimation()
-		{
-			if (_isInertiaAnimationRunning && Content is UIElement contentElt)
-			{
-				var visual = contentElt.Visual;
-				visual.StopAnimation(nameof(Visual.AnchorPoint));
-				// StopAnimation triggers the Stopped callback which calls OnInertiaAnimationCompleted
-			}
-		}
-
 		private void TryEnableDirectManipulation(object sender, PointerRoutedEventArgs args)
 		{
 			if (args.Pointer.PointerDeviceType is not (_PointerDeviceType.Pen or _PointerDeviceType.Touch))
@@ -754,7 +596,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_touchInertia = null;
 
 			// Stop any running composition-driven inertia animation (user touched during fling).
-			StopInertiaAnimation();
+
 
 			return ComputeAcceptedManipulationModes();
 		}
@@ -1015,21 +857,17 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				// Instead of letting the inertia processor tick managed code every frame
-				// (physics → gesture recognizer → events → Set → viewport propagation),
-				// we pre-compute the exponential decay curve as a composition animation.
-				// This makes inertia as smooth as any other composition animation (e.g. RedirectVisual).
-				_touchInertia = null; // Don't allow inertia processor ticks in OnUpdated
+				// We can handle the inertia scrolling, configure to accept allow it by assigning the _touchInertia field.
+				_touchInertia = args.Manipulation;
 
-				// Complete the gesture to stop the inertia processor from ticking.
-				// OnCompleted will see _touchInertia == null && IsInertial, so it early-returns
-				// without touching intermediate mode.
-				recognizer.CompleteGesture();
+				// Even if usually empty, make sure to apply the delta
+				var deltaX = Math.Clamp(-args.Delta.Translation.X, scrollable.Left, scrollable.Right);
+				var deltaY = Math.Clamp(-args.Delta.Translation.Y, scrollable.Up, scrollable.Down);
 
-				StartInertiaAnimation(
-					args.Velocities,
-					inertia.DesiredDisplacementDeceleration,
-					scrollable);
+				Set(
+					horizontalOffset: HorizontalOffset + deltaX,
+					verticalOffset: VerticalOffset + deltaY,
+					options: new(DisableAnimation: true, IsTouch: true, IsIntermediate: true));
 			}
 
 			return true;
@@ -1040,13 +878,6 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (args?.IsInertial is true && _touchInertia is null)
 			{
-				if (_isInertiaAnimationRunning)
-				{
-					// The inertia is now driven by a composition animation, not the processor.
-					// Don't touch intermediate mode — the animation's Stopped callback handles it.
-					return;
-				}
-
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 #if __SKIA__
 				Scroller?.LeaveIntermediateViewChangedMode(raiseFinalViewChanged: false);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -614,8 +614,11 @@ namespace Microsoft.UI.Xaml.Controls
 			var maxV = Scroller?.ScrollableHeight ?? Math.Max(0, ExtentHeight - ViewportHeight);
 
 			// Where ongoing inertia (if any) would coast to, otherwise the current offset.
-			var prevProjH = _wheelInertia is { IsRunning: true } projH ? projH.ProjectedFinalH : HorizontalOffset;
-			var prevProjV = _wheelInertia is { IsRunning: true } projV ? projV.ProjectedFinalV : VerticalOffset;
+			// The projection is unbounded (offset + v/k), so it must be clamped to the scrollable
+			// range before being compared: an over-the-bound baseline would otherwise always differ
+			// from the clamped new projection and wrongly absorb wheel events at the bound.
+			var prevProjH = _wheelInertia is { IsRunning: true } projH ? Math.Clamp(projH.ProjectedFinalH, 0, maxH) : HorizontalOffset;
+			var prevProjV = _wheelInertia is { IsRunning: true } projV ? Math.Clamp(projV.ProjectedFinalV, 0, maxV) : VerticalOffset;
 			var newProjH = Math.Clamp(prevProjH + dxPx, 0, maxH);
 			var newProjV = Math.Clamp(prevProjV + dyPx, 0, maxV);
 
@@ -649,16 +652,16 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		private void OnRenderingFlushTouchUpdate(object? sender, object e)
-		{
-			// Unsubscribe immediately — we re-subscribe on next touch move if needed.
-			CompositionTarget.Rendering -= _touchUpdateHandler;
-			FlushPendingTouchUpdate();
-		}
+			=> FlushPendingTouchUpdate();
 
 		private void FlushPendingTouchUpdate()
 		{
 			if (_hasPendingTouchUpdate)
 			{
+				// Unsubscribe here (and not only from the Rendering callback) so that flushing from
+				// OnUnloaded also detaches from the static event, instead of leaving the presenter
+				// rooted until a tick that may never come.
+				CompositionTarget.Rendering -= _touchUpdateHandler;
 				_hasPendingTouchUpdate = false;
 				Updated(_pendingTouchHOffset, _pendingTouchVOffset, _pendingTouchIsIntermediate);
 			}
@@ -687,8 +690,9 @@ namespace Microsoft.UI.Xaml.Controls
 			// cannot fight with the new manipulation's direction.
 			_touchInertia = null;
 
-			// Stop any running composition-driven inertia animation (user touched during fling).
-
+			// Stop any running composition-driven inertia animation (user touched during fling),
+			// otherwise the wheel coast keeps issuing Set() calls that fight the new manipulation.
+			_wheelInertia?.Stop();
 
 			return ComputeAcceptedManipulationModes();
 		}
@@ -1036,7 +1040,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// this as an explicit, named multiplier so it can be tuned independently of the base decay.
 			private const double VelocityBoost = 1.15;
 
-			// Stop the loop when both axes have less than ~0.6 px/frame remaining velocity.
+			// Stop the loop when both axes have less than ~0.17 px/frame remaining velocity.
 			private const double VelocityThreshold = GestureRecognizer.Manipulation.InertiaProcessor.VelocityThreshold;
 
 			private readonly ScrollContentPresenter _owner;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -240,6 +240,13 @@ namespace Microsoft.UI.Xaml.Controls
 				(child as ICustomScrollInfo)?.ApplyViewport(ref finalSize);
 			}
 
+#if __SKIA__
+			// WinUI-aligned: flush pending scroll offset updates to the ScrollViewer.
+			// On WinUI, ArrangeOverride → VerifyScrollData → InvalidateScrollOwner
+			// → put_HorizontalOffset/VerticalOffset updates the DPs during the arrange pass.
+			Scroller?.OnPresenterArranged();
+#endif
+
 			return finalSize;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -256,6 +256,13 @@ namespace Microsoft.UI.Xaml.Controls
 				(child as ICustomScrollInfo)?.ApplyViewport(ref finalSize);
 			}
 
+#if __SKIA__
+			// WinUI-aligned: flush pending scroll offset updates to the ScrollViewer.
+			// On WinUI, ArrangeOverride → VerifyScrollData → InvalidateScrollOwner
+			// → put_HorizontalOffset/VerticalOffset updates the DPs during the arrange pass.
+			Scroller?.OnPresenterArranged();
+#endif
+
 			return finalSize;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -332,9 +332,10 @@ namespace Microsoft.UI.Xaml.Controls
 					}
 					else
 					{
-						success = Set(
-							horizontalOffset: TargetHorizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, delta),
-							disableAnimation: false);
+						// Velocity-based wheel inertia: each notch adds a velocity impulse to a per-VSync
+						// integration loop with exponential decay. Rapid spinning coalesces into higher
+						// peak velocity (longer scroll), instead of restarting a 1 s eased animation per notch.
+						success = TryStartWheelInertia(GetHorizontalScrollWheelDelta(DesiredSize, delta), 0);
 					}
 #endif
 				}
@@ -356,9 +357,8 @@ namespace Microsoft.UI.Xaml.Controls
 					}
 					else
 					{
-						success = Set(
-							verticalOffset: TargetVerticalOffset + GetVerticalScrollWheelDelta(DesiredSize, -delta),
-							disableAnimation: false);
+						// Velocity-based wheel inertia (see horizontal branch).
+						success = TryStartWheelInertia(0, GetVerticalScrollWheelDelta(DesiredSize, -delta));
 					}
 #endif
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -223,12 +223,10 @@ namespace Microsoft.UI.Xaml.Controls
 				(child as ICustomScrollInfo)?.ApplyViewport(ref finalSize);
 			}
 
-#if __SKIA__
 			// WinUI-aligned: flush pending scroll offset updates to the ScrollViewer.
 			// On WinUI, ArrangeOverride → VerifyScrollData → InvalidateScrollOwner
 			// → put_HorizontalOffset/VerticalOffset updates the DPs during the arrange pass.
 			Scroller?.OnPresenterArranged();
-#endif
 
 			return finalSize;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -223,6 +223,13 @@ namespace Microsoft.UI.Xaml.Controls
 				(child as ICustomScrollInfo)?.ApplyViewport(ref finalSize);
 			}
 
+#if __SKIA__
+			// WinUI-aligned: flush pending scroll offset updates to the ScrollViewer.
+			// On WinUI, ArrangeOverride → VerifyScrollData → InvalidateScrollOwner
+			// → put_HorizontalOffset/VerticalOffset updates the DPs during the arrange pass.
+			Scroller?.OnPresenterArranged();
+#endif
+
 			return finalSize;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -325,9 +325,10 @@ namespace Microsoft.UI.Xaml.Controls
 					}
 					else
 					{
-						success = Set(
-							horizontalOffset: TargetHorizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, horizontalDelta),
-							disableAnimation: false);
+						// Velocity-based wheel inertia: each notch adds a velocity impulse to a per-VSync
+						// integration loop with exponential decay. Rapid spinning coalesces into higher
+						// peak velocity (longer scroll), instead of restarting a 1 s eased animation per notch.
+						success = TryStartWheelInertia(GetHorizontalScrollWheelDelta(DesiredSize, horizontalDelta), 0);
 					}
 				}
 				else if (canScrollVertically && !properties.IsHorizontalMouseWheel)
@@ -343,9 +344,8 @@ namespace Microsoft.UI.Xaml.Controls
 					}
 					else
 					{
-						success = Set(
-							verticalOffset: TargetVerticalOffset + GetVerticalScrollWheelDelta(DesiredSize, -delta),
-							disableAnimation: false);
+						// Velocity-based wheel inertia (see horizontal branch).
+						success = TryStartWheelInertia(0, GetVerticalScrollWheelDelta(DesiredSize, -delta));
 					}
 				}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1496,7 +1496,7 @@ namespace Microsoft.UI.Xaml.Controls
 				return;
 			}
 
-			_ = Dispatcher.RunIdleAsync(e =>
+			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				if (_hasPendingUpdate)
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1242,15 +1242,28 @@ namespace Microsoft.UI.Xaml.Controls
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
 #if __SKIA__
-			// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
-			// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
-			// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 			_pendingScrollIsIntermediate = isIntermediate;
-			_hasPendingScrollUpdate = true;
 
-			_presenter?.InvalidateArrange();
+			if (UpdatesMode == Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
+			{
+				// Synchronous mode: update DPs immediately (used for testing).
+				// This bypasses the WinUI-aligned deferred path so that test assertions
+				// can read VerticalOffset/HorizontalOffset right after input injection.
+				_hasPendingScrollUpdate = false;
+				HorizontalOffset = horizontalOffset;
+				VerticalOffset = verticalOffset;
+				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+			}
+			else
+			{
+				// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
+				// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
+				// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+				_hasPendingScrollUpdate = true;
+				_presenter?.InvalidateArrange();
+			}
 #else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1241,50 +1241,58 @@ namespace Microsoft.UI.Xaml.Controls
 		// Presenter to Control, i.e. OnPresenterScrolled
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
+#if __SKIA__
+			// Skia: synchronous delay/counter mechanism matching WinUI behavior.
+			// Offsets are set immediately; RaiseViewChanged respects the delay counter.
+			HorizontalOffset = horizontalOffset;
+			VerticalOffset = verticalOffset;
+
+			RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+#else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 
 			if (isIntermediate && UpdatesMode != Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
 			{
 				RequestUpdate();
-				_snapPointsTimer?.Stop();
 			}
 			else
 			{
 				Update(isIntermediate);
-
-				if (isIntermediate)
-				{
-					// when intermediate (aka manual) scrolling occurs,
-					// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
-					_snapPointsTimer?.Stop();
-				}
-				if (!isIntermediate
-#if __APPLE_UIKIT__ || __ANDROID__
-					&& (_presenter as ListViewBaseScrollContentPresenter)?.NativePanel?.UseNativeSnapping != true
+			}
 #endif
-					)
+
+			if (isIntermediate)
+			{
+				// when intermediate (aka manual) scrolling occurs,
+				// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
+				_snapPointsTimer?.Stop();
+			}
+			else if (!isIntermediate
+#if __APPLE_UIKIT__ || __ANDROID__
+				&& (_presenter as ListViewBaseScrollContentPresenter)?.NativePanel?.UseNativeSnapping != true
+#endif
+				)
+			{
+				if (HorizontalSnapPointsType != SnapPointsType.None
+					|| VerticalSnapPointsType != SnapPointsType.None
+					|| ShouldSnapToTouchTextBox())
 				{
-					if (HorizontalSnapPointsType != SnapPointsType.None
-						|| VerticalSnapPointsType != SnapPointsType.None
-						|| ShouldSnapToTouchTextBox())
+					_horizontalOffsetForSnapPoints = horizontalOffset;
+					_verticalOffsetForSnapPoints = verticalOffset;
+
+					if (_snapPointsTimer == null)
 					{
-						_horizontalOffsetForSnapPoints = horizontalOffset;
-						_verticalOffsetForSnapPoints = verticalOffset;
-
-						if (_snapPointsTimer == null)
+						_snapPointsTimer = global::Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
+						_snapPointsTimer.IsRepeating = false;
+						_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
+						_snapPointsTimer.Tick += (snd, evt) =>
 						{
-							_snapPointsTimer = global::Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
-							_snapPointsTimer.IsRepeating = false;
-							_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
-							_snapPointsTimer.Tick += (snd, evt) =>
-							{
-								DelayedMoveToSnapPoint();
-							};
-						}
-
-						_snapPointsTimer.Start();
+							DelayedMoveToSnapPoint();
+						};
 					}
+
+					_snapPointsTimer.Start();
 				}
 			}
 
@@ -1304,13 +1312,132 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			ZoomFactor = zoomFactor;
 
+#if __SKIA__
+			RaiseViewChanged(isIntermediate: false);
+#else
 			// Note: We should also defer the intermediate zoom changes
 			Update(isIntermediate: false);
+#endif
 
 			UpdateZoomedContentAlignment();
 		}
 
 		#region Deferred update (i.e. ViewChanged) support
+#if __SKIA__
+		// WinUI-compatible synchronous delay/counter mechanism for ViewChanged event batching.
+		// WinUI uses m_iViewChangedDelay as a nestable counter: callers increment via DelayViewChanged()
+		// before operations that may trigger multiple property changes, then decrement via FlushViewChanged().
+		// Events are stored while the counter is positive and raised when it returns to zero.
+		private bool m_isViewChangedDelayed;
+		private bool m_isDelayedViewChangedIntermediate;
+		private bool m_isInIntermediateViewChangedMode;
+		private bool m_isViewChangedRaisedInIntermediateMode;
+		private int m_iViewChangedDelay;
+
+		/// <summary>
+		/// Increments the delay counter to prevent ViewChanged from being raised.
+		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
+		/// </summary>
+		internal void DelayViewChanged()
+		{
+			m_iViewChangedDelay++;
+		}
+
+		/// <summary>
+		/// Decrements the delay counter and raises any stored ViewChanged event
+		/// when the counter reaches zero.
+		/// </summary>
+		internal void FlushViewChanged()
+		{
+			Debug.Assert(m_iViewChangedDelay > 0);
+
+			m_iViewChangedDelay--;
+
+			if (m_iViewChangedDelay == 0 && m_isViewChangedDelayed)
+			{
+				RaiseViewChanged(m_isDelayedViewChangedIntermediate);
+			}
+		}
+
+		/// <summary>
+		/// Raises the ViewChanged event, or stores it for later if the delay counter is active.
+		/// When delayed, only the latest isIntermediate value is retained.
+		/// </summary>
+		private void RaiseViewChanged(bool isIntermediate)
+		{
+			if (m_iViewChangedDelay > 0)
+			{
+				// Batch: store the event for later, keeping the latest isIntermediate value.
+				m_isViewChangedDelayed = true;
+				m_isDelayedViewChangedIntermediate = isIntermediate;
+				return;
+			}
+
+			if (m_isInIntermediateViewChangedMode)
+			{
+				// Track that ViewChanged was raised during intermediate mode so that
+				// LeaveIntermediateViewChangedMode can raise a final non-intermediate event.
+				m_isViewChangedRaisedInIntermediateMode = true;
+			}
+
+			m_isViewChangedDelayed = false;
+
+			if (AutomationPeer.ListenerExistsHelper(AutomationEvents.PropertyChanged) &&
+				GetAutomationPeer() is ScrollViewerAutomationPeer peer)
+			{
+				peer.RaiseAutomationEvents(
+					ExtentWidth,
+					ExtentHeight,
+					ViewportWidth,
+					ViewportHeight,
+					MinHorizontalOffset,
+					MinVerticalOffset,
+					HorizontalOffset,
+					VerticalOffset);
+			}
+
+			UpdatePartial(isIntermediate);
+
+			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
+		}
+
+		/// <summary>
+		/// Enters intermediate mode. All ViewChanged events raised while in this mode
+		/// will have IsIntermediate set to true. A final non-intermediate event is raised
+		/// when leaving intermediate mode via <see cref="LeaveIntermediateViewChangedMode"/>.
+		/// </summary>
+		internal void EnterIntermediateViewChangedMode()
+		{
+			if (!m_isInIntermediateViewChangedMode)
+			{
+				m_isInIntermediateViewChangedMode = true;
+				m_isViewChangedRaisedInIntermediateMode = false;
+			}
+		}
+
+		/// <summary>
+		/// Leaves intermediate mode. If ViewChanged was raised during intermediate mode
+		/// and <paramref name="raiseFinalViewChanged"/> is true, raises a final
+		/// ViewChanged event with IsIntermediate=false.
+		/// </summary>
+		internal void LeaveIntermediateViewChangedMode(bool raiseFinalViewChanged)
+		{
+			if (m_isInIntermediateViewChangedMode)
+			{
+				m_isInIntermediateViewChangedMode = false;
+
+				if (m_isViewChangedRaisedInIntermediateMode)
+				{
+					m_isViewChangedRaisedInIntermediateMode = false;
+
+					if (raiseFinalViewChanged)
+					{
+						RaiseViewChanged(isIntermediate: false);
+					}
+				}
+			}
+		}
+#else
 		private bool _hasPendingUpdate;
 		private double _pendingHorizontalOffset;
 		private double _pendingVerticalOffset;
@@ -1361,6 +1488,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
 		}
+#endif
 
 		partial void UpdatePartial(bool isIntermediate);
 		#endregion
@@ -1496,12 +1624,32 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (verticalOffsetChanged || horizontalOffsetChanged || zoomFactorChanged)
 			{
+#if __SKIA__
+				// Batch ViewChanged events during the programmatic view change.
+				// When disableAnimation is true, the entire SCP → OnPresenterScrolled chain
+				// is synchronous, so the delay counter batches the events within this scope.
+				DelayViewChanged();
+				try
+				{
+					return ChangeViewCore(
+						horizontalOffset,
+						verticalOffset,
+						zoomFactor,
+						disableAnimation,
+						shouldSnap: true);
+				}
+				finally
+				{
+					FlushViewChanged();
+				}
+#else
 				return ChangeViewCore(
 					horizontalOffset,
 					verticalOffset,
 					zoomFactor,
 					disableAnimation,
 					shouldSnap: true);
+#endif
 			}
 			else
 			{
@@ -1535,8 +1683,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private static readonly bool _indicatorResetDisabled = _indicatorResetDelay == TimeSpan.MaxValue;
 		private DispatcherQueueTimer? _indicatorResetTimer;
 		private string? _indicatorState;
-		//private bool m_isInIntermediateViewChangedMode;
-		//private bool m_isViewChangedRaisedInIntermediateMode;
 		//private bool m_isDraggingThumb;
 
 		private void PrepareScrollIndicator() // OnApplyTemplate

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1242,12 +1242,15 @@ namespace Microsoft.UI.Xaml.Controls
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
 #if __SKIA__
-			// Skia: synchronous delay/counter mechanism matching WinUI behavior.
-			// Offsets are set immediately; RaiseViewChanged respects the delay counter.
-			HorizontalOffset = horizontalOffset;
-			VerticalOffset = verticalOffset;
+			// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
+			// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
+			// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+			_pendingHorizontalOffset = horizontalOffset;
+			_pendingVerticalOffset = verticalOffset;
+			_pendingScrollIsIntermediate = isIntermediate;
+			_hasPendingScrollUpdate = true;
 
-			RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+			_presenter?.InvalidateArrange();
 #else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
@@ -1334,6 +1337,14 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool m_isViewChangedRaisedInIntermediateMode;
 		private int m_iViewChangedDelay;
 
+		// Pending offsets — applied during ArrangeOverride to align with WinUI behavior.
+		// On WinUI, offsets are stored via SetOffsetsWithExtents + InvalidateArrange and
+		// applied during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+		private double _pendingHorizontalOffset;
+		private double _pendingVerticalOffset;
+		private bool _pendingScrollIsIntermediate;
+		private bool _hasPendingScrollUpdate;
+
 		/// <summary>
 		/// Increments the delay counter to prevent ViewChanged from being raised.
 		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
@@ -1417,8 +1428,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		/// <summary>
 		/// Leaves intermediate mode. If ViewChanged was raised during intermediate mode
-		/// and <paramref name="raiseFinalViewChanged"/> is true, raises a final
-		/// ViewChanged event with IsIntermediate=false.
+		/// and <paramref name="raiseFinalViewChanged"/> is true, ensures a final
+		/// ViewChanged event with IsIntermediate=false is raised.
+		/// When a pending scroll update exists (from OnPresenterScrolled), the final event
+		/// is raised during the arrange pass via <see cref="OnPresenterArranged"/>.
 		/// </summary>
 		internal void LeaveIntermediateViewChangedMode(bool raiseFinalViewChanged)
 		{
@@ -1430,11 +1443,32 @@ namespace Microsoft.UI.Xaml.Controls
 				{
 					m_isViewChangedRaisedInIntermediateMode = false;
 
-					if (raiseFinalViewChanged)
+					if (raiseFinalViewChanged && !_hasPendingScrollUpdate)
 					{
+						// No pending scroll update will trigger an arrange, so raise directly.
 						RaiseViewChanged(isIntermediate: false);
 					}
+					// Otherwise, the pending scroll update from OnCompleted's Set(IsIntermediate: false)
+					// will raise the final non-intermediate event during OnPresenterArranged.
 				}
+			}
+		}
+
+		/// <summary>
+		/// Called from <see cref="ScrollContentPresenter.ArrangeOverride"/> to flush
+		/// pending scroll offset updates. Aligns with WinUI where offset DPs are updated
+		/// during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+		/// </summary>
+		internal void OnPresenterArranged()
+		{
+			if (_hasPendingScrollUpdate)
+			{
+				_hasPendingScrollUpdate = false;
+
+				HorizontalOffset = _pendingHorizontalOffset;
+				VerticalOffset = _pendingVerticalOffset;
+
+				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode);
 			}
 		}
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1270,15 +1270,28 @@ namespace Microsoft.UI.Xaml.Controls
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
 #if __SKIA__
-			// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
-			// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
-			// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 			_pendingScrollIsIntermediate = isIntermediate;
-			_hasPendingScrollUpdate = true;
 
-			_presenter?.InvalidateArrange();
+			if (UpdatesMode == Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
+			{
+				// Synchronous mode: update DPs immediately (used for testing).
+				// This bypasses the WinUI-aligned deferred path so that test assertions
+				// can read VerticalOffset/HorizontalOffset right after input injection.
+				_hasPendingScrollUpdate = false;
+				HorizontalOffset = horizontalOffset;
+				VerticalOffset = verticalOffset;
+				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+			}
+			else
+			{
+				// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
+				// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
+				// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+				_hasPendingScrollUpdate = true;
+				_presenter?.InvalidateArrange();
+			}
 #else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1270,12 +1270,15 @@ namespace Microsoft.UI.Xaml.Controls
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
 #if __SKIA__
-			// Skia: synchronous delay/counter mechanism matching WinUI behavior.
-			// Offsets are set immediately; RaiseViewChanged respects the delay counter.
-			HorizontalOffset = horizontalOffset;
-			VerticalOffset = verticalOffset;
+			// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
+			// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
+			// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+			_pendingHorizontalOffset = horizontalOffset;
+			_pendingVerticalOffset = verticalOffset;
+			_pendingScrollIsIntermediate = isIntermediate;
+			_hasPendingScrollUpdate = true;
 
-			RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+			_presenter?.InvalidateArrange();
 #else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
@@ -1362,6 +1365,14 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool m_isViewChangedRaisedInIntermediateMode;
 		private int m_iViewChangedDelay;
 
+		// Pending offsets — applied during ArrangeOverride to align with WinUI behavior.
+		// On WinUI, offsets are stored via SetOffsetsWithExtents + InvalidateArrange and
+		// applied during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+		private double _pendingHorizontalOffset;
+		private double _pendingVerticalOffset;
+		private bool _pendingScrollIsIntermediate;
+		private bool _hasPendingScrollUpdate;
+
 		/// <summary>
 		/// Increments the delay counter to prevent ViewChanged from being raised.
 		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
@@ -1445,8 +1456,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		/// <summary>
 		/// Leaves intermediate mode. If ViewChanged was raised during intermediate mode
-		/// and <paramref name="raiseFinalViewChanged"/> is true, raises a final
-		/// ViewChanged event with IsIntermediate=false.
+		/// and <paramref name="raiseFinalViewChanged"/> is true, ensures a final
+		/// ViewChanged event with IsIntermediate=false is raised.
+		/// When a pending scroll update exists (from OnPresenterScrolled), the final event
+		/// is raised during the arrange pass via <see cref="OnPresenterArranged"/>.
 		/// </summary>
 		internal void LeaveIntermediateViewChangedMode(bool raiseFinalViewChanged)
 		{
@@ -1458,11 +1471,32 @@ namespace Microsoft.UI.Xaml.Controls
 				{
 					m_isViewChangedRaisedInIntermediateMode = false;
 
-					if (raiseFinalViewChanged)
+					if (raiseFinalViewChanged && !_hasPendingScrollUpdate)
 					{
+						// No pending scroll update will trigger an arrange, so raise directly.
 						RaiseViewChanged(isIntermediate: false);
 					}
+					// Otherwise, the pending scroll update from OnCompleted's Set(IsIntermediate: false)
+					// will raise the final non-intermediate event during OnPresenterArranged.
 				}
+			}
+		}
+
+		/// <summary>
+		/// Called from <see cref="ScrollContentPresenter.ArrangeOverride"/> to flush
+		/// pending scroll offset updates. Aligns with WinUI where offset DPs are updated
+		/// during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+		/// </summary>
+		internal void OnPresenterArranged()
+		{
+			if (_hasPendingScrollUpdate)
+			{
+				_hasPendingScrollUpdate = false;
+
+				HorizontalOffset = _pendingHorizontalOffset;
+				VerticalOffset = _pendingVerticalOffset;
+
+				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode);
 			}
 		}
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1269,50 +1269,58 @@ namespace Microsoft.UI.Xaml.Controls
 		// Presenter to Control, i.e. OnPresenterScrolled
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
+#if __SKIA__
+			// Skia: synchronous delay/counter mechanism matching WinUI behavior.
+			// Offsets are set immediately; RaiseViewChanged respects the delay counter.
+			HorizontalOffset = horizontalOffset;
+			VerticalOffset = verticalOffset;
+
+			RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+#else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 
 			if (isIntermediate && UpdatesMode != Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
 			{
 				RequestUpdate();
-				_snapPointsTimer?.Stop();
 			}
 			else
 			{
 				Update(isIntermediate);
-
-				if (isIntermediate)
-				{
-					// when intermediate (aka manual) scrolling occurs,
-					// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
-					_snapPointsTimer?.Stop();
-				}
-				if (!isIntermediate
-#if __APPLE_UIKIT__ || __ANDROID__
-					&& (_presenter as ListViewBaseScrollContentPresenter)?.NativePanel?.UseNativeSnapping != true
+			}
 #endif
-					)
+
+			if (isIntermediate)
+			{
+				// when intermediate (aka manual) scrolling occurs,
+				// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
+				_snapPointsTimer?.Stop();
+			}
+			else if (!isIntermediate
+#if __APPLE_UIKIT__ || __ANDROID__
+				&& (_presenter as ListViewBaseScrollContentPresenter)?.NativePanel?.UseNativeSnapping != true
+#endif
+				)
+			{
+				if (HorizontalSnapPointsType != SnapPointsType.None
+					|| VerticalSnapPointsType != SnapPointsType.None
+					|| ShouldSnapToTouchTextBox())
 				{
-					if (HorizontalSnapPointsType != SnapPointsType.None
-						|| VerticalSnapPointsType != SnapPointsType.None
-						|| ShouldSnapToTouchTextBox())
+					_horizontalOffsetForSnapPoints = horizontalOffset;
+					_verticalOffsetForSnapPoints = verticalOffset;
+
+					if (_snapPointsTimer == null)
 					{
-						_horizontalOffsetForSnapPoints = horizontalOffset;
-						_verticalOffsetForSnapPoints = verticalOffset;
-
-						if (_snapPointsTimer == null)
+						_snapPointsTimer = global::Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
+						_snapPointsTimer.IsRepeating = false;
+						_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
+						_snapPointsTimer.Tick += (snd, evt) =>
 						{
-							_snapPointsTimer = global::Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
-							_snapPointsTimer.IsRepeating = false;
-							_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
-							_snapPointsTimer.Tick += (snd, evt) =>
-							{
-								DelayedMoveToSnapPoint();
-							};
-						}
-
-						_snapPointsTimer.Start();
+							DelayedMoveToSnapPoint();
+						};
 					}
+
+					_snapPointsTimer.Start();
 				}
 			}
 
@@ -1332,13 +1340,132 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			ZoomFactor = zoomFactor;
 
+#if __SKIA__
+			RaiseViewChanged(isIntermediate: false);
+#else
 			// Note: We should also defer the intermediate zoom changes
 			Update(isIntermediate: false);
+#endif
 
 			UpdateZoomedContentAlignment();
 		}
 
 		#region Deferred update (i.e. ViewChanged) support
+#if __SKIA__
+		// WinUI-compatible synchronous delay/counter mechanism for ViewChanged event batching.
+		// WinUI uses m_iViewChangedDelay as a nestable counter: callers increment via DelayViewChanged()
+		// before operations that may trigger multiple property changes, then decrement via FlushViewChanged().
+		// Events are stored while the counter is positive and raised when it returns to zero.
+		private bool m_isViewChangedDelayed;
+		private bool m_isDelayedViewChangedIntermediate;
+		private bool m_isInIntermediateViewChangedMode;
+		private bool m_isViewChangedRaisedInIntermediateMode;
+		private int m_iViewChangedDelay;
+
+		/// <summary>
+		/// Increments the delay counter to prevent ViewChanged from being raised.
+		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
+		/// </summary>
+		internal void DelayViewChanged()
+		{
+			m_iViewChangedDelay++;
+		}
+
+		/// <summary>
+		/// Decrements the delay counter and raises any stored ViewChanged event
+		/// when the counter reaches zero.
+		/// </summary>
+		internal void FlushViewChanged()
+		{
+			Debug.Assert(m_iViewChangedDelay > 0);
+
+			m_iViewChangedDelay--;
+
+			if (m_iViewChangedDelay == 0 && m_isViewChangedDelayed)
+			{
+				RaiseViewChanged(m_isDelayedViewChangedIntermediate);
+			}
+		}
+
+		/// <summary>
+		/// Raises the ViewChanged event, or stores it for later if the delay counter is active.
+		/// When delayed, only the latest isIntermediate value is retained.
+		/// </summary>
+		private void RaiseViewChanged(bool isIntermediate)
+		{
+			if (m_iViewChangedDelay > 0)
+			{
+				// Batch: store the event for later, keeping the latest isIntermediate value.
+				m_isViewChangedDelayed = true;
+				m_isDelayedViewChangedIntermediate = isIntermediate;
+				return;
+			}
+
+			if (m_isInIntermediateViewChangedMode)
+			{
+				// Track that ViewChanged was raised during intermediate mode so that
+				// LeaveIntermediateViewChangedMode can raise a final non-intermediate event.
+				m_isViewChangedRaisedInIntermediateMode = true;
+			}
+
+			m_isViewChangedDelayed = false;
+
+			if (AutomationPeer.ListenerExistsHelper(AutomationEvents.PropertyChanged) &&
+				GetAutomationPeer() is ScrollViewerAutomationPeer peer)
+			{
+				peer.RaiseAutomationEvents(
+					ExtentWidth,
+					ExtentHeight,
+					ViewportWidth,
+					ViewportHeight,
+					MinHorizontalOffset,
+					MinVerticalOffset,
+					HorizontalOffset,
+					VerticalOffset);
+			}
+
+			UpdatePartial(isIntermediate);
+
+			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
+		}
+
+		/// <summary>
+		/// Enters intermediate mode. All ViewChanged events raised while in this mode
+		/// will have IsIntermediate set to true. A final non-intermediate event is raised
+		/// when leaving intermediate mode via <see cref="LeaveIntermediateViewChangedMode"/>.
+		/// </summary>
+		internal void EnterIntermediateViewChangedMode()
+		{
+			if (!m_isInIntermediateViewChangedMode)
+			{
+				m_isInIntermediateViewChangedMode = true;
+				m_isViewChangedRaisedInIntermediateMode = false;
+			}
+		}
+
+		/// <summary>
+		/// Leaves intermediate mode. If ViewChanged was raised during intermediate mode
+		/// and <paramref name="raiseFinalViewChanged"/> is true, raises a final
+		/// ViewChanged event with IsIntermediate=false.
+		/// </summary>
+		internal void LeaveIntermediateViewChangedMode(bool raiseFinalViewChanged)
+		{
+			if (m_isInIntermediateViewChangedMode)
+			{
+				m_isInIntermediateViewChangedMode = false;
+
+				if (m_isViewChangedRaisedInIntermediateMode)
+				{
+					m_isViewChangedRaisedInIntermediateMode = false;
+
+					if (raiseFinalViewChanged)
+					{
+						RaiseViewChanged(isIntermediate: false);
+					}
+				}
+			}
+		}
+#else
 		private bool _hasPendingUpdate;
 		private double _pendingHorizontalOffset;
 		private double _pendingVerticalOffset;
@@ -1400,6 +1527,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
 		}
+#endif
 
 		partial void UpdatePartial(bool isIntermediate);
 		#endregion
@@ -1554,12 +1682,32 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (verticalOffsetChanged || horizontalOffsetChanged || zoomFactorChanged)
 			{
+#if __SKIA__
+				// Batch ViewChanged events during the programmatic view change.
+				// When disableAnimation is true, the entire SCP → OnPresenterScrolled chain
+				// is synchronous, so the delay counter batches the events within this scope.
+				DelayViewChanged();
+				try
+				{
+					return ChangeViewCore(
+						horizontalOffset,
+						verticalOffset,
+						zoomFactor,
+						disableAnimation,
+						shouldSnap: true);
+				}
+				finally
+				{
+					FlushViewChanged();
+				}
+#else
 				return ChangeViewCore(
 					horizontalOffset,
 					verticalOffset,
 					zoomFactor,
 					disableAnimation,
 					shouldSnap: true);
+#endif
 			}
 			else
 			{
@@ -1691,8 +1839,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private static readonly bool _indicatorResetDisabled = _indicatorResetDelay == TimeSpan.MaxValue;
 		private DispatcherQueueTimer? _indicatorResetTimer;
 		private string? _indicatorState;
-		//private bool m_isInIntermediateViewChangedMode;
-		//private bool m_isViewChangedRaisedInIntermediateMode;
 		//private bool m_isDraggingThumb;
 
 		private void PrepareScrollIndicator() // OnApplyTemplate

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1280,9 +1280,13 @@ namespace Microsoft.UI.Xaml.Controls
 				// This bypasses the WinUI-aligned deferred path so that test assertions
 				// can read VerticalOffset/HorizontalOffset right after input injection.
 				_hasPendingScrollUpdate = false;
+
+				var oldHorizontalOffset = HorizontalOffset;
+				var oldVerticalOffset = VerticalOffset;
+
 				HorizontalOffset = horizontalOffset;
 				VerticalOffset = verticalOffset;
-				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode, oldHorizontalOffset, oldVerticalOffset);
 			}
 			else
 			{
@@ -1386,6 +1390,11 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingScrollIsIntermediate;
 		private bool _hasPendingScrollUpdate;
 
+		// Offsets as they were before the first batched change, so the automation peer still sees
+		// a real old → new transition when the batch is eventually flushed.
+		private double m_delayedViewChangedOldHorizontalOffset;
+		private double m_delayedViewChangedOldVerticalOffset;
+
 		/// <summary>
 		/// Increments the delay counter to prevent ViewChanged from being raised.
 		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
@@ -1407,19 +1416,33 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (m_iViewChangedDelay == 0 && m_isViewChangedDelayed)
 			{
-				RaiseViewChanged(m_isDelayedViewChangedIntermediate);
+				RaiseViewChanged(m_isDelayedViewChangedIntermediate, m_delayedViewChangedOldHorizontalOffset, m_delayedViewChangedOldVerticalOffset);
 			}
 		}
+
+		/// <summary>
+		/// Raises the ViewChanged event for a change that did not alter the offsets.
+		/// </summary>
+		private void RaiseViewChanged(bool isIntermediate)
+			=> RaiseViewChanged(isIntermediate, HorizontalOffset, VerticalOffset);
 
 		/// <summary>
 		/// Raises the ViewChanged event, or stores it for later if the delay counter is active.
 		/// When delayed, only the latest isIntermediate value is retained.
 		/// </summary>
-		private void RaiseViewChanged(bool isIntermediate)
+		/// <param name="oldHorizontalOffset">The horizontal offset before the change, as expected by the automation peer.</param>
+		/// <param name="oldVerticalOffset">The vertical offset before the change, as expected by the automation peer.</param>
+		private void RaiseViewChanged(bool isIntermediate, double oldHorizontalOffset, double oldVerticalOffset)
 		{
 			if (m_iViewChangedDelay > 0)
 			{
 				// Batch: store the event for later, keeping the latest isIntermediate value.
+				if (!m_isViewChangedDelayed)
+				{
+					m_delayedViewChangedOldHorizontalOffset = oldHorizontalOffset;
+					m_delayedViewChangedOldVerticalOffset = oldVerticalOffset;
+				}
+
 				m_isViewChangedDelayed = true;
 				m_isDelayedViewChangedIntermediate = isIntermediate;
 				return;
@@ -1444,8 +1467,8 @@ namespace Microsoft.UI.Xaml.Controls
 					ViewportHeight,
 					MinHorizontalOffset,
 					MinVerticalOffset,
-					HorizontalOffset,
-					VerticalOffset);
+					oldHorizontalOffset,
+					oldVerticalOffset);
 			}
 
 			UpdatePartial(isIntermediate);
@@ -1506,10 +1529,13 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				_hasPendingScrollUpdate = false;
 
+				var oldHorizontalOffset = HorizontalOffset;
+				var oldVerticalOffset = VerticalOffset;
+
 				HorizontalOffset = _pendingHorizontalOffset;
 				VerticalOffset = _pendingVerticalOffset;
 
-				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode);
+				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode, oldHorizontalOffset, oldVerticalOffset);
 			}
 		}
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1178,7 +1178,6 @@ namespace Microsoft.UI.Xaml.Controls
 		// Presenter to Control, i.e. OnPresenterScrolled
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
-#if __SKIA__
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 			_pendingScrollIsIntermediate = isIntermediate;
@@ -1205,19 +1204,6 @@ namespace Microsoft.UI.Xaml.Controls
 				_hasPendingScrollUpdate = true;
 				_presenter?.InvalidateArrange();
 			}
-#else
-			_pendingHorizontalOffset = horizontalOffset;
-			_pendingVerticalOffset = verticalOffset;
-
-			if (isIntermediate && UpdatesMode != Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
-			{
-				RequestUpdate();
-			}
-			else
-			{
-				Update(isIntermediate);
-			}
-#endif
 
 			if (isIntermediate)
 			{
@@ -1259,18 +1245,12 @@ namespace Microsoft.UI.Xaml.Controls
 			// Recalculate scrollable dimensions with new zoom factor
 			UpdateDimensionProperties();
 
-#if __SKIA__
 			RaiseViewChanged(isIntermediate: false);
-#else
-			// Note: We should also defer the intermediate zoom changes
-			Update(isIntermediate: false);
-#endif
 
 			UpdateZoomedContentAlignment();
 		}
 
 		#region Deferred update (i.e. ViewChanged) support
-#if __SKIA__
 		// WinUI-compatible synchronous delay/counter mechanism for ViewChanged event batching.
 		// WinUI uses m_iViewChangedDelay as a nestable counter: callers increment via DelayViewChanged()
 		// before operations that may trigger multiple property changes, then decrement via FlushViewChanged().
@@ -1437,69 +1417,6 @@ namespace Microsoft.UI.Xaml.Controls
 				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode, oldHorizontalOffset, oldVerticalOffset);
 			}
 		}
-#else
-		private bool _hasPendingUpdate;
-		private double _pendingHorizontalOffset;
-		private double _pendingVerticalOffset;
-
-		private void RequestUpdate()
-		{
-			if (_hasPendingUpdate)
-			{
-				return;
-			}
-
-			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-			{
-				if (_hasPendingUpdate)
-				{
-					Update(isIntermediate: true);
-				}
-			});
-			_hasPendingUpdate = true;
-		}
-
-		private void Update(bool isIntermediate)
-		{
-			_hasPendingUpdate = false;
-
-			var oldHorizontalOffset = HorizontalOffset;
-			var oldVerticalOffset = VerticalOffset;
-
-			HorizontalOffset = _pendingHorizontalOffset;
-			VerticalOffset = _pendingVerticalOffset;
-
-			if (!isIntermediate && (oldHorizontalOffset != HorizontalOffset || oldVerticalOffset != VerticalOffset))
-			{
-				// Mirrors ScrollContentPresenter_Partial.cpp:871 (SetHorizontalOffsetPrivate /
-				// SetVerticalOffsetPrivate): discrete offset changes schedule an arrange so that
-				// AnchoringArrangeOverride re-selects CurrentAnchor against the new viewport.
-				// Intermediate ticks (DManip-driven inertia / drag) are skipped to match WinUI,
-				// which lets the compositor drive offsets during manipulation without re-running
-				// layout per frame.
-				InvalidateArrange();
-			}
-
-			// Not ideal, and doesn't match WinUI. This can miss raising some automation events.
-			if (AutomationPeer.ListenerExistsHelper(AutomationEvents.PropertyChanged) &&
-				GetAutomationPeer() is ScrollViewerAutomationPeer peer)
-			{
-				peer.RaiseAutomationEvents(
-					ExtentWidth,
-					ExtentHeight,
-					ViewportWidth,
-					ViewportHeight,
-					MinHorizontalOffset,
-					MinVerticalOffset,
-					oldHorizontalOffset,
-					oldVerticalOffset);
-			}
-
-			UpdatePartial(isIntermediate);
-
-			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
-		}
-#endif
 
 		partial void UpdatePartial(bool isIntermediate);
 		#endregion
@@ -1654,7 +1571,6 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (verticalOffsetChanged || horizontalOffsetChanged || zoomFactorChanged)
 			{
-#if __SKIA__
 				// Batch ViewChanged events during the programmatic view change.
 				// When disableAnimation is true, the entire SCP → OnPresenterScrolled chain
 				// is synchronous, so the delay counter batches the events within this scope.
@@ -1672,14 +1588,6 @@ namespace Microsoft.UI.Xaml.Controls
 				{
 					FlushViewChanged();
 				}
-#else
-				return ChangeViewCore(
-					horizontalOffset,
-					verticalOffset,
-					zoomFactor,
-					disableAnimation,
-					shouldSnap: true);
-#endif
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1178,46 +1178,54 @@ namespace Microsoft.UI.Xaml.Controls
 		// Presenter to Control, i.e. OnPresenterScrolled
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
+#if __SKIA__
+			// Skia: synchronous delay/counter mechanism matching WinUI behavior.
+			// Offsets are set immediately; RaiseViewChanged respects the delay counter.
+			HorizontalOffset = horizontalOffset;
+			VerticalOffset = verticalOffset;
+
+			RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+#else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 
 			if (isIntermediate && UpdatesMode != Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
 			{
 				RequestUpdate();
-				_snapPointsTimer?.Stop();
 			}
 			else
 			{
 				Update(isIntermediate);
+			}
+#endif
 
-				if (isIntermediate)
+			if (isIntermediate)
+			{
+				// when intermediate (aka manual) scrolling occurs,
+				// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
+				_snapPointsTimer?.Stop();
+			}
+			else if (!isIntermediate
+				)
+			{
+				if (HorizontalSnapPointsType != SnapPointsType.None
+					|| VerticalSnapPointsType != SnapPointsType.None)
 				{
-					// when intermediate (aka manual) scrolling occurs,
-					// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
-					_snapPointsTimer?.Stop();
-				}
-				if (!isIntermediate
-					)
-				{
-					if (HorizontalSnapPointsType != SnapPointsType.None
-						|| VerticalSnapPointsType != SnapPointsType.None)
+					_horizontalOffsetForSnapPoints = horizontalOffset;
+					_verticalOffsetForSnapPoints = verticalOffset;
+
+					if (_snapPointsTimer == null)
 					{
-						_horizontalOffsetForSnapPoints = horizontalOffset;
-						_verticalOffsetForSnapPoints = verticalOffset;
-
-						if (_snapPointsTimer == null)
+						_snapPointsTimer = global::Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
+						_snapPointsTimer.IsRepeating = false;
+						_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
+						_snapPointsTimer.Tick += (snd, evt) =>
 						{
-							_snapPointsTimer = global::Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
-							_snapPointsTimer.IsRepeating = false;
-							_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
-							_snapPointsTimer.Tick += (snd, evt) =>
-							{
-								DelayedMoveToSnapPoint();
-							};
-						}
-
-						_snapPointsTimer.Start();
+							DelayedMoveToSnapPoint();
+						};
 					}
+
+					_snapPointsTimer.Start();
 				}
 			}
 
@@ -1231,13 +1239,132 @@ namespace Microsoft.UI.Xaml.Controls
 			// Recalculate scrollable dimensions with new zoom factor
 			UpdateDimensionProperties();
 
+#if __SKIA__
+			RaiseViewChanged(isIntermediate: false);
+#else
 			// Note: We should also defer the intermediate zoom changes
 			Update(isIntermediate: false);
+#endif
 
 			UpdateZoomedContentAlignment();
 		}
 
 		#region Deferred update (i.e. ViewChanged) support
+#if __SKIA__
+		// WinUI-compatible synchronous delay/counter mechanism for ViewChanged event batching.
+		// WinUI uses m_iViewChangedDelay as a nestable counter: callers increment via DelayViewChanged()
+		// before operations that may trigger multiple property changes, then decrement via FlushViewChanged().
+		// Events are stored while the counter is positive and raised when it returns to zero.
+		private bool m_isViewChangedDelayed;
+		private bool m_isDelayedViewChangedIntermediate;
+		private bool m_isInIntermediateViewChangedMode;
+		private bool m_isViewChangedRaisedInIntermediateMode;
+		private int m_iViewChangedDelay;
+
+		/// <summary>
+		/// Increments the delay counter to prevent ViewChanged from being raised.
+		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
+		/// </summary>
+		internal void DelayViewChanged()
+		{
+			m_iViewChangedDelay++;
+		}
+
+		/// <summary>
+		/// Decrements the delay counter and raises any stored ViewChanged event
+		/// when the counter reaches zero.
+		/// </summary>
+		internal void FlushViewChanged()
+		{
+			Debug.Assert(m_iViewChangedDelay > 0);
+
+			m_iViewChangedDelay--;
+
+			if (m_iViewChangedDelay == 0 && m_isViewChangedDelayed)
+			{
+				RaiseViewChanged(m_isDelayedViewChangedIntermediate);
+			}
+		}
+
+		/// <summary>
+		/// Raises the ViewChanged event, or stores it for later if the delay counter is active.
+		/// When delayed, only the latest isIntermediate value is retained.
+		/// </summary>
+		private void RaiseViewChanged(bool isIntermediate)
+		{
+			if (m_iViewChangedDelay > 0)
+			{
+				// Batch: store the event for later, keeping the latest isIntermediate value.
+				m_isViewChangedDelayed = true;
+				m_isDelayedViewChangedIntermediate = isIntermediate;
+				return;
+			}
+
+			if (m_isInIntermediateViewChangedMode)
+			{
+				// Track that ViewChanged was raised during intermediate mode so that
+				// LeaveIntermediateViewChangedMode can raise a final non-intermediate event.
+				m_isViewChangedRaisedInIntermediateMode = true;
+			}
+
+			m_isViewChangedDelayed = false;
+
+			if (AutomationPeer.ListenerExistsHelper(AutomationEvents.PropertyChanged) &&
+				GetAutomationPeer() is ScrollViewerAutomationPeer peer)
+			{
+				peer.RaiseAutomationEvents(
+					ExtentWidth,
+					ExtentHeight,
+					ViewportWidth,
+					ViewportHeight,
+					MinHorizontalOffset,
+					MinVerticalOffset,
+					HorizontalOffset,
+					VerticalOffset);
+			}
+
+			UpdatePartial(isIntermediate);
+
+			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
+		}
+
+		/// <summary>
+		/// Enters intermediate mode. All ViewChanged events raised while in this mode
+		/// will have IsIntermediate set to true. A final non-intermediate event is raised
+		/// when leaving intermediate mode via <see cref="LeaveIntermediateViewChangedMode"/>.
+		/// </summary>
+		internal void EnterIntermediateViewChangedMode()
+		{
+			if (!m_isInIntermediateViewChangedMode)
+			{
+				m_isInIntermediateViewChangedMode = true;
+				m_isViewChangedRaisedInIntermediateMode = false;
+			}
+		}
+
+		/// <summary>
+		/// Leaves intermediate mode. If ViewChanged was raised during intermediate mode
+		/// and <paramref name="raiseFinalViewChanged"/> is true, raises a final
+		/// ViewChanged event with IsIntermediate=false.
+		/// </summary>
+		internal void LeaveIntermediateViewChangedMode(bool raiseFinalViewChanged)
+		{
+			if (m_isInIntermediateViewChangedMode)
+			{
+				m_isInIntermediateViewChangedMode = false;
+
+				if (m_isViewChangedRaisedInIntermediateMode)
+				{
+					m_isViewChangedRaisedInIntermediateMode = false;
+
+					if (raiseFinalViewChanged)
+					{
+						RaiseViewChanged(isIntermediate: false);
+					}
+				}
+			}
+		}
+#else
 		private bool _hasPendingUpdate;
 		private double _pendingHorizontalOffset;
 		private double _pendingVerticalOffset;
@@ -1299,6 +1426,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			ViewChanged?.Invoke(this, new ScrollViewerViewChangedEventArgs { IsIntermediate = isIntermediate });
 		}
+#endif
 
 		partial void UpdatePartial(bool isIntermediate);
 		#endregion
@@ -1453,12 +1581,32 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (verticalOffsetChanged || horizontalOffsetChanged || zoomFactorChanged)
 			{
+#if __SKIA__
+				// Batch ViewChanged events during the programmatic view change.
+				// When disableAnimation is true, the entire SCP → OnPresenterScrolled chain
+				// is synchronous, so the delay counter batches the events within this scope.
+				DelayViewChanged();
+				try
+				{
+					return ChangeViewCore(
+						horizontalOffset,
+						verticalOffset,
+						zoomFactor,
+						disableAnimation,
+						shouldSnap: true);
+				}
+				finally
+				{
+					FlushViewChanged();
+				}
+#else
 				return ChangeViewCore(
 					horizontalOffset,
 					verticalOffset,
 					zoomFactor,
 					disableAnimation,
 					shouldSnap: true);
+#endif
 			}
 			else
 			{
@@ -1588,8 +1736,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private static readonly bool _indicatorResetDisabled = _indicatorResetDelay == TimeSpan.MaxValue;
 		private DispatcherQueueTimer? _indicatorResetTimer;
 		private string? _indicatorState;
-		//private bool m_isInIntermediateViewChangedMode;
-		//private bool m_isViewChangedRaisedInIntermediateMode;
 		//private bool m_isDraggingThumb;
 
 		private void PrepareScrollIndicator() // OnApplyTemplate

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1179,15 +1179,28 @@ namespace Microsoft.UI.Xaml.Controls
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
 #if __SKIA__
-			// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
-			// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
-			// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
 			_pendingScrollIsIntermediate = isIntermediate;
-			_hasPendingScrollUpdate = true;
 
-			_presenter?.InvalidateArrange();
+			if (UpdatesMode == Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
+			{
+				// Synchronous mode: update DPs immediately (used for testing).
+				// This bypasses the WinUI-aligned deferred path so that test assertions
+				// can read VerticalOffset/HorizontalOffset right after input injection.
+				_hasPendingScrollUpdate = false;
+				HorizontalOffset = horizontalOffset;
+				VerticalOffset = verticalOffset;
+				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+			}
+			else
+			{
+				// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
+				// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
+				// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+				_hasPendingScrollUpdate = true;
+				_presenter?.InvalidateArrange();
+			}
 #else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1179,12 +1179,15 @@ namespace Microsoft.UI.Xaml.Controls
 		internal void OnPresenterScrolled(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
 #if __SKIA__
-			// Skia: synchronous delay/counter mechanism matching WinUI behavior.
-			// Offsets are set immediately; RaiseViewChanged respects the delay counter.
-			HorizontalOffset = horizontalOffset;
-			VerticalOffset = verticalOffset;
+			// WinUI-aligned behavior: store pending offsets and defer DP updates to ArrangeOverride.
+			// On WinUI, SetOffsetsWithExtents stores offsets in ScrollData + InvalidateArrange;
+			// the DPs are updated during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+			_pendingHorizontalOffset = horizontalOffset;
+			_pendingVerticalOffset = verticalOffset;
+			_pendingScrollIsIntermediate = isIntermediate;
+			_hasPendingScrollUpdate = true;
 
-			RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+			_presenter?.InvalidateArrange();
 #else
 			_pendingHorizontalOffset = horizontalOffset;
 			_pendingVerticalOffset = verticalOffset;
@@ -1260,6 +1263,14 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool m_isInIntermediateViewChangedMode;
 		private bool m_isViewChangedRaisedInIntermediateMode;
 		private int m_iViewChangedDelay;
+
+		// Pending offsets — applied during ArrangeOverride to align with WinUI behavior.
+		// On WinUI, offsets are stored via SetOffsetsWithExtents + InvalidateArrange and
+		// applied during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+		private double _pendingHorizontalOffset;
+		private double _pendingVerticalOffset;
+		private bool _pendingScrollIsIntermediate;
+		private bool _hasPendingScrollUpdate;
 
 		/// <summary>
 		/// Increments the delay counter to prevent ViewChanged from being raised.
@@ -1344,8 +1355,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		/// <summary>
 		/// Leaves intermediate mode. If ViewChanged was raised during intermediate mode
-		/// and <paramref name="raiseFinalViewChanged"/> is true, raises a final
-		/// ViewChanged event with IsIntermediate=false.
+		/// and <paramref name="raiseFinalViewChanged"/> is true, ensures a final
+		/// ViewChanged event with IsIntermediate=false is raised.
+		/// When a pending scroll update exists (from OnPresenterScrolled), the final event
+		/// is raised during the arrange pass via <see cref="OnPresenterArranged"/>.
 		/// </summary>
 		internal void LeaveIntermediateViewChangedMode(bool raiseFinalViewChanged)
 		{
@@ -1357,11 +1370,32 @@ namespace Microsoft.UI.Xaml.Controls
 				{
 					m_isViewChangedRaisedInIntermediateMode = false;
 
-					if (raiseFinalViewChanged)
+					if (raiseFinalViewChanged && !_hasPendingScrollUpdate)
 					{
+						// No pending scroll update will trigger an arrange, so raise directly.
 						RaiseViewChanged(isIntermediate: false);
 					}
+					// Otherwise, the pending scroll update from OnCompleted's Set(IsIntermediate: false)
+					// will raise the final non-intermediate event during OnPresenterArranged.
 				}
+			}
+		}
+
+		/// <summary>
+		/// Called from <see cref="ScrollContentPresenter.ArrangeOverride"/> to flush
+		/// pending scroll offset updates. Aligns with WinUI where offset DPs are updated
+		/// during ArrangeOverride → VerifyScrollData → put_HorizontalOffset/VerticalOffset.
+		/// </summary>
+		internal void OnPresenterArranged()
+		{
+			if (_hasPendingScrollUpdate)
+			{
+				_hasPendingScrollUpdate = false;
+
+				HorizontalOffset = _pendingHorizontalOffset;
+				VerticalOffset = _pendingVerticalOffset;
+
+				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode);
 			}
 		}
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1189,9 +1189,13 @@ namespace Microsoft.UI.Xaml.Controls
 				// This bypasses the WinUI-aligned deferred path so that test assertions
 				// can read VerticalOffset/HorizontalOffset right after input injection.
 				_hasPendingScrollUpdate = false;
+
+				var oldHorizontalOffset = HorizontalOffset;
+				var oldVerticalOffset = VerticalOffset;
+
 				HorizontalOffset = horizontalOffset;
 				VerticalOffset = verticalOffset;
-				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode);
+				RaiseViewChanged(isIntermediate || m_isInIntermediateViewChangedMode, oldHorizontalOffset, oldVerticalOffset);
 			}
 			else
 			{
@@ -1285,6 +1289,11 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _pendingScrollIsIntermediate;
 		private bool _hasPendingScrollUpdate;
 
+		// Offsets as they were before the first batched change, so the automation peer still sees
+		// a real old → new transition when the batch is eventually flushed.
+		private double m_delayedViewChangedOldHorizontalOffset;
+		private double m_delayedViewChangedOldVerticalOffset;
+
 		/// <summary>
 		/// Increments the delay counter to prevent ViewChanged from being raised.
 		/// Must be paired with a call to <see cref="FlushViewChanged"/>.
@@ -1306,19 +1315,33 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (m_iViewChangedDelay == 0 && m_isViewChangedDelayed)
 			{
-				RaiseViewChanged(m_isDelayedViewChangedIntermediate);
+				RaiseViewChanged(m_isDelayedViewChangedIntermediate, m_delayedViewChangedOldHorizontalOffset, m_delayedViewChangedOldVerticalOffset);
 			}
 		}
+
+		/// <summary>
+		/// Raises the ViewChanged event for a change that did not alter the offsets.
+		/// </summary>
+		private void RaiseViewChanged(bool isIntermediate)
+			=> RaiseViewChanged(isIntermediate, HorizontalOffset, VerticalOffset);
 
 		/// <summary>
 		/// Raises the ViewChanged event, or stores it for later if the delay counter is active.
 		/// When delayed, only the latest isIntermediate value is retained.
 		/// </summary>
-		private void RaiseViewChanged(bool isIntermediate)
+		/// <param name="oldHorizontalOffset">The horizontal offset before the change, as expected by the automation peer.</param>
+		/// <param name="oldVerticalOffset">The vertical offset before the change, as expected by the automation peer.</param>
+		private void RaiseViewChanged(bool isIntermediate, double oldHorizontalOffset, double oldVerticalOffset)
 		{
 			if (m_iViewChangedDelay > 0)
 			{
 				// Batch: store the event for later, keeping the latest isIntermediate value.
+				if (!m_isViewChangedDelayed)
+				{
+					m_delayedViewChangedOldHorizontalOffset = oldHorizontalOffset;
+					m_delayedViewChangedOldVerticalOffset = oldVerticalOffset;
+				}
+
 				m_isViewChangedDelayed = true;
 				m_isDelayedViewChangedIntermediate = isIntermediate;
 				return;
@@ -1343,8 +1366,8 @@ namespace Microsoft.UI.Xaml.Controls
 					ViewportHeight,
 					MinHorizontalOffset,
 					MinVerticalOffset,
-					HorizontalOffset,
-					VerticalOffset);
+					oldHorizontalOffset,
+					oldVerticalOffset);
 			}
 
 			UpdatePartial(isIntermediate);
@@ -1405,10 +1428,13 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				_hasPendingScrollUpdate = false;
 
+				var oldHorizontalOffset = HorizontalOffset;
+				var oldVerticalOffset = VerticalOffset;
+
 				HorizontalOffset = _pendingHorizontalOffset;
 				VerticalOffset = _pendingVerticalOffset;
 
-				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode);
+				RaiseViewChanged(_pendingScrollIsIntermediate || m_isInIntermediateViewChangedMode, oldHorizontalOffset, oldVerticalOffset);
 			}
 		}
 #else


### PR DESCRIPTION
## Summary

Third slice of the split from `dev/mazi/rendering-fixes`. Independent of the render-loop/platform slices (#23047 / #23048) — touches input and `ScrollViewer` only.

- **Intermediate scrolling updates mode** on `ScrollViewer` with scrolling notifications aligned to WinUI's state model.
- **`VelocityTracker`** (new) feeding the manipulation pipeline for smoother flicks.
- **`InertiaProcessor`** reworked for smoother deceleration; four iterative refinements bundled as `feat: Inertial smoothness` / `II` / `III` / `IV`.
- **ScrollContentPresenter / ScrollViewer** perf and correctness fixes (invalid scroll state updates, stale coercion).
- **Runtime tests**: `Given_ScrollViewer.ValidateScrollingBehavior` covers the new update model.

Split out of the original bundled branch `dev/mazi/rendering-fixes`.

## Test plan

- [ ] `dotnet build src/Uno.UI-Skia-only.slnf`
- [ ] `dotnet test src/Uno.UI/Uno.UI.Tests.csproj`
- [ ] Runtime tests: `Given_ScrollViewer` suite on Skia Desktop
- [ ] Manual: drag-to-scroll and flick-to-inertia in `SamplesApp` ScrollViewer samples — confirm smooth trajectory, no jitter when `Rendering` subscribers are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)