### PR TITLE
perf(skia): cache blurred ThemeShadow images via 9-slice + surface pool

### DIFF
--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -54,6 +54,8 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	private int _shadowOnlyImageBlurMargin;
 	private Vector2 _shadowOnlyImageSize;        // Cached content size (bucketed up to ShadowCacheGrowStride).
 	private ShadowState? _shadowOnlyImageStateKey;
+	// Session opacity baked into the cached image — invalidate if it changes.
+	private float _shadowOnlyImageOpacity;
 
 	// Coarse stride applied to the cached content size so that small drag/scroll-
 	// induced size changes don't force a rebuild. With a 128 px stride a Visual
@@ -615,10 +617,12 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 		var actualW = Math.Max(1, (int)Math.Ceiling(Size.X));
 		var actualH = Math.Max(1, (int)Math.Ceiling(Size.Y));
 
-		// 9-slice needs at least 2*blurMargin in each axis (corners) plus a
-		// small middle stretch region to be well-defined.
-		var minCachedContentW = 2 * blurMargin + 8;
-		var minCachedContentH = 2 * blurMargin + 8;
+		// 9-slice only needs cachedContentW/H >= 1 so the inner stretch region
+		// is non-empty — the blur margin is added separately when computing
+		// imgW/imgH below. The previous floor of `2*blurMargin + 8` double-
+		// counted the margin and inflated cache memory for small visuals.
+		const int minCachedContentW = 1;
+		const int minCachedContentH = 1;
 
 		var cachedContentW = (int)_shadowOnlyImageSize.X;
 		var cachedContentH = (int)_shadowOnlyImageSize.Y;
@@ -628,7 +632,8 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			&& ReferenceEquals(_shadowOnlyImageStateKey, shadowState)
 			&& _shadowOnlyImageBlurMargin == blurMargin
 			&& cachedContentW >= actualW
-			&& cachedContentH >= actualH;
+			&& cachedContentH >= actualH
+			&& _shadowOnlyImageOpacity == session.Opacity;
 
 		if (!cacheValid)
 		{
@@ -689,6 +694,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			_shadowOnlyImageBlurMargin = blurMargin;
 			_shadowOnlyImageSize = new Vector2(cacheW, cacheH);
 			_shadowOnlyImageStateKey = shadowState;
+			_shadowOnlyImageOpacity = session.Opacity;
 			cachedContentW = cacheW;
 			cachedContentH = cacheH;
 

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -46,6 +46,91 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	private IntPtr _childrenPicture;
 	private int _framesSinceSubtreeNotChanged;
 
+	// Cached blurred shadow output. When a Visual has a ShadowState we render
+	// the subtree picture once through the shadow image filter and snapshot
+	// the result here; subsequent renders draw the cached image (via 9-slice to
+	// fit the current Visual size) instead of running the blur each frame.
+	private SKImage? _shadowOnlyImage;
+	private int _shadowOnlyImageBlurMargin;
+	private Vector2 _shadowOnlyImageSize;        // Cached content size (bucketed up to ShadowCacheGrowStride).
+	private ShadowState? _shadowOnlyImageStateKey;
+
+	// Coarse stride applied to the cached content size so that small drag/scroll-
+	// induced size changes don't force a rebuild. With a 128 px stride a Visual
+	// that grows 410→450→500→550→600 px hits buckets {512, 640} = 2 rebuilds,
+	// instead of one per pixel.
+	private const int ShadowCacheGrowStride = 128;
+
+	// Refuse cache allocations beyond this dimension in either axis; fall back
+	// to the unbatched per-frame path. Protects against pathological Visual
+	// sizes producing multi-megabyte surfaces.
+	private const int MaxShadowCacheDim = 4096;
+
+	// Bounded pool of reusable SKSurfaces keyed by exact (width, height). Avoids
+	// per-build pixel-buffer allocations when the same cache size is rebuilt.
+	private readonly struct PooledShadowSurface
+	{
+		public PooledShadowSurface(SKSurface surface, int width, int height)
+		{
+			Surface = surface;
+			Width = width;
+			Height = height;
+		}
+		public SKSurface Surface { get; }
+		public int Width { get; }
+		public int Height { get; }
+	}
+	private static readonly List<PooledShadowSurface> s_shadowSurfacePool = new();
+	private const int MaxPooledShadowSurfaces = 24;
+
+	private static SKSurface? RentShadowSurface(int width, int height)
+	{
+		lock (s_shadowSurfacePool)
+		{
+			for (var i = 0; i < s_shadowSurfacePool.Count; i++)
+			{
+				var entry = s_shadowSurfacePool[i];
+				if (entry.Width == width && entry.Height == height)
+				{
+					s_shadowSurfacePool.RemoveAt(i);
+					return entry.Surface;
+				}
+			}
+		}
+
+		try
+		{
+			return SKSurface.Create(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul));
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static void ReturnShadowSurface(SKSurface surface, int width, int height)
+	{
+		lock (s_shadowSurfacePool)
+		{
+			if (s_shadowSurfacePool.Count < MaxPooledShadowSurfaces)
+			{
+				s_shadowSurfacePool.Add(new PooledShadowSurface(surface, width, height));
+				return;
+			}
+		}
+		surface.Dispose();
+	}
+
+	internal void DisposeShadowCache()
+	{
+		if (_shadowOnlyImage is not null)
+		{
+			_shadowOnlyImage.Dispose();
+			_shadowOnlyImage = null;
+			_shadowOnlyImageStateKey = null;
+		}
+	}
+
 	private VisualFlags _flags = VisualFlags.MatrixDirty | VisualFlags.PaintDirty | VisualFlags.ChildrenSKPictureInvalid;
 
 	private const int SK_MaxS32FitsInFloat = 2147483520;
@@ -380,155 +465,333 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			}
 			else
 			{
-				var recorder = new SKPictureRecorder();
-				var recordingCanvas = recorder.BeginRecording(InfiniteClipRect);
-				// child.Render will reapply the total transform matrix, so we need to invert ours.
-				Matrix4x4.Invert(TotalMatrix, out var rootTransform);
-				_factory.CreateInstance(this, recordingCanvas, ref rootTransform, session.Opacity, out var childSession);
-				using (childSession)
-				{
-					PaintStep(this, childSession);
-					PostPaintingClipStep(this, recordingCanvas);
-					RenderChildrenStep(this, childSession, applyChildOptimization);
-				}
-
-				unsafe
-				{
-					var childrenPicture = UnoSkiaApi.sk_picture_recorder_end_recording(recorder.Handle);
-
-					UnoSkiaApi.sk_canvas_draw_picture(canvas.Handle, childrenPicture, null, ShadowState.ShadowOnlyPaint.Handle);
-					UnoSkiaApi.sk_canvas_draw_picture(canvas.Handle, childrenPicture, null, IntPtr.Zero);
-
-					UnoSkiaApi.sk_refcnt_safe_unref(childrenPicture);
-				}
+				RenderWithShadowCache(in session, canvas, applyChildOptimization);
 			}
 		}
