### PR TITLE
fix(alc): stop shared framework caches/resources from pinning collectible AssemblyLoadContexts

### DIFF
--- a/specs/044-alc-memory-leak-fixes/spec.md
+++ b/specs/044-alc-memory-leak-fixes/spec.md
@@ -1,0 +1,101 @@
+# 044 — Collectible-ALC Memory Leak Fixes (XamlParseContext, AlcContentHost, ResourceDictionary)
+
+## Problem
+
+A downstream consumer hosts secondary applications in collectible `AssemblyLoadContext`s
+(see spec 000). On every secondary-app reload, `ALC.Unload()` was called but the ALC was
+never collected: each reload leaked one full copy of the previous app's object graph
+(≈ +48 MB managed / +420K live objects / +150 MB RSS per reload on a representative app),
+reaching OOM within ~10–15 reloads.
+
+`dotnet-dump` SOS `gcroot` on a leaked secondary `Application` instance (~11,000 unique
+root paths) identified three independent pinning mechanisms in Uno.UI, all surviving
+`Application.CleanupNonDefaultAlcCaches()`.
+
+## Root causes
+
+### 1. `XamlParseContext` strongly captures the ALC
+
+`XamlParseContext._assemblyLoadContext` was a strong field. Parse contexts are retained
+long-term by `ResourceBinding.ParseContext` and `ThemeResourceReference.ParseContext` on
+elements reachable from non-collectible statics (generated `GlobalStaticResources`
+singletons of pooled assemblies, host-side singletons). Additionally, the lazy
+by-`AssemblyName` resolution in the getter scans `AppDomain.CurrentDomain.GetAssemblies()`
+and could permanently cache a **collectible** ALC inside a **never-dying static**
+`__ParseContext_` instance. Any retained ALC reference pins the LoaderAllocator and the
+entire previous app graph.
+
+### 2. `AlcContentHost` retains projected resources after teardown
+
+`AlcContentHost.UpdateMergedResources()` cleared and re-merged `MergedDictionaries`, but
+never removed previously **copied** theme-dictionary entries and direct resources. After
+the secondary app's content was cleared, its brushes/styles/templates (potentially typed
+in the collectible ALC) stayed in the host control's `Resources` forever.
+
+### 3. `ResourceDictionary` not-found cache pins collectible `Type` keys
+
+Typed resource lookups (e.g. implicit-style probes for secondary-app element types
+hosted in the host visual tree) that miss are cached in the dictionary's
+`_keyNotFoundCache` as `ResourceKey`s holding the **`RuntimeType`** strongly. Element-level
+dictionaries (e.g. a host page's `Resources`) live for the host's lifetime and are never
+touched by `CleanupNonDefaultAlcCaches` (which only invalidates the current Application's
+cache, without propagation). A single cached collectible `RuntimeType` pins
+`LoaderAllocator → ALC → entire previous app graph`. gcroot showed 10,378 root paths
+through one such cache entry.
+
+## Fixes
+
+1. **`XamlParseContext` (UI/Xaml/XamlParseContext.cs):** the ALC is now held via
+   `WeakReference<AssemblyLoadContext>`, with a strong fast-path field used only for
+   `AssemblyLoadContext.Default` (process-immortal, avoids the allocation). When a
+   previously resolved weak target has been collected, the lazy by-name resolution re-runs,
+   so a freshly loaded same-name assembly resolves to the NEW ALC — consistent with the
+   hot-reload "bump to live registration" behavior in `ResourceResolver`. While a secondary
+   app is active its ALC is strongly rooted by the hosting side (live windows, visual tree,
+   executing threads), so weakness here only changes post-unload behavior: the getter
+   returns `null` and `ResourceResolver.TryTopLevelRetrieval` falls back to the host
+   (its documented priority order).
+
+2. **`AlcContentHost` (UI/Xaml/Window/AlcContentHost.cs):** the control now tracks exactly
+   which theme-dictionary keys and direct-resource keys it copied, and removes them at the
+   start of every `UpdateMergedResources()` before re-copying from the (new) source app.
+   Clearing `Content` therefore drops all references to the previous app's resource objects.
+
+3. **`ResourceDictionary` (UI/Xaml/ResourceDictionary.cs):** typed keys whose
+   `Type.IsCollectible` is true are never added to `_keyNotFoundCache`
+   (`CanCacheKeyNotFound`). Re-probing such keys is cheap compared to leaking an entire
+   secondary app; non-collectible keys keep the existing caching behavior.
+
+## Validation
+
+Red/fix/green (each test fails on the pre-fix code):
+
+- `Uno.UI.Tests/Windows_UI_Xaml/Given_XamlParseContext.cs`
+  - `When_Collectible_Alc_Unloaded_Then_Context_Does_Not_Pin_It` — a strongly-held parse
+    context must not keep an unloaded collectible ALC alive; getter returns null after
+    collection. (Red before fix 1; green after.)
+  - Live-ALC and default-ALC behavioral tests (pass before and after).
+- `Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary_NotFoundCache.cs`
+  - `When_Collectible_Type_Key_Misses_Then_Cache_Does_Not_Pin_Type` — uses a
+    `RunAndCollect`-emitted type; the dictionary must not pin it after a not-found probe.
+    (Red before fix 3; green after.)
+  - Non-collectible keys still miss consistently (behavioral guard).
+- `Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs`
+  - `When_SecondaryAppContentCleared_Then_ProjectedResourcesRemovedFromHost` — direct
+    resources and theme dictionaries projected from the secondary app (new fixtures in
+    `AlcApp/App.xaml`) are removed when content is cleared. (Red before fix 2; green after.)
+- Full unit suite: identical pass/fail set with and without the fixes (baseline-compared);
+  zero regressions. Full ALC runtime suite: 33 passing; one pre-existing order-dependent
+  flake (`When_TopLevelLookupFromSecondaryAlcContext_HasHostValue_Then_SecondaryWins`)
+  fails identically on the unfixed baseline and passes in isolation on the fixed build.
+- End-to-end in the secondary-app host: across 4 load/reload cycles with a forced-GC heap
+  dump after each, the secondary `Application` instance count stays at **1** (previously
+  +1 per reload — one fully leaked app graph each time).
+
+## Notes / follow-ups
+
+- The host process retains small (120-byte) collectible-ALC wrapper shells (+1 per reload,
+  no graph behind them) — negligible; candidate follow-up.
+- A separate host-side accumulation (~+40 MB/reload of host-side dependency-object and
+  resource-initializer trees, not reachable from the secondary app graph) remains and is
+  tracked downstream.

--- a/specs/044-alc-memory-leak-fixes/spec.md
+++ b/specs/044-alc-memory-leak-fixes/spec.md
@@ -1,4 +1,4 @@
-# 044 — Collectible-ALC Memory Leak Fixes (XamlParseContext, AlcContentHost, ResourceDictionary)
+# 044 — Collectible-ALC Memory Leak Fixes (XamlParseContext, ResourceDictionary, Resource DataContext)
 
 ## Problem
 
@@ -9,8 +9,8 @@ never collected: each reload leaked one full copy of the previous app's object g
 reaching OOM within ~10–15 reloads.
 
 `dotnet-dump` SOS `gcroot` on a leaked secondary `Application` instance (~11,000 unique
-root paths) identified three independent pinning mechanisms in Uno.UI, all surviving
-`Application.CleanupNonDefaultAlcCaches()`.
+root paths) identified independent pinning mechanisms in Uno.UI, all surviving
+`Application.CleanupNonDefaultAlcCaches()`. This change addresses the three covered below.
 
 ## Root causes
 
