### PR TITLE
fix(repeater): prevent UniformGridLayout divide-by-zero

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/UniformGridLayout/Given_UniformGridLayout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/UniformGridLayout/Given_UniformGridLayout.cs
@@ -59,4 +59,54 @@ public class Given_UniformGridLayout
 
 		Math.Abs(originalHeight * 2 - newHeight).Should().BeLessThan(20, "we devided the width by 2, so the height of each should be about the double of the original"); // We allow about a line of difference for wrapping consideration
 	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public async Task When_AvailableMinorSizeSmallerThanItem_Then_DoesNotThrow()
+	{
+		// Regression test for https://github.com/unoplatform/uno/issues/23366
+		// When a UniformGridLayout is measured with a finite minor-axis (here: width) available size
+		// that is smaller than a single MinItemWidth, GetItemsPerLine used to truncate the items-per-line
+		// count to 0. GetMajorSize / GetLayoutRectForDataIndex then divided by that count, throwing an
+		// unhandled DivideByZeroException that took down the dispatcher loop.
+		// The layout must instead clamp to a single column, matching WinUI.
+		using var template = new DynamicDataTemplate(() => new Border
+		{
+			Background = new SolidColorBrush(Microsoft.UI.Colors.SkyBlue),
+			Child = new TextBlock()
+		});
+		var sut = new ItemsRepeater
+		{
+			ItemsSource = Enumerable.Range(0, 20),
+			ItemTemplate = template.Value,
+			Layout = new UniformGridLayout
+			{
+				MinItemWidth = 140,
+				MinItemHeight = 40,
+			}
+		};
+
+		// The host is deliberately narrower than a single MinItemWidth (140) so that the
+		// minor-axis (width) available size passed to the layout is smaller than one item.
+		var host = new Grid
+		{
+			Width = 100,
+			Height = 300,
+			Children = { sut }
+		};
+
+		// Loading and laying out used to throw a DivideByZeroException through the layout pass.
+		await UITestHelper.Load(host, h => h.ActualWidth > 0 && h.ActualHeight > 0);
+
+		// Force extra measure passes through the realization-rect anchoring path where the
+		// exception used to surface, to make the repro deterministic.
+		sut.InvalidateMeasure();
+		host.UpdateLayout();
+		await UITestHelper.WaitForIdle();
+
+		// Reaching this point means the layout clamped to a single column instead of throwing.
+		// The first item must have been realized.
+		sut.TryGetElement(0).Should().NotBeNull("the layout should clamp to a single column instead of throwing");
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/UniformGridLayout/UniformGridLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/UniformGridLayout/UniformGridLayout.cs
@@ -342,8 +342,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (availableSizeMinor.IsFinite())
 			{
+				// Floor the computed count at 1 to match WinUI: when the available minor size is smaller than a
+				// single item, the (uint) cast would otherwise truncate to 0, leading to a DivideByZeroException
+				// in GetMajorSize / GetLayoutRectForDataIndex. See https://github.com/unoplatform/uno/issues/23366.
 				return Math.Min(
-					(uint)((availableSizeMinor + MinItemSpacing()) / GetMinorItemSizeWithSpacing(context)),
+					Math.Max(1u, (uint)((availableSizeMinor + MinItemSpacing()) / GetMinorItemSizeWithSpacing(context))),
 					maximumRowsOrColumns);
 			}
 


### PR DESCRIPTION
**GitHub Issue:** closes #23366

## PR Type:

🐞 Bugfix

## What changed? 🚀

An `ItemsRepeater` using a `UniformGridLayout` with `MinItemWidth` (or `MinItemHeight`) set crashed with an unhandled `System.DivideByZeroException` whenever it was measured with a finite minor-axis available size that was smaller than a single item. This could happen transiently during startup/relayout (e.g. a parent column briefly narrower than one item), and the unhandled exception bubbled up through `NativeDispatcher`, taking down the dispatcher loop.

### Root cause

In `UniformGridLayout.GetItemsPerLine`, the finite-available-size branch did **not** floor the computed value at `1`:

```csharp
if (availableSizeMinor.IsFinite())
{
    return Math.Min(
        (uint)((availableSizeMinor + MinItemSpacing()) / GetMinorItemSizeWithSpacing(context)),
        maximumRowsOrColumns);
}
```

When `availableSizeMinor` is smaller than one item, the `(uint)` cast truncates the result to `0`. `GetMajorSize` (and `GetLayoutRectForDataIndex`) then divide by it → `DivideByZeroException`. The `MUX_ASSERT(itemsPerLine > 0)` is a no-op in Release builds, so it provided no protection.

This is a divergence from WinUI, whose implementation floors the count at `1u`:

```cpp
// microsoft-ui-xaml/src/controls/dev/Repeater/UniformGridLayout.cpp
return std::min(
    std::max(1u, static_cast<unsigned int>((availableSizeMinor + MinItemSpacing()) / GetMinorItemSizeWithSpacing(context))),
    maximumRowsOrColumns);
```

Note that the sibling `Algorithm_GetExtent` already applied this `Math.Max(1u, ...)` floor, which is why the extent path never crashed — only the anchoring path (`GetItemsPerLine`) was missing it.

### Fix

Restore the `Math.Max(1u, ...)` floor in `GetItemsPerLine` to match WinUI. The layout now clamps to a single column/row instead of throwing.

### Test

Added the runtime test `Given_UniformGridLayout.When_AvailableMinorSizeSmallerThanItem_Then_DoesNotThrow`, which hosts an `ItemsRepeater` + `UniformGridLayout (MinItemWidth=140)` inside a 100px-wide container. It was verified to fail before the fix (the layout crash prevented any element from being realized) and to pass after.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests (`Given_UniformGridLayout.When_AvailableMinorSizeSmallerThanItem_Then_DoesNotThrow`)
- [ ] 📚 Docs have been added/updated following the documentation template (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
