### PR TITLE
fix(hotreload): decide batch merge under the solution-update gate

### DIFF
--- a/specs/044-hotreload-late-batch-result-loss/spec.md
+++ b/specs/044-hotreload-late-batch-result-loss/spec.md
@@ -1,0 +1,165 @@
+# Fix Specification: Hot-Reload Operation Loses the Result of Late-Merged Batches
+
+**Repo**: `uno` (Uno.HotReload)
+**Created**: 2026-06-10
+**Status**: Planned
+**Input**: A file-change batch merged into an in-flight `HotReloadOperation` can have its compile
+result (including `Failed` + error diagnostics) silently discarded when the operation was already
+completed by an earlier pass. Status consumers then see `Success` / no diagnostics while the
+workspace no longer compiles.
+
+---
+
+## Problem Statement
+
+### Symptom
+
+Observed by a downstream consumer (agent-driven workspace tooling hosting Roslyn in a WASM
+worker): a `.xaml` file was written twice in quick succession — an initial write, then an
+automated post-write correction of the same file ~0.5 s later. The hot-reload status for the
+covering operation reported `Success`, "no diagnostics". A full build of the same workspace
+minutes later failed on that exact file (`UXAML0001` "Unable to find class name for toplevel
+control" + `CS1061` for the missing `InitializeComponent`). The failure of the second hot-reload
+pass had been computed — and thrown away.
+
+### Why (current code)
+
+Three cooperating behaviors in `src/Uno.HotReload`:
+
+1. **`HotReloadManager.ProcessFileChanges`** (`HotReloadManager.cs`) merges an incoming batch
+   into the current operation when the path sets intersect and the operation has not completed:
+
+   ```csharp
+   var hotReload = await _tracker.StartOrContinueHotReload().ConfigureAwait(false);
+   var files = await filesAsync.ConfigureAwait(false);
+   if (!hotReload.TryMerge(files))
+   {
+       hotReload = await _tracker.StartHotReload(files).ConfigureAwait(false);
+   }
+   ```
+
+   `TryMerge` checks completion (`_result is -1`) **at merge time**. The pass itself then queues
+   on `_solutionUpdateGate`, so it can execute **after** the operation has been completed by an
+   earlier pass. Nothing re-validates the operation between the merge and the pass.
+
+2. **`ProcessSolutionChanged`** runs the merged pass against the (now-completed) operation and
+   reports its outcome through `hotReload.Complete(...)`.
+
+3. **`HotReloadOperation.Complete`** (`Tracking/HotReloadOperation.cs`) drops any completion after
+   the first, including its diagnostics, with no trace:
+
+   ```csharp
+   if (Interlocked.CompareExchange(ref _result, (int)result, -1) is not -1)
+   {
+       return; // Already completed
+   }
+   ```
+
+Net effect: first pass completes the operation (`Success` at time T); the later pass updates
+`CurrentSolution` with the newer file content (the manager sets `workspace.CurrentSolution`
+*before* emitting), compiles it, fails — and the `Failed` + diagnostics vanish. The tracker's
+`Current`/`Last` still expose the `Success` operation. The workspace is left containing source
+that no longer compiles, with no surviving signal.
+
+### Timing window
+
+The window is `[merge accepted, operation completed]`. Any producer that writes the same file
+twice within one debounce-plus-compile interval can hit it; the faster the first pass, the wider
+the practical exposure.
+
+---
+
+## Fix Design
+
+### Root-cause fix (decide the merge under the gate)
+
+The merge decision is currently made **outside** `_solutionUpdateGate`, so it can be invalidated
+while the pass waits for the gate. Moving the `TryMerge`/`StartHotReload` decision **inside** the
+gate removes the window entirely:
+
+```csharp
+var hotReload = await _tracker.StartOrContinueHotReload().ConfigureAwait(false); // early Processing notification — unchanged
+var files = await filesAsync.ConfigureAwait(false);   // outside the gate: don't hold it during debounce
+using var _ = await _solutionUpdateGate.LockAsync(ct).ConfigureAwait(false);
+if (!hotReload.TryMerge(files))
+{
+    hotReload = await _tracker.StartHotReload(files).ConfigureAwait(false);
+}
+await ProcessSolutionChanged(hotReload, files, ct).ConfigureAwait(false);
+```
+
+Why this is sufficient: passes are serialized by the gate, and an operation processed by a pass
+is completed *before* that pass releases the gate. A `TryMerge` evaluated under the gate can
+therefore no longer be invalidated by a concurrent pass completion — if the operation completed,
+`TryMerge` fails (`_result` set) and the batch gets its own tracked operation N+1, exactly as if
+it had arrived after completion (which, observably, it did).
+
+Side effects, all acceptable or better:
+- The early `StartOrContinueHotReload()` call stays where it is, so the immediate `Processing`
+  state notification is unchanged.
+- The op's abort timer is no longer re-armed at merge time but at gate acquisition; an op kept
+  waiting >30 s behind a long pass aborts and the batch is routed to a fresh op — more correct.
+- `ConsideredFilePaths` reflects the batch only once it is actually about to be processed.
+
+Residual window: an **out-of-band** completion (30 s abort timer, explicit abort) landing *during*
+the pass still loses that pass's result — rare, and made observable by the hardening below.
+
+### Defensive hardening (labeled as such, not the fix)
+
+`HotReloadOperation.Complete`: when a completion is discarded because the operation already
+completed, report it instead of returning silently — `_owner` reporter warning including the
+dropped result and diagnostic count. No behavioral change beyond observability.
+
+### Testability seam
+
+`HotReloadManager` takes the concrete reflection wrapper `WatchHotReloadService`. Extract a
+minimal interface (`IWatchHotReloadService`: `StartSessionAsync`, `EmitSolutionUpdateAsync`,
+`EndSession`) implemented by the existing wrapper, so the manager can be unit-tested with a stub
+emitter. No public-API change for consumers (type is internal to the library's wiring).
+
+---
+
+## Test Plan (red first — commits between steps)
+
+New project `src/Uno.HotReload.Tests` (none exists for this library).
+
+Red tests (must fail on current code):
+
+1. **`ProcessFileChanges_BatchMergedIntoCompletedOp_TracksItsOwnResult`** (manager level)
+   - Stub `IWatchHotReloadService`: first emit returns success/updates, second emit returns an
+     error diagnostic.
+   - Drive two `ProcessFileChanges` calls whose batches intersect; hold the second batch's
+     `filesAsync` until the first pass completed the operation (deterministic — no sleeps:
+     the test controls the `Task<ImmutableHashSet<string>>` and the stub emitter's completion).
+   - Assert the tracker's last operation reflects the second pass: `Result == Failed` (or
+     `RudeEdit`) and its diagnostics are present.
+2. **`Complete_AfterCompleted_ReportsDroppedResult`** (operation level)
+   - `Complete(Success)` then `Complete(Failed, diagnostics)`; assert the reporter received a
+     warning mentioning the dropped result (and the first result is unchanged).
+3. Non-regression: a batch merged and processed **while** the operation is still pending keeps
+   today's behavior (single operation, its result wins).
+
+Then:
+
+- Fix per design above.
+- All new tests green; existing solution-filter build unaffected.
+
+## Progress
+
+- [ ] `src/Uno.HotReload.Tests` project created and wired to the unit-test solution filter
+- [ ] Seam: `IWatchHotReloadService` extracted (wrapper implements it; manager consumes it)
+- [ ] Red test 1 (manager: late-merged batch result tracked) — confirmed failing
+- [ ] Red test 2 (operation: dropped completion reported) — confirmed failing
+- [ ] Non-regression test 3 — confirmed passing pre-fix (guards the merge fast-path)
+- [ ] Commit (tests + seam, red)
+- [ ] Fix: `TryMerge`/`StartHotReload` decision moved under `_solutionUpdateGate` in `ProcessFileChanges`
+- [ ] Hardening: `Complete` reports dropped completions
+- [ ] All tests green
+- [ ] Commit (fix, green)
+
+## Validation Evidence (per repo protocol)
+
+- **Code review assessment**: _(fill)_
+- **Compile validation**: _(fill — project/solution + result)_
+- **Runtime validation**: unit tests above; downstream integration validated by the consumer via
+  a local package override _(tracked downstream, no identifiers here)_.

--- a/specs/044-hotreload-late-batch-result-loss/spec.md
+++ b/specs/044-hotreload-late-batch-result-loss/spec.md
@@ -146,20 +146,24 @@ Then:
 
 ## Progress
 
-- [ ] `src/Uno.HotReload.Tests` project created and wired to the unit-test solution filter
-- [ ] Seam: `IWatchHotReloadService` extracted (wrapper implements it; manager consumes it)
-- [ ] Red test 1 (manager: late-merged batch result tracked) — confirmed failing
-- [ ] Red test 2 (operation: dropped completion reported) — confirmed failing
-- [ ] Non-regression test 3 — confirmed passing pre-fix (guards the merge fast-path)
-- [ ] Commit (tests + seam, red)
-- [ ] Fix: `TryMerge`/`StartHotReload` decision moved under `_solutionUpdateGate` in `ProcessFileChanges`
-- [ ] Hardening: `Complete` reports dropped completions
-- [ ] All tests green
-- [ ] Commit (fix, green)
+- [x] `src/Uno.HotReload.Tests` project created and wired to `Uno.UI.slnx` + `Uno.UI-UnitTests-only.slnf`
+- [x] Seam: `IWatchHotReloadService` extracted (wrapper implements it; manager consumes it; internal ctor + `InternalsVisibleTo`)
+- [x] Red test 1 (`When_BatchMergedIntoCompletedOperation_Then_ItsResultIsTracked`) — confirmed failing: expected `RudeEdit`, observed `Success` (the exact production defect)
+- [x] Red test 2 (`When_CompletingAnAlreadyCompletedOperation_Then_DroppedResultIsReported`) — confirmed failing: no warning emitted
+- [x] Non-regression tests (`When_SingleBatch…`, `When_BatchMergedIntoPendingOperation…`, `When_PreviousOperationAbortedByNext…`) — passing pre-fix
+- [x] Commit (tests + seam, red)
+- [x] Fix: `TryMerge`/`StartHotReload` decision moved under `_solutionUpdateGate` in `ProcessFileChanges` (root-cause fix)
+- [x] Hardening: `Complete` reports dropped completions via the tracker reporter, except chain-aborts (`isFromNext`) (defensive hardening)
+- [x] All 5 tests green post-fix
+- [x] Commit (fix, green)
 
 ## Validation Evidence (per repo protocol)
 
-- **Code review assessment**: _(fill)_
-- **Compile validation**: _(fill — project/solution + result)_
-- **Runtime validation**: unit tests above; downstream integration validated by the consumer via
-  a local package override _(tracked downstream, no identifiers here)_.
+- **Code review assessment**: merge decision is now made while holding the same gate under which
+  operations are completed, so a completed operation can no longer absorb a pending batch; the
+  late batch becomes operation N+1 whose result and diagnostics surface through the tracker.
+- **Compile validation**: `src/Uno.HotReload/Uno.HotReload.csproj` (Debug, net9.0 + net10.0) — 0 errors;
+  `src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj` (direct consumer) — 0 warnings / 0 errors.
+- **Runtime validation**: `dotnet test src/Uno.HotReload.Tests` — 5/5 passed (deterministic
+  interleaving via controlled `filesAsync` tasks and a gated stub emitter; no sleeps). Downstream
+  integration validated by the consumer via a local package override.

--- a/specs/044-hotreload-late-batch-result-loss/spec.md
+++ b/specs/044-hotreload-late-batch-result-loss/spec.md
@@ -2,7 +2,7 @@
 
 **Repo**: `uno` (Uno.HotReload)
 **Created**: 2026-06-10
-**Status**: Planned
+**Status**: Implemented
 **Input**: A file-change batch merged into an in-flight `HotReloadOperation` can have its compile
 result (including `Failed` + error diagnostics) silently discarded when the operation was already
 completed by an earlier pass. Status consumers then see `Success` / no diagnostics while the

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -81,9 +81,8 @@ public class Given_HotReloadManager
 
 	[TestMethod]
 	[Description(
-		"Merge fast-path guard: a batch arriving while the operation exists but has not been " +
-		"processed yet merges into it and is processed as that same single operation.")]
-	public async Task When_BatchMergedIntoPendingOperation_Then_SingleOperationTracksIt()
+		"Merge fast-path guard: a batch arriving while an operation exists but has not been processed yet should be processed by that existing operation (i.e., the second caller should not start a new operation).")]
+	public async Task When_BatchMergedIntoPendingOperation_Then_SecondCallerProcessesExistingOperation()
 	{
 		using var harness = new HotReloadManagerHarness(
 			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Tests.TestUtils;
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.Tests;
+
+[TestClass]
+public class Given_HotReloadManager
+{
+	private static readonly TimeSpan _testTimeout = TimeSpan.FromSeconds(30);
+
+	[TestMethod]
+	[Description(
+		"A batch whose files intersect an in-flight operation merges into it, but its compile " +
+		"pass runs after the operation was completed by the first pass. The late pass's outcome " +
+		"(here a rude edit with diagnostics) must surface on a tracked operation — not be " +
+		"silently dropped because the merged-into operation already completed.")]
+	public async Task When_BatchMergedIntoCompletedOperation_Then_ItsResultIsTracked()
+	{
+		var firstEmitEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var releaseFirstEmit = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		using var harness = new HotReloadManagerHarness(async call =>
+		{
+			if (call == 1)
+			{
+				firstEmitEntered.SetResult();
+				await releaseFirstEmit.Task;
+				return ([HotReloadManagerHarness.CreateEmptyUpdate()], []);
+			}
+
+			// Second pass: the (corrupted) content fails to compile.
+			return ([], [HotReloadManagerHarness.CreateRudeEditDiagnostic()]);
+		});
+
+		var firstBatch = ImmutableHashSet.Create("/work/Model.cs", "/work/Page.xaml");
+		var secondBatch = ImmutableHashSet.Create("/work/Page.xaml"); // intersects → merges
+
+		// Pass 1 enters the emitter (holding the solution-update gate) and blocks there.
+		var firstProcess = harness.Manager.ProcessFileChanges(Task.FromResult(firstBatch), CancellationToken.None);
+		await firstEmitEntered.Task.WaitAsync(_testTimeout);
+
+		// Batch 2 arrives while the operation is in flight, then queues on the gate.
+		var secondProcess = harness.Manager.ProcessFileChanges(Task.FromResult(secondBatch), CancellationToken.None);
+
+		// Pass 1 completes the operation with Success; pass 2 then runs and fails.
+		releaseFirstEmit.SetResult();
+		await firstProcess.WaitAsync(_testTimeout);
+		await secondProcess.WaitAsync(_testTimeout);
+
+		harness.Tracker.Current.Should().BeNull();
+		var last = harness.Tracker.Last;
+		last.Should().NotBeNull();
+		last!.Result.Should().Be(
+			HotReloadOperationResult.RudeEdit,
+			"the most recently processed batch failed to compile, and that outcome must be visible to status consumers");
+		last.Diagnostics.Should().NotBeNull("the failing pass produced diagnostics that must not be dropped");
+		last.Diagnostics!.Value.Should().Contain(d => d.Id == "ENC0033");
+	}
+
+	[TestMethod]
+	[Description(
+		"Happy path guard: a single batch flows through detector → updater → emitter and " +
+		"completes its operation with Success, shipping the deltas to the handler.")]
+	public async Task When_SingleBatch_Then_OperationCompletesSuccess()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
+				([HotReloadManagerHarness.CreateEmptyUpdate()], [])));
+
+		var batch = ImmutableHashSet.Create("/work/Model.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Current.Should().BeNull();
+		harness.Tracker.Last.Should().NotBeNull();
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Success);
+		harness.Handler.Updates.Should().HaveCount(1);
+	}
+
+	[TestMethod]
+	[Description(
+		"Merge fast-path guard: a batch arriving while the operation exists but has not been " +
+		"processed yet merges into it and is processed as that same single operation.")]
+	public async Task When_BatchMergedIntoPendingOperation_Then_SingleOperationTracksIt()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
+				([HotReloadManagerHarness.CreateEmptyUpdate()], [])));
+
+		// First call creates the operation, then suspends awaiting its (still pending) batch.
+		var pendingBatch = new TaskCompletionSource<ImmutableHashSet<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+		var firstProcess = harness.Manager.ProcessFileChanges(pendingBatch.Task, CancellationToken.None);
+
+		var pendingOperation = harness.Tracker.Current;
+		pendingOperation.Should().NotBeNull("the manager starts/continues an operation before awaiting the batch");
+
+		// Second call merges its files into that pending operation and processes it.
+		var batch = ImmutableHashSet.Create("/work/Page.xaml");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last.Should().BeSameAs(pendingOperation, "an unprocessed pending operation absorbs intersecting batches");
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Success);
+
+		// Unblock the first call so the test ends clean.
+		pendingBatch.SetResult(batch);
+		await firstProcess.WaitAsync(_testTimeout);
+	}
+}