+	}
 
-		static void PaintStep(Visual visual, in PaintingSession session)
-		{
-			// Rendering shouldn't depend on matrix or clip adjustments happening in a visual's Paint. That should
-			// be specific to that visual and should not affect the rendering of any other visual.
+	private static void PaintStep(Visual visual, in PaintingSession session)
+	{
+		// Rendering shouldn't depend on matrix or clip adjustments happening in a visual's Paint. That should
+		// be specific to that visual and should not affect the rendering of any other visual.
 #if DEBUG
-			var saveCount = session.Canvas.SaveCount;
+		var saveCount = session.Canvas.SaveCount;
 #endif
-			if (visual.RequiresRepaintOnEveryFrame)
+		if (visual.RequiresRepaintOnEveryFrame)
+		{
+			// why bother with a recorder when it's going to get repainted next frame? just paint directly
+			visual.Paint(session);
+		}
+		else
+		{
+			if ((visual._flags & VisualFlags.PaintDirty) != 0)
 			{
-				// why bother with a recorder when it's going to get repainted next frame? just paint directly
-				visual.Paint(session);
-			}
-			else
-			{
-				if ((visual._flags & VisualFlags.PaintDirty) != 0)
-				{
-					visual._flags &= ~VisualFlags.PaintDirty;
+				visual._flags &= ~VisualFlags.PaintDirty;
 
-					var recordingCanvas = _recorder.BeginRecording(InfiniteClipRect);
-					_factory.CreateInstance(visual, recordingCanvas, ref session.RootTransform, session.Opacity, out var recorderSession);
-					// To debug what exactly gets repainted, replace the following line with `Paint(in session);`
-					visual.Paint(in recorderSession);
+				var recordingCanvas = _recorder.BeginRecording(InfiniteClipRect);
+				_factory.CreateInstance(visual, recordingCanvas, ref session.RootTransform, session.Opacity, out var recorderSession);
+				// To debug what exactly gets repainted, replace the following line with `Paint(in session);`
+				visual.Paint(in recorderSession);
 
-					var picture = UnoSkiaApi.sk_picture_recorder_end_recording(_recorder.Handle);
-
-					if (visual._picture != IntPtr.Zero)
-					{
-						UnoSkiaApi.sk_refcnt_safe_unref(visual._picture);
-					}
-
-					visual._picture = picture;
-				}
+				var picture = UnoSkiaApi.sk_picture_recorder_end_recording(_recorder.Handle);
 
 				if (visual._picture != IntPtr.Zero)
 				{
-					unsafe
-					{
-						UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, visual._picture, null, IntPtr.Zero);
-					}
+					UnoSkiaApi.sk_refcnt_safe_unref(visual._picture);
 				}
-			}
-#if DEBUG
-			Debug.Assert(saveCount == session.Canvas.SaveCount);
-#endif
-		}
 
-		static void PostPaintingClipStep(Visual visual, SKCanvas canvas)
-		{
-#if DEBUG
-			canvas.Save();
-			if (visual.GetPostPaintingClipping() is { } postClip)
-			{
-				canvas.ClipPath(postClip, antialias: true);
+				visual._picture = picture;
 			}
 
-			var nonOptimizedClip = (canvas.DeviceClipBounds, canvas.IsClipRect);
-			canvas.Restore();
-#endif
-			visual.ApplyPostPaintingClipping(canvas);
-#if DEBUG
-			Debug.Assert(nonOptimizedClip.IsClipRect == canvas.IsClipRect && nonOptimizedClip.DeviceClipBounds == canvas.DeviceClipBounds);
-#endif
-		}
-
-		static void RenderChildrenStep(Visual visual, PaintingSession session, bool applyChildOptimization)
-		{
-			if (visual._childrenPicture != IntPtr.Zero)
+			if (visual._picture != IntPtr.Zero)
 			{
 				unsafe
 				{
-					UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, visual._childrenPicture, null, IntPtr.Zero);
+					UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, visual._picture, null, IntPtr.Zero);
 				}
 			}
