### PR TITLE
fix(alc): release AlcContentHost projections + RemoteControl shared state on teardown

### DIFF
--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -35,6 +35,35 @@ namespace Uno.UI.Dispatching
 
 		private readonly Dictionary<object, (Action? renderAction, int normalItemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
 
+		/// <summary>
+		/// Removes composition-target render registrations matching the predicate. Nothing else
+		/// ever removes entries, so a closed secondary-app window's CompositionTarget otherwise
+		/// stays registered forever — pinning its visual tree (and its collectible
+		/// AssemblyLoadContext) through this process-lifetime dispatcher.
+		/// </summary>
+		internal void RemoveCompositionTargets(Predicate<object> shouldRemove)
+		{
+			lock (_gate)
+			{
+				List<object>? toRemove = null;
+				foreach (var key in _compositionTargets.Keys)
+				{
+					if (shouldRemove(key))
+					{
+						(toRemove ??= new()).Add(key);
+					}
+				}
+
+				if (toRemove is not null)
+				{
+					foreach (var key in toRemove)
+					{
+						_compositionTargets.Remove(key);
+					}
+				}
+			}
+		}
+
 		private NativeDispatcherPriority _currentPriority;
 
 		private int _globalCount;

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlClient_CollectibleCallbacks.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlClient_CollectibleCallbacks.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using Uno.UI.RemoteControl;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+[TestClass]
+public class Given_RemoteControlClient_CollectibleCallbacks
+{
+	// Synthetic "collectibility" predicate: a real collectible ALC cannot be staged in a plain unit
+	// test, so we classify by method name instead and verify the invocation-list filtering itself.
+	private static readonly Func<Action<RemoteControlClient>, bool> IsCollectible =
+		static a => a.Method.Name.StartsWith("Drop", StringComparison.Ordinal);
+
+	private static void Keep1(RemoteControlClient _)
+	{
+	}
+
+	private static void Keep2(RemoteControlClient _)
+	{
+	}
+
+	private static void Drop1(RemoteControlClient _)
+	{
+	}
+
+	private static void Drop2(RemoteControlClient _)
+	{
+	}
+
+	[TestMethod]
+	public void FilterCollectibleInvocations_WhenSingleNonCollectible_ReturnsSameInstance()
+	{
+		Action<RemoteControlClient> action = Keep1;
+
+		var result = RemoteControlClient.FilterCollectibleInvocations(action, IsCollectible);
+
+		result.Should().BeSameAs(action);
+	}
+
+	[TestMethod]
+	public void FilterCollectibleInvocations_WhenSingleCollectible_ReturnsNull()
+	{
+		Action<RemoteControlClient> action = Drop1;
+
+		var result = RemoteControlClient.FilterCollectibleInvocations(action, IsCollectible);
+
+		result.Should().BeNull();
+	}
+
+	[TestMethod]
+	public void FilterCollectibleInvocations_WhenAllEntriesCollectible_ReturnsNull()
+	{
+		Action<RemoteControlClient> action = Drop1;
+		action += Drop2;
+
+		var result = RemoteControlClient.FilterCollectibleInvocations(action, IsCollectible);
+
+		result.Should().BeNull();
+	}
+
+	[TestMethod]
+	public void FilterCollectibleInvocations_WhenNoEntryCollectible_ReturnsSameInstance()
+	{
+		Action<RemoteControlClient> action = Keep1;
+		action += Keep2;
+
+		var result = RemoteControlClient.FilterCollectibleInvocations(action, IsCollectible);
+
+		result.Should().BeSameAs(action);
+	}
+
+	[TestMethod]
+	public void FilterCollectibleInvocations_WhenMulticastMixed_KeepsOnlyNonCollectibleEntries()
+	{
+		// A combined delegate whose Target/Method reflect only one entry — the whole thing must not be
+		// dropped (nor kept) wholesale; only the collectible entry should be removed.
+		Action<RemoteControlClient> action = Keep1;
+		action += Drop1;
+		action += Keep2;
+
+		var result = RemoteControlClient.FilterCollectibleInvocations(action, IsCollectible);
+
+		result.Should().NotBeNull();
+		var keptMethods = new List<string>();
+		foreach (var entry in result!.GetInvocationList())
+		{
+			keptMethods.Add(entry.Method.Name);
+		}
+
+		keptMethods.Should().Equal(nameof(Keep1), nameof(Keep2));
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlJsonOptions_Reset.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_RemoteControlJsonOptions_Reset.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RemoteControl.Messaging;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+[TestClass]
+public class Given_RemoteControlJsonOptions_Reset
+{
+	[TestCleanup]
+	public void Cleanup() => RemoteControlJsonOptions.Reset();
+
+	[TestMethod]
+	public void When_Reset_Then_Registered_SourceGenerated_Context_Is_Released()
+	{
+		var tracker = RegisterContextAndDropStrongReference();
+
+		RemoteControlJsonOptions.Reset();
+
+		for (var i = 0; i < 10 && tracker.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		Assert.IsFalse(
+			tracker.IsAlive,
+			"Reset() must drop the cached options and the registered JsonSerializerContext. A secondary " +
+			"(collectible-ALC) app registers a per-ALC context; holding it on this shared static pins that " +
+			"app's AssemblyLoadContext after unload.");
+	}
+
+	[TestMethod]
+	public void When_Reset_Then_Default_Options_Are_Recreated_Lazily()
+	{
+		RemoteControlJsonOptions.Reset();
+
+		var options = RemoteControlJsonOptions.Default;
+
+		Assert.IsNotNull(options, "Default options must be recreated lazily after Reset().");
+	}
+
+	// Registering then dropping the only strong reference in a non-inlined frame ensures the just-registered
+	// context is not pinned by a lingering local when we assert collection.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference RegisterContextAndDropStrongReference()
+	{
+		var context = new ResetProbeJsonContext(new JsonSerializerOptions());
+		RemoteControlJsonOptions.SetSourceGeneratedContext(context);
+		return new WeakReference(context);
+	}
+}
+
+[JsonSerializable(typeof(string))]
+internal partial class ResetProbeJsonContext : JsonSerializerContext
+{
+}

--- a/src/Uno.UI.RemoteControl.Messaging/DevServerDiagnostics.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/DevServerDiagnostics.cs
@@ -1,5 +1,6 @@
-﻿#nullable enable
+#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Uno.UI.RemoteControl.HotReload.Messages;
@@ -8,15 +9,39 @@ namespace Uno.UI.RemoteControl;
 
 public static class DevServerDiagnostics
 {
-	private static readonly AsyncLocal<ISink> _current = new();
+	// The AsyncLocal stores a mutable HOLDER rather than the sink itself. ExecutionContext
+	// snapshots are immutable: when a sink set on a thread's ambient context flows into
+	// long-lived captures (timers, CancellationTokenSource registrations, pooled connections,
+	// the UI thread's ambient context), those snapshots can never be scrubbed from outside.
+	// A sink owned by a collectible AssemblyLoadContext (a secondary app's
+	// RemoteControlClient.StatusSink) would then pin that ALC for the captures' lifetime —
+	// for process-lifetime timers, forever. The holder lives in this shared (default-ALC)
+	// assembly, so snapshots only ever capture a default-ALC object; clearing the holder's
+	// Sink propagates to every snapshot at once because they all reference the same holder.
+	private static readonly AsyncLocal<SinkHolder> _current = new();
+
+	// Weak registry of every holder handed out, so ClearCollectibleSinks can reach holders
+	// captured in contexts that are no longer the current flow.
+	private static readonly List<WeakReference<SinkHolder>> _holders = new();
+	private static readonly object _holdersGate = new();
 
 	/// <summary>
 	/// Gets the current (async-local) sink for dev-server diagnostics.
 	/// </summary>
 	public static ISink Current
 	{
-		get => _current.Value ?? NullSink.Instance;
-		set => _current.Value = value;
+		get => _current.Value?.Sink ?? NullSink.Instance;
+		set
+		{
+			var holder = new SinkHolder(value);
+			lock (_holdersGate)
+			{
+				_holders.RemoveAll(static wr => !wr.TryGetTarget(out _));
+				_holders.Add(new WeakReference<SinkHolder>(holder));
+			}
+
+			_current.Value = holder;
+		}
 	}
 
 	/// <summary>
@@ -25,11 +50,49 @@ public static class DevServerDiagnostics
 	/// AsyncLocal → StatusSink → RemoteControlClient reference chain.
 	/// </summary>
 	public static void ResetCurrent()
-		=> _current.Value = NullSink.Instance;
+		=> _current.Value = new SinkHolder(NullSink.Instance);
+
+	/// <summary>
+	/// Detaches every tracked sink that belongs to a collectible AssemblyLoadContext, including
+	/// sinks captured in ExecutionContext snapshots that are not reachable from the calling flow
+	/// (timers, CTS registrations, pooled connections). Call during secondary-app (ALC) teardown:
+	/// without this, those captures pin the unloading ALC for their own lifetime.
+	/// </summary>
+	public static void ClearCollectibleSinks()
+	{
+		lock (_holdersGate)
+		{
+			for (var i = _holders.Count - 1; i >= 0; i--)
+			{
+				if (!_holders[i].TryGetTarget(out var holder))
+				{
+					_holders.RemoveAt(i);
+					continue;
+				}
+
+#if NET5_0_OR_GREATER
+				if (holder.Sink is { } sink && sink.GetType().Assembly.IsCollectible)
+				{
+					holder.Sink = null;
+				}
+#else
+				// Assembly.IsCollectible is unavailable on this target; collectible ALCs do not
+				// exist there either, but the shared assembly may still be serving a runtime
+				// that has them — clear every tracked sink (teardown-time best effort).
+				holder.Sink = null;
+#endif
+			}
+		}
+	}
 
 	public interface ISink
 	{
 		void ReportInvalidFrame<TContent>(Frame frame);
+	}
+
+	private sealed class SinkHolder(ISink? sink)
+	{
+		public ISink? Sink { get; set; } = sink;
 	}
 
 	private class NullSink : ISink

--- a/src/Uno.UI.RemoteControl.Messaging/DevServerDiagnostics.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/DevServerDiagnostics.cs
@@ -71,7 +71,7 @@ public static class DevServerDiagnostics
 				}
 
 #if NET5_0_OR_GREATER
-				if (holder.Sink is { } sink && sink.GetType().Assembly.IsCollectible)
+				if (holder.Sink is { } sink && sink.GetType().IsCollectible)
 				{
 					holder.Sink = null;
 				}

--- a/src/Uno.UI.RemoteControl.Messaging/InProcessFrameTransport.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/InProcessFrameTransport.cs
@@ -67,7 +67,20 @@ internal sealed class InProcessFrameTransport : IFrameTransport
 					return null; // Closed, return null.
 				}
 
-				await _signal.WaitAsync(ct);
+				// Bounded wait: a waiter parked on the semaphore when the endpoint closes can lose
+				// the single Release() race (or be parked when Dispose runs — SemaphoreSlim.Dispose
+				// does NOT complete pending waiters) and then hang forever. Its async state machine
+				// roots the endpoint, the cancellation registration, and everything they capture —
+				// in host scenarios that pins the previewed app's collectible AssemblyLoadContext.
+				// The periodic re-check guarantees any orphaned waiter self-completes.
+				try
+				{
+					await _signal.WaitAsync(TimeSpan.FromSeconds(5), ct);
+				}
+				catch (ObjectDisposedException)
+				{
+					return null; // Disposed while parked — the endpoint is gone.
+				}
 
 				// The transport may have been closed while awaiting the signal, so re-check the closure flags.
 				if (_isRemoteClosed != 0 || _isClosed != 0)

--- a/src/Uno.UI.RemoteControl.Messaging/RemoteControlJsonOptions.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/RemoteControlJsonOptions.cs
@@ -30,6 +30,14 @@ public static class RemoteControlJsonOptions
 		_options = CreateOptions(context);
 	}
 
+	/// <summary>
+	/// Drops the cached options + the registered source-generated context. A secondary (collectible-ALC)
+	/// app's <see cref="RemoteControlClient"/> registers a per-ALC <see cref="JsonSerializerContext"/>
+	/// (<c>RemoteControlJsonContext.Default</c>); holding it on this shared static pins that app's
+	/// AssemblyLoadContext after unload. Called on app teardown; options are recreated lazily.
+	/// </summary>
+	public static void Reset() => _options = null;
+
 	private static JsonSerializerOptions CreateOptions(JsonSerializerContext? sourceGenerated)
 	{
 		return new JsonSerializerOptions

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -1190,6 +1190,11 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 		// client's per-ALC RemoteControlJsonContext.Default on the shared (default-ALC) RemoteControlJsonOptions;
 		// leaving it set pins the secondary app's collectible ALC after unload. Recreated lazily on next use.
 		Messaging.RemoteControlJsonOptions.Reset();
+
+		// Drain any queued OnRemoteControlClientAvailable callbacks whose target lives in a collectible ALC.
+		// A secondary app that only ever calls CreateAdditional (SetAsDefaultInstance=false) never drains the
+		// shared waiting list, so its captured per-ALC closures would pin the collectible ALC after unload.
+		RemoveCollectibleAlcWaitingCallbacks();
 	}
 
 	// The three helpers below are internal (rather than private) to allow unit testing via InternalsVisibleTo.

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.WebSockets;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions;
@@ -124,6 +125,49 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 					break;
 				}
 			}