--- a/src/Uno.HotReload.Tests/Given_HotReloadOperation.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadOperation.cs
@@ -1,0 +1,67 @@
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Tests.TestUtils;
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.Tests;
+
+[TestClass]
+public class Given_HotReloadOperation
+{
+	[TestMethod]
+	[Description(
+		"Completing an already-completed operation keeps the first result (immutable outcome) " +
+		"but must report the dropped completion through the reporter instead of returning " +
+		"silently — a swallowed Failed-with-diagnostics is how broken content gets reported " +
+		"as a clean hot-reload.")]
+	public async Task When_CompletingAnAlreadyCompletedOperation_Then_DroppedResultIsReported()
+	{
+		var reporter = new RecordingReporter();
+		var tracker = new HotReloadTracker((_, _) => ValueTask.CompletedTask, reporter: reporter);
+
+		var operation = await tracker.StartHotReload(ImmutableHashSet.Create("/work/Page.xaml"));
+		await operation.Complete(HotReloadOperationResult.Success);
+
+		var diagnostic = Diagnostic.Create(
+			new DiagnosticDescriptor(
+				"ENC0033",
+				"Rude edit",
+				"Deleting a method requires restarting the application",
+				"EditAndContinue",
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			Location.None);
+		await operation.Complete(HotReloadOperationResult.Failed, diagnostics: ImmutableArray.Create(diagnostic));
+
+		// First completion wins — the operation's outcome is immutable.
+		operation.Result.Should().Be(HotReloadOperationResult.Success);
+		operation.Diagnostics.Should().BeNull();
+
+		// But the dropped completion must leave a trace.
+		reporter.Warnings.Should().Contain(
+			w => w.Contains("already completed"),
+			"a late Complete(Failed) carries information that must not vanish silently");
+	}
+
+	[TestMethod]
+	[Description(
+		"Chain-abort completions (a newer operation completing marks its predecessors Aborted) " +
+		"are routine lifecycle management, not lost results — they must not produce warnings.")]
+	public async Task When_PreviousOperationAbortedByNext_Then_NoWarningIsReported()
+	{
+		var reporter = new RecordingReporter();
+		var tracker = new HotReloadTracker((_, _) => ValueTask.CompletedTask, reporter: reporter);
+
+		var first = await tracker.StartHotReload(ImmutableHashSet.Create("/work/A.cs"));
+		var second = await tracker.StartHotReload(ImmutableHashSet.Create("/work/B.cs"));
+
+		// First completes on its own; the newer operation's completion then walks the
+		// chain and re-completes it as Aborted — a routine, ignorable late completion.
+		await first.Complete(HotReloadOperationResult.Success);
+		await second.Complete(HotReloadOperationResult.Success);
+
+		first.Result.Should().Be(HotReloadOperationResult.Success);
+		reporter.Warnings.Should().BeEmpty("chain-aborting an already-completed predecessor is routine, not a dropped result");
+	}
+}

--- a/src/Uno.HotReload.Tests/TestUtils/HotReloadManagerHarness.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/HotReloadManagerHarness.cs
@@ -1,0 +1,121 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Diffing;
+using Uno.HotReload.Microsoft;
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.Tests.TestUtils;
+
+/// <summary>
+/// Minimal harness around <see cref="HotReloadManager"/>: an in-memory
+/// workspace with a single empty C# project, a real <see cref="HotReloadTracker"/>,
+/// and stubbed detector / updater / emitter so tests control exactly what each
+/// hot-reload pass produces.
+/// </summary>
+internal sealed class HotReloadManagerHarness : IDisposable
+{
+	private readonly AdhocWorkspace _workspace;
+	private int _updateCount;
+
+	public HotReloadManagerHarness(Func<int, Task<(ImmutableArray<Update> Updates, ImmutableArray<Diagnostic> Diagnostics)>> onEmit)
+	{
+		_workspace = new AdhocWorkspace();
+		var project = _workspace.AddProject("TestProject", LanguageNames.CSharp);
+
+		Reporter = new RecordingReporter();
+		Tracker = new HotReloadTracker((_, _) => ValueTask.CompletedTask, reporter: Reporter);
+		Handler = new RecordingHandler();
+
+		var projectId = project.Id;
+		var detector = new StubChangesDetector();
+		// Each pass must yield a different solution snapshot, otherwise the
+		// manager short-circuits with NoChanges before reaching the emitter.
+		var updater = new StubSolutionUpdater(solution =>
+			solution.WithProjectAssemblyName(projectId, $"TestProject{Interlocked.Increment(ref _updateCount)}"));
+
+		Manager = new HotReloadManager(
+			_workspace,
+			new StubWatchService(onEmit),
+			Handler,
+			detector,
+			updater,
+			Tracker);
+	}
+
+	public HotReloadManager Manager { get; }
+
+	public HotReloadTracker Tracker { get; }
+
+	public RecordingReporter Reporter { get; }
+
+	public RecordingHandler Handler { get; }
+
+	public static Update CreateEmptyUpdate()
+		=> new(Guid.NewGuid(), [], [], [], []);
+
+	public static Diagnostic CreateRudeEditDiagnostic()
+		=> Diagnostic.Create(
+			new DiagnosticDescriptor(
+				"ENC0033",
+				"Rude edit",
+				"Deleting a method requires restarting the application",
+				"EditAndContinue",
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			Location.None);
+
+	public void Dispose()
+		=> Manager.Dispose();
+
+	internal sealed class RecordingHandler : IHotReloadHandler
+	{
+		private readonly List<HotReloadUpdate> _updates = [];
+		private readonly Lock _gate = new();
+
+		public IReadOnlyList<HotReloadUpdate> Updates
+		{
+			get
+			{
+				lock (_gate)
+				{
+					return [.. _updates];
+				}
+			}
+		}
+
+		public ValueTask SendAsync(HotReloadUpdate update, CancellationToken ct)
+		{
+			lock (_gate)
+			{
+				_updates.Add(update);
+			}
+
+			return ValueTask.CompletedTask;
+		}
+	}
+
+	private sealed class StubWatchService(
+		Func<int, Task<(ImmutableArray<Update> Updates, ImmutableArray<Diagnostic> Diagnostics)>> onEmit) : IWatchHotReloadService
+	{
+		private int _calls;
+
+		public Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken)
+			=> onEmit(Interlocked.Increment(ref _calls));
+
+		public void EndSession()
+		{
+		}
+	}
+
+	private sealed class StubChangesDetector : IChangesDetector
+	{
+		public ValueTask<ChangeSet> DiscoverChangesAsync(Solution solution, ImmutableHashSet<string> files, CancellationToken ct)
+			=> ValueTask.FromResult(ChangeSet.IgnoreAll([]));
+	}
+
+	private sealed class StubSolutionUpdater(Func<Solution, Solution> mutate) : ISolutionUpdater
+	{
+		public ValueTask<SolutionUpdateResult> UpdateAsync(Solution solution, ChangeSet changeSet, CancellationToken ct)
+			=> ValueTask.FromResult(new SolutionUpdateResult(mutate(solution), ChangeSet.IgnoreAll([])));
+	}
+}

--- a/src/Uno.HotReload.Tests/TestUtils/RecordingReporter.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/RecordingReporter.cs
@@ -1,0 +1,70 @@
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.Tests.TestUtils;
+
+/// <summary>
+/// Captures every message routed through the tracker's reporter so tests can
+/// assert on warnings/errors emitted by the hot-reload pipeline.
+/// </summary>
+internal sealed class RecordingReporter : IReporter
+{
+	private readonly List<string> _verbose = [];
+	private readonly List<string> _output = [];
+	private readonly List<string> _warnings = [];
+	private readonly List<string> _errors = [];
+	private readonly Lock _gate = new();
+
+	public IReadOnlyList<string> Warnings
+	{
+		get
+		{
+			lock (_gate)
+			{
+				return [.. _warnings];
+			}
+		}
+	}
+
+	public IReadOnlyList<string> Errors
+	{
+		get
+		{
+			lock (_gate)
+			{
+				return [.. _errors];
+			}
+		}
+	}
+
+	public void Verbose(string message)
+	{
+		lock (_gate)
+		{
+			_verbose.Add(message);
+		}
+	}
+
+	public void Output(string message)
+	{
+		lock (_gate)
+		{
+			_output.Add(message);
+		}
+	}
+
+	public void Warn(string message)
+	{
+		lock (_gate)
+		{
+			_warnings.Add(message);
+		}
+	}
+
+	public void Error(string message)
+	{
+		lock (_gate)
+		{
+			_errors.Add(message);
+		}
+	}
+}

--- a/src/Uno.HotReload.Tests/Uno.HotReload.Tests.csproj
+++ b/src/Uno.HotReload.Tests/Uno.HotReload.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="MSTest.Sdk/4.0.2">
+
+	<PropertyGroup>
+		<TargetFramework>$(NetUnitTests)</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AwesomeAssertions" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.HotReload\Uno.HotReload.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.HotReload/AssemblyInfo.cs
+++ b/src/Uno.HotReload/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Uno.UI.SourceGenerators.Tests")]
+[assembly: InternalsVisibleTo("Uno.HotReload.Tests")]

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -80,15 +80,17 @@ public sealed class HotReloadManager : IDisposable
 
 	private readonly FastAsyncLock _solutionUpdateGate = new();
 	private readonly Workspace _innerWorkspace;
-	private readonly WatchHotReloadService _watchService;
+	private readonly IWatchHotReloadService _watchService;
 	private readonly IHotReloadHandler _handler;
 	private readonly IHotReloadTracker _tracker;
 	private readonly IChangesDetector _changesDetector;
 	private readonly ISolutionUpdater _solutionUpdater;
 
-	private HotReloadManager(
+	// Internal (not private) so unit tests can drive the manager with a stub
+	// IWatchHotReloadService; production code goes through CreateAsync.
+	internal HotReloadManager(
 		Workspace innerWorkspace,
-		WatchHotReloadService watchService,
+		IWatchHotReloadService watchService,
 		IHotReloadHandler handler,
 		IChangesDetector changesDetector,
 		ISolutionUpdater solutionUpdater,

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -113,15 +113,22 @@ public sealed class HotReloadManager : IDisposable
 		// Notify the start of the hot-reload processing as soon as possible, even before the buffering of file change is completed
 		var hotReload = await _tracker.StartOrContinueHotReload().ConfigureAwait(false);
 		var files = await filesAsync.ConfigureAwait(false);
-		if (!hotReload.TryMerge(files))
-		{
-			hotReload = await _tracker.StartHotReload(files).ConfigureAwait(false);
-		}
 
 		// Process the batch of files (sequentially!)
 		try
 		{
 			using var _ = await _solutionUpdateGate.LockAsync(ct).ConfigureAwait(false);
+
+			// The merge decision must be made under the gate: operations are completed by the
+			// pass that processes them, which runs while holding this gate. Deciding earlier
+			// allows a batch to merge into an operation that completes before the batch's own
+			// pass runs — that pass's outcome (e.g. Failed + diagnostics) would then be dropped
+			// by the already-completed operation, reporting broken content as a clean reload.
+			if (!hotReload.TryMerge(files))
+			{
+				hotReload = await _tracker.StartHotReload(files).ConfigureAwait(false);
+			}
+
 			await ProcessSolutionChanged(hotReload, files, ct).ConfigureAwait(false);
 		}
 		catch (Exception e)

--- a/src/Uno.HotReload/Microsoft/IWatchHotReloadService.cs
+++ b/src/Uno.HotReload/Microsoft/IWatchHotReloadService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Uno.HotReload.Microsoft;
+
+/// <summary>
+/// Abstraction over the Roslyn watch hot-reload service consumed by
+/// <see cref="HotReloadManager"/>. Exists so the manager's orchestration
+/// (operation lifecycle, merge/completion ordering) can be unit-tested with a
+/// stub emitter; production code always goes through
+/// <see cref="WatchHotReloadService"/>.
+/// </summary>
+internal interface IWatchHotReloadService
+{
+	/// <summary>
+	/// Compiles <paramref name="solution"/> against the session baseline and
+	/// returns the metadata deltas plus the diagnostics produced by the emit.
+	/// </summary>
+	Task<(ImmutableArray<Update> updates, ImmutableArray<Diagnostic> diagnostics)> EmitSolutionUpdateAsync(Solution solution, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Ends the underlying edit-and-continue session.
+	/// </summary>
+	void EndSession();
+}

--- a/src/Uno.HotReload/Microsoft/WatchHotReloadService.uno.cs
+++ b/src/Uno.HotReload/Microsoft/WatchHotReloadService.uno.cs
@@ -6,7 +6,7 @@ using Uno.HotReload.Microsoft;
 
 namespace Uno.HotReload.Microsoft;
 
-partial class WatchHotReloadService
+partial class WatchHotReloadService : IWatchHotReloadService
 {
 	public static async ValueTask<WatchHotReloadService> CreateAsync(Workspace workspace, string[] metadataUpdateCapabilities, CancellationToken ct)
 	{

--- a/src/Uno.HotReload/Tracking/HotReloadOperation.cs
+++ b/src/Uno.HotReload/Tracking/HotReloadOperation.cs
@@ -246,7 +246,16 @@ public class HotReloadOperation
 		// Check if not already disposed
 		if (Interlocked.CompareExchange(ref _result, (int)result, -1) is not -1)
 		{
-			return; // Already completed
+			// Already completed. Chain-aborts from a newer operation are routine, but any other
+			// late completion carries an outcome (potentially Failed + diagnostics) that is about
+			// to be discarded — leave a trace instead of losing it silently.
+			if (!isFromNext)
+			{
+				_owner.ReportWarn(
+					$"Hot-reload operation {Id} already completed as {Result}; dropping late completion {result} ({diagnostics?.Length ?? 0} diagnostic(s)).");
+			}
+
+			return;
 		}
 
 		try

--- a/src/Uno.HotReload/Tracking/HotReloadTracker.cs
+++ b/src/Uno.HotReload/Tracking/HotReloadTracker.cs
@@ -81,6 +81,8 @@ public sealed class HotReloadTracker(
 
 	internal void ReportError(string message) => _reporter.Error(message);
 
+	internal void ReportWarn(string message) => _reporter.Warn(message);
+
 	public async ValueTask<HotReloadOperation> StartHotReload(ImmutableHashSet<string>? files)
 	{
 		var previous = Current;

--- a/src/Uno.UI-UnitTests-only.slnf
+++ b/src/Uno.UI-UnitTests-only.slnf
@@ -15,6 +15,7 @@
       "Uno.Foundation.Logging\\Uno.Foundation.Logging.csproj",
       "Uno.Foundation\\Uno.Foundation.Skia.csproj",
       "Uno.HotReload\\Uno.HotReload.csproj",
+      "Uno.HotReload.Tests\\Uno.HotReload.Tests.csproj",
       "Uno.UI.Adapter.Microsoft.Extensions.Logging\\Uno.UI.Adapter.Microsoft.Extensions.Logging.csproj",
       "Uno.UI.Composition\\Uno.UI.Composition.Skia.csproj",
       "Uno.UI.Dispatching\\Uno.UI.Dispatching.Skia.csproj",

--- a/src/Uno.UI.slnx
+++ b/src/Uno.UI.slnx
@@ -92,6 +92,9 @@
     <Project Path="Uno.HotReload/Uno.HotReload.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Release" />
     </Project>
+    <Project Path="Uno.HotReload.Tests/Uno.HotReload.Tests.csproj">
+      <BuildType Solution="Release_NoSamples|*" Project="Debug" />
+    </Project>
     <Project Path="Uno.UI.DevServer.Cli.Tests/Uno.UI.DevServer.Cli.Tests.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Debug" />
     </Project>


### PR DESCRIPTION
**GitHub Issue:** closes #

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior.** In `HotReloadManager.ProcessFileChanges`, the `TryMerge`/`StartHotReload` decision is made **before** acquiring `_solutionUpdateGate`, while operations are completed by the pass that processes them — which runs **under** that gate. A file-change batch can therefore merge into an in-flight `HotReloadOperation`, wait on the gate, and have its compile pass run **after** the operation was already completed by an earlier pass. `HotReloadOperation.Complete` silently drops any completion after the first (`// Already completed` early-return), so the late pass's outcome — including `Failed` with error diagnostics — vanishes without a trace.

Observed downstream (agent-driven workspace tooling hosting Roslyn in a WASM worker): a `.xaml` file written twice in quick succession (initial write + automated post-write correction ~0.5 s later) was reported as a clean hot-reload (`Success`, no diagnostics) while the workspace content no longer compiled; a full build minutes later failed on that exact file (`UXAML0001` + `CS1061`).

**This PR (root-cause fix).** The merge decision is moved under `_solutionUpdateGate`. Since passes are serialized by the gate and an operation is completed before its pass releases it, a `TryMerge` evaluated under the gate can no longer be invalidated by a concurrent completion: if the operation completed, `TryMerge` fails and the batch is routed to a fresh tracked operation (N+1) whose result and diagnostics surface normally through the tracker. The early `StartOrContinueHotReload()` call stays where it is, so the immediate `Processing` state notification is unchanged, and `await filesAsync` remains outside the gate so it isn't held during debounce.

**Defensive hardening (labeled as such).** `HotReloadOperation.Complete` now reports dropped late completions through the tracker's reporter (result + diagnostic count) instead of returning silently. Chain-aborts from a newer operation (`isFromNext`) stay silent — they are routine lifecycle management. The residual window (an out-of-band completion such as the 30 s abort timer landing *during* a pass) is thereby observable.

**Testability.** Extracted an internal `IWatchHotReloadService` seam over the existing reflection wrapper so the manager's orchestration can be unit-tested with a stub emitter, and added the `Uno.HotReload.Tests` project (wired into `Uno.UI.slnx` and `Uno.UI-UnitTests-only.slnf`) — the library previously had no test coverage.

**Tests (red → fix → green, committed in that order):**
- `When_BatchMergedIntoCompletedOperation_Then_ItsResultIsTracked` — deterministic repro of the defect (no sleeps: controlled `filesAsync` tasks + gated stub emitter). Failed pre-fix with `Success` instead of `RudeEdit`; green post-fix.
- `When_CompletingAnAlreadyCompletedOperation_Then_DroppedResultIsReported` — failed pre-fix (silent drop); green post-fix.
- Non-regression guards: single-batch happy path, merge into a pending (not-yet-processed) operation, and chain-abort of an already-completed predecessor producing no warning.

Spec with full analysis: `specs/044-hotreload-late-batch-result-loss/spec.md`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — unit tests in the new `Uno.HotReload.Tests` project (5 tests, deterministic)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A (internal hot-reload infrastructure; analysis recorded in `specs/044-hotreload-late-batch-result-loss/spec.md`)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A (no UI change)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
