### PR TITLE
fix(devserver): cross-add-in type sharing via file-system probe in AddInLoadContext

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
@@ -210,6 +210,85 @@ public class DevServerTests
 		}
 	}
 
+	// ------------------------------------------------------------------ cross-add-in type sharing regression (#23304)
+
+	[TestMethod]
+	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]
+	[Description("Regression for #23304: when two add-ins share a contract assembly (e.g. Uno.Licensing.Sdk.Contracts) " +
+		"that is physically present only in the provider's directory and absent from the consumer's .deps.json, " +
+		"the host must pre-load the assembly into Default ALC (via AddInSharedAssemblyPatterns glob) so that both " +
+		"add-ins get a single ILicensingTestContract Type identity and DI resolution succeeds.")]
+	public async Task DevServer_ShouldResolveSharedContractAcrossAddIns_WhenContractOnlyInProviderDirectory()
+	{
+		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
+		var providerDll = Path.Combine(
+			testAssemblyDir, "Fixtures", "AddInWithSharedContractProvider", "AddInWithSharedContractProvider.dll");
+		var consumerDll = Path.Combine(
+			testAssemblyDir, "Fixtures", "AddInWithSharedContractConsumer", "AddInWithSharedContractConsumer.dll");
+
+		File.Exists(providerDll).Should()
+			.BeTrue("provider fixture must be staged by _BuildAndCopyAddInTestFixtures");
+		File.Exists(consumerDll).Should()
+			.BeTrue("consumer fixture must be staged by _BuildAndCopyAddInTestFixtures");
+
+		// The contracts DLL must be in the provider's directory (the fix loads it from there).
+		var contractsDll = Path.Combine(
+			testAssemblyDir, "Fixtures", "AddInWithSharedContractProvider", "Uno.Licensing.TestContracts.dll");
+		File.Exists(contractsDll).Should()
+			.BeTrue("Uno.Licensing.TestContracts.dll must be in the provider's fixture directory (Private=true on the ProjectReference)");
+
+		// The contracts DLL must NOT be in the consumer's directory (simulates the real scenario).
+		var consumerContractsDll = Path.Combine(
+			testAssemblyDir, "Fixtures", "AddInWithSharedContractConsumer", "Uno.Licensing.TestContracts.dll");
+		File.Exists(consumerContractsDll).Should()
+			.BeFalse("Uno.Licensing.TestContracts.dll must NOT be in the consumer's fixture directory (Private=false on the ProjectReference)");
+
+		var sentinel = Path.Combine(Path.GetTempPath(), $"shared-contract-{Guid.NewGuid():N}.txt");
+		try
+		{
+			await using var helper = new DevServerTestHelper(
+				_logger,
+				environmentVariables: new Dictionary<string, string>
+				{
+					["UNO_DEVSERVER_TEST_SHARED_CONTRACT_SENTINEL"] = sentinel,
+				});
+
+			try
+			{
+				var started = await helper.StartAsync(
+					CT,
+					extraArgs: $"--addins \"{providerDll}\" \"{consumerDll}\"");
+				helper.EnsureStarted();
+
+				started.Should().BeTrue("dev server should start with both cross-add-in fixtures loaded");
+				helper.AssertRunning();
+
+				// If the fix works: EagerLoadFromDirectory finds Uno.Licensing.TestContracts.dll in
+				// the provider's dir (matches Uno.Licensing.*.dll), loads it into Default ALC, and
+				// both add-ins bridge to the same Type. The consumer's IHostedService receives the
+				// ILicensingTestContract instance registered by the provider and writes this sentinel.
+				//
+				// Without the fix: FileNotFoundException or InvalidOperationException during add-in
+				// activation prevents the sentinel from being written.
+				File.Exists(sentinel).Should().BeTrue(
+					"ConsumerHostedService.StartAsync must have been invoked with ILicensingTestContract " +
+					"resolved from DI, proving cross-add-in type sharing works when the contract DLL is " +
+					"only in the provider's directory");
+			}
+			finally
+			{
+				await helper.StopAsync(CT);
+			}
+		}
+		finally
+		{
+			if (File.Exists(sentinel))
+			{
+				File.Delete(sentinel);
+			}
+		}
+	}
+
 	// ------------------------------------------------------------------ cross-major version regression (#23287)
 
 	[TestMethod]

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/DevServerTests.cs
@@ -215,9 +215,9 @@ public class DevServerTests
 	[TestMethod]
 	[Retry(2, MillisecondsDelayBetweenRetries = 1000)]
 	[Description("Regression for #23304: when two add-ins share a contract assembly (e.g. Uno.Licensing.Sdk.Contracts) " +
-		"that is physically present only in the provider's directory and absent from the consumer's .deps.json, " +
-		"the host must pre-load the assembly into Default ALC (via AddInSharedAssemblyPatterns glob) so that both " +
-		"add-ins get a single ILicensingTestContract Type identity and DI resolution succeeds.")]
+		"that is physically present only in the provider's directory and absent from every add-in's .deps.json, " +
+		"the file-system probe (step 4) in AddInLoadContext.Load must locate the DLL, load it once into the shared " +
+		"AddInLoadContext, and give both add-ins a single ILicensingTestContract Type identity so DI resolution succeeds.")]
 	public async Task DevServer_ShouldResolveSharedContractAcrossAddIns_WhenContractOnlyInProviderDirectory()
 	{
 		var testAssemblyDir = Path.GetDirectoryName(typeof(DevServerTests).Assembly.Location)!;
@@ -255,25 +255,45 @@ public class DevServerTests
 
 			try
 			{
+				// Host parses --addins as a semicolon-separated path list (see
+				// Program.cs and ConfigurationExtensions.GetAddinsValue). Passing two
+				// space-separated paths would leave Microsoft.Extensions.Configuration
+				// to drop the second one as an unmatched positional argument.
 				var started = await helper.StartAsync(
 					CT,
-					extraArgs: $"--addins \"{providerDll}\" \"{consumerDll}\"");
+					extraArgs: $"--addins \"{providerDll};{consumerDll}\"");
 				helper.EnsureStarted();
 
 				started.Should().BeTrue("dev server should start with both cross-add-in fixtures loaded");
 				helper.AssertRunning();
 
-				// If the fix works: EagerLoadFromDirectory finds Uno.Licensing.TestContracts.dll in
-				// the provider's dir (matches Uno.Licensing.*.dll), loads it into Default ALC, and
-				// both add-ins bridge to the same Type. The consumer's IHostedService receives the
-				// ILicensingTestContract instance registered by the provider and writes this sentinel.
+				// If the fix works: AddInLoadContext.Load's file-system probe (step 4) finds
+				// Uno.Licensing.TestContracts.dll in the provider's directory and loads it
+				// once into the shared AddInLoadContext. Both add-ins then see the same Type
+				// identity; the consumer's IHostedService receives the ILicensingTestContract
+				// instance registered by the provider and writes its AssemblyQualifiedName
+				// to the sentinel file.
 				//
-				// Without the fix: FileNotFoundException or InvalidOperationException during add-in
-				// activation prevents the sentinel from being written.
+				// Without the fix: FileNotFoundException or InvalidOperationException during
+				// add-in activation prevents the sentinel from being written.
 				File.Exists(sentinel).Should().BeTrue(
 					"ConsumerHostedService.StartAsync must have been invoked with ILicensingTestContract " +
 					"resolved from DI, proving cross-add-in type sharing works when the contract DLL is " +
 					"only in the provider's directory");
+
+				// Stronger assertion: the sentinel contains the AQN of the contract type the
+				// consumer actually received from DI. If a regression left two distinct Type
+				// instances of ILicensingTestContract in play, DI would have failed before
+				// StartAsync ran — but as a belt-and-braces check, confirm the AQN refers to
+				// the shared contracts assembly rather than some unrelated fallback string.
+				var sentinelContent = File.ReadAllText(sentinel).Trim();
+				sentinelContent.Should().Contain(
+					"Uno.Licensing.TestContracts",
+					"the resolved contract type must come from the shared contracts assembly");
+				sentinelContent.Should().NotBe(
+					"resolved",
+					"the consumer must have received a concrete ILicensingTestContract instance whose AQN " +
+					"identifies the contracts assembly, not the placeholder string written when AQN was null");
 			}
 			finally
 			{

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/AddInWithSharedContractConsumer.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/AddInWithSharedContractConsumer.csproj
@@ -4,25 +4,28 @@
 		Test fixture: the "consumer" side of the cross-add-in type-sharing regression test.
 
 		This add-in does NOT have Uno.Licensing.TestContracts.dll in its output directory
-		(Private=false on the project reference). It does NOT use EnableDynamicLoading=true
-		so no .deps.json is generated, meaning AssemblyDependencyResolver step 3 cannot
-		resolve Uno.Licensing.TestContracts for this add-in.
+		(Private=false on the project reference). Its own .deps.json has no runtime entry
+		for the contracts assembly either, so AssemblyDependencyResolver (step 3 of
+		AddInLoadContext.Load) cannot resolve it from the consumer's add-in directory.
 
-		Without the fix, the ILicensingTestContract parameter in ConsumerHostedService cannot
-		be resolved: type identity is broken because the DLL was never loaded into Default ALC
-		and the consumer's resolver has no deps.json entry for it.
+		Without the fix, the ILicensingTestContract parameter in ConsumerHostedService
+		cannot be resolved: the contracts DLL is not in Default ALC, not in host TPA, and
+		not in this add-in's deps.json. Steps 1-3 all return null and the runtime throws
+		FileNotFoundException during DI activation.
 
-		With the fix, AssemblyHelper pre-loads Uno.Licensing.TestContracts.dll from the
-		provider's directory into Default ALC (matching the Uno.Licensing.*.dll glob).
-		AddInLoadContext.Load step 1 (TryBridgeBySimpleName) then serves the same type
-		instance to both add-ins, so DI resolves ILicensingTestContract successfully.
+		With the fix, step 4 (file-system probe) of AddInLoadContext.Load locates the
+		DLL in the *provider* add-in's directory and loads it once into the shared add-in
+		ALC. Both add-ins then see the same ILicensingTestContract Type identity and DI
+		resolves successfully.
 	-->
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<!-- Intentionally no EnableDynamicLoading — no .deps.json produced. -->
+		<!-- Intentionally no EnableDynamicLoading — the SDK still emits a .deps.json for
+		     this add-in, but Uno.Licensing.TestContracts is not declared as a runtime asset
+		     in it. -->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/AddInWithSharedContractConsumer.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/AddInWithSharedContractConsumer.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		Test fixture: the "consumer" side of the cross-add-in type-sharing regression test.
+
+		This add-in does NOT have Uno.Licensing.TestContracts.dll in its output directory
+		(Private=false on the project reference). It does NOT use EnableDynamicLoading=true
+		so no .deps.json is generated, meaning AssemblyDependencyResolver step 3 cannot
+		resolve Uno.Licensing.TestContracts for this add-in.
+
+		Without the fix, the ILicensingTestContract parameter in ConsumerHostedService cannot
+		be resolved: type identity is broken because the DLL was never loaded into Default ALC
+		and the consumer's resolver has no deps.json entry for it.
+
+		With the fix, AssemblyHelper pre-loads Uno.Licensing.TestContracts.dll from the
+		provider's directory into Default ALC (matching the Uno.Licensing.*.dll glob).
+		AddInLoadContext.Load step 1 (TryBridgeBySimpleName) then serves the same type
+		instance to both add-ins, so DI resolves ILicensingTestContract successfully.
+	-->
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<!-- Intentionally no EnableDynamicLoading — no .deps.json produced. -->
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Private=false: compile-time reference only; DLL is NOT copied to this add-in's
+		     output directory. This simulates the real scenario where Uno.Licensing.Sdk.Contracts
+		     is a transitive compile-time ref but not a runtime asset in the consuming add-in. -->
+		<ProjectReference Include="..\Uno.Licensing.TestContracts\Uno.Licensing.TestContracts.csproj"
+		                  Private="false" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/Stub.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Uno.Licensing.TestContracts;
+using Uno.Utils.DependencyInjection;
+
+// Registers a hosted service that depends on ILicensingTestContract from DI.
+// ILicensingTestContract is provided by the companion AddInWithSharedContractProvider add-in.
+// Without the cross-add-in eager-load fix, the type identity of ILicensingTestContract
+// differs between add-ins (or the contracts assembly cannot be loaded at all), causing
+// System.InvalidOperationException: Unable to resolve service for type ILicensingTestContract.
+[assembly: ServiceCollectionExtension(typeof(ServicesRegistration))]
+
+namespace Uno.Utils.DependencyInjection;
+
+public sealed class ServicesRegistration
+{
+	public ServicesRegistration(IServiceCollection services)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+
+		// The ConsumerHostedService constructor takes ILicensingTestContract.
+		// Referencing the type here forces JIT to resolve Uno.Licensing.TestContracts
+		// from this add-in's ALC context. Without the fix, this fails with
+		// FileNotFoundException because the contracts DLL is not in this add-in's
+		// output directory and not in Default ALC.
+		services.AddHostedService<ConsumerHostedService>();
+	}
+}
+
+/// <summary>
+/// Hosted service that receives <see cref="ILicensingTestContract"/> from DI.
+/// The contract instance is registered by the provider add-in; if the two add-ins
+/// share the same type identity (via Default ALC bridging), DI resolves it successfully.
+/// </summary>
+public sealed class ConsumerHostedService(ILicensingTestContract _contract) : IHostedService
+{
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_ = _contract;
+
+		var sentinel = Environment.GetEnvironmentVariable(
+			"UNO_DEVSERVER_TEST_SHARED_CONTRACT_SENTINEL");
+		if (!string.IsNullOrEmpty(sentinel))
+		{
+			File.WriteAllText(sentinel, _contract.GetType().AssemblyQualifiedName ?? "resolved");
+		}
+
+		return Task.CompletedTask;
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+internal sealed class ServiceCollectionExtensionAttribute(Type type) : Attribute
+{
+	public Type Type { get; } = type;
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractConsumer/Stub.cs
@@ -9,9 +9,11 @@ using Uno.Utils.DependencyInjection;
 
 // Registers a hosted service that depends on ILicensingTestContract from DI.
 // ILicensingTestContract is provided by the companion AddInWithSharedContractProvider add-in.
-// Without the cross-add-in eager-load fix, the type identity of ILicensingTestContract
-// differs between add-ins (or the contracts assembly cannot be loaded at all), causing
-// System.InvalidOperationException: Unable to resolve service for type ILicensingTestContract.
+// The contracts DLL is physically present in the provider's directory but absent from
+// the consumer's directory and its .deps.json. Without the cross-add-in fix (step 4
+// file-system probe inside AddInLoadContext.Load), JIT resolution of ILicensingTestContract
+// throws FileNotFoundException; with the fix, both add-ins share a single Type identity
+// and DI resolves the registered service successfully.
 [assembly: ServiceCollectionExtension(typeof(ServicesRegistration))]
 
 namespace Uno.Utils.DependencyInjection;
@@ -24,29 +26,28 @@ public sealed class ServicesRegistration
 
 		// The ConsumerHostedService constructor takes ILicensingTestContract.
 		// Referencing the type here forces JIT to resolve Uno.Licensing.TestContracts
-		// from this add-in's ALC context. Without the fix, this fails with
+		// from this add-in's ALC context. Without the fix this fails with
 		// FileNotFoundException because the contracts DLL is not in this add-in's
-		// output directory and not in Default ALC.
+		// output directory and not in any deps.json.
 		services.AddHostedService<ConsumerHostedService>();
 	}
 }
 
 /// <summary>
 /// Hosted service that receives <see cref="ILicensingTestContract"/> from DI.
