### PR TITLE
test: Add ItemsRepeater scroll sample

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ChatAutoScroll.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ChatAutoScroll.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+
+namespace UITests.Windows_UI_Xaml_Controls.Repeater;
+
+/// <summary>
+/// Self-contained auto-scroll behavior for an ItemsRepeater inside a ScrollViewer, modelled on a
+/// typical chat conversation panel. When enabled it scrolls to the bottom as items are added, but
+/// respects the user's scroll position (won't fight a scroll-up) and skips while the pointer is
+/// over the chat. Used by <see cref="ItemsRepeaterChatConversation"/> to reproduce the dynamic
+/// layout churn (UpdateLayout + ChangeView on add) that a static list lacks.
+/// </summary>
+public static class ChatAutoScroll
+{
+	private const double ScrollTolerance = 100.0;
+
+	private static readonly ConditionalWeakTable<ItemsRepeater, ScrollState> _states = new();
+
+	public static readonly DependencyProperty IsEnabledProperty =
+		DependencyProperty.RegisterAttached(
+			"IsEnabled",
+			typeof(bool),
+			typeof(ChatAutoScroll),
+			new PropertyMetadata(false, OnIsEnabledChanged));
+
+	public static bool GetIsEnabled(DependencyObject obj) => (bool)obj.GetValue(IsEnabledProperty);
+
+	public static void SetIsEnabled(DependencyObject obj, bool value) => obj.SetValue(IsEnabledProperty, value);
+
+	private static void OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		if (d is not ItemsRepeater repeater)
+		{
+			return;
+		}
+
+		if ((bool)e.NewValue)
+		{
+			AttachBehavior(repeater);
+		}
+		else
+		{
+			DetachBehavior(repeater);
+		}
+	}
+
+	private static void AttachBehavior(ItemsRepeater repeater)
+	{
+		var state = new ScrollState(repeater);
+		_states.AddOrUpdate(repeater, state);
+
+		repeater.Unloaded += state.OnUnloaded;
+
+		state.ItemsSourceCallbackToken =
+			repeater.RegisterPropertyChangedCallback(ItemsRepeater.ItemsSourceProperty, state.OnItemsSourceChanged);
+
+		if (repeater.ItemsSource is INotifyCollectionChanged incc)
+		{
+			state.SubscribeCollection(incc);
+		}
+
+		if (repeater.IsLoaded)
+		{
+			state.FindAndAttachScrollViewer();
+		}
+		else
+		{
+			repeater.Loaded += state.OnLoaded;
+		}
+	}
+
+	private static void DetachBehavior(ItemsRepeater repeater)
+	{
+		if (_states.TryGetValue(repeater, out var state))
+		{
+			state.Detach();
+			_states.Remove(repeater);
+		}
+	}
+
+	private static ScrollViewer FindAncestorScrollViewer(DependencyObject element)
+	{
+		var parent = VisualTreeHelper.GetParent(element);
+		while (parent is not null)
+		{
+			if (parent is ScrollViewer sv)
+			{
+				return sv;
+			}
+
+			parent = VisualTreeHelper.GetParent(parent);
+		}
+
+		return null;
+	}
+
+	private sealed class ScrollState
+	{
+		private readonly ItemsRepeater _repeater;
+		private ScrollViewer _scrollViewer;
+		private INotifyCollectionChanged _currentCollection;
+		private bool _isAtBottom = true;
+		private bool _isMouseOver;
+		private bool _scrollToBottomPending;
+
+		public long ItemsSourceCallbackToken { get; set; }
+
+		public ScrollState(ItemsRepeater repeater) => _repeater = repeater;
+
+		public void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			_repeater.Loaded -= OnLoaded;
+			FindAndAttachScrollViewer();
+		}
+
+		public void OnUnloaded(object sender, RoutedEventArgs e) => DetachBehavior(_repeater);
+
+		public void FindAndAttachScrollViewer()
+		{
+			_scrollViewer = FindAncestorScrollViewer(_repeater);
+			if (_scrollViewer is not null)
+			{
+				_scrollViewer.ViewChanged += OnViewChanged;
+				_scrollViewer.PointerEntered += OnPointerEntered;
+				_scrollViewer.PointerExited += OnPointerExited;
+				UpdateIsAtBottom();
+			}
+		}
+
+		public void OnItemsSourceChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			UnsubscribeCollection();
+
+			if (_repeater.ItemsSource is INotifyCollectionChanged incc)
+			{
+				SubscribeCollection(incc);
+			}
+		}
+
+		public void SubscribeCollection(INotifyCollectionChanged collection)
+		{
+			_currentCollection = collection;
+			collection.CollectionChanged += OnCollectionChanged;
+		}
+
+		private void UnsubscribeCollection()
+		{
+			if (_currentCollection is not null)
+			{
+				_currentCollection.CollectionChanged -= OnCollectionChanged;
+				_currentCollection = null;
+			}
+		}
+
+		private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			// Only Add/Reset bring new content to the bottom. Replace/Remove must not override
+			// the user's scroll position.
+			var shouldScroll = e.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Reset;
+			if (!shouldScroll)
+			{
+				return;
+			}
+
+			// Pointer over the chat → don't interrupt the user's reading/scroll position.
+			if (_isMouseOver || !_isAtBottom || _scrollToBottomPending)
+			{
+				return;
+			}
+
+			_scrollToBottomPending = true;
+
+			// Defer to let layout settle after the new item is measured.
+			if (!_repeater.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+			{
+				_scrollToBottomPending = false;
+				ScrollToBottomCore();
+			}))
+			{
+				_scrollToBottomPending = false;
+			}
+		}
+
+		private void OnViewChanged(object sender, ScrollViewerViewChangedEventArgs e) => UpdateIsAtBottom();
+
+		private void OnPointerEntered(object sender, PointerRoutedEventArgs e) => _isMouseOver = true;
+
+		private void OnPointerExited(object sender, PointerRoutedEventArgs e) => _isMouseOver = false;
+
+		private void UpdateIsAtBottom()
+		{
+			if (_scrollViewer is null)
+			{
+				return;
+			}
+
+			var scrollableHeight = _scrollViewer.ScrollableHeight;
+			var verticalOffset = _scrollViewer.VerticalOffset;
+			_isAtBottom = scrollableHeight <= 0 || (scrollableHeight - verticalOffset) <= ScrollTolerance;
+		}
+
+		private void ScrollToBottomCore()
+		{
+			if (_scrollViewer is null)
+			{
+				return;
+			}
+
+			// Force a layout pass so newly-measured items are reflected in ScrollableHeight
+			// before we issue ChangeView.
+			try
+			{
+				_scrollViewer.UpdateLayout();
+			}
+			catch (InvalidOperationException)
+			{
+				// A layout cycle was detected; the next collection-changed event retries.
+				return;
+			}
+
+			var scrollableHeight = _scrollViewer.ScrollableHeight;
+			if (scrollableHeight <= 0)
+			{
+				return;
+			}
+
+			_scrollViewer.ChangeView(null, scrollableHeight, null, disableAnimation: true);
+		}
+
+		public void Detach()
+		{
+			UnsubscribeCollection();
+
+			_repeater.UnregisterPropertyChangedCallback(ItemsRepeater.ItemsSourceProperty, ItemsSourceCallbackToken);
+			_repeater.Loaded -= OnLoaded;
+			_repeater.Unloaded -= OnUnloaded;
+
+			if (_scrollViewer is not null)
+			{
+				_scrollViewer.ViewChanged -= OnViewChanged;
+				_scrollViewer.PointerEntered -= OnPointerEntered;
+				_scrollViewer.PointerExited -= OnPointerExited;
+				_scrollViewer = null;
+			}
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterChatConversation.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterChatConversation.xaml
@@ -1,0 +1,392 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.Repeater.ItemsRepeaterChatConversation"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Repeater"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <!--  User message: right-aligned bubble with a fixed left gutter  -->
+        <DataTemplate x:Key="ChatUserTemplate" x:DataType="local:ChatMessage">
+            <Grid Padding="0,4" ColumnDefinitions="60,*">
+                <Border
+                    Grid.Column="1"
+                    Margin="0,0,16,0"
+                    Padding="12,8,12,10"
+                    HorizontalAlignment="Right"
+                    Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
+                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8">
+                    <StackPanel Spacing="4">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{Binding Text}"
+                            TextWrapping="Wrap" />
+                        <!--  Nested horizontal image-attachment repeater (repeater-inside-item)  -->
+                        <mux:ItemsRepeater
+                            Margin="0,4,0,0"
+                            ItemsSource="{Binding Images}"
+                            Visibility="{Binding ImagesVisibility}">
+                            <mux:ItemsRepeater.Layout>
+                                <mux:StackLayout Orientation="Horizontal" Spacing="6" />
+                            </mux:ItemsRepeater.Layout>
+                            <mux:ItemsRepeater.ItemTemplate>
+                                <DataTemplate x:DataType="local:ChatImageAttachment">
+                                    <Border
+                                        Width="36"
+                                        Height="36"
+                                        Background="{Binding Fill}"
+                                        CornerRadius="4" />
+                                </DataTemplate>
+                            </mux:ItemsRepeater.ItemTemplate>
+                        </mux:ItemsRepeater>
+                        <TextBlock
+                            HorizontalAlignment="Right"
+                            FontSize="10"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Text="{Binding Timestamp}" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </DataTemplate>
+
+        <!--  Assistant (standard) message: left-aligned body text with an optional image grid  -->
+        <DataTemplate x:Key="ChatAssistantTemplate" x:DataType="local:ChatMessage">
+            <StackPanel Padding="20,12,44,12">
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    Text="{Binding Text}"
+                    TextWrapping="Wrap" />
+                <!--  Nested wrapping image grid (repeater-inside-item, variable row count -> variable height)  -->
+                <mux:ItemsRepeater
+                    MaxWidth="320"
+                    Margin="0,8,0,0"
+                    HorizontalAlignment="Left"
+                    ItemsSource="{Binding Images}"
+                    Visibility="{Binding ImagesVisibility}">
+                    <mux:ItemsRepeater.Layout>
+                        <mux:UniformGridLayout
+                            ItemsStretch="None"
+                            MinColumnSpacing="6"
+                            MinItemHeight="64"
+                            MinItemWidth="64"
+                            MinRowSpacing="6" />
+                    </mux:ItemsRepeater.Layout>
+                    <mux:ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="local:ChatImageAttachment">
+                            <Border
+                                Width="64"
+                                Height="64"
+                                Background="{Binding Fill}"
+                                CornerRadius="6" />
+                        </DataTemplate>
+                    </mux:ItemsRepeater.ItemTemplate>
+                </mux:ItemsRepeater>
+            </StackPanel>
+        </DataTemplate>
+
+        <!--  Reasoning: collapsible Expander section (the only Expander-based item)  -->
+        <DataTemplate x:Key="ChatReasoningTemplate" x:DataType="local:ChatMessage">
+            <Border Padding="20,2">
+                <Expander
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Stretch"
+                    IsExpanded="{Binding IsReasoningExpanded, Mode=OneWay}">
+                    <Expander.Header>
+                        <Grid MinHeight="32" ColumnDefinitions="Auto,*">
+                            <FontIcon
+                                Grid.Column="0"
+                                Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                FontSize="14"
+                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                                Glyph="&#xE10B;" />
+                            <TextBlock
+                                Grid.Column="1"
+                                VerticalAlignment="Center"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{Binding ReasoningHeader}" />
+                        </Grid>
+                    </Expander.Header>
+                    <TextBlock
+                        Margin="28,4,4,8"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{Binding Text}"
+                        TextWrapping="Wrap" />
+                </Expander>
+            </Border>
+        </DataTemplate>
+
+        <!--  Tool call: single-line step row with status icon, optional file pill and diff/entry counts  -->
+        <DataTemplate x:Key="ChatToolCallTemplate" x:DataType="local:ChatMessage">
+            <Border Padding="16,3,20,3">
+                <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,*">
+                    <Grid
+                        Grid.Column="0"
+                        Width="20"
+                        Height="20"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center">
+                        <mux:ProgressRing
+                            Width="14"
+                            Height="14"
+                            IsActive="True"
+                            Visibility="{Binding ToolProgressVisibility}" />
+                        <FontIcon
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="14"
+                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                            Glyph="&#xE10B;"
+                            Visibility="{Binding ToolSuccessVisibility}" />
+                        <FontIcon
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="14"
+                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                            Glyph="&#xE783;"
+                            Visibility="{Binding ToolFailureVisibility}" />
+                    </Grid>
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        FontSize="13"
+                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                        Text="{Binding ToolStatusText}"
+                        TextTrimming="CharacterEllipsis" />
+                    <Border
+                        Grid.Column="2"
+                        Height="18"
+                        Margin="6,0,0,0"
+                        VerticalAlignment="Center"
+                        Background="{ThemeResource ControlFillColorDefaultBrush}"
+                        CornerRadius="4"
+                        Visibility="{Binding ToolFileNameVisibility}">
+                        <TextBlock
+                            Padding="6,0"
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{Binding ToolFileName}" />
+                    </Border>
+                    <StackPanel
+                        Grid.Column="3"
+                        Margin="8,0,0,0"
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        Spacing="6">
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                            Text="{Binding ToolDiffAddedText}"
+                            Visibility="{Binding ToolDiffVisibility}" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                            Text="{Binding ToolDiffRemovedText}"
+                            Visibility="{Binding ToolDiffRemovedVisibility}" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Text="{Binding ToolEntryCountText}"
+                            Visibility="{Binding ToolEntryCountVisibility}" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <!--  Thinking indicator: spinner + status text  -->
+        <DataTemplate x:Key="ChatThinkingTemplate" x:DataType="local:ChatMessage">
+            <Grid Padding="20,10,44,10" ColumnDefinitions="Auto,*">
+                <mux:ProgressRing
+                    Grid.Column="0"
+                    Width="16"
+                    Height="16"
+                    Margin="0,0,10,0"
+                    VerticalAlignment="Center"
+                    IsActive="True" />
+                <TextBlock
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="{Binding Text}" />
+            </Grid>
+        </DataTemplate>
+
+        <!--  Benchmark line: bold accent text  -->
+        <DataTemplate x:Key="ChatBenchmarkTemplate" x:DataType="local:ChatMessage">
+            <Grid Padding="20,6,44,6">
+                <TextBlock
+                    FontSize="12"
+                    FontWeight="Bold"
+                    Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                    Text="{Binding Text}" />
+            </Grid>
+        </DataTemplate>
+
+        <!--  Outcome card: Success / Warning / Critical variants toggled by binding  -->
+        <DataTemplate x:Key="ChatOutcomeTemplate" x:DataType="local:ChatMessage">
+            <Grid Padding="16,4">
+                <Border
+                    Padding="16,12"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Visibility="{Binding OutcomeSuccessVisibility}">
+                    <Grid ColumnDefinitions="Auto,*">
+                        <FontIcon
+                            Grid.Column="0"
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="20"
+                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                            Glyph="&#xE930;" />
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <TextBlock
+                                FontWeight="SemiBold"
+                                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                Text="{Binding OutcomeTitle}" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{Binding OutcomeSubtitle}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <Border
+                    Padding="16,12"
+                    Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                    BorderBrush="{ThemeResource SystemFillColorCautionBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Visibility="{Binding OutcomeWarningVisibility}">
+                    <Grid ColumnDefinitions="Auto,*">
+                        <FontIcon
+                            Grid.Column="0"
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="20"
+                            Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                            Glyph="&#xE7BA;" />
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <TextBlock
+                                FontWeight="SemiBold"
+                                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                Text="{Binding OutcomeTitle}" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{Binding OutcomeSubtitle}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <Border
+                    Padding="16,12"
+                    Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
+                    BorderBrush="{ThemeResource SystemFillColorCriticalBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Visibility="{Binding OutcomeCriticalVisibility}">
+                    <Grid ColumnDefinitions="Auto,*">
+                        <FontIcon
+                            Grid.Column="0"
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Center"
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            FontSize="20"
+                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                            Glyph="&#xE783;" />
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <TextBlock
+                                FontWeight="SemiBold"
+                                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                Text="{Binding OutcomeTitle}" />
+                            <TextBlock
+                                FontSize="12"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{Binding OutcomeSubtitle}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
+        </DataTemplate>
+
+        <local:ChatMessageTemplateSelector
+            x:Key="ChatTemplateSelector"
+            AssistantTemplate="{StaticResource ChatAssistantTemplate}"
+            BenchmarkTemplate="{StaticResource ChatBenchmarkTemplate}"
+            OutcomeTemplate="{StaticResource ChatOutcomeTemplate}"
+            ReasoningTemplate="{StaticResource ChatReasoningTemplate}"
+            ThinkingTemplate="{StaticResource ChatThinkingTemplate}"
+            ToolCallTemplate="{StaticResource ChatToolCallTemplate}"
+            UserTemplate="{StaticResource ChatUserTemplate}" />
+    </Page.Resources>
+
+    <Grid Padding="12" RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            MaxWidth="640"
+            HorizontalAlignment="Left"
+            Style="{ThemeResource BodyTextBlockStyle}"
+            TextWrapping="Wrap">
+            ScrollViewer + ItemsRepeater chat conversation mimicking an agentic-assistant UI: right-aligned user bubbles, assistant replies, reasoning expanders, tool-call rows, outcome cards, thinking/benchmark lines, and nested image-attachment repeaters, all on a cooking topic. Heights vary widely and auto-scroll-on-add is enabled. Generation is seeded, so reloading and clicking "Add" always produce identical results.
+        </TextBlock>
+
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="6">
+            <Button Click="OnTopClick" Content="Top" />
+            <Button Click="OnBottomClick" Content="Bottom" />
+            <Button Click="OnAddItemsClick" Content="Add 20 items" />
+            <Button Click="OnRemoveExpandersClick" Content="Remove expanders" />
+            <Button Click="OnClearClick" Content="Clear" />
+            <Button Click="OnResetClick" Content="Reset" />
+            <TextBlock
+                x:Name="StatusText"
+                VerticalAlignment="Center"
+                FontSize="12"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+        </StackPanel>
+
+        <Border
+            Grid.Row="2"
+            VerticalAlignment="Stretch"
+            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+            BorderThickness="1">
+            <ScrollViewer
+                x:Name="Scroller"
+                HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto">
+                <mux:ItemsRepeater
+                    x:Name="Repeater"
+                    Margin="0,16,0,12"
+                    VerticalAlignment="Bottom"
+                    local:ChatAutoScroll.IsEnabled="True"
+                    ItemTemplate="{StaticResource ChatTemplateSelector}">
+                    <mux:ItemsRepeater.Layout>
+                        <mux:StackLayout Orientation="Vertical" Spacing="0" />
+                    </mux:ItemsRepeater.Layout>
+                </mux:ItemsRepeater>
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterChatConversation.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterChatConversation.xaml.cs
@@ -1,0 +1,622 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Text;
+using Windows.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.Repeater;
+
+[Sample(
+	"ItemsRepeater",
+	IsManualTest = true,
+	Description = "ScrollViewer + ItemsRepeater chat conversation mimicking an agentic-assistant UI (user bubbles, " +
+		"assistant replies, reasoning expanders, tool-call rows, outcome cards, thinking/benchmark lines, plus nested " +
+		"image-attachment repeaters) on a cooking topic. Message height varies widely (cooking copy + lorem ipsum + " +
+		"image grids) and auto-scroll-on-add is enabled. Generation is seeded, so reloading the sample and" +
+		"clicking \"Add\" produce identical results every time.")]
+public sealed partial class ItemsRepeaterChatConversation : Page
+{
+	// A fixed seed makes the conversation fully reproducible: a freshly created page (reload)
+	// always re-seeds to the same value, and every "Add"/"Reset" walks the same RNG sequence.
+	private const int Seed = 20260520;
+	private const int DefaultMessageCount = 120;
+	private const int AddMessageCount = 20;
+
+	private readonly ObservableCollection<ChatMessage> _items = new();
+
+	// Generation state. The RNG and pending buffer persist for the lifetime of the page so that
+	// consecutive "Add" clicks deterministically continue the same conversation. Whole turns are
+	// generated into _pending and dequeued one message at a time to satisfy exact item counts.
+	private readonly Queue<ChatMessage> _pending = new();
+	private Random _rng = new(Seed);
+	private DateTime _clock;
+	private int _nextIndex;
+
+	public ItemsRepeaterChatConversation()
+	{
+		InitializeComponent();
+		ResetState();
+		AddMessages(DefaultMessageCount);
+		Repeater.ItemsSource = _items;
+		UpdateStatus();
+	}
+
+	private void ResetState()
+	{
+		_rng = new Random(Seed);
+		_clock = new DateTime(2026, 5, 20, 9, 0, 0);
+		_nextIndex = 0;
+		_pending.Clear();
+	}
+
+	private void AddMessages(int count)
+	{
+		for (var i = 0; i < count; i++)
+		{
+			if (_pending.Count == 0)
+			{
+				GenerateTurn();
+			}
+
+			_items.Add(_pending.Dequeue());
+		}
+	}
+
+	// --- Conversation flow ---------------------------------------------------
+
+	private void GenerateTurn()
+	{
+		// A turn loosely follows the agentic pattern: the user asks, the assistant optionally
+		// thinks/reasons, runs a few tools, replies, and occasionally posts a benchmark or outcome.
+		_pending.Enqueue(MakeUser());
+
+		if (_rng.NextDouble() < 0.15)
+		{
+			_pending.Enqueue(MakeThinking());
+		}
+		else if (_rng.NextDouble() < 0.55)
+		{
+			_pending.Enqueue(MakeReasoning());
+		}
+
+		var toolCount = _rng.Next(1, 5);
+		for (var i = 0; i < toolCount; i++)
+		{
+			_pending.Enqueue(MakeToolCall());
+		}
+
+		_pending.Enqueue(MakeAssistant());
+
+		if (_rng.NextDouble() < 0.08)
+		{
+			_pending.Enqueue(MakeBenchmark());
+		}
+
+		if (_rng.NextDouble() < 0.30)
+		{
+			_pending.Enqueue(MakeOutcome());
+		}
+	}
+
+	private ChatMessage MakeUser()
+	{
+		var parts = _rng.Next(1, 4);
+		var sb = new StringBuilder();
+		for (var i = 0; i < parts; i++)
+		{
+			if (i > 0)
+			{
+				sb.Append(' ');
+			}
+
+			sb.Append(Pick(UserPrompts));
+		}
+
+		// Occasionally pad a user message with lorem so some bubbles wrap to several lines.
+		if (_rng.NextDouble() < 0.2)
+		{
+			sb.Append(' ').Append(BuildText(1, 3, loremBias: 0.8));
+		}
+
+		return new ChatMessage
+		{
+			Index = _nextIndex++,
+			Kind = ChatMessageKind.User,
+			Text = sb.ToString(),
+			Images = MaybeImages(probability: 0.22, min: 1, max: 3),
+			Timestamp = NextTimestamp(),
+		};
+	}
+
+	private ChatMessage MakeAssistant() => new()
+	{
+		Index = _nextIndex++,
+		Kind = ChatMessageKind.Assistant,
+		// Wide range of sentence counts (and optional image grids) gives the large height
+		// variance the sample is built to surface in the repeater's virtualization.
+		Text = BuildText(1, 10, loremBias: 0.4),
+		Images = MaybeImages(probability: 0.16, min: 2, max: 6),
+		Timestamp = NextTimestamp(),
+	};
+
+	private ChatMessage MakeReasoning() => new()
+	{
+		Index = _nextIndex++,
+		Kind = ChatMessageKind.Reasoning,
+		ReasoningHeader = Pick(ReasoningHeaders),
+		Text = BuildText(2, 7, loremBias: 0.5),
+		IsReasoningExpanded = _rng.NextDouble() < 0.4,
+		Timestamp = NextTimestamp(),
+	};
+
+	private ChatMessage MakeThinking() => new()
+	{
+		Index = _nextIndex++,
+		Kind = ChatMessageKind.Thinking,
+		Text = Pick(ThinkingTexts),
+		Timestamp = NextTimestamp(),
+	};
+
+	private ChatMessage MakeBenchmark() => new()
+	{
+		Index = _nextIndex++,
+		Kind = ChatMessageKind.Benchmark,
+		Text = $"Generated in {_rng.Next(8, 120) / 10.0:0.0} s · {_rng.Next(120, 4000):N0} tokens · {_rng.Next(1, 24)} tool calls",
+		Timestamp = NextTimestamp(),
+	};
+
+	private ChatMessage MakeToolCall()
+	{
+		string status;
+		string fileName = null;
+		string addedText = null;
+		string removedText = null;
+		string entryCountText = null;
+
+		switch (_rng.Next(4))
+		{
+			case 0:
+				status = "Searching the recipe index";
+				entryCountText = $"{_rng.Next(8, 120)} matches";
+				break;
+			case 1:
+				status = "Reading";
+				fileName = Pick(RecipeFiles);
+				entryCountText = $"{_rng.Next(20, 400)} lines";
+				break;
+			case 2:
+				status = "Updating";
+				fileName = Pick(RecipeFiles);
+				addedText = $"+{_rng.Next(1, 40)}";
+				if (_rng.NextDouble() < 0.7)
+				{
+					removedText = $"-{_rng.Next(1, 20)}";
+				}
+
+				break;
+			default:
+				status = Pick(ToolMiscActions);
+				break;
+		}
+
+		var roll = _rng.NextDouble();
+		var state = roll < 0.82 ? ToolCallState.Success
+			: roll < 0.94 ? ToolCallState.Failure
+			: ToolCallState.InProgress;
+
+		return new ChatMessage
+		{
+			Index = _nextIndex++,
+			Kind = ChatMessageKind.ToolCall,
+			ToolState = state,
+			ToolStatusText = status,
+			ToolFileName = fileName,
+			ToolDiffAddedText = addedText,
+			ToolDiffRemovedText = removedText,
+			ToolEntryCountText = entryCountText,
+			Timestamp = NextTimestamp(),
+		};
+	}
+
+	private ChatMessage MakeOutcome()
+	{
+		var roll = _rng.NextDouble();
+		var severity = roll < 0.5 ? OutcomeSeverity.Success
+			: roll < 0.8 ? OutcomeSeverity.Warning
+			: OutcomeSeverity.Critical;
+
+		var (title, subtitle) = severity switch
+		{
+			OutcomeSeverity.Success => (Pick(SuccessTitles), Pick(SuccessSubtitles)),
+			OutcomeSeverity.Warning => (Pick(WarningTitles), Pick(WarningSubtitles)),
+			_ => (Pick(CriticalTitles), Pick(CriticalSubtitles)),
+		};
+
+		return new ChatMessage
+		{
+			Index = _nextIndex++,
+			Kind = ChatMessageKind.Outcome,
+			Severity = severity,
+			OutcomeTitle = title,
+			OutcomeSubtitle = subtitle,
+			Timestamp = NextTimestamp(),
+		};
+	}
+
+	// --- Text / image helpers ------------------------------------------------
+
+	private string BuildText(int minSentences, int maxSentences, double loremBias)
+	{
+		var count = _rng.Next(minSentences, maxSentences + 1);
+		var sb = new StringBuilder();
+		for (var i = 0; i < count; i++)
+		{
+			var pool = _rng.NextDouble() < loremBias ? LoremSentences : CookingSentences;
+			sb.Append(Pick(pool));
+
+			if (i < count - 1)
+			{
+				// Occasionally break into a new paragraph for taller, more varied bodies.
+				sb.Append(_rng.NextDouble() < 0.18 ? "\n\n" : " ");
+			}
+		}
+
+		return sb.ToString();
+	}
+
+	private ChatImageAttachment[] MaybeImages(double probability, int min, int max)
+	{
+		if (_rng.NextDouble() >= probability)
+		{
+			return null;
+		}
+
+		var count = _rng.Next(min, max + 1);
+		var images = new ChatImageAttachment[count];
+		for (var i = 0; i < count; i++)
+		{
+			images[i] = new ChatImageAttachment { Fill = Pick(ImagePalette) };
+		}
+
+		return images;
+	}
+
+	private string NextTimestamp()
+	{
+		_clock = _clock.AddMinutes(_rng.Next(1, 4));
+		return _clock.ToString("h:mm tt");
+	}
+
+	private T Pick<T>(T[] pool) => pool[_rng.Next(pool.Length)];
+
+	// --- Button handlers -----------------------------------------------------
+
+	private void OnTopClick(object sender, RoutedEventArgs e) =>
+		Scroller.ChangeView(null, 0, null, disableAnimation: true);
+
+	private void OnBottomClick(object sender, RoutedEventArgs e) =>
+		Scroller.ChangeView(null, Scroller.ScrollableHeight, null, disableAnimation: true);
+
+	private void OnAddItemsClick(object sender, RoutedEventArgs e)
+	{
+		AddMessages(AddMessageCount);
+		UpdateStatus();
+	}
+
+	private void OnRemoveExpandersClick(object sender, RoutedEventArgs e)
+	{
+		// Reasoning messages are the only Expander-based items in this conversation.
+		for (var i = _items.Count - 1; i >= 0; i--)
+		{
+			if (_items[i].Kind == ChatMessageKind.Reasoning)
+			{
+				_items.RemoveAt(i);
+			}
+		}
+
+		UpdateStatus();
+	}
+
+	private void OnClearClick(object sender, RoutedEventArgs e)
+	{
+		_items.Clear();
+		UpdateStatus();
+	}
+
+	private void OnResetClick(object sender, RoutedEventArgs e)
+	{
+		_items.Clear();
+		ResetState();
+		AddMessages(DefaultMessageCount);
+		Scroller.ChangeView(null, Scroller.ScrollableHeight, null, disableAnimation: true);
+		UpdateStatus();
+	}
+
+	private void UpdateStatus() =>
+		StatusText.Text = $"{_items.Count} messages";
+
+	// --- Mock data pools -----------------------------------------------------
+
+	private static readonly Brush[] ImagePalette =
+	[
+		new SolidColorBrush(Color.FromArgb(255, 76, 175, 80)),
+		new SolidColorBrush(Color.FromArgb(255, 66, 133, 244)),
+		new SolidColorBrush(Color.FromArgb(255, 255, 152, 0)),
+		new SolidColorBrush(Color.FromArgb(255, 229, 57, 53)),
+		new SolidColorBrush(Color.FromArgb(255, 156, 39, 176)),
+		new SolidColorBrush(Color.FromArgb(255, 0, 150, 136)),
+	];
+
+	private static readonly string[] ThinkingTexts =
+	[
+		"Thinking…",
+		"Working out the best approach…",
+		"Planning the next few steps…",
+		"Reviewing the recipe constraints…",
+	];
+
+	private static readonly string[] UserPrompts =
+	[
+		"How do I stop my risotto from turning gluey?",
+		"Can you scale this recipe up for eight guests?",
+		"What can I use instead of buttermilk?",
+		"Why did my bread come out so dense this time?",
+		"Suggest a side dish that goes with roast lamb.",
+		"How long should I rest a steak after searing?",
+		"My sauce keeps splitting, what am I doing wrong?",
+		"Can we make this dessert without refined sugar?",
+		"What's the trick to a really crisp chicken skin?",
+		"Give me a quick weeknight pasta idea.",
+		"How do I know when the caramel is ready?",
+		"Is there a vegetarian version of this stew?",
+	];
+
+	private static readonly string[] CookingSentences =
+	[
+		"Start by browning the aromatics gently so they sweeten rather than scorch.",
+		"Add the stock a ladle at a time, stirring until each addition is absorbed.",
+		"A splash of acid right at the end will brighten the whole dish.",
+		"Rest the meat under loose foil so the juices redistribute before carving.",
+		"Toast the spices in a dry pan until they smell fragrant, then grind them.",
+		"Keep the heat moderate; rushing the sear will steam the surface instead.",
+		"Season in layers as you go rather than all at once at the very end.",
+		"Whisk constantly while you drizzle in the oil so the emulsion holds together.",
+		"Let the dough prove somewhere warm until it has roughly doubled in size.",
+		"Reduce the sauce until it coats the back of a spoon, then taste again.",
+		"Salt the pasta water generously; it should taste like the sea.",
+		"Deglaze the pan with a little wine to lift all the caramelised bits.",
+		"Chill the butter so it stays in distinct flakes through the pastry.",
+		"Finish with a knob of cold butter to give the sauce a glossy sheen.",
+	];
+
+	// Classic lorem ipsum lines, used to introduce realistic length variability.
+	private static readonly string[] LoremSentences =
+	[
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+		"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+		"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.",
+		"Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.",
+		"Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.",
+		"Neque porro quisquam est qui dolorem ipsum quia dolor sit amet consectetur.",
+		"Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse.",
+		"At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis.",
+		"Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus.",
+	];
+
+	private static readonly string[] ReasoningHeaders =
+	[
+		"Planning the menu",
+		"Thinking about substitutions",
+		"Working out the timings",
+		"Balancing the flavours",
+		"Choosing a cooking method",
+		"Checking the technique",
+	];
+
+	private static readonly string[] ToolMiscActions =
+	[
+		"Scaling the ingredient quantities",
+		"Converting grams to cups",
+		"Calculating the total cook time",
+		"Validating the shopping list",
+		"Checking the allergen list",
+		"Estimating oven preheat time",
+	];
+
+	private static readonly string[] RecipeFiles =
+	[
+		"risotto.md",
+		"pantry.json",
+		"menu.yaml",
+		"timings.txt",
+		"shopping-list.md",
+		"allergens.md",
+		"oven-log.txt",
+	];
+
+	private static readonly string[] SuccessTitles =
+	[
+		"Dish ready to serve", "Timer finished", "All steps complete",
+	];
+
+	private static readonly string[] SuccessSubtitles =
+	[
+		"Everything is plated and still warm",
+		"The roast has reached its target temperature",
+		"The bread has finished its second proof",
+	];
+
+	private static readonly string[] WarningTitles =
+	[
+		"Oven needs attention", "Ingredient running low", "Taste and adjust",
+	];
+
+	private static readonly string[] WarningSubtitles =
+	[
+		"The temperature has drifted above the target",
+		"Only a handful of fresh basil leaves left",
+		"Season the soup before the final simmer",
+	];
+
+	private static readonly string[] CriticalTitles =
+	[
+		"The sauce has split", "Burnt the base", "Step failed",
+	];
+
+	private static readonly string[] CriticalSubtitles =
+	[
+		"Take it off the heat and whisk in a little cold water",
+		"Decant the unburnt portion into a clean pan immediately",
+		"The previous tool call could not be completed",
+	];
+}
+
+public enum ChatMessageKind
+{
+	User,
+	Assistant,
+	Reasoning,
+	ToolCall,
+	Outcome,
+	Thinking,
+	Benchmark,
+}
+
+public enum ToolCallState
+{
+	InProgress,
+	Success,
+	Failure,
+}
+
+public enum OutcomeSeverity
+{
+	Success,
+	Warning,
+	Critical,
+}
+
+public sealed class ChatImageAttachment
+{
+	public Brush Fill { get; init; }
+}
+
+public sealed class ChatMessage : INotifyPropertyChanged
+{
+	private bool _isReasoningExpanded;
+
+	public int Index { get; init; }
+
+	public ChatMessageKind Kind { get; init; }
+
+	public string Text { get; init; } = string.Empty;
+
+	public string Timestamp { get; init; } = string.Empty;
+
+	public ChatImageAttachment[] Images { get; init; }
+
+	// Reasoning
+	public string ReasoningHeader { get; init; } = string.Empty;
+
+	public bool IsReasoningExpanded
+	{
+		get => _isReasoningExpanded;
+		set
+		{
+			if (_isReasoningExpanded != value)
+			{
+				_isReasoningExpanded = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsReasoningExpanded)));
+			}
+		}
+	}
+
+	// Tool call
+	public ToolCallState ToolState { get; init; }
+
+	public string ToolStatusText { get; init; } = string.Empty;
+
+	public string ToolFileName { get; init; }
+
+	public string ToolDiffAddedText { get; init; }
+
+	public string ToolDiffRemovedText { get; init; }
+
+	public string ToolEntryCountText { get; init; }
+
+	// Outcome
+	public OutcomeSeverity Severity { get; init; }
+
+	public string OutcomeTitle { get; init; } = string.Empty;
+
+	public string OutcomeSubtitle { get; init; } = string.Empty;
+
+	// Computed visibilities, kept on the model so the templates stay binding-only.
+	public Visibility ImagesVisibility => Vis(Images is { Length: > 0 });
+
+	public Visibility ToolProgressVisibility => Vis(ToolState == ToolCallState.InProgress);
+
+	public Visibility ToolSuccessVisibility => Vis(ToolState == ToolCallState.Success);
+
+	public Visibility ToolFailureVisibility => Vis(ToolState == ToolCallState.Failure);
+
+	public Visibility ToolFileNameVisibility => Vis(!string.IsNullOrEmpty(ToolFileName));
+
+	public Visibility ToolDiffVisibility => Vis(ToolDiffAddedText is not null);
+
+	public Visibility ToolDiffRemovedVisibility => Vis(ToolDiffRemovedText is not null);
+
+	public Visibility ToolEntryCountVisibility => Vis(ToolEntryCountText is not null);
+
+	public Visibility OutcomeSuccessVisibility => Vis(Severity == OutcomeSeverity.Success);
+
+	public Visibility OutcomeWarningVisibility => Vis(Severity == OutcomeSeverity.Warning);
+
+	public Visibility OutcomeCriticalVisibility => Vis(Severity == OutcomeSeverity.Critical);
+
+	public event PropertyChangedEventHandler PropertyChanged;
+
+	private static Visibility Vis(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+}
+
+public sealed class ChatMessageTemplateSelector : DataTemplateSelector
+{
+	public DataTemplate UserTemplate { get; set; }
+
+	public DataTemplate AssistantTemplate { get; set; }
+
+	public DataTemplate ReasoningTemplate { get; set; }
+
+	public DataTemplate ToolCallTemplate { get; set; }
+
+	public DataTemplate OutcomeTemplate { get; set; }
+
+	public DataTemplate ThinkingTemplate { get; set; }
+
+	public DataTemplate BenchmarkTemplate { get; set; }
+
+	protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+	{
+		if (item is ChatMessage message)
+		{
+			return message.Kind switch
+			{
+				ChatMessageKind.User => UserTemplate,
+				ChatMessageKind.Reasoning => ReasoningTemplate,
+				ChatMessageKind.ToolCall => ToolCallTemplate,
+				ChatMessageKind.Outcome => OutcomeTemplate,
+				ChatMessageKind.Thinking => ThinkingTemplate,
+				ChatMessageKind.Benchmark => BenchmarkTemplate,
+				_ => AssistantTemplate,
+			};
+		}
+
+		return AssistantTemplate;
+	}
+}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterChatConversation.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterChatConversation.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using Windows.UI;
 using Microsoft.UI.Xaml;
