### PR TITLE
docs(vscode): document .lscache files from C# Dev Kit 3.20+

### DIFF
--- a/build/cSpell.json
+++ b/build/cSpell.json
@@ -157,6 +157,7 @@
 	"commandbar",
 	"CLSID",
 	"datatransfer",
+	"dotnettools",
 	"Divio's",
 	"emcc",
 	"emscripten",

--- a/doc/articles/common-issues-vscode.md
+++ b/doc/articles/common-issues-vscode.md
@@ -36,10 +36,16 @@ After upgrading to **C# Dev Kit 3.20** or later, opening an Uno solution in VS C
 
 This is **not an Uno issue** and **not an error**. `.lscache` files are language-service caches written by the C# Dev Kit project system. They cache project metadata (references, target frameworks, output paths, restored package info) so the workspace can load quickly on the next session, and they regenerate automatically if deleted.
 
-They are safe to commit to source control if you prefer to keep them tracked. If you'd rather exclude them, add the following line to your repository's `.gitignore`:
+Because they are generated caches, we recommend excluding them from source control. Add the following line to your repository's `.gitignore`:
 
 ```text
 *.lscache
+```
+
+If they were already committed, untrack them (while keeping the local copies) with:
+
+```bash
+git rm --cached '*.lscache'
 ```
 
 This behavior is owned by the C# Dev Kit project system and tracked upstream at [microsoft/vscode-dotnettools#3080](https://github.com/microsoft/vscode-dotnettools/issues/3080).

--- a/doc/articles/common-issues-vscode.md
+++ b/doc/articles/common-issues-vscode.md
@@ -30,6 +30,20 @@ They are also accessible using the status bar Uno logo: hover your mouse pointer
 
 If the extension is not behaving properly, try using the `Developer: Reload Window` (or `Ctrl+R`) command in the palette.
 
+## `.lscache` files appearing in the solution
+
+After upgrading to **C# Dev Kit 3.20** or later, opening an Uno solution in VS Code may produce a large batch of untracked `<ProjectName>.csproj.lscache` files next to each project. Uno solutions typically have multiple platform heads and test projects, so the visual impact is larger than for a typical .NET solution.
+
+This is **not an Uno issue** and **not an error**. `.lscache` files are language-service caches written by the C# Dev Kit project system. They contain cached project metadata (references, target frameworks, output paths, restored package info) so the workspace can load quickly on the next session. The format is plain text, contains no source code or secrets, and the files regenerate automatically if deleted.
+
+They are safe to commit to source control if you prefer to keep them tracked. If you'd rather exclude them, add the following line to your repository's `.gitignore`:
+
+```
+*.lscache
+```
+
+This behavior is owned by the C# Dev Kit project system and tracked upstream at [microsoft/vscode-dotnettools#3080](https://github.com/microsoft/vscode-dotnettools/issues/3080).
+
 ## Reporting issues
 
 You can report issues directly from VS Code by either:

--- a/doc/articles/common-issues-vscode.md
+++ b/doc/articles/common-issues-vscode.md
@@ -34,7 +34,7 @@ If the extension is not behaving properly, try using the `Developer: Reload Wind
 
 After upgrading to **C# Dev Kit 3.20** or later, opening an Uno solution in VS Code may produce a large batch of untracked `<ProjectName>.csproj.lscache` files next to each project. Uno solutions typically have multiple platform heads and test projects, so the visual impact is larger than for a typical .NET solution.
 
-This is **not an Uno issue** and **not an error**. `.lscache` files are language-service caches written by the C# Dev Kit project system. They contain cached project metadata (references, target frameworks, output paths, restored package info) so the workspace can load quickly on the next session. The format is plain text, contains no source code or secrets, and the files regenerate automatically if deleted.
+This is **not an Uno issue** and **not an error**. `.lscache` files are language-service caches written by the C# Dev Kit project system. They cache project metadata (references, target frameworks, output paths, restored package info) so the workspace can load quickly on the next session, and they regenerate automatically if deleted.
 
 They are safe to commit to source control if you prefer to keep them tracked. If you'd rather exclude them, add the following line to your repository's `.gitignore`:
 

--- a/doc/articles/common-issues-vscode.md
+++ b/doc/articles/common-issues-vscode.md
@@ -38,7 +38,7 @@ This is **not an Uno issue** and **not an error**. `.lscache` files are language
 
 They are safe to commit to source control if you prefer to keep them tracked. If you'd rather exclude them, add the following line to your repository's `.gitignore`:
 
-```
+```text
 *.lscache
 ```
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.vscode/issues/1380

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

📚 Documentation content changes


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