-/// The contract instance is registered by the provider add-in; if the two add-ins
-/// share the same type identity (via Default ALC bridging), DI resolves it successfully.
+/// The contract instance is registered by the provider add-in; when both add-ins share
+/// the same Type identity (because <c>AddInLoadContext.Load</c>'s file-system probe loads
+/// the contracts DLL once into the shared add-in context), DI resolves it successfully.
 /// </summary>
-public sealed class ConsumerHostedService(ILicensingTestContract _contract) : IHostedService
+public sealed class ConsumerHostedService(ILicensingTestContract contract) : IHostedService
 {
 	public Task StartAsync(CancellationToken cancellationToken)
 	{
-		_ = _contract;
-
 		var sentinel = Environment.GetEnvironmentVariable(
 			"UNO_DEVSERVER_TEST_SHARED_CONTRACT_SENTINEL");
 		if (!string.IsNullOrEmpty(sentinel))
 		{
-			File.WriteAllText(sentinel, _contract.GetType().AssemblyQualifiedName ?? "resolved");
+			File.WriteAllText(sentinel, contract.GetType().AssemblyQualifiedName ?? "resolved");
 		}
 
 		return Task.CompletedTask;

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractProvider/AddInWithSharedContractProvider.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractProvider/AddInWithSharedContractProvider.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		Test fixture: the "provider" side of the cross-add-in type-sharing regression test.
+
+		This add-in physically ships Uno.Licensing.TestContracts.dll in its output directory
+		(via the normal project reference below) and registers DefaultLicensingTestContract
+		in the DI container. It does NOT use EnableDynamicLoading=true so no .deps.json is
+		generated — forcing AssemblyDependencyResolver in AddInLoadContext to return null for
+		step 3, making the only resolution path through Default ALC (step 1).
+
+		The fix under test: AssemblyHelper.Load pre-loads Uno.Licensing.*.dll from every
+		add-in directory into Default ALC before creating AddInLoadContext, so that
+		TryBridgeBySimpleName can serve the type to both add-ins with a single identity.
+	-->
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<!-- Intentionally no EnableDynamicLoading — no .deps.json produced.
+		     Ensures step-3 (AssemblyDependencyResolver) cannot resolve Uno.Licensing.TestContracts,
+		     so the only path is through Default ALC via the eager-load fix. -->
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Private=true (default) — copies Uno.Licensing.TestContracts.dll to this add-in's
+		     output directory, making it discoverable by the Uno.Licensing.*.dll glob in
+		     HostAssemblyResolution.AddInSharedAssemblyPatterns. -->
+		<ProjectReference Include="..\Uno.Licensing.TestContracts\Uno.Licensing.TestContracts.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractProvider/AddInWithSharedContractProvider.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractProvider/AddInWithSharedContractProvider.csproj
@@ -5,22 +5,24 @@
 
 		This add-in physically ships Uno.Licensing.TestContracts.dll in its output directory
 		(via the normal project reference below) and registers DefaultLicensingTestContract
-		in the DI container. It does NOT use EnableDynamicLoading=true so no .deps.json is
-		generated — forcing AssemblyDependencyResolver in AddInLoadContext to return null for
-		step 3, making the only resolution path through Default ALC (step 1).
+		in the DI container. Uno.Licensing.TestContracts is intentionally not listed in the
+		add-in's runtime asset graph (no EnableDynamicLoading, so the .deps.json that SDK
+		emits does not include the contracts assembly as a runtime asset), forcing
+		AssemblyDependencyResolver in AddInLoadContext to return null for step 3.
 
-		The fix under test: AssemblyHelper.Load pre-loads Uno.Licensing.*.dll from every
-		add-in directory into Default ALC before creating AddInLoadContext, so that
-		TryBridgeBySimpleName can serve the type to both add-ins with a single identity.
+		The fix under test: AddInLoadContext.Load step 4 probes the file system of every
+		registered add-in directory by simple name and loads the co-located DLL into the
+		shared add-in ALC, giving both add-ins a single ILicensingTestContract Type identity
+		without requiring the host to know which assemblies are shared.
 	-->
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<!-- Intentionally no EnableDynamicLoading — no .deps.json produced.
-		     Ensures step-3 (AssemblyDependencyResolver) cannot resolve Uno.Licensing.TestContracts,
-		     so the only path is through Default ALC via the eager-load fix. -->
+		<!-- Intentionally no EnableDynamicLoading — the SDK still emits a .deps.json for
+		     this add-in, but Uno.Licensing.TestContracts is not declared as a runtime asset
+		     in it, so step 3 (AssemblyDependencyResolver) cannot resolve the contracts. -->
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -29,8 +31,7 @@
 
 	<ItemGroup>
 		<!-- Private=true (default) — copies Uno.Licensing.TestContracts.dll to this add-in's
-		     output directory, making it discoverable by the Uno.Licensing.*.dll glob in
-		     HostAssemblyResolution.AddInSharedAssemblyPatterns. -->
+		     output directory, where step 4 (file-system probe) can discover it by name. -->
 		<ProjectReference Include="..\Uno.Licensing.TestContracts\Uno.Licensing.TestContracts.csproj" />
 	</ItemGroup>
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractProvider/Stub.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/AddInWithSharedContractProvider/Stub.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Uno.Licensing.TestContracts;
+using Uno.Utils.DependencyInjection;
+
+// Registers the ILicensingTestContract implementation in the shared DI container.
+// The [ServiceCollectionExtension] attribute causes the DevServer host to call the
+// ServicesRegistration ctor during add-in activation, proving that
+// Uno.Licensing.TestContracts was resolved (via Default ALC bridge from the fix) and
+// that the DI registration succeeded.
+[assembly: ServiceCollectionExtension(typeof(ServicesRegistration))]
+
+namespace Uno.Utils.DependencyInjection;
+
+public sealed class ServicesRegistration
+{
+	public ServicesRegistration(IServiceCollection services)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+
+		// Register the contract implementation so consumers can resolve ILicensingTestContract.
+		// This line also forces Uno.Licensing.TestContracts to be resolved at JIT time,
+		// reproducing the FileNotFoundException that occurs without the eager-load fix.
+		services.AddSingleton<ILicensingTestContract, DefaultLicensingTestContract>();
+	}
+}
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+internal sealed class ServiceCollectionExtensionAttribute(Type type) : Attribute
+{
+	public Type Type { get; } = type;
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Contracts.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Contracts.cs
@@ -1,0 +1,11 @@
+namespace Uno.Licensing.TestContracts;
+
+/// <summary>
+/// Test stand-in for Uno.Licensing.Sdk.Contracts::ILicensingService.
+/// Named to match the "Uno.Licensing.*.dll" glob in
+/// HostAssemblyResolution.AddInSharedAssemblyPatterns so the cross-add-in
+/// type-sharing regression test exercises the real fix path.
+/// </summary>
+public interface ILicensingTestContract { }
+
+public sealed class DefaultLicensingTestContract : ILicensingTestContract { }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Contracts.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Contracts.cs
@@ -1,10 +1,11 @@
 namespace Uno.Licensing.TestContracts;
 
 /// <summary>
-/// Test stand-in for Uno.Licensing.Sdk.Contracts::ILicensingService.
-/// Named to match the "Uno.Licensing.*.dll" glob in
-/// HostAssemblyResolution.AddInSharedAssemblyPatterns so the cross-add-in
-/// type-sharing regression test exercises the real fix path.
+/// Test stand-in for <c>Uno.Licensing.Sdk.Contracts::ILicensingService</c>.
+/// The cross-add-in type-sharing regression test relies on this assembly being
+/// physically present in the provider add-in's directory but absent from every
+/// add-in's deps.json — exercising the file-system probe (step 4) in
+/// <c>AddInLoadContext.Load</c>.
 /// </summary>
 public interface ILicensingTestContract { }
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Uno.Licensing.TestContracts.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Uno.Licensing.TestContracts.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		Test contracts fixture for Uno.UI.RemoteControl.DevServer.Tests.
+
+		Mimics Uno.Licensing.Sdk.Contracts: an unsigned assembly whose simple name matches
+		the "Uno.Licensing.*.dll" glob in HostAssemblyResolution.AddInSharedAssemblyPatterns.
+
+		It is intentionally NOT produced with EnableDynamicLoading=true and is only physically
+		present in the *provider* add-in's output directory — not in the consumer's — so that
+		the regression test for cross-add-in type sharing can verify that EagerLoadFromDirectory
+		(called by AssemblyHelper before building AddInLoadContext) loads the DLL into Default
+		ALC and allows both add-ins to share a single ILicensingTestContract type identity.
+	-->
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<!-- No EnableDynamicLoading — no deps.json; the only way to resolve this assembly
+		     at runtime is through Default ALC (via the eager-load fix). -->
+	</PropertyGroup>
+
+</Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Uno.Licensing.TestContracts.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Fixtures/Uno.Licensing.TestContracts/Uno.Licensing.TestContracts.csproj
@@ -3,22 +3,22 @@
 	<!--
 		Test contracts fixture for Uno.UI.RemoteControl.DevServer.Tests.
 
-		Mimics Uno.Licensing.Sdk.Contracts: an unsigned assembly whose simple name matches
-		the "Uno.Licensing.*.dll" glob in HostAssemblyResolution.AddInSharedAssemblyPatterns.
-
-		It is intentionally NOT produced with EnableDynamicLoading=true and is only physically
-		present in the *provider* add-in's output directory — not in the consumer's — so that
-		the regression test for cross-add-in type sharing can verify that EagerLoadFromDirectory
-		(called by AssemblyHelper before building AddInLoadContext) loads the DLL into Default
-		ALC and allows both add-ins to share a single ILicensingTestContract type identity.
+		Mimics Uno.Licensing.Sdk.Contracts: an unsigned contract assembly that is physically
+		present in the *provider* add-in's output directory but NOT in the consumer's, and
+		NOT listed in either add-in's deps.json. This reproduces the post-PR #23287 failure
+		scenario in which AddInLoadContext.Load steps 1-3 all return null because:
+		  1. The host TPA does not reference this assembly.
+		  2. AssemblyDependencyResolver only consults deps.json (which omits the entry).
+		Step 4 — the file-system probe across registered add-in directories — is what
+		recovers the load and gives both add-ins a single Type identity.
 	-->
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
-		<!-- No EnableDynamicLoading — no deps.json; the only way to resolve this assembly
-		     at runtime is through Default ALC (via the eager-load fix). -->
+		<!-- No EnableDynamicLoading — the consuming add-ins have no deps.json entry for
+		     this assembly. Only the file-system probe in AddInLoadContext.Load can find it. -->
 	</PropertyGroup>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
@@ -23,11 +23,7 @@ public class Given_AddInLoadContext
 		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
 
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		// PKT must be set so the symmetric PKT guard in step 1 accepts the bridge;
-		// an unsigned request would be refused for a strong-named loaded assembly.
-		var requested = new AssemblyName("System.Text.Json");
-		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
-		var loaded = ctx.LoadFromAssemblyName(requested);
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Json"));
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"System.Text.Json must bridge to the host's already-loaded instance");
@@ -40,10 +36,7 @@ public class Given_AddInLoadContext
 		var hostAssembly = typeof(ILogger).Assembly;
 
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		// PKT must be set so the symmetric PKT guard in step 1 accepts the bridge.
-		var requested = new AssemblyName("Microsoft.Extensions.Logging.Abstractions");
-		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
-		var loaded = ctx.LoadFromAssemblyName(requested);
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("Microsoft.Extensions.Logging.Abstractions"));
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"ILogger assembly must bridge to the host's instance for log sinks to work across the boundary");
@@ -57,10 +50,7 @@ public class Given_AddInLoadContext
 		var hostAssembly = typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly;
 
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		// PKT must be set so the symmetric PKT guard in step 1 accepts the bridge.
-		var requested = new AssemblyName("System.Text.Encodings.Web");
-		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
-		var loaded = ctx.LoadFromAssemblyName(requested);
+		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Encodings.Web"));
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"System.Text.Encodings.Web must bridge to the host's instance regardless of which major version the add-in compiled against");
@@ -109,10 +99,6 @@ public class Given_AddInLoadContext
 		// cannot satisfy this request; only step-1 can. Removing the step-1 bridge in
 		// AddInLoadContext.Load causes ctx.LoadFromAssemblyName to throw here, turning
 		// this into a genuine red test.
