### PR TITLE
Fix: ListView scroll when using SwipeControl

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
@@ -22,6 +22,7 @@ using Uno.Extensions;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.Toolkit.DevTools.Input;
+using MUXControlsTestApp.Utilities;
 
 #if HAS_UNO_WINUI
 using GestureRecognizer = Microsoft.UI.Input.GestureRecognizer;
@@ -1521,6 +1522,61 @@ public class Given_InputManager
 		finger.Drag(from: svBounds.GetCenter(), to: svBounds.GetCenter().Offset(y: -100));
 		sv.VerticalOffset.Should().BeGreaterThan(0, because: "scrolling should still work after toggling a ToggleSwitch");
 		await TestServices.WindowHelper.WaitForIdle();
+	}
+
+	[TestMethod]
+#if __WASM__
+	[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
+#elif !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	public async Task When_SwipeControlInListView_Then_VerticalScrollStillWorks()
+	{
+		// Regression coverage for the SwipeControl-in-ListView vertical-scroll-dies bug.
+		// PR #23135 added an after-press redo of CancelDirectManipulations to fix pinch
+		// on a ManipulationMode=Scale Grid inside a scrollable ScrollViewer on Skia Android.
+		// That redo cancelled ALL ancestor direct manipulations regardless of axis, so a
+		// SwipeControl (TranslateX) inside a ListView caused the ListView's
+		// ScrollContentPresenter (TranslateY) DM to be cancelled and vertical scrolling
+		// would die. ConflictsWithRequester is now axis-aware: a pure-X-translation
+		// requester must not cancel a pure-Y-translation ancestor.
+
+		var listView = new ListView
+		{
+			Width = 250,
+			Height = 200,
+		};
+		for (var i = 0; i < 50; i++)
+		{
+			var leftItems = new SwipeItems();
+			leftItems.Add(new SwipeItem { Text = "Action" });
+			listView.Items.Add(new SwipeControl
+			{
+				Width = 220,
+				Height = 40,
+				Content = new TextBlock { Text = $"Item {i}" },
+				LeftItems = leftItems,
+			});
+		}
+
+		await UITestHelper.Load(listView);
+
+		var sv = listView.FindVisualChildByType<ScrollViewer>()
+			?? throw new InvalidOperationException("ListView did not contain a ScrollViewer");
+		sv.UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous;
+		sv.IsScrollInertiaEnabled = false;
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		sv.VerticalOffset.Should().Be(0, because: "we start at the top");
+
+		var lvBounds = listView.GetAbsoluteBounds();
+		finger.Drag(from: lvBounds.GetCenter(), to: lvBounds.GetCenter().Offset(y: -100));
+
+		sv.VerticalOffset.Should().BeGreaterThan(0,
+			because: "a vertical drag on a ListView whose items are SwipeControls must still scroll vertically; " +
+					 "the SwipeControl's TranslateX direct-manipulation must not cancel the ScrollContentPresenter's TranslateY DM.");
 	}
 
 	private static void SetCursorShape(CoreCursor cursor)

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
@@ -1399,14 +1399,14 @@ public class Given_InputManager
 #elif !HAS_INPUT_INJECTOR
 	[Ignore("InputInjector is not supported on this platform.")]
 #endif
-	[DataRow(ManipulationModes.None)]
-	[DataRow(ManipulationModes.TranslateX)]
-	[DataRow(ManipulationModes.TranslateY)]
-	[DataRow(ManipulationModes.TranslateRailsX)]
-	[DataRow(ManipulationModes.TranslateRailsY)]
-	[DataRow(ManipulationModes.TranslateInertia)]
-	[DataRow(ManipulationModes.All)] // Does **NOT** include System
-	public async Task When_DirectManipulationDisabled(ManipulationModes mode)
+	[DataRow(ManipulationModes.None, false)]
+	[DataRow(ManipulationModes.TranslateX, true)] // Descendant claims X only -> parent's Y-axis scroll must still work.
+	[DataRow(ManipulationModes.TranslateY, false)]
+	[DataRow(ManipulationModes.TranslateRailsX, false)]
+	[DataRow(ManipulationModes.TranslateRailsY, false)]
+	[DataRow(ManipulationModes.TranslateInertia, false)]
+	[DataRow(ManipulationModes.All, false)] // Does **NOT** include System
+	public async Task When_DirectManipulationDisabled(ManipulationModes mode, bool expectsAncestorScroll)
 	{
 		ScrollViewer sv;
 		var ui = new Grid
@@ -1441,7 +1441,16 @@ public class Given_InputManager
 
 		await UITestHelper.WaitForIdle();
 
-		sv.VerticalOffset.Should().Be(0);
+		if (expectsAncestorScroll)
+		{
+			// Descendant declares a non-conflicting axis, so the ancestor ScrollViewer's
+			// vertical-scroll DM must NOT be cancelled by the descendant claim.
+			sv.VerticalOffset.Should().BeGreaterThan(0);
+		}
+		else
+		{
+			sv.VerticalOffset.Should().Be(0);
+		}
 	}
 
 	private CoreCursorType? GetCursorShape()

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
@@ -1402,7 +1402,7 @@ public class Given_InputManager
 	[DataRow(ManipulationModes.None, false)]
 	[DataRow(ManipulationModes.TranslateX, true)] // Descendant claims X only -> parent's Y-axis scroll must still work.
 	[DataRow(ManipulationModes.TranslateY, false)]
-	[DataRow(ManipulationModes.TranslateRailsX, false)]
+	[DataRow(ManipulationModes.TranslateRailsX, true)] // Rails-X is still an X-axis claim; doesn't conflict with Y-axis parent.
 	[DataRow(ManipulationModes.TranslateRailsY, false)]
 	[DataRow(ManipulationModes.TranslateInertia, false)]
 	[DataRow(ManipulationModes.All, false)] // Does **NOT** include System

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -364,6 +364,15 @@ namespace Microsoft.UI.Xaml.Controls
 			// cannot fight with the new manipulation's direction.
 			_touchInertia = null;
 
+			return ComputeAcceptedManipulationModes();
+		}
+
+		/// <inheritdoc />
+		ManipulationModes IDirectManipulationHandler.GetCurrentlyAcceptedModes()
+			=> ComputeAcceptedManipulationModes();
+
+		private ManipulationModes ComputeAcceptedManipulationModes()
+		{
 			var mode = ManipulationModes.None;
 			var scrollable = GetScrollableOffsets();
 			if (scrollable.Horizontally)

--- a/src/Uno.UI/UI/Xaml/Internal/IDirectManipulationHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/IDirectManipulationHandler.cs
@@ -28,6 +28,20 @@ internal interface IDirectManipulationHandler
 	ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args);
 
 	/// <summary>
