### PR TITLE
fix(devserver): Extend loopback candidates to IPv6 and mobile emulators

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlClient_LoopbackCandidates.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlClient_LoopbackCandidates.cs
@@ -1,0 +1,96 @@
+using Uno.UI.RemoteControl;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+[TestClass]
+public class Given_RemoteControlClient_LoopbackCandidates
+{
+	[TestMethod]
+	[DataRow("127.0.0.1", true)]
+	[DataRow("[::1]", true)]
+	[DataRow("::1", false)] // no brackets — not a valid URI endpoint
+	[DataRow("localhost", false)]
+	[DataRow("192.168.1.1", false)]
+	[DataRow("10.0.2.2", false)]
+	public void IsLoopbackAddress_ShouldMatchOnlyLoopbackLiterals(string endpoint, bool expected)
+		=> RemoteControlClient.IsLoopbackAddress(endpoint).Should().Be(expected);
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_WhenNoCandidates_ReturnsSameArray()
+	{
+		(string, int)[] addresses = [("192.168.1.10", 5000)];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, [], 5000);
+
+		result.Should().BeSameAs(addresses);
+	}
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_PrependsCandidatesBeforeExistingAddresses()
+	{
+		(string, int)[] addresses = [("192.168.1.10", 5000)];
+		string[] candidates = ["127.0.0.1", "[::1]"];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, candidates, 5000);
+
+		result.Should().Equal(
+			("127.0.0.1", 5000),
+			("[::1]", 5000),
+			("192.168.1.10", 5000));
+	}
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_SkipsCandidateAlreadyPresent()
+	{
+		(string, int)[] addresses = [("127.0.0.1", 5000), ("192.168.1.10", 5000)];
+		string[] candidates = ["127.0.0.1", "[::1]"];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, candidates, 5000);
+
+		result.Should().Equal(
+			("[::1]", 5000),
+			("127.0.0.1", 5000),
+			("192.168.1.10", 5000));
+	}
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_SkipCandidateIsCaseInsensitive()
+	{
+		// Address already present with different casing — must still be skipped
+		(string, int)[] addresses = [("[::1]", 5000)];
+		string[] candidates = ["[::1]".ToUpperInvariant()];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, candidates, 5000);
+
+		result.Should().Equal(("[::1]", 5000));
+	}
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_DoesNotSkipCandidateWithDifferentPort()
+	{
+		// Address 127.0.0.1 exists but on a different port — candidate should still be prepended
+		(string, int)[] addresses = [("127.0.0.1", 9999), ("192.168.1.10", 5000)];
+		string[] candidates = ["127.0.0.1"];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, candidates, 5000);
+
+		result.Should().Equal(
+			("127.0.0.1", 5000),
+			("127.0.0.1", 9999),
+			("192.168.1.10", 5000));
+	}
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_PreservesOrderOfCandidates()
+	{
+		(string, int)[] addresses = [("192.168.1.10", 5000)];
+		string[] candidates = ["10.0.2.2", "127.0.0.1"];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, candidates, 5000);
+
+		result.Should().Equal(
+			("10.0.2.2", 5000),
+			("127.0.0.1", 5000),
+			("192.168.1.10", 5000));
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlClient_LoopbackCandidates.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlClient_LoopbackCandidates.cs
@@ -12,8 +12,31 @@ public class Given_RemoteControlClient_LoopbackCandidates
 	[DataRow("localhost", false)]
 	[DataRow("192.168.1.1", false)]
 	[DataRow("10.0.2.2", false)]
-	public void IsLoopbackAddress_ShouldMatchOnlyLoopbackLiterals(string endpoint, bool expected)
+	public void IsLoopbackAddress_ReturnsTrueForLoopbackLiteralsOnly(string endpoint, bool expected)
 		=> RemoteControlClient.IsLoopbackAddress(endpoint).Should().Be(expected);
