### PR TITLE
fix: Wasm keyboard focus to re-enter app repeatedly with a11y

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Input/FocusTrapRepro/FocusTrapRepro.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Input/FocusTrapRepro/FocusTrapRepro.xaml
@@ -1,0 +1,38 @@
+<Page x:Class="UITests.Windows_UI_Xaml_Input.FocusTrapRepro.FocusTrapRepro"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  IsTabStop="False"
+	  mc:Ignorable="d">
+
+	<StackPanel HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Spacing="16">
+		<TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+				   Text="Tab / Shift+Tab should cycle through these controls and the browser repeatedly."
+				   TextWrapping="Wrap" />
+
+		<Button x:Name="BeforeTextBoxButton"
+				AutomationProperties.AutomationId="BeforeTextBoxButton"
+				AutomationProperties.Name="Before text box button"
+				Content="Before text box button"
+				IsTabStop="True"
+				TabIndex="0" />
+
+		<TextBox x:Name="FocusTrapTextBox"
+				 AutomationProperties.AutomationId="FocusTrapTextBox"
+				 AutomationProperties.Name="Focus trap text box"
+				 IsTabStop="True"
+				 MinWidth="280"
+				 PlaceholderText="Focus trap text box"
+				 TabIndex="1" />
+
+		<Button x:Name="AfterTextBoxButton"
+				AutomationProperties.AutomationId="AfterTextBoxButton"
+				AutomationProperties.Name="After text box button"
+				Content="After text box button"
+				IsTabStop="True"
+				TabIndex="2" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Input/FocusTrapRepro/FocusTrapRepro.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Input/FocusTrapRepro/FocusTrapRepro.xaml
@@ -1,38 +1,44 @@
-<Page x:Class="UITests.Windows_UI_Xaml_Input.FocusTrapRepro.FocusTrapRepro"
-	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  IsTabStop="False"
-	  mc:Ignorable="d">
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Input.FocusTrapRepro.FocusTrapRepro"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    IsTabStop="False"
+    mc:Ignorable="d">
 
-	<StackPanel HorizontalAlignment="Center"
-				VerticalAlignment="Center"
-				Spacing="16">
-		<TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-				   Text="Tab / Shift+Tab should cycle through these controls and the browser repeatedly."
-				   TextWrapping="Wrap" />
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Spacing="16">
+        <TextBlock
+            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+            Text="Tab / Shift+Tab should cycle through these controls and the browser repeatedly."
+            TextWrapping="Wrap" />
 
-		<Button x:Name="BeforeTextBoxButton"
-				AutomationProperties.AutomationId="BeforeTextBoxButton"
-				AutomationProperties.Name="Before text box button"
-				Content="Before text box button"
-				IsTabStop="True"
-				TabIndex="0" />
+        <Button
+            x:Name="BeforeTextBoxButton"
+            AutomationProperties.AutomationId="BeforeTextBoxButton"
+            AutomationProperties.Name="Before text box button"
+            Content="Before text box button"
+            IsTabStop="True"
+            TabIndex="0" />
 
-		<TextBox x:Name="FocusTrapTextBox"
-				 AutomationProperties.AutomationId="FocusTrapTextBox"
-				 AutomationProperties.Name="Focus trap text box"
-				 IsTabStop="True"
-				 MinWidth="280"
-				 PlaceholderText="Focus trap text box"
-				 TabIndex="1" />
+        <TextBox
+            x:Name="FocusTrapTextBox"
+            MinWidth="280"
+            AutomationProperties.AutomationId="FocusTrapTextBox"
+            AutomationProperties.Name="Focus trap text box"
+            IsTabStop="True"
+            PlaceholderText="Focus trap text box"
+            TabIndex="1" />
 
