### PR TITLE
fix(xaml): Emit bindings when sibling Extension exists

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2049,6 +2049,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private INamedTypeSymbol? GetMarkupExtensionType(XamlType? xamlType)
+			// When resolving the concrete markup extension type to instantiate, prefer the "Extension"-suffixed
+			// type, following the XAML markup extension naming convention (e.g. {local:Foo} resolves FooExtension).
+			=> GetMarkupExtensionType(xamlType, preferExtensionSuffix: true);
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private INamedTypeSymbol? GetMarkupExtensionType(XamlType? xamlType, bool preferExtensionSuffix)
 		{
 			if (xamlType == null)
 			{
@@ -2064,8 +2070,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// In this case, we go through this code path as it's much more efficient than FindType.
 				var baseTypeString = $"{ns}.{xamlType.Name}";
 
-				// Try finding the type with "Extension" suffix first, then without
-				return FindMarkupExtensionType(baseTypeString + "Extension") ?? FindMarkupExtensionType(baseTypeString);
+				return ResolveMarkupExtensionType(baseTypeString, preferExtensionSuffix);
 			}
 
 			// When implicit XAML namespaces are enabled, mirror the element-type resolution
@@ -2080,7 +2085,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (_globalClrNamespaces.Length > 0
 					&& (trimmedNamespace == XamlConstants.PresentationXamlXmlNamespace || string.IsNullOrEmpty(trimmedNamespace)))
 				{
-					if (FindMarkupExtensionTypeInNamespacesWithAmbiguityCheck(xamlType.Name, _globalClrNamespaces) is INamedTypeSymbol globalResult)
+					if (FindMarkupExtensionTypeInNamespacesWithAmbiguityCheck(xamlType.Name, _globalClrNamespaces, preferExtensionSuffix) is INamedTypeSymbol globalResult)
 					{
 						return globalResult;
 					}
@@ -2091,7 +2096,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (_allXmlnsDefinitions != null
 					&& !_knownNamespaces.ContainsKey(trimmedNamespace)
 					&& _allXmlnsDefinitions.TryGetValue(trimmedNamespace, out var xmlnsDefNamespaces)
-					&& FindMarkupExtensionTypeInNamespaces(xamlType.Name, xmlnsDefNamespaces) is INamedTypeSymbol xmlnsDefResult)
+					&& FindMarkupExtensionTypeInNamespaces(xamlType.Name, xmlnsDefNamespaces, preferExtensionSuffix) is INamedTypeSymbol xmlnsDefResult)
 				{
 					return xmlnsDefResult;
 				}
@@ -2102,30 +2107,57 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return null;
 		}
 
+		/// <summary>
+		/// Resolves a markup extension type from its fully qualified base name (i.e. the name without the
+		/// "Extension" suffix).
+		/// </summary>
+		/// <param name="preferExtensionSuffix">
+		/// When <see langword="true"/>, the markup extension is being resolved for a curly-brace usage (or for the
+		/// concrete type to instantiate), so the "Extension"-suffixed type wins per the XAML markup extension naming
+		/// convention. When <see langword="false"/>, the exact name is resolved first and the "Extension"-suffixed
+		/// name is only used as a fallback when the exact name does not resolve to any type. This prevents an unrelated
+		/// type (e.g. an element <c>FluentIcon</c>) from being misidentified as a markup extension simply because a
+		/// sibling <c>FluentIconExtension</c> exists in the same namespace. See
+		/// https://github.com/unoplatform/uno/issues/21992.
+		/// </param>
+		private INamedTypeSymbol? ResolveMarkupExtensionType(string baseTypeString, bool preferExtensionSuffix)
+		{
+			if (preferExtensionSuffix)
+			{
+				// Try finding the type with "Extension" suffix first, then without
+				return FindMarkupExtensionType(baseTypeString + "Extension") ?? FindMarkupExtensionType(baseTypeString);
+			}
+
+			// Exact name first: a type that resolves but is not a markup extension blocks the "Extension" fallback.
+			if (_metadataHelper.FindTypeByFullName(baseTypeString) is INamedTypeSymbol exactType)
+			{
+				return exactType.Is(Generation.MarkupExtensionSymbol.Value) ? exactType : null;
+			}
+
+			return baseTypeString.EndsWith("Extension", StringComparison.Ordinal)
+				? null
+				: FindMarkupExtensionType(baseTypeString + "Extension");
+		}
+
 		private INamedTypeSymbol? FindMarkupExtensionType(string fullTypeName)
 		{
 			return _metadataHelper.FindTypeByFullName(fullTypeName) is INamedTypeSymbol type && type.Is(Generation.MarkupExtensionSymbol.Value) ? type : null;
 		}
 