+
+	[TestMethod]
+	[DataRow("127.0.0.1", true)]
+	[DataRow("[::1]", true)]
+	[DataRow("10.0.2.2", true)]
+	[DataRow("localhost", false)]
+	[DataRow("192.168.1.1", false)]
+	public void IsPriorityCandidate_ReturnsTrueForLoopbackAndAndroidAlias(string endpoint, bool expected)
+		=> RemoteControlClient.IsPriorityCandidate(endpoint).Should().Be(expected);
+
+	[TestMethod]
+	[DataRow("127.0.0.1", "127.0.0.1", true)]   // exact match
+	[DataRow("127.0.0.1", "[::1]", true)]        // loopback equivalence
+	[DataRow("[::1]", "127.0.0.1", true)]        // loopback equivalence, reversed
+	[DataRow("[::1]", "[::1]", true)]            // exact match
+	[DataRow("127.0.0.1", "10.0.2.2", false)]   // 10.0.2.2 outside loopback equivalence group
+	[DataRow("10.0.2.2", "127.0.0.1", false)]   // 10.0.2.2 outside loopback equivalence group
+	[DataRow("10.0.2.2", "10.0.2.2", true)]     // exact match still works
+	[DataRow("192.168.1.1", "192.168.1.1", true)]  // non-loopback exact match
+	[DataRow("192.168.1.1", "192.168.1.2", false)] // non-loopback mismatch
+	[DataRow(null, "127.0.0.1", false)]          // no preferred → no match
+	public void IsPreferredEndpointMatch_MatchesExactOrLoopbackEquivalent(string? preferred, string candidate, bool expected)
+		=> RemoteControlClient.IsPreferredEndpointMatch(preferred, candidate).Should().Be(expected);
 
 	[TestMethod]
 	public void BuildAddressListWithLoopback_WhenNoCandidates_ReturnsSameArray()
@@ -21,6 +44,17 @@ public class Given_RemoteControlClient_LoopbackCandidates
 		(string, int)[] addresses = [("192.168.1.10", 5000)];
 
 		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, [], 5000);
+
+		result.Should().BeSameAs(addresses);
+	}
+
+	[TestMethod]
+	public void BuildAddressListWithLoopback_WhenAllCandidatesAlreadyPresent_ReturnsSameArray()
+	{
+		(string, int)[] addresses = [("127.0.0.1", 5000), ("[::1]", 5000), ("192.168.1.10", 5000)];
+		string[] candidates = ["127.0.0.1", "[::1]"];
+
+		var result = RemoteControlClient.BuildAddressListWithLoopback(addresses, candidates, 5000);
 
 		result.Should().BeSameAs(addresses);
 	}
@@ -54,7 +88,7 @@ public class Given_RemoteControlClient_LoopbackCandidates
 	}
 
 	[TestMethod]
-	public void BuildAddressListWithLoopback_SkipCandidateIsCaseInsensitive()
+	public void BuildAddressListWithLoopback_SkipsCandidateIsCaseInsensitive()
 	{
 		// Address already present with different casing — must still be skipped
 		(string, int)[] addresses = [("[::1]", 5000)];

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -9,7 +9,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices.JavaScript;
 using System.Text;
@@ -267,25 +266,10 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 			}
 			else
 			{
-				// For WASM and desktop platforms, add loopback address for better reliability and airplane mode support
-				// Mobile platforms (iOS, Android) should not use loopback as they connect to a different machine
-				if ((OperatingSystem.IsBrowser()
-					|| OperatingSystem.IsWindows()
-					|| OperatingSystem.IsLinux()
-					|| OperatingSystem.IsMacOS()))
+				var serverPort = _serverAddresses.Select(addr => addr.port).Where(p => p > 0).FirstOrDefault();
+				if (serverPort > 0)
 				{
-					var serverPort = _serverAddresses.Select(addr => addr.port).Where(p => p > 0).FirstOrDefault();
-					if (serverPort > 0)
-					{
-						var loopbackAddress = IPAddress.Loopback.ToString().ToLowerInvariant();
-						var hasLoopback = _serverAddresses.Any(addr => addr.endpoint.Equals(loopbackAddress, StringComparison.OrdinalIgnoreCase) && addr.port == serverPort);
-
-						if (!hasLoopback)
-						{
-							// Prepend loopback address to give it priority
-							_serverAddresses = new[] { (loopbackAddress, serverPort) }.Concat(_serverAddresses).ToArray();
-						}
-					}
+					_serverAddresses = BuildAddressListWithLoopback(_serverAddresses, GetLoopbackCandidates(), serverPort);
 				}
 			}
 		}
