### PR TITLE
feat(skia): add local font URI overrides to NotoFontFallbackService

### DIFF
--- a/src/Uno.UI.Tests/Helpers/Given_NotoFontFallbackService.cs
+++ b/src/Uno.UI.Tests/Helpers/Given_NotoFontFallbackService.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml.Documents.TextFormatting;
+
+namespace Uno.UI.Tests.Helpers;
+
+[TestClass]
+public class Given_NotoFontFallbackService
+{
+	// Minimal synthetic range list used by all greedy-selection tests.
+	private static readonly IReadOnlyList<(int Start, int End, List<string> Fonts)> _ranges = new List<(int, int, List<string>)>
+	{
+		(0x0041, 0x005B, new List<string> { "FontA" }),           // A-Z
+		(0x0600, 0x0650, new List<string> { "FontB", "FontA" }), // Arabic subset (both fonts cover it)
+		(0x4E00, 0x4E10, new List<string> { "FontC" }),           // CJK subset
+	};
+
+	[TestMethod]
+	public void WhenNoCodepoints_ThenEmptyListReturned()
+	{
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([], _ranges);
+		result.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public void WhenSingleRangeCodepoint_ThenSingleFontReturned()
+	{
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([0x0041], _ranges);
+		result.Should().HaveCount(1).And.Contain("FontA");
+	}
+
+	[TestMethod]
+	public void WhenCodepointsSpanTwoDisjointFonts_ThenBothFontsReturned()
+	{
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([0x0041, 0x4E00], _ranges);
+		result.Should().HaveCount(2).And.Contain("FontA").And.Contain("FontC");
+	}
+
+	[TestMethod]
+	public void WhenCodepointsCoveredByTwoFonts_ThenGreedyPicksSingleCoveringFont()
+	{
+		// 0x0600 is in the range covered by both FontB and FontA; greedy should pick one.
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([0x0600], _ranges);
+		result.Should().HaveCount(1);
+	}
+
+	[TestMethod]
+	public void WhenFontACoversMoreCodepoints_ThenGreedyPrefersIt()
+	{
+		// FontA covers A-Z and the Arabic range; FontB covers only the Arabic range.
+		// Give it both A-Z and an Arabic codepoint — FontA alone should cover both.
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([0x0041, 0x0600], _ranges);
+		result.Should().HaveCount(1).And.Contain("FontA");
+	}
+
+	[TestMethod]
+	public void WhenCodepointOutsideAllRanges_ThenEmptyListReturned()
+	{
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([0x9999], _ranges);
+		result.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public void WhenDuplicateCodepointsSupplied_ThenResultDeduplicates()
+	{
+		var result = NotoFontFallbackService.GetMinimalFontsForCodepoints([0x0041, 0x0041, 0x0041], _ranges);
+		result.Should().HaveCount(1).And.Contain("FontA");
+	}
+
+	// ── LocalFontUriOverrides ────────────────────────────────────────────────
+
+	[TestMethod]
+	public void WhenLocalFontUriOverridesIsEmpty_ThenItIsNotNull()
+	{
+		NotoFontFallbackService.LocalFontUriOverrides.Should().NotBeNull();
+	}
+
+	[TestMethod]
+	public void WhenUriIsRegistered_ThenItCanBeRetrieved()
+	{
+		var key = $"TestFont_{Guid.NewGuid()}";
+		var uri = new Uri("ms-appx:///Assets/Fonts/Test.ttf");
+
+		NotoFontFallbackService.LocalFontUriOverrides[key] = uri;
+
+		NotoFontFallbackService.LocalFontUriOverrides.Should().ContainKey(key)
+			.WhoseValue.Should().Be(uri);
+
+		NotoFontFallbackService.LocalFontUriOverrides.Remove(key);
+	}
+
+	// ── DisableRemoteFontFallback ────────────────────────────────────────────
+
+	[TestMethod]
+	public void WhenDisableRemoteFontFallbackIsNotSet_ThenItDefaultsToFalse()
+	{
+		NotoFontFallbackService.DisableRemoteFontFallback.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void WhenDisableRemoteFontFallbackIsSet_ThenItCanBeToggled()
+	{
+		var original = NotoFontFallbackService.DisableRemoteFontFallback;
+		try
+		{
+			NotoFontFallbackService.DisableRemoteFontFallback = true;
+			NotoFontFallbackService.DisableRemoteFontFallback.Should().BeTrue();
+
+			NotoFontFallbackService.DisableRemoteFontFallback = false;
+			NotoFontFallbackService.DisableRemoteFontFallback.Should().BeFalse();
+		}
+		finally
+		{
+			NotoFontFallbackService.DisableRemoteFontFallback = original;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Documents/FontFallbackService.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/FontFallbackService.skia.cs
@@ -54,6 +54,23 @@ internal class NotoFontFallbackService : IFontFallbackService
 
 	public static NotoFontFallbackService Instance { get; } = new NotoFontFallbackService();
 
+	/// <summary>
+	/// Per-font URI overrides for apps that cannot reach the default GitHub-hosted Noto fonts
+	/// (e.g. due to a Content Security Policy). Keys are font names as stored in
+	/// <see cref="FallbackFontMaps"/> (e.g. <c>"SimplifiedChinese"</c>, <c>"Noto Sans Arabic"</c>).
+	/// Values must be URIs resolvable by <see cref="Uno.Helpers.AppDataUriEvaluator"/>,
+	/// such as <c>ms-appx:///Assets/Fonts/NotoSansCJKsc-Regular.otf</c>.
+	/// When an override is present the remote GitHub URL is never attempted for that font.
+	/// </summary>
+	public static Dictionary<string, Uri> LocalFontUriOverrides { get; } = new();
+
+	/// <summary>
+	/// When <see langword="true"/>, fonts that have no entry in <see cref="LocalFontUriOverrides"/>
+	/// are silently skipped instead of being fetched from the remote GitHub URLs. Use this in
+	/// environments where outbound connections to raw.githubusercontent.com are blocked.
+	/// </summary>
+	public static bool DisableRemoteFontFallback { get; set; }
+
 	private NotoFontFallbackService()
 	{
 		_memoizedGetFontNameForCodepoint = ((Func<int, Task<string?>>)GetFontNameForCodepointInternal).AsMemoized();
@@ -119,9 +136,21 @@ internal class NotoFontFallbackService : IFontFallbackService
 				};
 			}
 
-			var map = FallbackFontMaps.FontWeightsToRawUrls[font];
-			// TODO: use weight/stretch/style to pick the best match
-			var uri = new Uri(map["Regular"]);
+			if (DisableRemoteFontFallback && !LocalFontUriOverrides.ContainsKey(font))
+			{
+				this.LogWarning()?.Warn($"Remote font fallback is disabled and no local override is registered for '{font}'. Font will not be loaded.");
+				_fetchedFonts[font] = null;
+				continue;
+			}
+
+			Uri uri;
+			if (!LocalFontUriOverrides.TryGetValue(font, out uri!))
+			{
+				var map = FallbackFontMaps.FontWeightsToRawUrls[font];
+				// TODO: use weight/stretch/style to pick the best match
+				uri = new Uri(map["Regular"]);
+			}
+
 			try
 			{
 				var stream = await AppDataUriEvaluator.ToStream(uri, CancellationToken.None);


### PR DESCRIPTION
## Problem

`NotoFontFallbackService` always fetches fallback fonts from hardcoded
GitHub raw-content URLs (e.g. `raw.githubusercontent.com/notofonts/...`).
Apps deployed behind a restrictive Content Security Policy that does not
whitelist that domain fail silently — every fallback font request is
blocked by the browser and the characters render as tofu.

## Solution

Add two static opt-in properties to `NotoFontFallbackService`:

**`LocalFontUriOverrides`** — a `Dictionary<string, Uri>` that maps font
names (as used in `FallbackFontMaps`, e.g. `"SimplifiedChinese"`,
`"Noto Sans Arabic"`) to app-supplied URIs. Any URI resolvable by
`AppDataUriEvaluator` is accepted, including `ms-appx://` paths pointing
to fonts bundled in the app package. When an override is present the
remote GitHub URL is never attempted for that font.

**`DisableRemoteFontFallback`** — when `true`, fonts with no registered
override are silently skipped rather than hitting the remote URLs. Useful
for fully air-gapped or CSP-locked environments.

## Usage (consumer side)

```csharp
// App.xaml.cs — before first render
NotoFontFallbackService.LocalFontUriOverrides["SimplifiedChinese"] =
    new Uri("ms-appx:///Assets/Fonts/NotoSansCJKsc-Regular.otf");
NotoFontFallbackService.LocalFontUriOverrides["Noto Sans Arabic"] =
    new Uri("ms-appx:///Assets/Fonts/NotoSansArabic-Regular.ttf");

// Optionally suppress all remaining remote fetches:
NotoFontFallbackService.DisableRemoteFontFallback = true;
