### PR TITLE
fix(devserver): Reliable startup — host TFM fallback + spawn convergence + ideChannel surfacing

### DIFF
--- a/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
+++ b/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
@@ -125,31 +125,46 @@ How different SDK versions affect add-in discovery.
 
 ### TFM fallback resolver
 
-`UnoToolsLocator.GetHostExecutable` resolves the host directory in two steps:
+`UnoToolsLocator.TryResolveHostLaunchPlan` is the single host-discovery code path
+shared by `ResolveHostExecutableAsync` (direct launch) and `DiscoverAsync` (MCP /
+doctor surfaces). Resolution is three-stage:
 
 1. **Exact match first**. `tools/rc/host/{requestedTfm}/Uno.UI.RemoteControl.Host.{exe,dll}`.
-2. **Compatible fallback**. When the exact TFM directory is absent,
-   `TryResolveHostTfm` enumerates `tools/rc/host/net{X}.{Y}/` entries, keeps the ones
-   with `(major, minor) <= (requestedMajor, requestedMinor)`, and returns the highest.
-   The rule never picks a TFM newer than the requested runtime because .NET cannot
-   load an assembly compiled against a future major.
+2. **Compatible fallback capped at one major**. When the exact TFM directory is
+   absent, `TryResolveHostTfm` enumerates `tools/rc/host/net{X}.{Y}/` entries,
+   keeps the ones with `requestedMajor - 1 <= major <= requestedMajor` and
+   `(major, minor) <= (requestedMajor, requestedMinor)`, and returns the highest.
+   The one-major cap matches what `DOTNET_ROLL_FORWARD=Major` can actually cover
+   at runtime; picking further back would hand out a host the runtime cannot
+   load even with roll-forward enabled.
+3. **Refuse to roll up**. A TFM newer than the requested runtime is never
+   selected — .NET cannot load an assembly compiled against a future major.
 
 OS-suffixed monikers (`net10.0-windows…`) and pre-net5 monikers (`netstandard2.0`,
 `netcoreapp3.1`, `net472`) are filtered out — only the short `net{major}.{minor}` form
-is a candidate.
+is a candidate. The enumeration returns TFMs sorted numerically by `(major, minor)`,
+so the user-facing "present" list in error messages reads naturally.
 
-Pairs with a runtime-side safeguard on the spawn path: the CLI sets
-`DOTNET_ROLL_FORWARD=Major` in the host process environment (see
-`DevServerProcessHelper.CreateDotnetProcessStartInfo(enableMajorRollForward: true)`),
-so a host built for `net{N}` can still start on a machine whose only installed
-runtime is `net{N+1}`. On exact-TFM matches the variable is a no-op; on fallback it
-is the guarantee that the selected host actually runs.
+The resolver returns a `HostLaunchPlan { HostPath, RequiresMajorRollForward }`,
+with `RequiresMajorRollForward` set **only** when fallback was taken (exact match
+leaves it false). Every host-spawn site (`CliManager.BuildHostArgs`,
+`StartCommandHandler.BuildDirectLaunchArgs`/`BuildControllerModeArgs`,
+`DevServerMonitor.StartProcess`) threads the flag through to
+`DevServerProcessHelper.CreateDotnetProcessStartInfo(enableMajorRollForward: …)`,
+which sets `DOTNET_ROLL_FORWARD=Major` on the child process environment. This
+coupling means:
+
+- Exact match: no roll-forward override — pinned-major setups (global.json,
+  ambient `DOTNET_ROLL_FORWARD`) are respected.
+- Fallback: `DOTNET_ROLL_FORWARD=Major` is the guarantee that the selected host
+  (one major below the runtime) actually starts.
 
 ### Risks
 
 | Risk | Scenario | Impact | Mitigation |
 |------|----------|--------|------------|
-| TFM mismatch | `dotnet --version` reports 10.0 but Host only has `net9.0` binary | Host not found | `TryResolveHostTfm` falls back to the highest `net{X}.{Y}` ≤ requested; `DOTNET_ROLL_FORWARD=Major` lets the older-TFM host start on the newer runtime |
+| TFM mismatch (one-major gap) | `dotnet --version` reports 10.0 but Host only has `net9.0` binary | Host not found | `TryResolveHostTfm` falls back to the highest `net{X}.{Y}` ≤ requested (within one major); `HostLaunchPlan.RequiresMajorRollForward` propagates to the spawn; `DOTNET_ROLL_FORWARD=Major` lets the older-TFM host start on the newer runtime |
+| TFM mismatch (multi-major gap) | Host ships only `net5.0`, runtime is `net10.0` | Runtime cannot load the host even with roll-forward | Resolver refuses (one-major cap) and returns null → clear "no compatible TFM" error instead of a silent crash at launch |
 | `global.json` pins older SDK | Project uses 9.0 but system default is 10.0 | Wrong TFM selected | Respect `global.json` SDK version, not `dotnet --version` |
 | Preview SDK version string | `10.0.100-preview.1` | Parser fails | `GetDotNetVersion` strips preview suffix before TFM computation |
 | New major lands (net11, net12, …) | Package has not shipped the new TFM yet | Resolver returns an older host | Expected behaviour — automatic via the fallback resolver, no code change |
@@ -161,7 +176,11 @@ is the guarantee that the selected host actually runs.
 - [ ] `global.json` pins 9.0 with 10.0 installed → `net9.0` TFM used
 - [x] Host package only has `net9.0` but SDK is 10.0 → fallback to `net9.0` and `DOTNET_ROLL_FORWARD=Major` on spawn (covered by `Given_UnoToolsLocator`)
 - [x] Host package has only `net11.0` but SDK is 10.0 → resolver returns null rather than pick a higher TFM
+- [x] Host package has only `net5.0`/`net6.0` but SDK is 10.0 → resolver returns null (multi-major gap refused, paired with `DOTNET_ROLL_FORWARD=Major` semantics)
+- [x] Exact TFM match → `HostLaunchPlan.RequiresMajorRollForward` is false, helper does not force `DOTNET_ROLL_FORWARD=Major` (pinned-major setups preserved)
 - [x] Non-`net{X}.{Y}` directories under `tools/rc/host/` are ignored
+- [x] `EnumerateHostTfms` result is sorted numerically by `(major, minor)` (not string-ordinal)
+- [x] `DiscoverAsync` and `ResolveHostExecutableAsync` share the same resolver (MCP `discover`, `doctor`, and direct launch agree)
 - [ ] Cache invalidated when `global.json` changes
 
 ---

--- a/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
+++ b/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
@@ -159,6 +159,18 @@ coupling means:
 - Fallback: `DOTNET_ROLL_FORWARD=Major` is the guarantee that the selected host
   (one major below the runtime) actually starts.
 
+### `disco --json` public contract
+
+`DiscoveryInfo.HostRequiresMajorRollForward` is surfaced in the `disco --json`
+payload as the `hostRequiresMajorRollForward` boolean. This is an **additive
+committed field**: `true` indicates that the resolver had to fall back to an
+older-major host and that the spawn path will set `DOTNET_ROLL_FORWARD=Major`;
+`false` indicates an exact-TFM match with no roll-forward override. External
+tools (IDE extensions, doctor-style diagnostics, CI scripts) may rely on it
+to distinguish "host is native to the current runtime" from "host is selected
+via fallback and may behave differently under upgrades". Renaming or removing
+this field is a breaking schema change for those consumers.
+
 ### Risks
 
 | Risk | Scenario | Impact | Mitigation |

--- a/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
+++ b/specs/001-fast-devserver-startup/spec-appendix-g-compatibility-matrix.md
@@ -118,24 +118,50 @@ How different SDK versions affect add-in discovery.
 | .NET SDK | TFM | Host Binary Location | `dotnet tool` R2R Support | Notes |
 |----------|-----|---------------------|:-------------------------:|-------|
 | 9.0 | `net9.0` | `tools/rc/host/net9.0/` | No | Current |
-| 10.0 | `net10.0` | `tools/rc/host/net10.0/` | **Yes** (RID-specific tools) | Target for Phase 2 |
-| Preview | `net{x}.0` | May not match installed SDKs | Varies | Edge case |
+| 10.0 | `net10.0` | `tools/rc/host/net10.0/` | **Yes** (RID-specific tools) | Current |
+| 11.0+ | `net{N}.0` | `tools/rc/host/net{N}.0/` when shipped, otherwise fall back to highest `net{M}.0` with `M <= N` | Yes | Automatic via `UnoToolsLocator.TryResolveHostTfm` — no code change when a new major lands |
+| Preview | `net{x}.0` | May not match installed SDKs | Varies | Preview suffix stripped by `GetDotNetVersion`; same fallback path as above |
 | Multiple installed | Depends on `global.json` | Must match pinned SDK | N/A | See section 13 |
+
+### TFM fallback resolver
+
+`UnoToolsLocator.GetHostExecutable` resolves the host directory in two steps:
+
+1. **Exact match first**. `tools/rc/host/{requestedTfm}/Uno.UI.RemoteControl.Host.{exe,dll}`.
+2. **Compatible fallback**. When the exact TFM directory is absent,
+   `TryResolveHostTfm` enumerates `tools/rc/host/net{X}.{Y}/` entries, keeps the ones
+   with `(major, minor) <= (requestedMajor, requestedMinor)`, and returns the highest.
+   The rule never picks a TFM newer than the requested runtime because .NET cannot
+   load an assembly compiled against a future major.
+
+OS-suffixed monikers (`net10.0-windows…`) and pre-net5 monikers (`netstandard2.0`,
+`netcoreapp3.1`, `net472`) are filtered out — only the short `net{major}.{minor}` form
+is a candidate.
+
+Pairs with a runtime-side safeguard on the spawn path: the CLI sets
+`DOTNET_ROLL_FORWARD=Major` in the host process environment (see
+`DevServerProcessHelper.CreateDotnetProcessStartInfo(enableMajorRollForward: true)`),
+so a host built for `net{N}` can still start on a machine whose only installed
+runtime is `net{N+1}`. On exact-TFM matches the variable is a no-op; on fallback it
+is the guarantee that the selected host actually runs.
 
 ### Risks
 
 | Risk | Scenario | Impact | Mitigation |
 |------|----------|--------|------------|
-| TFM mismatch | `dotnet --version` reports 10.0 but Host only has `net9.0` binary | Host not found | Scan available TFMs, pick best match (section 13 Phase 3) |
+| TFM mismatch | `dotnet --version` reports 10.0 but Host only has `net9.0` binary | Host not found | `TryResolveHostTfm` falls back to the highest `net{X}.{Y}` ≤ requested; `DOTNET_ROLL_FORWARD=Major` lets the older-TFM host start on the newer runtime |
 | `global.json` pins older SDK | Project uses 9.0 but system default is 10.0 | Wrong TFM selected | Respect `global.json` SDK version, not `dotnet --version` |
-| Preview SDK version string | `10.0.100-preview.1` | Parser fails | Robust version parsing, ignore preview suffix for TFM |
+| Preview SDK version string | `10.0.100-preview.1` | Parser fails | `GetDotNetVersion` strips preview suffix before TFM computation |
+| New major lands (net11, net12, …) | Package has not shipped the new TFM yet | Resolver returns an older host | Expected behaviour — automatic via the fallback resolver, no code change |
 
 ### Validation
 
-- [ ] .NET 9.0 installed → `net9.0` TFM, Host found
-- [ ] .NET 10.0 installed → `net10.0` TFM, Host found
+- [x] .NET 9.0 installed → `net9.0` TFM, Host found
+- [x] .NET 10.0 installed → `net10.0` TFM, Host found
 - [ ] `global.json` pins 9.0 with 10.0 installed → `net9.0` TFM used
-- [ ] Host package only has `net9.0` but SDK is 10.0 → fallback to `net9.0` with warning
+- [x] Host package only has `net9.0` but SDK is 10.0 → fallback to `net9.0` and `DOTNET_ROLL_FORWARD=Major` on spawn (covered by `Given_UnoToolsLocator`)
+- [x] Host package has only `net11.0` but SDK is 10.0 → resolver returns null rather than pick a higher TFM
+- [x] Non-`net{X}.{Y}` directories under `tools/rc/host/` are ignored
 - [ ] Cache invalidated when `global.json` changes
 
 ---

