### PR TITLE
fix(theming): ensure ThemeResource updates on first walk without spurious events

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/ThemeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ThemeHelper.cs
@@ -35,6 +35,7 @@ namespace Uno.UI.RuntimeTests.Helpers
 #if HAS_UNO
 		public static IDisposable UseApplicationDarkTheme()
 		{
+			AssertFullWindowForApplicationTheme();
 			var originalTheme = Application.Current.RequestedTheme;
 			var wasExplicit = Application.Current.IsThemeSetExplicitly;
 			Application.Current.SetExplicitRequestedTheme(ApplicationTheme.Dark);
@@ -57,6 +58,7 @@ namespace Uno.UI.RuntimeTests.Helpers
 		/// </summary>
 		public static IDisposable UseApplicationLightTheme()
 		{
+			AssertFullWindowForApplicationTheme();
 			var originalTheme = Application.Current.RequestedTheme;
 			var wasExplicit = Application.Current.IsThemeSetExplicitly;
 			Application.Current.SetExplicitRequestedTheme(ApplicationTheme.Light);
@@ -72,6 +74,24 @@ namespace Uno.UI.RuntimeTests.Helpers
 					Application.Current.SetExplicitRequestedTheme(null);
 				}
 			});
+		}
+
+		// The SamplesApp test runner pins RequestedTheme=Light on its outer Frame
+		// (App.Tests.cs HandleRuntimeTests). When tests run in the embedded host
+		// (UseActualWindowRoot=false), that Frame sits between the application root
+		// and the test content, so app-level theme changes cannot reach the test
+		// subtree. [RequiresFullWindow] reparents to the actual window root and
+		// bypasses the Frame.
+		private static void AssertFullWindowForApplicationTheme()
+		{
+			if (!TestServices.WindowHelper.UseActualWindowRoot)
+			{
+				Assert.Fail(
+					"ThemeHelper.UseApplicationDarkTheme/UseApplicationLightTheme require " +
+					"[RequiresFullWindow] on the test method. Without it, the SamplesApp " +
+					"runtime-test Frame (RequestedTheme=Light, set in App.Tests.cs) blocks " +
+					"app-level theme propagation to the test content.");
+			}
 		}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Helpers/ThemeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ThemeHelper.cs
@@ -51,6 +51,28 @@ namespace Uno.UI.RuntimeTests.Helpers
 				}
 			});
 		}
+
+		/// <summary>
+		/// Ensure light theme is applied at the application level for the course of a single test.
+		/// </summary>
+		public static IDisposable UseApplicationLightTheme()
+		{
+			var originalTheme = Application.Current.RequestedTheme;
+			var wasExplicit = Application.Current.IsThemeSetExplicitly;
+			Application.Current.SetExplicitRequestedTheme(ApplicationTheme.Light);
+
+			return new DisposableAction(() =>
+			{
+				if (wasExplicit)
+				{
+					Application.Current.SetExplicitRequestedTheme(originalTheme);
+				}
+				else
+				{
+					Application.Current.SetExplicitRequestedTheme(null);
+				}
+			});
+		}
 #endif
 
 		public static ElementTheme CurrentTheme

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3230,6 +3230,7 @@ public class Given_ElementTheme
 
 #if HAS_UNO
 	[TestMethod]
+	[RequiresFullWindow]
 	public async Task When_App_Theme_Changes_Explicit_Element_Keeps_Own_Resources()
 	{
 		// Element with RequestedTheme=Light should keep Light resources
@@ -3295,6 +3296,7 @@ public class Given_ElementTheme
 	}
 
 	[TestMethod]