@@ -25,14 +25,7 @@ and could permanently cache a **collectible** ALC inside a **never-dying static*
 `__ParseContext_` instance. Any retained ALC reference pins the LoaderAllocator and the
 entire previous app graph.
 
-### 2. `AlcContentHost` retains projected resources after teardown
-
-`AlcContentHost.UpdateMergedResources()` cleared and re-merged `MergedDictionaries`, but
-never removed previously **copied** theme-dictionary entries and direct resources. After
-the secondary app's content was cleared, its brushes/styles/templates (potentially typed
-in the collectible ALC) stayed in the host control's `Resources` forever.
-
-### 3. `ResourceDictionary` not-found cache pins collectible `Type` keys
+### 2. `ResourceDictionary` not-found cache pins collectible `Type` keys
 
 Typed resource lookups (e.g. implicit-style probes for secondary-app element types
 hosted in the host visual tree) that miss are cached in the dictionary's
@@ -42,6 +35,16 @@ touched by `CleanupNonDefaultAlcCaches` (which only invalidates the current Appl
 cache, without propagation). A single cached collectible `RuntimeType` pins
 `LoaderAllocator → ALC → entire previous app graph`. gcroot showed 10,378 root paths
 through one such cache entry.
+
+### 3. Resources inherit / cache the host subtree's `DataContext`
+
+A `DependencyObject` stored as a value in a `ResourceDictionary` inherited (and cached) the
+`DataContext` of the subtree it was applied into. A shared resource (e.g. a brush in a
+generated `GlobalStaticResources` singleton) is rooted by a long-lived dictionary yet is
+pulled into many short-lived subtrees via `{StaticResource}`/`{ThemeResource}`. Caching one
+such subtree's `DataContext` keeps it — and everything it transitively references — alive
+forever; when that subtree lives in a collectible ALC, the cached `DataContext` pins the
+whole context. This also diverges from WinUI, where resources have no `DataContext`.
 
 ## Fixes
 
@@ -56,15 +59,19 @@ through one such cache entry.
    returns `null` and `ResourceResolver.TryTopLevelRetrieval` falls back to the host
    (its documented priority order).
 
-2. **`AlcContentHost` (UI/Xaml/Window/AlcContentHost.cs):** the control now tracks exactly
-   which theme-dictionary keys and direct-resource keys it copied, and removes them at the
-   start of every `UpdateMergedResources()` before re-copying from the (new) source app.
-   Clearing `Content` therefore drops all references to the previous app's resource objects.
-
-3. **`ResourceDictionary` (UI/Xaml/ResourceDictionary.cs):** typed keys whose
+2. **`ResourceDictionary` (UI/Xaml/ResourceDictionary.cs):** typed keys whose
    `Type.IsCollectible` is true are never added to `_keyNotFoundCache`
