### PR TITLE
feat(win32): VSync and dedicated render thread

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -176,6 +176,7 @@ DwmExtendFrameIntoClientArea
 DwmSetWindowAttribute
 DwmDefWindowProc
 DWM_SYSTEMBACKDROP_TYPE
+DwmFlush
 EmptyClipboard
 EnableMouseInPointer
 EndPaint

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -49,13 +49,7 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 			_displayInformation?.NotifyDpiChanged();
 		}
 
-		if (_refreshRate != oldRefreshRate)
-		{
-			if (FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
-			{
-				_framePacer.UpdateTargetFps(_refreshRate);
-			}
-		}
+		// _refreshRate is still tracked for display information consumers.
 	}
 
 	private unsafe (DisplayInfo, float) GetDisplayInfo()

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -49,7 +49,14 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 			_displayInformation?.NotifyDpiChanged();
 		}
 
-		// _refreshRate is still tracked for display information consumers.
+		if (_refreshRate != oldRefreshRate
+			&& FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
+		{
+			// Renderers that pace via VSync (GL wglSwapInterval, software DwmFlush) are
+			// already aligned to the refresh rate and treat this as a no-op. The software
+			// DwmFlush degraded fallback (FramePacer) uses it to retarget.
+			_renderer?.UpdateRefreshRate(_refreshRate);
+		}
 	}
 
 	private unsafe (DisplayInfo, float) GetDisplayInfo()

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -52,11 +52,8 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 		if (_refreshRate != oldRefreshRate
 			&& FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
 		{
-			// Presentation is paced on the render thread by hardware VSync (GL wglSwapInterval,
-			// software DwmFlush), which blocks until the monitor's actual refresh — so those
-			// renderers are already aligned and ignore this. Only the software DwmFlush degraded
-			// fallback paces with a software timer (FramePacer) instead of VSync, and so needs the
-			// new rate to stay aligned; that's the one path UpdateRefreshRate actually retargets.
+			// VSync-paced renderers are already aligned to the monitor's refresh and ignore this;
+			// only the software-timer-paced DwmFlush degraded fallback actually retargets.
 			_renderer?.UpdateRefreshRate(_refreshRate);
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -52,9 +52,11 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 		if (_refreshRate != oldRefreshRate
 			&& FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
 		{
-			// Renderers that pace via VSync (GL wglSwapInterval, software DwmFlush) are
-			// already aligned to the refresh rate and treat this as a no-op. The software
-			// DwmFlush degraded fallback (FramePacer) uses it to retarget.
+			// Presentation is paced on the render thread by hardware VSync (GL wglSwapInterval,
+			// software DwmFlush), which blocks until the monitor's actual refresh — so those
+			// renderers are already aligned and ignore this. Only the software DwmFlush degraded
+			// fallback paces with a software timer (FramePacer) instead of VSync, and so needs the
+			// new rate to stay aligned; that's the one path UpdateRefreshRate actually retargets.
 			_renderer?.UpdateRefreshRate(_refreshRate);
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -109,6 +109,9 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 	private unsafe void OnRenderingNegativePathReevaluated(object? sender, SKPath path)
 	{
+		Debug.Assert(Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess,
+			$"{nameof(OnRenderingNegativePathReevaluated)} must run on the UI thread.");
+
 		if (_presenter.Content is not Win32NativeWindow window)
 		{
 			return;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32RenderPacer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32RenderPacer.cs
@@ -8,27 +8,35 @@ using Windows.Win32.Foundation;
 namespace Uno.UI.Runtime.Skia.Win32;
 
 /// <summary>
-/// Paces a render thread to the DWM compositor's vsync via <see cref="PInvoke.DwmFlush"/>.
-/// Used by renderers whose present returns without blocking (software BitBlt, Vulkan MAILBOX),
-/// so the dedicated render thread doesn't spin and render frames the compositor just discards.
-/// After repeated DwmFlush failures (DWM paused, RDP reconnect, fast user switch, GPU TDR) it
-/// degrades permanently to a timer-driven <see cref="FramePacer"/> — losing vsync alignment
-/// beats risking a hung render thread on every frame.
+/// Paces a render thread, either to the DWM compositor's vsync via <see cref="PInvoke.DwmFlush"/>
+/// or to a fixed frame rate via a timer-driven <see cref="FramePacer"/>. Used by renderers whose
+/// present returns without blocking (software BitBlt, Vulkan MAILBOX) so the dedicated render thread
+/// doesn't spin and render frames the compositor just discards.
+/// <para>
+/// When following the refresh rate it blocks on <see cref="PInvoke.DwmFlush"/>; after repeated
+/// failures (DWM paused, RDP reconnect, fast user switch, GPU TDR) it degrades permanently to the
+/// timer — losing vsync alignment beats a hung render thread. Otherwise it always paces with the
+/// timer, honoring a custom FeatureConfiguration.CompositionTarget.FrameRate
+/// (SetFrameRateAsScreenRefreshRate = false).
+/// </para>
 /// </summary>
-internal sealed class Win32VSyncPacer : IDisposable
+internal sealed class Win32RenderPacer : IDisposable
 {
 	// After this many consecutive DwmFlush failures we stop calling DwmFlush and pace via the timer.
 	private const int DwmFlushFailureThreshold = 3;
 
+	private readonly bool _followRefreshRate;
 	private readonly FramePacer _framePacer;
 	private readonly AutoResetEvent _frameDeadlineReached = new(false);
 
 	private int _consecutiveDwmFlushFailures;
 	private bool _dwmFlushDegraded;
 
-	/// <param name="fps">Target frame rate for the degraded timer fallback.</param>
-	public Win32VSyncPacer(double fps)
+	/// <param name="fps">Timer target — the degraded fallback, or the active pacer when not following the refresh rate.</param>
+	/// <param name="followRefreshRate">True: pace to the display refresh via DwmFlush. False: pace to <paramref name="fps"/> via the timer.</param>
+	public Win32RenderPacer(double fps, bool followRefreshRate)
 	{
+		_followRefreshRate = followRefreshRate;
 		_framePacer = new FramePacer(fps, () => _frameDeadlineReached.Set());
 	}
 
@@ -39,14 +47,16 @@ internal sealed class Win32VSyncPacer : IDisposable
 	public void OnFrameStart() => _framePacer.OnFrameStart();
 
 	/// <summary>
-	/// Blocks until the compositor's next vsync (or the <see cref="FramePacer"/> deadline once
-	/// degraded). Call after presenting the frame.
+	/// Blocks until it's time for the next frame — the compositor's next vsync when following the
+	/// refresh rate, otherwise the timer deadline. Call after presenting the frame.
 	/// </summary>
-	public void WaitForVSync()
+	public void WaitForNextFrame()
 	{
-		var paceViaFramePacer = _dwmFlushDegraded;
+		// When not following the display refresh, pace via the timer at the configured FrameRate;
+		// DwmFlush would instead lock the loop to the refresh rate.
+		var paceViaFramePacer = !_followRefreshRate || _dwmFlushDegraded;
 
-		if (!_dwmFlushDegraded)
+		if (_followRefreshRate && !_dwmFlushDegraded)
 		{
 			var dwmFlushResult = PInvoke.DwmFlush();
 			if (dwmFlushResult.Failed)

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32VSyncPacer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32VSyncPacer.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using Uno.Foundation.Logging;
+using Uno.UI.Runtime.Skia.Hosting;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+/// <summary>
+/// Paces a render thread to the DWM compositor's vsync via <see cref="PInvoke.DwmFlush"/>.
+/// Used by renderers whose present returns without blocking (software BitBlt, Vulkan MAILBOX),
+/// so the dedicated render thread doesn't spin and render frames the compositor just discards.
+/// After repeated DwmFlush failures (DWM paused, RDP reconnect, fast user switch, GPU TDR) it
+/// degrades permanently to a timer-driven <see cref="FramePacer"/> — losing vsync alignment
+/// beats risking a hung render thread on every frame.
+/// </summary>
+internal sealed class Win32VSyncPacer : IDisposable
+{
+	// After this many consecutive DwmFlush failures we stop calling DwmFlush and pace via the timer.
+	private const int DwmFlushFailureThreshold = 3;
+
+	private readonly FramePacer _framePacer;
+	private readonly AutoResetEvent _frameDeadlineReached = new(false);
+
+	private int _consecutiveDwmFlushFailures;
+	private bool _dwmFlushDegraded;
+
+	/// <param name="fps">Target frame rate for the degraded timer fallback.</param>
+	public Win32VSyncPacer(double fps)
+	{
+		_framePacer = new FramePacer(fps, () => _frameDeadlineReached.Set());
+	}
+
+	/// <summary>
+	/// Anchors the absolute target tick at the start of every frame so a subsequent degraded
+	/// <see cref="FramePacer"/> wait schedules at the next deadline (no drift). Call before presenting.
+	/// </summary>
+	public void OnFrameStart() => _framePacer.OnFrameStart();
+
+	/// <summary>
+	/// Blocks until the compositor's next vsync (or the <see cref="FramePacer"/> deadline once
+	/// degraded). Call after presenting the frame.
+	/// </summary>
+	public void WaitForVSync()
+	{
+		var paceViaFramePacer = _dwmFlushDegraded;
+
+		if (!_dwmFlushDegraded)
+		{
+			var dwmFlushResult = PInvoke.DwmFlush();
+			if (dwmFlushResult.Failed)
+			{
+				_consecutiveDwmFlushFailures++;
+				this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
+
+				if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+				{
+					_dwmFlushDegraded = true;
+					this.LogWarn()?.Warn(
+						$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
+						$"falling back to FramePacer-driven pacing at {_framePacer.TargetIntervalMs:F1} ms. " +
+						"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
+				}
+
+				paceViaFramePacer = true;
+			}
+			else
+			{
+				_consecutiveDwmFlushFailures = 0;
+			}
+		}
+
+		if (paceViaFramePacer)
+		{
+			_framePacer.RequestFrame();
+			_frameDeadlineReached.WaitOne();
+		}
+	}
+
+	/// <summary>
+	/// Retargets the degraded <see cref="FramePacer"/> (e.g. when the screen refresh rate changes).
+	/// </summary>
+	public void UpdateTargetFps(double fps) => _framePacer.UpdateTargetFps(fps);
+
+	public void Dispose()
+	{
+		_framePacer.Dispose();
+		_frameDeadlineReached.Dispose();
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading;
+using SkiaSharp;
+using Uno.Foundation.Logging;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal partial class Win32WindowWrapper
+{
+	/// <summary>
+	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt).
+	/// The UI thread records SKPictures and signals this thread to present them.
+	/// This mirrors the pattern used by WPF (milcore render thread) and the
+	/// Uno Android GL thread.
+	/// </summary>
+	private sealed class RenderThread : IDisposable
+	{
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _frameSignal = new(false);
+		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly IRenderer _renderer;
+		private readonly Func<(SKPath clipPath, int width, int height)?> _drawFrame;
+		private readonly Action<SKPath> _onClipPathUpdated;
+		private readonly Action _onFramePresented;
+		private volatile bool _disposed;
+
+		internal RenderThread(
+			IRenderer renderer,
+			Func<(SKPath, int, int)?> drawFrame,
+			Action<SKPath> onClipPathUpdated,
+			Action onFramePresented)
+		{
+			_renderer = renderer;
+			_drawFrame = drawFrame;
+			_onClipPathUpdated = onClipPathUpdated;
+			_onFramePresented = onFramePresented;
+			_thread = new Thread(RenderLoop) { Name = "Uno Render Thread", IsBackground = true };
+			_thread.Start();
+		}
+
+		/// <summary>
+		/// Signals the render thread that a new frame is available for presentation.
+		/// Multiple calls while the thread is busy coalesce into a single wake-up
+		/// (AutoResetEvent semantics). Resets the present-completion event before
+		/// signaling so a subsequent <see cref="WaitForNextPresent"/> always observes
+		/// the next presentation, never a stale one from a prior frame.
+		/// </summary>
+		internal void SignalNewFrame()
+		{
+			_presentedEvent.Reset();
+			_frameSignal.Set();
+		}
+
+		/// <summary>
+		/// Blocks the calling thread until the render thread finishes presenting a frame.
+		/// Used by ShowCore to ensure the first frame is painted before the window is shown.
+		/// Returns true if a present completed within the timeout, false otherwise.
+		/// </summary>
+		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+		private void RenderLoop()
+		{
+			while (!_disposed)
+			{
+				_frameSignal.WaitOne();
+				if (_disposed)
+				{
+					break;
+				}
+
+				_renderer.StartPaint();
+				try
+				{
+					var result = _drawFrame();
+					if (result is { } frame)
+					{
+						var (clipPath, width, height) = frame;
+						_onClipPathUpdated(clipPath);
+						_renderer.CopyPixels(width, height); // SwapBuffers/BitBlt — may block for VSync
+
+						_presentedEvent.Set();
+						_onFramePresented();
+					}
+				}
+				catch (Exception ex)
+				{
+					typeof(RenderThread).LogError()?.Error($"Render thread error: {ex}");
+				}
+				finally
+				{
+					_renderer.EndPaint();
+				}
+			}
+		}
+
+		public void Dispose()
+		{
+			_disposed = true;
+			_frameSignal.Set(); // Unblock if waiting
+
+			// 250 ms covers a present (~16 ms at 60 Hz) plus slack. If that fails, the GPU
+			// is likely hung. Wait one more bounded interval (2 s) and then abandon: leaving
+			// the render thread (background, marked at construction) blocked is preferable
+			// to hanging the UI thread on window close. The leaked synchronization
+			// primitives and renderer outlive the thread, so the OS reclaims them at exit.
+			var joined = _thread.Join(timeout: TimeSpan.FromMilliseconds(250));
+			if (!joined)
+			{
+				typeof(RenderThread).LogWarn()?.Warn(
+					"Render thread did not exit within 250 ms during dispose; waiting up to 2 s more " +
+					"before abandoning. This usually indicates a stuck GPU present " +
+					"(SwapBuffers/BitBlt/DwmFlush blocked).");
+
+				joined = _thread.Join(timeout: TimeSpan.FromSeconds(2));
+				if (!joined)
+				{
+					typeof(RenderThread).LogError()?.Error(
+						"Render thread still alive after 2 s; abandoning to keep window close responsive. " +
+						"Leaking _frameSignal, _presentedEvent and renderer until process exit.");
+					return;
+				}
+			}
+
+			_frameSignal.Dispose();
+			_presentedEvent.Dispose();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -21,19 +21,16 @@ internal partial class Win32WindowWrapper
 		private readonly IRenderer _renderer;
 		private readonly Func<(SKPath clipPath, int width, int height)?> _drawFrame;
 		private readonly Action<SKPath> _onClipPathUpdated;
-		private readonly Action _onFramePresented;
 		private volatile bool _disposed;
 
 		internal RenderThread(
 			IRenderer renderer,
 			Func<(SKPath, int, int)?> drawFrame,
-			Action<SKPath> onClipPathUpdated,
-			Action onFramePresented)
+			Action<SKPath> onClipPathUpdated)
 		{
 			_renderer = renderer;
 			_drawFrame = drawFrame;
 			_onClipPathUpdated = onClipPathUpdated;
-			_onFramePresented = onFramePresented;
 			_thread = new Thread(RenderLoop) { Name = "Uno Render Thread", IsBackground = true };
 			_thread.Start();
 		}
@@ -68,9 +65,12 @@ internal partial class Win32WindowWrapper
 					break;
 				}
 
-				_renderer.StartPaint();
+				var startPaintSucceeded = false;
 				try
 				{
+					_renderer.StartPaint();
+					startPaintSucceeded = true;
+
 					var result = _drawFrame();
 					if (result is { } frame)
 					{
@@ -79,7 +79,6 @@ internal partial class Win32WindowWrapper
 						_renderer.CopyPixels(width, height); // SwapBuffers/BitBlt — may block for VSync
 
 						_presentedEvent.Set();
-						_onFramePresented();
 					}
 				}
 				catch (Exception ex)
@@ -88,7 +87,10 @@ internal partial class Win32WindowWrapper
 				}
 				finally
 				{
-					_renderer.EndPaint();
+					if (startPaintSucceeded)
+					{
+						_renderer.EndPaint();
+					}
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -8,10 +8,8 @@ namespace Uno.UI.Runtime.Skia.Win32;
 internal partial class Win32WindowWrapper
 {
 	/// <summary>
-	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt).
-	/// The UI thread records SKPictures and signals this thread to present them.
-	/// This mirrors the pattern used by WPF (milcore render thread) and the
-	/// Uno Android GL thread.
+	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt), mirroring
+	/// WPF's milcore render thread. The UI thread records SKPictures and signals presents.
 	/// </summary>
 	private sealed class RenderThread : IDisposable
 	{
@@ -36,11 +34,9 @@ internal partial class Win32WindowWrapper
 		}
 
 		/// <summary>
-		/// Signals the render thread that a new frame is available for presentation.
-		/// Multiple calls while the thread is busy coalesce into a single wake-up
-		/// (AutoResetEvent semantics). Resets the present-completion event before
-		/// signaling so a subsequent <see cref="WaitForNextPresent"/> always observes
-		/// the next presentation, never a stale one from a prior frame.
+		/// Signals that a new frame is available; calls coalesce into a single wake-up. Resets
+		/// the present-completion event so <see cref="WaitForNextPresent"/> always observes the
+		/// next present, never a stale one.
 		/// </summary>
 		internal void SignalNewFrame()
 		{
@@ -49,9 +45,7 @@ internal partial class Win32WindowWrapper
 		}
 
 		/// <summary>
-		/// Blocks the calling thread until the render thread finishes presenting a frame.
-		/// Used by ShowCore to ensure the first frame is painted before the window is shown.
-		/// Returns true if a present completed within the timeout, false otherwise.
+		/// Blocks until the render thread presents a frame; false if the timeout elapsed first.
 		/// </summary>
 		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
 
@@ -98,23 +92,18 @@ internal partial class Win32WindowWrapper
 		public void Dispose() => DisposeAndTryJoin();
 
 		/// <summary>
-		/// Stops the render thread and waits for it to exit. Returns <c>true</c> if the
-		/// thread joined within the backstop, <c>false</c> if it had to be abandoned while
-		/// still potentially executing inside a native present (SwapBuffers/BitBlt/DwmFlush).
-		/// When this returns <c>false</c>, the caller MUST NOT dispose any renderer/surface
-		/// resources the abandoned thread might still be touching — doing so would free native
-		/// GPU resources out from under it and risk a use-after-free.
+		/// Stops the render thread. Returns <c>false</c> when the thread had to be abandoned
+		/// (stuck in a native present); the caller must then not dispose renderer/surface
+		/// resources the abandoned thread might still be touching.
 		/// </summary>
 		internal bool DisposeAndTryJoin()
 		{
 			_disposed = true;
 			_frameSignal.Set(); // Unblock if waiting
 
-			// 250 ms covers a present (~16 ms at 60 Hz) plus slack. If that fails, the GPU
-			// is likely hung. Wait one more bounded interval (2 s) and then abandon: leaving
-			// the render thread (background, marked at construction) blocked is preferable
-			// to hanging the UI thread on window close. The leaked synchronization
-			// primitives and renderer outlive the thread, so the OS reclaims them at exit.
+			// 250 ms covers a present (~16 ms at 60 Hz) plus slack; after one more bounded wait
+			// (2 s), abandon the background thread — leaking the renderer and synchronization
+			// primitives until process exit beats hanging the UI thread on window close.
 			var joined = _thread.Join(timeout: TimeSpan.FromMilliseconds(250));
 			if (!joined)
 			{

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -95,7 +95,17 @@ internal partial class Win32WindowWrapper
 			}
 		}
 
-		public void Dispose()
+		public void Dispose() => DisposeAndTryJoin();
+
+		/// <summary>
+		/// Stops the render thread and waits for it to exit. Returns <c>true</c> if the
+		/// thread joined within the backstop, <c>false</c> if it had to be abandoned while
+		/// still potentially executing inside a native present (SwapBuffers/BitBlt/DwmFlush).
+		/// When this returns <c>false</c>, the caller MUST NOT dispose any renderer/surface
+		/// resources the abandoned thread might still be touching — doing so would free native
+		/// GPU resources out from under it and risk a use-after-free.
+		/// </summary>
+		internal bool DisposeAndTryJoin()
 		{
 			_disposed = true;
 			_frameSignal.Set(); // Unblock if waiting
@@ -119,12 +129,13 @@ internal partial class Win32WindowWrapper
 					typeof(RenderThread).LogError()?.Error(
 						"Render thread still alive after 2 s; abandoning to keep window close responsive. " +
 						"Leaking _frameSignal, _presentedEvent and renderer until process exit.");
-					return;
+					return false;
 				}
 			}
 
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
+			return true;
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -89,42 +89,22 @@ internal partial class Win32WindowWrapper
 			}
 		}
 
-		public void Dispose() => DisposeAndTryJoin();
-
 		/// <summary>
-		/// Stops the render thread. Returns <c>false</c> when the thread had to be abandoned
-		/// (stuck in a native present); the caller must then not dispose renderer/surface
-		/// resources the abandoned thread might still be touching.
+		/// Stops the render thread, waits for it to exit, then releases its synchronization
+		/// primitives. The join is intentionally unbounded: the loop only delays observing
+		/// <see cref="_disposed"/> while a present is in flight, and a present completes in bounded
+		/// time (a vsync wait, or a GPU TDR reset for a hung present), so the thread always exits.
+		/// The caller must dispose the renderer and surface only after this returns — once the
+		/// thread, the sole user of those resources, is guaranteed stopped.
 		/// </summary>
-		internal bool DisposeAndTryJoin()
+		public void Dispose()
 		{
 			_disposed = true;
-			_frameSignal.Set(); // Unblock if waiting
-
-			// 250 ms covers a present (~16 ms at 60 Hz) plus slack; after one more bounded wait
-			// (2 s), abandon the background thread — leaking the renderer and synchronization
-			// primitives until process exit beats hanging the UI thread on window close.
-			var joined = _thread.Join(timeout: TimeSpan.FromMilliseconds(250));
-			if (!joined)
-			{
-				typeof(RenderThread).LogWarn()?.Warn(
-					"Render thread did not exit within 250 ms during dispose; waiting up to 2 s more " +
-					"before abandoning. This usually indicates a stuck GPU present " +
-					"(SwapBuffers/BitBlt/DwmFlush blocked).");
-
-				joined = _thread.Join(timeout: TimeSpan.FromSeconds(2));
-				if (!joined)
-				{
-					typeof(RenderThread).LogError()?.Error(
-						"Render thread still alive after 2 s; abandoning to keep window close responsive. " +
-						"Leaking _frameSignal, _presentedEvent and renderer until process exit.");
-					return false;
-				}
-			}
+			_frameSignal.Set(); // Wake the loop if it's parked in WaitOne
+			_thread.Join();
 
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
-			return true;
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
@@ -14,5 +14,14 @@ internal partial class Win32WindowWrapper
 		void CopyPixels(int width, int height);
 		bool IsSoftware();
 		void Reinitialize();
+
+		/// <summary>
+		/// Notifies the renderer of a screen refresh rate change. Renderers that pace
+		/// internally via VSync (GL via wglSwapInterval, software DwmFlush) are
+		/// inherently aligned to the refresh rate and can ignore this; renderers that
+		/// pace via a software timer (e.g. the software DwmFlush degraded fallback
+		/// FramePacer) can use it to retarget.
+		/// </summary>
+		void UpdateRefreshRate(double fps);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
@@ -16,11 +16,8 @@ internal partial class Win32WindowWrapper
 		void Reinitialize();
 
 		/// <summary>
-		/// Notifies the renderer of a screen refresh rate change. Renderers that pace
-		/// internally via VSync (GL via wglSwapInterval, software DwmFlush) are
-		/// inherently aligned to the refresh rate and can ignore this; renderers that
-		/// pace via a software timer (e.g. the software DwmFlush degraded fallback
-		/// FramePacer) can use it to retarget.
+		/// Notifies the renderer of a screen refresh rate change. VSync-paced renderers ignore
+		/// this; software-timer-paced ones (e.g. the DwmFlush degraded fallback) retarget.
 		/// </summary>
 		void UpdateRefreshRate(double fps);
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -15,6 +15,9 @@ internal partial class Win32WindowWrapper
 {
 	private class GlRenderer : IRenderer
 	{
+		[UnmanagedFunctionPointer(CallingConvention.Winapi)]
+		private delegate int WglSwapIntervalEXT(int interval);
+
 		private readonly HWND _hwnd;
 		private readonly HDC _hdc;
 		private HGLRC _glContext; // recreated when window is extended into titlebar
@@ -103,6 +106,21 @@ internal partial class Win32WindowWrapper
 					version is null
 						? $"{nameof(PInvoke.glGetString)} failed with error code {PInvoke.glGetError().ToString("X", CultureInfo.InvariantCulture)}"
 						: $"OpenGL Version: {Marshal.PtrToStringUTF8((IntPtr)version)}");
+			}
+
+			// Enable VSync so SwapBuffers blocks until the next display refresh.
+			// Without this, some GPU drivers default to swap interval 0,
+			// causing SwapBuffers to return immediately and the render loop
+			// to spin at hundreds of fps.
+			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
+			if (wglSwapIntervalAddr != IntPtr.Zero)
+			{
+				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
+				if (wglSwapInterval(1) == 0)
+				{
+					typeof(GlRenderer).LogWarn()?.Warn(
+						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
+				}
 			}
 
 			var grGlInterface = GRGlInterface.Create();

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -139,6 +139,14 @@ internal partial class Win32WindowWrapper
 				return null;
 			}
 
+			// Detach the GL context from the calling thread before returning, so a downstream
+			// render thread can make it current. WglCurrentContextDisposable above doesn't
+			// restore to "no context" when there was none before, so we detach explicitly.
+			if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
+			{
+				typeof(GlRenderer).LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
+			}
+
 			return new GlRenderer(hwnd, hdc, glContext, grGlInterface, grContext);
 		}
 
@@ -208,5 +216,9 @@ internal partial class Win32WindowWrapper
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
 			_grContext = GRContext.CreateGl(_grGlInterface);
 		}
+
+		// VSync via wglSwapInterval(1) already paces SwapBuffers at the screen
+		// refresh rate, so no retargeting is needed here.
+		void IRenderer.UpdateRefreshRate(double fps) { }
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -25,14 +25,18 @@ internal partial class Win32WindowWrapper
 		private GRContext _grContext; // recreated when window is extended into titlebar
 		private GRBackendRenderTarget? _renderTarget; // recreated on size updates
 		private Win32Helper.WglCurrentContextDisposable? _paintDisposable;
+		// Non-null only when honoring a fixed FrameRate (SetFrameRateAsScreenRefreshRate = false);
+		// otherwise wglSwapInterval(1) blocks SwapBuffers at the display refresh and paces the loop.
+		private readonly Win32RenderPacer? _pacer;
 
-		private GlRenderer(HWND hwnd, HDC hdc, HGLRC glContext, GRGlInterface grGlInterface, GRContext grContext)
+		private GlRenderer(HWND hwnd, HDC hdc, HGLRC glContext, GRGlInterface grGlInterface, GRContext grContext, Win32RenderPacer? pacer)
 		{
 			_hwnd = hwnd;
 			_hdc = hdc;
 			_glContext = glContext;
 			_grGlInterface = grGlInterface;
 			_grContext = grContext;
+			_pacer = pacer;
 		}
 
 		public static unsafe GlRenderer? TryCreateGlRenderer(HWND hwnd)
@@ -108,7 +112,10 @@ internal partial class Win32WindowWrapper
 						: $"OpenGL Version: {Marshal.PtrToStringUTF8((IntPtr)version)}");
 			}
 
-			TryEnableVSync();
+			var followRefreshRate = FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate;
+			// Swap interval 1 blocks SwapBuffers at the refresh; for a fixed FrameRate use 0 and let
+			// the timer pace the loop instead.
+			SetSwapInterval(followRefreshRate ? 1 : 0);
 
 			var grGlInterface = GRGlInterface.Create();
 
@@ -133,22 +140,26 @@ internal partial class Win32WindowWrapper
 				typeof(GlRenderer).LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
 			}
 
-			return new GlRenderer(hwnd, hdc, glContext, grGlInterface, grContext);
+			var pacer = followRefreshRate
+				? null
+				: new Win32RenderPacer(FeatureConfiguration.CompositionTarget.FrameRate, followRefreshRate: false);
+			return new GlRenderer(hwnd, hdc, glContext, grGlInterface, grContext, pacer);
 		}
 
-		// Enable VSync so SwapBuffers blocks until the next display refresh; some drivers
-		// default to swap interval 0, letting the render loop spin at hundreds of fps.
-		// The swap interval is per-context, so re-apply this whenever an HGLRC is created.
-		private static void TryEnableVSync()
+		// Sets the GL swap interval: 1 blocks SwapBuffers until the next display refresh (vsync),
+		// 0 doesn't block (used when a fixed FrameRate is paced by the timer instead). Some drivers
+		// default to 0, letting the render loop spin. Per-context, so re-apply whenever an HGLRC
+		// is created.
+		private static void SetSwapInterval(int interval)
 		{
 			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
 			if (wglSwapIntervalAddr != IntPtr.Zero)
 			{
 				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
-				if (wglSwapInterval(1) == 0)
+				if (wglSwapInterval(interval) == 0)
 				{
 					typeof(GlRenderer).LogWarn()?.Warn(
-						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
+						$"Failed to set GL swap interval {interval} via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
 				}
 			}
 		}
@@ -201,14 +212,21 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.CopyPixels(int width, int height)
 		{
+			_pacer?.OnFrameStart();
+
 			var success = PInvoke.SwapBuffers(_hdc);
 			if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SwapBuffers)} failed: {Win32Helper.GetErrorMessage()}"); }
+
+			// Fixed-FrameRate path: SwapBuffers ran with swap interval 0 (non-blocking), so pace the
+			// loop with the timer. When following the refresh, swap interval 1 already blocked above.
+			_pacer?.WaitForNextFrame();
 		}
 
 		bool IRenderer.IsSoftware() => false;
 
 		void IDisposable.Dispose()
 		{
+			_pacer?.Dispose();
 			ReleaseGlContext(_hwnd, _hdc, _glContext, _grGlInterface, _grContext, _renderTarget);
 		}
 
@@ -217,12 +235,12 @@ internal partial class Win32WindowWrapper
 			ReleaseGlContext(_hwnd, new HDC(IntPtr.Zero), _glContext, null, _grContext, _renderTarget);
 			_glContext = PInvoke.wglCreateContext(_hdc);
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
-			TryEnableVSync();
+			SetSwapInterval(_pacer is null ? 1 : 0);
 			_grContext = GRContext.CreateGl(_grGlInterface);
 		}
 
-		// VSync via wglSwapInterval(1) already paces SwapBuffers at the screen
-		// refresh rate, so no retargeting is needed here.
+		// Following the refresh: swap interval 1 paces SwapBuffers, nothing to retarget. Fixed
+		// FrameRate uses a static timer rate. UpdateRefreshRate only fires in the former case.
 		void IRenderer.UpdateRefreshRate(double fps) { }
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -244,7 +244,12 @@ internal partial class Win32WindowWrapper
 			}
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
 			SetSwapInterval(_pacer is null ? 1 : 0);
