### PR TITLE
docs: Revise .NET version support for latest Uno Platform bits

### DIFF
--- a/doc/articles/getting-started/wizard/includes/framework.md
+++ b/doc/articles/getting-started/wizard/includes/framework.md
@@ -1,4 +1,4 @@
-This setting lets you choose the .NET version to target. The default is .NET 9.0, but you can also choose .NET 10.0!
+This setting lets you choose the .NET version to target. The default is .NET 10.0, and .NET 9.0 remains supported.
 
 - #### .NET 9.0
 
@@ -6,7 +6,7 @@ This setting lets you choose the .NET version to target. The default is .NET 9.0
     As a Standard Term Support (STS) release, it is now supported for **24 months (until November 10, 2026)**. See the [STS latest announcement](https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/) for more details.
 
     > [!NOTE]
-    > For **mobile workloads**, there is **no change yet**, support remains at **18 months**. See [MAUI support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/maui) for more details.
+    > For **mobile workloads**, there is **no change yet**, support remains at **18 months (until May 12, 2026)**. See [MAUI support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/maui) for more details.
 
     ```dotnetcli
     dotnet new unoapp -tfm net9.0
@@ -16,7 +16,7 @@ This setting lets you choose the .NET version to target. The default is .NET 9.0
 
     [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview), the successor to .NET 9, includes improvements in performance, C# 14 support, and long-term platform stability.
     As a Long Term Support (LTS) release, it will be supported for **three years (until November 2028)**.
-    At the moment, it is in preview and the least stable option for new projects.
+    .NET 10 is now the stable and default runtime option for new Uno Platform projects, while .NET 9 remains supported.
 
     ```dotnetcli
     dotnet new unoapp -tfm net10.0

