### PR TITLE
Chore: ipados flag numeric pad

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -110,15 +110,13 @@ WinRTFeatureConfiguration.MessageDialog.StyleOverride = "CustomMessageDialogStyl
 
 ### Disable the iPadOS 26 floating number pad popover (iOS)
 
-iPadOS 26 introduced a floating number pad popover that detaches from `UITextField` when a numeric keyboard is requested. This change has received widespread criticism in the Apple ecosystem for being inconsistent and disruptive. The popover can obscure nearby UI elements, interfere with app-defined overlays near numeric inputs, and behaves inconsistently across iPad models, Stage Manager, and split-view modes. There is no system-wide setting to disable this feature; each app must opt out individually.
-
-To restore the docked numeric keyboard behavior on iPad, consistent with pre-iPadOS 26 and other Uno targets, set the following flag early during your app's startup:
+On iPadOS 26, `UITextField` displays the numeric keyboard as a floating popover instead of a docked keyboard. Setting `Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover` to `true` opts out of this behavior and restores the docked keyboard:
 
 ```csharp
 Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover = true;
 ```
 
-This flag is iOS Skia-only and has no effect on other platforms or on iOS versions prior to 26. Defaults to `false` (native iPadOS 26 behavior is preserved).
+The flag only takes effect on iOS Skia, on iOS 26 or later, and only affects `TextBox` instances configured for a numeric keyboard on iPad. It has no effect on other platforms, on iOS versions prior to 26, or on non-numeric keyboards. Defaults to `false`.
 
 ## ToolTips
 

