### PR TITLE
test: Disable flaky runtime tests on WASM and Skia Android

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1585,6 +1585,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		// Flaky on Skia Android - https://github.com/unoplatform/uno/issues/9080
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaAndroid)]
 #if __APPLE_UIKIT__ || __ANDROID__
 		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
 #endif
@@ -2216,6 +2218,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		// Flaky on Skia Android - https://github.com/unoplatform/uno/issues/9080
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaAndroid)]
 #if __APPLE_UIKIT__ || __ANDROID__
 		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_PathMarkupParser.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_PathMarkupParser.cs
@@ -83,7 +83,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 
 #if !WINAPPSDK
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI | RuntimeTestPlatforms.SkiaWasm)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI | RuntimeTestPlatforms.SkiaWasm | RuntimeTestPlatforms.NativeWasm)]
 		public void When_Path_FillRule_F0_Is_EvenOdd()
 		{
 			var geometry = (StreamGeometry)XamlBindingHelper.ConvertValue(typeof(Geometry), "F0 M 0,0 L 10,0 10,10 0,10 Z");
@@ -91,7 +91,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 		}
 
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI | RuntimeTestPlatforms.SkiaWasm)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI | RuntimeTestPlatforms.SkiaWasm | RuntimeTestPlatforms.NativeWasm)]
 		public void When_Path_FillRule_F1_Is_Nonzero()
 		{
 			var geometry = (StreamGeometry)XamlBindingHelper.ConvertValue(typeof(Geometry), "F1 M 0,0 L 10,0 10,10 0,10 Z");


### PR DESCRIPTION
## Summary
- Exclude `When_Path_FillRule_F0_Is_EvenOdd` and `When_Path_FillRule_F1_Is_Nonzero` on Native WASM via `PlatformCondition`
- Exclude `When_LargeExtent_And_Very_Large_List_Scroll_To_End_And_Back_Half_Size` and `When_SmallExtent_And_Large_List_Scroll_To_End_Half_Size` on Skia Android, marked as flaky and tracked in #9080

## Test plan
- [ ] CI runtime tests pass on WASM and Skia Android with the affected tests skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)