@@ -395,7 +379,8 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 					ApplicationData.Current.LocalSettings.Values.TryGetValue(lastEndpointKey, out var lastValue) &&
 					lastValue is string lastEp
 						? _serverAddresses
-							.FirstOrDefault(srv => srv.endpoint.Equals(lastEp, StringComparison.OrdinalIgnoreCase))
+							.FirstOrDefault(srv => srv.endpoint.Equals(lastEp, StringComparison.OrdinalIgnoreCase)
+								|| (IsLoopbackAddress(lastEp) && IsLoopbackAddress(srv.endpoint)))
 							.endpoint
 						: default;
 			}
@@ -411,8 +396,12 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 					{
 						// Note: If we have a preferred endpoint (last known to be successful), we delay a bit the connection to other endpoints.
 						//		 This is to reduce the number of (task cancelled / socket) exceptions at startup by giving a chance to the preferred endpoint to succeed first.
+						//		 Loopback addresses (127.0.0.1, [::1]) are treated as equivalent for this purpose.
 						var cts = new CancellationTokenSource();
-						var delay = preferred is null || preferred.Equals(srv.endpoint, StringComparison.OrdinalIgnoreCase) ? 0 : 3000;
+						var delay = preferred is null
+							|| preferred.Equals(srv.endpoint, StringComparison.OrdinalIgnoreCase)
+							|| (IsLoopbackAddress(preferred) && IsLoopbackAddress(srv.endpoint))
+							? 0 : 3000;
 						var task = Connect(serverUri, delay, cts.Token);
 
 						return (task, srv.endpoint, cts);
@@ -983,5 +972,68 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 		{
 			Instance = null;
 		}
+	}
+
+	/// <summary>Returns true if <paramref name="endpoint"/> is an IPv4 or IPv6 local loopback literal.</summary>
+	internal static bool IsLoopbackAddress(string endpoint)
+		=> endpoint.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)
+			|| endpoint.Equals("[::1]", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Returns the ordered list of loopback IP candidates to prepend to the server address list for the current
+	/// platform and runtime environment. IP literals are used (rather than "localhost") to avoid DNS resolution on
+	/// the startup-critical path and to ensure both address families are tried independently via the existing
+	/// parallel-race connection strategy.
+	/// </summary>
+	private static IReadOnlyList<string> GetLoopbackCandidates()
+	{
+#if __WASM__
+		return ["127.0.0.1", "[::1]"];
+#elif __ANDROID__
+		// On AVD, 10.0.2.2 is the conventional host-machine alias. 127.0.0.1 covers adb-reverse setups.
+		var fingerprint = Android.OS.Build.Fingerprint;
+		var isEmulator = fingerprint is { Length: > 0 }
+			&& fingerprint.StartsWith("generic", StringComparison.OrdinalIgnoreCase);
+		if (isEmulator)
+		{
+			return ["10.0.2.2", "127.0.0.1"];
+		}
+		return [];
+#elif __IOS__ || __TVOS__
+#if __MACCATALYST__
+		// Mac Catalyst runs natively on macOS — loopback always reaches the host machine.
+		return ["127.0.0.1", "[::1]"];
+#else
+		if (ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR)
+		{
+			return ["127.0.0.1", "[::1]"];
+		}
+		return [];
+#endif
+#else
+		// Skia desktop (Windows, Linux, macOS) and Reference build.
+		return ["127.0.0.1", "[::1]"];
+#endif
+	}
+
+	/// <summary>
+	/// Returns a new address list with <paramref name="loopbackCandidates"/> for <paramref name="port"/> prepended,
+	/// skipping any candidate already present in <paramref name="addresses"/>.
+	/// </summary>
+	internal static (string endpoint, int port)[] BuildAddressListWithLoopback(
+		(string endpoint, int port)[] addresses,
+		IReadOnlyList<string> loopbackCandidates,
+		int port)
+	{
+		if (loopbackCandidates.Count == 0)
+		{
+			return addresses;
+		}
+
+		var toAdd = loopbackCandidates
+			.Where(c => !addresses.Any(a => a.endpoint.Equals(c, StringComparison.OrdinalIgnoreCase) && a.port == port))
+			.Select(c => (c, port));
+
+		return [.. toAdd, .. addresses];
 	}
 }

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -269,7 +269,7 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 				var serverPort = _serverAddresses.Select(addr => addr.port).Where(p => p > 0).FirstOrDefault();
 				if (serverPort > 0)
 				{
-					_serverAddresses = BuildAddressListWithLoopback(_serverAddresses, GetLoopbackCandidates(), serverPort);
+					_serverAddresses = BuildAddressListWithLoopback(_serverAddresses, GetDevServerHostCandidates(), serverPort);
 				}
 			}
 		}