--- a/doc/articles/migrating-from-net9-to-net10.md
+++ b/doc/articles/migrating-from-net9-to-net10.md
@@ -9,12 +9,11 @@ Migrating from .NET 9 to .NET 10 is a generally straightforward process. Below a
 To upgrade to .NET 10:
 
 - First, read [What's New in .NET 10](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview).
-- Use **[.NET 10 RC1](https://devblogs.microsoft.com/dotnet/dotnet-10-rc-1/)** along with:
-  - **Visual Studio** - the latest version of [Visual Studio 2026 Insiders](https://visualstudio.microsoft.com/insiders/), as recommended by Microsoft in their [announcement](https://devblogs.microsoft.com/dotnet/dotnet-10-rc-1/#🚀-get-started).
-    Use version **18.0.0 [11104.47]** or later to ensure compatibility with the [latest stable Uno Platform extension](https://aka.platform.uno/vs-extension-marketplace).
-  - **Visual Studio Code** - the latest version of [Visual Studio Code](https://code.visualstudio.com/Download) and the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) extension, also recommended by Microsoft in the same [announcement](https://devblogs.microsoft.com/dotnet/dotnet-10-rc-1/#🚀-get-started).
+- Install the **.NET 10 SDK** and ensure your IDE is up to date:
+  - **Visual Studio** - the latest stable version of [Visual Studio 2026](https://visualstudio.microsoft.com/), which includes native .NET 10 support.
+  - **Visual Studio Code** - the latest version of [Visual Studio Code](https://code.visualstudio.com/Download) and the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) extension.
   - **Rider** - the latest stable version, as .NET 10 support has been available since [Rider 2025.1](https://www.jetbrains.com/rider/whatsnew/2025-1/).
-- Run the latest stable version of [uno.check](xref:UnoCheck.UsingUnoCheck) with the [`--pre-major` parameter](https://aka.platform.uno/uno-check-pre-major) to install .NET 10.
+- Run the latest stable version of [uno.check](xref:UnoCheck.UsingUnoCheck) to install the required .NET 10 workloads.
 - Uno Platform provides an updated [Visual Studio extension](https://aka.platform.uno/vs-extension-marketplace) in the store that supports Visual Studio 2026 and the new `.slnx` solution format.
 - Change all your target framework (TFM) references from `net9.0` to `net10.0`, and from `net9.0-*` to `net10.0-*`.
 - Clean your project by deleting the `bin` and `obj` folders.

--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -27,6 +27,14 @@ When upgrading to Uno Platform 6.4, make sure to update your IDE extension or pl
 - [Visual Studio Code extension](https://aka.platform.uno/vscode-extension-marketplace)
 - [Rider plugin](https://aka.platform.uno/rider-extension-marketplace)
 
+### .NET 10 is now the default
+
+**Uno Platform 6.4** aligns with the General Availability of **.NET 10 (LTS)**, released in November 2025, making it the stable and default target framework for new Uno Platform projects.
+
+- The project wizard and `dotnet new unoapp` now default to `net10.0`.
+- .NET 9 continues to be supported alongside .NET 10.
+- To upgrade an existing .NET 9 project to .NET 10, see our [migration guide](xref:Uno.Development.MigratingFromNet9ToNet10).
+
 ## Uno Platform 6.3
 
 **Uno Platform 6.3** introduces support for **.NET 10 RC1** and removes **.NET 8** targets.

--- a/doc/articles/net-version-support.md
+++ b/doc/articles/net-version-support.md
@@ -10,27 +10,23 @@ This page lists supported .NET versions and [C# language versions](https://learn
 
 ## Table of supported versions
 
-# [**Uno Platform 6.3 and later**](#tab/uno63)
+# [**Uno Platform 6.5 and later**](#tab/uno65)
 
-| Platform                                   | Default .NET version | Default C# version |  Max .NET version | Max C# version |
+| Platform                                   | Default .NET version | Default C# version |  Min .NET version | Max C# version |
 |--------------------------------------------|:--------------------:|:------------------:|:-----------------:|:--------------:|
-| WebAssembly                                | .NET 9               | 13                 | .NET 10           | 14             |
-| Skia Desktop                               | .NET 9               | 13                 | .NET 10           | 14             |
-| WinAppSDK                                  | .NET 9               | 13                 | .NET 10           | 14             |
-| iOS, Android                               | .NET 9               | 13                 | .NET 10           | 14             |
+| WebAssembly                                | .NET 10               | 13                 | .NET 9           | 14             |
+| Skia Desktop                               | .NET 10               | 13                 | .NET 9           | 14             |
+| WinAppSDK                                  | .NET 10               | 13                 | .NET 9           | 14             |
+| iOS, Android                               | .NET 10               | 13                 | .NET 9           | 14             |
 
 ### Notes
 
 - In Uno Platform 6.3, support for .NET 8 has been removed.
 - [.NET 9.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview), the successor to .NET 8, has a special focus on cloud-native apps and performance.
   As a Standard Term Support (STS) release, it is now supported for **24 months (until November 10, 2026)**. See the [STS latest announcement](https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/) for more details.
-
-  > [!NOTE]
-  > For **mobile workloads**, there is **no change yet**, support remains at **18 months**. See [MAUI support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/maui) for more details.
-
 - [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview), the successor to .NET 9, includes improvements in performance, C# 14 support, and long-term platform stability.
   As a Long Term Support (LTS) release, it will be supported for **three years (until November 2028)**.
-  At the moment, it is in preview and the least stable option for new projects.
+  At the moment, .NET 10 is the stable version and the default runtime option for new Uno Platform projects.
 
 # [**Uno Platform 5 and later**](#tab/uno5)
 

--- a/doc/articles/net-version-support.md
+++ b/doc/articles/net-version-support.md
@@ -10,32 +10,49 @@ This page lists supported .NET versions and [C# language versions](https://learn
 
 ## Table of supported versions
 
-# [**Uno Platform 6.5 and later**](#tab/uno65)
+# [**Uno Platform 6.4 and later**](#tab/uno64)
 
-| Platform                                   | Default .NET version | Default C# version |  Min .NET version | Max C# version |
-|--------------------------------------------|:--------------------:|:------------------:|:-----------------:|:--------------:|
-| WebAssembly                                | .NET 10               | 13                 | .NET 9           | 14             |
-| Skia Desktop                               | .NET 10               | 13                 | .NET 9           | 14             |
-| WinAppSDK                                  | .NET 10               | 13                 | .NET 9           | 14             |
-| iOS, Android                               | .NET 10               | 13                 | .NET 9           | 14             |
+| Platform                                   | Default .NET version | Default C# version | Min .NET version | Min C# version | Max .NET version | Max C# version |
+|--------------------------------------------|:--------------------:|:------------------:|:----------------:|:--------------:|:----------------:|:--------------:|
+| WebAssembly                                | .NET 10              | 14                 | .NET 9           | 13             | .NET 10          | 14             |
+| Skia Desktop                               | .NET 10              | 14                 | .NET 9           | 13             | .NET 10          | 14             |
+| WinAppSDK                                  | .NET 10              | 14                 | .NET 9           | 13             | .NET 10          | 14             |
+| iOS, Android                               | .NET 10              | 14                 | .NET 9           | 13             | .NET 10          | 14             |
+
+### Notes
+
+- [.NET 9.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview), the successor to .NET 8, has a special focus on cloud-native apps and performance.
+  As a Standard Term Support (STS) release, it is now supported for **24 months (until November 10, 2026)**. See the [STS latest announcement](https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/) for more details.
+
+  > [!NOTE]
+  > For **mobile workloads**, there is **no change yet**, support remains at **18 months (until May 12, 2026)**. See [MAUI support policy](https://dotnet.microsoft.com/en-us/platform/support/policy/maui) for more details.
+
+- [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview), the successor to .NET 9, includes improvements in performance, C# 14 support, and long-term platform stability.
+  As a Long Term Support (LTS) release, it will be supported for **three years (until November 2028)**.
+  .NET 10 is now the stable and default runtime option for new Uno Platform projects, while .NET 9 remains supported.
+
+# [**Uno Platform 6.3**](#tab/uno63)
+
+| Platform                                   | Default .NET version | Default C# version | Min .NET version | Min C# version | Max .NET version | Max C# version |
+|--------------------------------------------|:--------------------:|:------------------:|:----------------:|:--------------:|:----------------:|:--------------:|
+| WebAssembly                                | .NET 9               | 13                 | .NET 9           | 13             | .NET 10          | 14             |
+| Skia Desktop                               | .NET 9               | 13                 | .NET 9           | 13             | .NET 10          | 14             |
+| WinAppSDK                                  | .NET 9               | 13                 | .NET 9           | 13             | .NET 10          | 14             |
+| iOS, Android                               | .NET 9               | 13                 | .NET 9           | 13             | .NET 10          | 14             |
 
 ### Notes
 
 - In Uno Platform 6.3, support for .NET 8 has been removed.
-- [.NET 9.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview), the successor to .NET 8, has a special focus on cloud-native apps and performance.
-  As a Standard Term Support (STS) release, it is now supported for **24 months (until November 10, 2026)**. See the [STS latest announcement](https://devblogs.microsoft.com/dotnet/dotnet-sts-releases-supported-for-24-months/) for more details.
-- [.NET 10.0](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview), the successor to .NET 9, includes improvements in performance, C# 14 support, and long-term platform stability.
-  As a Long Term Support (LTS) release, it will be supported for **three years (until November 2028)**.
-  At the moment, .NET 10 is the stable version and the default runtime option for new Uno Platform projects.
+- In Uno Platform 6.3, .NET 10 support was available as preview/RC support (not yet the stable default).
 
 # [**Uno Platform 5 and later**](#tab/uno5)
 
-| Platform                                   | Default .NET version | Default C# version |  Max .NET version | Max C# version |
-|--------------------------------------------|:--------------------:|:------------------:|:-----------------:|:--------------:|
-| WebAssembly                                | .NET 8               | 12                 | .NET 9            | 13             |
-| Skia Desktop                               | .NET 8               | 12                 | .NET 9            | 13             |
-| WinAppSDK                                  | .NET 8               | 12                 | .NET 9            | 13             |
-| iOS, Android                               | .NET 8               | 12                 | .NET 9            | 13             |
+| Platform                                   | Default .NET version | Default C# version | Min .NET version | Min C# version | Max .NET version | Max C# version |
+|--------------------------------------------|:--------------------:|:------------------:|:----------------:|:--------------:|:----------------:|:--------------:|
+| WebAssembly                                | .NET 8               | 12                 | .NET 8           | 12             | .NET 9           | 13             |
+| Skia Desktop                               | .NET 8               | 12                 | .NET 8           | 12             | .NET 9           | 13             |
+| WinAppSDK                                  | .NET 8               | 12                 | .NET 8           | 12             | .NET 9           | 13             |
+| iOS, Android                               | .NET 8               | 12                 | .NET 8           | 12             | .NET 9           | 13             |
 
 ### Notes
 

--- a/doc/articles/uno-publishing-desktop.linux.md
+++ b/doc/articles/uno-publishing-desktop.linux.md
@@ -51,9 +51,6 @@ The `.desktop` filename MUST conform to the [Desktop File](https://specification
 
 If you wish, you can generate a default snap manifest and desktop file by running the command above, then tweak them.
 
-> [!NOTE]
-> .NET 9 publishing and cross-publishing are not supported as of Uno 5.5, we will support .NET 9 publishing soon.
-
 #### CI Restrictions
 
 When building in a CI environment, security restrictions may prevent LXD and Multipass from running properly.


### PR DESCRIPTION
Updated the supported .NET versions for Uno Platform 6.4+ and removed stale details.

## PR Type:
📚 Documentation content changes

## What changed? 🚀
Updates to .NET runtime versions for latest Uno Platform bits

## PR Checklist ✅
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)