### PR TITLE
fix(theming): resolve focus visual brush against element's effective theme

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_FocusVisuals.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_FocusVisuals.cs
@@ -1,66 +1,168 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
 
-namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+[TestClass]
+public class Given_FrameworkElement_FocusVisuals
 {
-	[TestClass]
-	public class Given_FrameworkElement_FocusVisuals
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_PrimaryThickness_Default()
 	{
-		[TestMethod]
-		[RunsOnUIThread]
-		public void When_PrimaryThickness_Default()
-		{
-			var element = new PlainFrameworkElement();
-			var actualThickness = element.FocusVisualPrimaryThickness;
-			var expectedThickness = ThicknessFromUniformLength(2);
-			Assert.AreEqual(expectedThickness, actualThickness);
-		}
-
-		[TestMethod]
-		[RunsOnUIThread]
-		public void When_SecondaryThickness_Default()
-		{
-			var element = new PlainFrameworkElement();
-			var actualThickness = element.FocusVisualSecondaryThickness;
-			var expectedThickness = ThicknessFromUniformLength(1);
-			Assert.AreEqual(expectedThickness, actualThickness);
-		}
-
-		[TestMethod]
-		[RunsOnUIThread]
-		public void When_Margin_Default()
-		{
-			var element = new PlainFrameworkElement();
-			var actualMargin = element.FocusVisualMargin;
-			var expectedMargin = ThicknessFromUniformLength(0);
-			Assert.AreEqual(expectedMargin, actualMargin);
-		}
-
-		[TestMethod]
-		[RunsOnUIThread]
-		public void When_PrimaryBrush_Default()
-		{
-			var element = new PlainFrameworkElement();
-			var expectedBrush = Application.Current.Resources["SystemControlFocusVisualPrimaryBrush"];
-			var actualBrush = element.FocusVisualPrimaryBrush;
-			Assert.AreEqual(expectedBrush, actualBrush);
-		}
-
-		[TestMethod]
-		[RunsOnUIThread]
-		public void When_SecondaryBrush_Default()
-		{
-			var element = new PlainFrameworkElement();
-			var expectedBrush = Application.Current.Resources["SystemControlFocusVisualSecondaryBrush"];
-			var actualBrush = element.FocusVisualSecondaryBrush;
-			Assert.AreEqual(expectedBrush, actualBrush);
-		}
-
-		private static Thickness ThicknessFromUniformLength(double uniformLength) =>
-			new Thickness(uniformLength);
+		var element = new PlainFrameworkElement();
+		var actualThickness = element.FocusVisualPrimaryThickness;
+		var expectedThickness = ThicknessFromUniformLength(2);
+		Assert.AreEqual(expectedThickness, actualThickness);
 	}
 
-	public partial class PlainFrameworkElement : FrameworkElement
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SecondaryThickness_Default()
 	{
+		var element = new PlainFrameworkElement();
+		var actualThickness = element.FocusVisualSecondaryThickness;
+		var expectedThickness = ThicknessFromUniformLength(1);
+		Assert.AreEqual(expectedThickness, actualThickness);
 	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_Margin_Default()
+	{
+		var element = new PlainFrameworkElement();
+		var actualMargin = element.FocusVisualMargin;
+		var expectedMargin = ThicknessFromUniformLength(0);
+		Assert.AreEqual(expectedMargin, actualMargin);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_PrimaryBrush_Default()
+	{
+		var element = new PlainFrameworkElement();
+		var expectedBrush = Application.Current.Resources["SystemControlFocusVisualPrimaryBrush"];
+		var actualBrush = element.FocusVisualPrimaryBrush;
+		Assert.AreEqual(expectedBrush, actualBrush);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_SecondaryBrush_Default()
+	{
+		var element = new PlainFrameworkElement();
+		var expectedBrush = Application.Current.Resources["SystemControlFocusVisualSecondaryBrush"];
+		var actualBrush = element.FocusVisualSecondaryBrush;
+		Assert.AreEqual(expectedBrush, actualBrush);
+	}
+
+#if HAS_UNO
+	// Regression coverage: focus visual brush must follow the focused element's
+	// effective theme (its RequestedTheme or its parent's), not the app/system theme.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Element_RequestedTheme_Light_App_Dark_Primary_Brush_Is_Light()
+	{
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var element = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Light };
+		WindowHelper.WindowContent = element;
+		await WindowHelper.WaitForLoaded(element);
+
+		Assert.AreEqual(ElementTheme.Light, element.ActualTheme);
+
+		var brush = element.FocusVisualPrimaryBrush as SolidColorBrush;
+		Assert.IsNotNull(brush);
+		Assert.AreEqual(Color.FromArgb(0xE4, 0x00, 0x00, 0x00), brush.Color);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Element_RequestedTheme_Dark_App_Light_Primary_Brush_Is_Dark()
+	{
+		using var _ = ThemeHelper.UseApplicationLightTheme();
+
+		var element = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Dark };
+		WindowHelper.WindowContent = element;
+		await WindowHelper.WaitForLoaded(element);
+
+		Assert.AreEqual(ElementTheme.Dark, element.ActualTheme);
+
+		var brush = element.FocusVisualPrimaryBrush as SolidColorBrush;
+		Assert.IsNotNull(brush);
+		Assert.AreEqual(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF), brush.Color);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Element_RequestedTheme_Light_App_Dark_Secondary_Brush_Is_Light()
+	{
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var element = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Light };
+		WindowHelper.WindowContent = element;
+		await WindowHelper.WaitForLoaded(element);
+
+		Assert.AreEqual(ElementTheme.Light, element.ActualTheme);
+
+		var brush = element.FocusVisualSecondaryBrush as SolidColorBrush;
+		Assert.IsNotNull(brush);
+		Assert.AreEqual(Color.FromArgb(0xB3, 0xFF, 0xFF, 0xFF), brush.Color);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Element_RequestedTheme_Dark_App_Light_Secondary_Brush_Is_Dark()
+	{
+		using var _ = ThemeHelper.UseApplicationLightTheme();
+
+		var element = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Dark };
+		WindowHelper.WindowContent = element;
+		await WindowHelper.WaitForLoaded(element);
+
+		Assert.AreEqual(ElementTheme.Dark, element.ActualTheme);
+
+		var brush = element.FocusVisualSecondaryBrush as SolidColorBrush;
+		Assert.IsNotNull(brush);
+		Assert.AreEqual(Color.FromArgb(0xB3, 0x00, 0x00, 0x00), brush.Color);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Child_Inherits_Parent_RequestedTheme_Light_Primary_Brush_Is_Light()
+	{
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var parent = new Border { Width = 100, Height = 100, RequestedTheme = ElementTheme.Light };
+		var child = new Border { Width = 50, Height = 50 };
+		parent.Child = child;
+
+		WindowHelper.WindowContent = parent;
+		await WindowHelper.WaitForLoaded(parent);
+
+		Assert.AreEqual(ElementTheme.Light, child.ActualTheme);
+
+		var brush = child.FocusVisualPrimaryBrush as SolidColorBrush;
+		Assert.IsNotNull(brush);
+		Assert.AreEqual(Color.FromArgb(0xE4, 0x00, 0x00, 0x00), brush.Color);
+	}
+#endif
+
+	private static Thickness ThicknessFromUniformLength(double uniformLength) =>
+		new Thickness(uniformLength);
+}
+
+public partial class PlainFrameworkElement : FrameworkElement
+{
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -523,15 +523,18 @@ namespace Microsoft.UI.Xaml
 				return value;
 			}
 
-			if (this == FrameworkElement.FocusVisualPrimaryBrushProperty &&
-				ResourceResolver.TryStaticRetrieval("SystemControlFocusVisualPrimaryBrush", null, out var primaryBrush))
+			// MUX Reference: DependencyProperty.cpp GetDefaultFocusVisualBrush — WinUI resolves
+			// the focus visual brush against `targetObject->GetTheme()` so an element with
+			// an explicit RequestedTheme (different from the app's) still gets brushes from
+			// its own theme dictionary. Mirror that here by pushing the element's effective
+			// theme onto the resource resolution stack.
+			if (this == FrameworkElement.FocusVisualPrimaryBrushProperty)
 			{
-				return primaryBrush;
+				return ResolveFocusVisualBrushDefault(referenceObject, "SystemControlFocusVisualPrimaryBrush");
 			}
-			else if (this == FrameworkElement.FocusVisualSecondaryBrushProperty &&
-				ResourceResolver.TryStaticRetrieval("SystemControlFocusVisualSecondaryBrush", null, out var secondaryBrush))
+			else if (this == FrameworkElement.FocusVisualSecondaryBrushProperty)
 			{
-				return secondaryBrush;
+				return ResolveFocusVisualBrushDefault(referenceObject, "SystemControlFocusVisualSecondaryBrush");
 			}
 
 			if (this == UIElement.IsTabStopProperty)
@@ -615,6 +618,68 @@ namespace Microsoft.UI.Xaml
 			}
 
 			return _ownerTypeMetadata.DefaultValue;
+		}
+
+		// MUX Reference: microsoft-ui-xaml2/src/dxaml/xcp/core/core/elements/DependencyProperty.cpp
+		// lines 131-150 (GetDefaultFocusVisualBrush) and 309-345. WinUI passes
+		// `targetObject->GetTheme()` to the resource lookup so an element with
+		// an explicit RequestedTheme picks brushes from its own theme dictionary
+		// rather than the app's active theme.
+		private static object ResolveFocusVisualBrushDefault(DependencyObject referenceObject, string resourceKey)
+		{
+			var themeKey = GetEffectiveThemeKey(referenceObject);
+			var activeTheme = ResourceDictionary.GetActiveTheme();
+			var needsPush = themeKey is not null && !themeKey.Equals(activeTheme.Key);
+
+			if (needsPush)
+			{
+				ResourceDictionary.PushRequestedThemeForSubTree(themeKey);
+			}
+
+			try
+			{
+				if (ResourceResolver.TryStaticRetrieval(resourceKey, null, out var brush))
+				{
+					return brush;
+				}
+			}
+			finally
+			{
+				if (needsPush)
+				{
+					ResourceDictionary.PopRequestedThemeForSubTree();
+				}
+			}
+
+			return null;
+		}
+
+		// Returns the base theme key ("Light"/"Dark") that applies to the element,
+		// mirroring FrameworkElement.ActualTheme's resolution: prefer the element's
+		// own _theme (set during the theme walk), then fall back to the application
+		// theme. Returns null when neither is available.
+		private static string GetEffectiveThemeKey(DependencyObject referenceObject)
+		{
+			if (referenceObject is UIElement element)
+			{
+				var baseTheme = Theming.GetBaseValue(element.GetTheme());
+				if (baseTheme == Theme.None)
+				{
+					baseTheme = Theming.FromElementTheme(
+						Application.Current?.ActualElementTheme ?? ElementTheme.Light);
+				}
+
+				if (baseTheme == Theme.Light)
+				{
+					return "Light";
+				}
+				if (baseTheme == Theme.Dark)
+				{
+					return "Dark";
+				}
+			}
+
+			return null;
 		}
 
 		public override int GetHashCode() => CachedHashCode;