+		}
+	}
+
+	/// <summary>
+	/// Removes queued <see cref="OnRemoteControlClientAvailable"/> callbacks whose target lives in a collectible
+	/// (non-default) <see cref="AssemblyLoadContext"/>. Such callbacks are registered by code in a previewed app's
+	/// ALC waiting for the default <see cref="Instance"/>; when that app only ever creates additional clients
+	/// (<see cref="CreateAdditional"/>, with SetAsDefaultInstance=false) the waiting list never drains, so the
+	/// captured per-ALC closures pin the collectible ALC after unload. Called on ALC teardown.
+	/// </summary>
+	public static void RemoveCollectibleAlcWaitingCallbacks()
+	{
+		while (true)
+		{
+			var current = _waitingList;
+			if (current is null || current.Count == 0)
+			{
+				return;
+			}
+
+			var kept = current.Where(static a => !IsCollectibleTarget(a)).ToArray();
+			if (kept.Length == current.Count)
+			{
+				return; // nothing collectible to remove
+			}
+
+			IReadOnlyCollection<Action<RemoteControlClient>>? next = kept.Length == 0 ? null : kept;
+			if (ReferenceEquals(Interlocked.CompareExchange(ref _waitingList, next, current), current))
+			{
+				return;
+			}
+		}
+
+		static bool IsCollectibleTarget(Action<RemoteControlClient> action)
+		{
+			var declaringType = action.Target?.GetType() ?? action.Method.DeclaringType;
+			if (declaringType is null)
+			{
+				return false;
+			}
+
+			var alc = AssemblyLoadContext.GetLoadContext(declaringType.Assembly);
+			return alc is not null && alc != AssemblyLoadContext.Default && alc.IsCollectible;
 		}
 	}
 
@@ -307,8 +351,22 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 		{
 			if (Interlocked.CompareExchange(ref _state, States.Active, States.Ready) is States.Ready)
 			{
+				// Scope the diagnostics sink to ProcessMessages' execution flow and restore the
+				// caller's ambient value afterwards. EnsureActive runs on the caller (e.g. UI)
+				// thread; assigning DevServerDiagnostics.Current unscoped would persist the sink
+				// in that thread's ambient ExecutionContext and flow it into every context
+				// captured thereafter (timers, continuations, dispatcher enqueues), pinning the
+				// StatusSink → owner graph and any collectible AssemblyLoadContext it reaches.
+				var previousSink = DevServerDiagnostics.Current;
 				DevServerDiagnostics.Current = Owner._status;
-				_ = Owner.ProcessMessages(Transport!, _ct.Token);
+				try
+				{
+					_ = Owner.ProcessMessages(Transport!, _ct.Token);
+				}
+				finally
+				{
+					DevServerDiagnostics.Current = previousSink;
+				}
 			}
 		}
 
@@ -959,31 +1017,40 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 		}
 
 		Timer? timer = default;
-		timer = new Timer(async _ =>
+
+		// Suppress ExecutionContext flow while creating the long-lived keep-alive timer. The
+		// timer is held by the process-global TimerQueue for the connection's lifetime; if it
+		// captured the current ambient context it would also capture (and pin) whatever is
+		// ambient on this thread — including the DevServerDiagnostics sink — keeping the
+		// StatusSink → owner graph and any collectible AssemblyLoadContext alive indefinitely.
+		using (System.Threading.ExecutionContext.SuppressFlow())
 		{
-			try
+			timer = new Timer(async _ =>
 			{
-				if (this.Log().IsEnabled(LogLevel.Trace))
+				try
 				{
-					this.Log().Trace($"Sending Keepalive frame from client");
-				}
+					if (this.Log().IsEnabled(LogLevel.Trace))
+					{
+						this.Log().Trace($"Sending Keepalive frame from client");
+					}
 
-				_ping = _ping.Next();
-				_status.ReportPing(_ping);
-				await SendMessage(_ping);
-			}
-			catch (Exception error)
-			{
-				if (this.Log().IsEnabled(LogLevel.Trace))
+					_ping = _ping.Next();
+					_status.ReportPing(_ping);
+					await SendMessage(_ping);
+				}
+				catch (Exception error)
 				{
-					this.Log().Trace("Keepalive failed");
-				}
+					if (this.Log().IsEnabled(LogLevel.Trace))
+					{
+						this.Log().Trace("Keepalive failed");
+					}
 
-				_status.ReportKeepAliveAborted(error);
-				Interlocked.CompareExchange(ref _keepAliveTimer, null, timer);
-				timer?.Dispose();
-			}
-		});
+					_status.ReportKeepAliveAborted(error);
+					Interlocked.CompareExchange(ref _keepAliveTimer, null, timer);
+					timer?.Dispose();
+				}
+			});
+		}
 
 		if (Interlocked.CompareExchange(ref _keepAliveTimer, timer, null) is null)
 		{
@@ -1118,6 +1185,11 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 		{
 			Instance = null;
 		}
+
+		// Drop the shared RemoteControlJsonOptions' source-generated context. CreateClient registers this
+		// client's per-ALC RemoteControlJsonContext.Default on the shared (default-ALC) RemoteControlJsonOptions;
+		// leaving it set pins the secondary app's collectible ALC after unload. Recreated lazily on next use.
+		Messaging.RemoteControlJsonOptions.Reset();
 	}
 
 	// The three helpers below are internal (rather than private) to allow unit testing via InternalsVisibleTo.

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -145,13 +145,28 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 				return;
 			}
 