-   (`CanCacheKeyNotFound`). Re-probing such keys is cheap compared to leaking an entire
-   secondary app; non-collectible keys keep the existing caching behavior.
+   (`CanCacheKeyNotFound`, applied once via `TryCacheKeyNotFound`). Re-probing such keys is
+   cheap compared to leaking an entire secondary app; non-collectible keys keep the existing
+   caching behavior.
+
+3. **Resource `DataContext` (UI/Xaml/DependencyObjectStore.cs, UI/Xaml/ResourceDictionary.cs):**
+   a `DependencyObject` stored as a value in a `ResourceDictionary` is flagged
+   (`IsResourceDictionaryItem`, backed by a single-byte `[Flags] StoreFlags` bitfield) so it
+   does not inherit or cache the `DataContext` of the subtree it is applied into — matching
+   WinUI parity. Only `DataContext` is blocked; other inherited properties (FlowDirection,
+   theme, …) still propagate, and `{Binding}` on the elements a resource/style is applied to
+   still resolves via their own inherited `DataContext`.
 
 ## Validation
 
@@ -76,24 +83,28 @@ Red/fix/green (each test fails on the pre-fix code):
     collection. (Red before fix 1; green after.)
   - Live-ALC and default-ALC behavioral tests (pass before and after).
 - `Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary_NotFoundCache.cs`
-  - `When_Collectible_Type_Key_Misses_Then_Cache_Does_Not_Pin_Type` — uses a
-    `RunAndCollect`-emitted type; the dictionary must not pin it after a not-found probe.
-    (Red before fix 3; green after.)
+  - A `RunAndCollect`-emitted collectible type must not be pinned by the dictionary after a
+    not-found probe. (Red before fix 2; green after.)
   - Non-collectible keys still miss consistently (behavioral guard).
-- `Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs`
-  - `When_SecondaryAppContentCleared_Then_ProjectedResourcesRemovedFromHost` — direct
-    resources and theme dictionaries projected from the secondary app (new fixtures in
-    `AlcApp/App.xaml`) are removed when content is cleared. (Red before fix 2; green after.)
+- `Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs`
+  - Element flagged `IsResourceDictionaryItem` on store; a resource in a subtree with a
+    `DataContext` does not inherit it; a normal logical child still inherits; a `{Binding}`
+    on a normal element still resolves via inherited `DataContext`. (Red before fix 3; green
+    after.)
 - Full unit suite: identical pass/fail set with and without the fixes (baseline-compared);
-  zero regressions. Full ALC runtime suite: 33 passing; one pre-existing order-dependent
-  flake (`When_TopLevelLookupFromSecondaryAlcContext_HasHostValue_Then_SecondaryWins`)
-  fails identically on the unfixed baseline and passes in isolation on the fixed build.
-- End-to-end in the secondary-app host: across 4 load/reload cycles with a forced-GC heap
+  zero regressions.
+- End-to-end in the secondary-app host (measured with the full collectible-ALC fix
+  workstream, of which this PR is a part): across 4 load/reload cycles with a forced-GC heap
   dump after each, the secondary `Application` instance count stays at **1** (previously
   +1 per reload — one fully leaked app graph each time).
 
 ## Notes / follow-ups
 