### PR DESCRIPTION
**GitHub Issue:** closes #23242

## PR Type:

🐞 Bugfix

## What changed? 🚀

`DependencyProperty.GetDefaultValue` resolved the default values for `FocusVisualPrimaryBrush` / `FocusVisualSecondaryBrush` via `ResourceResolver.TryStaticRetrieval("SystemControlFocusVisual…Brush", null, …)`. The `null` context made the lookup pick whichever theme was currently active at the application level, so an element inside a subtree with an explicit `RequestedTheme` different from `Application.Current.RequestedTheme` would receive brushes from the *wrong* theme dictionary. The focus visual then rendered with system/app-theme colors instead of the focused element's effective theme.

This change pushes the focused element's effective theme onto the resource resolution stack (`ResourceDictionary.PushRequestedThemeForSubTree`) around the static lookup, matching WinUI's `CDependencyProperty::GetDefaultFocusVisualBrush` which resolves against `targetObject->GetTheme()` (MUX reference: `microsoft-ui-xaml2/src/dxaml/xcp/core/core/elements/DependencyProperty.cpp`, lines 131-150 and 309-345).

`GetEffectiveThemeKey` mirrors `FrameworkElement.ActualTheme`'s fallback chain (element `_theme` → `Application.Current.ActualElementTheme` → `Light`).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

### Tests added

Five new `[RequiresFullWindow]` runtime tests in `Given_FrameworkElement_FocusVisuals` cover:

- Element with `RequestedTheme=Light` while app is Dark → primary brush is Light (`#E4000000`).
- Element with `RequestedTheme=Dark` while app is Light → primary brush is Dark (`#FFFFFFFF`).
- Same coverage for the secondary brush (`#B3FFFFFF` Light / `#B3000000` Dark).
- Child inheriting the parent's `RequestedTheme=Light` while app is Dark → primary brush is Light.

All 10 tests in the class pass on Skia Desktop (5 existing + 5 new).