### PR TITLE
fix(theming): honor owner theme in VisualState setter

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxNavReproOtherPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxNavReproOtherPage.xaml
@@ -1,0 +1,6 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.CheckBoxNavReproOtherPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<!-- The "other tab": navigating here forces the checkbox page to fully unload before we navigate back. -->
+	<TextBlock Text="Other" />
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxNavReproOtherPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/CheckBoxNavReproOtherPage.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+public sealed partial class CheckBoxNavReproOtherPage : Page
+{
+	public CheckBoxNavReproOtherPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FlatButtonNavReproPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FlatButtonNavReproPage.xaml
@@ -1,0 +1,40 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FlatButtonNavReproPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<!--
+		Replicates Kahua's KahuaFlatButtonStyle (used by KahuaFlatIconButtonStyle, the calendar/picker icon
+		buttons in the items grid): the PointerOver background is applied through a VisualState.Setter whose
+		value is a {ThemeResource} — NOT a storyboard key-frame. The app-level override resolves the key Blue
+		in Light and Red in Default(Dark), revealing which theme the setter resolved.
+	-->
+	<Page.Resources>
+		<Style x:Key="ReproFlatButtonStyle" TargetType="Button">
+			<Setter Property="Background" Value="Transparent" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+						<Grid x:Name="Root" Background="{TemplateBinding Background}">
+							<ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" />
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<VisualState.Setters>
+											<Setter Target="Root.Background" Value="{ThemeResource ButtonBackgroundPointerOver}" />
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</Page.Resources>
+
+	<Button x:Name="SUT"
+	        x:FieldModifier="public"
+	        Width="80"
+	        Height="32"
+	        Style="{StaticResource ReproFlatButtonStyle}" />
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FlatButtonNavReproPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FlatButtonNavReproPage.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+public sealed partial class FlatButtonNavReproPage : Page
+{
+	public FlatButtonNavReproPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
@@ -14,23 +14,19 @@ using Colors = Windows.UI.Colors;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
-	// Regression tests for an application-level {ThemeResource} override of the stock Fluent v2 CheckBox
-	// brushes. The stock CheckBox template applies its checked-state brushes through storyboard key-frames
-	// (e.g. <DiscreteObjectKeyFrame Value="{ThemeResource CheckBoxCheckBackgroundFillChecked}" />), and the
-	// per-storyboard-begin refresh re-resolves each key-frame against the dictionary it was pinned to. When the
-	// override lives at application level (merged after XamlControlsResources) it is reachable only through the
-	// top-level resource fallback, so it must be re-pinned there; otherwise a checked CheckBox reverts to the
-	// stock brush on a visual-state re-entry.
+	// Regression tests for {ThemeResource} resolution of controls living in a subtree pinned to an explicit
+	// RequestedTheme that differs from the application theme (a Light-pinned subtree under a Dark application).
 	[TestClass]
 	[RunsOnUIThread]
 	public class Given_CheckBox_ThemeResource_Regression
 	{
 #if HAS_UNO
-		// App-level override (merged after XamlControlsResources), a Dark application with a Light-pinned
-		// subtree, a checked CheckBox, and a post-load visual-state re-entry (IsChecked toggled off then on).
-		// The re-entry runs ObjectAnimationUsingKeyFrames.Begin() -> EnsureKeyFrameThemeResources(), which
-		// re-resolves the key-frame against its pinned dictionary only. Without the top-level re-pin the box
-		// reverts from the Blue override to the stock brush.
+		// App-level override (merged after XamlControlsResources) of the stock Fluent v2 CheckBox brushes. The stock
+		// template applies its checked-state brushes through storyboard key-frames (e.g.
+		// <DiscreteObjectKeyFrame Value="{ThemeResource CheckBoxCheckBackgroundFillChecked}" />), and the
+		// per-storyboard-begin refresh re-resolves each key-frame against the dictionary it was pinned to. When the
+		// override lives at application level it is reachable only through the top-level resource fallback, so it
+		// must be re-pinned there; otherwise a checked CheckBox reverts to the stock brush on a visual-state re-entry.
 		[TestMethod]
 		[RequiresFullWindow]
 		public async Task When_App_Override_Checked_Survives_IsChecked_Reentry_Under_Dark_App()
@@ -114,6 +110,63 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			{
 				Application.Current.Resources.MergedDictionaries.Remove(overrides);
 			}
+		}
+
+		// kahua-private#482: a control's PointerOver background applied through a VisualState.Setter whose value is a
+		// {ThemeResource} (the shape used by Kahua's flat icon buttons / DataGrid date cells) must resolve against the
+		// owner's inherited theme, not the application theme. Here the button lives in a Light-pinned Frame under a
+		// Dark application; the override resolves Blue in Light and Red in Default(Dark). Re-materialising the page
+		// through Frame navigation and re-entering PointerOver must keep the Light (Blue) value.
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_VisualStateSetter_PointerOver_Keeps_Light_After_Frame_Navigation_Under_Dark_App()
+		{
+			using var _ = ThemeHelper.UseApplicationDarkTheme();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var overrides = new ThemeNavReproOverrides();
+			Application.Current.Resources.MergedDictionaries.Add(overrides);
+			try
+			{
+				// The Light pin lives on the Frame, mirroring Kahua's ThemeAssist RequestedTheme=Light on the root Frame.
+				var frame = new Frame { RequestedTheme = ElementTheme.Light };
+				await UITestHelper.Load(frame);
+
+				var firstButton = await NavigateAndGetFlatButton(frame);
+				var first = await EnterPointerOverAndScreenShot(firstButton);
+				ImageAssert.HasColorAt(first, first.Width / 2, first.Height / 2, Colors.Blue, tolerance: 40);
+
+				// Navigate away, then back to a fresh instance of the page (re-materialisation under the Light pin).
+				frame.Navigate(typeof(CheckBoxNavReproOtherPage));
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var secondButton = await NavigateAndGetFlatButton(frame);
+				var second = await EnterPointerOverAndScreenShot(secondButton);
+				// Must still be Blue (Light); Red would mean the setter resolved the Dark sub-dictionary.
+				ImageAssert.HasColorAt(second, second.Width / 2, second.Height / 2, Colors.Blue, tolerance: 40);
+			}
+			finally
+			{
+				Application.Current.Resources.MergedDictionaries.Remove(overrides);
+			}
+		}
+
+		private static async Task<Button> NavigateAndGetFlatButton(Frame frame)
+		{
+			frame.Navigate(typeof(FlatButtonNavReproPage));
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var page = (FlatButtonNavReproPage)frame.Content;
+			await TestServices.WindowHelper.WaitForLoaded(page.SUT);
+			await TestServices.WindowHelper.WaitForIdle();
+			return page.SUT;
+		}
+
+		private static async Task<RawBitmap> EnterPointerOverAndScreenShot(Button button)
+		{
+			VisualStateManager.GoToState(button, "PointerOver", useTransitions: true);
+			await TestServices.WindowHelper.WaitForIdle();
+			return await UITestHelper.ScreenShot(button);
 		}
 #endif
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ThemeNavReproOverrides.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ThemeNavReproOverrides.xaml
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ThemeNavReproOverrides"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<!--
+		App-level override of the stock Button PointerOver background, mirroring Kahua's FluentOverrides.xaml.
+		Light => Blue, Default(Dark) => Red, so a test can observe which theme dictionary the PointerOver
+		key-frame resolved against after navigation.
+	-->
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Blue" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Default">
+			<SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Red" />
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ThemeNavReproOverrides.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ThemeNavReproOverrides.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+public sealed partial class ThemeNavReproOverrides : ResourceDictionary
+{
+	public ThemeNavReproOverrides()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -425,33 +425,54 @@ namespace Uno.UI
 		/// </returns>
 		internal static bool ApplyVisualStateSetter(SpecializedResourceDictionary.ResourceKey resourceKey, object context, BindingPath bindingPath, DependencyPropertyValuePrecedences precedence, ResourceUpdateReason updateReason)
 		{
-			if (TryVisualTreeRetrieval(resourceKey, context, out var value, out var providingDictionary)
-				&& bindingPath.DataContext != null)
+			var isThemeResource = (updateReason & ResourceUpdateReason.ThemeResource) != 0;
+
+			// Push the owner element's inherited theme so the dictionary lookup below selects the owner's
+			// Light/Dark sub-dictionary instead of falling back to the ambient active theme (Themes.Active).
+			// Without this, a VisualState.Setter whose value is a {ThemeResource} resolves against the application
+			// theme when it is applied outside a theme walk (e.g. a control re-applying a visual state on a
+			// recycled container), painting the wrong theme's brush on an element that lives in a subtree pinned to
+			// a different RequestedTheme. This mirrors the push already done by ApplyResource for direct bindings.
+			var owner = bindingPath.DataContext as DependencyObject;
+			var pushedOwnerTheme = isThemeResource && ThemeResourceReference.PushOwnerThemeIfDifferent(owner);
+
+			try
 			{
-				var property = DependencyProperty.GetProperty(bindingPath.DataContext.GetType(), bindingPath.LeafPropertyName);
-				if (property != null && bindingPath.DataContext is IDependencyObjectStoreProvider provider)
+				if (TryVisualTreeRetrieval(resourceKey, context, out var value, out var providingDictionary)
+					&& bindingPath.DataContext != null)
 				{
-					// Set current resource value
-					bindingPath.Value = value;
-
-					if ((updateReason & ResourceUpdateReason.ThemeResource) != 0)
+					var property = DependencyProperty.GetProperty(bindingPath.DataContext.GetType(), bindingPath.LeafPropertyName);
+					if (property != null && bindingPath.DataContext is IDependencyObjectStoreProvider provider)
 					{
-						// Use pinned-dictionary path for theme resources
-						var themeRef = new ThemeResourceReference(
-							resourceKey, providingDictionary, value, isResolved: true, context,
-							updateReason, precedence, bindingPath);
-						provider.Store.SetThemeResourceBinding(property, themeRef);
+						// Set current resource value
+						bindingPath.Value = value;
+
+						if (isThemeResource)
+						{
+							// Use pinned-dictionary path for theme resources
+							var themeRef = new ThemeResourceReference(
+								resourceKey, providingDictionary, value, isResolved: true, context,
+								updateReason, precedence, bindingPath);
+							provider.Store.SetThemeResourceBinding(property, themeRef);
+						}
+
+						// Always register ResourceBinding for re-pin at load time and
+						// HotReload support, matching the dual-registration in ApplyResource.
+						provider.Store.SetResourceBinding(property, resourceKey, updateReason, context, precedence, bindingPath);
+
+						return true;
 					}
+				}
 
-					// Always register ResourceBinding for re-pin at load time and
-					// HotReload support, matching the dual-registration in ApplyResource.
-					provider.Store.SetResourceBinding(property, resourceKey, updateReason, context, precedence, bindingPath);
-
-					return true;
+				return false;
+			}
+			finally
+			{
+				if (pushedOwnerTheme)
+				{
+					ResourceDictionary.PopRequestedThemeForSubTree();
 				}
 			}
-
-			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
**GitHub Issue:** closes #23396

## PR Type:
Bugfix

## What changed? 🚀

A property set through a `VisualState.Setter` whose value is a `{ThemeResource}` could paint the wrong theme's brush for an element living in a subtree pinned to a `RequestedTheme` that differs from the application theme (e.g. a `RequestedTheme="Light"` subtree under a Dark application). When the visual state is applied outside a theme walk — for instance when a virtualizing/recycling control re-applies a recycled container's visual state after navigation — `ResourceResolver.ApplyVisualStateSetter` resolved the resource against the ambient active (application) theme instead of the element's inherited theme, so the element rendered the Dark brush while its subtree was Light.

The fix pushes the owner element's inherited theme around the dictionary lookup in `ApplyVisualStateSetter` (via `ThemeResourceReference.PushOwnerThemeIfDifferent`), mirroring the push the direct `{ThemeResource}` binding path (`ApplyResource`) already performs, so the setter selects the owner's Light/Dark sub-dictionary rather than falling back to `Themes.Active`.

A runtime regression test is added in `Given_CheckBox_ThemeResource_Regression` (`When_VisualStateSetter_PointerOver_Keeps_Light_After_Frame_Navigation_Under_Dark_App`) exercising a flat-button-style `VisualState.Setter` PointerOver `{ThemeResource}` in a Light-pinned `Frame` under a Dark application across navigation. The fix was additionally validated end-to-end in a downstream consumer app whose items-grid icon buttons rendered a dark hover square under a Light-pinned subtree; with the fix the hover background resolves the correct Light value (confirmed via instrumented theme-resolution logging: pre-fix the setter resolved with `active=Dark`/`ownerTheme=Light`, post-fix it pushes the owner theme and resolves the Light value).

## PR Checklist ✅

- [x] 🧪 Added Runtime tests (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the documentation template (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)