### PR TITLE
fix(devserver): keep MCP meta-tools available for the full session

### DIFF
--- a/specs/001-fast-devserver-startup/spec-appendix-a-startup-workflow.md
+++ b/specs/001-fast-devserver-startup/spec-appendix-a-startup-workflow.md
@@ -343,7 +343,7 @@ sequenceDiagram
     end
 ```
 
-> **Note**: The tool cache (`tools-cache.json`) has been removed. For MCP clients that do not re-query `list_tools` after `tools/list_changed`, the meta-tools `uno_discover_tools` and `uno_execute_tool` provide an alternative mechanism to discover and call upstream tools.
+> **Note**: The tool cache (`tools-cache.json`) has been removed. The meta-tools `uno_discover_tools` and `uno_execute_tool` now provide a stable compatibility mechanism to discover and call upstream tools throughout the session, even as `tools/list_changed` updates the direct tool set.
 
 ### Clients Without `list_changed` Support
 
@@ -722,4 +722,4 @@ Both layers are self-discovering — no hardcoded package names. A new add-in pa
 
 ### Tool Cache (Removed)
 
-The `ToolCacheFile` (`tools-cache.json`) has been removed. There is no more file persistence for tool definitions (`IsToolCacheEnabled`, `PersistToolCacheIfNeeded`, `RefreshCachedToolsFromUpstreamAsync` no longer exist). The meta-tools `uno_discover_tools` (returns upstream tools with full schemas) and `uno_execute_tool` (forwards a tool call to the upstream by name) replace the cache as the mechanism for MCP clients that do not re-query `list_tools` after `tools/list_changed`.
+The `ToolCacheFile` (`tools-cache.json`) has been removed. There is no more file persistence for tool definitions (`IsToolCacheEnabled`, `PersistToolCacheIfNeeded`, `RefreshCachedToolsFromUpstreamAsync` no longer exist). The meta-tools `uno_discover_tools` (returns upstream tools with full schemas) and `uno_execute_tool` (forwards a tool call to the upstream by name) replace the cache as a stable compatibility mechanism while the direct tool set changes during the session.

--- a/specs/001-fast-devserver-startup/spec-appendix-e-reference.md
+++ b/specs/001-fast-devserver-startup/spec-appendix-e-reference.md
@@ -15,14 +15,14 @@ These tools are provided directly by the DevServer MCP bridge before the upstrea
 | `uno_health` | Returns the current `HealthReport` state for the bridge and selected workspace | Always |
 | `uno_app_select_solution` | Explicitly selects a Uno solution by absolute solution path and starts/restarts DevServer when needed | Always |
 | `uno_app_initialize` | Initializes the workspace. Takes `workspaceDirectory` (required) and `solutionPath` (optional), blocks until the DevServer is connected, and returns status plus available tools. Replaces the former `uno_app_set_roots`. | Force-roots-fallback (auto-detected when client lacks `roots` capability and workspace is unresolved, or explicit via `--force-roots-fallback`) |
-| `uno_discover_tools` | Returns upstream tools with full schemas. Compatibility meta-tool for MCP clients that do not re-query `list_tools` after `tools/list_changed`. | Always (after upstream connection) |
-| `uno_execute_tool` | Forwards a tool call to the upstream by name. Compatibility meta-tool for MCP clients that do not re-query `list_tools` after `tools/list_changed`. | Always (after upstream connection) |
+| `uno_discover_tools` | Returns upstream tools with full schemas. Compatibility meta-tool that remains available for the full session as the direct tool set changes. | Always (after upstream connection) |
+| `uno_execute_tool` | Forwards a tool call to the upstream by name. Compatibility meta-tool that remains available for the full session as the direct tool set changes. | Always (after upstream connection) |
 
 `uno_app_select_solution` is implemented in `uno.devserver`, not `uno.app-mcp`, because solution selection affects pre-host behavior: workspace resolution, DevServer lifecycle, and health.
 
 ### E.1b Upstream app tools (reference from uno.app-mcp)
 
-> **Note**: The tool count visible to the AI model depends on the user's license tier. `MCPToolsObserverService` filters tools via `[LicenseFeatures]` attributes. For MCP clients that do not re-query `list_tools` after `tools/list_changed`, the meta-tools `uno_discover_tools` and `uno_execute_tool` provide an alternative mechanism to access upstream tools.
+> **Note**: The tool count visible to the AI model depends on the user's license tier. `MCPToolsObserverService` filters tools via `[LicenseFeatures]` attributes. The meta-tools `uno_discover_tools` and `uno_execute_tool` remain available as a stable compatibility mechanism to access upstream tools even while `tools/list_changed` updates the direct tool set.
 >
 > **Known discrepancy**: The public docs (`doc/articles/features/using-the-uno-mcps.md`) do not list all tools (e.g., `uno_app_start` is missing, Business tier not documented). The table below reflects the **actual server code** (`uno.app-mcp`), not the docs. See also `uno.app-mcp/README.md` alongside this spec for upstream action items.
 

--- a/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
+++ b/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
@@ -165,7 +165,7 @@ How different SDK versions affect add-in discovery.
 
 | Risk | Scenario | Impact | Mitigation |
 |------|----------|--------|------------|
-| Client doesn't support `tools/list_changed` | Tool list updates after initial response | Client never sees updated tools | `--mcp-wait-tools-list` blocks until upstream responds. Additionally, meta-tools `uno_discover_tools` and `uno_execute_tool` allow clients to discover and invoke upstream tools without re-querying `list_tools`. |
+| Client doesn't support `tools/list_changed` | Tool list updates after initial response | Client never sees updated tools | `--mcp-wait-tools-list` blocks until upstream responds. Additionally, meta-tools `uno_discover_tools` and `uno_execute_tool` remain available throughout the session as a stable compatibility path to upstream tools. |
 | Client doesn't support `resources` | `uno://health` not accessible | No diagnostics | `uno_health` tool as universal fallback |
 | Client doesn't support `roots` | Workspace not discovered | Discovery fails | Roots fallback auto-detected when client lacks `roots` capability and workspace is unresolved; `--force-roots-fallback` still available for explicit override |
 | No client supports `resources/subscribe` | Health push notifications never received | Clients must poll or rely on `tools/list_changed` | Design for pull-based health (tool call), not push-based (subscription) |