-			else if (!visual._enablePictureCollapsingOptimization
-					 || visual._framesSinceSubtreeNotChanged < visual._pictureCollapsingOptimizationFrameThreshold
-					 || !applyChildOptimization
-					 || visual.GetSubTreeVisualCount() < visual._pictureCollapsingOptimizationVisualCountThreshold)
+		}
+#if DEBUG
+		Debug.Assert(saveCount == session.Canvas.SaveCount);
+#endif
+	}
+
+	private static void PostPaintingClipStep(Visual visual, SKCanvas canvas)
+	{
+#if DEBUG
+		canvas.Save();
+		if (visual.GetPostPaintingClipping() is { } postClip)
+		{
+			canvas.ClipPath(postClip, antialias: true);
+		}
+
+		var nonOptimizedClip = (canvas.DeviceClipBounds, canvas.IsClipRect);
+		canvas.Restore();
+#endif
+		visual.ApplyPostPaintingClipping(canvas);
+#if DEBUG
+		Debug.Assert(nonOptimizedClip.IsClipRect == canvas.IsClipRect && nonOptimizedClip.DeviceClipBounds == canvas.DeviceClipBounds);
+#endif
+	}
+
+	private static void RenderChildrenStep(Visual visual, PaintingSession session, bool applyChildOptimization)
+	{
+		if (visual._childrenPicture != IntPtr.Zero)
+		{
+			unsafe
+			{
+				UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, visual._childrenPicture, null, IntPtr.Zero);
+			}
+		}
+		else if (!visual._enablePictureCollapsingOptimization
+				 || visual._framesSinceSubtreeNotChanged < visual._pictureCollapsingOptimizationFrameThreshold
+				 || !applyChildOptimization
+				 || visual.GetSubTreeVisualCount() < visual._pictureCollapsingOptimizationVisualCountThreshold)
+		{
+			foreach (var child in visual.GetChildrenInRenderOrder())
+			{
+				child.Render(in session, applyChildOptimization);
+			}
+		}
+		else
+		{
+			var recorder = new SKPictureRecorder();
+			var recordingCanvas = recorder.BeginRecording(InfiniteClipRect);
+			// child.Render will reapply the total transform matrix, so we need to invert ours.
+			Matrix4x4.Invert(visual.TotalMatrix, out var rootTransform);
+			_factory.CreateInstance(visual, recordingCanvas, ref rootTransform, session.Opacity, out var childSession);
+			using (childSession)
 			{
 				foreach (var child in visual.GetChildrenInRenderOrder())
 				{
-					child.Render(in session, applyChildOptimization);
+					child.Render(in childSession, applyChildOptimization: false);
 				}
+			}
+
+			var picture = IntPtr.Zero;
+
+			unsafe
+			{
+				picture = UnoSkiaApi.sk_picture_recorder_end_recording(recorder.Handle);
+				UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, picture, null, IntPtr.Zero);
+			}
+
+			// The visual can be set on a ChildrenSKPictureInvalid path after the render has started.
+			// In such case, we should not cache this picture. Not only it is outdated, it will also lead to a corrupted state,
+			// where subtree rendering is skipped with the cached picture,
+			// and its descendant can't invalidate the cached picture since they area already on a ChildrenSKPictureInvalid path.
+			if ((visual._flags & VisualFlags.ChildrenSKPictureInvalid) == 0)
+			{
+				if (visual._childrenPicture != IntPtr.Zero)
+				{
+					UnoSkiaApi.sk_refcnt_safe_unref(visual._childrenPicture);
+				}
+
+				visual._childrenPicture = picture;
 			}
 			else
 			{
-				var recorder = new SKPictureRecorder();
-				var recordingCanvas = recorder.BeginRecording(InfiniteClipRect);
-				// child.Render will reapply the total transform matrix, so we need to invert ours.
-				Matrix4x4.Invert(visual.TotalMatrix, out var rootTransform);
-				_factory.CreateInstance(visual, recordingCanvas, ref rootTransform, session.Opacity, out var childSession);
-				using (childSession)
-				{
-					foreach (var child in visual.GetChildrenInRenderOrder())
-					{
-						child.Render(in childSession, applyChildOptimization: false);
-					}
-				}
-
-				var picture = IntPtr.Zero;
-
-				unsafe
-				{
-					picture = UnoSkiaApi.sk_picture_recorder_end_recording(recorder.Handle);
-					UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, picture, null, IntPtr.Zero);
-				}
-
-				// The visual can be set on a ChildrenSKPictureInvalid path after the render has started.
-				// In such case, we should not cache this picture. Not only it is outdated, it will also lead to a corrupted state,
-				// where subtree rendering is skipped with the cached picture,
-				// and its descendant can't invalidate the cached picture since they area already on a ChildrenSKPictureInvalid path.
-				if ((visual._flags & VisualFlags.ChildrenSKPictureInvalid) == 0)
-				{
-					if (visual._childrenPicture != IntPtr.Zero)
-					{
-						UnoSkiaApi.sk_refcnt_safe_unref(visual._childrenPicture);
-					}
-
-					visual._childrenPicture = picture;
-				}
-				else
-				{
-					UnoSkiaApi.sk_refcnt_safe_unref(picture);
-				}
+				UnoSkiaApi.sk_refcnt_safe_unref(picture);
 			}
 		}