--- a/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
@@ -1,0 +1,160 @@
+using System.IO;
+using AwesomeAssertions;
+using Uno.UI.DevServer.Cli.Helpers;
+
+namespace Uno.UI.DevServer.Cli.Tests;
+
+[TestClass]
+public class Given_UnoToolsLocator
+{
+	[TestMethod]
+	[DataRow("net10.0", 10, 0)]
+	[DataRow("net9.0", 9, 0)]
+	[DataRow("net11.0", 11, 0)]
+	[DataRow("net5.0", 5, 0)]
+	[Description("TryParseNetTfm must accept any net{major}.{minor} moniker with major >= 5. " +
+		"Guards forward compatibility — a net11.0 or net12.0 host directory shipped by a future " +
+		"Uno.Sdk must be recognised without a code change, otherwise adding a new TFM would " +
+		"silently break the resolver the way the net9 → net10 transition did for Uno.Sdk " +
+		"6.1.0-dev.30 (issue followed up from uno.studio PR #1024 / Chefs sample).")]
+	public void When_Parsing_Valid_Net_Tfm_Then_Returns_Version(string input, int expectedMajor, int expectedMinor)
+	{
+		var success = UnoToolsLocator.TryParseNetTfm(input, out var major, out var minor);
+
+		success.Should().BeTrue();
+		major.Should().Be(expectedMajor);
+		minor.Should().Be(expectedMinor);
+	}
+
+	[TestMethod]
+	[DataRow(null)]
+	[DataRow("")]
+	[DataRow("netstandard2.0")]
+	[DataRow("netcoreapp3.1")]
+	[DataRow("net472")]
+	[DataRow("net10.0-windows10.0.19041")]
+	[DataRow("net4.8")]
+	[DataRow("random-folder")]
+	[Description("TryParseNetTfm must reject monikers the resolver cannot compare on a " +
+		"single (major, minor) axis: pre-net5 frameworks (netstandard, netcoreapp, netfx), " +
+		"platform-suffixed TFMs (net10.0-windows…), and anything that doesn't parse as " +
+		"net{int}.{int}. Unexpected subdirectories under tools/rc/host/ must be ignored " +
+		"rather than crashing discovery.")]
+	public void When_Parsing_Invalid_Or_Non_Net_Tfm_Then_Returns_False(string? input)
+	{
+		var success = UnoToolsLocator.TryParseNetTfm(input, out _, out _);
+
+		success.Should().BeFalse();
+	}
+
+	[TestMethod]
+	[Description("Exact TFM match always wins over fallback candidates. Mandatory: we must not " +
+		"accidentally \"fall back\" from net10 to net9 when the host actually ships a net10 " +
+		"directory — that would forego all forward-targeting fixes the host gains in each new " +
+		"major.")]
+	public void When_Requested_Tfm_Is_Available_Then_Returns_Exact_Match()
+	{
+		var tfms = new[] { "net8.0", "net9.0", "net10.0" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().Be("net10.0");
+	}
+
+	[TestMethod]
+	[Description("When the requested TFM is not shipped (older Uno.Sdk predating the dotnet SDK " +
+		"currently installed), return the highest available TFM <= the request. Regresses the " +
+		"Chefs.sln case from the PR follow-up: Uno.Sdk 6.1.0-dev.30 only ships net8 / net9 hosts " +
+		"but the user has .NET 10.0.201 — we must pick net9 so the host starts (paired with " +
+		"DOTNET_ROLL_FORWARD=Major for the runtime side).")]
+	public void When_Requested_Tfm_Is_Missing_Then_Falls_Back_To_Highest_Compatible()
+	{
+		var tfms = new[] { "net8.0", "net9.0" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().Be("net9.0");
+	}
+
+	[TestMethod]
+	[Description("Future-proofing for net11 and later: if the user still has .NET 10 but the " +
+		"package now ships net11 only, the resolver must refuse to pick net11 because a net10 " +
+		"runtime cannot load a net11 assembly. Returning null here lets the caller surface a " +
+		"clean \"no compatible TFM\" error instead of handing back a host that would simply " +
+		"crash at startup.")]
+	public void When_Only_Higher_Tfms_Are_Available_Then_Returns_Null()
+	{
+		var tfms = new[] { "net11.0", "net12.0" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("When several compatible candidates exist we pick the highest of them, not the " +
+		"lowest — sticking with the most recent host surface area the package happens to ship. " +
+		"Covers the happy path of the fallback when multiple older TFMs are present.")]
+	public void When_Multiple_Compatible_Tfms_Exist_Then_Returns_Highest()
+	{
+		var tfms = new[] { "net8.0", "net9.0" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().Be("net9.0");
+	}
+
+	[TestMethod]
+	[Description("Minor-version ordering: net10.5 must be preferred over net10.0 when both are " +
+		"present and the request is net10.5 or higher. Minor differences are unlikely in practice " +
+		"(uno.winui.devserver currently only ships net{major}.0) but the resolver supports them " +
+		"so that hypothetical future service-release builds are handled correctly.")]
+	public void When_Candidates_Differ_By_Minor_Then_Highest_Minor_Wins()
+	{
+		var tfms = new[] { "net10.0", "net10.5" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.5").Should().Be("net10.5");
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net11.0").Should().Be("net10.5");
+	}
+
+	[TestMethod]
+	[Description("Empty tools/rc/host directories must surface as null rather than NRE-ing — " +
+		"callers translate null into a user-facing \"no compatible TFM available\" error that " +
+		"points at a likely cause (missing/partial package restore).")]
+	public void When_No_Tfms_Are_Available_Then_Returns_Null()
+	{
+		UnoToolsLocator.TryResolveHostTfm(System.Array.Empty<string>(), "net10.0").Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("EnumerateHostTfms must silently return an empty array when the host directory " +
+		"itself is missing — this happens for malformed packages and during cache eviction. Any " +
+		"other behaviour would force the caller to wrap the enumeration in its own Directory.Exists " +
+		"guard, duplicating the check.")]
+	public void When_Host_Root_Directory_Does_Not_Exist_Then_Returns_Empty()
+	{
+		var missing = Path.Combine(Path.GetTempPath(), "uno-tests-does-not-exist-" + System.Guid.NewGuid().ToString("N"));
+
+		UnoToolsLocator.EnumerateHostTfms(missing).Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("EnumerateHostTfms must skip non-net TFM directories that happen to exist under " +
+		"tools/rc/host/. Older Uno package versions occasionally carried legacy folders " +
+		"(e.g. support tooling or templates) beside the TFM buckets; including those in the " +
+		"candidate list would break TryResolveHostTfm's major/minor comparison.")]
+	public void When_Host_Root_Contains_Non_Net_Folders_Then_They_Are_Filtered_Out()
+	{
+		var root = Path.Combine(Path.GetTempPath(), "uno-tests-host-" + System.Guid.NewGuid().ToString("N"));
+		try
+		{
+			Directory.CreateDirectory(Path.Combine(root, "net9.0"));
+			Directory.CreateDirectory(Path.Combine(root, "net10.0"));
+			Directory.CreateDirectory(Path.Combine(root, "netstandard2.0"));
+			Directory.CreateDirectory(Path.Combine(root, "some-feature-folder"));
+
+			var tfms = UnoToolsLocator.EnumerateHostTfms(root);
+
+			tfms.Should().BeEquivalentTo(new[] { "net9.0", "net10.0" });
+		}
+		finally
+		{
+			if (Directory.Exists(root))
+			{
+				Directory.Delete(root, recursive: true);
+			}
+		}
+	}
+}

--- a/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
@@ -315,7 +315,7 @@ public class Given_UnoToolsLocator
 		"points at a likely cause (missing/partial package restore).")]
 	public void When_No_Tfms_Are_Available_Then_Returns_Null()
 	{
-		UnoToolsLocator.TryResolveHostTfm(Array.Empty<string>(), "net10.0").Should().BeNull();
+		UnoToolsLocator.TryResolveHostTfm([], "net10.0").Should().BeNull();
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -119,7 +120,7 @@ public class Given_UnoToolsLocator
 		"any future consumer that assumes the returned array is ordered by version.")]
 	public void When_Host_Root_Contains_Mixed_Majors_Then_Result_Is_Sorted_By_Version()
 	{
-		var root = Path.Combine(Path.GetTempPath(), "uno-tests-host-sort-" + System.Guid.NewGuid().ToString("N"));
+		var root = Path.Combine(Path.GetTempPath(), "uno-tests-host-sort-" + Guid.NewGuid().ToString("N"));
 		try
 		{
 			Directory.CreateDirectory(Path.Combine(root, "net9.0"));
@@ -145,7 +146,7 @@ public class Given_UnoToolsLocator
 		"both go through this resolver, so one fixture pins both entry points.")]
 	public void When_Exact_Tfm_Missing_And_Fallback_Exists_Then_Plan_Flags_RollForward()
 	{
-		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-" + System.Guid.NewGuid().ToString("N"));
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-" + Guid.NewGuid().ToString("N"));
 		try
 		{
 			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net9.0");
@@ -173,7 +174,7 @@ public class Given_UnoToolsLocator
 		"would otherwise be silently overridden on every exact-match launch.")]
 	public void When_Exact_Tfm_Available_Then_Plan_Does_Not_Flag_RollForward()
 	{
-		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-exact-" + System.Guid.NewGuid().ToString("N"));
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-exact-" + Guid.NewGuid().ToString("N"));
 		try
 		{
 			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net10.0");
@@ -202,7 +203,7 @@ public class Given_UnoToolsLocator
 		"switched to the .dll and bypassed the native shim on Windows.")]
 	public void When_Both_Exe_And_Dll_Present_In_Fallback_Directory_Then_Exe_Wins()
 	{
-		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-exe-wins-" + System.Guid.NewGuid().ToString("N"));
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-exe-wins-" + Guid.NewGuid().ToString("N"));
 		try
 		{
 			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net9.0");
@@ -231,7 +232,7 @@ public class Given_UnoToolsLocator
 		"instead of returning a launch plan with a bogus path.")]
 	public void When_Host_Directory_Exists_But_Is_Empty_Then_Plan_Is_Null()
 	{
-		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-empty-" + System.Guid.NewGuid().ToString("N"));
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-empty-" + Guid.NewGuid().ToString("N"));
 		try
 		{
 			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net10.0");
@@ -258,7 +259,7 @@ public class Given_UnoToolsLocator
 	{
 		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
 			hostPath: "stub.dll",
-			arguments: System.Array.Empty<string>(),
+			arguments: Array.Empty<string>(),
 			workingDirectory: Path.GetTempPath(),
 			redirectOutput: true,
 			enableMajorRollForward: true);
@@ -275,7 +276,7 @@ public class Given_UnoToolsLocator
 	public void When_EnableMajorRollForward_Is_False_Then_Helper_Does_Not_Force_Major()
 	{
 		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
-			"stub.dll", System.Array.Empty<string>(), Path.GetTempPath(),
+			"stub.dll", Array.Empty<string>(), Path.GetTempPath(),
 			redirectOutput: true, enableMajorRollForward: false);
 
 		if (psi.Environment.TryGetValue("DOTNET_ROLL_FORWARD", out var value))
@@ -314,7 +315,7 @@ public class Given_UnoToolsLocator
 		"points at a likely cause (missing/partial package restore).")]
 	public void When_No_Tfms_Are_Available_Then_Returns_Null()
 	{
-		UnoToolsLocator.TryResolveHostTfm(System.Array.Empty<string>(), "net10.0").Should().BeNull();
+		UnoToolsLocator.TryResolveHostTfm(Array.Empty<string>(), "net10.0").Should().BeNull();
 	}
 
 	[TestMethod]
@@ -324,7 +325,7 @@ public class Given_UnoToolsLocator
 		"guard, duplicating the check.")]
 	public void When_Host_Root_Directory_Does_Not_Exist_Then_Returns_Empty()
 	{
-		var missing = Path.Combine(Path.GetTempPath(), "uno-tests-does-not-exist-" + System.Guid.NewGuid().ToString("N"));
+		var missing = Path.Combine(Path.GetTempPath(), "uno-tests-does-not-exist-" + Guid.NewGuid().ToString("N"));
 
 		UnoToolsLocator.EnumerateHostTfms(missing).Should().BeEmpty();
 	}
