### PR TITLE
feat(scrollviewer): Implement CurrentAnchor and scroll anchoring

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2609,6 +2609,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Anchoring.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7668,6 +7672,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Add_Remove.xaml.cs">
       <DependentUpon>ScrollViewer_Add_Remove.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Anchoring.xaml.cs">
+      <DependentUpon>ScrollViewer_Anchoring.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml.cs">
       <DependentUpon>ScrollViewer_Clipping.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Anchoring.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Anchoring.xaml
@@ -1,0 +1,74 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Anchoring"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="500"
+    d:DesignWidth="500"
+    mc:Ignorable="d">
+    <Grid Padding="12" RowDefinitions="Auto,Auto,*,Auto">
+        <StackPanel
+            Grid.Row="0"
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button
+                x:Name="InsertAboveButton"
+                Click="InsertAbove_Click"
+                Content="Insert 80px above" />
+            <Button
+                x:Name="RemoveAboveButton"
+                Click="RemoveAbove_Click"
+                Content="Remove top" />
+            <Button
+                x:Name="InsertBelowButton"
+                Click="InsertBelow_Click"
+                Content="Insert 80px below" />
+            <Button
+                x:Name="ScrollTopButton"
+                Click="ScrollTop_Click"
+                Content="Top" />
+            <Button
+                x:Name="ScrollBottomButton"
+                Click="ScrollBottom_Click"
+                Content="Bottom" />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="1"
+            Margin="0,8"
+            Orientation="Horizontal"
+            Spacing="12">
+            <TextBlock VerticalAlignment="Center" Text="VerticalAnchorRatio:" />
+            <ComboBox x:Name="RatioCombo" SelectionChanged="Ratio_SelectionChanged">
+                <ComboBoxItem Content="NaN (disabled)" />
+                <ComboBoxItem Content="0.0 (near edge)" />
+                <ComboBoxItem Content="0.5 (center)" IsSelected="True" />
+                <ComboBoxItem Content="1.0 (far edge)" />
+            </ComboBox>
+            <TextBlock
+                x:Name="CurrentAnchorText"
+                VerticalAlignment="Center"
+                Text="CurrentAnchor: —" />
+        </StackPanel>
+
+        <ScrollViewer
+            x:Name="TargetScrollViewer"
+            Grid.Row="2"
+            BorderBrush="{ThemeResource SystemBaseMediumBrush}"
+            BorderThickness="1"
+            HorizontalScrollBarVisibility="Disabled"
+            HorizontalScrollMode="Disabled"
+            VerticalAnchorRatio="0.5"
+            VerticalScrollBarVisibility="Auto"
+            VerticalScrollMode="Enabled">
+            <StackPanel x:Name="ContentPanel" Orientation="Vertical" />
+        </ScrollViewer>
+
+        <TextBlock
+            x:Name="OffsetText"
+            Grid.Row="3"
+            Margin="0,8,0,0"
+            Text="VerticalOffset: 0" />
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Anchoring.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Anchoring.xaml.cs
@@ -1,0 +1,110 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+
+namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[Sample("Scrolling", Description = "Demonstrates ScrollViewer.CurrentAnchor and VerticalAnchorRatio. Insert/remove items above the viewport anchor; the ScrollViewer preserves the anchor's visual position.")]
+	public sealed partial class ScrollViewer_Anchoring : UserControl
+	{
+		private int _counter;
+
+		public ScrollViewer_Anchoring()
+		{
+			this.InitializeComponent();
+
+			for (int i = 0; i < 15; i++)
+			{
+				ContentPanel.Children.Add(CreateItem());
+			}
+
+			Loaded += OnLoaded;
+		}
+
+		private Border CreateItem()
+		{
+			var index = _counter++;
+			var border = new Border
+			{
+				Width = 280,
+				Height = 80,
+				Margin = new Thickness(4),
+				Background = new SolidColorBrush(index % 2 == 0 ? Colors.LightBlue : Colors.LightCoral),
+				Child = new TextBlock
+				{
+					Text = $"Item #{index}",
+					HorizontalAlignment = HorizontalAlignment.Center,
+					VerticalAlignment = VerticalAlignment.Center,
+				},
+			};
+			border.Loaded += (_, _) => TargetScrollViewer.RegisterAnchorCandidate(border);
+			border.Unloaded += (_, _) => TargetScrollViewer.UnregisterAnchorCandidate(border);
+			return border;
+		}
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			TargetScrollViewer.ViewChanged += (_, _) => UpdateStatus();
+			UpdateStatus();
+		}
+
+		private void UpdateStatus()
+		{
+			var anchor = TargetScrollViewer.CurrentAnchor;
+			var tb = (anchor as Border)?.Child as TextBlock;
+			CurrentAnchorText.Text = $"CurrentAnchor: {tb?.Text ?? "(none)"}";
+			OffsetText.Text = $"VerticalOffset: {TargetScrollViewer.VerticalOffset:F1} / ScrollableHeight: {TargetScrollViewer.ScrollableHeight:F1}";
+		}
+
+		private void InsertAbove_Click(object sender, RoutedEventArgs e)
+		{
+			ContentPanel.Children.Insert(0, CreateItem());
+			UpdateStatus();
+		}
+
+		private void RemoveAbove_Click(object sender, RoutedEventArgs e)
+		{
+			if (ContentPanel.Children.Count > 0)
+			{
+				ContentPanel.Children.RemoveAt(0);
+			}
+			UpdateStatus();
+		}
+
+		private void InsertBelow_Click(object sender, RoutedEventArgs e)
+		{
+			ContentPanel.Children.Add(CreateItem());
+			UpdateStatus();
+		}
+
+		private void ScrollTop_Click(object sender, RoutedEventArgs e)
+		{
+			TargetScrollViewer.ChangeView(null, 0, null, disableAnimation: true);
+		}
+
+		private void ScrollBottom_Click(object sender, RoutedEventArgs e)
+		{
+			TargetScrollViewer.ChangeView(null, TargetScrollViewer.ScrollableHeight, null, disableAnimation: true);
+		}
+
+		private void Ratio_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (RatioCombo.SelectedIndex < 0)
+			{
+				return;
+			}
+			TargetScrollViewer.VerticalAnchorRatio = RatioCombo.SelectedIndex switch
+			{
+				0 => double.NaN,
+				1 => 0.0,
+				2 => 0.5,
+				3 => 1.0,
+				_ => double.NaN,
+			};
+			UpdateStatus();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Anchoring.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Anchoring.xaml.cs
@@ -21,8 +21,11 @@ namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 				ContentPanel.Children.Add(CreateItem());
 			}
 
+			TargetScrollViewer.ViewChanged += OnViewChanged;
 			Loaded += OnLoaded;
 		}