-			_grContext = GRContext.CreateGl(_grGlInterface);
+			if (GRContext.CreateGl(_grGlInterface) is not { } grContext)
+			{
+				typeof(GlRenderer).LogError()?.Error($"{nameof(GRContext)}.{nameof(GRContext.CreateGl)} failed during {nameof(IRenderer.Reinitialize)}.");
+				return;
+			}
+			_grContext = grContext;
 		}
 
 		// Following the refresh: swap interval 1 paces SwapBuffers, nothing to retarget. Fixed

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -108,20 +108,7 @@ internal partial class Win32WindowWrapper
 						: $"OpenGL Version: {Marshal.PtrToStringUTF8((IntPtr)version)}");
 			}
 
-			// Enable VSync so SwapBuffers blocks until the next display refresh.
-			// Without this, some GPU drivers default to swap interval 0,
-			// causing SwapBuffers to return immediately and the render loop
-			// to spin at hundreds of fps.
-			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
-			if (wglSwapIntervalAddr != IntPtr.Zero)
-			{
-				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
-				if (wglSwapInterval(1) == 0)
-				{
-					typeof(GlRenderer).LogWarn()?.Warn(
-						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
-				}
-			}
+			TryEnableVSync();
 
 			var grGlInterface = GRGlInterface.Create();
 
@@ -139,15 +126,31 @@ internal partial class Win32WindowWrapper
 				return null;
 			}
 
