### PR TITLE
fix(devserver): isolate add-ins in a custom AssemblyLoadContext

### DIFF
--- a/src/Uno.UI-Skia-only.slnf
+++ b/src/Uno.UI-Skia-only.slnf
@@ -65,6 +65,7 @@
       "Uno.UI.FluentTheme.v2\\Uno.UI.FluentTheme.v2.Skia.csproj",
       "Uno.UI.FluentTheme\\Uno.UI.FluentTheme.Skia.csproj",
       "Uno.UI.RemoteControl.DevServer.Tests\\Uno.UI.RemoteControl.DevServer.Tests.csproj",
+      "Uno.UI.RemoteControl.DevServer.Tests\\Fixtures\\AddInWithCrossMajorVersionRefs\\AddInWithCrossMajorVersionRefs.csproj",
       "Uno.UI.RemoteControl.Host\\Uno.UI.RemoteControl.Host.csproj",
       "Uno.UI.RemoteControl.Messaging\\Uno.UI.RemoteControl.Messaging.csproj",
       "Uno.UI.RemoteControl.Server.Processors\\Uno.UI.RemoteControl.Server.Processors.csproj",

--- a/src/Uno.UI-Skia-only.slnf
+++ b/src/Uno.UI-Skia-only.slnf
@@ -66,6 +66,7 @@
       "Uno.UI.FluentTheme\\Uno.UI.FluentTheme.Skia.csproj",
       "Uno.UI.RemoteControl.DevServer.Tests\\Uno.UI.RemoteControl.DevServer.Tests.csproj",
       "Uno.UI.RemoteControl.DevServer.Tests\\Fixtures\\AddInWithCrossMajorVersionRefs\\AddInWithCrossMajorVersionRefs.csproj",
+      "Uno.UI.RemoteControl.DevServer.Tests\\Fixtures\\AddInWithDiServiceRegistration\\AddInWithDiServiceRegistration.csproj",
       "Uno.UI.RemoteControl.Host\\Uno.UI.RemoteControl.Host.csproj",
       "Uno.UI.RemoteControl.Messaging\\Uno.UI.RemoteControl.Messaging.csproj",
       "Uno.UI.RemoteControl.Server.Processors\\Uno.UI.RemoteControl.Server.Processors.csproj",

--- a/src/Uno.UI-UnitTests-only.slnf
+++ b/src/Uno.UI-UnitTests-only.slnf
@@ -23,6 +23,7 @@
       "Uno.UI.DevServer.Cli.Tests\\Uno.UI.DevServer.Cli.Tests.csproj",
       "Uno.UI.RemoteControl.DevServer.Tests\\Uno.UI.RemoteControl.DevServer.Tests.csproj",
       "Uno.UI.RemoteControl.DevServer.Tests\\Fixtures\\AddInWithCrossMajorVersionRefs\\AddInWithCrossMajorVersionRefs.csproj",
+      "Uno.UI.RemoteControl.DevServer.Tests\\Fixtures\\AddInWithDiServiceRegistration\\AddInWithDiServiceRegistration.csproj",
       "Uno.UI.Tests.ViewLibraryProps\\Uno.UI.Tests.ViewLibraryProps.csproj",
       "Uno.UI.Tests.ViewLibrary\\Uno.UI.Tests.ViewLibrary.csproj",
       "Uno.UI.Tests\\Uno.UI.Unit.Tests.csproj",

--- a/src/Uno.UI-UnitTests-only.slnf
+++ b/src/Uno.UI-UnitTests-only.slnf
@@ -22,6 +22,7 @@
       "Uno.UI.FluentTheme\\Uno.UI.FluentTheme.Tests.csproj",
       "Uno.UI.DevServer.Cli.Tests\\Uno.UI.DevServer.Cli.Tests.csproj",
       "Uno.UI.RemoteControl.DevServer.Tests\\Uno.UI.RemoteControl.DevServer.Tests.csproj",
+      "Uno.UI.RemoteControl.DevServer.Tests\\Fixtures\\AddInWithCrossMajorVersionRefs\\AddInWithCrossMajorVersionRefs.csproj",
       "Uno.UI.Tests.ViewLibraryProps\\Uno.UI.Tests.ViewLibraryProps.csproj",
       "Uno.UI.Tests.ViewLibrary\\Uno.UI.Tests.ViewLibrary.csproj",
       "Uno.UI.Tests\\Uno.UI.Unit.Tests.csproj",

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
@@ -100,4 +100,51 @@ public class DevServerTests
 		started.Should().BeTrue("dev server should start successfully");
 		helper.IsRunning.Should().BeFalse("dev server should not be running after stopping");
 	}
