### PR TITLE
feat(sdk): add DisableImplicitUnoWinAppSdkPackages property

### DIFF
--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -191,14 +191,14 @@ to your `Directory.Build.props` file or `csproj` file. You will be then able to 
 > [!NOTE]
 > When disabling Implicit Uno Packages it is recommended that you use the `$(UnoVersion)` to set the version of the core Uno packages that are versioned with the SDK as the SDK requires `Uno.WinUI` to be the same version as the SDK to ensure proper compatibility.
 >
-> For the narrower scenario of a library that is essentially a *WinUI library* that also happens to support Uno cross-targets — and that should not leak `Uno.WinUI` to WinAppSdk-only consumers, or needs a strong-named output on Windows — see the [WinAppSdk-only libraries](#winappsdk-only-libraries) section below.
+> For the narrower scenario of a library that is essentially a *WinUI library* that also happens to support Uno cross-targets — and that should not leak `Uno.WinUI` to WinAppSDK-only consumers, or needs a strong-named output on Windows — see the [WinAppSDK-only libraries](#winappsdk-only-libraries) section below.
 
-## WinAppSdk-only libraries
+## WinAppSDK-only libraries
 
 When you author a library that is *only* a WinUI library on the Windows App SDK target (and uses the rest of the `Uno.Sdk` solely for cross-platform target frameworks), you may want the Windows build to contain no implicit Uno dependencies. Two common motivations:
 
-- Avoid leaking `Uno.WinUI` (~100 MB) as a transitive NuGet dependency to consumers that only target the Windows App SDK.
-- Strong-name the Windows-targeted assembly. `Uno.WinUI` is not strong-named, so a referencing assembly cannot be strong-named either.
+- Avoid leaking `Uno.WinUI` as a transitive NuGet dependency to consumers that only target the Windows App SDK.
+- Compile to a strong-named assembly on Windows for scenarios that require a fully strong-named dependency chain (organizational policy, certain hosts, or downstream consumers that only accept strong-named references). `Uno.WinUI` is not strong-named, so leaving it as an implicit reference would block those scenarios.
 
 Enable this with:
 
@@ -222,7 +222,7 @@ The property is intentionally scoped:
 If you still need one of the stripped packages on Windows for a specific reason, add it back explicitly:
 
 ```xml
-<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+<ItemGroup Condition="$(TargetFramework.Contains('windows10'))">
     <PackageReference Include="Uno.Resizetizer" Version="$(UnoResizetizerVersion)" PrivateAssets="all" />
 </ItemGroup>
 ```

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -190,6 +190,45 @@ to your `Directory.Build.props` file or `csproj` file. You will be then able to 
 
 > [!NOTE]
 > When disabling Implicit Uno Packages it is recommended that you use the `$(UnoVersion)` to set the version of the core Uno packages that are versioned with the SDK as the SDK requires `Uno.WinUI` to be the same version as the SDK to ensure proper compatibility.
+>
+> For the narrower scenario of a library that is essentially a *WinUI library* that also happens to support Uno cross-targets — and that should not leak `Uno.WinUI` to WinAppSdk-only consumers, or needs a strong-named output on Windows — see the [WinAppSdk-only libraries](#winappsdk-only-libraries) section below.
+
+## WinAppSdk-only libraries
+
+When you author a library that is *only* a WinUI library on the Windows App SDK target (and uses the rest of the `Uno.Sdk` solely for cross-platform target frameworks), you may want the Windows build to contain no implicit Uno dependencies. Two common motivations:
+
+- Avoid leaking `Uno.WinUI` (~100 MB) as a transitive NuGet dependency to consumers that only target the Windows App SDK.
+- Strong-name the Windows-targeted assembly. `Uno.WinUI` is not strong-named, so a referencing assembly cannot be strong-named either.
+
+Enable this with:
+
+```xml
+<DisableImplicitUnoWinAppSdkPackages>true</DisableImplicitUnoWinAppSdkPackages>
+```
+
+When set, `Uno.Sdk` stops adding the following implicit package references on the `net*-windows10*` target framework:
+
+- `Uno.WinUI` (also removes the bundled `Uno.UI.Toolkit.dll` it ships under `lib/net*-windows10.0.19041.0/`)
+- `Uno.Resizetizer`
+- `Uno.Sdk.Extras`
+- `Uno.Settings.DevServer`
+
+The property is intentionally scoped:
+
+- It only takes effect on the Windows App SDK target framework. Other targets (Android, iOS, Skia Desktop, WebAssembly, …) are unaffected, so the cross-platform side of your library still uses `Uno.WinUI` and the rest of the Uno stack.
+- Packages added through `UnoFeatures` (Toolkit, Material, Cupertino, Simple, csharpmarkup, prism, maps, foldable, skia/Graphics2DSK, glcanvas, mvvm, dsp, Uno.Extensions.*, …) are *not* stripped. Opting into a `UnoFeatures` value is treated as an explicit request for that package, even when this property is set.
+- Non-Uno implicit packages (`Microsoft.WindowsAppSDK`, `Microsoft.Windows.SDK.BuildTools`, `CommunityToolkit.Mvvm`, `SkiaSharp.Views.WinUI`, …) keep flowing as usual.
+
+If you still need one of the stripped packages on Windows for a specific reason, add it back explicitly:
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <PackageReference Include="Uno.Resizetizer" Version="$(UnoResizetizerVersion)" PrivateAssets="all" />
+</ItemGroup>
+```
+
+> [!NOTE]
+> This property is aimed at libraries (`IsPackable=true`). Application heads typically need the implicit Uno packages on Windows to run, so setting this on a head project is not recommended.
 
 ## Supported OS Platform versions
 

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -56,6 +56,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 
 	<PropertyGroup>
 		<DisableImplicitUnoPackages Condition=" '$(DisableImplicitUnoPackages)' == '' ">false</DisableImplicitUnoPackages>
+		<DisableImplicitUnoWinAppSdkPackages Condition=" '$(DisableImplicitUnoWinAppSdkPackages)' == '' ">false</DisableImplicitUnoWinAppSdkPackages>
 
 		<!-- Disable analyzers provided by Microsoft.AspNetCore.App -->
 		<DisableImplicitAspNetCoreAnalyzers Condition=" '$(DisableImplicitAspNetCoreAnalyzers)' == '' ">true</DisableImplicitAspNetCoreAnalyzers>

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -95,6 +95,10 @@
 			"description": "Disables the extra targets from being loaded which implicitly add NuGet packages.",
 			"type": "bool"
 		},
+		"DisableImplicitUnoWinAppSdkPackages": {
+			"description": "When set to true on a library, prevents the Uno.Sdk from implicitly adding the base Uno.* package references (Uno.WinUI, Uno.Resizetizer, Uno.Sdk.Extras, Uno.Settings.DevServer) on the Windows App SDK (net*-windows10*) target framework. UnoFeatures-driven packages (Toolkit, Material, Extensions, ...) still flow as usual. Use for WinUI libraries cross-targeted to Uno that want to avoid leaking Uno.WinUI as a transitive dependency to WinAppSdk consumers or to compile to a strong-named assembly on Windows.",
+			"type": "bool"
+		},
 		"DisableImplicitUnoNamespaces": {
 			"description": "Disables implicit namespaces that come specifically from the Uno.Sdk.",
 			"type": "bool"

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -122,6 +122,20 @@
 	<Import Project="$(MSBuildThisFileDirectory)Uno.Implicit.Packages.ProjectSystem.Uno.targets"
 		Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''" />
 
+	<!--
+		WinAppSdk-only library mode: when DisableImplicitUnoWinAppSdkPackages is set, strip the base
+		(unconditionally-injected) Uno.* implicit packages on the Windows TFM. UnoFeatures-driven
+		packages (Toolkit, Material, Cupertino, Extensions, Graphics2DSK, etc.) are intentionally
+		left in place — opting into a UnoFeature is treated as an explicit intent to include that
+		package even when this property is set.
+	-->
+	<ItemGroup Condition=" '$(DisableImplicitUnoWinAppSdkPackages)' == 'true' AND $(TargetFramework.Contains('windows10')) ">
+		<_UnoProjectSystemPackageReference Remove="Uno.WinUI" />
+		<_UnoProjectSystemPackageReference Remove="Uno.Resizetizer" />
+		<_UnoProjectSystemPackageReference Remove="Uno.Sdk.Extras" />
+		<_UnoProjectSystemPackageReference Remove="Uno.Settings.DevServer" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="@(_UnoProjectSystemPackageReference)" Exclude="@(PackageReference)" />
 	</ItemGroup>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -123,13 +123,18 @@
 		Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''" />
 
 	<!--
-		WinAppSdk-only library mode: when DisableImplicitUnoWinAppSdkPackages is set, strip the base
+		WinAppSDK-only library mode: when DisableImplicitUnoWinAppSdkPackages is set, strip the base
 		(unconditionally-injected) Uno.* implicit packages on the Windows TFM. UnoFeatures-driven
 		packages (Toolkit, Material, Cupertino, Extensions, Graphics2DSK, etc.) are intentionally
-		left in place — opting into a UnoFeature is treated as an explicit intent to include that
+		left in place — opting into an UnoFeature is treated as an explicit intent to include that
 		package even when this property is set.
+
+		The strip is gated to library projects (i.e. non-executable output): application heads need
+		the implicit Uno packages on Windows to build and run, so setting the property on a head
+		project is a no-op rather than a way to break the head's build from a shared
+		Directory.Build.props.
 	-->
-	<ItemGroup Condition=" '$(DisableImplicitUnoWinAppSdkPackages)' == 'true' AND $(TargetFramework.Contains('windows10')) ">
+	<ItemGroup Condition=" '$(DisableImplicitUnoWinAppSdkPackages)' == 'true' AND $(TargetFramework.Contains('windows10')) AND '$(_ImplicitRestoreOutputType)' != 'WinExe' AND '$(_ImplicitRestoreOutputType)' != 'Exe' ">
 		<_UnoProjectSystemPackageReference Remove="Uno.WinUI" />
 		<_UnoProjectSystemPackageReference Remove="Uno.Resizetizer" />
 		<_UnoProjectSystemPackageReference Remove="Uno.Sdk.Extras" />


### PR DESCRIPTION
## Summary

Adds a new MSBuild property `DisableImplicitUnoWinAppSdkPackages` to `Uno.Sdk`. When set to `true` on a library, the SDK no longer implicitly adds the base Uno.* package references on the Windows App SDK (`net*-windows10*`) target framework:

- `Uno.WinUI` (which also bundles `Uno.UI.Toolkit.dll` inside its Windows `lib/` folder)
- `Uno.Resizetizer`
- `Uno.Sdk.Extras`
- `Uno.Settings.DevServer`

Defaults to `false`, so existing projects are unaffected.

## Why

This enables two scenarios for WinUI libraries that *also* cross-target Uno:

- Avoiding a transitive `Uno.WinUI` (~100 MB) dependency for consumers that only target the Windows App SDK.
- Strong-naming the Windows-targeted assembly (`Uno.WinUI` is not strong-named, so a referencing assembly cannot be either).

## Scope

- Takes effect only when the TFM contains `windows10`. All other targets (Android, iOS, Skia Desktop, WebAssembly, ...) are unaffected.
- `UnoFeatures`-driven packages (Toolkit, Material, Cupertino, Simple, csharpmarkup, prism, maps, foldable, skia/Graphics2DSK, glcanvas, mvvm, dsp, `Uno.Extensions.*`, ...) are intentionally left untouched - opting into a `UnoFeatures` value remains an explicit request for that package.
- Non-Uno implicit packages (`Microsoft.WindowsAppSDK`, `Microsoft.Windows.SDK.BuildTools`, `CommunityToolkit.Mvvm`, `SkiaSharp.Views.WinUI`, ...) keep flowing as usual.
- Users can still add any stripped package back via an explicit `<PackageReference>`.

## Files changed

- `src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets` - removal `ItemGroup` for the four base packages on the Windows TFM, placed after all platform/extensions imports and before the design-time `PackageReference` materialization.
- `src/Uno.Sdk/Sdk/Sdk.props` - explicit default (`false`).
- `src/Uno.Sdk/Sdk/Sdk.props.buildschema.json` - IntelliSense entry.
- `doc/articles/features/using-the-uno-sdk.md` - new "WinAppSdk-only libraries" section, cross-linked from the existing "Disabling Implicit Uno Packages" note.

## Test plan

- [ ] Build `Uno.Sdk` succeeds locally (verified: 0 warnings, 0 errors).
- [ ] In a sample cross-targeted library csproj (`net10.0;net10.0-windows10.0.19041.0`), with `DisableImplicitUnoWinAppSdkPackages=true`:
  - The Windows TFM's `obj/project.assets.json` must not list `Uno.WinUI`, `Uno.Resizetizer`, `Uno.Sdk.Extras`, or `Uno.Settings.DevServer`.
  - With a `UnoFeatures` value set (e.g. `Toolkit`), the corresponding Uno package (`Uno.Toolkit.WinUI`) must still appear on the Windows TFM.
  - The non-Windows TFM must be unchanged (still references `Uno.WinUI`).
- [ ] `dotnet pack` of the sample lib produces a `.nuspec` whose `<group targetFramework="net10.0-windows10.0.19041.0">` does not list `Uno.WinUI` as a `<dependency>`.
- [ ] Default behavior (property unset) remains unchanged - smoke test by building one of the existing Windows-targeted apps.

Fixes #22485