@@ -336,7 +337,7 @@ public class Given_UnoToolsLocator
 		"candidate list would break TryResolveHostTfm's major/minor comparison.")]
 	public void When_Host_Root_Contains_Non_Net_Folders_Then_They_Are_Filtered_Out()
 	{
-		var root = Path.Combine(Path.GetTempPath(), "uno-tests-host-" + System.Guid.NewGuid().ToString("N"));
+		var root = Path.Combine(Path.GetTempPath(), "uno-tests-host-" + Guid.NewGuid().ToString("N"));
 		try
 		{
 			Directory.CreateDirectory(Path.Combine(root, "net9.0"));

--- a/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
@@ -259,7 +259,7 @@ public class Given_UnoToolsLocator
 	{
 		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
 			hostPath: "stub.dll",
-			arguments: Array.Empty<string>(),
+			arguments: [],
 			workingDirectory: Path.GetTempPath(),
 			redirectOutput: true,
 			enableMajorRollForward: true);
@@ -276,7 +276,7 @@ public class Given_UnoToolsLocator
 	public void When_EnableMajorRollForward_Is_False_Then_Helper_Does_Not_Force_Major()
 	{
 		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
-			"stub.dll", Array.Empty<string>(), Path.GetTempPath(),
+			"stub.dll", [], Path.GetTempPath(),
 			redirectOutput: true, enableMajorRollForward: false);
 
 		if (psi.Environment.TryGetValue("DOTNET_ROLL_FORWARD", out var value))

--- a/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Given_UnoToolsLocator.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using AwesomeAssertions;
 using Uno.UI.DevServer.Cli.Helpers;
 
@@ -83,6 +85,203 @@ public class Given_UnoToolsLocator
 		var tfms = new[] { "net11.0", "net12.0" };
 
 		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("One-major cap on the fallback: DOTNET_ROLL_FORWARD=Major (the env var the " +
+		"spawn path sets when the resolver returns a fallback host) allows exactly one major " +
+		"version jump. Picking a two-major-or-more gap (e.g. net5 host under a net10 runtime) " +
+		"would hand back a binary the runtime cannot actually load and make the roll-forward " +
+		"claim in HostLaunchPlan a lie. Regression guard against skeptic review of " +
+		"https://github.com/unoplatform/uno/pull/23124.")]
+	public void When_Only_Tfms_More_Than_One_Major_Below_Exist_Then_Returns_Null()
+	{
+		var tfms = new[] { "net5.0", "net6.0", "net7.0" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("Cap boundary: when the requested runtime is net10, a net9 host is acceptable " +
+		"(one-major jump, covered by DOTNET_ROLL_FORWARD=Major) but a net8 host is not. The " +
+		"resolver must pick net9 even when net8 is also present.")]
+	public void When_Both_One_And_Two_Majors_Below_Are_Available_Then_Picks_One_Major_Below()
+	{
+		var tfms = new[] { "net8.0", "net9.0" };
+
+		UnoToolsLocator.TryResolveHostTfm(tfms, "net10.0").Should().Be("net9.0");
+	}
+
+	[TestMethod]
+	[Description("EnumerateHostTfms must sort numerically by (major, minor), not by ordinal " +
+		"string. Ordinal sort places `net10.0` before `net9.0` because '1' < '9', which would " +
+		"make the user-facing \"present TFMs\" list in the error log confusing and would break " +
+		"any future consumer that assumes the returned array is ordered by version.")]
+	public void When_Host_Root_Contains_Mixed_Majors_Then_Result_Is_Sorted_By_Version()
+	{
+		var root = Path.Combine(Path.GetTempPath(), "uno-tests-host-sort-" + System.Guid.NewGuid().ToString("N"));
+		try
+		{
+			Directory.CreateDirectory(Path.Combine(root, "net9.0"));
+			Directory.CreateDirectory(Path.Combine(root, "net10.0"));
+			Directory.CreateDirectory(Path.Combine(root, "net8.0"));
+
+			UnoToolsLocator.EnumerateHostTfms(root).Should().Equal("net8.0", "net9.0", "net10.0");
+		}
+		finally
+		{
+			if (Directory.Exists(root))
+			{
+				Directory.Delete(root, recursive: true);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Description("TryResolveHostLaunchPlan picks the fallback net9 host when the exact net10 " +
+		"directory is missing and flags RequiresMajorRollForward=true so the spawn path will " +
+		"set DOTNET_ROLL_FORWARD=Major. End-to-end guard for issue #23123 (Chefs.sln + " +
+		"Uno.Sdk 6.1.0-dev.30 + .NET 10 SDK): `ResolveHostExecutableAsync` and `DiscoverAsync` " +
+		"both go through this resolver, so one fixture pins both entry points.")]
+	public void When_Exact_Tfm_Missing_And_Fallback_Exists_Then_Plan_Flags_RollForward()
+	{
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-" + System.Guid.NewGuid().ToString("N"));
+		try
+		{
+			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net9.0");
+			Directory.CreateDirectory(hostDir);
+			File.WriteAllText(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll"), "stub");
+
+			var plan = UnoToolsLocator.TryResolveHostLaunchPlan(pkg, "net10.0");
+
+			plan.Should().NotBeNull();
+			plan!.HostPath.Should().Be(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll"));
+			plan.RequiresMajorRollForward.Should().BeTrue();
+		}
+		finally
+		{
+			if (Directory.Exists(pkg))
+			{
+				Directory.Delete(pkg, recursive: true);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Description("TryResolveHostLaunchPlan with an exact TFM match must not flag the " +
+		"RollForward requirement: pinned majors (via global.json or DOTNET_ROLL_FORWARD ambient) " +
+		"would otherwise be silently overridden on every exact-match launch.")]
+	public void When_Exact_Tfm_Available_Then_Plan_Does_Not_Flag_RollForward()
+	{
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-exact-" + System.Guid.NewGuid().ToString("N"));
+		try
+		{
+			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net10.0");
+			Directory.CreateDirectory(hostDir);
+			File.WriteAllText(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe"), "stub");
+
+			var plan = UnoToolsLocator.TryResolveHostLaunchPlan(pkg, "net10.0");
+
+			plan.Should().NotBeNull();
+			plan!.HostPath.Should().Be(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe"));
+			plan.RequiresMajorRollForward.Should().BeFalse();
+		}
+		finally
+		{
+			if (Directory.Exists(pkg))
+			{
+				Directory.Delete(pkg, recursive: true);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Description(".exe shim is preferred over the managed .dll when both exist in the fallback " +
+		"host directory — matches the resolution order of ResolveHostExecutableAsync prior to " +
+		"the fallback refactor. Guards against a regression where the fallback path silently " +
+		"switched to the .dll and bypassed the native shim on Windows.")]
+	public void When_Both_Exe_And_Dll_Present_In_Fallback_Directory_Then_Exe_Wins()
+	{
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-exe-wins-" + System.Guid.NewGuid().ToString("N"));
+		try
+		{
+			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net9.0");
+			Directory.CreateDirectory(hostDir);
+			File.WriteAllText(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe"), "stub-exe");
+			File.WriteAllText(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll"), "stub-dll");
+
+			var plan = UnoToolsLocator.TryResolveHostLaunchPlan(pkg, "net10.0");
+
+			plan.Should().NotBeNull();
+			plan!.HostPath.Should().EndWith(".exe");
+			plan.RequiresMajorRollForward.Should().BeTrue();
+		}
+		finally
+		{
+			if (Directory.Exists(pkg))
+			{
+				Directory.Delete(pkg, recursive: true);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Description("Defensive: an empty host directory (package extracted but layout corrupted) " +
+		"must surface as null — the caller turns that into a clean \"no compatible TFM\" error " +
+		"instead of returning a launch plan with a bogus path.")]
+	public void When_Host_Directory_Exists_But_Is_Empty_Then_Plan_Is_Null()
+	{
+		var pkg = Path.Combine(Path.GetTempPath(), "uno-tests-pkg-empty-" + System.Guid.NewGuid().ToString("N"));
+		try
+		{
+			var hostDir = Path.Combine(pkg, "tools", "rc", "host", "net10.0");
+			Directory.CreateDirectory(hostDir);
+
+			UnoToolsLocator.TryResolveHostLaunchPlan(pkg, "net10.0").Should().BeNull();
+		}
+		finally
+		{
+			if (Directory.Exists(pkg))
+			{
+				Directory.Delete(pkg, recursive: true);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Description("Integration guard for DevServerProcessHelper.CreateDotnetProcessStartInfo: " +
+		"when the caller opts in via enableMajorRollForward=true, DOTNET_ROLL_FORWARD=Major " +
+		"must actually land on the spawned process' Environment dictionary. Without this " +
+		"assertion, nothing in the suite actually exercises the roll-forward contract — a " +
+		"refactor could silently drop the env var and every other test would still pass.")]
+	public void When_EnableMajorRollForward_Is_True_Then_DOTNET_ROLL_FORWARD_Major_Is_Set_On_Process_Environment()
+	{
+		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
+			hostPath: "stub.dll",
+			arguments: System.Array.Empty<string>(),
+			workingDirectory: Path.GetTempPath(),
+			redirectOutput: true,
+			enableMajorRollForward: true);
+
+		psi.Environment.Should().ContainKey("DOTNET_ROLL_FORWARD")
+			.WhoseValue.Should().Be("Major");
+	}
+
+	[TestMethod]
+	[Description("Symmetric guard: exact TFM match (no fallback) must leave the pinned-major " +
+		"scenario alone — the helper must not unconditionally force DOTNET_ROLL_FORWARD=Major " +
+		"when the caller opted out. If the parent already sets it explicitly we propagate it; " +
+		"what we forbid is the helper overwriting that to Major on its own.")]
+	public void When_EnableMajorRollForward_Is_False_Then_Helper_Does_Not_Force_Major()
+	{
+		var psi = DevServerProcessHelper.CreateDotnetProcessStartInfo(
+			"stub.dll", System.Array.Empty<string>(), Path.GetTempPath(),
+			redirectOutput: true, enableMajorRollForward: false);
+
+		if (psi.Environment.TryGetValue("DOTNET_ROLL_FORWARD", out var value))
+		{
+			value.Should().NotBe("Major");
+		}
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -129,12 +129,14 @@ internal class CliManager
 			}
 
 			workingDirectory ??= requestedWorkingDirectory;
-			var hostPath = await _unoToolsLocator.ResolveHostExecutableAsync(workingDirectory);
+			var hostLaunchPlan = await _unoToolsLocator.ResolveHostExecutableAsync(workingDirectory);
 
-			if (hostPath is null)
+			if (hostLaunchPlan is null)
 			{
 				return 1; // errors already logged
 			}
+
+			var hostPath = hostLaunchPlan.HostPath;
 
 			// Resolve add-ins via convention-based discovery for the start command
 			string? resolvedAddIns = null;
@@ -151,7 +153,8 @@ internal class CliManager
 				var startHandler = CreateStartCommandHandler();
 				return await startHandler.RunAsync(
 					hostPath, originalArgs, workingDirectory, resolvedAddIns,
-					workspaceResolution?.SelectedSolutionPath);
+					workspaceResolution?.SelectedSolutionPath,
+					enableMajorRollForward: hostLaunchPlan.RequiresMajorRollForward);
 			}
 
 			// Non-start commands (stop, list, cleanup) still use controller mode
@@ -160,7 +163,7 @@ internal class CliManager
 				string.Equals(originalArgs[0], "cleanup", StringComparison.OrdinalIgnoreCase)
 			);
 
-			var startInfo = BuildHostArgs(hostPath, originalArgs, workingDirectory, redirectOutput: true, addins: null);
+			var startInfo = BuildHostArgs(hostPath, originalArgs, workingDirectory, redirectOutput: true, addins: null, enableMajorRollForward: hostLaunchPlan.RequiresMajorRollForward);
 
 			var (ExitCode, StdOut, StdErr) = await DevServerProcessHelper.RunConsoleProcessAsync(startInfo, _logger, forwardOutputToConsole: requiresHostOutputPassthrough);
 			return ExitCode;
@@ -887,7 +890,7 @@ internal class CliManager
 			servers, jsonOutput, allScopes, allIdes, dryRun, ideDefinitionsPath, serverDefinitionsPath);
 	}
 
-	private ProcessStartInfo BuildHostArgs(string hostPath, string[] originalArgs, string workingDirectory, bool redirectOutput = true, string? addins = null)
+	private ProcessStartInfo BuildHostArgs(string hostPath, string[] originalArgs, string workingDirectory, bool redirectOutput = true, string? addins = null, bool enableMajorRollForward = false)
 	{
 		// Use --command=<verb> (single token) instead of --command <verb> (two tokens)
 		// to work around argument splitting observed on some CI environments where
@@ -905,7 +908,7 @@ internal class CliManager
 			args.Add(addins);
 		}
 
-		return DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput, enableMajorRollForward: true);
+		return DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput, enableMajorRollForward: enableMajorRollForward);
 	}
 
 	private StartCommandHandler CreateStartCommandHandler()

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -905,7 +905,7 @@ internal class CliManager
 			args.Add(addins);
 		}
 
-		return DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput);
+		return DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput, enableMajorRollForward: true);
 	}
 
 	private StartCommandHandler CreateStartCommandHandler()

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -37,7 +37,8 @@ internal static class DevServerProcessHelper
 		IEnumerable<string> arguments,
 		string workingDirectory,
 		bool redirectOutput,
-		bool redirectInput = false)
+		bool redirectInput = false,
+		bool enableMajorRollForward = false)
 	{
 		var useDotnet = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || hostPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
 
@@ -72,6 +73,17 @@ internal static class DevServerProcessHelper
 
 		PropagateDotnetRootVariables(psi);
 		PropagateXdgVariables(psi);
+
+		if (enableMajorRollForward)
+		{
+			// Override the host's runtimeconfig.json rollForward policy so a host compiled for
+			// an older major (e.g. net9.0 because that's the most recent TFM shipped by an
+			// older Uno.Sdk) can still start on a machine whose only installed runtime is a
+			// newer major (e.g. net10.0). Safe for dev tools; a no-op when the exact TFM
+			// runtime is installed. Used by the host spawn path alongside UnoToolsLocator's
+			// TFM fallback resolver.
+			psi.Environment["DOTNET_ROLL_FORWARD"] = "Major";
+		}
 
 		return psi;
 	}

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -6,6 +6,8 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Uno.UI.RemoteControl.Host;
 
 namespace Uno.UI.DevServer.Cli.Helpers;
 
@@ -338,6 +340,19 @@ internal static class DevServerProcessHelper
 			// Streams may not be available
 		}
 
+		// Backfill the ambient registry with the ideChannelId we passed via --ideChannel.
+		// Older host versions (Uno.WinUI.DevServer < ~6.6) don't include IdeChannelId in
+		// their own registration, leaving disco's `activeServers[].ideChannelId` null and
+		// preventing uno.studio's DevServerLauncher from adopting the host without
+		// re-spawning a duplicate. The sidecar is removed automatically when the host
+		// process is no longer alive.
+		var ideChannelId = ExtractIdeChannel(startInfo.Arguments);
+		if (!string.IsNullOrWhiteSpace(ideChannelId))
+		{
+			var ambient = new AmbientRegistry(NullLogger.Instance);
+			ambient.WriteAuxiliaryRegistration(targetProcessId: process.Id, ideChannelId: ideChannelId);
+		}
+
 		// Extract the port from the args to probe for readiness
 		var port = ExtractPort(startInfo.Arguments);
 		if (port <= 0)
@@ -390,6 +405,21 @@ internal static class DevServerProcessHelper
 		}
 
 		return 0;
+	}
+
+	private static string? ExtractIdeChannel(string arguments)
+	{
+		var parts = arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+		for (var i = 0; i < parts.Length - 1; i++)
+		{
+			if (string.Equals(parts[i], "--ideChannel", StringComparison.OrdinalIgnoreCase))
+			{
+				// Strip surrounding quotes that the args builder may have added.
+				return parts[i + 1].Trim('"');
+			}
+		}
+
+		return null;
 	}
 
 	private static async Task<bool> WaitForTcpReadyAsync(int port, int timeoutMs)

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
@@ -115,6 +115,16 @@ public sealed class DiscoveryInfo
 	public string? HostPath { get; init; }
 
 	/// <summary>
+	/// True when <see cref="HostPath"/> was selected via one-major TFM fallback
+	/// (the package did not ship a host for the current <see cref="DotNetTfm"/>,
+	/// so the resolver picked the previous major instead). Callers that actually
+	/// spawn the host must then set <c>DOTNET_ROLL_FORWARD=Major</c> on the child
+	/// process environment — see
+	/// <c>DevServerProcessHelper.CreateDotnetProcessStartInfo(enableMajorRollForward)</c>.
+	/// </summary>
+	public bool HostRequiresMajorRollForward { get; init; }
+
+	/// <summary>
 	/// Gets the resolved Settings application (Studio / Licensing) path.
 	/// </summary>
 	public string? SettingsPath { get; init; }

--- a/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DiscoveryInfo.cs
@@ -182,7 +182,7 @@ public sealed class ActiveServerInfo
 	public DateTime StartTime { get; init; }
 	public string? IdeChannelId { get; init; }
 	public string? SolutionPath { get; init; }
-	public IReadOnlyList<ProcessChainEntry> ProcessChain { get; init; } = Array.Empty<ProcessChainEntry>();
+	public IReadOnlyList<ProcessChainEntry> ProcessChain { get; init; } = [];
 
 	/// <summary>
 	/// True when this server's solution matches one of the working directory's

--- a/src/Uno.UI.DevServer.Cli/Helpers/HostLaunchPlan.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/HostLaunchPlan.cs
@@ -1,0 +1,22 @@
+namespace Uno.UI.DevServer.Cli.Helpers;
+
+/// <summary>
+/// How to launch the DevServer host: path to the executable / managed entry-point
+/// DLL, and whether the selected TFM is older than the current runtime (in which
+/// case the spawn path must set <c>DOTNET_ROLL_FORWARD=Major</c> so the host
+/// actually starts).
+/// </summary>
+/// <param name="HostPath">
+/// Absolute path to <c>Uno.UI.RemoteControl.Host.exe</c> (preferred on Windows)
+/// or <c>Uno.UI.RemoteControl.Host.dll</c> (used when the <c>.exe</c> shim is
+/// absent, e.g. cross-platform builds). Never null.
+/// </param>
+/// <param name="RequiresMajorRollForward">
+/// True when the host was selected via one-major fallback
+/// (see <see cref="UnoToolsLocator.TryResolveHostTfm"/>) and the spawned process
+/// must therefore honour <c>DOTNET_ROLL_FORWARD=Major</c>. False for exact-TFM
+/// matches — setting the flag then would still work but would mask unrelated
+/// roll-forward behaviour the user may have pinned via <c>global.json</c> or
+/// ambient env vars.
+/// </param>
+internal sealed record HostLaunchPlan(string HostPath, bool RequiresMajorRollForward);

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -153,21 +153,25 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			errors.Add("Unable to determine dotnet --version.");
 		}
 
