### PR TITLE
chore: Remove PDB files when DebugType is none or DebugSymbols is false

### DIFF
--- a/build/nuget/uno.winui.runtime-replace.targets
+++ b/build/nuget/uno.winui.runtime-replace.targets
@@ -102,4 +102,19 @@
 	</ItemGroup>
 
 
+	<Target Name="RemovePdbFilesFromOutput"
+			AfterTargets="ReplaceUnoRuntime;ResolveLockFileCopyLocalFiles"
+			Condition="'$(DebugType)' == 'none' or '$(DebugSymbols)' == 'false'">
+		<ItemGroup>
+			<_ReferenceCopyLocalPathsPdbToRemove
+				Include="@(ReferenceCopyLocalPaths)"
+				Condition="'%(Extension)' == '.pdb'" />
+			<_RuntimeTargetsCopyLocalItemsPdbToRemove
+				Include="@(RuntimeTargetsCopyLocalItems)"
+				Condition="'%(Extension)' == '.pdb'" />
+
+			<ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsPdbToRemove)" />
+			<RuntimeTargetsCopyLocalItems Remove="@(_RuntimeTargetsCopyLocalItemsPdbToRemove)" />
+		</ItemGroup>
+	</Target>
 </Project>


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/459

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Adds an MSBuild target `RemovePdbFilesFromOutput` in `uno.winui.runtime-replace.targets` that removes `.pdb` files from `ReferenceCopyLocalPaths` and `RuntimeTargetsCopyLocalItems` when `$(DebugType)` is `none` or `$(DebugSymbols)` is `false`, preventing PDB files from being included in the output.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)