### PR TITLE
docs: Update .NET version support for latest Uno Platform

### DIFF
--- a/doc/articles/net-version-support.md
+++ b/doc/articles/net-version-support.md
@@ -10,7 +10,7 @@ This page lists supported .NET versions and [C# language versions](https://learn
 
 ## Table of supported versions
 
-# [**Uno Platform 6.5 and later**](#tab/uno63)
+# [**Uno Platform 6.5 and later**](#tab/uno65)
 
 | Platform                                   | Default .NET runtime | Default C# version |  Min .NET version | Max C# version |
 |--------------------------------------------|:--------------------:|:------------------:|:-----------------:|:--------------:|

--- a/doc/articles/net-version-support.md
+++ b/doc/articles/net-version-support.md
@@ -10,27 +10,23 @@ This page lists supported .NET versions and [C# language versions](https://learn
 
 ## Table of supported versions
 
-# [**Uno Platform 6.3 and later**](#tab/uno63)
+# [**Uno Platform 6.5 and later**](#tab/uno63)
 
-| Platform                                   | Default .NET version | Default C# version |  Max .NET version | Max C# version |
+| Platform                                   | Default .NET runtime | Default C# version |  Min .NET version | Max C# version |
 |--------------------------------------------|:--------------------:|:------------------:|:-----------------:|:--------------:|
-| WebAssembly                                | .NET 9               | 13                 | .NET 10           | 14             |
-| Skia Desktop                               | .NET 9               | 13                 | .NET 10           | 14             |
-| WinAppSDK                                  | .NET 9               | 13                 | .NET 10           | 14             |
-| iOS, Android                               | .NET 9               | 13                 | .NET 10           | 14             |
+| WebAssembly                                | .NET 10               | 13                 | .NET 9           | 14             |
+| Skia Desktop                               | .NET 10               | 13                 | .NET 9           | 14             |
+| WinAppSDK                                  | .NET 10               | 13                 | .NET 9           | 14             |
+| iOS, Android                               | .NET 10               | 13                 | .NET 9           | 14             |
 
 ### Notes
 
-- In Uno Platform 6.3, support for .NET 8 has been removed.
+- Since Uno Platform 6.3, support for .NET 8 has been removed.
 - [.NET 9.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview), the successor to .NET 8, has a special focus on cloud-native apps and performance.
   As a Standard Term Support (STS) release, it is now supported for **24 months (until November 10, 2026)**. See the [STS latest announcement](https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/) for more details.
-
-  > [!NOTE]
-  > For **mobile workloads**, there is **no change yet**, support remains at **18 months**. See [MAUI support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/maui) for more details.
-
 - [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview), the successor to .NET 9, includes improvements in performance, C# 14 support, and long-term platform stability.
   As a Long Term Support (LTS) release, it will be supported for **three years (until November 2028)**.
-  At the moment, it is in preview and the least stable option for new projects.
+  At the moment, .NET 10 is the most stable runtime and the default option for new Uno Platform projects.
 
 # [**Uno Platform 5 and later**](#tab/uno5)
 


### PR DESCRIPTION
## PR Type:
📚 Documentation content changes

## What changed? 🚀
Updating .NET runtime info to match latest Uno Platform bits. 
I don't think the Mobile section matters any more, in line with .NET MAUI's .NET 9 support.

## PR Checklist ✅
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ❗ Contains **NO** breaking changes
- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.