### PR TITLE
ci: Fix lock threads workflow permissions

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  discussions: write
 
 concurrency:
   group: lock-threads
@@ -30,3 +31,5 @@ jobs:
 
           pr-inactive-days: '7'
           pr-lock-reason: 'resolved'
+
+          log-output: true


### PR DESCRIPTION
## Summary
- Add `discussions: write` permission so `dessant/lock-threads@v5` can lock stale discussions (the action processes discussions by default, which was causing "Resource not accessible by integration" failures)
- Enable `log-output: true` for better diagnostics on future runs

Fixes the failing run: https://github.com/unoplatform/uno/actions/runs/25169549361

## Test plan
- [ ] Manually trigger the Lock Threads workflow via `workflow_dispatch` and confirm it completes without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)