### PR TITLE
fix: App-level ThemeResource overrides lost on storyboard keyframes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxReproOverrides.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxReproOverrides.xaml
@@ -1,0 +1,23 @@
+﻿<ResourceDictionary x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.CheckBoxReproOverrides"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<!--
+		An application-level override of the stock Fluent CheckBox*Checked brushes via StaticResource
+		INDIRECTION to a palette brush, inside ThemeDictionaries "Light" + "Default". Light => Blue,
+		Default => Red, so a test can observe which theme dictionary actually resolved.
+	-->
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<SolidColorBrush x:Key="ReproPaletteBrush" Color="Blue" />
+			<StaticResource x:Key="CheckBoxCheckBackgroundFillChecked" ResourceKey="ReproPaletteBrush" />
+			<StaticResource x:Key="CheckBoxCheckBackgroundStrokeChecked" ResourceKey="ReproPaletteBrush" />
+			<StaticResource x:Key="CheckBoxCheckGlyphForegroundChecked" ResourceKey="ReproPaletteBrush" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Default">
+			<SolidColorBrush x:Key="ReproPaletteBrush" Color="Red" />
+			<StaticResource x:Key="CheckBoxCheckBackgroundFillChecked" ResourceKey="ReproPaletteBrush" />
+			<StaticResource x:Key="CheckBoxCheckBackgroundStrokeChecked" ResourceKey="ReproPaletteBrush" />
+			<StaticResource x:Key="CheckBoxCheckGlyphForegroundChecked" ResourceKey="ReproPaletteBrush" />
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxReproOverrides.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxReproOverrides.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+public sealed partial class CheckBoxReproOverrides : ResourceDictionary
+{
+	public CheckBoxReproOverrides()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
@@ -1,0 +1,120 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp.Utilities;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+#if HAS_UNO_WINUI || WINAPPSDK || WINUI
+using Colors = Microsoft.UI.Colors;
+#else
+using Colors = Windows.UI.Colors;
+#endif
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	// Regression tests for an application-level {ThemeResource} override of the stock Fluent v2 CheckBox
+	// brushes. The stock CheckBox template applies its checked-state brushes through storyboard key-frames
+	// (e.g. <DiscreteObjectKeyFrame Value="{ThemeResource CheckBoxCheckBackgroundFillChecked}" />), and the
+	// per-storyboard-begin refresh re-resolves each key-frame against the dictionary it was pinned to. When the
+	// override lives at application level (merged after XamlControlsResources) it is reachable only through the
+	// top-level resource fallback, so it must be re-pinned there; otherwise a checked CheckBox reverts to the
+	// stock brush on a visual-state re-entry.
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_CheckBox_ThemeResource_Regression
+	{
+#if HAS_UNO
+		// App-level override (merged after XamlControlsResources), a Dark application with a Light-pinned
+		// subtree, a checked CheckBox, and a post-load visual-state re-entry (IsChecked toggled off then on).
+		// The re-entry runs ObjectAnimationUsingKeyFrames.Begin() -> EnsureKeyFrameThemeResources(), which
+		// re-resolves the key-frame against its pinned dictionary only. Without the top-level re-pin the box
+		// reverts from the Blue override to the stock brush.
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_App_Override_Checked_Survives_IsChecked_Reentry_Under_Dark_App()
+		{
+			using var _ = ThemeHelper.UseApplicationDarkTheme();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// App-level override using StaticResource indirection inside ThemeDictionaries (Light=Blue, Default=Red).
+			var overrides = new CheckBoxReproOverrides();
+			Application.Current.Resources.MergedDictionaries.Add(overrides);
+			try
+			{
+				var lightRoot = new Border { RequestedTheme = ElementTheme.Light };
+				var checkBox = new CheckBox { IsChecked = true, MinWidth = 0 };
+				lightRoot.Child = checkBox;
+
+				await UITestHelper.Load(lightRoot);
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var box = checkBox.FindVisualChildByName("NormalRectangle") as FrameworkElement;
+				Assert.IsNotNull(box, "NormalRectangle template part not found.");
+
+				// Baseline: the Light subtree resolves the Blue override.
+				var initial = await UITestHelper.ScreenShot(checkBox);
+				ImageAssert.HasColorAtChild(initial, box, box.ActualWidth / 2, box.ActualHeight / 2, Colors.Blue, tolerance: 40);
+
+				// Pure visual-state re-entry into CheckedNormal (GoToState -> storyboard.Begin), with no full
+				// resource-binding pass to correct the value afterwards.
+				checkBox.IsChecked = false;
+				await TestServices.WindowHelper.WaitForIdle();
+				checkBox.IsChecked = true;
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var after = await UITestHelper.ScreenShot(checkBox);
+				// Must still be the Blue override, not the stock-pinned value.
+				ImageAssert.HasColorAtChild(after, box, box.ActualWidth / 2, box.ActualHeight / 2, Colors.Blue, tolerance: 40);
+			}
+			finally
+			{
+				Application.Current.Resources.MergedDictionaries.Remove(overrides);
+			}
+		}
+
+		// Same setup, but the re-entry is driven by toggling IsEnabled (CheckedNormal -> CheckedDisabled ->
+		// CheckedNormal); asserts in the enabled CheckedNormal state after the round-trip.
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_App_Override_Checked_Survives_IsEnabled_Toggle_Under_Dark_App()
+		{
+			using var _ = ThemeHelper.UseApplicationDarkTheme();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var overrides = new CheckBoxReproOverrides();
+			Application.Current.Resources.MergedDictionaries.Add(overrides);
+			try
+			{
+				var lightRoot = new Border { RequestedTheme = ElementTheme.Light };
+				var checkBox = new CheckBox { IsChecked = true, MinWidth = 0 };
+				lightRoot.Child = checkBox;
+
+				await UITestHelper.Load(lightRoot);
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var box = checkBox.FindVisualChildByName("NormalRectangle") as FrameworkElement;
+				Assert.IsNotNull(box, "NormalRectangle template part not found.");
+
+				var initial = await UITestHelper.ScreenShot(checkBox);
+				ImageAssert.HasColorAtChild(initial, box, box.ActualWidth / 2, box.ActualHeight / 2, Colors.Blue, tolerance: 40);
+
+				// CheckedNormal -> CheckedDisabled -> CheckedNormal (each transition re-begins a storyboard).
+				checkBox.IsEnabled = false;
+				await TestServices.WindowHelper.WaitForIdle();
+				checkBox.IsEnabled = true;
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var after = await UITestHelper.ScreenShot(checkBox);
+				// Must still be the Blue override, not the stock-pinned value.
+				ImageAssert.HasColorAtChild(after, box, box.ActualWidth / 2, box.ActualHeight / 2, Colors.Blue, tolerance: 40);
+			}
+			finally
+			{
+				Application.Current.Resources.MergedDictionaries.Remove(overrides);
+			}
+		}
+#endif
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Data/ThemeResourceReference.cs
+++ b/src/Uno.UI/UI/Xaml/Data/ThemeResourceReference.cs
@@ -342,9 +342,18 @@ internal sealed class ThemeResourceReference
 				}
 			}
 