+	}
+
+	// Cached-shadow render path. Renders the subtree picture once through the
+	// blur image filter into a pooled SKSurface, snapshots the result as an
+	// SKImage (keyed on the ShadowState reference and the bucketed Visual
+	// size), and reuses that image on subsequent renders. Size changes within
+	// the cached dimensions are handled via 9-slice scaling instead of
+	// rebuilding; growth past the cached size rebuilds at the next stride
+	// bucket. Mirrors WinUI's own SpriteVisual+NineGrid optimization for
+	// ThemeShadow.
+	private void RenderWithShadowCache(in PaintingSession session, SKCanvas canvas, bool applyChildOptimization)
+	{
+		var shadowState = ShadowState!;
+		var sigma = Math.Max(shadowState.SigmaX, shadowState.SigmaY);
+		var blurMargin = (int)Math.Ceiling(sigma * 3
+			+ Math.Max(Math.Abs(shadowState.Dx), Math.Abs(shadowState.Dy))
+			+ 4);
+
+		var actualW = Math.Max(1, (int)Math.Ceiling(Size.X));
+		var actualH = Math.Max(1, (int)Math.Ceiling(Size.Y));
+
+		// 9-slice needs at least 2*blurMargin in each axis (corners) plus a
+		// small middle stretch region to be well-defined.
+		var minCachedContentW = 2 * blurMargin + 8;
+		var minCachedContentH = 2 * blurMargin + 8;
+
+		var cachedContentW = (int)_shadowOnlyImageSize.X;
+		var cachedContentH = (int)_shadowOnlyImageSize.Y;
+
+		var cacheValid =
+			_shadowOnlyImage is not null
+			&& ReferenceEquals(_shadowOnlyImageStateKey, shadowState)
+			&& _shadowOnlyImageBlurMargin == blurMargin
+			&& cachedContentW >= actualW
+			&& cachedContentH >= actualH;
+
+		if (!cacheValid)
+		{
+			DisposeShadowCache();
+
+			static int RoundUpToStride(int v) => ((v + ShadowCacheGrowStride - 1) / ShadowCacheGrowStride) * ShadowCacheGrowStride;
+
+			var cacheW = Math.Max(RoundUpToStride(actualW), minCachedContentW);
+			var cacheH = Math.Max(RoundUpToStride(actualH), minCachedContentH);
+			var imgW = cacheW + 2 * blurMargin;
+			var imgH = cacheH + 2 * blurMargin;
+
+			if (imgW > MaxShadowCacheDim || imgH > MaxShadowCacheDim)
+			{
+				// Too large to cache reasonably; fall back to per-frame blur draw.
+				RenderShadowUncached(in session, canvas, applyChildOptimization);
+				return;
+			}
+
+			using var recorder = new SKPictureRecorder();
+			var recordingCanvas = recorder.BeginRecording(InfiniteClipRect);
+			// child.Render will reapply the total transform matrix, so we need
+			// to invert ours.
+			Matrix4x4.Invert(TotalMatrix, out var rootTransform);
+			_factory.CreateInstance(this, recordingCanvas, ref rootTransform, session.Opacity, out var childSession);
+			using (childSession)
+			{
+				PaintStep(this, childSession);
+				PostPaintingClipStep(this, recordingCanvas);
+				RenderChildrenStep(this, childSession, applyChildOptimization);
+			}
+			using var picture = recorder.EndRecording();
+
+			var surface = RentShadowSurface(imgW, imgH);
+			if (surface is null)
+			{
+				// Surface allocation failed; fall back to per-frame blur draw on
+				// the just-recorded picture.
+				canvas.DrawPicture(picture, shadowState.ShadowOnlyPaint);
+				canvas.DrawPicture(picture);
+				return;
+			}
+
+			var surfaceCanvas = surface.Canvas;
+			surfaceCanvas.ResetMatrix();
+			surfaceCanvas.Clear(SKColors.Transparent);
+			surfaceCanvas.Translate(blurMargin, blurMargin);
+			// Single blur image-filter pass per cache entry — the work we are
+			// trying to avoid running every frame in the prior implementation.
+			surfaceCanvas.DrawPicture(picture, shadowState.ShadowOnlyPaint);
+
+			_shadowOnlyImage = surface.Snapshot();
+			// Skia's snapshot is copy-on-write; the next time the surface is
+			// drawn into, the image's pixels are detached, so it's safe to
+			// return the surface to the pool now.
+			ReturnShadowSurface(surface, imgW, imgH);
+
+			_shadowOnlyImageBlurMargin = blurMargin;
+			_shadowOnlyImageSize = new Vector2(cacheW, cacheH);
+			_shadowOnlyImageStateKey = shadowState;
+			cachedContentW = cacheW;
+			cachedContentH = cacheH;
+
+			// Freshly built — draw cached shadow + the just-recorded content
+			// picture (avoids re-rendering the subtree for the content layer).
+			DrawShadowNineSlice(canvas, _shadowOnlyImage, blurMargin, cachedContentW, cachedContentH, actualW, actualH);
+			canvas.DrawPicture(picture);
+		}
+		else
+		{
+			DrawShadowNineSlice(canvas, _shadowOnlyImage!, _shadowOnlyImageBlurMargin, cachedContentW, cachedContentH, actualW, actualH);
+
+			// Render content directly on the outer canvas (no recording wrapper).
+			PaintStep(this, session);
+			PostPaintingClipStep(this, canvas);
+			RenderChildrenStep(this, session, applyChildOptimization);
+		}
+	}
+
+	// Pre-cache fallback: record subtree and apply the blur image filter at
+	// draw time. Used when the cached image bounds would exceed
+	// MaxShadowCacheDim (rare).
+	private void RenderShadowUncached(in PaintingSession session, SKCanvas canvas, bool applyChildOptimization)
+	{
+		using var recorder = new SKPictureRecorder();
+		var recordingCanvas = recorder.BeginRecording(InfiniteClipRect);
+		Matrix4x4.Invert(TotalMatrix, out var rootTransform);
+		_factory.CreateInstance(this, recordingCanvas, ref rootTransform, session.Opacity, out var childSession);
+		using (childSession)
+		{
+			PaintStep(this, childSession);
+			PostPaintingClipStep(this, recordingCanvas);
+			RenderChildrenStep(this, childSession, applyChildOptimization);
+		}
+		using var picture = recorder.EndRecording();
+
+		canvas.DrawPicture(picture, ShadowState!.ShadowOnlyPaint);
+		canvas.DrawPicture(picture);
+	}
+
+	// Draws the cached blurred shadow image into the outer canvas using
+	// 9-slice scaling: the four corner regions stay 1:1 (preserving blur
+	// shape), the four edges stretch along one axis, and the middle
+	// stretches both ways. The cached image is sized
+	// (cachedContentW + 2*blurMargin) × (cachedContentH + 2*blurMargin),
+	// laid out so the visual's local origin maps to pixel
+	// (blurMargin, blurMargin).
+	private static void DrawShadowNineSlice(
+		SKCanvas canvas,
+		SKImage image,
+		int blurMargin,
+		int cachedContentW,
+		int cachedContentH,
+		int actualW,
+		int actualH)
+	{
+		var srcLeft = 0;
+		var srcInnerLeft = blurMargin;
+		var srcInnerRight = blurMargin + cachedContentW;
+		var srcRight = (2 * blurMargin) + cachedContentW;
+
+		var srcTop = 0;
+		var srcInnerTop = blurMargin;
+		var srcInnerBottom = blurMargin + cachedContentH;
+		var srcBottom = (2 * blurMargin) + cachedContentH;
+
+		var dstLeft = -blurMargin;
+		var dstInnerLeft = 0;
+		var dstInnerRight = actualW;
+		var dstRight = actualW + blurMargin;
+
+		var dstTop = -blurMargin;
+		var dstInnerTop = 0;
+		var dstInnerBottom = actualH;
+		var dstBottom = actualH + blurMargin;
+
+		DrawShadowPatch(canvas, image, srcLeft, srcTop, srcInnerLeft, srcInnerTop, dstLeft, dstTop, dstInnerLeft, dstInnerTop);
+		DrawShadowPatch(canvas, image, srcInnerLeft, srcTop, srcInnerRight, srcInnerTop, dstInnerLeft, dstTop, dstInnerRight, dstInnerTop);
+		DrawShadowPatch(canvas, image, srcInnerRight, srcTop, srcRight, srcInnerTop, dstInnerRight, dstTop, dstRight, dstInnerTop);
+
+		DrawShadowPatch(canvas, image, srcLeft, srcInnerTop, srcInnerLeft, srcInnerBottom, dstLeft, dstInnerTop, dstInnerLeft, dstInnerBottom);
+		DrawShadowPatch(canvas, image, srcInnerLeft, srcInnerTop, srcInnerRight, srcInnerBottom, dstInnerLeft, dstInnerTop, dstInnerRight, dstInnerBottom);
+		DrawShadowPatch(canvas, image, srcInnerRight, srcInnerTop, srcRight, srcInnerBottom, dstInnerRight, dstInnerTop, dstRight, dstInnerBottom);
+
+		DrawShadowPatch(canvas, image, srcLeft, srcInnerBottom, srcInnerLeft, srcBottom, dstLeft, dstInnerBottom, dstInnerLeft, dstBottom);
+		DrawShadowPatch(canvas, image, srcInnerLeft, srcInnerBottom, srcInnerRight, srcBottom, dstInnerLeft, dstInnerBottom, dstInnerRight, dstBottom);
+		DrawShadowPatch(canvas, image, srcInnerRight, srcInnerBottom, srcRight, srcBottom, dstInnerRight, dstInnerBottom, dstRight, dstBottom);
+	}
+
+	private static void DrawShadowPatch(
+		SKCanvas canvas,
+		SKImage image,
+		int sl, int st, int sr, int sb,
+		int dl, int dt, int dr, int db)
+	{
+		if (sl >= sr || st >= sb || dl >= dr || dt >= db)
+		{
+			// Zero/negative-area patch (e.g. visual smaller than 2*blurMargin); skip.
+			return;
+		}
+		var src = new SKRect(sl, st, sr, sb);
+		var dst = new SKRect(dl, dt, dr, db);
+		canvas.DrawImage(image, src, dst);
 	}
 
 	internal void GetNativeViewPathAndZOrder(SKPath clipFromParent, SKPath clipPath, List<Visual> nativeVisualsInZOrder)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ThemeShadow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ThemeShadow.cs