@@ -379,8 +379,7 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 					ApplicationData.Current.LocalSettings.Values.TryGetValue(lastEndpointKey, out var lastValue) &&
 					lastValue is string lastEp
 						? _serverAddresses
-							.FirstOrDefault(srv => srv.endpoint.Equals(lastEp, StringComparison.OrdinalIgnoreCase)
-								|| (IsLoopbackAddress(lastEp) && IsLoopbackAddress(srv.endpoint)))
+							.FirstOrDefault(srv => IsPreferredEndpointMatch(lastEp, srv.endpoint))
 							.endpoint
 						: default;
 			}
@@ -394,14 +393,14 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 				{
 					if (TryParse(srv.endpoint, srv.port, isHttps, out var serverUri))
 					{
-						// Note: If we have a preferred endpoint (last known to be successful), we delay a bit the connection to other endpoints.
-						//		 This is to reduce the number of (task cancelled / socket) exceptions at startup by giving a chance to the preferred endpoint to succeed first.
-						//		 Loopback addresses (127.0.0.1, [::1]) are treated as equivalent for this purpose.
+						// Note: Priority candidates (loopback literals and Android AVD host alias) always get delay=0.
+						//		 When a preferred endpoint is known (last successful), others wait 3 s to give it a head start.
+						//		 When no preferred is known (first launch), non-priority addresses wait 500 ms so local
+						//		 loopback candidates win the race before LAN addresses are attempted.
 						var cts = new CancellationTokenSource();
-						var delay = preferred is null
-							|| preferred.Equals(srv.endpoint, StringComparison.OrdinalIgnoreCase)
-							|| (IsLoopbackAddress(preferred) && IsLoopbackAddress(srv.endpoint))
-							? 0 : 3000;
+						var delay = IsPriorityCandidate(srv.endpoint) || IsPreferredEndpointMatch(preferred, srv.endpoint)
+							? 0
+							: preferred is null ? 500 : 3000;
 						var task = Connect(serverUri, delay, cts.Token);
 
 						return (task, srv.endpoint, cts);
@@ -974,42 +973,74 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 		}
 	}
 
+	// The three helpers below are internal (rather than private) to allow unit testing via InternalsVisibleTo.
+
 	/// <summary>Returns true if <paramref name="endpoint"/> is an IPv4 or IPv6 local loopback literal.</summary>
 	internal static bool IsLoopbackAddress(string endpoint)
-		=> endpoint.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)
-			|| endpoint.Equals("[::1]", StringComparison.OrdinalIgnoreCase);
+		=> endpoint.Equals("127.0.0.1", StringComparison.Ordinal)
+			|| endpoint.Equals("[::1]", StringComparison.Ordinal);
 
 	/// <summary>
-	/// Returns the ordered list of loopback IP candidates to prepend to the server address list for the current
-	/// platform and runtime environment. IP literals are used (rather than "localhost") to avoid DNS resolution on
-	/// the startup-critical path and to ensure both address families are tried independently via the existing
-	/// parallel-race connection strategy.
+	/// Returns true if <paramref name="endpoint"/> is a high-priority dev-server candidate that should be attempted
+	/// before LAN addresses: loopback literals (<c>127.0.0.1</c>, <c>[::1]</c>) and the Android AVD host alias
+	/// (<c>10.0.2.2</c>).
 	/// </summary>