-			// Detach the GL context from the calling thread before returning, so a downstream
-			// render thread can make it current. WglCurrentContextDisposable above doesn't
-			// restore to "no context" when there was none before, so we detach explicitly.
+			// Detach the GL context from the calling thread so the render thread can make it
+			// current later (WglCurrentContextDisposable doesn't restore to "no context").
 			if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
 			{
 				typeof(GlRenderer).LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
 			}
 
 			return new GlRenderer(hwnd, hdc, glContext, grGlInterface, grContext);
+		}
+
+		// Enable VSync so SwapBuffers blocks until the next display refresh; some drivers
+		// default to swap interval 0, letting the render loop spin at hundreds of fps.
+		// The swap interval is per-context, so re-apply this whenever an HGLRC is created.
+		private static void TryEnableVSync()
+		{
+			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
+			if (wglSwapIntervalAddr != IntPtr.Zero)
+			{
+				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
+				if (wglSwapInterval(1) == 0)
+				{
+					typeof(GlRenderer).LogWarn()?.Warn(
+						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
+				}
+			}
 		}
 
 		private static void ReleaseGlContext(HWND hwnd, HDC hdc, HGLRC glContext, GRGlInterface? grGlInterface, GRContext? grContext, GRBackendRenderTarget? renderTarget)
@@ -214,6 +217,7 @@ internal partial class Win32WindowWrapper
 			ReleaseGlContext(_hwnd, new HDC(IntPtr.Zero), _glContext, null, _grContext, _renderTarget);
 			_glContext = PInvoke.wglCreateContext(_hdc);
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
+			TryEnableVSync();
 			_grContext = GRContext.CreateGl(_grGlInterface);
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -237,6 +237,11 @@ internal partial class Win32WindowWrapper
 			// recreates it) doesn't dispose the same instance again.
 			_renderTarget = null;
 			_glContext = PInvoke.wglCreateContext(_hdc);
+			if (_glContext == HGLRC.Null)
+			{
+				typeof(GlRenderer).LogError()?.Error($"{nameof(PInvoke.wglCreateContext)} failed during {nameof(IRenderer.Reinitialize)}: {Win32Helper.GetErrorMessage()}");
+				return;
+			}
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
 			SetSwapInterval(_pacer is null ? 1 : 0);
 			_grContext = GRContext.CreateGl(_grGlInterface);

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -233,6 +233,9 @@ internal partial class Win32WindowWrapper
 		void IRenderer.Reinitialize()
 		{
 			ReleaseGlContext(_hwnd, new HDC(IntPtr.Zero), _glContext, null, _grContext, _renderTarget);
+			// ReleaseGlContext disposed the render target; null it so the next UpdateSize (which
+			// recreates it) doesn't dispose the same instance again.
+			_renderTarget = null;
 			_glContext = PInvoke.wglCreateContext(_hdc);
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
 			SetSwapInterval(_pacer is null ? 1 : 0);

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
@@ -13,7 +14,15 @@ internal partial class Win32WindowWrapper
 {
 	private class SoftwareRenderer(HWND hwnd) : IRenderer
 	{
+		// Pacing fallback when DwmFlush hangs/fails repeatedly (DWM paused, RDP reconnect,
+		// fast user switch, GPU TDR). After this many consecutive failures we stop calling
+		// DwmFlush and use a fixed sleep to keep the render loop bounded.
+		private const int DwmFlushFailureThreshold = 3;
+		private const int FallbackPacingMs = 16; // ~60 Hz
+
 		private HBITMAP _hBitmap;
+		private int _consecutiveDwmFlushFailures;
+		private bool _dwmFlushDegraded;
 
 		public void StartPaint() { }
 		public void EndPaint() { }
@@ -82,6 +91,46 @@ internal partial class Win32WindowWrapper
 
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
+
+			// Block until the DWM compositor's next VSync to pace frames.
+			// Without this, BitBlt returns instantly (unlike GL's SwapBuffers
+			// which blocks for VSync), causing the render loop to spin at
+			// hundreds of fps — wasting CPU and reporting misleading frame rates.
+			//
+			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung
+			// during RDP reconnect, fast user switch, or a GPU TDR), give up on
+			// DwmFlush and use a fixed sleep. We never re-enable DwmFlush in this
+			// renderer instance — once degraded, stay degraded for the lifetime of
+			// the window. Better to lose vsync alignment than to risk hanging the
+			// render thread on each frame.
+			if (_dwmFlushDegraded)
+			{
+				Thread.Sleep(FallbackPacingMs);
+				return;
+			}
+
+			var dwmFlushResult = PInvoke.DwmFlush();
+			if (dwmFlushResult.Failed)
+			{
+				_consecutiveDwmFlushFailures++;
+				this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
+
+				if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+				{
+					_dwmFlushDegraded = true;
+					this.LogWarn()?.Warn(
+						$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
+						$"falling back to {FallbackPacingMs} ms sleep-based pacing. " +
+						"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
+				}
+
+				// Pace the failing call so we don't spin at full speed.
+				Thread.Sleep(FallbackPacingMs);
+			}
+			else
+			{
+				_consecutiveDwmFlushFailures = 0;
+			}
 		}
 
 		bool IRenderer.IsSoftware() => true;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -1,28 +1,43 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Windows.Win32;
-using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.Gdi;
 using SkiaSharp;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI.Runtime.Skia.Hosting;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
 internal partial class Win32WindowWrapper
 {
-	private class SoftwareRenderer(HWND hwnd) : IRenderer
+	private class SoftwareRenderer : IRenderer
 	{
 		// Pacing fallback when DwmFlush hangs/fails repeatedly (DWM paused, RDP reconnect,
 		// fast user switch, GPU TDR). After this many consecutive failures we stop calling
-		// DwmFlush and use a fixed sleep to keep the render loop bounded.
+		// DwmFlush and pace via FramePacer instead.
 		private const int DwmFlushFailureThreshold = 3;
-		private const int FallbackPacingMs = 16; // ~60 Hz
+
+		private readonly HWND _hwnd;
+		private readonly FramePacer _framePacer;
+		private readonly AutoResetEvent _frameDeadlineReached = new(false);
 
 		private HBITMAP _hBitmap;
 		private int _consecutiveDwmFlushFailures;
 		private bool _dwmFlushDegraded;
+
+		public SoftwareRenderer(HWND hwnd)
+		{
+			_hwnd = hwnd;
+			// Self-correcting absolute-time pacer used as the fallback when DwmFlush is degraded.
+			// Initialized at FeatureConfiguration.CompositionTarget.FrameRate; retargeted to the
+			// screen refresh rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
+			_framePacer = new FramePacer(
+				FeatureConfiguration.CompositionTarget.FrameRate,
+				() => _frameDeadlineReached.Set());
+		}
 
 		public void StartPaint() { }
 		public void EndPaint() { }
@@ -59,7 +74,11 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.CopyPixels(int width, int height)
 		{
-			var paintDc = PInvoke.GetDC(hwnd);
+			// Anchor the absolute target tick at the start of every frame so a subsequent
+			// FramePacer.RequestFrame schedules wake-up at the next deadline (no drift).
+			_framePacer.OnFrameStart();
+
+			var paintDc = PInvoke.GetDC(_hwnd);
 			if (paintDc == new HDC(IntPtr.Zero))
 			{
 				this.LogError()?.Error($"{nameof(PInvoke.GetDC)} failed: {Win32Helper.GetErrorMessage()}");
@@ -69,7 +88,7 @@ internal partial class Win32WindowWrapper
 			{
 				var success = PInvoke.ReleaseDC(hwnd, lpPaint) == 1;
 				if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
-			}, hwnd, paintDc);
+			}, _hwnd, paintDc);
 
 			var bitmapDc = PInvoke.CreateCompatibleDC(paintDc);
 			if (bitmapDc == new HDC(IntPtr.Zero))
@@ -92,44 +111,49 @@ internal partial class Win32WindowWrapper
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
 
-			// Block until the DWM compositor's next VSync to pace frames.
-			// Without this, BitBlt returns instantly (unlike GL's SwapBuffers
-			// which blocks for VSync), causing the render loop to spin at
-			// hundreds of fps — wasting CPU and reporting misleading frame rates.
+			// Pace the frame. Normally DwmFlush blocks until the DWM compositor's next VSync
+			// (BitBlt itself returns instantly, so without pacing the render loop spins at
+			// hundreds of fps — wasting CPU and reporting misleading frame rates).
 			//
-			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung
-			// during RDP reconnect, fast user switch, or a GPU TDR), give up on
-			// DwmFlush and use a fixed sleep. We never re-enable DwmFlush in this
-			// renderer instance — once degraded, stay degraded for the lifetime of
-			// the window. Better to lose vsync alignment than to risk hanging the
+			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung during
+			// RDP reconnect, fast user switch, or a GPU TDR), give up on DwmFlush and pace via
+			// FramePacer's self-correcting absolute-time scheduling. We never re-enable
+			// DwmFlush in this renderer instance — once degraded, stay degraded for the
+			// lifetime of the window. Better to lose vsync alignment than to risk hanging the
 			// render thread on each frame.
-			if (_dwmFlushDegraded)
-			{
-				Thread.Sleep(FallbackPacingMs);
-				return;
-			}
+			var paceViaFramePacer = _dwmFlushDegraded;
 
-			var dwmFlushResult = PInvoke.DwmFlush();
-			if (dwmFlushResult.Failed)
+			if (!_dwmFlushDegraded)
 			{
-				_consecutiveDwmFlushFailures++;
-				this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
-
-				if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+				var dwmFlushResult = PInvoke.DwmFlush();
+				if (dwmFlushResult.Failed)
 				{
-					_dwmFlushDegraded = true;
-					this.LogWarn()?.Warn(
-						$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
-						$"falling back to {FallbackPacingMs} ms sleep-based pacing. " +
-						"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
-				}
+					_consecutiveDwmFlushFailures++;
+					this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
 
-				// Pace the failing call so we don't spin at full speed.
-				Thread.Sleep(FallbackPacingMs);
+					if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+					{
+						_dwmFlushDegraded = true;
+						this.LogWarn()?.Warn(
+							$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
+							$"falling back to FramePacer-driven pacing at {_framePacer.TargetIntervalMs:F1} ms. " +
+							"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
+					}
+
+					// Pace this failed frame via FramePacer; subsequent frames will also use the
+					// degraded branch above and pace the same way.
+					paceViaFramePacer = true;
+				}
+				else
+				{
+					_consecutiveDwmFlushFailures = 0;
+				}
 			}
-			else
+
+			if (paceViaFramePacer)
 			{
-				_consecutiveDwmFlushFailures = 0;
+				_framePacer.RequestFrame();
+				_frameDeadlineReached.WaitOne();
 			}
 		}
 
@@ -137,8 +161,12 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.Reinitialize() { }
 
+		void IRenderer.UpdateRefreshRate(double fps) => _framePacer.UpdateTargetFps(fps);
+
 		void IDisposable.Dispose()
 		{
+			_framePacer.Dispose();
+			_frameDeadlineReached.Dispose();
 			var success = PInvoke.DeleteObject(_hBitmap) == 1;
 			if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.DeleteObject)} failed: {Win32Helper.GetErrorMessage()}"); }
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 using SkiaSharp;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
-using Uno.UI.Runtime.Skia.Hosting;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
@@ -15,26 +13,17 @@ internal partial class Win32WindowWrapper
 {
 	private class SoftwareRenderer : IRenderer
 	{
-		// After this many consecutive DwmFlush failures (DWM paused, RDP reconnect, fast user
-		// switch, GPU TDR), we stop calling DwmFlush and pace via FramePacer instead.
-		private const int DwmFlushFailureThreshold = 3;
-
 		private readonly HWND _hwnd;
-		private readonly FramePacer _framePacer;
-		private readonly AutoResetEvent _frameDeadlineReached = new(false);
+		private readonly Win32VSyncPacer _vsyncPacer;
 
 		private HBITMAP _hBitmap;
-		private int _consecutiveDwmFlushFailures;
-		private bool _dwmFlushDegraded;
 
 		public SoftwareRenderer(HWND hwnd)
 		{
 			_hwnd = hwnd;
-			// Fallback pacer used when DwmFlush is degraded; retargeted to the screen refresh
-			// rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
-			_framePacer = new FramePacer(
-				FeatureConfiguration.CompositionTarget.FrameRate,
-				() => _frameDeadlineReached.Set());
+			// BitBlt returns instantly, so the loop is paced to vsync here; retargeted to the
+			// screen refresh rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
+			_vsyncPacer = new Win32VSyncPacer(FeatureConfiguration.CompositionTarget.FrameRate);
 		}
 
 		public void StartPaint() { }
@@ -72,9 +61,7 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.CopyPixels(int width, int height)
 		{
-			// Anchor the absolute target tick at the start of every frame so a subsequent
-			// FramePacer.RequestFrame schedules wake-up at the next deadline (no drift).
-			_framePacer.OnFrameStart();
+			_vsyncPacer.OnFrameStart();
 
 			var paintDc = PInvoke.GetDC(_hwnd);
 			if (paintDc == new HDC(IntPtr.Zero))
@@ -109,56 +96,19 @@ internal partial class Win32WindowWrapper
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
 
-			// Pace the frame: DwmFlush blocks until the compositor's next VSync (BitBlt returns
-			// instantly, so the loop would otherwise spin unthrottled). After repeated failures,
-			// degrade permanently to FramePacer pacing — losing vsync alignment beats risking a
-			// hung render thread on every frame.
-			var paceViaFramePacer = _dwmFlushDegraded;
-
-			if (!_dwmFlushDegraded)
-			{
-				var dwmFlushResult = PInvoke.DwmFlush();
-				if (dwmFlushResult.Failed)
-				{
-					_consecutiveDwmFlushFailures++;
-					this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
-
-					if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
-					{
-						_dwmFlushDegraded = true;
-						this.LogWarn()?.Warn(
-							$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
-							$"falling back to FramePacer-driven pacing at {_framePacer.TargetIntervalMs:F1} ms. " +
-							"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
-					}
-
-					// Pace this failed frame via FramePacer; subsequent frames will also use the
-					// degraded branch above and pace the same way.
-					paceViaFramePacer = true;
-				}
-				else
-				{
-					_consecutiveDwmFlushFailures = 0;
-				}
-			}
-
-			if (paceViaFramePacer)
-			{
-				_framePacer.RequestFrame();
-				_frameDeadlineReached.WaitOne();
-			}
+			// BitBlt returns instantly, so block until the compositor's next vsync to pace the loop.
+			_vsyncPacer.WaitForVSync();
 		}
 
 		bool IRenderer.IsSoftware() => true;
 
 		void IRenderer.Reinitialize() { }
 
-		void IRenderer.UpdateRefreshRate(double fps) => _framePacer.UpdateTargetFps(fps);
+		void IRenderer.UpdateRefreshRate(double fps) => _vsyncPacer.UpdateTargetFps(fps);
 
 		void IDisposable.Dispose()
 		{
-			_framePacer.Dispose();
-			_frameDeadlineReached.Dispose();
+			_vsyncPacer.Dispose();
 			var success = PInvoke.DeleteObject(_hBitmap) == 1;
 			if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.DeleteObject)} failed: {Win32Helper.GetErrorMessage()}"); }
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -15,9 +15,8 @@ internal partial class Win32WindowWrapper
 {
 	private class SoftwareRenderer : IRenderer
 	{
-		// Pacing fallback when DwmFlush hangs/fails repeatedly (DWM paused, RDP reconnect,
-		// fast user switch, GPU TDR). After this many consecutive failures we stop calling
-		// DwmFlush and pace via FramePacer instead.
+		// After this many consecutive DwmFlush failures (DWM paused, RDP reconnect, fast user
+		// switch, GPU TDR), we stop calling DwmFlush and pace via FramePacer instead.
 		private const int DwmFlushFailureThreshold = 3;
 
 		private readonly HWND _hwnd;
@@ -31,9 +30,8 @@ internal partial class Win32WindowWrapper
 		public SoftwareRenderer(HWND hwnd)
 		{
 			_hwnd = hwnd;
-			// Self-correcting absolute-time pacer used as the fallback when DwmFlush is degraded.
-			// Initialized at FeatureConfiguration.CompositionTarget.FrameRate; retargeted to the
-			// screen refresh rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
+			// Fallback pacer used when DwmFlush is degraded; retargeted to the screen refresh
+			// rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
 			_framePacer = new FramePacer(
 				FeatureConfiguration.CompositionTarget.FrameRate,
 				() => _frameDeadlineReached.Set());
@@ -98,8 +96,8 @@ internal partial class Win32WindowWrapper
 			}
 			using var bitmapDcDisposable = new DisposableStruct<HDC>(static bitmapDc =>
 			{
-				var success = PInvoke.DeleteObject(new HGDIOBJ(bitmapDc.Value)) == 1;
-				if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
+				var success = PInvoke.DeleteDC(bitmapDc);
+				if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.DeleteDC)} failed: {Win32Helper.GetErrorMessage()}"); }
 			}, bitmapDc);
 
 			if (PInvoke.SelectObject(bitmapDc, _hBitmap) == 0)
@@ -111,16 +109,10 @@ internal partial class Win32WindowWrapper
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
 
-			// Pace the frame. Normally DwmFlush blocks until the DWM compositor's next VSync
-			// (BitBlt itself returns instantly, so without pacing the render loop spins at
-			// hundreds of fps — wasting CPU and reporting misleading frame rates).
-			//
-			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung during
-			// RDP reconnect, fast user switch, or a GPU TDR), give up on DwmFlush and pace via
-			// FramePacer's self-correcting absolute-time scheduling. We never re-enable
-			// DwmFlush in this renderer instance — once degraded, stay degraded for the
-			// lifetime of the window. Better to lose vsync alignment than to risk hanging the
-			// render thread on each frame.
+			// Pace the frame: DwmFlush blocks until the compositor's next VSync (BitBlt returns
+			// instantly, so the loop would otherwise spin unthrottled). After repeated failures,
+			// degrade permanently to FramePacer pacing — losing vsync alignment beats risking a
+			// hung render thread on every frame.
 			var paceViaFramePacer = _dwmFlushDegraded;
 
 			if (!_dwmFlushDegraded)

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -14,16 +14,18 @@ internal partial class Win32WindowWrapper
 	private class SoftwareRenderer : IRenderer
 	{
 		private readonly HWND _hwnd;
-		private readonly Win32VSyncPacer _vsyncPacer;
+		private readonly Win32RenderPacer _pacer;
 
 		private HBITMAP _hBitmap;
 
 		public SoftwareRenderer(HWND hwnd)
 		{
 			_hwnd = hwnd;
-			// BitBlt returns instantly, so the loop is paced to vsync here; retargeted to the
-			// screen refresh rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
-			_vsyncPacer = new Win32VSyncPacer(FeatureConfiguration.CompositionTarget.FrameRate);
+			// BitBlt returns instantly, so the loop is paced here: to the display refresh when
+			// SetFrameRateAsScreenRefreshRate is on, otherwise to the configured FrameRate.
+			_pacer = new Win32RenderPacer(
+				FeatureConfiguration.CompositionTarget.FrameRate,
+				FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate);
 		}
 
 		public void StartPaint() { }
@@ -61,7 +63,7 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.CopyPixels(int width, int height)
 		{
-			_vsyncPacer.OnFrameStart();
+			_pacer.OnFrameStart();
 
 			var paintDc = PInvoke.GetDC(_hwnd);
 			if (paintDc == new HDC(IntPtr.Zero))
@@ -97,18 +99,18 @@ internal partial class Win32WindowWrapper
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
 
 			// BitBlt returns instantly, so block until the compositor's next vsync to pace the loop.
-			_vsyncPacer.WaitForVSync();
+			_pacer.WaitForNextFrame();
 		}
 
 		bool IRenderer.IsSoftware() => true;
 
 		void IRenderer.Reinitialize() { }
 
-		void IRenderer.UpdateRefreshRate(double fps) => _vsyncPacer.UpdateTargetFps(fps);
+		void IRenderer.UpdateRefreshRate(double fps) => _pacer.UpdateTargetFps(fps);
 
 		void IDisposable.Dispose()
 		{
-			_vsyncPacer.Dispose();
+			_pacer.Dispose();
 			var success = PInvoke.DeleteObject(_hBitmap) == 1;
 			if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.DeleteObject)} failed: {Win32Helper.GetErrorMessage()}"); }
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
@@ -152,5 +152,8 @@ internal partial class Win32WindowWrapper
 			_deviceLock = null;
 			_vulkanContext.Dispose();
 		}
+
+		// Vulkan presents through its own VSync-aware swapchain, so no retargeting is needed here.
+		public void UpdateRefreshRate(double fps) { }
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
@@ -24,7 +24,9 @@ internal partial class Win32WindowWrapper
 	private class VulkanRenderer : IRenderer
 	{
 		private readonly HWND _hwnd;
-		private readonly Win32VSyncPacer _vsyncPacer = new(FeatureConfiguration.CompositionTarget.FrameRate);
+		private readonly Win32RenderPacer _pacer = new(
+			FeatureConfiguration.CompositionTarget.FrameRate,
+			FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate);
 		private VulkanContext _vulkanContext;
 		private IDisposable? _deviceLock;
 		private bool _skipPresent;
@@ -112,7 +114,7 @@ internal partial class Win32WindowWrapper
 			if (_vulkanContext.CachedSkSurface == null || _vulkanContext.GrContext == null)
 				return;
 
-			_vsyncPacer.OnFrameStart();
+			_pacer.OnFrameStart();
 
 			// Flush Skia commands to the Vulkan intermediate image
 			_vulkanContext.CachedSkSurface.Canvas.Flush();
@@ -126,7 +128,7 @@ internal partial class Win32WindowWrapper
 				// MAILBOX present returns without blocking, so pace the render thread to the
 				// compositor's vsync here; otherwise it spins at thousands of fps rendering frames
 				// the presentation engine discards. MAILBOX keeps latency low and stays tear-free.
-				_vsyncPacer.WaitForVSync();
+				_pacer.WaitForNextFrame();
 			}
 			_skipPresent = false;
 		}
@@ -158,12 +160,12 @@ internal partial class Win32WindowWrapper
 		{
 			_deviceLock?.Dispose();
 			_deviceLock = null;
-			_vsyncPacer.Dispose();
+			_pacer.Dispose();
 			_vulkanContext.Dispose();
 		}
 
 		// Retargets the vsync pacer's degraded timer fallback (MAILBOX itself ignores this);
 		// mirrors the software renderer for the SetFrameRateAsScreenRefreshRate path.
-		public void UpdateRefreshRate(double fps) => _vsyncPacer.UpdateTargetFps(fps);
+		public void UpdateRefreshRate(double fps) => _pacer.UpdateTargetFps(fps);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
@@ -24,6 +24,7 @@ internal partial class Win32WindowWrapper
 	private class VulkanRenderer : IRenderer
 	{
 		private readonly HWND _hwnd;
+		private readonly Win32VSyncPacer _vsyncPacer = new(FeatureConfiguration.CompositionTarget.FrameRate);
 		private VulkanContext _vulkanContext;
 		private IDisposable? _deviceLock;
 		private bool _skipPresent;
@@ -111,6 +112,8 @@ internal partial class Win32WindowWrapper
 			if (_vulkanContext.CachedSkSurface == null || _vulkanContext.GrContext == null)
 				return;
 
+			_vsyncPacer.OnFrameStart();
+
 			// Flush Skia commands to the Vulkan intermediate image
 			_vulkanContext.CachedSkSurface.Canvas.Flush();
 			_vulkanContext.GrContext.Flush();
@@ -119,6 +122,11 @@ internal partial class Win32WindowWrapper
 			{
 				// Blit intermediate image to swapchain and present
 				_vulkanContext.BlitAndPresent();
+
+				// MAILBOX present returns without blocking, so pace the render thread to the
+				// compositor's vsync here; otherwise it spins at thousands of fps rendering frames
+				// the presentation engine discards. MAILBOX keeps latency low and stays tear-free.
+				_vsyncPacer.WaitForVSync();
 			}
 			_skipPresent = false;
 		}
@@ -150,10 +158,12 @@ internal partial class Win32WindowWrapper
 		{
 			_deviceLock?.Dispose();
 			_deviceLock = null;
+			_vsyncPacer.Dispose();
 			_vulkanContext.Dispose();
 		}
 
-		// Vulkan presents through its own VSync-aware swapchain, so no retargeting is needed here.
-		public void UpdateRefreshRate(double fps) { }
+		// Retargets the vsync pacer's degraded timer fallback (MAILBOX itself ignores this);
+		// mirrors the software renderer for the SetFrameRateAsScreenRefreshRate path.
+		public void UpdateRefreshRate(double fps) => _vsyncPacer.UpdateTargetFps(fps);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -1,38 +1,34 @@
 using System;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.OpenGL;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
-using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
-using Uno.UI.Runtime.Skia.Hosting;
-using Windows.Win32;
-using Windows.Win32.Foundation;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
 internal partial class Win32WindowWrapper
 {
-	private readonly FramePacer _framePacer;
-	private int _renderCount;
 	private SKSurface? _surface;
-	private bool _rendering;
+	private RenderThread? _renderThread;
 
 	public event EventHandler<SKPath>? RenderingNegativePathReevaluated; // not necessarily changed
 
-	private FramePacer CreateFramePacer()
-	{
-		return new FramePacer(
-			_refreshRate,
-			() => NativeDispatcher.Main.Enqueue(Render, NativeDispatcherPriority.High));
-	}
-
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
-		var success = PInvoke.InvalidateRect(_hwnd, default(RECT*), true);
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}"); }
+		// Mark the window dirty for WM_PAINT. This handles external repaints (window
+		// uncovering, restore from minimized) where Windows generates WM_PAINT.
+		// Like WPF (InvalidateRect in HwndTarget).
+		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
+		{
+			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
+		}
 
-		_framePacer.RequestFrame();
+		// Signal the render thread to present the current frame.
+		_renderThread?.SignalNewFrame();
 	}
 
 	private void ReinitializeRenderer()
@@ -42,45 +38,66 @@ internal partial class Win32WindowWrapper
 		_surface = null;
 	}
 
-	private void Render()
+	private void InitializeRenderThread()
 	{
-		if (_rendererDisposed || _rendering)
+		// TryCreateGlRenderer leaves the GL context current on the UI thread
+		// (WglCurrentContextDisposable doesn't restore to "no context" when there
+		// was none before). Detach it so the render thread can make it current.
+		// No-op for the software renderer (no GL context to detach).
+		if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
 		{
-			return;
+			this.LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
 		}
 
-		_framePacer.OnFrameStart();
-
-		this.LogTrace()?.Trace($"Render {this._renderCount++}");
-
-		_renderer.StartPaint();
-		using var paintDisposable = new DisposableStruct<IRenderer>(static r => r.EndPaint(), _renderer);
-
-		// In some cases, if a call to a synchronization method such as Monitor.Enter or Task.Wait()
-		// happens inside Paint(), the dotnet runtime can itself call WndProc, which can lead to
-		// Paint() becoming reentrant which can cause crashes.
-		_rendering = true;
-		try
-		{
-			var nativeElementClipPath = ((CompositionTarget)((IXamlRootHost)this).RootElement!.Visual.CompositionTarget!).OnNativePlatformFrameRequested(_surface?.Canvas, size =>
+		_renderThread = new RenderThread(
+			_renderer,
+			drawFrame: DrawFrame,
+			onClipPathUpdated: clipPath =>
 			{
-				_surface?.Dispose();
-				_surface = _renderer.UpdateSize((int)size.Width, (int)size.Height);
-				return _surface.Canvas;
-			});
-			RenderingNegativePathReevaluated?.Invoke(this, nativeElementClipPath);
-		}
-		finally
+				NativeDispatcher.Main.Enqueue(() =>
+					RenderingNegativePathReevaluated?.Invoke(this, clipPath),
+					NativeDispatcherPriority.Normal);
+			},
+			onFramePresented: () => { });
+	}
+
+	/// <summary>
+	/// Called on the render thread. Replays the last recorded SKPicture to
+	/// the canvas and returns the clip path and client dimensions for CopyPixels.
+	/// Returns null when there is no frame to present yet — this avoids a wasted
+	/// CopyPixels (BitBlt + DwmFlush, or SwapBuffers presenting an uninitialised
+	/// back buffer) for WM_PAINT messages that arrive before the first synchronous
+	/// render.
+	/// </summary>
+	private unsafe (SKPath clipPath, int width, int height)? DrawFrame()
+	{
+		var ct = ((IXamlRootHost)this).RootElement?.Visual.CompositionTarget as CompositionTarget;
+		if (ct is null || _rendererDisposed)
 		{
-			_rendering = false;
+			return null;
+		}
+
+		var clipPath = ct.OnNativePlatformFrameRequested(_surface?.Canvas, size =>
+		{
+			_surface?.Dispose();
+			_surface = _renderer.UpdateSize((int)size.Width, (int)size.Height);
+			return _surface.Canvas;
+		});
+
+		// _surface is created lazily inside the resizeFunc only when there's an actual
+		// frame to draw. If it's still null, the CompositionTarget has not recorded
+		// anything yet — nothing to present.
+		if (_surface is null)
+		{
+			return null;
 		}
 
 		if (!PInvoke.GetClientRect(_hwnd, out RECT clientRect))
 		{
 			this.LogError()?.Error($"{nameof(PInvoke.GetClientRect)} failed: {Win32Helper.GetErrorMessage()}");
-			return;
+			return null;
 		}
-		// this may call WM_ERASEBKGND
-		_renderer.CopyPixels(clientRect.Width, clientRect.Height);
+
+		return (clipPath, clientRect.Width, clientRect.Height);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -1,7 +1,6 @@
 using System;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.OpenGL;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
 using Uno.Foundation.Logging;
@@ -40,15 +39,6 @@ internal partial class Win32WindowWrapper
 
 	private void InitializeRenderThread()
 	{
-		// TryCreateGlRenderer leaves the GL context current on the UI thread
-		// (WglCurrentContextDisposable doesn't restore to "no context" when there
-		// was none before). Detach it so the render thread can make it current.
-		// No-op for the software renderer (no GL context to detach).
-		if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
-		{
-			this.LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
-		}
-
 		_renderThread = new RenderThread(
 			_renderer,
 			drawFrame: DrawFrame,
@@ -57,8 +47,7 @@ internal partial class Win32WindowWrapper
 				NativeDispatcher.Main.Enqueue(() =>
 					RenderingNegativePathReevaluated?.Invoke(this, clipPath),
 					NativeDispatcherPriority.Normal);
-			},
-			onFramePresented: () => { });
+			});
 	}
 
 	/// <summary>

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -19,9 +19,7 @@ internal partial class Win32WindowWrapper
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
 		// Mark the window dirty and let Windows coalesce it into a WM_PAINT, whose handler