-			// 3. Try top-level resources as last resort
-			if (Uno.UI.ResourceResolver.TryTopLevelRetrieval(ResourceKey, ParseContext, out var topLevelValue))
+			// 3. Try top-level resources as last resort, pinning the providing dictionary so the
+			//    pinned-dictionary-only RefreshValue path re-resolves the (app-level) override directly
+			//    afterwards instead of reverting to a stale parse-time pin (a {ThemeResource} on a
+			//    storyboard key-frame whose template lives in a framework/control dictionary, while the
+			//    key is overridden at application level).
+			if (Uno.UI.ResourceResolver.TryTopLevelRetrieval(ResourceKey, ParseContext, out var topLevelValue, out var topLevelDict))
 			{
+				if (topLevelDict is not null)
+				{
+					_targetDictionary = new WeakReference<ResourceDictionary>(topLevelDict);
+				}
+
 				SetResolvedValue(topLevelValue);
 				return topLevelValue;
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs
@@ -542,9 +542,28 @@ public partial class DependencyObjectStore
 
 			if (!wasSet)
 			{
-				if (ResourceResolver.TryTopLevelRetrieval(binding.ResourceKey, binding.ParseContext, out var value))
+				// The resource wasn't found in the in-scope (non-app) dictionaries, but may be provided by
+				// an application-level dictionary — e.g. an app-merged ThemeDictionaries override of a Fluent
+				// control resource (CheckBoxCheckBackgroundFillChecked, ...). Resolve it AND pin the providing
+				// dictionary onto the _themeResources entry. Without this re-pin a ThemeResource bound on a
+				// non-FrameworkElement owner (a storyboard key-frame, a VisualState Setter) keeps its parse-time
+				// pin — the STOCK control dictionary that declared the template, which also defines the key — so
+				// the pinned-dictionary-only ThemeResourceReference.RefreshValue path (invoked by
+				// ObjectAnimationUsingKeyFrames.EnsureKeyFrameThemeResources on every storyboard begin) keeps
+				// re-resolving the stock value and shadows the app-level override.
+				if (ResourceResolver.TryTopLevelRetrieval(binding.ResourceKey, binding.ParseContext, out var topLevelValue, out var topLevelDict))
 				{
-					SetResourceBindingValue(property, binding, value);
+					SetResourceBindingValue(property, binding, topLevelValue);
+
+					if (topLevelDict is not null && _themeResources is not null)
+					{
+						var themeRef = _themeResources.Get(property, binding.Precedence);
+						if (themeRef is not null)
+						{
+							themeRef.SetTargetDictionary(topLevelDict);
+							themeRef.LastResolvedValue = topLevelValue;
+						}
+					}
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Theming.cs
@@ -533,6 +533,7 @@ public partial class DependencyObjectStore
 						if (themeRef is not null)
 						{
 							themeRef.LastResolvedValue = value;
+							themeRef.IsResolved = true;
 						}
 					}
 
@@ -562,6 +563,9 @@ public partial class DependencyObjectStore
 						{
 							themeRef.SetTargetDictionary(topLevelDict);
 							themeRef.LastResolvedValue = topLevelValue;
+							// Mark resolved: IsResolved distinguishes "resolved to null" from "not yet
+							// resolved" (UpdateThemeReference skips deferred refs whose value is null).
+							themeRef.IsResolved = true;
 						}
 					}
 				}


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/491