+
+		private void OnViewChanged(object sender, ScrollViewerViewChangedEventArgs e) => UpdateStatus();
 
 		private Border CreateItem()
 		{
@@ -47,7 +50,6 @@ namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			TargetScrollViewer.ViewChanged += (_, _) => UpdateStatus();
 			UpdateStatus();
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_Anchoring.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_Anchoring.cs
@@ -1,0 +1,559 @@
+#pragma warning disable IDE0055 // Fix formatting
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.Foundation.Metadata;
+using Windows.UI;
+
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ScrollViewerTests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_ScrollViewer_Anchoring
+{
+	private const double ItemHeight = 100;
+	private const double ItemWidth = 100;
+	private const int ItemCount = 20;
+	private const double ViewportSize = 300;
+
+	private static (ScrollViewer sv, StackPanel content, List<Border> items) BuildVertical(double itemHeight = ItemHeight, int count = ItemCount)
+	{
+		var items = new List<Border>();
+		var panel = new StackPanel { Orientation = Orientation.Vertical };
+		for (int i = 0; i < count; i++)
+		{
+			var b = new Border
+			{
+				Width = 200,
+				Height = itemHeight,
+				Background = new SolidColorBrush(i % 2 == 0 ? Colors.LightBlue : Colors.LightCoral),
+				Tag = i,
+			};
+			panel.Children.Add(b);
+			items.Add(b);
+		}
+
+		var sv = new ScrollViewer
+		{
+			Width = 250,
+			Height = ViewportSize,
+			Content = panel,
+		};
+
+		return (sv, panel, items);
+	}
+
+	private static (ScrollViewer sv, StackPanel content, List<Border> items) BuildHorizontal(double itemWidth = ItemWidth, int count = ItemCount)
+	{
+		var items = new List<Border>();
+		var panel = new StackPanel { Orientation = Orientation.Horizontal };
+		for (int i = 0; i < count; i++)
+		{
+			var b = new Border
+			{
+				Width = itemWidth,
+				Height = 200,
+				Background = new SolidColorBrush(i % 2 == 0 ? Colors.LightBlue : Colors.LightCoral),
+				Tag = i,
+			};
+			panel.Children.Add(b);
+			items.Add(b);
+		}
+
+		var sv = new ScrollViewer
+		{
+			Width = ViewportSize,
+			Height = 250,
+			HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+			HorizontalScrollMode = ScrollMode.Enabled,
+			VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
+			VerticalScrollMode = ScrollMode.Disabled,
+			Content = panel,
+		};
+
+		return (sv, panel, items);
+	}
+
+	private static async Task ScrollToVerticalAsync(ScrollViewer sv, double offset)
+	{
+		var tcs = new TaskCompletionSource<bool>();
+		void OnChanged(object s, ScrollViewerViewChangedEventArgs e)
+		{
+			if (!e.IsIntermediate)
+			{
+				tcs.TrySetResult(true);
+			}
+		}
+		sv.ViewChanged += OnChanged;
+		try
+		{
+			sv.ChangeView(null, offset, null, disableAnimation: true);
+			await Task.WhenAny(tcs.Task, Task.Delay(2000));
+		}
+		finally
+		{
+			sv.ViewChanged -= OnChanged;
+		}
+		await WindowHelper.WaitForIdle();
+	}
+
+	private static async Task ScrollToHorizontalAsync(ScrollViewer sv, double offset)
+	{
+		var tcs = new TaskCompletionSource<bool>();
+		void OnChanged(object s, ScrollViewerViewChangedEventArgs e)
+		{
+			if (!e.IsIntermediate)
+			{
+				tcs.TrySetResult(true);
+			}
+		}
+		sv.ViewChanged += OnChanged;
+		try
+		{
+			sv.ChangeView(offset, null, null, disableAnimation: true);
+			await Task.WhenAny(tcs.Task, Task.Delay(2000));
+		}
+		finally
+		{
+			sv.ViewChanged -= OnChanged;
+		}
+		await WindowHelper.WaitForIdle();
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task CurrentAnchor_Null_WhenNoRatios()
+	{
+		var (sv, panel, items) = BuildVertical();
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsNull(sv.CurrentAnchor, "CurrentAnchor should be null when both ratios are NaN (default).");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task CurrentAnchor_Null_WhenNoCandidates()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsNull(sv.CurrentAnchor, "CurrentAnchor should be null when no candidates are registered.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task CurrentAnchor_SelectsClosestCandidate_Vertical()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		// Scroll so items[5] is centered: item top = 5*100=500, center=550. Viewport center at offset+150.
+		// offset = 400 → viewport [400, 700], center 550 matches item 5 (500..600).
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.AreSame(items[5], sv.CurrentAnchor, $"Expected items[5] as anchor, got Tag={((sv.CurrentAnchor as Border)?.Tag)}");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task CurrentAnchor_SelectsClosestCandidate_Horizontal()
+	{
+		var (sv, panel, items) = BuildHorizontal();
+		sv.HorizontalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		// Items are 100 wide. Offset 400 → viewport [400, 700], center 550 matches item 5 (500..600).
+		await ScrollToHorizontalAsync(sv, 400);
+
+		Assert.AreSame(items[5], sv.CurrentAnchor);
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task CurrentAnchor_UpdatesOnScroll()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		await ScrollToVerticalAsync(sv, 400);
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+		var first = sv.CurrentAnchor;
+
+		await ScrollToVerticalAsync(sv, 1000);
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+		var second = sv.CurrentAnchor;
+
+		Assert.AreNotSame(first, second, "CurrentAnchor should change as the viewport moves.");
+		Assert.AreSame(items[11], second, "At offset 1000, center 1150 matches items[11] (1100..1200).");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task Register_Unregister_Roundtrip()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		// Unregister items[5] which would be the nearest at offset 400.
+		sv.UnregisterAnchorCandidate(items[5]);
+
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.AreNotSame(items[5], sv.CurrentAnchor, "Unregistered item should not be chosen.");
+		// Either items[4] or items[6] depending on tie-break.
+		Assert.IsTrue(sv.CurrentAnchor == items[4] || sv.CurrentAnchor == items[6]);
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task Register_Duplicate_Allowed_Unregister_Removes_One()
+	{
+		// WinUI allows duplicate registrations (see ScrollViewer_Partial.cpp:9373 —
+		// Release builds do NOT dedup; Unregister removes only the first match).
+		// After triple register + single unregister, the candidate should STILL be chosen.
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		sv.RegisterAnchorCandidate(items[5]);
+		sv.RegisterAnchorCandidate(items[5]);
+		sv.RegisterAnchorCandidate(items[5]);
+
+		sv.UnregisterAnchorCandidate(items[5]);
+
+		await ScrollToVerticalAsync(sv, 400);
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreSame(items[5], sv.CurrentAnchor,
+			"Register does not dedup; a single Unregister after triple-register still leaves the item as a candidate.");
+
+		// Two more unregisters drain the remaining copies.
+		sv.UnregisterAnchorCandidate(items[5]);
+		sv.UnregisterAnchorCandidate(items[5]);
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsNull(sv.CurrentAnchor, "After as many Unregisters as Registers, no candidate remains.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task AnchorRequested_Raised_WithCandidates()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		sv.RegisterAnchorCandidate(items[3]);
+		sv.RegisterAnchorCandidate(items[7]);
+
+		int raised = 0;
+		IList<UIElement> seenCandidates = null;
+		sv.AnchorRequested += (s, e) =>
+		{
+			raised++;
+			seenCandidates = e.AnchorCandidates;
+		};
+
+		await ScrollToVerticalAsync(sv, 400);
+		_ = sv.CurrentAnchor; // force evaluation
+
+		Assert.IsTrue(raised > 0, "AnchorRequested should have fired.");
+		Assert.IsNotNull(seenCandidates);
+		CollectionAssert.Contains(seenCandidates.ToList(), items[3]);
+		CollectionAssert.Contains(seenCandidates.ToList(), items[7]);
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task AnchorRequested_Handler_OverrideAnchor()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		sv.AnchorRequested += (s, e) =>
+		{
+			e.Anchor = items[0]; // force the far-away item
+		};
+
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.AreSame(items[0], sv.CurrentAnchor, "Handler override via e.Anchor should take precedence.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task AnchorRequested_Handler_CanModifyCandidates()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		sv.AnchorRequested += (s, e) =>
+		{
+			// Remove items[5] (and neighbors) so they cannot be chosen.
+			e.AnchorCandidates.Remove(items[5]);
+			e.AnchorCandidates.Remove(items[4]);
+			e.AnchorCandidates.Remove(items[6]);
+		};
+
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.AreNotSame(items[5], sv.CurrentAnchor);
+		Assert.AreNotSame(items[4], sv.CurrentAnchor);
+		Assert.AreNotSame(items[6], sv.CurrentAnchor);
+		Assert.IsTrue(sv.CurrentAnchor == items[3] || sv.CurrentAnchor == items[7]);
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task Anchoring_PreservesPosition_OnContentGrowAbove()
+	{
+		// Semantic guarantee: after inserting content above the anchor, the anchor element
+		// stays at approximately the same visual position within the viewport.
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		await ScrollToVerticalAsync(sv, 400);
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+		var anchor = sv.CurrentAnchor as Border;
+		Assert.IsNotNull(anchor);
+		var anchorYBefore = anchor.TransformToVisual(sv).TransformPoint(new Windows.Foundation.Point(0, 0)).Y;
+
+		var inserted = new Border { Width = 200, Height = 100, Background = new SolidColorBrush(Colors.LightGreen) };
+		panel.Children.Insert(0, inserted);
+
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+
+		var anchorYAfter = anchor.TransformToVisual(sv).TransformPoint(new Windows.Foundation.Point(0, 0)).Y;
+		Assert.AreEqual(anchorYBefore, anchorYAfter, 2.0, "Anchor's Y position within the viewport should be preserved.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task Anchoring_PreservesPosition_OnContentShrinkAbove()
+	{
+		// Semantic guarantee: removing content above the anchor keeps the anchor at the
+		// same visual position (offset decreases to compensate).
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		foreach (var item in items)
+		{
+			sv.RegisterAnchorCandidate(item);
+		}
+
+		await ScrollToVerticalAsync(sv, 400);
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+		var anchor = sv.CurrentAnchor as Border;
+		Assert.IsNotNull(anchor);
+		var anchorYBefore = anchor.TransformToVisual(sv).TransformPoint(new Windows.Foundation.Point(0, 0)).Y;
+
+		panel.Children.RemoveAt(0);
+		sv.UnregisterAnchorCandidate(items[0]);
+
+		sv.InvalidateArrange();
+		await WindowHelper.WaitForIdle();
+
+		var anchorYAfter = anchor.TransformToVisual(sv).TransformPoint(new Windows.Foundation.Point(0, 0)).Y;
+		Assert.AreEqual(anchorYBefore, anchorYAfter, 2.0, "Anchor's Y position within the viewport should be preserved after content removal above.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task Anchoring_Ignored_CollapsedCandidate()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		sv.RegisterAnchorCandidate(items[5]);
+		items[5].Visibility = Visibility.Collapsed;
+
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.IsNull(sv.CurrentAnchor, "A collapsed candidate must not be chosen.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task Anchoring_Ignored_NonDescendantCandidate()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		// An element NOT inside the ScrollViewer's content subtree.
+		var outsider = new Border { Width = 50, Height = 50 };
+		sv.RegisterAnchorCandidate(outsider);
+
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.IsNull(sv.CurrentAnchor, "A non-descendant candidate must not be chosen.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task FarEdge_Anchoring_VerticalRatio1()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 1.0;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		// Scroll to bottom.
+		await ScrollToVerticalAsync(sv, sv.ScrollableHeight);
+		var offsetBefore = sv.VerticalOffset;
+		var extentBefore = sv.ExtentHeight;
+
+		// Add content (which grows extent by 100). Since we are at the far edge with ratio 1.0,
+		// the scroll offset should shift by the same amount so we remain pinned to the bottom.
+		var inserted = new Border { Width = 200, Height = 100, Background = new SolidColorBrush(Colors.LightGreen) };
+		panel.Children.Insert(0, inserted);
+
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(extentBefore + 100, sv.ExtentHeight, 1.5, "Extent should have grown.");
+		Assert.AreEqual(offsetBefore + 100, sv.VerticalOffset, 1.5, "Offset should follow the bottom edge.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task NearEdge_NoAdjustment_At_Ratio0()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.0;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		// At offset 0 (near edge). Add content below - should not shift.
+		var added = new Border { Width = 200, Height = 100, Background = new SolidColorBrush(Colors.LightGreen) };
+		panel.Children.Add(added);
+
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(0, sv.VerticalOffset, 0.5, "At near edge with ratio 0, offset should remain at 0.");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task IScrollAnchorProvider_Cast_Works()
+	{
+		var (sv, panel, items) = BuildVertical();
+		sv.VerticalAnchorRatio = 0.5;
+
+		WindowHelper.WindowContent = sv;
+		await WindowHelper.WaitForLoaded(sv);
+
+		var provider = (IScrollAnchorProvider)sv;
+
+		foreach (var item in items)
+		{
+			provider.RegisterAnchorCandidate(item);
+		}
+
+		await ScrollToVerticalAsync(sv, 400);
+
+		Assert.AreSame(items[5], provider.CurrentAnchor);
+
+		provider.UnregisterAnchorCandidate(items[5]);
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreNotSame(items[5], provider.CurrentAnchor);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_Anchoring.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_Anchoring.cs
@@ -85,6 +85,13 @@ public class Given_ScrollViewer_Anchoring
 
 	private static async Task ScrollToVerticalAsync(ScrollViewer sv, double offset)
 	{
+		// ChangeView to the current offset is a no-op and doesn't raise ViewChanged, so skip the wait.
+		if (Math.Abs(sv.VerticalOffset - offset) < 0.5)
+		{
+			await WindowHelper.WaitForIdle();
+			return;
+		}
+
 		var tcs = new TaskCompletionSource<bool>();
 		void OnChanged(object s, ScrollViewerViewChangedEventArgs e)
 		{
@@ -97,7 +104,11 @@ public class Given_ScrollViewer_Anchoring
 		try
 		{
 			sv.ChangeView(null, offset, null, disableAnimation: true);
-			await Task.WhenAny(tcs.Task, Task.Delay(2000));
+			var completed = await Task.WhenAny(tcs.Task, Task.Delay(2000));
+			if (completed != tcs.Task)
+			{
+				Assert.Fail($"Timed out waiting for vertical scroll to complete. Requested offset: {offset}, current VerticalOffset: {sv.VerticalOffset}.");
+			}
 		}
 		finally
 		{
@@ -108,6 +119,13 @@ public class Given_ScrollViewer_Anchoring
 
 	private static async Task ScrollToHorizontalAsync(ScrollViewer sv, double offset)
 	{
+		// ChangeView to the current offset is a no-op and doesn't raise ViewChanged, so skip the wait.
+		if (Math.Abs(sv.HorizontalOffset - offset) < 0.5)
+		{
+			await WindowHelper.WaitForIdle();
+			return;
+		}
+
 		var tcs = new TaskCompletionSource<bool>();
 		void OnChanged(object s, ScrollViewerViewChangedEventArgs e)
 		{
@@ -120,7 +138,11 @@ public class Given_ScrollViewer_Anchoring
 		try
 		{
 			sv.ChangeView(offset, null, null, disableAnimation: true);
-			await Task.WhenAny(tcs.Task, Task.Delay(2000));
+			var completed = await Task.WhenAny(tcs.Task, Task.Delay(2000));
+			if (completed != tcs.Task)
+			{
+				Assert.Fail($"Timed out waiting for horizontal scroll to complete. Requested offset: {offset}, current HorizontalOffset: {sv.HorizontalOffset}.");
+			}
 		}
 		finally
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/AnchorRequestedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/AnchorRequestedEventArgs.cs
@@ -3,42 +3,5 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Controls
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-	[global::Uno.NotImplemented]
-#endif
-	public partial class AnchorRequestedEventArgs
-	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		internal AnchorRequestedEventArgs()
-		{
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.UIElement Anchor
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member UIElement AnchorRequestedEventArgs.Anchor is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=UIElement%20AnchorRequestedEventArgs.Anchor");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs", "UIElement AnchorRequestedEventArgs.Anchor");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::System.Collections.Generic.IList<global::Microsoft.UI.Xaml.UIElement> AnchorCandidates
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member IList<UIElement> AnchorRequestedEventArgs.AnchorCandidates is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IList%3CUIElement%3E%20AnchorRequestedEventArgs.AnchorCandidates");
-			}
-		}
-#endif
-		// Forced skipping of method Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs.Anchor.get
-		// Forced skipping of method Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs.Anchor.set
-		// Forced skipping of method Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs.AnchorCandidates.get
-	}
+	// Skipping already declared type Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/AnchorRequestedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/AnchorRequestedEventArgs.cs
@@ -3,5 +3,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Controls
 {
-	// Skipping already declared type Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs
+#if false || false || false || false || false || false || false
+	[global::Uno.NotImplemented]
+#endif
+	public partial class AnchorRequestedEventArgs
+	{
+		// Skipping already declared property Anchor
+		// Skipping already declared property AnchorCandidates
+		// Forced skipping of method Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs.Anchor.get
+		// Forced skipping of method Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs.Anchor.set
+		// Forced skipping of method Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs.AnchorCandidates.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/IScrollAnchorProvider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/IScrollAnchorProvider.cs
@@ -3,12 +3,8 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Controls
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-	[global::Uno.NotImplemented]
-#endif
 	public partial interface IScrollAnchorProvider
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		global::Microsoft.UI.Xaml.UIElement CurrentAnchor
 		{
 			get;
@@ -16,8 +12,6 @@ namespace Microsoft.UI.Xaml.Controls
 #endif
 #if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		void RegisterAnchorCandidate(global::Microsoft.UI.Xaml.UIElement element);
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		void UnregisterAnchorCandidate(global::Microsoft.UI.Xaml.UIElement element);
 #endif
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.IScrollAnchorProvider.CurrentAnchor.get

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/IScrollAnchorProvider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/IScrollAnchorProvider.cs
@@ -5,15 +5,9 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial interface IScrollAnchorProvider
 	{
-		global::Microsoft.UI.Xaml.UIElement CurrentAnchor
-		{
-			get;
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		void RegisterAnchorCandidate(global::Microsoft.UI.Xaml.UIElement element);
-		void UnregisterAnchorCandidate(global::Microsoft.UI.Xaml.UIElement element);
-#endif
+		// Skipping already declared property CurrentAnchor
+		// Skipping already declared method Microsoft.UI.Xaml.Controls.IScrollAnchorProvider.RegisterAnchorCandidate(Microsoft.UI.Xaml.UIElement)
+		// Skipping already declared method Microsoft.UI.Xaml.Controls.IScrollAnchorProvider.UnregisterAnchorCandidate(Microsoft.UI.Xaml.UIElement)
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.IScrollAnchorProvider.CurrentAnchor.get
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/ScrollViewer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/ScrollViewer.cs
@@ -21,14 +21,7 @@ namespace Microsoft.UI.Xaml.Controls
 		// Skipping already declared property ComputedVerticalScrollBarVisibilityProperty
 		// Skipping already declared property ExtentHeightProperty
 		// Skipping already declared property ExtentWidthProperty
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty HorizontalAnchorRatioProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(HorizontalAnchorRatio), typeof(double),
-			typeof(global::Microsoft.UI.Xaml.Controls.ScrollViewer),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(double)));
-#endif
+		// Skipping already declared property HorizontalAnchorRatioProperty
 		// Skipping already declared property HorizontalOffsetProperty
 		// Skipping already declared property HorizontalScrollBarVisibilityProperty
 		// Skipping already declared property HorizontalScrollModeProperty
@@ -134,14 +127,7 @@ namespace Microsoft.UI.Xaml.Controls
 			typeof(global::Microsoft.UI.Xaml.Controls.ScrollViewer),
 			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.UIElement)));
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty VerticalAnchorRatioProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(VerticalAnchorRatio), typeof(double),
-			typeof(global::Microsoft.UI.Xaml.Controls.ScrollViewer),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(double)));
-#endif
+		// Skipping already declared property VerticalAnchorRatioProperty
 		// Skipping already declared property VerticalOffsetProperty
 		// Skipping already declared property VerticalScrollBarVisibilityProperty
 		// Skipping already declared property VerticalScrollModeProperty
@@ -187,20 +173,7 @@ namespace Microsoft.UI.Xaml.Controls
 		// Skipping already declared property CurrentAnchor
 		// Skipping already declared property ExtentHeight
 		// Skipping already declared property ExtentWidth
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public double HorizontalAnchorRatio
-		{
-			get
-			{
-				return (double)this.GetValue(HorizontalAnchorRatioProperty);
-			}
-			set
-			{
-				this.SetValue(HorizontalAnchorRatioProperty, value);
-			}
-		}
-#endif
+		// Skipping already declared property HorizontalAnchorRatio
 		// Skipping already declared property HorizontalOffset
 		// Skipping already declared property HorizontalScrollBarVisibility
 		// Skipping already declared property HorizontalScrollMode
@@ -378,20 +351,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public double VerticalAnchorRatio
-		{
-			get
-			{
-				return (double)this.GetValue(VerticalAnchorRatioProperty);
-			}
-			set
-			{
-				this.SetValue(VerticalAnchorRatioProperty, value);
-			}
-		}
-#endif
+		// Skipping already declared property VerticalAnchorRatio
 		// Skipping already declared property VerticalOffset
 		// Skipping already declared property VerticalScrollBarVisibility
 		// Skipping already declared property VerticalScrollMode

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/ScrollViewer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/ScrollViewer.cs
@@ -633,20 +633,8 @@ namespace Microsoft.UI.Xaml.Controls
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.ViewChanged.remove
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.ViewChanging.add
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.ViewChanging.remove
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public void RegisterAnchorCandidate(global::Microsoft.UI.Xaml.UIElement element)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Controls.ScrollViewer", "void ScrollViewer.RegisterAnchorCandidate(UIElement element)");
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public void UnregisterAnchorCandidate(global::Microsoft.UI.Xaml.UIElement element)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Controls.ScrollViewer", "void ScrollViewer.UnregisterAnchorCandidate(UIElement element)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.Controls.ScrollViewer.RegisterAnchorCandidate(Microsoft.UI.Xaml.UIElement)
+		// Skipping already declared method Microsoft.UI.Xaml.Controls.ScrollViewer.UnregisterAnchorCandidate(Microsoft.UI.Xaml.UIElement)
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.BringIntoViewOnFocusChange.get
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.BringIntoViewOnFocusChange.set
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.CanContentRenderOutsideBounds.get
@@ -716,22 +704,7 @@ namespace Microsoft.UI.Xaml.Controls
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.ZoomSnapPoints.get
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.ZoomSnapPointsType.get
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.ZoomSnapPointsType.set
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public event global::Windows.Foundation.TypedEventHandler<global::Microsoft.UI.Xaml.Controls.ScrollViewer, global::Microsoft.UI.Xaml.Controls.AnchorRequestedEventArgs> AnchorRequested
-		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Controls.ScrollViewer", "event TypedEventHandler<ScrollViewer, AnchorRequestedEventArgs> ScrollViewer.AnchorRequested");
-			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Controls.ScrollViewer", "event TypedEventHandler<ScrollViewer, AnchorRequestedEventArgs> ScrollViewer.AnchorRequested");
-			}
-		}
-#endif
+		// Skipping already declared event Microsoft.UI.Xaml.Controls.ScrollViewer.AnchorRequested
 #if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public event global::System.EventHandler<object> DirectManipulationCompleted

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -214,6 +214,11 @@ namespace Microsoft.UI.Xaml.Controls
 				// Give opportunity to the the content to define the viewport size itself
 				(child as ICustomScrollInfo)?.ApplyViewport(ref desired);
 
+				// Mirror of ScrollViewer_Partial.cpp:9440 OnScrollContentPresenterMeasured.
+				// When the SCP is (re-)measured and the owning ScrollViewer has anchoring active,
+				// force ArrangeOverride to re-run so the anchoring offset correction fires.
+				Scroller?.OnScrollContentPresenterMeasured();
+
 				return new Size(
 					Math.Min(availableSize.Width, desired.Width),
 					Math.Min(availableSize.Height, desired.Height)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/AnchorRequestedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/AnchorRequestedEventArgs.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+public sealed partial class AnchorRequestedEventArgs
+{
+	private readonly List<UIElement> _anchorCandidates = new();
+
+	internal AnchorRequestedEventArgs()
+	{
+	}
+
+	public UIElement? Anchor { get; set; }
+
+	public IList<UIElement> AnchorCandidates => _anchorCandidates;
+
+	internal void Reset(IEnumerable<UIElement> candidates)
+	{
+		Anchor = null;
+		_anchorCandidates.Clear();
+		foreach (var c in candidates)
+		{
+			_anchorCandidates.Add(c);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/IScrollAnchorProvider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/IScrollAnchorProvider.cs
@@ -1,0 +1,62 @@
+namespace Microsoft.UI.Xaml.Controls
+{
+	/// <summary>
+	/// Specifies a contract for a scrolling control that supports scroll anchoring.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Scroll anchoring is when a scrolling control automatically changes the position of its
+	/// viewport to prevent the content from visibly jumping. The jump is caused by a change in
+	/// the content's layout. The scroll anchor provider applies a shift after observing a change
+	/// in the position of an anchor element within the content.
+	/// </para>
+	/// <para>
+	/// It's the responsibility of the implementing scroll control to determine what policy it
+	/// will use in choosing a <see cref="CurrentAnchor"/> from the set of registered candidates.
+	/// </para>
+	/// </remarks>
+	public partial interface IScrollAnchorProvider
+	{
+		/// <summary>
+		/// Gets the currently chosen anchor element to use for scroll anchoring.
+		/// </summary>
+		/// <value>
+		/// The most recently chosen <see cref="UIElement"/> for scroll anchoring after a layout pass,
+		/// or <c>null</c>. If there are no anchor candidates registered with the
+		/// <see cref="IScrollAnchorProvider"/> or none have been chosen, then CurrentAnchor is <c>null</c>.
+		/// </value>
+		UIElement CurrentAnchor { get; }
+
+		/// <summary>
+		/// Registers a <see cref="UIElement"/> as a potential scroll anchor candidate.
+		/// </summary>
+		/// <param name="element">
+		/// A <see cref="UIElement"/> within the subtree of the <see cref="IScrollAnchorProvider"/>.
+		/// </param>
+		/// <remarks>
+		/// When an element has <see cref="UIElement.CanBeScrollAnchor"/> set to <c>true</c>, the
+		/// framework locates the first <see cref="IScrollAnchorProvider"/> in that element's chain
+		/// of ancestors and automatically calls its <see cref="RegisterAnchorCandidate"/> method.
+		/// This occurs both when the property is set on an existing element or an element is added
+		/// to the live tree with the property already set.
+		/// Similarly, when the property is set to <c>false</c> (or an element is removed from the
+		/// visual tree with the property set to <c>true</c>), the framework calls
+		/// <see cref="UnregisterAnchorCandidate"/> on the first <see cref="IScrollAnchorProvider"/>.
+		/// </remarks>
+		void RegisterAnchorCandidate(UIElement element);
+
+		/// <summary>
+		/// Unregisters a <see cref="UIElement"/> as a potential scroll anchor candidate.
+		/// </summary>
+		/// <param name="element">
+		/// A <see cref="UIElement"/> within the subtree of the <see cref="IScrollAnchorProvider"/>.
+		/// </param>
+		/// <remarks>
+		/// When an element's <see cref="UIElement.CanBeScrollAnchor"/> property changes to <c>false</c>
+		/// (or the element is removed from the visual tree), the framework locates the first
+		/// <see cref="IScrollAnchorProvider"/> in that element's chain of ancestors and automatically
+		/// calls its <see cref="UnregisterAnchorCandidate"/> method.
+		/// </remarks>
+		void UnregisterAnchorCandidate(UIElement element);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/IScrollAnchorProvider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/IScrollAnchorProvider.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Microsoft.UI.Xaml.Controls
 {
 	/// <summary>
@@ -25,7 +27,7 @@ namespace Microsoft.UI.Xaml.Controls
 		/// or <c>null</c>. If there are no anchor candidates registered with the
 		/// <see cref="IScrollAnchorProvider"/> or none have been chosen, then CurrentAnchor is <c>null</c>.
 		/// </value>
-		UIElement CurrentAnchor { get; }
+		UIElement? CurrentAnchor { get; }
 
 		/// <summary>
 		/// Registers a <see cref="UIElement"/> as a potential scroll anchor candidate.
@@ -34,14 +36,14 @@ namespace Microsoft.UI.Xaml.Controls
 		/// A <see cref="UIElement"/> within the subtree of the <see cref="IScrollAnchorProvider"/>.
 		/// </param>
 		/// <remarks>
-		/// When an element has <see cref="UIElement.CanBeScrollAnchor"/> set to <c>true</c>, the
-		/// framework locates the first <see cref="IScrollAnchorProvider"/> in that element's chain
-		/// of ancestors and automatically calls its <see cref="RegisterAnchorCandidate"/> method.
-		/// This occurs both when the property is set on an existing element or an element is added
-		/// to the live tree with the property already set.
-		/// Similarly, when the property is set to <c>false</c> (or an element is removed from the
-		/// visual tree with the property set to <c>true</c>), the framework calls
-		/// <see cref="UnregisterAnchorCandidate"/> on the first <see cref="IScrollAnchorProvider"/>.
+		/// In the current Uno implementation, callers must invoke this method explicitly. Automatic
+		/// registration driven by <see cref="UIElement.CanBeScrollAnchor"/> is not yet wired up
+		/// (see <c>UpdateAnchorCandidateOnParentScrollProvider</c> in <c>UIElement.mux.cs</c>).
+		/// On WinUI, when an element has <see cref="UIElement.CanBeScrollAnchor"/> set to <c>true</c>,
+		/// the framework locates the first <see cref="IScrollAnchorProvider"/> in that element's chain
+		/// of ancestors and automatically calls its <see cref="RegisterAnchorCandidate"/> method,
+		/// both when the property is set on an existing element and when an element is added to the
+		/// live tree with the property already set.
 		/// </remarks>
 		void RegisterAnchorCandidate(UIElement element);
 
@@ -52,10 +54,12 @@ namespace Microsoft.UI.Xaml.Controls
 		/// A <see cref="UIElement"/> within the subtree of the <see cref="IScrollAnchorProvider"/>.
 		/// </param>
 		/// <remarks>
-		/// When an element's <see cref="UIElement.CanBeScrollAnchor"/> property changes to <c>false</c>
-		/// (or the element is removed from the visual tree), the framework locates the first
-		/// <see cref="IScrollAnchorProvider"/> in that element's chain of ancestors and automatically
-		/// calls its <see cref="UnregisterAnchorCandidate"/> method.
+		/// In the current Uno implementation, callers must invoke this method explicitly. Automatic
+		/// unregistration driven by <see cref="UIElement.CanBeScrollAnchor"/> (or by an element
+		/// leaving the visual tree) is not yet wired up. On WinUI, when the property changes to
+		/// <c>false</c> (or the element is removed from the visual tree), the framework locates the
+		/// first <see cref="IScrollAnchorProvider"/> in that element's chain of ancestors and
+		/// automatically calls its <see cref="UnregisterAnchorCandidate"/> method.
 		/// </remarks>
 		void UnregisterAnchorCandidate(UIElement element);
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Anchoring.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Anchoring.cs
@@ -1,0 +1,597 @@
+#nullable enable
+// Ported from microsoft-ui-xaml2/src/dxaml/xcp/dxaml/lib/ScrollViewer_Partial.cpp
+// (ScrollViewer::EnsureAnchorElementSelection, ProcessAnchorCandidate,
+//  ComputeViewportAnchorPoint, ComputeElementAnchorPointAndBounds,
+//  ComputeViewportToElementAnchorPointsDistance, PerformPositionAdjustment,
+//  IsAnchoring, IsElementValidAnchor, GetDescendantBounds,
+//  RegisterAnchorCandidateImpl, UnregisterAnchorCandidateImpl, RaiseAnchorRequested,
+//  ResetAnchorElement, ClearAnchorCandidates, get_CurrentAnchorImpl).
+using System.Collections.Generic;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Helpers.WinUI;
+using Windows.Foundation;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+public partial class ScrollViewer
+{
+	// Used when HorizontalAnchorRatio or VerticalAnchorRatio is 0.0 or 1.0 to determine
+	// whether the Content is scrolled to an edge. It is declared at an edge if it's within 1/10th of a pixel.
+	private const double c_edgeDetectionTolerance = 0.1;
+
+	private readonly List<UIElement> m_anchorCandidates = new();
+
+	private UIElement? m_anchorElement;
+	private Rect m_anchorElementBounds;
+	private bool m_isAnchorElementDirty;
+
+	private AnchorRequestedEventArgs? m_anchorRequestedEventArgs;
+
+	// Cached post-arrange state used for far-edge anchoring comparisons.
+	private double m_unzoomedExtentWidth;
+	private double m_unzoomedExtentHeight;
+	private double m_viewportWidthCache;
+	private double m_viewportHeightCache;
+
+	private double m_pendingViewportShiftX;
+	private double m_pendingViewportShiftY;
+
+	public event global::Windows.Foundation.TypedEventHandler<ScrollViewer, AnchorRequestedEventArgs>? AnchorRequested;
+
+	public UIElement? CurrentAnchor
+	{
+		get
+		{
+			IsAnchoring(out var isAnchoringElementHorizontally, out var isAnchoringElementVertically, out _, out _);
+
+			if (!isAnchoringElementHorizontally && !isAnchoringElementVertically)
+			{
+				return null;
+			}
+
+			var content = Content as UIElement;
+			if (content is null)
+			{
+				return null;
+			}
+
+			var preArrangeViewport = new Rect(
+				HorizontalOffset + m_pendingViewportShiftX,
+				VerticalOffset + m_pendingViewportShiftY,
+				ViewportWidth,
+				ViewportHeight);
+
+			EnsureAnchorElementSelection(preArrangeViewport);
+			return m_anchorElement;
+		}
+	}
+
+	public void RegisterAnchorCandidate(UIElement element)
+	{
+		if (element is null)
+		{
+			throw new global::System.ArgumentNullException(nameof(element));
+		}
+
+		// Note: WinUI Release builds do not dedup. Preserve that behavior (duplicate registers are allowed).
+		m_anchorCandidates.Add(element);
+		m_isAnchorElementDirty = true;
+	}
+
+	public void UnregisterAnchorCandidate(UIElement element)
+	{
+		if (element is null)
+		{
+			throw new global::System.ArgumentNullException(nameof(element));
+		}
+
+		// Remove only the first match (parity with WinUI).
+		var index = m_anchorCandidates.IndexOf(element);
+		if (index >= 0)
+		{
+			m_anchorCandidates.RemoveAt(index);
+			m_isAnchorElementDirty = true;
+		}
+	}
+
+	private void ClearAnchorCandidates()
+	{
+		m_anchorCandidates.Clear();
+		m_isAnchorElementDirty = true;
+	}
+
+	private void ResetAnchorElement()
+	{
+		if (m_anchorElement is not null)
+		{
+			m_anchorElement = null;
+			m_anchorElementBounds = default;
+			m_isAnchorElementDirty = false;
+		}
+	}
+
+	// Computes whether element / far-edge anchoring is active per dimension.
+	private void IsAnchoring(
+		out bool isAnchoringElementHorizontally,
+		out bool isAnchoringElementVertically,
+		out bool isAnchoringFarEdgeHorizontally,
+		out bool isAnchoringFarEdgeVertically)
+	{
+		isAnchoringElementHorizontally = false;
+		isAnchoringElementVertically = false;
+		isAnchoringFarEdgeHorizontally = false;
+		isAnchoringFarEdgeVertically = false;
+
+		var horizontalAnchorRatio = HorizontalAnchorRatio;
+		var verticalAnchorRatio = VerticalAnchorRatio;
+
+		if (!double.IsNaN(horizontalAnchorRatio))
+		{
+			if (horizontalAnchorRatio == 0.0 || horizontalAnchorRatio == 1.0)
+			{
+				if (horizontalAnchorRatio == 1.0 &&
+					HorizontalOffset + ViewportWidth - ExtentWidth > -c_edgeDetectionTolerance)
+				{
+					isAnchoringFarEdgeHorizontally = true;
+				}
+				else if (!(horizontalAnchorRatio == 0.0 && HorizontalOffset < c_edgeDetectionTolerance))
+				{
+					isAnchoringElementHorizontally = true;
+				}
+			}
+			else
+			{
+				isAnchoringElementHorizontally = true;
+			}
+		}
+
+		if (!double.IsNaN(verticalAnchorRatio))
+		{
+			if (verticalAnchorRatio == 0.0 || verticalAnchorRatio == 1.0)
+			{
+				if (verticalAnchorRatio == 1.0 &&
+					VerticalOffset + ViewportHeight - ExtentHeight > -c_edgeDetectionTolerance)
+				{
+					isAnchoringFarEdgeVertically = true;
+				}
+				else if (!(verticalAnchorRatio == 0.0 && VerticalOffset < c_edgeDetectionTolerance))
+				{
+					isAnchoringElementVertically = true;
+				}
+			}
+			else
+			{
+				isAnchoringElementVertically = true;
+			}
+		}
+	}
+
+	private void ComputeViewportAnchorPoint(
+		Rect zoomedViewport,
+		out double viewportAnchorPointHorizontalOffset,
+		out double viewportAnchorPointVerticalOffset)
+	{
+		// ScrollViewer's managed pipeline has zoomFactor == 1, so the unzoomed bounds equal the zoomed bounds.
+		ComputeAnchorPoint(zoomedViewport, out viewportAnchorPointHorizontalOffset, out viewportAnchorPointVerticalOffset);
+	}
+
+	private void ComputeElementAnchorPoint(
+		bool isForPreArrange,
+		out double elementAnchorPointHorizontalOffset,
+		out double elementAnchorPointVerticalOffset)
+	{
+		elementAnchorPointHorizontalOffset = double.NaN;
+		elementAnchorPointVerticalOffset = double.NaN;
+
+		if (m_anchorElement is null)
+		{
+			return;
+		}
+
+		Rect anchorElementBounds;
+		if (isForPreArrange)
+		{
+			anchorElementBounds = m_anchorElementBounds;
+		}
+		else
+		{
+			var content = Content as UIElement;
+			anchorElementBounds = content is not null
+				? GetDescendantBounds(content, m_anchorElement)
+				: m_anchorElementBounds;
+		}
+
+		ComputeAnchorPoint(anchorElementBounds, out elementAnchorPointHorizontalOffset, out elementAnchorPointVerticalOffset);
+	}
+
+	private void ComputeAnchorPoint(Rect bounds, out double anchorPointX, out double anchorPointY)
+	{
+		var horizontalAnchorRatio = HorizontalAnchorRatio;
+		var verticalAnchorRatio = VerticalAnchorRatio;
+
+		anchorPointX = double.IsNaN(horizontalAnchorRatio)
+			? double.NaN
+			: bounds.X + horizontalAnchorRatio * bounds.Width;
+
+		anchorPointY = double.IsNaN(verticalAnchorRatio)
+			? double.NaN
+			: bounds.Y + verticalAnchorRatio * bounds.Height;
+	}
+
+	private Size ComputeViewportToElementAnchorPointsDistance(Rect zoomedViewport, bool isForPreArrange)
+	{
+		if (m_anchorElement is null)
+		{
+			return new Size(float.NaN, float.NaN);
+		}
+
+		if (!isForPreArrange && !IsElementValidAnchor(m_anchorElement))
+		{
+			return new Size(float.NaN, float.NaN);
+		}
+
+		ComputeElementAnchorPoint(isForPreArrange,
+			out var elementAnchorPointHorizontalOffset,
+			out var elementAnchorPointVerticalOffset);
+		ComputeViewportAnchorPoint(zoomedViewport,
+			out var viewportAnchorPointHorizontalOffset,
+			out var viewportAnchorPointVerticalOffset);
+
+		// Round to 6 decimal places to avoid layout cycles due to float/double conversions (parity with WinUI).
+		return new Size(
+			double.IsNaN(viewportAnchorPointHorizontalOffset)
+				? float.NaN
+				: (float)(global::System.Math.Round((elementAnchorPointHorizontalOffset - viewportAnchorPointHorizontalOffset) * 1000000) / 1000000),
+			double.IsNaN(viewportAnchorPointVerticalOffset)
+				? float.NaN
+				: (float)(global::System.Math.Round((elementAnchorPointVerticalOffset - viewportAnchorPointVerticalOffset) * 1000000) / 1000000));
+	}
+
+	private void RaiseAnchorRequested()
+	{
+		if (AnchorRequested is null)
+		{
+			return;
+		}
+
+		m_anchorRequestedEventArgs ??= new AnchorRequestedEventArgs();
+		m_anchorRequestedEventArgs.Reset(m_anchorCandidates);
+		AnchorRequested.Invoke(this, m_anchorRequestedEventArgs);
+	}
+
+	// Raises AnchorRequested and selects an anchor based on either the handler's Anchor
+	// override, or the closest candidate to the viewport anchor point.
+	private void EnsureAnchorElementSelection(Rect zoomedViewport)
+	{
+		if (!m_isAnchorElementDirty)
+		{
+			return;
+		}
+
+		m_anchorElement = null;
+		m_anchorElementBounds = default;
+		m_isAnchorElementDirty = false;
+
+		var content = Content as UIElement;
+		if (content is null)
+		{
+			return;
+		}
+
+		ComputeViewportAnchorPoint(zoomedViewport,
+			out var viewportAnchorPointHorizontalOffset,
+			out var viewportAnchorPointVerticalOffset);
+
+		RaiseAnchorRequested();
+
+		UIElement? requestedAnchor = m_anchorRequestedEventArgs?.Anchor;
+		IList<UIElement>? candidateOverride = m_anchorRequestedEventArgs?.AnchorCandidates;
+
+		if (requestedAnchor is not null && IsElementValidAnchor(requestedAnchor, content))
+		{
+			m_anchorElement = requestedAnchor;
+			m_anchorElementBounds = GetDescendantBounds(content, requestedAnchor);
+			return;
+		}
+
+		var bestAnchorCandidateDistance = double.MaxValue;
+		UIElement? bestAnchorCandidate = null;
+		Rect bestAnchorCandidateBounds = default;
+
+		var viewportAnchorBounds = zoomedViewport;
+
+		var candidates = candidateOverride ?? (IList<UIElement>)m_anchorCandidates;
+		foreach (var candidate in candidates)
+		{
+			ProcessAnchorCandidate(
+				candidate,
+				content,
+				viewportAnchorBounds,
+				viewportAnchorPointHorizontalOffset,
+				viewportAnchorPointVerticalOffset,
+				ref bestAnchorCandidateDistance,
+				ref bestAnchorCandidate,
+				ref bestAnchorCandidateBounds);
+		}
+
+		if (bestAnchorCandidate is not null)
+		{
+			m_anchorElement = bestAnchorCandidate;
+			m_anchorElementBounds = bestAnchorCandidateBounds;
+		}
+	}
+
+	private void ProcessAnchorCandidate(
+		UIElement anchorCandidate,
+		UIElement content,
+		Rect viewportAnchorBounds,
+		double viewportAnchorPointHorizontalOffset,
+		double viewportAnchorPointVerticalOffset,
+		ref double bestAnchorCandidateDistance,
+		ref UIElement? bestAnchorCandidate,
+		ref Rect bestAnchorCandidateBounds)
+	{
+		if (!IsElementValidAnchor(anchorCandidate, content))
+		{
+			return;
+		}
+
+		var anchorCandidateBounds = GetDescendantBounds(content, anchorCandidate);
+
+		if (!SharedHelpers.DoRectsIntersect(viewportAnchorBounds, anchorCandidateBounds))
+		{
+			return;
+		}
+
+		double distance = 0;
+		if (!double.IsNaN(viewportAnchorPointHorizontalOffset))
+		{
+			distance += global::System.Math.Pow(viewportAnchorPointHorizontalOffset - anchorCandidateBounds.X, 2);
+			distance += global::System.Math.Pow(viewportAnchorPointHorizontalOffset - (anchorCandidateBounds.X + anchorCandidateBounds.Width), 2);
+		}
+
+		if (!double.IsNaN(viewportAnchorPointVerticalOffset))
+		{
+			distance += global::System.Math.Pow(viewportAnchorPointVerticalOffset - anchorCandidateBounds.Y, 2);
+			distance += global::System.Math.Pow(viewportAnchorPointVerticalOffset - (anchorCandidateBounds.Y + anchorCandidateBounds.Height), 2);
+		}
+
+		if (distance <= bestAnchorCandidateDistance)
+		{
+			bestAnchorCandidate = anchorCandidate;
+			bestAnchorCandidateBounds = anchorCandidateBounds;
+			bestAnchorCandidateDistance = distance;
+		}
+	}
+
+	private bool IsElementValidAnchor(UIElement element)
+	{
+		var content = Content as UIElement;
+		return content is not null && IsElementValidAnchor(element, content);
+	}
+
+	private static bool IsElementValidAnchor(UIElement element, UIElement content)
+	{
+		return element.Visibility == Visibility.Visible &&
+			(element == content || SharedHelpers.IsAncestor(element, content));
+	}
+
+	private Rect GetDescendantBounds(UIElement content, UIElement descendant)
+	{
+		var descendantAsFE = descendant as FrameworkElement;
+		var descendantRect = new Rect(
+			0.0,
+			0.0,
+			descendantAsFE?.ActualWidth ?? 0,
+			descendantAsFE?.ActualHeight ?? 0);
+
+		var contentAsFE = content as FrameworkElement;
+		Thickness contentMargin = contentAsFE?.Margin ?? default;
+
+		var transform = descendant.TransformToVisual(content);
+		return transform.TransformBounds(new Rect(
+			contentMargin.Left + descendantRect.X,
+			contentMargin.Top + descendantRect.Y,
+			descendantRect.Width,
+			descendantRect.Height));
+	}
+
+	// Applies a flicker-less shift of the ScrollViewer's offset.
+	// Clamps negative adjustments to avoid stepping into negative territory.
+	private void PerformPositionAdjustment(bool isHorizontalDimension, double unzoomedAdjustment, Rect zoomedViewport)
+	{
+		// zoomFactor is 1 in Uno's managed ScrollViewer pipeline.
+		var zoomedAdjustment = unzoomedAdjustment;
+
+		if (isHorizontalDimension)
+		{
+			var zoomedHorizontalOffset = zoomedViewport.X;
+			if (zoomedAdjustment < 0 && -zoomedAdjustment > zoomedHorizontalOffset)
+			{
+				zoomedAdjustment = -zoomedHorizontalOffset;
+			}
+			var newHorizontalOffset = zoomedAdjustment + zoomedHorizontalOffset;
+			ChangeView(newHorizontalOffset, null, null, disableAnimation: true);
+		}
+		else
+		{
+			var zoomedVerticalOffset = zoomedViewport.Y;
+			if (zoomedAdjustment < 0 && -zoomedAdjustment > zoomedVerticalOffset)
+			{
+				zoomedAdjustment = -zoomedVerticalOffset;
+			}
+			var newVerticalOffset = zoomedAdjustment + zoomedVerticalOffset;
+			ChangeView(null, newVerticalOffset, null, disableAnimation: true);
+		}
+	}
+
+	// Orchestrates anchoring around base.ArrangeOverride. Mirrors ScrollViewer_Partial.cpp:2112-2320.
+	internal Size AnchoringArrangeOverride(Size finalSize, global::System.Func<Size, Size> baseArrange)
+	{
+		var child = Content as UIElement;
+		if (child is null)
+		{
+			return baseArrange(finalSize);
+		}
+
+		IsAnchoring(
+			out var isAnchoringElementHorizontally,
+			out var isAnchoringElementVertically,
+			out var isAnchoringFarEdgeHorizontally,
+			out var isAnchoringFarEdgeVertically);
+
+		if (!(isAnchoringElementHorizontally || isAnchoringElementVertically ||
+			  isAnchoringFarEdgeHorizontally || isAnchoringFarEdgeVertically))
+		{
+			ResetAnchorElement();
+			var result = baseArrange(finalSize);
+			m_isAnchorElementDirty = true;
+			return result;
+		}
+
+		var preArrangeViewportX = HorizontalOffset + m_pendingViewportShiftX;
+		var preArrangeViewportY = VerticalOffset + m_pendingViewportShiftY;
+		var preArrangeViewportWidth = ViewportWidth;
+		var preArrangeViewportHeight = ViewportHeight;
+		var preArrangeViewport = new Rect(preArrangeViewportX, preArrangeViewportY, preArrangeViewportWidth, preArrangeViewportHeight);
+
+		Size preArrangeDistance = new(float.NaN, float.NaN);
+		if (isAnchoringElementHorizontally || isAnchoringElementVertically)
+		{
+			EnsureAnchorElementSelection(preArrangeViewport);
+			preArrangeDistance = ComputeViewportToElementAnchorPointsDistance(preArrangeViewport, isForPreArrange: true);
+		}
+		else
+		{
+			ResetAnchorElement();
+		}
+
+		var arrangeResult = baseArrange(finalSize);
+
+		// WinUI updates its extent/viewport members during the arrange pass; Uno delays the DP
+		// update until AfterArrange, which means PerformPositionAdjustment's clamping sees stale
+		// values. Eagerly sync now so the anchor offset correction uses post-arrange state.
+		UpdateDimensionProperties();
+
+		m_pendingViewportShiftX = 0;
+		m_pendingViewportShiftY = 0;
+
+		var childAsFE = child as FrameworkElement;
+		Thickness childMargin = childAsFE?.Margin ?? default;
+		var childRenderSize = child.RenderSize;
+		var finalChildWidth = global::System.Math.Max(
+			finalSize.Width,
+			global::System.Math.Max(0, childRenderSize.Width + childMargin.Left + childMargin.Right));
+		var finalChildHeight = global::System.Math.Max(
+			finalSize.Height,
+			global::System.Math.Max(0, childRenderSize.Height + childMargin.Top + childMargin.Bottom));
+
+		var postArrangeViewportWidth = ViewportWidth;
+		var postArrangeViewportHeight = ViewportHeight;
+		var postArrangeViewport = new Rect(preArrangeViewportX, preArrangeViewportY, postArrangeViewportWidth, postArrangeViewportHeight);
+
+		// Snapshot previous extent/viewport before updating the cache, then update immediately so
+		// any re-entrant arrange triggered by PerformPositionAdjustment doesn't double-apply.
+		var prevUnzoomedExtentWidth = m_unzoomedExtentWidth;
+		var prevUnzoomedExtentHeight = m_unzoomedExtentHeight;
+		var prevViewportWidthCache = m_viewportWidthCache;
+		var prevViewportHeightCache = m_viewportHeightCache;
+		m_unzoomedExtentWidth = finalChildWidth;
+		m_unzoomedExtentHeight = finalChildHeight;
+		m_viewportWidthCache = postArrangeViewport.Width;
+		m_viewportHeightCache = postArrangeViewport.Height;
+
+		if (!double.IsNaN(preArrangeDistance.Width) || !double.IsNaN(preArrangeDistance.Height))
+		{
+			var postArrangeDistance = ComputeViewportToElementAnchorPointsDistance(postArrangeViewport, isForPreArrange: false);
+
+			// Now switch to the actual post-arrange offsets for the adjustment viewport.
+			postArrangeViewport = new Rect(HorizontalOffset, VerticalOffset, postArrangeViewportWidth, postArrangeViewportHeight);
+
+			if (isAnchoringElementHorizontally &&
+				!double.IsNaN(preArrangeDistance.Width) &&
+				!double.IsNaN(postArrangeDistance.Width) &&
+				preArrangeDistance.Width != postArrangeDistance.Width)
+			{
+				var unzoomedAdjustment = postArrangeDistance.Width - preArrangeDistance.Width;
+				PerformPositionAdjustment(true, unzoomedAdjustment, postArrangeViewport);
+				m_pendingViewportShiftX = unzoomedAdjustment;
+			}
+
+			if (isAnchoringElementVertically &&
+				!double.IsNaN(preArrangeDistance.Height) &&
+				!double.IsNaN(postArrangeDistance.Height) &&
+				preArrangeDistance.Height != postArrangeDistance.Height)
+			{
+				var unzoomedAdjustment = postArrangeDistance.Height - preArrangeDistance.Height;
+				PerformPositionAdjustment(false, unzoomedAdjustment, postArrangeViewport);
+				m_pendingViewportShiftY = unzoomedAdjustment;
+			}
+		}
+
+		// Far-edge anchoring: use the previous extent/viewport (snapshot BEFORE the cache update).
+		if (isAnchoringFarEdgeHorizontally)
+		{
+			double unzoomedAdjustment = 0;
+			if (finalChildWidth > prevUnzoomedExtentWidth)
+			{
+				unzoomedAdjustment = finalChildWidth - prevUnzoomedExtentWidth;
+			}
+			if (prevViewportWidthCache > postArrangeViewport.Width)
+			{
+				unzoomedAdjustment += prevViewportWidthCache - postArrangeViewport.Width;
+			}
+			if (unzoomedAdjustment != 0)
+			{
+				PerformPositionAdjustment(true, unzoomedAdjustment, postArrangeViewport);
+			}
+		}
+
+		if (isAnchoringFarEdgeVertically)
+		{
+			double unzoomedAdjustment = 0;
+			if (finalChildHeight > prevUnzoomedExtentHeight)
+			{
+				unzoomedAdjustment = finalChildHeight - prevUnzoomedExtentHeight;
+			}
+			if (prevViewportHeightCache > postArrangeViewport.Height)
+			{
+				unzoomedAdjustment += prevViewportHeightCache - postArrangeViewport.Height;
+			}
+			if (unzoomedAdjustment != 0)
+			{
+				PerformPositionAdjustment(false, unzoomedAdjustment, postArrangeViewport);
+			}
+		}
+
+		m_isAnchorElementDirty = true;
+		return arrangeResult;
+	}
+
+	// Marks the anchor element dirty and triggers a reselection on the next arrange or
+	// CurrentAnchor access. Called from property-changed callbacks and other mutators.
+	internal void InvalidateAnchorElement()
+	{
+		m_isAnchorElementDirty = true;
+	}
+
+	// Ported from ScrollViewer_Partial.cpp:9440 ScrollViewer::OnScrollContentPresenterMeasured.
+	// Called by ScrollContentPresenter after its MeasureOverride completes so that, when anchoring
+	// is active, ScrollViewer.ArrangeOverride re-runs (and drives the pre/post anchor adjustment).
+	// Without this hook Uno's layout short-circuit skips ArrangeCore when the SV's own finalRect
+	// is unchanged, so the anchoring flow would not fire on grandchild extent changes.
+	internal void OnScrollContentPresenterMeasured()
+	{
+		IsAnchoring(
+			out var isAnchoringElementHorizontally,
+			out var isAnchoringElementVertically,
+			out var isAnchoringFarEdgeHorizontally,
+			out var isAnchoringFarEdgeVertically);
+
+		if (isAnchoringElementHorizontally || isAnchoringElementVertically ||
+			isAnchoringFarEdgeHorizontally || isAnchoringFarEdgeVertically)
+		{
+			InvalidateArrange();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Anchoring.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Anchoring.cs
@@ -26,6 +26,9 @@ public partial class ScrollViewer
 	private bool m_isAnchorElementDirty;
 
 	private AnchorRequestedEventArgs? m_anchorRequestedEventArgs;
+	// Matches WinUI's m_useCandidatesFromArgs flag (ScrollViewer_Partial.cpp:16169/16173/16520).
+	// Without it, Anchor/AnchorCandidates from a prior handler persist after handlers detach.
+	private bool m_useCandidatesFromArgs;
 
 	// Cached post-arrange state used for far-edge anchoring comparisons.
 	private double m_unzoomedExtentWidth;
@@ -35,6 +38,33 @@ public partial class ScrollViewer
 
 	private double m_pendingViewportShiftX;
 	private double m_pendingViewportShiftY;
+
+	// Set when AnchoringArrangeOverride eagerly syncs dimension DPs, so AfterArrange can skip the duplicate call.
+	private bool m_dimensionsUpdatedInArrange;
+
+	public static DependencyProperty HorizontalAnchorRatioProperty { get; } =
+		DependencyProperty.Register(
+			nameof(HorizontalAnchorRatio), typeof(double),
+			typeof(ScrollViewer),
+			new FrameworkPropertyMetadata(double.NaN));
+
+	public double HorizontalAnchorRatio
+	{
+		get => (double)GetValue(HorizontalAnchorRatioProperty);
+		set => SetValue(HorizontalAnchorRatioProperty, value);
+	}
+
+	public static DependencyProperty VerticalAnchorRatioProperty { get; } =
+		DependencyProperty.Register(
+			nameof(VerticalAnchorRatio), typeof(double),
+			typeof(ScrollViewer),
+			new FrameworkPropertyMetadata(double.NaN));
+
+	public double VerticalAnchorRatio
+	{
+		get => (double)GetValue(VerticalAnchorRatioProperty);
+		set => SetValue(VerticalAnchorRatioProperty, value);
+	}
 
 	public event global::Windows.Foundation.TypedEventHandler<ScrollViewer, AnchorRequestedEventArgs>? AnchorRequested;
 
@@ -125,7 +155,7 @@ public partial class ScrollViewer
 		var horizontalAnchorRatio = HorizontalAnchorRatio;
 		var verticalAnchorRatio = VerticalAnchorRatio;
 
-		if (!double.IsNaN(horizontalAnchorRatio))
+		if (!double.IsNaN(horizontalAnchorRatio) && !double.IsPositiveInfinity(ViewportWidth))
 		{
 			if (horizontalAnchorRatio == 0.0 || horizontalAnchorRatio == 1.0)
 			{
@@ -145,7 +175,7 @@ public partial class ScrollViewer
 			}
 		}
 
-		if (!double.IsNaN(verticalAnchorRatio))
+		if (!double.IsNaN(verticalAnchorRatio) && !double.IsPositiveInfinity(ViewportHeight))
 		{
 			if (verticalAnchorRatio == 0.0 || verticalAnchorRatio == 1.0)
 			{
@@ -251,12 +281,14 @@ public partial class ScrollViewer
 	{
 		if (AnchorRequested is null)
 		{
+			m_useCandidatesFromArgs = false;
 			return;
 		}
 
 		m_anchorRequestedEventArgs ??= new AnchorRequestedEventArgs();
 		m_anchorRequestedEventArgs.Reset(m_anchorCandidates);
 		AnchorRequested.Invoke(this, m_anchorRequestedEventArgs);
+		m_useCandidatesFromArgs = true;
 	}
 
 	// Raises AnchorRequested and selects an anchor based on either the handler's Anchor
@@ -284,8 +316,8 @@ public partial class ScrollViewer
 
 		RaiseAnchorRequested();
 
-		UIElement? requestedAnchor = m_anchorRequestedEventArgs?.Anchor;
-		IList<UIElement>? candidateOverride = m_anchorRequestedEventArgs?.AnchorCandidates;
+		UIElement? requestedAnchor = m_useCandidatesFromArgs ? m_anchorRequestedEventArgs?.Anchor : null;
+		IList<UIElement>? candidateOverride = m_useCandidatesFromArgs ? m_anchorRequestedEventArgs?.AnchorCandidates : null;
 
 		if (requestedAnchor is not null && IsElementValidAnchor(requestedAnchor, content))
 		{
@@ -472,6 +504,7 @@ public partial class ScrollViewer
 		// update until AfterArrange, which means PerformPositionAdjustment's clamping sees stale
 		// values. Eagerly sync now so the anchor offset correction uses post-arrange state.
 		UpdateDimensionProperties();
+		m_dimensionsUpdatedInArrange = true;
 
 		m_pendingViewportShiftX = 0;
 		m_pendingViewportShiftY = 0;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Anchoring.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Anchoring.cs
@@ -5,7 +5,7 @@
 //  ComputeViewportToElementAnchorPointsDistance, PerformPositionAdjustment,
 //  IsAnchoring, IsElementValidAnchor, GetDescendantBounds,
 //  RegisterAnchorCandidateImpl, UnregisterAnchorCandidateImpl, RaiseAnchorRequested,
-//  ResetAnchorElement, ClearAnchorCandidates, get_CurrentAnchorImpl).
+//  ResetAnchorElement, get_CurrentAnchorImpl).
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.Helpers.WinUI;
@@ -122,12 +122,6 @@ public partial class ScrollViewer
 			m_anchorCandidates.RemoveAt(index);
 			m_isAnchorElementDirty = true;
 		}
-	}
-
-	private void ClearAnchorCandidates()
-	{
-		m_anchorCandidates.Clear();
-		m_isAnchorElementDirty = true;
 	}
 
 	private void ResetAnchorElement()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -639,11 +639,6 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <remarks>Unlike the LayoutInformation.GetLayoutSlot(), this property is set **BEFORE** arranging the children of the ScrollViewer</remarks>
 		internal Size ViewportArrangeSize { get; private set; }
 
-		// Note for implementers: Search for SharedHelpers.IsRS5OrHigher() in ItemsRepeaterScrollHost.cs
-		// => This should be re-enabled AND this class also gives the base implementation for the anchoring
-		[global::Uno.NotImplemented]
-		public UIElement? CurrentAnchor => null;
-
 		/// <summary>
 		/// Cached value of <see cref="Uno.UI.Xaml.Controls.ScrollViewer.UpdatesModeProperty"/>,
 		/// in order to not access the DP on each scroll (perf considerations)
@@ -686,11 +681,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			ViewportArrangeSize = finalSize;
 
-			var arrangeSize = base.ArrangeOverride(finalSize);
-			TrimOverscroll(Orientation.Horizontal);
-			TrimOverscroll(Orientation.Vertical);
-
-			return arrangeSize;
+			return AnchoringArrangeOverride(finalSize, size =>
+			{
+				var arranged = base.ArrangeOverride(size);
+				TrimOverscroll(Orientation.Horizontal);
+				TrimOverscroll(Orientation.Vertical);
+				return arranged;
+			});
 		}
 
 		partial void TrimOverscroll(Orientation orientation);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -702,7 +702,14 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			base.OnLayoutUpdated();
 #endif
-			UpdateDimensionProperties();
+			if (m_dimensionsUpdatedInArrange)
+			{
+				m_dimensionsUpdatedInArrange = false;
+			}
+			else
+			{
+				UpdateDimensionProperties();
+			}
 			UpdateZoomedContentAlignment();
 		}
 


### PR DESCRIPTION
## Summary

Implements `ScrollViewer.CurrentAnchor`, `RegisterAnchorCandidate` / `UnregisterAnchorCandidate`, the `AnchorRequested` event, and honors `HorizontalAnchorRatio` / `VerticalAnchorRatio` — previously stubbed with `[NotImplemented]`. With this change, a `ScrollViewer` that has an anchor ratio set will preserve the visual position of its chosen anchor element when content above it grows or shrinks (the classic "chat window" / "log view" use case).

Ported line-for-line from `microsoft-ui-xaml2/src/dxaml/xcp/dxaml/lib/ScrollViewer_Partial.cpp` using `/winui-port`:

- `CurrentAnchor` getter (`get_CurrentAnchorImpl`)
- `RegisterAnchorCandidateImpl` / `UnregisterAnchorCandidateImpl` (preserves WinUI's allow-duplicate release-build semantics)
- `RaiseAnchorRequested` + `AnchorRequestedEventArgs` (with `Anchor` and mutable `AnchorCandidates`)
- `IsAnchoring`, `ComputeAnchorPoint` / `ComputeViewportAnchorPoint` / `ComputeElementAnchorPoint`
- `ComputeViewportToElementAnchorPointsDistance`
- `EnsureAnchorElementSelection`, `ProcessAnchorCandidate`
- `GetDescendantBounds`, `IsElementValidAnchor`
- `PerformPositionAdjustment`
- `ArrangeOverride` orchestration (pre-distance → baseArrange → post-distance → offset correction, plus far-edge anchoring against the cached extent/viewport)

To match WinUI's behavior on Uno, `ScrollContentPresenter.MeasureOverride` now calls `ScrollViewer.OnScrollContentPresenterMeasured` (mirror of `ScrollViewer_Partial.cpp:9440`), which invalidates arrange when anchoring is active. Without this hook, Uno's layout short-circuit would skip `ArrangeCore` when the SV's own `finalRect` is unchanged, and the anchoring flow would not fire on grandchild extent changes.

## Scope

- Works for the managed `ScrollContentPresenter` pipeline (Skia + WASM).
- `CurrentAnchor` / `Register` / `Unregister` / `AnchorRequested` surface is available on all platforms.
- Out of scope: `CanContentRenderOutsideBounds` (still stubbed — separate feature), zoom-factor coupling during anchoring (managed SV's `ZoomFactor` is always 1), integration with native scroll containers on Android/iOS.

## Test plan

- [x] 17 runtime tests added (`Given_ScrollViewer_Anchoring`) covering:
  - `CurrentAnchor` null cases (no ratios, no candidates)
  - Closest-candidate selection (vertical and horizontal)
  - `CurrentAnchor` updates on scroll
  - Register / Unregister roundtrip and duplicate-allow semantics
  - `AnchorRequested` firing, handler anchor override, handler candidate-list mutation
  - Position preservation on content grow/shrink above anchor
  - Collapsed and non-descendant candidate rejection
  - Far-edge anchoring (`VerticalAnchorRatio == 1.0`) and near-edge no-op (`== 0.0`)
  - `IScrollAnchorProvider` cast
- [x] All 17 pass on **native WinUI** via `/winui-runtime-tests` (validates tests encode correct reference behavior).
- [x] All 17 pass on **Uno Skia** via `/runtime-tests`.
- [x] Full `Given_ScrollViewer` regression suite: no new failures (four pre-existing flaky tests unchanged, confirmed via `git stash` baseline).
- [x] Manual smoke in `SamplesApp.Skia.Generic` via the new `ScrollViewer_Anchoring` sample (insert above / remove above / ratio picker, live `CurrentAnchor` and offset readout).
- [x] Runtime tests on WASM (not executed locally — shares the managed SCP code path but worth running in CI).

Closes #4548
Closes #23043

🤖 Generated with [Claude Code](https://claude.com/claude-code)