### PR TITLE
fix: Keyboard shift-tab navigation handling regression

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserKeyboardInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserKeyboardInputSource.ts
@@ -2,11 +2,15 @@
 	export class BrowserKeyboardInputSource {
 		private static _exports: any;
 		private static _source: any;
-		// True once the user has Tab'd past the "Enable Accessibility" button into the XAML app.
-		// Without a11y enabled, document.activeElement stays on the button (no FocusSynchronizer),
-		// so we can't infer in-app focus from the DOM. This flag tracks it instead so subsequent
-		// Shift+Tab presses are routed to the managed FocusManager rather than exiting the app.
-		private static _hasTabbedIntoApp: boolean = false;
+		// True once focus has entered the XAML app — either by Tab'ing past the
+		// "Enable Accessibility" button, clicking anywhere in the app surface, or
+		// having focus land on a non-button DOM element (e.g. via a programmatic
+		// XAML focus call that synced to the DOM). Without a11y enabled,
+		// document.activeElement stays on the button (no FocusSynchronizer), so
+		// we can't infer in-app focus from the DOM alone. This flag tracks it so
+		// subsequent Shift+Tab presses on the button are routed to the managed
+		// FocusManager rather than exiting the app.
+		private static _hasUserEnteredApp: boolean = false;
 
 		public static initialize(inputSource: any): any {
 			if (BrowserKeyboardInputSource._exports == undefined) {
@@ -15,12 +19,30 @@
 			}
 
 			BrowserKeyboardInputSource._source = inputSource;
+			// Reset cross-session state so a re-initialization (hot-reload, new
+			// host instance on the same page) doesn't inherit a stale flag.
+			BrowserKeyboardInputSource._hasUserEnteredApp = false;
 			BrowserKeyboardInputSource.subscribeKeyboardEvents();
 		}
 
 		private static subscribeKeyboardEvents() {
 			document.addEventListener("keydown", BrowserKeyboardInputSource.onKeyboardEvent);
 			document.addEventListener("keyup", BrowserKeyboardInputSource.onKeyboardEvent);
+			// Treat any focus or pointer interaction targeting anything other
+			// than the "Enable Accessibility" button as "user has entered the app".
+			// This covers clicks on the canvas, focus moving to other focusable
+			// DOM elements (semantic tree, native overlays, programmatic focus
+			// that syncs to the DOM), in addition to Tab navigation handled below.
+			document.addEventListener("focusin", BrowserKeyboardInputSource.onActivityInApp);
+			document.addEventListener("pointerdown", BrowserKeyboardInputSource.onActivityInApp);
+		}
+
+		private static onActivityInApp(evt: Event): void {
+			const target = evt.target as HTMLElement | null;
+			if (!target || target.id === "uno-enable-accessibility") {
+				return;
+			}
+			BrowserKeyboardInputSource._hasUserEnteredApp = true;
 		}
 
 		private static onKeyboardEvent(evt: KeyboardEvent): void {
@@ -38,11 +60,12 @@
 						return;
 					}
 
-					// Button focused + Shift+Tab BEFORE user has entered the XAML app — let
-					// browser move focus back to the previous browser-level focusable (e.g.
-					// the address bar). Once focus has entered the app, Shift+Tab must reach
-					// the managed FocusManager so the user can navigate backward in XAML.
-					if (isOnButton && evt.shiftKey && !BrowserKeyboardInputSource._hasTabbedIntoApp) {
+					// Button focused + Shift+Tab BEFORE the user has entered the XAML
+					// app — let browser move focus back to the previous browser-level
+					// focusable (e.g. the address bar). Once focus has entered the app,
+					// Shift+Tab must reach the managed FocusManager so the user can
+					// navigate backward in XAML.
+					if (isOnButton && evt.shiftKey && !BrowserKeyboardInputSource._hasUserEnteredApp) {
 						return;
 					}
 
@@ -50,7 +73,7 @@
 					// This is the moment XAML takes focus from the button, so remember it
 					// to keep future Shift+Tab presses routed through managed.
 					if (isOnButton && !evt.shiftKey) {
-						BrowserKeyboardInputSource._hasTabbedIntoApp = true;
+						BrowserKeyboardInputSource._hasUserEnteredApp = true;
 					}
 				}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserKeyboardInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserKeyboardInputSource.ts
@@ -2,7 +2,12 @@
 	export class BrowserKeyboardInputSource {
 		private static _exports: any;
 		private static _source: any;
-		
+		// True once the user has Tab'd past the "Enable Accessibility" button into the XAML app.
+		// Without a11y enabled, document.activeElement stays on the button (no FocusSynchronizer),
+		// so we can't infer in-app focus from the DOM. This flag tracks it instead so subsequent
+		// Shift+Tab presses are routed to the managed FocusManager rather than exiting the app.
+		private static _hasTabbedIntoApp: boolean = false;
+
 		public static initialize(inputSource: any): any {
 			if (BrowserKeyboardInputSource._exports == undefined) {
 				const browserExports = WebAssemblyWindowWrapper.getAssemblyExports();
@@ -33,12 +38,20 @@
 						return;
 					}
 
-					// Button focused + Shift+Tab — let browser move focus back naturally
-					if (isOnButton && evt.shiftKey) {
+					// Button focused + Shift+Tab BEFORE user has entered the XAML app — let
+					// browser move focus back to the previous browser-level focusable (e.g.
+					// the address bar). Once focus has entered the app, Shift+Tab must reach
+					// the managed FocusManager so the user can navigate backward in XAML.
+					if (isOnButton && evt.shiftKey && !BrowserKeyboardInputSource._hasTabbedIntoApp) {
 						return;
 					}
 
-					// Button focused + Tab (no shift) — fall through to managed FocusManager
+					// Button focused + Tab (no shift) — fall through to managed FocusManager.
+					// This is the moment XAML takes focus from the button, so remember it
+					// to keep future Shift+Tab presses routed through managed.
+					if (isOnButton && !evt.shiftKey) {
+						BrowserKeyboardInputSource._hasTabbedIntoApp = true;
+					}
 				}
 
 				// Don't route keyup to managed code while on the button


### PR DESCRIPTION
**GitHub Issue:** closes #23700

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia for WebAssembly, once keyboard focus had entered the XAML app, pressing **Shift+Tab** while the prepended *Enable Accessibility* button was focused exited the app to the browser instead of navigating backward within XAML. Forward **Tab** worked, so the first focusable element became a backward dead-end.

`BrowserKeyboardInputSource` now tracks whether focus has entered the app (`_hasUserEnteredApp`), set by:
- Tab'ing past the accessibility button,
- any `pointerdown` (e.g. clicking a control — which also focuses it), and
- any `focusin` on a non-button element (covers programmatic/DOM focus).

Shift+Tab on the button is only left to the browser **before** focus has entered the app; afterward it routes to the managed `FocusManager`. The flag is reset in `initialize()` so a re-initialization (hot reload / new host on the same page) can't inherit stale state.

The routing decision was extracted into a pure `shouldLetBrowserHandleTabKeydown` predicate and covered by a deterministic `Given_BrowserKeyboardInputSource` SkiaWasm runtime test.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)