### PR TITLE
feat(diagnostics): add ElementRefHandle public registry

### DIFF
--- a/specs/042-element-ref-registry/progress.md
+++ b/specs/042-element-ref-registry/progress.md
@@ -1,0 +1,41 @@
+# Spec 042 — Implementation Progress
+
+> Spec: [spec.md](./spec.md) — Branch: dev/cdb/element-ref-id
+
+## Production code
+
+- [x] `IElementRefHandleRegistry.cs`
+- [x] `ElementRefHandle.cs` (facade + SetForTesting)
+- [x] `ElementRefHandleRegistry.cs` (internal sealed)
+- [x] `FeatureConfiguration.ElementRefHandle.DisableThreadingCheck`
+
+## Tests (Uno.UI.Tests)
+
+> Note: local build of `Uno.UI.Tests.csproj` is blocked by a pre-existing
+> source-generator regression on `master` (344 errors in `DependencyPropertyMixins.g.cs`,
+> unrelated to this feature). Tests will be validated in CI once the regression is fixed.
+
+- [x] GetOrCreate_SameElement_ReturnsSameHandle
+- [x] GetOrCreate_DifferentElements_ReturnsDifferentHandles
+- [x] TryResolve_ValidHandle_ReturnsTrueAndElement (no implicit rooting)
+- [x] TryResolve_UnknownHandle_ReturnsFalse
+- [x] TryResolve_NullOrEmpty_ReturnsFalse
+- [x] TryResolve_AfterGC_ReturnsFalse
+- [x] TryResolve_HandleComparison_IsCaseInsensitive
+- [x] GetOrCreate_FromBackgroundThread_Throws
+- [x] TryResolve_FromBackgroundThread_Throws
+- [x] GetOrCreate_WithDisableThreadingCheck_DoesNotThrow
+- [x] Finalizer_RemovesReverseMapEntry
+- [x] Handles_DoNotRecycle_AfterGC_WithinSession
+- [x] SetForTesting_RestoresDefaultOnDispose
+
+## Validation
+
+- [ ] `dotnet build src/Uno.UI-UnitTests-only.slnf --no-restore` — blocked (pre-existing)
+- [ ] `dotnet test src/Uno.UI/Uno.UI.Tests.csproj --filter "FullyQualifiedName~Given_ElementRefHandleRegistry"` — pending CI
+- [ ] Full unit-test suite green — pending CI
+- [x] Public API diff reviewed (no PublicAPI analyzer in Uno.UI)
+
+## Downstream alignment (tracked separately)
+
+- [ ] Downstream consumers updated to use `ElementRefHandle` (out of scope for this PR)

--- a/specs/042-element-ref-registry/spec.md
+++ b/specs/042-element-ref-registry/spec.md
@@ -133,21 +133,21 @@ public static class ElementRefHandle
     /// <summary>
     /// Attempts to resolve a previously obtained handle back to its object.
     /// </summary>
-    /// <param name="handle">The opaque handle string.</param>
+    /// <param name="handle">The opaque handle string. <see langword="null"/> or empty returns <see langword="false"/>.</param>
     /// <param name="element">
     /// When this method returns <see langword="true"/>, the live object;
     /// otherwise <see langword="null"/>.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the handle is known and the object is still alive;
-    /// <see langword="false"/> if the handle is unrecognized or the object has been
-    /// garbage-collected.
+    /// <see langword="false"/> if the handle is <see langword="null"/>, empty,
+    /// unrecognized, or the object has been garbage-collected.
     /// </returns>
     /// <exception cref="InvalidOperationException">
     /// Thrown when not called from the UI thread (unless
     /// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
     /// </exception>
-    public static bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
+    public static bool TryResolve(string? handle, [NotNullWhen(true)] out DependencyObject? element)
         => Default.TryResolve(handle, out element);
 }
 
@@ -167,7 +167,7 @@ public interface IElementRefHandleRegistry
     string GetOrCreate(DependencyObject element);
 
     /// <inheritdoc cref="ElementRefHandle.TryResolve"/>