@@ -70,21 +70,30 @@ public class Given_ThemeShadow
 		WindowHelper.WindowContent = border;
 		await WindowHelper.WaitForLoaded(border);
 		await WindowHelper.WaitForIdle();
-
-		// Changing Translation.Z mutates the ShadowState (offsets and sigmas
-		// recompute), which must invalidate any cached image. Without
-		// invalidation we'd render last frame's shadow at the new offset.
-		border.Translation = new Vector3(0, 0, 48);
+		// A second idle wait gives the renderer a chance to commit a paint pass
+		// after layout settled, so the cache has a chance to be populated.
 		await WindowHelper.WaitForIdle();
 
-		// Re-rendering after the change should not throw; the cache may rebuild
-		// to a new entry, but the old entry must not leak. The strongest
-		// observable assertion is that the visual still renders and the cache
-		// either points at a fresh image or is null.
-		var afterChange = s_shadowOnlyImageField.GetValue(border.Visual);
-		Assert.IsTrue(
-			afterChange is null || afterChange is SkiaSharp.SKImage,
-			"After ShadowState change, cache must be null or hold a freshly built SKImage.");
+		var cacheBeforeChange = s_shadowOnlyImageField.GetValue(border.Visual);
+		if (cacheBeforeChange is null)
+		{
+			Assert.Inconclusive(
+				"Shadow cache was not populated by the initial render — test environment did not produce a render pass.");
+		}
+
+		// Changing Translation.Z mutates ShadowState (offsets and sigmas
+		// recompute). The cache key includes the ShadowState reference and
+		// blur margin, so the next render must rebuild — the SKImage instance
+		// must change (or be released entirely).
+		border.Translation = new Vector3(0, 0, 48);
+		await WindowHelper.WaitForIdle();
+		await WindowHelper.WaitForIdle();
+
+		var cacheAfterChange = s_shadowOnlyImageField.GetValue(border.Visual);
+		Assert.AreNotSame(
+			cacheBeforeChange,
+			cacheAfterChange,
+			"Cache must rebuild (different SKImage instance) after ShadowState change.");
 	}
 
 	[TestMethod]