## PR Type:

🤖 Bug

## What changed? 🚀

Fix App-Level ThemeResource overrides

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample — _N/A: no runtime/product code changes_
- [ ] 📚 Docs added/updated following the documentation template — _N/A: this PR **is** contributor-facing agent docs_
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — _N/A: no UI changes_
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other open pull requests (optional)



## More Details

An application-level `{ThemeResource}` override of a stock Fluent control brush that is applied through a storyboard key-frame (for example a `CheckBox`'s `CheckBoxCheckBackgroundFillChecked`) was ignored after a visual-state re-entry: the checked box reverted to the stock brush and appeared unchecked until a pointer-over repainted it. 

`ObjectAnimationUsingKeyFrames.EnsureKeyFrameThemeResources` refreshes each key-frame on every storyboard begin through the pinned-dictionary-only `ThemeResourceReference.RefreshValue`, and the key-frame is pinned to the stock control dictionary that declared the template; an application-level override of the key is reachable only via the top-level resource fallback, which set the value but never re-pinned the reference, so the next refresh resolved the stock value again. 

The fix re-pins the `_themeResources` entry to the application-level providing dictionary whenever a value is resolved via `TryTopLevelRetrieval` (in `DependencyObjectStore.InnerUpdateResourceBindingsUnsafe` and `ThemeResourceReference.RefreshValueWithTreeWalk`), so subsequent refreshes resolve the override, while content reparented out of its declaring scope (popup/flyout/tooltip) keeps its existing pin. Adds runtime tests for a checked CheckBox under a Dark application with a Light-pinned subtree that survives `IsChecked` and `IsEnabled` visual-state re-entries.
