### PR TITLE
ci: Add /apply-xaml-style workflow and drift-comment check

### DIFF
--- a/.github/workflows/xaml-style-apply.yml
+++ b/.github/workflows/xaml-style-apply.yml
@@ -1,0 +1,165 @@
+name: XAML Styler Apply
+
+# Responds to `/apply-xaml-style` PR comments. Re-runs `dotnet xstyler` and
+# pushes `chore: Apply XAML styler` to the PR's head branch. Only works for
+# PRs from branches in this repo — fork PRs must apply the patch manually.
+#
+# Safety:
+#   - `startsWith` on the comment body (not `contains`) so the drift-check
+#     workflow's instructional comment (which mentions `/apply-xaml-style`
+#     further down in its body) cannot self-trigger this workflow.
+#   - Bot comments are excluded via `comment.user.type`.
+#   - As an additional safety net, events caused by the default GITHUB_TOKEN
+#     do not trigger further workflow runs.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.repository == 'unoplatform/uno' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot' &&
+      startsWith(github.event.comment.body, '/apply-xaml-style')
+    name: Apply XAML Styler
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Resolve PR and authorize commenter
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const head = pr.data.head;
+            const baseFullName = `${context.repo.owner}/${context.repo.repo}`;
+            const isFork = !head.repo || head.repo.full_name !== baseFullName;
+
+            const commenter = context.payload.comment.user.login;
+            const assoc = context.payload.comment.author_association;
+            const allowedAssoc = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const isAuthor = commenter === pr.data.user.login;
+            if (!isAuthor && !allowedAssoc.includes(assoc)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `@${commenter} you are not permitted to trigger \`/apply-xaml-style\` on this PR (only the PR author or repo collaborators can).`,
+              });
+              core.setFailed(`User ${commenter} (${assoc}) is not permitted to trigger /apply-xaml-style.`);
+              return;
+            }
+
+            if (isFork) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: 'Cannot auto-apply to a fork branch. Please download the `xaml-style-patch` artifact from the latest **XAML Style Check** run and apply it locally (`git apply` + commit + push).',
+              });
+              core.setFailed('Fork PR — cannot auto-apply.');
+              return;
+            }
+
+            core.setOutput('ref', head.ref);
+            core.setOutput('sha', head.sha);
+
+      - name: Acknowledge with reaction
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dotnet tools
+        run: dotnet tool restore
+
+      - name: Run XAML Styler
+        run: dotnet xstyler -d src/SamplesApp -r
+
+      - name: Commit and push if drift
+        id: commit
+        shell: bash
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No drift — nothing to commit."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git add -A
+          git commit -m 'chore: Apply XAML styler'
+          git push origin HEAD:${{ steps.pr.outputs.ref }}
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Comment with outcome
+        if: always() && steps.pr.outputs.ref != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pushed = '${{ steps.commit.outputs.pushed }}' === 'true';
+            const jobStatus = '${{ job.status }}';
+            let body;
+            if (jobStatus === 'success' && pushed) {
+              body = [
+                'Pushed `chore: Apply XAML styler` to this PR branch.',
+                '',
+                'GitHub does not re-trigger workflows for commits pushed by the default bot, so the **XAML Style Check** will not automatically re-run. To turn it green, push any additional commit (for example `git commit --allow-empty -m "ci: re-run"`) or ask a maintainer to re-run the check.',
+              ].join('\n');
+            } else if (jobStatus === 'success' && !pushed) {
+              body = 'Ran XAML Styler — no drift detected, nothing to commit.';
+            } else {
+              body = 'The apply workflow failed. See the workflow logs for details.';
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: React success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1',
+            });
+
+      - name: React failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1',
+            });

--- a/.github/workflows/xaml-style-check.yml
+++ b/.github/workflows/xaml-style-check.yml
@@ -6,10 +6,17 @@ on:
       - 'src/SamplesApp/**/*.xaml'
       - 'src/SamplesApp/Settings.XamlStyler'
       - '.config/dotnet-tools.json'