+		var hostRequiresMajorRollForward = false;
 		if (!string.IsNullOrWhiteSpace(devServerPackagePath) && !string.IsNullOrWhiteSpace(dotNetTfm))
 		{
-			var hostExe = Path.Combine(devServerPackagePath, "tools", "rc", "host", dotNetTfm, "Uno.UI.RemoteControl.Host.exe");
-			var hostDll = Path.Combine(devServerPackagePath, "tools", "rc", "host", dotNetTfm, "Uno.UI.RemoteControl.Host.dll");
-			if (File.Exists(hostExe))
+			// Uses the same resolver as ResolveHostExecutableAsync so the two entry points
+			// never disagree about whether a host is available (the old exact-TFM probe here
+			// would return null even when the fallback resolver found a compatible binary,
+			// which misled MCP / doctor diagnostics and DevServerMonitor).
+			var plan = TryResolveHostLaunchPlan(devServerPackagePath!, dotNetTfm!);
+			if (plan is not null)
 			{
-				hostPath = hostExe;
-			}
-			else if (File.Exists(hostDll))
-			{
-				hostPath = hostDll;
+				hostPath = plan.HostPath;
+				hostRequiresMajorRollForward = plan.RequiresMajorRollForward;
 			}
 			else
 			{
-				errors.Add("DevServer host not found in package at expected paths.");
+				var available = EnumerateHostTfms(Path.Combine(devServerPackagePath!, "tools", "rc", "host"));
+				errors.Add(available.Length == 0
+					? "DevServer host not found in package at expected paths."
+					: $"DevServer host not found in package: no compatible TFM available for {dotNetTfm} (present: {string.Join(", ", available)}).");
 			}
 		}
 
@@ -279,6 +283,7 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			DotNetVersion = dotNetVersion,
 			DotNetTfm = dotNetTfm,
 			HostPath = hostPath,
+			HostRequiresMajorRollForward = hostRequiresMajorRollForward,
 			SettingsPath = settingsPath,
 			AddIns = resolvedAddIns,
 			AddInsDiscoveryMethod = addInsDiscoveryMethod,
@@ -322,7 +327,7 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		return studioPath;
 	}
 
-	public async Task<string?> ResolveHostExecutableAsync(string workDirectory)
+	public async Task<HostLaunchPlan?> ResolveHostExecutableAsync(string workDirectory)
 	{
 		var sdkVersion = await GetSdkVersionFromGlobalJson(workDirectory);
 		if (sdkVersion.sdkVersion == null || sdkVersion.sdkPackage == null)
@@ -340,13 +345,13 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		}
 		_logger.LogDebug("Found Uno SDK: {UnoSdkPath}", unoSdkPath);
 
-		var hostPath = await GetHostExecutable(unoSdkPath);
-		if (hostPath is null)
+		var plan = await GetHostLaunchPlan(unoSdkPath);
+		if (plan is null)
 		{
 			_logger.LogError("Could not determine DevServer host executable path.");
 			return null;
 		}
-		return hostPath;
+		return plan;
 	}
 
 	private async Task<(string? sdkPackage, string? sdkVersion)> GetSdkVersionFromGlobalJson(string searchDirectory)
@@ -499,7 +504,7 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		}
 	}
 
-	private async Task<string?> GetHostExecutable(string unoSdkPath)
+	private async Task<HostLaunchPlan?> GetHostLaunchPlan(string unoSdkPath)
 	{
 		try
 		{
@@ -521,48 +526,32 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 				return null;
 			}
 
-			var hostRoot = Path.Combine(devServerPackagePath, "tools", "rc", "host");
-			var availableTfms = EnumerateHostTfms(hostRoot);
-			var resolvedTfm = TryResolveHostTfm(availableTfms, dotnetVersion);
-			if (resolvedTfm is null)
+			var plan = TryResolveHostLaunchPlan(devServerPackagePath, dotnetVersion);
+			if (plan is null)
 			{
+				var available = EnumerateHostTfms(Path.Combine(devServerPackagePath, "tools", "rc", "host"));
 				_logger.LogError(
 					"DevServer host not found in package: no compatible TFM available for {RequestedTfm} (present: {AvailableTfms}).",
 					dotnetVersion,
-					availableTfms.Length == 0 ? "<none>" : string.Join(", ", availableTfms));
+					available.Length == 0 ? "<none>" : string.Join(", ", available));
 				return null;
 			}
 
-			if (!string.Equals(resolvedTfm, dotnetVersion, StringComparison.OrdinalIgnoreCase))
+			if (plan.RequiresMajorRollForward)
 			{
-				// Running a lower-TFM host under a higher runtime is safe as long as roll-forward
-				// allows it. The host spawn path sets DOTNET_ROLL_FORWARD=Major so a net9 host can
-				// start on a machine that has only the net10 runtime installed — see
-				// DevServerProcessHelper.CreateDotnetProcessStartInfo.
+				// One-major fallback only (see TryResolveHostTfm): the spawn path must be told
+				// to set DOTNET_ROLL_FORWARD=Major via HostLaunchPlan.RequiresMajorRollForward,
+				// otherwise the older-TFM host's runtimeconfig rollForward=minor will refuse to
+				// start on a newer-major runtime.
 				_logger.LogInformation(
-					"Uno.WinUI.DevServer {Version} does not ship a host for {RequestedTfm}; falling back to {ResolvedTfm}.",
+					"Uno.WinUI.DevServer {Version} does not ship a host for {RequestedTfm}; falling back to an older-major binary ({HostPath}). DOTNET_ROLL_FORWARD=Major will be set on the spawn so the host starts on the installed runtime.",
 					devServerPackageVersion,
 					dotnetVersion,
-					resolvedTfm);
+					plan.HostPath);
 			}
 
-			var hostDir = Path.Combine(hostRoot, resolvedTfm);
-			var hostExe = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe");
-			if (File.Exists(hostExe))
-			{
-				_logger.LogDebug("Found DevServer Host: {Path}", hostExe);
-				return hostExe;
-			}
-
-			var hostDll = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll");
-			if (File.Exists(hostDll))
-			{
-				_logger.LogDebug("Found DevServer Host: {Path}", hostDll);
-				return hostDll;
-			}
-
-			_logger.LogError("DevServer host not found in package at expected paths under {HostDir}.", hostDir);
-			return null;
+			_logger.LogDebug("Found DevServer Host: {Path}", plan.HostPath);
+			return plan;
 		}
 		catch (Exception ex)
 		{
@@ -572,10 +561,50 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 	}
 
 	/// <summary>
+	/// Pure, test-friendly resolver shared by <see cref="GetHostLaunchPlan"/> and
+	/// <see cref="DiscoverAsync"/>. Given the DevServer NuGet package path and the
+	/// TFM requested by the current runtime, it returns the host path and whether
+	/// the caller must enable <c>DOTNET_ROLL_FORWARD=Major</c> on the spawn.
+	/// Returns <c>null</c> when the package does not ship a compatible host
+	/// (either nothing at all, or only TFMs newer than the runtime, or only TFMs
+	/// more than one major below the runtime — see <see cref="TryResolveHostTfm"/>
+	/// for the one-major cap rationale).
+	/// </summary>
+	internal static HostLaunchPlan? TryResolveHostLaunchPlan(string devServerPackagePath, string requestedTfm)
+	{
+		var hostRoot = Path.Combine(devServerPackagePath, "tools", "rc", "host");
+		var availableTfms = EnumerateHostTfms(hostRoot);
+		var resolvedTfm = TryResolveHostTfm(availableTfms, requestedTfm);
+		if (resolvedTfm is null)
+		{
+			return null;
+		}
+
+		var hostDir = Path.Combine(hostRoot, resolvedTfm);
+		var hostExe = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe");
+		string? hostPath = File.Exists(hostExe)
+			? hostExe
+			: File.Exists(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll"))
+				? Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll")
+				: null;
+		if (hostPath is null)
+		{
+			return null;
+		}
+
+		var requiresMajorRollForward = !string.Equals(resolvedTfm, requestedTfm, StringComparison.OrdinalIgnoreCase);
+		return new HostLaunchPlan(hostPath, requiresMajorRollForward);
+	}
+
+	/// <summary>
 	/// Enumerates the <c>net{X}.{Y}</c> subdirectories that exist under
 	/// <paramref name="hostRoot"/> (i.e. <c>tools/rc/host</c>). Non-matching entries
 	/// (pre-net5 monikers, feature folders, …) are ignored. Returns an empty array
 	/// when the directory does not exist so the caller can surface a clean error.
+	/// The result is sorted by parsed (major, minor) in ascending order; string-ordinal
+	/// sort would incorrectly place <c>net10.0</c> before <c>net9.0</c>, which is
+	/// harmless for <see cref="TryResolveHostTfm"/> (it re-sorts numerically) but misleads
+	/// the user-facing "present" list in the error log.
 	/// </summary>
 	internal static string[] EnumerateHostTfms(string hostRoot)
 	{
@@ -586,9 +615,13 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 
 		return Directory.EnumerateDirectories(hostRoot)
 			.Select(Path.GetFileName)
-			.Where(name => TryParseNetTfm(name, out _, out _))
-			.Select(name => name!)
-			.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+			.Select(name => TryParseNetTfm(name, out var major, out var minor)
+				? (valid: true, name: name!, major, minor)
+				: (valid: false, name: (string?)null, major: 0, minor: 0))
+			.Where(entry => entry.valid)
+			.OrderBy(entry => entry.major)
+			.ThenBy(entry => entry.minor)
+			.Select(entry => entry.name!)
 			.ToArray();
 	}
 
@@ -596,8 +629,12 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 	/// Picks the best available TFM for <paramref name="requestedTfm"/> from
 	/// <paramref name="availableTfms"/>. Exact matches win. Otherwise returns the
 	/// highest <c>net{X}.{Y}</c> that is <b>less than or equal to</b>
-	/// <paramref name="requestedTfm"/> — we never pick a TFM newer than the runtime,
-	/// because .NET cannot roll back to a version the host wasn't compiled against.
+	/// <paramref name="requestedTfm"/> and within one major of it — we never pick
+	/// a TFM newer than the runtime, because .NET cannot roll back to a version
+	/// the host wasn't compiled against, and we never pick more than one major
+	/// below either, because that is exactly what <c>DOTNET_ROLL_FORWARD=Major</c>
+	/// covers (one major jump). A wider gap would silently select a host the
+	/// runtime cannot actually load.
 	/// Returns <c>null</c> when nothing suitable is available.
 	/// </summary>
 	internal static string? TryResolveHostTfm(string[] availableTfms, string requestedTfm)
@@ -613,10 +650,17 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			return exact;
 		}
 
+		// One-major cap: DOTNET_ROLL_FORWARD=Major allows exactly one major jump.
+		// Anything further (e.g. net5 host under net10) is not loadable even with
+		// roll-forward enabled, and picking such a host would be misleading.
+		const int MaxMajorGap = 1;
+		var minMajor = reqMajor - MaxMajorGap;
+
 		var candidates = new List<(string tfm, int major, int minor)>();
 		foreach (var tfm in availableTfms)
 		{
 			if (TryParseNetTfm(tfm, out var major, out var minor)
+				&& major >= minMajor
 				&& (major < reqMajor || (major == reqMajor && minor <= reqMinor)))
 			{
 				candidates.Add((tfm, major, minor));
@@ -838,3 +882,24 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		}
 	}
 }
+
+/// <summary>
+/// How to launch the DevServer host: path to the executable / managed entry-point
+/// DLL, and whether the selected TFM is older than the current runtime (in which
+/// case the spawn path must set <c>DOTNET_ROLL_FORWARD=Major</c> so the host
+/// actually starts).
+/// </summary>
+/// <param name="HostPath">
+/// Absolute path to <c>Uno.UI.RemoteControl.Host.exe</c> (preferred on Windows)
+/// or <c>Uno.UI.RemoteControl.Host.dll</c> (used when the <c>.exe</c> shim is
+/// absent, e.g. cross-platform builds). Never null.
+/// </param>
+/// <param name="RequiresMajorRollForward">
+/// True when the host was selected via one-major fallback
+/// (see <see cref="UnoToolsLocator.TryResolveHostTfm"/>) and the spawned process
+/// must therefore honour <c>DOTNET_ROLL_FORWARD=Major</c>. False for exact-TFM
+/// matches — setting the flag then would still work but would mask unrelated
+/// roll-forward behaviour the user may have pinned via <c>global.json</c> or
+/// ambient env vars.
+/// </param>
+internal sealed record HostLaunchPlan(string HostPath, bool RequiresMajorRollForward);

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -521,21 +521,47 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 				return null;
 			}
 
-			var hostExe = Path.Combine(devServerPackagePath, "tools", "rc", "host", dotnetVersion, "Uno.UI.RemoteControl.Host.exe");
+			var hostRoot = Path.Combine(devServerPackagePath, "tools", "rc", "host");
+			var availableTfms = EnumerateHostTfms(hostRoot);
+			var resolvedTfm = TryResolveHostTfm(availableTfms, dotnetVersion);
+			if (resolvedTfm is null)
+			{
+				_logger.LogError(
+					"DevServer host not found in package: no compatible TFM available for {RequestedTfm} (present: {AvailableTfms}).",
+					dotnetVersion,
+					availableTfms.Length == 0 ? "<none>" : string.Join(", ", availableTfms));
+				return null;
+			}
+
+			if (!string.Equals(resolvedTfm, dotnetVersion, StringComparison.OrdinalIgnoreCase))
+			{
+				// Running a lower-TFM host under a higher runtime is safe as long as roll-forward
+				// allows it. The host spawn path sets DOTNET_ROLL_FORWARD=Major so a net9 host can
+				// start on a machine that has only the net10 runtime installed — see
+				// DevServerProcessHelper.CreateDotnetProcessStartInfo.
+				_logger.LogInformation(
+					"Uno.WinUI.DevServer {Version} does not ship a host for {RequestedTfm}; falling back to {ResolvedTfm}.",
+					devServerPackageVersion,
+					dotnetVersion,
+					resolvedTfm);
+			}
+
+			var hostDir = Path.Combine(hostRoot, resolvedTfm);
+			var hostExe = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe");
 			if (File.Exists(hostExe))
 			{
 				_logger.LogDebug("Found DevServer Host: {Path}", hostExe);
 				return hostExe;
 			}
 
-			var hostDll = Path.Combine(devServerPackagePath, "tools", "rc", "host", dotnetVersion, "Uno.UI.RemoteControl.Host.dll");
+			var hostDll = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll");
 			if (File.Exists(hostDll))
 			{
 				_logger.LogDebug("Found DevServer Host: {Path}", hostDll);
 				return hostDll;
 			}
 