+- **`AlcContentHost` projected-resource retention** — `AlcContentHost.UpdateMergedResources()`
+  re-merges `MergedDictionaries` but does not remove previously **copied** theme-dictionary
+  entries / direct resources, so cleared secondary-app resources can linger in the host
+  control's `Resources`. This is a related collectible-ALC pin tracked separately and is
+  **not** part of this PR.
 - The host process retains small (120-byte) collectible-ALC wrapper shells (+1 per reload,
   no graph behind them) — negligible; candidate follow-up.
 - A separate host-side accumulation (~+40 MB/reload of host-side dependency-object and

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs
@@ -1,0 +1,95 @@
+#if HAS_UNO
+#nullable enable
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_ResourceDictionary_DataContext
+	{
+		// Resources stored in a ResourceDictionary must not inherit/cache the DataContext of the subtree
+		// they are applied into (WinUI parity — resources have no DataContext). Caching it would keep that
+		// DataContext, and for a previewed app its collectible AssemblyLoadContext, alive forever via the
+		// long-lived dictionary. These runtime tests guard the reviewer concern that this block does not
+		// regress style-based binding DataContext propagation: a Style is itself a resource, but the element
+		// it is applied to is not, so the styled element must keep inheriting DataContext and its bindings
+		// must still resolve.
+
+		[TestMethod]
+		public async Task When_Resource_Style_Applied_Then_Styled_Element_Still_Resolves_DataContext_Binding()
+		{
+			var root = (Grid)XamlReader.Load(
+				"""
+				<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					  Width="100"
+					  Height="100">
+					<Grid.Resources>
+						<Style x:Key="ProbeStyle" TargetType="Border">
+							<Setter Property="MinWidth" Value="10" />
+						</Style>
+					</Grid.Resources>
+					<Border Style="{StaticResource ProbeStyle}" Tag="{Binding Value}" />
+				</Grid>
+				""");
+
+			var probe = (Border)root.Children[0];
+			root.DataContext = new BindingProbe { Value = "bound!" };
+
+			await UITestHelper.Load(root, x => x.IsLoaded);
+
+			Assert.AreEqual(
+				"bound!",
+				probe.Tag,
+				"applying a (resource) Style must not strip the styled element's inherited DataContext; " +
+				"its {Binding} must still resolve.");
+		}
+
+		[TestMethod]
+		public async Task When_Resource_In_DataContext_Subtree_Then_Resource_Has_No_DataContext_But_Child_Does()
+		{
+			var root = (Grid)XamlReader.Load(
+				"""
+				<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					  Width="100"
+					  Height="100">
+					<Grid.Resources>
+						<Border x:Key="ResBorder" />
+					</Grid.Resources>
+					<Border />
+				</Grid>
+				""");
+
+			var resourceBorder = (Border)root.Resources["ResBorder"];
+			var child = (Border)root.Children[0];
+			var dataContext = new BindingProbe { Value = "host" };
+			root.DataContext = dataContext;
+
+			await UITestHelper.Load(root, x => x.IsLoaded);
+
+			Assert.IsNull(
+				resourceBorder.DataContext,
+				"a resource must not inherit the host subtree's DataContext (WinUI parity); inheriting it would " +
+				"pin that DataContext — and a previewed app's collectible AssemblyLoadContext — alive via the dictionary.");
+
+			Assert.AreSame(
+				dataContext,
+				child.DataContext,
+				"an ordinary logical child must still inherit DataContext; only ResourceDictionary items are exempt.");
+		}
+
+		private sealed class BindingProbe
+		{
+			public string? Value { get; set; }
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs
@@ -1,0 +1,67 @@
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_ResourceDictionary_DataContext
+	{
+		// A shared resource (e.g. a brush in a GlobalStaticResources singleton) is rooted by a long-lived
+		// ResourceDictionary, yet it is pulled into many short-lived subtrees via {StaticResource}/{ThemeResource}.
+		// If such a resource inherited/cached the DataContext of the subtree it is applied into, it would keep that
+		// DataContext — and everything it transitively references — alive forever. When the subtree lives in a
+		// collectible AssemblyLoadContext (a previewed app), that retention pins the whole context and prevents it
+		// from unloading. WinUI gives resources no DataContext; these tests guard that parity.
+
+		[TestMethod]
+		public void When_Element_Stored_In_ResourceDictionary_Then_Flagged_As_ResourceDictionaryItem()
+		{
+			var resource = new Border();
+
+			var dictionary = new ResourceDictionary { ["res"] = resource };
+
+			Assert.IsTrue(
+				((IDependencyObjectStoreProvider)resource).Store.IsResourceDictionaryItem,
+				"An element stored as a ResourceDictionary value must be flagged so it does not inherit/cache DataContext.");
+
+			Assert.IsTrue(dictionary.ContainsKey("res"));
+		}
+
+		[TestMethod]
+		public void When_Resource_Element_In_Subtree_With_DataContext_Then_Resource_Does_Not_Inherit_It()
+		{
+			var resource = new Border();
+			var host = new Grid();
+			host.Resources["res"] = resource;
+
+			var dataContext = new object();
+			host.DataContext = dataContext;
+
+			Assert.IsNull(
+				resource.DataContext,
+				"Resources have no DataContext (WinUI parity); inheriting it would pin the subtree's DataContext — " +
+				"and, for a previewed app, its collectible AssemblyLoadContext — alive via the shared dictionary.");
+		}
+
+		[TestMethod]
+		public void When_NonResource_Child_In_Subtree_With_DataContext_Then_It_Still_Inherits()
+		{
+			// Guard against over-blocking: only ResourceDictionary items are exempted; ordinary children
+			// must still inherit DataContext as usual.
+			var child = new Border();
+			var host = new Grid();
+			host.Children.Add(child);
+
+			var dataContext = new object();
+			host.DataContext = dataContext;
+
+			Assert.AreSame(
+				dataContext,
+				child.DataContext,
+				"A normal logical child must continue to inherit DataContext; only ResourceDictionary items are exempt.");
+		}
+	}
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_DataContext.cs
@@ -3,6 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml
 {
@@ -62,6 +63,35 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 				dataContext,
 				child.DataContext,
 				"A normal logical child must continue to inherit DataContext; only ResourceDictionary items are exempt.");
+		}
+
+		[TestMethod]
+		public void When_Element_Binding_Uses_Inherited_DataContext_Then_It_Still_Resolves()
+		{
+			// Guards the reviewer concern that blocking DataContext on resources could break binding in styles.
+			// A Style's setter {Binding} resolves against the *styled element's* DataContext, and the block is
+			// scoped to ResourceDictionary items — never the elements a resource/style is applied to. So a
+			// {Binding} on a normal element must still resolve via inherited DataContext, even while resources
+			// in the same tree carry none.
+			var vm = new BindingProbe { Value = "bound!" };
+
+			var host = new Grid();
+			var child = new Border();
+			host.Children.Add(child);
+			child.SetBinding(FrameworkElement.TagProperty, new Binding { Path = new PropertyPath(nameof(BindingProbe.Value)) });
+
+			host.DataContext = vm; // propagates to the child, where the binding evaluates
+
+			Assert.AreEqual(
+				"bound!",
+				child.Tag,
+				"a {Binding} on a normal element must still resolve via inherited DataContext; the DataContext " +
+				"block is scoped to ResourceDictionary items, not the elements styles/resources are applied to.");
+		}
+
+		private sealed class BindingProbe
+		{
+			public string? Value { get; set; }
 		}
 	}
 }

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_NotFoundCache.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_NotFoundCache.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_ResourceDictionary_NotFoundCache
+	{
+		[TestMethod]
+		public void When_Collectible_Type_Key_Misses_Then_Cache_Does_Not_Pin_Type()
+		{
+			var (dictionary, typeTracker) = ProbeDictionaryWithCollectibleTypeKey();
+
+			for (var i = 0; i < 10 && typeTracker.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsFalse(
+				typeTracker.IsAlive,
+				"A not-found lookup keyed by a collectible Type must not be cached in the dictionary's " +
+				"key-not-found cache; the cached RuntimeType pins its LoaderAllocator and the whole " +
+				"collectible AssemblyLoadContext after unload.");
+
+			GC.KeepAlive(dictionary);
+		}
+
+		[TestMethod]
+		public void When_NonCollectible_Type_Key_Misses_Then_Lookup_Still_Misses()
+		{
+			var dictionary = new ResourceDictionary();
+
+			// Non-collectible types remain cacheable; behavior must stay a miss on re-query.
+			Assert.IsFalse(dictionary.TryGetValue(typeof(Given_ResourceDictionary_NotFoundCache), out _, shouldCheckSystem: false));
+			Assert.IsFalse(dictionary.TryGetValue(typeof(Given_ResourceDictionary_NotFoundCache), out _, shouldCheckSystem: false));
+		}
+
+		/// <summary>
+		/// Probes a dictionary with a collectible Type key in a non-inlined frame so the JIT
+		/// cannot extend the local Type reference's lifetime into the caller's GC loop.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static (ResourceDictionary Dictionary, WeakReference TypeTracker) ProbeDictionaryWithCollectibleTypeKey()
+		{
+			var collectibleType = EmitCollectibleType();
+			Assert.IsTrue(collectibleType.IsCollectible, "Pre-condition: the emitted type must be collectible.");
+
+			var dictionary = new ResourceDictionary();
+
+			// A miss for a typed key (e.g. an implicit-style lookup for a type from a
+			// collectible ALC) goes through the key-not-found cache path.
+			Assert.IsFalse(dictionary.TryGetValue(collectibleType, out _, shouldCheckSystem: false));
+
+			return (dictionary, new WeakReference(collectibleType));
+		}
+
+		private static Type EmitCollectibleType()
+		{
+			var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+				new AssemblyName("NotFoundCacheCollectibleProbe"),
+				AssemblyBuilderAccess.RunAndCollect);
+			var moduleBuilder = assemblyBuilder.DefineDynamicModule("Main");
+			var typeBuilder = moduleBuilder.DefineType("ProbeType", TypeAttributes.Public | TypeAttributes.Class);
+			return typeBuilder.CreateType();
+		}
+	}
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_NotFoundCache.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_ResourceDictionary_NotFoundCache.cs
@@ -19,6 +19,9 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			{
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
+				// A second collect after finalizers run reclaims the collectible type's LoaderAllocator
+				// deterministically — finalization can release the last references keeping it alive.
+				GC.Collect();
 			}
 
 			Assert.IsFalse(

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_XamlParseContext.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_XamlParseContext.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_XamlParseContext
+	{
+		[TestMethod]
+		public void When_Alc_Assigned_Then_Returned_While_Alive()
+		{
+			var alc = new AssemblyLoadContext("Given_XamlParseContext-alive", isCollectible: true);
+			try
+			{
+				var context = new XamlParseContext
+				{
+					AssemblyName = "NoSuchAssembly_XamlParseContextTest",
+					AssemblyLoadContext = alc,
+				};
+
+				Assert.AreSame(alc, context.AssemblyLoadContext, "The getter must return the live ALC while it is strongly held by the caller.");
+			}
+			finally
+			{
+				alc.Unload();
+			}
+		}
+
+		[TestMethod]
+		public void When_Default_Alc_Assigned_Then_Returned()
+		{
+			var context = new XamlParseContext
+			{
+				AssemblyName = "NoSuchAssembly_XamlParseContextTest",
+				AssemblyLoadContext = AssemblyLoadContext.Default,
+			};
+
+			Assert.AreSame(AssemblyLoadContext.Default, context.AssemblyLoadContext);
+		}
+
+		[TestMethod]
+		public void When_Collectible_Alc_Unloaded_Then_Context_Does_Not_Pin_It()
+		{
+			var (context, alcTracker) = CreateContextWithCollectibleAlc();
+
+			for (var i = 0; i < 10 && alcTracker.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsFalse(
+				alcTracker.IsAlive,
+				"XamlParseContext must hold the AssemblyLoadContext weakly; a strongly-held parse context must not prevent an unloaded collectible ALC from being collected.");
+
+			Assert.IsNull(
+				context.AssemblyLoadContext,
+				"After the ALC is collected and no same-name assembly is loaded, the getter must return null.");
+
+			GC.KeepAlive(context);
+		}
+
+		/// <summary>
+		/// The assignment frame is isolated in a non-inlined method so the JIT cannot
+		/// extend the lifetime of the local ALC reference into the collection loop of
+		/// the calling test.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static (XamlParseContext Context, WeakReference AlcTracker) CreateContextWithCollectibleAlc()
+		{
+			var alc = new AssemblyLoadContext("Given_XamlParseContext-collectible", isCollectible: true);
+
+			var context = new XamlParseContext
+			{
+				// Deliberately not a loaded assembly: after the ALC is collected, the
+				// lazy by-name re-resolution must find nothing and return null.
+				AssemblyName = "NoSuchAssembly_XamlParseContextTest",
+				AssemblyLoadContext = alc,
+			};
+
+			Assert.AreSame(alc, context.AssemblyLoadContext, "Pre-condition: the getter must return the live ALC before unload.");
+
+			var tracker = new WeakReference(alc);
+			alc.Unload();
+
+			return (context, tracker);
+		}
+	}
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_XamlParseContext.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_XamlParseContext.cs
@@ -50,6 +50,9 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			{
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
+				// A second collect after finalizers run reclaims the unloaded collectible ALC
+				// deterministically — finalization can release the last references that keep it alive.
+				GC.Collect();
 			}
 
 			Assert.IsFalse(

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using Uno.UI.DataBinding;
@@ -284,7 +284,25 @@ namespace Microsoft.UI.Xaml
 		/// retention pins the whole context and prevents it from unloading. Only DataContext is blocked; other
 		/// inherited properties (FlowDirection, theme, …) still propagate so resource visuals render correctly.
 		/// </remarks>
-		internal bool IsResourceDictionaryItem { get; set; }
+		internal bool IsResourceDictionaryItem
+		{
+			get => (_storeFlags & StoreFlags.IsResourceDictionaryItem) != 0;
+			set => _storeFlags = value
+				? _storeFlags | StoreFlags.IsResourceDictionaryItem
+				: _storeFlags & ~StoreFlags.IsResourceDictionaryItem;
+		}
+
+		// Single-byte bitfield for boolean per-store flags. A DependencyObjectStore is allocated once per
+		// DependencyObject, so per-instance size matters; folding flags here keeps that footprint flat as
+		// more are added. Prefer extending StoreFlags over introducing new standalone bool fields.
+		[Flags]
+		private enum StoreFlags : byte
+		{
+			None = 0,
+			IsResourceDictionaryItem = 1 << 0,
+		}
+
+		private StoreFlags _storeFlags;
 
 		/// <summary>
 		/// Returns the current effective value of a dependency property from a DependencyObject.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -271,6 +271,22 @@ namespace Microsoft.UI.Xaml
 		public bool IsAutoPropertyInheritanceEnabled { get; set; } = true;
 
 		/// <summary>
+		/// Set when this object is stored as a value in a <see cref="ResourceDictionary"/>. Such resources must not
+		/// inherit/cache the <see cref="DataContextProperty"/> from the subtree they are applied into (this matches
+		/// WinUI, where resources have no DataContext).
+		/// </summary>
+		/// <remarks>
+		/// A shared resource (e.g. a brush or shape in a <c>GlobalStaticResources</c> singleton) is rooted by a
+		/// long-lived dictionary, yet it is pulled into many short-lived subtrees via <c>{StaticResource}</c>/
+		/// <c>{ThemeResource}</c>. If it cached the inherited DataContext of one such subtree, the resource would
+		/// keep that DataContext (and everything it transitively references) alive forever. When the subtree lives
+		/// in a collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/> (e.g. a previewed app), that
+		/// retention pins the whole context and prevents it from unloading. Only DataContext is blocked; other
+		/// inherited properties (FlowDirection, theme, …) still propagate so resource visuals render correctly.
+		/// </remarks>
+		internal bool IsResourceDictionaryItem { get; set; }
+
+		/// <summary>
 		/// Returns the current effective value of a dependency property from a DependencyObject.
 		/// </summary>
 		/// <param name="property">The <see cref="DependencyProperty" /> identifier of the property for which to retrieve the value. </param>
@@ -1279,6 +1295,17 @@ namespace Microsoft.UI.Xaml
 
 		private void OnParentPropertyChangedCallback(ManagedWeakReference sourceInstance, DependencyProperty parentProperty, object? newValue)
 		{
+			// A ResourceDictionary item must not inherit/cache DataContext (WinUI behaviour — resources
+			// have no DataContext). Blocking it here also blocks propagation to this resource's own inherited-property
+			// children (e.g. a shape resource's gradient brush), since DataContext is applied via the SetValue below.
+			// Without this, a shared resource pulled into a subtree via {StaticResource}/{ThemeResource} permanently
+			// caches that subtree's DataContext; when the subtree lives in a collectible AssemblyLoadContext it pins
+			// the whole ALC. Other inherited properties are unaffected.
+			if (IsResourceDictionaryItem && parentProperty.UniqueId == _parentDataContextProperty.UniqueId)
+			{
+				return;
+			}
+
 			// WinUI: Foreground propagates through TextFormatting, NOT through DP inheritance.
 			// In Uno, Foreground has FrameworkPropertyMetadataOptions.Inherits which auto-cascades
 			// to ALL descendants. This breaks element-level theming because a parent's theme change

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -490,6 +490,11 @@ namespace Microsoft.UI.Xaml
 					newDictionary._parent = this;
 					ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 				}
+				else if (value is IDependencyObjectStoreProvider provider)
+				{
+					// Resources do not inherit DataContext (see DependencyObjectStore.IsResourceDictionaryItem).
+					provider.Store.IsResourceDictionaryItem = true;
+				}
 			}
 
 			InvalidateNotFoundCache(true, resourceKey);
@@ -530,6 +535,11 @@ namespace Microsoft.UI.Xaml
 					if (newValue is ResourceDictionary)
 					{
 						ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
+					}
+					else if (newValue is IDependencyObjectStoreProvider materializedProvider)
+					{
+						// Resources do not inherit DataContext (see DependencyObjectStore.IsResourceDictionaryItem).
+						materializedProvider.Store.IsResourceDictionaryItem = true;
 					}
 
 					if (!FeatureConfiguration.ResourceDictionary.IncludeUnreferencedDictionaries)

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -1,4 +1,4 @@
-﻿//#define DEBUG_SET_RESOURCE_SOURCE
+//#define DEBUG_SET_RESOURCE_SOURCE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -171,6 +171,19 @@ namespace Microsoft.UI.Xaml
 		private static bool CanCacheKeyNotFound(in ResourceKey resourceKey)
 			=> resourceKey.TypeKey is not { IsCollectible: true };
 
+		/// <summary>
+		/// Records <paramref name="resourceKey"/> in the key-not-found cache when caching is enabled and the
+		/// key is safe to cache (see <see cref="CanCacheKeyNotFound"/>). Centralised so the collectible-key
+		/// guard is applied identically at every not-found site, rather than repeated inline.
+		/// </summary>
+		private void TryCacheKeyNotFound(in ResourceKey resourceKey, bool useKeysNotFoundCache, bool shouldCheckSystem)
+		{
+			if (useKeysNotFoundCache && !shouldCheckSystem && CanCacheKeyNotFound(resourceKey))
+			{
+				KeyNotFoundCache.Add(resourceKey);
+			}
+		}
+
 		internal object Lookup(object key)
 		{
 			if (!TryGetValue(key, out var value))
@@ -332,10 +345,7 @@ namespace Microsoft.UI.Xaml
 				return ResourceResolver.TrySystemResourceRetrieval(modifiedKey, out value);
 			}
 
-			if (useKeysNotFoundCache && !shouldCheckSystem && CanCacheKeyNotFound(resourceKey))
-			{
-				KeyNotFoundCache.Add(resourceKey);
-			}
+			TryCacheKeyNotFound(resourceKey, useKeysNotFoundCache, shouldCheckSystem);
 
 			return false;
 		}
@@ -410,10 +420,7 @@ namespace Microsoft.UI.Xaml
 				}
 			}
 