-	private static IReadOnlyList<string> GetLoopbackCandidates()
+	internal static bool IsPriorityCandidate(string endpoint)
+		=> IsLoopbackAddress(endpoint)
+			|| endpoint.Equals("10.0.2.2", StringComparison.Ordinal); // Android AVD host-machine alias
+
+	/// <summary>
+	/// Returns true if <paramref name="candidate"/> should receive a zero-delay head-start because it matches
+	/// <paramref name="preferred"/>. Loopback literals are treated as equivalent to each other.
+	/// </summary>
+	internal static bool IsPreferredEndpointMatch(string? preferred, string candidate)
+		=> preferred is not null
+			&& (preferred.Equals(candidate, StringComparison.OrdinalIgnoreCase)
+				|| (IsLoopbackAddress(preferred) && IsLoopbackAddress(candidate)));
+
+	/// <summary>
+	/// Returns the ordered list of high-priority dev-server address candidates to prepend to the server address list
+	/// for the current platform and runtime environment. IP literals are used (rather than "localhost") to avoid DNS
+	/// resolution on the startup-critical path and to ensure both address families are tried independently via the
+	/// existing parallel-race connection strategy.
+	/// </summary>
+	private static IReadOnlyList<string> GetDevServerHostCandidates()
 	{
 #if __WASM__
 		return ["127.0.0.1", "[::1]"];
-#elif __ANDROID__
-		// On AVD, 10.0.2.2 is the conventional host-machine alias. 127.0.0.1 covers adb-reverse setups.
-		var fingerprint = Android.OS.Build.Fingerprint;
-		var isEmulator = fingerprint is { Length: > 0 }
-			&& fingerprint.StartsWith("generic", StringComparison.OrdinalIgnoreCase);
-		if (isEmulator)
-		{
-			return ["10.0.2.2", "127.0.0.1"];
-		}
-		return [];
-#elif __IOS__ || __TVOS__
-#if __MACCATALYST__
+#elif __MACCATALYST__
 		// Mac Catalyst runs natively on macOS — loopback always reaches the host machine.
 		return ["127.0.0.1", "[::1]"];
-#else
+#elif __IOS__ || __TVOS__
+		// Canonical source: Uno.DeviceHelper.IsSimulator in Uno.UWP (internal, not accessible from here).
 		if (ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR)
 		{
 			return ["127.0.0.1", "[::1]"];
 		}
-		return [];
-#endif
+		return Array.Empty<string>();
+#elif __ANDROID__
+		// Multi-field heuristic sourced from flutter/plus_plugins device_info_plus (same logic in SamplesApp Main.Android.cs).
+		// Covers AVD (10.0.2.2 = host-machine alias), adb-reverse (127.0.0.1), and Genymotion.
+		var isEmulator =
+			(Android.OS.Build.Brand!.StartsWith("generic", StringComparison.OrdinalIgnoreCase)
+				&& Android.OS.Build.Device!.StartsWith("generic", StringComparison.OrdinalIgnoreCase))
+			|| Android.OS.Build.Fingerprint!.StartsWith("generic", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Fingerprint.StartsWith("unknown", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Hardware!.Contains("goldfish", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Hardware.Contains("ranchu", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Model!.Contains("google_sdk", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Model.Contains("Emulator", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Model.Contains("Android SDK built for x86", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Manufacturer!.Contains("Genymotion", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product!.Contains("sdk_google", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product.Contains("google_sdk", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product.Contains("sdk", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product.Contains("sdk_x86", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product.Contains("vbox86p", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product.Contains("emulator", StringComparison.OrdinalIgnoreCase)
+			|| Android.OS.Build.Product.Contains("simulator", StringComparison.OrdinalIgnoreCase);
+
+		return isEmulator ? ["10.0.2.2", "127.0.0.1"] : Array.Empty<string>();
 #else
 		// Skia desktop (Windows, Linux, macOS) and Reference build.
 		return ["127.0.0.1", "[::1]"];
@@ -1017,23 +1048,29 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 	}
 
 	/// <summary>
-	/// Returns a new address list with <paramref name="loopbackCandidates"/> for <paramref name="port"/> prepended,
-	/// skipping any candidate already present in <paramref name="addresses"/>.
+	/// Returns a new address list with <paramref name="hostCandidates"/> for <paramref name="port"/> prepended,
+	/// skipping any candidate already present in <paramref name="addresses"/> at that port.
+	/// Returns the original <paramref name="addresses"/> instance unchanged when nothing is prepended.
 	/// </summary>
 	internal static (string endpoint, int port)[] BuildAddressListWithLoopback(
 		(string endpoint, int port)[] addresses,
-		IReadOnlyList<string> loopbackCandidates,
+		IReadOnlyList<string> hostCandidates,
 		int port)
 	{
-		if (loopbackCandidates.Count == 0)
+		if (hostCandidates.Count == 0)
 		{
 			return addresses;
 		}
 
-		var toAdd = loopbackCandidates
+		var toAdd = hostCandidates
 			.Where(c => !addresses.Any(a => a.endpoint.Equals(c, StringComparison.OrdinalIgnoreCase) && a.port == port))
-			.Select(c => (c, port));
+			.ToList();
 
-		return [.. toAdd, .. addresses];
+		if (toAdd.Count == 0)
+		{
+			return addresses;
+		}
+
+		return [.. toAdd.Select(c => (c, port)), .. addresses];
 	}
 }


### PR DESCRIPTION
## Summary

Closes #17757

The client-side loopback address list used to contain only `127.0.0.1` (IPv4), and was entirely skipped for mobile platforms. This left two gaps:

- On dual-stack machines or environments where the dev-server binds to IPv6, `[::1]` was never tried.
- iOS Simulator, Mac Catalyst, and Android Emulator can all reach the host via a loopback or host-alias address, but were treated the same as real devices.

### Changes

**`RemoteControlClient.cs`**

- Replaces the single `127.0.0.1` prepend with `GetLoopbackCandidates()`, a platform-specific helper using `#if` blocks (consistent with the rest of `Uno.UI.RemoteControl`):

  | Target | Candidates prepended |
  |---|---|
  | WASM, Skia desktop | `127.0.0.1`, `[::1]` |
  | iOS Simulator / Mac Catalyst | `127.0.0.1`, `[::1]` |
  | Android Emulator (AVD, detected via `Build.Fingerprint`) | `10.0.2.2`, `127.0.0.1` |
  | iOS / Android real devices | *(none — IDE injects the LAN address)* |

  IP literals are used instead of `"localhost"` to avoid DNS resolution on the startup-critical path and because `ClientWebSocket.ConnectAsync` does not guarantee Happy Eyeballs — passing a hostname picks a single address family.

- `127.0.0.1` and `[::1]` are now treated as **equivalent** in the last-known-good `preferred` endpoint matching (introduced in #17781). A session that connected via `127.0.0.1` gives a zero delay to `[::1]` on the next start, and vice versa. Without this, switching families would silently reset the 3-second head-start.

- Extracts `BuildAddressListWithLoopback` as an `internal static` method for unit testability.

**`Given_RemoteControlClient_LoopbackCandidates.cs`** — 7 unit tests covering:
- `IsLoopbackAddress` for all recognized literals and non-loopback cases.
- `BuildAddressListWithLoopback`: prepend order, deduplication, case-insensitive skip, port-scoped skip, empty candidate list (returns same instance).

## Test plan

- [ ] Build and run `Uno.UI.RemoteControl.DevServer.Tests` — new tests should pass.
- [ ] Run Skia Desktop SamplesApp with devserver: confirm connection uses `127.0.0.1` or `[::1]` at first start (no LAN-address noise in logs).
- [ ] Run on a machine with VPN or multiple NICs active: confirm reduction of first-chance WebSocket exceptions at startup.
- [ ] Run on Android Emulator (AVD): confirm `10.0.2.2` appears first in the candidate list.
- [ ] Run on iOS Simulator: confirm `127.0.0.1`/`[::1]` appear in the candidate list.
- [ ] Run on a real Android/iOS device: confirm no loopback candidates are added (LAN address injected by IDE is used as-is).