### PR TITLE
feat(wasm): add StorageFile.RegisterApplicationUriAssetAsync

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_RegisterApplicationUriAsset.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_RegisterApplicationUriAsset.cs
@@ -1,4 +1,4 @@
-#if !WINAPPSDK
+#if __WASM__
 #nullable enable
 
 using System;
@@ -36,10 +36,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 
 			Assert.IsNotNull(file);
 
-			var actualBytes = await FileIO.ReadBufferAsync(file);
-			Assert.AreEqual((uint)expectedContent.Length, actualBytes.Length, "File size mismatch.");
-
-			var actualContent = Encoding.UTF8.GetString(actualBytes.ToArray());
+			var actualContent = await FileIO.ReadTextAsync(file);
 			Assert.AreEqual("hello from runtime registered asset", actualContent);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_RegisterApplicationUriAsset.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_RegisterApplicationUriAsset.cs
@@ -1,0 +1,79 @@
+#if !WINAPPSDK
+#nullable enable
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Storage;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
+{
+	/// <summary>
+	/// Tests for <see cref="StorageFile.RegisterApplicationUriAssetAsync"/>, which allows
+	/// runtime code to inject asset content so that subsequent
+	/// <see cref="StorageFile.GetFileFromApplicationUriAsync"/> calls resolve paths that are
+	/// absent from the compile-time <c>uno-assets.txt</c> manifest.
+	/// </summary>
+	[TestClass]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Wasm)]
+	public class Given_StorageFile_RegisterApplicationUriAsset
+	{
+		[TestMethod]
+		public async Task When_Asset_Registered_Then_GetFileFromApplicationUri_Succeeds()
+		{
+			const string assetPath = "RuntimeTests/RegisteredAsset.txt";
+			var expectedContent = Encoding.UTF8.GetBytes("hello from runtime registered asset");
+
+			using var stream = new MemoryStream(expectedContent);
+			await StorageFile.RegisterApplicationUriAssetAsync(assetPath, stream);
+
+			var uri = new Uri($"ms-appx:///{assetPath}");
+			var file = await StorageFile.GetFileFromApplicationUriAsync(uri);
+
+			Assert.IsNotNull(file);
+
+			var actualBytes = await FileIO.ReadBufferAsync(file);
+			Assert.AreEqual((uint)expectedContent.Length, actualBytes.Length, "File size mismatch.");
+
+			var actualContent = Encoding.UTF8.GetString(actualBytes.ToArray());
+			Assert.AreEqual("hello from runtime registered asset", actualContent);
+		}
+
+		[TestMethod]
+		public async Task When_Asset_Registered_With_LeadingSlash_Then_Resolves()
+		{
+			const string assetPath = "/RuntimeTests/RegisteredAssetWithSlash.txt";
+			var content = Encoding.UTF8.GetBytes("leading slash is trimmed");
+
+			using var stream = new MemoryStream(content);
+			await StorageFile.RegisterApplicationUriAssetAsync(assetPath, stream);
+
+			// Both with and without the leading slash should resolve.
+			var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///RuntimeTests/RegisteredAssetWithSlash.txt"));
+
+			Assert.IsNotNull(file);
+		}
+
+		[TestMethod]
+		public async Task When_Asset_Registered_Twice_Then_Content_Is_Latest()
+		{
+			const string assetPath = "RuntimeTests/RegisteredAsset_Overwrite.txt";
+
+			using var first = new MemoryStream(Encoding.UTF8.GetBytes("first content"));
+			await StorageFile.RegisterApplicationUriAssetAsync(assetPath, first);
+
+			using var second = new MemoryStream(Encoding.UTF8.GetBytes("second content"));
+			await StorageFile.RegisterApplicationUriAssetAsync(assetPath, second);
+
+			var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{assetPath}"));
+			var actualContent = await FileIO.ReadTextAsync(file);
+
+			Assert.AreEqual("second content", actualContent);
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Storage/Helpers/AssetsManager.wasm.cs
+++ b/src/Uno.UWP/Storage/Helpers/AssetsManager.wasm.cs
@@ -38,6 +38,48 @@ namespace Windows.Storage.Helpers
 			return new HashSet<string>(SplitMatch().Split(assets), StringComparer.OrdinalIgnoreCase);
 		}
 
+		/// <summary>
+		/// Registers a runtime asset so that subsequent <c>ms-appx:///</c> resolution
+		/// succeeds for paths absent from the compile-time <c>uno-assets.txt</c> manifest.
+		/// </summary>
+		/// <param name="assetPath">
+		/// The asset path as it would appear in a <c>ms-appx:///</c> URI
+		/// (e.g. <c>Fonts/Inter-Regular.ttf</c> or <c>/Fonts/Inter-Regular.ttf</c>).
+		/// A leading <c>/</c> is trimmed automatically.
+		/// </param>
+		/// <param name="content">
+		/// Stream containing the asset bytes. The stream is read from its current position;
+		/// the caller retains ownership and is responsible for disposal.
+		/// </param>
+		/// <param name="ct">Cancellation token.</param>
+		internal static async Task RegisterAssetAsync(string assetPath, Stream content, CancellationToken ct)
+		{
+			var updatedPath = assetPath.TrimStart('/');
+
+			var localPath = Path.Combine(
+				ApplicationData.Current.LocalFolder.Path,
+				".assetsCache",
+				AssetsPathBuilder.UNO_BOOTSTRAP_APP_BASE,
+				updatedPath);
+
+			// Use the same per-path gate as DownloadAsset to serialize concurrent
+			// registrations for the same path and avoid torn writes.
+			using var assetLock = await _assetsGate.LockForAsset(ct, updatedPath);
+
+			if (Path.GetDirectoryName(localPath) is { Length: > 0 } dir)
+			{
+				Directory.CreateDirectory(dir);
+			}
+
+			await using var outStream = File.Create(localPath);
+			await content.CopyToAsync(outStream, ct);
+
+			// Register in the in-memory manifest after the file is fully written so that
+			// a concurrent DownloadAsset call cannot observe the path without its content.
+			var assetSet = await Assets.Value;
+			assetSet.Add(updatedPath);
+		}
+
 		public static async Task<string> DownloadAsset(CancellationToken ct, string assetPath)
 		{
 			var updatedPath = assetPath.TrimStart("/");

--- a/src/Uno.UWP/Storage/StorageFile.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.wasm.cs
@@ -13,6 +13,30 @@ namespace Windows.Storage
 {
 	partial class StorageFile
 	{
+		/// <summary>
+		/// Registers a runtime asset so that subsequent calls to
+		/// <see cref="GetFileFromApplicationUriAsync(Uri)"/> succeed for
+		/// <c>ms-appx:///</c> paths that are absent from the compile-time
+		/// <c>uno-assets.txt</c> manifest.
+		/// </summary>
+		/// <remarks>
+		/// On WASM, <c>ms-appx:///</c> resolution is gated by a static manifest baked at
+		/// build time. This method lets runtime code (e.g. plugin hosts or hot-reload
+		/// tooling) inject asset content without requiring it to be listed in the manifest.
+		/// </remarks>
+		/// <param name="assetPath">
+		/// The asset path as it would appear in a <c>ms-appx:///</c> URI
+		/// (e.g. <c>Fonts/Inter-Regular.ttf</c> or <c>/Fonts/Inter-Regular.ttf</c>).
+		/// A leading <c>/</c> is trimmed automatically.
+		/// </param>
+		/// <param name="content">
+		/// Stream containing the asset bytes. The stream is read from its current position;
+		/// the caller retains ownership and is responsible for disposal.
+		/// </param>
+		/// <param name="ct">Cancellation token.</param>
+		public static Task RegisterApplicationUriAssetAsync(string assetPath, Stream content, CancellationToken ct = default)
+			=> AssetsManager.RegisterAssetAsync(assetPath, content, ct);
+
 		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{
 			if (uri.Scheme != "ms-appx")


### PR DESCRIPTION
## Summary

Adds a public WASM-only API to register runtime assets so that `ms-appx:///` URIs resolve for paths absent from the compile-time `uno-assets.txt` manifest.

### Problem

`AssetsManager.DownloadAsset` gates resolution on a static in-memory `HashSet<string>` populated from `uno-assets.txt` at host build time. Host applications that load secondary content (plugins, inner apps) need to resolve assets from NuGet packages the host does not reference — those paths are absent from the manifest and throw `FileNotFoundException`.

The workaround in downstream consumers was to access `AssetsManager.Assets` via reflection, which is fragile and inappropriate.

### Changes

- `AssetsManager.RegisterAssetAsync` (internal): writes content to `.assetsCache/{UNO_BOOTSTRAP_APP_BASE}/{path}` using the same per-path `ConcurrentEntryManager` gate as `DownloadAsset`, then adds the path to the in-memory manifest after the file is fully written (prevents a concurrent `DownloadAsset` from observing the path before its content is ready).
- `StorageFile.RegisterApplicationUriAssetAsync` (public, WASM-only): thin public entry-point delegating to `AssetsManager.RegisterAssetAsync`.
- `Given_StorageFile_RegisterApplicationUriAsset`: WASM runtime tests covering the happy path, leading-slash normalization, and overwrite semantics.

## Test plan

- [ ] WASM runtime tests in `Given_StorageFile_RegisterApplicationUriAsset` pass
- [ ] Existing `Given_ApplicationStorage` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)