-		// signals the render thread to present. Presenting here too would double-present the
-		// same content (and re-block on VSync for GL), so WM_PAINT is the single present path,
-		// like WPF's HwndTarget (InvalidateRect here, present on WM_PAINT).
+		// signals the render thread — the single present path, like WPF's HwndTarget.
 		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
 		{
 			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
@@ -49,12 +47,9 @@ internal partial class Win32WindowWrapper
 	}
 
 	/// <summary>
-	/// Called on the render thread. Replays the last recorded SKPicture to
-	/// the canvas and returns the clip path and client dimensions for CopyPixels.
-	/// Returns null when there is no frame to present yet — this avoids a wasted
-	/// CopyPixels (BitBlt + DwmFlush, or SwapBuffers presenting an uninitialised
-	/// back buffer) for WM_PAINT messages that arrive before the first synchronous
-	/// render.
+	/// Called on the render thread. Replays the last recorded SKPicture and returns the clip
+	/// path and client dimensions for CopyPixels, or null when there is no frame to present
+	/// yet (avoids presenting an uninitialised back buffer before the first render).
 	/// </summary>
 	private unsafe (SKPath clipPath, int width, int height)? DrawFrame()
 	{
@@ -71,9 +66,8 @@ internal partial class Win32WindowWrapper
 			return _surface.Canvas;
 		});
 