+
+	[TestMethod]
+	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]
+	[Description("Regression for #23287: host must satisfy an add-in's older-major AssemblyRefs to shared-framework OOB packages (e.g. System.Text.Encodings.Web 8.0.0.0 in a net8.0 add-in) from its own newer-major loaded instance — without throwing FileNotFoundException during startup.")]
+	public async Task DevServer_ShouldStart_WithAddInThatHasCrossMajorVersionFrameworkRefs()
+	{
+		// The fixture is built as a net8.0 class library that touches
+		// JavaScriptEncoder.Default in a static cctor (see
+		// Fixtures/AddInWithCrossMajorVersionRefs). Its compiled AssemblyRef to
+		// System.Text.Encodings.Web embeds at v8.0.0.0, which won't strict-match
+		// the v9/v10 the host has loaded from its shared framework. Without the
+		// AddInLoadContext + Default.Resolving bridging in
+		// Uno.UI.RemoteControl.Host this manifests as the original client crash
+		// (KiotaJsonSerializationContext..cctor → FNF Encodings.Web 8.0.0.0).
+		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
+		var fixtureDll = Path.Combine(
+			testAssemblyDir,
+			"Fixtures",
+			"AddInWithCrossMajorVersionRefs",
+			"AddInWithCrossMajorVersionRefs.dll");
+
+		File.Exists(fixtureDll).Should()
+			.BeTrue("test fixture DLL must be copied to test output by the _CopyAddInTestFixtures target");
+
+		await using var helper = new DevServerTestHelper(_logger);
+
+		try
+		{
+			var started = await helper.StartAsync(CT, extraArgs: $"--addins \"{fixtureDll}\"");
+			helper.EnsureStarted();
+
+			started.Should().BeTrue("dev server should start successfully with the cross-major-version add-in loaded");
+			helper.AssertRunning();
+			helper.AssertConsoleOutputContains("Now listening on:");
+
+			// Frame the negative assertion by class-of-bug, not by today's specific
+			// stack — keeps the test relevant as host TFMs roll forward.
+			helper.ConsoleOutput
+				.Should().NotMatchRegex(
+					@"Unhandled exception[\s\S]*FileNotFoundException[\s\S]*System\.Text\.Encodings\.Web",
+					because: "host must bridge cross-major-version AssemblyRefs from add-ins via Default.Resolving instead of crashing");
+		}
+		finally
+		{
+			await helper.StopAsync(CT);
+		}
+	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
@@ -226,17 +226,6 @@ public class DevServerTests
 		// AssemblyRefs are actually resolved — exercising the AddInLoadContext
 		// load path and the AssemblyLoadContext.Default.Resolving handler in
 		// Uno.UI.RemoteControl.Host rather than sitting dormant in metadata.
-		//
-		// This is a positive-outcome regression test: depending on the .NET
-		// runtime version, the binder may also successfully lax-bind these refs
-		// even without the host's fix, so a "must throw FileNotFoundException
-		// without the fix" assertion isn't deterministic across runtimes. The
-		// failure modes this catches are the ones that WOULD remain regardless
-		// of runtime laxness: a fatal crash in add-in load, the ctor never being
-		// invoked at all (broken attribute scan), or the host failing to reach
-		// the listening state. The end-to-end repro in
-		// D:\Dev\Uno-Pocs\DevServerLicensingRepro\ covers the real Kiota /
-		// Uno.Settings.DevServer path on a runtime that does still strict-bind.
 		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
 		var fixtureDll = Path.Combine(
 			testAssemblyDir,
@@ -247,30 +236,57 @@ public class DevServerTests
 		File.Exists(fixtureDll).Should()
 			.BeTrue("test fixture DLL must be copied to test output by the _BuildAndCopyAddInTestFixtures target");
 
-		await using var helper = new DevServerTestHelper(_logger);
-
+		var versionSentinel = Path.Combine(
+			Path.GetTempPath(), $"encodingsweb-version-{Guid.NewGuid():N}.txt");
 		try
 		{
-			var started = await helper.StartAsync(CT, extraArgs: $"--addins \"{fixtureDll}\"");
-			helper.EnsureStarted();
+			await using var helper = new DevServerTestHelper(
+				_logger,
+				environmentVariables: new Dictionary<string, string>
+				{
+					["UNO_DEVSERVER_TEST_ENCODINGSWEB_VERSION_PATH"] = versionSentinel,
+				});
 
-			started.Should().BeTrue("dev server should start successfully with the cross-major-version add-in loaded");
-			helper.AssertRunning();
-			helper.AssertConsoleOutputContains("Now listening on:");
-			helper.AssertConsoleOutputContains("Loading add-in assembly");
+			try
+			{
+				var started = await helper.StartAsync(CT, extraArgs: $"--addins \"{fixtureDll}\"");
+				helper.EnsureStarted();
 
-			// Runtime-stable assertion: a fatal CLR "Unhandled exception" banner
-			// terminates the process before "Now listening on:" is reached, so
-			// rather than substring-matching on the phrase (which could match a
-			// non-fatal logger message containing the literal text) we just
-			// confirm the host process is still alive and has actually reached
-			// the listening state. If the add-in load pipeline regresses in a
-			// way that crashes startup, this combination of asserts fails.
-			helper.IsRunning.Should().BeTrue("host process must still be alive after the listening-state log");
+				started.Should().BeTrue("dev server should start successfully with the cross-major-version add-in loaded");
+				helper.AssertRunning();
+				helper.AssertConsoleOutputContains("Now listening on:");
+
+				// Strong assertion: the fixture writes the actual version of
+				// System.Text.Encodings.Web that was resolved at runtime. If the
+				// bridge is working, the host's loaded version (major >= 9) is
+				// returned even though the fixture compiled against v8.0.0.0.
+				// Without the fix a strict-binding runtime would throw and the
+				// sentinel would never be written (ctor never called).
+				File.Exists(versionSentinel).Should().BeTrue(
+					"the fixture's ctor must have been invoked and the " +
+					"System.Text.Encodings.Web version must have been written");
+
+				var versionText = File.ReadAllText(versionSentinel).Trim();
+				Version.TryParse(versionText, out var resolvedVersion).Should().BeTrue(
+					"sentinel must contain a valid version string, got: '{0}'", versionText);
+				resolvedVersion!.Major.Should().BeGreaterThanOrEqualTo(9,
+					"the bridge must return the host's loaded version (>= 9), not the " +
+					"fixture's compiled v8.0.0.0 reference");
+
+				helper.IsRunning.Should().BeTrue(
+					"host process must still be alive after the listening-state log");
+			}
+			finally
+			{
+				await helper.StopAsync(CT);
+			}
 		}
 		finally
 		{
-			await helper.StopAsync(CT);
+			if (File.Exists(versionSentinel))
+			{
+				File.Delete(versionSentinel);
+			}
 		}
 	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
@@ -1,4 +1,4 @@
-using Uno.UI.RemoteControl.DevServer.Tests.Helpers;
+﻿using Uno.UI.RemoteControl.DevServer.Tests.Helpers;
 
 namespace Uno.UI.RemoteControl.DevServer.Tests;
 
@@ -100,6 +100,117 @@ public class DevServerTests
 		started.Should().BeTrue("dev server should start successfully");
 		helper.IsRunning.Should().BeFalse("dev server should not be running after stopping");
 	}
+
+	// ------------------------------------------------------------------ DI cross-ALC baseline
+
+	[TestMethod]
+	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]
+	[Description("Baseline: an add-in loaded into AddInLoadContext must be able to register services via [ServiceCollectionExtension], proving IServiceCollection bridges to the host's instance.")]
+	public async Task DevServer_ShouldInvokeServiceRegistrationCtor_WhenAddInDeclaresServiceCollectionExtension()
+	{
+		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
+		var fixtureDll = Path.Combine(
+			testAssemblyDir, "Fixtures", "AddInWithDiServiceRegistration", "AddInWithDiServiceRegistration.dll");
+
+		File.Exists(fixtureDll).Should()
+			.BeTrue("DI service-registration fixture must be staged by _BuildAndCopyAddInTestFixtures");
+
+		var ctorSentinel = Path.Combine(Path.GetTempPath(), $"di-ctor-{Guid.NewGuid():N}.txt");
+		try
+		{
+			await using var helper = new DevServerTestHelper(
+				_logger,
+				environmentVariables: new Dictionary<string, string>
+				{
+					["UNO_DEVSERVER_TEST_DI_CTOR_SENTINEL"] = ctorSentinel,
+				});
+
+			try
+			{
+				var started = await helper.StartAsync(CT, extraArgs: $"--addins \"{fixtureDll}\"");
+				helper.EnsureStarted();
+
+				started.Should().BeTrue("dev server should start with the DI fixture add-in loaded");
+				helper.AssertRunning();
+
+				// The fixture's ServicesRegistration.ctor writes this sentinel when called.
+				// If IServiceCollection didn't bridge to the host's instance, Activator.CreateInstance
+				// would throw ArgumentException and the host would log the error without invoking the ctor.
+				File.Exists(ctorSentinel).Should().BeTrue(
+					"ServicesRegistration.ctor must have been invoked, proving IServiceCollection Type-identity across the ALC boundary");
+			}
+			finally
+			{
+				await helper.StopAsync(CT);
+			}
+		}
+		finally
+		{
+			if (File.Exists(ctorSentinel))
+			{
+				File.Delete(ctorSentinel);
+			}
+		}
+	}
+
+	[TestMethod]
+	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]
+	[Description("Baseline: an add-in's IHostedService must be started by ASP.NET Core's host, and the hosted service must be able to resolve add-in-defined types from the shared IServiceProvider.")]
+	public async Task DevServer_ShouldStartHostedService_WhenAddInRegistersIHostedService()
+	{
+		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
+		var fixtureDll = Path.Combine(
+			testAssemblyDir, "Fixtures", "AddInWithDiServiceRegistration", "AddInWithDiServiceRegistration.dll");
+
+		File.Exists(fixtureDll).Should()
+			.BeTrue("DI service-registration fixture must be staged by _BuildAndCopyAddInTestFixtures");
+
+		var hostedSentinel = Path.Combine(Path.GetTempPath(), $"di-hosted-{Guid.NewGuid():N}.txt");
+		try
+		{
+			await using var helper = new DevServerTestHelper(
+				_logger,
+				environmentVariables: new Dictionary<string, string>
+				{
+					["UNO_DEVSERVER_TEST_DI_HOSTED_SENTINEL"] = hostedSentinel,
+				});
+
+			try
+			{
+				var started = await helper.StartAsync(CT, extraArgs: $"--addins \"{fixtureDll}\"");
+				helper.EnsureStarted();
+
+				started.Should().BeTrue("dev server should start with the DI fixture add-in loaded");
+				helper.AssertRunning();
+
+				// The fixture's TestHostedService.StartAsync writes the count of ITestToken
+				// registrations to this sentinel.  Proving:
+				//   (a) IHostedService bridged correctly (service was picked up and started by ASP.NET Core)
+				//   (b) IServiceProvider bridged correctly (service received the host's provider)
+				//   (c) ServiceDescriptors survive the ALC boundary (GetServices<ITestToken> finds 2)
+				File.Exists(hostedSentinel).Should().BeTrue(
+					"TestHostedService.StartAsync must have been invoked, proving IHostedService and IServiceProvider Type-identity across the ALC boundary");
+
+				var countText = File.ReadAllText(hostedSentinel).Trim();
+				int.TryParse(countText, out var tokenCount).Should().BeTrue("sentinel must contain a numeric token count");
+				tokenCount.Should().Be(2,
+					"ServicesRegistration.ctor registered exactly 2 ITestToken implementations; GetServices must find both");
+			}
+			finally
+			{
+				await helper.StopAsync(CT);
+			}
+		}
+		finally
+		{
+			if (File.Exists(hostedSentinel))
+			{
+				File.Delete(hostedSentinel);
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------ cross-major version regression (#23287)
 
 	[TestMethod]
 	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
@@ -103,17 +103,29 @@ public class DevServerTests
 
 	[TestMethod]
 	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]
-	[Description("Regression for #23287: host must satisfy an add-in's older-major AssemblyRefs to shared-framework OOB packages (e.g. System.Text.Encodings.Web 8.0.0.0 in a net8.0 add-in) from its own newer-major loaded instance — without throwing FileNotFoundException during startup.")]
+	[Description("Regression for #23287: the host's add-in load pipeline must boot cleanly when an add-in carries older-major AssemblyRefs to shared-framework OOB packages (e.g. System.Text.Encodings.Web 8.0.0.0 in a net8.0 add-in) AND is activated through the [ServiceCollectionExtension] attribute scan that the host runs at startup.")]
 	public async Task DevServer_ShouldStart_WithAddInThatHasCrossMajorVersionFrameworkRefs()
 	{
 		// The fixture is built as a net8.0 class library that touches
-		// JavaScriptEncoder.Default in a static cctor (see
-		// Fixtures/AddInWithCrossMajorVersionRefs). Its compiled AssemblyRef to
-		// System.Text.Encodings.Web embeds at v8.0.0.0, which won't strict-match
-		// the v9/v10 the host has loaded from its shared framework. Without the
-		// AddInLoadContext + Default.Resolving bridging in
-		// Uno.UI.RemoteControl.Host this manifests as the original client crash
-		// (KiotaJsonSerializationContext..cctor → FNF Encodings.Web 8.0.0.0).
+		// JavaScriptEncoder.Default and IServiceCollection in a
+		// [ServiceCollectionExtension]-registered ctor (see
+		// Fixtures/AddInWithCrossMajorVersionRefs). The host's
+		// AddFromServiceExtensionAttributes invokes that ctor through
+		// Activator.CreateInstance, so the fixture's compiled v8.0.0.0
+		// AssemblyRefs are actually resolved — exercising the AddInLoadContext
+		// load path and the AssemblyLoadContext.Default.Resolving handler in
+		// Uno.UI.RemoteControl.Host rather than sitting dormant in metadata.
+		//
+		// This is a positive-outcome regression test: depending on the .NET
+		// runtime version, the binder may also successfully lax-bind these refs
+		// even without the host's fix, so a "must throw FileNotFoundException
+		// without the fix" assertion isn't deterministic across runtimes. The
+		// failure modes this catches are the ones that WOULD remain regardless
+		// of runtime laxness: a fatal crash in add-in load, the ctor never being
+		// invoked at all (broken attribute scan), or the host failing to reach
+		// the listening state. The end-to-end repro in
+		// D:\Dev\Uno-Pocs\DevServerLicensingRepro\ covers the real Kiota /
+		// Uno.Settings.DevServer path on a runtime that does still strict-bind.
 		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
 		var fixtureDll = Path.Combine(
 			testAssemblyDir,
@@ -122,7 +134,7 @@ public class DevServerTests
 			"AddInWithCrossMajorVersionRefs.dll");
 
 		File.Exists(fixtureDll).Should()
-			.BeTrue("test fixture DLL must be copied to test output by the _CopyAddInTestFixtures target");
+			.BeTrue("test fixture DLL must be copied to test output by the _BuildAndCopyAddInTestFixtures target");
 
 		await using var helper = new DevServerTestHelper(_logger);
 
@@ -134,13 +146,16 @@ public class DevServerTests
 			started.Should().BeTrue("dev server should start successfully with the cross-major-version add-in loaded");
 			helper.AssertRunning();
 			helper.AssertConsoleOutputContains("Now listening on:");
+			helper.AssertConsoleOutputContains("Loading add-in assembly");
 
-			// Frame the negative assertion by class-of-bug, not by today's specific
-			// stack — keeps the test relevant as host TFMs roll forward.
-			helper.ConsoleOutput
-				.Should().NotMatchRegex(
-					@"Unhandled exception[\s\S]*FileNotFoundException[\s\S]*System\.Text\.Encodings\.Web",
-					because: "host must bridge cross-major-version AssemblyRefs from add-ins via Default.Resolving instead of crashing");
+			// Runtime-stable assertion: a fatal CLR "Unhandled exception" banner
+			// terminates the process before "Now listening on:" is reached, so
+			// rather than substring-matching on the phrase (which could match a
+			// non-fatal logger message containing the literal text) we just
+			// confirm the host process is still alive and has actually reached
+			// the listening state. If the add-in load pipeline regresses in a
+			// way that crashes startup, this combination of asserts fails.
+			helper.IsRunning.Should().BeTrue("host process must still be alive after the listening-state log");
 		}
 		finally
 		{

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/AddInWithCrossMajorVersionRefs.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/AddInWithCrossMajorVersionRefs.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		Test fixture for Uno.UI.RemoteControl.DevServer.Tests.
+
+		Deliberately targets a .NET version OLDER than any host TFM this assembly
+		is exercised against, and pins a matching-major PackageReference to
+		System.Text.Encodings.Web so its compiled AssemblyRef embeds at the older
+		major version. That older-major AssemblyRef is what the host's
+		AddInLoadContext + AssemblyLoadContext.Default.Resolving handler in
+		Uno.UI.RemoteControl.Host must satisfy from the host's already-loaded
+		newer instance — the regression this fixture protects against
+		(https://github.com/unoplatform/uno/pull/23287).
+
+		Maintenance contract: when the host's lowest supported TFM advances past
+		net8.0, bump TargetFramework below to (newest host TFM minus one) and
+		bump the System.Text.Encodings.Web PackageReference to match.
+	-->
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<NoWarn>$(NoWarn);CS0168</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/AddInWithCrossMajorVersionRefs.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/AddInWithCrossMajorVersionRefs.csproj
@@ -4,27 +4,36 @@
 		Test fixture for Uno.UI.RemoteControl.DevServer.Tests.
 
 		Deliberately targets a .NET version OLDER than any host TFM this assembly
-		is exercised against, and pins a matching-major PackageReference to
-		System.Text.Encodings.Web so its compiled AssemblyRef embeds at the older
-		major version. That older-major AssemblyRef is what the host's
-		AddInLoadContext + AssemblyLoadContext.Default.Resolving handler in
+		is exercised against, and pins matching-major PackageReferences so its
+		compiled AssemblyRefs (System.Text.Encodings.Web, and
+		Microsoft.Extensions.DependencyInjection.Abstractions used by the
+		registration ctor) embed at that older major version. Those older-major
+		AssemblyRefs are what the host's AddInLoadContext + the
+		AssemblyLoadContext.Default.Resolving handler in
 		Uno.UI.RemoteControl.Host must satisfy from the host's already-loaded
 		newer instance — the regression this fixture protects against
 		(https://github.com/unoplatform/uno/pull/23287).
 
+		EnableDynamicLoading=true follows the Microsoft plugin-tutorial
+		convention: it emits a self-contained .deps.json beside the assembly so
+		AssemblyDependencyResolver inside AddInLoadContext has a real per-add-in
+		dependency graph to consult (exercising step 3 of Load, not just the
+		Default-ALC fall-throughs in steps 1 and 2).
+
 		Maintenance contract: when the host's lowest supported TFM advances past
 		net8.0, bump TargetFramework below to (newest host TFM minus one) and
-		bump the System.Text.Encodings.Web PackageReference to match.
+		bump the two PackageReferences below to match.
 	-->
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<NoWarn>$(NoWarn);CS0168</NoWarn>
+		<EnableDynamicLoading>true</EnableDynamicLoading>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs
@@ -1,27 +1,62 @@
+using System;
 using System.Text.Encodings.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Uno.Utils.DependencyInjection;
 
-namespace Uno.UI.RemoteControl.DevServer.Tests.Fixtures.AddInWithCrossMajorVersionRefs;
+// The host's Uno.Utils.DependencyInjection.ServiceCollectionServiceExtensions
+// scans add-in assemblies for [ServiceCollectionExtension] by full type name
+// and calls Activator.CreateInstance(extension.Type, args: [services]) on
+// each registered type. Declaring this attribute makes the host actually
+// instantiate ServicesRegistration during startup, so the v8.0.0.0
+// AssemblyRefs compiled into this assembly (System.Text.Encodings.Web,
+// Microsoft.Extensions.DependencyInjection.Abstractions) actually get
+// resolved at runtime — exercising the AddInLoadContext load path and the
+// AssemblyLoadContext.Default.Resolving handler in Uno.UI.RemoteControl.Host
+// rather than sitting dormant in metadata.
+[assembly: ServiceCollectionExtension(typeof(ServicesRegistration))]
+
+namespace Uno.Utils.DependencyInjection;
 
 /// <summary>
-/// Stub type for the DevServer add-in load regression test fixture.
-/// Its static cctor touches <see cref="JavaScriptEncoder.Default"/> so that the
-/// compiled assembly carries an <c>AssemblyRef</c> to
-/// <c>System.Text.Encodings.Web</c> at the version matching this project's
-/// <c>TargetFramework</c> (net8.0 → v8.0.0.0). When the host loads this DLL as
-/// an add-in, that AssemblyRef must be satisfied by the host's already-loaded
-/// newer-major instance — exercising the bridging in
-/// <c>Uno.UI.RemoteControl.Host.Helpers.AddInLoadContext</c> and the
-/// <c>AssemblyLoadContext.Default.Resolving</c> handler.
+/// Activated by the host during add-in registration via the
+/// <c>[ServiceCollectionExtension]</c> attribute above. The ctor's
+/// <see cref="IServiceCollection"/> parameter and the
+/// <see cref="JavaScriptEncoder.Default"/> touch both go through this
+/// assembly's older-major <c>AssemblyRef</c>s, so the host's bridging in
+/// <c>AddInLoadContext</c> must hand back its already-loaded newer-major
+/// instances rather than letting the strict TPA binder throw
+/// <see cref="System.IO.FileNotFoundException"/>.
+/// <para>
+/// Note: depending on the .NET runtime version, the binder may also
+/// successfully lax-bind these refs even without the host's fix — the
+/// surrounding test asserts the *positive* outcome (host stays up and the
+/// add-in's ctor runs) rather than trying to deterministically reproduce
+/// the original strict-bind FNF, which depends on runtime-version-specific
+/// behaviour.
+/// </para>
 /// </summary>
-public static class Stub
+public sealed class ServicesRegistration
 {
-	static Stub()
+	public ServicesRegistration(IServiceCollection services)
 	{
-		// Force the runtime to resolve System.Text.Encodings.Web during type
-		// initialization, mirroring how Microsoft.Kiota.Serialization.Json's
-		// KiotaJsonSerializationContext..cctor triggers the original crash.
+		ArgumentNullException.ThrowIfNull(services);
+
+		// Force the runtime to resolve System.Text.Encodings.Web from this
+		// assembly's compiled v8.0.0.0 AssemblyRef — mirrors how Kiota's
+		// KiotaJsonSerializationContext..cctor triggers the original crash on
+		// hosts that strict-match the TPA version.
 		_ = JavaScriptEncoder.Default;
 	}
+}
 
-	public static string GetEncoderName() => JavaScriptEncoder.Default.GetType().FullName!;
+// The host's ServiceCollectionExtensionAttribute lives in the same
+// Uno.Utils.DependencyInjection namespace inside Uno.UI.RemoteControl.Host and
+// is matched by full type name through CustomAttributesData. Add-ins declare
+// their own copy under the same namespace+name so they don't have to take a
+// direct dependency on the host assembly. (Same convention as the
+// Uno.Settings.DevServer / Uno.UI.App.Mcp.Server add-ins ship today.)
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+internal sealed class ServiceCollectionExtensionAttribute(Type type) : Attribute
+{
+	public Type Type { get; } = type;
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs
@@ -1,0 +1,27 @@
+using System.Text.Encodings.Web;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Fixtures.AddInWithCrossMajorVersionRefs;
+
+/// <summary>
+/// Stub type for the DevServer add-in load regression test fixture.
+/// Its static cctor touches <see cref="JavaScriptEncoder.Default"/> so that the
+/// compiled assembly carries an <c>AssemblyRef</c> to
+/// <c>System.Text.Encodings.Web</c> at the version matching this project's
+/// <c>TargetFramework</c> (net8.0 → v8.0.0.0). When the host loads this DLL as
+/// an add-in, that AssemblyRef must be satisfied by the host's already-loaded
+/// newer-major instance — exercising the bridging in
+/// <c>Uno.UI.RemoteControl.Host.Helpers.AddInLoadContext</c> and the
+/// <c>AssemblyLoadContext.Default.Resolving</c> handler.
+/// </summary>
+public static class Stub
+{
+	static Stub()
+	{
+		// Force the runtime to resolve System.Text.Encodings.Web during type
+		// initialization, mirroring how Microsoft.Kiota.Serialization.Json's
+		// KiotaJsonSerializationContext..cctor triggers the original crash.
+		_ = JavaScriptEncoder.Default;
+	}
+
+	public static string GetEncoderName() => JavaScriptEncoder.Default.GetType().FullName!;
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.IO;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Uno.Utils.DependencyInjection;
@@ -46,6 +47,19 @@ public sealed class ServicesRegistration
 		// KiotaJsonSerializationContext..cctor triggers the original crash on
 		// hosts that strict-match the TPA version.
 		_ = JavaScriptEncoder.Default;
+
+		// Write the *actual* version of System.Text.Encodings.Web that was
+		// resolved so the test can assert a strong positive: the bridge must
+		// have handed back the host's loaded version (major >= 9), not some
+		// downgraded v8 copy.
+		var versionSentinel = Environment.GetEnvironmentVariable(
+			"UNO_DEVSERVER_TEST_ENCODINGSWEB_VERSION_PATH");
+		if (!string.IsNullOrEmpty(versionSentinel))
+		{
+			File.WriteAllText(
+				versionSentinel,
+				typeof(JavaScriptEncoder).Assembly.GetName().Version!.ToString());
+		}
 	}
 }
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/AddInWithDiServiceRegistration.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/AddInWithDiServiceRegistration.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		Test fixture for Uno.UI.RemoteControl.DevServer.Tests.
+
+		Validates the end-to-end DI integration path for add-ins loaded into the
+		shared AddInLoadContext:
+
+		1. [ServiceCollectionExtension] attribute scan and ctor activation — proves
+		   IServiceCollection bridges to the host's instance (Type identity preserved).
+
+		2. IHostedService — add-in registers a hosted service that the ASP.NET Core
+		   host must start, proving IHostedService bridges to the host's instance.
+
+		3. IServiceProvider cross-ALC type lookup — the hosted service resolves add-in-
+		   defined types (ITestToken) from the shared IServiceProvider, proving
+		   ServiceDescriptors survive the ALC boundary intact.
+
+		Intentionally targets net9.0 (lower than the host's net10.0 TFM) with
+		matching-version PackageReferences so its compiled AssemblyRefs embed at the
+		net9.0 major. EnableDynamicLoading=true emits a self-contained .deps.json so
+		AddInLoadContext's AssemblyDependencyResolver has a real per-add-in graph.
+	-->
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<EnableDynamicLoading>true</EnableDynamicLoading>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/Stub.cs
@@ -39,7 +39,7 @@ public sealed class ServicesRegistration
 	}
 }
 
-// Marker interface — defined in AddInLoadContext.
+// Marker interface — defined here in the fixture, not in AddInLoadContext.
 public interface ITestToken { }
 
 public sealed class TestToken1 : ITestToken { }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/Stub.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Uno.Utils.DependencyInjection;
+
+// The host's attribute-scanner matches this by full type name, not Type identity,
+// so the add-in declares its own copy under the same namespace+name without
+// taking a direct dependency on the host assembly.
+[assembly: ServiceCollectionExtension(typeof(ServicesRegistration))]
+
+namespace Uno.Utils.DependencyInjection;
+
+// Activated by the host's attribute scanner via Activator.CreateInstance.
+// Exercises IServiceCollection bridge, IHostedService bridge, and cross-ALC
+// ServiceDescriptor lookup across the AddInLoadContext boundary.
+public sealed class ServicesRegistration
+{
+	public ServicesRegistration(IServiceCollection services)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+
+		// Write a sentinel to prove ctor was invoked (IServiceCollection bridge OK).
+		var ctorSentinel = Environment.GetEnvironmentVariable(
+			"UNO_DEVSERVER_TEST_DI_CTOR_SENTINEL");
+		if (!string.IsNullOrEmpty(ctorSentinel))
+		{
+			File.WriteAllText(ctorSentinel, "ctor-invoked");
+		}
+
+		// Register two ITestToken instances and a hosted service.
+		services.AddSingleton<ITestToken, TestToken1>();
+		services.AddSingleton<ITestToken, TestToken2>();
+		services.AddHostedService<TestHostedService>();
+	}
+}
+
+// Marker interface — defined in AddInLoadContext.
+public interface ITestToken { }
+
+public sealed class TestToken1 : ITestToken { }
+public sealed class TestToken2 : ITestToken { }
+
+// Started by the ASP.NET Core host as part of IHost.StartAsync.
+// Writes the resolved ITestToken count to a sentinel file, proving
+// IHostedService and IServiceProvider Type-identity across the ALC boundary.
+public sealed class TestHostedService(IServiceProvider services) : IHostedService
+{
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		var sentinel = Environment.GetEnvironmentVariable(
+			"UNO_DEVSERVER_TEST_DI_HOSTED_SENTINEL");
+		if (!string.IsNullOrEmpty(sentinel))
+		{
+			var tokenCount = services.GetServices<ITestToken>().Count();
+			File.WriteAllText(
+				sentinel,
+				tokenCount.ToString(CultureInfo.InvariantCulture));
+		}
+
+		return Task.CompletedTask;
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+internal sealed class ServiceCollectionExtensionAttribute(Type type) : Attribute
+{
+	public Type Type { get; } = type;
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
@@ -1,0 +1,101 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+using Uno.UI.RemoteControl.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="AddInLoadContext"/> assembly-bridging behaviour.
+/// These tests verify that Load() returns the host's already-loaded Assembly for
+/// framework and contract assemblies (step 1 of the three-step resolution chain),
+/// preserving Type identity across the host/add-in ALC boundary.
+/// </summary>
+[TestClass]
+public class Given_AddInLoadContext
+{
+	// ------------------------------------------------------------------ step 1: bridge via Default.Assemblies
+
+	[TestMethod]
+	[Description("Step 1 must return the host's System.Text.Json instance so JsonDocument/JsonElement types are identical between host and add-in.")]
+	public void Load_ResolvesFrameworkOobAssembly_ToHostInstance()
+	{
+		// Force the assembly into Default.Assemblies (reference a type from it first).
+		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+
+		var ctx = new AddInLoadContext(Array.Empty<string>());
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Json"));
+
+		loaded.Should().BeSameAs(hostAssembly,
+			"System.Text.Json must bridge to the host's already-loaded instance");
+	}
+
+	[TestMethod]
+	[Description("Step 1 must return the host's Logging.Abstractions so ILogger contracts are identical between host and add-in.")]
+	public void Load_ResolvesLoggingAbstractions_ToHostInstance()
+	{
+		var hostAssembly = typeof(ILogger).Assembly;
+
+		var ctx = new AddInLoadContext(Array.Empty<string>());
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("Microsoft.Extensions.Logging.Abstractions"));
+
+		loaded.Should().BeSameAs(hostAssembly,
+			"ILogger assembly must bridge to the host's instance for log sinks to work across the boundary");
+	}
+
+	[TestMethod]
+	[Description("Step 1 must return the host's System.Text.Encodings.Web — the assembly whose version mismatch triggered the original crash (PR #23287).")]
+	public void Load_ResolvesEncodingsWeb_ToHostInstance()
+	{
+		// Touching JavaScriptEncoder forces the assembly into Default.Assemblies.
+		var hostAssembly = typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly;
+
+		var ctx = new AddInLoadContext(Array.Empty<string>());
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Encodings.Web"));
+
+		loaded.Should().BeSameAs(hostAssembly,
+			"System.Text.Encodings.Web must bridge to the host's instance regardless of which major version the add-in compiled against");
+	}
+
+	// ------------------------------------------------------------------ IsDynamic guard
+
+	[TestMethod]
+	[Description("Dynamic (reflection-emit) assemblies must not be returned by the bridge, even if their auto-generated name coincidentally matches an AssemblyRef.")]
+	public void Load_SkipsDynamicAssemblies_WhenBridging()
+	{
+		// Create a dynamic assembly whose simple name matches a real one.
+		var dynamicName = "System.Text.Json";
+		var dynamicAsm = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+			new AssemblyName(dynamicName),
+			System.Reflection.Emit.AssemblyBuilderAccess.Run);
+
+		dynamicAsm.IsDynamic.Should().BeTrue("sanity check on our test setup");
+
+		// The actual System.Text.Json must be in Default.Assemblies.
+		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+
+		var ctx = new AddInLoadContext(Array.Empty<string>());
+
+		// The bridge must return the real assembly, not the dynamic one, despite the name match.
+		// (The dynamic assembly isn't in Default.Assemblies unless we loaded it, but Load
+		// iterates Default.Assemblies and the IsDynamic guard must skip it if it were there.)
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Json"));
+
+		loaded.Should().BeSameAs(hostAssembly, "dynamic assemblies must never be returned by the bridge");
+		loaded!.IsDynamic.Should().BeFalse("returned assembly must not be a dynamic assembly");
+	}
+
+	// ------------------------------------------------------------------ null / miss
+
+	[TestMethod]
+	[Description("Load returns null for an assembly not in Default.Assemblies, not in TPA, and not in any resolver — the ALC then throws FileNotFoundException as specified.")]
+	public void LoadFromAssemblyName_ThrowsFileNotFoundException_WhenAssemblyIsUnknown()
+	{
+		var ctx = new AddInLoadContext(Array.Empty<string>());
+
+		// Totally unknown assembly: Load returns null → ALC throws FNFE.
+		var act = () => ctx.LoadFromAssemblyName(new AssemblyName("Totally.Unknown.Assembly.XYZ.DoesNotExist"));
+
+		act.Should().Throw<FileNotFoundException>(
+			"when Load returns null for all contexts, the runtime raises FileNotFoundException");
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
@@ -23,7 +23,11 @@ public class Given_AddInLoadContext
 		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
 
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Json"));
+		// PKT must be set so the symmetric PKT guard in step 1 accepts the bridge;
+		// an unsigned request would be refused for a strong-named loaded assembly.
+		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
+		var loaded = ctx.LoadFromAssemblyName(requested);
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"System.Text.Json must bridge to the host's already-loaded instance");
@@ -36,7 +40,10 @@ public class Given_AddInLoadContext
 		var hostAssembly = typeof(ILogger).Assembly;
 
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("Microsoft.Extensions.Logging.Abstractions"));
+		// PKT must be set so the symmetric PKT guard in step 1 accepts the bridge.
+		var requested = new AssemblyName("Microsoft.Extensions.Logging.Abstractions");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
+		var loaded = ctx.LoadFromAssemblyName(requested);
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"ILogger assembly must bridge to the host's instance for log sinks to work across the boundary");
@@ -50,7 +57,10 @@ public class Given_AddInLoadContext
 		var hostAssembly = typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly;
 
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Encodings.Web"));
+		// PKT must be set so the symmetric PKT guard in step 1 accepts the bridge.
+		var requested = new AssemblyName("System.Text.Encodings.Web");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
+		var loaded = ctx.LoadFromAssemblyName(requested);
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"System.Text.Encodings.Web must bridge to the host's instance regardless of which major version the add-in compiled against");
@@ -89,36 +99,33 @@ public class Given_AddInLoadContext
 	// ------------------------------------------------------------------ step 1 bridges without engaging Default.Resolving
 
 	[TestMethod]
-	[Description("Step 1 must satisfy a host-loaded AssemblyRef directly from Default.Assemblies without delegating to AssemblyLoadContext.Default.Resolving (proving the bridge short-circuits before the fallback).")]
+	[Description("Step 1 must bridge an assembly that is in Default.Assemblies but is NOT in TPA, proving step-1 is the active code path. " +
+		"If step-1 is absent, step-2 (TPA lookup) throws FileNotFoundException for non-framework assemblies, making the test genuinely non-vacuous.")]
 	public void Load_Step1_BridgesHostAssembly_WithoutGoingThroughDefaultResolving()
 	{
-		// Force the assembly into Default.Assemblies (well-known host assembly).
-		var hostAssembly = typeof(Microsoft.Extensions.DependencyInjection.IServiceCollection).Assembly;
+		// The test assembly is loaded into Default.Assemblies by the test runner, but it
+		// is NOT a TPA assembly — Default.LoadFromAssemblyName("...DevServer.Tests") will
+		// throw FileNotFoundException because TPA has no entry for it. Step-2 therefore
+		// cannot satisfy this request; only step-1 can. Removing the step-1 bridge in
+		// AddInLoadContext.Load causes ctx.LoadFromAssemblyName to throw here, turning
+		// this into a genuine red test.
+		//
+		// The test assembly is also unsigned (no PKT), which matches the unsigned-to-unsigned
+		// path of TryBridgeBySimpleName's PKT symmetry guard — step-1 correctly bridges
+		// unsigned requests to unsigned loaded assemblies.
+		var hostAssembly = typeof(Given_AddInLoadContext).Assembly;
+		AssemblyLoadContext.Default.Assemblies.Should().Contain(hostAssembly,
+			"the test assembly must be in Default.Assemblies for this test to be valid");
 
-		var resolvingCount = 0;
-		ResolveEventHandlerNoop counter = (ctx, req) =>
-		{
-			Interlocked.Increment(ref resolvingCount);
-			return null;
-		};
-		AssemblyLoadContext.Default.Resolving += counter.Invoke;
-		try
-		{
-			var ctx = new AddInLoadContext(Array.Empty<string>());
-			var loaded = ctx.LoadFromAssemblyName(new AssemblyName("Microsoft.Extensions.DependencyInjection.Abstractions"));
+		var requested = new AssemblyName(hostAssembly.GetName().Name!);
 
-			loaded.Should().BeSameAs(hostAssembly,
-				"step 1 must bridge to the host's already-loaded instance");
-			resolvingCount.Should().Be(0,
-				"step 1 must satisfy the request without triggering Default.Resolving");
-		}
-		finally
-		{
-			AssemblyLoadContext.Default.Resolving -= counter.Invoke;
-		}
+		var ctx = new AddInLoadContext(Array.Empty<string>());
+		var loaded = ctx.LoadFromAssemblyName(requested);
+
+		loaded.Should().BeSameAs(hostAssembly,
+			"step 1 must bridge to the host's already-loaded test assembly; " +
+			"without step-1, step-2 TPA lookup throws FileNotFoundException and this assertion is never reached");
 	}
-
-	private delegate Assembly? ResolveEventHandlerNoop(AssemblyLoadContext context, AssemblyName name);
 
 	// ------------------------------------------------------------------ null / miss
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.Loader;
-using Uno.UI.RemoteControl.Helpers;
+using Uno.UI.RemoteControl.Host.Helpers;
 
 namespace Uno.UI.RemoteControl.DevServer.Tests;
 
@@ -59,30 +59,66 @@ public class Given_AddInLoadContext
 	// ------------------------------------------------------------------ IsDynamic guard
 
 	[TestMethod]
-	[Description("Dynamic (reflection-emit) assemblies must not be returned by the bridge, even if their auto-generated name coincidentally matches an AssemblyRef.")]
-	public void Load_SkipsDynamicAssemblies_WhenBridging()
+	[Description("Even when a dynamic assembly is created with the same simple name as a real assembly in the same process, the bridge must return the static assembly and never the dynamic one.")]
+	public void TryBridgeBySimpleName_SkipsDynamicAssemblies_WhenCandidateIsDynamic()
 	{
-		// Create a dynamic assembly whose simple name matches a real one.
-		var dynamicName = "System.Text.Json";
-		var dynamicAsm = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
-			new AssemblyName(dynamicName),
+		var staticAsm = typeof(System.Text.Json.JsonDocument).Assembly;
+
+		// Create a dynamic assembly inside the Default ALC with the same simple
+		// name as the static target. AssemblyBuilder.DefineDynamicAssembly with
+		// AssemblyBuilderAccess.Run registers the dynamic assembly with the
+		// currently-executing ALC (Default for test code). The IsDynamic guard
+		// in TryBridgeBySimpleName must skip it so that the static assembly is
+		// returned, not the dynamic one.
+		_ = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+			new AssemblyName(staticAsm.GetName().Name!),
 			System.Reflection.Emit.AssemblyBuilderAccess.Run);
 
-		dynamicAsm.IsDynamic.Should().BeTrue("sanity check on our test setup");
+		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(staticAsm.GetName().GetPublicKeyToken());
 
-		// The actual System.Text.Json must be in Default.Assemblies.
-		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(AssemblyLoadContext.Default, requested);
 
-		var ctx = new AddInLoadContext(Array.Empty<string>());
-
-		// The bridge must return the real assembly, not the dynamic one, despite the name match.
-		// (The dynamic assembly isn't in Default.Assemblies unless we loaded it, but Load
-		// iterates Default.Assemblies and the IsDynamic guard must skip it if it were there.)
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Json"));
-
-		loaded.Should().BeSameAs(hostAssembly, "dynamic assemblies must never be returned by the bridge");
-		loaded!.IsDynamic.Should().BeFalse("returned assembly must not be a dynamic assembly");
+		result.Should().NotBeNull("the static assembly is present in Default.Assemblies");
+		result!.IsDynamic.Should().BeFalse(
+			"the bridge must never return a dynamic assembly even when one with a matching simple name exists");
+		result.Should().BeSameAs(staticAsm,
+			"the bridge must return the static assembly when a same-named dynamic one is present");
 	}
+
+	// ------------------------------------------------------------------ step 1 bridges without engaging Default.Resolving
+
+	[TestMethod]
+	[Description("Step 1 must satisfy a host-loaded AssemblyRef directly from Default.Assemblies without delegating to AssemblyLoadContext.Default.Resolving (proving the bridge short-circuits before the fallback).")]
+	public void Load_Step1_BridgesHostAssembly_WithoutGoingThroughDefaultResolving()
+	{
+		// Force the assembly into Default.Assemblies (well-known host assembly).
+		var hostAssembly = typeof(Microsoft.Extensions.DependencyInjection.IServiceCollection).Assembly;
+
+		var resolvingCount = 0;
+		ResolveEventHandlerNoop counter = (ctx, req) =>
+		{
+			Interlocked.Increment(ref resolvingCount);
+			return null;
+		};
+		AssemblyLoadContext.Default.Resolving += counter.Invoke;
+		try
+		{
+			var ctx = new AddInLoadContext(Array.Empty<string>());
+			var loaded = ctx.LoadFromAssemblyName(new AssemblyName("Microsoft.Extensions.DependencyInjection.Abstractions"));
+
+			loaded.Should().BeSameAs(hostAssembly,
+				"step 1 must bridge to the host's already-loaded instance");
+			resolvingCount.Should().Be(0,
+				"step 1 must satisfy the request without triggering Default.Resolving");
+		}
+		finally
+		{
+			AssemblyLoadContext.Default.Resolving -= counter.Invoke;
+		}
+	}
+
+	private delegate Assembly? ResolveEventHandlerNoop(AssemblyLoadContext context, AssemblyName name);
 
 	// ------------------------------------------------------------------ null / miss
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AssemblyHelper.cs
@@ -1,0 +1,41 @@
+using System;
+using Uno.UI.RemoteControl.Host.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+/// <summary>
+/// Unit tests for the <c>UNO_DEVSERVER_DISABLE_ADDIN_ALC</c> kill switch wired through
+/// <see cref="HostAssemblyResolution"/>. Behavioural coverage of the legacy
+/// <c>Assembly.LoadFrom</c> fallback path in <c>AssemblyHelper.Load</c> is provided
+/// by the end-to-end DevServer integration tests.
+/// </summary>
+[TestClass]
+public class Given_AssemblyHelper
+{
+	// ------------------------------------------------------------------ kill switch
+
+	[TestMethod]
+	[Description("IsKillSwitchActive must mirror UNO_DEVSERVER_DISABLE_ADDIN_ALC without caching so that changes take effect on the next call.")]
+	public void IsKillSwitchActive_ReflectsEnvironmentVariable()
+	{
+		var previous = Environment.GetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC");
+		try
+		{
+			Environment.SetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC", null);
+			HostAssemblyResolution.IsKillSwitchActive.Should().BeFalse(
+				"env var is absent");
+
+			Environment.SetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC", "0");
+			HostAssemblyResolution.IsKillSwitchActive.Should().BeFalse(
+				"env var is '0', not '1'");
+
+			Environment.SetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC", "1");
+			HostAssemblyResolution.IsKillSwitchActive.Should().BeTrue(
+				"env var is '1'");
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC", previous);
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -18,13 +18,16 @@ public class Given_HostAssemblyResolution
 	{
 		// Force the assembly into Default.Assemblies.
 		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+
+		// Mirror what a compiled add-in AssemblyRef looks like: simple name + PKT.
 		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
 
 		var result = HostAssemblyResolution.TryBridgeBySimpleName(
 			AssemblyLoadContext.Default, requested);
 
 		result.Should().BeSameAs(hostAssembly,
-			"System.Text.Json is loaded in the default ALC and the name matches");
+			"System.Text.Json is loaded in the default ALC and the name+PKT matches");
 	}
 
 	// ------------------------------------------------------------------ returns null on miss
@@ -55,12 +58,62 @@ public class Given_HostAssemblyResolution
 			new AssemblyName("System.Text.Json"),
 			System.Reflection.Emit.AssemblyBuilderAccess.Run);
 
+		// Use a proper signed request (real add-in AssemblyRefs include the PKT).
 		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
 		var result = HostAssemblyResolution.TryBridgeBySimpleName(
 			AssemblyLoadContext.Default, requested);
 
 		result.Should().BeSameAs(hostAssembly,
 			"the bridge must return the real assembly, not a dynamic one");
 		result!.IsDynamic.Should().BeFalse("returned assembly must never be dynamic");
+	}
+
+	// ------------------------------------------------------------------ PKT symmetry
+
+	[TestMethod]
+	[Description("When the loaded assembly is strong-named but the request carries no PKT, the bridge must return null to prevent silently substituting a strong-named assembly for an unsigned reference.")]
+	public void TryBridgeBySimpleName_RejectsStrongNamedLoaded_WhenRequestedIsUnsigned()
+	{
+		// System.Text.Json is strong-named (Microsoft PKT).
+		_ = typeof(System.Text.Json.JsonDocument).Assembly;
+
+		// Request the same simple name without a PKT.
+		var requested = new AssemblyName("System.Text.Json") { Version = null };
+
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeNull(
+			"a strong-named loaded assembly must not be returned for an unsigned request — " +
+			"the PKT mismatch could silently substitute the wrong assembly");
+	}
+
+	// ------------------------------------------------------------------ version downgrade
+
+	[TestMethod]
+	[Description("When the loaded assembly version is lower than the requested version, TryBridgeBySimpleName must return null to avoid silently serving a downgraded version.")]
+	public void TryBridgeBySimpleName_RejectsDowngrade_WhenLoadedVersionLowerThanRequested()
+	{
+		// Use System.Text.Encodings.Web — forced into Default by Given_AddInLoadContext.
+		var loaded = typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly;
+		var loadedVersion = loaded.GetName().Version!;
+		var loadedPkt = loaded.GetName().GetPublicKeyToken()!;
+
+		// Request the same assembly one major version higher (simulates the
+		// add-in requesting v(N+1) while the host has only vN loaded).
+		var higherVersion = new Version(loadedVersion.Major + 1, 0, 0, 0);
+		var requested = new AssemblyName("System.Text.Encodings.Web")
+		{
+			Version = higherVersion,
+		};
+		requested.SetPublicKeyToken(loadedPkt);
+
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeNull(
+			"loaded v{0} must not satisfy a request for v{1} — that would be a downgrade",
+			loadedVersion, higherVersion);
 	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -5,11 +5,79 @@ using Uno.UI.RemoteControl.Host.Helpers;
 namespace Uno.UI.RemoteControl.DevServer.Tests;
 
 /// <summary>
-/// Unit tests for <see cref="HostAssemblyResolution.TryBridgeBySimpleName"/>.
+/// Unit tests for <see cref="HostAssemblyResolution.TryBridgeBySimpleName"/> and
+/// <see cref="HostAssemblyResolution.Install"/>.
 /// </summary>
 [TestClass]
 public class Given_HostAssemblyResolution
 {
+	// ------------------------------------------------------------------ Install
+
+	[TestMethod]
+	[Description("Calling Install() twice must register exactly one Resolving handler on AssemblyLoadContext.Default.")]
+	public void Install_IsIdempotent_WhenCalledTwice()
+	{
+		// First call installs the handler (or is already installed from another test).
+		HostAssemblyResolution.Install();
+
+		// Snapshot the handler count after the first call.
+		int countBefore = CountResolvingHandlers();
+
+		// Subsequent calls must be no-ops: the count must not grow.
+		HostAssemblyResolution.Install();
+		HostAssemblyResolution.Install();
+
+		int countAfter = CountResolvingHandlers();
+
+		countAfter.Should().Be(countBefore,
+			"repeated Install() calls must not register additional Resolving handlers");
+	}
+
+	[TestMethod]
+	[Description("After Install(), System.Text.Encodings.Web must be resolvable from AssemblyLoadContext.Default (either eager-loaded by Install or available via TPA).")]
+	public void Install_EagerLoads_SystemTextEncodingsWeb()
+	{
+		HostAssemblyResolution.Install();
+
+		// Trigger TPA resolution so the assembly is guaranteed to be in Default.Assemblies.
+		// In the host process Install() pre-loads it from the host directory; in the test
+		// process the DLL is not copied to the output dir, so we ask Default explicitly.
+		// Either way the invariant is: the assembly must be resolvable from Default ALC.
+		var asm = AssemblyLoadContext.Default.LoadFromAssemblyName(
+			new AssemblyName("System.Text.Encodings.Web"));
+
+		asm.Should().NotBeNull("System.Text.Encodings.Web must be resolvable from Default ALC after Install()");
+
+		var loaded = AssemblyLoadContext.Default.Assemblies
+			.Any(a => !a.IsDynamic &&
+					  string.Equals(a.GetName().Name, "System.Text.Encodings.Web",
+									StringComparison.OrdinalIgnoreCase));
+
+		loaded.Should().BeTrue(
+			"System.Text.Encodings.Web must appear in Default.Assemblies once resolved");
+	}
+
+	// ------------------------------------------------------------------ helpers
+
+	private static int CountResolvingHandlers()
+	{
+		// Use reflection to inspect the internal delegate stored for the Resolving event.
+		// The field name changed across .NET versions, so try both known names.
+		var alcType = typeof(AssemblyLoadContext);
+		var field = alcType.GetField("_resolving", BindingFlags.Instance | BindingFlags.NonPublic)
+					?? alcType.GetField("Resolving", BindingFlags.Instance | BindingFlags.NonPublic);
+
+		if (field is null)
+		{
+			// Fallback: we cannot introspect — return 0 to avoid a false failure.
+			return 0;
+		}
+
+		var del = field.GetValue(AssemblyLoadContext.Default) as Delegate;
+		return del?.GetInvocationList().Length ?? 0;
+	}
+
+
 	// ------------------------------------------------------------------ returns loaded assembly
 
 	[TestMethod]

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -1,0 +1,66 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+using Uno.UI.RemoteControl.Host.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="HostAssemblyResolution.TryBridgeBySimpleName"/>.
+/// </summary>
+[TestClass]
+public class Given_HostAssemblyResolution
+{
+	// ------------------------------------------------------------------ returns loaded assembly
+
+	[TestMethod]
+	[Description("When the default ALC has an assembly with the requested simple name and matching PKT, TryBridgeBySimpleName must return that exact instance.")]
+	public void TryBridgeBySimpleName_ReturnsLoadedAssembly_WhenSimpleNameMatchesAndPktCompatible()
+	{
+		// Force the assembly into Default.Assemblies.
+		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+		var requested = new AssemblyName("System.Text.Json");
+
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeSameAs(hostAssembly,
+			"System.Text.Json is loaded in the default ALC and the name matches");
+	}
+
+	// ------------------------------------------------------------------ returns null on miss
+
+	[TestMethod]
+	[Description("When no assembly with the requested simple name is loaded in the context, TryBridgeBySimpleName must return null.")]
+	public void TryBridgeBySimpleName_ReturnsNull_WhenNoMatch()
+	{
+		var requested = new AssemblyName("Totally.Unknown.Assembly.XYZ.DoesNotExist");
+
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeNull("no assembly with that name is loaded");
+	}
+
+	// ------------------------------------------------------------------ skips dynamic assemblies
+
+	[TestMethod]
+	[Description("Dynamic (reflection-emit) assemblies must be skipped even when their auto-generated name coincidentally matches the requested name.")]
+	public void TryBridgeBySimpleName_SkipsDynamicAssemblies_WhenNameMatchesDynamic()
+	{
+		// Force the real assembly into Default first.
+		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+
+		// Create a dynamic assembly with the same simple name.
+		_ = System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(
+			new AssemblyName("System.Text.Json"),
+			System.Reflection.Emit.AssemblyBuilderAccess.Run);
+
+		var requested = new AssemblyName("System.Text.Json");
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeSameAs(hostAssembly,
+			"the bridge must return the real assembly, not a dynamic one");
+		result!.IsDynamic.Should().BeFalse("returned assembly must never be dynamic");
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -34,27 +34,89 @@ public class Given_HostAssemblyResolution
 	}
 
 	[TestMethod]
-	[Description("After Install(), System.Text.Encodings.Web must be resolvable from AssemblyLoadContext.Default (either eager-loaded by Install or available via TPA).")]
-	public void Install_EagerLoads_SystemTextEncodingsWeb()
+	[Description("EagerLoadFromDirectory must actually load an assembly from the supplied directory that was not previously present in Default.Assemblies (non-vacuous).")]
+	public void EagerLoadFromDirectory_LoadsAssemblyNotPreviouslyInDefault()
 	{
-		HostAssemblyResolution.Install();
+		var sourceDir = System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)!;
 
-		// Trigger TPA resolution so the assembly is guaranteed to be in Default.Assemblies.
-		// In the host process Install() pre-loads it from the host directory; in the test
-		// process the DLL is not copied to the output dir, so we ask Default explicitly.
-		// Either way the invariant is: the assembly must be resolvable from Default ALC.
-		var asm = AssemblyLoadContext.Default.LoadFromAssemblyName(
-			new AssemblyName("System.Text.Encodings.Web"));
+		// Build the set of simple names currently in Default.Assemblies so we
+		// can pick a candidate that is NOT already loaded — otherwise the
+		// eager-load would be a no-op for our test target.
+		var alreadyLoaded = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var asm in AssemblyLoadContext.Default.Assemblies)
+		{
+			if (!asm.IsDynamic && asm.GetName().Name is { } n)
+			{
+				alreadyLoaded.Add(n);
+			}
+		}
 
-		asm.Should().NotBeNull("System.Text.Encodings.Web must be resolvable from Default ALC after Install()");
+		string? pickedFile = null;
+		foreach (var pattern in new[] { "System.*.dll", "Microsoft.Extensions.*.dll" })
+		{
+			foreach (var path in System.IO.Directory.EnumerateFiles(sourceDir, pattern))
+			{
+				var simple = System.IO.Path.GetFileNameWithoutExtension(path);
+				if (!alreadyLoaded.Contains(simple))
+				{
+					pickedFile = path;
+					break;
+				}
+			}
 
-		var loaded = AssemblyLoadContext.Default.Assemblies
-			.Any(a => !a.IsDynamic &&
-					  string.Equals(a.GetName().Name, "System.Text.Encodings.Web",
-									StringComparison.OrdinalIgnoreCase));
+			if (pickedFile is not null)
+			{
+				break;
+			}
+		}
 
-		loaded.Should().BeTrue(
-			"System.Text.Encodings.Web must appear in Default.Assemblies once resolved");
+		if (pickedFile is null)
+		{
+			Assert.Inconclusive(
+				"Could not find any System.*.dll or Microsoft.Extensions.*.dll under the test " +
+				"directory that is not already loaded in AssemblyLoadContext.Default. " +
+				"EagerLoadFromDirectory cannot be exercised on this runtime.");
+			return;
+		}
+
+		// Stage the picked file into an isolated temp directory so the helper
+		// has only one candidate to consider (keeps the assertion focused).
+		var tempDir = System.IO.Path.Combine(
+			System.IO.Path.GetTempPath(),
+			"uno-eager-load-test-" + Guid.NewGuid().ToString("N"));
+		System.IO.Directory.CreateDirectory(tempDir);
+		try
+		{
+			var stagedPath = System.IO.Path.Combine(tempDir, System.IO.Path.GetFileName(pickedFile));
+			System.IO.File.Copy(pickedFile, stagedPath);
+
+			var pickedSimpleName = System.IO.Path.GetFileNameWithoutExtension(pickedFile);
+
+			var loadedCount = HostAssemblyResolution.EagerLoadFromDirectory(tempDir);
+
+			loadedCount.Should().BeGreaterThan(0,
+				"the staged candidate '{0}' was not in Default.Assemblies and must be eager-loaded",
+				pickedSimpleName);
+
+			var nowPresent = AssemblyLoadContext.Default.Assemblies.Any(a =>
+				!a.IsDynamic &&
+				string.Equals(a.GetName().Name, pickedSimpleName, StringComparison.OrdinalIgnoreCase));
+
+			nowPresent.Should().BeTrue(
+				"'{0}' must appear in Default.Assemblies after EagerLoadFromDirectory",
+				pickedSimpleName);
+		}
+		finally
+		{
+			try
+			{
+				System.IO.Directory.Delete(tempDir, recursive: true);
+			}
+			catch
+			{
+				/* best-effort cleanup */
+			}
+		}
 	}
 
 	// ------------------------------------------------------------------ helpers
@@ -69,7 +131,12 @@ public class Given_HostAssemblyResolution
 
 		if (field is null)
 		{
-			// Fallback: we cannot introspect — return 0 to avoid a false failure.
+			// We cannot introspect the Resolving delegate on this runtime.
+			// Refuse to silently return 0 — that would let a regression in
+			// Install()'s idempotency slip through unnoticed.
+			Assert.Inconclusive(
+				"Cannot reflect the Resolving handler field on AssemblyLoadContext " +
+				"on this runtime; idempotency assertion is not verifiable here.");
 			return 0;
 		}
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/4.0.2">
+﻿<Project Sdk="MSTest.Sdk/4.0.2">
 
 	<PropertyGroup>
 		<TargetFramework>$(NetCurrent)</TargetFramework>
@@ -78,6 +78,7 @@
 
 		<!-- Link add-in load-context helpers for unit testing -->
 		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\AddInLoadContext.cs" Link="Helpers\AddInLoadContext.cs" />
+		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\HostAssemblyResolution.cs" Link="Helpers\HostAssemblyResolution.cs" />
 
 		<!-- Link ConfigurationExtensions for add-in value parsing tests -->
 		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\ConfigurationExtensions.cs" Link="Helpers\ConfigurationExtensions.cs" />

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -98,6 +98,19 @@
 		<ProjectReference Include="..\Uno.UI.RemoteControl.Server\Uno.UI.RemoteControl.Server.csproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Uno.UI.RemoteControl.Server.Processors\Uno.UI.RemoteControl.Server.Processors.csproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Uno.UI.RemoteControl.TestProcessor\Uno.UI.RemoteControl.TestProcessor.csproj" ReferenceOutputAssembly="false" />
+
+		<!--
+			Add-in test fixture, intentionally net8.0 and referenced only so CI
+			restore picks it up. The fixture's compile graph stays decoupled
+			from this project (Fixtures\** is removed from default globs above)
+			and the actual build + output staging is driven by the
+			_BuildAndCopyAddInTestFixtures target below, not by this reference.
+		-->
+		<ProjectReference Include="Fixtures\AddInWithCrossMajorVersionRefs\AddInWithCrossMajorVersionRefs.csproj"
+		                  ReferenceOutputAssembly="false"
+		                  SkipGetTargetFrameworkProperties="true"
+		                  UndefineProperties="TargetFramework"
+		                  Private="false" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -122,15 +135,24 @@
 		         RemoveProperties="TargetFramework">
 			<Output TaskParameter="TargetOutputs" ItemName="_AddInTestFixtureOutput" />
 		</MSBuild>
+
+		<!--
+			Stage the *entire* fixture bin contents (not just the main DLL / PDB
+			/ deps.json) so the per-add-in AssemblyDependencyResolver branch in
+			AddInLoadContext.Load has a real graph to consult. EnableDynamicLoading
+			on the fixture also drops private NuGet payloads next to its main
+			DLL (e.g. Microsoft.Extensions.DependencyInjection.Abstractions.dll
+			v8.0.0.0); those need to ship to the test bin too, otherwise the
+			deps.json paths the resolver returns don't actually exist on disk
+			and step 3 of AddInLoadContext.Load can't serve add-in-private
+			assemblies.
+		-->
 		<ItemGroup>
-			<_AddInTestFixtureFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)%(_AddInTestFixtureOutput.Filename).dll" />
-			<_AddInTestFixtureFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)%(_AddInTestFixtureOutput.Filename).pdb" />
-			<_AddInTestFixtureFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)%(_AddInTestFixtureOutput.Filename).deps.json" />
+			<_AddInTestFixtureBinFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)**\*" />
 		</ItemGroup>
