### PR TITLE
fix: Enhance secondary ALC resource refresh logic

### DIFF
--- a/specs/044-alc-secondary-app-resource-refresh/spec.md
+++ b/specs/044-alc-secondary-app-resource-refresh/spec.md
@@ -1,0 +1,53 @@
+# Hot-reload resource refresh for apps hosted in a secondary ALC
+
+**Status:** Implemented. Diagnostic instrumentation has been removed; only the behavioral change remains.
+
+---
+
+## Context
+
+A host process can load a consumer application into a per-app collectible `AssemblyLoadContext` (ALC) and render it in-process (Skia desktop and WASM). The consumer app's `Application` instance is a **secondary** ALC application — it is registered in `Application`'s ALC registry (`Application.EnumerateSecondaryApplications()`), and is **never** `Application.Current` (which always returns the default-ALC/host application).
+
+## Problem
+
+`ClientHotReloadProcessor.UpdateGlobalResources` (in `HotReload/ClientHotReloadProcessor.MetadataUpdate.cs`) only ever:
+
+- walked `Application.Current.Resources` to find/refresh source-backed merged dictionaries, and
+- called `Application.Current.UpdateResourceBindingsForHotReload()`.
+
+When the edited resource dictionary belongs to a **secondary-ALC** app, its source-backed dictionaries live in *that* app's `Application.Resources`, not in `Application.Current` (the host). So a hot-reload edit to a consumer app's source-backed `ResourceDictionary` (e.g. a themed colors/fonts/resources file) was **never refreshed**, and the inner app's visual tree bindings were never re-evaluated.
+
+The host (`Application.Current`) merged-dictionary tree contained zero matches for an edited dictionary, while the inner ALC app contained all the matching source-backed entries.
+
+## Fix
+
+`UpdateGlobalResources` now refreshes the host **and every secondary-ALC application**:
+
+- New `RefreshResourcesForApp(Application? app, HashSet<string> updatedSources)`:
+  - pins the resolution context to that app's own ALC via `ResourceResolver.SetResolutionContext(alc)` so `RefreshMergedDictionary` resolves each source against the correct ALC-scoped registry, not the global one;
+  - walks the app's merged-dictionary graph and refreshes only source-backed dictionaries whose normalized source is in `updatedSources`;
+  - calls `app.UpdateResourceBindingsForHotReload()` only when at least one dictionary was refreshed.
+- `UpdateResourceDictionaries` now **returns the count** of refreshed dictionaries (so the binding re-eval is gated).
+- The call site iterates `Application.Current` then `Application.EnumerateSecondaryApplications()`.
+
+These APIs are `internal` in Uno.UI and visible to Uno.UI.RemoteControl via `InternalsVisibleTo`.
+
+Theme libraries that register an `[assembly: MetadataUpdateHandler]` (e.g. a base theme's `UpdateApplication` that re-runs the theme's own `UpdateSource`) are discovered and invoked in the secondary ALC by `HotReloadAgent.GetMetadataUpdateHandlerActions()`, which scans both the current ALC and the default ALC, deduping by assembly name.
+
+## Scope note
+
+This fix correctly propagates hot-reload edits of *source-backed* dictionaries (including ones a theme library does not manage, e.g. a merged "theme resources" file) and re-evaluates the inner app's bindings. It is a self-contained RemoteControl change and stands on its own merits. Any remaining theme-library display behavior (e.g. color-only overrides not reaching `StaticResource`-bound brushes) is a separate concern tracked downstream and is independent of this fix.
+
+## Files changed
+
+- `src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs` — the secondary-ALC refresh fix (`RefreshResourcesForApp`, `UpdateResourceDictionaries` returns count, call-site loop over the host and every secondary app).
+- `src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs` — no behavior change (diagnostic logging only, since removed).
+- `src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs` — runtime tests for the secondary-ALC refresh (see below).
+
+## Build
+
+Build the **Reference** variant (this is what the host and inner ALC load from `lib/net10.0`), not Skia:
+
+```
+cd src && dotnet build Uno.UI.RemoteControl/Uno.UI.RemoteControl.Reference.csproj -c Debug
+```

