### PR TITLE
chore: Lower BindingPropertyHelper severity

### DIFF
--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -236,7 +236,10 @@ namespace Uno.UI.DataBinding
 						}
 						else
 						{
-							_log.ErrorFormat("The [{0}] property does not exist on type [{1}]", property, type);
+							if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+							{
+								_log.DebugFormat("The [{0}] property does not exist on type [{1}]", property, type);
+							}
 							return null;
 						}
 					}
@@ -277,7 +280,10 @@ namespace Uno.UI.DataBinding
 						}
 						else
 						{
-							_log.ErrorFormat("The Indexer property getter does not exist on type [{0}]", type);
+							if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+							{
+								_log.DebugFormat("The Indexer property getter does not exist on type [{0}]", type);
+							}
 							return null;
 						}
 					}
@@ -315,7 +321,10 @@ namespace Uno.UI.DataBinding
 						return type;
 					}
 
-					_log.ErrorFormat("The [{0}] property getter does not exist on type [{1}]", property, type);
+					if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+					{
+						_log.DebugFormat("The [{0}] property getter does not exist on type [{1}]", property, type);
+					}
 					return null;
 				}
 			}
@@ -528,14 +537,20 @@ namespace Uno.UI.DataBinding
 							}
 							else
 							{
-								_log.ErrorFormat($"The index [{0}] was outside of the bounds of the [{1}]", index, type);
+								if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+								{
+									_log.DebugFormat($"The index [{0}] was outside of the bounds of the [{1}]", index, type);
+								}
 								return DependencyProperty.UnsetValue;
 							}
 						};
 					}
 					else
 					{
-						_log.ErrorFormat("The property [{0}] is not valid for [{1}]", property, type);
+						if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+						{
+							_log.DebugFormat("The property [{0}] is not valid for [{1}]", property, type);
+						}
 					}
 				}
 				else if (type.Is<IList>())
@@ -552,14 +567,20 @@ namespace Uno.UI.DataBinding
 							}
 							else
 							{
-								_log.ErrorFormat($"The index [{0}] was outside of the bounds of the [{1}]", index, type);
+								if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+								{
+									_log.DebugFormat($"The index [{0}] was outside of the bounds of the [{1}]", index, type);
+								}
 								return DependencyProperty.UnsetValue;
 							}
 						};
 					}
 					else
 					{
-						_log.ErrorFormat("The property [{0}] is not valid for [{1}]", property, type);
+						if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+						{
+							_log.DebugFormat("The property [{0}] is not valid for [{1}]", property, type);
+						}
 					}
 				}
 