--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -106,6 +106,20 @@ When `ContentDialog` version is used, it uses the default `ContentDialog` style.
 WinRTFeatureConfiguration.MessageDialog.StyleOverride = "CustomMessageDialogStyle";
 ```
 
+## TextBox
+
+### Disable the iPadOS 26 floating number pad popover (iOS)
+
+iPadOS 26 introduced a floating number pad popover that detaches from `UITextField` when a numeric keyboard is requested. This change has received widespread criticism in the Apple ecosystem for being inconsistent and disruptive. The popover can obscure nearby UI elements, interfere with app-defined overlays near numeric inputs, and behaves inconsistently across iPad models, Stage Manager, and split-view modes. There is no system-wide setting to disable this feature; each app must opt out individually.
+
+To restore the docked numeric keyboard behavior on iPad, consistent with pre-iPadOS 26 and other Uno targets, set the following flag early during your app's startup:
+
+```csharp
+Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover = true;
+```
+
+This flag is iOS Skia-only and has no effect on other platforms or on iOS versions prior to 26. Defaults to `false` (native iPadOS 26 behavior is preserved).
+
 ## ToolTips
 
 By default, `ToolTips` are disabled on all platforms except for WebAssembly and Skia (see [#10791](https://github.com/unoplatform/uno/issues/10791)). To enable them on a specific platform, set the `UseToolTips` configuration flag to `true`. You can add the following in the end of the `App` constructor:

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -147,6 +147,14 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 		_textBoxView.AutocapitalizationType = InputScopeHelper.ConvertInputScopeToCapitalization(textBox.InputScope);
 		_textBoxView.KeyboardType = InputScopeHelper.ConvertInputScopeToKeyboardType(textBox.InputScope);
 
+		// Apply the iOS 26 number-pad-popover opt-out after KeyboardType is set so the iPad +
+		// numeric-keyboard gate is evaluated against the final value. Single-line only; the
+		// popover is a UITextField behavior and does not apply to UITextView (multiline).
+		if (_textBoxView is SinglelineInvisibleTextBoxView singleline)
+		{
+			singleline.TryDisableNumberPadPopover();
+		}
+
 		_textBoxView.SpellCheckingType = textBox.IsSpellCheckEnabled ? UITextSpellCheckingType.Yes : UITextSpellCheckingType.No;
 		_textBoxView.AutocorrectionType = textBox.IsSpellCheckEnabled ? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -347,12 +347,11 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 	private bool ShouldAnchorToTextBox()
 		=> _textBoxView is { } view && IsFloatingNumericKeypad(view.KeyboardType);
 
-	// Single source of truth for "should we anchor/expand the caret rect so
-	// iPad's floating numeric keypad positions adjacent to the full control?"
-	// Also consumed by SinglelineInvisibleTextBoxView.GetFirstRectForRange /
-	// GetCaretRectForPosition. Keep the two call sites in sync by routing
-	// through this helper.
-	internal static bool IsFloatingNumericKeypad(UIKeyboardType keyboardType)
+	// Returns true when the textfield is on iPad with a numeric keyboard type —
+	// the configuration where iOS displays (or would display) the floating
+	// number-pad popover. Used by TryDisableNumberPadPopover to decide whether
+	// the setAllowsNumberPadPopover: opt-out is relevant for this field.
+	internal static bool IsIPadNumericKeyboard(UIKeyboardType keyboardType)
 	{
 		if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
 		{
@@ -364,6 +363,24 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 			UIKeyboardType.DecimalPad or
 			UIKeyboardType.NumbersAndPunctuation or
 			UIKeyboardType.PhonePad;
+	}
+
+	// Single source of truth for "should we anchor/expand the caret rect so
+	// iPad's floating numeric keypad positions adjacent to the full control?"
+	// Also consumed by SinglelineInvisibleTextBoxView.GetFirstRectForRange /
+	// GetCaretRectForPosition. Keep the two call sites in sync by routing
+	// through this helper.
+	// When FeatureConfiguration.TextBox.DisableNumberPadPopover is true the
+	// popover is opted out via setAllowsNumberPadPopover:, so no anchoring or
+	// frame adjustments are needed and we return false.
+	internal static bool IsFloatingNumericKeypad(UIKeyboardType keyboardType)
+	{
+		if (global::Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover)
+		{
+			return false;
+		}
+
+		return IsIPadNumericKeyboard(keyboardType);
 	}
 
 	private static bool CouldBecomeFirstResponder(FrameworkElement? element)

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -69,7 +69,7 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 			return;
 		}
 
-		if (!InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType))
+		if (!InvisibleTextBoxViewExtension.IsIPadNumericKeyboard(KeyboardType))
 		{
 			return;
 		}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -48,6 +48,8 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 	[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
 	private static extern void void_objc_msgSend_bool(IntPtr receiver, IntPtr selector, [MarshalAs(UnmanagedType.I1)] bool arg);
 
+	private static readonly Selector s_setAllowsNumberPadPopoverSelector = new("setAllowsNumberPadPopover:");
+
 	// iOS 26 introduced a floating number pad popover for UITextField on iPad when a numeric
 	// keyboard is active. The opt-out (-[UITextField setAllowsNumberPadPopover:]) is not yet in
 	// the dotnet/macios bindings (no PR/issue tracking it as of Xcode 26.2 Bindings Status), so
@@ -66,13 +68,12 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 			return;
 		}
 
-		var selector = new Selector("setAllowsNumberPadPopover:");
-		if (!RespondsToSelector(selector))
+		if (!RespondsToSelector(s_setAllowsNumberPadPopoverSelector))
 		{
 			return;
 		}
 
-		void_objc_msgSend_bool(Handle, selector.Handle, false);
+		void_objc_msgSend_bool(Handle, s_setAllowsNumberPadPopoverSelector.Handle, false);
 	}
 
 	public bool IsCompatible(Microsoft.UI.Xaml.Controls.TextBox textBox) => !textBox.AcceptsReturn;

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -41,8 +41,6 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 		{
 			IsKeyboardHiddenOnEnter = true
 		};
-
-		TryDisableNumberPadPopover();
 	}
 
 	[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
@@ -56,7 +54,10 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 	// we invoke the selector directly via objc_msgSend. Setting via KVC (setValue:forKey:) is
 	// unreliable for Swift-bridged BOOL properties and was observed to leave the field in a state
 	// where no keyboard would appear at all on iOS 26.
-	private void TryDisableNumberPadPopover()
+	// Called from InvisibleTextBoxViewExtension.UpdateProperties after KeyboardType is set so the
+	// IsFloatingNumericKeypad gate (iPad idiom + numeric keyboard) is evaluated against the final
+	// value rather than the constructor default.
+	internal void TryDisableNumberPadPopover()
 	{
 		if (!global::Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover)
 		{
@@ -64,6 +65,11 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 		}
 
 		if (!OperatingSystem.IsIOSVersionAtLeast(26))
+		{
+			return;
+		}
+
+		if (!InvisibleTextBoxViewExtension.IsFloatingNumericKeypad(KeyboardType))
 		{
 			return;
 		}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -40,6 +40,25 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 		{
 			IsKeyboardHiddenOnEnter = true
 		};
+
+		TryDisableNumberPadPopover();
+	}
+
+	// iOS 26 introduced a floating number pad popover for UITextField on iPad when a numeric
+	// keyboard is active. The opt-out (allowsNumberPadPopover) is not in the current iOS bindings,
+	// so set it via KVC and gate with a selector check to no-op on iOS < 26.
+	private void TryDisableNumberPadPopover()
+	{
+		if (!global::Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover)
+		{
+			return;
+		}
+
+		var selector = new ObjCRuntime.Selector("setAllowsNumberPadPopover:");
+		if (RespondsToSelector(selector))
+		{
+			SetValueForKey(NSNumber.FromBoolean(false), (NSString)"allowsNumberPadPopover");
+		}
 	}
 
 	public bool IsCompatible(Microsoft.UI.Xaml.Controls.TextBox textBox) => !textBox.AcceptsReturn;

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using CoreGraphics;
 using Foundation;
 using Microsoft.UI.Xaml.Controls;
@@ -44,9 +45,15 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 		TryDisableNumberPadPopover();
 	}
 
+	[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+	private static extern void void_objc_msgSend_bool(IntPtr receiver, IntPtr selector, [MarshalAs(UnmanagedType.I1)] bool arg);
+
 	// iOS 26 introduced a floating number pad popover for UITextField on iPad when a numeric
-	// keyboard is active. The opt-out (allowsNumberPadPopover) is not in the current iOS bindings,
-	// so set it via KVC and gate with a selector check to no-op on iOS < 26.
+	// keyboard is active. The opt-out (-[UITextField setAllowsNumberPadPopover:]) is not yet in
+	// the dotnet/macios bindings (no PR/issue tracking it as of Xcode 26.2 Bindings Status), so
+	// we invoke the selector directly via objc_msgSend. Setting via KVC (setValue:forKey:) is
+	// unreliable for Swift-bridged BOOL properties and was observed to leave the field in a state
+	// where no keyboard would appear at all on iOS 26.
 	private void TryDisableNumberPadPopover()
 	{
 		if (!global::Uno.UI.FeatureConfiguration.TextBox.DisableNumberPadPopover)
@@ -54,11 +61,18 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 			return;
 		}
 
-		var selector = new ObjCRuntime.Selector("setAllowsNumberPadPopover:");
-		if (RespondsToSelector(selector))
+		if (!OperatingSystem.IsIOSVersionAtLeast(26))
 		{
-			SetValueForKey(NSNumber.FromBoolean(false), (NSString)"allowsNumberPadPopover");
+			return;
 		}
+
+		var selector = new Selector("setAllowsNumberPadPopover:");
+		if (!RespondsToSelector(selector))
+		{
+			return;
+		}
+
+		void_objc_msgSend_bool(Handle, selector.Handle, false);
 	}
 
 	public bool IsCompatible(Microsoft.UI.Xaml.Controls.TextBox textBox) => !textBox.AcceptsReturn;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -593,6 +593,18 @@ namespace Uno.UI
 			/// </summary>
 			public static List<(Stream dictionary, Stream affixes)> CustomSpellCheckDictionaries { get; set; }
 
+			/// <summary>
+			/// When set to <see langword="true"/>, disables the floating number pad popover that iOS 26
+			/// introduced for <c>UITextField</c> when a numeric keyboard is used on iPad (by setting
+			/// <c>UITextField.allowsNumberPadPopover</c> to <see langword="false"/>).
+			/// Defaults to <see langword="false"/> (native iOS 26 behavior is preserved).
+			/// </summary>
+			/// <remarks>
+			/// This is currently an iOS Skia-only feature and has no effect on other platforms or
+			/// on iOS versions prior to 26.
+			/// </remarks>
+			public static bool DisableNumberPadPopover { get; set; }
+
 #if __ANDROID__
 			/// <summary>
 			/// The legacy <see cref="Microsoft.UI.Xaml.Controls.TextBox.InputScope"/> prevents invalid input on hardware keyboard.


### PR DESCRIPTION
**GitHub Issue:** related https://github.com/unoplatform/kahua-private/issues/453

  iOS 26 introduced a floating number pad popover that detaches from UITextField on iPad whenever a numeric keyboard is requested. The behavior has been broadly criticized across the Apple ecosystem, developers and end users alike report it as inconsistent:

  - It can occlude surrounding UI (labels, validation messages, adjacent fields) that apps were already laying out around a docked keyboard.
  - It collides with apps that anchor their own overlays, tooltips, or inline number pickers near numeric inputs.
  - The most important is that behavior differs depending on iPad model, Stage Manager state, and split-view configuration, making layout impossible to predict.
  - There is no system-level setting to turn it off, each app has to opt out individually via UITextField.allowsNumberPadPopover.


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->