### PR TITLE
fix: Buffer HR metadata updates when dispatcher is unavailable

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
@@ -53,6 +54,12 @@ partial class ClientHotReloadProcessor
 		}
 	}
 
+	/// <summary>
+	/// Pending type updates that arrived before <see cref="CurrentWindow"/> was set.
+	/// Drained by <see cref="SetWindow"/> once a window with a valid dispatcher is available.
+	/// </summary>
+	private static readonly ConcurrentQueue<(HotReloadClientOperation? Hr, Type[] Types)> _pendingUpdates = new();
+
 	internal static Window? CurrentWindow { get; private set; }
 
 	private static (bool value, string reason) ShouldReload()
@@ -80,6 +87,9 @@ partial class ClientHotReloadProcessor
 			CurrentWindow.Activated += ShowDiagnosticsOnFirstActivation;
 		}
 #endif
+
+		// Drain any metadata updates that arrived before the window was registered.
+		DrainPendingUpdates();
 	}
 
 #if HAS_UNO_WINUI // No diag to show currently on windows (so no WINUI)
@@ -566,24 +576,64 @@ partial class ClientHotReloadProcessor
 			_log.Trace($"UpdateApplication (changed types: {string.Join(", ", types.Select(s => s.ToString()))})");
 		}
 
+		if (!TryDispatchUpdate(hr, types))
+		{
+			// Window/dispatcher not available yet — buffer for replay when SetWindow is called.
+			_pendingUpdates.Enqueue((hr, types));
+			if (_log.IsEnabled(LogLevel.Warning))
+			{
+				_log.Warn($"Dispatcher not available yet, queuing metadata update for replay when Window is set. Queued types: {string.Join(", ", types.Select(s => s.ToString()))}");
+			}
+		}
+	}
+
+	/// <summary>
+	/// Attempts to dispatch a metadata update to the UI thread via the current window's dispatcher.
+	/// </summary>
+	/// <returns><c>true</c> if the update was dispatched; <c>false</c> if no window/dispatcher is available.</returns>
+	private static bool TryDispatchUpdate(HotReloadClientOperation? hr, Type[] types)
+	{
 #if WINUI
 		if (CurrentWindow is { DispatcherQueue: { } dispatcherQueue } window)
 		{
 			dispatcherQueue.TryEnqueue(async () => await ReloadWithUpdatedTypes(hr, window, types));
+			return true;
 		}
 #else
 		if (CurrentWindow is { Dispatcher: { } dispatcher } window)
 		{
 			_ = dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () => await ReloadWithUpdatedTypes(hr, window, types));
+			return true;
 		}
 #endif
-		else
+		return false;
+	}
+
+	/// <summary>
+	/// Drains metadata updates that were queued before a window was available, dispatching them
+	/// now that <see cref="CurrentWindow"/> is set.
+	/// </summary>
+	private static void DrainPendingUpdates()
+	{
+		while (_pendingUpdates.TryDequeue(out var pending))
 		{
-			var errorMsg = $"Unable to access Dispatcher/DispatcherQueue in order to invoke {nameof(ReloadWithUpdatedTypes)}. Make sure you have enabled hot-reload (Window.UseStudio()) in app startup. See https://aka.platform.uno/hot-reload";
-			hr?.ReportError(new InvalidOperationException(errorMsg));
-			if (_log.IsEnabled(LogLevel.Warning))
+			if (TryDispatchUpdate(pending.Hr, pending.Types))
 			{
-				_log.Warn(errorMsg);
+				if (_log.IsEnabled(LogLevel.Information))
+				{
+					_log.Info($"Replayed queued metadata update: {string.Join(", ", pending.Types.Select(s => s.ToString()))}");
+				}
+			}
+			else
+			{
+				// Still can't dispatch (e.g., window set but dispatcher is null).
+				// Re-enqueue and stop — will retry on next SetWindow call.
+				_pendingUpdates.Enqueue(pending);
+				if (_log.IsEnabled(LogLevel.Warning))
+				{
+					_log.Warn("Window is set but dispatcher is still unavailable, re-queued pending updates.");
+				}
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
**GitHub Issue:** closes #

## PR Type:

🐞 Bugfix

## What changed? 🚀

When a hot-reload metadata update arrives before `Window.UseStudio()` / `EnableHotReload()` has completed (race condition during app startup), `ClientHotReloadProcessor.UpdateApplicationCore` fails with:

> "Unable to access Dispatcher/DispatcherQueue in order to invoke ReloadWithUpdatedTypes. Make sure you have enabled hot-reload (Window.UseStudio()) in app startup."

This is a timing issue — the app has `UseStudio()` configured correctly, but the .NET runtime delivers the first metadata delta before `SetWindow()` has been called.

**Fix:** Instead of failing when the dispatcher is unavailable, metadata updates are now buffered in a `ConcurrentQueue` and replayed when `SetWindow()` is called. This eliminates the race condition entirely.

- Added `_pendingUpdates` queue to buffer early deltas
- Extracted `TryDispatchUpdate()` to attempt dispatcher-based dispatch
- Added `DrainPendingUpdates()` called from `SetWindow()` to replay buffered updates
- No more hard failure — early deltas are applied as soon as the window is ready

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)