@@ -17,7 +18,7 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater;
 	Description = "ScrollViewer + ItemsRepeater chat conversation mimicking an agentic-assistant UI (user bubbles, " +
 		"assistant replies, reasoning expanders, tool-call rows, outcome cards, thinking/benchmark lines, plus nested " +
 		"image-attachment repeaters) on a cooking topic. Message height varies widely (cooking copy + lorem ipsum + " +
-		"image grids) and auto-scroll-on-add is enabled. Generation is seeded, so reloading the sample and" +
+		"image grids) and auto-scroll-on-add is enabled. Generation is seeded, so reloading the sample and " +
 		"clicking \"Add\" produce identical results every time.")]
 public sealed partial class ItemsRepeaterChatConversation : Page
 {
@@ -166,7 +167,8 @@ public sealed partial class ItemsRepeaterChatConversation : Page
 	{
 		Index = _nextIndex++,
 		Kind = ChatMessageKind.Benchmark,
-		Text = $"Generated in {_rng.Next(8, 120) / 10.0:0.0} s · {_rng.Next(120, 4000):N0} tokens · {_rng.Next(1, 24)} tool calls",
+		// Invariant so the generated text stays identical regardless of the machine's culture.
+		Text = FormattableString.Invariant($"Generated in {_rng.Next(8, 120) / 10.0:0.0} s · {_rng.Next(120, 4000):N0} tokens · {_rng.Next(1, 24)} tool calls"),
 		Timestamp = NextTimestamp(),
 	};
 
@@ -289,7 +291,7 @@ public sealed partial class ItemsRepeaterChatConversation : Page
 	private string NextTimestamp()
 	{
 		_clock = _clock.AddMinutes(_rng.Next(1, 4));
-		return _clock.ToString("h:mm tt");
+		return _clock.ToString("h:mm tt", CultureInfo.InvariantCulture);
 	}
 
 	private T Pick<T>(T[] pool) => pool[_rng.Next(pool.Length)];
@@ -477,7 +479,7 @@ public sealed partial class ItemsRepeaterChatConversation : Page
 	];
 }
 