+      - '.github/workflows/xaml-style-check.yml'
+  workflow_dispatch:
 
 jobs:
   xaml-style:
+    if: github.repository == 'unoplatform/uno'
+    name: XAML Style Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -20,5 +27,71 @@ jobs:
       - name: Restore dotnet tools
         run: dotnet tool restore
 
-      - name: Check XAML formatting
-        run: dotnet xstyler -d src/SamplesApp -r -p
+      - name: Run XAML Styler
+        run: dotnet xstyler -d src/SamplesApp -r
+
+      - name: Detect drift
+        id: drift
+        shell: bash
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "No drift detected."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::XAML Styler drift detected."
+            git add -A
+            git diff --cached > xaml-style.patch
+            echo "---- git status ----"
+            git status
+            echo "---- git diff (truncated to 400 lines) ----"
+            git -c color.ui=always diff --cached | head -n 400
+          fi
+
+      - name: Upload patch artifact
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: xaml-style-patch
+          path: xaml-style.patch
+          if-no-files-found: error
+
+      - name: Post drift comment
+        if: steps.drift.outputs.drift == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const shortSha = process.env.HEAD_SHA.slice(0, 7);
+            const body = [
+              `### XAML Styler drift detected on \`${shortSha}\``,
+              '',
+              'XAML files under `src/SamplesApp/` are not formatted according to `src/SamplesApp/Settings.XamlStyler`.',
+              '',
+              '**To apply automatically** (PRs from branches in this repo only): comment `/apply-xaml-style` on this PR and a bot will push `chore: Apply XAML styler` to the head branch.',
+              '',
+              '**To apply manually** (required for PRs from forks):',
+              `1. Download the \`xaml-style-patch\` artifact from [this run](${process.env.RUN_URL}).`,
+              '2. In your local checkout of the PR branch:',
+              '   ```',
+              '   git apply xaml-style.patch',
+              '   git add -A',
+              '   git commit -m "chore: Apply XAML styler"',
+              '   git push',
+              '   ```',
+              '',
+              'Or re-run the formatter locally: `dotnet tool restore && dotnet xstyler -d src/SamplesApp -r`.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: Fail if drift detected
+        if: steps.drift.outputs.drift == 'true'
+        shell: bash
+        run: exit 1


### PR DESCRIPTION
## Summary

- Upgrades `.github/workflows/xaml-style-check.yml` to the drift-detection pattern used by the WinAppSDK sync-generator check (#23085): on failure it uploads the unified diff as the `xaml-style-patch` artifact and posts a PR comment explaining how to fix.
- Adds `.github/workflows/xaml-style-apply.yml`, triggered by a `/apply-xaml-style` PR comment. It re-runs `dotnet xstyler -d src/SamplesApp -r`, commits `chore: Apply XAML styler`, and pushes to the PR head branch. Authorized for PR author or repo collaborators; fork PRs fall back to the manual `git apply` instructions in the check's drift comment.
- Safety: the apply workflow uses `startsWith` on the comment body and excludes bot comments, so the check's instructional comment (which mentions the slash command) can't self-trigger apply.

## Test plan

- [ ] Open a test PR with a deliberate xstyler formatting regression; confirm **XAML Style Check** fails, uploads `xaml-style-patch`, and posts the drift comment.
- [ ] Comment `/apply-xaml-style`; confirm 👀 reaction, `chore: Apply XAML styler` is pushed to the PR branch, ±1 reaction, and the outcome comment is posted.
- [ ] Push a trivial follow-up commit and verify the check goes green.
- [ ] From a fork, comment `/apply-xaml-style` and confirm the workflow refuses with the manual-apply instructions.
- [ ] Verify the check's own drift comment does **not** re-trigger the apply workflow (the `startsWith` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)