-		private INamedTypeSymbol? FindMarkupExtensionTypeInNamespaces(string name, string[] namespaces)
+		private INamedTypeSymbol? FindMarkupExtensionTypeInNamespaces(string name, string[] namespaces, bool preferExtensionSuffix)
 		{
 			foreach (var @namespace in namespaces)
 			{
-				if (FindMarkupExtensionType($"{@namespace}.{name}Extension") is INamedTypeSymbol withSuffix)
+				if (ResolveMarkupExtensionType($"{@namespace}.{name}", preferExtensionSuffix) is INamedTypeSymbol match)
 				{
-					return withSuffix;
-				}
-
-				if (FindMarkupExtensionType($"{@namespace}.{name}") is INamedTypeSymbol withoutSuffix)
-				{
-					return withoutSuffix;
+					return match;
 				}
 			}
 
 			return null;
 		}
 
-		private INamedTypeSymbol? FindMarkupExtensionTypeInNamespacesWithAmbiguityCheck(string name, string[] namespaces)
+		private INamedTypeSymbol? FindMarkupExtensionTypeInNamespacesWithAmbiguityCheck(string name, string[] namespaces, bool preferExtensionSuffix)
 		{
 			INamedTypeSymbol? firstMatch = null;
 			string? firstNamespace = null;
@@ -2133,8 +2165,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			foreach (var @namespace in namespaces)
 			{
-				var match = FindMarkupExtensionType($"{@namespace}.{name}Extension")
-					?? FindMarkupExtensionType($"{@namespace}.{name}");
+				var match = ResolveMarkupExtensionType($"{@namespace}.{name}", preferExtensionSuffix);
 
 				if (match is not null)
 				{
@@ -2170,8 +2201,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		}
 
 		private bool IsCustomMarkupExtensionType(XamlType? xamlType) =>
-			// Determine if the type is a custom markup extension
-			GetMarkupExtensionType(xamlType) != null;
+			// Determine if the type is a custom markup extension.
+			// Unlike GetMarkupExtensionType (which resolves the concrete type to instantiate and therefore prefers the
+			// "Extension"-suffixed type per the XAML naming convention), this membership test resolves the exact name
+			// first so an object element whose type is not a markup extension is not misclassified just because a
+			// sibling "<Name>Extension" markup extension exists in the same namespace.
+			// See https://github.com/unoplatform/uno/issues/21992.
+			GetMarkupExtensionType(xamlType, preferExtensionSuffix: false) != null;
 
 		private bool IsXamlTypeConverter(INamedTypeSymbol? symbol)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_MarkupExtension.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_MarkupExtension.cs
@@ -121,6 +121,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 
 			Assert.AreEqual(nameof(TargetValueExtension), (page.Nested as TextBlock).Tag);
 		}
+
+		[TestMethod]
+		public async Task When_MarkupExtension_SiblingControlExtension()
+		{
+			// A control element (SiblingExtensionControl) must not be misidentified as a markup extension just
+			// because a sibling SiblingExtensionControlExtension exists in the same namespace. The element must be
+			// instantiated and its bindings must be emitted. See https://github.com/unoplatform/uno/issues/21992.
+			var page = new MarkupExtension_SiblingExtension();
+			await UITestHelper.Load(page, isLoaded: x => x.IsLoaded);
+
+			Assert.AreEqual("literal", (page.Literal as SiblingExtensionControl).Value, "Literal value was not set (control was likely dropped).");
+			Assert.AreEqual("bound", (page.XBind as SiblingExtensionControl).Value, "x:Bind binding code was not emitted.");
+			Assert.AreEqual("bound", (page.Bound as SiblingExtensionControl).Value, "Binding code was not emitted.");
+		}
+#endif
+
+#if HAS_UNO
+		[TestMethod]
+		public async Task When_MarkupExtension_SiblingControlExtension_XamlReader()
+		{
+			// Same scenario as When_MarkupExtension_SiblingControlExtension, but exercising the runtime XamlReader.
+			var panel = (StackPanel)Microsoft.UI.Xaml.Markup.XamlReader.Load("""
+				<StackPanel xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				            xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+					<local:SiblingExtensionControl x:Name="Literal" Value="literal" />
+					<local:SiblingExtensionControl x:Name="Bound" Value="{Binding}" />
+				</StackPanel>
+				""");
+
+			panel.DataContext = "bound";
+			await UITestHelper.Load(panel, isLoaded: x => x.IsLoaded); // bare Control has no template => 0 size, so bypass the size-based load check
+
+			var literal = (SiblingExtensionControl)panel.FindName("Literal");
+			var bound = (SiblingExtensionControl)panel.FindName("Bound");
+
+			Assert.AreEqual("literal", literal.Value, "Literal value was not set (control was likely dropped).");
+			Assert.AreEqual("bound", bound.Value, "Binding was not processed for the control.");
+		}
 #endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_SiblingExtension.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_SiblingExtension.xaml
@@ -1,0 +1,12 @@
+<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup.MarkupExtension_SiblingExtension"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+	<StackPanel>
+		<!-- A control whose name + "Extension" matches a sibling markup extension in the same namespace.
+		     The element must be treated as the control, not the markup extension (#21992). -->
+		<local:SiblingExtensionControl x:Name="Literal" x:FieldModifier="Public" Value="literal" />
+		<local:SiblingExtensionControl x:Name="XBind" x:FieldModifier="Public" Value="{x:Bind BoundValue}" />
+		<local:SiblingExtensionControl x:Name="Bound" x:FieldModifier="Public" Value="{Binding BoundValue}" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_SiblingExtension.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_SiblingExtension.xaml.cs
@@ -1,0 +1,40 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup;
+
+public sealed partial class MarkupExtension_SiblingExtension : Page
+{
+	public MarkupExtension_SiblingExtension()
+	{
+		this.InitializeComponent();
+
+		// Required for the {Binding BoundValue} usage.
+		DataContext = this;
+	}
+
+	public string BoundValue => "bound";
+}
+
+/// <summary>
+/// A regular control (not a markup extension) that has a sibling <see cref="SiblingExtensionControlExtension"/>
+/// markup extension declared in the same namespace. Used to validate that the XAML generator/reader does not
+/// misidentify the control element as a markup extension (https://github.com/unoplatform/uno/issues/21992).
+/// </summary>
+public partial class SiblingExtensionControl : Control
+{
+	public string Value
+	{
+		get => (string)GetValue(ValueProperty);
+		set => SetValue(ValueProperty, value);
+	}
+
+	public static readonly DependencyProperty ValueProperty =
+		DependencyProperty.Register(nameof(Value), typeof(string), typeof(SiblingExtensionControl), new PropertyMetadata(null));
+}
+
+public sealed class SiblingExtensionControlExtension : MarkupExtension
+{
+	protected override object ProvideValue() => "from-extension";
+}


### PR DESCRIPTION
**GitHub Issue:** closes #21992

## PR Type:

🐞 Bugfix

## What changed? 🚀

When a control type and a markup extension named `<ControlName>Extension` lived in the **same namespace** (e.g. `FluentIcon` + `FluentIconExtension`), the XAML source generator misidentified the `<FluentIcon>` *element* as a markup extension. This happened because `IsCustomMarkupExtensionType` resolved the `"Extension"`-suffixed name first, so the unrelated `FluentIconExtension` markup extension was matched instead of the `FluentIcon` control.

The consequences for the affected element were:
- it was filtered out of its parent, so it never reached the visual tree, and
- its binding code (`{x:Bind}` / `{Binding}` on its properties) was never emitted — the reported symptom (data binding on custom dependency properties silently doing nothing under Uno while working on WinAppSDK).

### Fix
The two responsibilities that were conflated in a single resolver are now separated:
- **`IsCustomMarkupExtensionType`** (the *membership* test) resolves the **exact name first** — an existing non-markup-extension type now blocks the `"Extension"` fallback, so `<FluentIcon>` is correctly treated as an element.
- **`GetMarkupExtensionType`** (which picks the concrete type to *instantiate* for a genuine `{curly-brace}` usage) keeps the **suffix-first** XAML naming convention.

Because every `GetMarkupExtensionType` call is gated by the membership test, an element never reaches instantiation, while real `{Foo}` markup extensions still prefer `FooExtension`. This aligns the generator with the runtime `XamlReader`, which already used exact-first resolution.

### Tests
Added `Given_MarkupExtension` runtime tests covering both code paths for a control that has a sibling `…Extension` markup extension in the same namespace:
- `When_MarkupExtension_SiblingControlExtension` — XAML source generator path (literal value, `{x:Bind}`, and `{Binding}`)
- `When_MarkupExtension_SiblingControlExtension_XamlReader` — runtime `XamlReader.Load` path

All 10 `Given_MarkupExtension` tests pass on Skia Desktop, including `When_MarkupExtension_FullNameFirst` which confirms the `"Extension"`-suffix priority for `{curly-brace}` usages is preserved (no regression).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
