### PR TITLE
fix: Use ms-appx URI for SamplesApp App.xaml merged dictionary

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml
@@ -34,7 +34,7 @@
 
             <ResourceDictionary.MergedDictionaries>
                 <win:XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <ResourceDictionary Source="Windows_UI_Xaml_Controls\ListView\MeasureDetectorControl\MeasureDetectorControl.xaml" />
+                <ResourceDictionary Source="ms-appx:///Windows_UI_Xaml_Controls/ListView/MeasureDetectorControl/MeasureDetectorControl.xaml" />
                 <MapResources xmlns="using:Uno.UI.Maps" />
             </ResourceDictionary.MergedDictionaries>
 


### PR DESCRIPTION
## Problem

The `MeasureDetectorControl` resource dictionary merged into `App.xaml` (SamplesApp) used a **relative** `Source`:

```xml
<ResourceDictionary Source="Windows_UI_Xaml_Controls\ListView\MeasureDetectorControl\MeasureDetectorControl.xaml" />
```

After the SamplesApp shared-project restructuring (samples moved from `UITests.Shared` to `SamplesApp.Samples`), native WinUI no longer resolves this relative path at startup. The app crashes during `App` initialization with a `XamlParseException` (WinRT stowed exception `0xC000027B`) **before any runtime test runs**, taking down the whole WinUI runtime-test job.

## Fix

Switch to an absolute `ms-appx:///` URI:

```xml
<ResourceDictionary Source="ms-appx:///Windows_UI_Xaml_Controls/ListView/MeasureDetectorControl/MeasureDetectorControl.xaml" />
```

This resolves reliably on all platforms and restores SamplesApp startup.

## Validation

- Built `SamplesApp.Windows` (WinAppSDK) and confirmed the app now starts and enumerates runtime tests (241 fixtures) instead of crashing at startup with the stowed `XamlParseException`.
- Skia/Uno unaffected — the relative path already worked there and `ms-appx:///` is equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