@@ -613,7 +634,10 @@ namespace Uno.UI.DataBinding
 						{
 							var empty = Funcs.CreateMemoized<object>(() =>
 							{
-								_log.ErrorFormat("The Indexer Getter does not exist on [{0}]", type);
+								if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+								{
+									_log.DebugFormat("The Indexer Getter does not exist on [{0}]", type);
+								}
 								return DependencyProperty.UnsetValue;
 							});
 
@@ -635,7 +659,10 @@ namespace Uno.UI.DataBinding
 					{
 						var empty = Funcs.CreateMemoized<object>(() =>
 						{
-							_log.ErrorFormat("The Indexer property getter does not exist on type [{0}]", type);
+							if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+							{
+								_log.DebugFormat("The Indexer property getter does not exist on type [{0}]", type);
+							}
 							return DependencyProperty.UnsetValue;
 						});
 
@@ -697,7 +724,10 @@ namespace Uno.UI.DataBinding
 					{
 						var emptyProperty = Funcs.CreateMemoized<object>(() =>
 						{
-							_log.ErrorFormat("The Property [{0}] Getter does not exist on [{1}]", property, type);
+							if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+							{
+								_log.DebugFormat("The Property [{0}] Getter does not exist on [{1}]", property, type);
+							}
 							return DependencyProperty.UnsetValue;
 						});
 
@@ -803,7 +833,10 @@ namespace Uno.UI.DataBinding
 				// No getter has been found
 				var empty = Funcs.CreateMemoized<object>(() =>
 				{
-					_log.ErrorFormat("The [{0}] property getter does not exist on type [{1}]", property, type);
+					if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+					{
+						_log.DebugFormat("The [{0}] property getter does not exist on type [{1}]", property, type);
+					}
 					return DependencyProperty.UnsetValue;
 				});
 
@@ -900,7 +933,13 @@ namespace Uno.UI.DataBinding
 							else
 							{
 								var once = Actions.CreateOnce(
-									() => _log.ErrorFormat("The Indexer property setter does not exist on type [{0}]", type)
+									() =>
+									{
+										if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+										{
+											_log.DebugFormat("The Indexer property setter does not exist on type [{0}]", type);
+										}
+									}
 								);
 
 								return delegate { once(); };
@@ -938,7 +977,13 @@ namespace Uno.UI.DataBinding
 						else
 						{
 							var once = Actions.CreateOnce(
-								() => _log.ErrorFormat("The Indexer Setter does not exist on [{0}]", type)
+								() =>
+								{
+									if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+									{
+										_log.DebugFormat("The Indexer Setter does not exist on [{0}]", type);
+									}
+								}
 							);
 
 							return delegate { once(); };
@@ -947,7 +992,13 @@ namespace Uno.UI.DataBinding
 					else
 					{
 						var once = Actions.CreateOnce(
-							() => _log.ErrorFormat("The Indexer property setter does not exist on type [{0}]", type)
+							() =>
+							{
+								if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+								{
+									_log.DebugFormat("The Indexer property setter does not exist on type [{0}]", type);
+								}
+							}
 						);
 
 						return delegate { once(); };
@@ -982,7 +1033,13 @@ namespace Uno.UI.DataBinding
 						}
 
 						var once = Actions.CreateOnce(
-							() => _log.ErrorFormat("The property setter for [{0}] does not exist on [{1}]", property, type)
+							() =>
+							{
+								if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+								{
+									_log.DebugFormat("The property setter for [{0}] does not exist on [{1}]", property, type);
+								}
+							}
 						);
 
 						return delegate { once(); };
@@ -1064,7 +1121,13 @@ namespace Uno.UI.DataBinding
 				}
 
 				var once = Actions.CreateOnce(
-					() => _log.ErrorFormat("The property setter for [{0}] does not exist on [{1}]", property, type)
+					() =>
+					{
+						if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+						{
+							_log.DebugFormat("The property setter for [{0}] does not exist on [{1}]", property, type);
+						}
+					}
 				);
 
 				return delegate { once(); };
@@ -1091,7 +1154,10 @@ namespace Uno.UI.DataBinding
 				// No getter has been found
 				var empty = Funcs.CreateMemoized<object>(() =>
 				{
-					_log.ErrorFormat("The [{0}] substitute property getter does not exist on type [{1}]", property, type);
+					if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+					{
+						_log.DebugFormat("The [{0}] substitute property getter does not exist on type [{1}]", property, type);
+					}
 					return DependencyProperty.UnsetValue;
 				});
 
@@ -1116,7 +1182,13 @@ namespace Uno.UI.DataBinding
 			}
 
 			var once = Actions.CreateOnce(
-				() => _log.ErrorFormat("The property unsetter for [{0}] does not exist on [{1}]", property, type)
+				() =>
+				{
+					if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+					{
+						_log.DebugFormat("The property unsetter for [{0}] does not exist on [{1}]", property, type);
+					}
+				}
 			);
 
 			return delegate { once(); };


### PR DESCRIPTION
## Summary

- Downgrades `BindingPropertyHelper`''s "property / indexer / setter / unsetter does not exist on type" and "index out of bounds" / "property is not valid" messages from `LogLevel.Error` to a guarded `LogLevel.Debug`.
- These fire on every routine `{Binding}` fallback (DataContext transitions, optional paths, polymorphic types). On WASM they surface as red `fail:` entries in the browser console and drown out real errors. In WPF/WinUI the same scenario is a non-error silent fallback to `UnsetValue`.
- Structural / misconfiguration sites stay at `Error`:
  - `"The attached property Getter for [X] must be static"`
  - `"The type UnoGetMemberBinder is not available, likely caused by an incorrect Linker configuration."`
  - `"The type UnoSetMemberBinder is not available, likely caused by an incorrect Linker configuration."`
- No runtime behavior change — getters still return `UnsetValue`, setters / unsetters are still no-ops, `InternalGetPropertyType` still returns `null`. Only the log level moves.

## Escape hatch

Apps that want to keep diagnosing missing bindings can opt back in via standard `Microsoft.Extensions.Logging` config — no Uno-specific API needed:

```csharp
builder.AddFilter("Uno.UI.DataBinding.BindingPropertyHelper", LogLevel.Debug);
```

## Test plan

- [ ] CI unit tests: `Uno.UI.Tests` (no assertions on these log messages expected)
- [ ] Manual WASM SamplesApp — open DevTools console, exercise binding-heavy samples, confirm there are no `fail: Uno.UI.DataBinding.BindingPropertyHelper` entries for the routine fallback messages
- [ ] Opt-in verification — add the filter line above, confirm messages reappear at `dbug:` level
- [ ] Structural sites still log at Error when reached (rare; can be exercised by adding a non-static attached-property `Get`-method to a sample)