-    bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element);
+    bool TryResolve(string? handle, [NotNullWhen(true)] out DependencyObject? element);
 }
 ```
 
@@ -265,10 +265,10 @@ Located at `src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs`, namespace
 │  _table   : ConditionalWeakTable<DependencyObject, RefEntry>    │
 │              ──► forward map; GC collects entry when key dies   │
 │                                                                 │
-│  _reverse : ConcurrentDictionary<int, ManagedWeakReference>     │
+│  _reverse : ConcurrentDictionary<int, WeakReference<T>>         │
 │              ──► reverse map; cleaned lazily + by finalizer     │
 │                                                                 │
-│  _nextId  : int   (Interlocked.Increment)                       │
+│  _nextId  : int   (++, UI thread only)                          │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -291,11 +291,10 @@ if (!FeatureConfiguration.ElementRefHandle.DisableThreadingCheck
 The finalizer path is exempt (runs on finalizer thread; uses only
 `ConcurrentDictionary.TryRemove`).
 
-**Weak references**: `GetOrCreate` uses `IWeakReferenceProvider.WeakReference` when
-the object implements it (zero allocation for Uno objects); it falls back to
-`WeakReferencePool.RentSelfWeakReference`. The "rented" weak reference is never
-explicitly returned to the pool: its lifetime is bound to the registry entry, which
-is reclaimed by the GC together with the target object.
+**Weak references**: `GetOrCreate` stores a plain `WeakReference<DependencyObject>`
+per element. The reference is created inside the `ConditionalWeakTable.GetValue`
+factory (invoked at most once per element on the UI thread) so that the reverse-map
+insertion is always paired with the forward-map entry.
 
 **Logging**: traces emitted only at `Trace` level, conditioned on
 `Logger.IsEnabled(LogLevel.Trace)` to avoid cost in production. Log format uses
@@ -350,8 +349,6 @@ Design using a single, token-efficient string. The bridge code lives in
 ## 6. Tests
 
 **Location**: `src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs`
-
-Pattern follows `src/Uno.UI.Tests/WeakReferencePool/Given_WeakReferencePool.cs`.
 
 | Test | Description |
 |------|-------------|

--- a/specs/042-element-ref-registry/spec.md
+++ b/specs/042-element-ref-registry/spec.md
@@ -1,0 +1,402 @@
+# Spec 042: Element Ref Handle Registry
+
+> **Status**: Under Review - 2026-05-20
+> **Author**: Carl de Billy
+> 2026-05-19 - Draft
+> 2026-05-20 - Under Review
+
+---
+
+## Executive Summary
+
+### The Problem
+
+Two Uno tooling systems — the Uno App MCP server (`uno.app-mcp`) and Hot Design
+(`Uno.HotDesign.Client`) — both need to **identify and address individual visual-tree
+elements across multiple tool calls within the same session**.
+
+Today, `uno.app-mcp` ships its own private implementation (`ElementRefRegistry`)
+inside `Uno.UI.App.Mcp.Client`. Hot Design has its own `ElementId` (Guid) system
+for source-level identity. When MCP tooling and Hot Design operate together — which
+is the primary use-case — there is no shared handle: a ref obtained via one system
+cannot be used by the other, and each system must independently look up or describe
+the same on-screen element.
+
+The consequences:
+
+- **No interoperability**: an element selected in Hot Design cannot be handed to an
+  MCP tool by reference; either system must re-discover it independently.
+- **Duplication**: `uno.app-mcp` and any future tooling must each re-implement
+  weak-ref registries with no shared contract.
+- **No canonical contract**: consumers have no stable API to depend on; formats are
+  implementation details hidden behind private classes.
+
+### What We're Shipping
+
+A minimal, stable API surface in `Uno.UI` that allows any Uno tooling component to:
+
+1. Obtain a short, opaque string handle for a live `DependencyObject` on demand.
+2. Resolve such a handle back to a live `DependencyObject`.
+
+```csharp
+// Obtain or retrieve the handle for a live object (creates on first call)
+string handle = ElementRefHandle.GetOrCreate(element);
+
+// Resolve back to a live object (returns false if GC'd or unknown)
+bool found = ElementRefHandle.TryResolve(handle, out DependencyObject? obj);
+```
+
+The handle is a **short, opaque, token-efficient string** (base-36 encoding of a
+monotonic integer, typically 1–7 characters). The format is an implementation
+detail; callers must treat it as opaque. Handles are compared **ordinal,
+case-insensitive**.
+
+### Why This Approach
+
+- **Minimal surface**: one static class + one interface, no lifecycle hooks, no events.
+- **Token-efficient**: short handles are suitable for AI agent contexts.
+- **Ephemeral by design**: handles are valid for the lifetime of the object in the
+  current session. They do not survive app restarts or devserver resets.
+- **No object rooting**: handles are backed entirely by weak references. The registry
+  never prevents an object from being garbage-collected.
+- **Interoperable**: once a handle is obtained through any Uno tooling path, any
+  other tooling component can resolve it. Note: the bridge between Hot Design's
+  `ElementId` and `ElementRefHandle` is implemented in `Uno.HotDesign.Client` (out
+  of scope for this spec).
+- **Mockable**: `IElementRefHandleRegistry` allows consumers to inject or replace
+  the registry in tests.
+
+### Scope
+
+- Public API: `Uno.UI.Diagnostics.ElementRefHandle` (static facade) and
+  `Uno.UI.Diagnostics.IElementRefHandleRegistry` (interface).
+- Internal implementation: `Uno.UI.Diagnostics.ElementRefHandleRegistry` in `Uno.UI`.
+- Handle format: base-36 encoded `int` (implementation detail, not part of the contract).
+- Consumers: `Uno.UI.App.Mcp.Client` (replaces its private `ElementRefRegistry`) and
+  `Uno.HotDesign.Client` (interoperability with its existing `ElementId` system).
+- Not in scope: XAML/XML serialization of the visual tree, element bounds or metadata,
+  persistence across sessions, Hot Design `ElementId` ↔ handle bridge.
+
+---
+
+## 1. Public API
+
+Namespace: `Uno.UI.Diagnostics`
+Assembly: `Uno.UI`
+
+```csharp
+namespace Uno.UI.Diagnostics;
+
+/// <summary>
+/// Provides short opaque handles to live <see cref="DependencyObject"/> instances
+/// for use by diagnostic and tooling components within a session.
+/// </summary>
+/// <remarks>
+/// Handles are ephemeral: they are valid only as long as the object is alive in
+/// the current session. They do not survive application restarts or devserver resets.
+/// <para>
+/// The handle format is an implementation detail; callers must treat handles as
+/// opaque strings. Handle comparison is ordinal, case-insensitive.
+/// </para>
+/// <para>
+/// Both methods must be called from the UI thread. A violation throws
+/// <see cref="InvalidOperationException"/> unless
+/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set.
+/// </para>
+/// </remarks>
+public static class ElementRefHandle
+{
+    /// <summary>
+    /// Gets the active registry instance. Defaults to
+    /// <see cref="ElementRefHandleRegistry"/>.
+    /// </summary>
+    /// <remarks>
+    /// Read-only in production. Replaced internally for testing scenarios via
+    /// <c>ElementRefHandle.SetForTesting(IElementRefHandleRegistry)</c>.
+    /// </remarks>
+    public static IElementRefHandleRegistry Default { get; }
+
+    /// <summary>
+    /// Returns the opaque handle for <paramref name="element"/>,
+    /// creating one if this is the first call for this object.
+    /// </summary>
+    /// <param name="element">The object to identify. Must not be null.</param>
+    /// <returns>A short opaque string that can be passed to <see cref="TryResolve"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when not called from the UI thread (unless
+    /// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
+    /// </exception>
+    public static string GetOrCreate(DependencyObject element)
+        => Default.GetOrCreate(element);
+
+    /// <summary>
+    /// Attempts to resolve a previously obtained handle back to its object.
+    /// </summary>
+    /// <param name="handle">The opaque handle string.</param>
+    /// <param name="element">
+    /// When this method returns <see langword="true"/>, the live object;
+    /// otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the handle is known and the object is still alive;
+    /// <see langword="false"/> if the handle is unrecognized or the object has been
+    /// garbage-collected.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when not called from the UI thread (unless
+    /// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
+    /// </exception>
+    public static bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
+        => Default.TryResolve(handle, out element);
+}
+
+/// <summary>
+/// Defines the contract for a session-scoped registry of opaque handles
+/// to live <see cref="DependencyObject"/> instances.
+/// </summary>
+/// <remarks>
+/// This interface is public to allow injection in consumer tests
+/// (e.g. <c>Uno.UI.App.Mcp.Client</c>, <c>Uno.HotDesign.Client</c>).
+/// Future additions will be made as default interface methods to preserve
+/// binary compatibility.
+/// </remarks>
+public interface IElementRefHandleRegistry
+{
+    /// <inheritdoc cref="ElementRefHandle.GetOrCreate"/>
+    string GetOrCreate(DependencyObject element);
+
+    /// <inheritdoc cref="ElementRefHandle.TryResolve"/>
+    bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element);
+}
+```
+
+### Thread safety
+
+Both `GetOrCreate` and `TryResolve` must be called from the **UI thread**. This
+constraint is **enforced at runtime**: a violation throws `InvalidOperationException`.
+The check follows the same pattern as `DependencyProperty.GetProperty`
+(`src/Uno.UI/UI/Xaml/DependencyProperty.cs`) and can be disabled via
+`FeatureConfiguration.ElementRefHandle.DisableThreadingCheck`.
+
+The `RefEntry` finalizer (reverse-map cleanup) is **exempt** from this check: it
+runs on the finalizer thread and uses only `ConcurrentDictionary.TryRemove`, which
+is thread-safe by design.
+
+### Null handling
+
+`GetOrCreate` throws `ArgumentNullException` on a null element. `TryResolve` with
+a null or empty handle returns `false` without throwing.
+
+---
+
+## 2. Handle Format
+
+The handle is the base-36 encoding of a monotonic `int` counter. Examples: `"1"`,
+`"z4"`, `"3w5e"`. The maximum length for a positive 32-bit integer is 7 characters.
+
+The format is documented here for transparency, but is **not a contract**. Callers
+must never parse, inspect, or generate handles. Future implementations may change
+the encoding without notice as long as existing handles from the current session
+remain resolvable.
+
+**Handle type**: the handle is a plain `string`. This is intentional: handles are
+frequently embedded in JSON payloads or AI agent prompts where a native string
+representation is preferable to a custom struct.
+
+**Comparison rule**: handles are compared **ordinal, case-insensitive**. This
+protects against involuntary case-folding by intermediate transports — particularly
+AI agents (small models may "normalise" short tokens that look like words: `"cat"` →
+`"Cat"`, `"fox"` → `"FOX"`) and text serialisation paths that uppercase or
+title-case identifiers.
+
+**Counter lifetime**: the counter resets each process start. The first handle issued
+in a session has an unspecified value (implementation detail). Handles never recycle
+within a session.
+
+**Counter limit**: `int.MaxValue` (~2.1 billion). Reaching it would require
+allocating billions of `DependencyObject` instances in a single session, which is
+not a realistic scenario for tooling workloads. If a future use case approaches this
+limit, the handle-generation algorithm will be revised; the public contract is
+unaffected because the format is opaque.
+
+**Security model — capability-by-knowledge**: handles are monotonic and predictable
+by design. An adversary with the ability to call `TryResolve` arbitrarily could
+enumerate the keyspace to address any registered element. This is acceptable because
+the registry is only consumed by trusted tooling (MCP server, Hot Design) within a
+developer's own session; there is no production attack surface. If a future scenario
+introduces an untrusted caller, a per-session nonce can be added without changing
+the public contract (the format is opaque).
+
+Rationale for base-36 (vs. UUID/GUID): substantially shorter, URL-safe without
+encoding, and well within token budgets for AI agent contexts.
+
+---
+
+## 3. Lifetime and Invalidation
+
+- A handle is **valid** from its creation until its `DependencyObject` is
+  garbage-collected or the application session ends.
+- The registry holds **only weak references** to objects. No object is rooted by
+  the registry.
+- `TryResolve` performs lazy cleanup: when it finds that the object for a given
+  handle has been collected, it removes the reverse-map entry and returns `false`.
+- A `RefEntry` finalizer performs **eager cleanup** of the forward map entry (via
+  `ConditionalWeakTable`) and the reverse map entry (via `ConcurrentDictionary`)
+  when the object is collected.
+- **Hot reload**: handles are not guaranteed to survive a hot-reload cycle that
+  re-materializes objects. Callers that require stability across hot-reload must
+  re-acquire handles after a reload event. This limitation is tracked as a future
+  improvement (see §8 Open Items).
+
+---
+
+## 4. Internal Implementation
+
+### `ElementRefHandleRegistry` (internal)
+
+Located at `src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs`, namespace
+`Uno.UI.Diagnostics`. Implements `IElementRefHandleRegistry`.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ElementRefHandleRegistry  (internal sealed)                    │
+│                                                                 │
+│  _table   : ConditionalWeakTable<DependencyObject, RefEntry>    │
+│              ──► forward map; GC collects entry when key dies   │
+│                                                                 │
+│  _reverse : ConcurrentDictionary<int, ManagedWeakReference>     │
+│              ──► reverse map; cleaned lazily + by finalizer     │
+│                                                                 │
+│  _nextId  : int   (Interlocked.Increment)                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**`RefEntry`** is a private sealed class holding the numeric id. Its finalizer calls
+`OnObjectCollected(id)` to remove the reverse-map entry once the
+`ConditionalWeakTable` releases it.
+
+**Thread enforcement**: `GetOrCreate` and `TryResolve` start with the standard Uno
+UI-thread guard, mirroring `DependencyProperty.GetProperty`:
+
+```csharp
+if (!FeatureConfiguration.ElementRefHandle.DisableThreadingCheck
+    && !NativeDispatcher.Main.HasThreadAccess)
+{
+    throw new InvalidOperationException(
+        "ElementRefHandle should not be accessed from a non-UI thread.");
+}
+```
+
+The finalizer path is exempt (runs on finalizer thread; uses only
+`ConcurrentDictionary.TryRemove`).
+
+**Weak references**: `GetOrCreate` uses `IWeakReferenceProvider.WeakReference` when
+the object implements it (zero allocation for Uno objects); it falls back to
+`WeakReferencePool.RentSelfWeakReference`. The "rented" weak reference is never
+explicitly returned to the pool: its lifetime is bound to the registry entry, which
+is reclaimed by the GC together with the target object.
+
+**Logging**: traces emitted only at `Trace` level, conditioned on
+`Logger.IsEnabled(LogLevel.Trace)` to avoid cost in production. Log format uses
+`{HandleString}` and `{ObjectTypeName}` only — never `obj.ToString()` (PII risk for
+TextBox/PasswordBox content).
+
+### `ElementRefHandle` (public facade)
+
+Located at `src/Uno.UI/Diagnostics/ElementRefHandle.cs`. Thin static wrapper that
+delegates to `ElementRefHandle.Default`, which is initialized to an instance of
+`ElementRefHandleRegistry`. The `Default` property is get-only; it is replaced for
+testing via `internal static void SetForTesting(IElementRefHandleRegistry)`,
+accessible from test assemblies via `[InternalsVisibleTo]`.
+
+### File layout
+
+```
+src/Uno.UI/Diagnostics/
+  IElementRefHandleRegistry.cs    ← public interface
+  ElementRefHandle.cs             ← public static facade
+  ElementRefHandleRegistry.cs     ← internal sealed class (IElementRefHandleRegistry)
+```
+
+---
+
+## 5. Relationship with Hot Design's `ElementId`
+
+Hot Design (`Uno.HotDesign.Client`) has its own element-identity system based on
+`ElementId` (a `Guid`), issued by the devserver, stored as an attached property, and
+designed for XAML-source stability across reparses.
+
+These two systems serve **different purposes** and are **complementary**:
+
+| | `ElementRefHandle` (this spec) | Hot Design `ElementId` |
+|---|---|---|
+| **Primary use** | Session-scoped tooling (MCP, diagnostics) | XAML designer, property editor |
+| **ID format** | Short base-36 string (token-efficient) | Guid ("D" format) |
+| **Issuing authority** | App-side, on-demand | Devserver-issued, eagerly at parse time |
+| **Storage** | In-memory CWT (no object mutation) | Attached property on the `DependencyObject` |
+| **Hot-reload stability** | Not guaranteed (see §8) | Maintained via element-id matcher |
+| **GC semantics** | Weak-ref only, no rooting | Attached DP keeps a string value on the element |
+
+**Interoperability**: Hot Design tooling that needs to bridge between the two systems
+will use `ElementRefHandle.GetOrCreate` to obtain a short handle for an element whose
+`ElementId` is already known, and will emit that handle alongside the `ElementId` in
+its responses. This enables MCP tool calls to refer to an element selected in Hot
+Design using a single, token-efficient string. The bridge code lives in
+`Uno.HotDesign.Client` and is out of scope for this spec.
+
+---
+
+## 6. Tests
+
+**Location**: `src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs`
+
+Pattern follows `src/Uno.UI.Tests/WeakReferencePool/Given_WeakReferencePool.cs`.
+
+| Test | Description |
+|------|-------------|
+| `GetOrCreate_SameElement_ReturnsSameHandle` | Idempotence: multiple calls for the same object return the same string. Ensures token-budget stability when the same element is referenced repeatedly. |
+| `GetOrCreate_DifferentElements_ReturnsDifferentHandles` | Two distinct objects get distinct handles. |
+| `TryResolve_ValidHandle_ReturnsTrueAndElement` | Round-trip: resolve the handle back to the object. Drops the intermediate strong reference before resolving to prove the registry does not implicitly root the object. |
+| `TryResolve_UnknownHandle_ReturnsFalse` | An unknown handle string returns false. |
+| `TryResolve_NullOrEmpty_ReturnsFalse` | Null and empty string return false without throwing. |
+| `TryResolve_AfterGC_ReturnsFalse` | After forcing GC on the object, `TryResolve` returns false and the reverse map is cleaned (covers both lazy cleanup and finalizer path). |
+| `TryResolve_HandleComparison_IsCaseInsensitive` | The same handle in upper and lower case resolves to the same object. |
+| `GetOrCreate_FromBackgroundThread_Throws` | Calling `GetOrCreate` off the UI thread throws `InvalidOperationException`. |
+| `TryResolve_FromBackgroundThread_Throws` | Calling `TryResolve` off the UI thread throws `InvalidOperationException`. |
+| `GetOrCreate_WithDisableThreadingCheck_DoesNotThrow` | Setting `FeatureConfiguration.ElementRefHandle.DisableThreadingCheck` suppresses the thread check. |
+| `Finalizer_RemovesReverseMapEntry` | After GC, the finalizer eagerly removes the reverse-map entry before `TryResolve` is ever called. Distinguishes eager cleanup from lazy. |
+| `Handles_DoNotRecycle_AfterGC_WithinSession` | After an object is collected, a new registration for a fresh object receives a different handle — no id recycling within a session. |
+| `SetForTesting_RestoresDefaultOnDispose` | `SetForTesting` returns an `IDisposable`; on dispose, `Default` is restored to the original registry. |
+
+---
+
+## 7. Migration: `Uno.UI.App.Mcp.Client`
+
+`uno.app-mcp` currently ships a private `ElementRefRegistry` in
+`Uno.UI.App.Mcp.Client`. Once this spec is implemented and a new Uno NuGet is
+available, the following changes are made to `uno.app-mcp` in a single PR:
+
+1. Bump the Uno SDK/package version to the one containing `ElementRefHandle`.
+2. Replace all call sites of `ElementRefRegistry.GetOrCreateId(...)` with
+   `ElementRefHandle.GetOrCreate(...)`.
+3. Replace all call sites of `ElementRefRegistry.TryGetElement(...)` with
+   `ElementRefHandle.TryResolve(...)`.
+4. Delete `src/Uno.UI.App.Mcp.Client/Helpers/ElementRefRegistry.cs`.
+
+Handles are opaque and their format is not part of the contract. Any handles
+produced by the old private registry are not expected to be resolvable by the new
+public one; the migration removes the old registry in the same PR so no parallel
+operation occurs.
+
+---
+
+## 8. Open Items
+
+| # | Item | Priority |
+|---|------|----------|
+| 1 | **Hot-reload stability**: handles are not guaranteed to survive a hot-reload cycle that re-materializes objects. Define a notification mechanism (e.g., `IHotReloadHandler`) that allows the registry to re-associate or invalidate handles when objects are replaced. Note: the reference implementation in `uno.app-mcp` does not handle this scenario either; to be addressed when a concrete need arises. | P2 |
+| 2 | **Cross-process protection**: handles are session-scoped and in-process. A future hardening step could reject handles that were not issued by the current session (e.g., via a per-session nonce prefix), to guard against handles being accidentally forwarded across process boundaries. | P3 |
+| 3 | **Registration hook**: expose a registration event or callback for tooling that wants to observe when objects receive or lose handles (e.g., to update a visual overlay). | P3 |
+| 4 | **Finalizer-free cleanup**: evaluate whether the `RefEntry` finalizer is necessary or whether lazy cleanup in `TryResolve` plus a periodic sweep suffices, to reduce pressure on the finalization queue. | P3 |
+| 5 | **Metrics**: expose a `Meter` `Uno.UI.Diagnostics.ElementRefHandle` (Counter `elementref.handle.created` / `elementref.handle.miss`, Gauge `elementref.handle.table_size`) for runtime observability. | P3 |

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
@@ -30,8 +30,8 @@ public class Given_ElementRefHandle_Threading
 	{
 		var registry = new ElementRefHandleRegistry();
 
-		Assert.ThrowsException<InvalidOperationException>(
-			() => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult());
+		Action act = () => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult();
+		act.Should().Throw<InvalidOperationException>().WithMessage("*non-UI thread*");
 	}
 
 	[TestMethod]
@@ -39,8 +39,8 @@ public class Given_ElementRefHandle_Threading
 	{
 		var registry = new ElementRefHandleRegistry();
 
-		Assert.ThrowsException<InvalidOperationException>(
-			() => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult());
+		Action act = () => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult();
+		act.Should().Throw<InvalidOperationException>().WithMessage("*non-UI thread*");
 	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
@@ -1,6 +1,8 @@
 // The threading check itself is platform-agnostic, but this test cannot be expressed
-// on WASM: the runtime is single-threaded, so Task.Run executes synchronously on the
-// UI thread — there is no way to call from a non-UI thread to trigger the check.
+// on single-threaded runtimes: Task.Run executes synchronously on the UI thread, so
+// there is no way to call from a non-UI thread to trigger the check.
+// Native WASM (!__WASM__) is always single-threaded. Skia WASM Browser is excluded
+// at the method level via [PlatformCondition] for the same reason.
 #if HAS_UNO && !__WASM__
 using System;
 using System.Threading.Tasks;
@@ -29,6 +31,7 @@ public class Given_ElementRefHandle_Threading
 	}
 
 	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
 	public void When_GetOrCreate_FromBackgroundThread_Throws()
 	{
 		var registry = new ElementRefHandleRegistry();
@@ -38,6 +41,7 @@ public class Given_ElementRefHandle_Threading
 	}
 
 	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
 	public void When_TryResolve_FromBackgroundThread_Throws()
 	{
 		var registry = new ElementRefHandleRegistry();

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
@@ -1,0 +1,46 @@
+#if HAS_UNO
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Diagnostics;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Diagnostics;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_ElementRefHandle_Threading
+{
+	private bool _savedDisableThreadingCheck;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		_savedDisableThreadingCheck = FeatureConfiguration.ElementRefHandle.DisableThreadingCheck;
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = _savedDisableThreadingCheck;
+	}
+
+	[TestMethod]
+	public void When_GetOrCreate_FromBackgroundThread_Throws()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		Assert.ThrowsException<InvalidOperationException>(
+			() => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult());
+	}
+
+	[TestMethod]
+	public void When_TryResolve_FromBackgroundThread_Throws()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		Assert.ThrowsException<InvalidOperationException>(
+			() => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult());
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Diagnostics/Given_ElementRefHandle_Threading.cs
@@ -1,4 +1,7 @@
-#if HAS_UNO
+// The threading check itself is platform-agnostic, but this test cannot be expressed
+// on WASM: the runtime is single-threaded, so Task.Run executes synchronously on the
+// UI thread — there is no way to call from a non-UI thread to trigger the check.
+#if HAS_UNO && !__WASM__
 using System;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Diagnostics;
+
+namespace Uno.UI.Tests.Diagnostics;
+
+[TestClass]
+public class Given_ElementRefHandleRegistry
+{
+	[TestInitialize]
+	public void Initialize()
+	{
+		// Unit tests run off the UI thread; opt out of the thread check globally.
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = true;
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = true;
+	}
+
+	[TestMethod]
+	public void When_GetOrCreate_SameElement_ReturnsSameHandle()
+	{
+		var registry = new ElementRefHandleRegistry();
+		var element = new Grid();
+
+		var h1 = registry.GetOrCreate(element);
+		var h2 = registry.GetOrCreate(element);
+
+		Assert.AreEqual(h1, h2);
+	}
+
+	[TestMethod]
+	public void When_GetOrCreate_DifferentElements_ReturnsDifferentHandles()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		var h1 = registry.GetOrCreate(new Grid());
+		var h2 = registry.GetOrCreate(new Grid());
+
+		Assert.AreNotEqual(h1, h2);
+	}
+
+	[TestMethod]
+	public void When_TryResolve_ValidHandle_ReturnsTrueAndElement()
+	{
+		var registry = new ElementRefHandleRegistry();
+		var element = new Grid();
+
+		// Obtain the handle then clear the local strong reference.
+		var handle = GetHandleAndRelease(registry, element);
+
+		// The registry must not implicitly root the object — element is still alive
+		// because we hold it in this method's scope.
+		var found = registry.TryResolve(handle, out var resolved);
+
+		Assert.IsTrue(found);
+		Assert.AreSame(element, resolved);
+	}
+
+	[TestMethod]
+	public void When_TryResolve_UnknownHandle_ReturnsFalse()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		var found = registry.TryResolve("zzzzzzz", out var element);
+
+		Assert.IsFalse(found);
+		Assert.IsNull(element);
+	}
+
+	[TestMethod]
+	public void When_TryResolve_NullHandle_ReturnsFalse()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		var found = registry.TryResolve(null!, out var element);
+
+		Assert.IsFalse(found);
+		Assert.IsNull(element);
+	}
+
+	[TestMethod]
+	public void When_TryResolve_EmptyHandle_ReturnsFalse()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		var found = registry.TryResolve(string.Empty, out var element);
+
+		Assert.IsFalse(found);
+		Assert.IsNull(element);
+	}
+
+	[TestMethod]
+	public void When_TryResolve_AfterGC_ReturnsFalse()
+	{
+		var registry = new ElementRefHandleRegistry();
+		var handle = RegisterAndRelease(registry);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		var found = registry.TryResolve(handle, out var element);
+
+		Assert.IsFalse(found);
+		Assert.IsNull(element);
+	}
+
+	[TestMethod]
+	public void When_TryResolve_HandleComparison_IsCaseInsensitive()
+	{
+		var registry = new ElementRefHandleRegistry();
+		var element = new Grid();
+		var handle = registry.GetOrCreate(element);
+
+		var foundUpper = registry.TryResolve(handle.ToUpperInvariant(), out var resolvedUpper);
+		var foundLower = registry.TryResolve(handle.ToLowerInvariant(), out var resolvedLower);
+
+		Assert.IsTrue(foundUpper);
+		Assert.IsTrue(foundLower);
+		Assert.AreSame(element, resolvedUpper);
+		Assert.AreSame(element, resolvedLower);
+	}
+
+	[TestMethod]
+	public void When_GetOrCreate_FromBackgroundThread_Throws()
+	{
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
+
+		var registry = new ElementRefHandleRegistry();
+
+		var ex = Assert.ThrowsException<InvalidOperationException>(
+			() => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult());
+
+		Assert.IsTrue(ex.Message.Contains("non-UI thread", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
+	public void When_TryResolve_FromBackgroundThread_Throws()
+	{
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
+
+		var registry = new ElementRefHandleRegistry();
+
+		var ex = Assert.ThrowsException<InvalidOperationException>(
+			() => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult());
+
+		Assert.IsTrue(ex.Message.Contains("non-UI thread", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
+	public void When_GetOrCreate_WithDisableThreadingCheck_DoesNotThrow()
+	{
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = true;
+
+		var registry = new ElementRefHandleRegistry();
+
+		// Should not throw even when called from a background thread.
+		var handle = Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult();
+
+		Assert.IsFalse(string.IsNullOrEmpty(handle));
+	}
+
+	[TestMethod]
+	public void When_Finalizer_RemovesReverseMapEntry()
+	{
+		var registry = new ElementRefHandleRegistry();
+		var handle = RegisterAndRelease(registry);
+
+		// First GC collects the Grid; WaitForPendingFinalizers lets RefEntry's finalizer run.
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		// The finalizer (not TryResolve) should have cleaned the reverse map.
+		// We verify by resolving: it must return false, proving the entry is gone.
+		var found = registry.TryResolve(handle, out _);
+
+		Assert.IsFalse(found);
+	}
+
+	[TestMethod]
+	public void When_Handles_DoNotRecycle_AfterGC_WithinSession()
+	{
+		var registry = new ElementRefHandleRegistry();
+
+		var firstHandle = RegisterAndRelease(registry);
+
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+
+		// Register a fresh object; it must receive a new, distinct handle.
+		var secondHandle = registry.GetOrCreate(new Grid());
+
+		Assert.AreNotEqual(firstHandle, secondHandle);
+	}
+
+	[TestMethod]
+	public void When_SetForTesting_RestoresDefaultOnDispose()
+	{
+		var original = ElementRefHandle.Default;
+		var fake = new FakeRegistry();
+
+		using (ElementRefHandle.SetForTesting(fake))
+		{
+			Assert.AreSame(fake, ElementRefHandle.Default);
+		}
+
+		Assert.AreSame(original, ElementRefHandle.Default);
+	}
+
+	// ─── helpers ────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Registers a new Grid in the registry and returns its handle.
+	/// The Grid is created in a no-inlined frame so the JIT cannot keep
+	/// a reference alive on the stack of the calling method.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static string RegisterAndRelease(ElementRefHandleRegistry registry)
+		=> registry.GetOrCreate(new Grid());
+
+	/// <summary>
+	/// Registers <paramref name="element"/> and returns its handle via a separate
+	/// stack frame so the caller retains the only strong reference.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static string GetHandleAndRelease(ElementRefHandleRegistry registry, object element)
+		=> registry.GetOrCreate((Microsoft.UI.Xaml.DependencyObject)element);
+
+	private sealed class FakeRegistry : IElementRefHandleRegistry
+	{
+		public string GetOrCreate(Microsoft.UI.Xaml.DependencyObject element) => "fake";
+		public bool TryResolve(string handle, out Microsoft.UI.Xaml.DependencyObject? element)
+		{
+			element = null;
+			return false;
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -237,7 +238,7 @@ public class Given_ElementRefHandleRegistry
 	private sealed class FakeRegistry : IElementRefHandleRegistry
 	{
 		public string GetOrCreate(Microsoft.UI.Xaml.DependencyObject element) => "fake";
-		public bool TryResolve(string handle, out Microsoft.UI.Xaml.DependencyObject? element)
+		public bool TryResolve(string handle, [NotNullWhen(true)] out Microsoft.UI.Xaml.DependencyObject? element)
 		{
 			element = null;
 			return false;

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -13,17 +13,20 @@ namespace Uno.UI.Tests.Diagnostics;
 [TestClass]
 public class Given_ElementRefHandleRegistry
 {
+	private bool _savedDisableThreadingCheck;
+
 	[TestInitialize]
 	public void Initialize()
 	{
 		// Unit tests run off the UI thread; opt out of the thread check globally.
+		_savedDisableThreadingCheck = FeatureConfiguration.ElementRefHandle.DisableThreadingCheck;
 		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = true;
 	}
 
 	[TestCleanup]
 	public void Cleanup()
 	{
-		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = _savedDisableThreadingCheck;
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -21,7 +21,7 @@ public class Given_ElementRefHandleRegistry
 	[TestCleanup]
 	public void Cleanup()
 	{
-		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = true;
+		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -136,10 +138,8 @@ public class Given_ElementRefHandleRegistry
 
 		var registry = new ElementRefHandleRegistry();
 
-		var ex = Assert.ThrowsException<InvalidOperationException>(
-			() => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult());
-
-		Assert.IsTrue(ex.Message.Contains("non-UI thread", StringComparison.OrdinalIgnoreCase));
+		Action act = () => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult();
+		act.Should().Throw<InvalidOperationException>().WithMessage("*non-UI thread*");
 	}
 
 	[TestMethod]
@@ -149,10 +149,8 @@ public class Given_ElementRefHandleRegistry
 
 		var registry = new ElementRefHandleRegistry();
 
-		var ex = Assert.ThrowsException<InvalidOperationException>(
-			() => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult());
-
-		Assert.IsTrue(ex.Message.Contains("non-UI thread", StringComparison.OrdinalIgnoreCase));
+		Action act = () => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult();
+		act.Should().Throw<InvalidOperationException>().WithMessage("*non-UI thread*");
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -58,7 +58,8 @@ public class Given_ElementRefHandleRegistry
 		var registry = new ElementRefHandleRegistry();
 		var element = new Grid();
 
-		// Obtain the handle then clear the local strong reference.
+		// Obtain the handle via a separate no-inline frame so the JIT cannot keep
+		// additional temporary references alive on this frame's stack.
 		var handle = GetHandleAndRelease(registry, element);
 
 		// The registry must not implicitly root the object — element is still alive

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -217,7 +217,8 @@ public class Given_ElementRefHandleRegistry
 
 	private sealed class FakeRegistry : IElementRefHandleRegistry
 	{
-		public string GetOrCreate(Microsoft.UI.Xaml.DependencyObject element) => "fake";
+		public string GetOrCreate(Microsoft.UI.Xaml.DependencyObject element)
+			=> RuntimeHelpers.GetHashCode(element).ToString("x");
 		public bool TryResolve(string? handle, [NotNullWhen(true)] out Microsoft.UI.Xaml.DependencyObject? element)
 		{
 			element = null;

--- a/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
+++ b/src/Uno.UI.Tests/Diagnostics/Given_ElementRefHandleRegistry.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -83,7 +82,7 @@ public class Given_ElementRefHandleRegistry
 	{
 		var registry = new ElementRefHandleRegistry();
 
-		var found = registry.TryResolve(null!, out var element);
+		var found = registry.TryResolve(null, out var element);
 
 		Assert.IsFalse(found);
 		Assert.IsNull(element);
@@ -130,28 +129,6 @@ public class Given_ElementRefHandleRegistry
 		Assert.IsTrue(foundLower);
 		Assert.AreSame(element, resolvedUpper);
 		Assert.AreSame(element, resolvedLower);
-	}
-
-	[TestMethod]
-	public void When_GetOrCreate_FromBackgroundThread_Throws()
-	{
-		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
-
-		var registry = new ElementRefHandleRegistry();
-
-		Action act = () => Task.Run(() => registry.GetOrCreate(new Grid())).GetAwaiter().GetResult();
-		act.Should().Throw<InvalidOperationException>().WithMessage("*non-UI thread*");
-	}
-
-	[TestMethod]
-	public void When_TryResolve_FromBackgroundThread_Throws()
-	{
-		FeatureConfiguration.ElementRefHandle.DisableThreadingCheck = false;
-
-		var registry = new ElementRefHandleRegistry();
-
-		Action act = () => Task.Run(() => registry.TryResolve("1", out _)).GetAwaiter().GetResult();
-		act.Should().Throw<InvalidOperationException>().WithMessage("*non-UI thread*");
 	}
 
 	[TestMethod]
@@ -238,7 +215,7 @@ public class Given_ElementRefHandleRegistry
 	private sealed class FakeRegistry : IElementRefHandleRegistry
 	{
 		public string GetOrCreate(Microsoft.UI.Xaml.DependencyObject element) => "fake";
-		public bool TryResolve(string handle, [NotNullWhen(true)] out Microsoft.UI.Xaml.DependencyObject? element)
+		public bool TryResolve(string? handle, [NotNullWhen(true)] out Microsoft.UI.Xaml.DependencyObject? element)
 		{
 			element = null;
 			return false;

--- a/src/Uno.UI/Diagnostics/ElementRefHandle.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandle.cs
@@ -79,6 +79,7 @@ public static class ElementRefHandle
 	/// </summary>
 	internal static IDisposable SetForTesting(IElementRefHandleRegistry registry)
 	{
+		ArgumentNullException.ThrowIfNull(registry);
 		var previous = Interlocked.Exchange(ref _default, registry);
 		return new RestoreScope(previous);
 	}

--- a/src/Uno.UI/Diagnostics/ElementRefHandle.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandle.cs
@@ -56,21 +56,21 @@ public static class ElementRefHandle
 	/// <summary>
 	/// Attempts to resolve a previously obtained handle back to its object.
 	/// </summary>
-	/// <param name="handle">The opaque handle string.</param>
+	/// <param name="handle">The opaque handle string. <see langword="null"/> or empty returns <see langword="false"/>.</param>
 	/// <param name="element">
 	/// When this method returns <see langword="true"/>, the live object;
 	/// otherwise <see langword="null"/>.
 	/// </param>
 	/// <returns>
 	/// <see langword="true"/> if the handle is known and the object is still alive;
-	/// <see langword="false"/> if the handle is unrecognized or the object has been
-	/// garbage-collected.
+	/// <see langword="false"/> if the handle is <see langword="null"/>, empty, unrecognized,
+	/// or the object has been garbage-collected.
 	/// </returns>
 	/// <exception cref="InvalidOperationException">
 	/// Thrown when not called from the UI thread (unless
 	/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
 	/// </exception>
-	public static bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
+	public static bool TryResolve(string? handle, [NotNullWhen(true)] out DependencyObject? element)
 		=> Volatile.Read(ref _default).TryResolve(handle, out element);
 
 	/// <summary>

--- a/src/Uno.UI/Diagnostics/ElementRefHandle.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandle.cs
@@ -1,0 +1,88 @@
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.Diagnostics;
+
+/// <summary>
+/// Provides short opaque handles to live <see cref="DependencyObject"/> instances
+/// for use by diagnostic and tooling components within a session.
+/// </summary>
+/// <remarks>
+/// Handles are ephemeral: they are valid only as long as the object is alive in
+/// the current session. They do not survive application restarts or devserver resets.
+/// <para>
+/// The handle format is an implementation detail; callers must treat handles as
+/// opaque strings. Handle comparison is ordinal, case-insensitive.
+/// </para>
+/// <para>
+/// Both methods must be called from the UI thread. A violation throws
+/// <see cref="InvalidOperationException"/> unless
+/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set.
+/// </para>
+/// </remarks>
+public static class ElementRefHandle
+{
+	private static IElementRefHandleRegistry _default = new ElementRefHandleRegistry();
+
+	/// <summary>
+	/// Gets the active registry instance. Defaults to <see cref="ElementRefHandleRegistry"/>.
+	/// </summary>
+	/// <remarks>
+	/// Read-only in production. Replaced internally for testing scenarios via
+	/// <see cref="SetForTesting"/>.
+	/// </remarks>
+	public static IElementRefHandleRegistry Default => _default;
+
+	/// <summary>
+	/// Returns the opaque handle for <paramref name="element"/>,
+	/// creating one if this is the first call for this object.
+	/// </summary>
+	/// <param name="element">The object to identify. Must not be null.</param>
+	/// <returns>A short opaque string that can be passed to <see cref="TryResolve"/>.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="element"/> is null.</exception>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown when not called from the UI thread (unless
+	/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
+	/// </exception>
+	public static string GetOrCreate(DependencyObject element)
+		=> _default.GetOrCreate(element);
+
+	/// <summary>
+	/// Attempts to resolve a previously obtained handle back to its object.
+	/// </summary>
+	/// <param name="handle">The opaque handle string.</param>
+	/// <param name="element">
+	/// When this method returns <see langword="true"/>, the live object;
+	/// otherwise <see langword="null"/>.
+	/// </param>
+	/// <returns>
+	/// <see langword="true"/> if the handle is known and the object is still alive;
+	/// <see langword="false"/> if the handle is unrecognized or the object has been
+	/// garbage-collected.
+	/// </returns>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown when not called from the UI thread (unless
+	/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
+	/// </exception>
+	public static bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
+		=> _default.TryResolve(handle, out element);
+
+	/// <summary>
+	/// Replaces <see cref="Default"/> with <paramref name="registry"/> for the duration
+	/// of the returned scope. Disposing the scope restores the previous registry.
+	/// </summary>
+	internal static IDisposable SetForTesting(IElementRefHandleRegistry registry)
+	{
+		var previous = _default;
+		_default = registry;
+		return new RestoreScope(previous);
+	}
+
+	private sealed class RestoreScope(IElementRefHandleRegistry previous) : IDisposable
+	{
+		public void Dispose() => _default = previous;
+	}
+}

--- a/src/Uno.UI/Diagnostics/ElementRefHandle.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandle.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.UI.Xaml;
 
 namespace Uno.UI.Diagnostics;
@@ -25,16 +26,18 @@ namespace Uno.UI.Diagnostics;
 /// </remarks>
 public static class ElementRefHandle
 {
+	// Read via Volatile.Read; written only through Interlocked.Exchange (in SetForTesting/RestoreScope)
+	// to guarantee visibility across threads when DisableThreadingCheck is true in test environments.
 	private static IElementRefHandleRegistry _default = new ElementRefHandleRegistry();
 
 	/// <summary>
 	/// Gets the active registry instance. Defaults to <see cref="ElementRefHandleRegistry"/>.
 	/// </summary>
 	/// <remarks>
-	/// Read-only in production. Replaced internally for testing scenarios via
-	/// <see cref="SetForTesting"/>.
+	/// Do not cache this value — it may be temporarily replaced by <see cref="SetForTesting"/>.
+	/// Always access the registry through this property or the static forwarding methods.
 	/// </remarks>
-	public static IElementRefHandleRegistry Default => _default;
+	public static IElementRefHandleRegistry Default => Volatile.Read(ref _default);
 
 	/// <summary>
 	/// Returns the opaque handle for <paramref name="element"/>,
@@ -48,7 +51,7 @@ public static class ElementRefHandle
 	/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
 	/// </exception>
 	public static string GetOrCreate(DependencyObject element)
-		=> _default.GetOrCreate(element);
+		=> Volatile.Read(ref _default).GetOrCreate(element);
 
 	/// <summary>
 	/// Attempts to resolve a previously obtained handle back to its object.
@@ -68,7 +71,7 @@ public static class ElementRefHandle
 	/// <see cref="FeatureConfiguration.ElementRefHandle.DisableThreadingCheck"/> is set).
 	/// </exception>
 	public static bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
-		=> _default.TryResolve(handle, out element);
+		=> Volatile.Read(ref _default).TryResolve(handle, out element);
 
 	/// <summary>
 	/// Replaces <see cref="Default"/> with <paramref name="registry"/> for the duration
@@ -76,13 +79,12 @@ public static class ElementRefHandle
 	/// </summary>
 	internal static IDisposable SetForTesting(IElementRefHandleRegistry registry)
 	{
-		var previous = _default;
-		_default = registry;
+		var previous = Interlocked.Exchange(ref _default, registry);
 		return new RestoreScope(previous);
 	}
 
 	private sealed class RestoreScope(IElementRefHandleRegistry previous) : IDisposable
 	{
-		public void Dispose() => _default = previous;
+		public void Dispose() => Interlocked.Exchange(ref _default, previous);
 	}
 }

--- a/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
@@ -1,13 +1,11 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Microsoft.UI.Xaml;
 using Uno.Foundation.Logging;
-using Uno.UI.DataBinding;
 using Uno.UI.Dispatching;
 
 namespace Uno.UI.Diagnostics;
@@ -32,7 +30,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 	}
 
 	private readonly ConditionalWeakTable<DependencyObject, RefEntry> _table = new();
-	private readonly ConcurrentDictionary<int, ManagedWeakReference> _reverse = new();
+	private readonly Dictionary<int, WeakReference<DependencyObject>> _reverse = new();
 
 	// A 32-bit counter supports ~2.1 billion unique handles per session. Diagnostic tools
 	// operate on the live visual tree of a running app — exhausting this counter would
@@ -48,17 +46,12 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 
 		ArgumentNullException.ThrowIfNull(element);
 
-		var entry = _table.GetValue(element, e => new RefEntry(Interlocked.Increment(ref _nextId), this));
-
-		// Note: _table.GetValue and _reverse.TryAdd are two separate operations. When
-		// DisableThreadingCheck is true, a concurrent call may observe the handle as
-		// unresolvable during the window between these two lines. This is an accepted
-		// trade-off: the threading check guarantees single-threaded access in normal use.
-		var weakRef = element is IWeakReferenceProvider provider
-			? (provider.WeakReference ?? WeakReferencePool.RentSelfWeakReference(provider))
-			: WeakReferencePool.RentWeakReference(element, element);
-
-		_reverse.TryAdd(entry.Id, weakRef);
+		var entry = _table.GetValue(element, e =>
+		{
+			var id = ++_nextId;
+			_reverse[id] = new WeakReference<DependencyObject>(e);
+			return new RefEntry(id, this);
+		});
 
 		var handle = ToBase36(entry.Id);
 
@@ -89,7 +82,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 			return false;
 		}
 
-		if (!_reverse.TryGetValue(numericId, out var mwr))
+		if (!_reverse.TryGetValue(numericId, out var weakRef))
 		{
 			if (_log.IsEnabled(LogLevel.Trace))
 			{
@@ -99,14 +92,14 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 			return false;
 		}
 
-		if (mwr.Target is DependencyObject target)
+		if (weakRef.TryGetTarget(out var target))
 		{
 			element = target;
 			return true;
 		}
 
 		// Lazy cleanup: object was GC'd before the RefEntry finalizer ran.
-		_reverse.TryRemove(numericId, out _);
+		_reverse.Remove(numericId);
 
 		if (_log.IsEnabled(LogLevel.Trace))
 		{
@@ -116,7 +109,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 		return false;
 	}
 
-	private void OnObjectCollected(int id) => _reverse.TryRemove(id, out _);
+	private void OnObjectCollected(int id) => _reverse.Remove(id);
 
 	private static string ToBase36(int value)
 	{
@@ -124,7 +117,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 
 		if (value <= 0)
 		{
-			// IDs are issued by Interlocked.Increment starting at 1; a non-positive value is a bug.
+			// IDs are issued by ++_nextId starting at 1; a non-positive value is a bug.
 			throw new ArgumentOutOfRangeException(nameof(value), value, "Handle ID must be positive.");
 		}
 

--- a/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
@@ -1,7 +1,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
@@ -30,7 +30,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 	}
 
 	private readonly ConditionalWeakTable<DependencyObject, RefEntry> _table = new();
-	private readonly Dictionary<int, WeakReference<DependencyObject>> _reverse = new();
+	private readonly ConcurrentDictionary<int, WeakReference<DependencyObject>> _reverse = new();
 
 	// A 32-bit counter supports ~2.1 billion unique handles per session. Diagnostic tools
 	// operate on the live visual tree of a running app — exhausting this counter would
@@ -99,7 +99,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 		}
 
 		// Lazy cleanup: object was GC'd before the RefEntry finalizer ran.
-		_reverse.Remove(numericId);
+		_reverse.TryRemove(numericId, out _);
 
 		if (_log.IsEnabled(LogLevel.Trace))
 		{
@@ -109,7 +109,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 		return false;
 	}
 
-	private void OnObjectCollected(int id) => _reverse.Remove(id);
+	private void OnObjectCollected(int id) => _reverse.TryRemove(id, out _);
 
 	private static string ToBase36(int value)
 	{

--- a/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
@@ -70,7 +70,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 		return handle;
 	}
 
-	public bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
+	public bool TryResolve(string? handle, [NotNullWhen(true)] out DependencyObject? element)
 	{
 		if (!FeatureConfiguration.ElementRefHandle.DisableThreadingCheck && !NativeDispatcher.Main.HasThreadAccess)
 		{

--- a/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
@@ -1,0 +1,173 @@
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.UI.Xaml;
+using Uno.Foundation.Logging;
+using Uno.UI.DataBinding;
+using Uno.UI.Dispatching;
+
+namespace Uno.UI.Diagnostics;
+
+internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
+{
+	private static readonly Logger _log = typeof(ElementRefHandleRegistry).Log();
+
+	private sealed class RefEntry
+	{
+		private readonly ElementRefHandleRegistry _registry;
+
+		public RefEntry(int id, ElementRefHandleRegistry registry)
+		{
+			Id = id;
+			_registry = registry;
+		}
+
+		public int Id { get; }
+
+		~RefEntry() => _registry.OnObjectCollected(Id);
+	}
+
+	private readonly ConditionalWeakTable<DependencyObject, RefEntry> _table = new();
+	private readonly ConcurrentDictionary<int, ManagedWeakReference> _reverse = new();
+	private int _nextId;
+
+	public string GetOrCreate(DependencyObject element)
+	{
+		if (!FeatureConfiguration.ElementRefHandle.DisableThreadingCheck && !NativeDispatcher.Main.HasThreadAccess)
+		{
+			throw new InvalidOperationException("ElementRefHandle should not be accessed from a non-UI thread.");
+		}
+
+		ArgumentNullException.ThrowIfNull(element);
+
+		var entry = _table.GetValue(element, e => new RefEntry(Interlocked.Increment(ref _nextId), this));
+
+		var weakRef = (element as IWeakReferenceProvider)?.WeakReference
+			?? WeakReferencePool.RentSelfWeakReference((IWeakReferenceProvider)element);
+
+		_reverse.TryAdd(entry.Id, weakRef);
+
+		var handle = ToBase36(entry.Id);
+
+		if (_log.IsEnabled(LogLevel.Trace))
+		{
+			_log.Trace($"ElementRefHandle registered: handle={handle} type={element.GetType().FullName}");
+		}
+
+		return handle;
+	}
+
+	public bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element)
+	{
+		if (!FeatureConfiguration.ElementRefHandle.DisableThreadingCheck && !NativeDispatcher.Main.HasThreadAccess)
+		{
+			throw new InvalidOperationException("ElementRefHandle should not be accessed from a non-UI thread.");
+		}
+
+		element = null;
+
+		if (!TryParseBase36(handle, out var numericId))
+		{
+			if (_log.IsEnabled(LogLevel.Trace))
+			{
+				_log.Trace($"ElementRefHandle miss: handle={(handle ?? "(null)")} cause=unknown");
+			}
+
+			return false;
+		}
+
+		if (!_reverse.TryGetValue(numericId, out var mwr))
+		{
+			if (_log.IsEnabled(LogLevel.Trace))
+			{
+				_log.Trace($"ElementRefHandle miss: handle={handle} cause=unknown");
+			}
+
+			return false;
+		}
+
+		if (mwr.Target is DependencyObject target)
+		{
+			element = target;
+			return true;
+		}
+
+		// Lazy cleanup: object was GC'd before the RefEntry finalizer ran.
+		_reverse.TryRemove(numericId, out _);
+
+		if (_log.IsEnabled(LogLevel.Trace))
+		{
+			_log.Trace($"ElementRefHandle miss: handle={handle} cause=gc-collected");
+		}
+
+		return false;
+	}
+
+	private void OnObjectCollected(int id) => _reverse.TryRemove(id, out _);
+
+	private static string ToBase36(int value)
+	{
+		const string alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+		if (value <= 0)
+		{
+			return "0";
+		}
+
+		Span<char> buffer = stackalloc char[8];
+		int pos = buffer.Length;
+		int x = value;
+
+		while (x > 0)
+		{
+			buffer[--pos] = alphabet[x % 36];
+			x /= 36;
+		}
+
+		return new string(buffer[pos..]);
+	}
+
+	private static bool TryParseBase36(string? s, out int value)
+	{
+		value = 0;
+
+		if (string.IsNullOrEmpty(s))
+		{
+			return false;
+		}
+
+		int acc = 0;
+
+		foreach (var ch in s)
+		{
+			int digit = ch switch
+			{
+				>= '0' and <= '9' => ch - '0',
+				>= 'a' and <= 'z' => ch - 'a' + 10,
+				>= 'A' and <= 'Z' => ch - 'A' + 10,
+				_ => -1
+			};
+
+			if (digit < 0)
+			{
+				return false;
+			}
+
+			try
+			{
+				checked { acc = acc * 36 + digit; }
+			}
+			catch (OverflowException)
+			{
+				return false;
+			}
+		}
+
+		value = acc;
+		return true;
+	}
+}

--- a/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/ElementRefHandleRegistry.cs
@@ -33,6 +33,10 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 
 	private readonly ConditionalWeakTable<DependencyObject, RefEntry> _table = new();
 	private readonly ConcurrentDictionary<int, ManagedWeakReference> _reverse = new();
+
+	// A 32-bit counter supports ~2.1 billion unique handles per session. Diagnostic tools
+	// operate on the live visual tree of a running app — exhausting this counter would
+	// require registering every frame for ~8 years at 60 fps. No overflow guard needed.
 	private int _nextId;
 
 	public string GetOrCreate(DependencyObject element)
@@ -46,8 +50,13 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 
 		var entry = _table.GetValue(element, e => new RefEntry(Interlocked.Increment(ref _nextId), this));
 
-		var weakRef = (element as IWeakReferenceProvider)?.WeakReference
-			?? WeakReferencePool.RentSelfWeakReference((IWeakReferenceProvider)element);
+		// Note: _table.GetValue and _reverse.TryAdd are two separate operations. When
+		// DisableThreadingCheck is true, a concurrent call may observe the handle as
+		// unresolvable during the window between these two lines. This is an accepted
+		// trade-off: the threading check guarantees single-threaded access in normal use.
+		var weakRef = element is IWeakReferenceProvider provider
+			? (provider.WeakReference ?? WeakReferencePool.RentSelfWeakReference(provider))
+			: WeakReferencePool.RentWeakReference(element, element);
 
 		_reverse.TryAdd(entry.Id, weakRef);
 
@@ -74,7 +83,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 		{
 			if (_log.IsEnabled(LogLevel.Trace))
 			{
-				_log.Trace($"ElementRefHandle miss: handle={(handle ?? "(null)")} cause=unknown");
+				_log.Trace($"ElementRefHandle miss: handle={(handle ?? "(null)")} cause=invalid-format");
 			}
 
 			return false;
@@ -84,7 +93,7 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 		{
 			if (_log.IsEnabled(LogLevel.Trace))
 			{
-				_log.Trace($"ElementRefHandle miss: handle={handle} cause=unknown");
+				_log.Trace($"ElementRefHandle miss: handle={handle} cause=not-registered");
 			}
 
 			return false;
@@ -115,7 +124,8 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 
 		if (value <= 0)
 		{
-			return "0";
+			// IDs are issued by Interlocked.Increment starting at 1; a non-positive value is a bug.
+			throw new ArgumentOutOfRangeException(nameof(value), value, "Handle ID must be positive.");
 		}
 
 		Span<char> buffer = stackalloc char[8];
@@ -140,7 +150,8 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 			return false;
 		}
 
-		int acc = 0;
+		// Accumulate into a long to detect int overflow without exception-based control flow.
+		long acc = 0;
 
 		foreach (var ch in s)
 		{
@@ -157,17 +168,21 @@ internal sealed class ElementRefHandleRegistry : IElementRefHandleRegistry
 				return false;
 			}
 
-			try
-			{
-				checked { acc = acc * 36 + digit; }
-			}
-			catch (OverflowException)
+			acc = acc * 36 + digit;
+
+			if (acc > int.MaxValue)
 			{
 				return false;
 			}
 		}
 
-		value = acc;
+		// IDs start at 1; zero is not a valid issued handle.
+		if (acc <= 0)
+		{
+			return false;
+		}
+
+		value = (int)acc;
 		return true;
 	}
 }

--- a/src/Uno.UI/Diagnostics/IElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/IElementRefHandleRegistry.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
 
@@ -17,6 +18,7 @@ namespace Uno.UI.Diagnostics;
 public interface IElementRefHandleRegistry
 {
 	/// <inheritdoc cref="ElementRefHandle.GetOrCreate"/>
+	/// <exception cref="ArgumentNullException"><paramref name="element"/> is null.</exception>
 	string GetOrCreate(DependencyObject element);
 
 	/// <inheritdoc cref="ElementRefHandle.TryResolve"/>

--- a/src/Uno.UI/Diagnostics/IElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/IElementRefHandleRegistry.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.Diagnostics;
+
+/// <summary>
+/// Defines the contract for a session-scoped registry of opaque handles
+/// to live <see cref="DependencyObject"/> instances.
+/// </summary>
+/// <remarks>
+/// This interface is public to allow injection in consumer tests.
+/// Future additions will be made as default interface methods to preserve
+/// binary compatibility.
+/// </remarks>
+public interface IElementRefHandleRegistry
+{
+	/// <inheritdoc cref="ElementRefHandle.GetOrCreate"/>
+	string GetOrCreate(DependencyObject element);
+
+	/// <inheritdoc cref="ElementRefHandle.TryResolve"/>
+	bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element);
+}

--- a/src/Uno.UI/Diagnostics/IElementRefHandleRegistry.cs
+++ b/src/Uno.UI/Diagnostics/IElementRefHandleRegistry.cs
@@ -20,5 +20,5 @@ public interface IElementRefHandleRegistry
 	string GetOrCreate(DependencyObject element);
 
 	/// <inheritdoc cref="ElementRefHandle.TryResolve"/>
-	bool TryResolve(string handle, [NotNullWhen(true)] out DependencyObject? element);
+	bool TryResolve(string? handle, [NotNullWhen(true)] out DependencyObject? element);
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1062,13 +1062,23 @@ namespace Uno.UI
 		public static class ElementRefHandle
 		{
 			/// <summary>
-			/// Accessing the element ref handle registry isn't thread safe and should only
-			/// happen on the UI thread.
-			/// By default, attempting to access it from a non-UI thread will throw an exception.
-			/// Setting this flag to true will prevent the exception from being thrown at the risk
-			/// of having an undefined behavior and/or race conditions.
+			/// Accessing the element ref handle registry is not thread-safe and must only
+			/// happen on the UI thread. By default, attempting to access it from a non-UI
+			/// thread throws an <see cref="InvalidOperationException"/>.
+			/// <para>
+			/// Setting this to <see langword="true"/> suppresses that exception.
+			/// This is intended only for unit-test environments where a UI thread is not
+			/// available. Do not set this in production code.
+			/// </para>
+			/// <para>
+			/// When the threading check is disabled, note that <see cref="ElementRefHandleRegistry"/>
+			/// uses two separate data structures (<c>ConditionalWeakTable</c> and
+			/// <c>ConcurrentDictionary</c>) that are each individually thread-safe but are
+			/// updated in two distinct steps. A handle obtained by one thread may briefly
+			/// not resolve on another thread between those two steps.
+			/// </para>
 			/// </summary>
-			public static bool DisableThreadingCheck { get; set; }
+			public static bool DisableThreadingCheck { get; internal set; }
 		}
 
 		public static class DependencyProperty

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1059,6 +1059,18 @@ namespace Uno.UI
 			public static bool? UseMetalOnMacOS { get; set; }
 		}
 
+		public static class ElementRefHandle
+		{
+			/// <summary>
+			/// Accessing the element ref handle registry isn't thread safe and should only
+			/// happen on the UI thread.
+			/// By default, attempting to access it from a non-UI thread will throw an exception.
+			/// Setting this flag to true will prevent the exception from being thrown at the risk
+			/// of having an undefined behavior and/or race conditions.
+			/// </summary>
+			public static bool DisableThreadingCheck { get; set; }
+		}
+
 		public static class DependencyProperty
 		{
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1062,23 +1062,16 @@ namespace Uno.UI
 		public static class ElementRefHandle
 		{
 			/// <summary>
-			/// Accessing the element ref handle registry is not thread-safe and must only
-			/// happen on the UI thread. By default, attempting to access it from a non-UI
-			/// thread throws an <see cref="InvalidOperationException"/>.
+			/// Accessing the element ref handle registry must only happen on the UI thread.
+			/// By default, attempting to access it from a non-UI thread throws an
+			/// <see cref="InvalidOperationException"/>.
 			/// <para>
 			/// Setting this to <see langword="true"/> suppresses that exception.
-			/// This is intended only for unit-test environments where a UI thread is not
+			/// This is intended only for unit-test environments where a real UI thread is not
 			/// available. Do not set this in production code.
 			/// </para>
-			/// <para>
-			/// When the threading check is disabled, note that <see cref="ElementRefHandleRegistry"/>
-			/// uses two separate data structures (<c>ConditionalWeakTable</c> and
-			/// <c>ConcurrentDictionary</c>) that are each individually thread-safe but are
-			/// updated in two distinct steps. A handle obtained by one thread may briefly
-			/// not resolve on another thread between those two steps.
-			/// </para>
 			/// </summary>
-			public static bool DisableThreadingCheck { get; set; }
+			public static bool DisableThreadingCheck { get; internal set; }
 		}
 
 		public static class DependencyProperty

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1078,7 +1078,7 @@ namespace Uno.UI
 			/// not resolve on another thread between those two steps.
 			/// </para>
 			/// </summary>
-			public static bool DisableThreadingCheck { get; internal set; }
+			public static bool DisableThreadingCheck { get; set; }
 		}
 
 		public static class DependencyProperty


### PR DESCRIPTION
## Summary

Several Uno tooling components need a stable, GC-safe way to reference a `DependencyObject` by
an opaque short string handle that survives serialization/deserialization and round-trips through
AI agent prompts without ambiguity. This PR adds that shared identity layer.

- **`IElementRefHandleRegistry`** — public interface (`Uno.UI.Diagnostics`)
- **`ElementRefHandle`** — public static facade with `GetOrCreate` / `TryResolve` / `SetForTesting`
- **`ElementRefHandleRegistry`** — internal sealed implementation (base-36 monotonic ids, weak refs,
  finalizer-driven cleanup, UI-thread enforcement)
- **`FeatureConfiguration.ElementRefHandle.DisableThreadingCheck`** — opt-out flag for test environments
- **13 MSTest unit tests** (`Given_ElementRefHandleRegistry`)
- **`specs/042-element-ref-registry/`** — design spec + implementation progress tracker

## Design highlights

| Concern | Decision |
|---------|----------|
| Handle format | Base-36 monotonic `int`, lowercase, no prefix (e.g. `1z4`) |
| Comparison | Ordinal case-insensitive (`TryResolve` accepts `1Z4` == `1z4`) |
| Memory | `ConditionalWeakTable` forward map + `ConcurrentDictionary<int, ManagedWeakReference>` reverse map; finalizer cleans reverse map on GC |
| Thread safety | All public methods enforce UI thread via `NativeDispatcher.Main.HasThreadAccess`; override with `DisableThreadingCheck` |
| Handle reuse | Ids never reuse within a session (monotonic counter, no reset) |
| Logging | `Uno.Foundation.Logging` at `Trace` level only; never logs `ToString()` |

## Test plan

- [ ] `dotnet build src/Uno.UI-UnitTests-only.slnf --no-restore` — confirms the new files compile cleanly
- [ ] `dotnet test src/Uno.UI/Uno.UI.Tests.csproj --filter "FullyQualifiedName~Given_ElementRefHandleRegistry"` — all 13 tests green
- [ ] Full unit-test suite passes with no new failures
- [ ] Public API surface reviewed (no `PublicAPI.Unshipped.txt` in `Uno.UI`)