+	/// Side-effect-free preview of the modes this handler would currently claim if a manipulation
+	/// were to start right now. Used by <see cref="InputManager.PointerManager.CancelDirectManipulations"/>
+	/// to decide whether a descendant's cancel request actually conflicts with this handler
+	/// (e.g. a <see cref="ManipulationModes.TranslateX"/>-only descendant must not cancel a
+	/// <see cref="ManipulationModes.TranslateY"/>-only ancestor scroller).
+	/// </summary>
+	/// <remarks>
+	/// Returning <see cref="ManipulationModes.All"/> (the default) preserves the legacy "cancel everything"
+	/// behavior for handlers that don't expose their effective modes.
+	/// </remarks>
+	ManipulationModes GetCurrentlyAcceptedModes()
+		=> ManipulationModes.All;
+
+	/// <summary>
 	/// Determines if a pointer point is in handler's bounds, so a new pointer can be added to the current direct-manipulation.
 	/// </summary>
 	bool CanAddPointerAt(in Point absoluteLocation)

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -124,19 +124,32 @@ partial class InputManager
 		}
 
 		/// <summary>
-		/// Cancel direct manipulations on ancestors of <paramref name="requestingElement"/> when they would
-		/// actually conflict with the element's declared <see cref="UIElement.ManipulationMode"/>.
+		/// Cancel direct manipulations whose handler is owned by <paramref name="requestingElement"/>
+		/// itself or by any of its ancestors, when they would actually conflict with the element's
+		/// declared <see cref="UIElement.ManipulationMode"/>.
 		/// </summary>
 		/// <remarks>
