### PR TITLE
fix: cancel parent direct manipulations after press bubble completes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
+using Uno.Extensions;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.Toolkit.Extensions;
 using Uno.UI.Toolkit.DevTools.Input;
@@ -49,5 +54,132 @@ public partial class Given_UIElement
 
 		completed.X.Should().BeApproximately(-100, precision: 1);
 		completed.Y.Should().BeApproximately(10, precision: 1);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	public async Task When_PinchOnScaleGrid_InsideScrollViewer_Then_ManipulationDoesNotCompletePrematurely()
+	{
+		// Two conditions are required to actually reproduce the bug:
+		//
+		//   1. Content MUST be bigger than the viewport — otherwise ScrollContentPresenter.OnStarting
+		//      returns ManipulationModes.None and DirectManipulation.ProcessDown completes the recognizer
+		//      immediately (see DirectManipulation.cs), so there's no live DM to misbehave.
+		//
+		//   2. The pressed element MUST be a child of the Scale grid (not the grid itself) — the bug
+		//      is specific to the managed-bubbling case where Grid.OnPointerDown runs with
+		//      ctx=OnManagedBubbling during the bubble, and its CancelDirectManipulations() fires
+		//      BEFORE ScrollContentPresenter (further up the tree) has registered its DM.
+		// Rectangle pinned to the visible portion of the ScrollViewer viewport (top-left of the
+		// 600x600 Grid) so that the centre-of-viewport touches used below actually hit it —
+		// otherwise the Grid itself becomes the OriginalSource and the bug doesn't reproduce.
+		var rectangle = new Rectangle
+		{
+			Width = 300,
+			Height = 300,
+			HorizontalAlignment = HorizontalAlignment.Left,
+			VerticalAlignment = VerticalAlignment.Top,
+			Fill = new SolidColorBrush(Colors.Red),
+		};
+
+		var grid = new Grid
+		{
+			Width = 600,
+			Height = 600,
+			Background = new SolidColorBrush(Colors.Blue),
+			ManipulationMode = ManipulationModes.Scale,
+			Children = { rectangle },
+		};
+
+		var sut = new ScrollViewer
+		{
+			Width = 300,
+			Height = 300,
+			Background = new SolidColorBrush(Colors.Black),
+			Content = grid,
+		};
+
+		var releasing = false;
+		var completedDuringGesture = false;
+		var deltaCount = 0;
+		var maxScaleDeviation = 0f;
+		var stagesWithDeltas = 0;
+		var stageDeltaCount = 0;
+
+		grid.ManipulationDelta += (_, e) =>
+		{
+			deltaCount++;
+			stageDeltaCount++;
+			var deviation = Math.Abs(e.Delta.Scale - 1f);
+			if (deviation > maxScaleDeviation)
+			{
+				maxScaleDeviation = deviation;
+			}
+		};
+		grid.ManipulationCompleted += (_, _) =>
+		{
+			if (!releasing)
+			{
+				completedDuringGesture = true;
+			}
+		};
+
+		var bounds = await UITestHelper.Load(sut);
+
+		// Two independent injectors so each Finger owns its own injection state and can hold a distinct
+		// PointerId — the default single-injector Finger API is single-touch only.
+		var injector1 = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init injector 1");
+		var injector2 = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init injector 2");
+		using var finger1 = injector1.GetFinger(id: 101);
+		using var finger2 = injector2.GetFinger(id: 102);
+
+		// The Grid is 600x600 but only its top-left 300x300 is visible through the ScrollViewer.
+		// Use the ScrollViewer bounds so touches land inside the viewport.
+		var center = new Point(bounds.X + bounds.Width / 2, bounds.Y + bounds.Height / 2);
+
+		finger1.Press(new Point(center.X - 20, center.Y));
+		await TestServices.WindowHelper.WaitForIdle();
+		finger2.Press(new Point(center.X + 20, center.Y));
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Fan the fingers outward in stages. A perfectly symmetric spread keeps the midpoint fixed
+		// and never trips DM; real touches always drift, so the test deliberately introduces Y
+		// drift on both fingers (finger1 down, finger2 down a smaller amount) so that the
+		// SCP DM's TranslateY threshold (15 px on touch) is crossed by the second pointer
+		// partway through the gesture — exactly the Android repro.
+		const int stageCount = 60;
+
+		for (var stage = 1; stage <= stageCount; stage++)
+		{
+			stageDeltaCount = 0;
+
+			var spread = stage * 25;
+			finger1.MoveTo(new Point(center.X - 20 - spread - stage * 3, center.Y + stage * 2), steps: 5);
+			await TestServices.WindowHelper.WaitForIdle();
+			finger2.MoveTo(new Point(center.X + 20 + spread, center.Y + stage), steps: 5);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			if (stageDeltaCount > 0)
+			{
+				stagesWithDeltas++;
+			}
+		}
+
+		releasing = true;
+		finger2.Release();
+		await TestServices.WindowHelper.WaitForIdle();
+		finger1.Release();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Sanity: the gesture did something at all.
+		deltaCount.Should().BeGreaterThan(0, "Grid.ManipulationDelta should fire at least at the start of a two-finger pinch");
+		maxScaleDeviation.Should().BeGreaterThan(0.1f, "the first few deltas of a widening pinch should report a Scale noticeably different from 1");
+
+		// The actual regression assertions — these are what fail while the bug is live:
+		completedDuringGesture.Should().BeFalse("Grid.ManipulationCompleted must not fire while both fingers are still pressed; if it does, ScrollViewer's DirectManipulation has cancelled the pointers mid-gesture");
+		stagesWithDeltas.Should().Be(stageCount, $"Grid.ManipulationDelta should keep firing through every stage of the pinch; it stopped firing after {stagesWithDeltas}/{stageCount} stages because the pointers were redirected to ScrollViewer's DirectManipulation");
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -52,6 +52,8 @@ partial class InputManager
 		// This unified ordered list is required to make sure, in case of conflicting manipulations kinds, it's the top most recognizer that is able to start first.
 		private readonly PointerTypePseudoDictionary<Queue<IGestureRecognizer>> _gestureRecognizers = new();
 
+		private UIElement? _pendingDirectManipulationCancelRequester;
+
 		internal void RegisterDirectManipulationHandler(PointerIdentifier pointer, IDirectManipulationHandler handler)
 			=> RegisterDirectManipulationHandlerCore(pointer, handler);
 
@@ -126,6 +128,8 @@ partial class InputManager
 		/// </summary>
 		internal bool CancelDirectManipulations(UIElement requestingElement)
 		{
+			_pendingDirectManipulationCancelRequester ??= requestingElement;
+
 			var cancelled = false;
 			foreach (var manipulation in _directManipulations)
 			{
@@ -168,6 +172,8 @@ partial class InputManager
 
 		private bool BeforePressTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
 		{
+			_pendingDirectManipulationCancelRequester = null;
+
 			// First we scavenge all manipulations that are no longer active
 			_directManipulations.Scavenge();
 
@@ -199,6 +205,12 @@ partial class InputManager
 				{
 					recognizer.ProcessDown(args);
 				}
+			}
+
+			if (_pendingDirectManipulationCancelRequester is { } requester)
+			{
+				CancelDirectManipulations(requester);
+				_pendingDirectManipulationCancelRequester = null;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1187,6 +1187,13 @@ namespace Microsoft.UI.Xaml
 #endif
 			}
 
+			// A non-System ManipulationMode means this element claims the gesture; cancel any ancestor DMs
+			// that exist at this point AND set a flag so InputManager.PointerManager.AfterPressForDirectManipulation
+			// re-runs the cancel walk once the press bubble has settled — otherwise DMs registered LATER in
+			// the bubble (typically by a ScrollContentPresenter higher up the tree, after this element has
+			// already been visited via ctx=OnManagedBubbling) would survive and steal the pointer on the next
+			// move. The flag is plumbed through InputManager.PointerManager.CancelDirectManipulations, so
+			// end-user calls to UIElement.CancelDirectManipulations get the same after-bubble redo.
 			if (!ManipulationMode.HasFlag(ManipulationModes.System))
 			{
 				CancelDirectManipulations();


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/434

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->