### PR TITLE
WebView2 fixes

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -4,8 +4,10 @@ using Microsoft.UI.Xaml;
 using Uno.Foundation.Logging;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -25,13 +27,19 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 {
 	private static readonly SKPoint[] _conicPoints = new SKPoint[32 * 3]; // 3 points per quad
 
+	// Tracks the desired Uno z-order of native child HWNDs per parent window so SetZIndex can place
+	// each child relative to its lower sibling deterministically, instead of depending on the caller
+	// invoking SetZIndex for every host in ascending order.
+	private static readonly Dictionary<nint, SortedDictionary<int, nint>> _childZOrderByParent = new();
+
 	private readonly ContentPresenter _presenter;
 	private readonly SKPath _tempPath = new();
-	private SKPath? _lastClipPath;
 	private Rect _lastArrangeRect;
+	private Rect _pendingArrangeRect;
+	private bool _arrangePending;
 	private string? _lastFinalSvgClipPath;
 	private HRGN _lastClipHrgn;
-	private bool _showWindowOnNextArrange;
+	private bool _showWindowOnNextRender;
 
 	public Win32NativeElementHostingExtension(ContentPresenter presenter)
 	{
@@ -87,7 +95,7 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 		PInvoke.SetWindowLong((HWND)window.Hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (oldStyleVal | (int)WINDOW_STYLE.WS_CLIPSIBLINGS) & ~(int)WINDOW_STYLE.WS_CAPTION); // removes the title bar and borders
 
 		_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_HIDE);
-		_showWindowOnNextArrange = true; // only show the window after the first arrange to avoid the split-second flicker between showing the window and positioning/clipping it correctly.
+		_showWindowOnNextRender = true; // only show the window after the first render that has consumed an arrange, to avoid the split-second flicker between showing the window and positioning/clipping it correctly.
 
 		var oldParent = PInvoke.SetParent((HWND)window.Hwnd, Hwnd);
 		if (oldParent == HWND.Null && Marshal.GetLastWin32Error() != 0)
@@ -101,8 +109,53 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 	private unsafe void OnRenderingNegativePathReevaluated(object? sender, SKPath path)
 	{
-		_lastClipPath = path;
+		if (_presenter.Content is not Win32NativeWindow window)
+		{
+			return;
+		}
 
+		var consumedArrange = false;
+		if (_arrangePending)
+		{
+			_arrangePending = false;
+			consumedArrange = true;
+			_lastArrangeRect = _pendingArrangeRect;
+			_lastFinalSvgClipPath = null; // force clip recomputation for the new arrange rect
+
+			var posSuccess = PInvoke.SetWindowPos(
+				(HWND)window.Hwnd,
+				HWND.Null,
+				(int)_lastArrangeRect.X,
+				(int)_lastArrangeRect.Y,
+				(int)_lastArrangeRect.Width,
+				(int)_lastArrangeRect.Height,
+				SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+			if (!posSuccess)
+			{
+				this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} failed: {Win32Helper.GetErrorMessage()}");
+			}
+		}
+
+		try
+		{
+			ApplyClipPath(path);
+		}
+		finally
+		{
+			// Reveal the window only after position + clip are applied for the first time,
+			// to avoid a split-second flash of an unpositioned / unclipped window. Gating on
+			// consumedArrange ensures we never show before the first ArrangeNativeElement has
+			// been applied (e.g., if a render fires between Attach and the initial arrange).
+			if (_showWindowOnNextRender && consumedArrange)
+			{
+				_showWindowOnNextRender = false;
+				_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
+			}
+		}
+	}
+
+	private unsafe void ApplyClipPath(SKPath path)
+	{
 		_tempPath.Rewind();
 		_tempPath.AddRect(_lastArrangeRect.ToSKRect());
 		path.Op(_tempPath, SKPathOp.Intersect, _tempPath);
@@ -273,6 +326,9 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			throw new ArgumentException($"content is not a {nameof(Win32NativeWindow)} instance.", nameof(content));
 		}
 
+		var parentHwnd = (nint)Hwnd;
+		var childHwnd = window.Hwnd;
+
 		_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_HIDE);
 
 		var oldParent = PInvoke.SetParent((HWND)window.Hwnd, HWND.Null);
