### PR TITLE
feat(listview): implement INCC Move with minimal container reuse

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -76,6 +76,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		/// Size = 152w x 29h
 		/// </summary>
 		private DataTemplate FixedSizeItemTemplate => _testsResources["FixedSizeItemTemplate"] as DataTemplate;
+		private const double FixedSizeItemHeight = 29;
 
 		private DataTemplate NV286_Template => _testsResources["NV286_Template"] as DataTemplate;
 		private DataTemplate DefaultItemTemplate => _testsResources["DefaultItemTemplate"] as DataTemplate;
@@ -5301,6 +5302,63 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 			}
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_INCC_Move_MinimalUpdate()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 30).Select(x => $"Item {x}"));
+			var sut = new ListView
+			{
+				Height = 10 * FixedSizeItemHeight,
+				ItemsSource = source,
+				ItemTemplate = FixedSizeItemTemplate, // height=29
+			};
+
+			await UITestHelper.Load(sut, x => x.IsLoaded);
+			await UITestHelper.WaitForIdle();
+#if DEBUG
+			var tree1 = sut.TreeGraph(DescribeLVI);
+#endif
+
+			// Capture containers at indices 0–3 before the move
+			var containersBefore = new ListViewItem[4];
+			for (int i = 0; i < containersBefore.Length; i++)
+			{
+				containersBefore[i] = sut.ContainerFromIndex(i) as ListViewItem;
+				Assert.IsNotNull(containersBefore[i], $"Before: container at index {i} is null");
+				Assert.AreEqual(source[i], containersBefore[i].DataContext, $"Before: container at index {i} has wrong DataContext");
+			}
+
+			// Move "Item 1" from index 1 to index 2 → source becomes [Item 0, Item 2, Item 1, Item 3, ...]
+			source.Move(1, 2);
+			await UITestHelper.WaitForIdle();
+#if DEBUG
+			var tree2 = sut.TreeGraph(DescribeLVI);
+#endif
+
+			// Source order is now correct
+			Assert.AreEqual("Item 2", source[1]);
+			Assert.AreEqual("Item 1", source[2]);
+
+			// Containers at each position should reflect the new data order, and IndexFromContainer must agree
+			var containersAfter = new ListViewItem[4];
+			for (int i = 0; i < containersAfter.Length; i++)
+			{
+				containersAfter[i] = sut.ContainerFromIndex(i) as ListViewItem;
+				Assert.IsNotNull(containersAfter[i], $"After: container at index {i} is null");
+				Assert.AreEqual(source[i], containersAfter[i].DataContext, $"After: container at index {i} has wrong DataContext");
+				Assert.AreEqual(i, sut.IndexFromContainer(containersAfter[i]), $"After: IndexFromContainer disagrees for container at index {i}");
+			}
+
+			// The same container instances must be reused — no full re-materialization.
+			// After Move(1→2): the container for "Item 1" travels to position 2, "Item 2" shifts to 1, bookends are unchanged.
+			Assert.AreSame(containersBefore[0], containersAfter[0], "Container at 0→0 must be the same instance");
+			Assert.AreSame(containersBefore[1], containersAfter[2], "Container at 1→2 must be the same instance (moved item)");
+			Assert.AreSame(containersBefore[2], containersAfter[1], "Container at 2→1 must be the same instance (displaced item)");
+			Assert.AreSame(containersBefore[3], containersAfter[3], "Container at 3→3 must be the same instance");
+		}
 	}
 
 	public partial class Given_ListViewBase // data class, data-context, view-model, template-selector
@@ -5702,6 +5760,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.IsFalse(reference.IsAlive);
 		}
