### PR TITLE
ipados numberbox keypad anchor

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_KeyboardPlacement.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_KeyboardPlacement.xaml
@@ -28,6 +28,21 @@
                 TextAlignment="Center"
                 TextWrapping="Wrap" />
 
+            <!--  Top spacer to force scrolling so a NumberBox can be positioned near the top of the viewport. Repro for keypad popup showing at (0,0) covering the NumberBox when it is too close to the top of the page.  -->
+            <Border
+                Height="800"
+                Background="{ThemeResource SystemControlBackgroundListLowBrush}"
+                CornerRadius="8">
+                <TextBlock
+                    Margin="16"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                    Text="Scroll down, then tap a NumberBox while it sits near the top of the viewport to reproduce the keypad-popup placement issue."
+                    TextAlignment="Center"
+                    TextWrapping="Wrap" />
+            </Border>
+
             <!--  Decimal Pad section  -->
             <StackPanel
                 Padding="16"
@@ -262,6 +277,49 @@
                         Value="3" />
                 </Grid>
             </StackPanel>
+
+            <!--  Left-aligned, unlabeled NumberBoxes with 6px padding. Repro for the native number pad flyout being positioned on top of the NumberBox, covering its visible area.  -->
+            <StackPanel
+                Padding="16"
+                Background="{ThemeResource SystemControlBackgroundListLowBrush}"
+                CornerRadius="8"
+                Spacing="12">
+
+                <TextBlock
+                    FontSize="16"
+                    FontWeight="SemiBold"
+                    Text="Left-Aligned NumberBoxes (Padding 15)" />
+
+                <controls:NumberBox
+                    x:Name="LeftAlignedNumberBox1"
+                    Padding="15"
+                    HorizontalAlignment="Left"
+                    AutomationProperties.Name="LeftAlignedNumberBox1"
+                    PlaceholderText="0"
+                    Value="0" />
+
+                <controls:NumberBox
+                    x:Name="LeftAlignedNumberBox2"
+                    Padding="15"
+                    HorizontalAlignment="Left"
+                    AutomationProperties.Name="LeftAlignedNumberBox2"
+                    PlaceholderText="0"
+                    Value="0" />
+
+                <controls:NumberBox
+                    x:Name="LeftAlignedNumberBox3"
+                    Padding="15"
+                    HorizontalAlignment="Left"
+                    AutomationProperties.Name="LeftAlignedNumberBox3"
+                    PlaceholderText="0"
+                    Value="0" />
+            </StackPanel>
+
+            <!--  Bottom spacer so any NumberBox above can be scrolled up to the top of the viewport.  -->
+            <Border
+                Height="800"
+                Background="{ThemeResource SystemControlBackgroundListLowBrush}"
+                CornerRadius="8" />
 
         </StackPanel>
     </ScrollViewer>

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -329,13 +329,21 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 	}
 
 	private bool ShouldAnchorToTextBox()
+		=> _textBoxView is { } view && IsFloatingNumericKeypad(view.KeyboardType);
+
+	// Single source of truth for "should we anchor/expand the caret rect so
+	// iPad's floating numeric keypad positions adjacent to the full control?"
+	// Also consumed by SinglelineInvisibleTextBoxView.GetFirstRectForRange /
+	// GetCaretRectForPosition. Keep the two call sites in sync by routing
+	// through this helper.
+	internal static bool IsFloatingNumericKeypad(UIKeyboardType keyboardType)
 	{
 		if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
 		{
 			return false;
 		}
 
-		return _textBoxView?.KeyboardType is
+		return keyboardType is
 			UIKeyboardType.NumberPad or
 			UIKeyboardType.DecimalPad or
 			UIKeyboardType.NumbersAndPunctuation or

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -47,29 +47,14 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 	// position the iPad floating numeric keypad. Returning the view's full
 	// Bounds makes the keypad anchor adjacent to the whole NumberBox rather
 	// than overlapping it when the field has non-default Padding or sits
-	// near a screen edge. Only applied on iPad + numeric keyboard types —
-	// the same condition the extension uses to anchor the native view —
-	// so other scenarios (iPhone, text entry) keep native caret/selection
-	// behavior.
+	// near a screen edge. Gated by the same condition the extension uses
+	// to anchor the native view (see InvisibleTextBoxViewExtension.
+	// IsFloatingNumericKeypad) so other scenarios keep native behavior.
 	public override CGRect GetFirstRectForRange(UITextRange range)
-		=> ShouldAnchorToBounds() ? Bounds : base.GetFirstRectForRange(range);
+		=> InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType) ? Bounds : base.GetFirstRectForRange(range);
 
 	public override CGRect GetCaretRectForPosition(UITextPosition? position)
-		=> ShouldAnchorToBounds() ? Bounds : base.GetCaretRectForPosition(position);
-
-	private bool ShouldAnchorToBounds()
-	{
-		if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
-		{
-			return false;
-		}
-
-		return KeyboardType is
-			UIKeyboardType.NumberPad or
-			UIKeyboardType.DecimalPad or
-			UIKeyboardType.NumbersAndPunctuation or
-			UIKeyboardType.PhonePad;
-	}
+		=> InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType) ? Bounds : base.GetCaretRectForPosition(position);
 
 	public override void Paste(NSObject? sender) => HandlePaste(() => base.Paste(sender));
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreGraphics;
 using Foundation;
 using Microsoft.UI.Xaml.Controls;
 using ObjCRuntime;
@@ -41,6 +42,34 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 	}
 
 	public bool IsCompatible(Microsoft.UI.Xaml.Controls.TextBox textBox) => !textBox.AcceptsReturn;
+
+	// UIKit uses the first-responder's firstRect/caretRect (UITextInput) to
+	// position the iPad floating numeric keypad. Returning the view's full
+	// Bounds makes the keypad anchor adjacent to the whole NumberBox rather
+	// than overlapping it when the field has non-default Padding or sits
+	// near a screen edge. Only applied on iPad + numeric keyboard types —
+	// the same condition the extension uses to anchor the native view —
+	// so other scenarios (iPhone, text entry) keep native caret/selection
+	// behavior.
+	public override CGRect GetFirstRectForRange(UITextRange range)
+		=> ShouldAnchorToBounds() ? Bounds : base.GetFirstRectForRange(range);
+
+	public override CGRect GetCaretRectForPosition(UITextPosition? position)
+		=> ShouldAnchorToBounds() ? Bounds : base.GetCaretRectForPosition(position);
+
+	private bool ShouldAnchorToBounds()
+	{
+		if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
+		{
+			return false;
+		}
+
+		return KeyboardType is
+			UIKeyboardType.NumberPad or
+			UIKeyboardType.DecimalPad or
+			UIKeyboardType.NumbersAndPunctuation or
+			UIKeyboardType.PhonePad;
+	}
 
 	public override void Paste(NSObject? sender) => HandlePaste(() => base.Paste(sender));
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/453

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

The anchor was not correct when the `NumberBox` had any Padding or custom template added to it.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->