-		//
-		// The test assembly is also unsigned (no PKT), which matches the unsigned-to-unsigned
-		// path of TryBridgeBySimpleName's PKT symmetry guard — step-1 correctly bridges
-		// unsigned requests to unsigned loaded assemblies.
 		var hostAssembly = typeof(Given_AddInLoadContext).Assembly;
 		AssemblyLoadContext.Default.Assemblies.Should().Contain(hostAssembly,
 			"the test assembly must be in Default.Assemblies for this test to be valid");
@@ -140,5 +126,161 @@ public class Given_AddInLoadContext
 
 		act.Should().Throw<FileNotFoundException>(
 			"when Load returns null for all contexts, the runtime raises FileNotFoundException");
+	}
+
+	// ------------------------------------------------------------------ step 4: file-system probe across add-in directories
+	//
+	// Steps 1-3 do not probe the file system: step 1 only consults already-loaded assemblies in Default
+	// ALC, step 2 only consults the host's TPA, and step 3 only consults each add-in's .deps.json (see
+	// AssemblyDependencyResolver — https://learn.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblydependencyresolver).
+	// When a contract DLL is physically present in an add-in's directory but absent from every add-in's
+	// deps.json (a packaging quirk that occurs when a transitive contract assembly is not exposed as a
+	// runtime asset), the first three steps all return null and the call site sees a FileNotFoundException.
+	// The step-4 file-system probe iterates the known add-in directories — exactly what Assembly.LoadFrom's
+	// default runtime probing used to do implicitly before PR #23287 — without requiring the host to know
+	// the assembly name in advance. Zero white-list, zero add-in modification.
+
+	private static string StagedConsumerDll => Path.Combine(
+		Path.GetDirectoryName(typeof(Given_AddInLoadContext).Assembly.Location)!,
+		"Fixtures", "AddInWithSharedContractConsumer", "AddInWithSharedContractConsumer.dll");
+
+	private static string StagedContractsDll => Path.Combine(
+		Path.GetDirectoryName(typeof(Given_AddInLoadContext).Assembly.Location)!,
+		"Fixtures", "AddInWithSharedContractProvider", "Uno.Licensing.TestContracts.dll");
+
+	private static void AssertContractsNotInDefaultAlc()
+	{
+		AssemblyLoadContext.Default.Assemblies
+			.Should().NotContain(a => string.Equals(a.GetName().Name, "Uno.Licensing.TestContracts", StringComparison.OrdinalIgnoreCase),
+				"this test exercises the file-system probe; the contracts assembly is not allowed in Default ALC at this point");
+	}
+
+	/// <summary>
+	/// Stages an add-in's <c>.dll</c> and its real <c>.deps.json</c> side-by-side in
+	/// <paramref name="targetDir"/>. Copying the genuine deps.json is what makes the
+	/// test reproduce the production failure: with a well-formed deps.json that does
+	/// not list the contract assembly, <see cref="AssemblyDependencyResolver"/> reports
+	/// "no match" instead of falling back to a permissive directory scan it sometimes
+	/// performs when no deps.json is found at all. Without this fidelity step 3 of
+	/// <see cref="AddInLoadContext.Load"/> would resolve the contract from the directory
+	/// and bypass step 4 entirely, making the test green even without the fix.
+	/// </summary>
+	private static string StageAddIn(string sourceDll, string targetDir, string newDllName)
+	{
+		var anchor = Path.Combine(targetDir, newDllName);
+		File.Copy(sourceDll, anchor);
+
+		// Copy the matching .deps.json so AssemblyDependencyResolver behaves as in
+		// production (well-formed graph that simply does not contain the target
+		// contract assembly), not in a degraded "no deps.json" mode.
+		var sourceDepsJson = Path.ChangeExtension(sourceDll, ".deps.json");
+		if (File.Exists(sourceDepsJson))
+		{
+			var targetDepsJson = Path.ChangeExtension(anchor, ".deps.json");
+			File.Copy(sourceDepsJson, targetDepsJson);
+		}
+
+		return anchor;
+	}
+
+	[TestMethod]
+	[Description("File-system probe: when an assembly is physically present in an add-in directory but absent from every add-in's deps.json, AddInLoadContext.Load must locate and load it by enumerating the add-in directories.")]
+	public void Load_ResolvesAssemblyFromAddInDirectory_WhenNotInAnyDepsJson()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue(
+			"the consumer add-in fixture must be staged by _BuildAndCopyAddInTestFixtures");
+		File.Exists(StagedContractsDll).Should().BeTrue(
+			"the contracts fixture must be staged by _BuildAndCopyAddInTestFixtures");
+
+		AssertContractsNotInDefaultAlc();
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "uno-step4-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			// Stage the anchor add-in WITH its real .deps.json (which intentionally
+			// does NOT list Uno.Licensing.TestContracts). Then drop the contract DLL
+			// next to it on disk. Step 3 returns null because the resolver respects
+			// the deps.json; only the new step-4 file-system probe can satisfy the
+			// request.
+			var anchorPath = StageAddIn(StagedConsumerDll, tempDir, "AddInWithSharedContractConsumer.dll");
+			File.Copy(StagedContractsDll, Path.Combine(tempDir, "Uno.Licensing.TestContracts.dll"));
+
+			var ctx = new AddInLoadContext([anchorPath]);
+
+			var resolved = ctx.LoadFromAssemblyName(new AssemblyName("Uno.Licensing.TestContracts"));
+
+			resolved.Should().NotBeNull("the file-system probe step must locate the DLL co-located with the add-in");
+			resolved.GetName().Name.Should().Be("Uno.Licensing.TestContracts");
+		}
+		finally
+		{
+			try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("File-system probe must scan every add-in directory, not only the directory of the first add-in — this is what makes cross-add-in type sharing work when the contract DLL is physically present in one add-in's directory but missing from another's.")]
+	public void Load_ProbesAllAddInDirectories_NotOnlyTheFirst()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue();
+		File.Exists(StagedContractsDll).Should().BeTrue();
+
+		AssertContractsNotInDefaultAlc();
+
+		var dirA = Path.Combine(Path.GetTempPath(), "uno-step4-A-" + Guid.NewGuid().ToString("N"));
+		var dirB = Path.Combine(Path.GetTempPath(), "uno-step4-B-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(dirA);
+		Directory.CreateDirectory(dirB);
+		try
+		{
+			// dirA holds the consumer-style anchor with its real .deps.json (no
+			// contracts entry). dirB holds another anchor plus the contracts DLL
+			// on disk. The probe must reach dirB even though the first registered
+			// directory is dirA — mirrors the production scenario where consumer
+			// and provider live in separate per-add-in directories.
+			var anchorA = StageAddIn(StagedConsumerDll, dirA, "AddInWithSharedContractConsumer.dll");
+			var anchorB = StageAddIn(StagedConsumerDll, dirB, "AddInWithSharedContractConsumer.dll");
+			File.Copy(StagedContractsDll, Path.Combine(dirB, "Uno.Licensing.TestContracts.dll"));
+
+			var ctx = new AddInLoadContext([anchorA, anchorB]);
+
+			var resolved = ctx.LoadFromAssemblyName(new AssemblyName("Uno.Licensing.TestContracts"));
+
+			resolved.Should().NotBeNull(
+				"the probe must consider every registered add-in directory; dirB contains the contracts DLL even though dirA does not");
+			resolved.GetName().Name.Should().Be("Uno.Licensing.TestContracts");
+		}
+		finally
+		{
+			try { Directory.Delete(dirA, recursive: true); } catch { /* best-effort */ }
+			try { Directory.Delete(dirB, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("When all four resolution steps fail (no Default match, no TPA hit, no resolver, no file on disk in any add-in directory), Load returns null so the runtime surfaces a clean FileNotFoundException at the call site.")]
+	public void Load_ReturnsNull_WhenAssemblyNotFoundAnywhere()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue();
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "uno-step4-miss-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var anchorPath = StageAddIn(StagedConsumerDll, tempDir, "AddInWithSharedContractConsumer.dll");
+
+			var ctx = new AddInLoadContext([anchorPath]);
+
+			// Use a name that cannot possibly resolve through any of the four steps.
+			Action act = () => ctx.LoadFromAssemblyName(new AssemblyName("Totally.Unknown.Assembly.XYZ.DoesNotExist"));
+
+			act.Should().Throw<FileNotFoundException>(
+				"when no step (including the file-system probe) can satisfy the request, Load returns null and the runtime throws");
+		}
+		finally
+		{
+			try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
 	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
@@ -5,10 +5,13 @@ using Uno.UI.RemoteControl.Host.Helpers;
 namespace Uno.UI.RemoteControl.DevServer.Tests;
 
 /// <summary>
-/// Unit tests for <see cref="AddInLoadContext"/> assembly-bridging behaviour.
-/// These tests verify that Load() returns the host's already-loaded Assembly for
-/// framework and contract assemblies (step 1 of the three-step resolution chain),
-/// preserving Type identity across the host/add-in ALC boundary.
+/// Unit tests for <see cref="AddInLoadContext"/> assembly-bridging behaviour and the
+/// four-step resolution chain: (1) host-bridge via <c>Default.Assemblies</c>, (2) host
+/// TPA via <c>Default.LoadFromAssemblyName</c>, (3) per-add-in
+/// <see cref="System.Runtime.Loader.AssemblyDependencyResolver"/>, (4) file-system probe
+/// across registered add-in directories. The tests assert both happy paths and the
+/// guards (dynamic-skip, version downgrade refusal, path-traversal rejection, per-
+/// candidate load-failure isolation) that keep cross-add-in Type identity stable.
 /// </summary>
 [TestClass]
 public class Given_AddInLoadContext
@@ -277,6 +280,134 @@ public class Given_AddInLoadContext
 
 			act.Should().Throw<FileNotFoundException>(
 				"when no step (including the file-system probe) can satisfy the request, Load returns null and the runtime throws");
+		}
+		finally
+		{
+			try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("File-system probe must enforce the same version-downgrade guard as steps 1 and 2: a request for a higher version than the on-disk candidate's must return null rather than silently serving the older copy.")]
+	public void Load_RefusesDowngrade_WhenCandidateVersionLowerThanRequested()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue();
+		File.Exists(StagedContractsDll).Should().BeTrue();
+
+		AssertContractsNotInDefaultAlc();
+
+		// Read the candidate's actual version so the test stays correct as the
+		// fixture's Version property evolves with the surrounding repo.
+		var candidateVersion = AssemblyName.GetAssemblyName(StagedContractsDll).Version!;
+		var higherVersion = new Version(candidateVersion.Major + 1, 0, 0, 0);
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "uno-step4-version-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var anchorPath = StageAddIn(StagedConsumerDll, tempDir, "AddInWithSharedContractConsumer.dll");
+			File.Copy(StagedContractsDll, Path.Combine(tempDir, "Uno.Licensing.TestContracts.dll"));
+
+			var ctx = new AddInLoadContext([anchorPath]);
+
+			// Ask for a strictly-higher major than what's on disk. Step 4 must NOT
+			// substitute the older copy — mirrors the symmetric downgrade guard
+			// in steps 1 and 2.
+			var requested = new AssemblyName("Uno.Licensing.TestContracts") { Version = higherVersion };
+
+			Action act = () => ctx.LoadFromAssemblyName(requested);
+
+			act.Should().Throw<FileNotFoundException>(
+				"step 4 must refuse a candidate whose version is strictly lower than the requested version " +
+				"(found v{0}, requested v{1})", candidateVersion, higherVersion);
+		}
+		finally
+		{
+			try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("File-system probe must load assemblies into the AddInLoadContext itself, not into Default ALC. Loading into Default would leak the contract type and break the isolation guarantee that PR #23287 set up.")]
+	public void Load_StoresProbedAssemblyInAddInLoadContext_NotInDefault()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue();
+		File.Exists(StagedContractsDll).Should().BeTrue();
+
+		AssertContractsNotInDefaultAlc();
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "uno-step4-alc-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var anchorPath = StageAddIn(StagedConsumerDll, tempDir, "AddInWithSharedContractConsumer.dll");
+			File.Copy(StagedContractsDll, Path.Combine(tempDir, "Uno.Licensing.TestContracts.dll"));
+
+			var ctx = new AddInLoadContext([anchorPath]);
+			var resolved = ctx.LoadFromAssemblyName(new AssemblyName("Uno.Licensing.TestContracts"));
+
+			AssemblyLoadContext.GetLoadContext(resolved).Should().BeSameAs(ctx,
+				"step 4 must keep the probed assembly inside the AddInLoadContext so cross-add-in Type identity is preserved without leaking the contract into Default ALC");
+		}
+		finally
+		{
+			try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("File-system probe must reject malformed simple names that could escape the add-in directory via path traversal characters. The AssemblyName(string) ctor blocks separators on its own, but AssemblyName.Name has a public setter that does not — so the defensive guard inside Load is reachable through that path and worth exercising.")]
+	public void Load_RejectsPathTraversalInAssemblyName()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue();
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "uno-step4-traversal-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var anchorPath = StageAddIn(StagedConsumerDll, tempDir, "AddInWithSharedContractConsumer.dll");
+
+			var ctx = new AddInLoadContext([anchorPath]);
+
+			// Use the Name property setter to bypass the constructor's parser.
+			var hostileName = new AssemblyName { Name = "..\\..\\foo" };
+
+			Action act = () => ctx.LoadFromAssemblyName(hostileName);
+
+			act.Should().Throw<FileNotFoundException>(
+				"step 4 must reject names that contain path separators rather than probing them");
+		}
+		finally
+		{
+			try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("File-system probe must isolate per-candidate load failures: a corrupt or non-managed DLL whose name matches the request must not abort the resolution chain — the runtime should see a clean FileNotFoundException as if no candidate had matched.")]
+	public void Load_SwallowsLoadFailure_AndReturnsNull_WhenCandidateCannotBeLoaded()
+	{
+		File.Exists(StagedConsumerDll).Should().BeTrue();
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "uno-step4-bad-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var anchorPath = StageAddIn(StagedConsumerDll, tempDir, "AddInWithSharedContractConsumer.dll");
+
+			// Drop a file with a .dll extension whose contents are NOT a valid managed assembly.
+			// LoadFromAssemblyPath will throw BadImageFormatException — step 4 must swallow it.
+			var badDllPath = Path.Combine(tempDir, "Not.A.Real.Assembly.dll");
+			File.WriteAllBytes(badDllPath, [0x00, 0x01, 0x02, 0x03]);
+
+			var ctx = new AddInLoadContext([anchorPath]);
+
+			Action act = () => ctx.LoadFromAssemblyName(new AssemblyName("Not.A.Real.Assembly"));
+
+			// The runtime surfaces FileNotFoundException once Load returns null — not the
+			// raw BadImageFormatException from inside step 4.
+			act.Should().Throw<FileNotFoundException>(
+				"step 4 must catch per-candidate load failures and treat them as misses so the resolution chain stays consistent");
 		}
 		finally
 		{

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_AddInLoadContext.cs
@@ -19,41 +19,53 @@ public class Given_AddInLoadContext
 	// ------------------------------------------------------------------ step 1: bridge via Default.Assemblies
 
 	[TestMethod]
-	[Description("Step 1 must return the host's System.Text.Json instance so JsonDocument/JsonElement types are identical between host and add-in.")]
+	[Description("Step 1 must return the host's System.Text.Json instance so JsonDocument/JsonElement types are identical between host and add-in. Request carries the real PKT to mirror how compiled add-in AssemblyRefs reach the bridge.")]
 	public void Load_ResolvesFrameworkOobAssembly_ToHostInstance()
 	{
 		// Force the assembly into Default.Assemblies (reference a type from it first).
 		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
 
+		// Real AssemblyRefs to strong-named framework assemblies include the PKT.
+		// Setting it here keeps the test representative and exercises the PKT
+		// match in TryBridgeBySimpleName.
+		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
+
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Json"));
+		var loaded = ctx.LoadFromAssemblyName(requested);
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"System.Text.Json must bridge to the host's already-loaded instance");
 	}
 
 	[TestMethod]