@@ -281,12 +337,24 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			this.LogError()?.Error($"{nameof(PInvoke.SetParent)} failed: {Win32Helper.GetErrorMessage()}");
 		}
 
+		if (_childZOrderByParent.TryGetValue(parentHwnd, out var siblings))
+		{
+			foreach (var staleKey in siblings.Where(pair => pair.Value == childHwnd).Select(pair => pair.Key).ToList())
+			{
+				siblings.Remove(staleKey);
+			}
+			if (siblings.Count == 0)
+			{
+				_childZOrderByParent.Remove(parentHwnd);
+			}
+		}
+
 		((Win32WindowWrapper)XamlRootMap.GetHostForRoot(_presenter.XamlRoot!)!).RenderingNegativePathReevaluated -= OnRenderingNegativePathReevaluated;
 	}
 
 	public void ArrangeNativeElement(object content, Rect arrangeRect)
 	{
-		if (content is not Win32NativeWindow window)
+		if (content is not Win32NativeWindow)
 		{
 			throw new ArgumentException($"content is not a {nameof(Win32NativeWindow)} instance.", nameof(content));
 		}
@@ -298,36 +366,18 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 		var width = arrangeRect.Width * scale;
 		var height = arrangeRect.Height * scale;
 
-		_lastArrangeRect = new Rect(
+		// Stash the intended rect and defer SetWindowPos to OnRenderingNegativePathReevaluated,
+		// which fires between the Skia picture playback and CopyPixels. Moving the child HWND
+		// at that point keeps its position update temporally adjacent to the parent framebuffer
+		// present, so DWM is more likely to see both updates in the same compose cycle — rather
+		// than compositing the child at a new position over the parent's previous frame (visible
+		// as flicker when scrolling a native element).
+		_pendingArrangeRect = new Rect(
 			double.IsFinite(x) ? x : 0,
 			double.IsFinite(y) ? y : 0,
 			double.IsFinite(width) ? width : 0,
 			double.IsFinite(height) ? height : 0);
-
-		var success = PInvoke.SetWindowPos(
-				(HWND)window.Hwnd,
-				HWND.Null,
-				(int)_lastArrangeRect.X,
-				(int)_lastArrangeRect.Y,
-				(int)_lastArrangeRect.Width,
-				(int)_lastArrangeRect.Height,
-				SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
-		if (!success)
-		{
-			this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} failed: {Win32Helper.GetErrorMessage()}");
-		}
-
-		if (_lastClipPath is not null)
-		{
-			_lastFinalSvgClipPath = null; // force reapply clip path after arranging
-			OnRenderingNegativePathReevaluated(this, _lastClipPath);
-		}
-
-		if (_showWindowOnNextArrange)
-		{
-			_showWindowOnNextArrange = false;
-			_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
-		}
+		_arrangePending = true;
 	}
 
 	public Size MeasureNativeElement(object content, Size childMeasuredSize, Size availableSize)
@@ -377,5 +427,54 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 		var success = PInvoke.SetLayeredWindowAttributes((HWND)window.Hwnd, new COLORREF(0), (byte)Math.Round(opacity * 255), LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_ALPHA);
 		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SetLayeredWindowAttributes)} failed: {Win32Helper.GetErrorMessage()}"); }
