### PR TITLE
test: Validate ms-appdata font loading on Skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -811,6 +811,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/19731")]
 		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf")]
 		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf#Roboto")]
 		public async Task When_FontFamily_From_MsAppData_Local(string font)
@@ -818,9 +819,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var sourceUri = new Uri("ms-appx:///Uno.UI.RuntimeTests/Assets/Fonts/Roboto-Regular.ttf");
 			var sourceFile = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(sourceUri);
 
+			// Unique per-invocation folder so the two DataRow variants never race on the same directory.
+			var folderName = $"MsAppDataFontTest_{Guid.NewGuid():N}";
 			var localFolder = Windows.Storage.ApplicationData.Current.LocalFolder;
 			var fontsFolder = await localFolder.CreateFolderAsync(
-				"MsAppDataFontTest",
+				folderName,
 				Windows.Storage.CreationCollisionOption.OpenIfExists);
 			await sourceFile.CopyAsync(fontsFolder, "Roboto-Regular.ttf", Windows.Storage.NameCollisionOption.ReplaceExisting);
 
@@ -838,7 +841,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreNotEqual(0, SUT.DesiredSize.Width);
 				Assert.AreNotEqual(0, SUT.DesiredSize.Height);
 
-				SUT.FontFamily = new FontFamily(font);
+				SUT.FontFamily = new FontFamily(font.Replace("MsAppDataFontTest", folderName));
 
 				int counter = 3;
 
@@ -859,8 +862,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				{
 					await fontsFolder.DeleteAsync(Windows.Storage.StorageDeleteOption.PermanentDelete);
 				}
-				catch
+				catch (Exception ex)
 				{
+					// Cleanup is best-effort — surface the failure without failing the test.
+					Console.WriteLine($"Failed to delete '{folderName}': {ex}");
 				}
 			}
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -810,6 +810,62 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf")]
+		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf#Roboto")]
+		public async Task When_FontFamily_From_MsAppData_Local(string font)
+		{
+			var sourceUri = new Uri("ms-appx:///Uno.UI.RuntimeTests/Assets/Fonts/Roboto-Regular.ttf");
+			var sourceFile = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(sourceUri);
+
+			var localFolder = Windows.Storage.ApplicationData.Current.LocalFolder;
+			var fontsFolder = await localFolder.CreateFolderAsync(
+				"MsAppDataFontTest",
+				Windows.Storage.CreationCollisionOption.OpenIfExists);
+			await sourceFile.CopyAsync(fontsFolder, "Roboto-Regular.ttf", Windows.Storage.NameCollisionOption.ReplaceExisting);
+
+			try
+			{
+				var SUT = new TextBlock { Text = "abcd" };
+				WindowHelper.WindowContent = SUT;
+				await WindowHelper.WaitForIdle();
+
+				var size = new Size(1000, 1000);
+				SUT.Measure(size);
+
+				var originalSize = SUT.DesiredSize;
+
+				Assert.AreNotEqual(0, SUT.DesiredSize.Width);
+				Assert.AreNotEqual(0, SUT.DesiredSize.Height);
+
+				SUT.FontFamily = new FontFamily(font);
+
+				int counter = 3;
+
+				do
+				{
+					await WindowHelper.WaitForIdle();
+					await Task.Delay(100);
+
+					SUT.InvalidateMeasure();
+				}
+				while (SUT.DesiredSize == originalSize && counter-- > 0);
+
+				Assert.AreNotEqual(originalSize, SUT.DesiredSize);
+			}
+			finally
+			{
+				try
+				{
+					await fontsFolder.DeleteAsync(Windows.Storage.StorageDeleteOption.PermanentDelete);
+				}
+				catch
+				{
+				}
+			}
+		}
+
+		[TestMethod]
 #if !__ANDROID__
 		[Ignore("Android-only test for AndroidAssets backward compatibility")]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -817,6 +817,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/19731")]
 		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf")]
 		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf#Roboto")]
 		public async Task When_FontFamily_From_MsAppData_Local(string font)
@@ -824,9 +825,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var sourceUri = new Uri("ms-appx:///Uno.UI.RuntimeTests/Assets/Fonts/Roboto-Regular.ttf");
 			var sourceFile = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(sourceUri);
 
+			// Unique per-invocation folder so the two DataRow variants never race on the same directory.
+			var folderName = $"MsAppDataFontTest_{Guid.NewGuid():N}";
 			var localFolder = Windows.Storage.ApplicationData.Current.LocalFolder;
 			var fontsFolder = await localFolder.CreateFolderAsync(
-				"MsAppDataFontTest",
+				folderName,
 				Windows.Storage.CreationCollisionOption.OpenIfExists);
 			await sourceFile.CopyAsync(fontsFolder, "Roboto-Regular.ttf", Windows.Storage.NameCollisionOption.ReplaceExisting);
 
@@ -844,7 +847,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreNotEqual(0, SUT.DesiredSize.Width);
 				Assert.AreNotEqual(0, SUT.DesiredSize.Height);
 
-				SUT.FontFamily = new FontFamily(font);
+				SUT.FontFamily = new FontFamily(font.Replace("MsAppDataFontTest", folderName));
 
 				int counter = 3;
 
@@ -865,8 +868,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				{
 					await fontsFolder.DeleteAsync(Windows.Storage.StorageDeleteOption.PermanentDelete);
 				}
