### PR TITLE
chore: update windowsScaledPool to Windows2025-20260406-1

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -25,7 +25,7 @@ pr:
       - '**/*.md'
 
 variables:
-  windowsScaledPool: 'Windows2022-20250720-1'
+  windowsScaledPool: 'Windows2025-20260406-1'
   linuxVMImage: 'ubuntu-22.04'
 
   enable_dotnet_cache: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -53,7 +53,7 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   windows2019HostedVMImage: 'windows-2019'
   windows2022HostedVMImage: 'windows-2022'
-  windowsScaledPool: 'Windows2022-20250720-1'
+  windowsScaledPool: 'Windows2025-20260406-1'
   linuxVMImage: 'ubuntu-24.04'
   linuxScaledPool: 'Ubuntu2404-20251016'
   macOSVMImage: 'macOS-15'


### PR DESCRIPTION
Update windowsScaledPool to Windows2025-20260406-1. Windows2025-20260406-1 includes Visual Studo 2026 and MSBuild 18, which are prerequisites for targeting .NET *10* and .NET 11 for many of our projects.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
🏗️ Build or CI related changes

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