-	[Description("Step 1 must return the host's Logging.Abstractions so ILogger contracts are identical between host and add-in.")]
+	[Description("Step 1 must return the host's Logging.Abstractions so ILogger contracts are identical between host and add-in. Request carries the real PKT to mirror how compiled add-in AssemblyRefs reach the bridge.")]
 	public void Load_ResolvesLoggingAbstractions_ToHostInstance()
 	{
 		var hostAssembly = typeof(ILogger).Assembly;
 
+		var requested = new AssemblyName("Microsoft.Extensions.Logging.Abstractions");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
+
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("Microsoft.Extensions.Logging.Abstractions"));
+		var loaded = ctx.LoadFromAssemblyName(requested);
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"ILogger assembly must bridge to the host's instance for log sinks to work across the boundary");
 	}
 
 	[TestMethod]
-	[Description("Step 1 must return the host's System.Text.Encodings.Web — the assembly whose version mismatch triggered the original crash (PR #23287).")]
+	[Description("Step 1 must return the host's System.Text.Encodings.Web — the assembly whose version mismatch triggered the original crash (PR #23287). Request carries the real PKT to mirror how Kiota's net8 AssemblyRef reaches the bridge.")]
 	public void Load_ResolvesEncodingsWeb_ToHostInstance()
 	{
 		// Touching JavaScriptEncoder forces the assembly into Default.Assemblies.
 		var hostAssembly = typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly;
 
+		var requested = new AssemblyName("System.Text.Encodings.Web");
+		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
+
 		var ctx = new AddInLoadContext(Array.Empty<string>());
-		var loaded = ctx.LoadFromAssemblyName(new AssemblyName("System.Text.Encodings.Web"));
+		var loaded = ctx.LoadFromAssemblyName(requested);
 
 		loaded.Should().BeSameAs(hostAssembly,
 			"System.Text.Encodings.Web must bridge to the host's instance regardless of which major version the add-in compiled against");

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -119,6 +119,127 @@ public class Given_HostAssemblyResolution
 		}
 	}
 
+	// ------------------------------------------------------------------ pattern constants
+
+	[TestMethod]
+	[Description("DefaultEagerLoadPatterns must include the System.* and Microsoft.Extensions.* globs that the host has always eager-loaded.")]
+	public void DefaultEagerLoadPatterns_ContainsExpectedSystemAndExtensionsGlobs()
+	{
+		HostAssemblyResolution.DefaultEagerLoadPatterns.Should().Contain("System.*.dll",
+			"System.* assemblies must be eager-loaded to bridge cross-major OOB package refs");
+		HostAssemblyResolution.DefaultEagerLoadPatterns.Should().Contain("Microsoft.Extensions.*.dll",
+			"Microsoft.Extensions.* assemblies must be eager-loaded to bridge Logging/Configuration refs");
+	}
+
+	[TestMethod]
+	[Description("AddInSharedAssemblyPatterns must include Uno.Licensing.*.dll so that Uno.Licensing.Sdk.Contracts is pre-loaded into Default ALC and shared across add-ins.")]
+	public void AddInSharedAssemblyPatterns_ContainsUnoLicensingPattern()
+	{
+		HostAssemblyResolution.AddInSharedAssemblyPatterns.Should().Contain("Uno.Licensing.*.dll",
+			"pre-loading Uno.Licensing.*.dll from add-in directories is the fix for cross-add-in ILicensingService type-identity failures");
+	}
+
+	// ------------------------------------------------------------------ custom patterns filtering
+
+	[TestMethod]
+	[Description("When a custom patterns array is supplied, EagerLoadFromDirectory must enumerate only files matching those patterns and must NOT load files matching the default System.*/Microsoft.Extensions.* patterns.")]
+	public void EagerLoadFromDirectory_WithCustomPattern_SkipsFilesNotMatchingCustomPattern()
+	{
+		var sourceDir = System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)!;
+
+		// Find any System.*.dll in the source dir to stage in our isolated temp dir.
+		var systemDll = System.IO.Directory
+			.EnumerateFiles(sourceDir, "System.*.dll")
+			.FirstOrDefault();
+
+		if (systemDll is null)
+		{
+			Assert.Inconclusive("No System.*.dll found in test output directory; cannot stage the test candidate.");
+			return;
+		}
+
+		var tempDir = System.IO.Path.Combine(
+			System.IO.Path.GetTempPath(),
+			"uno-custom-pattern-test-" + Guid.NewGuid().ToString("N"));
+		System.IO.Directory.CreateDirectory(tempDir);
+		try
+		{
+			System.IO.File.Copy(systemDll, System.IO.Path.Combine(tempDir, System.IO.Path.GetFileName(systemDll)));
+
+			// Call with a custom pattern that matches NOTHING in the temp dir.
+			var count = HostAssemblyResolution.EagerLoadFromDirectory(
+				tempDir,
+				["Uno.Licensing.*.dll"]);
+
+			count.Should().Be(0,
+				"a System.*.dll staged in the temp dir must not be loaded when the pattern is 'Uno.Licensing.*.dll'");
+		}
+		finally
+		{
+			try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
+	[TestMethod]
+	[Description("When patterns is null, EagerLoadFromDirectory must fall back to DefaultEagerLoadPatterns and behave identically to the zero-argument overload.")]
+	public void EagerLoadFromDirectory_WithNullPatterns_FallsBackToDefaultPatterns()
+	{
+		var sourceDir = System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)!;
+
+		// Build the set already loaded so we can find an unloaded candidate.
+		var alreadyLoaded = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var asm in System.Runtime.Loader.AssemblyLoadContext.Default.Assemblies)
+		{
+			if (!asm.IsDynamic && asm.GetName().Name is { } n)
+			{
+				alreadyLoaded.Add(n);
+			}
+		}
+
+		string? pickedFile = null;
+		foreach (var pattern in new[] { "System.*.dll", "Microsoft.Extensions.*.dll" })
+		{
+			foreach (var path in System.IO.Directory.EnumerateFiles(sourceDir, pattern))
+			{
+				if (!alreadyLoaded.Contains(System.IO.Path.GetFileNameWithoutExtension(path)))
+				{
+					pickedFile = path;
+					break;
+				}
+			}
+
+			if (pickedFile is not null) break;
+		}
+
+		if (pickedFile is null)
+		{
+			Assert.Inconclusive(
+				"No unloaded System.* or Microsoft.Extensions.* DLL found; " +
+				"null-pattern fallback cannot be exercised on this runtime.");
+			return;
+		}
+
+		var tempDir = System.IO.Path.Combine(
+			System.IO.Path.GetTempPath(),
+			"uno-null-pattern-test-" + Guid.NewGuid().ToString("N"));
+		System.IO.Directory.CreateDirectory(tempDir);
+		try
+		{
+			System.IO.File.Copy(pickedFile, System.IO.Path.Combine(tempDir, System.IO.Path.GetFileName(pickedFile)));
+
+			// null patterns → should use DefaultEagerLoadPatterns (System.* matches).
+			var count = HostAssemblyResolution.EagerLoadFromDirectory(tempDir, null);
+
+			count.Should().BeGreaterThan(0,
+				"passing null for patterns must fall back to DefaultEagerLoadPatterns, which includes System.*.dll; " +
+				"the staged '{0}' must be loaded", System.IO.Path.GetFileName(pickedFile));
+		}
+		finally
+		{
+			try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+		}
+	}
+
 	// ------------------------------------------------------------------ helpers
 
 	private static int CountResolvingHandlers()

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -131,115 +131,6 @@ public class Given_HostAssemblyResolution
 			"Microsoft.Extensions.* assemblies must be eager-loaded to bridge Logging/Configuration refs");
 	}
 
-	[TestMethod]
-	[Description("AddInSharedAssemblyPatterns must include Uno.Licensing.*.dll so that Uno.Licensing.Sdk.Contracts is pre-loaded into Default ALC and shared across add-ins.")]
-	public void AddInSharedAssemblyPatterns_ContainsUnoLicensingPattern()
-	{
-		HostAssemblyResolution.AddInSharedAssemblyPatterns.Should().Contain("Uno.Licensing.*.dll",
-			"pre-loading Uno.Licensing.*.dll from add-in directories is the fix for cross-add-in ILicensingService type-identity failures");
-	}
-
-	// ------------------------------------------------------------------ custom patterns filtering
-
-	[TestMethod]
-	[Description("When a custom patterns array is supplied, EagerLoadFromDirectory must enumerate only files matching those patterns and must NOT load files matching the default System.*/Microsoft.Extensions.* patterns.")]
-	public void EagerLoadFromDirectory_WithCustomPattern_SkipsFilesNotMatchingCustomPattern()
-	{
-		var sourceDir = System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)!;
-
-		// Find any System.*.dll in the source dir to stage in our isolated temp dir.
-		var systemDll = System.IO.Directory
-			.EnumerateFiles(sourceDir, "System.*.dll")
-			.FirstOrDefault();
-
-		if (systemDll is null)
-		{
-			Assert.Inconclusive("No System.*.dll found in test output directory; cannot stage the test candidate.");
-			return;
-		}
-
-		var tempDir = System.IO.Path.Combine(
-			System.IO.Path.GetTempPath(),
-			"uno-custom-pattern-test-" + Guid.NewGuid().ToString("N"));
-		System.IO.Directory.CreateDirectory(tempDir);
-		try
-		{
-			System.IO.File.Copy(systemDll, System.IO.Path.Combine(tempDir, System.IO.Path.GetFileName(systemDll)));
-
-			// Call with a custom pattern that matches NOTHING in the temp dir.
-			var count = HostAssemblyResolution.EagerLoadFromDirectory(
-				tempDir,
-				["Uno.Licensing.*.dll"]);
-
-			count.Should().Be(0,
-				"a System.*.dll staged in the temp dir must not be loaded when the pattern is 'Uno.Licensing.*.dll'");
-		}
-		finally
-		{
-			try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
-		}
-	}
-
-	[TestMethod]
-	[Description("When patterns is null, EagerLoadFromDirectory must fall back to DefaultEagerLoadPatterns and behave identically to the zero-argument overload.")]
-	public void EagerLoadFromDirectory_WithNullPatterns_FallsBackToDefaultPatterns()
-	{
-		var sourceDir = System.IO.Path.GetDirectoryName(typeof(HostAssemblyResolution).Assembly.Location)!;
-
-		// Build the set already loaded so we can find an unloaded candidate.
-		var alreadyLoaded = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
-		foreach (var asm in System.Runtime.Loader.AssemblyLoadContext.Default.Assemblies)
-		{
-			if (!asm.IsDynamic && asm.GetName().Name is { } n)
-			{
-				alreadyLoaded.Add(n);
-			}
-		}
-
-		string? pickedFile = null;
-		foreach (var pattern in new[] { "System.*.dll", "Microsoft.Extensions.*.dll" })
-		{
-			foreach (var path in System.IO.Directory.EnumerateFiles(sourceDir, pattern))
-			{
-				if (!alreadyLoaded.Contains(System.IO.Path.GetFileNameWithoutExtension(path)))
-				{
-					pickedFile = path;
-					break;
-				}
-			}
-
-			if (pickedFile is not null) break;
-		}
-
-		if (pickedFile is null)
-		{
-			Assert.Inconclusive(
-				"No unloaded System.* or Microsoft.Extensions.* DLL found; " +
-				"null-pattern fallback cannot be exercised on this runtime.");
-			return;
-		}
-
-		var tempDir = System.IO.Path.Combine(
-			System.IO.Path.GetTempPath(),
-			"uno-null-pattern-test-" + Guid.NewGuid().ToString("N"));
-		System.IO.Directory.CreateDirectory(tempDir);
-		try
-		{
-			System.IO.File.Copy(pickedFile, System.IO.Path.Combine(tempDir, System.IO.Path.GetFileName(pickedFile)));
-
-			// null patterns → should use DefaultEagerLoadPatterns (System.* matches).
-			var count = HostAssemblyResolution.EagerLoadFromDirectory(tempDir, null);
-
-			count.Should().BeGreaterThan(0,
-				"passing null for patterns must fall back to DefaultEagerLoadPatterns, which includes System.*.dll; " +
-				"the staged '{0}' must be loaded", System.IO.Path.GetFileName(pickedFile));
-		}
-		finally
-		{
-			try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
-		}
-	}
-
 	// ------------------------------------------------------------------ helpers
 
 	private static int CountResolvingHandlers()
