### PR TITLE
feat(ci): in-job retry for flaky runtime test shards

### DIFF
--- a/build/test-scripts/android-run-skia-runtime-tests.sh
+++ b/build/test-scripts/android-run-skia-runtime-tests.sh
@@ -129,6 +129,10 @@ FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
 # Maximum seconds between heartbeat emissions before the watchdog kills the app.
 HEARTBEAT_TIMEOUT_S=${HEARTBEAT_TIMEOUT_S:-300}
 
+# Set by run_android_tests when the heartbeat watchdog fires.
+HUNG_TEST_NAME=""
+HUNG_HB_AGE=0
+
 UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_BASE_PATH="/storage/emulated/0/Android/data/$UNO_UITEST_APP_ID/files"
 
 # Starts the app and waits for the result file to appear on device.
@@ -183,7 +187,20 @@ run_android_tests() {
 		local HB_AGE=$(( SECONDS - LAST_HB_S ))
 		if [ "$PREV_HB_COUNT" -gt 0 ] && [ $HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
 			echo "##[error]No heartbeat for ${HB_AGE}s — test appears hung."
+			# Print the last 3 heartbeats for context
 			$ANDROID_HOME/platform-tools/adb shell logcat -d | grep 'UNO-RT-HEARTBEAT' | tail -3
+
+			# Extract the name of the hung test from the last STARTING heartbeat without a matching COMPLETED
+			local last_starting
+			last_starting=$($ANDROID_HOME/platform-tools/adb shell logcat -d \
+				| grep 'UNO-RT-HEARTBEAT' | grep 'STARTING' | tail -1 \
+				| sed 's/.*STARTING //')
+			if [ -n "$last_starting" ]; then
+				HUNG_TEST_NAME="$last_starting"
+				HUNG_HB_AGE=$HB_AGE
+				echo "##[error]Hung test identified: $HUNG_TEST_NAME (no heartbeat for ${HB_AGE}s)"
+			fi
+
 			$ANDROID_HOME/platform-tools/adb shell am force-stop "$UNO_UITEST_APP_ID" || true
 			break
 		fi
@@ -209,6 +226,14 @@ run_android_tests "$UITEST_RUNTIME_TESTS_FILTER" "$UITEST_RUNTIME_AUTOSTART_RESU
 # create $BUILD_SOURCESDIRECTORY/build/uitests-failure-results before exiting, so that `PublishBuildArtifacts@1` doesn't error out just because the tests crashed.
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 
+# When the watchdog fires the result file is never written; synthesise a failure entry
+# so the rest of the pipeline has something to work with.
+if [ ! -f "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH" ] && [ -n "$HUNG_TEST_NAME" ]; then
+	HUNG_SIMPLE=$(echo "$HUNG_TEST_NAME" | sed 's/(.*//')
+	echo "##[warning]Creating synthetic result for hung test '$HUNG_SIMPLE' (${HUNG_HB_AGE}s without heartbeat)."
+	run_nunit_tool create-hung-result "$HUNG_SIMPLE" "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH" "$HUNG_HB_AGE"
+fi
+
 if [ ! -f "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH" ]; then
 	echo "ERROR: The test results file $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH does not exist (did nunit crash ?)"
 	exit 1
@@ -220,12 +245,29 @@ run_nunit_tool fail-empty $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH
 FAILED_COUNT=$(run_nunit_tool count-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH | tail -1)
 run_nunit_tool list-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH $UNO_TESTS_FAILED_LIST
 
+RERUN_RESULT_PATH="$BUILD_SOURCESDIRECTORY/build/TestResult-rerun.xml"
+
+if [ -n "$HUNG_TEST_NAME" ]; then
+	# Watchdog fired: rerun the full shard but skip the hung test so we get results for
+	# all the tests that never ran.  The hung test remains marked Failed in the merged output.
+	HUNG_SIMPLE=$(echo "$HUNG_TEST_NAME" | sed 's/(.*//')
+	echo "##[warning]Watchdog retry: rerunning shard excluding '$HUNG_SIMPLE'..."
+	RERUN_FILTER=$(printf '~%s' "$HUNG_SIMPLE" | base64 -w 0)
+
+	run_android_tests "$RERUN_FILTER" "$RERUN_RESULT_PATH"
+
+	if [ -f "$RERUN_RESULT_PATH" ]; then
+		run_nunit_tool merge-results "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH" "$RERUN_RESULT_PATH" "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH"
+		run_nunit_tool list-failed "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH" "$UNO_TESTS_FAILED_LIST"
+	else
+		echo "##[warning]Watchdog retry did not produce a results file; original results kept."
+	fi
+
 # In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
+elif [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
 	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
 	RERUN_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)
-	RERUN_RESULT_PATH="$BUILD_SOURCESDIRECTORY/build/TestResult-rerun.xml"
 
 	run_android_tests "$RERUN_FILTER" "$RERUN_RESULT_PATH"
 

--- a/build/test-scripts/android-run-skia-runtime-tests.sh
+++ b/build/test-scripts/android-run-skia-runtime-tests.sh
@@ -120,66 +120,92 @@ echo "Emulator started"
 # Install the app
 $ANDROID_HOME/platform-tools/adb install $UNO_UITEST_ANDROIDAPK_PATH
 
-UITEST_RUNTIME_AUTOSTART_RESULT_FILENAME="TestResult-`date +"%Y%m%d%H%M%S"`.xml"
-UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH="$BUILD_SOURCESDIRECTORY/build/$UITEST_RUNTIME_AUTOSTART_RESULT_FILENAME"
+NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
+run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
+
 UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_BASE_PATH="/storage/emulated/0/Android/data/$UNO_UITEST_APP_ID/files"
-UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH="$UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_BASE_PATH/$UITEST_RUNTIME_AUTOSTART_RESULT_FILENAME"
 
-# grant the storage permission to the app to write the test results and read the environment file
-$ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permission.WRITE_EXTERNAL_STORAGE
-$ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permission.READ_EXTERNAL_STORAGE
+# Starts the app and waits for the result file to appear on device.
+# Arguments:
+#   $1  filter (base64-encoded test name list)
+#   $2  local output path for the XML result file
+run_android_tests() {
+	local filter="$1"
+	local local_result_path="$2"
+	local result_filename
+	result_filename="TestResult-$(date +"%Y%m%d%H%M%S").xml"
+	local device_result_path="$UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_BASE_PATH/$result_filename"
 
-# start the android app using environment variables using adb
-$ANDROID_HOME/platform-tools/adb shell am start \
-  -n $UNO_UITEST_APP_ID/crc6448f3b0362cbf4bc9.MainActivity \
-  -e UITEST_RUNTIME_TEST_GROUP "$UITEST_RUNTIME_TEST_GROUP" \
-  -e UITEST_RUNTIME_TEST_GROUP_COUNT "$UITEST_RUNTIME_TEST_GROUP_COUNT" \
-  -e UITEST_RUNTIME_AUTOSTART_RESULT_FILE "$UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH" \
-  -e UITEST_RUNTIME_TESTS_FILTER "$UITEST_RUNTIME_TESTS_FILTER" \
+	# grant the storage permission to the app to write the test results and read the environment file
+	$ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permission.WRITE_EXTERNAL_STORAGE
+	$ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permission.READ_EXTERNAL_STORAGE
 
-# Set the timeout in seconds
-UITEST_TEST_TIMEOUT_AS_MINUTES=${UITEST_TEST_TIMEOUT:0:${#UITEST_TEST_TIMEOUT}-1}
-TIMEOUT=$(($UITEST_TEST_TIMEOUT_AS_MINUTES * 60))
-END_TIME=$((SECONDS+TIMEOUT))
+	# start the android app using environment variables using adb
+	$ANDROID_HOME/platform-tools/adb shell am start \
+	  -n $UNO_UITEST_APP_ID/crc6448f3b0362cbf4bc9.MainActivity \
+	  -e UITEST_RUNTIME_TEST_GROUP "$UITEST_RUNTIME_TEST_GROUP" \
+	  -e UITEST_RUNTIME_TEST_GROUP_COUNT "$UITEST_RUNTIME_TEST_GROUP_COUNT" \
+	  -e UITEST_RUNTIME_AUTOSTART_RESULT_FILE "$device_result_path" \
+	  -e UITEST_RUNTIME_TESTS_FILTER "$filter" \
 
-echo "Waiting for $UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH to be available..."
+	# Set the timeout in seconds
+	local UITEST_TEST_TIMEOUT_AS_MINUTES=${UITEST_TEST_TIMEOUT:0:${#UITEST_TEST_TIMEOUT}-1}
+	local TIMEOUT=$(($UITEST_TEST_TIMEOUT_AS_MINUTES * 60))
+	local END_TIME=$((SECONDS+TIMEOUT))
 
-while [[ ! $($ANDROID_HOME/platform-tools/adb shell test -e "$UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH" > /dev/null) && $SECONDS -lt $END_TIME ]]; do
-    sleep 15
+	echo "Waiting for $device_result_path to be available..."
+
+	while [[ ! $($ANDROID_HOME/platform-tools/adb shell test -e "$device_result_path" > /dev/null) && $SECONDS -lt $END_TIME ]]; do
+	    sleep 15
+
+		## Dump the emulator's system log
+		$ANDROID_HOME/platform-tools/adb shell logcat -d > $LOGS_PATH/android-device-log-$UNO_UITEST_BUCKET_ID-$UITEST_RUNTIME_TEST_GROUP-$UITEST_TEST_MODE_NAME.interim.txt
+
+	    # exit loop early if the app is not running anymore
+	    if ! $ANDROID_HOME/platform-tools/adb shell ps | grep "$UNO_UITEST_APP_ID" > /dev/null; then
+	        echo "The app is not running anymore"
+	        break
+	    fi
+	done
+
+	$ANDROID_HOME/platform-tools/adb pull $device_result_path "$local_result_path" || echo "ERROR: could not adb pull $device_result_path"
 
 	## Dump the emulator's system log
-	$ANDROID_HOME/platform-tools/adb shell logcat -d > $LOGS_PATH/android-device-log-$UNO_UITEST_BUCKET_ID-$UITEST_RUNTIME_TEST_GROUP-$UITEST_TEST_MODE_NAME.interim.txt
+	$ANDROID_HOME/platform-tools/adb shell logcat -d > $LOGS_PATH/android-device-log-$UNO_UITEST_BUCKET_ID-$UITEST_RUNTIME_TEST_GROUP-$UITEST_TEST_MODE_NAME.txt
+}
 
-    # exit loop if the APP_PID is not running anymore
-    if ! $ANDROID_HOME/platform-tools/adb shell ps | grep "$UNO_UITEST_APP_ID" > /dev/null; then
-        echo "The app is not running anymore"
-        break
-    fi
-done
+# --- First run ---
 
-$ANDROID_HOME/platform-tools/adb pull $UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH $UITEST_RUNTIME_AUTOSTART_RESULT_FILENAME || echo "ERROR: could not adb pull $UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH"
-
-## Dump the emulator's system log
-$ANDROID_HOME/platform-tools/adb shell logcat -d > $LOGS_PATH/android-device-log-$UNO_UITEST_BUCKET_ID-$UITEST_RUNTIME_TEST_GROUP-$UITEST_TEST_MODE_NAME.txt
+UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH="$BUILD_SOURCESDIRECTORY/build/TestResult-original.xml"
+run_android_tests "$UITEST_RUNTIME_TESTS_FILTER" "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH"
 
 # create $BUILD_SOURCESDIRECTORY/build/uitests-failure-results before exiting, so that `PublishBuildArtifacts@1` doesn't error out just because the tests crashed.
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 
-if [ ! -f "$UITEST_RUNTIME_AUTOSTART_RESULT_FILENAME" ]; then
-	echo "ERROR: The test results file $UITEST_RUNTIME_AUTOSTART_RESULT_FILENAME does not exist (did nunit crash ?)"
+if [ ! -f "$UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH" ]; then
+	echo "ERROR: The test results file $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH does not exist (did nunit crash ?)"
 	exit 1
 fi
 
-## Export the failed tests list for reuse in a pipeline retry
-pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
-
-echo "Running NUnitTransformTool"
-
 ## Fail the build when no test results could be read
-dotnet run fail-empty $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH
+run_nunit_tool fail-empty $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH
 
-if [ $? -eq 0 ]; then
-	dotnet run list-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH $UNO_TESTS_FAILED_LIST
+FAILED_COUNT=$(run_nunit_tool count-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH)
+run_nunit_tool list-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH $UNO_TESTS_FAILED_LIST
+
+# In-job retry: if a small number of tests failed, rerun only those to catch flakes
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
+
+	RERUN_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)
+	RERUN_RESULT_PATH="$BUILD_SOURCESDIRECTORY/build/TestResult-rerun.xml"
+
+	run_android_tests "$RERUN_FILTER" "$RERUN_RESULT_PATH"
+
+	if [ -f "$RERUN_RESULT_PATH" ]; then
+		run_nunit_tool merge-results $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH $RERUN_RESULT_PATH $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH
+		run_nunit_tool list-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH $UNO_TESTS_FAILED_LIST
+	else
+		echo "##[warning]Rerun did not produce a results file; original results kept."
+	fi
 fi
-
-popd

--- a/build/test-scripts/android-run-skia-runtime-tests.sh
+++ b/build/test-scripts/android-run-skia-runtime-tests.sh
@@ -126,6 +126,9 @@ run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 # Maximum failures to trigger an in-job retry; overridable via env var.
 FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
 
+# Maximum seconds between heartbeat emissions before the watchdog kills the app.
+HEARTBEAT_TIMEOUT_S=${HEARTBEAT_TIMEOUT_S:-300}
+
 UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_BASE_PATH="/storage/emulated/0/Android/data/$UNO_UITEST_APP_ID/files"
 
 # Starts the app and waits for the result file to appear on device.
@@ -143,6 +146,9 @@ run_android_tests() {
 	$ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permission.WRITE_EXTERNAL_STORAGE
 	$ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permission.READ_EXTERNAL_STORAGE
 
+	# Clear logcat so heartbeat line counting starts fresh for this run.
+	$ANDROID_HOME/platform-tools/adb logcat -c
+
 	# start the android app using environment variables using adb
 	$ANDROID_HOME/platform-tools/adb shell am start \
 	  -n $UNO_UITEST_APP_ID/crc6448f3b0362cbf4bc9.MainActivity \
@@ -158,11 +164,29 @@ run_android_tests() {
 
 	echo "Waiting for $device_result_path to be available..."
 
+	local PREV_HB_COUNT=0
+	local LAST_HB_S=$SECONDS
+
 	while [[ ! $($ANDROID_HOME/platform-tools/adb shell test -e "$device_result_path" > /dev/null) && $SECONDS -lt $END_TIME ]]; do
 	    sleep 15
 
 		## Dump the emulator's system log
 		$ANDROID_HOME/platform-tools/adb shell logcat -d > $LOGS_PATH/android-device-log-$UNO_UITEST_BUCKET_ID-$UITEST_RUNTIME_TEST_GROUP-$UITEST_TEST_MODE_NAME.interim.txt
+
+		# Heartbeat watchdog: count heartbeat lines in logcat; if count stalls, the test may be hung.
+		local HB_COUNT
+		HB_COUNT=$($ANDROID_HOME/platform-tools/adb shell logcat -d | grep -c 'UNO-RT-HEARTBEAT' || echo 0)
+		if [ "$HB_COUNT" -gt "$PREV_HB_COUNT" ]; then
+			PREV_HB_COUNT=$HB_COUNT
+			LAST_HB_S=$SECONDS
+		fi
+		local HB_AGE=$(( SECONDS - LAST_HB_S ))
+		if [ "$PREV_HB_COUNT" -gt 0 ] && [ $HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
+			echo "##[error]No heartbeat for ${HB_AGE}s — test appears hung."
+			$ANDROID_HOME/platform-tools/adb shell logcat -d | grep 'UNO-RT-HEARTBEAT' | tail -3
+			$ANDROID_HOME/platform-tools/adb shell am force-stop "$UNO_UITEST_APP_ID" || true
+			break
+		fi
 
 	    # exit loop early if the app is not running anymore
 	    if ! $ANDROID_HOME/platform-tools/adb shell ps | grep "$UNO_UITEST_APP_ID" > /dev/null; then

--- a/build/test-scripts/android-run-skia-runtime-tests.sh
+++ b/build/test-scripts/android-run-skia-runtime-tests.sh
@@ -123,6 +123,9 @@ $ANDROID_HOME/platform-tools/adb install $UNO_UITEST_ANDROIDAPK_PATH
 NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
 run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 
+# Maximum failures to trigger an in-job retry; overridable via env var.
+FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
+
 UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_BASE_PATH="/storage/emulated/0/Android/data/$UNO_UITEST_APP_ID/files"
 
 # Starts the app and waits for the result file to appear on device.
@@ -190,11 +193,11 @@ fi
 ## Fail the build when no test results could be read
 run_nunit_tool fail-empty $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH
 
-FAILED_COUNT=$(run_nunit_tool count-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH)
+FAILED_COUNT=$(run_nunit_tool count-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH | tail -1)
 run_nunit_tool list-failed $UITEST_RUNTIME_AUTOSTART_RESULT_LOCAL_PATH $UNO_TESTS_FAILED_LIST
 
 # In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
 	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
 	RERUN_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -269,22 +269,47 @@ then
 
 	echo "Waiting for $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE to be available..."
 
+	# Heartbeat watchdog state (count-based, mirrors Android approach).
+	# IOS_HB_COUNT tracks lines in the stream file; if count stalls the test is hung.
+	# IOS_LAST_HB_S tracks when count last advanced, for age calculation.
+	IOS_PREV_HB_COUNT=0
+	IOS_LAST_HB_S=$SECONDS
+	IOS_HUNG_TEST_NAME=""
+	IOS_HUNG_HB_AGE=0
+
 	# Loop until the file exists or the timeout is reached
 	while [[ ! -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" && $SECONDS -lt $END_TIME ]]; do
-		# echo "Waiting $INTERVAL seconds for test results to be written to $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE";
 		sleep $INTERVAL
 
-		# Heartbeat watchdog: if tests have started but no new marker in HEARTBEAT_TIMEOUT_S, abort.
-		if [ -s "$IOS_HEARTBEAT_LOG" ]; then
-			IOS_HB_AGE=$(( $(date +%s) - $(stat -f %m "$IOS_HEARTBEAT_LOG") ))
-			if [ $IOS_HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
-				echo "##[error]No heartbeat for ${IOS_HB_AGE}s — test appears hung. Last heartbeats:"
-				tail -3 "$IOS_HEARTBEAT_LOG"
-				kill $IOS_LOG_STREAM_PID 2>/dev/null || true
-				rm -f "$IOS_HEARTBEAT_LOG" || true
-				xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
-				break
-			fi
+		# Count heartbeat lines captured so far by the background stream.
+		IOS_HB_COUNT=$(grep -c 'UNO-RT-HEARTBEAT' "$IOS_HEARTBEAT_LOG" 2>/dev/null || echo 0)
+		if [ "$IOS_HB_COUNT" -gt "$IOS_PREV_HB_COUNT" ]; then
+			IOS_PREV_HB_COUNT=$IOS_HB_COUNT
+			IOS_LAST_HB_S=$SECONDS
+		fi
+		IOS_HB_AGE=$(( SECONDS - IOS_LAST_HB_S ))
+
+		# Watchdog: heartbeats have started but stopped advancing.
+		if [ "$IOS_PREV_HB_COUNT" -gt 0 ] && [ "$IOS_HB_AGE" -gt "$HEARTBEAT_TIMEOUT_S" ]; then
+			echo "##[error]No heartbeat for ${IOS_HB_AGE}s — test appears hung. Last heartbeats:"
+			tail -3 "$IOS_HEARTBEAT_LOG"
+			IOS_HUNG_TEST_NAME=$(grep 'STARTING' "$IOS_HEARTBEAT_LOG" | tail -1 | sed 's/.*STARTING //')
+			IOS_HUNG_HB_AGE=$IOS_HB_AGE
+			[ -n "$IOS_HUNG_TEST_NAME" ] && echo "##[error]Hung test identified: $IOS_HUNG_TEST_NAME"
+			kill $IOS_LOG_STREAM_PID 2>/dev/null || true
+			rm -f "$IOS_HEARTBEAT_LOG" || true
+			xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
+			break
+		fi
+
+		# Fallback: no heartbeats at all after 2× the timeout — app may be stuck at startup
+		# or the log stream is not capturing heartbeats. Kill to avoid hour-long hangs.
+		if [ "$IOS_PREV_HB_COUNT" -eq 0 ] && [ "$IOS_HB_AGE" -gt $(( HEARTBEAT_TIMEOUT_S * 2 )) ]; then
+			echo "##[error]No heartbeats received for ${IOS_HB_AGE}s — app stuck at startup or log stream not working. Terminating."
+			kill $IOS_LOG_STREAM_PID 2>/dev/null || true
+			rm -f "$IOS_HEARTBEAT_LOG" || true
+			xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
+			break
 		fi
 
 		# exit loop if the APP_PID is not running anymore
@@ -298,11 +323,42 @@ then
 	rm -f "$IOS_HEARTBEAT_LOG" || true
 
 	if ! [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
- 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, waiting 2 seconds"
- 		sleep 2
- 	fi
-  
-	# if the file exists, show a message
+		sleep 2
+	fi
+
+	# Helper: wait for a simulator run and apply the heartbeat watchdog.
+	# $1 = result file path, $2 = app pid, $3 = timeout end ($SECONDS), $4 = heartbeat log path, $5 = log stream PID
+	ios_wait_for_result() {
+		local result_file="$1" app_pid="$2" end_time="$3" hb_log="$4" stream_pid="$5"
+		local prev_hb=0 last_hb_s=$SECONDS
+
+		while [[ ! -f "$result_file" && $SECONDS -lt $end_time ]]; do
+			sleep $INTERVAL
+			local hb_count
+			hb_count=$(grep -c 'UNO-RT-HEARTBEAT' "$hb_log" 2>/dev/null || echo 0)
+			if [ "$hb_count" -gt "$prev_hb" ]; then prev_hb=$hb_count; last_hb_s=$SECONDS; fi
+			local age=$(( SECONDS - last_hb_s ))
+			if [ "$prev_hb" -gt 0 ] && [ "$age" -gt "$HEARTBEAT_TIMEOUT_S" ]; then
+				echo "##[error]No heartbeat for ${age}s in retry run — test appears hung."
+				tail -3 "$hb_log"
+				kill "$stream_pid" 2>/dev/null || true
+				rm -f "$hb_log" || true
+				xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
+				break
+			fi
+			if [ "$prev_hb" -eq 0 ] && [ "$age" -gt $(( HEARTBEAT_TIMEOUT_S * 2 )) ]; then
+				echo "##[error]No heartbeats in retry for ${age}s — terminating."
+				kill "$stream_pid" 2>/dev/null || true
+				rm -f "$hb_log" || true
+				xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
+				break
+			fi
+			if ! ps -p "$app_pid" > /dev/null; then echo "The app is not running anymore (retry run)"; break; fi
+		done
+		kill "$stream_pid" 2>/dev/null || true
+		rm -f "$hb_log" || true
+	}
+
 	if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is available, the test run is complete."
 
@@ -310,14 +366,13 @@ then
 		cp -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
 
 		# In-job retry: if a small number of tests failed, rerun only those to catch flakes.
-		# The simulator is still running at this point so we can relaunch the app immediately.
-		IOS_FAILED_COUNT=$(run_nunit_tool_ios count-failed "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" | tail -1)
+		IOS_FAILED_COUNT=$(run_nunit_tool_ios count-failed "$UNO_ORIGINAL_TEST_RESULTS" | tail -1)
 
 		if [ "$IOS_FAILED_COUNT" -gt 0 ] && [ "$IOS_FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
 			echo "##[warning]$IOS_FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
 			mkdir -p $(dirname ${UNO_TESTS_RUNTIMETESTS_FAILED_LIST})
-			run_nunit_tool_ios list-failed "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST"
+			run_nunit_tool_ios list-failed "$UNO_ORIGINAL_TEST_RESULTS" "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST"
 
 			export SIMCTL_CHILD_UITEST_RUNTIME_TESTS_FILTER=$(cat "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST" | base64 -b 0)
 			export SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE=/tmp/TestResult-rerun-$(date +"%Y%m%d%H%M%S").xml
@@ -325,37 +380,14 @@ then
 			xcrun simctl launch "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID"
 			RETRY_APP_PID=$(xcrun simctl spawn "$UITEST_IOSDEVICE_ID" launchctl list | grep "$SAMPLESAPP_BUNDLE_ID" | awk '{print $1}')
 
-			IOS_RETRY_HEARTBEAT_LOG=$(mktemp /tmp/uno-rt-heartbeat-retry.XXXXXX)
+			RETRY_HB_LOG=$(mktemp /tmp/uno-rt-heartbeat-retry.XXXXXX)
 			xcrun simctl spawn "$UITEST_IOSDEVICE_ID" log stream \
 				--predicate 'eventMessage CONTAINS "UNO-RT-HEARTBEAT"' \
-				>> "$IOS_RETRY_HEARTBEAT_LOG" &
-			IOS_RETRY_LOG_STREAM_PID=$!
+				>> "$RETRY_HB_LOG" &
+			RETRY_STREAM_PID=$!
 
-			RETRY_END_TIME=$((SECONDS + TIMEOUT))
-			while [[ ! -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" && $SECONDS -lt $RETRY_END_TIME ]]; do
-				sleep $INTERVAL
-
-				if [ -s "$IOS_RETRY_HEARTBEAT_LOG" ]; then
-					IOS_RETRY_HB_AGE=$(( $(date +%s) - $(stat -f %m "$IOS_RETRY_HEARTBEAT_LOG") ))
-					if [ $IOS_RETRY_HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
-						echo "##[error]No heartbeat for ${IOS_RETRY_HB_AGE}s in retry run — test appears hung."
-						tail -3 "$IOS_RETRY_HEARTBEAT_LOG"
-						kill $IOS_RETRY_LOG_STREAM_PID 2>/dev/null || true
-						rm -f "$IOS_RETRY_HEARTBEAT_LOG" || true
-						xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
-						break
-					fi
-				fi
-
-				# exit loop early if the retry app is not running anymore
-				if ! ps -p $RETRY_APP_PID > /dev/null; then
-					echo "The app is not running anymore (retry run)"
-					break
-				fi
-			done
-
-			kill $IOS_RETRY_LOG_STREAM_PID 2>/dev/null || true
-			rm -f "$IOS_RETRY_HEARTBEAT_LOG" || true
+			ios_wait_for_result "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" \
+				"$RETRY_APP_PID" "$((SECONDS + TIMEOUT))" "$RETRY_HB_LOG" "$RETRY_STREAM_PID"
 
 			if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
 				run_nunit_tool_ios merge-results "$UNO_ORIGINAL_TEST_RESULTS" "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
@@ -364,6 +396,36 @@ then
 				echo "##[warning]Rerun did not produce a results file; original results kept."
 			fi
 		fi
+
+	elif [ -n "$IOS_HUNG_TEST_NAME" ]; then
+		# Watchdog fired: create a synthetic failure record then rerun the shard excluding the hung test.
+		IOS_HUNG_SIMPLE=$(echo "$IOS_HUNG_TEST_NAME" | sed 's/(.*//')
+		echo "##[warning]Creating synthetic result for hung test '$IOS_HUNG_SIMPLE' (${IOS_HUNG_HB_AGE}s without heartbeat)."
+		run_nunit_tool_ios create-hung-result "$IOS_HUNG_SIMPLE" "$UNO_ORIGINAL_TEST_RESULTS" "$IOS_HUNG_HB_AGE"
+
+		echo "##[warning]Watchdog retry: rerunning shard excluding '$IOS_HUNG_SIMPLE'..."
+		export SIMCTL_CHILD_UITEST_RUNTIME_TESTS_FILTER=$(printf '~%s' "$IOS_HUNG_SIMPLE" | base64 -b 0)
+		export SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE=/tmp/TestResult-watchdog-retry-$(date +"%Y%m%d%H%M%S").xml
+
+		xcrun simctl launch "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID"
+		RETRY_APP_PID=$(xcrun simctl spawn "$UITEST_IOSDEVICE_ID" launchctl list | grep "$SAMPLESAPP_BUNDLE_ID" | awk '{print $1}')
+
+		RETRY_HB_LOG=$(mktemp /tmp/uno-rt-heartbeat-retry.XXXXXX)
+		xcrun simctl spawn "$UITEST_IOSDEVICE_ID" log stream \
+			--predicate 'eventMessage CONTAINS "UNO-RT-HEARTBEAT"' \
+			>> "$RETRY_HB_LOG" &
+		RETRY_STREAM_PID=$!
+
+		ios_wait_for_result "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" \
+			"$RETRY_APP_PID" "$((SECONDS + TIMEOUT))" "$RETRY_HB_LOG" "$RETRY_STREAM_PID"
+
+		if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
+			run_nunit_tool_ios merge-results "$UNO_ORIGINAL_TEST_RESULTS" "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
+			run_nunit_tool_ios list-failed "$UNO_ORIGINAL_TEST_RESULTS" "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST"
+		else
+			echo "##[warning]Watchdog retry did not produce a results file; original results kept."
+		fi
+
 	else
 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, the test run has timed out."
 	fi

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -275,6 +275,36 @@ then
 
 		# Copy the results to the build directory
 		cp -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
+
+		# In-job retry: if a small number of tests failed, rerun only those to catch flakes.
+		# The simulator is still running at this point so we can relaunch the app immediately.
+		NUNIT_TOOL_DIR_IOS="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
+		run_nunit_tool_ios() { (cd "$NUNIT_TOOL_DIR_IOS" && dotnet run "$@"); }
+
+		IOS_FAILED_COUNT=$(run_nunit_tool_ios count-failed "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE")
+
+		if [ "$IOS_FAILED_COUNT" -gt 0 ] && [ "$IOS_FAILED_COUNT" -le 20 ]; then
+			echo "##[warning]$IOS_FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
+
+			mkdir -p $(dirname ${UNO_TESTS_RUNTIMETESTS_FAILED_LIST})
+			run_nunit_tool_ios list-failed "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST"
+
+			export SIMCTL_CHILD_UITEST_RUNTIME_TESTS_FILTER=$(cat "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST" | base64 -b 0)
+			export SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE=/tmp/TestResult-rerun-$(date +"%Y%m%d%H%M%S").xml
+
+			xcrun simctl launch "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID"
+
+			RETRY_END_TIME=$((SECONDS + TIMEOUT))
+			while [[ ! -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" && $SECONDS -lt $RETRY_END_TIME ]]; do
+				sleep $INTERVAL
+			done
+
+			if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
+				run_nunit_tool_ios merge-results "$UNO_ORIGINAL_TEST_RESULTS" "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
+			else
+				echo "##[warning]Rerun did not produce a results file; original results kept."
+			fi
+		fi
 	else
 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, the test run has timed out."
 	fi

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -199,6 +199,9 @@ run_nunit_tool_ios() { (cd "$NUNIT_TOOL_DIR" && dotnet run --no-build "$@"); }
 # Maximum failures to trigger an in-job retry; overridable via env var.
 FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
 
+# Maximum seconds between heartbeat emissions before the watchdog kills the app.
+HEARTBEAT_TIMEOUT_S=${HEARTBEAT_TIMEOUT_S:-300}
+
 cd $BUILD_SOURCESDIRECTORY/build
 
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
@@ -250,11 +253,19 @@ then
 	export APP_PID=`xcrun simctl spawn "$UITEST_IOSDEVICE_ID" launchctl list | grep "$SAMPLESAPP_BUNDLE_ID" | awk '{print $1}'`
 	echo "App PID: $APP_PID"
 
-	# Set the timeout in seconds 
+	# Set the timeout in seconds
 	UITEST_TEST_TIMEOUT_AS_MINUTES=${UITEST_TEST_TIMEOUT:0:${#UITEST_TEST_TIMEOUT}-1}
 	TIMEOUT=$(($UITEST_TEST_TIMEOUT_AS_MINUTES * 60))
 	INTERVAL=15
 	END_TIME=$((SECONDS+TIMEOUT))
+
+	# Stream simulator device logs in background; filter for heartbeat markers.
+	# Console.WriteLine from .NET iOS is routed through NSLog and appears in the simulator syslog.
+	IOS_HEARTBEAT_LOG=$(mktemp /tmp/uno-rt-heartbeat.XXXXXX)
+	xcrun simctl spawn "$UITEST_IOSDEVICE_ID" log stream \
+		--predicate 'eventMessage CONTAINS "UNO-RT-HEARTBEAT"' \
+		>> "$IOS_HEARTBEAT_LOG" &
+	IOS_LOG_STREAM_PID=$!
 
 	echo "Waiting for $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE to be available..."
 
@@ -263,12 +274,28 @@ then
 		# echo "Waiting $INTERVAL seconds for test results to be written to $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE";
 		sleep $INTERVAL
 
+		# Heartbeat watchdog: if tests have started but no new marker in HEARTBEAT_TIMEOUT_S, abort.
+		if [ -s "$IOS_HEARTBEAT_LOG" ]; then
+			IOS_HB_AGE=$(( $(date +%s) - $(stat -f %m "$IOS_HEARTBEAT_LOG") ))
+			if [ $IOS_HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
+				echo "##[error]No heartbeat for ${IOS_HB_AGE}s — test appears hung. Last heartbeats:"
+				tail -3 "$IOS_HEARTBEAT_LOG"
+				kill $IOS_LOG_STREAM_PID 2>/dev/null || true
+				rm -f "$IOS_HEARTBEAT_LOG" || true
+				xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
+				break
+			fi
+		fi
+
 		# exit loop if the APP_PID is not running anymore
 		if ! ps -p $APP_PID > /dev/null; then
 			echo "The app is not running anymore"
 			break
 		fi
 	done
+
+	kill $IOS_LOG_STREAM_PID 2>/dev/null || true
+	rm -f "$IOS_HEARTBEAT_LOG" || true
 
 	if ! [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
  		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, waiting 2 seconds"
@@ -298,9 +325,27 @@ then
 			xcrun simctl launch "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID"
 			RETRY_APP_PID=$(xcrun simctl spawn "$UITEST_IOSDEVICE_ID" launchctl list | grep "$SAMPLESAPP_BUNDLE_ID" | awk '{print $1}')
 
+			IOS_RETRY_HEARTBEAT_LOG=$(mktemp /tmp/uno-rt-heartbeat-retry.XXXXXX)
+			xcrun simctl spawn "$UITEST_IOSDEVICE_ID" log stream \
+				--predicate 'eventMessage CONTAINS "UNO-RT-HEARTBEAT"' \
+				>> "$IOS_RETRY_HEARTBEAT_LOG" &
+			IOS_RETRY_LOG_STREAM_PID=$!
+
 			RETRY_END_TIME=$((SECONDS + TIMEOUT))
 			while [[ ! -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" && $SECONDS -lt $RETRY_END_TIME ]]; do
 				sleep $INTERVAL
+
+				if [ -s "$IOS_RETRY_HEARTBEAT_LOG" ]; then
+					IOS_RETRY_HB_AGE=$(( $(date +%s) - $(stat -f %m "$IOS_RETRY_HEARTBEAT_LOG") ))
+					if [ $IOS_RETRY_HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
+						echo "##[error]No heartbeat for ${IOS_RETRY_HB_AGE}s in retry run — test appears hung."
+						tail -3 "$IOS_RETRY_HEARTBEAT_LOG"
+						kill $IOS_RETRY_LOG_STREAM_PID 2>/dev/null || true
+						rm -f "$IOS_RETRY_HEARTBEAT_LOG" || true
+						xcrun simctl terminate "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID" || true
+						break
+					fi
+				fi
 
 				# exit loop early if the retry app is not running anymore
 				if ! ps -p $RETRY_APP_PID > /dev/null; then
@@ -308,6 +353,9 @@ then
 					break
 				fi
 			done
+
+			kill $IOS_RETRY_LOG_STREAM_PID 2>/dev/null || true
+			rm -f "$IOS_RETRY_HEARTBEAT_LOG" || true
 
 			if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
 				run_nunit_tool_ios merge-results "$UNO_ORIGINAL_TEST_RESULTS" "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -193,6 +193,12 @@ pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
 dotnet build
 popd
 
+NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
+run_nunit_tool_ios() { (cd "$NUNIT_TOOL_DIR" && dotnet run --no-build "$@"); }
+
+# Maximum failures to trigger an in-job retry; overridable via env var.
+FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
+
 cd $BUILD_SOURCESDIRECTORY/build
 
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
@@ -278,12 +284,9 @@ then
 
 		# In-job retry: if a small number of tests failed, rerun only those to catch flakes.
 		# The simulator is still running at this point so we can relaunch the app immediately.
-		NUNIT_TOOL_DIR_IOS="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
-		run_nunit_tool_ios() { (cd "$NUNIT_TOOL_DIR_IOS" && dotnet run "$@"); }
+		IOS_FAILED_COUNT=$(run_nunit_tool_ios count-failed "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" | tail -1)
 
-		IOS_FAILED_COUNT=$(run_nunit_tool_ios count-failed "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE")
-
-		if [ "$IOS_FAILED_COUNT" -gt 0 ] && [ "$IOS_FAILED_COUNT" -le 20 ]; then
+		if [ "$IOS_FAILED_COUNT" -gt 0 ] && [ "$IOS_FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
 			echo "##[warning]$IOS_FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
 			mkdir -p $(dirname ${UNO_TESTS_RUNTIMETESTS_FAILED_LIST})
@@ -293,14 +296,22 @@ then
 			export SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE=/tmp/TestResult-rerun-$(date +"%Y%m%d%H%M%S").xml
 
 			xcrun simctl launch "$UITEST_IOSDEVICE_ID" "$SAMPLESAPP_BUNDLE_ID"
+			RETRY_APP_PID=$(xcrun simctl spawn "$UITEST_IOSDEVICE_ID" launchctl list | grep "$SAMPLESAPP_BUNDLE_ID" | awk '{print $1}')
 
 			RETRY_END_TIME=$((SECONDS + TIMEOUT))
 			while [[ ! -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" && $SECONDS -lt $RETRY_END_TIME ]]; do
 				sleep $INTERVAL
+
+				# exit loop early if the retry app is not running anymore
+				if ! ps -p $RETRY_APP_PID > /dev/null; then
+					echo "The app is not running anymore (retry run)"
+					break
+				fi
 			done
 
 			if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
 				run_nunit_tool_ios merge-results "$UNO_ORIGINAL_TEST_RESULTS" "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" "$UNO_ORIGINAL_TEST_RESULTS"
+				run_nunit_tool_ios list-failed "$UNO_ORIGINAL_TEST_RESULTS" "$UNO_TESTS_RUNTIMETESTS_FAILED_LIST"
 			else
 				echo "##[warning]Rerun did not produce a results file; original results kept."
 			fi
@@ -379,11 +390,13 @@ fi
 
 if [ "$UITEST_AUTOMATED_GROUP" == 'RuntimeTests' ];
 then
-	## Fail the build when no runtime test results could be read
-	dotnet run fail-empty $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE
+	## Fail the build when no runtime test results could be read.
+	## Use UNO_ORIGINAL_TEST_RESULTS which holds the merged result after a retry,
+	## or the first-run copy when no retry was triggered.
+	dotnet run fail-empty $UNO_ORIGINAL_TEST_RESULTS
 
 	if [ $? -eq 0 ]; then
-		dotnet run list-failed $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE $UNO_TESTS_RUNTIMETESTS_FAILED_LIST
+		dotnet run list-failed $UNO_ORIGINAL_TEST_RESULTS $UNO_TESTS_RUNTIMETESTS_FAILED_LIST
 	fi
 fi
 

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -25,24 +25,44 @@ USE_XVFB=${1:-true}
 sudo chmod a+rw /dev/dri/card* 2>/dev/null || true
 sudo chmod a+rw /dev/fb* 2>/dev/null || true
 
-cd $SamplesAppArtifactPath
-if [ "$USE_XVFB" = "true" ]; then
-	xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE' || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
-else
-	dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE || true
-fi
+NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
+run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
+
+run_skia_tests() {
+	# $RUNTIME_TESTS_OUTPUT is exported so it is visible in the sh -c subshell below.
+	export RUNTIME_TESTS_OUTPUT="$1"
+	cd $SamplesAppArtifactPath
+	if [ "$USE_XVFB" = "true" ]; then
+		# Sometimes we crash during app shutdown, so we force a 0 exit code.
+		xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$RUNTIME_TESTS_OUTPUT' || true
+	else
+		dotnet SamplesApp.Skia.Generic.dll --runtime-tests="$RUNTIME_TESTS_OUTPUT" || true
+	fi
+}
+
+run_skia_tests "$TEST_RESULTS_FILE"
 
 ## Export the failed tests list for reuse in a pipeline retry
-pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 
-echo "Running NUnitTransformTool"
-
 ## Fail the build when no test results could be read
-dotnet run fail-empty $TEST_RESULTS_FILE
+run_nunit_tool fail-empty $TEST_RESULTS_FILE
 
-if [ $? -eq 0 ]; then
-	dotnet run list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+FAILED_COUNT=$(run_nunit_tool count-failed $TEST_RESULTS_FILE)
+run_nunit_tool list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+
+# In-job retry: if a small number of tests failed, rerun only those to catch flakes
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
+	export UITEST_RUNTIME_TESTS_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)
+
+	TEST_RESULTS_RERUN_FILE="${TEST_RESULTS_FILE%.xml}-rerun.xml"
+	run_skia_tests "$TEST_RESULTS_RERUN_FILE"
+
+	if [ -f "$TEST_RESULTS_RERUN_FILE" ]; then
+		run_nunit_tool merge-results $TEST_RESULTS_FILE $TEST_RESULTS_RERUN_FILE $TEST_RESULTS_FILE
+		run_nunit_tool list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+	else
+		echo "##[warning]Rerun did not produce a results file; original results kept."
+	fi
 fi
-
-popd

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -28,6 +28,9 @@ sudo chmod a+rw /dev/fb* 2>/dev/null || true
 NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
 run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 
+# Maximum failures to trigger an in-job retry; overridable via env var.
+FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
+
 run_skia_tests() {
 	# $RUNTIME_TESTS_OUTPUT is exported so it is visible in the sh -c subshell below.
 	export RUNTIME_TESTS_OUTPUT="$1"
@@ -48,11 +51,11 @@ mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 ## Fail the build when no test results could be read
 run_nunit_tool fail-empty $TEST_RESULTS_FILE
 
-FAILED_COUNT=$(run_nunit_tool count-failed $TEST_RESULTS_FILE)
+FAILED_COUNT=$(run_nunit_tool count-failed $TEST_RESULTS_FILE | tail -1)
 run_nunit_tool list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
 
 # In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
 	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 	export UITEST_RUNTIME_TESTS_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)
 

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -31,16 +31,43 @@ run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 # Maximum failures to trigger an in-job retry; overridable via env var.
 FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
 
+# Maximum seconds between heartbeat emissions before the watchdog kills the app.
+HEARTBEAT_TIMEOUT_S=${HEARTBEAT_TIMEOUT_S:-300}
+
 run_skia_tests() {
 	# $RUNTIME_TESTS_OUTPUT is exported so it is visible in the sh -c subshell below.
 	export RUNTIME_TESTS_OUTPUT="$1"
+	local HEARTBEAT_LOG
+	HEARTBEAT_LOG=$(mktemp /tmp/uno-rt-heartbeat.XXXXXX)
+	: > "$HEARTBEAT_LOG"
+
 	cd $SamplesAppArtifactPath
 	if [ "$USE_XVFB" = "true" ]; then
-		# Sometimes we crash during app shutdown, so we force a 0 exit code.
-		xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$RUNTIME_TESTS_OUTPUT' || true
+		# tee forwards all output to the CI log while grep filters heartbeat markers to HEARTBEAT_LOG.
+		xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$RUNTIME_TESTS_OUTPUT' \
+			2>&1 | tee >(grep --line-buffered '##UNO-RT-HEARTBEAT##' >> "$HEARTBEAT_LOG") &
 	else
-		dotnet SamplesApp.Skia.Generic.dll --runtime-tests="$RUNTIME_TESTS_OUTPUT" || true
+		dotnet SamplesApp.Skia.Generic.dll --runtime-tests="$RUNTIME_TESTS_OUTPUT" \
+			2>&1 | tee >(grep --line-buffered '##UNO-RT-HEARTBEAT##' >> "$HEARTBEAT_LOG") &
 	fi
+	local PIPE_PID=$!
+
+	# Watchdog: once the first heartbeat is received, kill if no new heartbeat within HEARTBEAT_TIMEOUT_S.
+	while kill -0 $PIPE_PID 2>/dev/null; do
+		sleep 10
+		if [ -s "$HEARTBEAT_LOG" ]; then
+			local HB_AGE=$(( $(date +%s) - $(stat -c %Y "$HEARTBEAT_LOG") ))
+			if [ $HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
+				echo "##[error]No heartbeat for ${HB_AGE}s — test appears hung. Last heartbeats:"
+				tail -3 "$HEARTBEAT_LOG"
+				kill -9 $PIPE_PID 2>/dev/null || true
+				rm -f "$HEARTBEAT_LOG"
+				exit 1
+			fi
+		fi
+	done
+	wait $PIPE_PID || true
+	rm -f "$HEARTBEAT_LOG"
 }
 
 run_skia_tests "$TEST_RESULTS_FILE"

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -17,20 +17,37 @@ if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
 	fi
 fi
 
+NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
+run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
+
 cd $SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
 
 ## Export the failed tests list for reuse in a pipeline retry
-pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 
 echo "Running NUnitTransformTool"
 
 ## Fail the build when no test results could be read
-dotnet run fail-empty $TEST_RESULTS_FILE
+run_nunit_tool fail-empty $TEST_RESULTS_FILE
 
-if [ $? -eq 0 ]; then
-	dotnet run list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+FAILED_COUNT=$(run_nunit_tool count-failed $TEST_RESULTS_FILE)
+run_nunit_tool list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+
+# In-job retry: if a small number of tests failed, rerun only those to catch flakes
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
+	export UITEST_RUNTIME_TESTS_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -b 0)
+
+	TEST_RESULTS_RERUN_FILE="${TEST_RESULTS_FILE%.xml}-rerun.xml"
+
+	cd $SamplesAppArtifactPath
+	dotnet SamplesApp.Skia.Generic.dll --runtime-tests="$TEST_RESULTS_RERUN_FILE" || true
+
+	if [ -f "$TEST_RESULTS_RERUN_FILE" ]; then
+		run_nunit_tool merge-results $TEST_RESULTS_FILE $TEST_RESULTS_RERUN_FILE $TEST_RESULTS_FILE
+		run_nunit_tool list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+	else
+		echo "##[warning]Rerun did not produce a results file; original results kept."
+	fi
 fi
-
-popd

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -20,8 +20,12 @@ fi
 NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
 run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 
+# Maximum failures to trigger an in-job retry; overridable via env var.
+FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
+
 cd $SamplesAppArtifactPath
-dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
+# Sometimes we crash during app shutdown, so we force a 0 exit code (same as Linux).
+dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE || true
 
 ## Export the failed tests list for reuse in a pipeline retry
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
@@ -31,11 +35,11 @@ echo "Running NUnitTransformTool"
 ## Fail the build when no test results could be read
 run_nunit_tool fail-empty $TEST_RESULTS_FILE
 
-FAILED_COUNT=$(run_nunit_tool count-failed $TEST_RESULTS_FILE)
+FAILED_COUNT=$(run_nunit_tool count-failed $TEST_RESULTS_FILE | tail -1)
 run_nunit_tool list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
 
 # In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
 	echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 	export UITEST_RUNTIME_TESTS_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -b 0)
 

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -23,9 +23,41 @@ run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 # Maximum failures to trigger an in-job retry; overridable via env var.
 FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
 
-cd $SamplesAppArtifactPath
-# Sometimes we crash during app shutdown, so we force a 0 exit code (same as Linux).
-dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE || true
+# Maximum seconds between heartbeat emissions before the watchdog kills the app.
+HEARTBEAT_TIMEOUT_S=${HEARTBEAT_TIMEOUT_S:-300}
+
+run_macos_tests() {
+	local RESULTS_FILE="$1"
+	local HEARTBEAT_LOG
+	HEARTBEAT_LOG=$(mktemp /tmp/uno-rt-heartbeat.XXXXXX)
+	: > "$HEARTBEAT_LOG"
+
+	cd $SamplesAppArtifactPath
+	# tee forwards all output to the CI log while grep filters heartbeat markers to HEARTBEAT_LOG.
+	# Sometimes we crash during app shutdown, so the pipeline exit code is ignored via wait ... || true.
+	dotnet SamplesApp.Skia.Generic.dll --runtime-tests="$RESULTS_FILE" \
+		2>&1 | tee >(grep --line-buffered '##UNO-RT-HEARTBEAT##' >> "$HEARTBEAT_LOG") &
+	local PIPE_PID=$!
+
+	# Watchdog: once the first heartbeat is received, kill if no new heartbeat within HEARTBEAT_TIMEOUT_S.
+	while kill -0 $PIPE_PID 2>/dev/null; do
+		sleep 10
+		if [ -s "$HEARTBEAT_LOG" ]; then
+			local HB_AGE=$(( $(date +%s) - $(stat -f %m "$HEARTBEAT_LOG") ))
+			if [ $HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
+				echo "##[error]No heartbeat for ${HB_AGE}s — test appears hung. Last heartbeats:"
+				tail -3 "$HEARTBEAT_LOG"
+				kill -9 $PIPE_PID 2>/dev/null || true
+				rm -f "$HEARTBEAT_LOG"
+				exit 1
+			fi
+		fi
+	done
+	wait $PIPE_PID || true
+	rm -f "$HEARTBEAT_LOG"
+}
+
+run_macos_tests "$TEST_RESULTS_FILE"
 
 ## Export the failed tests list for reuse in a pipeline retry
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
@@ -45,8 +77,7 @@ if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES
 
 	TEST_RESULTS_RERUN_FILE="${TEST_RESULTS_FILE%.xml}-rerun.xml"
 
-	cd $SamplesAppArtifactPath
-	dotnet SamplesApp.Skia.Generic.dll --runtime-tests="$TEST_RESULTS_RERUN_FILE" || true
+	run_macos_tests "$TEST_RESULTS_RERUN_FILE"
 
 	if [ -f "$TEST_RESULTS_RERUN_FILE" ]; then
 		run_nunit_tool merge-results $TEST_RESULTS_FILE $TEST_RESULTS_RERUN_FILE $TEST_RESULTS_FILE

--- a/build/test-scripts/run-windows-skia-runtime-tests.ps1
+++ b/build/test-scripts/run-windows-skia-runtime-tests.ps1
@@ -40,8 +40,13 @@ function Invoke-NUnitToolCaptureOutput([string[]]$Arguments)
     }
 }
 
+# Set by Invoke-SkiaTests when the heartbeat watchdog fires.
+$script:HungTestName = $null
+$script:HungHbAge = 0
+
 # Runs the Skia app with a heartbeat watchdog. Kills the process if no ##UNO-RT-HEARTBEAT##
 # marker appears in stdout for more than $HeartbeatTimeoutS seconds.
+# Returns $true when the result file was written, $false when the watchdog killed the app.
 function Invoke-SkiaTests([string]$ResultsFile)
 {
     $heartbeatLog = [System.IO.Path]::GetTempFileName()
@@ -68,6 +73,7 @@ function Invoke-SkiaTests([string]$ResultsFile)
         }
     } -ArgumentList $ResultsFile, $artifactPath, $heartbeatLog
 
+    $watchdogFired = $false
     try
     {
         while ($job.State -eq 'Running')
@@ -81,10 +87,21 @@ function Invoke-SkiaTests([string]$ResultsFile)
                 if ($hbAge -gt $heartbeatTimeoutS)
                 {
                     Write-Host "##[error]No heartbeat for $([int]$hbAge)s — test appears hung. Last heartbeats:"
-                    Get-Content $heartbeatLog -Tail 3 | Write-Host
+                    $lastLines = Get-Content $heartbeatLog -Tail 3
+                    $lastLines | Write-Host
+
+                    # Extract the hung test name from the last STARTING line.
+                    $lastStarting = $lastLines | Where-Object { $_ -match 'STARTING' } | Select-Object -Last 1
+                    if ($lastStarting -match 'STARTING\s+(.+)$')
+                    {
+                        $script:HungTestName = $Matches[1].Trim()
+                        $script:HungHbAge = [int]$hbAge
+                        Write-Host "##[error]Hung test identified: $($script:HungTestName) (no heartbeat for $([int]$hbAge)s)"
+                    }
+
                     Stop-Job $job
-                    Remove-Item $heartbeatLog -Force -ErrorAction SilentlyContinue
-                    exit 1
+                    $watchdogFired = $true
+                    break
                 }
             }
         }
@@ -95,6 +112,8 @@ function Invoke-SkiaTests([string]$ResultsFile)
         Remove-Job $job -Force -ErrorAction SilentlyContinue
         Remove-Item $heartbeatLog -Force -ErrorAction SilentlyContinue
     }
+
+    return -not $watchdogFired
 }
 
 # Maximum failures to trigger an in-job retry; overridable via env var.
@@ -115,6 +134,14 @@ Invoke-SkiaTests $TEST_RESULTS_FILE
 ## Export the failed tests list for reuse in a pipeline retry
 New-Item -ItemType Directory -Force -Path (Split-Path $UNO_TESTS_FAILED_LIST)
 
+# When the watchdog fires the results file is never written; synthesise a failure record.
+if (-not (Test-Path $TEST_RESULTS_FILE) -and $script:HungTestName)
+{
+    $hungSimple = $script:HungTestName -replace '\(.*', ''
+    Write-Host "##[warning]Creating synthetic result for hung test '$hungSimple' ($($script:HungHbAge)s without heartbeat)."
+    Invoke-NUnitTool "create-hung-result", $hungSimple, $TEST_RESULTS_FILE, "$($script:HungHbAge)"
+}
+
 Write-Host "Running NUnitTransformTool"
 
 ## Fail the build when no test results could be read
@@ -123,8 +150,27 @@ Invoke-NUnitTool "fail-empty", $TEST_RESULTS_FILE
 $FAILED_COUNT = [int](Invoke-NUnitToolCaptureOutput "count-failed", $TEST_RESULTS_FILE)
 Invoke-NUnitTool "list-failed", $TEST_RESULTS_FILE, $UNO_TESTS_FAILED_LIST
 
-# In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if ($FAILED_COUNT -gt 0 -and $FAILED_COUNT -le $FlakeRetryMaxFailures) {
+if ($script:HungTestName)
+{
+    # Watchdog fired: rerun the full shard excluding the hung test so we collect results
+    # for all tests that never ran.  The hung test stays Failed in the merged output.
+    $hungSimple = $script:HungTestName -replace '\(.*', ''
+    Write-Host "##[warning]Watchdog retry: rerunning shard excluding '$hungSimple'..."
+    $excludeFilter = "~$hungSimple"
+    $env:UITEST_RUNTIME_TESTS_FILTER = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($excludeFilter))
+
+    Invoke-SkiaTests $TEST_RESULTS_RERUN_FILE
+
+    if (Test-Path $TEST_RESULTS_RERUN_FILE) {
+        Invoke-NUnitTool "merge-results", $TEST_RESULTS_FILE, $TEST_RESULTS_RERUN_FILE, $TEST_RESULTS_FILE
+        Invoke-NUnitTool "list-failed", $TEST_RESULTS_FILE, $UNO_TESTS_FAILED_LIST
+    } else {
+        Write-Host "##[warning]Watchdog retry did not produce a results file; original results kept."
+    }
+}
+elseif ($FAILED_COUNT -gt 0 -and $FAILED_COUNT -le $FlakeRetryMaxFailures)
+{
+    # In-job retry: if a small number of tests failed, rerun only those to catch flakes
     Write-Host "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
     $base64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content $UNO_TESTS_FAILED_LIST)))

--- a/build/test-scripts/run-windows-skia-runtime-tests.ps1
+++ b/build/test-scripts/run-windows-skia-runtime-tests.ps1
@@ -29,7 +29,8 @@ function Invoke-NUnitToolCaptureOutput([string[]]$Arguments)
     Push-Location "$env:BUILD_SOURCESDIRECTORY\src\Uno.NUnitTransformTool"
     try
     {
-        $result = dotnet run @Arguments
+        # dotnet run may emit build noise before the actual output; take only the last line.
+        $result = (dotnet run @Arguments | Select-Object -Last 1)
         Assert-ExitCodeIsZero
         return $result
     }
@@ -38,6 +39,9 @@ function Invoke-NUnitToolCaptureOutput([string[]]$Arguments)
         Pop-Location
     }
 }
+
+# Maximum failures to trigger an in-job retry; overridable via env var.
+$FlakeRetryMaxFailures = [int]($env:FLAKE_RETRY_MAX_FAILURES ?? "20")
 
 $UNO_TESTS_FAILED_LIST="$env:BUILD_SOURCESDIRECTORY\build\uitests-failure-results\failed-tests-windows-runtimetests-windows-$env:UITEST_RUNTIME_TEST_GROUP.txt"
 $TEST_RESULTS_FILE="$env:build_sourcesdirectory\build\skia-windows-runtime-tests-results.xml"
@@ -64,7 +68,7 @@ $FAILED_COUNT = [int](Invoke-NUnitToolCaptureOutput "count-failed", $TEST_RESULT
 Invoke-NUnitTool "list-failed", $TEST_RESULTS_FILE, $UNO_TESTS_FAILED_LIST
 
 # In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if ($FAILED_COUNT -gt 0 -and $FAILED_COUNT -le 20) {
+if ($FAILED_COUNT -gt 0 -and $FAILED_COUNT -le $FlakeRetryMaxFailures) {
     Write-Host "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
     $base64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content $UNO_TESTS_FAILED_LIST)))

--- a/build/test-scripts/run-windows-skia-runtime-tests.ps1
+++ b/build/test-scripts/run-windows-skia-runtime-tests.ps1
@@ -40,6 +40,63 @@ function Invoke-NUnitToolCaptureOutput([string[]]$Arguments)
     }
 }
 
+# Runs the Skia app with a heartbeat watchdog. Kills the process if no ##UNO-RT-HEARTBEAT##
+# marker appears in stdout for more than $HeartbeatTimeoutS seconds.
+function Invoke-SkiaTests([string]$ResultsFile)
+{
+    $heartbeatLog = [System.IO.Path]::GetTempFileName()
+    $heartbeatTimeoutS = [int]($env:HEARTBEAT_TIMEOUT_S ?? "300")
+    $artifactPath = $env:SamplesAppArtifactPath
+
+    # Run the app in a background job so we can monitor its stdout for heartbeat markers.
+    $job = Start-Job -ScriptBlock {
+        param($path, $dir, $hbLog)
+        Push-Location $dir
+        try
+        {
+            dotnet SamplesApp.Skia.Generic.dll "--runtime-tests=$path" 2>&1 | ForEach-Object {
+                Write-Output $_
+                if ($_ -match '##UNO-RT-HEARTBEAT##')
+                {
+                    [System.IO.File]::AppendAllText($hbLog, "$_`n")
+                }
+            }
+        }
+        finally
+        {
+            Pop-Location
+        }
+    } -ArgumentList $ResultsFile, $artifactPath, $heartbeatLog
+
+    try
+    {
+        while ($job.State -eq 'Running')
+        {
+            Start-Sleep -Seconds 10
+            Receive-Job $job  # flush output to console
+
+            if ((Test-Path $heartbeatLog) -and (Get-Item $heartbeatLog).Length -gt 0)
+            {
+                $hbAge = ((Get-Date) - (Get-Item $heartbeatLog).LastWriteTime).TotalSeconds
+                if ($hbAge -gt $heartbeatTimeoutS)
+                {
+                    Write-Host "##[error]No heartbeat for $([int]$hbAge)s — test appears hung. Last heartbeats:"
+                    Get-Content $heartbeatLog -Tail 3 | Write-Host
+                    Stop-Job $job
+                    Remove-Item $heartbeatLog -Force -ErrorAction SilentlyContinue
+                    exit 1
+                }
+            }
+        }
+        Receive-Job $job  # flush remaining output
+    }
+    finally
+    {
+        Remove-Job $job -Force -ErrorAction SilentlyContinue
+        Remove-Item $heartbeatLog -Force -ErrorAction SilentlyContinue
+    }
+}
+
 # Maximum failures to trigger an in-job retry; overridable via env var.
 $FlakeRetryMaxFailures = [int]($env:FLAKE_RETRY_MAX_FAILURES ?? "20")
 
@@ -53,8 +110,7 @@ if (Test-Path $UNO_TESTS_FAILED_LIST) {
     $env:UITEST_RUNTIME_TESTS_FILTER="$base64"
 }
 
-cd $env:SamplesAppArtifactPath
-dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
+Invoke-SkiaTests $TEST_RESULTS_FILE
 
 ## Export the failed tests list for reuse in a pipeline retry
 New-Item -ItemType Directory -Force -Path (Split-Path $UNO_TESTS_FAILED_LIST)
@@ -74,8 +130,7 @@ if ($FAILED_COUNT -gt 0 -and $FAILED_COUNT -le $FlakeRetryMaxFailures) {
     $base64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content $UNO_TESTS_FAILED_LIST)))
     $env:UITEST_RUNTIME_TESTS_FILTER = $base64
 
-    cd $env:SamplesAppArtifactPath
-    dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_RERUN_FILE
+    Invoke-SkiaTests $TEST_RESULTS_RERUN_FILE
 
     if (Test-Path $TEST_RESULTS_RERUN_FILE) {
         Invoke-NUnitTool "merge-results", $TEST_RESULTS_FILE, $TEST_RESULTS_RERUN_FILE, $TEST_RESULTS_FILE

--- a/build/test-scripts/run-windows-skia-runtime-tests.ps1
+++ b/build/test-scripts/run-windows-skia-runtime-tests.ps1
@@ -1,4 +1,4 @@
-﻿Set-PSDebug -Trace 1
+Set-PSDebug -Trace 1
 
 $ErrorActionPreference = 'Stop'
 
@@ -10,9 +10,38 @@ function Assert-ExitCodeIsZero()
 	}
 }
 
+function Invoke-NUnitTool([string[]]$Arguments)
+{
+    Push-Location "$env:BUILD_SOURCESDIRECTORY\src\Uno.NUnitTransformTool"
+    try
+    {
+        dotnet run @Arguments
+        Assert-ExitCodeIsZero
+    }
+    finally
+    {
+        Pop-Location
+    }
+}
+
+function Invoke-NUnitToolCaptureOutput([string[]]$Arguments)
+{
+    Push-Location "$env:BUILD_SOURCESDIRECTORY\src\Uno.NUnitTransformTool"
+    try
+    {
+        $result = dotnet run @Arguments
+        Assert-ExitCodeIsZero
+        return $result
+    }
+    finally
+    {
+        Pop-Location
+    }
+}
 
 $UNO_TESTS_FAILED_LIST="$env:BUILD_SOURCESDIRECTORY\build\uitests-failure-results\failed-tests-windows-runtimetests-windows-$env:UITEST_RUNTIME_TEST_GROUP.txt"
 $TEST_RESULTS_FILE="$env:build_sourcesdirectory\build\skia-windows-runtime-tests-results.xml"
+$TEST_RESULTS_RERUN_FILE="$env:build_sourcesdirectory\build\skia-windows-runtime-tests-results-rerun.xml"
 
 # convert the content of the file UNO_TESTS_FAILED_LIST to base64 and set it to UITEST_RUNTIME_TESTS_FILTER, if the file exists
 if (Test-Path $UNO_TESTS_FAILED_LIST) {
@@ -24,16 +53,30 @@ cd $env:SamplesAppArtifactPath
 dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
 
 ## Export the failed tests list for reuse in a pipeline retry
-pushd $env:BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
-mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST}) -Force
+New-Item -ItemType Directory -Force -Path (Split-Path $UNO_TESTS_FAILED_LIST)
 
-echo "Running NUnitTransformTool"
+Write-Host "Running NUnitTransformTool"
 
 ## Fail the build when no test results could be read
-dotnet run fail-empty $TEST_RESULTS_FILE
+Invoke-NUnitTool "fail-empty", $TEST_RESULTS_FILE
 
-Assert-ExitCodeIsZero
+$FAILED_COUNT = [int](Invoke-NUnitToolCaptureOutput "count-failed", $TEST_RESULTS_FILE)
+Invoke-NUnitTool "list-failed", $TEST_RESULTS_FILE, $UNO_TESTS_FAILED_LIST
 
-dotnet run list-failed $TEST_RESULTS_FILE $UNO_TESTS_FAILED_LIST
+# In-job retry: if a small number of tests failed, rerun only those to catch flakes
+if ($FAILED_COUNT -gt 0 -and $FAILED_COUNT -le 20) {
+    Write-Host "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
-popd
+    $base64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-Content $UNO_TESTS_FAILED_LIST)))
+    $env:UITEST_RUNTIME_TESTS_FILTER = $base64
+
+    cd $env:SamplesAppArtifactPath
+    dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_RERUN_FILE
+
+    if (Test-Path $TEST_RESULTS_RERUN_FILE) {
+        Invoke-NUnitTool "merge-results", $TEST_RESULTS_FILE, $TEST_RESULTS_RERUN_FILE, $TEST_RESULTS_FILE
+        Invoke-NUnitTool "list-failed", $TEST_RESULTS_FILE, $UNO_TESTS_FAILED_LIST
+    } else {
+        Write-Host "##[warning]Rerun did not produce a results file; original results kept."
+    }
+}

--- a/build/test-scripts/wasm-run-skia-runtime-tests.sh
+++ b/build/test-scripts/wasm-run-skia-runtime-tests.sh
@@ -36,6 +36,9 @@ export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-resul
 NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
 run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 
+# Maximum failures to trigger an in-job retry; overridable via env var.
+FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
+
 build_runtime_tests_url() {
     local results_file="$1"
     local filter="$2"
@@ -99,6 +102,10 @@ start_chrome_and_wait() {
 
     if ! test -f "$results_file"; then
         echo "##[error]Results file not created within ${WAIT_TIMEOUT_S}s — Chrome may be hung. Exiting."
+        killall -9 chrome || true
+        killall -9 xvfb-run || true
+        killall -9 Xvfb || true
+        killall -9 chrome_crashpad_handler || true
         exit 1
     fi
 }
@@ -112,8 +119,8 @@ if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
     UITEST_RUNTIME_TESTS_FILTER=${UITEST_RUNTIME_TESTS_FILTER//=/!}
 
     # echo the failed filter list, if not empty
-    if [ -n "$UNO_TESTS_FAILED_LIST" ]; then
-        echo "Tests to run: $UNO_TESTS_FAILED_LIST"
+    if [ -n "$UITEST_RUNTIME_TESTS_FILTER" ]; then
+        echo "Tests to run: $UITEST_RUNTIME_TESTS_FILTER"
     fi
 else
     export UITEST_RUNTIME_TESTS_FILTER=""
@@ -128,11 +135,11 @@ mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 ## Fail the build when no test results could be read
 run_nunit_tool fail-empty $RESULTS_FILE
 
-FAILED_COUNT=$(run_nunit_tool count-failed $RESULTS_FILE)
+FAILED_COUNT=$(run_nunit_tool count-failed $RESULTS_FILE | tail -1)
 run_nunit_tool list-failed $RESULTS_FILE $UNO_TESTS_FAILED_LIST
 
 # In-job retry: if a small number of tests failed, rerun only those to catch flakes
-if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le "$FLAKE_RETRY_MAX_FAILURES" ]; then
     echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
 
     RERUN_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)
@@ -148,4 +155,6 @@ if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
     else
         echo "##[warning]Rerun did not produce a results file; original results kept."
     fi
+
+    rm -f "$RESULTS_RERUN_FILE" || true
 fi

--- a/build/test-scripts/wasm-run-skia-runtime-tests.sh
+++ b/build/test-scripts/wasm-run-skia-runtime-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -x #echo on
 set -euo pipefail
 IFS=$'\n\t'
@@ -33,80 +33,119 @@ export RESULTS_CANARY_FILE="$RESULTS_FILE.canary"
 export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP:-}
 export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-skia-wasm-runtimetests-$UITEST_RUNTIME_TEST_GROUP-chromium.txt
 
+NUNIT_TOOL_DIR="$BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool"
+run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
+
+build_runtime_tests_url() {
+    local results_file="$1"
+    local filter="$2"
+
+    rawurlencode "$results_file"
+    local results_encoded=$ENCODED_RESULT
+
+    rawurlencode "$filter"
+    local filter_encoded=$ENCODED_RESULT
+
+    RUNTIME_TESTS_URL="http://localhost:8000/?--runtime-tests=${results_encoded}&--runtime-tests-group=${UITEST_RUNTIME_TEST_GROUP}&--runtime-tests-group-count=${UITEST_RUNTIME_TEST_GROUP_COUNT}&--runtime-test-filter=${filter_encoded}"
+}
+
+start_chrome_and_wait() {
+    local results_file="$1"
+    local canary_file="${results_file}.canary"
+
+    rm -f "$canary_file" || true
+
+    local TRY_COUNT=0
+    while [ $TRY_COUNT -lt 5 ]; do
+        # we use xvfb instead of headless chrome because using --enable-logging with --headless doesn't
+        # print the logs as expected
+        # for some reason, you have to run the next line twice or else it doesn't work
+        killall -9 chrome || true
+        killall -9 xvfb-run || true
+        killall -9 Xvfb || true
+        killall -9 chrome_crashpad_handler || true
+        rm -fr /tmp/.X99-lock || true
+        xvfb-run --auto-servernum google-chrome --enable-logging=stderr --no-sandbox "${RUNTIME_TESTS_URL}" &
+
+        # wait one minute for the canary file to be created, otherwise fail the script.
+        # This may happen if xvfb-run of chrome fails to start
+        for i in {1..6}; do
+            if test -f "$canary_file"; then
+                break
+            fi
+            sleep 10
+        done
+
+        if test -f "$canary_file"; then
+            break
+        fi
+
+        TRY_COUNT=$((TRY_COUNT+1))
+        echo "Canary file not found. retrying... (Tried $TRY_COUNT times)"
+    done
+
+    # if the canary file does not exist show a message and exit
+    if ! test -f "$canary_file"; then
+        echo "Canary file not found. The app may not have started? Exiting."
+        exit 1
+    fi
+
+    # Wait for results file with a watchdog timeout so a hung app does not stall the job
+    local WAIT_TIMEOUT_S=3600
+    local WAIT_END=$((SECONDS + WAIT_TIMEOUT_S))
+    while ! test -f "$results_file" && [ $SECONDS -lt $WAIT_END ]; do
+        sleep 10
+    done
+
+    if ! test -f "$results_file"; then
+        echo "##[error]Results file not created within ${WAIT_TIMEOUT_S}s — Chrome may be hung. Exiting."
+        exit 1
+    fi
+}
+
+# --- First run ---
+
 if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
-	export UITEST_RUNTIME_TESTS_FILTER=`cat $UNO_TESTS_FAILED_LIST | base64 -w 0`
+    export UITEST_RUNTIME_TESTS_FILTER=`cat $UNO_TESTS_FAILED_LIST | base64 -w 0`
 
     # Replace the `=` with `!` to avoid url encoding issues
     UITEST_RUNTIME_TESTS_FILTER=${UITEST_RUNTIME_TESTS_FILTER//=/!}
 
-	# echo the failed filter list, if not empty
-	if [ -n "$UNO_TESTS_FAILED_LIST" ]; then
-		echo "Tests to run: $UNO_TESTS_FAILED_LIST"
-	fi
+    # echo the failed filter list, if not empty
+    if [ -n "$UNO_TESTS_FAILED_LIST" ]; then
+        echo "Tests to run: $UNO_TESTS_FAILED_LIST"
+    fi
 else
     export UITEST_RUNTIME_TESTS_FILTER=""
 fi
 
-rawurlencode "$RESULTS_FILE"
-RESULTS_FILE_ENCODED=$ENCODED_RESULT
-
-rawurlencode "$UITEST_RUNTIME_TESTS_FILTER"
-UITEST_RUNTIME_TESTS_FILTER_ENCODED=$ENCODED_RESULT
-
-RUNTIME_TESTS_URL="http://localhost:8000/?--runtime-tests=${RESULTS_FILE_ENCODED}&--runtime-tests-group=${UITEST_RUNTIME_TEST_GROUP}&--runtime-tests-group-count=${UITEST_RUNTIME_TEST_GROUP_COUNT}&--runtime-test-filter=${UITEST_RUNTIME_TESTS_FILTER_ENCODED}"
-
-TRY_COUNT=0
-
-while [ $TRY_COUNT -lt 5 ]; do
-    # we use xvfb instead of headless chrome because using --enable-logging with --headless doesn't
-    # print the logs as expected
-    # for some reason, you have to run the next line twice or else it doesn't work
-    killall -9 chrome || true
-    killall -9 xvfb-run || true
-    killall -9 Xvfb || true
-    killall -9 chrome_crashpad_handler || true
-    rm -fr /tmp/.X99-lock || true
-    xvfb-run --auto-servernum google-chrome --enable-logging=stderr --no-sandbox "${RUNTIME_TESTS_URL}" &
-
-    # wait one minute for the canary file to be created, otherwise fail the script.
-    # This may happen if xvfb-run of chrome fails to start
-    for i in {1..6}; do
-        if test -f "$RESULTS_CANARY_FILE"; then
-            break
-        fi
-        sleep 10
-    done
-
-    # if the canary file exists, continue
-    if test -f "$RESULTS_CANARY_FILE"; then
-        break
-    fi
-
-    TRY_COUNT=$((TRY_COUNT+1))
-    echo "Canary file not found. retrying... (Tried $TRY_COUNT times)"
-done
-
-# if the canary file does not exist show a message and exit
-if ! test -f "$RESULTS_CANARY_FILE"; then
-    echo "Canary file not found. The app may not have started? Exiting."
-    exit 1
-fi
-
-while ! test -f "$RESULTS_FILE"; do
-    sleep 10
-done
+build_runtime_tests_url "$RESULTS_FILE" "$UITEST_RUNTIME_TESTS_FILTER"
+start_chrome_and_wait "$RESULTS_FILE"
 
 ## Export the failed tests list for reuse in a pipeline retry
-pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})
 
-echo "Running NUnitTransformTool"
-
 ## Fail the build when no test results could be read
-dotnet run fail-empty $RESULTS_FILE
+run_nunit_tool fail-empty $RESULTS_FILE
 
-if [ $? -eq 0 ]; then
-	dotnet run list-failed $RESULTS_FILE $UNO_TESTS_FAILED_LIST
+FAILED_COUNT=$(run_nunit_tool count-failed $RESULTS_FILE)
+run_nunit_tool list-failed $RESULTS_FILE $UNO_TESTS_FAILED_LIST
+
+# In-job retry: if a small number of tests failed, rerun only those to catch flakes
+if [ "$FAILED_COUNT" -gt 0 ] && [ "$FAILED_COUNT" -le 20 ]; then
+    echo "##[warning]$FAILED_COUNT test(s) failed — retrying in-job to filter flakes..."
+
+    RERUN_FILTER=$(cat $UNO_TESTS_FAILED_LIST | base64 -w 0)
+    RERUN_FILTER=${RERUN_FILTER//=/!}
+
+    RESULTS_RERUN_FILE="${RESULTS_FILE%.xml}-rerun.xml"
+    build_runtime_tests_url "$RESULTS_RERUN_FILE" "$RERUN_FILTER"
+    start_chrome_and_wait "$RESULTS_RERUN_FILE"
+
+    if [ -f "$RESULTS_RERUN_FILE" ]; then
+        run_nunit_tool merge-results $RESULTS_FILE $RESULTS_RERUN_FILE $RESULTS_FILE
+        run_nunit_tool list-failed $RESULTS_FILE $UNO_TESTS_FAILED_LIST
+    else
+        echo "##[warning]Rerun did not produce a results file; original results kept."
+    fi
 fi
-
-popd

--- a/build/test-scripts/wasm-run-skia-runtime-tests.sh
+++ b/build/test-scripts/wasm-run-skia-runtime-tests.sh
@@ -39,6 +39,9 @@ run_nunit_tool() { (cd "$NUNIT_TOOL_DIR" && dotnet run "$@"); }
 # Maximum failures to trigger an in-job retry; overridable via env var.
 FLAKE_RETRY_MAX_FAILURES=${FLAKE_RETRY_MAX_FAILURES:-20}
 
+# Maximum seconds between heartbeat emissions before the watchdog kills the app.
+HEARTBEAT_TIMEOUT_S=${HEARTBEAT_TIMEOUT_S:-300}
+
 build_runtime_tests_url() {
     local results_file="$1"
     local filter="$2"
@@ -55,6 +58,8 @@ build_runtime_tests_url() {
 start_chrome_and_wait() {
     local results_file="$1"
     local canary_file="${results_file}.canary"
+    local HEARTBEAT_LOG
+    HEARTBEAT_LOG=$(mktemp /tmp/uno-rt-heartbeat.XXXXXX)
 
     rm -f "$canary_file" || true
 
@@ -68,7 +73,11 @@ start_chrome_and_wait() {
         killall -9 Xvfb || true
         killall -9 chrome_crashpad_handler || true
         rm -fr /tmp/.X99-lock || true
-        xvfb-run --auto-servernum google-chrome --enable-logging=stderr --no-sandbox "${RUNTIME_TESTS_URL}" &
+        : > "$HEARTBEAT_LOG"
+        # tee forwards chrome's output to the CI log; grep captures heartbeat markers to HEARTBEAT_LOG.
+        # Console.log from WASM reaches Chrome's stderr via --enable-logging=stderr.
+        xvfb-run --auto-servernum google-chrome --enable-logging=stderr --no-sandbox "${RUNTIME_TESTS_URL}" \
+            2>&1 | tee >(grep --line-buffered '##UNO-RT-HEARTBEAT##' >> "$HEARTBEAT_LOG") &
 
         # wait one minute for the canary file to be created, otherwise fail the script.
         # This may happen if xvfb-run of chrome fails to start
@@ -90,15 +99,31 @@ start_chrome_and_wait() {
     # if the canary file does not exist show a message and exit
     if ! test -f "$canary_file"; then
         echo "Canary file not found. The app may not have started? Exiting."
+        rm -f "$HEARTBEAT_LOG" || true
         exit 1
     fi
 
-    # Wait for results file with a watchdog timeout so a hung app does not stall the job
+    # Wait for results file; check heartbeat watchdog every 10s once tests are running.
     local WAIT_TIMEOUT_S=3600
     local WAIT_END=$((SECONDS + WAIT_TIMEOUT_S))
     while ! test -f "$results_file" && [ $SECONDS -lt $WAIT_END ]; do
         sleep 10
+        if [ -s "$HEARTBEAT_LOG" ]; then
+            local HB_AGE=$(( $(date +%s) - $(stat -c %Y "$HEARTBEAT_LOG") ))
+            if [ $HB_AGE -gt $HEARTBEAT_TIMEOUT_S ]; then
+                echo "##[error]No heartbeat for ${HB_AGE}s — test appears hung. Last heartbeats:"
+                tail -3 "$HEARTBEAT_LOG"
+                killall -9 chrome || true
+                killall -9 xvfb-run || true
+                killall -9 Xvfb || true
+                killall -9 chrome_crashpad_handler || true
+                rm -f "$HEARTBEAT_LOG" || true
+                exit 1
+            fi
+        fi
     done
+
+    rm -f "$HEARTBEAT_LOG" || true
 
     if ! test -f "$results_file"; then
         echo "##[error]Results file not created within ${WAIT_TIMEOUT_S}s — Chrome may be hung. Exiting."

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestMethodInfo.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestMethodInfo.cs
@@ -74,10 +74,35 @@ internal record UnitTestMethodInfo
 			return true;
 		}
 
+		if (IsExcludedByFilters(filters))
+		{
+			return false;
+		}
+
+		var inclusionFilters = filters.Where(f => !f.StartsWith("~", StringComparison.Ordinal)).ToArray();
+		if (!inclusionFilters.Any())
+		{
+			return true; // only exclusion filters — include everything not excluded
+		}
+
 		var fullName = GetFullName();
-		return filters.Any(filter =>
+		return inclusionFilters.Any(filter =>
 			Name.Contains(filter, StrComp)
 			|| fullName.Contains(filter, StrComp));
+	}
+
+	private bool IsExcludedByFilters(string[]? filters)
+	{
+		if (!(filters?.Any() ?? false))
+		{
+			return false;
+		}
+
+		var fullName = GetFullName();
+		return filters
+			.Where(f => f.StartsWith("~", StringComparison.Ordinal))
+			.Select(f => f[1..])
+			.Any(excl => Name.Contains(excl, StrComp) || fullName.Contains(excl, StrComp));
 	}
 
 	private bool HasCustomAttribute<T>(MemberInfo? testMethod)
@@ -143,6 +168,11 @@ internal record UnitTestMethodInfo
 
 	public IEnumerable<TestCase> GetMatchingCases(string[]? filters)
 	{
+		if (IsExcludedByFilters(filters))
+		{
+			return [];
+		}
+
 		var cases = GetCases().ToArray();
 		if (!(filters?.Any() ?? false) || MatchesFilter(filters))
 		{
@@ -157,7 +187,21 @@ internal record UnitTestMethodInfo
 		var caseName = testCase.ToString();
 		var fullCaseName = GetFullName() + caseName;
 
-		return filters.Any(filter =>
+		// Exclusion filters: ~prefix means never run this case
+		foreach (var f in filters)
+		{
+			if (f.StartsWith("~", StringComparison.Ordinal))
+			{
+				var excl = f[1..];
+				if (caseName.Contains(excl, StrComp) || fullCaseName.Contains(excl, StrComp))
+				{
+					return false;
+				}
+			}
+		}
+
+		var inclusionFilters = filters.Where(f => !f.StartsWith("~", StringComparison.Ordinal)).ToArray();
+		return inclusionFilters.Any(filter =>
 			caseName.Contains(filter, StrComp)
 			|| fullCaseName.Contains(filter, StrComp));
 	}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -416,8 +416,19 @@ namespace Uno.UI.Samples.Tests
 			}
 		}
 
+		// Emits a line to stdout so CI scripts can detect hung tests via a heartbeat watchdog.
+		// The ##UNO-RT-HEARTBEAT## prefix allows grep-based filtering without affecting normal log noise.
+		private static void EmitHeartbeat(string phase, string testName, TimeSpan? duration = null)
+		{
+			var line = duration is { } d
+				? $"##UNO-RT-HEARTBEAT## {DateTime.UtcNow:O} {phase} {testName} {(long)d.TotalMilliseconds}ms"
+				: $"##UNO-RT-HEARTBEAT## {DateTime.UtcNow:O} {phase} {testName}";
+			Console.WriteLine(line);
+		}
+
 		private void ReportTestResult(UnitTestClassInfo testClassInfo, UnitTestMethodInfo testMethodInfo, string testName, TimeSpan duration, TestResult testResult, Exception error = null, string message = null, string console = null)
 		{
+			EmitHeartbeat("COMPLETED", testName, duration);
 			_testCases.Add(
 				new TestCaseResult
 				{
@@ -865,6 +876,7 @@ namespace Uno.UI.Samples.Tests
 					// This will help developers to identify faulty tests when the app is crashing.
 					await ReportMessage($"Running test {fullTestName}");
 					ReportTestsResults();
+					EmitHeartbeat("STARTING", fullTestName);
 
 					var sw = new Stopwatch();
 					var iterationFailed = false;

--- a/src/Uno.NUnitTransformTool/Program.cs
+++ b/src/Uno.NUnitTransformTool/Program.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -8,7 +8,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Transactions;
 using System.Xml;
 using Mono.Cecil;
 using Mono.Collections.Generic;
@@ -19,6 +18,13 @@ namespace Uno.ReferenceImplComparer
 	{
 		static int Main(string[] args)
 		{
+			if (args.Length == 0)
+			{
+				Console.Error.WriteLine("Usage: NUnitTransformTool <command> [args...]");
+				Console.Error.WriteLine("Commands: list-failed, fail-empty, count-failed, merge-results");
+				return 1;
+			}
+
 			switch (args[0])
 			{
 				case "list-failed":
@@ -29,15 +35,17 @@ namespace Uno.ReferenceImplComparer
 					return CountFailedTests(args[1]);
 				case "merge-results":
 					return MergeResults(args[1], args[2], args[3]);
+				default:
+					Console.Error.WriteLine($"Unknown command: {args[0]}");
+					Console.Error.WriteLine("Commands: list-failed, fail-empty, count-failed, merge-results");
+					return 1;
 			}
-
-			return 0;
 		}
 
 		private static int FailOnEmptyResults(string inputFile)
 		{
 			var doc = new XmlDocument();
-			doc.LoadXml(File.ReadAllText(inputFile));
+			doc.Load(inputFile);
 
 			var allNodes = doc.SelectNodes("//test-case");
 
@@ -58,7 +66,7 @@ namespace Uno.ReferenceImplComparer
 		private static int ListFailedTests(string inputFile, string outputFile)
 		{
 			var doc = new XmlDocument();
-			doc.LoadXml(File.ReadAllText(inputFile));
+			doc.Load(inputFile);
 
 			var failedNodes = doc.SelectNodes("//test-case[@result='Failed']")!;
 
@@ -67,16 +75,14 @@ namespace Uno.ReferenceImplComparer
 			{
 				var name = failedNode.GetAttribute("fullname");
 
-				// This is used to remove the test parameters from the test name, which are not used by the nunit-console runner.
+				// Remove test parameters from the name — nunit-console uses bare names in filters.
 				var simpleName = SimpleNameRegex().Replace(name, "");
 
 				failedTests.Add(simpleName);
 			}
 
-			// Add a dummy line to be used to rerun the test running in case
-			// tests get canceled. This condition happens when running nunit-console
-			// and the retry attribute which markes runners as cancelled and fails any
-			// subsequent test.
+			// Sentinel: ensures the filter expression is never empty even if the app cancelled
+			// some tests. Without it, an empty filter would run the full suite on retry.
 			failedTests.Add("invalid-test-for-retry");
 
 			File.WriteAllText(outputFile, string.Join(" | ", failedTests));
@@ -93,7 +99,7 @@ namespace Uno.ReferenceImplComparer
 		private static int CountFailedTests(string inputFile)
 		{
 			var doc = new XmlDocument();
-			doc.LoadXml(File.ReadAllText(inputFile));
+			doc.Load(inputFile);
 
 			var count = doc.SelectNodes("//test-case[@result='Failed']")?.Count ?? 0;
 
@@ -106,7 +112,9 @@ namespace Uno.ReferenceImplComparer
 		/// For each test in the rerun, its result in the original is replaced by
 		/// the rerun outcome.  If the rerun made a previously-failed test pass,
 		/// the failure details are removed and the test is marked retried="true".
-		/// Summary statistics on the root test-run element are recalculated.
+		/// Summary statistics on the root test-run and all test-suite elements are recalculated.
+		/// Parameter-suffixed names are normalised the same way list-failed normalises them so
+		/// that rerun results are matched even when NUnit includes full parameter strings.
 		/// </summary>
 		private static int MergeResults(string originalFile, string rerunFile, string outputFile)
 		{
@@ -116,12 +124,17 @@ namespace Uno.ReferenceImplComparer
 			var rerunDoc = new XmlDocument();
 			rerunDoc.Load(rerunFile);
 
+			// Build lookup using the same parameter-stripped key as ListFailedTests.
 			var originalCases = new Dictionary<string, XmlElement>();
 			foreach (XmlElement node in originalDoc.SelectNodes("//test-case")!)
 			{
 				var name = node.GetAttribute("fullname");
-				if (!string.IsNullOrEmpty(name))
-					originalCases.TryAdd(name, node);
+				if (string.IsNullOrEmpty(name))
+					continue;
+
+				var key = SimpleNameRegex().Replace(name, "");
+				if (!originalCases.TryAdd(key, node))
+					Console.Error.WriteLine($"##[warning]Duplicate test-case key '{key}' in original results — only first occurrence will be updated.");
 			}
 
 			var updatedCount = 0;
@@ -129,8 +142,11 @@ namespace Uno.ReferenceImplComparer
 			foreach (XmlElement rerunCase in rerunDoc.SelectNodes("//test-case")!)
 			{
 				var fullName = rerunCase.GetAttribute("fullname");
+				if (string.IsNullOrEmpty(fullName))
+					continue;
 
-				if (string.IsNullOrEmpty(fullName) || !originalCases.TryGetValue(fullName, out var originalCase))
+				var key = SimpleNameRegex().Replace(fullName, "");
+				if (!originalCases.TryGetValue(key, out var originalCase))
 					continue;
 
 				var originalResult = originalCase.GetAttribute("result");
@@ -156,26 +172,38 @@ namespace Uno.ReferenceImplComparer
 
 			RecalculateTestRunTotals(originalDoc);
 
-			originalDoc.Save(outputFile);
+			// Write atomically so a partial write never corrupts the original.
+			var tmpFile = outputFile + ".tmp";
+			originalDoc.Save(tmpFile);
+			File.Move(tmpFile, outputFile, overwrite: true);
+
 			Console.WriteLine($"Merged {updatedCount} test result(s) from rerun. Output: {outputFile}");
 			return 0;
 		}
 
 		private static void RecalculateTestRunTotals(XmlDocument doc)
 		{
-			var testRun = doc.SelectSingleNode("//test-run") as XmlElement;
-			if (testRun is null)
-				return;
+			// Update all intermediate test-suite nodes so nested suite counts are correct.
+			foreach (XmlElement suite in doc.SelectNodes("//test-suite")!.OfType<XmlElement>())
+				RecalculateSuiteOrRunTotals(suite);
 
+			// Update the root test-run element last.
+			if (doc.SelectSingleNode("//test-run") is XmlElement testRun)
+				RecalculateSuiteOrRunTotals(testRun);
+		}
+
+		private static void RecalculateSuiteOrRunTotals(XmlElement node)
+		{
 			var passed = 0;
 			var failed = 0;
 			var skipped = 0;
 			var inconclusive = 0;
 			var total = 0;
-			foreach (XmlElement node in doc.SelectNodes("//test-case")!)
+
+			foreach (XmlElement tc in node.SelectNodes(".//test-case")!.OfType<XmlElement>())
 			{
 				total++;
-				switch (node.GetAttribute("result"))
+				switch (tc.GetAttribute("result"))
 				{
 					case "Passed": passed++; break;
 					case "Failed": failed++; break;
@@ -184,12 +212,12 @@ namespace Uno.ReferenceImplComparer
 				}
 			}
 
-			testRun.SetAttribute("total", total.ToString(CultureInfo.InvariantCulture));
-			testRun.SetAttribute("passed", passed.ToString(CultureInfo.InvariantCulture));
-			testRun.SetAttribute("failed", failed.ToString(CultureInfo.InvariantCulture));
-			testRun.SetAttribute("skipped", skipped.ToString(CultureInfo.InvariantCulture));
-			testRun.SetAttribute("inconclusive", inconclusive.ToString(CultureInfo.InvariantCulture));
-			testRun.SetAttribute("result", failed > 0 ? "Failed" : "Passed");
+			node.SetAttribute("total", total.ToString(CultureInfo.InvariantCulture));
+			node.SetAttribute("passed", passed.ToString(CultureInfo.InvariantCulture));
+			node.SetAttribute("failed", failed.ToString(CultureInfo.InvariantCulture));
+			node.SetAttribute("skipped", skipped.ToString(CultureInfo.InvariantCulture));
+			node.SetAttribute("inconclusive", inconclusive.ToString(CultureInfo.InvariantCulture));
+			node.SetAttribute("result", failed > 0 ? "Failed" : "Passed");
 		}
 
 		[GeneratedRegex(@"\(([^)]*)\)")]

--- a/src/Uno.NUnitTransformTool/Program.cs
+++ b/src/Uno.NUnitTransformTool/Program.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -21,7 +22,7 @@ namespace Uno.ReferenceImplComparer
 			if (args.Length == 0)
 			{
 				Console.Error.WriteLine("Usage: NUnitTransformTool <command> [args...]");
-				Console.Error.WriteLine("Commands: list-failed, fail-empty, count-failed, merge-results");
+				Console.Error.WriteLine("Commands: list-failed, fail-empty, count-failed, merge-results, create-hung-result");
 				return 1;
 			}
 
@@ -35,9 +36,12 @@ namespace Uno.ReferenceImplComparer
 					return CountFailedTests(args[1]);
 				case "merge-results":
 					return MergeResults(args[1], args[2], args[3]);
+				case "create-hung-result":
+					// create-hung-result <testName> <outputFile> [hangSeconds]
+					return CreateHungResult(args[1], args[2], args.Length > 3 ? int.Parse(args[3], CultureInfo.InvariantCulture) : 0);
 				default:
 					Console.Error.WriteLine($"Unknown command: {args[0]}");
-					Console.Error.WriteLine("Commands: list-failed, fail-empty, count-failed, merge-results");
+					Console.Error.WriteLine("Commands: list-failed, fail-empty, count-failed, merge-results, create-hung-result");
 					return 1;
 			}
 		}
@@ -218,6 +222,49 @@ namespace Uno.ReferenceImplComparer
 			node.SetAttribute("skipped", skipped.ToString(CultureInfo.InvariantCulture));
 			node.SetAttribute("inconclusive", inconclusive.ToString(CultureInfo.InvariantCulture));
 			node.SetAttribute("result", failed > 0 ? "Failed" : "Passed");
+		}
+
+		/// <summary>
+		/// Produces a minimal NUnit XML result file that marks <paramref name="testName"/> as Failed
+		/// with a watchdog-timeout message.  The file can be merged with a later re-run result.
+		/// </summary>
+		private static int CreateHungResult(string testName, string outputFile, int hangSeconds)
+		{
+			var duration = hangSeconds > 0 ? hangSeconds.ToString(CultureInfo.InvariantCulture) : "300";
+			var message = hangSeconds > 0
+				? $"Test hung for {hangSeconds}s (no heartbeat). The CI watchdog terminated the test runner."
+				: "Test hung (no heartbeat). The CI watchdog terminated the test runner.";
+
+			// Sanitise for XML attribute/text content
+			testName = testName.Trim();
+			var safeName = SecurityElement.Escape(testName) ?? testName;
+			var safeMessage = SecurityElement.Escape(message) ?? message;
+
+			var xml = $"""
+				<?xml version="1.0" encoding="utf-8" standalone="no"?>
+				<test-run id="2" name="WatchdogSynthetic" fullname="WatchdogSynthetic" testcasecount="1"
+				          result="Failed" total="1" passed="0" failed="1" inconclusive="0" skipped="0">
+				  <test-suite type="Assembly" id="0-1000" name="WatchdogSynthetic" fullname="WatchdogSynthetic"
+				              testcasecount="1" result="Failed" total="1" passed="0" failed="1" inconclusive="0" skipped="0">
+				    <test-suite type="TestFixture" id="0-1001" name="WatchdogSynthetic" fullname="WatchdogSynthetic"
+				                testcasecount="1" result="Failed" total="1" passed="0" failed="1" inconclusive="0" skipped="0">
+				      <test-case id="0-1002" name="{safeName}" fullname="WatchdogSynthetic.{safeName}"
+				                 result="Failed" duration="{duration}">
+				        <failure>
+				          <message>{safeMessage}</message>
+				        </failure>
+				      </test-case>
+				    </test-suite>
+				  </test-suite>
+				</test-run>
+				""";
+
+			var tmpFile = outputFile + ".tmp";
+			File.WriteAllText(tmpFile, xml, Encoding.UTF8);
+			File.Move(tmpFile, outputFile, overwrite: true);
+
+			Console.WriteLine($"Created synthetic hung-test result: {testName} → {outputFile}");
+			return 0;
 		}
 
 		[GeneratedRegex(@"\(([^)]*)\)")]

--- a/src/Uno.NUnitTransformTool/Program.cs
+++ b/src/Uno.NUnitTransformTool/Program.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -24,6 +25,10 @@ namespace Uno.ReferenceImplComparer
 					return ListFailedTests(args[1], args[2]);
 				case "fail-empty":
 					return FailOnEmptyResults(args[1]);
+				case "count-failed":
+					return CountFailedTests(args[1]);
+				case "merge-results":
+					return MergeResults(args[1], args[2], args[3]);
 			}
 
 			return 0;
@@ -68,7 +73,7 @@ namespace Uno.ReferenceImplComparer
 				failedTests.Add(simpleName);
 			}
 
-			// Add a dummy line to be used to rerun the test running in case 
+			// Add a dummy line to be used to rerun the test running in case
 			// tests get canceled. This condition happens when running nunit-console
 			// and the retry attribute which markes runners as cancelled and fails any
 			// subsequent test.
@@ -79,6 +84,112 @@ namespace Uno.ReferenceImplComparer
 			Console.WriteLine($"Found {failedTests.Count} failed tests in {inputFile}.");
 
 			return 0;
+		}
+
+		/// <summary>
+		/// Prints the number of failed test-cases to stdout and exits with 0.
+		/// Callers capture stdout: FAILED=$(dotnet run count-failed results.xml)
+		/// </summary>
+		private static int CountFailedTests(string inputFile)
+		{
+			var doc = new XmlDocument();
+			doc.LoadXml(File.ReadAllText(inputFile));
+
+			var count = doc.SelectNodes("//test-case[@result='Failed']")?.Count ?? 0;
+
+			Console.WriteLine(count.ToString(CultureInfo.InvariantCulture));
+			return 0;
+		}
+
+		/// <summary>
+		/// Merges a rerun XML (subset of tests) into the original full XML.
+		/// For each test in the rerun, its result in the original is replaced by
+		/// the rerun outcome.  If the rerun made a previously-failed test pass,
+		/// the failure details are removed and the test is marked retried="true".
+		/// Summary statistics on the root test-run element are recalculated.
+		/// </summary>
+		private static int MergeResults(string originalFile, string rerunFile, string outputFile)
+		{
+			var originalDoc = new XmlDocument();
+			originalDoc.Load(originalFile);
+
+			var rerunDoc = new XmlDocument();
+			rerunDoc.Load(rerunFile);
+
+			var originalCases = new Dictionary<string, XmlElement>();
+			foreach (XmlElement node in originalDoc.SelectNodes("//test-case")!)
+			{
+				var name = node.GetAttribute("fullname");
+				if (!string.IsNullOrEmpty(name))
+					originalCases.TryAdd(name, node);
+			}
+
+			var updatedCount = 0;
+
+			foreach (XmlElement rerunCase in rerunDoc.SelectNodes("//test-case")!)
+			{
+				var fullName = rerunCase.GetAttribute("fullname");
+
+				if (string.IsNullOrEmpty(fullName) || !originalCases.TryGetValue(fullName, out var originalCase))
+					continue;
+
+				var originalResult = originalCase.GetAttribute("result");
+				var rerunResult = rerunCase.GetAttribute("result");
+
+				originalCase.SetAttribute("result", rerunResult);
+				originalCase.SetAttribute("retried", "true");
+				originalCase.SetAttribute("original-result", originalResult);
+
+				if (rerunCase.HasAttribute("duration"))
+					originalCase.SetAttribute("duration", rerunCase.GetAttribute("duration"));
+
+				if (rerunResult == "Passed")
+				{
+					// Remove failure details so Azure DevOps does not report the test as failed
+					var failureNode = originalCase.SelectSingleNode("failure");
+					if (failureNode != null)
+						originalCase.RemoveChild(failureNode);
+				}
+
+				updatedCount++;
+			}
+
+			RecalculateTestRunTotals(originalDoc);
+
+			originalDoc.Save(outputFile);
+			Console.WriteLine($"Merged {updatedCount} test result(s) from rerun. Output: {outputFile}");
+			return 0;
+		}
+
+		private static void RecalculateTestRunTotals(XmlDocument doc)
+		{
+			var testRun = doc.SelectSingleNode("//test-run") as XmlElement;
+			if (testRun is null)
+				return;
+
+			var passed = 0;
+			var failed = 0;
+			var skipped = 0;
+			var inconclusive = 0;
+			var total = 0;
+			foreach (XmlElement node in doc.SelectNodes("//test-case")!)
+			{
+				total++;
+				switch (node.GetAttribute("result"))
+				{
+					case "Passed": passed++; break;
+					case "Failed": failed++; break;
+					case "Skipped": skipped++; break;
+					case "Inconclusive": inconclusive++; break;
+				}
+			}
+
+			testRun.SetAttribute("total", total.ToString(CultureInfo.InvariantCulture));
+			testRun.SetAttribute("passed", passed.ToString(CultureInfo.InvariantCulture));
+			testRun.SetAttribute("failed", failed.ToString(CultureInfo.InvariantCulture));
+			testRun.SetAttribute("skipped", skipped.ToString(CultureInfo.InvariantCulture));
+			testRun.SetAttribute("inconclusive", inconclusive.ToString(CultureInfo.InvariantCulture));
+			testRun.SetAttribute("result", failed > 0 ? "Failed" : "Passed");
 		}
 
 		[GeneratedRegex(@"\(([^)]*)\)")]


### PR DESCRIPTION
## Summary

Runtime test shards occasionally fail due to transient flakes (timing,
emulator glitches, Chrome startup races). Today those failures require a
full pipeline retry, which queues behind all other jobs and wastes ~30 min.

This PR adds an **automatic in-job retry** scoped to the failed tests only,
on all six runtime test platforms.

### How it works

1. After the first run, `NUnitTransformTool count-failed` counts failures.
2. If **1 – 20** tests failed (configurable via `FLAKE_RETRY_MAX_FAILURES`),
   only those tests are re-executed using the existing filter mechanism.
3. `NUnitTransformTool merge-results` patches the original XML: retried
   tests that pass are marked `result="Passed" retried="true"
   original-result="Failed"` — the failure is not silently dropped.
4. If **> 20** tests failed the shard fails immediately (likely a real regression).

Platforms covered: Linux Skia, macOS Skia, Windows Skia (PS1),
WASM/Chromium, Android Skia, iOS Skia.

### Changes

**`NUnitTransformTool` (C#)**
- New `count-failed <xml>` command: prints failed test count to stdout,
  always exits 0 (callers compare the value, not the exit code).
- New `merge-results <original> <rerun> <output>` command: merges a rerun
  XML into the original, recalculates totals on all `test-suite` nodes
  and the root `test-run` element.
- Both commands use `SimpleNameRegex` consistently so parameterised test
  names match between filter generation and result lookup.
- Atomic write in `merge-results` (temp file + `File.Move`) to prevent
  corruption if the process is killed mid-write.
- `args[0]` bounds check; unknown commands exit 1 with usage text.

**Test scripts (bash / PS1)**
- In-job retry block added to all six platform scripts.
- WASM wait loop gains a 3600 s watchdog (was infinite); kills
  Chrome/Xvfb before exiting on timeout.
- `FLAKE_RETRY_MAX_FAILURES` env var controls the threshold (default 20)
  on all platforms without editing scripts.
- iOS retry loop gains a liveness check on the simulator app PID.