+	}
+
+	public bool SupportsZIndex() => true;
+
+	public void SetZIndex(object content, int zIndex)
+	{
+		if (content is not Win32NativeWindow window)
+		{
+			return;
+		}
+
+		var childHwnd = window.Hwnd;
+		var parentHwnd = (nint)Hwnd;
+
+		if (!_childZOrderByParent.TryGetValue(parentHwnd, out var siblings))
+		{
+			siblings = new SortedDictionary<int, nint>();
+			_childZOrderByParent[parentHwnd] = siblings;
+		}
+
+		// The child may have moved from a different z-index in a previous pass; drop any stale entry
+		// before recording the new one so the sibling lookup below stays consistent.
+		foreach (var staleKey in siblings.Where(pair => pair.Value == childHwnd).Select(pair => pair.Key).ToList())
+		{
+			siblings.Remove(staleKey);
+		}
+		siblings[zIndex] = childHwnd;
+
+		// Place the child immediately above the next-lower sibling we know about. If none exists
+		// (this is the lowest-known z-index under this parent), drop it to the bottom of the chain.
+		var hwndInsertAfter = new HWND(1); // HWND_BOTTOM
+		foreach (var pair in siblings.Reverse())
+		{
+			if (pair.Key < zIndex)
+			{
+				hwndInsertAfter = (HWND)pair.Value;
+				break;
+			}
+		}
+
+		var success = PInvoke.SetWindowPos(
+			(HWND)childHwnd,
+			hwndInsertAfter,
+			0, 0, 0, 0,
+			SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+		if (!success)
+		{
+			this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} (z-order) failed: {Win32Helper.GetErrorMessage()}");
+		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -150,6 +150,23 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			{
 				_showWindowOnNextRender = false;
 				_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_SHOWNORMAL);
+
+				// SW_SHOWNORMAL restores the window using its saved WINDOWPLACEMENT.rcNormalPosition,
+				// which still holds the old screen coordinates from before re-parenting. Those coordinates
+				// are now misinterpreted as parent-relative, placing the window at the wrong position.
+				// Re-applying SetWindowPos after ShowWindow overrides that restoration.
+				var posSuccess = PInvoke.SetWindowPos(
+					(HWND)window.Hwnd,
+					HWND.Null,
+					(int)_lastArrangeRect.X,
+					(int)_lastArrangeRect.Y,
+					(int)_lastArrangeRect.Width,
+					(int)_lastArrangeRect.Height,
+					SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+				if (!posSuccess)
+				{
+					this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} failed: {Win32Helper.GetErrorMessage()}");
+				}
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -182,6 +182,10 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 		Win32NativeElementHostingExtension? higher = null;
 		foreach (var ext in _attached)
 		{
+			if (ext._presenter.XamlRoot != _presenter.XamlRoot)
+			{
+				continue;
+			}
 			if (ext._zIndex > _zIndex && (higher is null || ext._zIndex < higher._zIndex))
 			{
 				higher = ext;

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -173,14 +173,6 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 		}
 	}
 
-	private void SetPosOnly(HWND childHwnd, int x, int y, int width, int height)
-	{
-		if (!PInvoke.SetWindowPos(childHwnd, default, x, y, width, height, SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE))
-		{
-			this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} (pos) failed: {Win32Helper.GetErrorMessage()}");
-		}
-	}
-
 	private void ApplyZOrder(HWND childHwnd)
 	{
 		// SetWindowPos's hWndInsertAfter is "the window to precede the positioned window in the

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -27,7 +26,7 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 {
 	private static readonly SKPoint[] _conicPoints = new SKPoint[32 * 3]; // 3 points per quad
 
-	// All currently-attached extensions across all hosts. Filtered by parent HWND when we need
+	// All currently-attached extensions across all hosts. Filtered by XamlRoot when we need
 	// to find a child's siblings to compute its z-order anchor.
 	private static readonly List<Win32NativeElementHostingExtension> _attached = new();
 

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -27,10 +27,9 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 {
 	private static readonly SKPoint[] _conicPoints = new SKPoint[32 * 3]; // 3 points per quad
 
-	// Tracks the desired Uno z-order of native child HWNDs per parent window so SetZIndex can place
-	// each child relative to its lower sibling deterministically, instead of depending on the caller
-	// invoking SetZIndex for every host in ascending order.
-	private static readonly Dictionary<nint, SortedDictionary<int, nint>> _childZOrderByParent = new();
+	// All currently-attached extensions across all hosts. Filtered by parent HWND when we need
+	// to find a child's siblings to compute its z-order anchor.
+	private static readonly List<Win32NativeElementHostingExtension> _attached = new();
 
 	private readonly ContentPresenter _presenter;
 	private readonly SKPath _tempPath = new();
@@ -40,6 +39,7 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 	private string? _lastFinalSvgClipPath;
 	private HRGN _lastClipHrgn;
 	private bool _showWindowOnNextRender;
+	private int _zIndex;
 
 	public Win32NativeElementHostingExtension(ContentPresenter presenter)
 	{
@@ -104,6 +104,7 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			return;
 		}
 
+		_attached.Add(this);
 		((Win32WindowWrapper)XamlRootMap.GetHostForRoot(_presenter.XamlRoot!)!).RenderingNegativePathReevaluated += OnRenderingNegativePathReevaluated;
 	}
 
@@ -167,7 +168,41 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 				{
 					this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} failed: {Win32Helper.GetErrorMessage()}");
 				}
+				ApplyZOrder((HWND)window.Hwnd);
 			}
+		}
+	}
+
+	private void SetPosOnly(HWND childHwnd, int x, int y, int width, int height)
+	{
+		if (!PInvoke.SetWindowPos(childHwnd, default, x, y, width, height, SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE))
+		{
+			this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} (pos) failed: {Win32Helper.GetErrorMessage()}");
+		}
+	}
+
+	private void ApplyZOrder(HWND childHwnd)
+	{
+		// SetWindowPos's hWndInsertAfter is "the window to precede the positioned window in the
+		// Z order" — i.e., the one that ends up *above* us, not below us. Place the child just
+		// below the lowest-zIndex sibling that's still higher than us; if none, HWND_TOP puts us
+		// at the top of the chain.
+		Win32NativeElementHostingExtension? higher = null;
+		foreach (var ext in _attached)
+		{
+			if (ext._zIndex > _zIndex && (higher is null || ext._zIndex < higher._zIndex))
+			{
+				higher = ext;
+			}
+		}
+
+		var insertAfter = higher is null
+			? default(HWND) // HWND_TOP
+			: (HWND)((Win32NativeWindow)higher._presenter.Content).Hwnd;
+
+		if (!PInvoke.SetWindowPos(childHwnd, insertAfter, 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE))
+		{
+			this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} (z-order) failed: {Win32Helper.GetErrorMessage()}");
 		}
 	}
 
