### PR TITLE
test: add app-level theme change scenario + fix DatePicker/TimePicker theme test failures

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -386,6 +386,77 @@ public class Given_ElementTheme
 			$"If White, ActualTheme was stale and the wrong dictionary was used.");
 	}
 
+#if HAS_UNO
+	[TestMethod]
+	[RequiresFullWindow]
+	public async Task When_AppTheme_Changes_ThemeResource_Resolved_During_Event_Returns_New_Value()
+	{
+		// Exact CSharpMarkup ThemeBindingProvider scenario:
+		// 1. App-level theme changes (not local RequestedTheme)
+		// 2. ActualThemeChanged fires on element
+		// 3. Handler reads element.ActualTheme to pick theme dictionary
+		// 4. Resolves resource from the chosen dictionary
+		//
+		// Before the fix (SetTheme after RaiseActualThemeChanged), step 3
+		// returned the OLD theme, causing step 4 to select the wrong
+		// dictionary and produce stale colors.
+		//
+		// MUX Reference: framework.cpp CUIElement::NotifyThemeChangedCore
+		// sets theme BEFORE raising the event.
+
+		using var lightScope = ThemeHelper.UseApplicationLightTheme();
+		await WindowHelper.WaitForIdle();
+
+		var element = new Border { Width = 100, Height = 100 };
+
+		// Set up theme dictionaries with distinct sentinel values
+		var lightDict = new ResourceDictionary();
+		lightDict["SentinelColor"] = Colors.White;
+		var darkDict = new ResourceDictionary();
+		darkDict["SentinelColor"] = Colors.Black;
+		element.Resources.ThemeDictionaries["Light"] = lightDict;
+		element.Resources.ThemeDictionaries["Dark"] = darkDict;
+
+		WindowHelper.WindowContent = element;
+		await WindowHelper.WaitForLoaded(element);
+
+		Assert.AreEqual(ElementTheme.Light, element.ActualTheme, "Should start Light");
+
+		ElementTheme? themeDuringEvent = null;
+		Windows.UI.Color? colorDuringAppThemeEvent = null;
+
+		element.ActualThemeChanged += (s, e) =>
+		{
+			var fe = (FrameworkElement)s;
+			themeDuringEvent = fe.ActualTheme;
+
+			// This is what CSharpMarkup's ThemeBindingProvider does:
+			// read ActualTheme, pick the matching dictionary, resolve resource.
+			var themeKey = fe.ActualTheme == ElementTheme.Dark ? "Dark" : "Light";
+			if (fe.Resources.ThemeDictionaries.TryGetValue(themeKey, out var dict)
+				&& dict is ResourceDictionary rd
+				&& rd.TryGetValue("SentinelColor", out var val))
+			{
+				colorDuringAppThemeEvent = (Windows.UI.Color)val;
+			}
+		};
+
+		using (ThemeHelper.UseApplicationDarkTheme())
+		{
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(ElementTheme.Dark, themeDuringEvent,
+				"ActualTheme should be Dark inside handler during app-level theme change");
+			Assert.IsNotNull(colorDuringAppThemeEvent,
+				"Resource should have been resolved during the event");
+			Assert.AreEqual(Colors.Black, (Windows.UI.Color)colorDuringAppThemeEvent,
+				$"Handler should resolve from Dark dictionary (Black), " +
+				$"but got {colorDuringAppThemeEvent}. " +
+				$"If White, ActualTheme was stale (CSharpMarkup canary scenario).");
+		}
+	}
+#endif
+
 	#endregion
 
 	#region Theme Resources

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -401,6 +401,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 #if __IOS__
 		[TestMethod]
+		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/15263")]
 		public async Task When_App_Theme_Dark_Native_Flyout_Theme()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -323,6 +323,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 #if __APPLE_UIKIT__
 		[TestMethod]
+		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/15263")]
 		public async Task When_App_Theme_Dark_Native_Flyout_Theme()
 		{


### PR DESCRIPTION
## Summary

Adds a runtime test covering the exact CSharpMarkup `ThemeBindingProvider` pattern: app-level theme change → `ActualThemeChanged` fires → handler reads `ActualTheme` to select theme dictionary → resolves resource from it.

Also fixes iOS DatePicker/TimePicker [native flyout theme tests](https://dev.azure.com/uno-platform/Uno%20Platform/_testManagement/runs?runId=3710141&resultId=100000&_a=resultSummary) that fail because `ThemeHelper.UseApplicationDarkTheme()` now requires `[RequiresFullWindow]`.

## What

- New test: `When_AppTheme_Changes_ThemeResource_Resolved_During_Event_Returns_New_Value`
- Validates that `ActualTheme` returns the **new** theme (not stale) when resolved inside `ActualThemeChanged` during an **app-level** theme switch, and that ThemeResource lookup from the correct dictionary succeeds.
- Adds missing `[RequiresFullWindow]` attribute to `Given_DatePicker.When_App_Theme_Dark_Native_Flyout_Theme` (iOS) and `Given_TimePicker.When_App_Theme_Dark_Native_Flyout_Theme` (Apple UIKit).

## Why

PR https://github.com/unoplatform/uno/pull/23197 fixed the root cause (`SetTheme` was called **after** `RaiseActualThemeChanged` instead of before) and included tests for:
- **Local** `RequestedTheme` change with resource resolution (`When_ThemeResource_Resolved_During_ActualThemeChanged_Returns_New_Value`)
- **App-level** theme change without resource resolution (`When_AppTheme_Changes_ActualTheme_Returns_New_Value_In_Handler`)

This PR adds the missing combination: **app-level** theme change **with** resource resolution — which is the exact scenario that caused the CSharpMarkup canary regression.

The DatePicker/TimePicker fix addresses `ThemeHelper.AssertFullWindowForApplicationTheme()` guard failures introduced by the same theme infrastructure changes — the tests call `UseApplicationDarkTheme()` which now requires the test method to be annotated with `[RequiresFullWindow]`.

## Related

- Fixes the gap identified in hardening coverage for the [CSharpMarkup canary failure](https://dev.azure.com/uno-platform/uno-private/_build/results?buildId=210875&amp;view=logs&amp;j=3f30db68-9271-53df-acd9-cedf73364d52&amp;t=ae72425f-c7be-5416-5cc2-374c342e0576)
- Related to https://github.com/unoplatform/uno/pull/23197 (fix: set theme before raising ActualThemeChanged event)
- Related to https://github.com/unoplatform/uno/pull/23178 (fix: ThemeResource first-walk issue)