-		// _surface is created lazily inside the resizeFunc only when there's an actual
-		// frame to draw. If it's still null, the CompositionTarget has not recorded
-		// anything yet — nothing to present.
+		// _surface is created lazily inside resizeFunc; still null means the CompositionTarget
+		// has not recorded anything yet — nothing to present.
 		if (_surface is null)
 		{
 			return null;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -18,16 +18,14 @@ internal partial class Win32WindowWrapper
 
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
-		// Mark the window dirty for WM_PAINT. This handles external repaints (window
-		// uncovering, restore from minimized) where Windows generates WM_PAINT.
-		// Like WPF (InvalidateRect in HwndTarget).
+		// Mark the window dirty and let Windows coalesce it into a WM_PAINT, whose handler
+		// signals the render thread to present. Presenting here too would double-present the
+		// same content (and re-block on VSync for GL), so WM_PAINT is the single present path,
+		// like WPF's HwndTarget (InvalidateRect here, present on WM_PAINT).
 		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
 		{
 			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
 		}
-
-		// Signal the render thread to present the current frame.
-		_renderThread?.SignalNewFrame();
 	}
 
 	private void ReinitializeRenderer()

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -16,15 +16,12 @@ internal partial class Win32WindowWrapper
 
 	public event EventHandler<SKPath>? RenderingNegativePathReevaluated; // not necessarily changed
 
