### PR TITLE
fix: Push element theme when Style is changed from code-behind

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3798,9 +3798,6 @@ public class Given_ElementTheme
 		await WindowHelper.WaitForLoaded(textBox);
 		await WindowHelper.WaitForIdle();
 
-		// Capture the default foreground before style change
-		var defaultFg = textBox.Foreground as SolidColorBrush;
-
 		// Apply custom style from code-behind
 		textBox.Style = style;
 		await WindowHelper.WaitForIdle();
@@ -3886,6 +3883,7 @@ public class Given_ElementTheme
 		}
 	}
 
+#if HAS_UNO
 	[TestMethod]
 	public async Task When_Style_With_Template_Applied_CodeBehind_In_Light_Subtree_Under_Dark_App()
 	{
@@ -3896,85 +3894,95 @@ public class Given_ElementTheme
 		// code-behind must resolve ThemeResources from the Light dictionary,
 		// not the Dark app-level dictionary.
 
-		var styleXaml = """
-			<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			       TargetType="TextBox">
-				<Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
-				<Setter Property="Template">
-					<Setter.Value>
-						<ControlTemplate TargetType="TextBox">
-							<Grid>
-								<ScrollViewer x:Name="ContentElement"
-								              Foreground="{TemplateBinding Foreground}"
-								              IsTabStop="False"
-								              ZoomMode="Disabled" />
-								<TextBlock x:Name="PlaceholderTextContentPresenter"
-								           Foreground="{ThemeResource TextControlPlaceholderForeground}"
-								           IsHitTestVisible="False"
-								           Text="{TemplateBinding PlaceholderText}" />
-								<VisualStateManager.VisualStateGroups>
-									<VisualStateGroup x:Name="CommonStates">
-										<VisualState x:Name="Normal" />
-										<VisualState x:Name="Focused">
-											<Storyboard>
-												<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
-													<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
-												</ObjectAnimationUsingKeyFrames>
-											</Storyboard>
-										</VisualState>
-									</VisualStateGroup>
-								</VisualStateManager.VisualStateGroups>
-							</Grid>
-						</ControlTemplate>
-					</Setter.Value>
-				</Setter>
-			</Style>
-			""";
-		var style = (Style)XamlReader.Load(styleXaml);
-
-		var container = new Border
+		// Force the application theme to Dark so the Light Border below truly
+		// represents a divergent subtree theme; otherwise, in environments where
+		// the app is already Light the scenario degenerates to same-theme and
+		// the regression isn't exercised.
+		using (ThemeHelper.UseApplicationDarkTheme())
 		{
-			Width = 300,
-			Height = 50,
-			RequestedTheme = ElementTheme.Light
-		};
-		var textBox = new TextBox { Text = "Hello", Width = 200 };
-		container.Child = textBox;
+			await WindowHelper.WaitForIdle();
 
-		WindowHelper.WindowContent = container;
-		await WindowHelper.WaitForLoaded(textBox);
-		await WindowHelper.WaitForIdle();
+			var styleXaml = """
+				<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				       TargetType="TextBox">
+					<Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+					<Setter Property="Template">
+						<Setter.Value>
+							<ControlTemplate TargetType="TextBox">
+								<Grid>
+									<ScrollViewer x:Name="ContentElement"
+									              Foreground="{TemplateBinding Foreground}"
+									              IsTabStop="False"
+									              ZoomMode="Disabled" />
+									<TextBlock x:Name="PlaceholderTextContentPresenter"
+									           Foreground="{ThemeResource TextControlPlaceholderForeground}"
+									           IsHitTestVisible="False"
+									           Text="{TemplateBinding PlaceholderText}" />
+									<VisualStateManager.VisualStateGroups>
+										<VisualStateGroup x:Name="CommonStates">
+											<VisualState x:Name="Normal" />
+											<VisualState x:Name="Focused">
+												<Storyboard>
+													<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+														<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
+													</ObjectAnimationUsingKeyFrames>
+												</Storyboard>
+											</VisualState>
+										</VisualStateGroup>
+									</VisualStateManager.VisualStateGroups>
+								</Grid>
+							</ControlTemplate>
+						</Setter.Value>
+					</Setter>
+				</Style>
+				""";
+			var style = (Style)XamlReader.Load(styleXaml);
 
-		// Apply the style from code-behind
-		textBox.Style = style;
-		await WindowHelper.WaitForIdle();
+			var container = new Border
+			{
+				Width = 300,
+				Height = 50,
+				RequestedTheme = ElementTheme.Light
+			};
+			var textBox = new TextBox { Text = "Hello", Width = 200 };
+			container.Child = textBox;
 
-		// Foreground should come from the Light theme dictionary (dark color)
-		var fg = textBox.Foreground as SolidColorBrush;
-		Assert.IsNotNull(fg, "Foreground brush should not be null");
-		var avgBrightness = (fg.Color.R + fg.Color.G + fg.Color.B) / 3;
+			WindowHelper.WindowContent = container;
+			await WindowHelper.WaitForLoaded(textBox);
+			await WindowHelper.WaitForIdle();
 
-		// In a Light theme subtree, TextControlForeground is dark (low brightness)
-		Assert.IsTrue(avgBrightness < 100,
-			$"TextBox in Light subtree: Foreground should be dark (from Light theme), " +
-			$"but was {fg.Color} (avg brightness={avgBrightness}). " +
-			$"If bright, ThemeResource resolved from the wrong (Dark/app-level) dictionary.");
+			// Apply the style from code-behind
+			textBox.Style = style;
+			await WindowHelper.WaitForIdle();
 
-		// Also verify the reference TextBox (with default style) matches
-		var refTextBox = new TextBox { Text = "Reference", Width = 200 };
-		container.Child = refTextBox;
-		await WindowHelper.WaitForLoaded(refTextBox);
-		await WindowHelper.WaitForIdle();
+			// Foreground should come from the Light theme dictionary (dark color)
+			var fg = textBox.Foreground as SolidColorBrush;
+			Assert.IsNotNull(fg, "Foreground brush should not be null");
+			var avgBrightness = (fg.Color.R + fg.Color.G + fg.Color.B) / 3;
 
-		var refFg = refTextBox.Foreground as SolidColorBrush;
-		Assert.IsNotNull(refFg, "Reference Foreground should not be null");
+			// In a Light theme subtree, TextControlForeground is dark (low brightness)
+			Assert.IsTrue(avgBrightness < 100,
+				$"TextBox in Light subtree: Foreground should be dark (from Light theme), " +
+				$"but was {fg.Color} (avg brightness={avgBrightness}). " +
+				$"If bright, ThemeResource resolved from the wrong (Dark/app-level) dictionary.");
 
-		// Both should resolve to the same theme's TextControlForeground
-		Assert.AreEqual(refFg.Color, fg.Color,
-			$"Code-behind styled TextBox Foreground ({fg.Color}) should match " +
-			$"default-styled TextBox Foreground ({refFg.Color}) in same Light subtree.");
+			// Also verify the reference TextBox (with default style) matches
+			var refTextBox = new TextBox { Text = "Reference", Width = 200 };
+			container.Child = refTextBox;
+			await WindowHelper.WaitForLoaded(refTextBox);
+			await WindowHelper.WaitForIdle();
+
+			var refFg = refTextBox.Foreground as SolidColorBrush;
+			Assert.IsNotNull(refFg, "Reference Foreground should not be null");
+
+			// Both should resolve to the same theme's TextControlForeground
+			Assert.AreEqual(refFg.Color, fg.Color,
+				$"Code-behind styled TextBox Foreground ({fg.Color}) should match " +
+				$"default-styled TextBox Foreground ({refFg.Color}) in same Light subtree.");
+		}
 	}
