### PR TITLE
fix: Prevent win32 cycle detection in UIA provider navigation

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -861,6 +861,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\UiaChildCycle_DataGrid.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Composition\CompositionPathTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6485,6 +6489,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\AutomationPropertiesExtensions_Role.xaml.cs">
       <DependentUpon>AutomationPropertiesExtensions_Role.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\UiaChildCycle_DataGrid.xaml.cs">
+      <DependentUpon>UiaChildCycle_DataGrid.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Composition\RotatingCubeGlCanvasElement.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Composition\SimpleTriangleGlCanvasElement.cs" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml
@@ -34,8 +34,9 @@
 
             <TextBlock TextWrapping="WrapWholeWords">
                 1. Open inspect.exe and point it at 'CycleContainer' below.
-                2. Expand the children. You should see a finite tree:
-                CycleContainer → CycleChild → (no children that loop back).
+                2. Expand the children. You should see a finite tree. `CycleContainer` may show
+                both an extra text child and `CycleChild`, but neither branch should loop back to
+                `CycleContainer` or repeat indefinitely.
                 3. All RuntimeIds must be different — no node should appear as its own ancestor.
                 4. Accessibility Insights 'Control View' should also show a clean tree.
             </TextBlock>

--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml
@@ -1,0 +1,64 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Automation.UiaChildCycle_DataGrid"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Automation"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="600"
+    d:DesignWidth="600"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel Padding="20" Spacing="16">
+
+            <TextBlock
+                AutomationProperties.HeadingLevel="Level1"
+                Style="{ThemeResource TitleTextBlockStyle}"
+                Text="UIA Child-Cycle Repro (DataGrid pattern)" />
+
+            <TextBlock TextWrapping="WrapWholeWords">
+                Repro for: Desktop Automation – DataGrid reports itself as a child recursively (#461).
+                The 'CycleContainer' below hosts a custom control whose AutomationPeer intentionally
+                returns the container's peer as one of its children — the same pattern as WCT's
+                DataGridRowsPresenterAutomationPeer calling CreatePeerForElement(DataGrid).
+                Expected: inspect.exe / Accessibility Insights show a finite tree with no repeated RuntimeIds.
+                Bug:      inspect.exe shows the same RuntimeId at every level, descending infinitely.
+            </TextBlock>
+
+            <TextBlock
+                Margin="0,8,0,0"
+                AutomationProperties.HeadingLevel="Level2"
+                Style="{ThemeResource SubtitleTextBlockStyle}"
+                Text="How to verify the fix" />
+
+            <TextBlock TextWrapping="WrapWholeWords">
+                1. Open inspect.exe and point it at 'CycleContainer' below.
+                2. Expand the children. You should see a finite tree:
+                CycleContainer → CycleChild → (no children that loop back).
+                3. All RuntimeIds must be different — no node should appear as its own ancestor.
+                4. Accessibility Insights 'Control View' should also show a clean tree.
+            </TextBlock>
+
+            <!--  The repro: CycleContainer wraps a CycleChildControl whose peer loops back  -->
+            <Border
+                Padding="12"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="4">
+                <StackPanel Spacing="8">
+                    <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="CycleContainer (inspect this in inspect.exe)" />
+                    <local:UiaCycleContainer
+                        x:Name="CycleContainer"
+                        AutomationProperties.AutomationId="UiaCycleContainer"
+                        AutomationProperties.Name="CycleContainer" />
+                </StackPanel>
+            </Border>
+
+            <!--  Additional plain controls so the UIA tree has something after CycleContainer  -->
+            <Button AutomationProperties.Name="ButtonAfterCycle" Content="Button after cycle (should be a sibling, not child of CycleContainer)" />
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml.cs
@@ -1,0 +1,147 @@
+#nullable enable
+// Repro for: Desktop Automation – DataGrid reports itself as a child recursively (#461)
+//
+// WCT DataGrid architecture that causes the cycle:
+//
+//   DataGrid (UIElement)
+//     └─ DataGridAutomationPeer (canonical, Owner=DataGrid)
+//          └─ GetChildrenCore() → visual tree walk → [DataGridRowsPresenterAutomationPeer, ...]
+//
+//   DataGridRowsPresenter (UIElement)
+//     └─ DataGridRowsPresenterAutomationPeer
+//          └─ GetChildrenCore() → GridPeer.GetChildPeers()
+//              where GridPeer = CreatePeerForElement(DataGrid) = DataGridAutomationPeer
+//
+// Result: DataGrid → DataGridRowsPresenter → [DataGridAutomationPeer again] → infinite cycle.
+//
+// This sample reproduces that exact pattern with minimal custom controls so it can be
+// verified without the WCT DataGrid package.
+
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Automation;
+
+[Sample(
+	"Automation",
+	Name = "UiaChildCycle_DataGrid",
+	Description = "Repro for #461: DataGrid UIA child-cycle. A custom peer deliberately returns its container's peer as a child (replicating WCT DataGridRowsPresenter). inspect.exe must show a finite tree with no repeated RuntimeIds.",
+	IsManualTest = true)]
+public sealed partial class UiaChildCycle_DataGrid : UserControl
+{
+	public UiaChildCycle_DataGrid()
+	{
+		this.InitializeComponent();
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// UiaCycleContainer — the outer container (analogous to DataGrid)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Container control whose AutomationPeer uses the visual-tree walk, placing
+/// <see cref="UiaCycleChild"/> as a child in the UIA tree.
+/// </summary>
+public class UiaCycleContainer : UserControl
+{
+	public UiaCycleContainer()
+	{
+		var child = new UiaCycleChild();
+		// Keep a reference so the child can reach back to us.
+		child.Container = this;
+		Content = new StackPanel
+		{
+			Children =
+			{
+				new TextBlock { Text = "CycleChild (inner)" },
+				child,
+			},
+		};
+	}
+
+	protected override AutomationPeer OnCreateAutomationPeer()
+		=> new UiaCycleContainerAutomationPeer(this);
+}
+
+/// <summary>
+/// AutomationPeer for <see cref="UiaCycleContainer"/>.
+/// Uses the standard visual-tree walk (base class behaviour), so its children
+/// will include <see cref="UiaCycleChildAutomationPeer"/>.
+/// </summary>
+public class UiaCycleContainerAutomationPeer : FrameworkElementAutomationPeer
+{
+	public UiaCycleContainerAutomationPeer(UiaCycleContainer owner) : base(owner) { }
+
+	protected override string GetClassNameCore() => "UiaCycleContainer";
+	protected override AutomationControlType GetAutomationControlTypeCore()
+		=> AutomationControlType.DataGrid;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// UiaCycleChild — the inner control (analogous to DataGridRowsPresenter)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Inner control whose AutomationPeer deliberately returns its container's peer
+/// as one of its children — the exact pattern in WCT's
+/// <c>DataGridRowsPresenterAutomationPeer.GetChildrenCore()</c> which calls
+/// <c>GridPeer.GetChildPeers()</c> where GridPeer = CreatePeerForElement(DataGrid).
+/// </summary>
+public class UiaCycleChild : UserControl
+{
+	/// <summary>Back-reference to the container (set by <see cref="UiaCycleContainer"/>).</summary>
+	internal UiaCycleContainer? Container { get; set; }
+
+	public UiaCycleChild()
+	{
+		Content = new TextBlock { Text = "I am the cycle child — my peer returns the container peer as a child" };
+	}
+
+	protected override AutomationPeer OnCreateAutomationPeer()
+		=> new UiaCycleChildAutomationPeer(this);
+}
+
+/// <summary>
+/// AutomationPeer for <see cref="UiaCycleChild"/>.
+/// Overrides <see cref="GetChildrenCore"/> to return the <em>container's</em>
+/// automation peer in addition to normal children — this is the exact bug pattern
+/// from WCT DataGrid.
+/// </summary>
+public class UiaCycleChildAutomationPeer : FrameworkElementAutomationPeer
+{
+	public UiaCycleChildAutomationPeer(UiaCycleChild owner) : base(owner) { }
+
+	protected override string GetClassNameCore() => "UiaCycleChild";
+	protected override AutomationControlType GetAutomationControlTypeCore()
+		=> AutomationControlType.Custom;
+
+	protected override IList<AutomationPeer> GetChildrenCore()
+	{
+		var peers = new List<AutomationPeer>();
+
+		// Normal visual children first (the TextBlock — won't have a peer, will be skipped)
+		if (base.GetChildrenCore() is { } baseChildren)
+		{
+			peers.AddRange(baseChildren);
+		}
+
+		// BUG PATTERN: deliberately inject the container's peer as a child.
+		// This replicates DataGridRowsPresenterAutomationPeer returning
+		// DataGridAutomationPeer via CreatePeerForElement(DataGrid).
+		var container = ((UiaCycleChild)Owner).Container;
+		if (container is not null)
+		{
+			var containerPeer = container.GetOrCreateAutomationPeer();
+			if (containerPeer is not null)
+			{
+				peers.Add(containerPeer);
+			}
+		}
+
+		return peers;
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml.cs
@@ -123,7 +123,8 @@ public class UiaCycleChildAutomationPeer : FrameworkElementAutomationPeer
 	{
 		var peers = new List<AutomationPeer>();
 
-		// Normal visual children first (the TextBlock — won't have a peer, will be skipped)
+		// Preserve any normal visual children first. For example, the TextBlock may
+		// contribute its own automation peer via base.GetChildrenCore().
 		if (base.GetChildrenCore() is { } baseChildren)
 		{
 			peers.AddRange(baseChildren);
@@ -135,7 +136,7 @@ public class UiaCycleChildAutomationPeer : FrameworkElementAutomationPeer
 		var container = ((UiaCycleChild)Owner).Container;
 		if (container is not null)
 		{
-			var containerPeer = container.GetOrCreateAutomationPeer();
+			var containerPeer = FrameworkElementAutomationPeer.CreatePeerForElement(container);
 			if (containerPeer is not null)
 			{
 				peers.Add(containerPeer);

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -536,12 +536,23 @@ internal class Win32RawElementProvider :
 			return null;
 		}
 
+		HashSet<Win32RawElementProvider>? ancestors = null;
 		for (var i = 0; i < children.Count; i++)
 		{
 			var provider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
-			if (provider is not null && !ReferenceEquals(provider, this))
+			if (provider is not null)
 			{
-				return provider;
+				ancestors ??= BuildAncestorSet();
+				if (!ancestors.Contains(provider))
+				{
+					return provider;
+				}
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn(
+						$"[UIA] Cycle detected: skipping child {provider.DescribeElement()} " +
+						$"(runtimeId={provider._runtimeId}) of {DescribeElement()} — it is an ancestor");
+				}
 			}
 		}
 		return null;
@@ -555,12 +566,23 @@ internal class Win32RawElementProvider :
 			return null;
 		}
 
+		HashSet<Win32RawElementProvider>? ancestors = null;
 		for (var i = children.Count - 1; i >= 0; i--)
 		{
 			var provider = _accessibility.GetProviderForPeer(children[i], resolveEventsSource: true);
-			if (provider is not null && !ReferenceEquals(provider, this))
+			if (provider is not null)
 			{
-				return provider;
+				ancestors ??= BuildAncestorSet();
+				if (!ancestors.Contains(provider))
+				{
+					return provider;
+				}
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn(
+						$"[UIA] Cycle detected: skipping child {provider.DescribeElement()} " +
+						$"(runtimeId={provider._runtimeId}) of {DescribeElement()} — it is an ancestor");
+				}
 			}
 		}
 		return null;
@@ -582,15 +604,20 @@ internal class Win32RawElementProvider :
 
 		var myPeer = GetAutomationPeer();
 		var foundSelf = false;
+		HashSet<Win32RawElementProvider>? ancestors = null;
 
 		for (var i = 0; i < siblings.Count; i++)
 		{
 			if (foundSelf)
 			{
 				var provider = _accessibility.GetProviderForPeer(siblings[i], resolveEventsSource: true);
-				if (provider is not null && !ReferenceEquals(provider, this))
+				if (provider is not null)
 				{
-					return provider;
+					ancestors ??= BuildAncestorSet();
+					if (!ancestors.Contains(provider))
+					{
+						return provider;
+					}
 				}
 			}
 			else if (IsSamePeer(siblings[i], myPeer))
@@ -617,6 +644,7 @@ internal class Win32RawElementProvider :
 
 		var myPeer = GetAutomationPeer();
 		Win32RawElementProvider? previous = null;
+		HashSet<Win32RawElementProvider>? ancestors = null;
 
 		for (var i = 0; i < siblings.Count; i++)
 		{
@@ -625,12 +653,44 @@ internal class Win32RawElementProvider :
 				return previous;
 			}
 			var provider = _accessibility.GetProviderForPeer(siblings[i], resolveEventsSource: true);
-			if (provider is not null && !ReferenceEquals(provider, this))
+			if (provider is not null)
 			{
-				previous = provider;
+				ancestors ??= BuildAncestorSet();
+				if (!ancestors.Contains(provider))
+				{
+					previous = provider;
+				}
 			}
 		}
 		return null;
+	}
+
+	/// <summary>
+	/// Builds a set containing this provider and all its ancestors in the UIA tree.
+	/// Used by child/sibling navigation to detect and break cycles where a descendant
+	/// peer resolves to an ancestor's provider (e.g. WCT DataGrid whose
+	/// DataGridRowsPresenterAutomationPeer returns the DataGrid's canonical peer
+	/// as a child via CreatePeerForElement).
+	/// </summary>
+	private HashSet<Win32RawElementProvider> BuildAncestorSet()
+	{
+		var ancestors = new HashSet<Win32RawElementProvider>(ReferenceEqualityComparer.Instance);
+		ancestors.Add(this);
+		var current = FindParentProvider();
+		var maxDepth = 200;
+		while (current is not null && maxDepth-- > 0)
+		{
+			if (!ancestors.Add(current))
+			{
+				break; // cycle in parent chain itself
+			}
+			if (current._isRoot)
+			{
+				break;
+			}
+			current = current.FindParentProvider();
+		}
+		return ancestors;
 	}
 
 	/// <summary>


### PR DESCRIPTION
GitHub Issue:** partially improves https://github.com/unoplatform/kahua-private/issues/461

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