@@ -219,7 +219,7 @@ These scenarios test the interaction between different DevServer launchers runni
 | Business | 12 | `tools/list_changed` sent |
 | Expired/None | 0 | Warning in health |
 
-> **Note**: The tool cache (`tools-cache.json`) has been removed. For clients that do not re-query `list_tools` after `tools/list_changed`, the meta-tools `uno_discover_tools` and `uno_execute_tool` provide an alternative mechanism to discover and call upstream tools.
+> **Note**: The tool cache (`tools-cache.json`) has been removed. The meta-tools `uno_discover_tools` and `uno_execute_tool` provide a stable compatibility mechanism to discover and call upstream tools while the direct tool set changes during the session.
 
 ### Validation
 

--- a/specs/001-fast-devserver-startup/spec.md
+++ b/specs/001-fast-devserver-startup/spec.md
@@ -159,7 +159,7 @@ Both use the same registration pattern:
 
 | ID | Requirement | Priority |
 |----|------------|----------|
-| **FR1** | MCP STDIO server starts and responds to `list_tools` within 1 second of process launch. For clients that do not re-query `list_tools` after `tools/list_changed`, meta-tools (`uno_discover_tools`, `uno_execute_tool`) provide access to upstream tools. | Must |
+| **FR1** | MCP STDIO server starts and responds to `list_tools` within 1 second of process launch. Compatibility meta-tools (`uno_discover_tools`, `uno_execute_tool`) remain available throughout the session as a stable path to upstream tools while the direct tool set changes. | Must |
 | **FR2** | Licensed MCP tools functional within 5 seconds of launch (warm cache). Tool count depends on license tier (Community 9, Pro 11, Business 12). | Must |
 | **FR3** | If host is not ready, tool calls return structured errors with remediation hints | Must |
 | **FR4** | `uno://health`, `uno_health`, and CLI `health` expose the same structured diagnostics model | Must |
