### PR TITLE
fix: Disable legacy VCLibs/UniversalCRT.Debug SDKReferences in Uno.Sdk WinAppSdk targets

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -15,6 +15,9 @@
 		<RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'==''">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 
 		<IsMSALSupported>true</IsMSALSupported>
+
+		<!-- Opt out of legacy VCLibs/UniversalCRT.Debug SDK framework package references added by Microsoft.WinUI.AppX.targets. -->
+		<WinUISDKReferences Condition=" '$(WinUISDKReferences)' == '' ">false</WinUISDKReferences>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" $(_IsExecutable) == 'true' ">


### PR DESCRIPTION
**GitHub Issue:** closes #23173

## PR Type:

🐞 Bugfix

## What changed? 🚀

Defaults `WinUISDKReferences` to `false` in `src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets`, alongside the other WinAppSdk-wide defaults.

`Microsoft.WinUI.AppX.targets` (shipped with the Windows App SDK) injects legacy `<SDKReference>` items for `Microsoft.VCLibs`, `Microsoft.VCLibs.Desktop`, and `Microsoft.UniversalCRT.Debug` whenever `WinUISDKReferences` is not explicitly disabled. With Hybrid CRT, these framework package references are no longer required, and they frequently cause build failures such as:

> Could not find SDK \"Microsoft.UniversalCRT.Debug, Version=10.0.26100.0\".

on machines that don't have the matching Universal CRT Debug Extension SDK installed.

The new property is gated with `Condition=\" '\$(WinUISDKReferences)' == '' \"` so consumers who still need the legacy SDK references can opt back in by setting `<WinUISDKReferences>true</WinUISDKReferences>` in their project.

The comment in `Microsoft.WinUI.AppX.targets` itself explicitly documents this opt-out:
> apps can still opt out of referencing these FWPs by setting `WinUISDKReferences='false'`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, build-only SDK property change
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, no public-API change
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)