+
+#if DEBUG
+		private static IEnumerable<string> DescribeLVI(object x)
+		{
+			if (x is not null) yield return $"Hash={x.GetHashCode()}";
+			if (x is ListViewItem lvi)
+			{
+				yield return $"Index={(ItemsControl.ItemsControlFromItemContainer(lvi)?.IndexFromContainer(lvi) ?? -1)}";
+				yield return $"DC={lvi.DataContext}";
+			}
+		}
+#endif
 
 		public partial class OnItemsChangedListView : ListView
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/CollectionChangedOperation.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/CollectionChangedOperation.cs
@@ -15,6 +15,7 @@ namespace Microsoft.UI.Xaml.Controls
 	internal class CollectionChangedOperation
 	{
 		public Uno.UI.IndexPath StartingIndex { get; }
+		public Uno.UI.IndexPath? NewStartingIndex { get; }
 		public int Range { get; }
 		public NotifyCollectionChangedAction Action { get; }
 		public Element ElementType { get; }
@@ -27,6 +28,15 @@ namespace Microsoft.UI.Xaml.Controls
 		public CollectionChangedOperation(Uno.UI.IndexPath startingIndex, int range, NotifyCollectionChangedAction action, Element elementType)
 		{
 			StartingIndex = startingIndex;
+			Range = range;
+			Action = action;
+			ElementType = elementType;
+		}
+
+		public CollectionChangedOperation(Uno.UI.IndexPath startingIndex, Uno.UI.IndexPath newStartingIndex, int range, NotifyCollectionChangedAction action, Element elementType)
+		{
+			StartingIndex = startingIndex;
+			NewStartingIndex = newStartingIndex;
 			Range = range;
 			Action = action;
 			ElementType = elementType;
@@ -64,6 +74,37 @@ namespace Microsoft.UI.Xaml.Controls
 							thisItemRemoved.StartingIndex.Row <= row && thisItemRemoved.EndIndex.Row >= row:
 					// This item has been removed or replaced, the index is no longer valid
 					return null;
+
+				case var itemMove when itemMove.ElementType == CollectionChangedOperation.Element.Item &&
+							itemMove.Action == NotifyCollectionChangedAction.Move &&
+							itemMove.StartingIndex.Section == section &&
+							itemMove.NewStartingIndex is Uno.UI.IndexPath newStart:
+					var oldMoveStart = itemMove.StartingIndex.Row;
+					var oldMoveEnd = oldMoveStart + itemMove.Range - 1;
+					var newMoveStart = newStart.Row;
+
+					if (row >= oldMoveStart && row <= oldMoveEnd)
+					{
+						// This item was moved — remap to new position preserving relative offset
+						row = newMoveStart + (row - oldMoveStart);
+					}
+					else if (oldMoveStart < newMoveStart)
+					{
+						// Forward move: items in the gap (oldMoveEnd, newMoveStart+Range] shift down
+						if (row > oldMoveEnd && row <= newMoveStart + itemMove.Range - 1)
+						{
+							row -= itemMove.Range;
+						}
+					}
+					else
+					{
+						// Backward move: items in the gap [newMoveStart, oldMoveStart) shift up
+						if (row >= newMoveStart && row < oldMoveStart)
+						{
+							row += itemMove.Range;
+						}
+					}
+					break;
 
 				// Group operations are currently unsupported
 				case var groupAdd when groupAdd.ElementType == CollectionChangedOperation.Element.Group &&

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/CollectionChangedOperation.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/CollectionChangedOperation.cs
@@ -78,7 +78,8 @@ namespace Microsoft.UI.Xaml.Controls
 				case var itemMove when itemMove.ElementType == CollectionChangedOperation.Element.Item &&
 							itemMove.Action == NotifyCollectionChangedAction.Move &&
 							itemMove.StartingIndex.Section == section &&
-							itemMove.NewStartingIndex is Uno.UI.IndexPath newStart:
+							itemMove.NewStartingIndex is Uno.UI.IndexPath newStart &&
+							newStart.Section == section:
 					var oldMoveStart = itemMove.StartingIndex.Row;
 					var oldMoveEnd = oldMoveStart + itemMove.Range - 1;
 					var newMoveStart = newStart.Row;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
@@ -62,6 +62,21 @@ namespace Microsoft.UI.Xaml.Controls
 			NativePanel?.NativeLayout?.NotifyCollectionChange(groupOperation: null);
 		}
 
+		private void MoveItems(int oldFirstItem, int newFirstItem, int count, int section)
+		{
+			if (count == 1)
+			{
+				var oldDisplayIndex = GetDisplayIndexFromIndexPath(Uno.UI.IndexPath.FromRowSection(oldFirstItem, section));
+				var newDisplayIndex = GetDisplayIndexFromIndexPath(Uno.UI.IndexPath.FromRowSection(newFirstItem, section));
+				NativePanel?.CurrentAdapter?.NotifyItemMoved(oldDisplayIndex, newDisplayIndex);
+				NativePanel?.NativeLayout?.NotifyCollectionChange(groupOperation: null);
+			}
+			else
+			{
+				Refresh();
+			}
+		}
+
 		partial void AddGroupItems(int groupIndex)
 		{
 			var adapter = NativePanel?.CurrentAdapter;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.UIKit.cs
@@ -177,6 +177,21 @@ namespace Microsoft.UI.Xaml.Controls
 			NativePanel?.ReloadItems(GetIndexPathsFromStartAndCount(firstItem, count, section));
 		}
 
+		private void MoveItems(int oldFirstItem, int newFirstItem, int count, int section)
+		{
+			if (count == 1)
+			{
+				var oldIndexPath = NSIndexPath.FromItemSection(oldFirstItem, section);
+				var newIndexPath = NSIndexPath.FromItemSection(newFirstItem, section);
+				NativePanel?.MoveItem(oldIndexPath, newIndexPath);
+				ManagedVirtualizingPanel?.GetLayouter().MoveItems(oldFirstItem, newFirstItem, count, section);
+			}
+			else
+			{
+				Refresh();
+			}
+		}
+
 		/// <summary>
 		/// Add a group using the native in-place modifier.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -835,9 +835,23 @@ namespace Microsoft.UI.Xaml.Controls
 
 					break;
 				case NotifyCollectionChangedAction.Move:
-					// TODO PBI #19974: Fully implement NotifyCollectionChangedActions and map them to the appropriate calls
-					// on UICollectionView, MoveItems
-					Refresh();
+					var moveCount = args.OldItems?.Count ?? args.NewItems?.Count ?? 0;
+					if (moveCount == 0 || args.OldStartingIndex == args.NewStartingIndex)
+					{
+						break;
+					}
+
+					if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+					{
+						this.Log().Debug($"Moving {moveCount} items from {args.OldStartingIndex} to {args.NewStartingIndex}");
+					}
+
+					var flatOldIdx = GetIndexFromIndexPath(Uno.UI.IndexPath.FromRowSection(args.OldStartingIndex, section));
+					var flatNewIdx = GetIndexFromIndexPath(Uno.UI.IndexPath.FromRowSection(args.NewStartingIndex, section));
+					SaveContainersBeforeMoveForIndexRepair(flatOldIdx, flatNewIdx, moveCount);
+					MoveItems(args.OldStartingIndex, args.NewStartingIndex, moveCount, section);
+					RepairIndices();
+
 					break;
 				case NotifyCollectionChangedAction.Reset:
 					CleanUpAllContainers();
@@ -911,6 +925,47 @@ namespace Microsoft.UI.Xaml.Controls
 				{
 					// we store the index, that should be set after the collection change
 					_containersForIndexRepair.Add(container, currentIndex - indexChange);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Stores materialized containers in the affected range so that their
+		/// <see cref="ItemsControl.IndexForItemContainerProperty"/> can be updated after a Move.
+		/// </summary>
+		private void SaveContainersBeforeMoveForIndexRepair(int oldStartingIndex, int newStartingIndex, int count)
+		{
+			_containersForIndexRepair.Clear();
+
+			if (oldStartingIndex == newStartingIndex)
+			{
+				return;
+			}
+
+			foreach (var container in MaterializedContainers)
+			{
+				var currentIndex = (int)container.GetValue(ItemsControl.IndexForItemContainerProperty);
+
+				if (currentIndex >= oldStartingIndex && currentIndex < oldStartingIndex + count)
+				{
+					// Moved item — preserve relative offset within the range
+					_containersForIndexRepair.Add(container, newStartingIndex + (currentIndex - oldStartingIndex));
+				}
+				else if (oldStartingIndex < newStartingIndex)
+				{
+					// Forward move: items in gap (oldEnd, newEnd] shift down by count
+					if (currentIndex > oldStartingIndex + count - 1 && currentIndex <= newStartingIndex + count - 1)
+					{
+						_containersForIndexRepair.Add(container, currentIndex - count);
+					}
+				}
+				else
+				{
+					// Backward move: items in gap [newStartingIndex, oldStartingIndex) shift up by count
+					if (currentIndex >= newStartingIndex && currentIndex < oldStartingIndex)
+					{
+						_containersForIndexRepair.Add(container, currentIndex + count);
+					}
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.managed.cs
@@ -57,6 +57,18 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		private void MoveItems(int oldFirstItem, int newFirstItem, int count, int section)
+		{
+			if (VirtualizingPanel != null)
+			{
+				VirtualizingPanel.GetLayouter().MoveItems(oldFirstItem, newFirstItem, count, section);
+			}
+			else
+			{
+				Refresh();
+			}
+		}
+
 		private void AddGroup(int groupIndexInView)
 		{
 			Refresh();

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.UIKit.cs
@@ -328,6 +328,36 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		public override void MoveItem(NSIndexPath indexPath, NSIndexPath newIndexPath)
+		{
+			if (TryApplyCollectionChange())
+			{
+				using (EnableOrDisableAnimations())
+				{
+					NativeLayout?.NotifyCollectionChange(new CollectionChangedOperation(
+						indexPath.ToIndexPath(),
+						newIndexPath.ToIndexPath(),
+						1,
+						NotifyCollectionChangedAction.Move,
+						CollectionChangedOperation.Element.Item
+					));
+
+					try
+					{
+						base.MoveItem(indexPath, newIndexPath);
+					}
+					catch (Exception e)
+					{
+						this.Log().Error("Error when updating collection", e);
+					}
+				}
+			}
+			else
+			{
+				NativeLayout?.NeedsRelayout();
+			}
+		}
+
 		/// <summary>
 		/// Check if in-place collection modification can be performed. If not, retrigger a refresh instead.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -868,6 +868,19 @@ namespace Microsoft.UI.Xaml.Controls
 			LightRefresh();
 		}
 
+		internal void MoveItems(int oldFirstItem, int newFirstItem, int count, int section)
+		{
+			_pendingCollectionChanges.Enqueue(new CollectionChangedOperation(
+				startingIndex: Uno.UI.IndexPath.FromRowSection(oldFirstItem, section),
+				newStartingIndex: Uno.UI.IndexPath.FromRowSection(newFirstItem, section),
+				range: count,
+				action: NotifyCollectionChangedAction.Move,
+				elementType: CollectionChangedOperation.Element.Item
+				));
+
+			LightRefresh();
+		}
+
 		/// <summary>
 		/// Update the display of the panel without clearing caches.
 		/// </summary>


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#452

## PR Type: ✨ Feature

## What changed? 🚀

Previously, `NotifyCollectionChangedAction.Move` on a `ListView`/`ListViewBase` items source always triggered a full `Refresh()`, discarding and re-materializing all visible containers. This PR implements proper in-place Move handling:

- **All platforms**: Routes `Move` through new platform-specific `MoveItems` methods instead of `Refresh()`
- **Managed/Skia**: Enqueues a `CollectionChangedOperation` with `NewStartingIndex` into the pending-changes queue and calls `LightRefresh()`, so the layouter remaps container positions without destroying them
- **Android**: Calls `RecyclerView.Adapter.NotifyItemMoved` for single-item moves; falls back to `Refresh()` for range moves
- **UIKit**: Calls `UICollectionView.MoveItem` for single-item moves; falls back to `Refresh()` for range moves
- **Index repair**: `SaveContainersBeforeMoveForIndexRepair` + `RepairIndices` updates `IndexForItemContainerProperty` on all affected materialized containers after the move
- **CollectionChangedOperation**: Extended with `NewStartingIndex` property and a new constructor for Move operations; `ApplyOffset` now handles the Move case with correct forward/backward index remapping
- **Runtime test**: `When_INCC_Move_MinimalUpdate` verifies that container instances are reused (not re-materialized) and that `DataContext` and indices are correct after a single-item move

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)