### PR TITLE
fix: Auto-include files in `Windows` folder

### DIFF
--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -319,7 +319,7 @@ As discussed above setting `EnableDefaultUnoItems` to false will disable these i
 
 ## Platform-Specific Folders
 
-In addition to the per-file suffixes described above, the Uno.Sdk recognizes a set of well-known subfolders under `Platforms/` that scope their contents to a single target. Files in these folders are automatically included only when the matching TFM is being built and excluded from every other TFM (the SDK removes them from `Compile`, `Page`, `Content`, `EmbeddedResource`, and `Manifest` for inactive platforms).
+In addition to the per-file suffixes described above, the Uno.Sdk recognizes a set of well-known sub-folders under `Platforms/` that scope their contents to a single target. Files in these folders are automatically included only when the matching TFM is being built and excluded from every other TFM (the SDK removes them from `Compile`, `Page`, `Content`, `EmbeddedResource`, and `Manifest` for inactive platforms).
 
 | Folder | TFM it applies to | Typical contents |
 |---|---|---|

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -317,6 +317,23 @@ As discussed above setting `EnableDefaultUnoItems` to false will disable these i
 >
 > This approach allows you to selectively remove pages from specific target frameworks while maintaining them in others.
 
+## Platform-Specific Folders
+
+In addition to the per-file suffixes described above, the Uno.Sdk recognizes a set of well-known subfolders under `Platforms/` that scope their contents to a single target. Files in these folders are automatically included only when the matching TFM is being built and excluded from every other TFM (the SDK removes them from `Compile`, `Page`, `Content`, `EmbeddedResource`, and `Manifest` for inactive platforms).
+
+| Folder | TFM it applies to | Typical contents |
+|---|---|---|
+| `Platforms/Android/` | `*-android` | `Main.Android.cs`, `AndroidManifest.xml`, Android resources |
+| `Platforms/iOS/` | `*-ios` | `Main.iOS.cs`, `Info.plist`, `Entitlements.plist`, `PrivacyInfo.xcprivacy` |
+| `Platforms/tvOS/` | `*-tvos` | tvOS-specific entry point and resources |
+| `Platforms/MacCatalyst/` | `*-maccatalyst` | Mac Catalyst entry point, `Info.plist`, `Entitlements.plist` |
+| `Platforms/MacOS/` | `*-macos` | macOS entry point, `Info.plist`, `Entitlements.plist` |
+| `Platforms/Desktop/` | `*-desktop` | `Program.cs` with the `UnoPlatformHostBuilder` configuration |
+| `Platforms/Wasm/` (or `Platforms/WebAssembly/`) | `*-browserwasm` | `Program.cs`, `wwwroot/`, `manifest.webmanifest` |
+| `Platforms/Windows/` | `*-windows10.*` | `Package.appxmanifest`, `app.manifest`, splash screens, tile/app-icon PNGs referenced by the manifest |
+
+The location of each folder can be overridden via the matching MSBuild property if your project uses a different layout: `PlatformsProjectFolder`, `AndroidProjectFolder`, `iOSProjectFolder`, `tvOSProjectFolder`, `MacCatalystProjectFolder`, `MacOSProjectFolder`, `DesktopProjectFolder`, `WasmProjectFolder`, `WindowsProjectFolder`.
+
 ## Apple Privacy Manifest Support
 
 Starting May 1st, 2024, Apple requires the inclusion of a new file, the [Privacy Manifest file](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) (named `PrivacyInfo.xcprivacy`), in app bundles. This file is crucial for complying with updated privacy regulations.

--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -81,11 +81,11 @@
 		This ItemGroup is the WinAppSDK-side equivalent: it includes the platform folder content
 		that the cross-platform Uno.DefaultItems globs would have picked up on other TFMs.
 	-->
-	<ItemGroup Condition=" '$(EnableDefaultUnoWindowsItems)' != 'false'
+	<ItemGroup Condition=" '$(EnableDefaultUnoItems)' == 'true'
 	                       AND '$(WindowsProjectFolder)' != ''
 	                       AND Exists('$(WindowsProjectFolder)') ">
 		<Content Include="$(WindowsProjectFolder)**\*.*"
-		         Exclude="$(WindowsProjectFolder)**\*.cs;$(WindowsProjectFolder)**\*.xaml;$(WindowsProjectFolder)**\*.resw;$(WindowsProjectFolder)**\*.appxmanifest;$(WindowsProjectFolder)app.manifest;$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)"
+		         Exclude="$(WindowsProjectFolder)**\*.cs;$(WindowsProjectFolder)**\*.xaml;$(WindowsProjectFolder)**\*.resw;$(WindowsProjectFolder)**\*.appxmanifest;$(WindowsProjectFolder)app.manifest;$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content);@(Page);@(ApplicationDefinition);@(EmbeddedResource);@(None);@(UnoImage);@(UnoIcon);@(UnoSplashScreen);@(UnoAsset)"
 		         CopyToOutputDirectory="PreserveNewest"
 		         IsDefaultItem="true" />
 	</ItemGroup>