@@ -136,23 +145,26 @@ public class Given_ThemeShadow
 		WindowHelper.WindowContent = border;
 		await WindowHelper.WaitForLoaded(border);
 		await WindowHelper.WaitForIdle();
+		await WindowHelper.WaitForIdle();
 
 		var cacheAfterFirstRender = s_shadowOnlyImageField.GetValue(border.Visual);
+		if (cacheAfterFirstRender is null)
+		{
+			Assert.Inconclusive(
+				"Shadow cache was not populated by the initial render — test environment did not produce a render pass.");
+		}
 
 		// Resize by 12 px in each axis — well within the 128px bucket stride.
 		border.Width = 112;
 		border.Height = 62;
 		await WindowHelper.WaitForIdle();
+		await WindowHelper.WaitForIdle();
 
 		var cacheAfterResize = s_shadowOnlyImageField.GetValue(border.Visual);
-
-		if (cacheAfterFirstRender is not null)
-		{
-			Assert.AreSame(
-				cacheAfterFirstRender,
-				cacheAfterResize,
-				"Resize within the same bucket stride must reuse the cached SKImage.");
-		}
+		Assert.AreSame(
+			cacheAfterFirstRender,
+			cacheAfterResize,
+			"Resize within the same bucket stride must reuse the cached SKImage instance.");
 	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ThemeShadow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ThemeShadow.cs
