### PR TITLE
fix: Address Skia FocusManager handling issues

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Input/Focus/FocusTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Input/Focus/FocusTests.cs
@@ -1768,6 +1768,199 @@ namespace Uno.UI.RuntimeTests.MUX.Input.Focus
 		//	});
 		//	await TestServices.WindowHelper.WaitForIdle();
 		//}
+
+		[TestMethod]
+		[TestProperty("Description", "Verify that TabFocusNavigation=Cycle keeps focus within the container when sibling controls exist")]
+		public async Task VerifyCycleDoesNotEscapeToSiblings()
+		{
+			const string rootPanelXaml =
+					@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+						<StackPanel x:Name='topBar'>
+							<Button x:Name='outsideBtn1' Content='Outside1'/>
+							<Button x:Name='outsideBtn2' Content='Outside2'/>
+						</StackPanel>
+						<StackPanel TabFocusNavigation='Cycle' x:Name='cycleContainer'>
+							<Button x:Name='insideA' Content='InsideA'/>
+							<Button x:Name='insideB' Content='InsideB'/>
+							<Button x:Name='insideC' Content='InsideC'/>
+						</StackPanel>
+					</StackPanel>";
+
+			StackPanel rootPanel = null;
+			Button insideA = null;
+			Button insideB = null;
+			Button insideC = null;
+			Button outsideBtn1 = null;
+
+			UIExecutor.Execute(() =>
+			{
+				rootPanel = (StackPanel)XamlReader.Load(rootPanelXaml);
+				insideA = (Button)rootPanel.FindName("insideA");
+				insideB = (Button)rootPanel.FindName("insideB");
+				insideC = (Button)rootPanel.FindName("insideC");
+				outsideBtn1 = (Button)rootPanel.FindName("outsideBtn1");
+
+				TestServices.WindowHelper.WindowContent = rootPanel;
+			});
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Start focus inside the cycle container
+			await FocusHelper.EnsureFocusAsync(insideA, FocusState.Keyboard);
+
+			string eventOrder = "";
+
+			Action<object, RoutedEventArgs> action = (s, e) =>
+			{
+				UIExecutor.Execute(() =>
+				{
+					eventOrder += $"[{(s as FrameworkElement).Name}]";
+				});
+			};
+
+			// Tab forward through the cycle container multiple times - focus should never leave
+			using (var testerA = new EventTester<Button, RoutedEventArgs>(insideA, "GotFocus", action))
+			using (var testerB = new EventTester<Button, RoutedEventArgs>(insideB, "GotFocus", action))
+			using (var testerC = new EventTester<Button, RoutedEventArgs>(insideC, "GotFocus", action))
+			using (var testerOut1 = new EventTester<Button, RoutedEventArgs>(outsideBtn1, "GotFocus", action))
+			{
+				// Tab forward: A->B, B->C, C->A (cycle), A->B, B->C, C->A (cycle)
+				for (int i = 0; i < 6; i++)
+				{
+					await SimulateTabAsync(rootPanel);
+					await TestServices.WindowHelper.WaitForIdle();
+				}
+
+				// Expect: B, C, A, B, C, A - never outsideBtn1 or outsideBtn2
+				const string expected = "[insideB][insideC][insideA][insideB][insideC][insideA]";
+				Verify.AreEqual(expected, eventOrder);
+			}
+		}
+
+		[TestMethod]
+		[TestProperty("Description", "Verify that Shift-Tab within a Cycle container cycles backward without escaping")]
+		public async Task VerifyCycleDoesNotEscapeOnShiftTab()
+		{
+			const string rootPanelXaml =
+					@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+						<Button x:Name='outsideBtn' Content='Outside'/>
+						<StackPanel TabFocusNavigation='Cycle' x:Name='cycleContainer'>
+							<Button x:Name='insideA' Content='InsideA'/>
+							<Button x:Name='insideB' Content='InsideB'/>
+							<Button x:Name='insideC' Content='InsideC'/>
+						</StackPanel>
+					</StackPanel>";
+
+			StackPanel rootPanel = null;
+			Button insideA = null;
+			Button insideB = null;
+			Button insideC = null;
+			Button outsideBtn = null;
+
+			UIExecutor.Execute(() =>
+			{
+				rootPanel = (StackPanel)XamlReader.Load(rootPanelXaml);
+				insideA = (Button)rootPanel.FindName("insideA");
+				insideB = (Button)rootPanel.FindName("insideB");
+				insideC = (Button)rootPanel.FindName("insideC");
+				outsideBtn = (Button)rootPanel.FindName("outsideBtn");
+
+				TestServices.WindowHelper.WindowContent = rootPanel;
+			});
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Start focus on the first element in the cycle container
+			await FocusHelper.EnsureFocusAsync(insideA, FocusState.Keyboard);
+
+			string eventOrder = "";
+
+			Action<object, RoutedEventArgs> action = (s, e) =>
+			{
+				UIExecutor.Execute(() =>
+				{
+					eventOrder += $"[{(s as FrameworkElement).Name}]";
+				});
+			};
+
+			using (var testerA = new EventTester<Button, RoutedEventArgs>(insideA, "GotFocus", action))
+			using (var testerB = new EventTester<Button, RoutedEventArgs>(insideB, "GotFocus", action))
+			using (var testerC = new EventTester<Button, RoutedEventArgs>(insideC, "GotFocus", action))
+			using (var testerOut = new EventTester<Button, RoutedEventArgs>(outsideBtn, "GotFocus", action))
+			{
+				// Shift-Tab from A should go to C (cycle backward), then B, then A, then C again
+				for (int i = 0; i < 4; i++)
+				{
+					await SimulateShiftTabAsync(rootPanel);
+					await TestServices.WindowHelper.WaitForIdle();
+				}
+
+				const string expected = "[insideC][insideB][insideA][insideC]";
+				Verify.AreEqual(expected, eventOrder);
+			}
+		}
+
+		[TestMethod]
+		[TestProperty("Description", "Verify Cycle works with deeply nested children")]
+		public async Task VerifyCycleWithDeeplyNestedChildren()
+		{
+			const string rootPanelXaml =
+					@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+						<Button x:Name='outsideBtn' Content='Outside'/>
+						<Border TabFocusNavigation='Cycle'>
+							<Grid>
+								<StackPanel>
+									<Button x:Name='insideA' Content='InsideA'/>
+									<Button x:Name='insideB' Content='InsideB'/>
+								</StackPanel>
+							</Grid>
+						</Border>
+					</StackPanel>";
+
+			StackPanel rootPanel = null;
+			Button insideA = null;
+			Button insideB = null;
+			Button outsideBtn = null;
+
+			UIExecutor.Execute(() =>
+			{
+				rootPanel = (StackPanel)XamlReader.Load(rootPanelXaml);
+				insideA = (Button)rootPanel.FindName("insideA");
+				insideB = (Button)rootPanel.FindName("insideB");
+				outsideBtn = (Button)rootPanel.FindName("outsideBtn");
+
+				TestServices.WindowHelper.WindowContent = rootPanel;
+			});
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await FocusHelper.EnsureFocusAsync(insideA, FocusState.Keyboard);
+
+			string eventOrder = "";
+
+			Action<object, RoutedEventArgs> action = (s, e) =>
+			{
+				UIExecutor.Execute(() =>
+				{
+					eventOrder += $"[{(s as FrameworkElement).Name}]";
+				});
+			};
+
+			using (var testerA = new EventTester<Button, RoutedEventArgs>(insideA, "GotFocus", action))
+			using (var testerB = new EventTester<Button, RoutedEventArgs>(insideB, "GotFocus", action))
+			using (var testerOut = new EventTester<Button, RoutedEventArgs>(outsideBtn, "GotFocus", action))
+			{
+				// Tab: A->B, B->A (cycle), A->B, B->A (cycle)
+				for (int i = 0; i < 4; i++)
+				{
+					await SimulateTabAsync(rootPanel);
+					await TestServices.WindowHelper.WaitForIdle();
+				}
+
+				const string expected = "[insideB][insideA][insideB][insideA]";
+				Verify.AreEqual(expected, eventOrder);
+			}
+		}
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
@@ -1029,6 +1029,24 @@ namespace Microsoft.UI.Xaml.Input
 						{
 							pChildStop = GetNextTabStopInternal(childNoRef, pCurrent, pNewTabStop, ref bCurrentPassed, ref pCurrentCompare);
 						}
