### PR TITLE
fix: Report UIA IsOffscreen for clipped elements

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/AccessibilityScreenReaderPage.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/AccessibilityScreenReaderPage.xaml
@@ -800,11 +800,16 @@
                         <Button Click="OnShowTarget" Content="Show" />
                     </StackPanel>
                     <TextBlock
+                        x:Name="VisibilityOffscreenResult"
+                        AutomationProperties.AutomationId="VisibilityOffscreenResult"
+                        FontWeight="SemiBold"
+                        Text="IsOffscreen = …" />
+                    <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{ThemeResource CaptionTextBlockStyle}"
                         TextWrapping="WrapWholeWords">
-                        Click "Collapse" and verify the button above reports IsOffscreen=True.
-                        Click "Show" and verify it reports IsOffscreen=False with a valid BoundingRectangle.
+                        The IsOffscreen value above is read live from the button's automation peer (no inspect.exe needed).
+                        Click "Collapse" and it should report IsOffscreen=True; click "Show" and it reports IsOffscreen=False.
                     </TextBlock>
                 </StackPanel>
             </Border>
@@ -826,10 +831,15 @@
                         <Button Click="OnSetOpacityOne" Content="Set Opacity=1" />
                     </StackPanel>
                     <TextBlock
+                        x:Name="OpacityOffscreenResult"
+                        AutomationProperties.AutomationId="OpacityOffscreenResult"
+                        FontWeight="SemiBold"
+                        Text="IsOffscreen = …" />
+                    <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{ThemeResource CaptionTextBlockStyle}"
                         TextWrapping="WrapWholeWords">
-                        An element with Opacity=0 should report IsOffscreen=True even though it is still Visible in the tree.
+                        An element with Opacity=0 should report IsOffscreen=True (shown live above) even though it is still Visible in the tree.
                     </TextBlock>
                 </StackPanel>
             </Border>
@@ -843,17 +853,80 @@
                 CornerRadius="8">
                 <StackPanel Spacing="8">
                     <StackPanel x:Name="AncestorPanel">
-                        <Button AutomationProperties.AutomationId="ChildOfCollapsibleParent" Content="Child of collapsible parent" />
+                        <Button
+                            x:Name="AncestorChildButton"
+                            AutomationProperties.AutomationId="ChildOfCollapsibleParent"
+                            Content="Child of collapsible parent" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Click="OnCollapseAncestor" Content="Collapse parent" />
                         <Button Click="OnShowAncestor" Content="Show parent" />
                     </StackPanel>
                     <TextBlock
+                        x:Name="AncestorOffscreenResult"
+                        AutomationProperties.AutomationId="AncestorOffscreenResult"
+                        FontWeight="SemiBold"
+                        Text="IsOffscreen = …" />
+                    <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         Style="{ThemeResource CaptionTextBlockStyle}"
                         TextWrapping="WrapWholeWords">
-                        When the parent StackPanel is collapsed, the child button should also report IsOffscreen=True.
+                        When the parent StackPanel is collapsed, the child button should also report IsOffscreen=True (shown live above).
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+
+            <!--  Offscreen via clipping (scrolled out of a ScrollViewer)  -->
+            <Border
+                Padding="12"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="8">
+                <StackPanel Spacing="8">
+                    <ScrollViewer
+                        x:Name="ClippingScrollViewer"
+                        Height="200"
+                        Background="{ThemeResource LayerFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        ViewChanged="OnClippingViewChanged">
+                        <StackPanel Padding="8" Spacing="8">
+                            <Button
+                                x:Name="ClippedTargetButton"
+                                AutomationProperties.AutomationId="ClippedTargetButton"
+                                Content="Scroll me out of view" />
+                            <Border
+                                Height="1000"
+                                Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
+                                CornerRadius="4">
+                                <TextBlock
+                                    Margin="8"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Filler content — scroll down so the button above leaves the viewport."
+                                    TextWrapping="WrapWholeWords" />
+                            </Border>
+                        </StackPanel>
+                    </ScrollViewer>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button Click="OnScrollTargetOut" Content="Scroll out" />
+                        <Button Click="OnScrollTargetIntoView" Content="Scroll into view" />
+                        <Button Click="OnCheckClippedOffscreen" Content="Check IsOffscreen" />
+                    </StackPanel>
+                    <TextBlock
+                        x:Name="ClippedOffscreenResult"
+                        AutomationProperties.AutomationId="ClippedOffscreenResult"
+                        FontWeight="SemiBold"
+                        Text="IsOffscreen = (scroll or click Check)" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        TextWrapping="WrapWholeWords">
+                        The IsOffscreen value above is read directly from the element's automation peer
+                        (FrameworkElementAutomationPeer.IsOffscreen()) and updates live as you scroll, so no
+                        external tool such as inspect.exe is required. Scroll the button out of the viewport
+                        and it should report IsOffscreen=True (even though it is still Visible and in the live
+                        tree); scroll it back into view and it reports IsOffscreen=False.
                     </TextBlock>
                 </StackPanel>
             </Border>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/AccessibilityScreenReaderPage.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/AccessibilityScreenReaderPage.xaml.cs