-			if (useKeysNotFoundCache && !shouldCheckSystem && CanCacheKeyNotFound(resourceKey))
-			{
-				KeyNotFoundCache.Add(resourceKey);
-			}
+			TryCacheKeyNotFound(resourceKey, useKeysNotFoundCache, shouldCheckSystem);
 
 			providingDictionary = null;
 			return false;

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -161,6 +161,16 @@ namespace Microsoft.UI.Xaml
 		private HashSet<ResourceKey> KeyNotFoundCache
 			=> _keyNotFoundCache ??= new(SpecializedResourceDictionary.ResourceKeyComparer.Default);
 
+		/// <summary>
+		/// A typed key whose <see cref="Type"/> comes from a collectible AssemblyLoadContext must
+		/// never enter the key-not-found cache: dictionaries live as long as their owning element
+		/// (often the host application's lifetime) and a cached RuntimeType pins its
+		/// LoaderAllocator — and through it the whole collectible ALC — long after unload.
+		/// Re-probing such keys is cheap compared to leaking the entire secondary app.
+		/// </summary>
+		private static bool CanCacheKeyNotFound(in ResourceKey resourceKey)
+			=> resourceKey.TypeKey is not { IsCollectible: true };
+
 		internal object Lookup(object key)
 		{
 			if (!TryGetValue(key, out var value))
@@ -322,7 +332,7 @@ namespace Microsoft.UI.Xaml
 				return ResourceResolver.TrySystemResourceRetrieval(modifiedKey, out value);
 			}
 
