### PR TITLE
fix(deps): bump Microsoft.Kiota.Abstractions to 1.22.2

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
+++ b/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
@@ -72,6 +72,8 @@
 			<!-- Workaround for https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2617 -->
 			<Version>5.56.0</Version>
 		</PackageReference>
+		<!-- Override vulnerable transitive Microsoft.Kiota.Abstractions 1.9.1 (GHSA-7j59-v9qr-6fq9, fixed in 1.22.0) pulled in by Microsoft.Graph 5.56.0 -->
+		<PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" Condition="'$(Configuration)'!='Debug'" />
 	</ItemGroup>
 
 	<Import Project="..\..\SourceGenerators\sourcegenerators.local.props" />

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -97,6 +97,7 @@
 	<ItemGroup>
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+		<PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -47,6 +47,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+		<PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -232,6 +232,7 @@
 		<PackageReference Include="Microsoft.Graph" Condition="'$(Configuration)'!='Debug' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))!='ios'"> <!-- Workaround for https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2617 -->
 			<Version>5.56.0</Version>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" Condition="'$(Configuration)'!='Debug' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))!='ios'" />
 		<PackageReference Include="Microsoft.Identity.Client">
 			<Version>4.72.1</Version>
 		</PackageReference>

--- a/src/SamplesApp/UnoIslands.Skia/UnoIslands.Skia.csproj
+++ b/src/SamplesApp/UnoIslands.Skia/UnoIslands.Skia.csproj
@@ -40,6 +40,7 @@
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+		<PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
@@ -48,6 +48,7 @@
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
+		<PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />


### PR DESCRIPTION
## Summary

- Override the vulnerable transitive `Microsoft.Kiota.Abstractions` 1.9.1 (advisory [GHSA-7j59-v9qr-6fq9](https://github.com/advisories/GHSA-7j59-v9qr-6fq9), high severity) pulled in by `Microsoft.Graph` 5.56.0.
- Pin to `1.22.2` (latest 1.x, fix landed in 1.22.0). Stays inside Microsoft.Graph 5.56.0''s `[1.9.1, 2.0.0)` constraint, so there is no risk of breaking the Graph dependency closure.
- Mirrors the existing `Configuration!=Debug` condition on the `Microsoft.Graph` reference, so Debug builds (where audit warnings are downgraded via `WarningsNotAsErrors` in `Directory.Build.props`) are untouched.

## Why

Release builds of any project that transitively pulls in `Microsoft.Graph` from `SamplesApp.Skia` were failing with:

```
NU1903: Warning As Error: Package ''Microsoft.Kiota.Abstractions'' 1.9.1 has a known high severity vulnerability,
https://github.com/advisories/GHSA-7j59-v9qr-6fq9
```

Observed on `SamplesApp.Skia.Generic` (which references `SamplesApp.Skia` via a `ProjectReference`).

The advisory: `RedirectHandler` middleware was forwarding sensitive headers (`Cookie`, `Proxy-Authorization`, custom headers) on cross-host redirects. Fixed in 1.22.0.

## Test plan

- [ ] `dotnet restore src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj` succeeds.
- [ ] Release build of `SamplesApp.Skia.Generic` no longer reports NU1903 for `Microsoft.Kiota.Abstractions`.
- [ ] Debug build of `SamplesApp.Skia.Generic` is unchanged (Microsoft.Graph + override are both Release-only).
- [ ] CI for `SamplesApp.Skia` and dependent heads passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)