+#endif
 
 	#endregion
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3643,4 +3643,338 @@ public class Given_ElementTheme
 	}
 
 	#endregion
+
+	#region Code-behind Style with ThemeResource (issue #455)
+
+	[TestMethod]
+	public async Task When_Style_Set_From_CodeBehind_ThemeResource_Foreground_Resolves_Correctly()
+	{
+		// Regression test: setting Style from code-behind should resolve
+		// ThemeResource values in the Style's setters using the correct theme.
+		// Issue: after element-level theming changes, ThemeResource values in
+		// code-behind-applied Styles could resolve with the wrong theme context.
+
+		var style = new Style(typeof(TextBox));
+		style.Setters.Add(new Setter(Control.ForegroundProperty, new SolidColorBrush(Colors.Red)));
+
+		var textBox = new TextBox { Text = "Hello", Width = 200 };
+		var container = new Border { Child = textBox, Width = 200, Height = 50 };
+
+		WindowHelper.WindowContent = container;
+		await WindowHelper.WaitForLoaded(textBox);
+		await WindowHelper.WaitForIdle();
+
+		// Apply style from code-behind AFTER the element is loaded
+		textBox.Style = style;
+		await WindowHelper.WaitForIdle();
+
+		var fg = textBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(fg, "Foreground should be a SolidColorBrush");
+		Assert.AreEqual(Colors.Red, fg.Color, "Foreground should match the style setter value");
+	}
+
+	[TestMethod]
+	public async Task When_Style_With_ThemeResource_Set_From_CodeBehind_Uses_Correct_Theme()
+	{
+		// This test uses a style with ThemeResource-based Foreground and verifies
+		// it resolves to the correct theme variant when applied from code-behind.
+		// The app theme determines which brush to expect.
+
+		var appTheme = Application.Current.RequestedTheme;
+
+		// Create a style via XamlReader to get real ThemeResource resolution
+		var xaml = """
+			<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			       TargetType="TextBox">
+				<Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+			</Style>
+			""";
+		var style = (Style)XamlReader.Load(xaml);
+
+		var textBox = new TextBox { Text = "Hello", Width = 200 };
+		var container = new Border { Child = textBox, Width = 200, Height = 50 };
+
+		WindowHelper.WindowContent = container;
+		await WindowHelper.WaitForLoaded(textBox);
+		await WindowHelper.WaitForIdle();
+
+		// Apply style from code-behind
+		textBox.Style = style;
+		await WindowHelper.WaitForIdle();
+
+		var fg = textBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(fg, "Foreground should be a SolidColorBrush after code-behind style");
+
+		// Also create a TextBox with the style set in XAML for comparison
+		var xaml2 = """
+			<TextBox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			         Text="Reference"
+			         Width="200"
+			         Style="{StaticResource DefaultTextBoxStyle}">
+			</TextBox>
+			""";
+		var refTextBox = (TextBox)XamlReader.Load(xaml2);
+		var refContainer = new StackPanel();
+		refContainer.Children.Add(refTextBox);
+
+		WindowHelper.WindowContent = refContainer;
+		await WindowHelper.WaitForLoaded(refTextBox);
+		await WindowHelper.WaitForIdle();
+
+		var refFg = refTextBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(refFg, "Reference Foreground should be a SolidColorBrush");
+
+		// The code-behind-applied ThemeResource should resolve to the same color
+		// as a normally-styled TextBox
+		Assert.AreEqual(refFg.Color, fg.Color,
+			$"Code-behind style ThemeResource Foreground ({fg.Color}) should match " +
+			$"XAML-applied style Foreground ({refFg.Color}) for theme {appTheme}");
+	}
+
+	[TestMethod]
+	public async Task When_Style_With_Template_Set_From_CodeBehind_VisualState_ThemeResources_Correct()
+	{
+		// Reproduces the core issue: a TextBox gets a custom Style (with Template)
+		// from code-behind. After the template is applied, visual state transitions
+		// should use correctly-resolved ThemeResource values.
+
+		// Create a custom style with a simplified template that has visual states
+		var xaml = """
+			<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			       TargetType="TextBox">
+				<Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+				<Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
+				<Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="TextBox">
+							<Grid>
+								<VisualStateManager.VisualStateGroups>
+									<VisualStateGroup x:Name="CommonStates">
+										<VisualState x:Name="Normal" />
+										<VisualState x:Name="PointerOver">
+											<VisualState.Setters>
+												<Setter Target="BorderElement.Background"
+												        Value="{ThemeResource TextControlBackgroundPointerOver}" />
+												<Setter Target="ContentElement.Foreground"
+												        Value="{ThemeResource TextControlForegroundPointerOver}" />
+											</VisualState.Setters>
+										</VisualState>
+										<VisualState x:Name="Focused">
+											<VisualState.Setters>
+												<Setter Target="BorderElement.Background"
+												        Value="{ThemeResource TextControlBackgroundFocused}" />
+												<Setter Target="ContentElement.Foreground"
+												        Value="{ThemeResource TextControlForegroundFocused}" />
+											</VisualState.Setters>
+										</VisualState>
+									</VisualStateGroup>
+								</VisualStateManager.VisualStateGroups>
+								<Border x:Name="BorderElement"
+								        Background="{TemplateBinding Background}"
+								        BorderBrush="{TemplateBinding BorderBrush}"
+								        BorderThickness="{TemplateBinding BorderThickness}">
+									<ScrollViewer x:Name="ContentElement"
+									              Foreground="{TemplateBinding Foreground}"
+									              HorizontalScrollMode="Auto"
+									              VerticalScrollMode="Auto" />
+								</Border>
+							</Grid>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			""";
+		var style = (Style)XamlReader.Load(xaml);
+
+		var textBox = new TextBox { Text = "Test text", Width = 200 };
+		var container = new StackPanel();
+		container.Children.Add(textBox);
+
+		WindowHelper.WindowContent = container;
+		await WindowHelper.WaitForLoaded(textBox);
+		await WindowHelper.WaitForIdle();
+
+		// Capture the default foreground before style change
+		var defaultFg = textBox.Foreground as SolidColorBrush;
+
+		// Apply custom style from code-behind
+		textBox.Style = style;
+		await WindowHelper.WaitForIdle();
+
+		// Check that Foreground resolved correctly after code-behind style
+		var afterStyleFg = textBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(afterStyleFg);
+
+		// The foreground should match the element's actual theme, not the app-level theme.
+		// Use ActualTheme (element-level) since ancestors may override RequestedTheme.
+		var elementTheme = textBox.ActualTheme;
+		if (elementTheme == ElementTheme.Dark)
+		{
+			var avg = (afterStyleFg.Color.R + afterStyleFg.Color.G + afterStyleFg.Color.B) / 3;
+			Assert.IsTrue(avg > 150,
+				$"In Dark element theme, Foreground should be light, but was {afterStyleFg.Color} (avg={avg})");
+		}
+		else
+		{
+			var avg = (afterStyleFg.Color.R + afterStyleFg.Color.G + afterStyleFg.Color.B) / 3;
+			Assert.IsTrue(avg < 100,
+				$"In Light element theme, Foreground should be dark, but was {afterStyleFg.Color} (avg={avg})");
+		}
+	}
+
+	[TestMethod]
+	public async Task When_Style_Set_From_CodeBehind_In_Opposite_Theme_Subtree()
+	{
+		// Most specific repro: element is in a subtree with a different theme
+		// than the application. Code-behind style should resolve ThemeResource
+		// to the SUBTREE's theme, not the application theme.
+
+		var appTheme = Application.Current.RequestedTheme;
+		var oppositeTheme = appTheme == ApplicationTheme.Dark
+			? ElementTheme.Light : ElementTheme.Dark;
+
+		var xaml = """
+			<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			       TargetType="TextBox">
+				<Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+			</Style>
+			""";
+		var style = (Style)XamlReader.Load(xaml);
+
+		// Create a container with opposite theme
+		var container = new Border
+		{
+			Width = 200,
+			Height = 50,
+			RequestedTheme = oppositeTheme
+		};
+		var textBox = new TextBox { Text = "Test", Width = 200 };
+		container.Child = textBox;
+
+		WindowHelper.WindowContent = container;
+		await WindowHelper.WaitForLoaded(textBox);
+		await WindowHelper.WaitForIdle();
+
+		// Apply style from code-behind
+		textBox.Style = style;
+		await WindowHelper.WaitForIdle();
+
+		var fg = textBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(fg);
+
+		// TextBox is in the OPPOSITE theme subtree
+		if (oppositeTheme == ElementTheme.Dark)
+		{
+			// In dark subtree, foreground should be light
+			var avg = (fg.Color.R + fg.Color.G + fg.Color.B) / 3;
+			Assert.IsTrue(avg > 150,
+				$"In Dark subtree, TextBox Foreground should be light after code-behind style, " +
+				$"but was {fg.Color} (avg={avg})");
+		}
+		else
+		{
+			// In light subtree, foreground should be dark
+			var avg = (fg.Color.R + fg.Color.G + fg.Color.B) / 3;
+			Assert.IsTrue(avg < 100,
+				$"In Light subtree, TextBox Foreground should be dark after code-behind style, " +
+				$"but was {fg.Color} (avg={avg})");
+		}
+	}
+
+	[TestMethod]
+	public async Task When_Style_With_Template_Applied_CodeBehind_In_Light_Subtree_Under_Dark_App()
+	{
+		// Regression test: app is in Dark theme, but the root
+		// FrameworkElement has RequestedTheme="Light" (common in apps that
+		// default to light UI). Applying a Style with a custom template
+		// containing ThemeResource-backed visual state animations from
+		// code-behind must resolve ThemeResources from the Light dictionary,
+		// not the Dark app-level dictionary.
+
+		var styleXaml = """
+			<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			       TargetType="TextBox">
+				<Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="TextBox">
+							<Grid>
+								<ScrollViewer x:Name="ContentElement"
+								              Foreground="{TemplateBinding Foreground}"
+								              IsTabStop="False"
+								              ZoomMode="Disabled" />
+								<TextBlock x:Name="PlaceholderTextContentPresenter"
+								           Foreground="{ThemeResource TextControlPlaceholderForeground}"
+								           IsHitTestVisible="False"
+								           Text="{TemplateBinding PlaceholderText}" />
+								<VisualStateManager.VisualStateGroups>
+									<VisualStateGroup x:Name="CommonStates">
+										<VisualState x:Name="Normal" />
+										<VisualState x:Name="Focused">
+											<Storyboard>
+												<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+													<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
+												</ObjectAnimationUsingKeyFrames>
+											</Storyboard>
+										</VisualState>
+									</VisualStateGroup>
+								</VisualStateManager.VisualStateGroups>
+							</Grid>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+			""";
+		var style = (Style)XamlReader.Load(styleXaml);
+
+		var container = new Border
+		{
+			Width = 300,
+			Height = 50,
+			RequestedTheme = ElementTheme.Light
+		};
+		var textBox = new TextBox { Text = "Hello", Width = 200 };
+		container.Child = textBox;
+
+		WindowHelper.WindowContent = container;
+		await WindowHelper.WaitForLoaded(textBox);
+		await WindowHelper.WaitForIdle();
+
+		// Apply the style from code-behind
+		textBox.Style = style;
+		await WindowHelper.WaitForIdle();
+
+		// Foreground should come from the Light theme dictionary (dark color)
+		var fg = textBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(fg, "Foreground brush should not be null");
+		var avgBrightness = (fg.Color.R + fg.Color.G + fg.Color.B) / 3;
+
+		// In a Light theme subtree, TextControlForeground is dark (low brightness)
+		Assert.IsTrue(avgBrightness < 100,
+			$"TextBox in Light subtree: Foreground should be dark (from Light theme), " +
+			$"but was {fg.Color} (avg brightness={avgBrightness}). " +
+			$"If bright, ThemeResource resolved from the wrong (Dark/app-level) dictionary.");
+
+		// Also verify the reference TextBox (with default style) matches
+		var refTextBox = new TextBox { Text = "Reference", Width = 200 };
+		container.Child = refTextBox;
+		await WindowHelper.WaitForLoaded(refTextBox);
+		await WindowHelper.WaitForIdle();
+
+		var refFg = refTextBox.Foreground as SolidColorBrush;
+		Assert.IsNotNull(refFg, "Reference Foreground should not be null");
+
+		// Both should resolve to the same theme's TextControlForeground
+		Assert.AreEqual(refFg.Color, fg.Color,
+			$"Code-behind styled TextBox Foreground ({fg.Color}) should match " +
+			$"default-styled TextBox Foreground ({refFg.Color}) in same Light subtree.");
+	}
+
+	#endregion
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -724,10 +724,13 @@ namespace Microsoft.UI.Xaml
 			// Themes.Active, which can differ from the element's theme when an ancestor has
 			// RequestedTheme set (e.g., RequestedTheme="Light" on root with OS in Dark mode).
 			var effectiveTheme = GetTheme();
