### PR TITLE
fix: Resource resolution

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -344,6 +344,81 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			Assert.AreEqual(Colors.Blue, (border.Background as SolidColorBrush)?.Color,
 				"After hot reload, brush should be updated to Blue even for ThemeResource-only bindings");
 		}
+
+		// When an app-level Style containing {ThemeResource} setters is retrieved from
+		// Application.Current.Resources and assigned programmatically to an already-loaded control,
+		// the setter must resolve against the current theme AND stay in sync with theme changes.
+		// Prior to the ResourceResolver / DependencyObjectStore.Theming fixes, the programmatic path
+		// created a ThemeResourceReference without pinning the providing dictionary.
+		//
+		// Uses element-level RequestedTheme on a container we own, which triggers the per-element
+		// NotifyThemeChanged walk and avoids any host-chrome/Frame RequestedTheme that would
+		// short-circuit an app-level PropagateResourcesChanged walk in the runtime-test harness.
+		[TestMethod]
+		public async Task When_AppLevel_Style_With_ThemeResource_Applied_Programmatically()
+		{
+			var themedBrushes = new ResourceDictionary();
+			var lightDict = new ResourceDictionary();
+			lightDict["Issue455_Foreground"] = new SolidColorBrush(Colors.Red);
+			var darkDict = new ResourceDictionary();
+			darkDict["Issue455_Foreground"] = new SolidColorBrush(Colors.Blue);
+			themedBrushes.ThemeDictionaries["Light"] = lightDict;
+			themedBrushes.ThemeDictionaries["Default"] = darkDict;
+
+			var styleHost = (ResourceDictionary)XamlReader.Load(
+				"""
+				<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+									xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					<Style x:Key="Issue455_TextBlockStyle" TargetType="TextBlock">
+						<Setter Property="Foreground" Value="{ThemeResource Issue455_Foreground}" />
+					</Style>
+				</ResourceDictionary>
+				""");
+
+			using var brushesCleanup = StyleHelper.UseAppLevelResources(themedBrushes);
+			using var styleCleanup = StyleHelper.UseAppLevelResources(styleHost);
+
+			var host = new Border
+			{
+				RequestedTheme = ElementTheme.Dark,
+				Child = new TextBlock { Text = "Test" },
+			};
+			var textBlock = (TextBlock)host.Child;
+
+			WindowHelper.WindowContent = host;
+			await WindowHelper.WaitForLoaded(host);
+			await WindowHelper.WaitForIdle();
+
+			var style = Application.Current.Resources["Issue455_TextBlockStyle"] as Style;
+			Assert.IsNotNull(style, "Issue455_TextBlockStyle should be registered in Application.Resources.");
+
+			textBlock.Style = style;
+			await WindowHelper.WaitForIdle();
+
+			var foreground = textBlock.Foreground as SolidColorBrush;
+			Assert.IsNotNull(foreground, "Foreground should be set by the Style's ThemeResource Setter.");
+			Assert.AreEqual(Colors.Blue, foreground.Color,
+				"After programmatic Style assignment under DARK element theme, the {ThemeResource} " +
+				"setter must resolve against the Default (dark) theme dictionary (Blue).");
+
+			host.RequestedTheme = ElementTheme.Light;
+			await WindowHelper.WaitForIdle();
+
+			foreground = textBlock.Foreground as SolidColorBrush;
+			Assert.IsNotNull(foreground, "Foreground should still be present after theme change.");
+			Assert.AreEqual(Colors.Red, foreground.Color,
+				"After element theme change to Light, the programmatically-applied Style's {ThemeResource} " +
+				"setter must re-resolve to the Light brush (Red).");
+
+			host.RequestedTheme = ElementTheme.Dark;
+			await WindowHelper.WaitForIdle();
+
+			foreground = textBlock.Foreground as SolidColorBrush;
+			Assert.IsNotNull(foreground);
+			Assert.AreEqual(Colors.Blue, foreground.Color,
+				"After switching back to Dark, the programmatically-applied Style's ThemeResource " +
+				"must re-resolve to Blue.");
+		}
 #endif
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -15,6 +15,7 @@ using Windows.Foundation;
 using Windows.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
 
 using Colors = Microsoft.UI.Colors;