-			_logger.LogError("DevServer host not found in package at expected paths");
+			_logger.LogError("DevServer host not found in package at expected paths under {HostDir}.", hostDir);
 			return null;
 		}
 		catch (Exception ex)
@@ -543,6 +569,101 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			_logger.LogWarning(ex, "Failed to locate host executable: {Message}", ex.Message);
 			return null;
 		}
+	}
+
+	/// <summary>
+	/// Enumerates the <c>net{X}.{Y}</c> subdirectories that exist under
+	/// <paramref name="hostRoot"/> (i.e. <c>tools/rc/host</c>). Non-matching entries
+	/// (pre-net5 monikers, feature folders, …) are ignored. Returns an empty array
+	/// when the directory does not exist so the caller can surface a clean error.
+	/// </summary>
+	internal static string[] EnumerateHostTfms(string hostRoot)
+	{
+		if (!Directory.Exists(hostRoot))
+		{
+			return Array.Empty<string>();
+		}
+
+		return Directory.EnumerateDirectories(hostRoot)
+			.Select(Path.GetFileName)
+			.Where(name => TryParseNetTfm(name, out _, out _))
+			.Select(name => name!)
+			.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+	}
+
+	/// <summary>
+	/// Picks the best available TFM for <paramref name="requestedTfm"/> from
+	/// <paramref name="availableTfms"/>. Exact matches win. Otherwise returns the
+	/// highest <c>net{X}.{Y}</c> that is <b>less than or equal to</b>
+	/// <paramref name="requestedTfm"/> — we never pick a TFM newer than the runtime,
+	/// because .NET cannot roll back to a version the host wasn't compiled against.
+	/// Returns <c>null</c> when nothing suitable is available.
+	/// </summary>
+	internal static string? TryResolveHostTfm(string[] availableTfms, string requestedTfm)
+	{
+		if (availableTfms.Length == 0 || !TryParseNetTfm(requestedTfm, out var reqMajor, out var reqMinor))
+		{
+			return null;
+		}
+
+		var exact = availableTfms.FirstOrDefault(t => string.Equals(t, requestedTfm, StringComparison.OrdinalIgnoreCase));
+		if (exact is not null)
+		{
+			return exact;
+		}
+
+		var candidates = new List<(string tfm, int major, int minor)>();
+		foreach (var tfm in availableTfms)
+		{
+			if (TryParseNetTfm(tfm, out var major, out var minor)
+				&& (major < reqMajor || (major == reqMajor && minor <= reqMinor)))
+			{
+				candidates.Add((tfm, major, minor));
+			}
+		}
+
+		return candidates
+			.OrderByDescending(v => v.major)
+			.ThenByDescending(v => v.minor)
+			.Select(v => v.tfm)
+			.FirstOrDefault();
+	}
+
+	/// <summary>
+	/// Parses a short <c>net{X}.{Y}</c> TFM (no OS platform suffix). Returns
+	/// <c>false</c> for pre-net5 monikers (<c>netstandard2.0</c>, <c>netcoreapp3.1</c>, …)
+	/// and anything with an OS bucket (<c>net10.0-windows</c>), which we don't use for
+	/// the DevServer host.
+	/// </summary>
+	internal static bool TryParseNetTfm(string? name, out int major, out int minor)
+	{
+		major = 0;
+		minor = 0;
+
+		if (string.IsNullOrEmpty(name) || !name!.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+		{
+			return false;
+		}
+
+		var rest = name.Substring(3);
+		// Reject OS-suffixed monikers outright. uno.winui.devserver host buckets are the
+		// short net{major}.{minor} form; a dash here means either a platform suffix
+		// (net10.0-windows…) or a feature band we don't want in the candidate list.
+		if (rest.IndexOf('-') >= 0)
+		{
+			return false;
+		}
+
+		var dotIndex = rest.IndexOf('.');
+		if (dotIndex < 0)
+		{
+			return false;
+		}
+
+		return int.TryParse(rest.Substring(0, dotIndex), out major)
+			&& int.TryParse(rest.Substring(dotIndex + 1), out minor)
+			&& major >= 5; // exclude netstandard, netcoreapp, netfx
 	}
 
 	private async Task<string?> GetSettingsExecutable(string unoSdkPath)

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -603,8 +603,8 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 	/// when the directory does not exist so the caller can surface a clean error.
 	/// The result is sorted by parsed (major, minor) in ascending order; string-ordinal
 	/// sort would incorrectly place <c>net10.0</c> before <c>net9.0</c>, which is
-	/// harmless for <see cref="TryResolveHostTfm"/> (it re-sorts numerically) but misleads
-	/// the user-facing "present" list in the error log.
+	/// harmless for <see cref="TryResolveHostTfm"/> (it scans in a single pass and is
+	/// order-independent) but misleads the user-facing "present" list in the error log.
 	/// </summary>
 	internal static string[] EnumerateHostTfms(string hostRoot)
 	{

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -582,19 +582,38 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 
 		var hostDir = Path.Combine(hostRoot, resolvedTfm);
 		var hostExe = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.exe");
-		string? hostPath = File.Exists(hostExe)
-			? hostExe
-			: File.Exists(Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll"))
-				? Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll")
+		var hostDll = Path.Combine(hostDir, "Uno.UI.RemoteControl.Host.dll");
+
+		// `Uno.UI.RemoteControl.Host.exe` is a Windows PE — `dotnet <exe>` on Linux/macOS
+		// fails. Prefer the framework-dependent `.dll` everywhere except Windows, where
+		// the `.exe` is the conventional entry point and `dotnet <exe>` is well-defined.
+		string? hostPath = OperatingSystem.IsWindows()
+			? File.Exists(hostExe)
+				? hostExe
+				: File.Exists(hostDll)
+					? hostDll
+					: null
+			: File.Exists(hostDll)
+				? hostDll
 				: null;
+
 		if (hostPath is null)
 		{
 			return null;
 		}
 
-		var requiresMajorRollForward = !string.Equals(resolvedTfm, requestedTfm, StringComparison.OrdinalIgnoreCase);
+		// Major-only downgrade is the trigger for DOTNET_ROLL_FORWARD=Major. A minor
+		// fallback (e.g. requested net10.5, available net10.0 — hypothetical today)
+		// stays inside the same major and shouldn't override the user's roll-forward
+		// policy. Equal TFMs need no roll-forward at all.
+		var requiresMajorRollForward = IsOneMajorFallback(requestedTfm, resolvedTfm);
 		return new HostLaunchPlan(hostPath, requiresMajorRollForward);
 	}
+
+	private static bool IsOneMajorFallback(string requestedTfm, string resolvedTfm)
+		=> TryParseNetTfm(requestedTfm, out var requestedMajor, out _)
+			&& TryParseNetTfm(resolvedTfm, out var resolvedMajor, out _)
+			&& resolvedMajor < requestedMajor;
 
 	/// <summary>
 	/// Enumerates the <c>net{X}.{Y}</c> subdirectories that exist under

--- a/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/UnoToolsLocator.cs
@@ -610,19 +610,34 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 	{
 		if (!Directory.Exists(hostRoot))
 		{
-			return Array.Empty<string>();
+			return [];
 		}
 
-		return Directory.EnumerateDirectories(hostRoot)
-			.Select(Path.GetFileName)
-			.Select(name => TryParseNetTfm(name, out var major, out var minor)
-				? (valid: true, name: name!, major, minor)
-				: (valid: false, name: (string?)null, major: 0, minor: 0))
-			.Where(entry => entry.valid)
-			.OrderBy(entry => entry.major)
-			.ThenBy(entry => entry.minor)
-			.Select(entry => entry.name!)
-			.ToArray();
+		// Explicit single pass — the LINQ chain we used to have had to carry a nullable
+		// sentinel through a Where filter and drop spurious `!` suppressions at the end.
+		// A loop is both shorter and free of null-forgiving.
+		var parsed = new List<(string name, int major, int minor)>();
+		foreach (var path in Directory.EnumerateDirectories(hostRoot))
+		{
+			var name = Path.GetFileName(path);
+			if (name is { Length: > 0 } && TryParseNetTfm(name, out var major, out var minor))
+			{
+				parsed.Add((name, major, minor));
+			}
+		}
+
+		parsed.Sort(static (a, b) =>
+		{
+			var c = a.major.CompareTo(b.major);
+			return c != 0 ? c : a.minor.CompareTo(b.minor);
+		});
+
+		var result = new string[parsed.Count];
+		for (var i = 0; i < parsed.Count; i++)
+		{
+			result[i] = parsed[i].name;
+		}
+		return result;
 	}
 
 	/// <summary>
@@ -644,34 +659,44 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			return null;
 		}
 
-		var exact = availableTfms.FirstOrDefault(t => string.Equals(t, requestedTfm, StringComparison.OrdinalIgnoreCase));
-		if (exact is not null)
-		{
-			return exact;
-		}
-
 		// One-major cap: DOTNET_ROLL_FORWARD=Major allows exactly one major jump.
 		// Anything further (e.g. net5 host under net10) is not loadable even with
 		// roll-forward enabled, and picking such a host would be misleading.
 		const int MaxMajorGap = 1;
 		var minMajor = reqMajor - MaxMajorGap;
 
-		var candidates = new List<(string tfm, int major, int minor)>();
+		// Single-pass "max under a cap". The cardinality here is the number of net{X}.{Y}
+		// folders shipped by a single DevServer package (currently 2-3) so we do not pay
+		// for a List + LINQ OrderByDescending chain; the explicit shape also handles the
+		// exact-match short-circuit without a second pass.
+		string? best = null;
+		var bestMajor = -1;
+		var bestMinor = -1;
+
 		foreach (var tfm in availableTfms)
 		{
-			if (TryParseNetTfm(tfm, out var major, out var minor)
-				&& major >= minMajor
-				&& (major < reqMajor || (major == reqMajor && minor <= reqMinor)))
+			if (string.Equals(tfm, requestedTfm, StringComparison.OrdinalIgnoreCase))
 			{
-				candidates.Add((tfm, major, minor));
+				return tfm;
+			}
+
+			if (!TryParseNetTfm(tfm, out var major, out var minor)
+				|| major < minMajor
+				|| major > reqMajor
+				|| (major == reqMajor && minor > reqMinor))
+			{
+				continue;
+			}
+
+			if (major > bestMajor || (major == bestMajor && minor > bestMinor))
+			{
+				best = tfm;
+				bestMajor = major;
+				bestMinor = minor;
 			}
 		}
 
-		return candidates
-			.OrderByDescending(v => v.major)
-			.ThenByDescending(v => v.minor)
-			.Select(v => v.tfm)
-			.FirstOrDefault();
+		return best;
 	}
 
 	/// <summary>
@@ -685,12 +710,17 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		major = 0;
 		minor = 0;
 
-		if (string.IsNullOrEmpty(name) || !name!.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+		// `string.IsNullOrEmpty` narrows nullability on the false branch, so no `!`
+		// suppression is needed on the subsequent AsSpan / StartsWith calls.
+		if (string.IsNullOrEmpty(name) || !name.StartsWith("net", StringComparison.OrdinalIgnoreCase))
 		{
 			return false;
 		}
 
-		var rest = name.Substring(3);
+		// Zero-copy parsing: slice the input as a span and let int.TryParse(ReadOnlySpan<char>)
+		// do the work. Avoids two Substring allocations per folder on every discovery.
+		var rest = name.AsSpan(3);
+
 		// Reject OS-suffixed monikers outright. uno.winui.devserver host buckets are the
 		// short net{major}.{minor} form; a dash here means either a platform suffix
 		// (net10.0-windows…) or a feature band we don't want in the candidate list.
@@ -699,14 +729,14 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 			return false;
 		}
 
-		var dotIndex = rest.IndexOf('.');
-		if (dotIndex < 0)
+		var dot = rest.IndexOf('.');
+		if (dot < 0)
 		{
 			return false;
 		}
 
-		return int.TryParse(rest.Substring(0, dotIndex), out major)
-			&& int.TryParse(rest.Substring(dotIndex + 1), out minor)
+		return int.TryParse(rest[..dot], out major)
+			&& int.TryParse(rest[(dot + 1)..], out minor)
 			&& major >= 5; // exclude netstandard, netcoreapp, netfx
 	}
 
@@ -882,24 +912,3 @@ internal class UnoToolsLocator(ILogger<UnoToolsLocator> logger, TargetsAddInReso
 		}
 	}
 }
-
-/// <summary>
-/// How to launch the DevServer host: path to the executable / managed entry-point
-/// DLL, and whether the selected TFM is older than the current runtime (in which
-/// case the spawn path must set <c>DOTNET_ROLL_FORWARD=Major</c> so the host
-/// actually starts).
-/// </summary>
-/// <param name="HostPath">
-/// Absolute path to <c>Uno.UI.RemoteControl.Host.exe</c> (preferred on Windows)
-/// or <c>Uno.UI.RemoteControl.Host.dll</c> (used when the <c>.exe</c> shim is
-/// absent, e.g. cross-platform builds). Never null.
-/// </param>
-/// <param name="RequiresMajorRollForward">
-/// True when the host was selected via one-major fallback
-/// (see <see cref="UnoToolsLocator.TryResolveHostTfm"/>) and the spawned process
-/// must therefore honour <c>DOTNET_ROLL_FORWARD=Major</c>. False for exact-TFM
-/// matches — setting the flag then would still work but would mask unrelated
-/// roll-forward behaviour the user may have pinned via <c>global.json</c> or
-/// ambient env vars.
-/// </param>
-internal sealed record HostLaunchPlan(string HostPath, bool RequiresMajorRollForward);

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -548,7 +548,7 @@ internal class DevServerMonitor(IServiceProvider services, ILogger<DevServerMoni
 		// Without it, the child process inherits our stdin — the MCP message pipe from
 		// the AI agent — and steals incoming JSON-RPC messages, causing random hangs.
 		var startInfo =
-			DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput: true, redirectInput: true);
+			DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput: true, redirectInput: true, enableMajorRollForward: true);
 
 		_logger.LogDebug("Starting server process: {File} {Args}", startInfo.FileName,
 			startInfo.Arguments);

--- a/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs
@@ -214,7 +214,7 @@ internal class DevServerMonitor(IServiceProvider services, ILogger<DevServerMoni
 							_currentDirectory,
 							port);
 						var (success, effectivePort) =
-							await StartProcess(hostPath, port, _currentDirectory, solution, ct);
+							await StartProcess(hostPath, port, _currentDirectory, solution, ct, enableMajorRollForward: discovery.HostRequiresMajorRollForward);
 						LogTimeline("start-process.complete", monitorCycleStopwatch.ElapsedMilliseconds,
 							$"success={success};port={effectivePort}");
 						if (!success)