@@ -343,9 +378,6 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			throw new ArgumentException($"content is not a {nameof(Win32NativeWindow)} instance.", nameof(content));
 		}
 
-		var parentHwnd = (nint)Hwnd;
-		var childHwnd = window.Hwnd;
-
 		_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_HIDE);
 
 		var oldParent = PInvoke.SetParent((HWND)window.Hwnd, HWND.Null);
@@ -354,18 +386,9 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 			this.LogError()?.Error($"{nameof(PInvoke.SetParent)} failed: {Win32Helper.GetErrorMessage()}");
 		}
 
-		if (_childZOrderByParent.TryGetValue(parentHwnd, out var siblings))
-		{
-			foreach (var staleKey in siblings.Where(pair => pair.Value == childHwnd).Select(pair => pair.Key).ToList())
-			{
-				siblings.Remove(staleKey);
-			}
-			if (siblings.Count == 0)
-			{
-				_childZOrderByParent.Remove(parentHwnd);
-			}
-		}
+		// WS_CHILD stays set across detach/re-attach cycles.
 
+		_attached.Remove(this);
 		((Win32WindowWrapper)XamlRootMap.GetHostForRoot(_presenter.XamlRoot!)!).RenderingNegativePathReevaluated -= OnRenderingNegativePathReevaluated;
 	}
 