-			var kept = current.Where(static a => !IsCollectibleTarget(a)).ToArray();
-			if (kept.Length == current.Count)
+			var changed = false;
+			var kept = new List<Action<RemoteControlClient>>(current.Count);
+			foreach (var action in current)
+			{
+				var filtered = FilterCollectibleInvocations(action, IsCollectibleTarget);
+				if (filtered is null)
+				{
+					changed = true; // every invocation-list entry was collectible — drop the callback
+				}
+				else
+				{
+					changed |= !ReferenceEquals(filtered, action); // some entries dropped, callback rebuilt
+					kept.Add(filtered);
+				}
+			}
+
+			if (!changed)
 			{
 				return; // nothing collectible to remove
 			}
 
-			IReadOnlyCollection<Action<RemoteControlClient>>? next = kept.Length == 0 ? null : kept;
+			IReadOnlyCollection<Action<RemoteControlClient>>? next = kept.Count == 0 ? null : kept.ToArray();
 			if (ReferenceEquals(Interlocked.CompareExchange(ref _waitingList, next, current), current))
 			{
 				return;
@@ -169,6 +184,45 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 			var alc = AssemblyLoadContext.GetLoadContext(declaringType.Assembly);
 			return alc is not null && alc != AssemblyLoadContext.Default && alc.IsCollectible;
 		}
+	}
+
+	/// <summary>
+	/// Filters a (possibly multicast) waiting-list callback down to the invocation-list entries that do
+	/// NOT satisfy <paramref name="isCollectible"/>. A combined delegate's <c>Target</c>/<c>Method</c>
+	/// reflect only one invocation-list entry, so classifying the whole delegate by those would wrongly
+	/// drop unrelated callbacks fused into it. This walks each entry individually and rebuilds a delegate
+	/// from the survivors.
+	/// </summary>
+	/// <returns>
+	/// The same instance when no entry is collectible; a new delegate of the surviving entries when only
+	/// some are; or <c>null</c> when every entry is collectible (the callback should be removed entirely).
+	/// </returns>
+	internal static Action<RemoteControlClient>? FilterCollectibleInvocations(
+		Action<RemoteControlClient> action,
+		Func<Action<RemoteControlClient>, bool> isCollectible)
+	{
+		var invocationList = action.GetInvocationList();
+		if (invocationList.Length == 1)
+		{
+			return isCollectible(action) ? null : action;
+		}
+
+		Action<RemoteControlClient>? kept = null;
+		var removedAny = false;
+		foreach (var entry in invocationList)
+		{
+			var typedEntry = (Action<RemoteControlClient>)entry;
+			if (isCollectible(typedEntry))
+			{
+				removedAny = true;
+			}
+			else
+			{
+				kept += typedEntry;
+			}
+		}
+
+		return removedAny ? kept : action;
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/App.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/App.xaml
@@ -9,6 +9,25 @@
                 <ResourceDictionary Source="ms-appx:///AlcAppResources.xaml" />
                 <ResourceDictionary Source="ms-appx:///Styles/CustomColors.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.ThemeDictionaries>
+                <!--
+                    Fixture for AlcContentHost teardown: theme dictionaries copied onto the
+                    host control must be removed when the secondary app content is cleared.
+                -->
+                <ResourceDictionary x:Key="Light">
+                    <Color x:Key="AlcAppThemeColor">#FF102030</Color>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="AlcAppThemeColor">#FFE0D0C0</Color>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+            <!--
+                Fixture for AlcContentHost teardown: a resource defined DIRECTLY in
+                Application.Resources (not via a merged dictionary). AlcContentHost copies
+                direct resources onto the host control and must remove them when the
+                secondary app content is cleared.
+            -->
+            <SolidColorBrush x:Key="AlcAppDirectBrush" Color="#FFAA1122" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -171,6 +171,44 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// Teardown hygiene via Unloaded: when the host discards the AlcContentHost (removes it from the
+	/// visual tree, e.g. its reference is set to null) WITHOUT first setting Content to null, the
+	/// resources it projected from the secondary app must still be released. Otherwise the detached
+	/// control keeps referencing the previous app's resource objects (potentially typed in the
+	/// collectible ALC), pinning the ALC after unload.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_ContentHostUnloaded_Then_ProjectedResourcesRemovedFromHost()
+	{
+		var contentHost = await StartSecondaryAlcAppAsync();
+
+		// Pre-conditions: the secondary app's direct resource and theme dictionaries were projected.
+		Assert.IsTrue(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"Pre-condition: AlcAppDirectBrush (direct Application.Resources entry) should be projected while the secondary app is hosted");
+		Assert.IsTrue(
+			contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var lightDictionary)
+				&& lightDictionary is ResourceDictionary lightResources
+				&& lightResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
+			"Pre-condition: the secondary app's Light theme dictionary should be projected while the secondary app is hosted");
+
+		// Teardown trigger: remove the host from the visual tree WITHOUT clearing Content, so only the
+		// Unloaded path runs (Content remains set to the secondary app's content).
+		Assert.IsNotNull(contentHost.Content, "Sanity: content is still set (not cleared) before the host is unloaded");
+		TestServices.WindowHelper.WindowContent = new Border();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"After the host is unloaded, the secondary app's direct resources must be removed from the host control's Resources");
+
+		var staleThemeEntryAfterUnload = contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var themeValueAfterUnload)
+			&& themeValueAfterUnload is ResourceDictionary themeResourcesAfterUnload
+			&& themeResourcesAfterUnload.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false);
+		Assert.IsFalse(staleThemeEntryAfterUnload,
+			"After the host is unloaded, the secondary app's theme dictionaries must be removed from the host control's Resources");
+	}
+
+	/// <summary>
 	/// Validates that ResourceDictionary.Source in App.xaml correctly resolves to the ALC-specific
 	/// dictionary when loaded from a secondary AssemblyLoadContext. This tests the fix for the issue
 	/// where both primary and secondary ALCs with the same resource URI pattern (e.g.,

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -131,6 +131,46 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// Teardown hygiene: the direct resources and theme dictionaries that AlcContentHost
+	/// copies from the secondary app onto the host control must be removed when the
+	/// secondary app content is cleared. Otherwise the host retains the previous app's
+	/// resource objects (potentially typed in the collectible ALC) after unload, keeping
+	/// them — and through them the ALC — alive across preview reloads.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_SecondaryAppContentCleared_Then_ProjectedResourcesRemovedFromHost()
+	{
+		var contentHost = await StartSecondaryAlcAppAsync();
+
+		// Pre-conditions: the secondary app's DIRECT resource and theme dictionaries
+		// were projected onto the host control (merged dictionaries are covered by
+		// the existing inheritance tests).
+		Assert.IsTrue(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"Pre-condition: AlcAppDirectBrush (direct Application.Resources entry) should be projected while the secondary app is hosted");
+		Assert.IsTrue(
+			contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var lightDictionary)
+				&& lightDictionary is ResourceDictionary lightResources
+				&& lightResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
+			"Pre-condition: the secondary app's Light theme dictionary should be projected while the secondary app is hosted");
+
+		// Teardown trigger: clear the hosted content. UpdateMergedResources re-runs with
+		// the host application as the source and must drop everything previously copied
+		// from the secondary app.
+		contentHost.Content = null;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"After content is cleared, the secondary app's direct resources must be removed from the host control's Resources");
+
+		var staleThemeEntry = contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var themeValue)
+			&& themeValue is ResourceDictionary themeResources
+			&& themeResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false);
+		Assert.IsFalse(staleThemeEntry,
+			"After content is cleared, the secondary app's theme dictionaries must be removed from the host control's Resources");
+	}
+
+	/// <summary>
 	/// Validates that ResourceDictionary.Source in App.xaml correctly resolves to the ALC-specific
 	/// dictionary when loaded from a secondary AssemblyLoadContext. This tests the fix for the issue
 	/// where both primary and secondary ALCs with the same resource URI pattern (e.g.,

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -209,6 +209,51 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// Restore-on-teardown: a theme dictionary that already existed on the host control before projection
+	/// (e.g. a consumer-defined "Light" dictionary on the AlcContentHost itself) must be RESTORED — not
+	/// dropped — when the projected secondary-app dictionaries are released on unload. Projection
+	/// overwrites the host's same-key dictionary while the secondary app is hosted, so a naive
+	/// "remove every projected key" teardown would silently lose the consumer's own dictionary.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_HostHasPreExistingThemeDictionary_Then_RestoredAfterUnload()
+	{
+		await StartSecondaryAlcAppAsync();
+
+		var secondaryApp = Application.GetForAssemblyLoadContext(_testAlc!);
+		Assert.IsNotNull(secondaryApp, "Secondary ALC app should be registered.");
+		Assert.IsTrue(secondaryApp!.Resources.ThemeDictionaries.ContainsKey("Light"),
+			"Sanity: the secondary app defines a Light theme dictionary to project.");
+
+		// A fresh host carrying its OWN consumer-defined Light theme dictionary.
+		var probe = new AlcContentHost();
+		var hostOwnedLight = new ResourceDictionary();
+		hostOwnedLight["HostOwnedThemeColor"] = Windows.UI.Colors.Red;
+		probe.Resources.ThemeDictionaries["Light"] = hostOwnedLight;
+
+		// Project the secondary app's resources: its Light dictionary overwrites the host's same-key one.
+		probe.SourceApplicationOverride = secondaryApp;
+
+		Assert.IsTrue(
+			probe.Resources.ThemeDictionaries.TryGetValue("Light", out var projectedLight)
+				&& projectedLight is ResourceDictionary projectedResources
+				&& projectedResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
+			"Pre-condition: the secondary app's Light dictionary should overwrite the host's while projected.");
+
+		// Teardown via Unloaded (no re-projection), exercising the restore path on release.
+		TestServices.WindowHelper.WindowContent = probe;
+		await TestServices.WindowHelper.WaitForLoaded(probe);
+		TestServices.WindowHelper.WindowContent = new Border();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(
+			probe.Resources.ThemeDictionaries.TryGetValue("Light", out var restoredLight)
+				&& ReferenceEquals(restoredLight, hostOwnedLight),
+			"After unload the host's own pre-existing Light theme dictionary must be restored, not removed.");
+	}
+
+	/// <summary>
 	/// Validates that ResourceDictionary.Source in App.xaml correctly resolves to the ALC-specific
 	/// dictionary when loaded from a secondary AssemblyLoadContext. This tests the fix for the issue
 	/// where both primary and secondary ALCs with the same resource URI pattern (e.g.,