@@ -470,7 +470,7 @@ internal class DevServerMonitor(IServiceProvider services, ILogger<DevServerMoni
 	}
 
 	internal async Task<(bool success, int effectivePort)> StartProcess(string hostPath, int port,
-		string workingDirectory, string? solution, CancellationToken ct)
+		string workingDirectory, string? solution, CancellationToken ct, bool enableMajorRollForward = false)
 	{
 		var processStartStopwatch = Stopwatch.StartNew();
 		// Check for existing DevServer instance via AmbientRegistry.
@@ -548,7 +548,7 @@ internal class DevServerMonitor(IServiceProvider services, ILogger<DevServerMoni
 		// Without it, the child process inherits our stdin — the MCP message pipe from
 		// the AI agent — and steals incoming JSON-RPC messages, causing random hangs.
 		var startInfo =
-			DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput: true, redirectInput: true, enableMajorRollForward: true);
+			DevServerProcessHelper.CreateDotnetProcessStartInfo(hostPath, args, workingDirectory, redirectOutput: true, redirectInput: true, enableMajorRollForward: enableMajorRollForward);
 
 		_logger.LogDebug("Starting server process: {File} {Args}", startInfo.FileName,
 			startInfo.Arguments);

--- a/src/Uno.UI.DevServer.Cli/StartCommandHandler.cs
+++ b/src/Uno.UI.DevServer.Cli/StartCommandHandler.cs
@@ -108,7 +108,8 @@ internal sealed class StartCommandHandler
 		string hostPath,
 		StartCommandArgs parsed,
 		string? addins,
-		string workingDirectory)
+		string workingDirectory,
+		bool enableMajorRollForward = false)
 	{
 		var args = new List<string>();
 
@@ -143,7 +144,7 @@ internal sealed class StartCommandHandler
 		args.AddRange(parsed.PassthroughArgs);
 
 		return DevServerProcessHelper.CreateDotnetProcessStartInfo(
-			hostPath, args, workingDirectory, redirectOutput: true, enableMajorRollForward: true);
+			hostPath, args, workingDirectory, redirectOutput: true, enableMajorRollForward: enableMajorRollForward);
 	}
 
 	/// <summary>
@@ -154,7 +155,8 @@ internal sealed class StartCommandHandler
 		string hostPath,
 		string[] originalArgs,
 		string workingDirectory,
-		string? addins)
+		string? addins,
+		bool enableMajorRollForward = false)
 	{
 		var command = originalArgs.Length > 0 ? originalArgs[0] : "start";
 		var args = new List<string> { $"--command={command}" };
@@ -170,7 +172,7 @@ internal sealed class StartCommandHandler
 		}
 
 		return DevServerProcessHelper.CreateDotnetProcessStartInfo(
-			hostPath, args, workingDirectory, redirectOutput: true, enableMajorRollForward: true);
+			hostPath, args, workingDirectory, redirectOutput: true, enableMajorRollForward: enableMajorRollForward);
 	}
 
 	/// <summary>
@@ -186,7 +188,8 @@ internal sealed class StartCommandHandler
 		string[] originalArgs,
 		string workingDirectory,
 		string? addins,
-		string? resolvedSolutionPath = null)
+		string? resolvedSolutionPath = null,
+		bool enableMajorRollForward = false)
 	{
 		var parsed = ParseStartArgs(originalArgs);
 
@@ -269,7 +272,7 @@ internal sealed class StartCommandHandler
 		}
 
 		// Build direct-mode args and spawn
-		var startInfo = BuildDirectLaunchArgs(hostPath, effectiveParsed, addins, workingDirectory);
+		var startInfo = BuildDirectLaunchArgs(hostPath, effectiveParsed, addins, workingDirectory, enableMajorRollForward: enableMajorRollForward);
 
 		_logger.LogInformation("Starting DevServer in direct mode: {Command} {Args}",
 			startInfo.FileName, startInfo.Arguments);

--- a/src/Uno.UI.DevServer.Cli/StartCommandHandler.cs
+++ b/src/Uno.UI.DevServer.Cli/StartCommandHandler.cs
@@ -143,7 +143,7 @@ internal sealed class StartCommandHandler
 		args.AddRange(parsed.PassthroughArgs);
 
 		return DevServerProcessHelper.CreateDotnetProcessStartInfo(
-			hostPath, args, workingDirectory, redirectOutput: true);
+			hostPath, args, workingDirectory, redirectOutput: true, enableMajorRollForward: true);
 	}
 
 	/// <summary>
@@ -170,7 +170,7 @@ internal sealed class StartCommandHandler
 		}
 
 		return DevServerProcessHelper.CreateDotnetProcessStartInfo(
-			hostPath, args, workingDirectory, redirectOutput: true);
+			hostPath, args, workingDirectory, redirectOutput: true, enableMajorRollForward: true);
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/AmbientRegistryTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/AmbientRegistryTests.cs
@@ -36,4 +36,88 @@ public class AmbientRegistryTests
 			registry.Unregister();
 		}
 	}
+
+	[TestMethod]
+	[Description("The CLI tool spawns hosts via direct process launch and writes a side-by-side " +
+		"auxiliary record carrying metadata the host itself didn't register (notably ideChannelId, " +
+		"absent from registrations produced by Uno.WinUI.DevServer versions older than the commit " +
+		"that added IdeChannelId to AmbientRegistry). Disco's view must read this sidecar so " +
+		"downstream consumers (uno.studio's DevServerLauncher) can adopt running hosts without " +
+		"requiring a Uno.WinUI.DevServer upgrade.")]
+	public void GetActiveDevServers_OverlaysSidecarIdeChannelIdWhenPrimaryRegistrationLacksIt()
+	{
+		using var loggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(b => { });
+		var logger = loggerFactory.CreateLogger("test");
+		var registry = new AmbientRegistry(logger);
+
+		// The "host" registers itself the way OLD Uno.WinUI.DevServer does — no ideChannelId.
+		// Use this process's pid so the IsProcessRunning probe in GetActiveDevServers returns true.
+		var hostPid = Environment.ProcessId;
+		registry.Register(solution: @"D:\src\repo\Repo.sln", ppid: 999, httpPort: 51717, ideChannelId: null);
+		try
+		{
+			// The CLI, which DID know the channel id (it passed --ideChannel to the host),
+			// drops a sidecar record with that information.
+			registry.WriteAuxiliaryRegistration(targetProcessId: hostPid, ideChannelId: "abc-123");
+
+			var found = registry.GetActiveDevServerForPort(51717);
+			found.Should().NotBeNull();
+			found!.IdeChannelId.Should().Be("abc-123",
+				"sidecar must overlay an ideChannelId when the primary registration left it null");
+		}
+		finally
+		{
+			registry.Unregister();
+		}
+	}
+
+	[TestMethod]
+	[Description("Sidecar must defer to the host's own registration when the host is recent enough " +
+		"to register an ideChannelId itself. The host's value is authoritative; the sidecar is a " +
+		"backfill mechanism for older hosts only.")]
+	public void GetActiveDevServers_DoesNotOverrideExistingPrimaryIdeChannelId()
+	{
+		using var loggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(b => { });
+		var logger = loggerFactory.CreateLogger("test");
+		var registry = new AmbientRegistry(logger);
+
+		var hostPid = Environment.ProcessId;
+		registry.Register(solution: @"D:\src\repo\Repo.sln", ppid: 999, httpPort: 51718, ideChannelId: "primary-channel");
+		try
+		{
+			registry.WriteAuxiliaryRegistration(targetProcessId: hostPid, ideChannelId: "sidecar-channel");
+
+			var found = registry.GetActiveDevServerForPort(51718);
+			found.Should().NotBeNull();
+			found!.IdeChannelId.Should().Be("primary-channel",
+				"the host's own ideChannelId wins over the sidecar — the sidecar is only a backfill for old hosts");
+		}
+		finally
+		{
+			registry.Unregister();
+		}
+	}
+
+	[TestMethod]
+	[Description("Sidecars must be cleaned up when their target process is no longer running, " +
+		"otherwise they accumulate forever and risk attaching stale ideChannelIds to recycled PIDs.")]
+	public void GetActiveDevServers_CleansStaleSidecarsForDeadProcesses()
+	{
+		using var loggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(b => { });
+		var logger = loggerFactory.CreateLogger("test");
+		var registry = new AmbientRegistry(logger);
+
+		// Pick a PID that we're sure is dead.
+		const int deadPid = int.MaxValue;
+		registry.WriteAuxiliaryRegistration(targetProcessId: deadPid, ideChannelId: "stale-channel");
+
+		// Trigger the read path which performs cleanup.
+		_ = registry.GetActiveDevServers().ToList();
+
+		var sidecarPath = Path.Combine(
+			AmbientRegistry.ResolveLocalApplicationDataPath(),
+			"Uno Platform", "DevServers",
+			$"devserver-{deadPid}.aux.json");
+		File.Exists(sidecarPath).Should().BeFalse("dead-PID sidecars must be removed on read");
+	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/DevServerHostDiscoveryTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/DevServerHostDiscoveryTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using Uno.UI.RemoteControl.VS.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Helpers;
+
+/// <summary>
+/// Pins the discovery JSON contract that <see cref="DevServerHostDiscovery"/> consumes
+/// to detect already-running DevServer hosts and skip the in-process spawn that would
+/// otherwise produce a duplicate (the CLI-driven launch flow + EntryPoint's legacy
+/// EnsureServerAsync currently each spawn one host for the same solution; this code path
+/// is the bridge that lets EntryPoint defer to the CLI's host).
+/// </summary>
+[TestClass]
+public class DevServerHostDiscoveryTests
+{
+	private const int CurrentDevenvPid = 6080;
+	private const string SolutionPath = @"C:\src\UnoApp1\UnoApp1.sln";
+
+	[TestMethod]
+	[Description("Disco emits a JSON payload with `activeServers[]`. The parser must accept the camelCase " +
+		"shape produced by the CLI (PropertyNamingPolicy = CamelCase).")]
+	public void ParseDiscoPayload_Reads_ActiveServers()
+	{
+		var json = """
+			{
+			  "selectedSolutionPath": "C:\\src\\UnoApp1\\UnoApp1.sln",
+			  "activeServers": [
+			    {
+			      "processId": 14376,
+			      "port": 51369,
+			      "parentProcessId": 6080,
+			      "solutionPath": "C:\\src\\UnoApp1\\UnoApp1.sln",
+			      "ideChannelId": null,
+			      "isInWorkspace": true
+			    }
+			  ]
+			}
+			""";
+
+		var servers = DevServerHostDiscovery.ParseActiveServers(json);
+
+		servers.Should().HaveCount(1);
+		var server = servers[0];
+		server.ProcessId.Should().Be(14376);
+		server.Port.Should().Be(51369);
+		server.ParentProcessId.Should().Be(6080);
+		server.SolutionPath.Should().Be(@"C:\src\UnoApp1\UnoApp1.sln");
+		server.IdeChannelId.Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("Match must be solution-path + parent-process scoped: a host running for THIS devenv's " +
+		"solution. This is what lets EntryPoint adopt the CLI-spawned sibling without confusing it for " +
+		"some other VS instance's host.")]
+	public void Match_PrefersSolutionPath_AndDevenvParent()
+	{
+		var servers = new List<DiscoveredDevServer>
+		{
+			new() { ProcessId = 100, Port = 5000, ParentProcessId = 9999, SolutionPath = SolutionPath },        // wrong ppid
+			new() { ProcessId = 200, Port = 5001, ParentProcessId = CurrentDevenvPid, SolutionPath = @"C:\Other.sln" }, // wrong solution
+			new() { ProcessId = 300, Port = 5002, ParentProcessId = CurrentDevenvPid, SolutionPath = SolutionPath },     // right
+		};
+
+		var match = DevServerHostDiscovery.Match(servers, SolutionPath, CurrentDevenvPid);
+
+		match.Should().NotBeNull();
+		match!.ProcessId.Should().Be(300);
+	}
+
+	[TestMethod]
+	[Description("Solution-path matching is case-insensitive on Windows (it's where the VS extension runs). " +
+		"`C:\\Src\\App\\App.sln` and `c:\\src\\app\\app.sln` denote the same file.")]
+	public void Match_IsCaseInsensitive_ForSolutionPath()
+	{
+		var servers = new List<DiscoveredDevServer>
+		{
+			new() { ProcessId = 1, Port = 5000, ParentProcessId = CurrentDevenvPid, SolutionPath = @"C:\SRC\UnoApp1\UnoApp1.sln" }
+		};
+
+		var match = DevServerHostDiscovery.Match(servers, @"C:\src\unoapp1\unoapp1.sln", CurrentDevenvPid);
+
+		match.Should().NotBeNull();
+	}
+
+	[TestMethod]
+	[Description("If no host matches BOTH solution and ppid, the match is null — better to spawn fresh than " +
+		"to adopt a sibling that belongs to another VS instance or another solution.")]
+	public void Match_ReturnsNull_WhenNoActiveServerSatisfiesBothCriteria()
+	{
+		var servers = new List<DiscoveredDevServer>
+		{
+			new() { ProcessId = 1, Port = 5000, ParentProcessId = CurrentDevenvPid, SolutionPath = @"C:\Other.sln" }
+		};
+
+		var match = DevServerHostDiscovery.Match(servers, SolutionPath, CurrentDevenvPid);
+
+		match.Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("Empty activeServers (no host running yet) returns null — caller must spawn.")]
+	public void Match_ReturnsNull_WhenNoActiveServers()
+	{
+		var match = DevServerHostDiscovery.Match([], SolutionPath, CurrentDevenvPid);
+
+		match.Should().BeNull();
+	}
+
+	[TestMethod]
+	[Description("Malformed/empty disco JSON must not blow up the host start path. The parser returns " +
+		"an empty list and the caller falls through to the existing spawn logic — degraded but recoverable.")]
+	public void ParseDiscoPayload_Tolerates_MalformedJson()
+	{
+		var servers = DevServerHostDiscovery.ParseActiveServers("not-valid-json");
+
+		servers.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("Missing `activeServers` key (older or partial CLI payload) returns empty rather than throwing.")]
+	public void ParseDiscoPayload_Tolerates_MissingActiveServersKey()
+	{
+		var servers = DevServerHostDiscovery.ParseActiveServers("""{ "selectedSolutionPath": "X" }""");
+
+		servers.Should().BeEmpty();
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/EntryPointRegressionTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/EntryPointRegressionTests.cs
@@ -58,4 +58,25 @@ public class EntryPointRegressionTests
 		// V3 constructor signature: (DTE2, string, AsyncPackage, string vsixChannelHandle)
 		source.Should().Contain("string vsixChannelHandle)");
 	}
+
+	[TestMethod]
+	[Description("EnsureServerAsync must consult DevServerHostDiscovery before spawning a host. " +
+		"Without this call, the legacy in-process spawn races with the CLI-driven launch flow " +
+		"(uno.studio VS extension, future VS Code / Rider plugins) and the user ends up with two " +
+		"phantom DevServer hosts on different ports for the same solution.")]
+	public void EntryPoint_EnsureServerAsync_ConsultsDevServerHostDiscoveryBeforeSpawn()
+	{
+		var source = ReadEntryPointSource();
+
+		// The probe must be wired in before the spawn (the `var pipeGuid = Guid.NewGuid();` line).
+		source.Should().Contain("DevServerHostDiscovery");
+		source.Should().Contain("TryFindHostAsync");
+
+		// Cheap structural pin: the probe call comes before the spawn argument string.
+		var probeIndex = source.IndexOf("TryFindHostAsync", StringComparison.Ordinal);
+		var spawnIndex = source.IndexOf("Uno.UI.RemoteControl.Host.dll", StringComparison.Ordinal);
+		probeIndex.Should().BeGreaterThan(0, "the discovery probe must be present");
+		spawnIndex.Should().BeGreaterThan(0, "the legacy spawn line must still exist");
+		probeIndex.Should().BeLessThan(spawnIndex, "the probe must run before the spawn so we can short-circuit");
+	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -27,6 +27,8 @@
 		<!-- Link sources directly so unit tests can compile without directly referencing the project output -->
 		<Compile Include="..\Uno.UI.RemoteControl.Server\AppLaunch\ApplicationLaunchMonitor.cs" Link="AppLaunch\ApplicationLaunchMonitor.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl.VS\AppLaunch\VsAppLaunchStateService.cs" Link="AppLaunch\VsAppLaunchStateService.cs" />
+		<Compile Include="..\Uno.UI.RemoteControl.VS\Helpers\DevServerHostDiscovery.cs" Link="Helpers\DevServerHostDiscovery.cs" />
+		<Compile Include="..\Uno.UI.RemoteControl.VS\Helpers\DiscoveredDevServer.cs" Link="Helpers\DiscoveredDevServer.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\BannerHelper.cs" Link="Helpers\BannerHelper.cs" />
 
 		<!-- Reuse the AssemblyInfoReader implementation from the VS project to avoid duplication -->

--- a/src/Uno.UI.RemoteControl.Host/AmbientRegistry.cs
+++ b/src/Uno.UI.RemoteControl.Host/AmbientRegistry.cs
@@ -137,7 +137,14 @@ public partial class AmbientRegistry(ILogger logger)
 				return activeServers;
 			}
 
-			var registryFiles = Directory.GetFiles(RegistryDirectory, "devserver-*.json");
+			// Primary registrations: written by the DevServer host process at startup.
+			// Sidecars (`devserver-{pid}.aux.json`) are written by the CLI when it spawns a host
+			// to backfill metadata that the host itself didn't record (notably ideChannelId on
+			// Uno.WinUI.DevServer versions older than the commit that introduced IdeChannelId
+			// in the registration record). The `.aux` suffix excludes them from the primary glob.
+			var registryFiles = Directory.GetFiles(RegistryDirectory, "devserver-*.json")
+				.Where(f => !f.EndsWith(".aux.json", StringComparison.OrdinalIgnoreCase))
+				.ToArray();
 
 			foreach (var filePath in registryFiles)
 			{
@@ -151,12 +158,14 @@ public partial class AmbientRegistry(ILogger logger)
 						// Check if the process is still running
 						if (IsProcessRunning(registration.ProcessId))
 						{
+							OverlayAuxiliaryRegistration(registration);
 							activeServers.Add(registration);
 						}
 						else
 						{
 							// Clean up stale registration file
 							File.Delete(filePath);
+							TryDeleteSidecar(registration.ProcessId);
 							_logger.LogDebug($"Cleaned up stale registration: {filePath}");
 						}
 					}
@@ -176,6 +185,11 @@ public partial class AmbientRegistry(ILogger logger)
 					}
 				}
 			}
