### PR TITLE
fix(skia): Stop FPS indicator from waking renderer when idle

### DIFF
--- a/src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs
+++ b/src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs
@@ -195,6 +195,10 @@ internal static class SkiaRenderHelper
 		private int _consecutiveIdleTicks;
 		private bool _isIdle;
 		private bool _timerRunning;
+		// Set when TimerTick triggers the final "show Idle" redraw, consumed by the next
+		// BeginFrame so that one render doesn't restart the 1 Hz timer and re-enter the
+		// active state we just left.
+		private bool _idleRedrawPending;
 
 		public FpsHelper(int numberOfFramesToCalculateFrameTime = 10)
 		{
@@ -224,7 +228,14 @@ internal static class SkiaRenderHelper
 			_measureThisFrame = IsEnabled;
 			if (_measureThisFrame)
 			{
-				if (!_timerRunning)
+				if (_idleRedrawPending)
+				{
+					// This render is the final "show Idle" pass we asked for from TimerTick.
+					// Restarting the 1 Hz timer here would immediately observe the just-bumped
+					// frame generation and flip _isIdle back to false, defeating idle detection.
+					_idleRedrawPending = false;
+				}
+				else if (!_timerRunning)
 				{
 					_fpsTimer.Change(TimeSpan.Zero, TimeSpan.FromSeconds(1));
 					_timerRunning = true;
@@ -478,12 +489,12 @@ internal static class SkiaRenderHelper
 				if (_consecutiveIdleTicks >= 2)
 				{
 					_isIdle = true;
-					RequestRedraw?.Invoke();
+					_idleRedrawPending = true;
 					_fpsTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 					_timerRunning = false;
+					RequestRedraw?.Invoke();
 					return;
 				}
-				RequestRedraw?.Invoke();
 			}
 			else
 			{
@@ -510,6 +521,7 @@ internal static class SkiaRenderHelper
 			_lastTimerTickGeneration = Interlocked.Read(ref _currentFrameGeneration);
 			_consecutiveIdleTicks = 0;
 			_isIdle = false;
+			_idleRedrawPending = false;
 			Fps = 0;
 			FrameTime = 0;
 			DroppedFrames = 0;


### PR DESCRIPTION
## Summary

Fixes #23204.

The FPS diagnostic panel is meant to do a single final redraw to "Idle" and then go quiet. In practice the numeric values kept updating every 2-3 seconds, indicating the panel itself was waking the renderer continuously.

Two compounding bugs in `FpsHelper` (`src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs`):

- **Bug A — first-idle-tick `RequestRedraw` sabotaged idle detection.** The `noNewFrames` branch of `TimerTick` called `RequestRedraw` on every first idle tick. The resulting render flowed through `OnFrameRecorded`, which bumped `_currentFrameGeneration`. The next tick observed the new generation, decided `noNewFrames = false`, and reset `_consecutiveIdleTicks = 0`. The counter could never reach 2 and idle was never entered. (Leftover from the original idle-indicator commit, where the redraw was needed before the `>= 2` early-return path was introduced.)
- **Bug B — final idle redraw restarted the 1 Hz timer via `BeginFrame`.** Even with Bug A fixed, the legitimate final idle redraw flowed through `Draw()` -> `RenderPicture()` -> `BeginFrame()`, which blindly restarted the timer because `!_timerRunning`. The immediate `TimeSpan.Zero` tick saw the just-recorded idle frame's bumped generation, cleared `_isIdle`, and the cycle restarted every 2-3 seconds.

## Changes

- Removed the spurious first-idle-tick `RequestRedraw` call in `TimerTick`.
- Added an `_idleRedrawPending` flag set when triggering the final idle redraw and consumed by `BeginFrame` to skip the timer restart for that one render.
- Cleared the flag in `StopTimer` so disable/re-enable cycles start fresh.

## Test plan

No automated runtime test covers this — it's a timing/wakeup behaviour. Manual verification on Skia desktop:

- [ ] Build `Uno.UI-Skia-only.slnf`.
- [ ] Run SamplesApp on Skia desktop and enable the FPS counter.
- [ ] Active rendering: numbers update once per second, dark background.
- [ ] Idle entry: stop interacting; within ~2 seconds the panel switches to the tinted "Idle" background and the bottom-right cell reads "Idle".
- [ ] Idle stability: leave idle for 30+ seconds; numbers stay frozen and the panel does not flicker. Confirm zero render wake-ups (a temporary log in `Render()` or watching CPU/GPU usage).
- [ ] Resume: interact again; numbers update on the next render and the background returns to the dark variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)