### PR TITLE
fix(xaml-reader): set properties on FrameworkTemplate (e.g. ControlTemplate.TargetType)

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader_FrameworkTemplate.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader_FrameworkTemplate.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
+{
+	[TestClass]
+	public class Given_XamlReader_FrameworkTemplate
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_ControlTemplate_TargetType()
+		{
+			var template = (ControlTemplate)XamlReader.Load("""
+				<ControlTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+								 TargetType="ContentControl">
+					<Border Background="Red" />
+				</ControlTemplate>
+				""");
+
+			Assert.IsNotNull(template);
+			Assert.AreEqual(typeof(ContentControl), template.TargetType);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_ControlTemplate_TargetType_Nested_In_Style()
+		{
+			var style = (Style)XamlReader.Load("""
+				<Style xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					   TargetType="ContentControl">
+					<Setter Property="Template">
+						<Setter.Value>
+							<ControlTemplate TargetType="ContentControl">
+								<Border Background="Red" />
+							</ControlTemplate>
+						</Setter.Value>
+					</Setter>
+				</Style>
+				""");
+
+			Assert.IsNotNull(style);
+
+			var templateSetter = style.Setters
+				.OfType<Setter>()
+				.Single(s => s.Property == ContentControl.TemplateProperty);
+			var template = (ControlTemplate)templateSetter.Value;
+
+			Assert.IsNotNull(template);
+			Assert.AreEqual(typeof(ContentControl), template.TargetType);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -245,8 +245,13 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				// reported even if we're not materializing the content explicitly.
 				ValidateContent(unknownContent?.Objects.FirstOrDefault());
 
-				var created = Activator.CreateInstance(type, /* owner: */null, /* factory: */builder);
+				var created = Activator.CreateInstance(type, /* owner: */null, /* factory: */builder)!;
 				TrySetContextualProperties(created, control);
+
+				foreach (var member in control.Members.Where(m => m != unknownContent && m != initializationMember))
+				{
+					ProcessNamedMember(control, created, member, rootInstance ?? created, settings);
+				}
 
 				return created;
 			}


### PR DESCRIPTION
**GitHub Issue:** closes #17434

## PR Type:

🐞 Bugfix

## What changed? 🚀

`XamlReader.Load` now sets XAML-declared properties on `FrameworkTemplate` subclasses, matching WinUI and the compiled XAML path.

Before this fix, the `FrameworkTemplate` branch in `XamlObjectBuilder.LoadObject` (`src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs`) only consumed the inner unknown-content node (used to build the template factory) and returned immediately — it never iterated `control.Members` to assign sibling members. The most visible casualty was `ControlTemplate.TargetType`, which stayed `null` after a runtime parse, even though every other branch in the same `LoadObject` method (`MarkupExtension`, `ResourceDictionary`, generic fallthrough) already iterates members.

The fix mirrors the `ResourceDictionary` branch pattern: after creating the template instance and applying contextual properties, iterate `control.Members` (excluding the unknown-content and `_Initialization` directive) and call `ProcessNamedMember` for each. The existing reflection-based `GetMemberProperty` path handles `ControlTemplate.TargetType` (a plain `Type?` CLR property) without any new conversion logic; `DataTemplate` and `ItemsPanelTemplate` have no extra XAML-settable properties so the loop is a no-op for them, but they remain compatible if more properties are added later.

Two parity runtime tests were added under `Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup.Given_XamlReader_FrameworkTemplate`, with no `#if HAS_UNO` gate so they also run against native WinUI:

- `When_ControlTemplate_TargetType` — standalone `<ControlTemplate TargetType="ContentControl">` asserts the parsed template's `TargetType`.
- `When_ControlTemplate_TargetType_Nested_In_Style` — `<Style>` containing a `Setter Property="Template"` whose value is a `<ControlTemplate TargetType="…">`, exercising the real-world style/setter path.

Both tests pass on WinUI native (`/winui-runtime-tests`) before and after the fix, fail on Uno before the fix, and pass on Uno after the fix. The full `Given_XamlReader` class (52 tests) continues to pass on Skia Desktop — no regressions.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)