### PR TITLE
fix(sdk): correct broken AndroidX package entries and add CI validation guard

### DIFF
--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -18,6 +18,7 @@ stages:
         README.md
         README/**
         build/**
+        src/Uno.Sdk/**
 
     - template: templates/gitversion-run.yml
     - template: setup/.azure-devops-setup-commitsar.yml

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -18,7 +18,7 @@ stages:
         README.md
         README/**
         build/**
-        src/Uno.Sdk/**
+        src/Uno.Sdk/packages.json
 
     - template: templates/gitversion-run.yml
     - template: setup/.azure-devops-setup-commitsar.yml

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -21,6 +21,7 @@ stages:
 
     - template: templates/gitversion-run.yml
     - template: setup/.azure-devops-setup-commitsar.yml
+    - template: setup/.azure-devops-setup-validate-packages.yml
     - template: setup/.azure-devops-setup-doc-validations.yml
 
   - job: DetermineScope

--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -44,6 +44,7 @@ Write-Host "Validating packages.json: $PackagesJsonPath" -ForegroundColor Cyan
 $json = Get-Content $PackagesJsonPath -Raw | ConvertFrom-Json
 $errors = @()
 $checked = 0
+$validatedPairs = @{}  # De-duplicate package+version pairs across groups
 
 # Placeholder versions that should not be validated against NuGet
 $placeholderVersions = @('DefaultUnoVersion')
@@ -83,11 +84,20 @@ foreach ($group in $json) {
                 continue
             }
 
+            # De-duplicate: skip if we already validated this package+version
+            $pairKey = "$($pkg.ToLowerInvariant())|$($version.ToLowerInvariant())"
+            if ($validatedPairs.ContainsKey($pairKey)) {
+                Write-Host "  [OK] $pkg $version ($label) - already validated" -ForegroundColor DarkGreen
+                continue
+            }
+            $validatedPairs[$pairKey] = $true
+
             $checked++
             $url = "https://api.nuget.org/v3-flatcontainer/$($pkg.ToLowerInvariant())/$($version.ToLowerInvariant())/$($pkg.ToLowerInvariant()).nuspec"
 
             try {
-                $response = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop
+                $response = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing `
+                    -TimeoutSec 30 -MaximumRetryCount 3 -RetryIntervalSec 2 -ErrorAction Stop
                 if ($response.StatusCode -eq 200) {
                     Write-Host "  [OK] $pkg $version ($label)" -ForegroundColor Green
                 }

--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -82,14 +82,21 @@ foreach ($group in $json) {
                 }
             }
             catch {
-                $statusCode = $_.Exception.Response.StatusCode.value__
-                if ($statusCode -eq 404) {
-                    Write-Host "  [MISSING] $pkg $version ($label) - NOT FOUND on NuGet" -ForegroundColor Red
-                    $errors += "Group '$groupName': $pkg $version ($label) does not exist on NuGet.org"
+                $httpResponse = $_.Exception.Response
+                if ($null -ne $httpResponse) {
+                    $statusCode = $httpResponse.StatusCode.value__
+                    if ($statusCode -eq 404) {
+                        Write-Host "  [MISSING] $pkg $version ($label) - NOT FOUND on NuGet" -ForegroundColor Red
+                        $errors += "Group '$groupName': $pkg $version ($label) does not exist on NuGet.org"
+                    }
+                    else {
+                        Write-Host "  [ERROR] $pkg $version ($label) - HTTP $statusCode" -ForegroundColor Yellow
+                        $errors += "Group '$groupName': $pkg $version ($label) - HTTP error $statusCode"
+                    }
                 }
                 else {
-                    Write-Host "  [ERROR] $pkg $version ($label) - HTTP $statusCode" -ForegroundColor Yellow
-                    $errors += "Group '$groupName': $pkg $version ($label) - HTTP error $statusCode"
+                    Write-Host "  [ERROR] $pkg $version ($label) - $($_.Exception.Message)" -ForegroundColor Yellow
+                    $errors += "Group '$groupName': $pkg $version ($label) - network error: $($_.Exception.Message)"
                 }
             }
         }

--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -22,8 +22,11 @@ $ErrorActionPreference = 'Stop'
 # (stable builds test with versions not yet public on NuGet.org)
 if (-not $WarningOnly) {
     $branch = $env:BUILD_SOURCEBRANCH
-    if ($branch -and $branch -like 'refs/heads/release/*') {
-        Write-Host "Detected release branch ($branch) - running in warning-only mode." -ForegroundColor Yellow
+    $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+    if (($branch -and $branch -like 'refs/heads/release/*') -or
+        ($targetBranch -and $targetBranch -like 'refs/heads/release/*')) {
+        $detected = if ($targetBranch -like 'refs/heads/release/*') { $targetBranch } else { $branch }
+        Write-Host "Detected release branch ($detected) - running in warning-only mode." -ForegroundColor Yellow
         $WarningOnly = $true
     }
 }

--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -1,0 +1,113 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Validates that all package IDs and versions in src/Uno.Sdk/packages.json exist on NuGet.org.
+
+.DESCRIPTION
+    Parses packages.json, skips groups with placeholder versions (e.g. "DefaultUnoVersion"),
+    and verifies each package ID + version (including versionOverride entries) against NuGet.org.
+    Exits with code 1 if any package/version is missing.
+
+.PARAMETER PackagesJsonPath
+    Path to the packages.json file. Defaults to src/Uno.Sdk/packages.json relative to repo root.
+#>
+param(
+    [string]$PackagesJsonPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve path
+if (-not $PackagesJsonPath) {
+    $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    $PackagesJsonPath = Join-Path $repoRoot 'src/Uno.Sdk/packages.json'
+}
+
+if (-not (Test-Path $PackagesJsonPath)) {
+    Write-Error "packages.json not found at: $PackagesJsonPath"
+    exit 1
+}
+
+Write-Host "Validating packages.json: $PackagesJsonPath" -ForegroundColor Cyan
+
+$json = Get-Content $PackagesJsonPath -Raw | ConvertFrom-Json
+$errors = @()
+$checked = 0
+
+# Placeholder versions that should not be validated against NuGet
+$placeholderVersions = @('DefaultUnoVersion')
+
+foreach ($group in $json) {
+    $groupName = $group.group
+    $baseVersion = $group.version
+    $packages = $group.packages
+
+    # Skip groups with placeholder versions
+    if ($placeholderVersions -contains $baseVersion) {
+        Write-Host "  [SKIP] $groupName (placeholder version: $baseVersion)" -ForegroundColor DarkGray
+        continue
+    }
+
+    # Collect all version+package combinations to check
+    $versionsToCheck = @()
+
+    # Base version
+    $versionsToCheck += @{ Version = $baseVersion; Label = 'base' }
+
+    # Version overrides (TFM-specific)
+    if ($group.PSObject.Properties['versionOverride'] -and $null -ne $group.versionOverride) {
+        $overrides = $group.versionOverride
+        foreach ($prop in $overrides.PSObject.Properties) {
+            $versionsToCheck += @{ Version = $prop.Value; Label = "override($($prop.Name))" }
+        }
+    }
+
+    foreach ($pkg in $packages) {
+        foreach ($vEntry in $versionsToCheck) {
+            $version = $vEntry.Version
+            $label = $vEntry.Label
+
+            # Also skip overrides that reference a placeholder
+            if ($placeholderVersions -contains $version) {
+                continue
+            }
+
+            $checked++
+            $url = "https://api.nuget.org/v3-flatcontainer/$($pkg.ToLowerInvariant())/$($version.ToLowerInvariant())/$($pkg.ToLowerInvariant()).nuspec"
+
+            try {
+                $response = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing -ErrorAction Stop
+                if ($response.StatusCode -eq 200) {
+                    Write-Host "  [OK] $pkg $version ($label)" -ForegroundColor Green
+                }
+            }
+            catch {
+                $statusCode = $_.Exception.Response.StatusCode.value__
+                if ($statusCode -eq 404) {
+                    Write-Host "  [MISSING] $pkg $version ($label) - NOT FOUND on NuGet" -ForegroundColor Red
+                    $errors += "Group '$groupName': $pkg $version ($label) does not exist on NuGet.org"
+                }
+                else {
+                    Write-Host "  [ERROR] $pkg $version ($label) - HTTP $statusCode" -ForegroundColor Yellow
+                    $errors += "Group '$groupName': $pkg $version ($label) - HTTP error $statusCode"
+                }
+            }
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Checked $checked package/version combinations." -ForegroundColor Cyan
+
+if ($errors.Count -gt 0) {
+    Write-Host ""
+    Write-Host "VALIDATION FAILED - $($errors.Count) error(s):" -ForegroundColor Red
+    foreach ($err in $errors) {
+        Write-Host "  - $err" -ForegroundColor Red
+    }
+    exit 1
+}
+else {
+    Write-Host "All packages validated successfully." -ForegroundColor Green
+    exit 0
+}

--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -12,10 +12,21 @@
     Path to the packages.json file. Defaults to src/Uno.Sdk/packages.json relative to repo root.
 #>
 param(
-    [string]$PackagesJsonPath
+    [string]$PackagesJsonPath,
+    [switch]$WarningOnly
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Auto-detect: on release/* branches, switch to warning-only mode
+# (stable builds test with versions not yet public on NuGet.org)
+if (-not $WarningOnly) {
+    $branch = $env:BUILD_SOURCEBRANCH
+    if ($branch -and $branch -like 'refs/heads/release/*') {
+        Write-Host "Detected release branch ($branch) - running in warning-only mode." -ForegroundColor Yellow
+        $WarningOnly = $true
+    }
+}
 
 # Resolve path
 if (-not $PackagesJsonPath) {
@@ -108,9 +119,19 @@ Write-Host "Checked $checked package/version combinations." -ForegroundColor Cya
 
 if ($errors.Count -gt 0) {
     Write-Host ""
-    Write-Host "VALIDATION FAILED - $($errors.Count) error(s):" -ForegroundColor Red
+    if ($WarningOnly) {
+        Write-Host "VALIDATION WARNINGS - $($errors.Count) package(s) not found on NuGet.org (non-fatal):" -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "VALIDATION FAILED - $($errors.Count) error(s):" -ForegroundColor Red
+    }
     foreach ($err in $errors) {
-        Write-Host "  - $err" -ForegroundColor Red
+        Write-Host "  - $err" -ForegroundColor $(if ($WarningOnly) { 'Yellow' } else { 'Red' })
+    }
+    if ($WarningOnly) {
+        Write-Host ""
+        Write-Host "Running in warning-only mode (stable branch) - not failing the build." -ForegroundColor Yellow
+        exit 0
     }
     exit 1
 }

--- a/build/ci/setup/.azure-devops-setup-validate-packages.yml
+++ b/build/ci/setup/.azure-devops-setup-validate-packages.yml
@@ -1,0 +1,7 @@
+steps:
+- task: PowerShell@2
+  displayName: Validate packages.json (NuGet existence check)
+  inputs:
+    pwsh: true
+    filePath: build/ci/scripts/validate-packages-json.ps1
+    arguments: '-PackagesJsonPath "$(Build.SourcesDirectory)/src/Uno.Sdk/packages.json"'

--- a/build/ci/setup/.azure-devops-setup-validate-packages.yml
+++ b/build/ci/setup/.azure-devops-setup-validate-packages.yml
@@ -5,3 +5,5 @@ steps:
     pwsh: true
     filePath: build/ci/scripts/validate-packages-json.ps1
     arguments: '-PackagesJsonPath "$(Build.SourcesDirectory)/src/Uno.Sdk/packages.json"'
+  env:
+    BUILD_SOURCEBRANCH: $(Build.SourceBranch)

--- a/doc/articles/features/android-auto.md
+++ b/doc/articles/features/android-auto.md
@@ -14,7 +14,7 @@ For projects using the `Uno.Sdk`, add the `AndroidAuto` feature to your project'
 <UnoFeatures>$(UnoFeatures);AndroidAuto</UnoFeatures>
 ```
 
-This automatically adds a reference to the `Xamarin.AndroidX.Car.App` package. New projects created from the Uno Platform templates with the **Android Auto** option enabled will also have the required manifest entries and the `automotive_app_desc.xml` resource stamped automatically.
+This automatically adds a reference to the `Xamarin.AndroidX.Car.App.App` package. New projects created from the Uno Platform templates with the **Android Auto** option enabled will also have the required manifest entries and the `automotive_app_desc.xml` resource stamped automatically.
 
 ## What gets configured
 

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -590,7 +590,7 @@
 					"helpUrl": "https://aka.platform.uno/feature-android-tv"
 				},
 				"AndroidAuto": {
-					"description": "Configures the Android head for Android Auto / Automotive OS (adds Xamarin.AndroidX.Car.App).",
+					"description": "Configures the Android head for Android Auto / Automotive OS (adds Xamarin.AndroidX.Car.App.App).",
 					"helpUrl": "https://aka.platform.uno/feature-android-auto"
 				},
 				"AndroidWear": {

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -281,7 +281,7 @@
 		"group": "AndroidXCarApp",
 		"version": "1.4.0.2",
 		"packages": [
-			"Xamarin.AndroidX.Car.App"
+			"Xamarin.AndroidX.Car.App.App"
 		],
 		"versionOverride": {
 			"net10.0": "1.4.0.3"
@@ -294,17 +294,17 @@
 			"Xamarin.AndroidX.Wear"
 		],
 		"versionOverride": {
-			"net10.0": "1.3.0.17"
+			"net10.0": "1.4.0.1"
 		}
 	},
 	{
 		"group": "AndroidXWearTiles",
-		"version": "1.4.0.2",
+		"version": "1.4.0.1",
 		"packages": [
 			"Xamarin.AndroidX.Wear.Tiles"
 		],
 		"versionOverride": {
-			"net10.0": "1.4.0.3"
+			"net10.0": "1.4.1"
 		}
 	},
 	{

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Android.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Android.targets
@@ -27,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';androidauto;'))">
-		<_UnoProjectSystemPackageReference Include="Xamarin.AndroidX.Car.App" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Xamarin.AndroidX.Car.App.App" ProjectSystem="true" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';androidwear;'))">


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno-private/issues/1126.
Related to https://github.com/unoplatform/uno-private/issues/1327.
Related to https://github.com/unoplatform/uno-private/issues/1328.

## Summary

Fixes 3 broken AndroidX package entries in `src/Uno.Sdk/packages.json` that were introduced in PR #23157, and adds a CI validation guard to prevent future recurrences.

## What

- **`Xamarin.AndroidX.Car.App`** → **`Xamarin.AndroidX.Car.App.App`** — the package ID was wrong (correct NuGet ID has the extra `.App` suffix). Updated in `packages.json`, `Uno.Implicit.Packages.ProjectSystem.Android.targets`, `Sdk.props.buildschema.json`, and `doc/articles/features/android-auto.md`.
- **`Xamarin.AndroidX.Wear`** net10.0 override **`1.3.0.17`** → **`1.4.0.1`** — version 1.3.0.17 does not exist on NuGet.org
- **`Xamarin.AndroidX.Wear.Tiles`** base **`1.4.0.2`** → **`1.4.0.1`**, net10.0 **`1.4.0.3`** → **`1.4.1`** — both original versions do not exist on NuGet.org
- Added `build/ci/scripts/validate-packages-json.ps1` — a PowerShell script that validates all package ID + version pairs in `packages.json` exist on NuGet.org via the flat container API (with timeout, retry, deduplication, and release-branch detection via both `BUILD_SOURCEBRANCH` and `SYSTEM_PULLREQUEST_TARGETBRANCH`)
- Integrated the guard into the Setup/Validations stage of the Azure DevOps CI pipeline (added `src/Uno.Sdk/packages.json` to sparse checkout)

## Why

These broken entries cause NuGet restore failures for any downstream consumer enabling AndroidAuto or Wear features, including new Uno.Sdk packages publication

(Issue caught after on [uno.templates](https://github.com/unoplatform/uno.templates) with the help of previous [fix(ci): block nuget publish on missing dependencies](https://github.com/unoplatform/uno.templates/pull/2009#top)#2009)

The CI guard prevents this class of issue from reaching `master` in the future.

## Validation

Ran `validate-packages-json.ps1` locally — all 122 package/version combinations now pass:

`
Checked 122 package/version combinations.
All packages validated successfully.
`

Related to previous PR: https://github.com/unoplatform/uno/pull/23157