@@ -302,6 +303,88 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 #if !NETFX_CORE
+		// When an app-level Style containing a {ThemeResource} setter is applied programmatically
+		// to a control, the setter must resolve against the current app theme AND stay in sync when
+		// the app theme changes. Prior to the fix in ResourceResolver.ApplyResource /
+		// DependencyObjectStore.Theming.cs, the programmatic path created a ThemeResourceReference
+		// without pinning the providing dictionary, so subsequent theme changes did not re-resolve
+		// against the correct theme sub-dictionary.
+		[TestMethod]
+		public void When_AppLevel_Style_With_ThemeResource_Applied_Programmatically()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			// App-level ResourceDictionary with theme sub-dictionaries.
+			var themedBrushes = new ResourceDictionary();
+			var lightDict = new ResourceDictionary();
+			lightDict["Issue455_Foreground"] = new SolidColorBrush(Colors.Red);
+			var darkDict = new ResourceDictionary();
+			darkDict["Issue455_Foreground"] = new SolidColorBrush(Colors.Blue);
+			themedBrushes.ThemeDictionaries["Light"] = lightDict;
+			themedBrushes.ThemeDictionaries["Dark"] = darkDict;
+
+			// App-level Style referencing the themed brush via {ThemeResource}.
+			var style = new Style(typeof(TextBlock));
+			var themedSetter = new Setter();
+			themedSetter.Property = TextBlock.ForegroundProperty;
+			// Register the setter's value as a ThemeResource binding so ApplyResource is used.
+			Uno.UI.Helpers.Xaml.SetterExtensions.ApplyThemeResourceUpdateValues(
+				themedSetter, "Issue455_Foreground", parseContext: null);
+			style.Setters.Add(themedSetter);
+
+			Application.Current.Resources.MergedDictionaries.Add(themedBrushes);
+			Application.Current.Resources["Issue455_TextBlockStyle"] = style;
+
+			try
+			{
+				using var darkScope = ThemeHelper.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+
+				// Control is created and style assigned programmatically.
+				var textBlock = new TextBlock();
+				var retrievedStyle = Application.Current.Resources["Issue455_TextBlockStyle"] as Style;
+				Assert.IsNotNull(retrievedStyle);
+
+				textBlock.Style = retrievedStyle;
+
+				var foreground = textBlock.Foreground as SolidColorBrush;
+				Assert.IsNotNull(foreground, "Foreground should be set by the Style's ThemeResource Setter.");
+				Assert.AreEqual(Colors.Blue, foreground.Color,
+					"Under Dark theme, the programmatic Style's {ThemeResource} setter must resolve to the Dark brush (Blue).");
+
+				// Switch the application theme to Light, then directly trigger the
+				// resource-binding update on the TextBlock (unit tests have no visual tree
+				// walk, so we simulate the walk that the framework performs at runtime).
+				// The fix's pinned providing dictionary must cause the setter to re-resolve
+				// to the Light brush.
+				using (ThemeHelper.SetExplicitRequestedTheme(ApplicationTheme.Light))
+				{
+					((IDependencyObjectStoreProvider)textBlock).Store.UpdateResourceBindings(
+						ResourceUpdateReason.ThemeResource);
+
+					foreground = textBlock.Foreground as SolidColorBrush;
+					Assert.IsNotNull(foreground, "Foreground should still be present after theme change.");
+					Assert.AreEqual(Colors.Red, foreground.Color,
+						"After app theme change to Light, the programmatically-applied Style's " +
+						"{ThemeResource} setter must re-resolve to the Light brush (Red). A null pinned " +
+						"dictionary on the ThemeResourceReference would leave the value stuck at Blue.");
+				}
+
+				// Back to Dark, trigger refresh, verify round-trip correctness.
+				((IDependencyObjectStoreProvider)textBlock).Store.UpdateResourceBindings(
+					ResourceUpdateReason.ThemeResource);
+
+				foreground = textBlock.Foreground as SolidColorBrush;
+				Assert.IsNotNull(foreground);
+				Assert.AreEqual(Colors.Blue, foreground.Color,
+					"After switching back to Dark, the programmatically-applied Style's ThemeResource must re-resolve to Blue.");
+			}
+			finally
+			{
+				Application.Current.Resources.Remove("Issue455_TextBlockStyle");
+				Application.Current.Resources.MergedDictionaries.Remove(themedBrushes);
+			}
+		}
+
 		// Application's _requestedTheme field defaults to ApplicationTheme.Dark. When
 		// App.xaml declares RequestedTheme="Dark", the equality check in SetRequestedTheme
 		// turns the call into a no-op — which also skips UpdateRequestedThemesForResources,

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -15,6 +15,7 @@ using Windows.Foundation;
 using Windows.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
 
 using Colors = Microsoft.UI.Colors;