--- a/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
@@ -172,6 +172,22 @@ namespace Uno.UI.DataBinding
 					RaiseValueChanged(null);
 
 					_propertyChanged.Disposable = null;
+
+					// The cached reflection accessors are normally kept so a same-typed DataContext
+					// can rebind cheaply — but when the previous DataContext type lives in a
+					// collectible AssemblyLoadContext, the cached RuntimeMethodInfo closures would
+					// pin that ALC's LoaderAllocator long after the source is gone (e.g. a designer
+					// binding whose secondary-app source was unloaded). Drop them; a rebind to a
+					// live collectible source simply rebuilds the accessors.
+					if (_dataContextType?.Assembly.IsCollectible == true)
+					{
+						IsDependencyPropertyValueSet = false;
+						_valueGetter = null;
+						_substituteValueGetter = null;
+						_valueSetter = null;
+						_valueUnsetter = null;
+						_dataContextType = null;
+					}
 				}
 			}
 

--- a/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #if !NETFX_CORE
 using System;
@@ -179,7 +179,7 @@ namespace Uno.UI.DataBinding
 					// pin that ALC's LoaderAllocator long after the source is gone (e.g. a designer
 					// binding whose secondary-app source was unloaded). Drop them; a rebind to a
 					// live collectible source simply rebuilds the accessors.