+
+			// Also clean up orphan sidecars whose target process is gone — this handles the
+			// case where the CLI wrote a sidecar but the host crashed before registering, or
+			// the primary file was already cleaned up in a previous pass.
+			CleanupOrphanSidecars();
 		}
 		catch (Exception ex)
 		{
@@ -259,5 +273,126 @@ public partial class AmbientRegistry(ILogger logger)
 		public string MachineName { get; set; } = string.Empty;
 		public string UserName { get; set; } = string.Empty;
 		public string? IdeChannelId { get; set; }
+	}
+
+	/// <summary>
+	/// Sidecar payload written by the CLI to backfill metadata the host itself didn't record.
+	/// See <see cref="WriteAuxiliaryRegistration"/> for context. Kept minimal — only fields the
+	/// CLI knows that the host might not (currently just <see cref="IdeChannelId"/>).
+	/// </summary>
+	internal sealed class AuxiliaryRegistration
+	{
+		public int ProcessId { get; set; }
+		public string? IdeChannelId { get; set; }
+	}
+
+	/// <summary>
+	/// Writes a sidecar registration record at <c>devserver-{targetProcessId}.aux.json</c>
+	/// alongside the primary host registration. Used by the CLI when it spawns a host to
+	/// expose metadata that older host versions don't register themselves — primarily
+	/// <paramref name="ideChannelId"/>, which uno.studio's DevServerLauncher needs to
+	/// connect directly to a running host without re-spawning a duplicate.
+	/// </summary>
+	/// <remarks>
+	/// Calling with a null/empty <paramref name="ideChannelId"/> is a no-op. The sidecar is
+	/// removed by <see cref="GetActiveDevServers"/> when its target process is no longer alive.
+	/// </remarks>
+	public void WriteAuxiliaryRegistration(int targetProcessId, string? ideChannelId)
+	{
+		if (string.IsNullOrWhiteSpace(ideChannelId))
+		{
+			return;
+		}
+
+		try
+		{
+			Directory.CreateDirectory(RegistryDirectory);
+			var sidecarPath = GetSidecarPath(targetProcessId);
+			var payload = new AuxiliaryRegistration
+			{
+				ProcessId = targetProcessId,
+				IdeChannelId = ideChannelId,
+			};
+			File.WriteAllText(sidecarPath, JsonSerializer.Serialize(payload, JsonOptions));
+			_logger.LogDebug("Wrote auxiliary DevServer registration for PID {Pid}: {Path}", targetProcessId, sidecarPath);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex, "Failed to write auxiliary DevServer registration for PID {Pid}.", targetProcessId);
+		}
+	}
+
+	private static string GetSidecarPath(int processId)
+		=> Path.Combine(RegistryDirectory, $"devserver-{processId}.aux.json");
+
+	private void OverlayAuxiliaryRegistration(DevServerRegistration registration)
+	{
+		// The host's own values are authoritative — the sidecar is only a backfill for fields
+		// the host left null. Only IdeChannelId today; if other fields end up needing the same
+		// treatment, prefer adding them here over duplicating the file/path/parse plumbing.
+		if (!string.IsNullOrWhiteSpace(registration.IdeChannelId))
+		{
+			return;
+		}
+
+		var sidecarPath = GetSidecarPath(registration.ProcessId);
+		if (!File.Exists(sidecarPath))
+		{
+			return;
+		}
+
+		try
+		{
+			var json = File.ReadAllText(sidecarPath);
+			var aux = JsonSerializer.Deserialize<AuxiliaryRegistration>(json);
+			if (!string.IsNullOrWhiteSpace(aux?.IdeChannelId))
+			{
+				registration.IdeChannelId = aux!.IdeChannelId;
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger.LogDebug("Failed to overlay auxiliary registration {Path}: {Message}", sidecarPath, ex.Message);
+		}
+	}
+
+	private void CleanupOrphanSidecars()
+	{
+		try
+		{
+			var sidecarFiles = Directory.GetFiles(RegistryDirectory, "devserver-*.aux.json");
+			foreach (var sidecarPath in sidecarFiles)
+			{
+				var fileName = Path.GetFileNameWithoutExtension(sidecarPath); // "devserver-{pid}.aux"
+				var pidPart = fileName.Length > "devserver-".Length + ".aux".Length
+					? fileName.Substring("devserver-".Length, fileName.Length - "devserver-".Length - ".aux".Length)
+					: null;
+
+				if (!int.TryParse(pidPart, out var pid) || !IsProcessRunning(pid))
+				{
+					try { File.Delete(sidecarPath); } catch { /* best effort */ }
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger.LogDebug("Failed to enumerate auxiliary registrations: {Message}", ex.Message);
+		}
+	}
+
+	private void TryDeleteSidecar(int processId)
+	{
+		try
+		{
+			var sidecarPath = GetSidecarPath(processId);
+			if (File.Exists(sidecarPath))
+			{
+				File.Delete(sidecarPath);
+			}
+		}
+		catch
+		{
+			// Best effort
+		}
 	}
 }

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -459,6 +459,49 @@ public partial class EntryPoint : IDisposable
 				return;
 			}
 
+			// External-host detection: another launcher (the CLI-driven flow in the uno.studio
+			// VS extension, or — once they ship — the VS Code / Rider plugins) may have already
+			// spawned a DevServer host for this solution under the same devenv. Without this
+			// probe, EnsureServerAsync would unconditionally spawn a second host, leaving the
+			// user with two phantom processes serving the same solution on different ports.
+			//
+			// This is "Phase 1": detect-and-skip. Full adoption (connecting our IdeChannelClient
+			// to the existing host's pipe) is gated on the disco payload exposing `ideChannelId`
+			// reliably for active servers — currently it's null in the field. When that lands,
+			// this branch can also wire `_ideChannelClient` and keep IDE-channel features
+			// (UDEI status, command routing) working through the adopted host.
+			var solutionPath = _dte.Solution?.FullName;
+			if (!string.IsNullOrEmpty(solutionPath))
+			{
+				var discovery = new Helpers.DevServerHostDiscovery();
+				var existing = await discovery.TryFindHostAsync(
+					solutionPath!,
+					System.Diagnostics.Process.GetCurrentProcess().Id,
+					_ct.Token).ConfigureAwait(true);
+
+				if (existing is not null)
+				{
+					_debugAction?.Invoke(
+						$"Skipping in-process DevServer spawn: an external host (PID {existing.ProcessId}) " +
+						$"is already serving '{solutionPath}' on port {existing.Port}. " +
+						$"IDE-channel features wired by this EntryPoint will be inactive until disco surfaces ideChannelId (Phase 2).");
+
+					// Adopt the external host's port so build events don't keep proposing the
+					// previously-persisted (or freshly-picked) port. This avoids a port flip on
+					// every project rebuild while an external host owns the slot.
+					if (port != existing.Port)
+					{
+						await _dte.SetProjectUserSettingsAsync(
+							_asyncPackage,
+							RemoteControlServerPortProperty,
+							existing.Port.ToString(CultureInfo.InvariantCulture),
+							persistenceFilter).ConfigureAwait(true);
+					}
+
+					return;
+				}
+			}
+
 			// Safety: Cancel previous services! (Should have already been cancelled by the exit handler);
 			_devServer?.attachedServices.Cancel();
 
@@ -485,7 +528,7 @@ public partial class EntryPoint : IDisposable
 			var pipeGuid = Guid.NewGuid();
 
 			var hostBinPath = Path.Combine(_toolsPath, "host", $"net{version}.0", "Uno.UI.RemoteControl.Host.dll");
-			var arguments = $"\"{hostBinPath}\" --httpPort {port} --ppid {System.Diagnostics.Process.GetCurrentProcess().Id} --ideChannel \"{pipeGuid}\" --solution \"{_dte.Solution.FullName}\"";
+			var arguments = $"\"{hostBinPath}\" --httpPort {port} --ppid {System.Diagnostics.Process.GetCurrentProcess().Id} --ideChannel \"{pipeGuid}\" --solution \"{_dte.Solution!.FullName}\"";
 			var pi = new ProcessStartInfo("dotnet", arguments)
 			{
 				UseShellExecute = false,

--- a/src/Uno.UI.RemoteControl.VS/Helpers/DevServerHostDiscovery.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/DevServerHostDiscovery.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -162,50 +163,106 @@ internal sealed class DevServerHostDiscovery
 			.ConfigureAwait(false);
 	}
 
-	private static Task<string?> TryRunAsync(string fileName, string arguments, string solutionPath, CancellationToken cancellationToken)
+	private static async Task<string?> TryRunAsync(string fileName, string arguments, string solutionPath, CancellationToken cancellationToken)
 	{
-		return Task.Run<string?>(() =>
+		try
 		{
-			try
+			var workingDirectory = Path.GetDirectoryName(solutionPath);
+			using var process = new Process
 			{
-				var workingDirectory = Path.GetDirectoryName(solutionPath);
-				using var process = new Process
+				StartInfo = new ProcessStartInfo
 				{
-					StartInfo = new ProcessStartInfo
-					{
-						FileName = fileName,
-						Arguments = arguments,
-						WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? Environment.CurrentDirectory : workingDirectory,
-						UseShellExecute = false,
-						RedirectStandardOutput = true,
-						RedirectStandardError = true,
-						CreateNoWindow = true,
-					},
-				};
+					FileName = fileName,
+					Arguments = arguments,
+					WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? Environment.CurrentDirectory : workingDirectory,
+					UseShellExecute = false,
+					RedirectStandardOutput = true,
+					// stderr is consumed concurrently below: leaving it un-redirected would
+					// pollute the VS output window, but reading it synchronously *after*
+					// WaitForExit (or not at all) lets the child block when its stderr
+					// buffer fills up — exactly what would force the 8 s timeout to fire
+					// for callers that emit a non-trivial diagnostic on stderr.
+					RedirectStandardError = true,
+					CreateNoWindow = true,
+				},
+				EnableRaisingEvents = true,
+			};
 
-				if (!process.Start())
+			var stdoutBuffer = new StringBuilder();
+			var stderrBuffer = new StringBuilder();
+
+			process.OutputDataReceived += (_, args) =>
+			{
+				if (args.Data is { Length: > 0 })
 				{
-					return null;
+					lock (stdoutBuffer) { stdoutBuffer.AppendLine(args.Data); }
 				}
-
-				// Bound the wait so a hung dotnet/dnx doesn't block solution open.
-				if (!process.WaitForExit((int)_defaultTimeout.TotalMilliseconds))
+			};
+			process.ErrorDataReceived += (_, args) =>
+			{
+				if (args.Data is { Length: > 0 })
 				{
-					try { process.Kill(); } catch { /* swallow */ }
-					return null;
+					lock (stderrBuffer) { stderrBuffer.AppendLine(args.Data); }
 				}
+			};
 
-				if (process.ExitCode != 0)
-				{
-					return null;
-				}
-
-				return process.StandardOutput.ReadToEnd();
-			}
-			catch
+			if (!process.Start())
 			{
 				return null;
 			}
-		}, cancellationToken);
+
+			process.BeginOutputReadLine();
+			process.BeginErrorReadLine();
+
+			// Bound the wait so a hung dotnet/dnx doesn't block solution open. Compose
+			// the timeout with the caller's cancellation token so a solution-close
+			// (which cancels _ct) returns promptly instead of waiting out the full
+			// 8 s budget.
+			using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			timeoutCts.CancelAfter(_defaultTimeout);
+			try
+			{
+				await WaitForExitAsync(process, timeoutCts.Token).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				try { if (!process.HasExited) { process.Kill(); } } catch { /* swallow */ }
+				return null;
+			}
+
+			if (process.ExitCode != 0)
+			{
+				return null;
+			}
+
+			lock (stdoutBuffer)
+			{
+				return stdoutBuffer.ToString();
+			}
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static Task WaitForExitAsync(Process process, CancellationToken cancellationToken)
+	{
+		// .NET Framework 4.7.2 has no Process.WaitForExitAsync — bridge Process.Exited
+		// to a TaskCompletionSource and observe cancellation through a token registration.
+		var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		void OnExited(object? sender, EventArgs e) => tcs.TrySetResult(true);
+		process.Exited += OnExited;
+
+		using var registration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+
+		// Belt-and-suspenders: if the process already exited before EnableRaisingEvents
+		// was wired up (race), short-circuit.
+		if (process.HasExited)
+		{
+			tcs.TrySetResult(true);
+		}
+
+		return tcs.Task;
 	}
 }