@@ -485,7 +485,7 @@ Program.Main()
 
 On first `list_tools`:
 - Return bridge tools (`uno_health`, `uno_app_select_solution`, `uno_app_initialize` when in force-roots-fallback mode) plus meta-tools (`uno_discover_tools`, `uno_execute_tool`)
-- Meta-tools allow clients that do not re-query `list_tools` after `tools/list_changed` to discover and invoke upstream tools
+- Meta-tools provide a stable compatibility path to discover and invoke upstream tools even as `tools/list_changed` updates the direct tool set
 - Tool *calls* that arrive before the host is ready get a structured error (not a hang)
 
 > **Implementation note**: The tool cache (`tools-cache.json`, `ToolCacheFile`) has been removed entirely. There is no more file persistence for tool definitions (`IsToolCacheEnabled`, `PersistToolCacheIfNeeded`, `RefreshCachedToolsFromUpstreamAsync` no longer exist). The meta-tools `uno_discover_tools` and `uno_execute_tool` replace the cache as the mechanism for clients to access tools that arrive after the initial `list_tools`. The `--force-generate-tool-cache` CLI option is now a no-op, kept for backward compatibility.
@@ -1166,7 +1166,7 @@ This refactoring is a **prerequisite** for the state machine (Phase 1c). All ser
 | Upstream `MCPToolsObserverService` TCS has no timeout | If license check throws or hangs **before** `TrySetResult()` at `:161`, upstream `list_tools` blocks forever (`MCPToolsObserverService.cs:194`, TCS at `:37`). Note: `TrySetResult()` IS called in the normal 0-tool path; the gap is exception/hang before that line. | **High (upstream bug)** | Upstream fix recommended — see `uno.app-mcp/README.md` alongside this spec. CLI-side 30s timeout (Phase 1a) mitigates for MCP mode once implemented. |
 | `.targets` diagnostic finds `tools/devserver/` but entry point unknown | Silently degraded state | Medium | Warning in health resource; do NOT load DLLs blindly |
 | Upstream `list_tools` blocks on license resolution | Slower than expected "functional tools" time | Medium | FR10 acknowledges this; CLI-side cache serves tools while upstream resolves |
-| **Tool cache removed** | The `tools-cache.json` file and all associated code (`IsToolCacheEnabled`, `PersistToolCacheIfNeeded`, `RefreshCachedToolsFromUpstreamAsync`) have been removed. Meta-tools (`uno_discover_tools`, `uno_execute_tool`) replace the cache as the mechanism for clients that do not re-query `list_tools` after `tools/list_changed`. `--force-generate-tool-cache` is now a no-op. | **Resolved** | Meta-tools provide a runtime mechanism that does not require file persistence. |
+| **Tool cache removed** | The `tools-cache.json` file and all associated code (`IsToolCacheEnabled`, `PersistToolCacheIfNeeded`, `RefreshCachedToolsFromUpstreamAsync`) have been removed. Meta-tools (`uno_discover_tools`, `uno_execute_tool`) replace the cache as the runtime compatibility mechanism for accessing upstream tools as the direct tool set changes. `--force-generate-tool-cache` is now a no-op. | **Resolved** | Meta-tools provide a runtime mechanism that does not require file persistence. |
 | **Controller bypass reimplementation scope** (Phase 1b) | Missing controller responsibilities break MCP mode | **Medium-High** | Controller has 9 responsibilities (see 1g table). Each must be reimplemented or explicitly delegated. High test coverage required — each responsibility needs a dedicated test. |
 | **VS extension launcher reflection fragility** | VS extension (`uno.studio`) uses reflection to load `Uno.UI.RemoteControl.VS.dll` and probe **two type names**: `Uno.UI.DevServer.VS.EntryPoint` then `Uno.UI.RemoteControl.VS.EntryPoint` (`DevServerLauncher.cs:302-303`), with v3/v2/v1 constructor probing (`DevServerLauncher.cs:313-326`). Changes to either type name or any constructor signature break the VS extension. | Medium | Lock both type names and all three constructor signatures (v1/v2/v3) with regression tests. See `uno.studio/README.md` alongside this spec for full signature details. |
 | **Rider auto-restart race condition** | Rider extension auto-restarts Host immediately on process exit. If CLI MCP mode kills and relaunches Host, Rider may race to restart its own copy → two instances. | **Medium** | AmbientRegistry pre-check exists **only in the controller path** (`Program.Command.cs:37-49`), NOT in the server-mode startup (`Program.cs` only registers at line 221, no pre-check). Rider launches Host directly (no controller). **Mitigation requires adding AmbientRegistry pre-check to the server-mode path** OR ensuring Rider uses the controller path. Test: MCP restarts Host while Rider is connected → verify only one instance survives. |
