### PR TITLE
ci: Build Android CoreCLR and NativeAOT on PRs, skip only runtime tests

### DIFF
--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia.yml
@@ -10,6 +10,7 @@ jobs:
 
 - job: Android_CorCLR_Tests
   displayName: ' ' ## Name is concatenated with the matrix group name
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   timeoutInMinutes: 45
   cancelTimeoutInMinutes: 0
   dependsOn: Skia_Android_CoreCLR_Tests_Build

--- a/build/ci/tests/.azure-devops-tests-android-nativeaot-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-nativeaot-skia.yml
@@ -10,6 +10,7 @@ jobs:
 
 - job: Android_NativeAOT_Tests
   displayName: ' ' ## Name is concatenated with the matrix group name
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   timeoutInMinutes: 45
   cancelTimeoutInMinutes: 0
   dependsOn: Skia_Android_NativeAOT_Tests_Build

--- a/build/ci/tests/.azure-devops-tests-skia-stages.yml
+++ b/build/ci/tests/.azure-devops-tests-skia-stages.yml
@@ -60,7 +60,6 @@ stages:
 
 - stage: runtime_tests_skia_android_coreclr
   displayName: Tests - Android+CoreCLR Skia
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   dependsOn:
     - Setup
 
@@ -78,7 +77,6 @@ stages:
 
 - stage: runtime_tests_skia_android_nativeaot
   displayName: Tests - Android+NativeAOT Skia
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   dependsOn:
     - Setup
 


### PR DESCRIPTION
**GitHub Issue:** closes #

## PR Type: 🏗️ Build or CI related changes

## What is the current behavior? 🤔

Since #22669, the whole `runtime_tests_skia_android_coreclr` and `runtime_tests_skia_android_nativeaot` stages are skipped on PR builds via a stage-level `condition`. That also skips the samples app **build** jobs (`Skia_Android_CoreCLR_Tests_Build`, `Skia_Android_NativeAOT_Tests_Build`), so build-time regressions affecting the CoreCLR/NativeAOT samples app are not caught until a change lands on `master`.

## What is the new behavior? 🚀

The PR-skip condition is moved from the stage level down to the two runtime **test** jobs (`Android_CorCLR_Tests` and `Android_NativeAOT_Tests`). As a result:

- ✅ The samples app **build** jobs run on PRs — catching CoreCLR/NativeAOT build breaks before merge.
- ⏭️ The runtime **test** matrices (which are the long-running emulator runs) still only execute on non-PR (e.g. `master`) builds, preserving the PR duration win from #22669.

Stage-level dependencies remain unchanged.

## PR Checklist ✅

- [x] 📝 Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] 🧪 Added Runtime/UI tests or manual sample (N/A — CI-only change).
- [ ] 📚 Docs added/updated (N/A).
- [ ] 🖼️ Validated Screenshots Compare Test Run (N/A).
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Follow-up to #22669.