### PR TITLE
fix(ListView): flicker when repositioning item

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -1241,19 +1241,24 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Popup_Above_AutoSuggestBox_And_SuggestionsList_changes()
 		{
+			// Setup an AutoSuggestBox near the bottom of page (covered by description bar),
+			// so its suggestion list only opens from above. Enter "a" (3 matches) then "ab" (2 matches),
+			// and compare the Y-position(top) of the popup before and after, which should increase (given that bottom is fixed).
+
+			var suggestions = new List<string> { "ab1", "ab2", "ac" };
+
 			var SUT = new AutoSuggestBox()
 			{
 				VerticalAlignment = VerticalAlignment.Bottom
 			};
-			var suggestions = new List<string> { "ab1", "ab2", "ac" };
 			SUT.ItemsSource = suggestions;
-
 			SUT.TextChanged += (sender, args) =>
 			{
 				if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
 				{
-					var filteredSuggestions =
-						suggestions.Where(s => s.StartsWith(sender.Text, StringComparison.OrdinalIgnoreCase)).ToList();
+					var filteredSuggestions = suggestions
+						.Where(s => s.StartsWith(sender.Text, StringComparison.OrdinalIgnoreCase))
+						.ToList();
 					sender.ItemsSource = filteredSuggestions;
 				}
 			};

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -394,11 +394,18 @@ namespace Microsoft.UI.Xaml.Controls
 				this.Log().LogDebug($"Calling {GetMethodTag()}, availableSize={availableSize}, _availableSize={_availableSize} {GetDebugInfo()}");
 			}
 
+			// Must be set before UpdateLayout: FillLayout → AddLine reads AvailableBreadth which reads _availableSize.
 			_availableSize = availableSize;
+
 			UpdateAverageLineHeight(); // Must be called before ScrapLayout(), or there won't be items to measure
 			ScrapLayout();
 			ApplyCollectionChanges();
 			UpdateLayout(extentAdjustment: _scrollAdjustmentForCollectionChanges, isScroll: false);
+
+			// OwnerPanel.UpdateLayout() inside UpdateLayout can trigger a nested ArrangeOverride which
+			// overwrites _availableSize with the stale viewport height; restore it so EstimatePanelSize
+			// uses the correct measure constraint.
+			_availableSize = availableSize;
 
 			return _lastMeasuredSize = EstimatePanelSize(isMeasure: true);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -469,7 +469,7 @@ namespace Microsoft.UI.Xaml.Controls
 			OwnerPanel.ShouldInterceptInvalidate = true;
 
 			UnfillLayout(extentAdjustment ?? 0);
-			FillLayout(extentAdjustment ?? 0);
+			var linesAdded = FillLayout(extentAdjustment ?? 0);
 			SetDynamicSeed(null, null);
 
 			CorrectForEstimationErrors();
@@ -485,6 +485,16 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 
 			OwnerPanel.ShouldInterceptInvalidate = false;
+
+			if (!isScroll && linesAdded > 0)
+			{
+				// If any new lines are materialized from FillLayout, we need to force an immediate layout.
+				// This is because the newly materialized lines are not arranged, and if a render pass happens to occur
+				// before the next layout pass, the listview will render with all item clustered at the top-left of the panel.
+				// This is particularly noticeable from the full refresh caused by NotifyCollectionChangedAction.Move (not properly implemented atm),
+				// as the user will notice a single frame of broken view between two correct frames.
+				OwnerPanel.UpdateLayout();
+			}
 		}
 
 		/// <summary>
@@ -508,8 +518,11 @@ namespace Microsoft.UI.Xaml.Controls
 		/// Adjustment to apply when calculating fillable area.
 		/// Used when a viewport change is not yet committed into the <see cref="ScrollOffset"/>.
 		/// </param>
-		private void FillLayout(double extentAdjustment)
+		/// <returns>The number of lines added</returns>
+		private int FillLayout(double extentAdjustment)
 		{
+			var prefillCount = _materializedLines.Count;
+
 			// Don't fill backward if we're doing a light rebuild (since we are starting from nearest previously-visible item)
 			if (!_dynamicSeedStart.HasValue)
 			{
@@ -533,6 +546,8 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				AddLine(Forward, reorderIndex);
 			}
+
+			return _materializedLines.Count - prefillCount;
 
 			void FillBackward()
 			{


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#452

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

When moving an item in a `ListView`, `NotifyCollectionChangedAction.Move` triggers a full panel refresh. `FillLayout` materializes new lines, but they are not arranged until the next layout pass. If a render pass occurs between materialization and arrangement, items appear clustered at `(0,0)` for one frame — visible as a brief flicker of broken layout.

This PR makes `FillLayout` return the number of lines it added, and forces an immediate `OwnerPanel.UpdateLayout()` after non-scroll refresh paths when new lines were materialized, ensuring items are arranged before the next render pass.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->