--- a/specs/044-alc-secondary-app-resource-refresh/spec.md
+++ b/specs/044-alc-secondary-app-resource-refresh/spec.md
@@ -51,3 +51,17 @@ Build the **Reference** variant (this is what the host and inner ALC load from `
 ```
 cd src && dotnet build Uno.UI.RemoteControl/Uno.UI.RemoteControl.Reference.csproj -c Debug
 ```
+
+## Follow-up: secondary-app binding refresh must use the owning app's theme
+
+The per-secondary-app `UpdateResourceBindingsForHotReload()` added here surfaced a latent defect in `Application.OnResourcesChanged` (`src/Uno.UI/UI/Xaml/Application.cs`). It is an instance method that walks the **process-global** content-root list (`WinUICoreServices.Instance.ContentRootCoordinator.ContentRoots`) and applied `this.InternalRequestedTheme` to *every* root via `NotifyThemeChanged`. When a host (default ALC) renders a consumer app in a secondary ALC and the two have different themes, the consumer app's refresh re-themed the host's content root (and the host's refresh would re-theme the consumer's). After a hot reload the host's visual tree adopted the consumer app's theme.
+
+**Fix:** derive each content root's theme from the application that **owns** it rather than from `this`. `Application.GetOwningApplication(ContentRoot)` (in `Application.Alc.cs`, guarded by `#if UNO_HAS_ENHANCED_LIFECYCLE` to match its only call site) resolves the owner from `XamlRoot.Content`'s `AssemblyLoadContext` via `GetForAssemblyLoadContext` (default-ALC content → `Current`; secondary-ALC content → its registered app). The lookup is gated on `HasSecondaryApps`, so the single-app (and single-app multi-window) path is byte-for-byte unchanged. The global calls (`DefaultBrushes.ResetDefaultThemeBrushes`, `ResourceResolver.UpdateSystemThemeBindings`) stay global and `PropagateResourcesChanged` is unchanged, so a consumer app's content nested in the host's tree still re-binds.
+
+**Regression test:** `Given_AlcContentHost.When_SecondaryAlcApp_HotReloadsResources_Then_HostThemeUnchanged` — host = Dark, secondary ALC app = Light; after the secondary app's `UpdateResourceBindingsForHotReload()`, a non-themed host probe's `ActualTheme` must stay Dark. RED before the fix, GREEN after.
+
+### Files changed (follow-up)
+
+- `src/Uno.UI/UI/Xaml/Application.cs` — `OnResourcesChanged` derives the per-root theme from the owning app.
+- `src/Uno.UI/UI/Xaml/Application.Alc.cs` — new `GetOwningApplication(ContentRoot)` helper.
+- `src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs` — regression test.

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -747,10 +747,23 @@ partial class ClientHotReloadProcessor
 				// source was rebuilt by this update — wherever it sits, including dictionaries nested inside
 				// typed ResourceDictionary subclasses (e.g. a SimpleTheme/BaseTheme theme referencing an
 				// override file via ColorOverrideSource).
-				UpdateResourceDictionaries(updatedSources, Application.Current.Resources);
+				//
+				// CRITICAL: the rebuilt dictionaries do NOT necessarily live in Application.Current. When the
+				// app is hosted inside a secondary AssemblyLoadContext (e.g. a host rendering a consumer app in
+				// a per-app ALC), Application.Current is the *host* application — the consumer app is a
+				// secondary-ALC Application registered in Application's ALC registry, never Current. The edited
+				// source-backed dictionaries are merged into the *inner* app's Application.Resources, so a
+				// host-only walk never reaches them. We therefore refresh the host AND every secondary
+				// application's resource tree.
+				RefreshResourcesForApp(Application.Current, updatedSources);
 
-				// Force the app reevaluate global resources changes
-				Application.Current.UpdateResourceBindingsForHotReload();
+				if (Application.HasSecondaryApps)
+				{
+					foreach (var secondary in Application.EnumerateSecondaryApplications())
+					{
+						RefreshResourcesForApp(secondary, updatedSources);
+					}
+				}
 			}
 #endif
 		}
@@ -758,9 +771,40 @@ partial class ClientHotReloadProcessor
 
 #if !(WINUI || WINAPPSDK || WINDOWS_UWP)
 	/// <summary>