+		/// Self-owned handlers are intentionally included: <see cref="ScrollContentPresenter"/>'s
+		/// <see cref="IDirectManipulationHandler.Owner"/> is its <c>ScrollOwner</c>
+		/// (the containing <see cref="ScrollViewer"/>), so callers like <see cref="FlipView"/> that
+		/// invoke <see cref="UIElement.CancelDirectManipulations"/> directly on their inner
+		/// <see cref="ScrollViewer"/> can release that ScrollViewer's own DM. Strict-ancestor-only
+		/// semantics would silently no-op those call sites.
+		///
 		/// History: PR #23135 added an after-press redo of this walk in <see cref="AfterPressForDirectManipulation"/>
 		/// to catch ancestor DMs that register LATE in the press bubble (specifically <see cref="ScrollContentPresenter"/>),
 		/// fixing pinch on a <c>ManipulationMode=Scale</c> grid inside a scrollable ScrollViewer on Skia Android.
 		/// That redo made the walk also cancel orthogonal-axis ancestors, which broke the common pattern of
 		/// <c>SwipeControl</c> (<c>TranslateX</c>) inside a <c>ListView</c> (<c>TranslateY</c>): the parent's
 		/// vertical-scroll DM was being cancelled, killing vertical scrolling. The walk is now axis-aware:
-		/// it only cancels ancestor DMs whose currently-accepted modes share an axis with the requester
+		/// it only cancels matching DMs whose currently-accepted modes share an axis with the requester
 		/// (or whenever the requester declares <c>Scale</c>/<c>Rotate</c>/<c>All</c>/no specific axis, in which
 		/// case the previous aggressive behavior is preserved).
