### PR TITLE
fix(ios): Merge duplicate GetFirstRectForRange override in SinglelineInvisibleTextBoxView

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -44,16 +44,6 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 
 	public bool IsCompatible(Microsoft.UI.Xaml.Controls.TextBox textBox) => !textBox.AcceptsReturn;
 
-	// UIKit uses the first-responder's firstRect/caretRect (UITextInput) to
-	// position the iPad floating numeric keypad. Returning the view's full
-	// Bounds makes the keypad anchor adjacent to the whole NumberBox rather
-	// than overlapping it when the field has non-default Padding or sits
-	// near a screen edge. Gated by the same condition the extension uses
-	// to anchor the native view (see InvisibleTextBoxViewExtension.
-	// IsFloatingNumericKeypad) so other scenarios keep native behavior.
-	public override CGRect GetFirstRectForRange(UITextRange range)
-		=> InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType) ? Bounds : base.GetFirstRectForRange(range);
-
 	public override CGRect GetCaretRectForPosition(UITextPosition? position)
 		=> InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType) ? Bounds : base.GetCaretRectForPosition(position);
 
@@ -229,8 +219,20 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 		base.UnmarkText();
 	}
 
+	// UIKit uses the first-responder's firstRect/caretRect (UITextInput) to
+	// position the iPad floating numeric keypad. Returning the view's full
+	// Bounds makes the keypad anchor adjacent to the whole NumberBox rather
+	// than overlapping it when the field has non-default Padding or sits
+	// near a screen edge. Gated by the same condition the extension uses
+	// to anchor the native view (see InvisibleTextBoxViewExtension.
+	// IsFloatingNumericKeypad) so other scenarios keep native behavior.
 	public override CoreGraphics.CGRect GetFirstRectForRange(UITextRange range)
 	{
+		if (InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType))
+		{
+			return Bounds;
+		}
+
 		var caretRect = AppleUIKitImeTextBoxExtension.Instance.GetCaretRect();
 		if (caretRect != Windows.Foundation.Rect.Empty && Superview is not null)
 		{
@@ -242,6 +244,7 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 			var windowRect = new CoreGraphics.CGRect(caretRect.X, caretRect.Y, caretRect.Width, caretRect.Height);
 			return ConvertRectFromView(windowRect, Superview);
 		}
+
 		return base.GetFirstRectForRange(range);
 	}
 


### PR DESCRIPTION
## Summary

Two recent PRs each added a separate `GetFirstRectForRange(UITextRange)` override to `SinglelineInvisibleTextBoxView`, causing `master` to fail the iOS build with:

```
SinglelineInvisibleTextBoxView.cs(232,38): error CS0111: Type 'SinglelineInvisibleTextBoxView' already defines a member called 'GetFirstRectForRange' with the same parameter types
```

The two overrides serve unrelated scenarios and do not conflict at runtime:

- **iPad floating numeric keypad anchoring** (`ef9a63d32b` / `63afc8ec5c`) — returns `Bounds` when `InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType)` is true, so the NumberBox floating keypad doesn't overlap the field.
- **IME composition candidate window positioning** (`f52f8ad8d1`) — returns the caret rect from `AppleUIKitImeTextBoxExtension.Instance.GetCaretRect()` (converted from superview coordinates) so CJK/IME candidate windows anchor at the caret.

This PR merges the two into a single override with precedence: floating keypad → IME composition → base. A NumberBox uses a numeric keyboard and doesn't compose IME text, so the ordering preserves both behaviors.

`MultilineInvisibleTextBoxView.cs` already has only the IME override (multiline text boxes are never NumberBoxes), so it is unaffected.

## Test plan

- [ ] `dotnet build src/Uno.UI.Runtime.Skia.AppleUIKit/Uno.UI.Runtime.Skia.AppleUIKit.csproj -f net9.0-ios18.0` succeeds (CS0111 gone).
- [ ] NumberBox on iPad: floating numeric keypad anchors adjacent to the view without overlap (regression check for PR #ef9a63d32b).
- [ ] TextBox with a CJK keyboard on iOS: IME candidate window positions at the caret during composition (regression check for PR #f52f8ad8d1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)