### PR TITLE
fix: Handle null Parent in ancestor layout clip

### DIFF
--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -122,7 +122,7 @@ public partial class ContainerVisual : Visual
 		if (isAncestorClip)
 		{
 			Matrix4x4.Invert(TotalMatrix, out var totalMatrixInverted);
-			var childToParentTransform = Parent!.TotalMatrix * totalMatrixInverted;
+			var childToParentTransform = (Parent?.TotalMatrix ?? Matrix4x4.Identity) * totalMatrixInverted;
 			if (!childToParentTransform.IsIdentity)
 			{
 				dst.Transform(childToParentTransform.ToSKMatrix());
@@ -142,7 +142,7 @@ public partial class ContainerVisual : Visual
 		if (isAncestorClip)
 		{
 			Matrix4x4.Invert(TotalMatrix, out var totalMatrixInverted);
-			var childToParentTransform = Parent!.TotalMatrix * totalMatrixInverted;
+			var childToParentTransform = (Parent?.TotalMatrix ?? Matrix4x4.Identity) * totalMatrixInverted;
 			if (!childToParentTransform.IsIdentity)
 			{
 				rect = rect.Transform(childToParentTransform.ToMatrix3x2());

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
@@ -126,6 +126,60 @@ public class Given_ContainerVisual
 		ImageAssert.DoesNotHaveColorAt(screenShot2, p, Colors.Red);
 	}
 
+	[TestMethod]
+	[RunsOnUIThread]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22416")]
+	public void GetArrangeClipPathInElementCoordinateSpace_NullParentAncestorClip_MapsToElementLocalSpace()
+	{
+		var compositor = TestServices.WindowHelper.XamlRoot.Compositor;
+		var visual = compositor.CreateContainerVisual();
+		visual.Offset = new Vector3(30, 20, 0);
+
+		// An ancestor (Panel) layout clip is stored in the parent's coordinate space.
+		// For an element at offset (30, 20), a local clip of (0, 0, 50, 40) is stored as (30, 20, 50, 40).
+		visual.LayoutClip = (new Rect(30, 20, 50, 40), true);
+
+		// No parent: mimics the composition root (RootVisual is a Panel) or a visual rendered standalone
+		// via RenderRootVisual. This used to throw a NullReferenceException (issue #22416).
+		Assert.IsNull(visual.Parent);
+
+		// SKPath overload (the one used by GetPrePaintingClipping during rendering).
+		using var path = new SKPath();
+		Assert.IsTrue(visual.GetArrangeClipPathInElementCoordinateSpace(path));
+		Assert.AreEqual(0f, path.Bounds.Left, 0.01f);
+		Assert.AreEqual(0f, path.Bounds.Top, 0.01f);
+		Assert.AreEqual(50f, path.Bounds.Right, 0.01f);
+		Assert.AreEqual(40f, path.Bounds.Bottom, 0.01f);
+
+		// Rect? overload.
+		var rect = visual.GetArrangeClipPathInElementCoordinateSpace();
+		Assert.IsNotNull(rect);
+		Assert.AreEqual(0, rect.Value.X, 0.01);
+		Assert.AreEqual(0, rect.Value.Y, 0.01);
+		Assert.AreEqual(50, rect.Value.Width, 0.01);
+		Assert.AreEqual(40, rect.Value.Height, 0.01);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22416")]
+	public void RenderRootVisual_NullParentAncestorClip_DoesNotThrow()
+	{
+		var compositor = TestServices.WindowHelper.XamlRoot.Compositor;
+		var visual = compositor.CreateContainerVisual();
+		visual.Size = new Vector2(100, 100);
+		visual.Offset = new Vector3(30, 20, 0);
+		visual.LayoutClip = (new Rect(30, 20, 50, 40), true);
+
+		Assert.IsNull(visual.Parent);
+
+		using var surface = SKSurface.Create(new SKImageInfo(100, 100, SKColorType.Bgra8888, SKAlphaType.Premul));
+
+		// Rendering a parent-less Panel-like visual carrying an ancestor layout clip used to throw a
+		// NullReferenceException inside GetArrangeClipPathInElementCoordinateSpace (issue #22416).
+		visual.RenderRootVisual(surface.Canvas, Vector2.Zero);
+	}
+
 	private class FrameCounterSKCanvasElement : SKCanvasElement
 	{
 		public int FrameCounter { get; private set; }


### PR DESCRIPTION
**GitHub Issue:** closes #22416

## PR Type:

🐞 Bugfix

## What changed? 🚀

A `Panel` applies its layout clip in the **parent's** coordinate space (`isAncestorClip`). `ContainerVisual.GetArrangeClipPathInElementCoordinateSpace` built the child-to-parent transform via `Parent!.TotalMatrix`, assuming a clipped visual always has a parent.

That assumption is wrong — a visual is legitimately rendered with a **null `Parent`** when:

- it is the composition root: `RootVisual` is itself a `Panel`, attached directly to `CompositionTarget.Root` (never through `VisualCollection.Add`), so its `Parent` stays `null`; or
- it is rendered standalone via `RenderRootVisual` (e.g. `RenderTargetBitmap`, `CompositionVisualSurface`, `RedirectVisual`, focus-visual / native-clip traversals).

When such a parentless `Panel` carries an `isAncestorClip` layout clip, painting it threw `System.NullReferenceException` (issue #22416).

### Root cause, not just a guard

The transform is `Parent.TotalMatrix * inverse(TotalMatrix)`. Since `TotalMatrix == localMatrix * Parent.TotalMatrix`, it reduces to `inverse(localMatrix)` — it simply undoes the element's own offset/transform to bring the parent-space clip into the element's local space; the `Parent.TotalMatrix` factor only cancels the parent component baked into the inverse.

With no parent, `TotalMatrix == localMatrix`, so substituting `Matrix4x4.Identity` for the missing parent yields exactly `inverse(TotalMatrix)` — the correct result. This matches WinUI (which applies only the element's own offset for ancestor clips and never reads a parent transform) and reuses the `Parent?.TotalMatrix ?? Matrix4x4.Identity` idiom already used by `TotalMatrix` and `RenderRootVisual`. A plain null-guard that skipped the transform would mis-position the clip whenever a parentless root has a non-zero offset.

Applied to both overloads of `GetArrangeClipPathInElementCoordinateSpace`.

## PR Checklist ✅

- [x] 🧪 Added runtime tests (`Given_ContainerVisual`) — fail with `NullReferenceException` before the fix, pass after
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