+		/// The axis aggregation in <see cref="ConflictsWithRequester"/> is restricted to handlers that
+		/// match the requester-or-ancestor predicate, so a co-resident handler on the same pointer
+		/// outside that chain (e.g. an <see cref="InteractionTracker"/> redirection whose default modes
+		/// preview is <see cref="ManipulationModes.All"/>) cannot widen the effective modes and force a
+		/// false-positive cancel.
 		/// </remarks>
 		internal bool CancelDirectManipulations(UIElement requestingElement)
 		{
@@ -146,8 +159,8 @@ partial class InputManager
 			var cancelled = false;
 			foreach (var manipulation in _directManipulations)
 			{
-				if (manipulation.Handlers.Any(IsForParentOfRequestingElement)
-					&& ConflictsWithRequester(requesterModes, manipulation))
+				if (manipulation.Handlers.Any(IsForRequesterOrAncestor)
+					&& ConflictsWithRequester(requesterModes, manipulation, IsForRequesterOrAncestor))
 				{
 					cancelled |= manipulation.Cancel();
 				}
@@ -155,11 +168,17 @@ partial class InputManager
 
 			return cancelled;
 
-			bool IsForParentOfRequestingElement(IDirectManipulationHandler handler)
+			// Matches handlers owned by `requestingElement` itself or by any of its ancestors.
+			// Self-inclusion is required for the FlipView-style "cancel my inner ScrollViewer's DM"
+			// path (see method <remarks>).
+			bool IsForRequesterOrAncestor(IDirectManipulationHandler handler)
 				=> handler.Owner is DependencyObject owner && requestingElement.GetAllParents(includeCurrent: true).Contains(owner);
 		}
 
-		private static bool ConflictsWithRequester(ManipulationModes requesterModes, DirectManipulation manipulation)
+		private static bool ConflictsWithRequester(
+			ManipulationModes requesterModes,
+			DirectManipulation manipulation,
+			Func<IDirectManipulationHandler, bool> isHandlerForRequesterOrAncestor)
 		{
 			const ManipulationModes TranslationAxes = ManipulationModes.TranslateX | ManipulationModes.TranslateY;
 			const ManipulationModes MultiPointer = ManipulationModes.Scale | ManipulationModes.Rotate;
@@ -182,17 +201,28 @@ partial class InputManager
 				return true;
 			}
 
-			// Pure translation request: only cancel ancestors whose currently-accepted modes overlap on
-			// the same axis. Any ancestor handler that doesn't expose an axis preview returns
-			// ManipulationModes.All by default, which keeps the legacy aggressive behavior for them.
+			// Pure translation request: only cancel handlers (owned by the requester or its ancestors)
+			// whose currently-accepted modes overlap on the same axis. We aggregate modes from
+			// requester-or-ancestor handlers only — a co-resident handler on the same DirectManipulation
+			// that falls outside that chain (e.g. an InteractionTracker redirection registered via
+			// RedirectPointer) whose default GetCurrentlyAcceptedModes() preview is ManipulationModes.All
+			// must not widen handlerModes to All and force cancellation of an in-chain handler whose
+			// effective axis doesn't actually conflict with the requester.
+			// In-chain handlers that don't expose an axis preview still return ManipulationModes.All
+			// by default, which keeps the legacy aggressive behavior for them.
 			var handlerModes = ManipulationModes.None;
 			foreach (var handler in manipulation.Handlers)
 			{
+				if (!isHandlerForRequesterOrAncestor(handler))
+				{
+					continue;
+				}
+
 				handlerModes |= handler.GetCurrentlyAcceptedModes();
 			}
 
-			// Ancestor wants to do multi-pointer gestures: a single-finger gesture on the descendant
-			// would steal pointers the ancestor needs, so treat it as a conflict to be safe.
+			// In-chain handler wants to do multi-pointer gestures: a single-finger gesture on the
+			// descendant would steal pointers it needs, so treat it as a conflict to be safe.
 			if ((handlerModes & MultiPointer) != 0)
 			{
 				return true;

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -124,16 +124,30 @@ partial class InputManager
 		}
 
 		/// <summary>
-		/// Cancel direct manipulation which are handled by the given <paramref name="requestingElement"/>.
+		/// Cancel direct manipulations on ancestors of <paramref name="requestingElement"/> when they would
+		/// actually conflict with the element's declared <see cref="UIElement.ManipulationMode"/>.
 		/// </summary>
+		/// <remarks>
+		/// History: PR #23135 added an after-press redo of this walk in <see cref="AfterPressForDirectManipulation"/>
+		/// to catch ancestor DMs that register LATE in the press bubble (specifically <see cref="ScrollContentPresenter"/>),
+		/// fixing pinch on a <c>ManipulationMode=Scale</c> grid inside a scrollable ScrollViewer on Skia Android.
+		/// That redo made the walk also cancel orthogonal-axis ancestors, which broke the common pattern of
+		/// <c>SwipeControl</c> (<c>TranslateX</c>) inside a <c>ListView</c> (<c>TranslateY</c>): the parent's
+		/// vertical-scroll DM was being cancelled, killing vertical scrolling. The walk is now axis-aware:
+		/// it only cancels ancestor DMs whose currently-accepted modes share an axis with the requester
+		/// (or whenever the requester declares <c>Scale</c>/<c>Rotate</c>/<c>All</c>/no specific axis, in which
+		/// case the previous aggressive behavior is preserved).
+		/// </remarks>
 		internal bool CancelDirectManipulations(UIElement requestingElement)
 		{
 			_pendingDirectManipulationCancelRequester ??= requestingElement;
 
+			var requesterModes = requestingElement.ManipulationMode;
 			var cancelled = false;
 			foreach (var manipulation in _directManipulations)
 			{
-				if (manipulation.Handlers.Any(IsForParentOfRequestingElement))
+				if (manipulation.Handlers.Any(IsForParentOfRequestingElement)
+					&& ConflictsWithRequester(requesterModes, manipulation))
 				{
 					cancelled |= manipulation.Cancel();
 				}
@@ -143,6 +157,48 @@ partial class InputManager
 
 			bool IsForParentOfRequestingElement(IDirectManipulationHandler handler)
 				=> handler.Owner is DependencyObject owner && requestingElement.GetAllParents(includeCurrent: true).Contains(owner);
+		}
+
+		private static bool ConflictsWithRequester(ManipulationModes requesterModes, DirectManipulation manipulation)
+		{
+			const ManipulationModes TranslationAxes = ManipulationModes.TranslateX | ManipulationModes.TranslateY;
+			const ManipulationModes MultiPointer = ManipulationModes.Scale | ManipulationModes.Rotate;
+
+			// No declared translation axis and no multi-pointer claim (e.g. ManipulationMode = System/None,
+			// or an explicit user-facing CancelDirectManipulations() call from an element that hasn't set
+			// ManipulationMode) -> fall back to the pre-axis-aware behavior of cancelling every ancestor DM.
+			var requesterAxes = requesterModes & TranslationAxes;
+			var requesterIsMultiPointer = (requesterModes & MultiPointer) != 0;
+			if (requesterAxes == 0 && !requesterIsMultiPointer)
+			{
+				return true;
+			}
+
+			// Multi-pointer gestures (pinch/rotate) and a translating ancestor share the first pointer:
+			// the ancestor would lock onto it before the second pointer arrives, aborting the descendant
+			// gesture. Cancel the ancestor unconditionally to preserve PR #23135's fix.
+			if (requesterIsMultiPointer)
+			{
+				return true;
+			}
+
+			// Pure translation request: only cancel ancestors whose currently-accepted modes overlap on
+			// the same axis. Any ancestor handler that doesn't expose an axis preview returns
+			// ManipulationModes.All by default, which keeps the legacy aggressive behavior for them.
+			var handlerModes = ManipulationModes.None;
+			foreach (var handler in manipulation.Handlers)
+			{
+				handlerModes |= handler.GetCurrentlyAcceptedModes();
+			}
+
+			// Ancestor wants to do multi-pointer gestures: a single-finger gesture on the descendant
+			// would steal pointers the ancestor needs, so treat it as a conflict to be safe.
+			if ((handlerModes & MultiPointer) != 0)
+			{
+				return true;
+			}
+
+			return (requesterAxes & handlerModes) != 0;
 		}
 
 		private bool IsRedirectedToManipulations(PointerIdentifier pointerId)

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -187,15 +187,30 @@ partial class InputManager
 			DirectManipulation manipulation,
 			Func<IDirectManipulationHandler, bool> isHandlerForRequesterOrAncestor)
 		{
-			const ManipulationModes TranslationAxes = ManipulationModes.TranslateX | ManipulationModes.TranslateY;
+			// Canonical translation axes: only TranslateX/Y count as actual translation on the
+			// handler side. Rails (TranslateRailsX/Y) are gesture-settings flags meant to constrain
+			// a translation axis, not to declare scrolling on their own. ScrollContentPresenter
+			// advertises rails whenever IsHorizontal/VerticalRailEnabled is set even on axes it
+			// doesn't scroll, so including rails in the handler-side mask would create false-positive
+			// overlaps with an X-axis requester (e.g. a SwipeControl) against a Y-only scroller.
+			const ManipulationModes XAxis = ManipulationModes.TranslateX;
+			const ManipulationModes YAxis = ManipulationModes.TranslateY;
+			// On the requester side rails still imply the corresponding translation axis (a
+			// TranslateRailsX-only descendant is still intending to translate on X), so they
+			// participate in the axis-claim test instead of falling through to the legacy
+			// cancel-everything path.
+			const ManipulationModes RequesterXClaim = XAxis | ManipulationModes.TranslateRailsX;
+			const ManipulationModes RequesterYClaim = YAxis | ManipulationModes.TranslateRailsY;
 			const ManipulationModes MultiPointer = ManipulationModes.Scale | ManipulationModes.Rotate;
 
 			// No declared translation axis and no multi-pointer claim (e.g. ManipulationMode = System/None,
-			// or an explicit user-facing CancelDirectManipulations() call from an element that hasn't set
-			// ManipulationMode) -> fall back to the pre-axis-aware behavior of cancelling every ancestor DM.
-			var requesterAxes = requesterModes & TranslationAxes;
+			// TranslateInertia alone, or an explicit user-facing CancelDirectManipulations() call from an
+			// element that hasn't set ManipulationMode) -> fall back to the pre-axis-aware behavior of
+			// cancelling every ancestor DM.
+			var requesterClaimsX = (requesterModes & RequesterXClaim) != 0;
+			var requesterClaimsY = (requesterModes & RequesterYClaim) != 0;
 			var requesterIsMultiPointer = (requesterModes & MultiPointer) != 0;
-			if (requesterAxes == 0 && !requesterIsMultiPointer)
+			if (!requesterClaimsX && !requesterClaimsY && !requesterIsMultiPointer)
 			{
 				return true;
 			}
@@ -235,7 +250,8 @@ partial class InputManager
 				return true;
 			}
 
-			return (requesterAxes & handlerModes) != 0;
+			return (requesterClaimsX && (handlerModes & XAxis) != 0)
+				|| (requesterClaimsY && (handlerModes & YAxis) != 0);
 		}
 
 		private bool IsRedirectedToManipulations(PointerIdentifier pointerId)

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -156,23 +156,30 @@ partial class InputManager
 			_pendingDirectManipulationCancelRequester ??= requestingElement;
 
 			var requesterModes = requestingElement.ManipulationMode;