-			var needsThemePush = effectiveTheme != Theme.None;
+			var baseTheme = Theming.GetBaseValue(effectiveTheme);
+			// HighContrast-only themes have a base of None; skip the push in that case
+			// (mirrors the short-circuit in NotifyThemeChangedCore).
+			var needsThemePush = baseTheme is Theme.Light or Theme.Dark;
 			if (needsThemePush)
 			{
-				var themeKey = Theming.GetBaseValue(effectiveTheme) == Theme.Light ? "Light" : "Dark";
+				var themeKey = baseTheme == Theme.Light ? "Light" : "Dark";
 				ResourceDictionary.PushRequestedThemeForSubTree(themeKey);
 			}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -707,12 +707,49 @@ namespace Microsoft.UI.Xaml
 		{
 			if (oldStyle == newStyle)
 			{
-				// Nothing to do
 				return;
 			}
 
-			oldStyle?.ClearInvalidProperties(this, newStyle, precedence);
+			ApplyStyleWithThemeContext(oldStyle, newStyle, precedence);
+		}
 
+		private void ApplyStyleWithThemeContext(Style oldStyle, Style newStyle, DependencyPropertyValuePrecedences precedence)
+		{
+#if UNO_HAS_ENHANCED_LIFECYCLE
+			// MUX Reference: CFrameworkElement::OnStyleChanged -> InvalidateProperty chain
+			// ThemeResource setters in the style must resolve using the element's effective
+			// theme, not the app-level Themes.Active. During initial loading (OnLoadingPartial),
+			// the theme is already pushed by the caller. When Style is changed from code-behind
+			// after loading, no theme context is present and ThemeResources resolve against
+			// Themes.Active, which can differ from the element's theme when an ancestor has
+			// RequestedTheme set (e.g., RequestedTheme="Light" on root with OS in Dark mode).
+			var effectiveTheme = GetTheme();
+			var needsThemePush = effectiveTheme != Theme.None;
+			if (needsThemePush)
+			{
+				var themeKey = Theming.GetBaseValue(effectiveTheme) == Theme.Light ? "Light" : "Dark";
+				ResourceDictionary.PushRequestedThemeForSubTree(themeKey);
+			}
+
+			try
+			{
+				ApplyStyleCore(oldStyle, newStyle, precedence);
+			}
+			finally
+			{
+				if (needsThemePush)
+				{
+					ResourceDictionary.PopRequestedThemeForSubTree();
+				}
+			}
+#else
+			ApplyStyleCore(oldStyle, newStyle, precedence);
+#endif
+		}
+
+		private void ApplyStyleCore(Style oldStyle, Style newStyle, DependencyPropertyValuePrecedences precedence)
+		{
+			oldStyle?.ClearInvalidProperties(this, newStyle, precedence);
 			newStyle?.ApplyTo(this, precedence);
 		}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/kahua-private/issues/455