@@ -450,48 +473,10 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 	public void SetZIndex(object content, int zIndex)
 	{
-		if (content is not Win32NativeWindow window)
+		_zIndex = zIndex;
+		if (content is Win32NativeWindow window)
 		{
-			return;
-		}
-
-		var childHwnd = window.Hwnd;
-		var parentHwnd = (nint)Hwnd;
-
-		if (!_childZOrderByParent.TryGetValue(parentHwnd, out var siblings))
-		{
-			siblings = new SortedDictionary<int, nint>();
-			_childZOrderByParent[parentHwnd] = siblings;
-		}
-
-		// The child may have moved from a different z-index in a previous pass; drop any stale entry
-		// before recording the new one so the sibling lookup below stays consistent.
-		foreach (var staleKey in siblings.Where(pair => pair.Value == childHwnd).Select(pair => pair.Key).ToList())
-		{
-			siblings.Remove(staleKey);
-		}
-		siblings[zIndex] = childHwnd;
-
-		// Place the child immediately above the next-lower sibling we know about. If none exists
-		// (this is the lowest-known z-index under this parent), drop it to the bottom of the chain.
-		var hwndInsertAfter = new HWND(1); // HWND_BOTTOM
-		foreach (var pair in siblings.Reverse())
-		{
-			if (pair.Key < zIndex)
-			{
-				hwndInsertAfter = (HWND)pair.Value;
-				break;
-			}
-		}
-
-		var success = PInvoke.SetWindowPos(
-			(HWND)childHwnd,
-			hwndInsertAfter,
-			0, 0, 0, 0,
-			SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
-		if (!success)
-		{
-			this.LogError()?.Error($"{nameof(PInvoke.SetWindowPos)} (z-order) failed: {Win32Helper.GetErrorMessage()}");
+			ApplyZOrder((HWND)window.Hwnd);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -122,16 +122,16 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		}
 		_webViewForNextCreateWindow = null;
 
+		if (_hwnd == HWND.Null)
+		{
+			throw new InvalidOperationException($"{nameof(PInvoke.CreateWindowEx)} failed: {Win32Helper.GetErrorMessage()}");
+		}
+
 		unsafe
 		{
 			// disable window maximize/minimize/restore animations to avoid visual glitches during initial window setup
 			BOOL fDisable = true;
 			PInvoke.DwmSetWindowAttribute(_hwnd, Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, &fDisable, (uint)Marshal.SizeOf(fDisable));
-		}
-
-		if (_hwnd == HWND.Null)
-		{
-			throw new InvalidOperationException($"{nameof(PInvoke.CreateWindowEx)} failed: {Win32Helper.GetErrorMessage()}");
 		}
 
 		if (this.Log().IsEnabled(LogLevel.Trace))

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.Web.WebView2.Core;
 using Uno.Foundation.Logging;
@@ -98,6 +99,8 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		_presenter = presenter;
 		_coreWebView = owner;
 
+		ForwardBackgroundToPresenter();
+
 		using var lpClassName = new Win32Helper.NativeNulTerminatedUtf16String(WindowClassName);
 
 		_webViewForNextCreateWindow = new WeakReference<Win32NativeWebView>(this);
@@ -107,12 +110,12 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 				0,
 				lpClassName,
 				new PCWSTR(),
-				0,
+				WINDOW_STYLE.WS_CHILDWINDOW | WINDOW_STYLE.WS_VISIBLE,
 				PInvoke.CW_USEDEFAULT,
 				PInvoke.CW_USEDEFAULT,
 				PInvoke.CW_USEDEFAULT,
 				PInvoke.CW_USEDEFAULT,
-				HWND.Null,
+				ParentHwnd,
 				HMENU.Null,
 				Win32Helper.GetHInstance(),
 				null);
@@ -150,6 +153,19 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 			var env = await NativeWebView.CoreWebView2Environment.CreateAsync(userDataFolder: userDataFolder);
 			var controller = await env.CreateCoreWebView2ControllerAsync(_hwnd);
 
+			// Hide until NavigationCompleted to suppress the initial black frame.
+			controller.IsVisible = false;
+
+			// Avoid setting DefaultBackgroundColor unless it exactly matches the background behind the
+			// WebView — a mismatch worsens the flash rather than hiding it.
+			// In the general case, it is actual beneficial to leave it out, since it won't be seen.
+			if (_presenter.Background is SolidColorBrush { Color: { } color })
+			{
+				// note: DefaultBackgroundColor do not accept color with non-255 alpha.
+				// > System.ArgumentException: Value does not fall within the expected range.
+				controller.DefaultBackgroundColor = Color.FromArgb(Byte.MaxValue, color.R, color.G, color.B);
+			}
+
 			tcs.SetResult(controller);
 		});
 
@@ -159,14 +175,6 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		}
 
 		_controller = tcs.Task.Result;
