### PR TITLE
fix(android): Include Low items in render gate to prevent starvation

### DIFF
--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -33,7 +33,7 @@ namespace Uno.UI.Dispatching
 
 		private readonly object _gate = new();
 
-		private readonly Dictionary<object, (Action? renderAction, int normalItemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
+		private readonly Dictionary<object, (Action? renderAction, int priorityItemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
 
 		private NativeDispatcherPriority _currentPriority;
 
@@ -102,13 +102,17 @@ namespace Uno.UI.Dispatching
 								@this.EnqueueNative(@this._currentPriority);
 							}
 
-							if (@this._currentPriority == NativeDispatcherPriority.Normal)
+							// The render gate counts Normal AND Low items. Decrement on either
+							// so Low items present at render-dispatch time get to run before the
+							// next render. See TryGetRenderAction for why this gate exists.
+							if (@this._currentPriority == NativeDispatcherPriority.Normal ||
+								@this._currentPriority == NativeDispatcherPriority.Low)
 							{
 								foreach (var (compositionTarget, details) in @this._compositionTargets)
 								{
-									if (details.normalItemsToProcessBeforeNextRenderAction > 0)
+									if (details.priorityItemsToProcessBeforeNextRenderAction > 0)
 									{
-										@this._compositionTargets[compositionTarget] = details with { normalItemsToProcessBeforeNextRenderAction = details.normalItemsToProcessBeforeNextRenderAction - 1 };
+										@this._compositionTargets[compositionTarget] = details with { priorityItemsToProcessBeforeNextRenderAction = details.priorityItemsToProcessBeforeNextRenderAction - 1 };
 									}
 								}
 							}
@@ -160,9 +164,17 @@ namespace Uno.UI.Dispatching
 				{
 					if (details.renderAction is not null)
 					{
-						if (details.normalItemsToProcessBeforeNextRenderAction == 0)
+						if (details.priorityItemsToProcessBeforeNextRenderAction == 0)
 						{
-							_compositionTargets[compositionTarget] = (renderAction: null, normalItemsToProcessBeforeNextRenderAction: _queues[(int)NativeDispatcherPriority.Normal].Count);
+							// Gate the next render on draining ALL currently-queued Normal AND Low items,
+							// not just Normal. Counting only Normal causes Low items to starve under
+							// continuous render saturation (when _isRenderingActive is true the
+							// rendering loop self-perpetuates — see CompositionTarget.Rendering.skia.cs
+							// Render() — and counter==0 makes render dispatch before the priority loop
+							// ever runs). Idle remains starvable by design.
+							_compositionTargets[compositionTarget] = (renderAction: null, priorityItemsToProcessBeforeNextRenderAction:
+								_queues[(int)NativeDispatcherPriority.Normal].Count +
+								_queues[(int)NativeDispatcherPriority.Low].Count);
 
 							_currentPriority = NativeDispatcherPriority.High;
 

--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -108,8 +108,13 @@ namespace Uno.UI.Dispatching
 							if (@this._currentPriority == NativeDispatcherPriority.Normal ||
 								@this._currentPriority == NativeDispatcherPriority.Low)
 							{
-								foreach (var (compositionTarget, details) in @this._compositionTargets)
+								// Snapshot the keys so we can mutate values inside the loop. Setting an
+								// existing key on Dictionary<,> bumps the enumerator version and would
+								// throw InvalidOperationException on the next MoveNext once
+								// _compositionTargets has more than one entry (multi-window apps).
+								foreach (var compositionTarget in @this._compositionTargets.Keys.ToArray())
 								{
+									var details = @this._compositionTargets[compositionTarget];
 									if (details.priorityItemsToProcessBeforeNextRenderAction > 0)
 									{
 										@this._compositionTargets[compositionTarget] = details with { priorityItemsToProcessBeforeNextRenderAction = details.priorityItemsToProcessBeforeNextRenderAction - 1 };

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_DispatcherQueue.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_DispatcherQueue.cs
@@ -45,5 +45,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_System
 			await UITestHelper.WaitForIdle();
 			CollectionAssert.AreEqual(new[] { 1, 3, 2 }, list);
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_Low_Priority_With_Active_Rendering_Subscriber_Does_Not_Starve()
+		{
+			// Regression test: subscribing to CompositionTarget.Rendering activates the
+			// self-perpetuating 60fps render cycle (RequestNewFrame + unconditional
+			// InvalidateRender at the end of every Render() in CompositionTarget.Rendering.skia.cs).
+			// The cycle queues a render in NativeDispatcher._compositionTargets at every
+			// vsync. Before the fix, the render gate (normalItemsToProcessBeforeNextRenderAction)
+			// only counted Normal queue items, so a Low-priority item enqueued under render
+			// saturation could starve indefinitely. The fix counts Normal+Low so Low items
+			// always get a chance to run before the next render.
+			var lowRan = new TaskCompletionSource<bool>();
+			EventHandler<object> renderingHandler = (_, _) => { /* keep _isRenderingActive true */ };
+
+			Microsoft.UI.Xaml.Media.CompositionTarget.Rendering += renderingHandler;
+			try
+			{
+				// Let the render cycle reach steady state.
+				await Task.Delay(100);
+
+				var enqueued = DispatcherQueue.GetForCurrentThread().TryEnqueue(
+					DispatcherQueuePriority.Low,
+					() => lowRan.TrySetResult(true));
+				Assert.IsTrue(enqueued, "TryEnqueue should accept the Low-priority item.");
+
+				// Allow up to 2s for the Low item to be dispatched. With the bug present, it
+				// never runs because every DispatchItems call dispatches a render first.
+				var completed = await Task.WhenAny(lowRan.Task, Task.Delay(2000));
+				Assert.AreSame(lowRan.Task, completed,
+					"Low-priority item starved while CompositionTarget.Rendering was active.");
+			}
+			finally
+			{
+				Microsoft.UI.Xaml.Media.CompositionTarget.Rendering -= renderingHandler;
+			}
+		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** related to https://github.com/unoplatform/kahua-private/issues/460

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