-		<Copy SourceFiles="@(_AddInTestFixtureFiles)"
-		      DestinationFolder="$(OutDir)Fixtures\AddInWithCrossMajorVersionRefs\"
-		      SkipUnchangedFiles="true"
-		      Condition="Exists('%(_AddInTestFixtureFiles.Identity)')" />
+		<Copy SourceFiles="@(_AddInTestFixtureBinFiles)"
+		      DestinationFolder="$(OutDir)Fixtures\AddInWithCrossMajorVersionRefs\%(RecursiveDir)"
+		      SkipUnchangedFiles="true" />
 	</Target>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -9,6 +9,20 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<!--
+			Test fixtures under Fixtures\ are built as standalone class libraries
+			(see _BuildAndCopyAddInTestFixtures target below). Keep them out of
+			this project's default Compile / None / EmbeddedResource globs so the
+			fixture's own obj-AssemblyInfo doesn't collide with this project's
+			auto-generated assembly attributes.
+		-->
+		<Compile Remove="Fixtures\**" />
+		<None Remove="Fixtures\**" />
+		<EmbeddedResource Remove="Fixtures\**" />
+		<None Include="Fixtures\**\*.cs;Fixtures\**\*.csproj" Visible="true" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" />
 		<PackageReference Include="MessagePack" Version="3.1.4" /> <!-- pin transient dependency -->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