-		<Button x:Name="AfterTextBoxButton"
-				AutomationProperties.AutomationId="AfterTextBoxButton"
-				AutomationProperties.Name="After text box button"
-				Content="After text box button"
-				IsTabStop="True"
-				TabIndex="2" />
-	</StackPanel>
+        <Button
+            x:Name="AfterTextBoxButton"
+            AutomationProperties.AutomationId="AfterTextBoxButton"
+            AutomationProperties.Name="After text box button"
+            Content="After text box button"
+            IsTabStop="True"
+            TabIndex="2" />
+    </StackPanel>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Input/FocusTrapRepro/FocusTrapRepro.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Input/FocusTrapRepro/FocusTrapRepro.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Input.FocusTrapRepro
+{
+	[Sample("Focus", Name = "FocusTrapRepro", Description = "Tab/Shift+Tab cycling between Uno controls and the browser (WASM a11y focus).")]
+	public sealed partial class FocusTrapRepro : Page
+	{
+		public FocusTrapRepro()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Accessibility/WebAssemblyAccessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Accessibility/WebAssemblyAccessibility.cs
@@ -63,6 +63,8 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 	// Subsystem managers (initialized during accessibility activation)
 	private LiveRegionManager? _liveRegionManager;
 	private FocusSynchronizer? _focusSynchronizer;
+	private UIElement? _focusSearchRoot;
+	private bool _suppressDeparture;
 	internal ModalFocusScope? ActiveModalScope { get; set; }
 	private readonly List<VirtualizedSemanticRegion> _virtualizedRegions = new();
 	private const int PreserveTextSelectionSentinel = -1;
@@ -730,6 +732,16 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 		// The FocusSynchronizer handles all focus sync via FocusManager.GotFocus
 		// and performs semantic tree resolution before calling into JS.
 		FocusManager.SuppressNativeFocus = true;
+
+		@this._focusSearchRoot = rootElement;
+		NativeMethods.InstallFocusSentinels();
+
+		var focusManager = global::Uno.UI.Xaml.Core.VisualTree.GetFocusManagerForElement(rootElement);
+		if (focusManager is not null)
+		{
+			focusManager.FocusObserver.FocusController.FocusDeparting -= @this.OnFocusDeparting;
+			focusManager.FocusObserver.FocusController.FocusDeparting += @this.OnFocusDeparting;
+		}
 	}
 
 	[JSExport]
@@ -952,6 +964,85 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 
 		// Focus leaving the semantic element is handled by the browser focus system.
 		// No explicit action needed here - the Uno FocusManager handles focus transitions.
+	}
+
+	[JSExport]
+	public static void OnFocusSentinel(bool isStart)
+	{
+		var @this = Instance;
+		var root = @this._focusSearchRoot;
+		if (root is null)
+		{
+			return;
+		}
+
+		var candidate = isStart
+			? FocusManager.FindFirstFocusableElement(root)
+			: FocusManager.FindLastFocusableElement(root);
+
+		var leaf = candidate is UIElement candidateElement
+			? @this.ResolveEntrySemanticLeaf(candidateElement, isStart)
+			: null;
+
+		if (leaf is not Control { IsFocusable: true } control)
+		{
+			return;
+		}
+
+		@this._suppressDeparture = true;
+		try
+		{
+			control.Focus(FocusState.Keyboard);
+
+			// Force the DOM sync: when control was already the XAML-focused element,
+			// GotFocus does not fire and DOM focus would stay stranded on the sentinel.
+			var semanticHandle = @this.ResolveToSemanticHandle(control);
+			if (semanticHandle != IntPtr.Zero)
+			{
+				NativeMethods.FocusSemanticElement(semanticHandle);
+			}
+		}
+		finally
+		{
+			@this._suppressDeparture = false;
+		}
+	}
+
+	// First/last descendant-or-self owning a focusable semantic element, skipping
+	// focusable containers (e.g. a navigation SplitView) that have none of their own.
+	private UIElement? ResolveEntrySemanticLeaf(UIElement root, bool first)
+	{
+		if (HasOwnFocusableSemanticElement(root))
+		{
+			return root;
+		}
+
+		var children = root.GetChildren();
+		var ordered = first ? children : children.Reverse();
+		foreach (var child in ordered)
+		{
+			if (child is UIElement childElement
+				&& ResolveEntrySemanticLeaf(childElement, first) is { } found)
+			{
+				return found;
+			}
+		}
+
+		return null;
+	}
+
+	private bool HasOwnFocusableSemanticElement(UIElement element)
+		=> HasSemanticElement(element.Visual.Handle)
+			&& IsAccessibilityFocusable(element, (element as Control)?.IsFocusable ?? element.IsFocusable);
+
+	private void OnFocusDeparting(object sender, object args)
+	{
+		if (_suppressDeparture)
+		{
+			return;
+		}
+
+		NativeMethods.FocusDepartureSentinel(BrowserKeyboardInputSource.LastTabWasForward);
 	}
 
 	private void UpdateIsFocusable(Control control, bool isFocusable)
@@ -2062,5 +2153,11 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 
 		[JSImport("globalThis.Uno.UI.Runtime.Skia.Accessibility.focusSemanticElement")]
 		internal static partial void FocusSemanticElement(IntPtr handle);
+
+		[JSImport("globalThis.Uno.UI.Runtime.Skia.Accessibility.installFocusSentinels")]
+		internal static partial void InstallFocusSentinels();
+
+		[JSImport("globalThis.Uno.UI.Runtime.Skia.Accessibility.focusDepartureSentinel")]
+		internal static partial void FocusDepartureSentinel(bool isForward);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserKeyboardInputSource.cs
@@ -16,6 +16,8 @@ internal partial class BrowserKeyboardInputSource : IUnoKeyboardInputSource
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
 