@@ -23,6 +23,8 @@ namespace UITests.Shared.Windows_UI_Xaml_Automation
 			// Refreshing on every layout pass keeps every readout correct after layout has run.
 			// Opacity and scrolling are render-only (no layout), so those are refreshed from their
 			// own handlers (opacity) and the ScrollViewer's ViewChanged (scrolling).
+			// Remove-then-add keeps a single subscription if the control is reloaded.
+			LayoutUpdated -= OnLayoutUpdated;
 			LayoutUpdated += OnLayoutUpdated;
 			RefreshAllOffscreenReadouts();
 		}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/AccessibilityScreenReaderPage.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/AccessibilityScreenReaderPage.xaml.cs
@@ -1,5 +1,6 @@
 using Uno.UI.Samples.Controls;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Automation
@@ -12,6 +13,44 @@ namespace UITests.Shared.Windows_UI_Xaml_Automation
 		public AccessibilityScreenReaderPage()
 		{
 			this.InitializeComponent();
+			Loaded += OnPageLoaded;
+		}
+
+		private void OnPageLoaded(object sender, RoutedEventArgs e)
+		{
+			// Visibility and ancestor-visibility changes only settle on a later layout pass, so
+			// reading IsOffscreen() synchronously in the click handler would observe stale bounds.
+			// Refreshing on every layout pass keeps every readout correct after layout has run.
+			// Opacity and scrolling are render-only (no layout), so those are refreshed from their
+			// own handlers (opacity) and the ScrollViewer's ViewChanged (scrolling).
+			LayoutUpdated += OnLayoutUpdated;
+			RefreshAllOffscreenReadouts();
+		}
+
+		private void OnLayoutUpdated(object sender, object e)
+			=> RefreshAllOffscreenReadouts();
+
+		private void RefreshAllOffscreenReadouts()
+		{
+			UpdateOffscreenReadout(VisibilityTargetButton, VisibilityOffscreenResult);
+			UpdateOffscreenReadout(OpacityTargetButton, OpacityOffscreenResult);
+			UpdateOffscreenReadout(AncestorChildButton, AncestorOffscreenResult);
+			UpdateOffscreenReadout(ClippedTargetButton, ClippedOffscreenResult);
+		}
+
+		// Reads IsOffscreen straight from an element's automation peer so each IsOffscreen
+		// scenario can be validated in-app, without inspect.exe or Accessibility Insights.
+		private static void UpdateOffscreenReadout(UIElement target, TextBlock result)
+		{
+			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(target);
+			var text = $"IsOffscreen = {peer?.IsOffscreen() ?? true}";
+
+			// Only assign when changed: setting Text invalidates layout, which would re-enter
+			// OnLayoutUpdated — the guard lets it settle after one pass instead of looping.
+			if (result.Text != text)
+			{
+				result.Text = text;
+			}
 		}
 
 		private void OnUpdateLiveRegion(object sender, RoutedEventArgs e)
@@ -27,19 +66,38 @@ namespace UITests.Shared.Windows_UI_Xaml_Automation
 		private void OnShowTarget(object sender, RoutedEventArgs e)
 			=> VisibilityTargetButton.Visibility = Visibility.Visible;
 