-public enum ChatMessageKind
+internal enum ChatMessageKind
 {
 	User,
 	Assistant,
@@ -488,26 +490,26 @@ public enum ChatMessageKind
 	Benchmark,
 }
 
-public enum ToolCallState
+internal enum ToolCallState
 {
 	InProgress,
 	Success,
 	Failure,
 }
 
-public enum OutcomeSeverity
+internal enum OutcomeSeverity
 {
 	Success,
 	Warning,
 	Critical,
 }
 
-public sealed class ChatImageAttachment
+internal sealed class ChatImageAttachment
 {
 	public Brush Fill { get; init; }
 }
 
-public sealed class ChatMessage : INotifyPropertyChanged
+internal sealed class ChatMessage : INotifyPropertyChanged
 {
 	private bool _isReasoningExpanded;
 
@@ -585,7 +587,7 @@ public sealed class ChatMessage : INotifyPropertyChanged
 	private static Visibility Vis(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
 }
 
-public sealed class ChatMessageTemplateSelector : DataTemplateSelector
+internal sealed class ChatMessageTemplateSelector : DataTemplateSelector
 {
 	public DataTemplate UserTemplate { get; set; }
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterMultiTemplate.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterMultiTemplate.xaml
@@ -191,6 +191,7 @@
             <Button Click="OnTopClick" Content="Top" />
             <Button Click="OnBottomClick" Content="Bottom" />
             <Button Click="OnAddItemsClick" Content="Add 20 items" />
+            <Button Click="OnRemoveExpandersClick" Content="Remove expanders" />
             <Button Click="OnClearClick" Content="Clear" />
             <Button Click="OnResetClick" Content="Reset" />
             <TextBlock

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterMultiTemplate.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeaterMultiTemplate.xaml.cs
@@ -131,6 +131,19 @@ public sealed partial class ItemsRepeaterMultiTemplate : Page
 		UpdateStatus();
 	}
 
+	private void OnRemoveExpandersClick(object sender, RoutedEventArgs e)
+	{
+		for (var i = _items.Count - 1; i >= 0; i--)
+		{
+			if (_items[i].ItemType == FeedItemType.DetailSection)
+			{
+				_items.RemoveAt(i);
+			}
+		}
+
+		UpdateStatus();
+	}
+
 	private void OnClearClick(object sender, RoutedEventArgs e)
 	{
 		_items.Clear();


### PR DESCRIPTION
## Overview

Adds two SamplesApp samples (under `Windows_UI_Xaml_Controls/Repeater`) for exercising `ItemsRepeater` behavior with mixed item templates and high per-item height variance.

### New sample: `ItemsRepeaterChatConversation`

A chat-style conversation backed by a single `ItemsRepeater` + `ScrollViewer`, with a `DataTemplateSelector` dispatching to seven message kinds:

- User bubble (right-aligned)
- Assistant reply (left body text)
- Reasoning section (the only `Expander`-based item)
- Tool-call row (status icon + optional file pill + diff/entry counts)
- Outcome card (Success / Warning / Critical)
- Thinking indicator (spinner + text)
- Benchmark line (accent text)

Notable characteristics, chosen to surface virtualization/layout behavior:

- **Nested image-attachment repeaters inside items** (horizontal row for user bubbles, wrapping `UniformGridLayout` grid for assistant messages).
- **Wide per-item height variance** — cooking copy mixed with lorem ipsum (1–10 sentences) and variable image grids.
- **Seeded, deterministic generation** — reloading the sample and clicking "Add" produce identical content every time, so behavior is reproducible.
- **`ChatAutoScroll`** — a small self-contained attached behavior that scrolls to the bottom on item add (deferred `UpdateLayout()` + `ChangeView`), while respecting the user's scroll position and pointer-over state.

Buttons: Top · Bottom · Add 20 items · Remove expanders · Clear · Reset.

### Updated sample: `ItemsRepeaterMultiTemplate`

Adds a **Remove expanders** button that removes all `Expander`-based items, to exercise item removal.

## Notes

- Both samples are `IsManualTest = true`.
- No runtime/control code is touched — SamplesApp only.

## Validation

- **Compile**: `SamplesApp.Skia.Generic` (net10.0) built green with the new sample (0 warnings, 0 errors).
- **Runtime**: launched Skia Desktop (Win32) and confirmed the sample loads and renders all message kinds; manual scroll/add behavior to be reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