@@ -269,21 +160,19 @@ public class Given_HostAssemblyResolution
 	// ------------------------------------------------------------------ returns loaded assembly
 
 	[TestMethod]
-	[Description("When the default ALC has an assembly with the requested simple name and matching PKT, TryBridgeBySimpleName must return that exact instance.")]
-	public void TryBridgeBySimpleName_ReturnsLoadedAssembly_WhenSimpleNameMatchesAndPktCompatible()
+	[Description("When the default ALC has an assembly with the requested simple name, TryBridgeBySimpleName must return that exact instance regardless of PKT (add-ins are unsigned in practice).")]
+	public void TryBridgeBySimpleName_ReturnsLoadedAssembly_WhenSimpleNameMatches()
 	{
 		// Force the assembly into Default.Assemblies.
 		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
 
-		// Mirror what a compiled add-in AssemblyRef looks like: simple name + PKT.
 		var requested = new AssemblyName("System.Text.Json");
-		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
 
 		var result = HostAssemblyResolution.TryBridgeBySimpleName(
 			AssemblyLoadContext.Default, requested);
 
 		result.Should().BeSameAs(hostAssembly,
-			"System.Text.Json is loaded in the default ALC and the name+PKT matches");
+			"System.Text.Json is loaded in the default ALC and the simple name matches");
 	}
 
 	// ------------------------------------------------------------------ returns null on miss
@@ -314,35 +203,13 @@ public class Given_HostAssemblyResolution
 			new AssemblyName("System.Text.Json"),
 			System.Reflection.Emit.AssemblyBuilderAccess.Run);
 
-		// Use a proper signed request (real add-in AssemblyRefs include the PKT).
 		var requested = new AssemblyName("System.Text.Json");
-		requested.SetPublicKeyToken(hostAssembly.GetName().GetPublicKeyToken());
 		var result = HostAssemblyResolution.TryBridgeBySimpleName(
 			AssemblyLoadContext.Default, requested);
 
 		result.Should().BeSameAs(hostAssembly,
 			"the bridge must return the real assembly, not a dynamic one");
 		result!.IsDynamic.Should().BeFalse("returned assembly must never be dynamic");
-	}
-
-	// ------------------------------------------------------------------ PKT symmetry
-
-	[TestMethod]
-	[Description("When the loaded assembly is strong-named but the request carries no PKT, the bridge must return null to prevent silently substituting a strong-named assembly for an unsigned reference.")]
-	public void TryBridgeBySimpleName_RejectsStrongNamedLoaded_WhenRequestedIsUnsigned()
-	{
-		// System.Text.Json is strong-named (Microsoft PKT).
-		_ = typeof(System.Text.Json.JsonDocument).Assembly;
-
-		// Request the same simple name without a PKT.
-		var requested = new AssemblyName("System.Text.Json") { Version = null };
-
-		var result = HostAssemblyResolution.TryBridgeBySimpleName(
-			AssemblyLoadContext.Default, requested);
-
-		result.Should().BeNull(
-			"a strong-named loaded assembly must not be returned for an unsigned request — " +
-			"the PKT mismatch could silently substitute the wrong assembly");
 	}
 
 	// ------------------------------------------------------------------ version downgrade
@@ -354,7 +221,6 @@ public class Given_HostAssemblyResolution
 		// Use System.Text.Encodings.Web — forced into Default by Given_AddInLoadContext.
 		var loaded = typeof(System.Text.Encodings.Web.JavaScriptEncoder).Assembly;
 		var loadedVersion = loaded.GetName().Version!;
-		var loadedPkt = loaded.GetName().GetPublicKeyToken()!;
 
 		// Request the same assembly one major version higher (simulates the
 		// add-in requesting v(N+1) while the host has only vN loaded).
@@ -363,7 +229,6 @@ public class Given_HostAssemblyResolution
 		{
 			Version = higherVersion,
 		};
-		requested.SetPublicKeyToken(loadedPkt);
 
 		var result = HostAssemblyResolution.TryBridgeBySimpleName(
 			AssemblyLoadContext.Default, requested);

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HostAssemblyResolution.cs
@@ -160,12 +160,14 @@ public class Given_HostAssemblyResolution
 	// ------------------------------------------------------------------ returns loaded assembly
 
 	[TestMethod]
-	[Description("When the default ALC has an assembly with the requested simple name, TryBridgeBySimpleName must return that exact instance regardless of PKT (add-ins are unsigned in practice).")]
-	public void TryBridgeBySimpleName_ReturnsLoadedAssembly_WhenSimpleNameMatches()
+	[Description("When the default ALC has an assembly with the requested simple name and the request carries no PKT, TryBridgeBySimpleName must return that instance — the unsigned-request path used by cross-add-in contract assemblies.")]
+	public void TryBridgeBySimpleName_ReturnsLoadedAssembly_WhenUnsignedRequestMatchesByName()
 	{
 		// Force the assembly into Default.Assemblies.
 		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
 
+		// Unsigned request: no PKT set. This matches how an unsigned add-in
+		// contract assembly arrives at the bridge.
 		var requested = new AssemblyName("System.Text.Json");
 
 		var result = HostAssemblyResolution.TryBridgeBySimpleName(
@@ -173,6 +175,46 @@ public class Given_HostAssemblyResolution
 
 		result.Should().BeSameAs(hostAssembly,
 			"System.Text.Json is loaded in the default ALC and the simple name matches");
+	}
+
+	[TestMethod]
+	[Description("When the requested AssemblyName carries a PublicKeyToken, TryBridgeBySimpleName must require the loaded assembly's PKT to match — otherwise a same-named assembly with a different (or absent) PKT could silently substitute the wrong identity.")]
+	public void TryBridgeBySimpleName_RefusesBridge_WhenSignedRequestPktDoesNotMatchLoaded()
+	{
+		// Force the strong-named host assembly into Default.Assemblies.
+		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+		var realPkt = hostAssembly.GetName().GetPublicKeyToken()!;
+		realPkt.Length.Should().BeGreaterThan(0, "the bridged framework assembly is expected to be strong-named");
+
+		// Build a fake PKT distinct from the real one (flip the last byte).
+		var fakePkt = (byte[])realPkt.Clone();
+		fakePkt[^1] = (byte)(fakePkt[^1] ^ 0xFF);
+
+		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(fakePkt);
+
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeNull(
+			"the loaded assembly's PKT differs from the signed request's PKT — bridging would be an identity swap");
+	}
+
+	[TestMethod]
+	[Description("When the requested AssemblyName carries a PublicKeyToken matching the loaded assembly's PKT, TryBridgeBySimpleName must return the loaded instance — the normal signed-framework bridge path (e.g. Kiota → System.Text.Encodings.Web).")]
+	public void TryBridgeBySimpleName_Bridges_WhenSignedRequestPktMatchesLoaded()
+	{
+		var hostAssembly = typeof(System.Text.Json.JsonDocument).Assembly;
+		var realPkt = hostAssembly.GetName().GetPublicKeyToken()!;
+
+		var requested = new AssemblyName("System.Text.Json");
+		requested.SetPublicKeyToken(realPkt);
+
+		var result = HostAssemblyResolution.TryBridgeBySimpleName(
+			AssemblyLoadContext.Default, requested);
+
+		result.Should().BeSameAs(hostAssembly,
+			"the signed request's PKT matches the loaded assembly — bridge must serve it");
 	}
 
 	// ------------------------------------------------------------------ returns null on miss

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -119,6 +119,21 @@
 		                  SkipGetTargetFrameworkProperties="true"
 		                  UndefineProperties="TargetFramework"
 		                  Private="false" />
+		<ProjectReference Include="Fixtures\Uno.Licensing.TestContracts\Uno.Licensing.TestContracts.csproj"
+		                  ReferenceOutputAssembly="false"
+		                  SkipGetTargetFrameworkProperties="true"
+		                  UndefineProperties="TargetFramework"
+		                  Private="false" />
+		<ProjectReference Include="Fixtures\AddInWithSharedContractProvider\AddInWithSharedContractProvider.csproj"
+		                  ReferenceOutputAssembly="false"
+		                  SkipGetTargetFrameworkProperties="true"
+		                  UndefineProperties="TargetFramework"
+		                  Private="false" />
+		<ProjectReference Include="Fixtures\AddInWithSharedContractConsumer\AddInWithSharedContractConsumer.csproj"
+		                  ReferenceOutputAssembly="false"
+		                  SkipGetTargetFrameworkProperties="true"
+		                  UndefineProperties="TargetFramework"
+		                  Private="false" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -167,6 +182,62 @@
 		</ItemGroup>
 		<Copy SourceFiles="@(_DiFixtureBinFiles)"
 		      DestinationFolder="$(OutDir)Fixtures\AddInWithDiServiceRegistration\%(RecursiveDir)"
+		      SkipUnchangedFiles="true" />
+
+		<!--
+			Cross-add-in shared type regression fixtures (#23287 / #23304):
+			Provider ships Uno.Licensing.TestContracts.dll in its directory;
+			Consumer does NOT (Private=false on the ProjectReference).
+			The test verifies that AssemblyHelper pre-loads Uno.Licensing.*.dll from
+			the provider directory into Default ALC before creating AddInLoadContext,
+			allowing both add-ins to share a single ILicensingTestContract type identity.
+		-->
+
+		<!-- Build provider (EnableDynamicLoading=false so Uno.Licensing.TestContracts is NOT in deps.json) -->
+		<MSBuild Projects="Fixtures\AddInWithSharedContractProvider\AddInWithSharedContractProvider.csproj"
+		         Properties="Configuration=$(Configuration)"
+		         Targets="Build"
+		         RemoveProperties="TargetFramework">
+			<Output TaskParameter="TargetOutputs" ItemName="_SharedProviderOutput" />
+		</MSBuild>
+		<ItemGroup>
+			<_SharedProviderBinFiles Include="%(_SharedProviderOutput.RootDir)%(_SharedProviderOutput.Directory)**\*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_SharedProviderBinFiles)"
+		      DestinationFolder="$(OutDir)Fixtures\AddInWithSharedContractProvider\%(RecursiveDir)"
+		      SkipUnchangedFiles="true" />
+
+		<!--
+			Explicitly stage Uno.Licensing.TestContracts.dll into the provider's fixture
+			directory. Without EnableDynamicLoading=true the ProjectReference does not copy
+			the DLL to the provider's bin, so we copy it manually here. The DLL matches the
+			"Uno.Licensing.*.dll" glob and must be physically present in the provider's
+			directory so EagerLoadFromDirectory can find and load it into Default ALC.
+			It is intentionally absent from the provider's deps.json so that step 3
+			(AssemblyDependencyResolver) cannot resolve it — the only path is the fix.
+		-->
+		<MSBuild Projects="Fixtures\Uno.Licensing.TestContracts\Uno.Licensing.TestContracts.csproj"
+		         Properties="Configuration=$(Configuration)"
+		         Targets="Build"
+		         RemoveProperties="TargetFramework">
+			<Output TaskParameter="TargetOutputs" ItemName="_ContractsOutput" />
+		</MSBuild>
+		<Copy SourceFiles="%(_ContractsOutput.FullPath)"
+		      DestinationFolder="$(OutDir)Fixtures\AddInWithSharedContractProvider\"
+		      SkipUnchangedFiles="true" />
+
+		<!-- Build consumer (does NOT include Uno.Licensing.TestContracts.dll — Private=false) -->
+		<MSBuild Projects="Fixtures\AddInWithSharedContractConsumer\AddInWithSharedContractConsumer.csproj"
+		         Properties="Configuration=$(Configuration)"
+		         Targets="Build"
+		         RemoveProperties="TargetFramework">
+			<Output TaskParameter="TargetOutputs" ItemName="_SharedConsumerOutput" />
+		</MSBuild>
+		<ItemGroup>
+			<_SharedConsumerBinFiles Include="%(_SharedConsumerOutput.RootDir)%(_SharedConsumerOutput.Directory)**\*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_SharedConsumerBinFiles)"
+		      DestinationFolder="$(OutDir)Fixtures\AddInWithSharedContractConsumer\%(RecursiveDir)"
 		      SkipUnchangedFiles="true" />
 
 	</Target>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -188,9 +188,9 @@
 			Cross-add-in shared type regression fixtures (#23287 / #23304):
 			Provider ships Uno.Licensing.TestContracts.dll in its directory;
 			Consumer does NOT (Private=false on the ProjectReference).
-			The test verifies that AssemblyHelper pre-loads Uno.Licensing.*.dll from
-			the provider directory into Default ALC before creating AddInLoadContext,
-			allowing both add-ins to share a single ILicensingTestContract type identity.
+			The contracts DLL is intentionally absent from every add-in's deps.json so the
+			test reproduces the production failure exactly: steps 1-3 of AddInLoadContext.Load
+			cannot resolve it. The file-system probe (step 4) is what makes the test green.
 		-->
 
 		<!-- Build provider (EnableDynamicLoading=false so Uno.Licensing.TestContracts is NOT in deps.json) -->
@@ -210,11 +210,11 @@
 		<!--
 			Explicitly stage Uno.Licensing.TestContracts.dll into the provider's fixture
 			directory. Without EnableDynamicLoading=true the ProjectReference does not copy
-			the DLL to the provider's bin, so we copy it manually here. The DLL matches the
-			"Uno.Licensing.*.dll" glob and must be physically present in the provider's
-			directory so EagerLoadFromDirectory can find and load it into Default ALC.
-			It is intentionally absent from the provider's deps.json so that step 3
-			(AssemblyDependencyResolver) cannot resolve it — the only path is the fix.
+			the DLL to the provider's bin, so we copy it manually here. The DLL must be
+			physically present in the provider's directory so the file-system probe (step 4
+			of AddInLoadContext.Load) can find it. It is intentionally absent from every
+			add-in's deps.json so that step 3 (AssemblyDependencyResolver) cannot resolve
+			it — the only path is the probe.
 		-->
 		<MSBuild Projects="Fixtures\Uno.Licensing.TestContracts\Uno.Licensing.TestContracts.csproj"
 		         Properties="Configuration=$(Configuration)"

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -38,6 +38,13 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 
 	private readonly AssemblyDependencyResolver[] _resolvers;
 
+	/// <summary>
+	/// Distinct directories of every registered add-in DLL. Used by step 4 of
+	/// <see cref="Load"/> to probe for a co-located <c>{simpleName}.dll</c>
+	/// when none of the other steps can satisfy the request.
+	/// </summary>
+	private readonly string[] _addInDirectories;
+
 	public AddInLoadContext(IEnumerable<string> addInPaths)
 		: base(name: "AddIns", isCollectible: false)
 	{
@@ -51,6 +58,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 		// caller's per-DLL try/catch and will surface there with a meaningful
 		// error.
 		var resolvers = new List<AssemblyDependencyResolver>();
+		var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		foreach (var path in addInPaths)
 		{
 			try
@@ -67,8 +75,18 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 					$"Uno.UI.RemoteControl.Host: AssemblyDependencyResolver construction failed for '{path}' " +
 					$"({ex}). Per-add-in dependency probing for this add-in will be skipped.");
 			}
+
+			// Remember the add-in's directory whether or not its dependency
+			// resolver was constructed successfully: step 4 still scans on the
+			// file system, which is independent of any deps.json.
+			var directory = Path.GetDirectoryName(path);
+			if (!string.IsNullOrEmpty(directory))
+			{
+				directories.Add(directory);
+			}
 		}
 		_resolvers = [.. resolvers];
+		_addInDirectories = [.. directories];
 	}
 
 	protected override Assembly? Load(AssemblyName assemblyName)