+	[RequiresFullWindow]
 	public async Task When_UseApplicationDarkTheme_Disposed_IsThemeSetExplicitly_Restored()
 	{
 		// Verify IsThemeSetExplicitly is restored to false after dispose
@@ -3885,6 +3887,7 @@ public class Given_ElementTheme
 
 #if HAS_UNO
 	[TestMethod]
+	[RequiresFullWindow]
 	public async Task When_Style_With_Template_Applied_CodeBehind_In_Light_Subtree_Under_Dark_App()
 	{
 		// Regression test: app is in Dark theme, but the root

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -4097,6 +4097,16 @@ public class Given_ElementTheme
 		await WindowHelper.WaitForLoaded(root);
 		await WindowHelper.WaitForIdle();
 
+		// Sanity-check: initial Light theme values should be Blue
+		var initialChildBrush = child.Background as SolidColorBrush;
+		var initialGrandchildBrush = grandchild.Background as SolidColorBrush;
+		Assert.IsNotNull(initialChildBrush);
+		Assert.IsNotNull(initialGrandchildBrush);
+		Assert.AreEqual(Colors.Blue, initialChildBrush.Color,
+			$"Child should start with Light resource (Blue). Got {initialChildBrush.Color}");
+		Assert.AreEqual(Colors.Blue, initialGrandchildBrush.Color,
+			$"Grandchild should start with Light resource (Blue). Got {initialGrandchildBrush.Color}");
+
 		// Switch to Dark
 		using (ThemeHelper.UseApplicationDarkTheme())
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3985,4 +3985,130 @@ public class Given_ElementTheme
 #endif
 
 	#endregion
+
+	#region Application Theme Change - ThemeResource Resolution
+
+	[TestMethod]
+#if !HAS_UNO
+	[Ignore("Test validates Uno-specific regression fix")]
+#endif
+	public async Task When_AppTheme_Changes_ThemeResource_Values_Update()
+	{
+		// Regression test for https://github.com/unoplatform/uno/issues/23177
+		// When switching app theme from Light to Dark, elements that haven't
+		// been through a prior theme walk (stored theme == Theme.None) should
+		// still get their ThemeResource bindings updated.
+
+		var root = (Grid)XamlReader.Load(
+			"""
+			<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+				<Grid.Resources>
+					<ResourceDictionary>
+						<ResourceDictionary.ThemeDictionaries>
+							<ResourceDictionary x:Key="Light">
+								<SolidColorBrush x:Key="TestBrush" Color="Green" />
+							</ResourceDictionary>
+							<ResourceDictionary x:Key="Dark">
+								<SolidColorBrush x:Key="TestBrush" Color="Red" />
+							</ResourceDictionary>
+						</ResourceDictionary.ThemeDictionaries>
+					</ResourceDictionary>
+				</Grid.Resources>
+				<Border x:Name="target" Width="50" Height="50"
+				        Background="{ThemeResource TestBrush}" />
+			</Grid>
+			""");
+
+		WindowHelper.WindowContent = root;
+		await WindowHelper.WaitForLoaded(root);
+		await WindowHelper.WaitForIdle();
+
+		var border = (Border)root.FindName("target");
+
+		// Verify initial Light theme value
+		var initialBrush = border.Background as SolidColorBrush;
+		Assert.IsNotNull(initialBrush, "Background should be a SolidColorBrush");
+		Assert.AreEqual(Colors.Green, initialBrush.Color,
+			$"Initial color should be Green (Light theme). Got {initialBrush.Color}");
+
+		// Switch to Dark theme at application level
+		using (ThemeHelper.UseApplicationDarkTheme())
+		{
+			await WindowHelper.WaitForIdle();
+
+			var darkBrush = border.Background as SolidColorBrush;
+			Assert.IsNotNull(darkBrush, "Background should be a SolidColorBrush after theme switch");
+			Assert.AreEqual(Colors.Red, darkBrush.Color,
+				$"After switching to Dark, ThemeResource should resolve to Red. Got {darkBrush.Color}");
+		}
+
+		// Verify switching back to Light works
+		await WindowHelper.WaitForIdle();
+		var restoredBrush = border.Background as SolidColorBrush;
+		Assert.IsNotNull(restoredBrush, "Background should be a SolidColorBrush after restoring theme");
+		Assert.AreEqual(Colors.Green, restoredBrush.Color,
+			$"After restoring Light, ThemeResource should resolve to Green. Got {restoredBrush.Color}");
+	}
+
+	[TestMethod]
+#if !HAS_UNO
+	[Ignore("Test validates Uno-specific regression fix")]
+#endif
+	public async Task When_AppTheme_Changes_Nested_Elements_ThemeResources_Update()
+	{
+		// Verify that nested elements (children, grandchildren) all get their
+		// ThemeResource bindings updated when the app theme changes.
+
+		var root = (StackPanel)XamlReader.Load(
+			"""
+			<StackPanel xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+				<StackPanel.Resources>
+					<ResourceDictionary>
+						<ResourceDictionary.ThemeDictionaries>
+							<ResourceDictionary x:Key="Light">
+								<SolidColorBrush x:Key="NestedBrush" Color="Blue" />
+							</ResourceDictionary>
+							<ResourceDictionary x:Key="Dark">
+								<SolidColorBrush x:Key="NestedBrush" Color="Orange" />
+							</ResourceDictionary>
+						</ResourceDictionary.ThemeDictionaries>
+					</ResourceDictionary>
+				</StackPanel.Resources>
+				<Border x:Name="child" Width="50" Height="50"
+				        Background="{ThemeResource NestedBrush}" />
+				<StackPanel>
+					<Border x:Name="grandchild" Width="50" Height="50"
+					        Background="{ThemeResource NestedBrush}" />
+				</StackPanel>
+			</StackPanel>
+			""");
+
+		WindowHelper.WindowContent = root;
+		await WindowHelper.WaitForLoaded(root);
+		await WindowHelper.WaitForIdle();
+
+		var child = (Border)root.FindName("child");
+		var grandchild = (Border)root.FindName("grandchild");
+
+		// Switch to Dark
+		using (ThemeHelper.UseApplicationDarkTheme())
+		{
+			await WindowHelper.WaitForIdle();
+
+			var childBrush = child.Background as SolidColorBrush;
+			var grandchildBrush = grandchild.Background as SolidColorBrush;
+
+			Assert.IsNotNull(childBrush);
+			Assert.IsNotNull(grandchildBrush);
+
+			Assert.AreEqual(Colors.Orange, childBrush.Color,
+				$"Child should use Dark resource (Orange). Got {childBrush.Color}");
+			Assert.AreEqual(Colors.Orange, grandchildBrush.Color,
+				$"Grandchild should use Dark resource (Orange). Got {grandchildBrush.Color}");
+		}
+	}
+
+	#endregion
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3990,6 +3990,7 @@ public class Given_ElementTheme
 
 #if HAS_UNO
 	[TestMethod]
+	[RequiresFullWindow]
 	public async Task When_AppTheme_Changes_ThemeResource_Values_Update()
 	{
 		// Regression test for https://github.com/unoplatform/uno/issues/23177
@@ -4053,6 +4054,7 @@ public class Given_ElementTheme
 	}
 
 	[TestMethod]
+	[RequiresFullWindow]
 	public async Task When_AppTheme_Changes_Nested_Elements_ThemeResources_Update()
 	{
 		// Verify that nested elements (children, grandchildren) all get their

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -4017,16 +4017,15 @@ public class Given_ElementTheme
 						</ResourceDictionary.ThemeDictionaries>
 					</ResourceDictionary>
 				</Grid.Resources>
-				<Border x:Name="target" Width="50" Height="50"
-				        Background="{ThemeResource TestBrush}" />
+				<Border x:Name="border" Width="50" Height="50" Background="{ThemeResource TestBrush}" />
 			</Grid>
 			""");
+
+		var border = (Border)root.FindName("border");
 
 		WindowHelper.WindowContent = root;
 		await WindowHelper.WaitForLoaded(root);
 		await WindowHelper.WaitForIdle();
-
-		var border = (Border)root.FindName("target");
 
 		// Verify initial Light theme value
 		var initialBrush = border.Background as SolidColorBrush;
@@ -4079,21 +4078,19 @@ public class Given_ElementTheme
 						</ResourceDictionary.ThemeDictionaries>
 					</ResourceDictionary>
 				</StackPanel.Resources>
-				<Border x:Name="child" Width="50" Height="50"
-				        Background="{ThemeResource NestedBrush}" />
+				<Border x:Name="child" Width="50" Height="50" Background="{ThemeResource NestedBrush}" />
 				<StackPanel>
-					<Border x:Name="grandchild" Width="50" Height="50"
-					        Background="{ThemeResource NestedBrush}" />
+					<Border x:Name="grandchild" Width="50" Height="50" Background="{ThemeResource NestedBrush}" />
 				</StackPanel>
 			</StackPanel>
 			""");
 
+		var child = (Border)root.FindName("child");
+		var grandchild = (Border)root.FindName("grandchild");
+
 		WindowHelper.WindowContent = root;
 		await WindowHelper.WaitForLoaded(root);
 		await WindowHelper.WaitForIdle();
-
-		var child = (Border)root.FindName("child");
-		var grandchild = (Border)root.FindName("grandchild");
 
 		// Switch to Dark
 		using (ThemeHelper.UseApplicationDarkTheme())

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3997,6 +3997,10 @@ public class Given_ElementTheme
 		// been through a prior theme walk (stored theme == Theme.None) should
 		// still get their ThemeResource bindings updated.
 
+		// Ensure we start in Light theme regardless of CI environment
+		using var _ = ThemeHelper.UseApplicationLightTheme();
+		await WindowHelper.WaitForIdle();
+
 		var root = (Grid)XamlReader.Load(
 			"""
 			<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -4054,6 +4058,10 @@ public class Given_ElementTheme
 	{
 		// Verify that nested elements (children, grandchildren) all get their
 		// ThemeResource bindings updated when the app theme changes.
+
+		// Ensure we start in Light theme regardless of CI environment
+		using var _ = ThemeHelper.UseApplicationLightTheme();
+		await WindowHelper.WaitForIdle();
 
 		var root = (StackPanel)XamlReader.Load(
 			"""

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -3988,10 +3988,8 @@ public class Given_ElementTheme
 
 	#region Application Theme Change - ThemeResource Resolution
 
+#if HAS_UNO
 	[TestMethod]
-#if !HAS_UNO
-	[Ignore("Test validates Uno-specific regression fix")]
-#endif
 	public async Task When_AppTheme_Changes_ThemeResource_Values_Update()
 	{
 		// Regression test for https://github.com/unoplatform/uno/issues/23177
@@ -4052,9 +4050,6 @@ public class Given_ElementTheme
 	}
 
 	[TestMethod]
-#if !HAS_UNO
-	[Ignore("Test validates Uno-specific regression fix")]
-#endif
 	public async Task When_AppTheme_Changes_Nested_Elements_ThemeResources_Update()
 	{
 		// Verify that nested elements (children, grandchildren) all get their
@@ -4109,6 +4104,7 @@ public class Given_ElementTheme
 				$"Grandchild should use Dark resource (Orange). Got {grandchildBrush.Color}");
 		}
 	}
+#endif
 
 	#endregion
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -106,6 +106,7 @@ public class Given_Window
 #if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
+	[RequiresFullWindow]
 	public async Task When_Secondary_Window_No_Background_Light_Dark()
 	{
 		AssertSupportsMultipleWindows();
@@ -134,6 +135,7 @@ public class Given_Window
 #if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
+	[RequiresFullWindow]
 	public async Task When_Secondary_Window_No_Background_Switch_Theme()
 	{
 		AssertSupportsMultipleWindows();

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
@@ -215,9 +215,11 @@ public partial class FrameworkElement
 	{
 		// 1. Determine if ActualTheme is changing
 		var oldTheme = GetTheme();
-		var appBaseTheme = Theming.FromElementTheme(
-			Application.Current?.ActualElementTheme ?? ElementTheme.Light);
-		var oldBase = oldTheme == Theme.None ? appBaseTheme : Theming.GetBaseValue(oldTheme);
+		// MUX Reference: Theming.cpp GetBaseValue(Theme::None) returns Theme::None,
+		// which never equals Light or Dark, ensuring themeChanged is always true for
+		// elements that haven't been through a theme walk yet. This guarantees
+		// UpdateThemeBindings is called on their first walk.
+		var oldBase = Theming.GetBaseValue(oldTheme);
 		var newBase = Theming.GetBaseValue(theme);
 
 		bool themeChanged = oldBase != newBase || forceRefresh;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
@@ -213,16 +213,23 @@ public partial class FrameworkElement
 	/// </summary>
 	private protected virtual void NotifyThemeChangedCore(Theme theme, bool forceRefresh)
 	{
-		// 1. Determine if ActualTheme is changing
+		// 1. Determine if theme is changing
 		var oldTheme = GetTheme();
-		// MUX Reference: Theming.cpp GetBaseValue(Theme::None) returns Theme::None,
-		// which never equals Light or Dark, ensuring themeChanged is always true for
-		// elements that haven't been through a theme walk yet. This guarantees
-		// UpdateThemeBindings is called on their first walk.
-		var oldBase = Theming.GetBaseValue(oldTheme);
 		var newBase = Theming.GetBaseValue(theme);
 
+		// MUX Reference: Theming.cpp GetBaseValue(Theme::None) returns Theme::None (0x00),
+		// which never equals Light or Dark, ensuring themeChanged is always true for
+		// elements that haven't been through a theme walk yet. This guarantees
+		// UpdateThemeBindings is called on their first walk (fixes #23177).
+		var oldBase = Theming.GetBaseValue(oldTheme);
 		bool themeChanged = oldBase != newBase || forceRefresh;
+
+		// MUX Reference: framework.cpp RaiseActiveThemeChangedEventIfChanging uses
+		// oldTheme == Theme::None ? GetBaseTheme() : GetBaseValue(oldTheme) to prevent
+		// spurious ActualThemeChanged events and foreground inheritance on first walk.
+		var appBaseTheme = Theming.FromElementTheme(Application.Current?.ActualElementTheme ?? ElementTheme.Light);
+		var oldBaseForEvent = oldTheme == Theme.None ? appBaseTheme : oldBase;
+		bool effectiveThemeChanged = oldBaseForEvent != newBase || forceRefresh;
 
 		// 2. PUSH this element's theme to global context
 		// The push/pop is still needed because ResourceDictionary.GetActiveThemeDictionary()
@@ -255,7 +262,7 @@ public partial class FrameworkElement
 			{
 				NotifyThemeChangedForInheritedProperties(theme, freeze: true);
 			}
-			else if (themeChanged)
+			else if (effectiveThemeChanged)
 			{
 				var parent = this.GetParent() as FrameworkElement;
 				var parentFg = parent?._themeForeground;
@@ -288,7 +295,7 @@ public partial class FrameworkElement
 			PropagateThemeToChildren(theme, forceRefresh);
 
 			// 6. Raise event LAST (WinUI: framework.cpp line 3317)
-			if (themeChanged)
+			if (effectiveThemeChanged)
 			{
 				RaiseActualThemeChanged();
 			}


### PR DESCRIPTION
## Summary

Fixes https://github.com/unoplatform/uno/issues/23177

#### Regression Introduced By

- **PR #22803** (merged 2026-03-20, @MartinZikmund)
- **PR #22887** (merged 2026-04-07, @MartinZikmund)

---

Splits the single `themeChanged` guard in `NotifyThemeChangedCore` into two independent guards to correctly handle the first theme walk scenario:

- **`themeChanged`** = `oldBase != newBase || forceRefresh` — gates `UpdateThemeBindings`. Always true on the first walk (Theme.None → Light/Dark), ensuring ThemeResource bindings resolve immediately.
- **`effectiveThemeChanged`** = `oldBaseForEvent != newBase || forceRefresh` — gates foreground inheritance and `RaiseActualThemeChanged()`. Uses WinUI's fallback pattern (`oldTheme == Theme.None ? appBaseTheme : oldBase`) to suppress spurious events when the effective theme hasn't actually changed.

## WinUI Alignment

This mirrors WinUI's `framework.cpp` `RaiseActiveThemeChangedEventIfChanging` which treats `Theme::None` as equivalent to the app's base theme for the purpose of event/state changes, while still allowing resource resolution to proceed.

## What This Fixes

- ThemeResource markup extensions now correctly update when the app theme is toggled for the first time (was previously blocked by `oldBase == newBase` being `None == None`).
- No spurious `ActualThemeChanged` events fire on the initial theme walk.
- Foreground inheritance only triggers when the effective theme genuinely changes.

## Test Infrastructure

- Added `ThemeHelper.UseApplicationLightTheme()` to explicitly set Light theme at the start of tests (no reliance on CI default).
- Added `ThemeHelper.AssertFullWindowForApplicationTheme()` guard — fails fast with a clear message if `UseApplicationDarkTheme` / `UseApplicationLightTheme` are called without `[RequiresFullWindow]`, preventing silent false-passes caused by the SamplesApp test runner's pinned `RequestedTheme=Light` Frame.
- Added `[RequiresFullWindow]` to all tests that change app-level theme (existing and new).
- Added two regression tests: `When_AppTheme_Changes_ThemeResource_Values_Update` and `When_AppTheme_Changes_Nested_Elements_ThemeResources_Update`.