@@ -1208,7 +1208,7 @@ This refactoring is a **prerequisite** for the state machine (Phase 1c). All ser
 
 ### Phase 1a: Immediate MCP Start (MCP-only)
 - Restructure `McpProxy` to start STDIO server immediately
-- Return bridge tools + meta-tools (`uno_discover_tools`, `uno_execute_tool`) on first `list_tools` for clients that do not re-query after `tools/list_changed`
+- Return bridge tools + meta-tools (`uno_discover_tools`, `uno_execute_tool`) on initial and subsequent `list_tools` responses so clients always retain a stable compatibility route
 - Structured error responses for premature tool calls
 - **Fix `list_tools` indefinite blocking** (FR11): bounded timeout, handle 0-tool case
 - **Fix `McpClientProxy.DisposeAsync` hang**: `TrySetCanceled()` on TCS before awaiting (process shutdown must not block)

--- a/specs/002-mcp-setup/spec.md
+++ b/specs/002-mcp-setup/spec.md
@@ -81,7 +81,7 @@ This is the existing MCP STDIO proxy. All current options remain:
 | `--port <port>` | Port for DevServer (default: auto-allocate) |
 | `--mcp-wait-tools-list` | Wait for upstream server tools before responding to `list_tools` |
 | `--force-roots-fallback` | Expose `uno_app_initialize` tool and defer workspace resolution until the tool is called. `uno_app_initialize` takes `workspaceDirectory` (required) and `solutionPath` (optional), blocks until the DevServer is connected, and returns status plus available tools. The provided directory is always accepted as workspace root, even when no Uno solution is found yet — the file watcher monitors the directory and auto-starts the DevServer when a solution appears. **Auto-detected**: when the MCP client does not advertise the `roots` capability and the workspace is not already resolved, the proxy automatically enables roots fallback behavior. The CLI flag is still supported for explicit override but is no longer required in most configurations. |
-| `--force-generate-tool-cache` | **Deprecated (no-op)**. Kept for backward compatibility but does nothing. The tool cache (`tools-cache.json`) has been removed; meta-tools (`uno_discover_tools` and `uno_execute_tool`) replace the cache as the mechanism for clients to access tools that arrive after the initial `list_tools`. |
+| `--force-generate-tool-cache` | **Deprecated (no-op)**. Kept for backward compatibility but does nothing. The tool cache (`tools-cache.json`) has been removed; meta-tools (`uno_discover_tools` and `uno_execute_tool`) replace the cache as the stable compatibility mechanism for accessing upstream tools as the direct tool set changes during the session. |
 | `--solution-dir <path>` | Explicit solution root |
 
 ### Subcommand: `mcp status`

--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_McpStdioServer.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_McpStdioServer.cs
@@ -1,9 +1,9 @@
+using System.Text.Json;
 using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using Uno.UI.DevServer.Cli.Helpers;
 using Uno.UI.DevServer.Cli.Mcp;