-
-		_controller.IsVisible = true;
-
-		// Do not set _controller.DefaultBackgroundColor here;
-		// The initial flash is now gone most of time or minimal in some case,
-		// setting the default background now actually worsen the initial load.
-		// note: DefaultBackgroundColor do not accept color with non-255 alpha.
-		// > System.ArgumentException: Value does not fall within the expected range.
 
 		_nativeWebView = _controller.CoreWebView2;
 		_nativeWebView.Settings.IsScriptEnabled = true;
@@ -190,6 +198,19 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		UpdateDocumentTitle();
 
 		presenter.Content = new Win32NativeWindow(_hwnd);
+	}
+
+	private void ForwardBackgroundToPresenter()
+	{
+		if (_coreWebView.Owner is WebView2 view && _presenter is { } cp)
+		{
+			cp.SetBinding(FrameworkElement.BackgroundProperty, new Binding()
+			{
+				Path = new(nameof(view.Background)),
+				Source = view,
+				Mode = BindingMode.OneWay
+			});
+		}
 	}
 
 	public event EventHandler<CoreWebView2WebResourceRequestedEventArgs>? WebResourceRequested;
@@ -306,6 +327,8 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 	private void NativeWebView_SourceChanged(object? sender, NativeWebView.CoreWebView2SourceChangedEventArgs e)
 	{
+		//_controller.IsVisible = true;
+
 		_coreWebView.Source = _nativeWebView.Source;
 	}
 
@@ -337,6 +360,8 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 	private void NativeWebView_NavigationCompleted(object? sender, NativeWebView.CoreWebView2NavigationCompletedEventArgs e)
 	{
+		_controller.IsVisible = true;
+
 		if (!_navigationIdToUriMap.TryGetValue(e.NavigationId, out var uriString))
 		{
 			if (this.Log().IsEnabled(LogLevel.Error))

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -1,6 +1,4 @@
 extern alias mswebview2;
-using NativeWebView = mswebview2::Microsoft.Web.WebView2.Core;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,16 +11,20 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Windows.Storage;
-using Windows.Win32;
-using Windows.Win32.Foundation;
-using Windows.Win32.UI.WindowsAndMessaging;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.Web.WebView2.Core;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.NativeElementHosting;
 using Uno.UI.Xaml.Controls;
+using Windows.Storage;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+using NativeWebView = mswebview2::Microsoft.Web.WebView2.Core;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
@@ -117,7 +119,12 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		}
 		_webViewForNextCreateWindow = null;
 
-		_ = PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_MINIMIZE);
+		unsafe
+		{
+			// disable window maximize/minimize/restore animations to avoid visual glitches during initial window setup
+			BOOL fDisable = true;
+			PInvoke.DwmSetWindowAttribute(_hwnd, Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, &fDisable, (uint)Marshal.SizeOf(fDisable));
+		}
 
 		if (_hwnd == HWND.Null)
 		{
@@ -141,7 +148,9 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		{
 			var userDataFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "WebView2");
 			var env = await NativeWebView.CoreWebView2Environment.CreateAsync(userDataFolder: userDataFolder);
-			tcs.SetResult(await env.CreateCoreWebView2ControllerAsync(_hwnd));
+			var controller = await env.CreateCoreWebView2ControllerAsync(_hwnd);
+
+			tcs.SetResult(controller);
 		});
 
 		while (!tcs.Task.IsCompleted)
@@ -150,6 +159,15 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		}
 
 		_controller = tcs.Task.Result;
