### PR TITLE
fix(x11): trap GLX context creation errors to fall back instead of aborting

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/Graphics/X11NativeOpenGLWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Graphics/X11NativeOpenGLWrapper.cs
@@ -46,6 +46,10 @@ internal class X11NativeOpenGLWrapper : INativeOpenGLWrapper
 		for (var c = 0; c < count; c++)
 		{
 			XVisualInfo* visual = GlxInterface.glXGetVisualFromFBConfig(_display, fbConfigs[c]);
+			if (visual == null)
+			{
+				continue;
+			}
 			using var visualDisposable = new DisposableStruct<IntPtr>(static aa => { _ = XLib.XFree(aa); }, (IntPtr)visual);
 			if (visual->depth == 32) // 24bit color + 8bit stencil as requested above
 			{
@@ -59,10 +63,16 @@ internal class X11NativeOpenGLWrapper : INativeOpenGLWrapper
 			throw new InvalidOperationException("Could not find a suitable framebuffer config.\n");
 		}
 
-		_glContext = GlxInterface.glXCreateNewContext(_display, bestFbc, GlxConsts.GLX_RGBA_TYPE, IntPtr.Zero, /* True */ 1);
-		if (_glContext == IntPtr.Zero)
+		// glXCreateNewContext returns a non-null handle even when the server rejects the request, so the
+		// failure only surfaces as an asynchronous X error. Trap it instead of letting Xlib abort the process.
+		using (var errorTrap = X11Helper.TrapErrors())
 		{
-			throw new InvalidOperationException($"{nameof(GlxInterface.glXCreateNewContext)} failed.");
+			_glContext = GlxInterface.glXCreateNewContext(_display, bestFbc, GlxConsts.GLX_RGBA_TYPE, IntPtr.Zero, /* True */ 1);
+			if (errorTrap.SyncAndHasError(_display) || _glContext == IntPtr.Zero)
+			{
+				throw new InvalidOperationException(
+					$"{nameof(GlxInterface.glXCreateNewContext)} failed ({(_glContext == IntPtr.Zero ? "returned a null context" : "X protocol error: " + errorTrap.ErrorText)}).");
+			}
 		}
 		_pBuffer = GlxInterface.glXCreatePbuffer(_display, bestFbc, new[] { (int)X11Helper.None });
 		if (_pBuffer == IntPtr.Zero)

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -510,6 +510,10 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		for (var c = 0; c < count; c++)
 		{
 			XVisualInfo* visual_ = GlxInterface.glXGetVisualFromFBConfig(display, ptr[c]);
+			if (visual_ == null)
+			{
+				continue;
+			}
 			if (visual_->depth == 32) // 24bit color + 8bit stencil as requested above
 			{
 				bestFbc = ptr[c];
@@ -518,17 +522,26 @@ internal partial class X11XamlRootHost : IXamlRootHost
 			}
 		}
 
-		if (visual == null)
+		// bestFbc and visual are always set together, but guard both: passing a null FBConfig to
+		// glXCreateNewContext is what produces the "Value in failed request: 0x0" BadValue.
+		if (visual == null || bestFbc == IntPtr.Zero)
 		{
-			throw new InvalidOperationException("Could not create correct visual window.\n");
+			throw new InvalidOperationException("Could not find a suitable GLX framebuffer config / visual.");
 		}
 
-		IntPtr context = GlxInterface.glXCreateNewContext(display, bestFbc, GlxConsts.GLX_RGBA_TYPE, IntPtr.Zero, /* True */ 1);
-		if (context == IntPtr.Zero)
+		// glXCreateNewContext allocates the context XID client-side and returns a non-null handle even
+		// when the server rejects the request, so the failure only surfaces as an asynchronous X error.
+		// Trap it (instead of letting Xlib abort the process) so the caller can fall back to another backend.
+		IntPtr context;
+		using (var errorTrap = X11Helper.TrapErrors())
 		{
-			throw new InvalidOperationException($"{nameof(GlxInterface.glXCreateNewContext)} failed and returned a null context.\n");
+			context = GlxInterface.glXCreateNewContext(display, bestFbc, GlxConsts.GLX_RGBA_TYPE, IntPtr.Zero, /* True */ 1);
+			if (errorTrap.SyncAndHasError(display) || context == IntPtr.Zero)
+			{
+				throw new InvalidOperationException(
+					$"{nameof(GlxInterface.glXCreateNewContext)} failed ({(context == IntPtr.Zero ? "returned a null context" : "X protocol error: " + errorTrap.ErrorText)}).");
+			}
 		}
-		_ = XLib.XSync(display, false);
 
 		XSetWindowAttributes attribs = default;
 		// Setting the colormap here is necessary, otherwise we get a GLX error on some environments. cf. https://github.com/unoplatform/uno/issues/21285

--- a/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/X11Helper.ErrorHandler.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/X11Helper.ErrorHandler.cs
@@ -1,0 +1,95 @@
+using System;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+internal static partial class X11Helper
+{
+	// Xlib's default error handler terminates the whole process when an X protocol error is
+	// delivered (for example a BadValue from X_GLXCreateNewContext on some drivers). That makes
+	// it impossible to fall back to another rendering backend, since the process dies before any
+	// managed catch block runs.
+	//
+	// Rather than replacing the handler process-wide (which would change behavior for every other
+	// X call), we install our handler only for the duration of a TrapErrors scope and restore the
+	// previously-active handler afterwards. Inside the scope errors are recorded for the caller to
+	// inspect; outside it Xlib's default behavior is unchanged.
+	// cf. https://github.com/unoplatform/uno/issues/23338
+
+	// Kept alive for the process lifetime so Xlib can safely hold a native function pointer to it
+	// while a trap is active.
+	private static readonly XErrorHandler _trapHandler = HandleTrappedError;
+
+	// The error handler is invoked synchronously on the thread that triggers the round-trip
+	// (typically an XSync), so the trap state is tracked per-thread.
+	[ThreadStatic] private static int _errorTrapDepth;
+	[ThreadStatic] private static bool _trappedErrorOccurred;
+	[ThreadStatic] private static byte _trappedErrorCode;
+	[ThreadStatic] private static XRequest _trappedErrorRequest;
+	[ThreadStatic] private static byte _trappedErrorMinorCode;
+
+	private static int HandleTrappedError(IntPtr display, ref XErrorEvent error)
+	{
+		if (_errorTrapDepth > 0)
+		{
+			_trappedErrorOccurred = true;
+			_trappedErrorCode = error.error_code;
+			_trappedErrorRequest = error.request_code;
+			_trappedErrorMinorCode = error.minor_code;
+		}
+
+		// The return value is ignored by Xlib. The important part is that we don't chain to the
+		// default handler, which would abort the process.
+		return 0;
+	}
+
+	/// <summary>
+	/// Begins a scope during which X protocol errors raised on the current thread are recorded
+	/// instead of aborting the process, allowing the caller to detect failures (such as GLX context
+	/// creation) that Xlib reports asynchronously. The previously-active error handler is restored
+	/// when the returned value is disposed.
+	/// </summary>
+	public static X11ErrorTrap TrapErrors() => new X11ErrorTrap();
+
+	internal ref struct X11ErrorTrap
+	{
+		private readonly IntPtr _previousHandler;
+		private bool _disposed;
+
+		public X11ErrorTrap()
+		{
+			if (_errorTrapDepth++ == 0)
+			{
+				_trappedErrorOccurred = false;
+			}
+			_previousHandler = XLib.XSetErrorHandler(_trapHandler);
+		}
+
+		/// <summary>Whether an X protocol error has been recorded since this trap began.</summary>
+		public readonly bool HasError => _trappedErrorOccurred;
+
+		/// <summary>A human-readable description of the last trapped error.</summary>
+		public readonly string ErrorText =>
+			$"error_code={_trappedErrorCode}, request_code={_trappedErrorRequest}, minor_code={_trappedErrorMinorCode}";
+
+		/// <summary>
+		/// Flushes pending requests with <see cref="XLib.XSync"/> so that any asynchronous protocol
+		/// errors are delivered to the handler, then returns whether an error was trapped.
+		/// </summary>
+		public readonly bool SyncAndHasError(IntPtr display)
+		{
+			_ = XLib.XSync(display, false);
+			return _trappedErrorOccurred;
+		}
+
+		public void Dispose()
+		{
+			if (!_disposed)
+			{
+				_disposed = true;
+				_errorTrapDepth--;
+				// Restore whatever handler was active before this trap (Xlib's default, or an outer trap).
+				_ = XLib.XSetErrorHandlerRaw(_previousHandler);
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_XLib.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_XLib.cs
@@ -241,6 +241,10 @@ namespace Uno.WinUI.Runtime.Skia.X11
 		[LibraryImport(libX11)]
 		public static partial IntPtr XSetErrorHandler(XErrorHandler error_handler);
 
+		// Used to restore a previously-active error handler by its raw pointer (e.g. Xlib's default).
+		[LibraryImport(libX11, EntryPoint = "XSetErrorHandler")]
+		public static partial IntPtr XSetErrorHandlerRaw(IntPtr error_handler);
+
 		[LibraryImport(libX11)]
 		public static partial int XConvertSelection(IntPtr display, IntPtr selection, IntPtr target, IntPtr property,
 			IntPtr requestor, IntPtr time);


### PR DESCRIPTION
Fixes #23338

## Problem

On the X11 Skia host, `glXCreateNewContext` failures arrive as an **asynchronous X protocol error** (`BadValue`), delivered when `XSync` flushes the queue. Since Uno never installed a custom X error handler, Xlib's **default handler aborted the process** before the managed fallback chain in `X11XamlRootHost.Initialize()` could run. The default desktop host therefore hard-crashes on first launch on machines where the GLX/OpenGL context path is broken (e.g. some NVIDIA + GLVND setups), even though Vulkan and software rendering work fine on the same box:

```
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  152 (GLX)
  Minor opcode of failed request:  24 (X_GLXCreateNewContext)
  Value in failed request:  0x0
```

GLX context XIDs are allocated client-side, so `glXCreateNewContext` returns a non-null handle even when the server rejects it — defeating the existing `context == IntPtr.Zero` check too.

## Fix

- **Scoped X error trap** (`X11Helper.ErrorHandler.cs`): a `TrapErrors()` scope installs an error handler that records protocol errors instead of aborting, and **restores the previously-active handler on dispose**. Global X-error behavior outside the scope is unchanged.
- `CreateGLXWindow` and `X11NativeOpenGLWrapper` now create the context inside the trap, `XSync` to force error delivery, and throw a managed exception on a trapped error → the existing fallback to EGL/software takes over instead of the process dying.
- **Defensive hardening:** skip null visuals from `glXGetVisualFromFBConfig` and explicitly bail when no suitable FBConfig/visual is found (the `Value in failed request: 0x0` null-FBConfig case).
- Added an `XSetErrorHandlerRaw(IntPtr)` binding to restore the saved handler by pointer.

## Validation

- **Compile:** `Uno.UI.Runtime.Skia.X11` builds clean.
- **Runtime (mechanism):** verified against the local libX11/libGL with a C repro reproducing the exact signature (opcode 152 / minor 24 / resourceid 0x0): inside the trap the error is caught and the process survives; after the scope ends the prior handler is restored and a subsequent GLX error aborts as before — confirming the scoping.
- **Runtime (full app on the affected GPU):** not reproducible in CI (driver-specific); the issue's repro should now fall back to EGL/software instead of aborting.