@@ -103,19 +121,13 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			//    other genuinely add-in-private assemblies aren't in host TPA, so
 			//    they fall through to the plugin resolvers below.
 			//
-			// We catch both FileNotFoundException AND FileLoadException /
-			// BadImageFormatException here: TPA can match an assembly by simple
-			// name but reject the load on a strong-name / version / image
-			// mismatch (exactly the cross-major scenario this class exists to
-			// paper over). If the default ALC can't satisfy this name for any
-			// of those reasons, the add-in's own deps.json may still carry a
-			// usable copy, so we keep falling through rather than bubbling up.
+			// We catch FileNotFoundException, FileLoadException and
+			// BadImageFormatException because TPA can match an assembly by
+			// simple name but reject the load on a version / image mismatch
+			// (exactly the cross-major scenario this class exists to paper
+			// over). When that happens we keep falling through to the
+			// add-in-private resolvers and the file-system probe.
 			//
-			// We also validate the loaded assembly's PublicKeyToken against the
-			// request before returning — same identity-swap guard as step 1
-			// and the Default.Resolving handler in Program.cs. Asking by simple
-			// name alone could otherwise hand back a same-name-but-different-PKT
-			// assembly from TPA, which we'd never silently substitute elsewhere.
 			// Guard against re-entrancy: if Default's Resolving handler (or a
 			// downstream load) cycles back into this method, skip step 2 and
 			// fall through to the add-in's private resolvers.
@@ -124,43 +136,20 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 				s_inDefaultLoad.Value = true;
 				try
 				{
-					// We request by simple name + culture only — versionless / PKT-less
-					// — so the host's TPA can pick whichever copy it shipped (intent: let
-					// TPA resolution pick the host's version). The strong-name identity
-					// is validated explicitly below before we hand the assembly back.
+					// We request by simple name + culture only so the host's TPA
+					// can pick whichever copy it shipped, regardless of the add-in's
+					// compiled-against version. The only post-hoc check is the
+					// version-downgrade guard below.
 					Assembly? loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
-					var requestedToken = assemblyName.GetPublicKeyToken();
-					if (requestedToken is { Length: > 0 })
-					{
-						// Signed request: loaded assembly must carry the same PKT.
-						var loadedToken = loaded.GetName().GetPublicKeyToken();
-						if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
-						{
-							loaded = null;
-						}
-					}
-					else
-					{
-						// Unsigned request: refuse a strong-named loaded assembly to match
-						// the symmetric PKT policy enforced by TryBridgeBySimpleName.
-						var loadedToken = loaded.GetName().GetPublicKeyToken();
-						if (loadedToken is { Length: > 0 })
-						{
-							loaded = null;
-						}
-					}
 
 					// Version guard: mirrors TryBridgeBySimpleName — refuse to serve a
 					// version lower than what the add-in requested.
-					if (loaded is not null)
+					var requestedVersion = assemblyName.Version;
+					var loadedVersion = loaded.GetName().Version;
+					if (requestedVersion is not null && loadedVersion is not null
+						&& loadedVersion < requestedVersion)
 					{
-						var requestedVersion = assemblyName.Version;
-						var loadedVersion = loaded.GetName().Version;
-						if (requestedVersion is not null && loadedVersion is not null
-							&& loadedVersion < requestedVersion)
-						{
-							loaded = null;
-						}
+						loaded = null;
 					}
 
 					if (loaded is not null)
@@ -170,7 +159,7 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 				}
 				catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
 				{
-					/* not in host TPA, or found but rejected (strong-name / version / image mismatch) */
+					/* not in host TPA, or found but rejected (version / image mismatch) */
 				}
 				finally
 				{
@@ -188,6 +177,30 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			if (path is not null)
 			{
 				return LoadFromAssemblyPath(path);
+			}
+		}
+
+		// 4. File-system probe across every registered add-in directory.
+		//    AssemblyDependencyResolver only consults .deps.json
+		//    (https://learn.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblydependencyresolver).
+		//    When a contract assembly is physically present in an add-in's directory
+		//    but absent from every add-in's deps.json (a transitive contract that
+		//    isn't surfaced as a runtime asset by the consuming packages), the first
+		//    three steps all return null and the runtime would throw
+		//    FileNotFoundException. This step mirrors the implicit directory probing
+		//    that Assembly.LoadFrom used to perform before add-in isolation was
+		//    introduced. Loading the assembly here keeps it inside this shared
+		//    AddInLoadContext, so every add-in gets the same Type identity and DI
+		//    resolution works across the add-in boundary.
+		if (name is not null)
+		{
+			foreach (var directory in _addInDirectories)
+			{
+				var candidate = Path.Combine(directory, name + ".dll");
+				if (File.Exists(candidate))
+				{
+					return LoadFromAssemblyPath(candidate);
+				}
 			}
 		}
 

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -39,11 +39,14 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 	private readonly AssemblyDependencyResolver[] _resolvers;
 
 	/// <summary>
-	/// Distinct directories of every registered add-in DLL. Used by step 4 of
-	/// <see cref="Load"/> to probe for a co-located <c>{simpleName}.dll</c>
-	/// when none of the other steps can satisfy the request.
+	/// Snapshot of every <c>.dll</c> co-located with a registered add-in, keyed by
+	/// simple name. Built once at construction time so step 4 of <see cref="Load"/>
+	/// is an O(1) dictionary lookup instead of a directory scan on every miss, and
+	/// so the resolution result is deterministic: when two add-in directories ship
+	/// the same simple name, the first one in the registration order wins —
+	/// independent of the host file-system enumeration order.
 	/// </summary>
-	private readonly string[] _addInDirectories;
+	private readonly Dictionary<string, string> _probeMap;
 
 	public AddInLoadContext(IEnumerable<string> addInPaths)
 		: base(name: "AddIns", isCollectible: false)
@@ -58,7 +61,9 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 		// caller's per-DLL try/catch and will surface there with a meaningful
 		// error.
 		var resolvers = new List<AssemblyDependencyResolver>();
-		var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var orderedDirectories = new List<string>();
+		var seenDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
 		foreach (var path in addInPaths)
 		{
 			try
@@ -78,15 +83,51 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 
 			// Remember the add-in's directory whether or not its dependency
 			// resolver was constructed successfully: step 4 still scans on the
-			// file system, which is independent of any deps.json.
+			// file system, which is independent of any deps.json. Preserve the
+			// caller-supplied registration order so first-add-in-wins is stable.
 			var directory = Path.GetDirectoryName(path);
-			if (!string.IsNullOrEmpty(directory))
+			if (!string.IsNullOrEmpty(directory) && seenDirectories.Add(directory))
 			{
-				directories.Add(directory);
+				orderedDirectories.Add(directory);
 			}
 		}
+
 		_resolvers = [.. resolvers];
-		_addInDirectories = [.. directories];
+
+		// Snapshot every .dll co-located with the registered add-ins exactly once.
+		// First match wins: a DLL appearing in the first registered directory is
+		// not shadowed by a same-named file in a later directory.
+		_probeMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var directory in orderedDirectories)
+		{
+			IEnumerable<string> dllPaths;
+			try
+			{
+				dllPaths = Directory.EnumerateFiles(directory, "*.dll");
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+			{
+				// Best-effort: an inaccessible add-in directory must not abort the
+				// whole probe snapshot; the per-add-in load will surface its own
+				// failure via AssemblyHelper's catch.
+				Console.Error.WriteLine(
+					$"Uno.UI.RemoteControl.Host: cannot enumerate add-in directory '{directory}' " +
+					$"for the file-system probe snapshot ({ex.GetType().Name}: {ex.Message}).");
+				continue;
+			}
+
+			foreach (var dllPath in dllPaths)
+			{
+				var simpleName = Path.GetFileNameWithoutExtension(dllPath);
+				if (!string.IsNullOrEmpty(simpleName))
+				{
+					// First-add-in-wins: TryAdd preserves the registration-order
+					// precedence so a later add-in can't silently shadow a contract
+					// shipped by an earlier one.
+					_probeMap.TryAdd(simpleName, dllPath);
+				}
+			}
+		}
 	}
 
 	protected override Assembly? Load(AssemblyName assemblyName)
@@ -180,10 +221,11 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 			}
 		}
 
-		// 4. File-system probe across every registered add-in directory.
-		//    AssemblyDependencyResolver only consults .deps.json
-		//    (https://learn.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblydependencyresolver).
-		//    When a contract assembly is physically present in an add-in's directory
+		// 4. File-system probe across the snapshot of DLLs co-located with the
+		//    registered add-ins. AssemblyDependencyResolver only consults
+		//    .deps.json
+		//    (https://learn.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblydependencyresolver):
+		//    when a contract assembly is physically present in an add-in's directory
 		//    but absent from every add-in's deps.json (a transitive contract that
 		//    isn't surfaced as a runtime asset by the consuming packages), the first
 		//    three steps all return null and the runtime would throw
@@ -192,20 +234,73 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 		//    introduced. Loading the assembly here keeps it inside this shared
 		//    AddInLoadContext, so every add-in gets the same Type identity and DI
 		//    resolution works across the add-in boundary.
-		if (name is not null)
+		if (name is null || !IsValidSimpleName(name))
 		{
-			foreach (var directory in _addInDirectories)
+			return null;
+		}
+
+		if (!_probeMap.TryGetValue(name, out var candidatePath))
+		{
+			return null;
+		}
+
+		// Symmetric downgrade guard with steps 1 and 2: refuse a candidate whose
+		// version is strictly lower than what the add-in requested. Reading the
+		// metadata is cheap relative to LoadFromAssemblyPath and avoids returning
+		// a silently-older copy that would later throw MissingMethodException at
+		// the first cross-assembly call.
+		var probeRequestedVersion = assemblyName.Version;
+		if (probeRequestedVersion is not null)
+		{
+			Version? candidateVersion;
+			try
 			{
-				var candidate = Path.Combine(directory, name + ".dll");
-				if (File.Exists(candidate))
-				{
-					return LoadFromAssemblyPath(candidate);
-				}
+				candidateVersion = AssemblyName.GetAssemblyName(candidatePath).Version;
+			}
+			catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException or IOException)
+			{
+				// Candidate vanished or is unreadable since the snapshot was taken;
+				// fall through to a clean null so the runtime surfaces FNFE.
+				Console.Error.WriteLine(
+					$"Uno.UI.RemoteControl.Host: file-system probe could not read metadata for '{candidatePath}' " +
+					$"({ex.GetType().Name}: {ex.Message}).");
+				return null;
+			}
+
+			if (candidateVersion is not null && candidateVersion < probeRequestedVersion)
+			{
+				return null;
 			}
 		}
 
-		return null;
+		try
+		{
+			var loaded = LoadFromAssemblyPath(candidatePath);
+			Console.Error.WriteLine(
+				$"Uno.UI.RemoteControl.Host: file-system probe loaded '{name}' from '{candidatePath}'.");
+			return loaded;
+		}
+		catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
+		{
+			// A malformed or partial DLL on disk must not abort the resolution
+			// chain — returning null lets the runtime surface a clean
+			// FileNotFoundException at the original AssemblyRef site.
+			Console.Error.WriteLine(
+				$"Uno.UI.RemoteControl.Host: file-system probe failed to load '{candidatePath}' " +
+				$"({ex.GetType().Name}: {ex.Message}).");
+			return null;
+		}
 	}