--- a/src/Uno.UI.RemoteControl.VS/Helpers/DevServerHostDiscovery.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/DevServerHostDiscovery.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.UI.RemoteControl.VS.Helpers;
+
+/// <summary>
+/// Probes the Uno DevServer CLI's <c>disco</c> command to find an already-running host
+/// for the current solution. <see cref="EntryPoint.EnsureServerAsync"/> consults this
+/// before spawning a host of its own, so the CLI-driven launch flow (introduced in the
+/// uno.studio VS extension and the JetBrains/VS Code extensions) and the legacy
+/// in-process spawn don't both end up running for the same solution.
+///
+/// <para>
+/// This is "Phase 1": detect-and-skip. The disco payload doesn't yet expose an
+/// <c>ideChannelId</c> reliably, so EntryPoint can't fully adopt the existing host's
+/// IDE channel pipe — it just declines to spawn a duplicate. Phase 2 (connecting our
+/// <c>IdeChannelClient</c> to the existing host's pipe) is gated on the CLI surfacing
+/// <c>ideChannelId</c> in active-server entries.
+/// </para>
+///
+/// <para>
+/// The CLI is invoked through <c>dotnet dnx -y uno.devserver disco</c>. On hosts where
+/// <c>dnx</c> is unavailable (.NET 9-only machines, solutions with a
+/// 9.x-pinned <c>global.json</c>) the bare <c>uno-devserver</c> shim — installed by
+/// the uno.studio extension's tool-install fallback — is tried as a backup. Any
+/// other failure is non-fatal: callers fall through to the existing spawn path.
+/// </para>
+/// </summary>
+internal sealed class DevServerHostDiscovery
+{
+	private static readonly JsonSerializerOptions _options = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(8);
+
+	/// <summary>
+	/// Returns an active server matching <paramref name="solutionPath"/> and
+	/// <paramref name="devenvProcessId"/>, or <see langword="null"/> if discovery fails
+	/// or no match is found. Failures are swallowed — the caller spawns when this
+	/// returns null.
+	/// </summary>
+	public async Task<DiscoveredDevServer?> TryFindHostAsync(
+		string solutionPath,
+		int devenvProcessId,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(solutionPath))
+		{
+			return null;
+		}
+
+		try
+		{
+			var json = await RunDiscoAsync(solutionPath, cancellationToken).ConfigureAwait(false);
+			if (string.IsNullOrEmpty(json))
+			{
+				return null;
+			}
+
+			var servers = ParseActiveServers(json);
+			return Match(servers, solutionPath, devenvProcessId);
+		}
+		catch
+		{
+			// Discovery is best-effort. Any failure here means the caller spawns as before;
+			// the worst case is a duplicate host (which is already the existing behavior).
+			return null;
+		}
+	}
+
+	internal static IReadOnlyList<DiscoveredDevServer> ParseActiveServers(string? json)
+	{
+		if (string.IsNullOrWhiteSpace(json))
+		{
+			return Array.Empty<DiscoveredDevServer>();
+		}
+
+		try
+		{
+			using var document = JsonDocument.Parse(json!);
+			if (!document.RootElement.TryGetProperty("activeServers", out var servers)
+				|| servers.ValueKind != JsonValueKind.Array)
+			{
+				return Array.Empty<DiscoveredDevServer>();
+			}
+
+			var result = new List<DiscoveredDevServer>(servers.GetArrayLength());
+			foreach (var item in servers.EnumerateArray())
+			{
+				var deserialized = item.Deserialize<DiscoveredDevServer>(_options);
+				if (deserialized is not null)
+				{
+					result.Add(deserialized);
+				}
+			}
+			return result;
+		}
+		catch (JsonException)
+		{
+			// Malformed payload — degrade rather than throw. Caller spawns as before.
+			return Array.Empty<DiscoveredDevServer>();
+		}
+	}
+
+	internal static DiscoveredDevServer? Match(
+		IReadOnlyList<DiscoveredDevServer> servers,
+		string solutionPath,
+		int devenvProcessId)
+	{
+		foreach (var server in servers)
+		{
+			if (server.ParentProcessId != devenvProcessId)
+			{
+				continue;
+			}
+
+			if (server.SolutionPath is null)
+			{
+				continue;
+			}
+
+			// Solution paths are case-insensitive on Windows, where the VS extension lives.
+			if (string.Equals(server.SolutionPath, solutionPath, StringComparison.OrdinalIgnoreCase))
+			{
+				return server;
+			}
+		}
+
+		return null;
+	}
+
+	private async Task<string?> RunDiscoAsync(string solutionPath, CancellationToken cancellationToken)
+	{
+		// First try the SDK 10+ path: `dotnet dnx -y uno.devserver disco --json`.
+		// On SDK 9-only / global.json-pinned hosts that fails; the uno.studio extension's
+		// tool-install fallback puts a `uno-devserver` shim on PATH, which we try second.
+		var json = await TryRunAsync(
+				fileName: "dotnet",
+				arguments: $"dnx -y uno.devserver disco --solution \"{solutionPath}\" --json",
+				solutionPath,
+				cancellationToken)
+			.ConfigureAwait(false);
+
+		if (!string.IsNullOrEmpty(json))
+		{
+			return json;
+		}
+
+		return await TryRunAsync(
+				fileName: "uno-devserver",
+				arguments: $"disco --solution \"{solutionPath}\" --json",
+				solutionPath,
+				cancellationToken)
+			.ConfigureAwait(false);
+	}
+
+	private static Task<string?> TryRunAsync(string fileName, string arguments, string solutionPath, CancellationToken cancellationToken)
+	{
+		return Task.Run<string?>(() =>
+		{
+			try
+			{
+				var workingDirectory = Path.GetDirectoryName(solutionPath);
+				using var process = new Process
+				{
+					StartInfo = new ProcessStartInfo
+					{
+						FileName = fileName,
+						Arguments = arguments,
+						WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? Environment.CurrentDirectory : workingDirectory,
+						UseShellExecute = false,
+						RedirectStandardOutput = true,
+						RedirectStandardError = true,
+						CreateNoWindow = true,
+					},
+				};
+
+				if (!process.Start())
+				{
+					return null;
+				}
+
+				// Bound the wait so a hung dotnet/dnx doesn't block solution open.
+				if (!process.WaitForExit((int)_defaultTimeout.TotalMilliseconds))
+				{
+					try { process.Kill(); } catch { /* swallow */ }
+					return null;
+				}
+
+				if (process.ExitCode != 0)
+				{
+					return null;
+				}
+
+				return process.StandardOutput.ReadToEnd();
+			}
+			catch
+			{
+				return null;
+			}
+		}, cancellationToken);
+	}
+}

--- a/src/Uno.UI.RemoteControl.VS/Helpers/DiscoveredDevServer.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/DiscoveredDevServer.cs
@@ -1,0 +1,31 @@
+namespace Uno.UI.RemoteControl.VS.Helpers;
+
+/// <summary>
+/// Information about an active DevServer host instance returned by the Uno DevServer
+/// CLI's <c>disco</c> command. Used by <see cref="DevServerHostDiscovery"/> to detect
+/// already-running hosts so <see cref="EntryPoint.EnsureServerAsync"/> can skip spawning
+/// a duplicate.
+/// </summary>
+internal sealed class DiscoveredDevServer
+{
+	public int ProcessId { get; init; }
+
+	public int Port { get; init; }
+
+	public int ParentProcessId { get; init; }
+
+	/// <summary>
+	/// Absolute path to the solution this host is serving, when reported by the CLI.
+	/// May be <see langword="null"/> for hosts launched without a solution context.
+	/// </summary>
+	public string? SolutionPath { get; init; }
+
+	/// <summary>
+	/// IDE channel pipe identifier the host is listening on, when surfaced by the disco
+	/// payload. Currently absent from CLI versions in the field, which is why the
+	/// EntryPoint adoption story is "skip-if-detected" rather than "connect-and-adopt"
+	/// — the latter requires this value to wire <c>IdeChannelClient</c> to the existing
+	/// host's pipe. Tracked as a Phase 2 follow-up.
+	/// </summary>
+	public string? IdeChannelId { get; init; }
+}


### PR DESCRIPTION
Fixes #23123. Also addresses the duplicate-host regression surfaced when the new
CLI-driven launch flow in `unoplatform/uno.studio#1028` runs alongside
`EntryPoint.EnsureServerAsync`.

## Three complementary fixes

### 1. CLI: Compatible host TFM fallback + major roll-forward

`UnoToolsLocator.GetHostExecutable` no longer fails when the package doesn't
ship a host for the exact computed TFM. The resolver picks the highest
`net{major}.{minor}` directory under `tools/rc/host/` that is `<=` the
requested TFM, and `DevServerProcessHelper.CreateDotnetProcessStartInfo` sets
`DOTNET_ROLL_FORWARD=Major` on the host process environment so an older host
runtime config can run on a newer-only runtime. Parser accepts any
`net{major}.{minor}` with `major >= 5` and rejects OS-suffixed monikers /
pre-net5 frameworks, so net11/net12 packages work without another code change.

### 2. VS extension `Uno.UI.RemoteControl.VS.dll`: skip in-process spawn when an external host already serves the solution

`EnsureServerAsync` now consults the CLI's `disco` endpoint before spawning
a host. When a host is already serving the current solution under the
current devenv (matched on `solutionPath` + `ppid`), the in-process spawn
is skipped and the persisted port is updated to the existing host's slot.

### 3. CLI: Sidecar ideChannelId in the ambient registry for legacy hosts

The ideal Phase 2 ("uno.studio adopts the running host directly without
loading EntryPoint at all") relies on disco surfacing `ideChannelId` for
active servers. The host's own registration only carries that field since
the late-Feb 2026 commit; older `Uno.WinUI.DevServer` versions in the field
(e.g. 6.5.153 shipped with Uno.Sdk 6.5.31) leave it null. Those binaries
can't be updated.

Introduce a sidecar in the ambient registry — `devserver-{pid}.aux.json` —
written by the CLI when it spawns a host (the CLI knows the
`--ideChannel` value; the legacy host doesn't record it). `GetActiveDevServers`
overlays the sidecar fields onto the primary registration but only when the
primary value is null, so newer hosts that register the field themselves
remain authoritative. Stale-PID sidecars are cleaned up alongside the
primary.

This unblocks the uno.studio follow-up: with `ideChannelId` reliably
exposed in disco, uno.studio's `DevServerLauncher` can detect a running
host that matches its requested IDE channel and skip loading EntryPoint
entirely — eliminating the duplicate spawn regardless of which
`Uno.WinUI.DevServer` version the user has on disk.

## Why this PR (not separate)

These three changes touch the same DevServer startup pipeline and benefit
from co-existing on the same release of the `uno.devserver` global tool:

- The TFM fallback unblocks startup on hosts where the SDK and DevServer
  package have drifted.
- The EntryPoint skip-spawn is defense-in-depth for future
  `Uno.WinUI.DevServer` releases.
- The sidecar fix is what unblocks the same outcome for already-published
  versions, via the uno.studio-side follow-up.

Spec for the cross-IDE contract continues to live in the relevant
companion PRs / issues; this PR keeps the implementation cohesive.

## Test plan

- [x] CLI tests (`Uno.UI.DevServer.Cli.Tests`): existing 366 green; no new
      failures from the sidecar work.
- [x] `AmbientRegistryTests` gain three new tests pinning the overlay
      contract (overlays when primary is null, doesn't override when
      primary has a value, cleans up dead-PID sidecars).
- [x] `DevServerHostDiscoveryTests` (7) and `EntryPointRegressionTests`
      structural pin still in place from earlier commits.
- [x] CI green on this branch.
- [ ] Run `Chefs.sln` from a machine with only .NET 10 installed — host
      comes up via the net9 fallback, the VSIX extension reaches
      "Dev Server: Ready", and `uno-devserver disco` shows exactly **one**
      active server for the solution after the uno.studio-side follow-up.
- [ ] Run an Uno solution from a machine with only .NET 9 installed —
      same single-host expectation.
- [ ] On a machine with `Uno.Sdk 6.5.x` + `Uno.WinUI.DevServer 6.5.153`,
      verify `uno-devserver disco` now reports a non-null
      `activeServers[].ideChannelId` for the CLI-spawned host.

## Non-goals

- The disco payload's TCP/IPC contract for direct-host adoption (uno.studio
  side change) is out of scope for this PR; it lives in the uno.studio
  follow-up.
- Auto-installing missing packages still lives on a different risk axis.