+
+						// Handling of 21H2 bug 32260809 as WinUI3: When the focus change occurs as the result of pCurrent's removal from the tree,
+						// childNoRef will never be set to pCurrent and thus bCurrentPassed will not be set to true above.
+						// This would lead to the wrong element getting focus. While GetNextTabStopInternal is processed, pCurrent still has
+						// its parent set, but pCurrent no longer appears in that parent's children collection. We detect the parent-child
+						// relationship and set bCurrentPassed to true so that pNewTabStop can later be set even though compareIndexResult
+						// may be 0. Unfortunately this only works when the leaving pCurrent element is the last focusable child for
+						// currentParent. pCurrent's ex-position within currentParent is unknown at this point and focusing a previous
+						// sibling would require deep changes.
+						if (!bCurrentPassed && childNoRef != null)
+						{
+							var currentParent = pCurrent?.GetParentInternal(publicParentOnly: false);
+
+							if (currentParent != null && (currentParent == childNoRef || childNoRef.IsAncestorOf(currentParent)))
+							{
+								bCurrentPassed = true;
+							}
+						}
 					}
 
 					if (pChildStop != null && (IsFocusable(pChildStop) || CanHaveFocusableChildren(pChildStop)))

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
@@ -1170,8 +1170,14 @@ namespace Microsoft.UI.Xaml.Input
 							}
 							else
 							{
-								pCurrent = parent;
-								parent = parentElement;
+								// We need to get out of the current scope in case of Once navigation mode, so
+								// reset the current and parent to search the next available focus control
+								pCurrent = parentElement;
+								parent = GetFocusParent(parentElement);
+								if (parent == null)
+								{
+									break;
+								}
 							}
 						}
 						else


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

The newer behavior should be closer to WinUI3. I found 2 confirmed bugs that could cause focus issues in edge cases:

### Bug 1: GetPreviousTabStop - Incorrect Once mode handling (line 1177)
In the !IsValidTabStopSearchCandidate(parent) branch, when a Once-mode ancestor is not focusable:

Before: pCurrent = parent; parent = parentElement; — set wrong element and didn't call GetFocusParent
After (matches WinUI): pCurrent = parentElement; parent = GetFocusParent(parentElement); with null check
This could cause the backward tab walk to set pCurrent to a non-valid element, preventing subsequent Cycle detection.

### Bug 2: GetNextTabStopInternal - Missing 21H2 fix (line 1042)
WinUI has a fix for bug 32260809: when the focused element is removed from the tree during focus change, bCurrentPassed is never set to true, causing the wrong element to get focus. Ported the IsAncestorOf check that detects parent-child relationships even after tree removal.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->