+
+	/// <summary>
+	/// Conservative filter to keep step 4 from probing names that would escape
+	/// the registered add-in directories. Add-in metadata-driven AssemblyRefs
+	/// never contain path separators, so any such name can be rejected.
+	/// </summary>
+	private static bool IsValidSimpleName(string name)
+		=> name.IndexOfAny(s_pathSeparators) < 0;
+
+	private static readonly char[] s_pathSeparators = ['/', '\\'];
 
 	protected override nint LoadUnmanagedDll(string unmanagedDllName)
 	{

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AddInLoadContext.cs
@@ -179,18 +179,38 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 				{
 					// We request by simple name + culture only so the host's TPA
 					// can pick whichever copy it shipped, regardless of the add-in's
-					// compiled-against version. The only post-hoc check is the
-					// version-downgrade guard below.
+					// compiled-against version. PKT and version are validated
+					// explicitly below before the assembly is handed back.
 					Assembly? loaded = Default.LoadFromAssemblyName(new AssemblyName(name) { CultureInfo = assemblyName.CultureInfo });
+
+					var loadedName = loaded.GetName();
+
+					// Asymmetric PKT match — mirrors TryBridgeBySimpleName. When the
+					// add-in's AssemblyRef specifies a PublicKeyToken (typical for
+					// signed framework assemblies such as System.Text.Json), refuse a
+					// TPA candidate whose PKT differs or is absent. Unsigned requests
+					// skip the check so cross-add-in contract loading still works.
+					var requestedPkt = assemblyName.GetPublicKeyToken();
+					if (requestedPkt is { Length: > 0 })
+					{
+						var loadedPkt = loadedName.GetPublicKeyToken();
+						if (loadedPkt is null || !loadedPkt.AsSpan().SequenceEqual(requestedPkt))
+						{
+							loaded = null;
+						}
+					}
 
 					// Version guard: mirrors TryBridgeBySimpleName — refuse to serve a
 					// version lower than what the add-in requested.
-					var requestedVersion = assemblyName.Version;
-					var loadedVersion = loaded.GetName().Version;
-					if (requestedVersion is not null && loadedVersion is not null
-						&& loadedVersion < requestedVersion)
+					if (loaded is not null)
 					{
-						loaded = null;
+						var requestedVersion = assemblyName.Version;
+						var loadedVersion = loadedName.Version;
+						if (requestedVersion is not null && loadedVersion is not null
+							&& loadedVersion < requestedVersion)
+						{
+							loaded = null;
+						}
 					}
 
 					if (loaded is not null)
@@ -276,7 +296,11 @@ internal sealed class AddInLoadContext : AssemblyLoadContext
 		try
 		{
 			var loaded = LoadFromAssemblyPath(candidatePath);
-			Console.Error.WriteLine(
+
+			// Successful probe is purely informational — keep it off stderr so
+			// IDE output panels (Visual Studio, Rider) do not flag it as an
+			// error during normal startup.
+			Console.Out.WriteLine(
 				$"Uno.UI.RemoteControl.Host: file-system probe loaded '{name}' from '{candidatePath}'.");
 			return loaded;
 		}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -80,6 +80,33 @@ public class AssemblyHelper
 				// assemblies while letting Microsoft.*/System.* and shared contract types
 				// resolve against the host's already-loaded versions. Add-ins still see
 				// each other's types (matching the prior Assembly.LoadFrom behaviour).
+
+				// Pre-load shared Uno Platform contract assemblies from each add-in
+				// directory into Default ALC so that TryBridgeBySimpleName (step 1 of
+				// AddInLoadContext.Load) can serve them to all add-ins with a single
+				// Type identity. Without this, assemblies such as Uno.Licensing.Sdk.Contracts
+				// that are not in the host's own TPA, and not always reachable via every
+				// add-in's AssemblyDependencyResolver (e.g. when a consuming add-in was
+				// published without EnableDynamicLoading or without a transitive deps.json
+				// entry), throw FileNotFoundException when .NET inspects the add-in
+				// processor's constructor signature through reflection.
+				foreach (var dll in distinctDlls)
+				{
+					var addInDir = System.IO.Path.GetDirectoryName(dll);
+					if (!string.IsNullOrEmpty(addInDir))
+					{
+						try
+						{
+							HostAssemblyResolution.EagerLoadFromDirectory(addInDir, HostAssemblyResolution.AddInSharedAssemblyPatterns);
+						}
+						catch (Exception ex)
+						{
+							_log.LogDebug("Eager-load of shared add-in assemblies from '{Dir}' failed ({Type}: {Message}).",
+								addInDir, ex.GetType().Name, ex.Message);
+						}
+					}
+				}
+
 				var loadContext = new AddInLoadContext(distinctDlls);
 
 				foreach (var dll in distinctDlls)

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -80,33 +80,13 @@ public class AssemblyHelper
 				// assemblies while letting Microsoft.*/System.* and shared contract types
 				// resolve against the host's already-loaded versions. Add-ins still see
 				// each other's types (matching the prior Assembly.LoadFrom behaviour).
-
-				// Pre-load shared Uno Platform contract assemblies from each add-in
-				// directory into Default ALC so that TryBridgeBySimpleName (step 1 of
-				// AddInLoadContext.Load) can serve them to all add-ins with a single
-				// Type identity. Without this, assemblies such as Uno.Licensing.Sdk.Contracts
-				// that are not in the host's own TPA, and not always reachable via every
-				// add-in's AssemblyDependencyResolver (e.g. when a consuming add-in was
-				// published without EnableDynamicLoading or without a transitive deps.json
-				// entry), throw FileNotFoundException when .NET inspects the add-in
-				// processor's constructor signature through reflection.
-				foreach (var dll in distinctDlls)
-				{
-					var addInDir = System.IO.Path.GetDirectoryName(dll);
-					if (!string.IsNullOrEmpty(addInDir))
-					{
-						try
-						{
-							HostAssemblyResolution.EagerLoadFromDirectory(addInDir, HostAssemblyResolution.AddInSharedAssemblyPatterns);
-						}
-						catch (Exception ex)
-						{
-							_log.LogDebug("Eager-load of shared add-in assemblies from '{Dir}' failed ({Type}: {Message}).",
-								addInDir, ex.GetType().Name, ex.Message);
-						}
-					}
-				}
-
+				//
+				// Cross-add-in shared contracts (e.g. Uno.Licensing.Sdk.Contracts) that
+				// happen to be physically present in only one add-in's directory — and
+				// missing from the other add-ins' deps.json — are handled inside
+				// AddInLoadContext.Load via the file-system probe step (step 4). The
+				// host therefore needs no knowledge of which contract assemblies to
+				// share across add-ins.
 				var loadContext = new AddInLoadContext(distinctDlls);
 
 				foreach (var dll in distinctDlls)

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -186,17 +186,14 @@ internal static class HostAssemblyResolution
 	/// already-loaded assembly from <paramref name="context"/> whose simple
 	/// name matches. Dynamic (reflection-emit) assemblies are skipped so
 	/// runtime-generated names that coincidentally collide with a real
-	/// <c>AssemblyRef</c> do not silently substitute the wrong type; and a
+	/// <c>AssemblyRef</c> do not silently substitute the wrong type; a
 	/// loaded assembly whose <see cref="System.Version"/> is strictly lower
-	/// than the requested version is rejected to prevent silent downgrades.
+	/// than the requested version is rejected to prevent silent downgrades;
+	/// and when the request carries a <see cref="AssemblyName.GetPublicKeyToken"/>
+	/// the loaded assembly's token must match — an identity check, not an
+	/// allow-list. Unsigned requests skip the PKT check (covers the
+	/// cross-add-in contract scenario where neither side is strong-named).
 	/// </summary>
-	/// <remarks>
-	/// No public-key-token comparison is performed: the host's add-in
-	/// scenario is unsigned-only on both sides (neither add-in DLLs nor
-	/// the contract assemblies they ship carry a strong name), so a PKT
-	/// check would never trigger in practice. Adding one back means
-	/// re-introducing a guard for a scenario the host never sees.
-	/// </remarks>
 	/// <returns>
 	/// The matching <see cref="Assembly"/> instance, or <c>null</c> when no
 	/// compatible candidate exists in <paramref name="context"/>.
@@ -210,6 +207,8 @@ internal static class HostAssemblyResolution
 		{
 			return null;
 		}
+
+		var requestedPkt = requested.GetPublicKeyToken();
 
 		foreach (var loaded in context.Assemblies)
 		{
@@ -226,6 +225,24 @@ internal static class HostAssemblyResolution
 			if (!string.Equals(loadedName.Name, simpleName, StringComparison.OrdinalIgnoreCase))
 			{
 				continue;
+			}
+
+			// Asymmetric PKT match: when the request specifies an identity (a
+			// non-empty PublicKeyToken — Kiota's net8 AssemblyRef to
+			// System.Text.Encodings.Web, etc.), refuse a loaded candidate whose
+			// token differs or is absent. When the request is unsigned (no PKT
+			// — Uno.Licensing.Sdk.Contracts and other cross-add-in unsigned
+			// contracts), skip the PKT check entirely. This is identity
+			// validation, not an allow-list: signed callers get the assembly
+			// they asked for, unsigned callers get whatever simple-name match
+			// is loaded.
+			if (requestedPkt is { Length: > 0 })
+			{
+				var loadedPkt = loadedName.GetPublicKeyToken();
+				if (loadedPkt is null || !loadedPkt.AsSpan().SequenceEqual(requestedPkt))
+				{
+					continue;
+				}
 			}
 
 			// Version guard: refuse to bridge when the loaded version is strictly

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -57,7 +57,7 @@ internal static class HostAssemblyResolution
 		// Operator-facing kill switch: disables both the Resolving handler and
 		// the eager-load pass. Useful to bisect production issues that may have
 		// been introduced by the add-in isolation work.
-		if (Environment.GetEnvironmentVariable("UNO_DEVSERVER_DISABLE_ADDIN_ALC") == "1")
+		if (IsKillSwitchActive)
 		{
 			return;
 		}
@@ -97,34 +97,22 @@ internal static class HostAssemblyResolution
 	}
 
 	/// <summary>
-	/// Default file-name globs used by <see cref="EagerLoadFromDirectory"/> when
-	/// no explicit <c>patterns</c> are supplied: the OOB shared-framework assemblies
-	/// most prone to cross-major-version AssemblyRef mismatches.
+	/// File-name globs used by <see cref="EagerLoadFromDirectory"/> to pre-load
+	/// the OOB shared-framework assemblies most prone to cross-major-version
+	/// <c>AssemblyRef</c> mismatches. Pre-loading them into
+	/// <see cref="AssemblyLoadContext.Default"/> lets
+	/// <see cref="TryBridgeBySimpleName"/> serve them to any <see cref="AddInLoadContext"/>
+	/// that asks for a different major version of the same simple name.
 	/// </summary>
-	internal static readonly string[] DefaultEagerLoadPatterns =
+	internal static readonly System.Collections.Immutable.ImmutableArray<string> DefaultEagerLoadPatterns =
 	[
 		"System.*.dll",
 		"Microsoft.Extensions.*.dll",
 	];
 
 	/// <summary>
-	/// File-name globs used when pre-loading shared Uno Platform contract
-	/// assemblies from add-in directories so that all add-ins share a single
-	/// <see cref="System.Type"/> identity for licensing and other cross-add-in
-	/// types (fixes <see cref="System.IO.FileNotFoundException"/> for
-	/// <c>Uno.Licensing.Sdk.Contracts</c> when a consuming add-in cannot resolve
-	/// it through its own <c>AssemblyDependencyResolver</c>).
-	/// </summary>
-	internal static readonly string[] AddInSharedAssemblyPatterns =
-	[
-		"Uno.Licensing.*.dll",
-	];
-
-	/// <summary>
-	/// Eager-loads DLLs matching <paramref name="patterns"/> from
+	/// Eager-loads DLLs matching <see cref="DefaultEagerLoadPatterns"/> from
 	/// <paramref name="dir"/> into <see cref="AssemblyLoadContext.Default"/>.
-	/// When <paramref name="patterns"/> is <see langword="null"/> or empty the
-	/// <see cref="DefaultEagerLoadPatterns"/> are used.
 	/// </summary>
 	/// <remarks>
 	/// Idempotent: assemblies already present in <see cref="AssemblyLoadContext.Default"/>
@@ -135,14 +123,12 @@ internal static class HostAssemblyResolution
 	/// across the host/add-in boundary.
 	/// </remarks>
 	/// <returns>The number of assemblies successfully eager-loaded by this call.</returns>
-	internal static int EagerLoadFromDirectory(string dir, string[]? patterns = null)
+	internal static int EagerLoadFromDirectory(string dir)
 	{
 		if (string.IsNullOrEmpty(dir) || !System.IO.Directory.Exists(dir))
 		{
 			return 0;
 		}
-
-		var effectivePatterns = patterns is { Length: > 0 } ? patterns : DefaultEagerLoadPatterns;
 
 		// Build a set of simple names already loaded so we can skip duplicates.
 		var alreadyLoaded = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -154,8 +140,8 @@ internal static class HostAssemblyResolution
 			}
 		}
 
-		// Discover DLLs matching the requested glob patterns.
-		var candidates = effectivePatterns
+		// Discover DLLs matching the default glob patterns.
+		var candidates = DefaultEagerLoadPatterns
 			.SelectMany(p => System.IO.Directory.EnumerateFiles(dir, p));
 
 		var loaded = 0;
@@ -198,10 +184,19 @@ internal static class HostAssemblyResolution
 	/// <summary>
 	/// Attempts to satisfy <paramref name="requested"/> by returning an
 	/// already-loaded assembly from <paramref name="context"/> whose simple
-	/// name matches. Dynamic (reflection-emit) assemblies and assemblies with
-	/// an incompatible <see cref="AssemblyName.GetPublicKeyToken"/> are
-	/// skipped, preventing silent identity swaps.
+	/// name matches. Dynamic (reflection-emit) assemblies are skipped so
+	/// runtime-generated names that coincidentally collide with a real
+	/// <c>AssemblyRef</c> do not silently substitute the wrong type; and a
+	/// loaded assembly whose <see cref="System.Version"/> is strictly lower
+	/// than the requested version is rejected to prevent silent downgrades.
 	/// </summary>
+	/// <remarks>
+	/// No public-key-token comparison is performed: the host's add-in
+	/// scenario is unsigned-only on both sides (neither add-in DLLs nor
+	/// the contract assemblies they ship carry a strong name), so a PKT
+	/// check would never trigger in practice. Adding one back means
+	/// re-introducing a guard for a scenario the host never sees.
+	/// </remarks>
 	/// <returns>
 	/// The matching <see cref="Assembly"/> instance, or <c>null</c> when no
 	/// compatible candidate exists in <paramref name="context"/>.
@@ -215,8 +210,6 @@ internal static class HostAssemblyResolution
 		{
 			return null;
 		}
-
-		var requestedToken = requested.GetPublicKeyToken();
 
 		foreach (var loaded in context.Assemblies)
 		{
@@ -233,31 +226,6 @@ internal static class HostAssemblyResolution
 			if (!string.Equals(loadedName.Name, simpleName, StringComparison.OrdinalIgnoreCase))
 			{
 				continue;
-			}
-
-			// Enforce symmetric PKT policy:
-			//   - Unsigned request → only bridge to an unsigned loaded assembly.
-			//     Returning a strong-named assembly for an unsigned reference
-			//     could silently substitute a different assembly whose name
-			//     coincidentally matches.
-			//   - Signed request → loaded assembly must carry the same PKT.
-			//     Returning a differently-signed assembly would be a
-			//     security-relevant identity swap.
-			var loadedToken = loadedName.GetPublicKeyToken();
-			if (requestedToken is { Length: > 0 })
-			{
-				if (loadedToken is null || !loadedToken.AsSpan().SequenceEqual(requestedToken))
-				{
-					continue;
-				}
-			}
-			else
-			{
-				// Request is unsigned: skip any strong-named loaded assembly.
-				if (loadedToken is { Length: > 0 })
-				{
-					continue;
-				}
 			}
 
 			// Version guard: refuse to bridge when the loaded version is strictly

--- a/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/HostAssemblyResolution.cs
@@ -31,19 +31,6 @@ internal static class HostAssemblyResolution
 	/// </summary>
 	private static int s_handlerInstalled;
 
-	/// <summary>
-	/// Trusted public key tokens accepted by <see cref="EagerLoadFromDirectory"/>.
-	/// Eager-loading an assembly whose PKT does not match one of these emits a
-	/// stderr warning (the assembly is still loaded — there is no .NET API to
-	/// unload it — but the <see cref="TryBridgeBySimpleName"/> guards prevent
-	/// returning a non-Microsoft assembly for a signed Microsoft request).
-	/// </summary>
-	private static readonly byte[][] s_trustedPkts =
-	[
-		[0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a], // Microsoft (b03f5f7f11d50a3a)
-		[0xcc, 0x7b, 0x13, 0xff, 0xcd, 0x2d, 0xdd, 0x51], // corefx / dotnet (cc7b13ffcd2ddd51)
-		[0xad, 0xb9, 0x79, 0x38, 0x29, 0xdd, 0xae, 0x60], // Microsoft.Extensions.* NuGet (adb9793829ddae60)
-	];
 
 	/// <summary>
 	/// Installs the cross-major-version assembly-resolution safety net on
@@ -110,26 +97,52 @@ internal static class HostAssemblyResolution
 	}
 
 	/// <summary>
-	/// Eager-loads <c>System.*.dll</c> and <c>Microsoft.Extensions.*.dll</c>
-	/// from <paramref name="hostDir"/> into <see cref="AssemblyLoadContext.Default"/>.
+	/// Default file-name globs used by <see cref="EagerLoadFromDirectory"/> when
+	/// no explicit <c>patterns</c> are supplied: the OOB shared-framework assemblies
+	/// most prone to cross-major-version AssemblyRef mismatches.
+	/// </summary>
+	internal static readonly string[] DefaultEagerLoadPatterns =
+	[
+		"System.*.dll",
+		"Microsoft.Extensions.*.dll",
+	];
+
+	/// <summary>
+	/// File-name globs used when pre-loading shared Uno Platform contract
+	/// assemblies from add-in directories so that all add-ins share a single
+	/// <see cref="System.Type"/> identity for licensing and other cross-add-in
+	/// types (fixes <see cref="System.IO.FileNotFoundException"/> for
+	/// <c>Uno.Licensing.Sdk.Contracts</c> when a consuming add-in cannot resolve
+	/// it through its own <c>AssemblyDependencyResolver</c>).
+	/// </summary>
+	internal static readonly string[] AddInSharedAssemblyPatterns =
+	[
+		"Uno.Licensing.*.dll",
+	];
+
+	/// <summary>
+	/// Eager-loads DLLs matching <paramref name="patterns"/> from
+	/// <paramref name="dir"/> into <see cref="AssemblyLoadContext.Default"/>.
+	/// When <paramref name="patterns"/> is <see langword="null"/> or empty the
+	/// <see cref="DefaultEagerLoadPatterns"/> are used.
 	/// </summary>
 	/// <remarks>
 	/// Idempotent: assemblies already present in <see cref="AssemblyLoadContext.Default"/>
-	/// (by simple name) are skipped, and individual load failures are
-	/// swallowed with a stderr breadcrumb. After a successful load the assembly's
-	/// public key token is validated against <see cref="s_trustedPkts"/>; a
-	/// mismatch only emits a warning because .NET provides no API to unload
-	/// from <see cref="AssemblyLoadContext.Default"/>. The <see cref="TryBridgeBySimpleName"/>
-	/// PKT guard prevents such an assembly from being substituted for a signed
-	/// Microsoft request later.
+	/// (by simple name) are skipped, and individual load failures are swallowed
+	/// with a stderr breadcrumb. Once loaded, <see cref="TryBridgeBySimpleName"/>
+	/// can return these assemblies to any <c>AddInLoadContext</c> that requests
+	/// them by name, preserving a single <see cref="System.Type"/> identity
+	/// across the host/add-in boundary.
 	/// </remarks>
 	/// <returns>The number of assemblies successfully eager-loaded by this call.</returns>
-	internal static int EagerLoadFromDirectory(string hostDir)
+	internal static int EagerLoadFromDirectory(string dir, string[]? patterns = null)
 	{
-		if (string.IsNullOrEmpty(hostDir) || !System.IO.Directory.Exists(hostDir))
+		if (string.IsNullOrEmpty(dir) || !System.IO.Directory.Exists(dir))
 		{
 			return 0;
 		}
+
+		var effectivePatterns = patterns is { Length: > 0 } ? patterns : DefaultEagerLoadPatterns;
 
 		// Build a set of simple names already loaded so we can skip duplicates.
 		var alreadyLoaded = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -141,10 +154,9 @@ internal static class HostAssemblyResolution
 			}
 		}
 
-		// Discover System.* and Microsoft.Extensions.* DLLs in the host directory.
-		var candidates =
-			System.IO.Directory.EnumerateFiles(hostDir, "System.*.dll")
-			.Concat(System.IO.Directory.EnumerateFiles(hostDir, "Microsoft.Extensions.*.dll"));
+		// Discover DLLs matching the requested glob patterns.
+		var candidates = effectivePatterns
+			.SelectMany(p => System.IO.Directory.EnumerateFiles(dir, p));
 
 		var loaded = 0;
 		var failed = 0;
@@ -159,23 +171,7 @@ internal static class HostAssemblyResolution
 
 			try
 			{
-				var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
-
-				// DLL-planting defence: if a file matching our System.* /
-				// Microsoft.Extensions.* glob is signed with a non-trusted PKT
-				// (or unsigned), warn loudly. We cannot unload it, but
-				// TryBridgeBySimpleName's PKT symmetry guard means a signed
-				// Microsoft request will still refuse to bridge to this
-				// assembly.
-				var pkt = asm.GetName().GetPublicKeyToken();
-				if (!IsTrustedPkt(pkt))
-				{
-					Console.Error.WriteLine(
-						$"Uno.UI.RemoteControl.Host: eager-loaded '{simpleName}' from '{path}' has an " +
-						$"untrusted public key token. Cross-boundary type identity for this assembly " +
-						"will be refused by the bridge.");
-				}
-
+				AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
 				loaded++;
 			}
 			catch (Exception ex)
@@ -192,17 +188,12 @@ internal static class HostAssemblyResolution
 		if (loaded + failed > 0)
 		{
 			Console.Error.WriteLine(
-				$"Uno.UI.RemoteControl.Host: eager-loaded {loaded} assemblies from '{hostDir}' " +
+				$"Uno.UI.RemoteControl.Host: eager-loaded {loaded} assemblies from '{dir}' " +
 				$"({failed} failures).");
 		}
 
 		return loaded;
 	}
-
-	private static bool IsTrustedPkt(byte[]? pkt) =>
-		pkt is { Length: > 0 } &&
-		s_trustedPkts.Any(t => t.AsSpan().SequenceEqual(pkt));
-
 
 	/// <summary>
 	/// Attempts to satisfy <paramref name="requested"/> by returning an


### PR DESCRIPTION
## Summary

https://github.com/unoplatform/uno/pull/23287 moved DevServer add-in loading from `Assembly.LoadFrom` (everything in `Default` ALC) into a shared isolated `AddInLoadContext`. That fixed three cross-major-version `FileNotFoundException`s (`Kiota`, `Mcp`, `ModelContextProtocol`) and must stay in place.

Side effect: contract assemblies physically present in **one** add-in's directory but absent from **every** add-in's `.deps.json` could no longer be resolved across the ALC boundary. `Uno.Licensing.Sdk.Contracts` falls into this bucket — the Settings add-in provides it, but the Mcp and HotDesign add-ins consume it via DI without listing it in their own `.deps.json`. At runtime this produces:

```
fail: Uno.UI.RemoteControl.Host.RemoteControlServer
  Failed to create server processor Uno.UI.App.Mcp.Server.McpServerProcessor ...
  System.IO.FileNotFoundException: Could not load file or assembly
  'Uno.Licensing.Sdk.Contracts, Version=1.0.0.0, ...'
```
```
fail: Uno.UI.RemoteControl.Host.RemoteControlServer
  Failed to create server processor Uno.UI.HotDesign.HotDesignSourceProcessor ...
  System.InvalidOperationException: Unable to resolve service for type
  'Uno.Licensing.Sdk.ILicensingService'
```

The "Initializing Uno Platform Studio, please wait…" overlay never resolves because these two processors never register.

Fixes https://github.com/unoplatform/uno/issues/23304.

## Fix — zero knowledge of which add-ins are loaded

The DevServer host has **no static list** of which contract assemblies need to be shared (no white-list, no per-product glob). The published add-ins are not modified — they continue to ship as-is.

### Root cause

The resolution chain inside `AddInLoadContext.Load(AssemblyName)` has three steps:

1. `TryBridgeBySimpleName(Default, …)` — already-loaded in Default ALC ?
2. `Default.LoadFromAssemblyName(…)` — listed in the host TPA ?
3. Each add-in's `AssemblyDependencyResolver.ResolveAssemblyToPath(…)` — listed in any `.deps.json` ?

[`AssemblyDependencyResolver` only consults `.deps.json`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.loader.assemblydependencyresolver). It does **not** probe the file system. When a contract DLL is physically present in an add-in directory but absent from every add-in's `.deps.json`, all three steps return null and the runtime throws `FileNotFoundException`. Before PR #23287, `Assembly.LoadFrom`'s implicit directory probing masked this packaging quirk.

### Step 4 — file-system probe

`AddInLoadContext.Load` gains a fourth, last-resort step: a `Dictionary<string,string>` snapshot built at construction time enumerates every `*.dll` co-located with the registered add-ins, keyed by simple name. Step 4 looks up the snapshot and `LoadFromAssemblyPath`'s the matching candidate into the shared add-in ALC. Every add-in then sees the same `Type` identity and DI resolves cleanly.

Properties:

- **Deterministic ordering**: the snapshot is built in caller-supplied registration order, first-add-in-wins. Independent of host file-system enumeration order.
- **Version-downgrade guard**: a candidate with a strictly-lower version than the request is refused, mirroring steps 1 and 2.
- **Per-candidate failure isolation**: `LoadFromAssemblyPath` failures (`BadImageFormatException`, etc.) are caught and treated as misses so the chain stays consistent.
- **Path-traversal guard**: `AssemblyName.Name` values containing path separators are rejected before any probe.
- **Cross-major scenarios untouched**: step 1 still bridges Kiota's net8 `System.Text.Encodings.Web 8.0.0.0` ref to the host's loaded v9/v10.

### Asymmetric PKT match

`TryBridgeBySimpleName` and `AddInLoadContext.Load` step 2 enforce a PKT match **only when the request carries a non-empty PublicKeyToken**. Signed framework `AssemblyRef`s (e.g. `System.Text.Json`, `System.Text.Encodings.Web` from compiled add-ins) require matching PKT — preventing identity swaps even if a same-name candidate sits in Default ALC. Unsigned requests (cross-add-in unsigned contracts) skip the check. This is identity validation, not an allow-list.

### Other cleanup

- Removed the unused `s_trustedPkts` / `IsTrustedPkt()` and the misleading `[ERROR] untrusted public key token` warning that the VS "Uno Platform" output panel flagged on every host startup.
- Step 4 successful probe-load messages go to `Console.Out` (informational); only genuine failures stay on `Console.Error`.
- `DevServer_ShouldResolveSharedContractAcrossAddIns…` fixes the `--addins` arg format (semicolon-separated, not space-separated — the previous form silently dropped the consumer add-in).