+
+		_controller.IsVisible = true;
+
+		// Do not set _controller.DefaultBackgroundColor here;
+		// The initial flash is now gone most of time or minimal in some case,
+		// setting the default background now actually worsen the initial load.
+		// note: DefaultBackgroundColor do not accept color with non-255 alpha.
+		// > System.ArgumentException: Value does not fall within the expected range.
+
 		_nativeWebView = _controller.CoreWebView2;
 		_nativeWebView.Settings.IsScriptEnabled = true;
 		_nativeWebView.Settings.IsWebMessageEnabled = true;

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -11,7 +11,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
@@ -131,7 +130,11 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		{
 			// disable window maximize/minimize/restore animations to avoid visual glitches during initial window setup
 			BOOL fDisable = true;
-			PInvoke.DwmSetWindowAttribute(_hwnd, Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, &fDisable, (uint)Marshal.SizeOf(fDisable));
+			var hr = PInvoke.DwmSetWindowAttribute(_hwnd, Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, &fDisable, (uint)Marshal.SizeOf(fDisable));
+			if (hr.Failed && this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"{nameof(PInvoke.DwmSetWindowAttribute)} failed for {Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED}: 0x{hr.Value:X8}");
+			}
 		}
 
 		if (this.Log().IsEnabled(LogLevel.Trace))
@@ -158,10 +161,10 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 			// Avoid setting DefaultBackgroundColor unless it exactly matches the background behind the
 			// WebView — a mismatch worsens the flash rather than hiding it.
-			// In the general case, it is actual beneficial to leave it out, since it won't be seen.
+			// In the general case, it is actually beneficial to leave it out, since it won't be seen.
 			if (_presenter.Background is SolidColorBrush { Color: { } color })
 			{
-				// note: DefaultBackgroundColor do not accept color with non-255 alpha.
+				// note: DefaultBackgroundColor does not accept color with non-255 alpha.
 				// > System.ArgumentException: Value does not fall within the expected range.
 				controller.DefaultBackgroundColor = Color.FromArgb(Byte.MaxValue, color.R, color.G, color.B);
 			}
@@ -327,8 +330,6 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 	private void NativeWebView_SourceChanged(object? sender, NativeWebView.CoreWebView2SourceChangedEventArgs e)
 	{
-		//_controller.IsVisible = true;
-
 		_coreWebView.Source = _nativeWebView.Source;
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -10,6 +10,7 @@ using Uno.UI;
 using Windows.Foundation;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml.Media;
+using Uno.UI.Extensions;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -162,26 +163,27 @@ partial class ContentPresenter
 		}
 		new Span<(int, ContentPresenter)>(rentedArray, 0, _nativeHosts.Count).Sort((one, two) => one.Item1 - two.Item1);
 
