### PR TITLE
fix(ci): Post drift comment when XAML/sync-gen diff exceeds 400 lines

### DIFF
--- a/.github/workflows/winappsdk-sync-check.yml
+++ b/.github/workflows/winappsdk-sync-check.yml
@@ -69,7 +69,7 @@ jobs:
             echo "---- git status ----"
             git status
             echo "---- git diff (truncated to 400 lines) ----"
-            git -c color.ui=always diff --cached | head -n 400
+            git -c color.ui=always diff --cached | head -n 400 || true
           fi
 
       - name: Upload patch artifact

--- a/.github/workflows/xaml-style-check.yml
+++ b/.github/workflows/xaml-style-check.yml
@@ -45,7 +45,7 @@ jobs:
             echo "---- git status ----"
             git status
             echo "---- git diff (truncated to 400 lines) ----"
-            git -c color.ui=always diff --cached | head -n 400
+            git -c color.ui=always diff --cached | head -n 400 || true
           fi
 
       - name: Upload patch artifact


### PR DESCRIPTION
**GitHub Issue:** closes #23187

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The `XAML Style Check` and `WinAppSDK Sync Generator Check` workflows are supposed to post a PR comment with apply instructions whenever drift is detected. When the drift is larger than ~400 lines, the `Detect drift` step itself fails with exit code 141 and the subsequent `Post drift comment` / `Upload patch artifact` / `Fail if drift detected` steps are silently skipped because their `if: steps.drift.outputs.drift == 'true'` condition is never satisfied.

Example failure: https://github.com/unoplatform/uno/actions/runs/25309801791/job/74193786071?pr=23180 — drift was detected but no PR comment was posted.

### Root cause

The `Detect drift` step runs under `bash --noprofile --norc -e -o pipefail` and contains:

```bash
git -c color.ui=always diff --cached | head -n 400
```

When the diff is larger than 400 lines, `head` closes its stdin after reading 400 lines. `git diff` continues writing, gets SIGPIPE on its next write, and exits 141. With `pipefail` the pipeline returns 141, and `set -e` aborts the step before it can record `drift=true`.

The same line exists in `winappsdk-sync-check.yml` and is just as vulnerable; it has not tripped yet because past sync-gen drifts have stayed under 400 lines.

### Fix

Append `|| true` to the truncated-diff pipeline in both workflows so SIGPIPE from `head` closing early does not abort the step. The patch artifact and the `drift=true` output are unaffected; the only change is that the colored, truncated console preview tolerates being cut short.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, CI workflow change
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)