+	/// Refreshes the source-backed dictionaries of a single application's resource tree and, when at least
+	/// one was refreshed, re-evaluates its resource bindings. The resolution context is pinned to the
+	/// application's own <see cref="AssemblyLoadContext"/> so that <c>RefreshMergedDictionary</c> resolves
+	/// each source against the correct (ALC-scoped) registry — essential when the app is hosted in a
+	/// secondary ALC, where the rebuilt dictionaries were registered into that ALC's scoped registry rather
+	/// than the global one.
+	/// </summary>
+	private static void RefreshResourcesForApp(Application? app, HashSet<string> updatedSources)
+	{
+		if (app?.Resources is not { } resources)
+		{
+			return;
+		}
+
+		var alc = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(app.GetType().Assembly)
+			?? System.Runtime.Loader.AssemblyLoadContext.Default;
+
+		int refreshed;
+		using (Uno.UI.ResourceResolver.SetResolutionContext(alc))
+		{
+			refreshed = UpdateResourceDictionaries(updatedSources, resources);
+		}
+
+		if (refreshed > 0)
+		{
+			// Force the app to reevaluate global resource changes.
+			app.UpdateResourceBindingsForHotReload();
+		}
+	}
+
+	/// <summary>
 	/// Recursively refreshes every source-backed <see cref="ResourceDictionary"/> reachable through
 	/// <see cref="ResourceDictionary.MergedDictionaries"/> whose source was rebuilt by the current
-	/// metadata update.
+	/// metadata update, returning the number of dictionaries that were refreshed.
 	/// </summary>
 	/// <remarks>
 	/// Matching is done on a normalized source key (see <see cref="NormalizeResourceDictionarySource"/>):
@@ -770,8 +814,10 @@ partial class ClientHotReloadProcessor
 	/// overrides are reached, but only the matched entry is reloaded via <c>RefreshMergedDictionary</c>.
 	/// A typed subclass is therefore never replaced unless its own source file was the one edited.
 	/// </remarks>
-	private static void UpdateResourceDictionaries(HashSet<string> updatedSources, ResourceDictionary root)
+	private static int UpdateResourceDictionaries(HashSet<string> updatedSources, ResourceDictionary root)
 	{
+		var refreshed = 0;
+
 		// Snapshot first: RefreshMergedDictionary mutates MergedDictionaries (it replaces the entry at its index).
 		foreach (var merged in root.MergedDictionaries.ToArray())
 		{
@@ -779,13 +825,16 @@ partial class ClientHotReloadProcessor
 				&& updatedSources.Contains(NormalizeResourceDictionarySource(source)))
 			{
 				root.RefreshMergedDictionary(merged);
+				refreshed++;
 			}
 		}
 
 		foreach (var merged in root.MergedDictionaries)
 		{
-			UpdateResourceDictionaries(updatedSources, merged);
+			refreshed += UpdateResourceDictionaries(updatedSources, merged);
 		}
+
+		return refreshed;
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -1013,6 +1013,113 @@ public class Given_AlcContentHost
 			"Keyboard input should still work after loading secondary ALC app");
 	}
 