-	unsafe void IXamlRootHost.InvalidateRender()
-	{
-		// Mark the window dirty and let Windows coalesce it into a WM_PAINT, whose handler
-		// signals the render thread — the single present path, like WPF's HwndTarget.
-		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
-		{
-			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
-		}
-	}
+	// Wake the render thread directly rather than via InvalidateRect/WM_PAINT. A synthesized
+	// WM_PAINT is the lowest-priority Win32 message, so the dispatcher's own posted messages
+	// (e.g. a WaitForIdle loop) outrank it in GetMessage and can starve it indefinitely —
+	// freezing the present and any per-present animation tick. OS-driven repaints
+	// (resize/uncover/show) still arrive through WM_PAINT. SignalNewFrame coalesces bursts.
+	void IXamlRootHost.InvalidateRender() => _renderThread?.SignalNewFrame();
 
 	private void ReinitializeRenderer()
 	{

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -493,25 +493,17 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		// An abandoned render thread (stuck in a native present) may still be executing inside
-		// _renderer.CopyPixels — disposing the renderer/surface then would be a use-after-free.
-		var renderThreadJoined = _renderThread?.DisposeAndTryJoin() ?? true;
+		// Stop and join the render thread before touching its resources: once Dispose returns, the
+		// thread — the sole user of the renderer/surface — has exited, so freeing them here cannot
+		// race an in-flight present.
+		_renderThread?.Dispose();
 		_renderThread = null;
-		if (renderThreadJoined)
-		{
-			// Dispose the cached SKSurface before the renderer: on Vulkan it references GPU
-			// resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs).
-			_surface?.Dispose();
-			_surface = null;
-			_renderer.Dispose();
-			_rendererDisposed = true;
-		}
-		else
-		{
-			this.LogError()?.Error(
-				"Render thread was abandoned during dispose; leaking the renderer and cached surface " +
-				"until process exit to avoid a use-after-free on native GPU resources.");
-		}
+		// Dispose the cached SKSurface before the renderer: on Vulkan it references GPU resources
+		// owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs).
+		_surface?.Dispose();
+		_surface = null;
+		_renderer.Dispose();
+		_rendererDisposed = true;
 		_backgroundDisposable?.Dispose();
 		DestroyIcons();
 		XamlRootMap.Unregister(XamlRoot!);

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -495,15 +495,31 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		_renderThread?.Dispose();
+		// DisposeAndTryJoin returns false only when the render thread was abandoned because it
+		// would not exit within the backstop (e.g. stuck in a native present). In that case the
+		// thread may still be executing inside _renderer.CopyPixels, so disposing the renderer or
+		// its cached surface here would free native GPU resources out from under it.
+		var renderThreadJoined = _renderThread?.DisposeAndTryJoin() ?? true;
 		_renderThread = null;
-		// Dispose the cached SKSurface before the renderer: on Vulkan it references
-		// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
-		// and the render thread has already been joined, so no background access remains.
-		_surface?.Dispose();
-		_surface = null;
-		_renderer.Dispose();
-		_rendererDisposed = true;
+		if (renderThreadJoined)
+		{
+			// Dispose the cached SKSurface before the renderer: on Vulkan it references
+			// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
+			// and the render thread has exited, so no background access remains.
+			_surface?.Dispose();
+			_surface = null;
+			_renderer.Dispose();
+			_rendererDisposed = true;
+		}
+		else
+		{
+			// Leak the renderer and cached surface for the remaining lifetime of the process
+			// rather than risk a use-after-free on the abandoned render thread; the OS reclaims
+			// them at exit.
+			this.LogError()?.Error(
+				"Render thread was abandoned during dispose; leaking the renderer and cached surface " +
+				"until process exit to avoid a use-after-free on native GPU resources.");
+		}
 		_backgroundDisposable?.Dispose();
 		DestroyIcons();
 		XamlRootMap.Unregister(XamlRoot!);

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -104,7 +104,6 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		Win32Host.RegisterWindow(_hwnd);
 
-		_framePacer = CreateFramePacer();
 		_renderer = FeatureConfiguration.Rendering.UseVulkanOnWin32
 			? (IRenderer?)VulkanRenderer.TryCreateVulkanRenderer(_hwnd)
 				?? (FeatureConfiguration.Rendering.UseOpenGLOnWin32 ?? true
@@ -113,6 +112,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 			: FeatureConfiguration.Rendering.UseOpenGLOnWin32 ?? true
 				? (IRenderer?)GlRenderer.TryCreateGlRenderer(_hwnd) ?? new SoftwareRenderer(_hwnd)
 				: new SoftwareRenderer(_hwnd);
+
+		InitializeRenderThread();
 
 		RegisterForBackgroundColor();
 
@@ -282,13 +283,16 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// This call is necessary when part of the window is outside the bounds of the screen and is then moved inside.
-				// In that case, the part that was outside the screen will remain unpainted until the next Render call, probably
-				// since Windows discards that part of the framebuffer thinking that that part will be drawn again during the
-				// WM_PAINT message that follows the movement of the window. However, we ignore WM_PAINT and depend on InvalidateRender
-				// and our render timer.
-				SynchronousRenderAndDraw(false);
+				// When the window moves and part of it was off-screen, Windows discards that part of
+				// the framebuffer. Signal the render thread to re-blit the exposed area.
+				_renderThread?.SignalNewFrame();
 				return new LRESULT(0);
+			case PInvoke.WM_PAINT:
+				// Signal the render thread to re-blit the current frame. WM_PAINT is generated
+				// when the window is uncovered, restored, or otherwise needs repainting.
+				// DefWindowProc calls BeginPaint/EndPaint to validate the update region.
+				_renderThread?.SignalNewFrame();
+				break;
 			case PInvoke.WM_GETMINMAXINFO:
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_GETMINMAXINFO)} message.");
 				if (Window?.AppWindow?.Presenter is OverlappedPresenter overlappedPresenter)