-			if (useKeysNotFoundCache && !shouldCheckSystem)
+			if (useKeysNotFoundCache && !shouldCheckSystem && CanCacheKeyNotFound(resourceKey))
 			{
 				KeyNotFoundCache.Add(resourceKey);
 			}
@@ -400,7 +410,7 @@ namespace Microsoft.UI.Xaml
 				}
 			}
 
-			if (useKeysNotFoundCache && !shouldCheckSystem)
+			if (useKeysNotFoundCache && !shouldCheckSystem && CanCacheKeyNotFound(resourceKey))
 			{
 				KeyNotFoundCache.Add(resourceKey);
 			}

--- a/src/Uno.UI/UI/Xaml/XamlParseContext.cs
+++ b/src/Uno.UI/UI/Xaml/XamlParseContext.cs
@@ -16,7 +16,12 @@ namespace Uno.UI.Xaml
 		// *************** WARNING ***************
 		// This class instance is not being replaced when a ResourceDictionary is being reloaded (i.e. we continue to use the instance of the original type)
 		// This is valid only because all information hosted by this class doesn't change on hot-reload.
-		// 
+		//
+		// The one exception is the AssemblyLoadContext below: it is held WEAKLY (for collectibility — see that
+		// field's remarks) and so its resolved value can lapse. That does not violate the reuse rule: while the app
+		// is alive the ALC identity is stable, and the reference only dies once that ALC is unloaded — which is
+		// teardown, not hot-reload.
+		//
 		// Any new property on this class should follow this same rule, or the resolution of this has to be changed to support hot-reload properly
 		// (search for "__ParseContext_" in the xaml generator).
 		// ***************************************