+	/// <summary>
+	/// Regression test for cross-ALC theme bleed during hot reload. A host app (Dark) renders a
+	/// secondary-ALC consumer app (Light) inside an <see cref="AlcContentHost"/>. When the inner
+	/// app's hot-reload resource refresh runs (<c>UpdateResourceBindingsForHotReload</c>, invoked
+	/// per secondary app by <c>ClientHotReloadProcessor.RefreshResourcesForApp</c>), it must NOT
+	/// re-theme the host's shell to its own theme.
+	/// </summary>
+	/// <remarks>
+	/// Root cause guarded: <c>Application.OnResourcesChanged</c> iterates the process-global
+	/// content-root list and applied <c>this.InternalRequestedTheme</c> to every root — so the
+	/// inner (Light) app re-themed the host's (Dark) content root. The fix derives the theme from
+	/// the app that OWNS each content root. Two host probes are asserted: a non-themed Border
+	/// (inherits the host app theme) and a Border nested under an explicit <c>RequestedTheme=Dark</c>
+	/// element (mirrors studio.live's themed shell root), so a run on the unfixed code pinpoints
+	/// exactly which shell elements flip.
+	/// </remarks>
+	[TestMethod]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_SecondaryAlcApp_HotReloadsResources_Then_HostThemeUnchanged()
+	{
+		var hostWasExplicit = Application.Current.IsThemeSetExplicitly;
+		var hostOriginal = Application.Current.RequestedTheme;
+
+		Application.HasSecondaryApps = true;
+		Application.Current.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+		try
+		{
+			// Host shell probes, siblings of the ALC host:
+			//  - probeA inherits the host app theme (no explicit RequestedTheme).
+			//  - probeBChild sits under an explicitly Dark element (mirrors AppRoot's themed subtree).
+			var probeA = new Border { Width = 20, Height = 20 };
+			var probeBChild = new Border { Width = 20, Height = 20 };
+			var probeB = new Border { RequestedTheme = ElementTheme.Dark, Child = probeBChild };
+
+			_contentHost = new AlcContentHost();
+			var container = new StackPanel { Children = { probeA, probeB, _contentHost } };
+
+			WindowHelper.ContentHostOverride = _contentHost;
+			TestServices.WindowHelper.WindowContent = container;
+			await TestServices.WindowHelper.WaitForLoaded(container);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Baseline established before any secondary app exists: the host shell is Dark.
+			Assert.AreEqual(ElementTheme.Dark, probeA.ActualTheme, "Baseline: non-themed host probe must be Dark.");
+			Assert.AreEqual(ElementTheme.Dark, probeBChild.ActualTheme, "Baseline: explicitly-Dark host subtree must be Dark.");
+
+			// Boot the secondary ALC app into _contentHost (mirrors StartSecondaryAlcAppAsync).
+			var alcAppPath = await BuildAlcAppAsync();
+			Assert.IsNotNull(alcAppPath, "AlcApp build should succeed");
+			var alcAppDirectory = Path.GetDirectoryName(alcAppPath)!;
+			_testAlc = new TestAssemblyLoadContext(alcAppDirectory);
+			var alcAppAssembly = _testAlc.LoadFromAssemblyPath(alcAppPath);
+			var programType = alcAppAssembly.GetType("AlcTestApp.Program");
+			var mainMethod = programType!.GetMethod("Main", BindingFlags.Public | BindingFlags.Static);
+			var appType = alcAppAssembly.GetType("AlcTestApp.App");
+			var mainThread = new System.Threading.Thread(() =>
+			{
+				try
+				{
+					mainMethod!.Invoke(null, new object[] { Array.Empty<string>() });
+				}
+				catch (Exception ex)
+				{
+					this.Log().Error("Secondary ALC app execution failed", ex);
+				}
+			})
+			{
+				IsBackground = true,
+				Name = "AlcApp-Main"
+			};
+			mainThread.Start();
+			await WaitForSecondaryWindowAsync(appType!);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Force the inner app to Light so host (Dark) != secondary (Light) deterministically.
+			var secondaryApp = Application.GetForAssemblyLoadContext(_testAlc!);
+			Assert.IsNotNull(secondaryApp, "Secondary ALC app must be registered.");
+			secondaryApp!.SetExplicitRequestedTheme(ApplicationTheme.Light);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Act: the inner (Light) app performs its hot-reload resource refresh — exactly what
+			// ClientHotReloadProcessor.RefreshResourcesForApp invokes on each secondary app.
+			secondaryApp.UpdateResourceBindingsForHotReload();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Assert: the inner app's Light theme must not have bled onto the host shell.
+			Assert.AreEqual(ElementTheme.Dark, probeA.ActualTheme,
+				"A secondary (Light) ALC app's hot-reload resource refresh re-themed the host's non-themed " +
+				"shell to Light. OnResourcesChanged applied the inner app's theme to the host content root.");
+			Assert.AreEqual(ElementTheme.Dark, probeBChild.ActualTheme,
+				"A secondary (Light) ALC app's hot-reload resource refresh re-themed the host's " +
+				"explicitly-Dark shell subtree to Light.");
+		}
+		finally
+		{
+			if (hostWasExplicit)
+			{
+				Application.Current.SetExplicitRequestedTheme(hostOriginal);
+			}
+			else
+			{
+				Application.Current.SetExplicitRequestedTheme(null);
+			}
+		}
+	}
+
 	private async Task<(AlcContentHost contentHost, Window alcWindow)> StartSecondaryAlcAppWithWindowAsync(string[]? launchArguments = null)
 	{
 		var contentHost = await StartSecondaryAlcAppAsync(launchArguments);

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -126,6 +126,21 @@ partial class Application
 		}
 	}
 
+#if UNO_HAS_ENHANCED_LIFECYCLE
+	/// <summary>
+	/// Returns the <see cref="Application"/> that owns <paramref name="contentRoot"/>, derived from the
+	/// <see cref="System.Runtime.Loader.AssemblyLoadContext"/> of its public root content. Default-ALC
+	/// content maps to the host (<see cref="Current"/>); secondary-ALC content maps to its registered
+	/// application. Returns <see langword="null"/> when the owner cannot be determined, in which case
+	/// callers fall back to the current application. Used by <c>OnResourcesChanged</c> so that one app's
+	/// theme refresh does not re-theme a content root owned by a different app sharing the process-global
+	/// content-root list. Guarded by the same symbol as its only call site (the enhanced-lifecycle theme
+	/// walk) so non-enhanced variants do not flag it as unused.
+	/// </summary>
+	private static Application GetOwningApplication(global::Uno.UI.Xaml.Core.ContentRoot contentRoot)
+		=> contentRoot?.XamlRoot?.Content is { } content ? GetForInstance(content) : null;
+#endif
+
 	/// <summary>
 	/// Enumerates all secondary-ALC <see cref="Application"/> instances currently registered.
 	/// Used by <see cref="ResourceResolver"/> as a last-resort fallback when a resource

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -629,7 +629,15 @@ namespace Microsoft.UI.Xaml
 #if UNO_HAS_ENHANCED_LIFECYCLE
 						if ((updateReason & ResourceUpdateReason.ThemeResource) != 0)
 						{
-							var theme = InternalRequestedTheme == ApplicationTheme.Dark ? Theme.Dark : Theme.Light;
+							// Re-apply the theme of the application that OWNS this content root, not `this`.
+							// The content-root list is process-global; when apps in multiple AssemblyLoadContexts
+							// share it (e.g. a host rendering a consumer app in a secondary ALC), a secondary
+							// app's resource refresh — such as its hot-reload pass — must not bleed its own theme
+							// onto the host's, or another app's, visual tree. Falls back to `this` when the owner
+							// is indeterminate, and is skipped when there are no secondary apps so the common
+							// single-app (and single-app multi-window) path is byte-for-byte unchanged.
+							var owningApp = (HasSecondaryApps ? GetOwningApplication(contentRoot) : null) ?? this;
+							var theme = owningApp.InternalRequestedTheme == ApplicationTheme.Dark ? Theme.Dark : Theme.Light;
 							var forceRefresh = (updateReason & ResourceUpdateReason.HotReload) != 0;
 							var rootFe = root as FrameworkElement ?? contentRoot.XamlRoot.Content as FrameworkElement;
 							rootFe?.NotifyThemeChanged(theme, forceRefresh);


### PR DESCRIPTION
This pull request introduces a critical fix to the hot-reload resource refresh mechanism for applications hosted in a secondary AssemblyLoadContext (ALC). Previously, hot-reload edits to resource dictionaries in secondary-ALC apps were not properly refreshed, leading to stale resources and incorrect theme propagation across multiple applications in the same process. The changes ensure that both the host and all secondary-ALC applications correctly refresh their resources and maintain their own themes during hot reloads. A regression test is also added to guarantee that theme changes in a secondary app do not inadvertently affect the host application's UI.

**Hot-reload resource refresh improvements:**

* `UpdateGlobalResources` now refreshes resources for both the host (`Application.Current`) and every secondary-ALC application, ensuring that hot-reload edits to resource dictionaries in secondary apps are correctly applied. (`src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs`)
* Introduced `RefreshResourcesForApp`, which refreshes only the relevant source-backed dictionaries in the correct ALC context and only triggers binding updates if changes occurred. (`src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs`)
* Modified `UpdateResourceDictionaries` to return the count of refreshed dictionaries, allowing for conditional binding updates. (`src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs`)

**Theme isolation and correctness:**

* Updated `Application.OnResourcesChanged` to derive the theme per content root from the owning application, preventing a secondary app's theme refresh from changing the host's theme. This uses the new `GetOwningApplication` helper, ensuring correct theme application in multi-ALC scenarios. (`src/Uno.UI/UI/Xaml/Application.cs`, `src/Uno.UI/UI/Xaml/Application.Alc.cs`) [[1]](diffhunk://#diff-cfe3432325e70608b255faca542c779d17ccf717db9e3cc0806354d0336287a1L632-R640) [[2]](diffhunk://#diff-3493fbe796fa04f3a78a0a340e946f24589046c5fd08dec0ed6f6d9b20f25c19R129-R143)

**Testing and documentation:**

* Added a regression test to verify that hot-reloading resources in a secondary-ALC app does not affect the host application's theme, ensuring correctness and preventing future regressions. (`src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs`)
* Provided detailed documentation and context for the changes, including build instructions and scope notes. (`specs/044-alc-secondary-app-resource-refresh/spec.md`)