### PR TITLE
fix(skia-win32): re-apply SetWindowPos after SW_SHOWNORMAL on first show

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -150,6 +150,23 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			{
 				_showWindowOnNextRender = false;
 				_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
+
+				// SW_SHOWNORMAL restores the window using its saved WINDOWPLACEMENT.rcNormalPosition,
+				// which still holds the old screen coordinates from before re-parenting. Those coordinates
+				// are now misinterpreted as parent-relative, placing the window at the wrong position.
+				// Re-applying SetWindowPos after ShowWindow overrides that restoration.
+				var posSuccess = PInvoke.SetWindowPos(
+					(HWND)window.Hwnd,
+					HWND.Null,
+					(int)_lastArrangeRect.X,
+					(int)_lastArrangeRect.Y,
+					(int)_lastArrangeRect.Width,
+					(int)_lastArrangeRect.Height,
+					SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+				if (!posSuccess)
+				{
+					this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} failed: {Win32Helper.GetErrorMessage()}");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#467

## PR Type:

🐞 Bugfix

## What is the current behavior? 🤔

Since #23126, native elements hosted in a Win32 Skia window are placed at the wrong position on first show. The element appears at its original screen coordinates (e.g. 268,291 / 1440×759) rather than at the correct parent-relative position (e.g. 0,141 / 991×500). Resizing the element by even 1 pixel corrects it.

## What is the new behavior? 🚀

Native elements appear at the correct position immediately on first show, without requiring a resize.

## Root cause

`SW_SHOWNORMAL` restores the window using its saved `WINDOWPLACEMENT.rcNormalPosition`, which still holds the old screen coordinates from before `SetParent` was called. Once the window is a child, those screen coordinates are reinterpreted as parent-relative offsets, placing the element at the wrong location.

The pre-#23126 code accidentally masked this: `ShowWindow` was called in `ArrangeNativeElement`, and a second arrange immediately followed with another `SetWindowPos` that corrected the position. After #23126 deferred show to the render handler, there was no subsequent `SetWindowPos` to fix it — hence the resize workaround worked (it triggered another `SetWindowPos` after the window was already visible).

**Fix:** re-apply `SetWindowPos` with the correct rect immediately after `SW_SHOWNORMAL`.

## PR Checklist ✅

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes