### PR TITLE
fix: Correct inverted Shift+wheel scrolling

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -1554,6 +1554,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22007")]
 		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaX11)] // Flaky on Skia X11 #9080
 #if __WASM__
 		[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
@@ -1563,7 +1564,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		public async Task When_Shift_MouseWheel_Then_ScrollHorizontally()
 		{
 #if WINAPPSDK
-			Assert.Inconclusive("Mouse pointer helper not supported on UWP.");
+			Assert.Inconclusive("Mouse pointer helper not supported on WinAppSDK.");
 #else
 			// Shift + vertical mouse wheel must scroll horizontally: wheel-down scrolls right,
 			// wheel-up scrolls left (matching WinUI / standard desktop behavior). See #22007.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -1553,6 +1553,62 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaX11)] // Flaky on Skia X11 #9080
+#if __WASM__
+		[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
+#elif !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_Shift_MouseWheel_Then_ScrollHorizontally()
+		{
+#if WINAPPSDK
+			Assert.Inconclusive("Mouse pointer helper not supported on UWP.");
+#else
+			// Shift + vertical mouse wheel must scroll horizontally: wheel-down scrolls right,
+			// wheel-up scrolls left (matching WinUI / standard desktop behavior). See #22007.
+			var sut = new ScrollViewer
+			{
+				Height = 256,
+				Width = 256,
+				HorizontalScrollBarVisibility = ScrollBarVisibility.Visible,
+				HorizontalScrollMode = ScrollMode.Enabled,
+				VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
+				Content = new Border
+				{
+					Height = 256,
+					Width = 4192,
+					Background = new SolidColorBrush(Colors.DeepPink)
+				}
+			};
+
+			var sutBounds = await UITestHelper.Load(sut);
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var mouse = input.GetMouse();
+
+			sut.HorizontalOffset.Should().Be(0);
+
+			mouse.MoveTo(sutBounds.GetCenter());
+
+			// Wheel down + Shift => scroll right (increasing horizontal offset).
+			mouse.Wheel(-120, Windows.System.VirtualKeyModifiers.Shift);
+
+			await UITestHelper.WaitForIdle(waitForCompositionAnimations: true);
+
+			sut.HorizontalOffset.Should().BeGreaterThan(0);
+			var afterWheelDown = sut.HorizontalOffset;
+
+			// Wheel up + Shift => scroll left (decreasing horizontal offset).
+			mouse.Wheel(120, Windows.System.VirtualKeyModifiers.Shift);
+
+			await UITestHelper.WaitForIdle(waitForCompositionAnimations: true);
+
+			sut.HorizontalOffset.Should().BeLessThan(afterWheelDown);
+#endif
+		}
+
+		[TestMethod]
 #if !UNO_HAS_MANAGED_SCROLL_PRESENTER
 		[Ignore("We're only testing managed scrollers.")]
 #endif

--- a/src/Uno.UI.Toolkit/DevTools/Input/Mouse.cs
+++ b/src/Uno.UI.Toolkit/DevTools/Input/Mouse.cs
@@ -180,6 +180,11 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 	public void Wheel(double delta, bool isHorizontal = false, uint steps = 1)
 		=> Inject(GetWheel(delta, isHorizontal, steps));
 
+#if HAS_UNO
+	internal void Wheel(double delta, VirtualKeyModifiers modifiers, bool isHorizontal = false, uint steps = 1)
+		=> Inject(GetWheel(delta, isHorizontal, steps).Select(info => (info, modifiers)));
+#endif
+
 	public void RightTap(Point location)
 	{
 		PressRight();

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -294,9 +294,15 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 				else if (canScrollHorizontally && (properties.IsHorizontalMouseWheel || e.KeyModifiers == VirtualKeyModifiers.Shift))
 				{
+					// A genuine horizontal wheel (IsHorizontalMouseWheel) already carries the correct horizontal
+					// sign (positive = right), matching WinUI's MouseWheelRight/MouseWheelLeft handling. A vertical
+					// wheel repurposed as horizontal via Shift uses the vertical convention (positive = wheel up),
+					// which must be negated so wheel-down scrolls right and wheel-up scrolls left -- the same inversion
+					// the vertical branch below applies. Without this negation, Shift + wheel scrolling is inverted (#22007).
+					var horizontalDelta = properties.IsHorizontalMouseWheel ? delta : -delta;
 #if __WASM__
 					success = Set(
-						horizontalOffset: TargetHorizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, delta),
+						horizontalOffset: TargetHorizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, horizontalDelta),
 						disableAnimation: false);
 #else
 					// Trackpad/touchpad-style scroll events can arrive at display-refresh rate (~60/s) with precise
@@ -316,9 +322,9 @@ namespace Microsoft.UI.Xaml.Controls
 						// (inline pickers) nearly unresponsive. Use delta directly as pixel offset
 						// for 1:1 trackpad-to-scroll mapping. Discrete mouse wheel (|delta| >= 120)
 						// still uses the standard formula for correct per-notch distance.
-						var hScrollAmount = Math.Abs(delta) < ScrollViewerDefaultMouseWheelDelta
-							? (double)delta
-							: GetHorizontalScrollWheelDelta(DesiredSize, delta);
+						var hScrollAmount = Math.Abs(horizontalDelta) < ScrollViewerDefaultMouseWheelDelta
+							? (double)horizontalDelta
+							: GetHorizontalScrollWheelDelta(DesiredSize, horizontalDelta);
 						success = Set(
 							horizontalOffset: HorizontalOffset + hScrollAmount,
 							options: new(DisableAnimation: true, IsIntermediate: false));
@@ -326,7 +332,7 @@ namespace Microsoft.UI.Xaml.Controls
 					else
 					{
 						success = Set(
-							horizontalOffset: TargetHorizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, delta),
+							horizontalOffset: TargetHorizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, horizontalDelta),
 							disableAnimation: false);
 					}
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -294,11 +294,8 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 				else if (canScrollHorizontally && (properties.IsHorizontalMouseWheel || e.KeyModifiers == VirtualKeyModifiers.Shift))
 				{
-					// A genuine horizontal wheel (IsHorizontalMouseWheel) already carries the correct horizontal
-					// sign (positive = right), matching WinUI's MouseWheelRight/MouseWheelLeft handling. A vertical
-					// wheel repurposed as horizontal via Shift uses the vertical convention (positive = wheel up),
-					// which must be negated so wheel-down scrolls right and wheel-up scrolls left -- the same inversion
-					// the vertical branch below applies. Without this negation, Shift + wheel scrolling is inverted (#22007).
+					// IsHorizontalMouseWheel already carries the correct sign (positive = right). A Shift-redirected
+					// vertical wheel uses the vertical convention (positive = up), so negate to get positive = right.
 					var horizontalDelta = properties.IsHorizontalMouseWheel ? delta : -delta;
 #if __WASM__
 					success = Set(


### PR DESCRIPTION
**GitHub Issue:** closes #22007

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia, holding **Shift** while scrolling the mouse wheel scrolled in the **wrong horizontal direction**: wheel-down scrolled left instead of right (and wheel-up scrolled right instead of left).

Shift + vertical mouse wheel is repurposed as horizontal scrolling. In `ScrollContentPresenter.PointerWheelScroll`, the horizontal-scroll branch used the raw vertical wheel delta without the sign inversion that the vertical branch applies. The vertical wheel convention is *positive = wheel up*, so reusing it as-is for horizontal offset produced the inverted direction.

The fix derives an effective horizontal delta:

```csharp
var horizontalDelta = properties.IsHorizontalMouseWheel ? delta : -delta;
```

- **Shift + vertical wheel** (`IsHorizontalMouseWheel == false`) now negates the delta, so wheel-down scrolls right and wheel-up scrolls left — the same inversion the vertical branch already applies. This matches WinUI (`ScrollViewer`/DirectManipulation) and standard desktop behavior.
- A **genuine horizontal wheel** (`IsHorizontalMouseWheel == true`, e.g. tilt wheel / touchpad) already carries the correct horizontal sign (positive = right, matching WinUI's `MouseWheelRight`/`MouseWheelLeft`) and is left unchanged — no regression.

The change is platform-uniform (applies to the WASM, iOS/macOS, and desktop paths). Verified against the Skia input sources: Win32, WPF and X11 all report Shift+wheel as `IsHorizontalMouseWheel == false` with the vertical delta convention; macOS swaps axes at the OS level (`true`) and is unaffected.

Added runtime test `Given_ScrollViewer.When_Shift_MouseWheel_Then_ScrollHorizontally` (fails before, passes after). A new internal `Mouse.Wheel(delta, modifiers, …)` injector overload was added so tests can inject modified wheel events.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)