-				catch
+				catch (Exception ex)
 				{
+					// Cleanup is best-effort — surface the failure without failing the test.
+					Console.WriteLine($"Failed to delete '{folderName}': {ex}");
 				}
 			}
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -816,6 +816,62 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf")]
+		[DataRow("ms-appdata:///local/MsAppDataFontTest/Roboto-Regular.ttf#Roboto")]
+		public async Task When_FontFamily_From_MsAppData_Local(string font)
+		{
+			var sourceUri = new Uri("ms-appx:///Uno.UI.RuntimeTests/Assets/Fonts/Roboto-Regular.ttf");
+			var sourceFile = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(sourceUri);
+
+			var localFolder = Windows.Storage.ApplicationData.Current.LocalFolder;
+			var fontsFolder = await localFolder.CreateFolderAsync(
+				"MsAppDataFontTest",
+				Windows.Storage.CreationCollisionOption.OpenIfExists);
+			await sourceFile.CopyAsync(fontsFolder, "Roboto-Regular.ttf", Windows.Storage.NameCollisionOption.ReplaceExisting);
+
+			try
+			{
+				var SUT = new TextBlock { Text = "abcd" };
+				WindowHelper.WindowContent = SUT;
+				await WindowHelper.WaitForIdle();
+
+				var size = new Size(1000, 1000);
+				SUT.Measure(size);
+
+				var originalSize = SUT.DesiredSize;
+
+				Assert.AreNotEqual(0, SUT.DesiredSize.Width);
+				Assert.AreNotEqual(0, SUT.DesiredSize.Height);
+
+				SUT.FontFamily = new FontFamily(font);
+
+				int counter = 3;
+
+				do
+				{
+					await WindowHelper.WaitForIdle();
+					await Task.Delay(100);
+
+					SUT.InvalidateMeasure();
+				}
+				while (SUT.DesiredSize == originalSize && counter-- > 0);
+
+				Assert.AreNotEqual(originalSize, SUT.DesiredSize);
+			}
+			finally
+			{
+				try
+				{
+					await fontsFolder.DeleteAsync(Windows.Storage.StorageDeleteOption.PermanentDelete);
+				}
+				catch
+				{
+				}
+			}
+		}
+
+		[TestMethod]
 #if !__ANDROID__
 		[Ignore("Android-only test for AndroidAssets backward compatibility")]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -828,16 +828,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// Unique per-invocation folder so the two DataRow variants never race on the same directory.
 			var folderName = $"MsAppDataFontTest_{Guid.NewGuid():N}";
 			var localFolder = Windows.Storage.ApplicationData.Current.LocalFolder;
-			var fontsFolder = await localFolder.CreateFolderAsync(
-				folderName,
-				Windows.Storage.CreationCollisionOption.OpenIfExists);
-			await sourceFile.CopyAsync(fontsFolder, "Roboto-Regular.ttf", Windows.Storage.NameCollisionOption.ReplaceExisting);
+			Windows.Storage.StorageFolder fontsFolder = null;
 
 			try
 			{
+				fontsFolder = await localFolder.CreateFolderAsync(
+					folderName,
+					Windows.Storage.CreationCollisionOption.FailIfExists);
+				await sourceFile.CopyAsync(fontsFolder, "Roboto-Regular.ttf", Windows.Storage.NameCollisionOption.ReplaceExisting);
+
 				var SUT = new TextBlock { Text = "abcd" };
 				WindowHelper.WindowContent = SUT;
-				await WindowHelper.WaitForIdle();
+				await WindowHelper.WaitForLoaded(SUT);
 
 				var size = new Size(1000, 1000);
 				SUT.Measure(size);
@@ -864,14 +866,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 			finally
 			{
-				try
+				WindowHelper.WindowContent = null;
+
+				if (fontsFolder is not null)
 				{
-					await fontsFolder.DeleteAsync(Windows.Storage.StorageDeleteOption.PermanentDelete);
-				}
-				catch (Exception ex)
-				{
-					// Cleanup is best-effort — surface the failure without failing the test.
-					Console.WriteLine($"Failed to delete '{folderName}': {ex}");
+					try
+					{
+						await fontsFolder.DeleteAsync(Windows.Storage.StorageDeleteOption.PermanentDelete);
+					}
+					catch (Exception ex)
+					{
+						// Cleanup is best-effort — a throw here would mask the real test failure.
+						Console.WriteLine($"Failed to delete '{folderName}': {ex}");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #19731

## PR Type:

🧪 Test

## What changed? 🚀

Adds a parameterized runtime test (`Given_TextBlock.When_FontFamily_From_MsAppData_Local`) that copies a font from `ms-appx` assets into `ApplicationData.Current.LocalFolder` and verifies that `FontFamily` resolves it via `ms-appdata:///local/...`, both with and without the `#FamilyName` suffix.

### Why a test is the fix

Tracing the Skia font-loading code path:

1. `FontFamily("ms-appdata:///local/...")` → `FontDetailsCache.GetFont`
2. `GetFontInternal` strips the `#FamilyName` suffix, then `Uri.TryCreate` parses the URI
3. `LoadTypefaceFromApplicationUriAsync` calls `AppDataUriEvaluator.ToStream(uri)` (`src/Uno.UI/UI/Xaml/Documents/TextFormatting/FontDetailsCache.skia.cs`)
4. `AppDataUriEvaluator.ToStream` already handles the `ms-appdata` scheme by mapping it to a filesystem path under `LocalFolder`/`RoamingFolder`/`TemporaryFolder` (`src/Uno.UWP/Helpers/AppDataUriEvaluator.cs`)
5. `SKTypeface.FromStream` loads the typeface from disk

So the support already exists on Skia targets — the test pins this behavior down to prevent regression. The assertion that `DesiredSize` changes after switching to the ms-appdata font proves the actual typeface is loaded (a silent fallback to the default font would leave `DesiredSize` unchanged).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)