@@ -91,5 +105,32 @@
 		<ProjectReference Include="..\Uno.UI.RemoteControl\Uno.UI.RemoteControl.Skia.csproj" />
 		<ProjectReference Include="..\Uno.UWP\Uno.Skia.csproj" />
 	</ItemGroup>
+
+	<!--
+		Build the cross-major-version-refs add-in test fixture and stage its
+		output under $(OutDir)Fixtures\ so DevServerTests can hand its path to
+		the host via the add-ins CLI flag. See Fixtures\AddInWithCrossMajorVersionRefs.
+
+		Done via MSBuild task (not ProjectReference) so the fixture's net8.0
+		TargetFramework stays decoupled from this test project's NetCurrent
+		TFM negotiation and from its compile / AssemblyInfo graph.
+	-->
+	<Target Name="_BuildAndCopyAddInTestFixtures" BeforeTargets="Build">
+		<MSBuild Projects="Fixtures\AddInWithCrossMajorVersionRefs\AddInWithCrossMajorVersionRefs.csproj"
+		         Properties="Configuration=$(Configuration)"
+		         Targets="Build"
+		         RemoveProperties="TargetFramework">
+			<Output TaskParameter="TargetOutputs" ItemName="_AddInTestFixtureOutput" />
+		</MSBuild>
+		<ItemGroup>
+			<_AddInTestFixtureFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)%(_AddInTestFixtureOutput.Filename).dll" />
+			<_AddInTestFixtureFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)%(_AddInTestFixtureOutput.Filename).pdb" />
+			<_AddInTestFixtureFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)%(_AddInTestFixtureOutput.Filename).deps.json" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_AddInTestFixtureFiles)"
+		      DestinationFolder="$(OutDir)Fixtures\AddInWithCrossMajorVersionRefs\"
+		      SkipUnchangedFiles="true"
+		      Condition="Exists('%(_AddInTestFixtureFiles.Identity)')" />
+	</Target>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -76,6 +76,9 @@
 		<Compile Include="..\Uno.UI.DevServer.Cli\Mcp\HealthReportFactory.cs" Link="Mcp\HealthReportFactory.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Mcp\McpJsonUtilities.cs" Link="Mcp\McpJsonUtilities.cs" />
 
+		<!-- Link add-in load-context helpers for unit testing -->
+		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\AddInLoadContext.cs" Link="Helpers\AddInLoadContext.cs" />
+
 		<!-- Link ConfigurationExtensions for add-in value parsing tests -->
 		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\ConfigurationExtensions.cs" Link="Helpers\ConfigurationExtensions.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl.Host\IDEChannel\IIdeChannelManager.cs" Link="IDEChannel\IIdeChannelManager.cs" />
@@ -100,13 +103,17 @@
 		<ProjectReference Include="..\Uno.UI.RemoteControl.TestProcessor\Uno.UI.RemoteControl.TestProcessor.csproj" ReferenceOutputAssembly="false" />
 
 		<!--
-			Add-in test fixture, intentionally net8.0 and referenced only so CI
-			restore picks it up. The fixture's compile graph stays decoupled
-			from this project (Fixtures\** is removed from default globs above)
-			and the actual build + output staging is driven by the
-			_BuildAndCopyAddInTestFixtures target below, not by this reference.
+			Add-in test fixtures. Referenced only so CI restore picks them up; the
+			actual build + output staging is driven by _BuildAndCopyAddInTestFixtures
+			below. Fixtures\** is removed from default globs above so their compile
+			graphs stay decoupled from this project.
 		-->
 		<ProjectReference Include="Fixtures\AddInWithCrossMajorVersionRefs\AddInWithCrossMajorVersionRefs.csproj"
+		                  ReferenceOutputAssembly="false"
+		                  SkipGetTargetFrameworkProperties="true"
+		                  UndefineProperties="TargetFramework"
+		                  Private="false" />
+		<ProjectReference Include="Fixtures\AddInWithDiServiceRegistration\AddInWithDiServiceRegistration.csproj"
 		                  ReferenceOutputAssembly="false"
 		                  SkipGetTargetFrameworkProperties="true"
 		                  UndefineProperties="TargetFramework"
@@ -120,39 +127,47 @@
 	</ItemGroup>
 
 	<!--
-		Build the cross-major-version-refs add-in test fixture and stage its
-		output under $(OutDir)Fixtures\ so DevServerTests can hand its path to
-		the host via the add-ins CLI flag. See Fixtures\AddInWithCrossMajorVersionRefs.
+		Build all add-in test fixtures and stage their output under $(OutDir)Fixtures\
+		so DevServerTests can hand paths to the host via the addins CLI flag.
 
-		Done via MSBuild task (not ProjectReference) so the fixture's net8.0
-		TargetFramework stays decoupled from this test project's NetCurrent
-		TFM negotiation and from its compile / AssemblyInfo graph.
+		Done via MSBuild task (not ProjectReference) so each fixture's TargetFramework
+		stays decoupled from this test project's NetCurrent TFM negotiation and from
+		its compile / AssemblyInfo graph.
+
+		Each fixture's full bin directory is staged (not just the main DLL) so
+		AssemblyDependencyResolver inside AddInLoadContext has a real dep graph to
+		consult (EnableDynamicLoading drops private NuGet payloads next to the DLL).
 	-->
 	<Target Name="_BuildAndCopyAddInTestFixtures" BeforeTargets="Build">
+
+		<!-- AddInWithCrossMajorVersionRefs: net8.0 fixture with v8 AssemblyRefs -->
 		<MSBuild Projects="Fixtures\AddInWithCrossMajorVersionRefs\AddInWithCrossMajorVersionRefs.csproj"
 		         Properties="Configuration=$(Configuration)"
 		         Targets="Build"
 		         RemoveProperties="TargetFramework">
-			<Output TaskParameter="TargetOutputs" ItemName="_AddInTestFixtureOutput" />
+			<Output TaskParameter="TargetOutputs" ItemName="_CrossMajorFixtureOutput" />
 		</MSBuild>
-
-		<!--
-			Stage the *entire* fixture bin contents (not just the main DLL / PDB
-			/ deps.json) so the per-add-in AssemblyDependencyResolver branch in
-			AddInLoadContext.Load has a real graph to consult. EnableDynamicLoading
-			on the fixture also drops private NuGet payloads next to its main
-			DLL (e.g. Microsoft.Extensions.DependencyInjection.Abstractions.dll
-			v8.0.0.0); those need to ship to the test bin too, otherwise the
-			deps.json paths the resolver returns don't actually exist on disk
-			and step 3 of AddInLoadContext.Load can't serve add-in-private
-			assemblies.
-		-->
 		<ItemGroup>
-			<_AddInTestFixtureBinFiles Include="%(_AddInTestFixtureOutput.RootDir)%(_AddInTestFixtureOutput.Directory)**\*" />
+			<_CrossMajorFixtureBinFiles Include="%(_CrossMajorFixtureOutput.RootDir)%(_CrossMajorFixtureOutput.Directory)**\*" />
 		</ItemGroup>
-		<Copy SourceFiles="@(_AddInTestFixtureBinFiles)"
+		<Copy SourceFiles="@(_CrossMajorFixtureBinFiles)"
 		      DestinationFolder="$(OutDir)Fixtures\AddInWithCrossMajorVersionRefs\%(RecursiveDir)"
 		      SkipUnchangedFiles="true" />
+
+		<!-- AddInWithDiServiceRegistration: net9.0 fixture for DI cross-ALC validation -->
+		<MSBuild Projects="Fixtures\AddInWithDiServiceRegistration\AddInWithDiServiceRegistration.csproj"
+		         Properties="Configuration=$(Configuration)"
+		         Targets="Build"
+		         RemoveProperties="TargetFramework">
+			<Output TaskParameter="TargetOutputs" ItemName="_DiFixtureOutput" />
+		</MSBuild>
+		<ItemGroup>
+			<_DiFixtureBinFiles Include="%(_DiFixtureOutput.RootDir)%(_DiFixtureOutput.Directory)**\*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_DiFixtureBinFiles)"
+		      DestinationFolder="$(OutDir)Fixtures\AddInWithDiServiceRegistration\%(RecursiveDir)"
+		      SkipUnchangedFiles="true" />
+
 	</Target>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsExtensions.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Uno.Utils.DependencyInjection;
 using Uno.UI.RemoteControl.Helpers;
 using Uno.UI.RemoteControl.Server.Telemetry;
