### PR TITLE
fix(skia-win32): Report exceptions escaping WndProc

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -214,15 +214,23 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 	[UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
 	private static LRESULT WndProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
 	{
-		if (_wrapperForNextCreateWindow is { } wrapper)
+		try
 		{
-			_hwndToWrapper[hwnd] = _wrapperForNextCreateWindow;
+			if (_wrapperForNextCreateWindow is { } wrapper)
+			{
+				_hwndToWrapper[hwnd] = _wrapperForNextCreateWindow;
+			}
+			else if (!_hwndToWrapper.TryGetValue(hwnd, out wrapper))
+			{
+				throw new Exception($"{nameof(WndProc)} was fired on a {nameof(HWND)} before it was added to, or after it was removed from, {nameof(_hwndToWrapper)}.");
+			}
+			return wrapper.WndProcInner(hwnd, msg, wParam, lParam);
 		}
-		else if (!_hwndToWrapper.TryGetValue(hwnd, out wrapper))
+		catch (Exception e)
 		{
-			throw new Exception($"{nameof(WndProc)} was fired on a {nameof(HWND)} before it was added to, or after it was removed from, {nameof(_hwndToWrapper)}.");
+			typeof(Win32WindowWrapper).LogError()?.Error($"An unhandled exception was thrown while processing win32 message 0x{msg:X4}.", e);
+			return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
 		}
-		return wrapper.WndProcInner(hwnd, msg, wParam, lParam);
 	}
 
 	private unsafe LRESULT WndProcInner(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/kahua-private/issues/489

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
