### PR TITLE
chore: update Uno.ICU to stable 77.2.1

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -76,7 +76,7 @@
 		<MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
 		<SkiaSharpVersion>3.119.0</SkiaSharpVersion>
 		<HarfbuzzSharpVersion>8.3.1.1</HarfbuzzSharpVersion>
-		<UnoICUVersion>77.2.0-dev.14</UnoICUVersion>
+		<UnoICUVersion>77.2.1</UnoICUVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updates UnoICUVersion from 77.2.0-dev.14 to 77.2.1 (stable release from the release/stable/77.2 branch).

Related to https://github.com/unoplatform/private/issues/1082