+using Uno.Utils.DependencyInjection;
 
 namespace Uno.UI.RemoteControl.Host.Extensibility;
 

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Uno.UI.RemoteControl.Helpers;
+
+/// <summary>
+/// Isolated <see cref="AssemblyLoadContext"/> shared by all DevServer add-ins.
+/// Resolves each add-in's own dependencies through its <c>.deps.json</c> (via
+/// per-add-in <see cref="AssemblyDependencyResolver"/> instances), and bridges
+/// host-loaded framework / contract assemblies (anything already present in
+/// the default ALC by simple name) so the host and the add-ins share a single
+/// <see cref="System.Type"/> identity for cross-boundary types.
+/// <para>
+/// Add-ins live in the same context as each other, so types defined in one
+/// add-in (e.g. <c>Uno.Licensing.Sdk.Contracts</c>) can be consumed by
+/// another (e.g. <c>Uno.UI.App.Mcp.Server</c>) — preserving the existing
+/// behaviour of <see cref="Assembly.LoadFrom(string)"/>.
+/// </para>
+/// </summary>
+internal sealed class AddInLoadContext : AssemblyLoadContext
+{
+	private readonly AssemblyDependencyResolver[] _resolvers;
+
+	public AddInLoadContext(IEnumerable<string> addInPaths)
+		: base(name: "AddIns", isCollectible: false)
+	{
+		_resolvers = addInPaths.Select(p => new AssemblyDependencyResolver(p)).ToArray();
+	}
+
+	protected override Assembly? Load(AssemblyName assemblyName)
+	{
+		var name = assemblyName.Name;
+
+		if (name is not null)
+		{
+			// 1. If the host has an assembly with this simple name already loaded
+			//    in the default ALC, return that exact instance. This:
+			//     - preserves Type identity for contract types
+			//       (IServiceCollection, IHostedService, ILogger, IConfiguration,
+			//       ...) so the host's reflection-based add-in registration
+			//       matches ctors,
+			//     - and bridges cross-version AssemblyRefs without going through
+			//       the default ALC's strict TPA binder. For example, Kiota's
+			//       net8.0 binary references System.Text.Encodings.Web v8.0.0.0;
+			//       the host has v9 or v10 loaded; returning the host's instance
+			//       directly satisfies the v8 ref within this ALC's lax
+			//       simple-name lookup.
+			foreach (var loaded in Default.Assemblies)
+			{
+				if (string.Equals(loaded.GetName().Name, name, System.StringComparison.OrdinalIgnoreCase))
+				{
+					return loaded;
+				}
+			}
+
+			// 2. The assembly isn't loaded yet in the default ALC, but the host's
+			//    TPA may still know about it (e.g. lazily-loaded framework OOB
+			//    packages like System.Text.Encodings.Web). Ask the default ALC to
+			//    load it by simple name — this triggers TPA-based resolution and
+			//    succeeds for anything the host's deps.json describes. Kiota and
+			//    other genuinely add-in-private assemblies aren't in host TPA, so
+			//    this safely throws FileNotFoundException for them and we fall
+			//    through to the plugin resolvers below.
+			try
+			{
+				return Default.LoadFromAssemblyName(new AssemblyName(name));
+			}
+			catch (FileNotFoundException)
+			{
+				// Not in host TPA — try plugin resolvers.
+			}
+		}
+
+		// 3. Plugin-private dependency — try each registered add-in's deps.json.
+		//    First match wins so add-ins can share private libraries (e.g. one
+		//    add-in's Contracts dll referenced by another) without duplication.
+		foreach (var resolver in _resolvers)
+		{
+			var path = resolver.ResolveAssemblyToPath(assemblyName);
+			if (path is not null)
+			{
+				return LoadFromAssemblyPath(path);
+			}
+		}
+
+		return null;
+	}
+
+	protected override nint LoadUnmanagedDll(string unmanagedDllName)
+	{
+		foreach (var resolver in _resolvers)
+		{
+			var path = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+			if (path is not null)
+			{
+				return LoadUnmanagedDllFromPath(path);
+			}
+		}
+
+		return nint.Zero;
+	}
+}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -28,7 +28,34 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 	public AddInLoadContext(IEnumerable<string> addInPaths)
 		: base(name: "AddIns", isCollectible: false)
 	{
-		_resolvers = addInPaths.Select(p => new AssemblyDependencyResolver(p)).ToArray();
+		// Construct one AssemblyDependencyResolver per add-in path, but tolerate
+		// per-path failures: AssemblyDependencyResolver's ctor throws when the
+		// path is invalid or the corresponding .deps.json is missing/corrupt. If
+		// we let that bubble out, a single bad add-in would abort loading of
+		// *all* add-ins — regressing the per-add-in failure isolation that the
+		// prior Assembly.LoadFrom loop in AssemblyHelper provided. The actual
+		// LoadFromAssemblyPath call for the offending add-in still runs in the
+		// caller's per-DLL try/catch and will surface there with a meaningful
+		// error.
+		var resolvers = new List<AssemblyDependencyResolver>();
+		foreach (var path in addInPaths)
+		{
+			try
+			{
+				resolvers.Add(new AssemblyDependencyResolver(path));
+			}
+			catch (Exception ex)
+			{
+				// No ILoggerFactory is available at AddInLoadContext construction
+				// time, so emit a stderr breadcrumb. The per-add-in load failure
+				// for this path will be logged through AssemblyHelper's existing
+				// per-DLL catch.
+				Console.Error.WriteLine(
+					$"Uno.UI.RemoteControl.Host: AssemblyDependencyResolver construction failed for '{path}' " +
+					$"({ex.GetType().Name}: {ex.Message}). Per-add-in dependency probing for this add-in will be skipped.");
+			}
+		}
+		_resolvers = [.. resolvers];
 	}
 
 	protected override Assembly? Load(AssemblyName assemblyName)
@@ -95,9 +122,30 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			// paper over). If the default ALC can't satisfy this name for any
 			// of those reasons, the add-in's own deps.json may still carry a
 			// usable copy, so we keep falling through rather than bubbling up.
+			//
+			// We also validate the loaded assembly's PublicKeyToken against the
+			// request before returning — same identity-swap guard as step 1
+			// and the Default.Resolving handler in Program.cs. Asking by simple
+			// name alone could otherwise hand back a same-name-but-different-PKT
+			// assembly from TPA, which we'd never silently substitute elsewhere.
 			try
 			{
-				return Default.LoadFromAssemblyName(new AssemblyName(name));
+				var loaded = Default.LoadFromAssemblyName(new AssemblyName(name));
+				if (requestedToken is { Length: > 0 })
+				{
+					var loadedToken = loaded.GetName().GetPublicKeyToken();
+					if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
+					{
+						// PKT mismatch — fall through to the add-in's own resolvers
+						// rather than substituting across strong-name identities.
+						loaded = null;
+					}
+				}
+
+				if (loaded is not null)
+				{
+					return loaded;
+				}
 			}
 			catch (FileNotFoundException) { /* not in host TPA */ }
 			catch (FileLoadException) { /* found in TPA but rejected (e.g. strong-name / version mismatch) */ }

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -132,11 +132,33 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 					var requestedToken = assemblyName.GetPublicKeyToken();
 					if (requestedToken is { Length: > 0 })
 					{
+						// Signed request: loaded assembly must carry the same PKT.
 						var loadedToken = loaded.GetName().GetPublicKeyToken();
 						if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
 						{
-							// PKT mismatch — fall through to the add-in's own resolvers
-							// rather than substituting across strong-name identities.
+							loaded = null;
+						}
+					}
+					else
+					{
+						// Unsigned request: refuse a strong-named loaded assembly to match
+						// the symmetric PKT policy enforced by TryBridgeBySimpleName.
+						var loadedToken = loaded.GetName().GetPublicKeyToken();
+						if (loadedToken is { Length: > 0 })
+						{
+							loaded = null;
+						}
+					}
+
+					// Version guard: mirrors TryBridgeBySimpleName — refuse to serve a
+					// version lower than what the add-in requested.
+					if (loaded is not null)
+					{
+						var requestedVersion = assemblyName.Version;
+						var loadedVersion = loaded.GetName().Version;
+						if (requestedVersion is not null && loadedVersion is not null
+							&& loadedVersion < requestedVersion)
+						{
 							loaded = null;
 						}
 					}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -49,12 +49,35 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			//       the host has v9 or v10 loaded; returning the host's instance
 			//       directly satisfies the v8 ref within this ALC's lax
 			//       simple-name lookup.
+			// Skip IsDynamic candidates (reflection-emit / source-generator
+			// assemblies could have an auto-generated name that coincidentally
+			// matches a real AssemblyRef) and require PublicKeyToken
+			// compatibility — same identity-swap guard as the
+			// AssemblyLoadContext.Default.Resolving handler in Program.cs.
+			var requestedToken = assemblyName.GetPublicKeyToken();
 			foreach (var loaded in Default.Assemblies)
 			{
-				if (string.Equals(loaded.GetName().Name, name, StringComparison.OrdinalIgnoreCase))
+				if (loaded.IsDynamic)
 				{
-					return loaded;
+					continue;
 				}
+
+				var loadedName = loaded.GetName();
+				if (!string.Equals(loadedName.Name, name, StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				if (requestedToken is { Length: > 0 })
+				{
+					var loadedToken = loadedName.GetPublicKeyToken();
+					if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
+					{
+						continue;
+					}
+				}
+
+				return loaded;
 			}
 
 			// 2. The assembly isn't loaded yet in the default ALC, but the host's

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using Uno.UI.RemoteControl.Host.Helpers;
 
 namespace Uno.UI.RemoteControl.Helpers;
 
@@ -76,35 +77,10 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			//       the host has v9 or v10 loaded; returning the host's instance
 			//       directly satisfies the v8 ref within this ALC's lax
 			//       simple-name lookup.
-			// Skip IsDynamic candidates (reflection-emit / source-generator
-			// assemblies could have an auto-generated name that coincidentally
-			// matches a real AssemblyRef) and require PublicKeyToken
-			// compatibility — same identity-swap guard as the
-			// AssemblyLoadContext.Default.Resolving handler in Program.cs.
-			var requestedToken = assemblyName.GetPublicKeyToken();
-			foreach (var loaded in Default.Assemblies)
+			var bridged = HostAssemblyResolution.TryBridgeBySimpleName(Default, assemblyName);
+			if (bridged is not null)
 			{
-				if (loaded.IsDynamic)
-				{
-					continue;
-				}
-
-				var loadedName = loaded.GetName();
-				if (!string.Equals(loadedName.Name, name, StringComparison.OrdinalIgnoreCase))
-				{
-					continue;
-				}
-
-				if (requestedToken is { Length: > 0 })
-				{
-					var loadedToken = loadedName.GetPublicKeyToken();
-					if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
-					{
-						continue;
-					}
-				}
-
-				return loaded;
+				return bridged;
 			}
 
 			// 2. The assembly isn't loaded yet in the default ALC, but the host's
@@ -131,6 +107,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			try
 			{
 				var loaded = Default.LoadFromAssemblyName(new AssemblyName(name));
+				var requestedToken = assemblyName.GetPublicKeyToken();
 				if (requestedToken is { Length: > 0 })
 				{
 					var loadedToken = loaded.GetName().GetPublicKeyToken();

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using Uno.UI.RemoteControl.Host.Helpers;
+using System.Threading;
 
-namespace Uno.UI.RemoteControl.Helpers;
+namespace Uno.UI.RemoteControl.Host.Helpers;
 
 /// <summary>
 /// Isolated <see cref="AssemblyLoadContext"/> shared by all DevServer add-ins.
@@ -24,6 +24,18 @@ namespace Uno.UI.RemoteControl.Helpers;
 /// </summary>
 internal sealed class AddInLoadContext : AssemblyLoadContext
 {
+	/// <summary>
+	/// Per-async-flow re-entrancy guard for step 2 (delegating to
+	/// <see cref="AssemblyLoadContext.Default"/>). If the host's
+	/// <c>Default.Resolving</c> handler ends up routing a probe back into this
+	/// context — directly or indirectly — we must not recurse into
+	/// <see cref="AssemblyLoadContext.LoadFromAssemblyName"/> on
+	/// <see cref="Default"/> again, otherwise we risk a StackOverflowException
+	/// or an opaque "already loading" failure. Skipping step 2 in that case
+	/// lets the call fall through to the add-in's private resolvers.
+	/// </summary>
+	private static readonly AsyncLocal<bool> s_inDefaultLoad = new();
+
 	private readonly AssemblyDependencyResolver[] _resolvers;
 
 	public AddInLoadContext(IEnumerable<string> addInPaths)
@@ -53,7 +65,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 				// per-DLL catch.
 				Console.Error.WriteLine(
 					$"Uno.UI.RemoteControl.Host: AssemblyDependencyResolver construction failed for '{path}' " +
-					$"({ex.GetType().Name}: {ex.Message}). Per-add-in dependency probing for this add-in will be skipped.");
+					$"({ex}). Per-add-in dependency probing for this add-in will be skipped.");
 			}
 		}
 		_resolvers = [.. resolvers];
@@ -104,29 +116,44 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			// and the Default.Resolving handler in Program.cs. Asking by simple
 			// name alone could otherwise hand back a same-name-but-different-PKT
 			// assembly from TPA, which we'd never silently substitute elsewhere.
-			try
+			// Guard against re-entrancy: if Default's Resolving handler (or a
+			// downstream load) cycles back into this method, skip step 2 and
+			// fall through to the add-in's private resolvers.
+			if (!s_inDefaultLoad.Value)
 			{
-				var loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
-				var requestedToken = assemblyName.GetPublicKeyToken();
-				if (requestedToken is { Length: > 0 })
+				s_inDefaultLoad.Value = true;
+				try
 				{
-					var loadedToken = loaded.GetName().GetPublicKeyToken();
-					if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
+					// We request by simple name + culture only — versionless / PKT-less
+					// — so the host's TPA can pick whichever copy it shipped (intent: let
+					// TPA resolution pick the host's version). The strong-name identity
+					// is validated explicitly below before we hand the assembly back.
+					var loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
+					var requestedToken = assemblyName.GetPublicKeyToken();
+					if (requestedToken is { Length: > 0 })
 					{
-						// PKT mismatch — fall through to the add-in's own resolvers
-						// rather than substituting across strong-name identities.
-						loaded = null;
+						var loadedToken = loaded.GetName().GetPublicKeyToken();
+						if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
+						{
+							// PKT mismatch — fall through to the add-in's own resolvers
+							// rather than substituting across strong-name identities.
+							loaded = null;
+						}
+					}
+
+					if (loaded is not null)
+					{
+						return loaded;
 					}
 				}
-
-				if (loaded is not null)
+				catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
 				{
-					return loaded;
+					/* not in host TPA, or found but rejected (strong-name / version / image mismatch) */
 				}
-			}
-			catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
-			{
-				/* not in host TPA, or found but rejected (strong-name / version / image mismatch) */
+				finally
+				{
+					s_inDefaultLoad.Value = false;
+				}
 			}
 		}
 

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -50,7 +51,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			//       simple-name lookup.
 			foreach (var loaded in Default.Assemblies)
 			{
-				if (string.Equals(loaded.GetName().Name, name, System.StringComparison.OrdinalIgnoreCase))
+				if (string.Equals(loaded.GetName().Name, name, StringComparison.OrdinalIgnoreCase))
 				{
 					return loaded;
 				}
@@ -62,16 +63,22 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			//    load it by simple name — this triggers TPA-based resolution and
 			//    succeeds for anything the host's deps.json describes. Kiota and
 			//    other genuinely add-in-private assemblies aren't in host TPA, so
-			//    this safely throws FileNotFoundException for them and we fall
-			//    through to the plugin resolvers below.
+			//    they fall through to the plugin resolvers below.
+			//
+			// We catch both FileNotFoundException AND FileLoadException /
+			// BadImageFormatException here: TPA can match an assembly by simple
+			// name but reject the load on a strong-name / version / image
+			// mismatch (exactly the cross-major scenario this class exists to
+			// paper over). If the default ALC can't satisfy this name for any
+			// of those reasons, the add-in's own deps.json may still carry a
+			// usable copy, so we keep falling through rather than bubbling up.
 			try
 			{
 				return Default.LoadFromAssemblyName(new AssemblyName(name));
 			}
-			catch (FileNotFoundException)
-			{
-				// Not in host TPA — try plugin resolvers.
-			}
+			catch (FileNotFoundException) { /* not in host TPA */ }
+			catch (FileLoadException) { /* found in TPA but rejected (e.g. strong-name / version mismatch) */ }
+			catch (BadImageFormatException) { /* found in TPA but unloadable image */ }
 		}
 
 		// 3. Plugin-private dependency — try each registered add-in's deps.json.

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -106,7 +106,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			// assembly from TPA, which we'd never silently substitute elsewhere.
 			try
 			{
-				var loaded = Default.LoadFromAssemblyName(new AssemblyName(name));
+				var loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
 				var requestedToken = assemblyName.GetPublicKeyToken();
 				if (requestedToken is { Length: > 0 })
 				{
@@ -124,9 +124,10 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 					return loaded;
 				}
 			}
-			catch (FileNotFoundException) { /* not in host TPA */ }
-			catch (FileLoadException) { /* found in TPA but rejected (e.g. strong-name / version mismatch) */ }
-			catch (BadImageFormatException) { /* found in TPA but unloadable image */ }
+			catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
+			{
+				/* not in host TPA, or found but rejected (strong-name / version / image mismatch) */
+			}
 		}
 
 		// 3. Plugin-private dependency — try each registered add-in's deps.json.

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -128,7 +128,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 					// — so the host's TPA can pick whichever copy it shipped (intent: let
 					// TPA resolution pick the host's version). The strong-name identity
 					// is validated explicitly below before we hand the assembly back.