-		// IsOffscreen: Opacity toggling
+		// IsOffscreen: Opacity toggling (render-only — no layout pass, so refresh directly)
 		private void OnSetOpacityZero(object sender, RoutedEventArgs e)
-			=> OpacityTargetButton.Opacity = 0;
+		{
+			OpacityTargetButton.Opacity = 0;
+			UpdateOffscreenReadout(OpacityTargetButton, OpacityOffscreenResult);
+		}
 
 		private void OnSetOpacityOne(object sender, RoutedEventArgs e)
-			=> OpacityTargetButton.Opacity = 1;
+		{
+			OpacityTargetButton.Opacity = 1;
+			UpdateOffscreenReadout(OpacityTargetButton, OpacityOffscreenResult);
+		}
 
-		// IsOffscreen: Ancestor visibility
+		// IsOffscreen: Ancestor visibility (readout refreshed by OnLayoutUpdated after layout)
 		private void OnCollapseAncestor(object sender, RoutedEventArgs e)
 			=> AncestorPanel.Visibility = Visibility.Collapsed;
 
 		private void OnShowAncestor(object sender, RoutedEventArgs e)
 			=> AncestorPanel.Visibility = Visibility.Visible;
+
+		// IsOffscreen: Clipping (scrolled out of a ScrollViewer's viewport)
+		private void OnScrollTargetOut(object sender, RoutedEventArgs e)
+			=> ClippingScrollViewer.ChangeView(null, 500, null, disableAnimation: true);
+
+		private void OnScrollTargetIntoView(object sender, RoutedEventArgs e)
+			=> ClippingScrollViewer.ChangeView(null, 0, null, disableAnimation: true);
+
+		private void OnClippingViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+			=> UpdateOffscreenReadout(ClippedTargetButton, ClippedOffscreenResult);
+
+		private void OnCheckClippedOffscreen(object sender, RoutedEventArgs e)
+			=> UpdateOffscreenReadout(ClippedTargetButton, ClippedOffscreenResult);
 
 		// IsEnabled / IsKeyboardFocusable toggling
 		private void OnDisableTarget(object sender, RoutedEventArgs e)

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -627,6 +627,25 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	}
 
 	/// <summary>
