### PR TITLE
fix(macOS): Avoid reentrant runModal in file pickers

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -326,6 +326,9 @@ internal static partial class NativeUno
 	internal static partial IntPtr /* const char* _Nullable * _Nullable */ uno_pick_multiple_files(string? prompt, string? identifier, int suggestedStartLocation,
 		string[] filters, int filterSize);
 
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_free_string_array(IntPtr array);
+
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]
 	internal static partial string? /* const char* _Nullable */ uno_pick_save_file(string? prompt, string? identifier, string? suggestedFileName, int suggestedStartLocation,
 		string[] filters, int filtersSize);

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -47,33 +47,31 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 
 	public async Task<IReadOnlyList<StorageFile>> PickMultipleFilesAsync(CancellationToken token)
 	{
-		IntPtr array;
-		if (NativeDispatcher.Main.HasThreadAccess)
+		// Always dispatch to the main thread via Enqueue (never call synchronously, even
+		// when already on the main thread). NSOpenPanel.runModal pumps the Cocoa event
+		// loop, and running it reentrantly from inside an in-flight pointer/click handler
+		// crashes the managed InputManager ("A pointer is already being processed") and
+		// can leave the returned char** pointer in a corrupt state, triggering an
+		// AccessViolationException when the C# side walks the array.
+		var tcs = new TaskCompletionSource<IntPtr>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+		NativeDispatcher.Main.Enqueue(() =>
 		{
-			array = NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
-		}
-		else
-		{
-			var tcs = new TaskCompletionSource<IntPtr>(TaskCreationOptions.RunContinuationsAsynchronously);
-			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
-			NativeDispatcher.Main.Enqueue(() =>
+			if (token.IsCancellationRequested)
 			{
-				if (token.IsCancellationRequested)
-				{
-					tcs.TrySetCanceled(token);
-					return;
-				}
-				try
-				{
-					tcs.TrySetResult(NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
-				}
-				catch (Exception ex)
-				{
-					tcs.TrySetException(ex);
-				}
-			});
-			array = await tcs.Task;
-		}
+				tcs.TrySetCanceled(token);
+				return;
+			}
+			try
+			{
+				tcs.TrySetResult(NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
+		});
+		var array = await tcs.Task;
 
 		if (array == IntPtr.Zero)
 		{
@@ -97,33 +95,26 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 
 	public async Task<StorageFile?> PickSingleFileAsync(CancellationToken token)
 	{
-		string? file;
-		if (NativeDispatcher.Main.HasThreadAccess)
+		// See PickMultipleFilesAsync for why we always Enqueue instead of branching on HasThreadAccess.
+		var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+		NativeDispatcher.Main.Enqueue(() =>
 		{
-			file = NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
-		}
-		else
-		{
-			var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
-			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
-			NativeDispatcher.Main.Enqueue(() =>
+			if (token.IsCancellationRequested)
 			{
-				if (token.IsCancellationRequested)
-				{
-					tcs.TrySetCanceled(token);
-					return;
-				}
-				try
-				{
-					tcs.TrySetResult(NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
-				}
-				catch (Exception ex)
-				{
-					tcs.TrySetException(ex);
-				}
-			});
-			file = await tcs.Task;
-		}
+				tcs.TrySetCanceled(token);
+				return;
+			}
+			try
+			{
+				tcs.TrySetResult(NativeUno.uno_pick_single_file(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
+		});
+		var file = await tcs.Task;
 
 		return file is null ? null : await StorageFile.GetFileFromPathAsync(file);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -62,12 +62,24 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 				tcs.TrySetCanceled(token);
 				return;
 			}
+			IntPtr nativeArray = IntPtr.Zero;
 			try
 			{
-				tcs.TrySetResult(NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length));
+				nativeArray = NativeUno.uno_pick_multiple_files(_prompt, _identifier, (int)_suggestedStartLocation, _filters, _filters.Length);
+				if (!tcs.TrySetResult(nativeArray) && nativeArray != IntPtr.Zero)
+				{
+					// Late cancellation: the awaiter has already observed cancellation and
+					// will not consume the array, so free it here to avoid leaking the
+					// malloc'd char** plus its strdup'd entries.
+					NativeUno.uno_free_string_array(nativeArray);
+				}
 			}
 			catch (Exception ex)
 			{
+				if (nativeArray != IntPtr.Zero)
+				{
+					NativeUno.uno_free_string_array(nativeArray);
+				}
 				tcs.TrySetException(ex);
 			}
 		});

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileOpenPickerExtension.cs
@@ -78,19 +78,27 @@ internal class MacOSFileOpenPickerExtension : IFileOpenPickerExtension
 			return Array.Empty<StorageFile>();
 		}
 
-		var files = new List<StorageFile>();
-		var ptr = Marshal.ReadIntPtr(array);
-		while (ptr != IntPtr.Zero)
+		try
 		{
-			var filename = Marshal.PtrToStringUTF8(ptr);
-			if (filename is not null)
+			var files = new List<StorageFile>();
+			var cursor = array;
+			var ptr = Marshal.ReadIntPtr(cursor);
+			while (ptr != IntPtr.Zero)
 			{
-				files.Add(await StorageFile.GetFileFromPathAsync(filename));
+				var filename = Marshal.PtrToStringUTF8(ptr);
+				if (filename is not null)
+				{
+					files.Add(await StorageFile.GetFileFromPathAsync(filename));
+				}
+				cursor += IntPtr.Size;
+				ptr = Marshal.ReadIntPtr(cursor);
 			}
-			array += IntPtr.Size;
-			ptr = Marshal.ReadIntPtr(array);
+			return files.ToArray();
 		}
-		return files.ToArray();
+		finally
+		{
+			NativeUno.uno_free_string_array(array);
+		}
 	}
 
 	public async Task<StorageFile?> PickSingleFileAsync(CancellationToken token)

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFileSavePickerExtension.cs
@@ -61,33 +61,28 @@ internal class MacOSFileSavePickerExtension : IFileSavePickerExtension
 
 	public async Task<StorageFile?> PickSaveFileAsync(CancellationToken token)
 	{
-		string? file;
-		if (NativeDispatcher.Main.HasThreadAccess)
+		// Always Enqueue — running NSSavePanel.runModal reentrantly from an in-flight
+		// pointer handler crashes InputManager and corrupts return state. See
+		// MacOSFileOpenPickerExtension.PickMultipleFilesAsync for full context.
+		var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+		NativeDispatcher.Main.Enqueue(() =>
 		{
-			file = NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length);
-		}
-		else
-		{
-			var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
-			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
-			NativeDispatcher.Main.Enqueue(() =>
+			if (token.IsCancellationRequested)
 			{
-				if (token.IsCancellationRequested)
-				{
-					tcs.TrySetCanceled(token);
-					return;
-				}
-				try
-				{
-					tcs.TrySetResult(NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length));
-				}
-				catch (Exception ex)
-				{
-					tcs.TrySetException(ex);
-				}
-			});
-			file = await tcs.Task;
-		}
+				tcs.TrySetCanceled(token);
+				return;
+			}
+			try
+			{
+				tcs.TrySetResult(NativeUno.uno_pick_save_file(_prompt, _identifier, _suggestedFileName, (int)_suggestedStartLocation, _filters, _filters.Length));
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
+		});
+		var file = await tcs.Task;
 
 		return file is null ? null : await StorageFile.GetFileFromPathAsync(file);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Storage/Pickers/MacOSFolderPickerExtension.cs
