### PR TITLE
fix: Avoid stack overflow in BindableTypeLinkerGeneratorTask

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserCategory.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserCategory.cs
@@ -30,6 +30,8 @@ namespace SampleControl.Entities
 
 		public int Count => SamplesContent.Count;
 
+		public MyInfo MyInfo => null;
+
 		public override bool Equals(object obj) =>
 			obj switch
 			{
@@ -74,5 +76,13 @@ namespace SampleControl.Entities
 		public static bool operator <=(SampleChooserCategory left, SampleChooserCategory right) => left.CompareTo(right) <= 0;
 
 		public static bool operator >=(SampleChooserCategory left, SampleChooserCategory right) => left.CompareTo(right) >= 0;
+	}
+
+	public class SomeInfo<T>
+	{
+	}
+
+	public class MyInfo : SomeInfo<MyInfo>
+	{
 	}
 }

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/BindableTypeLinkerGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/BindableTypeLinkerGeneratorTask.cs
@@ -257,6 +257,14 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				return null;
 			}
 
+			bool haveKey = typesToProperties.TryGetPreserveType(typeDefinition.FullName, out var key);
+
+			if (!haveKey)
+			{
+				key = new PreserveTypeDefinition(typeDefinition.FullName, typeDefinition);
+				typesToProperties[key] = EmptyPreservedPropertyInfo;
+			}
+
 			// Process generic arguments (e.g., List<Entity> should also process Entity)
 			if (typeReference is GenericInstanceType genericType)
 			{
@@ -267,13 +275,11 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				}
 			}
 
-			if (typesToProperties.TryGetPreserveType(typeDefinition.FullName, out var existingType))
+			if (haveKey)
 			{
 				// Already processed; return the *existing* key, so that callers can call `.AddContext()`
-				return existingType;
+				return key;
 			}
-
-			var key = new PreserveTypeDefinition(typeDefinition.FullName, typeDefinition);
 
 			if (HasBindableAttribute(typeDefinition))
 			{
@@ -288,7 +294,6 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 
 			if (!typeDefinition.HasProperties)
 			{
-				typesToProperties[key] = EmptyPreservedPropertyInfo;
 				return key;
 			}
 
@@ -298,7 +303,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			{
 				declaredProperties.Add(new PreservePropertyInfo(property.Name, property.PropertyType));
 			}
-			typesToProperties[key] = declaredProperties;
+			typesToProperties[key!] = declaredProperties;
 
 			foreach (var property in declaredProperties)
 			{


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/uno/issues/23147

The `<BindableTypeLinkerGeneratorTask*/>` task didn't properly support types which reference themselves in the inheritance list, for example:

	public class SomeInfo<T>
	{
	}

	public class MyInfo : SomeInfo<MyInfo>
	{
	}

	[Microsoft.UI.Xaml.Data.Bindable]
	public partial class SampleChooserCategory
	{
	    public MyInfo MyInfo => null;
	}

`BindableTypeLinkerGeneratorTask.AddDeclaredPropertyTypes()`, would try to "fully process" a type before "registering" the type within `typesToProperties`.

This fails in the above "self-referencing" scenario, because when processing `MyInfo`, it would first process the base class `SomeInfo<MyInfo>`, which would then process the type argument `MyInfo`, which would then process the base class `SomeInfo<MyInfo>`… and blow up with an MSB4217:

	% dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj \
	  -r android-arm64 -f net10.0-android -p:UnoTargetFrameworkOverride=net10.0-android \
	  -p:ApplicationId=uno.platform.samplesapp.skia.nativeaot -p:SkiaPublishAot=true \
	  -p:SkiaSharpVersion=3.119.2-preview.1 -bl
	…
	…/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets(483,3): error MSB4217:
	  Task host node exited prematurely. Diagnostic information may be found in files in the
	  temporary files directory named MSBuild_*.failure.txt.

To fix this, "registring a type within `typesToProperties`" needs to be done as a *two step* process:

 1. Register the type *as soon as it is seen*, by adding it to `typesToProperties` with an empty list of properties.

 2. Once the properties have been computed, update the registration with the actual list of properties.

This two step process allows the generator to "break the cycle" when processing such "self-referencing" types.

Updates `src/SamplesApp` to include a "test" for this scenario.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->