--- a/src/Uno.UI/UI/Xaml/XamlParseContext.cs
+++ b/src/Uno.UI/UI/Xaml/XamlParseContext.cs
@@ -23,16 +23,51 @@ namespace Uno.UI.Xaml
 
 		public string AssemblyName { get; set; }
 
-		private System.Runtime.Loader.AssemblyLoadContext _assemblyLoadContext;
+		// The non-default ALC is held WEAKLY so that long-lived XamlParseContext instances
+		// (e.g. captured by ResourceBinding/ThemeResourceReference on elements reachable from
+		// non-collectible statics such as generated GlobalStaticResources singletons) never
+		// pin a collectible AssemblyLoadContext. While the secondary app is active its ALC is
+		// strongly rooted by the hosting side (live windows, visual tree, executing threads);
+		// once the host releases it and Unload() completes, this weak reference dies and the
+		// previous app's whole object graph becomes collectible.
+		private System.WeakReference<System.Runtime.Loader.AssemblyLoadContext> _assemblyLoadContext;
+
+		// The default ALC is process-immortal: hold it directly to avoid a pointless
+		// WeakReference allocation (and TryGetTarget would always succeed anyway).
+		private System.Runtime.Loader.AssemblyLoadContext _defaultAssemblyLoadContext;
+
+		// Latches the lazy by-AssemblyName resolution when no matching assembly is loaded,
+		// so repeated misses don't re-scan AppDomain on every access.
 		private bool _assemblyLoadContextResolved;
 
 		public System.Runtime.Loader.AssemblyLoadContext AssemblyLoadContext
 		{
 			get
 			{
-				if (_assemblyLoadContext is not null || _assemblyLoadContextResolved)
+				if (_defaultAssemblyLoadContext is not null)
 				{
-					return _assemblyLoadContext;
+					return _defaultAssemblyLoadContext;
+				}
+
+				if (_assemblyLoadContext is not null)
+				{
+					if (_assemblyLoadContext.TryGetTarget(out var alc))
+					{
+						return alc;
+					}
+
+					// The previously resolved ALC was unloaded and collected. Drop the dead
+					// reference and re-run the lazy resolution below: when the same logical
+					// app has been re-loaded (hot reload), a same-name assembly now lives in
+					// a NEW ALC and must be picked up — mirroring the "bump to the live
+					// registration" behavior in ResourceResolver.
+					_assemblyLoadContext = null;
+					_assemblyLoadContextResolved = false;
+				}
+
+				if (_assemblyLoadContextResolved)
+				{
+					return null;
 				}
 
 				// Lazily resolve from AssemblyName so secondary-ALC consumers are reachable
@@ -48,18 +83,37 @@ namespace Uno.UI.Xaml
 					{
 						if (string.Equals(assembly.GetName().Name, AssemblyName, System.StringComparison.Ordinal))
 						{
-							_assemblyLoadContext = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
-							break;
+							var resolved = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
+							SetAssemblyLoadContext(resolved);
+							return resolved;
 						}
 					}
 				}
 
-				return _assemblyLoadContext;
+				return null;
 			}