-					if (_dataContextType?.Assembly.IsCollectible == true)
+					if (_dataContextType?.IsCollectible == true)
 					{
 						IsDependencyPropertyValueSet = false;
 						_valueGetter = null;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
@@ -31,6 +31,19 @@ namespace Uno.UI.DataBinding
 
 			internal GetPropertyTypeKey Clone() => new(_type!, _property!, _allowPrivateMembers, _cachedHashcode);
 
+			/// <summary>
+			/// Drops the last-queried key state. The pooled key instance is a static — without
+			/// this, it retains the last looked-up <see cref="Type"/> (potentially from a
+			/// collectible AssemblyLoadContext) past <c>ClearCaches</c>.
+			/// </summary>
+			internal void Reset()
+			{
+				_type = null;
+				_property = null;
+				_allowPrivateMembers = false;
+				_cachedHashcode = 0;
+			}
+
 			internal void Update(Type type, string property, bool allowPrivateMembers)
 			{
 				_type = type;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -75,6 +75,9 @@ namespace Uno.UI.DataBinding
 			_getSubstituteValueGetter.Clear();
 			_getValueUnsetter.Clear();
 			_getPropertyType.Clear();
+
+			// The pooled lookup key retains the last-queried Type past the dictionary clears.
+			_getPropertyTypeKey.Reset();
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -274,6 +274,42 @@ partial class Application
 		// ResourceResolver — remove Func delegates whose Target is from a non-default ALC
 		ResourceResolver.ClearNonDefaultAlcRegistrations();
 
+		// Shared resources (theme brushes etc.) first consumed by a secondary-ALC element record
+		// it as their InheritanceContext parent (DependencyObjectStore._associatedParent); nothing
+		// clears that association on unload, so host-lifetime resources pin the collectible ALC.
+		// Sweep every dictionary reachable from the host application and the master theme set.
+		try
+		{
+#if !__NETSTD_REFERENCE__
+			Uno.UI.GlobalStaticResources.MasterDictionary.ClearCollectibleAssociatedParents();
+#endif
+			_current?.Resources?.ClearCollectibleAssociatedParents();
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Application).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(Application).Log().Debug($"[ALC-CLEANUP] ClearCollectibleAssociatedParents error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
+		// Secondary-ALC code can subscribe to events on HOST visual-tree elements (e.g. a
+		// designer overlay tracking an ancestor's SizeChanged); those subscriptions are never
+		// removed when the secondary app unloads and each one pins the collectible ALC. Walk
+		// every live content root and prune delegate fields of invocation-list entries whose
+		// target or method lives in a collectible ALC.
+		try
+		{
+			PruneCollectibleAlcEventSubscriptions();
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Application).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(Application).Log().Debug($"[ALC-CLEANUP] PruneCollectibleAlcEventSubscriptions error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
 		// ResourceDictionary — invalidate _keyNotFoundCache on the host Application.
 		// The cache accumulates ResourceKey entries with TypeKey referencing ALC types.
 		// These entries pin RuntimeType → LoaderAllocator → ALC.
@@ -296,6 +332,144 @@ partial class Application
 			catch (Exception ex)
 			{
 				typeof(Application).Log().Trace($"[ALC-SCAN] Error during deep scan: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+	}
+
+	// Per-type cache of delegate-typed instance fields, to keep the teardown tree walk cheap.
+	private static readonly Dictionary<Type, global::System.Reflection.FieldInfo[]> _delegateFieldsCache = new();
+
+	/// <summary>
+	/// Walks every live content root's visual tree and removes, from each element's delegate
+	/// fields (compiler-generated event backing fields included), any invocation-list entry
+	/// whose target or declaring method lives in a collectible AssemblyLoadContext. Such
+	/// subscriptions are made by secondary-ALC code on host elements and are never undone when
+	/// the secondary app unloads — each one pins the unloaded ALC. Runs only during ALC teardown.
+	/// </summary>
+	[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "ALC cleanup reflection over live instances")]
+	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ALC cleanup reflection over live instances")]
+	private static void PruneCollectibleAlcEventSubscriptions()
+	{
+		var roots = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.ContentRoots;
+		for (var i = roots.Count - 1; i >= 0; i--)
+		{
+			if (i < roots.Count && roots[i].VisualTree?.RootElement is { } rootElement)
+			{
+				PruneCollectibleAlcEventSubscriptions(rootElement);
+			}
+		}
+	}
+
+	private static void PruneCollectibleAlcEventSubscriptions(DependencyObject element)
+	{
+		try
+		{
+			PruneCollectibleDelegateFields(element);
+		}
+		catch (Exception)
+		{
+			// One element refusing reflection must not abort the sweep of the rest of the tree.
+		}
+
+		// Element-level Resources dictionaries are not reachable from Application.Resources or
+		// the master theme set; their shared values can hold InheritanceContext associations
+		// into the unloaded app's elements just like app-level resources do.
+		try
+		{
+			if (element is FrameworkElement { Resources: { } elementResources })
+			{
+				elementResources.ClearCollectibleAssociatedParents();
+			}
+		}
+		catch (Exception)
+		{
+		}
+
+		// FrameworkElement content (e.g. a ContentControl's value) is normally also a visual
+		// child, but prune the Content DP value explicitly in case the visual link differs
+		// during teardown.
+		try
+		{
+			if (element is Controls.ContentControl { Content: DependencyObject contentChild })
+			{
+				PruneCollectibleDelegateFields(contentChild);
+			}
+		}
+		catch (Exception)
+		{
+		}
+
+		try
+		{
+			var childCount = Media.VisualTreeHelper.GetChildrenCount(element);
+			for (var i = 0; i < childCount; i++)
+			{
+				PruneCollectibleAlcEventSubscriptions(Media.VisualTreeHelper.GetChild(element, i));
+			}
+		}
+		catch (Exception)
+		{
+			// A subtree that cannot be enumerated mid-teardown must not abort the rest of the sweep.
+		}
+	}
+
+	[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "ALC cleanup reflection over live instances")]
+	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ALC cleanup reflection over live instances")]
+	private static void PruneCollectibleDelegateFields(object instance)
+	{
+		var type = instance.GetType();
+		if (type.Assembly.IsCollectible)
+		{
+			// Elements that themselves live in the collectible ALC die with it — and their
+			// subtree is theirs to keep; pruning is only needed on host-lifetime elements.
+			return;
+		}
+
+		if (!_delegateFieldsCache.TryGetValue(type, out var fields))
+		{
+			var list = new List<global::System.Reflection.FieldInfo>();
+			for (var t = type; t is not null && t != typeof(object); t = t.BaseType)
+			{
+				foreach (var field in t.GetFields(global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.DeclaredOnly))
+				{
+					if (typeof(Delegate).IsAssignableFrom(field.FieldType))
+					{
+						list.Add(field);
+					}
+				}
+			}
+
+			fields = list.ToArray();
+			_delegateFieldsCache[type] = fields;
+		}
+
+		foreach (var field in fields)
+		{
+			try
+			{
+				if (field.GetValue(instance) is not Delegate current)
+				{
+					continue;
+				}
+
+				Delegate updated = current;
+				foreach (var invocation in current.GetInvocationList())
+				{
+					if (invocation.Method.Module.Assembly.IsCollectible
+						|| invocation.Target?.GetType().Assembly.IsCollectible == true)
+					{
+						updated = Delegate.Remove(updated, invocation);
+					}
+				}
+
+				if (!ReferenceEquals(updated, current))
+				{
+					field.SetValue(instance, updated);
+				}
+			}
+			catch (Exception)
+			{
+				// A single inaccessible field must not abort pruning of the remaining fields.
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -430,7 +430,7 @@ partial class Application
 
 	private static void PruneCollectibleAlcEventSubscriptions(DependencyObject element)
 	{
-		if (element.GetType().Assembly.IsCollectible)
+		if (element.GetType().IsCollectible)
 		{
 			_treeContainsCollectibleElement = true;
 		}
@@ -491,7 +491,7 @@ partial class Application
 	internal static void PruneCollectibleDelegateFields(object instance)
 	{
 		var type = instance.GetType();
-		if (type.Assembly.IsCollectible)
+		if (type.IsCollectible)
 		{
 			// Elements that themselves live in the collectible ALC die with it — and their
 			// subtree is theirs to keep; pruning is only needed on host-lifetime elements.
@@ -528,8 +528,8 @@ partial class Application
 				Delegate updated = current;
 				foreach (var invocation in current.GetInvocationList())
 				{
-					if (invocation.Method.Module.Assembly.IsCollectible
-						|| invocation.Target?.GetType().Assembly.IsCollectible == true)
+					if (invocation.Method.DeclaringType?.IsCollectible == true
+						|| invocation.Target?.GetType().IsCollectible == true)
 					{
 						updated = Delegate.Remove(updated, invocation);
 					}

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.Loader;
 using Microsoft.UI.Xaml.Resources;
 using Uno.Foundation.Logging;
@@ -293,6 +294,20 @@ partial class Application
 			}
 		}
 
+		// ContentControl memoizes "does this DefaultStyleKey type have a default template" per
+		// Type; keys from the unloaded app's controls pin the ALC.
+		try
+		{
+			Controls.ContentControl.ClearHasDefaultTemplateCache();
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Application).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(Application).Log().Debug($"[ALC-CLEANUP] ClearHasDefaultTemplateCache error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
 		// Secondary-ALC code can subscribe to events on HOST visual-tree elements (e.g. a
 		// designer overlay tracking an ancestor's SizeChanged); those subscriptions are never
 		// removed when the secondary app unloads and each one pins the collectible ALC. Walk
@@ -307,6 +322,24 @@ partial class Application
 			if (typeof(Application).Log().IsEnabled(LogLevel.Debug))
 			{
 				typeof(Application).Log().Debug($"[ALC-CLEANUP] PruneCollectibleAlcEventSubscriptions error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
+		// NativeDispatcher render registrations are never removed; prune entries whose
+		// CompositionTarget's ContentRoot is no longer registered (a closed secondary-app
+		// surface). Runs AFTER the tree prune above so orphaned roots are already unregistered.
+		try
+		{
+			var rootCoordinator = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator;
+			Uno.UI.Dispatching.NativeDispatcher.Main.RemoveCompositionTargets(target =>
+				target is Media.CompositionTarget compositionTarget
+				&& !rootCoordinator.ContentRoots.Contains(compositionTarget.ContentRoot));
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Application).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(Application).Log().Debug($"[ALC-CLEANUP] CompositionTarget prune error: {ex.GetType().Name}: {ex.Message}");
 			}
 		}
 
@@ -350,18 +383,58 @@ partial class Application
 	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ALC cleanup reflection over live instances")]
 	private static void PruneCollectibleAlcEventSubscriptions()
 	{
-		var roots = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.ContentRoots;
+		var coordinator = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator;
+		var roots = coordinator.ContentRoots;
 		for (var i = roots.Count - 1; i >= 0; i--)
 		{
-			if (i < roots.Count && roots[i].VisualTree?.RootElement is { } rootElement)
+			if (i < roots.Count && roots[i] is { } root && root.VisualTree?.RootElement is { } rootElement)
 			{
+				_treeContainsCollectibleElement = false;
 				PruneCollectibleAlcEventSubscriptions(rootElement);
+
+				// A content root whose tree contains collectible-ALC elements belongs to an
+				// unloaded secondary app's surface (e.g. a designer popup island) — the window's
+				// own root is removed at CloseAlcWindow, but popup/island roots otherwise stay
+				// registered forever and pin the ALC through the coordinator.
+				if (_treeContainsCollectibleElement)
+				{
+					coordinator.RemoveContentRoot(root);
+				}
+			}
+		}
+
+		// Window-level events (Activated / SizeChanged / VisibilityChanged / Closed) live on the
+		// window implementation object, which is not part of any visual tree — a secondary-ALC
+		// subscriber on the HOST window (e.g. a designer client hooking Closed) is never undone
+		// by the tree walk above and would pin its ALC.
+		var windows = global::Uno.UI.ApplicationHelper.WindowsInternal.ToArray();
+		foreach (var window in windows)
+		{
+			try
+			{
+				PruneCollectibleDelegateFields(window);
+				if (window.WindowImplementation is { } windowImplementation)
+				{
+					PruneCollectibleDelegateFields(windowImplementation);
+				}
+			}
+			catch (Exception)
+			{
+				// One window refusing reflection must not abort pruning of the remaining windows.
 			}
 		}
 	}
 
+	[ThreadStatic]
+	private static bool _treeContainsCollectibleElement;
+
 	private static void PruneCollectibleAlcEventSubscriptions(DependencyObject element)
 	{
+		if (element.GetType().Assembly.IsCollectible)
+		{
+			_treeContainsCollectibleElement = true;
+		}
+
 		try
 		{
 			PruneCollectibleDelegateFields(element);
@@ -415,7 +488,7 @@ partial class Application
 
 	[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "ALC cleanup reflection over live instances")]
 	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ALC cleanup reflection over live instances")]
-	private static void PruneCollectibleDelegateFields(object instance)
+	internal static void PruneCollectibleDelegateFields(object instance)
 	{
 		var type = instance.GetType();
 		if (type.Assembly.IsCollectible)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -469,7 +469,9 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Gets whether the default style for the given type sets a non-null Template.
 		/// </summary>
-		private static Func<Type, bool> HasDefaultTemplate =
+		private static Func<Type, bool> HasDefaultTemplate = CreateHasDefaultTemplateMemo();
+
+		private static Func<Type, bool> CreateHasDefaultTemplateMemo() =>
 			Funcs.CreateMemoized((Type type) =>
 				Style.GetDefaultStyleForType(type) is Style defaultStyle
 					&& defaultStyle
@@ -478,6 +480,13 @@ namespace Microsoft.UI.Xaml.Controls
 						.OfType<Setter>()
 						.Any(s => s.Property == TemplateProperty && s.Value != null)
 			);
+
+		/// <summary>
+		/// Drops the memoized per-Type default-template lookups. The memoization dictionary keys
+		/// are DefaultStyleKey types — for controls from a collectible AssemblyLoadContext those
+		/// keys pin the ALC after unload. Called from ALC teardown cleanup.
+		/// </summary>
+		internal static void ClearHasDefaultTemplateCache() => HasDefaultTemplate = CreateHasDefaultTemplateMemo();
 
 		/// <summary>
 		/// Creates a ContentControl which can be measured without being added to the visual tree (eg as container in virtualized lists).

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -662,6 +662,7 @@ namespace Microsoft.UI.Xaml
 			if (_associatedParent == null)
 			{
 				_associatedParent = parent;
+				RegisterCollectibleParentAssociation(parent);
 			}
 			else
 			{
@@ -682,6 +683,108 @@ namespace Microsoft.UI.Xaml
 			if (ReferenceEquals(_associatedParent, parent))
 			{
 				_associatedParent = null;
+			}
+		}
+
+		/// <summary>
+		/// Clears <see cref="_associatedParent"/> when it references an object from a collectible
+		/// AssemblyLoadContext. A shared (e.g. theme-dictionary) resource first consumed by a
+		/// secondary-ALC element records that element as its associated parent; nothing
+		/// unassociates it when the element's ALC unloads (UnassociateParent only runs on value
+		/// changes), so the host-lifetime resource pins the collectible ALC. Invoked from
+		/// <see cref="Microsoft.UI.Xaml.ResourceDictionary.ClearCollectibleAssociatedParents"/>
+		/// during ALC teardown and from the per-ALC Unloading sweep below.
+		/// </summary>
+		internal void ClearCollectibleAssociatedParent()
+		{
+			var hadCollectibleAssociation = false;
+
+			// Two flavors of secondary-app parents: objects whose TYPE lives in the collectible
+			// ALC, and instances of SHARED types (Grid, Border, …) owned by the unloaded app —
+			// the latter are indistinguishable by type, but after unload they are detached
+			// (unloaded, parentless), so a detached-element association is also dropped. A live
+			// host element re-associates naturally on its next value assignment.
+			// IsLoaded == false also matches host elements that are merely unloaded at sweep time
+			// (e.g. a collapsed pane); clearing their association only resets InheritanceContext
+			// DataContext propagation for the shared resource, which re-establishes on the next
+			// value assignment — an acceptable cost for guaranteeing the unloaded app's detached
+			// elements (shared types, indistinguishable by ALC) release their hold.
+			if (_associatedParent is { } parent
+				&& (parent.GetType().Assembly.IsCollectible
+					|| parent is FrameworkElement { IsLoaded: false }))
+			{
+				_associatedParent = null;
+				hadCollectibleAssociation = true;
+			}
+
+			// The association may already have propagated the parent's DataContext into this
+			// store at Inheritance precedence; that propagated value (e.g. the secondary app's
+			// view model) survives the parent's removal and pins the value's ALC on its own.
+			if (hadCollectibleAssociation
+				|| GetValue(_dataContextProperty)?.GetType().Assembly.IsCollectible == true)
+			{
+				ClearInheritedDataContext();
+			}
+		}
+
+		// Stores that recorded a collectible-ALC object as their associated parent, grouped by
+		// that parent's ALC. Entries are swept (associated parent cleared) when the ALC unloads,
+		// so a host-lifetime shared resource can never outlive-pin a secondary app's ALC.
+		// CWT-keyed by the ALC so the registry itself never extends the ALC's lifetime.
+		private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<global::System.Runtime.Loader.AssemblyLoadContext, List<WeakReference<DependencyObjectStore>>> _collectibleParentAssociations = new();
+
+		private void RegisterCollectibleParentAssociation(object parent)
+		{
+			// Fast path: Assembly.IsCollectible is a cached flag; non-collectible parents
+			// (the overwhelmingly common case) exit here without touching the registry.
+			if (!parent.GetType().Assembly.IsCollectible)
+			{
+				return;
+			}
+
+			var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(parent.GetType().Assembly);
+			if (alc is null || !alc.IsCollectible)
+			{
+				return;
+			}
+
+			var list = _collectibleParentAssociations.GetValue(alc, static a =>
+			{
+				a.Unloading += static unloading =>
+				{
+					if (_collectibleParentAssociations.TryGetValue(unloading, out var stores))
+					{
+						lock (stores)
+						{
+							foreach (var weakStore in stores)
+							{
+								if (weakStore.TryGetTarget(out var store))
+								{
+									try
+									{
+										store.ClearCollectibleAssociatedParent();
+									}
+									catch (Exception)
+									{
+										// Unloading sweeps run on the unloading thread; a store
+										// that rejects off-thread DP access must not abort the
+										// sweep for the remaining stores.
+									}
+								}
+							}
+
+							stores.Clear();
+						}
+
+						_collectibleParentAssociations.Remove(unloading);
+					}
+				};
+				return new List<WeakReference<DependencyObjectStore>>();
+			});
+
+			lock (list)
+			{
+				list.Add(new WeakReference<DependencyObjectStore>(this));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -708,10 +708,13 @@ namespace Microsoft.UI.Xaml
 			// (e.g. a collapsed pane); clearing their association only resets InheritanceContext
 			// DataContext propagation for the shared resource, which re-establishes on the next
 			// value assignment — an acceptable cost for guaranteeing the unloaded app's detached
-			// elements (shared types, indistinguishable by ALC) release their hold.
+			// elements (shared types, indistinguishable by ALC) release their hold. An element
+			// whose ContentRoot has been unregistered from the coordinator (a closed secondary
+			// app's tree — popups included, which keep IsLoaded) is orphaned and also released.
 			if (_associatedParent is { } parent
 				&& (parent.GetType().Assembly.IsCollectible
-					|| parent is FrameworkElement { IsLoaded: false }))
+					|| parent is FrameworkElement { IsLoaded: false }
+					|| (parent is FrameworkElement orphanCandidate && IsOrphanedFromContentRoots(orphanCandidate))))
 			{
 				_associatedParent = null;
 				hadCollectibleAssociation = true;
@@ -724,6 +727,29 @@ namespace Microsoft.UI.Xaml
 				|| GetValue(_dataContextProperty)?.GetType().Assembly.IsCollectible == true)
 			{
 				ClearInheritedDataContext();
+			}
+		}
+
+		/// <summary>
+		/// Returns whether the element's visual tree no longer has a registered ContentRoot —
+		/// i.e. it belonged to a closed (secondary-app) tree whose root was unregistered from
+		/// the <see cref="Uno.UI.Xaml.Core.ContentRootCoordinator"/> on Window close.
+		/// </summary>
+		private static bool IsOrphanedFromContentRoots(FrameworkElement element)
+		{
+			try
+			{
+				var contentRoot = element.XamlRoot?.VisualTree?.ContentRoot;
+				if (contentRoot is null)
+				{
+					return true;
+				}
+
+				return !Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.ContentRoots.Contains(contentRoot);
+			}
+			catch (Exception)
+			{
+				return false;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 // fallback option for legacy DepObj from external library generated before templated-parent rework.
@@ -712,7 +712,7 @@ namespace Microsoft.UI.Xaml
 			// whose ContentRoot has been unregistered from the coordinator (a closed secondary
 			// app's tree — popups included, which keep IsLoaded) is orphaned and also released.
 			if (_associatedParent is { } parent
-				&& (parent.GetType().Assembly.IsCollectible
+				&& (parent.GetType().IsCollectible
 					|| parent is FrameworkElement { IsLoaded: false }
 					|| (parent is FrameworkElement orphanCandidate && IsOrphanedFromContentRoots(orphanCandidate))))
 			{
@@ -724,7 +724,7 @@ namespace Microsoft.UI.Xaml
 			// store at Inheritance precedence; that propagated value (e.g. the secondary app's
 			// view model) survives the parent's removal and pins the value's ALC on its own.
 			if (hadCollectibleAssociation
-				|| GetValue(_dataContextProperty)?.GetType().Assembly.IsCollectible == true)
+				|| GetValue(_dataContextProperty)?.GetType().IsCollectible == true)
 			{
 				ClearInheritedDataContext();
 			}
@@ -763,7 +763,7 @@ namespace Microsoft.UI.Xaml
 		{
 			// Fast path: Assembly.IsCollectible is a cached flag; non-collectible parents
 			// (the overwhelmingly common case) exit here without touching the registry.
-			if (!parent.GetType().Assembly.IsCollectible)
+			if (!parent.GetType().IsCollectible)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
@@ -45,6 +45,31 @@ namespace Microsoft.UI.Xaml
 
 			internal void Clear()
 				=> _entries.Clear();
+
+			/// <summary>
+			/// Removes entries whose key <see cref="Type"/> belongs to a non-default
+			/// (collectible) <see cref="System.Runtime.Loader.AssemblyLoadContext"/>, so the
+			/// app-lifetime dictionary does not pin an unloaded secondary app's types.
+			/// </summary>
+			internal void RemoveNonDefaultAlcEntries()
+			{
+				var defaultAlc = global::System.Runtime.Loader.AssemblyLoadContext.Default;
+				var keysToRemove = new global::System.Collections.Generic.List<Type>();
+
+				foreach (Type key in _entries.Keys)
+				{
+					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.Assembly);
+					if (alc is not null && alc != defaultAlc)
+					{
+						keysToRemove.Add(key);
+					}
+				}
+
+				foreach (var key in keysToRemove)
+				{
+					_entries.Remove(key);
+				}
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
@@ -18,10 +18,13 @@ namespace Microsoft.UI.Xaml
 			{
 				isNullable = type.IsNullable();
 
-				// Never cache collectible-assembly types: the app-lifetime dictionary would pin
-				// the type's AssemblyLoadContext after unload — and teardown sweeps themselves
-				// can re-query such types, racing any clear-on-teardown approach.
-				if (!type.Assembly.IsCollectible)
+				// Never cache collectible types: the app-lifetime dictionary would pin the
+				// type's AssemblyLoadContext after unload — and teardown sweeps themselves can
+				// re-query such types, racing any clear-on-teardown approach. Type.IsCollectible
+				// (not Assembly.IsCollectible) also covers generic instantiations whose
+				// DEFINITION lives in a shared assembly (e.g. ObservableCollection<T> from
+				// CoreLib) but whose type ARGUMENT is collectible.
+				if (!type.IsCollectible)
 				{
 					_isTypeNullableDictionary.Add(type, isNullable);
 				}
@@ -66,8 +69,10 @@ namespace Microsoft.UI.Xaml
 
 				foreach (Type key in _entries.Keys)
 				{
+					// Type.IsCollectible also catches generic instantiations over collectible
+					// type arguments, whose declaring assembly is a shared (default-ALC) one.
 					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.Assembly);
-					if (alc is not null && alc != defaultAlc)
+					if (key.IsCollectible || (alc is not null && alc != defaultAlc))
 					{
 						keysToRemove.Add(key);
 					}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
@@ -16,7 +16,15 @@ namespace Microsoft.UI.Xaml
 		{
 			if (!_isTypeNullableDictionary.TryGetValue(type, out var isNullable))
 			{
-				_isTypeNullableDictionary.Add(type, isNullable = type.IsNullable());
+				isNullable = type.IsNullable();
+
+				// Never cache collectible-assembly types: the app-lifetime dictionary would pin
+				// the type's AssemblyLoadContext after unload — and teardown sweeps themselves
+				// can re-query such types, racing any clear-on-teardown approach.
+				if (!type.Assembly.IsCollectible)
+				{
+					_isTypeNullableDictionary.Add(type, isNullable);
+				}
 			}
 
 			return isNullable;

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -61,6 +61,10 @@ namespace Microsoft.UI.Xaml
 			_registry.RemoveNonDefaultAlcEntries();
 			_getInheritedPropertiesForType.RemoveNonDefaultAlcEntries();
 			_getPropertyCache.RemoveNonDefaultAlcEntries();
+			_isTypeNullableDictionary.RemoveNonDefaultAlcEntries();
+
+			// The pooled lookup key retains the last-queried Type past the cache prunes.
+			_searchPropertyCacheEntry.Update(typeof(object), "");
 		}
 
 		private readonly PropertyMetadata _ownerTypeMetadata; // For perf consideration, we keep direct ref the metadata for the owner type

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -516,6 +516,12 @@ namespace Microsoft.UI.Xaml
 			}
 
 			_themeDictionaries?.ClearCollectibleAssociatedParents();
+
+			// The MATERIALIZED active theme dictionary may be reachable only through this cache:
+			// when the theme entry in _themeDictionaries is still a lazy stub, the stub is skipped
+			// above and the materialized dictionary it produced — holding the live brushes whose
+			// stores record cross-ALC associations — would never be visited.
+			_activeThemeDictionary?.ClearCollectibleAssociatedParents();
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -486,6 +486,39 @@ namespace Microsoft.UI.Xaml
 		}
 
 		/// <summary>
+		/// Clears <c>DependencyObjectStore._associatedParent</c> references into collectible
+		/// AssemblyLoadContexts on every materialized value of this dictionary (recursing into
+		/// nested, merged and theme dictionaries). A shared resource (e.g. a theme brush) first
+		/// consumed by a secondary-ALC element records that element as its InheritanceContext
+		/// parent; nothing unassociates it when the element's ALC unloads, so the host-lifetime
+		/// resource pins the collectible ALC. Called during ALC teardown from
+		/// <see cref="Application.CleanupNonDefaultAlcCaches"/>. Lazy (unmaterialized) entries
+		/// have no store and are skipped without being materialized.
+		/// </summary>
+		internal void ClearCollectibleAssociatedParents()
+		{
+			foreach (var value in _values.Values)
+			{
+				if (value is IDependencyObjectStoreProvider { Store: { } store })
+				{
+					store.ClearCollectibleAssociatedParent();
+				}
+				else if (value is ResourceDictionary nested)
+				{
+					nested.ClearCollectibleAssociatedParents();
+				}
+			}
+
+			var mergedCount = _mergedDictionaries.Count;
+			for (var i = 0; i < mergedCount; i++)
+			{
+				_mergedDictionaries[i].ClearCollectibleAssociatedParents();
+			}
+
+			_themeDictionaries?.ClearCollectibleAssociatedParents();
+		}
+
+		/// <summary>
 		/// If retrieved element is a <see cref="LazyInitializer"/> stub, materialize the actual object and replace the stub.
 		/// </summary>
 		private void TryMaterializeLazy(in ResourceKey key, ref object value)

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -975,6 +975,32 @@ namespace Uno.UI
 		{
 			RemoveNonDefaultAlcEntries(_registeredDictionariesByUri);
 			RemoveNonDefaultAlcEntries(_registeredDictionariesByFilepath);
+			RemoveNonDefaultAlcScopedRegistrations();
+		}
+
+		/// <summary>
+		/// Purges the ALC-scoped registry. The ConditionalWeakTable is NOT self-cleaning for a
+		/// collectible ALC being unloaded: the runtime holds a strong handle on the ALC object
+		/// until its LoaderAllocator dies, the live key keeps the CWT entry alive, and the
+		/// entry's <see cref="Func{TResult}"/> values point at generated code in that same ALC —
+		/// keeping the LoaderAllocator alive. The resulting cycle pins the ALC forever unless the
+		/// entry is removed explicitly on teardown.
+		/// </summary>
+		private static void RemoveNonDefaultAlcScopedRegistrations()
+		{
+			lock (_alcDictionariesLock)
+			{
+				List<System.Runtime.Loader.AssemblyLoadContext> toRemove = new();
+				foreach (var kvp in _registeredDictionariesByUriByAlc)
+				{
+					toRemove.Add(kvp.Key);
+				}
+
+				foreach (var alc in toRemove)
+				{
+					_registeredDictionariesByUriByAlc.Remove(alc);
+				}
+			}
 		}
 
 		private static void RemoveNonDefaultAlcEntries(Dictionary<string, Func<ResourceDictionary>> dictionary)

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -17,6 +17,14 @@ public sealed partial class AlcContentHost : ContentControl
 	private Application? _sourceApplicationOverride;
 	private Application? _contentApplication;
 
+	// Keys this control copied into its own Resources / ThemeDictionaries from the source
+	// application. Tracked so the next UpdateMergedResources removes exactly those entries:
+	// when the secondary app's content is cleared (app unloading), the host must not keep
+	// referencing the previous app's resource objects — they may be typed in the secondary
+	// (collectible) AssemblyLoadContext and would otherwise pin it after unload.
+	private readonly List<object> _copiedDirectResourceKeys = new();
+	private readonly List<object> _copiedThemeDictionaryKeys = new();
+
 	public AlcContentHost()
 	{
 		HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -64,6 +72,27 @@ public sealed partial class AlcContentHost : ContentControl
 
 	private void UpdateMergedResources()
 	{
+		// Remove everything previously projected from the (old) source application before
+		// recomputing the source. When the content is cleared on app unload the source falls
+		// back to the host application, and the previous app's resource objects must not be
+		// retained by this control (see the tracking fields for the rationale).
+		foreach (var key in _copiedDirectResourceKeys)
+		{
+			Resources.Remove(key);
+		}
+
+		_copiedDirectResourceKeys.Clear();
+
+		foreach (var key in _copiedThemeDictionaryKeys)
+		{
+			Resources.ThemeDictionaries.Remove(key);
+		}
+
+		_copiedThemeDictionaryKeys.Clear();
+
+		// Clear existing merged dictionaries to avoid duplicates
+		Resources.MergedDictionaries.Clear();
+
 		var sourceApp = _sourceApplicationOverride
 			?? _contentApplication
 			?? Application.GetForInstance(Content)
@@ -73,9 +102,6 @@ public sealed partial class AlcContentHost : ContentControl
 		{
 			return;
 		}
-
-		// Clear existing merged dictionaries to avoid duplicates
-		Resources.MergedDictionaries.Clear();
 
 		// Merge all resource dictionaries from the source application
 		foreach (var resourceDictionary in sourceApp.Resources.MergedDictionaries)
@@ -89,6 +115,7 @@ public sealed partial class AlcContentHost : ContentControl
 			foreach (var themeDictionary in sourceApp.Resources.ThemeDictionaries)
 			{
 				Resources.ThemeDictionaries[themeDictionary.Key] = themeDictionary.Value;
+				_copiedThemeDictionaryKeys.Add(themeDictionary.Key);
 			}
 		}
 
@@ -98,6 +125,7 @@ public sealed partial class AlcContentHost : ContentControl
 		foreach (var key in sourceApp.Resources.Keys.Except(Resources.Keys).ToList())
 		{
 			Resources[key] = sourceApp.Resources[key];
+			_copiedDirectResourceKeys.Add(key);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -33,6 +33,7 @@ public sealed partial class AlcContentHost : ContentControl
 		VerticalContentAlignment = VerticalAlignment.Stretch;
 
 		Loaded += OnLoaded;
+		Unloaded += OnUnloaded;
 	}
 
 	/// <summary>
@@ -70,12 +71,23 @@ public sealed partial class AlcContentHost : ContentControl
 		UpdateMergedResources();
 	}
 
-	private void UpdateMergedResources()
+	private void OnUnloaded(object sender, RoutedEventArgs e)
 	{
-		// Remove everything previously projected from the (old) source application before
-		// recomputing the source. When the content is cleared on app unload the source falls
-		// back to the host application, and the previous app's resource objects must not be
-		// retained by this control (see the tracking fields for the rationale).
+		// When the host discards this control (e.g. the previewed app is torn down and the
+		// host's reference is set to null / it is removed from the tree) without first setting
+		// Content to null, release everything projected from the secondary application so its
+		// resource objects — potentially typed in the collectible ALC — are not retained by this
+		// control after it leaves the tree, which would otherwise pin the ALC after unload.
+		// A subsequent re-Loaded re-projects via UpdateMergedResources.
+		ClearProjectedResources();
+		Resources.MergedDictionaries.Clear();
+	}
+
+	// Removes everything this control projected from the source application (direct resources and
+	// theme-dictionary entries) and clears the tracking lists. Shared by UpdateMergedResources
+	// (before recomputing the source) and OnUnloaded (on teardown).
+	private void ClearProjectedResources()
+	{
 		foreach (var key in _copiedDirectResourceKeys)
 		{
 			Resources.Remove(key);
@@ -89,6 +101,15 @@ public sealed partial class AlcContentHost : ContentControl
 		}
 
 		_copiedThemeDictionaryKeys.Clear();
+	}
+
+	private void UpdateMergedResources()
+	{
+		// Remove everything previously projected from the (old) source application before
+		// recomputing the source. When the content is cleared on app unload the source falls
+		// back to the host application, and the previous app's resource objects must not be
+		// retained by this control (see the tracking fields for the rationale).
+		ClearProjectedResources();
 
 		// Clear existing merged dictionaries to avoid duplicates
 		Resources.MergedDictionaries.Clear();

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -22,8 +22,32 @@ public sealed partial class AlcContentHost : ContentControl
 	// when the secondary app's content is cleared (app unloading), the host must not keep
 	// referencing the previous app's resource objects — they may be typed in the secondary
 	// (collectible) AssemblyLoadContext and would otherwise pin it after unload.
+	//
+	// Direct resources are only ever copied for keys the host does not already have (see the
+	// Except filter in UpdateMergedResources), so releasing them is a plain Remove. Theme
+	// dictionaries, however, OVERWRITE the host's same-key entry, so each projection records
+	// the host's previous value (and whether one existed) to restore it on release rather than
+	// dropping a consumer-defined dictionary the projection had shadowed.
 	private readonly List<object> _copiedDirectResourceKeys = new();
-	private readonly List<object> _copiedThemeDictionaryKeys = new();
+	private readonly List<ProjectedThemeDictionary> _copiedThemeDictionaries = new();
+
+	// A theme-dictionary key this control projected from the source application, paired with the
+	// host's own value for that key before the projection overwrote it.
+	private readonly struct ProjectedThemeDictionary
+	{
+		public ProjectedThemeDictionary(object key, bool hadPreviousValue, object? previousValue)
+		{
+			Key = key;
+			HadPreviousValue = hadPreviousValue;
+			PreviousValue = previousValue;
+		}
+
+		public object Key { get; }
+
+		public bool HadPreviousValue { get; }
+
+		public object? PreviousValue { get; }
+	}
 
 	public AlcContentHost()
 	{
@@ -95,12 +119,21 @@ public sealed partial class AlcContentHost : ContentControl
 
 		_copiedDirectResourceKeys.Clear();
 
-		foreach (var key in _copiedThemeDictionaryKeys)
+		foreach (var projected in _copiedThemeDictionaries)
 		{
-			Resources.ThemeDictionaries.Remove(key);
+			if (projected.HadPreviousValue)
+			{
+				// Restore the host's own dictionary that the projection overwrote, rather than
+				// dropping a consumer-defined entry (e.g. a host "Light" dictionary).
+				Resources.ThemeDictionaries[projected.Key] = projected.PreviousValue!;
+			}
+			else
+			{
+				Resources.ThemeDictionaries.Remove(projected.Key);
+			}
 		}
 
-		_copiedThemeDictionaryKeys.Clear();
+		_copiedThemeDictionaries.Clear();
 	}
 
 	private void UpdateMergedResources()
@@ -135,8 +168,9 @@ public sealed partial class AlcContentHost : ContentControl
 		{
 			foreach (var themeDictionary in sourceApp.Resources.ThemeDictionaries)
 			{
+				var hadPreviousValue = Resources.ThemeDictionaries.TryGetValue(themeDictionary.Key, out var previousValue);
 				Resources.ThemeDictionaries[themeDictionary.Key] = themeDictionary.Value;
-				_copiedThemeDictionaryKeys.Add(themeDictionary.Key);
+				_copiedThemeDictionaries.Add(new ProjectedThemeDictionary(themeDictionary.Key, hadPreviousValue, hadPreviousValue ? previousValue : null));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -254,6 +254,42 @@ partial class Window
 		// The native window was already closed during InitializeAlcWindowMode().
 		_appWindowMap.TryRemove(AppWindow, out _);
 
+		// The Window registered a DisplayInformation for its WindowId at construction; that
+		// static map has no other removal path, so it retains the closed window's
+		// implementation graph — including window-event subscribers from the secondary ALC
+		// (e.g. the Hot Design client's Closed handler) — for the process lifetime, pinning
+		// the ALC: DisplayInformation → native wrapper → DesktopWindow → Closed → client.
+		try
+		{
+			global::Windows.Graphics.Display.DisplayInformation.DestroyForWindowId(AppWindow.Id);
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Window).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+			{
+				typeof(Window).Log().Debug($"[ALC-CLEANUP] DisplayInformation.DestroyForWindowId error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
+		// Other WindowId-keyed statics (CoreDragDropManager's map, input managers, …) retain the
+		// closed window's implementation graph too. Rather than chasing every registry, strip the
+		// window-event subscriptions whose targets live in the collectible ALC (Closed/Activated/
+		// SizeChanged/VisibilityChanged on the implementation object). This window was removed
+		// from ApplicationHelper at InitializeAlcWindowMode, so the ALC-teardown window sweep in
+		// Application.CleanupNonDefaultAlcCaches never visits it — prune here, after RaiseClosed.
+		try
+		{
+			Application.PruneCollectibleDelegateFields(this);
+			Application.PruneCollectibleDelegateFields(_windowImplementation);
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Window).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+			{
+				typeof(Window).Log().Debug($"[ALC-CLEANUP] window delegate prune error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
 		// Remove this window's ContentRoot from the process-wide ContentRootCoordinator.
 		// RemoveContentRoot has no other caller, so an ALC window's content root otherwise
 		// stays registered forever — and its Window.Closed subscribers (e.g. Hot Design's

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -254,6 +254,18 @@ partial class Window
 		// The native window was already closed during InitializeAlcWindowMode().
 		_appWindowMap.TryRemove(AppWindow, out _);
 
+		// Remove this window's ContentRoot from the process-wide ContentRootCoordinator.
+		// RemoveContentRoot has no other caller, so an ALC window's content root otherwise
+		// stays registered forever — and its Window.Closed subscribers (e.g. Hot Design's
+		// client host) keep the collectible ALC pinned via the coordinator's list:
+		// CoreServices → ContentRootCoordinator → ContentRoot → XamlIslandRoot → Window →
+		// Closed handlers → per-ALC subscriber → LoaderAllocator.
+		var alcContentRoot = _windowImplementation.XamlRoot?.VisualTree?.ContentRoot;
+		if (alcContentRoot is not null)
+		{
+			Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.RemoveContentRoot(alcContentRoot);
+		}
+
 		// Purge Type-keyed caches (DependencyProperty registry, Style caches, etc.)
 		// that hold references to types from the ALC being torn down. Without this,
 		// these statics prevent the GC from collecting the ALC after Unload().

--- a/src/Uno.UI/UI/Xaml/Window/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.cs
@@ -121,6 +121,8 @@ public partial class Window
 
 	internal INativeWindowWrapper? NativeWrapper => _windowImplementation.NativeWindowWrapper;
 
+	internal IWindowImplementation WindowImplementation => _windowImplementation;
+
 	internal static Window GetFromAppWindow(AppWindow appWindow)
 	{
 		if (!_appWindowMap.TryGetValue(appWindow, out var window))

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
@@ -81,6 +81,20 @@ namespace Windows.Graphics.Display
 			}
 		}
 
+		/// <summary>
+		/// Removes the <see cref="DisplayInformation"/> registered for a window once that window is
+		/// closed. Without this, the static map retains the closed window's native wrapper graph
+		/// (and every event subscriber reachable from it) for the process lifetime — for a
+		/// secondary-app window in a collectible AssemblyLoadContext, that pins the entire ALC.
+		/// </summary>
+		internal static void DestroyForWindowId(WindowId windowId)
+		{
+			lock (_windowIdMapLock)
+			{
+				_windowIdMap.Remove(windowId);
+			}
+		}
+
 		public static DisplayOrientations AutoRotationPreferences
 		{
 			get => _autoRotationPreferences;


### PR DESCRIPTION
## Problem

A secondary app loaded into a **collectible** `AssemblyLoadContext` (ALC) leaves references behind on teardown that pin the ALC and prevent its collection: projected resources copied into a host content area, and shared default-context state on the remote-control client. This PR releases both.

## Changes

- **AlcContentHost removes projected secondary-app resources on teardown** — `UpdateMergedResources` tracks exactly which theme-dictionary and direct-resource keys it copied from the secondary app and removes them before re-copying (and on teardown), so cleared content no longer roots the secondary app's resource objects across reloads.
- **RemoteControl shared state no longer pins the ALC**:
  - `RemoteControlJsonOptions.Reset()` drops the cached options and the registered source-generated `JsonSerializerContext`. A secondary app registers a per-ALC context; holding it on this shared static pins that app's ALC after unload (recreated lazily).
  - `RemoteControlClient.RemoveCollectibleAlcWaitingCallbacks()` removes queued client-available callbacks whose target lives in a collectible ALC (the waiting list never drains when an app only ever calls `CreateAdditional`).
  - The ambient diagnostics sink is scoped to `ProcessMessages` and `ExecutionContext` flow is suppressed when creating the long-lived keep-alive timer, so the sink is not captured into process-global state and does not pin the status-sink → owner graph (and any collectible ALC it reaches).

## Tests (red/green)

- `Given_AlcContentHost` — projected resources are released and the ALC is collectible after teardown (new direct-resource + `ThemeDictionaries` fixtures in `AlcApp/App.xaml`).
- `Given_RemoteControlJsonOptions_Reset` (new) — a registered `JsonSerializerContext` is released after `Reset()`; default options recreate lazily.

Companion to #23413 (collectible-ALC memory-leak fixes; see `specs/044-alc-memory-leak-fixes` there). This PR delivers the `AlcContentHost` projected-resource follow-up noted in that spec, plus the RemoteControl shared-state release. Includes a commit by @derekraven1994 (AlcContentHost) grouped here by theme.
