### PR TITLE
fix: Prevent Android drawable files from leaking into all NuGet TFMs

### DIFF
--- a/src/Uno.Sdk/targets/Uno.DefaultItems.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.targets
@@ -6,7 +6,7 @@
 		<DefaultItemExcludes Condition="!$(DefaultItemExcludes.Contains('obj/**'))">$(DefaultItemExcludes);obj/**</DefaultItemExcludes>
 
 		<!-- Exclude the Stories folder when in Optimize (aka Release) build configuration -->
-		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoriesFolder)' != '' ">$(HotDesignStoriesFolder)/**</DefaultItemExcludes>
+		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoriesFolder)' != '' ">$(DefaultItemExcludes);$(HotDesignStoriesFolder)/**</DefaultItemExcludes>
 	</PropertyGroup>
 
 	<!-- Default Includes-->

--- a/src/Uno.Sdk/targets/Uno.Sdk.After.targets
+++ b/src/Uno.Sdk/targets/Uno.Sdk.After.targets
@@ -5,7 +5,7 @@
 	</ItemGroup>
 
 	<!-- Sanity check ensure that platform files for other targets are not included -->
-	<ItemGroup Condition=" $(_IsUnoSingleProjectAndLegacy) == 'true' and $(PlatformsProjectFolder) != '' and Exists($(PlatformsProjectFolder))">
+	<ItemGroup Condition=" '$(TargetFramework)' != '' ">
 		<Compile Remove="@(_IgnorePlatformFiles)" />
 		<Page Remove="@(_IgnorePlatformFiles)" />
 		<Content Remove="@(_IgnorePlatformFiles)" />


### PR DESCRIPTION
Broadens the platform file removal sanity check in Uno.Sdk.After.targets to fire for all Uno.Sdk projects, not just SingleProject ones. Also fixes DefaultItemExcludes replacement bug that lost bin/obj excludes in Release.

Fixes #22640, closes #22643

**GitHub Issue:** closes #22643

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