+
+			// Materialize the requester's self-and-ancestor chain once: the predicate runs up to
+			// twice per handler (once for the Any() pre-check, once inside ConflictsWithRequester's
+			// modes aggregation), and re-walking the visual tree each time would be O(handlers * depth)
+			// on every pointer-down. A HashSet gives O(1) Contains and is built in one pass.
+			var requesterAndAncestors = new HashSet<DependencyObject>(requestingElement.GetAllParents(includeCurrent: true));
+
+			// Matches handlers owned by `requestingElement` itself or by any of its ancestors.
+			// Self-inclusion is required for the FlipView-style "cancel my inner ScrollViewer's DM"
+			// path (see method <remarks>). Hoisted to a local Func so the delegate is allocated once.
+			Func<IDirectManipulationHandler, bool> isForRequesterOrAncestor = handler =>
+				handler.Owner is DependencyObject owner && requesterAndAncestors.Contains(owner);
+
 			var cancelled = false;
 			foreach (var manipulation in _directManipulations)
 			{
-				if (manipulation.Handlers.Any(IsForRequesterOrAncestor)
-					&& ConflictsWithRequester(requesterModes, manipulation, IsForRequesterOrAncestor))
+				if (manipulation.Handlers.Any(isForRequesterOrAncestor)
+					&& ConflictsWithRequester(requesterModes, manipulation, isForRequesterOrAncestor))
 				{
 					cancelled |= manipulation.Cancel();
 				}
 			}
 
 			return cancelled;
-
-			// Matches handlers owned by `requestingElement` itself or by any of its ancestors.
-			// Self-inclusion is required for the FlipView-style "cancel my inner ScrollViewer's DM"
-			// path (see method <remarks>).
-			bool IsForRequesterOrAncestor(IDirectManipulationHandler handler)
-				=> handler.Owner is DependencyObject owner && requestingElement.GetAllParents(includeCurrent: true).Contains(owner);
 		}
 
 		private static bool ConflictsWithRequester(


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/477

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀
CancelDirectManipulations cancelled every ancestor direct manipulation regardless of axis, so a SwipeControl (TranslateX) inside a ListView killed the parent ScrollContentPresenter's (TranslateY) DM and vertical scrolling died

Fix: Made ConflictsWithRequester axis-aware via a new IDirectManipulationHandler.GetCurrentlyAcceptedModes() peek — a pure-translation requester now only cancels ancestors that share an axis, while multi-pointer (Scale/Rotate) requesters and  System/None-mode requesters keep the legacy "cancel everything" behavior so pinch-in-ScrollViewer fix is preserved

related to this change: https://github.com/unoplatform/uno/pull/23135

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
