### PR TITLE
feat(build): Add UnoFastDevBuild property for faster local iteration

### DIFF
--- a/.claude/skills/runtime-tests/SKILL.md
+++ b/.claude/skills/runtime-tests/SKILL.md
@@ -43,18 +43,22 @@ Choose **Skia WASM** only when:
 - The user explicitly asks for WASM/browser testing, OR
 - The bug or behavior is WASM-specific (e.g., DOM interaction, browser rendering, JS interop)
 
+**Strict mode**: If the user input contains the keyword `strict`, omit the `-p:UnoFastDevBuild=true` and `-p:UnoTargetFrameworkOverride=net10.0` flags from the build command in Phase 1 so the build runs with full CI-equivalent analyzer coverage and all cross-targeted TFMs. Use this only when verifying that a change still compiles cleanly under CI strictness — for normal iteration the default (fast) flags should be left on.
+
 ### Phase 1: Build the Test App
 
 **CRITICAL**: Set timeout to 15+ minutes. **NEVER cancel builds.**
 
+The default build commands below pass `-p:UnoFastDevBuild=true` (disables analyzers for local iteration — has no effect on CI) and `-p:UnoTargetFrameworkOverride=net10.0` (skips the redundant net9.0 cross-targeted output for Skia libraries). Combined, these cut a clean `SamplesApp.Skia.Generic` build from ~3:23 → ~1:59 and a Uno.UI-incremental rebuild from ~2:23 → ~0:58 on a 32-core Windows machine. Omit both flags if the user requested `strict` mode (see Phase 0).
+
 #### Skia Desktop (default)
 ```bash
-dotnet build src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj -c Release -f net10.0
+dotnet build src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj -c Release -f net10.0 -p:UnoFastDevBuild=true -p:UnoTargetFrameworkOverride=net10.0
 ```
 
 #### Skia WASM
 ```bash
-dotnet publish src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj -c Release -f net10.0
+dotnet publish src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj -c Release -f net10.0 -p:UnoFastDevBuild=true -p:UnoTargetFrameworkOverride=net10.0
 ```
 
 Note: WASM requires `publish` (not just `build`) to produce the static web assets needed for hosting.
@@ -217,7 +221,7 @@ kill $HTTP_PID $COMPANION_PID 2>/dev/null || true
 | | Skia Desktop | Skia WASM |
 |-|-------------|-----------|
 | **Project** | `SamplesApp.Skia.Generic` | `SamplesApp.Skia.WebAssembly.Browser` |
-| **Build command** | `dotnet build ... -c Release -f net10.0` | `dotnet publish ... -c Release -f net10.0` |
+| **Build command** | `dotnet build ... -c Release -f net10.0 -p:UnoFastDevBuild=true -p:UnoTargetFrameworkOverride=net10.0` | `dotnet publish ... -c Release -f net10.0 -p:UnoFastDevBuild=true -p:UnoTargetFrameworkOverride=net10.0` |
 | **Run method** | `dotnet SamplesApp.Skia.Generic.dll --runtime-tests=...` | Browser navigates to URL with query params |
 | **Filter delivery** | `UITEST_RUNTIME_TESTS_FILTER` env var | `--runtime-test-filter` URL query param |
 | **Base64 `=` handling** | Standard base64 | Replace `=` with `!` before URL-encoding |

--- a/.claude/skills/winui-runtime-tests/SKILL.md
+++ b/.claude/skills/winui-runtime-tests/SKILL.md
@@ -74,6 +74,8 @@ Determine what to run from the user's input:
 
 If the user provides partial names, search `src/Uno.UI.RuntimeTests/Tests/` to resolve fully qualified test names (namespace + class + method).
 
+**Strict mode**: If the user input contains the keyword `strict`, omit the `-p:UnoFastDevBuild=true` flag from the MSBuild command in Phase 2 so the build runs with full CI-equivalent analyzer coverage. Use this only when verifying CI strictness — for normal iteration the fast-dev flag should be left on. (Note: `UnoTargetFrameworkOverride` does not apply here — the WinAppSDK head is already single-TFM `net9.0-windows10.0.19041.0`, configured in Phase 1c.)
+
 ### Phase 1: Prerequisites
 
 Run all prerequisite checks/setup in sequence.
