### PR TITLE
chore(ci): backport .NET SDK 10.0.105 pin (PR #23006) and Tmds.DBus.Protocol vulnerability fix to 6.5

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -23,6 +23,7 @@ variables:
   enable_dotnet_cache: true
   enable_emsdk_cache: true
   GlobalUnoCheckVersion: '1.33.0-dev.26'
+  DotNetSdkVersion: '10.0.105'
 
 stages:
 - template: build/ci/.azure-devops-stages-docs.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,6 +71,7 @@ variables:
   enable_dotnet_cache: true
   enable_emsdk_cache: true
   GlobalUnoCheckVersion: '1.34.0-dev.23'
+  DotNetSdkVersion: '10.0.105'
 
 stages:
 - template: build/ci/.azure-devops-stages.yml

--- a/build/ci/net10/_global.json
+++ b/build/ci/net10/_global.json
@@ -1,14 +1,14 @@
 {
 	"sdk": {
-		"version": "10.0.101",
+		"version": "10.0.105",
 		"allowPrerelease": true,
-		"rollForward": "latestMinor"
+		"rollForward": "disable"
 	},
 	"test": {
 		"runner": "Microsoft.Testing.Platform"
 	},
 	"tools": {
-		"dotnet": "10.0.101"
+		"dotnet": "10.0.105"
 	},
 	"msbuild-sdks": {
 		"MSBuild.Sdk.Extras": "3.0.44",

--- a/build/ci/templates/dotnet-install.yml
+++ b/build/ci/templates/dotnet-install.yml
@@ -1,5 +1,5 @@
 parameters:
-  defaultDotNetSdkVersion: "10.0.101"
+  defaultDotNetSdkVersion: "$(DotNetSdkVersion)"
   haveCheckout: true
 
 steps:

--- a/build/ci/templates/dotnet-setup-cache.yml
+++ b/build/ci/templates/dotnet-setup-cache.yml
@@ -5,7 +5,7 @@ steps:
   - task: Cache@2
     condition: eq(variables['enable_dotnet_cache'], 'true')
     inputs:
-      key: dotnet | "$(Agent.OS)" | "$(Agent.JobName)" | "$(GlobalUnoCheckVersion)" | "${{ parameters.UnoCheckParameters }}"
+      key: dotnet | "$(Agent.OS)" | "$(Agent.JobName)" | "$(GlobalUnoCheckVersion)" | "${{ parameters.UnoCheckParameters }}" | "$(DotNetSdkVersion)"
       path: $(DOTNET_INSTALL_DIR)
     displayName: Set Cache for dotnet install
 

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -277,7 +277,7 @@ jobs:
     displayName: Install .NET 10 SDK
     inputs:
       packageType: 'sdk'
-      version: '10.0.101'
+      version: '$(DotNetSdkVersion)'
 
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-install.yml

--- a/src/Uno.UI.Runtime.Skia.X11/Uno.UI.Runtime.Skia.X11.csproj
+++ b/src/Uno.UI.Runtime.Skia.X11/Uno.UI.Runtime.Skia.X11.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tmds.DBus.Protocol" Version="0.21.2" />
+		<PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Backports CI changes from master PR #23006 to `release/stable/6.5` and fixes a vulnerability in `Tmds.DBus.Protocol`.

## What

**SDK pin (backport of https://github.com/unoplatform/uno/pull/23006):**
- Pin .NET SDK to 10.0.105 with `rollForward: disable` in `_global.json`
- Add `DotNetSdkVersion` pipeline variable to `.vsts-ci.yml` and `.vsts-ci-docs.yml`
- Update `dotnet-install.yml` default to reference pipeline variable
- Add `DotNetSdkVersion` to dotnet cache key for proper invalidation on SDK changes
- Update tests-templates SDK version to use pipeline variable

**Vulnerability fix:**
- Bump `Tmds.DBus.Protocol` from 0.21.2 to 0.21.3 to resolve CVE-2026-39959 (NU1903 audit error)
  0.21.3 is the backported security fix. Master already has 0.92.0.

## Why

The 6.5 branch was picking up .NET SDK 10.0.203 via `rollForward: latestMinor`, which requires MSBuild 18.0 (unavailable on build agents). Pinning to 10.0.105 with `disable` prevents this. The `DotNetSdkVersion` variable approach matches master's pattern from PR #23006.

The `Tmds.DBus.Protocol` vulnerability causes NU1903 errors under `TreatWarningsAsErrors` in Release builds.

## Context
These fixes are required to get green CI on `release/stable/6.5` PRs. 
The immediate goal is unblocking PR #23096 CI Build.