-using System.Text.Json;
 
 namespace Uno.UI.DevServer.Cli.Tests.Mcp;
 
@@ -256,6 +256,19 @@ public class Given_McpStdioServer
 		server.OnListChangedNotificationSent();
 
 		// The client has not re-queried list_tools yet, so meta-tools should still be included
+		server.ShouldIncludeMetaTools.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[Description("ShouldIncludeMetaTools stays true after a client re-queries after list_changed so compatibility tools remain routable for the full session")]
+	public void ShouldIncludeMetaTools_AfterClientReQuery_RemainsTrue()
+	{
+		var server = CreateMcpStdioServer();
+
+		server.OnListChangedNotificationSent();
+		server.OnListToolsQueried();
+
+		server.ClientReQueriedAfterListChanged.Should().BeTrue();
 		server.ShouldIncludeMetaTools.Should().BeTrue();
 	}
 

--- a/src/Uno.UI.DevServer.Cli/Mcp/McpStdioServer.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/McpStdioServer.cs
@@ -28,10 +28,10 @@ internal class McpStdioServer(
 	internal const int InitializeTimeoutMs = 120_000; // 2 minutes
 
 	// ── Meta-tool definitions ──────────────────────────────────────────
-	// These tools provide a compatibility layer for MCP clients that do not
-	// re-query list_tools after a tools/list_changed notification. They are
-	// included in the initial list_tools response and removed once the client
-	// demonstrates support for tools/list_changed by re-querying.
+	// These tools provide a stable compatibility layer while the direct upstream
+	// tool set changes during DevServer startup, reconnects, or license-driven
+	// tool list updates. They stay published for the full session so MCP clients
+	// always retain a routable fallback path.
 
 	internal static readonly Tool InitializeTool = new()
 	{
@@ -197,7 +197,7 @@ internal class McpStdioServer(
 					return healthResult;
 				}
 
-				// Handle uno_discover_tools (meta-tool for clients without list_changed)
+				// Handle uno_discover_tools (stable compatibility meta-tool)
 				if (toolName == DiscoverToolsTool.Name)
 				{
 					try
@@ -247,7 +247,7 @@ internal class McpStdioServer(
 					}
 				}
 
-				// Handle uno_execute_tool (meta-tool for clients without list_changed)
+				// Handle uno_execute_tool (stable compatibility meta-tool)
 				if (toolName == ExecuteToolTool.Name)
 				{
 					if (ctx.Params?.Arguments is not { } executeArgs

--- a/src/Uno.UI.DevServer.Cli/Mcp/McpStdioServer.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/McpStdioServer.cs
@@ -66,8 +66,10 @@ internal class McpStdioServer(
 	};
 
 	// ── Meta-tool tracking state ───────────────────────────────────────
-	// Tracks whether the client supports tools/list_changed by observing
-	// whether it re-queries list_tools after a notification.
+	// Meta-tools stay published for the full session. Some MCP clients can
+	// transiently rebuild their routing table as the upstream tool set changes.
+	// Removing the compatibility tools after a re-query makes them non-routable
+	// exactly when the client still needs a stable fallback.
 	private volatile bool _listChangedNotificationSent;
 	private volatile bool _clientReQueriedAfterListChanged;
 
@@ -79,12 +81,17 @@ internal class McpStdioServer(
 		_listChangedNotificationSent = true;
 	}
 
-	/// <summary>
-	/// Returns true when meta-tools (uno_discover_tools, uno_execute_tool) should be included
-	/// in list_tools responses. Meta-tools are included until the client demonstrates support
-	/// for tools/list_changed by re-querying list_tools after a notification.
-	/// </summary>
-	internal bool ShouldIncludeMetaTools => !_clientReQueriedAfterListChanged;
+	internal void OnListToolsQueried()
+	{
+		if (_listChangedNotificationSent)
+		{
+			_clientReQueriedAfterListChanged = true;
+		}
+	}
+
+	internal bool ClientReQueriedAfterListChanged => _clientReQueriedAfterListChanged;
+
+	internal bool ShouldIncludeMetaTools => true;
 
 	private static void LogTimeline(ILogger logger, string stage, long elapsedMilliseconds, string details)
 	{
@@ -403,12 +410,9 @@ internal class McpStdioServer(
 				var listToolsStopwatch = Stopwatch.StartNew();
 				logger.LogTrace("RECV list_tools");
 
-				// Track whether the client re-queried after tools/list_changed.
-				// A re-query means the client supports list_changed and does not need meta-tools.
-				if (_listChangedNotificationSent)
-				{
-					_clientReQueriedAfterListChanged = true;
-				}
+				// Preserve the observation for diagnostics/tests, but keep the
+				// compatibility meta-tools published regardless of re-query state.
+				OnListToolsQueried();
 
 				await ensureRootsInitialized(ctx, tcs, ct);
 


### PR DESCRIPTION
## Summary

This is a functional MCP compatibility fix.

The DevServer bridge currently exposes two layers of tools:

- bridge/meta-tools such as `uno_discover_tools` and `uno_execute_tool`
- direct upstream tools such as `uno_app_start`, `uno_app_get_screenshot`, etc.

Previously, once the client re-queried `list_tools` after `tools/list_changed`, the bridge stopped publishing the meta-tools. In practice, that made the visible tool set non-monotonic during a session: some tools appeared, then disappeared, while the direct upstream tool set was still changing with DevServer readiness and reconnects.

Some MCP clients, especially Copilot-style clients, do not behave well when tools disappear mid-session. They can keep stale routing state or end up trying to call tools that are no longer available. When that happened here, interactive Uno MCP usage became unreliable.

This change keeps the compatibility meta-tools available for the full session, even after `tools/list_changed` and even while the direct upstream tool set is updated.

In other words: we keep Copilot's little fallback toy available so it does not get confused and cry when the direct tool list moves around.

## Problem

The old behavior created an unstable routing model:

- initial `list_tools` exposed bridge tools plus meta-tools
- upstream connected and `tools/list_changed` was sent
- client re-queried `list_tools`
- bridge removed `uno_discover_tools` / `uno_execute_tool`
- direct tools were still subject to readiness/reconnect timing

That left sessions in a bad state where:

- direct tools were visible but not actually ready, or
- compatibility tools were no longer routable, or
- the client had stale assumptions about which tools still existed

This was particularly visible with Copilot CLI, which could get mixed up when tools disappeared during the session.

## Fix

The bridge now keeps `uno_discover_tools` and `uno_execute_tool` published for the entire MCP session.

This provides a stable compatibility path to upstream tools regardless of:

- `tools/list_changed`
- client re-queries
- DevServer startup timing
- reconnect/reset churn

The direct tool set can still evolve, but the compatibility route remains stable.

## Why this is the right fix

This is not just a documentation or UX tweak. It is a functional fix to MCP routing stability.

The meta-tools are the safest compatibility surface we have. Removing them mid-session made tool publication non-monotonic and increased the chances of client-side routing drift.

Keeping them available gives clients a consistent fallback mechanism and makes the session behavior much more robust.

## Tests

Added a targeted regression test covering the broken behavior:

- reproduce the post-`tools/list_changed` re-query scenario
- verify that the compatibility meta-tools remain included
- confirm the fix keeps the session-compatible path available

This follows the intended bug-fix flow: red -> fix -> green.

## Spec updates

Updated MCP/DevServer specs to reflect the intended behavior:

- meta-tools are no longer described as a fallback only for clients that fail to re-query
- they are now documented as a stable compatibility mechanism throughout the session

## Validation

- Code review assessment: the bridge no longer removes the compatibility routing surface after a client re-query
- Compile validation: targeted DevServer CLI test suite passes
- Runtime validation: local package validation confirmed the behavior works in practice with the affected client flow

Closes #23076
