### PR TITLE
fix: add missing partial keyword to UiaCycleContainer and UiaCycleChild

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/UiaChildCycle_DataGrid.xaml.cs
@@ -46,7 +46,7 @@ public sealed partial class UiaChildCycle_DataGrid : UserControl
 /// Container control whose AutomationPeer uses the visual-tree walk, placing
 /// <see cref="UiaCycleChild"/> as a child in the UIA tree.
 /// </summary>
-public class UiaCycleContainer : UserControl
+public partial class UiaCycleContainer : UserControl
 {
 	public UiaCycleContainer()
 	{
@@ -91,7 +91,7 @@ public class UiaCycleContainerAutomationPeer : FrameworkElementAutomationPeer
 /// <c>DataGridRowsPresenterAutomationPeer.GetChildrenCore()</c> which calls
 /// <c>GridPeer.GetChildPeers()</c> where GridPeer = CreatePeerForElement(DataGrid).
 /// </summary>
-public class UiaCycleChild : UserControl
+public partial class UiaCycleChild : UserControl
 {
 	/// <summary>Back-reference to the container (set by <see cref="UiaCycleContainer"/>).</summary>
 	internal UiaCycleContainer? Container { get; set; }


### PR DESCRIPTION
Adds the missing `partial` modifier to `UiaCycleContainer` and `UiaCycleChild` class declarations in `UiaChildCycle_DataGrid.xaml.cs`.

Without `partial`, the XAML-generated partial class conflicts with the code-behind, causing **[CS0260 build errors on iOS Native and Android Native targets](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=211228&view=logs&j=a54adc20-f97a-5e02-19e8-cc33821dfc3e&t=50c2e5c6-4861-5ee5-b4ae-73b4c495ee2b&l=87)**.

Related to previous changes from: https://github.com/unoplatform/uno/pull/23198