### PR TITLE
feat: Enable `dotnet run` for packaged WinUI apps via WinApp build tools

### DIFF
--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -138,6 +138,7 @@ Here are the supported properties:
 | `SkiaSharpVersion`                  | [SkiaSharp.Skottie](https://www.nuget.org/packages/SkiaSharp.Skottie) and similar packages                           | Provides a cross-platform 2D graphics API for .NET platforms based on Google's Skia Graphics Library.          |
 | `SvgSkiaVersion`                    | [Svg.Skia](https://www.nuget.org/packages/Svg.Skia)                                                                  | Renders SVG files using the SkiaSharp graphics engine.                                                         |
 | `WinAppSdkBuildToolsVersion`        | [Microsoft.Windows.SDK.BuildTools](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools)                  | Contains the tools required to build applications for the Microsoft Windows App SDK.                           |
+| `WinAppSdkBuildToolsWinAppVersion`  | [Microsoft.Windows.SDK.BuildTools.WinApp](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp)    | Enables `dotnet run` to launch the packaged WinAppSDK app with package identity. See [Running packaged WinUI apps with `dotnet run`](#running-packaged-winui-apps-with-dotnet-run). |
 | `WinAppSdkVersion`                  | [Microsoft.WindowsAppSDK](https://www.nuget.org/packages/Microsoft.WindowsAppSDK)                                    | Provides project templates and tools for building Windows applications.                                        |
 | `WindowsCompatibilityVersion`       | [Microsoft.Windows.Compatibility](https://www.nuget.org/packages/Microsoft.Windows.Compatibility)                    | Enables Windows desktop apps to use .NET Core by providing access to additional Windows APIs.                  |
 
@@ -229,6 +230,39 @@ If you still need one of the stripped packages on Windows for a specific reason,
 
 > [!NOTE]
 > This property is aimed at libraries (`IsPackable=true`). Application heads typically need the implicit Uno packages on Windows to run, so setting this on a head project is not recommended.
+
+## Running packaged WinUI apps with `dotnet run`
+
+On the Windows App SDK target, the `Uno.Sdk` implicitly references the [`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp) package for executable (application head) projects. This package overrides the `dotnet run` behavior so that, instead of launching the raw executable, it registers a loose-layout package and launches the app **with package identity** — matching the experience of the [`dotnet new` templates for WinUI](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/). This means features that require package identity (such as notifications, app data, or `ApplicationData`) work the same way they do when the app is deployed from its MSIX package.
+
+The package is referenced with `PrivateAssets="all"`, so it does not flow to consumers of your project. It is only added to executable heads — libraries never pull it in.
+
+You can control this behavior with the following properties:
+
+| Property | Default | Effect |
+|----------|---------|--------|
+| `EnableWinAppRunSupport` | `true` | Set to `false` to keep the package reference but disable the `dotnet run` interception (the app then launches as a plain executable, without package identity). |
+| `UnoDisableWinAppRunSupport` | `false` | Set to `true` to suppress the **implicit** `Microsoft.Windows.SDK.BuildTools.WinApp` reference entirely, so the package is never restored. |
+| `WinAppSdkBuildToolsWinAppVersion` | (SDK-managed) | Overrides the version of the `Microsoft.Windows.SDK.BuildTools.WinApp` package. |
+
+For example, to turn the feature off while still restoring the package (useful if you set it conditionally), add to your `csproj` or `Directory.Build.props`:
+
+```xml
+<PropertyGroup>
+  <EnableWinAppRunSupport>false</EnableWinAppRunSupport>
+</PropertyGroup>
+```
+
+Or, to avoid restoring the package altogether:
+
+```xml
+<PropertyGroup>
+  <UnoDisableWinAppRunSupport>true</UnoDisableWinAppRunSupport>
+</PropertyGroup>
+```
+
+> [!NOTE]
+> `EnableWinAppRunSupport` is provided by the `Microsoft.Windows.SDK.BuildTools.WinApp` package itself, so it also works when you add the package explicitly. `UnoDisableWinAppRunSupport` is specific to the `Uno.Sdk` and only affects the implicit reference.
 
 ## Supported OS Platform versions
 

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -52,9 +52,7 @@
 
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" PrivateAssets="all" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -52,6 +52,9 @@
 
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260101001" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -258,6 +258,14 @@
 			"description": "Provides an explicit override for the version of the Microsoft.Windows.SDK.BuildTools to use.",
 			"type": "nuget-version"
 		},
+		"WinAppSdkBuildToolsWinAppVersion": {
+			"description": "Provides an explicit override for the version of the Microsoft.Windows.SDK.BuildTools.WinApp package. This package enables `dotnet run` to launch the packaged WinAppSDK app with package identity.",
+			"type": "nuget-version"
+		},
+		"UnoDisableWinAppRunSupport": {
+			"description": "When set to true, the Uno.Sdk will not implicitly reference Microsoft.Windows.SDK.BuildTools.WinApp for WinAppSDK executables. Set EnableWinAppRunSupport=false instead to keep the reference but disable the `dotnet run` interception.",
+			"type": "bool"
+		},
 		"UnoCoreLoggingSingletonVersion": {
 			"description": "Provides an explicit override for the version of Uno.Core.Logging.Singleton to use.",
 			"type": "nuget-version"

--- a/src/Uno.Sdk/Services/PackageManifest.cs
+++ b/src/Uno.Sdk/Services/PackageManifest.cs
@@ -147,6 +147,7 @@ internal class PackageManifest
 		public const string SvgSkia = nameof(SvgSkia);
 		public const string WinAppSdk = nameof(WinAppSdk);
 		public const string WinAppSdkBuildTools = nameof(WinAppSdkBuildTools);
+		public const string WinAppSdkBuildToolsWinApp = nameof(WinAppSdkBuildToolsWinApp);
 		public const string MicrosoftLoggingConsole = nameof(MicrosoftLoggingConsole);
 		public const string WindowsCompatibility = nameof(WindowsCompatibility);
 		public const string MsalClient = nameof(MsalClient);

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -101,6 +101,8 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 
 	public string? WinAppSdkBuildToolsVersion { get; set; }
 
+	public string? WinAppSdkBuildToolsWinAppVersion { get; set; }
+
 	public string? UnoCoreLoggingSingletonVersion { get; set; }
 
 	public string? UnoDspTasksVersion { get; set; }
@@ -268,6 +270,7 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 			.UpdateManifest(PackageManifest.Group.SvgSkia, SvgSkiaVersion)
 			.UpdateManifest(PackageManifest.Group.WinAppSdk, WinAppSdkVersion)
 			.UpdateManifest(PackageManifest.Group.WinAppSdkBuildTools, WinAppSdkBuildToolsVersion)
+			.UpdateManifest(PackageManifest.Group.WinAppSdkBuildToolsWinApp, WinAppSdkBuildToolsWinAppVersion)
 			.UpdateManifest(PackageManifest.Group.MicrosoftLoggingConsole, MicrosoftLoggingVersion)
 			.UpdateManifest(PackageManifest.Group.WindowsCompatibility, WindowsCompatibilityVersion)
 			.UpdateManifest(PackageManifest.Group.MsalClient, MicrosoftIdentityClientVersion)

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -135,6 +135,13 @@
 		]
 	},
 	{
+		"group": "WinAppSdkBuildToolsWinApp",
+		"version": "0.3.1",
+		"packages": [
+			"Microsoft.Windows.SDK.BuildTools.WinApp"
+		]
+	},
+	{
 		"group": "MicrosoftLoggingConsole",
 		"version": "9.0.14",
 		"packages": [

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
@@ -16,6 +16,7 @@
 		-->
 		<_UnoProjectSystemPackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp"
 		                                   ProjectSystem="true"
+		                                   PrivateAssets="all"
 		                                   Condition="$(_IsExecutable) == 'true' AND '$(UnoDisableWinAppRunSupport)' != 'true'" />
 	</ItemGroup>
 

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
@@ -8,6 +8,15 @@
 		<_UnoProjectSystemPackageReference Include="Microsoft.WindowsAppSDK" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Microsoft.Windows.SDK.BuildTools" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Core.Extensions.Logging.Singleton" ProjectSystem="true" Condition="$(_IsExecutable) == 'true'"/>
+		<!--
+			Enables `dotnet run` to launch the packaged WinAppSDK app with package identity
+			(see https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/).
+			Restricted to executables — the package only contributes a Run-target override; libraries should not pull it in.
+			Set EnableWinAppRunSupport=false in the project to opt out, or UnoDisableWinAppRunSupport=true to suppress this implicit reference entirely.
+		-->
+		<_UnoProjectSystemPackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp"
+		                                   ProjectSystem="true"
+		                                   Condition="$(_IsExecutable) == 'true' AND '$(UnoDisableWinAppRunSupport)' != 'true'" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';skia;')) OR $(UnoFeatures.Contains(';lottie;')) OR $(UnoFeatures.Contains(';svg;'))">

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
@@ -69,6 +69,7 @@
 				MicrosoftLoggingVersion="$(MicrosoftLoggingVersion)"
 				WinAppSdkVersion="$(WinAppSdkVersion)"
 				WinAppSdkBuildToolsVersion="$(WinAppSdkBuildToolsVersion)"
+				WinAppSdkBuildToolsWinAppVersion="$(WinAppSdkBuildToolsWinAppVersion)"
 				UnoCoreLoggingSingletonVersion="$(UnoCoreLoggingSingletonVersion)"
 				UnoDspTasksVersion="$(UnoDspTasksVersion)"
 				CommunityToolkitMvvmVersion="$(CommunityToolkitMvvmVersion)"


### PR DESCRIPTION
Related to #23345

## Summary

- Adds [`Microsoft.Windows.SDK.BuildTools.WinApp`](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp) (0.3.1) to ``SamplesApp.Windows`` and makes it an implicit reference for WinAppSDK executables produced by the Uno.Sdk, so ``dotnet run`` registers a loose-layout package and launches with package identity — the experience the new [`dotnet new` WinUI templates](https://devblogs.microsoft.com/ifdef-windows/introducing-dotnet-new-templates-for-winui/) bring to standalone WinUI apps.
- The package only overrides ``ComputeRunArguments`` and is gated on ``WindowsPackageType != 'None'`` + ``EnableWinAppRunSupport=true``, so ``dotnet build``, ``dotnet publish``, and the existing MSIX/AppX packaging flow are unaffected.

## Changes

**SamplesApp.Windows**
- `src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj` — direct ``PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1"``.

**Uno.Sdk implicit reference plumbing**
- `src/Uno.Sdk/packages.json` — new ``WinAppSdkBuildToolsWinApp`` group, default ``0.3.1``.
- `src/Uno.Sdk/Services/PackageManifest.cs` — ``Group.WinAppSdkBuildToolsWinApp`` constant.
- `src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs` — accepts and forwards ``WinAppSdkBuildToolsWinAppVersion``.
- `src/Uno.Sdk/targets/Uno.Implicit.Packages.targets` — passes the override to the resolver task.
- `src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets` — adds the implicit ``_UnoProjectSystemPackageReference`` gated on ``$(_IsExecutable) == 'true' AND '$(UnoDisableWinAppRunSupport)' != 'true'``.
- `src/Uno.Sdk/Sdk/Sdk.props.buildschema.json` — IntelliSense entries for ``WinAppSdkBuildToolsWinAppVersion`` and ``UnoDisableWinAppRunSupport``.

## Behavior matrix

| Project shape | Result |
|---|---|
| WinAppSDK class library | Unchanged (gated by ``_IsExecutable``). |
| WinAppSDK unpackaged single-project (``WindowsPackageType=None``) | Package referenced, run targets are no-ops, standard ``dotnet run`` is used. |
| WinAppSDK packaged single-project (``WindowsPackageType=MSIX``) | ``dotnet run`` performs loose-layout register + identity launch. |
| ``SamplesApp.Windows`` | ``dotnet run`` launches the packaged SamplesApp with identity. |

## Knobs

- ``WinAppSdkBuildToolsWinAppVersion`` — override the implicit version.
- ``UnoDisableWinAppRunSupport=true`` — drop the implicit reference entirely.
- ``EnableWinAppRunSupport=false`` — keep the reference but disable the ``dotnet run`` interception (e.g., to run unpackaged for debugging).

## Test plan

- [x] ``dotnet build src/Uno.Sdk/Uno.Sdk.csproj`` — clean.
- [x] ``dotnet format --verify-no-changes`` on touched C# files — clean.
- [x] ``dotnet restore src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj`` — ``Microsoft.Windows.SDK.BuildTools.WinApp/0.3.1`` resolved in ``project.assets.json``.
- [x] JSON files validated (``packages.json``, ``Sdk.props.buildschema.json``).
- [ ] Run ``dotnet run`` against ``SamplesApp.Windows`` on a WinAppSDK-enabled Windows host and confirm packaged launch.
- [ ] Run ``dotnet run`` against a Uno.Sdk-generated WinAppSDK app (packaged + unpackaged) to confirm the implicit reference flows through correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)