@@ -1,0 +1,158 @@
+﻿#if __SKIA__
+using System.Numerics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_ThemeShadow
+{
+	private static readonly FieldInfo s_shadowOnlyImageField =
+		typeof(global::Microsoft.UI.Composition.Visual).GetField(
+			"_shadowOnlyImage",
+			BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+	private static bool HasShadowCache(UIElement element)
+		=> s_shadowOnlyImageField.GetValue(element.Visual) is not null;
+
+	[TestMethod]
+	public async Task When_Shadow_Removed_Cache_Is_Released()
+	{
+		// Regression test for the ListView-item-recycle scenario from studio.live#1898.
+		// A recycled container removes its Shadow; the cached blurred SKImage must
+		// be released so the container's next use doesn't leak a now-orphan cache.
+		var border = new Border
+		{
+			Width = 100,
+			Height = 50,
+			Background = new SolidColorBrush(Colors.SkyBlue),
+			Shadow = new ThemeShadow(),
+			Translation = new Vector3(0, 0, 16),
+		};
+
+		WindowHelper.WindowContent = border;
+		await WindowHelper.WaitForLoaded(border);
+		await WindowHelper.WaitForIdle();
+
+		// Cache may or may not be populated depending on whether a frame ran while
+		// the shadow was applied; either way removing the shadow must clear it.
+		border.Shadow = null;
+		border.Translation = Vector3.Zero;
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(
+			HasShadowCache(border),
+			"Cached blurred shadow image must be disposed when Shadow is unset.");
+	}
+
+	[TestMethod]
+	public async Task When_Shadow_Changes_Cache_Is_Invalidated()
+	{
+		var border = new Border
+		{
+			Width = 100,
+			Height = 50,
+			Background = new SolidColorBrush(Colors.SkyBlue),
+			Shadow = new ThemeShadow(),
+			Translation = new Vector3(0, 0, 16),
+		};
+
+		WindowHelper.WindowContent = border;
+		await WindowHelper.WaitForLoaded(border);
+		await WindowHelper.WaitForIdle();
+
+		// Changing Translation.Z mutates the ShadowState (offsets and sigmas
+		// recompute), which must invalidate any cached image. Without
+		// invalidation we'd render last frame's shadow at the new offset.
+		border.Translation = new Vector3(0, 0, 48);
+		await WindowHelper.WaitForIdle();
+
+		// Re-rendering after the change should not throw; the cache may rebuild
+		// to a new entry, but the old entry must not leak. The strongest
+		// observable assertion is that the visual still renders and the cache
+		// either points at a fresh image or is null.
+		var afterChange = s_shadowOnlyImageField.GetValue(border.Visual);
+		Assert.IsTrue(
+			afterChange is null || afterChange is SkiaSharp.SKImage,
+			"After ShadowState change, cache must be null or hold a freshly built SKImage.");
+	}
+
+	[TestMethod]
+	public async Task When_Shadow_Applied_Visual_Renders()
+	{
+		// Smoke test: applying a ThemeShadow on a sized element with a positive
+		// Translation.Z does not throw and produces a renderable visual tree.
+		var grid = new Grid
+		{
+			Width = 200,
+			Height = 100,
+			Children =
+			{
+				new Rectangle
+				{
+					Width = 120,
+					Height = 60,
+					Fill = new SolidColorBrush(Colors.Turquoise),
+					Shadow = new ThemeShadow(),
+					Translation = new Vector3(0, 0, 32),
+				},
+			},
+		};
+
+		WindowHelper.WindowContent = grid;
+		await WindowHelper.WaitForLoaded(grid);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsNotNull(grid.Visual);
+		Assert.AreEqual(200, grid.ActualWidth);
+		Assert.AreEqual(100, grid.ActualHeight);
+	}
+
+	[TestMethod]
+	public async Task When_Shadow_Resized_Within_Bucket_Cache_Survives()
+	{
+		// The cache buckets size growth in 128px strides so that small drag/scroll
+		// resizes don't force a rebuild. Resizing within the same stride must keep
+		// the cached image alive.
+		var border = new Border
+		{
+			Width = 100,
+			Height = 50,
+			Background = new SolidColorBrush(Colors.SkyBlue),
+			Shadow = new ThemeShadow(),
+			Translation = new Vector3(0, 0, 16),
+		};
+
+		WindowHelper.WindowContent = border;
+		await WindowHelper.WaitForLoaded(border);
+		await WindowHelper.WaitForIdle();
+
+		var cacheAfterFirstRender = s_shadowOnlyImageField.GetValue(border.Visual);
+
+		// Resize by 12 px in each axis — well within the 128px bucket stride.
+		border.Width = 112;
+		border.Height = 62;
+		await WindowHelper.WaitForIdle();
+
+		var cacheAfterResize = s_shadowOnlyImageField.GetValue(border.Visual);
+
+		if (cacheAfterFirstRender is not null)
+		{
+			Assert.AreSame(
+				cacheAfterFirstRender,
+				cacheAfterResize,
+				"Resize within the same bucket stride must reuse the cached SKImage.");
+		}
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/UIElement.ThemeShadow.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.ThemeShadow.skia.cs
@@ -14,6 +14,10 @@ public partial class UIElement
 	partial void UnsetShadow()
 	{
 		Visual.ShadowState = null;
+		// Release the cached blurred shadow image so a recycled container
+		// (e.g. a ListView ItemContainer reused for a different item) doesn't
+		// keep the cache alive after its shadow is gone.
+		Visual.DisposeShadowCache();
 	}
 
 	partial void SetShadow()


### PR DESCRIPTION
Related to [#1898](https://github.com/unoplatform/studio.live/issues/1898)

## Possible Root cause

The Skia rendering path in [Visual.skia.cs](https://github.com/unoplatform/uno/blob/master/src/Uno.UI.Composition/Composition/Visual.skia.cs) rebuilt an `SKPictureRecorder` picture **and** applied an `SKImageFilter` blur **every frame** for any `Visual` carrying a `ShadowState` (set when `UIElement.Shadow + Translation.Z != 0`).

On a 60-item `ListView` with `ThemeShadow` applied per row, that was **60 blur-filter passes per frame**. During splitter resize the per-frame cost grew unbounded because nothing reused the previous frame's blurred output.

## Fix test to review

1. **Cache the blurred shadow output** — render the subtree picture once through the blur filter into a pooled `SKSurface`, snapshot the result as an `SKImage` keyed on `(ShadowState reference, blur margin, bucketed Visual size)`.
2. **9-slice scaling** — when the `Visual` size changes within the cached image's dimensions, draw via 9-slice (4 corners 1:1, edges stretch one axis, middle stretches both). Mirrors WinUI's own `SpriteVisual` + `NineGrid` path for `ThemeShadow`.
3. **Stride bucketing (128 px)** — round cached content size up to the next 128 px stride so small drag-induced size changes don't force a rebuild. A `Visual` that resizes 410 → 500 → 600 px hits two cache buckets `{512, 640}` instead of one rebuild per pixel.
4. **Bounded surface pool** — reuse `SKSurface` allocations across cache rebuilds, capped at 24 entries.
5. **Cache eviction** — `UnsetShadow()` calls `DisposeShadowCache()` so recycled containers (e.g. `ListView` `ItemContainer` reused for a different item) don't keep the cache alive.
6. **`MaxShadowCacheDim` safety** — visuals larger than 4096 px on either axis fall back to per-frame blur (rare; protects against multi-megabyte surface allocations).

## Performance results

Skia Desktop, Win32, .NET 10.0.201, pixel-dense laptop. Standalone HD-less repro ([Probe1898ShadowRepro.zip](https://github.com/user-attachments/files/28044998/Probe1898ShadowRepro.zip)), 60-item `ListView` with `ThemeShadow` on each row. Three scenarios per toggle state (idle / drag-splitter / scroll), 8-second drag and 6-second scroll segments.

**True baseline (master, no patch):**

| Scenario   | Dropped frames | Frame time avg | p95      |
|------------|----------------|----------------|----------|
| off-drag   | 100%           | 76.9 ms        | 92.0 ms  |
| on-drag    | 100%           | 154.6 ms       | 233.7 ms |
| on-scroll  | 100%           | 172.5 ms       | 194.9 ms |

**With patch (averaged across 3 runs):**

| Scenario   | Dropped frames | Frame time avg | p95     |
|------------|----------------|----------------|---------|
| off-drag   | ~20.6%         | 31.3 ms        | 44.8 ms |
| on-drag    | ~26.4%         | 31.9 ms        | 49.1 ms |
| on-scroll  | ~10.9%         | 31.2 ms        | 41.5 ms |

**Net win:** ~4x lower frame time and 60+ percentage-point lower dropped-frame rate with shadows on. Allocations on drag with shadows-on: 3535 → 3072 KB/frame (similar — the bulk is non-shadow allocation, tracked separately below).

## Cross-platform validation

The same Skia source compiles into one DLL used by every Skia host, so the change applies uniformly. End-to-end baseline-vs-patched A/B benchmarks were captured on all four Skia targets via the same repro app.

**Skia Desktop (Win32) — 3 runs averaged:** see table above.

**Skia Android (Pixel 9 Pro XL tablet emulator, API 36, 2560×1440):**

| Scenario   | Baseline avg ms | Patched avg ms | Speedup |
|------------|-----------------|----------------|---------|
| off-drag   | 152.9           | 48.5           | 3.2×    |
| off-scroll | 151.2           | 38.8           | 3.9×    |
| on-idle    | 260.9           | 39.5           | 6.6×    |
| **on-drag** | **278.8**      | **44.4**       | **6.3×** |
| on-scroll  | 300.3           | 40.4           | 7.4×    |

Patched on-drag (44.4 ms) ≈ patched off-drag (48.5 ms) — cache eliminates the shadow overhead on Android entirely.

**Skia WASM (Chromium, browserwasm target):**

| Scenario   | Baseline avg ms | Patched avg ms | Speedup |
|------------|-----------------|----------------|---------|
| off-idle   | 167.1           | 47.9           | 3.5×    |
| off-drag   | 333.1           | 196.2          | 1.7×    |
| on-idle    | 260.0           | 58.0           | 4.5×    |
| **on-drag** | **418.6**      | **298.5**      | **1.4×** |
| on-scroll  | 490.6           | 298.0          | 1.6×    |

WASM gains are largest on stable-shadow scenarios (idle/scroll). Drag improvement is more modest (1.4×) because the cache rebuilds repeatedly as the splitter sweeps through pixel sizes — identified as follow-up headroom below.

**Skia iOS (iPad Pro 13-inch M5, iOS 26.3 simulator on macOS x86_64):**

| Scenario   | Baseline avg ms | Patched avg ms | Speedup |
|------------|-----------------|----------------|---------|
| off-idle   | 40.1            | 26.8           | 1.5×    |
| off-drag   | 52.7            | 42.1           | 1.3×    |
| on-idle    | 61.5            | 22.3           | 2.8×    |
| **on-drag** | **64.3**       | **42.9**       | **1.5×** |
| on-scroll  | 70.9            | 29.3           | 2.4×    |

iOS on-idle drops to 22.3 ms (~45 fps with shadows on). Patched on-drag (42.9 ms) ≈ patched off-drag (42.1 ms) — same cache-eliminates-overhead pattern as Android.

The change touches only `src/Uno.UI.Composition/Composition/Visual.skia.cs` and the partial `UIElement.ThemeShadow.skia.cs` — no per-platform branches.

## Tests

New file: [Given_ThemeShadow.cs](https://github.com/unoplatform/uno/blob/93009e72d55593c04a569ea6674a32382748084f/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ThemeShadow.cs) (Skia-only) with 4 tests:

1. Cache disposal on `UnsetShadow()`.
2. Cache invalidation on `ShadowState` change.
3. Render-smoke (visual still draws with shadow applied after caching).
4. Stride-bucket cache survival on a small resize within the same 128 px bucket.

These assert **correctness and lifecycle** (deterministic, CI-safe) rather than perf budgets.

## Industry references

Compositor projects track perf via trend dashboards rather than hard CI gates, because micro-benchmarks on shared CI runners are too noisy to gate merges on. References:

- Skia Perf dashboard: https://perf.skia.org/
- Skia testing notes: https://skia.org/docs/dev/testing/
- Chromium perf-regression policy: https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/docs/speed/addressing_performance_regressions.md
- [Integration profiling](https://docs.flutter.dev/cookbook/testing/integration/profiling)

This PR follows that pattern: Skia-only `RuntimeTests` assert correctness and lifecycle (deterministic), not perf budgets (which would be flaky on CI). Perf was validated locally so far and reported in the table above.

## Leftover perf findings & follow-ups

The repro exposed two non-shadow issues that are **not** addressed here and are tracked separately:

- A ~32 fps cap during any interaction on Skia Desktop (independent of shadows / present even with the toggle off).
- ~3 MB/frame allocation during drag (only a small fraction is shadow-related).

Tracked in: 
- https://github.com/unoplatform/uno/issues/23292

### Known headroom in this initial test patch

- **WASM drag rebuild thrashing.** When the splitter sweeps through many pixel sizes, the cache crosses 128 px stride buckets repeatedly and rebuilds (~85 ms each). On Desktop/Android this is amortised well; on WASM (single-threaded JS) it caps the drag speedup at ~1.4×. Possible follow-up: larger stride or drag-time rebuild dampening. 
Left out of this PR to keep the change minimal and platform-agnostic so far and need overall validation.

## Repro sample

Attached: [Probe1898ShadowRepro.zip](https://github.com/user-attachments/files/28044998/Probe1898ShadowRepro.zip)

 Contents:

- 60-item `ListView` page with a `ThemeShadow` toggle and a splitter to drive the resize scenario.
- A benchmark runner with an `--auto-benchmark` flag that produces machine-readable JSON for A/B comparison between master and a patched build.
- Three scenarios baked in: idle, drag-splitter (8 s), scroll (6 s) — each captured per toggle state so before/after numbers stay paired.

To reproduce the baseline-vs-patched table above: run the sample once against a stock Uno build and once against this branch with `--auto-benchmark`, then diff the JSON outputs.