@@ -308,16 +312,14 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				if (_forcePaintOnNextEraseBkgndOrNcPaint)
 				{
 					_forcePaintOnNextEraseBkgndOrNcPaint = false;
-					// This call is necessary to avoid an initial blank frame during window startup.
-					// This follows from the SynchronousRenderAndDraw call in ShowCore
-					// The render timer might already be running. This is fine. The CompositionTarget
-					// contract allows calling OnNativePlatformFrameRequested multiple times.
-					Render();
+					// Signal the render thread to re-blit. The first frame was already painted
+					// by ShowCore (which waited for present), so the framebuffer has content.
+					_renderThread?.SignalNewFrame();
 					return new LRESULT(1);
 				}
 				else
 				{
-					// Paiting on WM_ERASEBKGND causes severe flickering in hosted native windows so we
+					// Painting on WM_ERASEBKGND causes severe flickering in hosted native windows so we
 					// only do it the first time when we really need to
 					return new LRESULT(0);
 				}
@@ -401,8 +403,18 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 			OnWindowSizeOrLocationChanged(); // In case the window size has changed but WM_SIZE is not fired yet. This happens specifically if the window is starting maximized using _pendingState
 			XamlRoot!.VisualTree.RootElement.UpdateLayout(); // relayout in response to the new window size
 		}