@@ -163,6 +165,8 @@ This is idempotent — safe to run every time. Skip only if you know Graphics3DG
 
 **CRITICAL**: Set bash timeout to **600000** (10 minutes). **NEVER cancel builds.**
 
+The default build below passes `-p:UnoFastDevBuild=true`, which disables analyzers and code-style enforcement for local iteration. Uno.UI compile on Windows has the same analyzer dominance as on Skia (~30s per compile), so this is a meaningful win. The flag is no-op on CI (guarded by `ContinuousIntegrationBuild`). Omit it if the user requested `strict` mode (see Phase 0).
+
 ```bash
 "$MSBUILD" "src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj" \
     -restore -t:Publish -m -v:m \
@@ -170,6 +174,7 @@ This is idempotent — safe to run every time. Skip only if you know Graphics3DG
     -p:Platform=x64 \
     -p:RuntimeIdentifier=win-x64 \
     -p:GenerateAppxPackageOnBuild=true \
+    -p:UnoFastDevBuild=true \
     -p:PackageCertificateThumbprint=$THUMBPRINT
 ```
 
@@ -177,6 +182,7 @@ This is idempotent — safe to run every time. Skip only if you know Graphics3DG
 - Use **dash syntax** (`-restore`, not `/r`) — forward slashes are eaten by bash
 - Use **`PackageCertificateThumbprint`** — most reliable signing method
 - The cert must be in the user's cert store already (Phase 1d handles this)
+- `-p:UnoFastDevBuild=true` is the local fast-iteration toggle; drop it under `strict` mode
 
 #### Build failure diagnostics
 
@@ -335,10 +341,13 @@ THUMBPRINT=$(cat ~/.uno-dev-cert-thumbprint)
     -p:Platform=x64 -p:Configuration=Release
 
 # --- Phase 2: Build MSIX (timeout: 600000ms) ---
+# Default: pass -p:UnoFastDevBuild=true for fast local iteration.
+# Drop the flag if the user requested `strict` mode.
 "$MSBUILD" "src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj" \
     -restore -t:Publish -m -v:m \
     -p:Configuration=Release -p:Platform=x64 -p:RuntimeIdentifier=win-x64 \
     -p:GenerateAppxPackageOnBuild=true \
+    -p:UnoFastDevBuild=true \
     -p:PackageCertificateThumbprint=$THUMBPRINT
 
 # --- Phase 3: Install MSIX ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ cd src
 cp crosstargeting_override.props.sample crosstargeting_override.props
 ```
 
-**2. Edit `crosstargeting_override.props`:**
+**2. Edit `crosstargeting_override.props`** (recommended fast-iteration config):
 ```xml
 <Project>
   <PropertyGroup>
@@ -82,9 +82,26 @@ cp crosstargeting_override.props.sample crosstargeting_override.props
     <!-- <UnoTargetFrameworkOverride>net10.0-android</UnoTargetFrameworkOverride>  Android -->
     <!-- <UnoTargetFrameworkOverride>net10.0-ios</UnoTargetFrameworkOverride>      iOS -->
     <!-- <UnoTargetFrameworkOverride>net10.0-windows10.0.19041.0</UnoTargetFrameworkOverride> Windows -->
