### PR TITLE
fix(theming): set theme before raising ActualThemeChanged event

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -243,6 +243,149 @@ public class Given_ElementTheme
 		Assert.IsGreaterThanOrEqualTo(1, themeChangedCount, "ActualThemeChanged should fire when RequestedTheme changes");
 	}
 
+	[TestMethod]
+	public async Task When_ActualThemeChanged_Fires_ActualTheme_Returns_New_Value()
+	{
+		// Validates that ActualTheme already reflects the new theme when
+		// ActualThemeChanged fires, matching WinUI behavior (framework.cpp:
+		// CUIElement::NotifyThemeChangedCore sets theme before
+		// RaiseActiveThemeChangedEventIfChanging raises the event).
+		var parent = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Light };
+		var child = new Border { Width = 50, Height = 50 };
+		parent.Child = child;
+
+		WindowHelper.WindowContent = parent;
+		await WindowHelper.WaitForLoaded(parent);
+
+		Assert.AreEqual(ElementTheme.Light, parent.ActualTheme, "Parent should start as Light");
+		Assert.AreEqual(ElementTheme.Light, child.ActualTheme, "Child should start as Light");
+
+		ElementTheme? parentThemeDuringEvent = null;
+		ElementTheme? childThemeDuringEvent = null;
+		ElementTheme? parentThemeSeenByChild = null;
+
+		parent.ActualThemeChanged += (s, e) =>
+		{
+			parentThemeDuringEvent = ((FrameworkElement)s).ActualTheme;
+		};
+
+		child.ActualThemeChanged += (s, e) =>
+		{
+			childThemeDuringEvent = ((FrameworkElement)s).ActualTheme;
+			// The child's handler should also see the parent's
+			// updated ActualTheme (not a stale value).
+			parentThemeSeenByChild = parent.ActualTheme;
+		};
+
+		parent.RequestedTheme = ElementTheme.Dark;
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(ElementTheme.Dark, parentThemeDuringEvent,
+			"Parent's ActualTheme should be Dark inside ActualThemeChanged handler");
+		Assert.AreEqual(ElementTheme.Dark, childThemeDuringEvent,
+			"Child's ActualTheme should be Dark inside ActualThemeChanged handler");
+		Assert.AreEqual(ElementTheme.Dark, parentThemeSeenByChild,
+			"Parent's ActualTheme should be Dark when observed from child's ActualThemeChanged handler");
+	}
+
+#if HAS_UNO
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task When_AppTheme_Changes_ActualTheme_Returns_New_Value_In_Handler()
+	{
+		// Same as above but via application-level theme change (ThemeHelper),
+		// which exercises the root→child propagation path that caused
+		// ActualTheme to return stale values before the fix.
+
+		// Ensure we start in Light. Keep the scope alive until after the
+		// Dark switch so the transition is always Light→Dark regardless
+		// of the runner's initial theme.
+		using var lightScope = ThemeHelper.UseApplicationLightTheme();
+		await WindowHelper.WaitForIdle();
+
+		var element = new Border { Width = 100, Height = 100 };
+
+		WindowHelper.WindowContent = element;
+		await WindowHelper.WaitForLoaded(element);
+
+		Assert.AreEqual(ElementTheme.Light, element.ActualTheme, "Element should start as Light");
+
+		ElementTheme? themeDuringEvent = null;
+
+		element.ActualThemeChanged += (s, e) =>
+		{
+			themeDuringEvent = ((FrameworkElement)s).ActualTheme;
+		};
+
+		using (ThemeHelper.UseApplicationDarkTheme())
+		{
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(ElementTheme.Dark, themeDuringEvent,
+				"ActualTheme should be Dark inside ActualThemeChanged handler during app theme change");
+			Assert.AreEqual(ElementTheme.Dark, element.ActualTheme,
+				"ActualTheme should remain Dark after event");
+		}
+	}
+#endif
+
+	[TestMethod]
+	public async Task When_ThemeResource_Resolved_During_ActualThemeChanged_Returns_New_Value()
+	{
+		// Mirrors the csharpmarkup ThemeBindingProvider pattern: use
+		// ActualTheme inside the ActualThemeChanged handler to pick the
+		// correct theme dictionary and resolve a resource from it.
+		// Before the fix, ActualTheme was stale during the event, so the
+		// handler would select the wrong dictionary and return the old
+		// theme's value.
+		var border = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Light };
+
+		// Local theme dictionaries with distinct sentinel colors per theme
+		var lightDict = new ResourceDictionary();
+		lightDict["TestColor"] = Colors.White;
+		var darkDict = new ResourceDictionary();
+		darkDict["TestColor"] = Colors.Black;
+		border.Resources.ThemeDictionaries["Light"] = lightDict;
+		border.Resources.ThemeDictionaries["Dark"] = darkDict;
+
+		WindowHelper.WindowContent = border;
+		await WindowHelper.WaitForLoaded(border);
+
+		Assert.AreEqual(ElementTheme.Light, border.ActualTheme, "Border should start as Light");
+
+		Windows.UI.Color? colorDuringEvent = null;
+		ElementTheme? themeDuringEvent = null;
+
+		border.ActualThemeChanged += (s, e) =>
+		{
+			var fe = (FrameworkElement)s;
+			themeDuringEvent = fe.ActualTheme;
+
+			// Use ActualTheme to pick the theme dictionary — this is the
+			// exact pattern ThemeBindingProvider uses. If ActualTheme is
+			// stale, we read from the wrong dictionary.
+			var themeKey = fe.ActualTheme == ElementTheme.Dark ? "Dark" : "Light";
+			if (fe.Resources.ThemeDictionaries.TryGetValue(themeKey, out var dict)
+				&& dict is ResourceDictionary rd
+				&& rd.TryGetValue("TestColor", out var val))
+			{
+				colorDuringEvent = (Windows.UI.Color)val;
+			}
+		};
+
+		border.RequestedTheme = ElementTheme.Dark;
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(ElementTheme.Dark, themeDuringEvent,
+			"ActualTheme should be Dark inside handler");
+
+		Assert.IsNotNull(colorDuringEvent);
+		Assert.AreEqual(Colors.Black, (Windows.UI.Color)colorDuringEvent,
+			$"Handler should have resolved the Dark dictionary (Black), " +
+			$"but got {colorDuringEvent}. " +
+			$"If White, ActualTheme was stale and the wrong dictionary was used.");
+	}
+
 	#endregion
 
 	#region Theme Resources

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
@@ -257,7 +257,7 @@ public partial class FrameworkElement
 
 		try
 		{
-			// 3. FREEZE inherited properties first (WinUI: framework.cpp line 3301-3307)
+			// 3. FREEZE inherited properties first (MUX Reference: framework.cpp line 3301-3307)
 			if (RequestedTheme != ElementTheme.Default)
 			{
 				NotifyThemeChangedForInheritedProperties(theme, freeze: true);
@@ -291,17 +291,24 @@ public partial class FrameworkElement
 				UpdateThemeBindings(ResourceUpdateReason.ThemeResource);
 			}
 
-			// 5. Propagate to children (they may push their own context)
+			// 5. Persist theme (MUX Reference: Theming.cpp line 155)
+			//    Done BEFORE propagating to children and raising the event so
+			//    that ActualTheme returns the new value both in this element's
+			//    and in descendants' ActualThemeChanged handlers. oldTheme was
+			//    already captured at the top of this method, UpdateThemeBindings
+			//    resolves resources from the pushed subtree context (not from
+			//    _theme), and PropagateThemeToChildren forwards the passed
+			//    `theme` parameter, so moving this earlier is safe.
+			SetTheme(theme);
+
+			// 6. Propagate to children (they may push their own context)
 			PropagateThemeToChildren(theme, forceRefresh);
 
-			// 6. Raise event LAST (WinUI: framework.cpp line 3317)
+			// 7. Raise event LAST (MUX Reference: framework.cpp line 3317)
 			if (effectiveThemeChanged)
 			{
 				RaiseActualThemeChanged();
 			}
-
-			// 7. Persist theme AFTER core walk (MUX Reference: Theming.cpp line 155)
-			SetTheme(theme);
 		}
 		finally
 		{


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/unoplatform/uno/pull/23178 Related to https://github.com/unoplatform/uno/issues/23177

Moves `SetTheme(theme)` before both `PropagateThemeToChildren` and `RaiseActualThemeChanged()` in `NotifyThemeChangedCore` so that `ActualTheme` returns the **new** value inside `ActualThemeChanged` event handlers.

### What was wrong

After PR #23178 (related to previous #22803 and #22887), `SetTheme(theme)` was called **after** `RaiseActualThemeChanged()`. This meant that reading `ActualTheme` inside an `ActualThemeChanged` handler returned the **old/stale** theme instead of the new one.

See, [related C# Markup Canary Tests failing](https://dev.azure.com/uno-platform/uno-private/_build/results?buildId=210809&amp;view=logs&amp;j=3f30db68-9271-53df-acd9-cedf73364d52&amp;t=ae72425f-c7be-5416-5cc2-374c342e0576) for more context

### WinUI alignment

WinUI's `framework.cpp` calls `CUIElement::NotifyThemeChangedCore(theme)` (which sets the theme) **before** `RaiseActiveThemeChangedEventIfChanging(theme)` (which fires the event). This fix aligns Uno with that ordering.

### Why moving SetTheme earlier is safe

- `oldTheme` is already captured at the top of `NotifyThemeChangedCore`
- `UpdateThemeBindings` and `PropagateThemeToChildren` use the passed `theme` parameter, not the stored theme
- Children read their own `_theme` field, not the parent's

## Tests added

- `When_ActualThemeChanged_Fires_ActualTheme_Returns_New_Value` — verifies parent and child `ActualTheme` return `Dark` inside `ActualThemeChanged` handler when `RequestedTheme` is set to `Dark`, and that the parent's `ActualTheme` is already updated when observed from the child's handler
- `When_AppTheme_Changes_ActualTheme_Returns_New_Value_In_Handler` — verifies `ActualTheme` returns `Dark` during app-level theme change via `ThemeHelper.UseApplicationDarkTheme()` (exercises root→child propagation path)
- `When_ThemeResource_Resolved_During_ActualThemeChanged_Returns_New_Value` — verifies that a local `ThemeDictionaries` resource resolves to the new theme's value when looked up via `ActualTheme` inside `ActualThemeChanged` (mimics the C# Markup `ThemeBindingProvider` pattern that triggered the original failure)