### PR TITLE
fix(listview): blank space above when refreshing after Move + SelectedIndex

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.Measure.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.Measure.cs
@@ -490,6 +490,55 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Move_Then_SetSelectedIndex_No_Blank_Above()
+		{
+			const string Data = "Alfa,Bravo,Charlie,Delta,Echo,Foxtrot,Golf,Hotel,India,Juliett,Kilo,Lima,Mike,November,Oscar,Papa,Quebec,Romeo,Sierra,Tango,Uniform,Victor,Whiskey,X-ray,Yankee,Zulu";
+			const double ViewportHeight = 200;
+			const double LineHeight = 29; // FixedSizeItemTemplate Height
+
+			var items = new ObservableCollection<string>(Data
+				.Split(',')
+				// must fill beyond the extended viewport: 1(base vp) + 0.5(extended vp)
+				.Take(1 + (int)Math.Round(1.5 * ViewportHeight / LineHeight, MidpointRounding.ToPositiveInfinity))
+			);
+			var SUT = new ListView
+			{
+				MaxHeight = ViewportHeight,
+				SelectionMode = ListViewSelectionMode.Single,
+				ItemsSource = items,
+				ItemContainerStyle = NoSpaceContainerStyle,
+				ItemTemplate = FixedSizeItemTemplate, // Height = 29
+			};
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			await WindowHelper.WaitForIdle();
+
+			// without ensuring this, we don't have a repro
+			var itemsStackPanel = SUT.FindFirstChild<ItemsStackPanel>();
+			Assert.IsNotNull(itemsStackPanel, "Expected ListView to use an ItemsStackPanel for virtualization.");
+
+			var materialized = itemsStackPanel.Children;
+			Assert.IsNotNull(materialized, "Expected ItemsStackPanel.Children to be available.");
+			Assert.IsTrue(materialized.Count > 0, "Expected at least one materialized child before validating virtualization.");
+			Assert.IsTrue(
+				materialized.Count < items.Count,
+				$"Expected materialized count ({materialized.Count}) < items count ({items.Count})");
+
+			// Repro: move item at index 2 to index 3, then select index 3
+			items.Move(2, 3);
+			SUT.SelectedIndex = 3;
+			await WindowHelper.WaitForIdle();
+
+			// Item 0 must be materialized — no blank above
+			var firstContainer = await WindowHelper.WaitForNonNull(() => SUT.ContainerFromIndex(0) as ListViewItem);
+
+			var bounds = firstContainer.GetRelativeBounds(SUT);
+			Assert.AreEqual(0, bounds.Y, 1, "Item at index 0 should be at the top of the ListView");
+		}
+
 		// Works around ScrollIntoView() not implemented for all platforms
 		private static void ScrollTo(ListViewBase listViewBase, double vOffset)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -518,10 +518,13 @@ namespace Microsoft.UI.Xaml.Controls
 
 			FillForward();
 
-			if (_dynamicSeedStart.HasValue && GetItemsEnd() <= ExtendedViewportEnd + extentAdjustment)
+			// FillForward may not have covered the full viewport, or the seed may sit mid-list
+			// leaving a blank gap above it — in both cases, FillBackward is needed.
+			if (_dynamicSeedStart.HasValue && (
+				(GetItemsEnd() <= ExtendedViewportEnd + extentAdjustment) ||
+				(GetItemsStart() > ExtendedViewportStart + extentAdjustment)
+			))
 			{
-				// if the FillForward didnt fully fill the current viewport,
-				// we may still need to a FillBackward, otherwise we risk having a leading blank space
 				FillBackward();
 			}
 


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#452

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔

When an `ObservableCollection` item is moved (`items.Move(2, 3)`) and then `SelectedIndex` is set on a virtualized `ListView`, a blank space appears above the selected item. The layout refresh uses a dynamic seed positioned mid-list; `FillForward()` fills forward from the seed but `FillBackward()` is never triggered because the forward fill completes successfully — leaving items above the seed unmaterialized.

## What is the new behavior? 🚀

`FillLayout` now also triggers `FillBackward()` when the first materialized item sits below `ExtendedViewportStart` (i.e., there is a visible gap above the seed), in addition to the existing check for an incomplete forward fill. Item 0 remains materialized and positioned at the top of the list with no blank space above it.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
Runtime test added: `When_Move_Then_SetSelectedIndex_No_Blank_Above` in `Given_ListViewBase.Measure.cs`.