### PR TITLE
fix(android): JNI-based setChecked to span AndroidX.Core 1.16/1.17

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/Accessibility/AccessibilityNodeInfoCompatJni.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Accessibility/AccessibilityNodeInfoCompatJni.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading;
+using Android.Runtime;
+using AndroidX.Core.View.Accessibility;
+
+namespace Uno.UI.Runtime.Skia.Android;
+
+/// <summary>
+/// Sets <c>AccessibilityNodeInfoCompat.checked</c> via JNI so the call works against any
+/// AndroidX.Core binding loaded at runtime. The C# binding for <c>setChecked</c> changed
+/// signature between AndroidX.Core 1.16 (<c>setChecked(boolean)</c>) and 1.17
+/// (<c>setChecked(int)</c> with state constants), which means a build compiled against one
+/// version throws <see cref="Java.Lang.NoSuchMethodError"/> at runtime when the consuming
+/// app pulls in the other version (see unoplatform/uno#22999). Probing both Java signatures
+/// here bypasses the managed property entirely.
+/// </summary>
+internal static class AccessibilityNodeInfoCompatJni
+{
+	private const string ClassName = "androidx/core/view/accessibility/AccessibilityNodeInfoCompat";
+
+	// Mirror AccessibilityNodeInfoCompat.CHECKED_STATE_* (AndroidX.Core 1.17+).
+	private const int CheckedStateFalse = 0;
+	private const int CheckedStateTrue = 1;
+
+	private static readonly object _initLock = new();
+	private static bool _initialized;
+	private static IntPtr _setCheckedIntId;
+	private static IntPtr _setCheckedBoolId;
+
+	public static void SetChecked(AccessibilityNodeInfoCompat node, bool isChecked)
+	{
+		EnsureInitialized();
+
+		if (_setCheckedIntId != IntPtr.Zero)
+		{
+			// AndroidX.Core 1.17+: setChecked(int state)
+			JNIEnv.CallVoidMethod(
+				node.Handle,
+				_setCheckedIntId,
+				new JValue(isChecked ? CheckedStateTrue : CheckedStateFalse));
+		}
+		else if (_setCheckedBoolId != IntPtr.Zero)
+		{
+			// AndroidX.Core 1.16 and earlier: setChecked(boolean)
+			JNIEnv.CallVoidMethod(
+				node.Handle,
+				_setCheckedBoolId,
+				new JValue(isChecked));
+		}
+		// else: neither signature exists on the loaded binding — skip silently rather than
+		// crash. This shouldn't happen in practice but keeps the helper safe by construction.
+	}
+
+	private static void EnsureInitialized()
+	{
+		if (Volatile.Read(ref _initialized))
+		{
+			return;
+		}
+
+		lock (_initLock)
+		{
+			if (_initialized)
+			{
+				return;
+			}
+
+			var classRef = JNIEnv.FindClass(ClassName);
+			_setCheckedIntId = TryGetMethodId(classRef, "setChecked", "(I)V");
+			_setCheckedBoolId = TryGetMethodId(classRef, "setChecked", "(Z)V");
+
+			Volatile.Write(ref _initialized, true);
+		}
+	}
+
+	private static IntPtr TryGetMethodId(IntPtr classRef, string name, string signature)
+	{
+		try
+		{
+			return JNIEnv.GetMethodID(classRef, name, signature);
+		}
+		catch (Java.Lang.Throwable)
+		{
+			return IntPtr.Zero;
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Android/Accessibility/UnoExploreByTouchHelper.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Accessibility/UnoExploreByTouchHelper.cs
@@ -215,7 +215,12 @@ internal sealed class UnoExploreByTouchHelper : ExploreByTouchHelper
 				node.ContentDescription = peer.GetName() ?? "";
 				node.Password = peer.IsPassword();
 				node.Enabled = peer.IsEnabled();
-				node.Checked = peer is IToggleProvider toggleProvider && toggleProvider.ToggleState == ToggleState.On;
+				// Call setChecked via JNI to stay compatible across the AndroidX.Core
+				// signature change in 1.17 (setChecked(boolean) -> setChecked(int)).
+				// See unoplatform/uno#22999.
+				AccessibilityNodeInfoCompatJni.SetChecked(
+					node,
+					peer is IToggleProvider toggleProvider && toggleProvider.ToggleState == ToggleState.On);
 				node.Checkable = peer is IToggleProvider;
 				node.Clickable = isClickable;
 				node.Editable = automationControlType == AutomationControlType.Edit;


### PR DESCRIPTION
## Summary

Fixes [#22999](https://github.com/unoplatform/uno/issues/22999) by calling `AccessibilityNodeInfoCompat.setChecked` through JNI rather than the managed C# property.

`Xamarin.AndroidX.Core 1.17.0` changed the `setChecked` binding from `setChecked(boolean)` to `setChecked(int)` (state constants). When Uno.UI is compiled against one binding version and the consuming app pulls in the other transitively (the reported case was `Sentry.Bindings.Android` ≥ 6.2.0 dragging in Core 1.17.0), the managed setter throws `MissingMethodException` at runtime.

Both binding versions wrap the same underlying Java method whose JNI signature simply changed from `(Z)V` to `(I)V`. The new `AccessibilityNodeInfoCompatJni` helper probes both signatures once on first use and dispatches to whichever the loaded binding exposes — no managed reflection, AOT/trim safe.

## Alternative to #23097

This is a deliberately narrower path than the already-merged [#23097](https://github.com/unoplatform/uno/pull/23097), which solved the same crash by bumping `Xamarin.AndroidX.AppCompat 1.7.0.7 → 1.7.1.3` and cascading newer Activity / Fragment / Lifecycle / SavedState / Collection bindings, plus raising `SupportedOSPlatformVersion` to 23. That cascade in turn forced uno.templates to either bump matching bindings on its side or ride the new minSdk 23 floor, and broke `Microsoft.Maui.Controls 10.0.60`'s transitively-pinned older `.Ktx` packages (NU1605/NU1608).

The JNI helper here resolves #22999 without touching AppCompat, the surrounding AndroidX stack, the minimum Android API level, or Maui's binding pins. Branch is based on the commit immediately before #23097 merged, so the PR diff shows exactly the cost of the fix.

> ⚠️ The branch base is pre-#23097. Conflicts with current master are expected and need manual reconciliation if this approach is preferred over #23097.

## Test plan

- [ ] Build `Uno.UI.Runtime.Skia.Android` against an `AndroidX.Core 1.16.x` baseline (default in the branch's base commit) and confirm `node.Checked` callers compile and run.
- [ ] In a SamplesApp Android head, add a transitive dependency that forces `Xamarin.AndroidX.Core 1.17.0+` (e.g. `Sentry.Bindings.Android 6.3.0`).
- [ ] Trigger an accessibility focus change on a `ToggleButton` / `CheckBox` so `UnoExploreByTouchHelper.OnPopulateNodeForVirtualView` runs.
- [ ] Confirm no `MissingMethodException` is logged and TalkBack reports the checked state correctly under both Core 1.16.x and 1.17.x.
- [ ] Repeat against a NativeAOT build to confirm the JNI path is trim/AOT-safe (no IL2026/IL3050 warnings, no runtime null at the cached method id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)