+
+    <!-- Disables analyzers + code-style enforcement for local builds. No effect on CI. -->
+    <UnoFastDevBuild>true</UnoFastDevBuild>
   </PropertyGroup>
 </Project>
 ```
+
+Or pass the same flags per-build instead of committing them:
+
+```bash
+dotnet build … -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true
+```
+
+**Why these flags:**
+- `UnoTargetFrameworkOverride` — restricts cross-targeted projects to a single TFM, skipping the redundant net9.0 outputs while you iterate on net10.0 (or vice versa).
+- `UnoFastDevBuild` — disables `RunAnalyzersDuringBuild`, `EnforceCodeStyleInBuild`, and the `Microsoft.CodeAnalysis.NetAnalyzers` package for local builds. **Guarded by `ContinuousIntegrationBuild`, so CI is never affected** — analyzer-strict checks still run on every PR. Set persistently via the `UNO_FAST_DEV_BUILD=true` environment variable if you'd rather not edit the file.
+
+Combined impact on `SamplesApp.Skia.Generic` (Windows, 32-core, warm NuGet cache): clean build ~3:23 → ~1:59, incremental rebuild after a Uno.UI edit ~2:23 → ~0:58. The `/runtime-tests` skill passes both flags by default (use `strict` to opt out for CI-equivalent coverage).
+
+**Do not commit `crosstargeting_override.props`** — it is per-developer config and is intentionally `.gitignore`d.
 
 **3. Use matching solution filter:**
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -272,6 +272,17 @@
 		<NoWarn>$(NoWarn);UNO0008</NoWarn>
 	</PropertyGroup>
 
+	<!--
+	UnoFastDevBuild: opt-in switch for local iteration that disables analyzers and code-style enforcement
+	to cut CoreCompile time. Guarded by ContinuousIntegrationBuild so CI never picks it up accidentally.
+	Enable per-build with `-p:UnoFastDevBuild=true` or persistently via the UNO_FAST_DEV_BUILD env var.
+	-->
+	<PropertyGroup Condition="('$(UnoFastDevBuild)' == 'true' or '$(UNO_FAST_DEV_BUILD)' == 'true') and '$(ContinuousIntegrationBuild)' != 'true'">
+		<RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+		<EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+		<UnoDisableNetAnalyzers>true</UnoDisableNetAnalyzers>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<UnoDisableNetAnalyzers Condition="('$(IsTestProject)' == 'true' or '$(IsSampleProject)' == 'true') and '$(UnoDisableNetAnalyzers)' == ''">true</UnoDisableNetAnalyzers>
 		<UnoDisableNetAnalyzers Condition="'$(UnoDisableNetAnalyzers)' == ''">false</UnoDisableNetAnalyzers>

--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -13,6 +13,7 @@
     <!-- See documentation for each property below -->
 
     <!--<UnoTargetFrameworkOverride>net10.0</UnoTargetFrameworkOverride>-->
+    <!--<UnoFastDevBuild>true</UnoFastDevBuild>-->
     <!--<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>-->
     <!--<OptimizeImplicitlyTriggeredBuild>true</OptimizeImplicitlyTriggeredBuild>-->
     <!--<UnoNugetOverrideVersion>6.4.0-dev.354</UnoNugetOverrideVersion>-->
@@ -53,8 +54,22 @@
         Always close the solution before changing or activating this property.
         *** WARNING ***
 
+      ### UnoFastDevBuild ###
+
+        Set to 'true' to disable analyzers, code-style enforcement, and the
+        Microsoft.CodeAnalysis.NetAnalyzers package for local builds. This is
+        the fastest way to iterate on Uno.UI when you don't need the full
+        CI-strict analyzer coverage.
+
+        No effect on CI — guarded by the ContinuousIntegrationBuild property,
+        so analyzer-strict checks still run on every PR. Can also be enabled
+        machine-wide via the UNO_FAST_DEV_BUILD=true environment variable.
+
+        DO NOT commit this file — it is per-developer config and is
+        intentionally gitignored.
+
       ### UnoNugetOverrideVersion ###
-      
+
         This property allows the override of the nuget local cache.
         Set it to the version you want to override, used in another app.
         You will see the override path in the build output.


### PR DESCRIPTION
**GitHub Issue:**
- closes unoplatform/uno-private#2018 (add `UnoFastDevBuild` MSBuild property)
- closes unoplatform/uno-private#2019 (`/runtime-tests` skill uses it)
- closes unoplatform/uno-private#2020 (`/winui-runtime-tests` skill uses it)
- closes unoplatform/uno-private#2026 (contributor docs)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Introduces a single opt-in MSBuild property — `UnoFastDevBuild` — that contributors can pass per build (`-p:UnoFastDevBuild=true`) or set machine-wide (`UNO_FAST_DEV_BUILD=true`) to disable the CI-strict analyzer suite during local iteration. When enabled it sets:

- `RunAnalyzersDuringBuild=false`
- `EnforceCodeStyleInBuild=false`
- `UnoDisableNetAnalyzers=true` (so the `Microsoft.CodeAnalysis.NetAnalyzers` preview package isn't even referenced and the `<Choose>` block falls into its `Otherwise` branch)

The whole `PropertyGroup` is guarded by `ContinuousIntegrationBuild != 'true'`, so **CI is never affected** — analyzer-strict checks still run on every PR.

The branch contains four logical commits:

1. **`feat(build)`** — adds the property to `src/Directory.Build.props`.
2. **`docs(runtime-tests)`** — `.claude/skills/runtime-tests/SKILL.md` now passes `-p:UnoFastDevBuild=true -p:UnoTargetFrameworkOverride=net10.0` by default for both Skia Desktop and Skia WASM; documents a `strict` opt-out keyword for when CI-equivalent analyzer coverage is wanted.
3. **`docs(winui-runtime-tests)`** — `.claude/skills/winui-runtime-tests/SKILL.md` now passes `-p:UnoFastDevBuild=true` on the Windows MSBuild invocation (TFM override does not apply — the WinAppSDK head is already single-TFM); documents the same `strict` opt-out.
4. **`docs`** — `AGENTS.md` "Build Setup" now recommends both flags up front with the timing impact below; `src/crosstargeting_override.props.sample` carries a commented `<UnoFastDevBuild>true</UnoFastDevBuild>` line plus a dedicated explanation paragraph emphasising "no effect on CI" and "do not commit this file".

Nothing in the change touches behaviour outside the opt-in path, so default builds are byte-identical.

## Measured impact

**Target**: `SamplesApp.Skia.Generic` (`-c Release -f net10.0 -p:UnoTargetFrameworkOverride=net10.0`).
**Branch difference**: branch additionally passes `-p:UnoFastDevBuild=true` — the only variable.
**Hardware**: i9-14900KF, 32 logical cores, post-reboot.
**Sampling**: `.NET PerformanceCounter('Processor', '% Processor Time', '_Total')` polled at 1 Hz in a background job; CPU-seconds = Σ(samples) ÷ 100 × 32.
**Setup per cold**: kill stray `dotnet`/`msbuild`/`VBCSCompiler` processes → `dotnet build-server shutdown` → `git clean -xfd`. Build server kept alive between cold→incremental on the same branch (mirrors real iteration). Apples-to-apples runs use a warmed OS file cache for both branches.

| Scenario | master wall | master CPU-sec | branch wall | branch CPU-sec | Δ wall | Δ CPU-sec |
|---|---:|---:|---:|---:|---:|---:|
| **Cold** (after `git clean -xfd`) | **1:39.02** (99.02 s) | **1942.10** | **1:03.72** (63.73 s) | **721.55** | **−35.6 %** | **−62.8 %** |
| **Incremental** (touch `src/Uno.UI/AssemblyInfo.cs`) | **1:21.39** (81.39 s) | **1352.24** | **0:50.35** (50.35 s) | **509.14** | **−38.1 %** | **−62.4 %** |

CPU utilisation confirms the mechanism: branch holds ~32–36 % avg CPU vs master's ~53–63 %. The build isn't running fewer parallel tasks — each task simply has less work to do because the analyzer pipeline is gone. The CPU-seconds metric is the more honest "did we actually do less work" number, and it's consistently ~63 % lower across both scenarios — well aligned with the analyzer-disabled CoreCompile reduction reported in the original issue.

**Note (n = 1 per cell)**: numbers are single samples, but the CPU-sec ratio is ~63 % in *both* cold and incremental, which is a strong internal sanity signal. Restore time is included in cold wall (real-world scenario).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A for a build property
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — `AGENTS.md`, `crosstargeting_override.props.sample`, both skill files
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A (no UI change)
- [x] ❗ Contains **NO** breaking changes — the new property is opt-in, default behaviour unchanged, CI explicitly guarded
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)