### PR TITLE
chore: fix Build Android+NativeAOT Skia Head step

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Helpers/FlyoutHelper.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Helpers/FlyoutHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -26,7 +27,9 @@ namespace Uno.UI.RuntimeTests.MUX.Helpers
 			return child as FrameworkElement;
 		}
 
-		public static async Task HideFlyout<T>(T flyoutControl)
+		public static async Task HideFlyout<
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)] T
+		>(T flyoutControl)
 			where T : FlyoutBase
 		{
 #if WINAPPSDK
@@ -46,7 +49,9 @@ namespace Uno.UI.RuntimeTests.MUX.Helpers
 #endif
 		}
 
-		internal static async Task OpenFlyout<T>(T flyoutControl, FrameworkElement target, FlyoutOpenMethod openMethod)
+		internal static async Task OpenFlyout<
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)] T
+		>(T flyoutControl, FrameworkElement target, FlyoutOpenMethod openMethod)
 			where T : FlyoutBase
 		{
 #if WINAPPSDK


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/pull/17292

The **Tests - Android+NativeAOT Skia > … > Build Android+NativeAOT Skia Head** step has been failing since 2026-04-14 with the following errors:

	ILC : Trim analysis error IL2091: Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<HideFlyout>d__1`1.MoveNext(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents', 'DynamicallyAccessedMemberTypes.NonPublicEvents' in 'Private.Infrastructure.TestServices.CreateSafeEventRegistration<T,TDelegate>(String)'. The generic parameter 'T' of 'Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<HideFlyout>d__1`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	ILC : Trim analysis error IL2091: Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1.MoveNext(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents', 'DynamicallyAccessedMemberTypes.NonPublicEvents' in 'Private.Infrastructure.TestServices.CreateSafeEventRegistration<T,TDelegate>(String)'. The generic parameter 'T' of 'Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	ILC : Trim analysis error IL2091: Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1.MoveNext(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents', 'DynamicallyAccessedMemberTypes.NonPublicEvents' in 'Private.Infrastructure.TestServices.CreateSafeEventRegistration<T,TDelegate>(String)'. The generic parameter 'T' of 'Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	ILC : Trim analysis error IL2091: Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<HideFlyout>d__1`1.MoveNext(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents', 'DynamicallyAccessedMemberTypes.NonPublicEvents' in 'Private.Infrastructure.TestServices.CreateSafeEventRegistration<T,TDelegate>(String)'. The generic parameter 'T' of 'Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<HideFlyout>d__1`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	ILC : Trim analysis error IL2091: Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1.MoveNext(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents', 'DynamicallyAccessedMemberTypes.NonPublicEvents' in 'Private.Infrastructure.TestServices.CreateSafeEventRegistration<T,TDelegate>(String)'. The generic parameter 'T' of 'Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	ILC : Trim analysis error IL2091: Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1.MoveNext(): 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicEvents', 'DynamicallyAccessedMemberTypes.NonPublicEvents' in 'Private.Infrastructure.TestServices.CreateSafeEventRegistration<T,TDelegate>(String)'. The generic parameter 'T' of 'Uno.UI.RuntimeTests.MUX.Helpers.FlyoutHelper.<OpenFlyout>d__2`1' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

In particular, this stage was green in [6.6.0-dev.1027][0], *skipped* in 6.6.0-dev.1028+3c03b and 6.6-dev.1028+2c5d, and began failing in [6.6-dev.1122][1].

It was likely broken by unoplatform/uno#17292, which updated `FlyoutHelper.HideFlyout<T>(T)` and
`FlyoutHelper.OpenFlyout<T>(T, FrameworkElement, FlyoutOpenMethod)` to call `CreateSafeEventRegistration<T, TDelegate>()` without adding matching annotations.

The fix is to update `FlyoutHelper` to add matching annotations to `FlyoutHelper.HideFlyout<T>(T)` and
`FlyoutHelper.OpenFlyout<T>(T, FrameworkElement, FlyoutOpenMethod)`.

[0]: https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=207165&view=results
[1]: https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=207183&view=results

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix
- 🏗️ Build or CI related changes

<!--
Copy the labels that apply to this PR and paste them above:

- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->