+	/// Returns the bounds, in root visual coordinates, of the effective clip applied to this visual's
+	/// own content by its ancestors (e.g. a ScrollViewer's viewport clip) and its own <see cref="Clip"/>.
+	/// Intersecting an element's bounds with this rect yields what's actually visible, which automation
+	/// uses to detect elements clipped entirely out of view (e.g. scrolled outside a ScrollViewer).
+	/// </summary>
+	internal Rect GetTotalClipRectInRootCoordinates()
+	{
+		var clipPath = _pathPool.Allocate();
+		using var clipPathDisposable = new DisposableStruct<SKPath>(static path => _pathPool.Free(path), clipPath);
+		clipPath.Rewind();
+
+		// skipPostPaintingClipping: true — a visual's own post-painting clip only affects its children,
+		// not the visual itself. Ancestor post-painting clips are still applied via the parent recursion.
+		GetTotalClipPath(clipPath, skipPostPaintingClipping: true);
+
+		return clipPath.Bounds.ToRect();
+	}
+
+	/// <summary>
 	/// Draws the content of this visual.
 	/// </summary>
 	/// <param name="session">The drawing session to use.</param>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -228,7 +228,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 
 		[TestMethod]
 		[RunsOnUIThread]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWasm | RuntimeTestPlatforms.NativeMobile)]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)] // IsOffscreen clipping is Skia-only.
 		public async Task When_Element_Scrolled_Out_Of_ScrollViewer_IsOffscreen()
 		{
 			var target = new Button { Content = "Subject", Width = 120, Height = 40 };

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 {
@@ -220,6 +224,49 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 			var automationPeer = new TestAutomationPeer();
 			var result = automationPeer.IsOffscreen();
 			Assert.IsFalse(result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWasm | RuntimeTestPlatforms.NativeMobile)]
+		public async Task When_Element_Scrolled_Out_Of_ScrollViewer_IsOffscreen()
+		{
+			var target = new Button { Content = "Subject", Width = 120, Height = 40 };
+			var scrollViewer = new ScrollViewer
+			{
+				Width = 200,
+				Height = 200,
+				Content = new StackPanel
+				{
+					Children =
+					{
+						target,
+						new Border { Height = 1000 },
+					},
+				},
+			};
+
+			try
+			{
+				await UITestHelper.Load(scrollViewer);
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(target);
+				Assert.IsNotNull(peer);
+
+				// The target sits at the top of the viewport, so it is visible.
+				Assert.IsFalse(peer.IsOffscreen(), "Element should be on-screen before scrolling.");
+
+				// Scroll the target completely above the viewport.
+				scrollViewer.ChangeView(null, 500, null, disableAnimation: true);
+				await WindowHelper.WaitForEqual(500, () => scrollViewer.VerticalOffset);
+				await WindowHelper.WaitForIdle();
+
+				Assert.IsTrue(peer.IsOffscreen(), "Element should be off-screen after being scrolled out of the viewport.");
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -843,7 +843,28 @@ namespace Microsoft.UI.Xaml
 
 			var transform = GetTransform(from: this, to: null);
 			var localRect = new Rect(0, 0, size.X, size.Y);
-			return transform.Transform(localRect);
+			var globalBounds = transform.Transform(localRect);
+
+			if (!ignoreClipping)
+			{
+				// Intersect with the effective clip applied by ancestors (e.g. a ScrollViewer's viewport).
+				// Without this, an element scrolled out of view still reports non-empty bounds and is
+				// wrongly considered on-screen (IsOffscreen == false).
+				// TODO: ignoreClippingOnScrollContentPresenters is not yet honored separately. Every caller
+				// currently passes false, so the full ancestor clip (including ScrollContentPresenters) applies.
+				var clip = Visual.GetTotalClipRectInRootCoordinates();
+
+				var left = Math.Max(globalBounds.Left, clip.Left);
+				var top = Math.Max(globalBounds.Top, clip.Top);
+				var right = Math.Min(globalBounds.Right, clip.Right);
+				var bottom = Math.Min(globalBounds.Bottom, clip.Bottom);
+
+				return right > left && bottom > top
+					? new Rect(left, top, right - left, bottom - top)
+					: default;
+			}
+
+			return globalBounds;
 #else
 			return default;
 #endif


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#495

## PR Type:

🐞 Bugfix

## What changed? 🚀

The UI Automation `IsOffscreen` property always returned `false`, even for an element scrolled out of a `ScrollViewer`'s viewport (visible to tools like Windows Inspect). `AutomationPeer.IsOffscreen()` determines off-screen state by checking whether an element's *clipped* global bounds are empty, via `UIElement.GetGlobalBoundsWithOptions(ignoreClipping: false, …)` — but that method accepted the `ignoreClipping`/`ignoreClippingOnScrollContentPresenters` parameters yet never applied any clipping, so it always returned the element's full, unclipped bounds. A scrolled-out element therefore still reported a non-empty rectangle and was treated as on-screen.

This PR makes `GetGlobalBoundsWithOptions` intersect the element's bounds with the effective clip applied by its ancestors (e.g. a `ScrollViewer`/`ScrollContentPresenter` viewport), reusing the existing `Visual.GetTotalClipPath` machinery already used by `SystemFocusVisual`. A fully clipped element now yields empty bounds, so `IsOffscreen` correctly reports `true` (and `GetBoundingRectangle` returns the visible region, matching WinUI). The implementation is Skia (`#if __SKIA__`).

Added a runtime test (`Given_AutomationPeer.When_Element_Scrolled_Out_Of_ScrollViewer_IsOffscreen`) that scrolls an element out of a `ScrollViewer` and asserts `IsOffscreen` flips from `false` to `true`. Validated fail-before/pass-after on Skia Desktop, with the full `Given_AutomationPeer` class passing (44/44, no regression in the default `IsOffscreen`/`GetBoundingRectangle` coverage).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