-		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.OnRenderFrameOpportunity(); // force an early render
-		Render();
+		// Force an early SKPicture record so the render thread has fresh content to present.
+		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.OnRenderFrameOpportunity();
+		// Signal the render thread and wait briefly for the present to land.
+		// Bounded so an unresponsive GPU does not stall WM_SIZE / WM_MOVE / ShowCore.
+		_renderThread?.SignalNewFrame();
+		var presentCompleted = _renderThread?.WaitForNextPresent(TimeSpan.FromMilliseconds(100));
+		if (presentCompleted == false)
+		{
+			this.LogWarn()?.Warn(
+				"Timed out waiting for the next present during synchronous render; " +
+				"the window may be shown before the first frame is displayed.");
+		}
 	}
 
 	private static System.Drawing.Point PointFromLParam(LPARAM lParam)
@@ -483,7 +495,13 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		_framePacer.Dispose();
+		_renderThread?.Dispose();
+		_renderThread = null;
+		// Dispose the cached SKSurface before the renderer: on Vulkan it references
+		// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
+		// and the render thread has already been joined, so no background access remains.
+		_surface?.Dispose();
+		_surface = null;
 		_renderer.Dispose();
 		_rendererDisposed = true;
 		_backgroundDisposable?.Dispose();

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -283,9 +283,9 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// When the window moves and part of it was off-screen, Windows discards that part of
-				// the framebuffer. Signal the render thread to re-blit the exposed area.
-				_renderThread?.SignalNewFrame();
+				// No present here: under DWM the window's backing surface survives the move, and
+				// any region that genuinely needs repainting is invalidated by the OS, which posts
+				// a WM_PAINT that signals the render thread.
 				return new LRESULT(0);
 			case PInvoke.WM_PAINT:
 				// Signal the render thread to re-blit the current frame. WM_PAINT is generated

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -283,14 +283,12 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// No present here: under DWM the window's backing surface survives the move, and
-				// any region that genuinely needs repainting is invalidated by the OS, which posts
-				// a WM_PAINT that signals the render thread.
+				// No present here: the DWM backing surface survives the move, and the OS
+				// invalidates any region needing repaint via WM_PAINT.
 				return new LRESULT(0);
 			case PInvoke.WM_PAINT:
-				// Signal the render thread to re-blit the current frame. WM_PAINT is generated
-				// when the window is uncovered, restored, or otherwise needs repainting.
-				// DefWindowProc calls BeginPaint/EndPaint to validate the update region.
+				// Signal the render thread to re-blit the current frame; DefWindowProc
+				// validates the update region via BeginPaint/EndPaint.
 				_renderThread?.SignalNewFrame();
 				break;
 			case PInvoke.WM_GETMINMAXINFO:
@@ -495,17 +493,14 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		// DisposeAndTryJoin returns false only when the render thread was abandoned because it
-		// would not exit within the backstop (e.g. stuck in a native present). In that case the
-		// thread may still be executing inside _renderer.CopyPixels, so disposing the renderer or
-		// its cached surface here would free native GPU resources out from under it.
+		// An abandoned render thread (stuck in a native present) may still be executing inside
+		// _renderer.CopyPixels — disposing the renderer/surface then would be a use-after-free.
 		var renderThreadJoined = _renderThread?.DisposeAndTryJoin() ?? true;
 		_renderThread = null;
 		if (renderThreadJoined)
 		{
-			// Dispose the cached SKSurface before the renderer: on Vulkan it references
-			// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
-			// and the render thread has exited, so no background access remains.
+			// Dispose the cached SKSurface before the renderer: on Vulkan it references GPU
+			// resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs).
 			_surface?.Dispose();
 			_surface = null;
 			_renderer.Dispose();
@@ -513,9 +508,6 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 		else
 		{
-			// Leak the renderer and cached surface for the remaining lifetime of the process
-			// rather than risk a use-after-free on the abandoned render thread; the OS reclaims
-			// them at exit.
 			this.LogError()?.Error(
 				"Render thread was abandoned during dispose; leaking the renderer and cached surface " +
 				"until process exit to avoid a use-after-free on native GPU resources.");


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/22239

## Summary

First half of a 2-PR split (foundation). Self-contained Win32-only enhancement that integrates cleanly with master's existing render scheduler. The follow-up PR (#23047) is the cross-platform `FrameTick` simplification and is rebased on this one.

### Render thread

- New `Win32WindowWrapper.RenderThread.cs`: dedicated background thread that owns `Draw + CopyPixels` (`SwapBuffers` / `BitBlt`). UI thread records `SKPicture`s and signals via `SignalNewFrame()`; render thread replays the picture, hands the clip path back to the UI thread, and presents.
- Replaces the timer-based `FramePacer` driving `Win32WindowWrapper.Render()`. The cross-platform render scheduler (`OnNativePlatformFrameRequested`, `EnqueueRender`, `OnRenderFrameOpportunity`) is unchanged — the render thread reuses it from a non-UI thread, and `EnqueueRenderCallback` still runs `Render()` on the UI thread to record the next `SKPicture`.
- Bounded join on dispose (250 ms primary + 2 s backstop) keeps window close responsive even if the GPU is hung.

### VSync

- **OpenGL**: `wglSwapIntervalEXT(1)` after GL context creation so `SwapBuffers` blocks until the next display refresh. Without this, some GPU drivers default to swap interval 0 and the render thread spins at hundreds of fps.
- **Software**: `DwmFlush` after `BitBlt` to pace at the DWM compositor's vsync. Includes a degraded-pacing fallback — after 3 consecutive `DwmFlush` failures (RDP reconnect, fast user switch, GPU TDR) we switch to a 16 ms `Thread.Sleep` for the lifetime of the renderer.

### Native-element clip path

- `Win32NativeElementHostingExtension.OnRenderingNegativePathReevaluated` now asserts UI-thread access. With the render thread dispatching the clip path back via `NativeDispatcher.Main.Enqueue`, this catches any future regression where the callback would be invoked off the UI thread.

### Why split into two PRs

The original branch bundled the render thread + vsync (Win32-local) with a cross-platform render-scheduler refactor (`FrameTick`, throttle, `OnFramePresented`). The two are logically independent: this PR slots the render thread into master's existing scheduler so the threading change can be reviewed and shipped on its own. The follow-up PR (#23047) introduces the new scheduler and re-points the Win32 render thread to it.

## Test plan

- [ ] `dotnet build src/Uno.UI-Skia-only.slnf -p:RunAnalyzersDuringBuild=false` succeeds.
- [ ] `SamplesApp.Skia.Generic` on Win32 (OpenGL renderer) runs steady-state animations at ~vsync rate (no spinning at hundreds of fps).
- [ ] Force software path: similar pacing via `DwmFlush`; degraded fallback triggers and logs after repeated failures.
- [ ] Close the window during heavy animation: render thread joins within 250 ms, no hang.
- [ ] No regression on Vulkan renderer (the render thread treats it the same as GL).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)