### PR TITLE
feat: Expose PushRequestedThemeForSubTreeByName/PopRequestedThemeForSubTreeByName as public API

### DIFF
--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -894,6 +894,23 @@ namespace Microsoft.UI.Xaml
 		internal static void PopRequestedThemeForSubTree()
 			=> Themes.PopRequestedThemeForSubTree();
 
+		/// <summary>
+		/// Pushes a theme onto the stack for the current element's subtree resource resolution.
+		/// This is an Uno Platform-specific API intended for framework use only.
+		/// </summary>
+		/// <param name="theme">The theme name (e.g. "Light", "Dark", "Default").</param>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void PushRequestedThemeForSubTreeByName(string theme)
+			=> Themes.PushRequestedThemeForSubTree(theme);
+
+		/// <summary>
+		/// Pops the theme from the stack after processing an element's subtree.
+		/// This is an Uno Platform-specific API intended for framework use only.
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void PopRequestedThemeForSubTreeByName()
+			=> Themes.PopRequestedThemeForSubTree();
+
 		internal static void SetActiveTheme(SpecializedResourceDictionary.ResourceKey key)
 			=> Themes.Active = key;
 


### PR DESCRIPTION
## Summary

Adds public `string`-accepting overloads of the internal theme-stack methods on `ResourceDictionary`, marked with `[EditorBrowsable(EditorBrowsableState.Never)]`.

This allows external packages (e.g. CSharpMarkup's `ThemeBindingProvider`) to manage the theme context without resorting to reflection, which is fragile, trim-unsafe, and breaks when internals change.

## What

- `ResourceDictionary.PushRequestedThemeForSubTreeByName(string theme)` — pushes the named theme onto the resolution stack
- `ResourceDictionary.PopRequestedThemeForSubTreeByName()` — pops the current theme from the stack

Both delegate to the existing internal `Themes.PushRequestedThemeForSubTree`/`PopRequestedThemeForSubTree` methods, leveraging the implicit `string` → `ResourceKey` conversion.

## Why

The CSharpMarkup `ThemeBindingProvider` (PR unoplatform/uno.csharpmarkup#881) initially uses reflection as a first draft to call internal `PushRequestedThemeForSubTree`/`PopRequestedThemeForSubTree`. Reviewers @MartinZikmund  and @dr1rrb requested that it would be best to expose a public API from Uno.UI instead.

## Design decisions

- **`string` parameter** instead of `ResourceKey`: The `ResourceKey` struct lives inside `internal class SpecializedResourceDictionary`, making it inaccessible to external consumers. The implicit conversion handles bridging internally.
- **`ByName` suffix**: Distinguishes from the existing internal `ResourceKey`-accepting overloads.
- **`[EditorBrowsable(Never)]`**: Keeps IntelliSense clean while allowing direct invocation by framework-aware packages.

---

- Related to https://github.com/unoplatform/uno.csharpmarkup/pull/881 
- And as a follow-up of [uno/pull/23178](https://github.com/unoplatform/uno/pull/23178) and [uno/pull/23197](https://github.com/unoplatform/uno/pull/23197) after initial regressions/changes from previous [uno/pull/22803](https://github.com/unoplatform/uno/pull/22803) and [uno/pull/22887](https://github.com/unoplatform/uno/pull/22887)