--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -66,6 +66,30 @@
 		</Content>
 	</ItemGroup>
 
+	<!--
+		Include manifest-referenced assets (splash screens, tiles, icons, etc.) that live under
+		the Windows platform folder.
+
+		For non-WinAppSDK TFMs, Uno.DefaultItems.targets provides a project-wide `**\*.png` (and
+		other image formats) Content glob that picks these files up; `_IgnorePlatformFiles` in
+		Uno.Common.targets then strips out the folders for inactive platforms. That entire
+		ItemGroup is gated on `!$(IsWinAppSdk)`, so on WinAppSDK none of those globs run.
+		WinAppSDK's own default Content glob only covers `Assets/**`, leaving files placed in
+		`Platforms/Windows/` invisible to the packaging pipeline — the produced .msix ends up
+		with manifest references pointing at missing files.
+
+		This ItemGroup is the WinAppSDK-side equivalent: it includes the platform folder content
+		that the cross-platform Uno.DefaultItems globs would have picked up on other TFMs.
+	-->
+	<ItemGroup Condition=" '$(EnableDefaultUnoWindowsItems)' != 'false'
+	                       AND '$(WindowsProjectFolder)' != ''
+	                       AND Exists('$(WindowsProjectFolder)') ">
+		<Content Include="$(WindowsProjectFolder)**\*.*"
+		         Exclude="$(WindowsProjectFolder)**\*.cs;$(WindowsProjectFolder)**\*.xaml;$(WindowsProjectFolder)**\*.resw;$(WindowsProjectFolder)**\*.appxmanifest;$(WindowsProjectFolder)app.manifest;$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Content)"
+		         CopyToOutputDirectory="PreserveNewest"
+		         IsDefaultItem="true" />
+	</ItemGroup>
+
 	<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
 	<Import Project="winappsdk-workaround.targets"
 			Condition=" $(_IsUnoSingleProjectAndLegacy) != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/>


### PR DESCRIPTION
**GitHub Issue:** closes #23283

## PR Type:

🐞 Bugfix

## What changed? 🚀

Files placed under `Platforms/Windows/` (e.g. `SplashScreen.scale-200.png`, `Square150x150Logo.png`, `app icon` assets, custom fonts, manifest-referenced binaries) were not being picked up on WinAppSDK builds, leaving the produced `.msix` with broken manifest references.

### Root cause

On WinAppSDK, the only default item globs that run are (from `Microsoft.WinUI.props`):

```xml
<ApplicationDefinition Include="App.xaml" />
<Page Include="**/*.xaml" />
<Content Include="Assets/**/*.*" />
```

Plus `Microsoft.NET.Sdk`'s `**/*.cs` Compile glob. That means:

- `.cs` and `.xaml` under `Platforms/Windows/` are already picked up.
- `.resw` is picked up by `Microsoft.WinUI.targets`'s PRIResource handling.
- **Assets** under `Platforms/Windows/` are not — WinAppSDK's `Assets/**/*.*` is scoped to the project root, not `Platforms/Windows/Assets/`, and Uno's cross-platform image globs in `Uno.DefaultItems.targets` are gated on `!$(IsWinAppSdk)`.

### Fix

Add a Content glob in `Uno.Common.WinAppSdk.targets` that includes everything under `$(WindowsProjectFolder)` except source/XAML/resw/manifest files (which already have their own handlers). The glob is gated on the existing `EnableDefaultUnoItems` flag so users who already opt out of Uno's default items don't need to discover a new switch. The `Exclude=` clause also strips items already promoted to `UnoImage`/`UnoIcon`/`UnoSplashScreen`/`UnoAsset`/`Page`/`ApplicationDefinition`/`EmbeddedResource`/`None` to avoid duplicate Content entries in the `.msix`.

Also updates `using-the-uno-sdk.md` to document that `Platforms/Windows/` is the canonical home for Windows-specific assets and manifest files.

### Notes

The investigation surfaced two stale lines worth cleaning up in a follow-up:

- `Uno.DefaultItems.targets:14` carries a comment about `__WindowsAppSdkDefaultImageIncludes`, which no longer exists in current WinAppSDK packages.
- `Uno.Common.WinAppSdk.targets:12` sets `EnableDefaultWindowsItems=false`, but that property has also been removed from current WinAppSDK targets — the line appears to be a no-op.

Both are tracked under #23283 for a separate cleanup PR.

## PR Checklist ✅

- [x] 🧪 Verified manually by running a WinAppSDK head with files under `Platforms/Windows/`.
- [x] 📚 Docs updated in `using-the-uno-sdk.md`.
- [x] ❗ Contains **NO** breaking changes (opt-in via existing `EnableDefaultUnoItems`).