-					var loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
+					Assembly? loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
 					var requestedToken = assemblyName.GetPublicKeyToken();
 					if (requestedToken is { Length: > 0 })
 					{

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -27,13 +27,28 @@ public class AssemblyHelper
 
 		try
 		{
-			foreach (var dll in dllFiles.Distinct(StringComparer.OrdinalIgnoreCase))
+			// All add-ins share a single AssemblyLoadContext backed by per-add-in
+			// AssemblyDependencyResolver instances. This isolates add-in dependency
+			// trees (e.g. Kiota's net8.0 binaries that hard-reference
+			// System.Text.Encodings.Web 8.0.0.0) from the host's framework
+			// assemblies while letting Microsoft.*/System.* and shared contract types
+			// resolve against the host's already-loaded versions. Add-ins still see
+			// each other's types (matching the prior Assembly.LoadFrom behaviour).
+			var distinctDlls = dllFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToImmutableList();
+			var loadContext = distinctDlls.Count > 0
+				? new AddInLoadContext(distinctDlls)
+				: null;
+
+			foreach (var dll in distinctDlls)
 			{
 				try
 				{
 					_log.Log(LogLevel.Debug, $"Loading add-in assembly '{dll}'.");
 
-					results.Add(new AssemblyLoadResult(dll, Assembly.LoadFrom(dll), null));
+					var assemblyName = AssemblyName.GetAssemblyName(dll);
+					var assembly = loadContext!.LoadFromAssemblyName(assemblyName);
+
+					results.Add(new AssemblyLoadResult(dll, assembly, null));
 				}
 				catch (Exception err)
 				{

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -41,49 +41,74 @@ public class AssemblyHelper
 
 		try
 		{
-			// All add-ins share a single AssemblyLoadContext backed by per-add-in
-			// AssemblyDependencyResolver instances. This isolates add-in dependency
-			// trees (e.g. Kiota's net8.0 binaries that hard-reference
-			// System.Text.Encodings.Web 8.0.0.0) from the host's framework
-			// assemblies while letting Microsoft.*/System.* and shared contract types
-			// resolve against the host's already-loaded versions. Add-ins still see
-			// each other's types (matching the prior Assembly.LoadFrom behaviour).
 			var distinctDlls = dllFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToImmutableArray();
-			var loadContext = distinctDlls.Length > 0
-				? new AddInLoadContext(distinctDlls)
-				: null;
 
-			if (loadContext is null)
+			if (distinctDlls.Length == 0)
 			{
 				return ImmutableList<AssemblyLoadResult>.Empty;
 			}
 
-			foreach (var dll in distinctDlls)
+			// Kill switch: revert to the legacy Assembly.LoadFrom behaviour so operators
+			// can bisect regressions introduced by the add-in isolation work without
+			// needing a redeployment. Both the ALC creation and the HostAssemblyResolution
+			// handler are skipped — the process returns to the pre-isolation state.
+			if (HostAssemblyResolution.IsKillSwitchActive)
 			{
-				try
+				foreach (var dll in distinctDlls)
 				{
-					_log.LogDebug("Loading add-in assembly {Dll}.", dll);
-
-					// Load the top-level add-in by file path so the caller's
-					// specific DLL is always what ends up in the context — going
-					// through LoadFromAssemblyName here would route through the
-					// Default.Assemblies / TPA fallback in AddInLoadContext.Load
-					// and could silently substitute a host-loaded assembly if the
-					// add-in's simple name happened to collide. Transitive deps
-					// still flow through that override as intended.
-					var assembly = loadContext.LoadFromAssemblyPath(dll);
-
-					results.Add(new AssemblyLoadResult(dll, assembly, null));
-				}
-				catch (Exception err)
-				{
-					failedCount++;
-					_log.LogError(err, "Failed to load assembly {Dll}.", dll);
-					results.Add(new AssemblyLoadResult(dll, null, err));
-
-					if (throwIfLoadFailed)
+					try
 					{
-						throw;
+						_log.LogDebug("Loading add-in assembly {Dll} (kill switch active — legacy Assembly.LoadFrom).", dll);
+						var assembly = Assembly.LoadFrom(dll);
+						results.Add(new AssemblyLoadResult(dll, assembly, null));
+					}
+					catch (Exception err)
+					{
+						failedCount++;
+						_log.LogError(err, "Failed to load assembly {Dll}.", dll);
+						results.Add(new AssemblyLoadResult(dll, null, err));
+						if (throwIfLoadFailed) throw;
+					}
+				}
+			}
+			else
+			{
+				// All add-ins share a single AssemblyLoadContext backed by per-add-in
+				// AssemblyDependencyResolver instances. This isolates add-in dependency
+				// trees (e.g. Kiota's net8.0 binaries that hard-reference
+				// System.Text.Encodings.Web 8.0.0.0) from the host's framework
+				// assemblies while letting Microsoft.*/System.* and shared contract types
+				// resolve against the host's already-loaded versions. Add-ins still see
+				// each other's types (matching the prior Assembly.LoadFrom behaviour).
+				var loadContext = new AddInLoadContext(distinctDlls);
+
+				foreach (var dll in distinctDlls)
+				{
+					try
+					{
+						_log.LogDebug("Loading add-in assembly {Dll}.", dll);
+
+						// Load the top-level add-in by file path so the caller's
+						// specific DLL is always what ends up in the context — going
+						// through LoadFromAssemblyName here would route through the
+						// Default.Assemblies / TPA fallback in AddInLoadContext.Load
+						// and could silently substitute a host-loaded assembly if the
+						// add-in's simple name happened to collide. Transitive deps
+						// still flow through that override as intended.
+						var assembly = loadContext.LoadFromAssemblyPath(dll);
+
+						results.Add(new AssemblyLoadResult(dll, assembly, null));
+					}
+					catch (Exception err)
+					{
+						failedCount++;
+						_log.LogError(err, "Failed to load assembly {Dll}.", dll);
+						results.Add(new AssemblyLoadResult(dll, null, err));
+
+						if (throwIfLoadFailed)
+						{
+							throw;
+						}
 					}
 				}
 			}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -45,8 +45,14 @@ public class AssemblyHelper
 				{
 					_log.Log(LogLevel.Debug, $"Loading add-in assembly '{dll}'.");
 
-					var assemblyName = AssemblyName.GetAssemblyName(dll);
-					var assembly = loadContext!.LoadFromAssemblyName(assemblyName);
+					// Load the top-level add-in by file path so the caller's
+					// specific DLL is always what ends up in the context — going
+					// through LoadFromAssemblyName here would route through the
+					// Default.Assemblies / TPA fallback in AddInLoadContext.Load
+					// and could silently substitute a host-loaded assembly if the
+					// add-in's simple name happened to collide. Transitive deps
+					// still flow through that override as intended.
+					var assembly = loadContext!.LoadFromAssemblyPath(dll);
 
 					results.Add(new AssemblyLoadResult(dll, assembly, null));
 				}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -39,6 +39,11 @@ public class AssemblyHelper
 				? new AddInLoadContext(distinctDlls)
 				: null;
 
+			if (loadContext is null)
+			{
+				return ImmutableList<AssemblyLoadResult>.Empty;
+			}
+
 			foreach (var dll in distinctDlls)
 			{
 				try
@@ -52,7 +57,7 @@ public class AssemblyHelper
 					// and could silently substitute a host-loaded assembly if the
 					// add-in's simple name happened to collide. Transitive deps
 					// still flow through that override as intended.
-					var assembly = loadContext!.LoadFromAssemblyPath(dll);
+					var assembly = loadContext.LoadFromAssemblyPath(dll);
 
 					results.Add(new AssemblyLoadResult(dll, assembly, null));
 				}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
+using Uno.UI.RemoteControl.Host.Helpers;
 using Uno.UI.RemoteControl.Server.Telemetry;
 
 namespace Uno.UI.RemoteControl.Helpers;
@@ -16,6 +17,19 @@ public class AssemblyHelper
 {
 	private static readonly ILogger _log = typeof(AssemblyHelper).Log();
 
+	/// <summary>
+	/// Loads the supplied add-in DLLs.
+	/// </summary>
+	/// <remarks>
+	/// As of the host add-in isolation work, all add-ins are loaded into a
+	/// shared <see cref="AddInLoadContext"/> backed by per-add-in
+	/// <see cref="System.Runtime.Loader.AssemblyDependencyResolver"/> instances.
+	/// This isolates add-in dependency trees (e.g. transitive packages whose
+	/// versions diverge from what the host loaded) while preserving Type
+	/// identity for framework / contract assemblies the host has already
+	/// loaded. Add-ins remain visible to each other inside the shared context,
+	/// matching the prior <see cref="Assembly.LoadFrom(string)"/> behaviour.
+	/// </remarks>
 	public static IImmutableList<AssemblyLoadResult> Load(IImmutableList<string> dllFiles, ITelemetry? telemetry = null, bool throwIfLoadFailed = false)
 	{
 		var startTime = Stopwatch.GetTimestamp();
@@ -34,8 +48,8 @@ public class AssemblyHelper
 			// assemblies while letting Microsoft.*/System.* and shared contract types
 			// resolve against the host's already-loaded versions. Add-ins still see
 			// each other's types (matching the prior Assembly.LoadFrom behaviour).
-			var distinctDlls = dllFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToImmutableList();
-			var loadContext = distinctDlls.Count > 0
+			var distinctDlls = dllFiles.Distinct(StringComparer.OrdinalIgnoreCase).ToImmutableArray();
+			var loadContext = distinctDlls.Length > 0
 				? new AddInLoadContext(distinctDlls)
 				: null;
 

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -34,8 +34,6 @@ public class AssemblyHelper
 	{
 		var startTime = Stopwatch.GetTimestamp();
 
-		telemetry?.TrackEvent("addin-loading-start", default(Dictionary<string, string>), null);
-
 		var results = ImmutableList.CreateBuilder<AssemblyLoadResult>();
 		var failedCount = 0;
 
@@ -47,6 +45,8 @@ public class AssemblyHelper
 			{
 				return ImmutableList<AssemblyLoadResult>.Empty;
 			}
+
+			telemetry?.TrackEvent("addin-loading-start", default(Dictionary<string, string>), null);
 
 			// Kill switch: revert to the legacy Assembly.LoadFrom behaviour so operators
 			// can bisect regressions introduced by the add-in isolation work without

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -43,7 +43,7 @@ public class AssemblyHelper
 			{
 				try
 				{
-					_log.Log(LogLevel.Debug, $"Loading add-in assembly '{dll}'.");
+					_log.LogDebug("Loading add-in assembly {Dll}.", dll);
 
 					// Load the top-level add-in by file path so the caller's
 					// specific DLL is always what ends up in the context — going
@@ -59,7 +59,7 @@ public class AssemblyHelper
 				catch (Exception err)
 				{
 					failedCount++;
-					_log.Log(LogLevel.Error, $"Failed to load assembly '{dll}'.", err);
+					_log.LogError(err, "Failed to load assembly {Dll}.", dll);
 					results.Add(new AssemblyLoadResult(dll, null, err));
 
 					if (throwIfLoadFailed)

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -45,7 +45,8 @@ internal static class HostAssemblyResolution
 			TryBridgeBySimpleName(ctx, req);
 
 		var resolvedHostDir = hostDir
-			?? System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location);
+			?? System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)
+			?? AppContext.BaseDirectory;
 
 		if (string.IsNullOrEmpty(resolvedHostDir))
 		{

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -1,0 +1,71 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Uno.UI.RemoteControl.Host.Helpers;
+
+/// <summary>
+/// Shared assembly-bridging policy for the DevServer host and its add-ins.
+/// Centralises the logic that returns an already-loaded assembly from the
+/// default ALC when a simple-name match is found, so that host and add-ins
+/// share a single <see cref="System.Type"/> identity for cross-boundary types.
+/// </summary>
+internal static class HostAssemblyResolution
+{
+	/// <summary>
+	/// Attempts to satisfy <paramref name="requested"/> by returning an
+	/// already-loaded assembly from <paramref name="context"/> whose simple
+	/// name matches. Dynamic (reflection-emit) assemblies and assemblies with
+	/// an incompatible <see cref="AssemblyName.GetPublicKeyToken"/> are
+	/// skipped, preventing silent identity swaps.
+	/// </summary>
+	/// <returns>
+	/// The matching <see cref="Assembly"/> instance, or <c>null</c> when no
+	/// compatible candidate exists in <paramref name="context"/>.
+	/// </returns>
+	internal static Assembly? TryBridgeBySimpleName(
+		AssemblyLoadContext context,
+		AssemblyName requested)
+	{
+		var simpleName = requested.Name;
+		if (simpleName is null)
+		{
+			return null;
+		}
+
+		var requestedToken = requested.GetPublicKeyToken();
+
+		foreach (var loaded in context.Assemblies)
+		{
+			// Skip reflection-emit / source-generator assemblies: their
+			// auto-generated names could coincidentally match a real AssemblyRef
+			// and we'd silently substitute them, causing downstream
+			// TypeLoadException / MissingMethodException.
+			if (loaded.IsDynamic)
+			{
+				continue;
+			}
+
+			var loadedName = loaded.GetName();
+			if (!string.Equals(loadedName.Name, simpleName, StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
+			// Only bridge assemblies with the same strong-name identity (or
+			// both unsigned). Returning a differently-signed assembly would be
+			// a security-relevant identity swap, not a version-mismatch workaround.
+			if (requestedToken is { Length: > 0 })
+			{
+				var loadedToken = loadedName.GetPublicKeyToken();
+				if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
+				{
+					continue;
+				}
+			}
+
+			return loaded;
+		}
+
+		return null;
+	}
+}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -14,12 +14,26 @@ namespace Uno.UI.RemoteControl.Host.Helpers;
 internal static class HostAssemblyResolution
 {
 	/// <summary>
-	/// 0 = not installed, 1 = installed.  Written once via
+	/// 0 = handler not subscribed, 1 = handler subscribed.  Written once via
 	/// <see cref="System.Threading.Interlocked.CompareExchange(ref int, int, int)"/>
-	/// so <see cref="Install"/> is safe to call from multiple threads or from
-	/// test fixtures that share the process-wide <see cref="AssemblyLoadContext.Default"/>.
+	/// so <see cref="Install"/> can subscribe the <c>Resolving</c> handler exactly
+	/// once even when called from multiple threads or from test fixtures that
+	/// share the process-wide <see cref="AssemblyLoadContext.Default"/>.
 	/// </summary>
-	private static int s_installed;
+	private static int s_handlerInstalled;
+
+	/// <summary>
+	/// Trusted public key tokens accepted by <see cref="EagerLoadFromDirectory"/>.
+	/// Eager-loading an assembly whose PKT does not match one of these emits a
+	/// stderr warning (the assembly is still loaded — there is no .NET API to
+	/// unload it — but the <see cref="TryBridgeBySimpleName"/> guards prevent
+	/// returning a non-Microsoft assembly for a signed Microsoft request).
+	/// </summary>
+	private static readonly byte[][] s_trustedPkts =
+	[
+		[0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a], // Microsoft (b03f5f7f11d50a3a)
+		[0xcc, 0x7b, 0x13, 0xff, 0xcd, 0x2d, 0xdd, 0x51], // corefx / dotnet (cc7b13ffcd2ddd51)
+	];
 
 	/// <summary>
 	/// Installs the cross-major-version assembly-resolution safety net on
@@ -29,6 +43,13 @@ internal static class HostAssemblyResolution
 	/// <remarks>
 	/// Idempotent: calling this method more than once (e.g. from unit tests that
 	/// share the same process) registers the <c>Resolving</c> handler exactly once.
+	/// The eager-load pass is also safe to repeat because it filters out
+	/// already-loaded assemblies by simple name.
+	/// <para>
+	/// The kill switch <c>UNO_DEVSERVER_DISABLE_ADDIN_ALC=1</c> short-circuits
+	/// this method entirely, leaving <see cref="AssemblyLoadContext.Default"/>
+	/// untouched.
+	/// </para>
 	/// </remarks>
 	/// <param name="hostDir">
 	/// Optional override for the directory from which DLLs are eager-loaded.
@@ -36,15 +57,23 @@ internal static class HostAssemblyResolution
 	/// </param>
 	internal static void Install(string? hostDir = null)
 	{
-		// CAS from 0 → 1: if the exchange returns anything other than 0 another
-		// caller already ran Install(), so bail out immediately (lock-free).
-		if (System.Threading.Interlocked.CompareExchange(ref s_installed, 1, 0) != 0)
+		// Operator-facing kill switch: disables both the Resolving handler and
+		// the eager-load pass. Useful to bisect production issues that may have
+		// been introduced by the add-in isolation work.
+		if (Environment.GetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC") == "1")
 		{
 			return;
 		}
 
-		AssemblyLoadContext.Default.Resolving += static (ctx, req) =>
-			TryBridgeBySimpleName(ctx, req);
+		// Subscribe the Resolving handler exactly once (lock-free CAS). The
+		// flag protects ONLY the subscription; the eager-load pass is gated
+		// independently by the per-simple-name dedup inside the loop so it
+		// remains safe to run on repeated Install() calls.
+		if (System.Threading.Interlocked.CompareExchange(ref s_handlerInstalled, 1, 0) == 0)
+		{
+			AssemblyLoadContext.Default.Resolving += static (ctx, req) =>
+				TryBridgeBySimpleName(ctx, req);
+		}
 
 		var resolvedHostDir = hostDir
 			?? System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)
@@ -53,6 +82,43 @@ internal static class HostAssemblyResolution
 		if (string.IsNullOrEmpty(resolvedHostDir))
 		{
 			return;
+		}
+
+		// Best-effort eager-load: IO / reflection errors must never crash the
+		// host startup path. The handler subscribed above remains the primary
+		// safety net even when this fails.
+		try
+		{
+			EagerLoadFromDirectory(resolvedHostDir);
+		}
+		catch (Exception ex)
+		{
+			Console.Error.WriteLine(
+				$"Uno.UI.RemoteControl.Host: eager-load from '{resolvedHostDir}' failed " +
+				$"({ex.GetType().Name}: {ex.Message}).");
+		}
+	}
+
+	/// <summary>
+	/// Eager-loads <c>System.*.dll</c> and <c>Microsoft.Extensions.*.dll</c>
+	/// from <paramref name="hostDir"/> into <see cref="AssemblyLoadContext.Default"/>.
+	/// </summary>
+	/// <remarks>
+	/// Idempotent: assemblies already present in <see cref="AssemblyLoadContext.Default"/>
+	/// (by simple name) are skipped, and individual load failures are
+	/// swallowed with a stderr breadcrumb. After a successful load the assembly's
+	/// public key token is validated against <see cref="s_trustedPkts"/>; a
+	/// mismatch only emits a warning because .NET provides no API to unload
+	/// from <see cref="AssemblyLoadContext.Default"/>. The <see cref="TryBridgeBySimpleName"/>
+	/// PKT guard prevents such an assembly from being substituted for a signed
+	/// Microsoft request later.
+	/// </remarks>
+	/// <returns>The number of assemblies successfully eager-loaded by this call.</returns>
+	internal static int EagerLoadFromDirectory(string hostDir)
+	{
+		if (string.IsNullOrEmpty(hostDir) || !System.IO.Directory.Exists(hostDir))
+		{
+			return 0;
 		}
 
 		// Build a set of simple names already loaded so we can skip duplicates.
@@ -67,8 +133,11 @@ internal static class HostAssemblyResolution
 
 		// Discover System.* and Microsoft.Extensions.* DLLs in the host directory.
 		var candidates =
-			System.IO.Directory.EnumerateFiles(resolvedHostDir, "System.*.dll")
-			.Concat(System.IO.Directory.EnumerateFiles(resolvedHostDir, "Microsoft.Extensions.*.dll"));
+			System.IO.Directory.EnumerateFiles(hostDir, "System.*.dll")
+			.Concat(System.IO.Directory.EnumerateFiles(hostDir, "Microsoft.Extensions.*.dll"));
+
+		var loaded = 0;
+		var failed = 0;
 
 		foreach (var path in candidates)
 		{
@@ -80,10 +149,28 @@ internal static class HostAssemblyResolution
 
 			try
 			{
-				AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+				var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+
+				// DLL-planting defence: if a file matching our System.* /
+				// Microsoft.Extensions.* glob is signed with a non-trusted PKT
+				// (or unsigned), warn loudly. We cannot unload it, but
+				// TryBridgeBySimpleName's PKT symmetry guard means a signed
+				// Microsoft request will still refuse to bridge to this
+				// assembly.
+				var pkt = asm.GetName().GetPublicKeyToken();
+				if (!IsTrustedPkt(pkt))
+				{
+					Console.Error.WriteLine(
+						$"Uno.UI.RemoteControl.Host: eager-loaded '{simpleName}' from '{path}' has an " +
+						$"untrusted public key token. Cross-boundary type identity for this assembly " +
+						"will be refused by the bridge.");
+				}
+
+				loaded++;
 			}
 			catch (Exception ex)
 			{
+				failed++;
 				Console.Error.WriteLine(
 					$"Uno.UI.RemoteControl.Host: eager-load of '{simpleName}' failed " +
 					$"({ex.GetType().Name}: {ex.Message}). " +
@@ -91,7 +178,20 @@ internal static class HostAssemblyResolution
 					"FileNotFoundException at runtime.");
 			}
 		}
+
+		if (loaded + failed > 0)
+		{
+			Console.Error.WriteLine(
+				$"Uno.UI.RemoteControl.Host: eager-loaded {loaded} assemblies from '{hostDir}' " +
+				$"({failed} failures).");
+		}
+
+		return loaded;
 	}
+
+	private static bool IsTrustedPkt(byte[]? pkt) =>
+		pkt is { Length: > 0 } &&
+		s_trustedPkts.Any(t => t.AsSpan().SequenceEqual(pkt));
 
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -14,6 +14,15 @@ namespace Uno.UI.RemoteControl.Host.Helpers;
 internal static class HostAssemblyResolution
 {
 	/// <summary>
+	/// <see langword="true"/> when <c>UNO_DEVSERVER_DISABLE_ADDIN_ALC=1</c> is set.
+	/// Evaluated once at first access; re-read each call so that tests that set the
+	/// variable before calling can observe the correct value without process restart.
+	/// </summary>
+	internal static bool IsKillSwitchActive =>
+		Environment.GetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC") == "1";
+
+
+	/// <summary>
 	/// 0 = handler not subscribed, 1 = handler subscribed.  Written once via
 	/// <see cref="System.Threading.Interlocked.CompareExchange(ref int, int, int)"/>
 	/// so <see cref="Install"/> can subscribe the <c>Resolving</c> handler exactly
@@ -33,6 +42,7 @@ internal static class HostAssemblyResolution
 	[
 		[0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a], // Microsoft (b03f5f7f11d50a3a)
 		[0xcc, 0x7b, 0x13, 0xff, 0xcd, 0x2d, 0xdd, 0x51], // corefx / dotnet (cc7b13ffcd2ddd51)
+		[0xad, 0xb9, 0x79, 0x38, 0x29, 0xdd, 0xae, 0x60], // Microsoft.Extensions.* NuGet (adb9793829ddae60)
 	];
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.Loader;
 
 namespace Uno.UI.RemoteControl.Host.Helpers;

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -12,6 +12,86 @@ namespace Uno.UI.RemoteControl.Host.Helpers;
 internal static class HostAssemblyResolution
 {
 	/// <summary>
+	/// 0 = not installed, 1 = installed.  Written once via
+	/// <see cref="System.Threading.Interlocked.CompareExchange(ref int, int, int)"/>
+	/// so <see cref="Install"/> is safe to call from multiple threads or from
+	/// test fixtures that share the process-wide <see cref="AssemblyLoadContext.Default"/>.
+	/// </summary>
+	private static int s_installed;
+
+	/// <summary>
+	/// Installs the cross-major-version assembly-resolution safety net on
+	/// <see cref="AssemblyLoadContext.Default"/> and eager-loads the
+	/// shared-framework OOB assemblies most prone to version-mismatch requests.
+	/// </summary>
+	/// <remarks>
+	/// Idempotent: calling this method more than once (e.g. from unit tests that
+	/// share the same process) registers the <c>Resolving</c> handler exactly once.
+	/// </remarks>
+	/// <param name="hostDir">
+	/// Optional override for the directory from which DLLs are eager-loaded.
+	/// When <see langword="null"/> the directory of this assembly is used.
+	/// </param>
+	internal static void Install(string? hostDir = null)
+	{
+		// CAS from 0 → 1: if the exchange returns anything other than 0 another
+		// caller already ran Install(), so bail out immediately (lock-free).
+		if (System.Threading.Interlocked.CompareExchange(ref s_installed, 1, 0) != 0)
+		{
+			return;
+		}
+
+		AssemblyLoadContext.Default.Resolving += static (ctx, req) =>
+			TryBridgeBySimpleName(ctx, req);
+
+		var resolvedHostDir = hostDir
+			?? System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location);
+
+		if (string.IsNullOrEmpty(resolvedHostDir))
+		{
+			return;
+		}
+
+		// Build a set of simple names already loaded so we can skip duplicates.
+		var alreadyLoaded = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var asm in AssemblyLoadContext.Default.Assemblies)
+		{
+			if (!asm.IsDynamic && asm.GetName().Name is { } n)
+			{
+				alreadyLoaded.Add(n);
+			}
+		}
+
+		// Discover System.* and Microsoft.Extensions.* DLLs in the host directory.
+		var candidates =
+			System.IO.Directory.EnumerateFiles(resolvedHostDir, "System.*.dll")
+			.Concat(System.IO.Directory.EnumerateFiles(resolvedHostDir, "Microsoft.Extensions.*.dll"));
+
+		foreach (var path in candidates)
+		{
+			var simpleName = System.IO.Path.GetFileNameWithoutExtension(path);
+			if (alreadyLoaded.Contains(simpleName))
+			{
+				continue;
+			}
+
+			try
+			{
+				AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+			}
+			catch (Exception ex)
+			{
+				Console.Error.WriteLine(
+					$"Uno.UI.RemoteControl.Host: eager-load of '{simpleName}' failed " +
+					$"({ex.GetType().Name}: {ex.Message}). " +
+					"Cross-major-version AssemblyRefs for this assembly may still throw " +
+					"FileNotFoundException at runtime.");
+			}
+		}
+	}
+
+
+	/// <summary>
 	/// Attempts to satisfy <paramref name="requested"/> by returning an
 	/// already-loaded assembly from <paramref name="context"/> whose simple
 	/// name matches. Dynamic (reflection-emit) assemblies and assemblies with

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -15,8 +15,8 @@ internal static class HostAssemblyResolution
 {
 	/// <summary>
 	/// <see langword="true"/> when <c>UNO_DEVSERVER_DISABLE_ADDIN_ALC=1</c> is set.
-	/// Evaluated once at first access; re-read each call so that tests that set the
-	/// variable before calling can observe the correct value without process restart.
+	/// Re-read on every access so that tests that set the variable before calling
+	/// can observe the updated value without a process restart.
 	/// </summary>
 	internal static bool IsKillSwitchActive =>
 		Environment.GetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC") == "1";

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -51,16 +51,40 @@ internal static class HostAssemblyResolution
 				continue;
 			}
 
-			// Only bridge assemblies with the same strong-name identity (or
-			// both unsigned). Returning a differently-signed assembly would be
-			// a security-relevant identity swap, not a version-mismatch workaround.
+			// Enforce symmetric PKT policy:
+			//   - Unsigned request → only bridge to an unsigned loaded assembly.
+			//     Returning a strong-named assembly for an unsigned reference
+			//     could silently substitute a different assembly whose name
+			//     coincidentally matches.
+			//   - Signed request → loaded assembly must carry the same PKT.
+			//     Returning a differently-signed assembly would be a
+			//     security-relevant identity swap.
+			var loadedToken = loadedName.GetPublicKeyToken();
 			if (requestedToken is { Length: > 0 })
 			{
-				var loadedToken = loadedName.GetPublicKeyToken();
 				if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
 				{
 					continue;
 				}
+			}
+			else
+			{
+				// Request is unsigned: skip any strong-named loaded assembly.
+				if (loadedToken is { Length: > 0 })
+				{
+					continue;
+				}
+			}
+
+			// Version guard: refuse to bridge when the loaded version is strictly
+			// lower than what was requested. That would be a silent downgrade —
+			// the caller asked for vN but gets v(N-1).
+			var requestedVersion = requested.Version;
+			var loadedVersion = loadedName.Version;
+			if (requestedVersion is not null && loadedVersion is not null
+				&& loadedVersion < requestedVersion)
+			{
+				continue;
 			}
 
 			return loaded;

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -32,13 +32,14 @@ namespace Uno.UI.RemoteControl.Host
 	{
 		/// <summary>
 		/// Shared-framework OOB assemblies that the host eager-loads from the
-		/// apphost directory during static initialization. Anything in this list
-		/// must satisfy two properties: (a) the bundled DLL exists in the host's
-		/// output directory (i.e. the SDK doesn't strip it via PackageOverride),
-		/// and (b) the host's own dependency graph or the add-ins it loads can
-		/// realistically embed a cross-major-version AssemblyRef to it. Extend
-		/// here as additional offenders are identified (e.g. another OOB package
-		/// referenced by ModelContextProtocol or by future add-in payloads).
+		/// apphost directory from <see cref="ConfigureAssemblyResolution"/>.
+		/// Anything in this list must satisfy two properties: (a) the bundled
+		/// DLL exists in the host's output directory (i.e. the SDK doesn't strip
+		/// it via PackageOverride), and (b) the host's own dependency graph or
+		/// the add-ins it loads can realistically embed a cross-major-version
+		/// AssemblyRef to it. Extend here as additional offenders are identified
+		/// (e.g. another OOB package referenced by ModelContextProtocol or by
+		/// future add-in payloads).
 		/// </summary>
 		private static readonly string[] s_eagerLoadedSharedAssemblyDllNames =
 		{
@@ -46,7 +47,15 @@ namespace Uno.UI.RemoteControl.Host
 			"System.Text.Encodings.Web.dll",
 		};
 
-		static Program()
+		/// <summary>
+		/// Install the cross-major-version assembly-resolution safety net used
+		/// by both the host process and the add-ins it loads. Called from the
+		/// top of <see cref="Main"/> rather than from a static constructor so
+		/// any failure surfaces as a normal exception (logged via stderr below)
+		/// instead of being wrapped in <see cref="TypeInitializationException"/>
+		/// the first time <see cref="Program"/> is touched.
+		/// </summary>
+		private static void ConfigureAssemblyResolution()
 		{
 			// The host process targets a specific .NET runtime, but its NuGet
 			// dependency graph (e.g. ModelContextProtocol 1.1.0) and the add-ins
@@ -164,6 +173,12 @@ namespace Uno.UI.RemoteControl.Host
 
 		static async Task Main(string[] args)
 		{
+			// Must run before anything else in Main so the Resolving handler and
+			// the eager-loaded shared-framework OOB instances are in place before
+			// ASP.NET Core / Kestrel / add-in load triggers the first
+			// cross-major-version AssemblyRef lookup.
+			ConfigureAssemblyResolution();
+
 			var startTime = Stopwatch.GetTimestamp();
 
 			ITelemetry? telemetry = null;

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -24,11 +24,91 @@ using Uno.UI.RemoteControl.Server.AppLaunch;
 using Uno.UI.RemoteControl.Server.Helpers;
 using Uno.UI.RemoteControl.Server.Telemetry;
 using Uno.UI.RemoteControl.Services;
+using System.Runtime.Loader;
 
 namespace Uno.UI.RemoteControl.Host
 {
 	partial class Program
 	{
+		static Program()
+		{
+			// The host process targets a specific .NET runtime, but its NuGet
+			// dependency graph (e.g. ModelContextProtocol 1.1.0) and the add-ins
+			// it loads (e.g. Microsoft.Kiota.* net8.0 binaries) can reference
+			// versions of shared framework OOB assemblies (System.Text.*,
+			// Microsoft.Extensions.*) that don't match what the runtime
+			// actually has loaded — typically a cross-major-version gap such as
+			// System.Text.Encodings.Web v8.0.0.0 (Kiota net8.0) or v10.0.0.0
+			// (compiled against net10 reference assemblies) against the host's
+			// v9.0.0.0 from Microsoft.NETCore.App 9.x.
+			//
+			// .NET Core/5+ removed app.config binding redirects, so the runtime
+			// fails such requests with FileNotFoundException by default. We
+			// reinstate the equivalent behaviour by handling the default ALC's
+			// Resolving event: when a request can't be satisfied by normal
+			// probing, fall back to any already-loaded assembly with the same
+			// simple name. This is invisible for well-behaved deps (Resolving
+			// only fires on FAILURE) and matches the lax-binding semantics
+			// developers used to get from binding redirects.
+			AssemblyLoadContext.Default.Resolving += static (context, requested) =>
+			{
+				if (requested.Name is not { } simpleName)
+				{
+					return null;
+				}
+
+				foreach (var loaded in context.Assemblies)
+				{
+					if (string.Equals(loaded.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase))
+					{
+						return loaded;
+					}
+				}
+
+				return null;
+			};
+
+			// Eager-load shared-framework OOB assemblies most prone to
+			// cross-major-version requests *by file path* from the apphost
+			// directory. The Resolving handler above can only return assemblies
+			// already in the load context, so we have to populate it before any
+			// versioned request fires.
+			//
+			// Loading by AssemblyName instead would hit .NET 9's "platform
+			// assembly" override for System.Text.Encodings.Web — the framework's
+			// v9 instance is forced into TPA even when the host's deps.json (and
+			// bundled DLL) is v10 — and a simple-name load then fails outright.
+			// `typeof(...).Assembly` is also unsafe here: with this project
+			// built by the .NET 10 SDK, typeof emits a v10 AssemblyRef which
+			// would itself trigger the very FileNotFoundException we want to
+			// prevent. Loading the apphost-dir file directly avoids both traps
+			// and gives the Resolving handler a candidate to satisfy later
+			// versioned requests from add-ins (Kiota net8.0 → v8.0.0.0) and
+			// from the host's own deps (ModelContextProtocol 1.1.0 → v10.0.0.0)
+			// without forcing every add-in to ship its own copy.
+			var hostDir = Path.GetDirectoryName(typeof(Program).Assembly.Location);
+			if (!string.IsNullOrEmpty(hostDir))
+			{
+				foreach (var dllName in new[] { "System.Text.Json.dll", "System.Text.Encodings.Web.dll" })
+				{
+					var path = Path.Combine(hostDir, dllName);
+					if (File.Exists(path))
+					{
+						try
+						{
+							AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+						}
+						catch
+						{
+							// Best effort: if the bundled file can't be loaded the
+							// Resolving handler simply won't have a candidate
+							// later and the original failure surfaces as normal.
+						}
+					}
+				}
+			}
+		}
+
 		static async Task Main(string[] args)
 		{
 			var startTime = Stopwatch.GetTimestamp();

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,111 +29,13 @@ namespace Uno.UI.RemoteControl.Host
 {
 	partial class Program
 	{
-		/// <summary>
-		/// Shared-framework OOB assemblies that the host eager-loads from the
-		/// apphost directory from <see cref="ConfigureAssemblyResolution"/>.
-		/// Anything in this list must satisfy two properties: (a) the bundled
-		/// DLL exists in the host's output directory (i.e. the SDK doesn't strip
-		/// it via PackageOverride), and (b) the host's own dependency graph or
-		/// the add-ins it loads can realistically embed a cross-major-version
-		/// AssemblyRef to it. Extend here as additional offenders are identified
-		/// (e.g. another OOB package referenced by ModelContextProtocol or by
-		/// future add-in payloads).
-		/// </summary>
-		private static readonly string[] s_eagerLoadedSharedAssemblyDllNames =
-		{
-			"System.Text.Json.dll",
-			"System.Text.Encodings.Web.dll",
-		};
-
-		/// <summary>
-		/// Install the cross-major-version assembly-resolution safety net used
-		/// by both the host process and the add-ins it loads. Called from the
-		/// top of <see cref="Main"/> rather than from a static constructor so
-		/// any failure surfaces as a normal exception (logged via stderr below)
-		/// instead of being wrapped in <see cref="TypeInitializationException"/>
-		/// the first time <see cref="Program"/> is touched.
-		/// </summary>
-		private static void ConfigureAssemblyResolution()
-		{
-			// The host process targets a specific .NET runtime, but its NuGet
-			// dependency graph (e.g. ModelContextProtocol 1.1.0) and the add-ins
-			// it loads (e.g. Microsoft.Kiota.* net8.0 binaries) can reference
-			// versions of shared framework OOB assemblies (System.Text.*,
-			// Microsoft.Extensions.*) that don't match what the runtime
-			// actually has loaded — typically a cross-major-version gap such as
-			// System.Text.Encodings.Web v8.0.0.0 (Kiota net8.0) or v10.0.0.0
-			// (compiled against net10 reference assemblies) against the host's
-			// v9.0.0.0 from Microsoft.NETCore.App 9.x.
-			//
-			// .NET Core/5+ removed app.config binding redirects, so the runtime
-			// fails such requests with FileNotFoundException by default. We
-			// reinstate the equivalent behaviour by handling the default ALC's
-			// Resolving event: when a request can't be satisfied by normal
-			// probing, fall back to any already-loaded assembly with the same
-			// simple name. This is invisible for well-behaved deps (Resolving
-			// only fires on FAILURE) and matches the lax-binding semantics
-			// developers used to get from binding redirects.
-			AssemblyLoadContext.Default.Resolving += static (context, requested) =>
-				HostAssemblyResolution.TryBridgeBySimpleName(context, requested);
-
-			// Eager-load shared-framework OOB assemblies most prone to
-			// cross-major-version requests *by file path* from the apphost
-			// directory. The Resolving handler above can only return assemblies
-			// already in the load context, so we have to populate it before any
-			// versioned request fires.
-			//
-			// Loading by AssemblyName instead would hit .NET 9's "platform
-			// assembly" override for System.Text.Encodings.Web — the framework's
-			// v9 instance is forced into TPA even when the host's deps.json (and
-			// bundled DLL) is v10 — and a simple-name load then fails outright.
-			// `typeof(...).Assembly` is also unsafe here: with this project
-			// built by the .NET 10 SDK, typeof emits a v10 AssemblyRef which
-			// would itself trigger the very FileNotFoundException we want to
-			// prevent. Loading the apphost-dir file directly avoids both traps
-			// and gives the Resolving handler a candidate to satisfy later
-			// versioned requests from add-ins (Kiota net8.0 → v8.0.0.0) and
-			// from the host's own deps (ModelContextProtocol 1.1.0 → v10.0.0.0)
-			// without forcing every add-in to ship its own copy.
-			var hostDir = Path.GetDirectoryName(typeof(Program).Assembly.Location);
-			if (!string.IsNullOrEmpty(hostDir))
-			{
-				foreach (var dllName in s_eagerLoadedSharedAssemblyDllNames)
-				{
-					var path = Path.Combine(hostDir, dllName);
-					if (!File.Exists(path))
-					{
-						continue;
-					}
-
-					try
-					{
-						AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
-					}
-					catch (Exception ex)
-					{
-						// Best effort: if the bundled file can't be loaded the
-						// Resolving handler simply won't have a candidate later
-						// and the original failure will surface as normal. Log a
-						// breadcrumb so a regression in this preload step doesn't
-						// silently disable the safety net — the host hasn't built
-						// its ILoggerFactory yet at this point, so write directly
-						// to stderr.
-						Console.Error.WriteLine(
-							$"Uno.UI.RemoteControl.Host: eager-load of '{dllName}' failed ({ex.GetType().Name}: {ex.Message}). " +
-							"Cross-major-version AssemblyRefs for this assembly may still throw FileNotFoundException at runtime.");
-					}
-				}
-			}
-		}
-
 		static async Task Main(string[] args)
 		{
 			// Must run before anything else in Main so the Resolving handler and
 			// the eager-loaded shared-framework OOB instances are in place before
 			// ASP.NET Core / Kestrel / add-in load triggers the first
 			// cross-major-version AssemblyRef lookup.
-			ConfigureAssemblyResolution();
+			HostAssemblyResolution.Install();
 
 			var startTime = Stopwatch.GetTimestamp();
 

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -31,12 +31,6 @@ namespace Uno.UI.RemoteControl.Host
 	{
 		static async Task Main(string[] args)
 		{
-			// Must run before anything else in Main so the Resolving handler and
-			// the eager-loaded shared-framework OOB instances are in place before
-			// ASP.NET Core / Kestrel / add-in load triggers the first
-			// cross-major-version AssemblyRef lookup.
-			HostAssemblyResolution.Install();
-
 			var startTime = Stopwatch.GetTimestamp();
 
 			ITelemetry? telemetry = null;
@@ -46,6 +40,12 @@ namespace Uno.UI.RemoteControl.Host
 
 			try
 			{
+				// Must run before anything else so the Resolving handler and
+				// the eager-loaded shared-framework OOB instances are in place before
+				// ASP.NET Core / Kestrel / add-in load triggers the first
+				// cross-major-version AssemblyRef lookup.
+				HostAssemblyResolution.Install();
+
 				var switchMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
 				{
 					["-c"] = "command",

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,12 +25,27 @@ using Uno.UI.RemoteControl.Server.AppLaunch;
 using Uno.UI.RemoteControl.Server.Helpers;
 using Uno.UI.RemoteControl.Server.Telemetry;
 using Uno.UI.RemoteControl.Services;
-using System.Runtime.Loader;
 
 namespace Uno.UI.RemoteControl.Host
 {
 	partial class Program
 	{
+		/// <summary>
+		/// Shared-framework OOB assemblies that the host eager-loads from the
+		/// apphost directory during static initialization. Anything in this list
+		/// must satisfy two properties: (a) the bundled DLL exists in the host's
+		/// output directory (i.e. the SDK doesn't strip it via PackageOverride),
+		/// and (b) the host's own dependency graph or the add-ins it loads can
+		/// realistically embed a cross-major-version AssemblyRef to it. Extend
+		/// here as additional offenders are identified (e.g. another OOB package
+		/// referenced by ModelContextProtocol or by future add-in payloads).
+		/// </summary>
+		private static readonly string[] s_eagerLoadedSharedAssemblyDllNames =
+		{
+			"System.Text.Json.dll",
+			"System.Text.Encodings.Web.dll",
+		};
+
 		static Program()
 		{
 			// The host process targets a specific .NET runtime, but its NuGet
@@ -57,12 +73,40 @@ namespace Uno.UI.RemoteControl.Host
 					return null;
 				}
 
+				var requestedToken = requested.GetPublicKeyToken();
+
 				foreach (var loaded in context.Assemblies)
 				{
-					if (string.Equals(loaded.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase))
+					// Skip reflection-emitted / source-generator-emitted dynamic
+					// assemblies: their auto-generated names could coincidentally
+					// collide with a real AssemblyRef and we'd silently substitute
+					// them, producing confusing downstream TypeLoadException /
+					// MissingMethodException failures.
+					if (loaded.IsDynamic)
 					{
-						return loaded;
+						continue;
 					}
+
+					var loadedName = loaded.GetName();
+					if (!string.Equals(loadedName.Name, simpleName, StringComparison.OrdinalIgnoreCase))
+					{
+						continue;
+					}
+
+					// Only bridge between assemblies with the same strong-name
+					// identity (or both unsigned). Returning a differently-signed
+					// assembly would be a security-relevant identity swap, not a
+					// version-mismatch papered over.
+					if (requestedToken is { Length: > 0 })
+					{
+						var loadedToken = loadedName.GetPublicKeyToken();
+						if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
+						{
+							continue;
+						}
+					}
+
+					return loaded;
 				}
 
 				return null;
@@ -89,21 +133,30 @@ namespace Uno.UI.RemoteControl.Host
 			var hostDir = Path.GetDirectoryName(typeof(Program).Assembly.Location);
 			if (!string.IsNullOrEmpty(hostDir))
 			{
-				foreach (var dllName in new[] { "System.Text.Json.dll", "System.Text.Encodings.Web.dll" })
+				foreach (var dllName in s_eagerLoadedSharedAssemblyDllNames)
 				{
 					var path = Path.Combine(hostDir, dllName);
-					if (File.Exists(path))
+					if (!File.Exists(path))
 					{
-						try
-						{
-							AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
-						}
-						catch
-						{
-							// Best effort: if the bundled file can't be loaded the
-							// Resolving handler simply won't have a candidate
-							// later and the original failure surfaces as normal.
-						}
+						continue;
+					}
+
+					try
+					{
+						AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+					}
+					catch (Exception ex)
+					{
+						// Best effort: if the bundled file can't be loaded the
+						// Resolving handler simply won't have a candidate later
+						// and the original failure will surface as normal. Log a
+						// breadcrumb so a regression in this preload step doesn't
+						// silently disable the safety net — the host hasn't built
+						// its ILoggerFactory yet at this point, so write directly
+						// to stderr.
+						Console.Error.WriteLine(
+							$"Uno.UI.RemoteControl.Host: eager-load of '{dllName}' failed ({ex.GetType().Name}: {ex.Message}). " +
+							"Cross-major-version AssemblyRefs for this assembly may still throw FileNotFoundException at runtime.");
 					}
 				}
 			}

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -76,50 +76,7 @@ namespace Uno.UI.RemoteControl.Host
 			// only fires on FAILURE) and matches the lax-binding semantics
 			// developers used to get from binding redirects.
 			AssemblyLoadContext.Default.Resolving += static (context, requested) =>
-			{
-				if (requested.Name is not { } simpleName)
-				{
-					return null;
-				}
-
-				var requestedToken = requested.GetPublicKeyToken();
-
-				foreach (var loaded in context.Assemblies)
-				{
-					// Skip reflection-emitted / source-generator-emitted dynamic
-					// assemblies: their auto-generated names could coincidentally
-					// collide with a real AssemblyRef and we'd silently substitute
-					// them, producing confusing downstream TypeLoadException /
-					// MissingMethodException failures.
-					if (loaded.IsDynamic)
-					{
-						continue;
-					}
-
-					var loadedName = loaded.GetName();
-					if (!string.Equals(loadedName.Name, simpleName, StringComparison.OrdinalIgnoreCase))
-					{
-						continue;
-					}
-
-					// Only bridge between assemblies with the same strong-name
-					// identity (or both unsigned). Returning a differently-signed
-					// assembly would be a security-relevant identity swap, not a
-					// version-mismatch papered over.
-					if (requestedToken is { Length: > 0 })
-					{
-						var loadedToken = loadedName.GetPublicKeyToken();
-						if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
-						{
-							continue;
-						}
-					}
-
-					return loaded;
-				}
-
-				return null;
-			};
+				HostAssemblyResolution.TryBridgeBySimpleName(context, requested);
 
 			// Eager-load shared-framework OOB assemblies most prone to
 			// cross-major-version requests *by file path* from the apphost

--- a/src/Uno.UI.RemoteControl/Helpers/ApplicationInfoHelper.cs
+++ b/src/Uno.UI.RemoteControl/Helpers/ApplicationInfoHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Diagnostics;
 using System.Runtime.Versioning;
 
 namespace Uno.UI.RemoteControl.Helpers;

--- a/src/Uno.UI.slnx
+++ b/src/Uno.UI.slnx
@@ -98,6 +98,9 @@
     <Project Path="Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Debug" />
     </Project>
+    <Project Path="Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/AddInWithCrossMajorVersionRefs.csproj">
+      <BuildType Solution="Release_NoSamples|*" Project="Debug" />
+    </Project>
     <Project Path="Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Release" />
     </Project>

--- a/src/Uno.UI.slnx
+++ b/src/Uno.UI.slnx
@@ -101,6 +101,9 @@
     <Project Path="Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/AddInWithCrossMajorVersionRefs.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Debug" />
     </Project>
+    <Project Path="Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithDiServiceRegistration/AddInWithDiServiceRegistration.csproj">
+      <BuildType Solution="Release_NoSamples|*" Project="Debug" />
+    </Project>
     <Project Path="Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Release" />
     </Project>


### PR DESCRIPTION
Fixes https://github.com/unoplatform/kahua-private/issues/483

## Summary

Replaces `Assembly.LoadFrom(dll)` add-in loading in `Uno.UI.RemoteControl.Host` with the [Microsoft-recommended plugin pattern](https://learn.microsoft.com/en-us/dotnet/core/tutorials/creating-app-with-plugin-support): a shared custom `AssemblyLoadContext` backed by per-add-in `AssemblyDependencyResolver` instances, plus a default-ALC `Resolving` fallback for cross-major-version framework assembly references.

This fixes the three `FileNotFoundException` crashes that surface during DevServer startup with the latest `Uno.Sdk` dev build (`6.7.0-dev.50`, which pulls `Uno.WinUI.DevServer 6.7.0-dev.144` + the **latest** `Uno.Settings.DevServer 1.8.0-dev.125` + `Uno.UI.App.Mcp 1.3.0-dev.16`):

1. **User-reported crash using `Uno.Sdk 6.7.0-dev.48`, still reproducing on `Uno.Sdk 6.7.0-dev.50` with the latest licensing add-in:**

   ```text
   Unhandled exception. ... ---> System.IO.FileNotFoundException: Could not load file or assembly
   'System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'.
      at Microsoft.Kiota.Serialization.Json.KiotaJsonSerializationContext..cctor()
      ...
      at Uno.Licensing.Sdk.Client.LicensingClient..ctor(IOptionsMonitor`1 options, IHttpClientFactory httpClients)
      ...
      at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
      at Uno.UI.RemoteControl.Host.Program.Main(String[] args)
   ```

   Note: `Uno.Settings.DevServer 1.8.0-dev.125` is the **post-`NetCurrent`-flip** licensing build (`Uno.Licensing.Sdk.dll` now net9.0, Kiota bumped to 1.22.2). The crash still happens because Kiota 1.22.2 only ships `lib/net8.0/` (no net9.0 TFM yet), so the net9.0 licensing project still resolves the **net8.0** Kiota binary, which hard-references `System.Text.Encodings.Web v8.0.0.0`. The host's TPA carries v10 (or v9 on vanilla .NET 9) and the default ALC won't lax-bind across the major-version gap.

2. `Uno.UI.App.Mcp.Server.MCPServicesRegistration..ctor` → FNF `Microsoft.Extensions.Configuration, Version=10.0.0.0` (MCP add-in built for `net10.0`; host TPA has v9).

3. `ModelContextProtocol.McpJsonUtilities.JsonContext..cctor()` → FNF `System.Text.Encodings.Web, Version=10.0.0.0`. `ModelContextProtocol 1.1.0` for `net9.0` was compiled against v10 reference assemblies of `System.Text.*`; on a .NET 9 runtime the framework's v9 is forced into TPA and the strict version match fails. This one is pre-existing in the host's own dependency graph — it was previously masked by the licensing crash, and would have started biting clients independently as soon as that crash went away.

## Why this change

The existing loader uses `Assembly.LoadFrom(dll)`, which loads every add-in into the **default** `AssemblyLoadContext`. That:

- pollutes the host's process with the add-in's transitive NuGet graph,
- can't bridge cross-major-version `AssemblyRef`s (the default ALC's TPA binder enforces strict version match for shared-framework OOB packages like `System.Text.Encodings.Web`), and
- makes one add-in's dependency choices break startup for every other add-in.

Microsoft explicitly steers against this pattern; the [tutorial](https://learn.microsoft.com/en-us/dotnet/core/tutorials/creating-app-with-plugin-support) and `AssemblyDependencyResolver`'s [design note](https://github.com/dotnet/runtime/issues/3835) recommend isolated `AssemblyLoadContext`s backed by per-plugin `.deps.json`, with framework assemblies deliberately not resolved by the plugin's resolver so host and plugin share the same `Type` identity.

## What this PR does

Host change (3 files in `Uno.UI.RemoteControl.Host`):

- **`Helpers/AddInLoadContext.cs`** *(new)* — single `AssemblyLoadContext` shared by all DevServer add-ins, holding per-add-in `AssemblyDependencyResolver`s. `Load(AssemblyName)` runs a three-step lookup:
  1. Walk `Default.Assemblies` for a matching simple name (so `IServiceCollection`, `IHostedService`, `ILogger`, `IConfiguration`, etc. resolve to the host's instance and cross-version refs like Kiota's v8 are satisfied by the host's v9/v10).
  2. Ask `Default.LoadFromAssemblyName(new AssemblyName(simpleName))` to trigger TPA-based lookup for lazily-loaded framework OOB packages the host knows about but hasn't yet loaded.
  3. Fall back to each plugin's `.deps.json` through its `AssemblyDependencyResolver`.

  Steps 1 and 2 both skip `IsDynamic` candidates (so reflection-emit / source-gen assemblies can't be coincidentally substituted) and enforce `PublicKeyToken` compatibility (so a strong-named request is never bridged to a differently-signed instance — that's a security-relevant identity swap rather than a version mismatch papered over). Step 2 also catches `FileLoadException` / `BadImageFormatException` in addition to `FileNotFoundException` so a TPA strong-name / image rejection still falls through to step 3.

  The ctor constructs each `AssemblyDependencyResolver` in its own try/catch and emits a stderr breadcrumb on failure, so a corrupt or missing `.deps.json` on one add-in doesn't abort loading of the others — preserving the per-add-in failure isolation the original `Assembly.LoadFrom` loop provided.

  Add-ins still share the context, so types defined in one (e.g. `Uno.Licensing.Sdk.Contracts`) can be consumed by another (e.g. `Uno.UI.App.Mcp.Server`).

- **`Helpers/AssemblyHelper.cs`** — swaps `Assembly.LoadFrom(dll)` for `loadContext.LoadFromAssemblyPath(dll)` (the entry-point load is by path so the caller's exact DLL always wins, even if the add-in's simple name happens to collide with something in the default ALC; transitive deps still flow through `AddInLoadContext.Load`).

- **`Program.cs`** — adds an explicit `ConfigureAssemblyResolution()` method called from the **first line of `Main`** (not from a static constructor — any failure now surfaces as a normal exception via the existing try/catch in Main rather than being wrapped in `TypeInitializationException`). It hooks `AssemblyLoadContext.Default.Resolving` as the .NET-Core equivalent of binding redirects with the same `IsDynamic` / PKT guards described above, and eager-loads `System.Text.Json.dll` + `System.Text.Encodings.Web.dll` from the apphost directory **by file path** (extracted to a `private static readonly string[]` for extensibility) so the Resolving handler has candidates ready. Loading by `AssemblyName` would hit the .NET 9 framework's "platform assembly" override for `System.Text.Encodings.Web` and fail outright; `typeof(...).Assembly` would itself emit a v10 `AssemblyRef` and trigger the same crash. Loading by file path side-steps both traps. Eager-load failures are logged via stderr (the host's `ILoggerFactory` isn't built yet at this point) so a regression in the preload step doesn't silently disable the safety net.

Regression test (new in `Uno.UI.RemoteControl.DevServer.Tests`):

- **`Fixtures/AddInWithCrossMajorVersionRefs/`** *(new)* — purpose-built `net8.0` class library following Microsoft's plugin-tutorial conventions (`<EnableDynamicLoading>true</EnableDynamicLoading>`). Pins `System.Text.Encodings.Web 8.0.0` + `Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2` so its compiled AssemblyRefs embed at v8.0.0.0. Declares `[assembly: Uno.Utils.DependencyInjection.ServiceCollectionExtension(typeof(ServicesRegistration))]` so the host's `AddFromServiceExtensionAttributes` actually invokes the ctor via `Activator.CreateInstance` at startup — the v8.0.0.0 AssemblyRefs get resolved at runtime instead of sitting dormant in metadata. Maintenance contract documented inline: bump the TFM + matching PackageReferences when the host's lowest supported TFM advances past net8.0.
- **`DevServerTests.cs`** — new `DevServer_ShouldStart_WithAddInThatHasCrossMajorVersionFrameworkRefs` test. Hands the fixture DLL to the host via `--addins`, asserts the host loads + activates the add-in, reaches `Now listening on:`, and `helper.IsRunning` stays true past that log (the runtime-stable invariant — a fatal CLR `Unhandled exception` banner terminates the process before the listening state). The comment block explicitly notes this is a positive-outcome regression: depending on the .NET runtime point release, the binder can also lax-bind the v8 ref on its own even without the host's fix, so a "must throw FNF without fix" assertion isn't deterministic across runtimes. The end-to-end repro under `D:\Dev\Uno-Pocs\DevServerLicensingRepro\` still covers the runtime-strict scenario against the real Kiota / `Uno.Settings.DevServer` payload.
- **`Uno.UI.RemoteControl.DevServer.Tests.csproj`** — removes `Fixtures\**` from the default `Compile` / `None` / `EmbeddedResource` globs (so the fixture's compile graph stays decoupled from the test project's), declares the fixture as a `<ProjectReference ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />` so CI restore picks it up, and adds a `_BuildAndCopyAddInTestFixtures` MSBuild target that builds the fixture and stages its entire bin (via `**\*` glob) under `$(OutDir)Fixtures\` so the per-add-in `AssemblyDependencyResolver` branch has a real graph to consult.
- **`Uno.UI.slnx`**, **`Uno.UI-Skia-only.slnf`**, **`Uno.UI-UnitTests-only.slnf`** — register the fixture project so it appears in the IDE solution views.

Diff stats (vs `origin/master`):

```text
 src/Uno.UI-Skia-only.slnf                                                                   |   1 +
 src/Uno.UI-UnitTests-only.slnf                                                              |   1 +
 src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs                                  |  62 +
 src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/*.csproj   |  39 (new)
 src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithCrossMajorVersionRefs/Stub.cs    |  62 (new)
 src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj        |  63 +
 src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs                                   | 183 (new)
 src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs                                     |  25 ±
 src/Uno.UI.RemoteControl.Host/Program.cs                                                    | 148 +
 src/Uno.UI.slnx                                                                             |   3 +
 10 files changed, 585 insertions(+), 2 deletions(-)
```

## Test plan

Validated locally end-to-end against the **published latest packages on nuget.org** (no licensing-side change required for this fix to work):

- `Uno.Sdk 6.7.0-dev.50`
- → `Uno.WinUI.DevServer 6.7.0-dev.144`
- → `Uno.Settings.DevServer 1.8.0-dev.125` (the **latest** licensing build, post-NetCurrent-flip)
- → `Uno.UI.App.Mcp 1.3.0-dev.16`

| Scenario | Host build | Result | Log |
|---|---|---|---|
| Baseline (no fix), cached `6.7.0-dev.144` host | — | **Crashes** — `Encodings.Web 8.0.0.0` FNF at `KiotaJsonSerializationContext..cctor` (matches client report) | `repro-output-sdk-dev50-unmodified.log` |
| `net9.0` host with this PR (`UnoTargetFrameworkOverride=net9.0`) | 0 errors | DevServer reaches `Application started. Press Ctrl+C to shut down.`, `Uno.Licensing.Sdk.LicensesStore[1]: Refreshing licenses token...` looping; **0 unhandled** | `repro-final-net9-sdk-dev50.log` |
| `net10.0` host with this PR (`UnoTargetFrameworkOverride=net10.0`) | 0 errors | same clean startup, **0 unhandled** | `repro-final-net10-sdk-dev50.log` |

Repro project at `D:\Dev\Uno-Pocs\DevServerLicensingRepro` (blank Uno desktop app pinned to `Uno.Sdk 6.7.0-dev.50`). For each TFM the test stages the host's `bin/Debug/net{9,10}.0/` over the cached `Uno.WinUI.DevServer` package and invokes `Uno.UI.RemoteControl.Host.exe --solution <repro>.sln` against the broken add-ins.

### Test plan for reviewers / CI

- [ ] Build `Uno.UI.RemoteControl.Host` for `net9.0` and `net10.0`; both should build clean
- [ ] Smoke-launch the built host against any Uno app's `.sln` and confirm `Application started.` (no `System.Text.Encodings.Web` / `Microsoft.Extensions.Configuration` `FileNotFoundException`s in the log)
- [ ] Hot Reload + IDE channel scenarios still work (regression check: add-ins are now in an isolated ALC instead of the default, so anything reflecting across the host/add-in boundary by `Type` could in theory regress — none observed in the manual runs, but worth a smoke pass)
- [ ] No regression on add-ins that previously loaded fine

## Considered alternative (not in this PR, kept locally for reference)

A licensing-repo workaround was drafted on `dev/agzi/fix-devserver-encodings-web` in `uno.licensing`: ship `System.Text.Encodings.Web v8.0.0.dll` inside `Uno.Settings.DevServer`'s `tools/devserver/` package output via `GeneratePathProperty` + `<None>`. Local validation showed it only relocates the crash — once the v8 DLL satisfies Kiota's `AssemblyRef`, the host's `System.Text.Json v10` follow-on requests `Encodings.Web v10` and the single-version-per-simple-name rule of `AssemblyLoadContext` makes it fatal. It also doesn't help the MCP path (which lives entirely in the default ALC of the host process). The host-side fix in this PR resolves all three failure modes with no licensing-repo change required.

## References

- [Microsoft Learn — Create a .NET Core application with plugins](https://learn.microsoft.com/en-us/dotnet/core/tutorials/creating-app-with-plugin-support)
- [`<EnableDynamicLoading>` MSBuild property](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enabledynamicloading)
- [`AssemblyDependencyResolver` deliberately excludes framework assemblies — dotnet/runtime#3835](https://github.com/dotnet/runtime/issues/3835)