+	internal static bool LastTabWasForward { get; private set; } = true;
+
 	[JSImport("globalThis.Uno.UI.Runtime.Skia.BrowserKeyboardInputSource.initialize")]
 	private static partial void Initialize([JSMarshalAs<JSType.Any>] object inputSource);
 
@@ -55,6 +57,11 @@ internal partial class BrowserKeyboardInputSource : IUnoKeyboardInputSource
 			},
 
 			unicodeKey: GetUnicodeKey(key));
+
+		if (down && string.Equals(key, "Tab", StringComparison.Ordinal))
+		{
+			LastTabWasForward = !shift;
+		}
 
 		if (down)
 		{

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/Accessibility.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/Accessibility.ts
@@ -8,6 +8,10 @@ namespace Uno.UI.Runtime.Skia {
 		private static containerElement: HTMLElement;
 		private static debugModeEnabled: boolean = false;
 
+		private static focusSentinelStart: HTMLDivElement | null = null;
+		private static focusSentinelEnd: HTMLDivElement | null = null;
+		private static isDepartingFocus: boolean = false;
+
 		// Managed callbacks from C#
 		private static managedEnableAccessibility: any;
 		private static managedOnScroll: any;
@@ -19,6 +23,7 @@ namespace Uno.UI.Runtime.Skia {
 		private static managedOnSelection: any;
 		private static managedOnFocus: any;
 		private static managedOnBlur: any;
+		private static managedOnSentinelFocus: any;
 
 		private static managedIsAutoEnableAccessibility: () => boolean;
 
@@ -46,6 +51,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.managedOnSelection = accessibilityExports.OnSelection;
 			this.managedOnFocus = accessibilityExports.OnFocus;
 			this.managedOnBlur = accessibilityExports.OnBlur;
+			this.managedOnSentinelFocus = accessibilityExports.OnFocusSentinel;
 
 			this.containerElement = document.getElementById("uno-body");
 
@@ -192,7 +198,7 @@ namespace Uno.UI.Runtime.Skia {
 
 		public static updateElementFocusability(element: HTMLElement, isFocusable: boolean) {
 			if (isFocusable) {
-				element.tabIndex = 0;
+				element.tabIndex = -1;
 			} else {
 				element.removeAttribute("tabIndex");
 			}
@@ -279,6 +285,67 @@ namespace Uno.UI.Runtime.Skia {
 			}
 		}
 
+		public static installFocusSentinels() {
+			if (!this.focusSentinelStart) {
+				this.focusSentinelStart = Accessibility.createFocusSentinel("uno-focus-sentinel-start", true);
+			}
+			if (!this.focusSentinelEnd) {
+				this.focusSentinelEnd = Accessibility.createFocusSentinel("uno-focus-sentinel-end", false);
+			}
+
+			document.body.insertBefore(this.focusSentinelStart, document.body.firstChild);
+			document.body.appendChild(this.focusSentinelEnd);
+		}
+
+		private static createFocusSentinel(id: string, isStart: boolean): HTMLDivElement {
+			const sentinel = document.createElement("div");
+			sentinel.id = id;
+			sentinel.tabIndex = 0;
+			sentinel.setAttribute("aria-hidden", "true");
+			sentinel.style.position = "fixed";
+			sentinel.style.width = "1px";
+			sentinel.style.height = "1px";
+			sentinel.style.padding = "0";
+			sentinel.style.margin = "-1px";
+			sentinel.style.overflow = "hidden";
+			sentinel.style.opacity = "0";
+			sentinel.style.pointerEvents = "none";
+			sentinel.style.top = "0";
+			sentinel.style.left = "0";
+
+			sentinel.addEventListener("focus", () => {
+				if (this.isDepartingFocus) {
+					return;
+				}
+				// Defer: browsers revert focus changes made synchronously inside a focus handler.
+				setTimeout(() => {
+					if (this.managedOnSentinelFocus) {
+						this.managedOnSentinelFocus(isStart);
+					}
+				}, 0);
+			});
+
+			return sentinel;
+		}
+
+		public static focusDepartureSentinel(isForward: boolean) {
+			const sentinel = isForward ? this.focusSentinelEnd : this.focusSentinelStart;
+			if (!sentinel) {
+				return;
+			}
+
+			this.isDepartingFocus = true;
+			sentinel.focus();
+			setTimeout(() => { this.isDepartingFocus = false; }, 0);
+		}
+
+		public static removeFocusSentinels() {
+			this.focusSentinelStart?.remove();
+			this.focusSentinelEnd?.remove();
+			this.focusSentinelStart = null;
+			this.focusSentinelEnd = null;
+		}
+
 		/**
 		 * Updates roving tabindex within an ARIA widget group.
 		 * Sets tabindex="0" on the active element and tabindex="-1" on
@@ -297,8 +364,7 @@ namespace Uno.UI.Runtime.Skia {
 				return;
 			}
 
-			// Set the active element to tabindex 0
-			activeElement.tabIndex = 0;
+			activeElement.tabIndex = -1;
 
 			// Determine the group scope. Only radio buttons (sharing the
 			// same 'name') and tab-role children of a tablist are grouped.

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
@@ -59,6 +59,7 @@
 			}
 
 			input.id = BrowserInvisibleTextBoxViewExtension.inputElementId;
+			input.tabIndex = -1;
 			input.spellcheck = false;
 			input.style.whiteSpace = "pre-wrap";
 			input.style.position = "absolute";

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/SemanticElements.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/SemanticElements.ts
@@ -151,7 +151,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			// Enable focus and interaction
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			if (label) {
@@ -198,7 +198,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('button');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			// aria-pressed for toggle button pattern (distinct from aria-checked for checkboxes)
@@ -247,7 +247,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('button');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			// role="switch" with aria-checked for ToggleSwitch (ARIA switch pattern)
@@ -301,7 +301,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			// Enable focus and interaction
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			// Set range properties
@@ -360,7 +360,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			// Enable focus and interaction
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			if (label) {
@@ -411,7 +411,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			// Enable focus and interaction
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			if (label) {
@@ -458,7 +458,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			// Enable focus for screen readers
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			// Reset default heading styles so they don't affect layout
@@ -508,7 +508,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			// Enable focus and interaction
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			element.value = value;
@@ -581,7 +581,7 @@ namespace Uno.UI.Runtime.Skia {
 			element.setAttribute('role', 'combobox');
 			element.setAttribute('aria-expanded', String(expanded));
 			element.setAttribute('aria-haspopup', 'listbox');
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			if (selectedValue) {
@@ -637,7 +637,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
 			element.setAttribute('role', 'listbox');
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 
 			if (multiselect) {
@@ -842,7 +842,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('a');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 			// Native <a> has implicit role="link" — no need to set explicitly
 
@@ -889,7 +889,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('div');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 			element.setAttribute('role', 'tablist');
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 			if (label) {
 				element.setAttribute('aria-label', label);
@@ -917,7 +917,7 @@ namespace Uno.UI.Runtime.Skia {
 			this.applyCommonStyles(element, x, y, width, height, handle);
 			element.setAttribute('role', 'tab');
 			element.setAttribute('aria-selected', String(selected));
-			element.tabIndex = selected ? 0 : -1;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 			if (label) {
 				element.setAttribute('aria-label', label);
@@ -962,7 +962,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('div');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 			element.setAttribute('role', 'tree');
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 			if (label) {
 				element.setAttribute('aria-label', label);
@@ -1110,7 +1110,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('table');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 			element.setAttribute('role', 'grid');
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 			if (label) {
 				element.setAttribute('aria-label', label);
@@ -1223,7 +1223,7 @@ namespace Uno.UI.Runtime.Skia {
 			const element = document.createElement('div');
 			this.applyCommonStyles(element, x, y, width, height, handle);
 			element.setAttribute('role', 'menu');
-			element.tabIndex = 0;
+			element.tabIndex = -1;
 			element.style.pointerEvents = 'none';
 			if (label) {
 				element.setAttribute('aria-label', label);


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix


## What changed? 🚀

The managed FocusManager is now the sole owner of the in-app tab order; the browser only carries focus across the app boundary.

All interactive semantic elements (and the invisible TextBox <input>) are now tabindex="-1" — still programmatically focusable and screen-reader reachable, but removed from the browser's native Tab sequence, so DOM focus tracks XAML focus exactly.
Added two boundary focus sentinels (uno-focus-sentinel-start/-end, the only browser-tabbable elements) bracketing the body. A Tab/Shift+Tab arriving from the browser chrome lands on a sentinel, which asks the FocusManager to focus the first/last focusable control.
Hooked FocusController.FocusDeparting so tabbing past the app edge routes DOM focus out through the matching sentinel, letting the browser's default Tab continue into the chrome (direction tracked from the last Tab keydown).
Re-entry resolves the first/last leaf that owns a focusable semantic element (skipping focusable containers like a nav SplitView) and force-syncs DOM focus to handle the already-focused no-op case.

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
