### PR TITLE
docs: mention simple theme

### DIFF
--- a/doc/articles/getting-started/wizard/includes/themes.md
+++ b/doc/articles/getting-started/wizard/includes/themes.md
@@ -2,9 +2,16 @@ Uno platform lets you decide easily which theme or skin to display throughout yo
 
 This option sets the generated theme or skin to be used in the generated app. The options available are:
 
+- **Simple**  
+    Simple is a lightweight design system that provides minimal, essential styling for controls. This is the default for the recommended preset.
+
+    ```dotnetcli
+    dotnet new unoapp -theme simple
+    ```
+
 - **Material**  
     Material is Google's design system.  
-    Learn more about [Material](https://material.io/). This option will result in an application that will have the material theme applied. This is the default for the recommended preset.  
+    Learn more about [Material](https://material.io/). This option will result in an application that will have the material theme applied.
 
     ```dotnetcli
     dotnet new unoapp -theme material

--- a/doc/articles/getting-started/wizard/includes/themes.md
+++ b/doc/articles/getting-started/wizard/includes/themes.md
@@ -3,7 +3,8 @@ Uno platform lets you decide easily which theme or skin to display throughout yo
 This option sets the generated theme or skin to be used in the generated app. The options available are:
 
 - **Simple**  
-    Simple is a lightweight design system that provides minimal, essential styling for controls. This is the default for the recommended preset.
+    Simple is a lightweight design system that provides minimal, essential styling for controls.  
+    Learn more about [Simple](xref:Uno.Themes.Simple.GetStarted). This is the default for the recommended preset.
 
     ```dotnetcli
     dotnet new unoapp -theme simple


### PR DESCRIPTION
**GitHub Issue:** closes #23167

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Documents new template parameter in the wizard guide:

- **Simple theme** (`-theme simple`): Added as the first theme option in `themes.md`, reflecting its new default status for the recommended preset. Removed "default for recommended" from Material.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