+		Console.WriteLine($"Ramez {string.Join(", ", new Span<(int, ContentPresenter)>(rentedArray, 0, _nativeHosts.Count).ToArray().Select(nh => nh.Item2.FindFirstAncestor<WebView2>().Name))}"); // For debug purposes, to verify the order is correct
 		for (var index = 0; index < _nativeHosts.Count; index++)
 		{
 			var host = rentedArray[index].Item2;
 			var order = rentedArray[index].Item1;
 
-			if (host._nativeElementHostingExtension.Value.SupportsZIndex())
+			if (host._nativeElementAttached)
 			{
-				host._nativeElementHostingExtension.Value.SetZIndex(host.Content, index);
-			}
-			else
-			{
-				if (host._nativeElementAttached)
+				if (order == -1)
 				{
-					if (order == -1)
+					// We're detaching the native element as it's no longer in view, but conceptually, it's still in the tree, so IsNativeHost is still true
+					Debug.Assert(host.IsNativeHost);
+					host._nativeElementAttached = false;
+					host._lastArrangeRect = null;
+					host._nativeElementHostingExtension.Value!.DetachNativeElement(host.Content);
+				}
+				else
+				{
+					if (host._nativeElementHostingExtension.Value.SupportsZIndex())
 					{
-						// We're detaching the native element as it's no longer in view, but conceptually, it's still in the tree, so IsNativeHost is still true
-						Debug.Assert(host.IsNativeHost);
-						host._nativeElementAttached = false;
-						host._lastArrangeRect = null;
-						host._nativeElementHostingExtension.Value!.DetachNativeElement(host.Content);
+						host._nativeElementHostingExtension.Value.SetZIndex(host.Content, index);
 					}
 					else
 					{
@@ -190,10 +192,14 @@ partial class ContentPresenter
 						host.ArrangeNativeElement();
 					}
 				}
-				else if (order != -1)
+			}
+			else if (order != -1)
+			{
+				host.AttachNativeElement();
+				host.ArrangeNativeElement();
+				if (host._nativeElementHostingExtension.Value.SupportsZIndex())
 				{
-					host.AttachNativeElement();
-					host.ArrangeNativeElement();
+					host._nativeElementHostingExtension.Value.SetZIndex(host.Content, index);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -163,7 +163,6 @@ partial class ContentPresenter
 		}
 		new Span<(int, ContentPresenter)>(rentedArray, 0, _nativeHosts.Count).Sort((one, two) => one.Item1 - two.Item1);
 
-		Console.WriteLine($"Ramez {string.Join(", ", new Span<(int, ContentPresenter)>(rentedArray, 0, _nativeHosts.Count).ToArray().Select(nh => nh.Item2.FindFirstAncestor<WebView2>().Name))}"); // For debug purposes, to verify the order is correct
 		for (var index = 0; index < _nativeHosts.Count; index++)
 		{
 			var host = rentedArray[index].Item2;

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -20,7 +20,7 @@ partial class ContentPresenter
 	private static readonly HashSet<ContentPresenter> _nativeHosts = new();
 
 	private bool _nativeElementAttached;
-	private IDisposable _frameRenderedDisposable;
+	private SerialDisposable _frameRenderedDisposable = new();
 	private Rect? _lastArrangeRect;
 
 	internal static bool HasNativeElements() => _nativeHosts.Count > 0;
@@ -90,7 +90,7 @@ partial class ContentPresenter
 		_nativeHosts.Add(this);
 		var ct = ((CompositionTarget)Visual.CompositionTarget)!;
 		ct.FrameRendered += OnFrameRendered;
-		_frameRenderedDisposable = Disposable.Create(() => ct.FrameRendered -= OnFrameRendered);
+		_frameRenderedDisposable.Disposable = Disposable.Create(() => ct.FrameRendered -= OnFrameRendered);
 	}
 
 	private void OnFrameRendered()
@@ -108,10 +108,9 @@ partial class ContentPresenter
 #endif
 		_nativeHosts.Remove(this);
 		_lastArrangeRect = null;
+		_frameRenderedDisposable.Disposable = null;
 		if (_nativeElementAttached)
 		{
-			_frameRenderedDisposable.Dispose();
-			_frameRenderedDisposable = null;
 			_nativeElementAttached = false;
 			_nativeElementHostingExtension.Value!.DetachNativeElement(content);
 		}
@@ -176,6 +175,7 @@ partial class ContentPresenter
 					Debug.Assert(host.IsNativeHost);
 					host._nativeElementAttached = false;
 					host._lastArrangeRect = null;
+					host._frameRenderedDisposable.Disposable = null;
 					host._nativeElementHostingExtension.Value!.DetachNativeElement(host.Content);
 				}
 				else

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -10,7 +10,6 @@ using Uno.UI;
 using Windows.Foundation;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml.Media;
-using Uno.UI.Extensions;
 
 namespace Microsoft.UI.Xaml.Controls;
 


### PR DESCRIPTION
**GitHub Issue:** 
closes https://github.com/unoplatform/kahua-private/issues/449
closes https://github.com/unoplatform/kahua-private/issues/467
closes https://github.com/unoplatform/kahua-private/issues/471

## PR Type: 🐞 Bugfix

## What changed? 🚀
- reverted the reverts from #23210 that was done in reaction to https://github.com/unoplatform/kahua-private/issues/471 where WebView2 content bleeds/leaks into other WebView2.
- improved the initial load for WebView2:
  - [k#449](https://github.com/unoplatform/kahua-private/issues/449) removed the bubbling window/frame from the windows minimize/restore animations
    <img width="455" height="204" alt="kxxx bubble window" src="https://github.com/user-attachments/assets/b0e5fc28-1765-43a2-9418-71a719e0bd64" />
  - [k#467](https://github.com/unoplatform/kahua-private/issues/467) removed the initial black frames when loading the webview
- [k#471](https://github.com/unoplatform/kahua-private/issues/471) fixed a bug where multiple webviews contents are bleeding/leaking into other webview

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)