-			set
+			set => SetAssemblyLoadContext(value);
+		}
+
+		private void SetAssemblyLoadContext(System.Runtime.Loader.AssemblyLoadContext value)
+		{
+			if (value is null)
 			{
-				_assemblyLoadContext = value;
-				_assemblyLoadContextResolved = value is not null;
+				_defaultAssemblyLoadContext = null;
+				_assemblyLoadContext = null;
+				_assemblyLoadContextResolved = false;
+			}
+			else if (ReferenceEquals(value, System.Runtime.Loader.AssemblyLoadContext.Default))
+			{
+				_defaultAssemblyLoadContext = value;
+				_assemblyLoadContext = null;
+				_assemblyLoadContextResolved = true;
+			}
+			else
+			{
+				_defaultAssemblyLoadContext = null;
+				_assemblyLoadContext = new System.WeakReference<System.Runtime.Loader.AssemblyLoadContext>(value);
+				_assemblyLoadContextResolved = true;
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

When a host loads an app into a **collectible** `AssemblyLoadContext` (ALC) and later unloads it, shared default-context framework state can retain references that reach into the collectible ALC and prevent it from being collected. Over repeated load/unload cycles these pins accumulate; on WASM (MonoVM), where `WebAssembly.Memory.grow()` is irreversible, this is eventually fatal.

This PR removes three such default-context → collectible-ALC references in the framework.

## Changes

- **XamlParseContext holds the ALC weakly** — the parse context no longer keeps a strong reference to the `AssemblyLoadContext` of the assembly it was created for.
- **ResourceDictionary not-found cache never caches collectible `Type` keys** — a cached `RuntimeType` pins its `LoaderAllocator` and the whole collectible ALC after unload; collectible type keys are no longer cached on a miss.
- **Resources do not inherit DataContext** (WinUI parity) — a `DependencyObject` stored as a value in a `ResourceDictionary` is flagged (`IsResourceDictionaryItem`) so it never inherits/caches the `DataContext` of the subtree it is applied into. A shared resource (e.g. a brush in a generated statics singleton) is rooted by a long-lived dictionary yet pulled into many short-lived subtrees via `{StaticResource}`/`{ThemeResource}`; caching one subtree's DataContext would keep it — and any collectible ALC it reaches — alive forever. Only DataContext is blocked; other inherited properties still propagate.

## Tests (red/green)

- `Given_XamlParseContext` — ALC is collectible after the parse context is released.
- `Given_ResourceDictionary_NotFoundCache` — a collectible `Type` key miss is not pinned.
- `Given_ResourceDictionary_DataContext` (new) — element flagged on store; resource does not inherit DataContext; a normal logical child still does.

Part of the collectible-ALC memory-leak fixes documented in `specs/044-alc-memory-leak-fixes` (see also `specs/000-alc-secondary-app-support`). Includes commits by @derekraven1994 (XamlParseContext, ResourceDictionary not-found cache, spec) grouped here by theme.
