### PR TITLE
feat: Use proper `XamlParseException` and `LayoutCycleException`

### DIFF
--- a/src/Uno.Foundation/Generated/2.0.0.0/Microsoft.UI.Xaml.Markup/XamlParseException.cs
+++ b/src/Uno.Foundation/Generated/2.0.0.0/Microsoft.UI.Xaml.Markup/XamlParseException.cs
@@ -3,34 +3,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Markup
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class XamlParseException : global::System.Exception
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public XamlParseException() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Markup.XamlParseException", "XamlParseException()");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.Markup.XamlParseException.XamlParseException()
 		// Forced skipping of method Microsoft.UI.Xaml.Markup.XamlParseException.XamlParseException()
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public XamlParseException(string message) : base(message)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Markup.XamlParseException", "XamlParseException(string message)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.Markup.XamlParseException.XamlParseException(string)
 		// Forced skipping of method Microsoft.UI.Xaml.Markup.XamlParseException.XamlParseException(string)
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public XamlParseException(string message, global::System.Exception innerException) : base(message, innerException)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Markup.XamlParseException", "XamlParseException(string message, Exception innerException)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.Markup.XamlParseException.XamlParseException(string, System.Exception)
 		// Forced skipping of method Microsoft.UI.Xaml.Markup.XamlParseException.XamlParseException(string, System.Exception)
 	}
 }

--- a/src/Uno.Foundation/Generated/2.0.0.0/Microsoft.UI.Xaml/LayoutCycleException.cs
+++ b/src/Uno.Foundation/Generated/2.0.0.0/Microsoft.UI.Xaml/LayoutCycleException.cs
@@ -3,34 +3,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class LayoutCycleException : global::System.Exception
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public LayoutCycleException() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.LayoutCycleException", "LayoutCycleException()");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.LayoutCycleException.LayoutCycleException()
 		// Forced skipping of method Microsoft.UI.Xaml.LayoutCycleException.LayoutCycleException()
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public LayoutCycleException(string message) : base(message)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.LayoutCycleException", "LayoutCycleException(string message)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.LayoutCycleException.LayoutCycleException(string)
 		// Forced skipping of method Microsoft.UI.Xaml.LayoutCycleException.LayoutCycleException(string)
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public LayoutCycleException(string message, global::System.Exception innerException) : base(message, innerException)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.LayoutCycleException", "LayoutCycleException(string message, Exception innerException)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.LayoutCycleException.LayoutCycleException(string, System.Exception)
 		// Forced skipping of method Microsoft.UI.Xaml.LayoutCycleException.LayoutCycleException(string, System.Exception)
 	}
 }

--- a/src/Uno.Foundation/Microsoft.UI.Xaml.Markup/XamlParseException.cs
+++ b/src/Uno.Foundation/Microsoft.UI.Xaml.Markup/XamlParseException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Microsoft.UI.Xaml.Markup;
+
+public partial class XamlParseException : Exception
+{
+	public XamlParseException() : base()
+	{
+	}
+
+	public XamlParseException(string message) : base(message)
+	{
+	}
+
+	public XamlParseException(string message, Exception innerException) : base(message, innerException)
+	{
+	}
+}