## Summary

- When `Style` is changed from code-behind after loading, `ThemeResource` setters resolved against `Themes.Active` (the app-level theme) instead of the element's effective theme
- This caused incorrect foreground colors when an ancestor overrides `RequestedTheme` to a different value than the OS theme (e.g., `RequestedTheme="Light"` on root with OS in Dark mode)
- Fix: push the element's effective theme in `OnStyleChanged` before applying the style, matching the pattern already used in `OnLoadingPartial`, `GoToState`, and `ApplyTargetStateSetters`

## Changes

- `FrameworkElement.cs`: Extract `ApplyStyleWithThemeContext` / `ApplyStyleCore` from `OnStyleChanged` to push `RequestedThemeForSubTree` around style application (enhanced lifecycle only)
- `Given_ElementTheme.cs`: Add 5 runtime tests covering code-behind style application with ThemeResource setters in same-theme and cross-theme subtrees

## Test plan

- [x] `When_Style_Set_From_CodeBehind_ThemeResource_Foreground_Resolves_Correctly` — basic sanity
- [x] `When_Style_With_ThemeResource_Set_From_CodeBehind_Uses_Correct_Theme` — XamlReader style with ThemeResource Foreground
- [x] `When_Style_With_Template_Set_From_CodeBehind_VisualState_ThemeResources_Correct` — custom template with visual state ThemeResources
- [x] `When_Style_Set_From_CodeBehind_In_Opposite_Theme_Subtree` — opposite-theme subtree
- [x] `When_Style_With_Template_Applied_CodeBehind_In_Light_Subtree_Under_Dark_App` — Light subtree under Dark app (exact repro scenario)

All 5 tests pass on Skia Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)