### PR TITLE
fix(deps): backport System.Security.Cryptography.Xml 8.0.3 bump to 6.5

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="Uno.Core.Extensions.Disposables" />
 
 		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on 6.0.0 which has a vulnerability -->
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">


### PR DESCRIPTION
Cherry-pick of commit 01dc6862e4 from #23046 to `release/stable/6.5`.

Bumps `System.Security.Cryptography.Xml` from 8.0.2 to 8.0.3 to resolve NU1901 build failure caused by known vulnerabilities ([GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx), [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf)).

Related to this backport CI Build failures for 6.5 : https://github.com/unoplatform/uno/pull/23096