--- a/src/Uno.Foundation/Microsoft.UI.Xaml/LayoutCycleException.cs
+++ b/src/Uno.Foundation/Microsoft.UI.Xaml/LayoutCycleException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Microsoft.UI.Xaml;
+
+public partial class LayoutCycleException : Exception
+{
+	public LayoutCycleException() : base()
+	{
+	}
+
+	public LayoutCycleException(string message) : base(message)
+	{
+	}
+
+	public LayoutCycleException(string message, Exception innerException) : base(message, innerException)
+	{
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_FromJson.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_FromJson.cs
@@ -7,8 +7,6 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.UI.Helpers;
-using Uno.Xaml;
-using XamlParseException = Uno.Xaml.XamlParseException;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Toolkit;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Uno.UI.Extensions;
 using Uno.UI.Helpers;
-using Uno.Xaml;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
@@ -14,7 +13,6 @@ using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Markup;
-using XamlParseException = Uno.Xaml.XamlParseException;
 using static Private.Infrastructure.TestServices;
 using System.Threading.Tasks;
 using Uno.Disposables;
@@ -650,7 +648,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 					""")
 			);
 
-			Assert.AreEqual(4, ex.LineNumber);
+			StringAssert.Contains(ex.Message, "[Line: 4");
 			Assert.AreEqual("Requested value 'Invalid' was not found.", ex.InnerException.Message);
 		}
 
@@ -684,9 +682,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			);
 
 			var aggregateException = (AggregateException)ex.InnerException;
-			Assert.AreEqual(5, (aggregateException.InnerExceptions[0] as XamlParseException).LineNumber);
 			Assert.AreEqual("Requested value 'Invalid' was not found. [Line: 5 Position: 6]", (aggregateException.InnerExceptions[0] as XamlParseException).Message);
-			Assert.AreEqual(11, (aggregateException.InnerExceptions[1] as XamlParseException).LineNumber);
 			Assert.AreEqual("Requested value 'Invalid2' was not found. [Line: 11 Position: 9]", (aggregateException.InnerExceptions[1] as XamlParseException).Message);
 		}
 
@@ -852,8 +848,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 
 				// The type 'Microsoft.UI.Xaml.Data.Binding' does not contain a property or event named 'Test'. [Line: 7 Position: 6]"
 				Assert.AreEqual("The type 'Microsoft.UI.Xaml.Data.Binding' does not contain a property or event named 'Test'. [Line: 7 Position: 6]", ex.Message);
-				Assert.AreEqual(7, ex.LineNumber);
-				Assert.AreEqual(6, ex.LinePosition);
 			}
 		}
 
@@ -989,10 +983,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 				Assert.HasCount(2, ae.InnerExceptions);
 				Assert.IsInstanceOfType<XamlParseException>(ae.InnerExceptions[0]);
 				Assert.IsInstanceOfType<XamlParseException>(ae.InnerExceptions[1]);
-				Assert.AreEqual(2, (ae.InnerExceptions[0] as XamlParseException).LineNumber);
-				Assert.AreEqual(3, (ae.InnerExceptions[0] as XamlParseException).LinePosition);
-				Assert.AreEqual(3, (ae.InnerExceptions[1] as XamlParseException).LineNumber);
-				Assert.AreEqual(3, (ae.InnerExceptions[1] as XamlParseException).LinePosition);
+				StringAssert.Contains(ae.InnerExceptions[0].Message, "[Line: 2 Position: 3]");
+				StringAssert.Contains(ae.InnerExceptions[1].Message, "[Line: 3 Position: 3]");
 			}
 		}
 
@@ -1017,10 +1009,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 				Assert.HasCount(2, ae.InnerExceptions);
 				Assert.IsInstanceOfType<XamlParseException>(ae.InnerExceptions[0]);
 				Assert.IsInstanceOfType<XamlParseException>(ae.InnerExceptions[1]);
-				Assert.AreEqual(2, (ae.InnerExceptions[0] as XamlParseException).LineNumber);
-				Assert.AreEqual(3, (ae.InnerExceptions[0] as XamlParseException).LinePosition);
-				Assert.AreEqual(4, (ae.InnerExceptions[1] as XamlParseException).LineNumber);
-				Assert.AreEqual(4, (ae.InnerExceptions[1] as XamlParseException).LinePosition);
+				StringAssert.Contains(ae.InnerExceptions[0].Message, "[Line: 2 Position: 3]");
+				StringAssert.Contains(ae.InnerExceptions[1].Message, "[Line: 4 Position: 4]");
 			}
 		}
 
@@ -1045,10 +1035,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 				Assert.HasCount(2, ae.InnerExceptions);
 				Assert.IsInstanceOfType<XamlParseException>(ae.InnerExceptions[0]);
 				Assert.IsInstanceOfType<XamlParseException>(ae.InnerExceptions[1]);
-				Assert.AreEqual(2, (ae.InnerExceptions[0] as XamlParseException).LineNumber);
-				Assert.AreEqual(3, (ae.InnerExceptions[0] as XamlParseException).LinePosition);
-				Assert.AreEqual(4, (ae.InnerExceptions[1] as XamlParseException).LineNumber);
-				Assert.AreEqual(4, (ae.InnerExceptions[1] as XamlParseException).LinePosition);
+				StringAssert.Contains(ae.InnerExceptions[0].Message, "[Line: 2 Position: 3]");
+				StringAssert.Contains(ae.InnerExceptions[1].Message, "[Line: 4 Position: 4]");
 			}
 		}
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -849,7 +849,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		[TestMethod]
 		public void When_ImplicitStyle_WithoutKey()
 		{
-			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() =>
+			Assert.ThrowsExactly<XamlParseException>(() =>
 			{
 				var s = GetContent(nameof(When_ImplicitStyle_WithoutKey));
 				var r = Microsoft.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
@@ -1094,7 +1094,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		public void When_CreateFromString_Invalid_MethodName()
 		{
 			var xaml = "<CreateFromStringInvalidMethodNameOwner Test=\"8\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
-			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]
@@ -1112,14 +1112,14 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		public void When_CreateFromString_Non_Static_Method()
 		{
 			var xaml = "<CreateFromStringNonStaticMethodOwner Test=\"4\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
-			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]
 		public void When_CreateFromString_Private_Static_Method()
 		{
 			var xaml = "<CreateFromStringPrivateStaticMethodOwner Test=\"21\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
-			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]
@@ -1137,15 +1137,14 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		public void When_CreateFromString_Invalid_Parameters()
 		{
 			var xaml = "<CreateFromStringInvalidParametersOwner Test=\"2\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
-			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]
 		public void When_CreateFromString_Invalid_Return_Type()
 		{
 			var xaml = "<CreateFromStringInvalidReturnTypeOwner Test=\"1\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
-			// TODO: This should throw XamlParseException too
-			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -19,7 +19,6 @@ using Uno.UI.Extensions;
 using Uno.UI.Helpers.Xaml;
 using Uno.UI.Xaml;
 using Uno.UI.Xaml.Markup;
-using Uno.Xaml;
 
 using Color = Windows.UI.Color;
 using System.Text;
@@ -34,7 +33,6 @@ using _View = Microsoft.UI.Xaml.UIElement;
 
 namespace Microsoft.UI.Xaml.Markup.Reader
 {
-	using XamlParseException = Uno.Xaml.XamlParseException;
 	[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Normal flow of operations")]
 	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Normal flow of operations")]
 	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Normal flow of operations")]
@@ -370,7 +368,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 						catch (Exception ex)
 						{
-							AddParseException(new XamlParseException($"Failed to parse member ({ex.Message})", ex, member.LineNumber, member.LinePosition));
+							AddParseException(new XamlParseException(FormatLineInfo($"Failed to parse member ({ex.Message})", member.LineNumber, member.LinePosition), ex));
 						}
 					}
 				}
@@ -705,10 +703,10 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						// > XamlParseException: The text associated with this error code could not be found.
 						// > Run -> Failed to assign to property 'Microsoft.UI.Xaml.Controls.TextBlock.Inlines' because the type 'Microsoft.UI.Xaml.Documents.Run' cannot be assigned to the type 'Microsoft.UI.Xaml.Documents.InlineCollection'. [Line: 22 Position: 8]'
 						// > string -> Failed to assign to property 'Microsoft.UI.Xaml.Controls.TextBlock.Inlines'. [Line: 20 Position: 7]'
-						throw new XamlParseException(value is Inline
+						throw new XamlParseException(FormatLineInfo(value is Inline
 							? $"Failed to assign to property '{typeof(TextBlock).FullName}.{nameof(TextBlock.Inlines)}' because the type '{value.GetType().FullName}' cannot be assigned to the type '{typeof(InlineCollection).FullName}'."
 							: $"Failed to assign to property '{typeof(TextBlock).FullName}.{nameof(TextBlock.Inlines)}'."
-						, null, control.LineNumber, control.LinePosition);
+						, control.LineNumber, control.LinePosition));
 					}
 					if (value is Inline inline)
 					{
@@ -862,11 +860,10 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 					}
 					else
 					{
-						throw new XamlParseException(
+						throw new XamlParseException(FormatLineInfo(
 							$"This Member '{propertyInfo.DeclaringType}.{propertyInfo.Name}' has more than one item, use the Items property"
-							, null
 							, member.LineNumber
-							, member.LinePosition);
+							, member.LinePosition));
 					}
 
 					static bool IsFrameworkElementResources(PropertyInfo propertyInfo) =>
@@ -1095,10 +1092,11 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			catch (Exception ex) when (!(ex is XamlParseException))
 			{
 				throw new XamlParseException(
-					$"Failed to process custom markup extension '{extensionNode.Type.Name}'.",
-					ex,
-					extensionNode.LineNumber,
-					extensionNode.LinePosition);
+					FormatLineInfo(
+						$"Failed to process custom markup extension '{extensionNode.Type.Name}'.",
+						extensionNode.LineNumber,
+						extensionNode.LinePosition),
+					ex);
 			}
 		}
 
@@ -1347,7 +1345,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				)
 				.Any();
 
-		private bool IsCustomMarkupExtension(XamlType xamlType)
+		private bool IsCustomMarkupExtension(Uno.Xaml.XamlType xamlType)
 		{
 			var type = TypeResolver.FindType(xamlType);
 			if (type == null && !xamlType.Name.EndsWith("Extension", StringComparison.Ordinal))
@@ -1519,15 +1517,15 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						var normalizedValue = memberValue?.Trim();
 						if (string.IsNullOrEmpty(normalizedValue))
 						{
-							throw new XamlParseException("RoutedEvent value cannot be empty.", null, member.LineNumber, member.LinePosition);
+							throw new XamlParseException(FormatLineInfo("RoutedEvent value cannot be empty.", member.LineNumber, member.LinePosition));
 						}
 
 						var dotIndex = normalizedValue!.LastIndexOf('.');
 						if (dotIndex <= 0 || dotIndex >= normalizedValue.Length - 1)
 						{
-							throw new XamlParseException(
+							throw new XamlParseException(FormatLineInfo(
 								$"Invalid RoutedEvent format '{memberValue}'. Expected format is 'TypeName.EventName' (e.g., 'FrameworkElement.Loaded').",
-								null, member.LineNumber, member.LinePosition);
+								member.LineNumber, member.LinePosition));
 						}
 
 						var typeName = normalizedValue.Substring(0, dotIndex);
@@ -1537,18 +1535,18 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						var type = TypeResolver.FindType(typeName);
 						if (type == null)
 						{
-							throw new XamlParseException(
+							throw new XamlParseException(FormatLineInfo(
 								$"Could not find type '{typeName}' for RoutedEvent '{memberValue}'.",
-								null, member.LineNumber, member.LinePosition);
+								member.LineNumber, member.LinePosition));
 						}
 
 						// EventTrigger only supports the Loaded event on FrameworkElement-derived types.
 						var isEventTriggerProperty = member.Owner?.Type?.Name == "EventTrigger";
 						if (isEventTriggerProperty && (eventName != "Loaded" || !typeof(FrameworkElement).IsAssignableFrom(type)))
 						{
-							throw new XamlParseException(
+							throw new XamlParseException(FormatLineInfo(
 								$"EventTrigger only supports the FrameworkElement.Loaded event, but got '{normalizedValue}'.",
-								null, member.LineNumber, member.LinePosition);
+								member.LineNumber, member.LinePosition));
 						}
 
 						return new RoutedEvent(Uno.UI.Xaml.RoutedEventFlag.None, eventName);
@@ -1765,7 +1763,20 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 		/// Queues a XamlParseException to be thrown later
 		/// </summary>
 		private void AddXamlParseException(string message, XamlObjectDefinition? lineInfo, Exception? exception = null)
-			=> AddParseException(new XamlParseException(message, exception, lineInfo?.LineNumber ?? 0, lineInfo?.LinePosition ?? 0));
+			=> AddParseException(new XamlParseException(FormatLineInfo(message, lineInfo?.LineNumber ?? 0, lineInfo?.LinePosition ?? 0), exception));
+
+		private static string FormatLineInfo(string message, int lineNumber, int linePosition)
+		{
+			if (lineNumber <= 0)
+			{
+				return message;
+			}
+			if (linePosition <= 0)
+			{
+				return string.Format(CultureInfo.InvariantCulture, "{0} [Line: {1}]", message, lineNumber);
+			}
+			return string.Format(CultureInfo.InvariantCulture, "{0} [Line: {1} Position: {2}]", message, lineNumber, linePosition);
+		}
 
 		private void AddParseException(XamlParseException xamlParseException)
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -1066,7 +1066,7 @@ namespace Microsoft.UI.Xaml
 				_traceLayoutCycle = false;
 			}
 
-			throw new InvalidOperationException("Layout cycle detected. For more information, see https://aka.platform.uno/layout-cycle");
+			throw new LayoutCycleException("Layout cycle detected. For more information, see https://aka.platform.uno/layout-cycle");
 #endif
 		}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/22929

## What changed? 🚀

Aligns two XAML-related exception types with their WinUI counterparts:

- **`Microsoft.UI.Xaml.LayoutCycleException`** — Adds a manual partial in `Uno.Foundation` (mirroring the `ElementNotEnabledException` pattern) and updates the generated stub to skip the duplicate `[Uno.NotImplemented]` constructors. `UIElement` now throws `LayoutCycleException` instead of `InvalidOperationException` when the layout iteration cap is exceeded, matching WinUI.
- **`Microsoft.UI.Xaml.Markup.XamlParseException`** — `XamlObjectBuilder` now constructs the WinUI-projected `Microsoft.UI.Xaml.Markup.XamlParseException` instead of `Uno.Xaml.XamlParseException`. Because the WinUI type does not expose `LineNumber` / `LinePosition` properties, line info is now encoded into the message via a `FormatLineInfo` helper (matching the `[Line: N Position: M]` suffix WinUI uses). A manual partial for `XamlParseException` is added so the generated stub does not raise `NotImplemented` warnings on construction.

## PR Type

✨ Feature (WinUI API alignment)

## Breaking change note

Code that previously caught `InvalidOperationException` to recover from layout cycles will no longer catch them — `LayoutCycleException` derives directly from `Exception`, matching WinUI's API shape. Consumers should catch `LayoutCycleException` (or `Exception`) instead.

Tests that asserted `XamlParseException.LineNumber` / `LinePosition` are updated to assert the `[Line: N Position: M]` suffix in the message, which is the format WinUI produces.

## PR Checklist ✅

- [x] 🧪 Existing runtime tests updated to cover the new exception type and message format
- [ ] 📚 Docs — n/a (API shape change matches WinUI)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results
- [x] ❗ Contains **NO** breaking changes — see breaking change note above