@@ -41,33 +41,28 @@ internal class MacOSFolderPickerExtension : IFolderPickerExtension
 
 	public async Task<StorageFolder?> PickSingleFolderAsync(CancellationToken token)
 	{
-		string? folder;
-		if (NativeDispatcher.Main.HasThreadAccess)
+		// Always Enqueue — running NSOpenPanel.runModal reentrantly from an in-flight
+		// pointer handler crashes InputManager and corrupts return state. See
+		// MacOSFileOpenPickerExtension.PickMultipleFilesAsync for full context.
+		var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+		NativeDispatcher.Main.Enqueue(() =>
 		{
-			folder = NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation);
-		}
-		else
-		{
-			var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
-			using var registration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
-			NativeDispatcher.Main.Enqueue(() =>
+			if (token.IsCancellationRequested)
 			{
-				if (token.IsCancellationRequested)
-				{
-					tcs.TrySetCanceled(token);
-					return;
-				}
-				try
-				{
-					tcs.TrySetResult(NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation));
-				}
-				catch (Exception ex)
-				{
-					tcs.TrySetException(ex);
-				}
-			});
-			folder = await tcs.Task;
-		}
+				tcs.TrySetCanceled(token);
+				return;
+			}
+			try
+			{
+				tcs.TrySetResult(NativeUno.uno_pick_single_folder(_prompt, _identifier, (int)_suggestedStartLocation));
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
+		});
+		var folder = await tcs.Task;
 
 		return folder is null ? null : await StorageFolder.GetFolderFromPathAsync(folder);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOPickers.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOPickers.h
@@ -26,5 +26,6 @@ char* _Nullable uno_pick_single_folder(const char* _Nullable prompt, const char*
 char* _Nullable uno_pick_single_file(const char* _Nullable prompt, const char* _Nullable identifier, PickerLocationId suggestedStartLocation, char* _Nonnull filters[_Nullable], int filterSize);
 char* _Nullable uno_pick_save_file(const char* _Nullable prompt, const char* _Nullable identifier, const char* _Nullable suggestedFileName, PickerLocationId suggestedStartLocation, char* _Nonnull filters[_Nullable], int filterSize);
 char* _Nullable * _Nullable uno_pick_multiple_files(const char* _Nullable prompt, const char* _Nullable identifier, PickerLocationId suggestedStartLocation, char* _Nonnull filters[_Nullable], int filterSize);
+void uno_free_string_array(char* _Nullable * _Nullable array);
 
 NS_ASSUME_NONNULL_END

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOPickers.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOPickers.m
@@ -165,6 +165,19 @@ char** uno_pick_multiple_files(const char* _Nullable prompt, const char* _Nullab
     return nil;
 }
 
+// Frees an array previously returned by uno_pick_multiple_files: each strdup'd
+// entry up to the trailing NULL sentinel, then the malloc'd outer array itself.
+void uno_free_string_array(char** array)
+{
+    if (!array) {
+        return;
+    }
+    for (char** p = array; *p != NULL; p++) {
+        free(*p);
+    }
+    free(array);
+}
+
 char* uno_pick_save_file(const char* _Nullable prompt, const char* _Nullable identifier, const char* _Nullable suggestedFileName, PickerLocationId suggestedStartLocation, char* filters[], int filterSize)
 {
     NSSavePanel *panel = [NSSavePanel savePanel];


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/23071

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->