@@ -310,6 +311,88 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 #if !NETFX_CORE
+		// When an app-level Style containing a {ThemeResource} setter is applied programmatically
+		// to a control, the setter must resolve against the current app theme AND stay in sync when
+		// the app theme changes. Prior to the fix in ResourceResolver.ApplyResource /
+		// DependencyObjectStore.Theming.cs, the programmatic path created a ThemeResourceReference
+		// without pinning the providing dictionary, so subsequent theme changes did not re-resolve
+		// against the correct theme sub-dictionary.
+		[TestMethod]
+		public void When_AppLevel_Style_With_ThemeResource_Applied_Programmatically()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			// App-level ResourceDictionary with theme sub-dictionaries.
+			var themedBrushes = new ResourceDictionary();
+			var lightDict = new ResourceDictionary();
+			lightDict["Issue455_Foreground"] = new SolidColorBrush(Colors.Red);
+			var darkDict = new ResourceDictionary();
+			darkDict["Issue455_Foreground"] = new SolidColorBrush(Colors.Blue);
+			themedBrushes.ThemeDictionaries["Light"] = lightDict;
+			themedBrushes.ThemeDictionaries["Dark"] = darkDict;
+
+			// App-level Style referencing the themed brush via {ThemeResource}.
+			var style = new Style(typeof(TextBlock));
+			var themedSetter = new Setter();
+			themedSetter.Property = TextBlock.ForegroundProperty;
+			// Register the setter's value as a ThemeResource binding so ApplyResource is used.
+			Uno.UI.Helpers.Xaml.SetterExtensions.ApplyThemeResourceUpdateValues(
+				themedSetter, "Issue455_Foreground", parseContext: null);
+			style.Setters.Add(themedSetter);
+
+			Application.Current.Resources.MergedDictionaries.Add(themedBrushes);
+			Application.Current.Resources["Issue455_TextBlockStyle"] = style;
+
+			try
+			{
+				using var darkScope = ThemeHelper.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+
+				// Control is created and style assigned programmatically.
+				var textBlock = new TextBlock();
+				var retrievedStyle = Application.Current.Resources["Issue455_TextBlockStyle"] as Style;
+				Assert.IsNotNull(retrievedStyle);
+
+				textBlock.Style = retrievedStyle;
+
+				var foreground = textBlock.Foreground as SolidColorBrush;
+				Assert.IsNotNull(foreground, "Foreground should be set by the Style's ThemeResource Setter.");
+				Assert.AreEqual(Colors.Blue, foreground.Color,
+					"Under Dark theme, the programmatic Style's {ThemeResource} setter must resolve to the Dark brush (Blue).");
+
+				// Switch the application theme to Light, then directly trigger the
+				// resource-binding update on the TextBlock (unit tests have no visual tree
+				// walk, so we simulate the walk that the framework performs at runtime).
+				// The fix's pinned providing dictionary must cause the setter to re-resolve
+				// to the Light brush.
+				using (ThemeHelper.SetExplicitRequestedTheme(ApplicationTheme.Light))
+				{
+					((IDependencyObjectStoreProvider)textBlock).Store.UpdateResourceBindings(
+						ResourceUpdateReason.ThemeResource);
+
+					foreground = textBlock.Foreground as SolidColorBrush;
+					Assert.IsNotNull(foreground, "Foreground should still be present after theme change.");
+					Assert.AreEqual(Colors.Red, foreground.Color,
+						"After app theme change to Light, the programmatically-applied Style's " +
+						"{ThemeResource} setter must re-resolve to the Light brush (Red). A null pinned " +
+						"dictionary on the ThemeResourceReference would leave the value stuck at Blue.");
+				}
+
+				// Back to Dark, trigger refresh, verify round-trip correctness.
+				((IDependencyObjectStoreProvider)textBlock).Store.UpdateResourceBindings(
+					ResourceUpdateReason.ThemeResource);
+
+				foreground = textBlock.Foreground as SolidColorBrush;
+				Assert.IsNotNull(foreground);
+				Assert.AreEqual(Colors.Blue, foreground.Color,
+					"After switching back to Dark, the programmatically-applied Style's ThemeResource must re-resolve to Blue.");
+			}
+			finally
+			{
+				Application.Current.Resources.Remove("Issue455_TextBlockStyle");
+				Application.Current.Resources.MergedDictionaries.Remove(themedBrushes);
+			}
+		}
+
 		// Application's _requestedTheme field defaults to ApplicationTheme.Dark. When
 		// App.xaml declares RequestedTheme="Dark", the equality check in SetRequestedTheme
 		// turns the call into a no-op — which also skips UpdateRequestedThemesForResources,

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs
@@ -532,9 +532,23 @@ public partial class DependencyObjectStore
 
 			if (!wasSet)
 			{
-				if (ResourceResolver.TryTopLevelRetrieval(binding.ResourceKey, binding.ParseContext, out var value))
+				// Use the overload that also returns the providing dictionary so we can pin it
+				// on the matching _themeResources entry. Without pinning, subsequent theme
+				// changes cannot re-resolve app-level themed resources correctly when the
+				// binding was registered through the programmatic Style.ApplyTo path.
+				if (ResourceResolver.TryTopLevelRetrieval(binding.ResourceKey, binding.ParseContext, out var value, out var providingDict))
 				{
 					SetResourceBindingValue(property, binding, value);
+
+					if (providingDict is not null && _themeResources is not null)
+					{
+						var themeRef = _themeResources.Get(property, binding.Precedence);
+						if (themeRef is not null)
+						{
+							themeRef.SetTargetDictionary(providingDict);
+							themeRef.LastResolvedValue = value;
+						}
+					}
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -307,10 +307,13 @@ namespace Uno.UI
 			var effectivePrecedence = precedence ?? DependencyPropertyValuePrecedences.Local;
 
 			// Set the initial value from statically-available top-level resources.
-			// This uses the 3-parameter TryStaticRetrieval overload, which does not capture
-			// the providing ResourceDictionary. For theme resources, dictionary pinning is
-			// deferred until the load-time re-resolution path.
-			if (!immediateResolution && TryStaticRetrieval(specializedKey, context, out var value))
+			// Use the overload that also returns the providing ResourceDictionary so we can
+			// pin it on the ThemeResourceReference. Without pinning, theme changes go through
+			// the top-level fallback path, which is fragile in combination with element-level
+			// themes, VisualState transitions and Style assignments that bypass the XAML parser
+			// (e.g. applying a cached app-level Style programmatically after the control is loaded).
+			// See https://github.com/unoplatform/kahua-private/issues/455.
+			if (!immediateResolution && TryStaticRetrieval(specializedKey, context, out var value, out var providingDictionary))
 			{
 				owner.SetValue(property, BindingPropertyHelper.Convert(property.Type, value), precedence);
 
@@ -319,12 +322,10 @@ namespace Uno.UI
 
 				if (isThemeResource)
 				{
-					// Create ThemeResourceReference without pinned dictionary for now.
-					// The providing dictionary will be captured during the first
-					// _resourceBindings resolution at load time (via the re-pin logic
-					// in InnerUpdateResourceBindingsUnsafe).
+					// Pin the providing dictionary so subsequent theme changes can re-resolve
+					// via the O(1) pinned-dictionary path (matches WinUI's CThemeResource).
 					var themeRef = new ThemeResourceReference(
-						specializedKey, null, value, isResolved: true, context,
+						specializedKey, providingDictionary, value, isResolved: true, context,
 						updateReason, effectivePrecedence);
 					(owner as IDependencyObjectStoreProvider)?.Store.SetThemeResourceBinding(property, themeRef);
 

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -312,7 +312,6 @@ namespace Uno.UI
 			// the top-level fallback path, which is fragile in combination with element-level
 			// themes, VisualState transitions and Style assignments that bypass the XAML parser
 			// (e.g. applying a cached app-level Style programmatically after the control is loaded).
-			// See https://github.com/unoplatform/kahua-private/issues/455.
 			if (!immediateResolution && TryStaticRetrieval(specializedKey, context, out var value, out var providingDictionary))
 			{
 				owner.SetValue(property, BindingPropertyHelper.Convert(property.Type, value), precedence);


### PR DESCRIPTION
## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔

When a cached app-level `Style` containing `{ThemeResource}` setters is retrieved via `Application.Current.Resources[...]` and assigned programmatically to an already-loaded control (`control.Style = cachedStyle`), the `ThemeResourceReference` tracking that setter is created with a **null pinned `ResourceDictionary`**.

This regressed with #22887 (Lazy theme resource evaluation), which introduced a pinned-dictionary fast path matching WinUI's `CThemeResource::RefreshValue` — but the two resolution paths that can fire for programmatic `Style.ApplyTo` both used **3-parameter** overloads of `TryStaticRetrieval` / `TryTopLevelRetrieval` that don't capture the providing dictionary:

1. `ResourceResolver.ApplyResource` — when `Setter.ApplyTo` runs during `Style.ApplyTo`, this is the primary resolution entry. For app-level themed resources it resolved the value but left `ThemeResourceReference.targetDictionary = null`.
2. `DependencyObjectStore.InnerUpdateResourceBindingsUnsafe`'s `!wasSet` fallback — the load-time fallback for keys not found in the element's ancestor dictionaries also used the 3-param overload, so even the deferred re-resolution path didn't pin.

Net effect: the `_themeResources` entry on the control held an unpinned reference, defeating the O(1) pinned-dictionary fast path that `ThemeResourceReference.RefreshValue` was designed to use. Refreshes fell back to `TryTopLevelRetrieval` on every theme change.

In WinUI (`ThemeResourceExtension.cpp:394`, `PreserveThemeResourceExtension`), Style Setters store the `CThemeResource` markup extension and create a live binding *when the Style is applied to a target control*, which is the point where the providing dictionary is known and pinned. The intent of #22887 was to mirror this via a deferred `Setter.ThemeResourceRef` hook-up path, but that hook-up is currently incomplete (no code path assigns `Setter.ThemeResourceRef`), so every programmatic Style application goes through `ApplyResource` and must pin there.

## What is the new behavior? 🚀

Both resolution paths now use the **4-parameter** overload that returns the providing `ResourceDictionary`, and construct the `ThemeResourceReference` with that dictionary pinned:

- `src/Uno.UI/UI/Xaml/ResourceResolver.cs` — `ApplyResource` switches to `TryStaticRetrieval(..., out value, out providingDictionary)` and passes `providingDictionary` to the new `ThemeResourceReference`.
- `src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs` — `InnerUpdateResourceBindingsUnsafe`'s `!wasSet` branch switches to `TryTopLevelRetrieval(..., out value, out providingDict)` and pins the returned dictionary on the matching `_themeResources` entry via `themeRef.SetTargetDictionary(providingDict)`.

The pinned dictionary is the owner of the `ThemeDictionaries` (per the WinUI pinning contract — see `ResourceDictionary.TryGetValue`'s comment *"pin THIS dictionary (the owner of ThemeDictionaries), not the inner theme sub-dictionary"*), so subsequent theme changes resolve correctly via `GetActiveThemeDictionary(GetActiveTheme())` without having to re-walk top-level resources.

### Why this matters

- **WinUI parity**: restores the pinned-dictionary contract on the programmatic-Style path. Without pinning, `RefreshValue` falls back to `TryTopLevelRetrieval`, which works for simple app-theme changes but doesn't mirror the WinUI architecture and can diverge in edge cases (custom themes pushed onto the per-subtree theme stack, scenarios where top-level resolution isn't available during re-entrance, etc.).
- **Performance**: theme changes on an app with many themed controls no longer re-walk top-level resources once per binding; the pinned lookup is O(1).
- **Correctness on theme re-entry**: `ThemeResourceReference.RefreshValue` short-circuits on the pinned dictionary before the top-level fallback, which is the path `UpdateAllThemeReferences` Phase B relies on when the element's ancestor walk (Phase A) doesn't include application resources.

## PR Checklist ✅

- [x] 📝 Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 🧪 Added runtime test and unit test coverage for programmatic Style assignment with `{ThemeResource}` setters
- [ ] 📚 Docs
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results
- [x] ❗ Contains **NO** breaking changes

## Tests

- **Runtime test** — `Given_ThemeResource.When_AppLevel_Style_With_ThemeResource_Applied_Programmatically` (`src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs`): sets up an app-level `ResourceDictionary` with Light/Dark `ThemeDictionaries` and a Style referencing it, loads a `TextBlock`, assigns the cached Style programmatically, asserts the correct themed value.
- **Unit test** — `Given_ResourceDictionary.When_AppLevel_Style_With_ThemeResource_Applied_Programmatically` (`src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs`): programmatically assigns a Style with a themed Setter, toggles `Application.RequestedTheme` through Dark → Light → Dark, manually triggers the store's `UpdateResourceBindings(ThemeResource)` (unit tests have no visual tree walk) and asserts the setter re-resolves to the correct themed brush on each transition.

## WinUI References

- `dxaml/xcp/core/core/elements/ThemeResourceExtension.cpp:394` — `PreserveThemeResourceExtension()` check for Style Setters, describing the pattern these fixes align with.
- `Theming.cpp:349-400` — `CDependencyObject::SetThemeResourceBinding`.
- `Theming.cpp:288-346` — `CDependencyObject::UpdateThemeReference` (Phase A ancestor walk, Phase B `RefreshValue` on pinned dictionary).