### PR TITLE
fix: restore XamlScope in ElementStub.Materialize for StaticResource resolution

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_StaticResource.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_StaticResource.xaml
@@ -1,0 +1,20 @@
+<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.xLoad_StaticResource"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <x:String x:Key="LazyString">RESOLVED</x:String>
+    </UserControl.Resources>
+
+    <StackPanel>
+        <ContentControl
+            x:Name="LazyControl"
+            x:FieldModifier="public"
+            x:Load="False"
+            Content="{StaticResource LazyString}" />
+    </StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_StaticResource.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_StaticResource.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class xLoad_StaticResource : UserControl
+	{
+		public xLoad_StaticResource()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -15,6 +15,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
 using SamplesApp.UITests;
+using Uno.Disposables;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 {
@@ -487,6 +488,39 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			Assert.AreEqual(1, SUT.GetChildren().Count(c => c is ElementStub));
 			Assert.AreEqual(0, SUT.GetChildren().Count(c => c is Border));
 		}
+
+#if HAS_UNO // need to access uno internal&specific: DepObjStore ResourceBinding
+		// Regression test for https://github.com/unoplatform/uno/issues/23088
+		// {StaticResource} on a lazily loaded element must resolve eagerly (without a ResourceBinding
+		// fallback) once the element is materialized.
+		[TestMethod]
+		public async Task When_xLoad_False_StaticResource_Resolves()
+		{
+			// ForceHotReloadDisabled is altering the execute logics, forcing ResourceBinding to always be created
+			var previousFlag = FeatureConfiguration.Xaml.ForceHotReloadDisabled;
+			FeatureConfiguration.Xaml.ForceHotReloadDisabled = true;
+			using var restoreFlag = Disposable.Create(() => FeatureConfiguration.Xaml.ForceHotReloadDisabled = previousFlag);
+
+			var setup = new xLoad_StaticResource();
+			TestServices.WindowHelper.WindowContent = setup;
+			await TestServices.WindowHelper.WaitForLoaded(setup, x => x.IsLoaded);
+
+			// Before materialisation the field is null (stub placeholder).
+			Assert.IsNull(setup.LazyControl, "Expected LazyControl to be null initially");
+
+			// force materialize by calling .FindName
+			setup.FindName(nameof(setup.LazyControl));
+			Assert.IsNotNull(setup.LazyControl, "LazyControl should be resolved by FindName('LazyControl')");
+
+			// note: we dont .WaitForIdle() because that will let ResourceBinding kicks in, if present.
+			var dos = (setup.LazyControl as IDependencyObjectStoreProvider)?.Store!;
+			var bindings = dos.GetResourceBindingsForProperty(ContentControl.ContentProperty).ToArray();
+			Assert.IsEmpty(bindings, "There is should be non ResourceBinding on the LazyControl.Content, if it resolved statically(still runtime).");
+			Assert.IsNotNull(setup.LazyControl);
+			Assert.AreEqual("RESOLVED", setup.LazyControl.Content);
+
+		}
+#endif
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -47,6 +47,11 @@ namespace Microsoft.UI.Xaml
 		private View _content;
 #endif
 
+		// Captures the resource scope at parse time so {StaticResource} lookups inside the
+		// lazily-created subtree can walk the same ancestor chain they would have seen if the
+		// element had been created eagerly (mirrors what FrameworkTemplate does).
+		private XamlScope _xamlScope;
+
 		/// <summary>
 		/// Ensures that materialization handles reentrancy properly.
 		/// This scenario can happen on android specifically because the Parent
@@ -123,6 +128,11 @@ namespace Microsoft.UI.Xaml
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 			_fromLegacyTemplate = TemplatedParentScope.GetCurrentTemplate() is { IsLegacyTemplate: true };
 #endif
+
+			// Capture the resource scope at construction time (during XAML parsing) so that
+			// {StaticResource} lookups in the lazily-materialised subtree can resolve against
+			// the same ancestor resource chain they would see during eager parsing.
+			_xamlScope = ResourceResolver.CurrentScope;
 		}
 
 		public ElementStub()
@@ -199,6 +209,7 @@ namespace Microsoft.UI.Xaml
 				try
 				{
 					_isMaterializing = true;
+					ResourceResolver.PushNewScope(_xamlScope);
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 					TemplatedParentScope.PushScope(GetTemplatedParent(), _fromLegacyTemplate);
 #endif
@@ -212,6 +223,7 @@ namespace Microsoft.UI.Xaml
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 					TemplatedParentScope.PopScope();
 #endif
+					ResourceResolver.PopScope();
 					_isMaterializing = false;
 				}
 			}


### PR DESCRIPTION
**GitHub Issue:** closes #23088, re: unoplatform/kahua-private#403

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

When an element has `x:Load="False"`, it is replaced by an `ElementStub` placeholder at parse time. When the element is later materialized, `ResourceResolver.CurrentScope` is empty (the parse-time scope has already been popped), so `{StaticResource}` lookups inside the lazily-created subtree fail to find resources in ancestor elements. This causes spurious warning logs as the resolution falls back to a deferred `ResourceBinding`.

## What is the new behavior? 🚀

`ElementStub` now captures `ResourceResolver.CurrentScope` at construction time (during XAML parsing), mirroring the existing pattern in `FrameworkTemplate`. When `MaterializeInner()` is called, the captured scope is pushed before the content builder runs and popped in the `finally` block. This allows `{StaticResource}` lookups inside lazily-materialized subtrees to correctly walk the ancestor resource chain and resolve eagerly without creating spurious `ResourceBinding` deferred bindings.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

The fix follows the exact same scope save/restore pattern already established in `FrameworkTemplate.cs` (lines 109, 189, 223). The new runtime test `Given_xLoad.When_xLoad_False_StaticResource_Resolves` verifies that after materialization, `ContentControl.ContentProperty` has no `ResourceBinding` (i.e., it resolved statically) and the value equals `"RESOLVED"`.