### PR TITLE
fix(alc): release AlcContentHost projections and resources on teardown

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/App.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/App.xaml
@@ -9,6 +9,25 @@
                 <ResourceDictionary Source="ms-appx:///AlcAppResources.xaml" />
                 <ResourceDictionary Source="ms-appx:///Styles/CustomColors.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.ThemeDictionaries>
+                <!--
+                    Fixture for AlcContentHost teardown: theme dictionaries copied onto the
+                    host control must be removed when the secondary app content is cleared.
+                -->
+                <ResourceDictionary x:Key="Light">
+                    <Color x:Key="AlcAppThemeColor">#FF102030</Color>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="AlcAppThemeColor">#FFE0D0C0</Color>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+            <!--
+                Fixture for AlcContentHost teardown: a resource defined DIRECTLY in
+                Application.Resources (not via a merged dictionary). AlcContentHost copies
+                direct resources onto the host control and must remove them when the
+                secondary app content is cleared.
+            -->
+            <SolidColorBrush x:Key="AlcAppDirectBrush" Color="#FFAA1122" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -214,6 +214,51 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// Restore-on-teardown: a theme dictionary that already existed on the host control before projection
+	/// (e.g. a consumer-defined "Light" dictionary on the AlcContentHost itself) must be RESTORED — not
+	/// dropped — when the projected secondary-app dictionaries are released on unload. Projection
+	/// overwrites the host's same-key dictionary while the secondary app is hosted, so a naive
+	/// "remove every projected key" teardown would silently lose the consumer's own dictionary.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_HostHasPreExistingThemeDictionary_Then_RestoredAfterUnload()
+	{
+		await StartSecondaryAlcAppAsync();
+
+		var secondaryApp = Application.GetForAssemblyLoadContext(_testAlc!);
+		Assert.IsNotNull(secondaryApp, "Secondary ALC app should be registered.");
+		Assert.IsTrue(secondaryApp!.Resources.ThemeDictionaries.ContainsKey("Light"),
+			"Sanity: the secondary app defines a Light theme dictionary to project.");
+
+		// A fresh host carrying its OWN consumer-defined Light theme dictionary.
+		var probe = new AlcContentHost();
+		var hostOwnedLight = new ResourceDictionary();
+		hostOwnedLight["HostOwnedThemeColor"] = Windows.UI.Colors.Red;
+		probe.Resources.ThemeDictionaries["Light"] = hostOwnedLight;
+
+		// Project the secondary app's resources: its Light dictionary overwrites the host's same-key one.
+		probe.SourceApplicationOverride = secondaryApp;
+
+		Assert.IsTrue(
+			probe.Resources.ThemeDictionaries.TryGetValue("Light", out var projectedLight)
+				&& projectedLight is ResourceDictionary projectedResources
+				&& projectedResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
+			"Pre-condition: the secondary app's Light dictionary should overwrite the host's while projected.");
+
+		// Teardown via Unloaded (no re-projection), exercising the restore path on release.
+		TestServices.WindowHelper.WindowContent = probe;
+		await TestServices.WindowHelper.WaitForLoaded(probe);
+		TestServices.WindowHelper.WindowContent = new Border();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(
+			probe.Resources.ThemeDictionaries.TryGetValue("Light", out var restoredLight)
+				&& ReferenceEquals(restoredLight, hostOwnedLight),
+			"After unload the host's own pre-existing Light theme dictionary must be restored, not removed.");
+	}
+
+	/// <summary>
 	/// Validates that ResourceDictionary.Source in App.xaml correctly resolves to the ALC-specific
 	/// dictionary when loaded from a secondary AssemblyLoadContext. This tests the fix for the issue
 	/// where both primary and secondary ALCs with the same resource URI pattern (e.g.,

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -254,8 +254,12 @@ public class Given_AlcContentHost
 			"Pre-condition: the secondary app's Light dictionary should overwrite the host's while projected.");
 
 		// Teardown via Unloaded (no re-projection), exercising the restore path on release.
-		TestServices.WindowHelper.WindowContent = probe;
-		await TestServices.WindowHelper.WaitForLoaded(probe);
+		// The probe renders no content, so on its own it never reaches the non-zero size WaitForLoaded
+		// requires; host it in a sized container and wait on that — the probe loads as its child, and
+		// swapping the window content then unloads it, firing the restore.
+		var container = new Border { Width = 50, Height = 50, Child = probe };
+		TestServices.WindowHelper.WindowContent = container;
+		await TestServices.WindowHelper.WaitForLoaded(container);
 		TestServices.WindowHelper.WindowContent = new Border();
 		await TestServices.WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -176,6 +176,44 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// Teardown hygiene via Unloaded: when the host discards the AlcContentHost (removes it from the
+	/// visual tree, e.g. its reference is set to null) WITHOUT first setting Content to null, the
+	/// resources it projected from the secondary app must still be released. Otherwise the detached
+	/// control keeps referencing the previous app's resource objects (potentially typed in the
+	/// collectible ALC), pinning the ALC after unload.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_ContentHostUnloaded_Then_ProjectedResourcesRemovedFromHost()
+	{
+		var contentHost = await StartSecondaryAlcAppAsync();
+
+		// Pre-conditions: the secondary app's direct resource and theme dictionaries were projected.
+		Assert.IsTrue(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"Pre-condition: AlcAppDirectBrush (direct Application.Resources entry) should be projected while the secondary app is hosted");
+		Assert.IsTrue(
+			contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var lightDictionary)
+				&& lightDictionary is ResourceDictionary lightResources
+				&& lightResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
+			"Pre-condition: the secondary app's Light theme dictionary should be projected while the secondary app is hosted");
+
+		// Teardown trigger: remove the host from the visual tree WITHOUT clearing Content, so only the
+		// Unloaded path runs (Content remains set to the secondary app's content).
+		Assert.IsNotNull(contentHost.Content, "Sanity: content is still set (not cleared) before the host is unloaded");
+		TestServices.WindowHelper.WindowContent = new Border();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"After the host is unloaded, the secondary app's direct resources must be removed from the host control's Resources");
+
+		var staleThemeEntryAfterUnload = contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var themeValueAfterUnload)
+			&& themeValueAfterUnload is ResourceDictionary themeResourcesAfterUnload
+			&& themeResourcesAfterUnload.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false);
+		Assert.IsFalse(staleThemeEntryAfterUnload,
+			"After the host is unloaded, the secondary app's theme dictionaries must be removed from the host control's Resources");
+	}
+
+	/// <summary>
 	/// Validates that ResourceDictionary.Source in App.xaml correctly resolves to the ALC-specific
 	/// dictionary when loaded from a secondary AssemblyLoadContext. This tests the fix for the issue
 	/// where both primary and secondary ALCs with the same resource URI pattern (e.g.,

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -148,9 +148,8 @@ public class Given_AlcContentHost
 	{
 		var contentHost = await StartSecondaryAlcAppAsync();
 
-		// Pre-conditions: the secondary app's DIRECT resource and theme dictionaries
-		// were projected onto the host control (merged dictionaries are covered by
-		// the existing inheritance tests).
+		// Pre-conditions: the secondary app's DIRECT resource, theme dictionaries, and merged
+		// dictionaries were projected onto the host control.
 		Assert.IsTrue(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
 			"Pre-condition: AlcAppDirectBrush (direct Application.Resources entry) should be projected while the secondary app is hosted");
 		Assert.IsTrue(
@@ -158,10 +157,14 @@ public class Given_AlcContentHost
 				&& lightDictionary is ResourceDictionary lightResources
 				&& lightResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
 			"Pre-condition: the secondary app's Light theme dictionary should be projected while the secondary app is hosted");
+		Assert.IsTrue(
+			contentHost.Resources.MergedDictionaries.Any(dict => dict.ContainsKey("TestTextBlockStyle")),
+			"Pre-condition: the secondary app's merged dictionaries should be surfaced while the secondary app is hosted");
 
-		// Teardown trigger: clear the hosted content. UpdateMergedResources re-runs with
-		// the host application as the source and must drop everything previously copied
-		// from the secondary app.
+		// Teardown trigger: clear the hosted content. UpdateMergedResources re-runs and, with no
+		// content (and no source override), must release every projection rather than re-resolve
+		// to a secondary app — otherwise a collectible-ALC-typed key/style/template would stay
+		// pinned on the host control and keep the ALC alive after unload.
 		contentHost.Content = null;
 		await TestServices.WindowHelper.WaitForIdle();
 
@@ -173,6 +176,10 @@ public class Given_AlcContentHost
 			&& themeResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false);
 		Assert.IsFalse(staleThemeEntry,
 			"After content is cleared, the secondary app's theme dictionaries must be removed from the host control's Resources");
+
+		Assert.IsFalse(
+			contentHost.Resources.MergedDictionaries.Any(dict => dict.ContainsKey("TestTextBlockStyle")),
+			"After content is cleared, the secondary app's merged dictionaries (holding ALC-typed styles/templates) must be released from the host control");
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -136,6 +136,46 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// Teardown hygiene: the direct resources and theme dictionaries that AlcContentHost
+	/// copies from the secondary app onto the host control must be removed when the
+	/// secondary app content is cleared. Otherwise the host retains the previous app's
+	/// resource objects (potentially typed in the collectible ALC) after unload, keeping
+	/// them — and through them the ALC — alive across preview reloads.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	public async Task When_SecondaryAppContentCleared_Then_ProjectedResourcesRemovedFromHost()
+	{
+		var contentHost = await StartSecondaryAlcAppAsync();
+
+		// Pre-conditions: the secondary app's DIRECT resource and theme dictionaries
+		// were projected onto the host control (merged dictionaries are covered by
+		// the existing inheritance tests).
+		Assert.IsTrue(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"Pre-condition: AlcAppDirectBrush (direct Application.Resources entry) should be projected while the secondary app is hosted");
+		Assert.IsTrue(
+			contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var lightDictionary)
+				&& lightDictionary is ResourceDictionary lightResources
+				&& lightResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false),
+			"Pre-condition: the secondary app's Light theme dictionary should be projected while the secondary app is hosted");
+
+		// Teardown trigger: clear the hosted content. UpdateMergedResources re-runs with
+		// the host application as the source and must drop everything previously copied
+		// from the secondary app.
+		contentHost.Content = null;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(contentHost.Resources.ContainsKey("AlcAppDirectBrush", shouldCheckSystem: false),
+			"After content is cleared, the secondary app's direct resources must be removed from the host control's Resources");
+
+		var staleThemeEntry = contentHost.Resources.ThemeDictionaries.TryGetValue("Light", out var themeValue)
+			&& themeValue is ResourceDictionary themeResources
+			&& themeResources.ContainsKey("AlcAppThemeColor", shouldCheckSystem: false);
+		Assert.IsFalse(staleThemeEntry,
+			"After content is cleared, the secondary app's theme dictionaries must be removed from the host control's Resources");
+	}
+
+	/// <summary>
 	/// Validates that ResourceDictionary.Source in App.xaml correctly resolves to the ALC-specific
 	/// dictionary when loaded from a secondary AssemblyLoadContext. This tests the fix for the issue
 	/// where both primary and secondary ALCs with the same resource URI pattern (e.g.,

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -17,6 +17,14 @@ public sealed partial class AlcContentHost : ContentControl
 	private Application? _sourceApplicationOverride;
 	private Application? _contentApplication;
 
+	// Keys this control copied into its own Resources / ThemeDictionaries from the source
+	// application. Tracked so the next UpdateMergedResources removes exactly those entries:
+	// when the secondary app's content is cleared (app unloading), the host must not keep
+	// referencing the previous app's resource objects — they may be typed in the secondary
+	// (collectible) AssemblyLoadContext and would otherwise pin it after unload.
+	private readonly List<object> _copiedDirectResourceKeys = new();
+	private readonly List<object> _copiedThemeDictionaryKeys = new();
+
 	public AlcContentHost()
 	{
 		HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -64,6 +72,27 @@ public sealed partial class AlcContentHost : ContentControl
 
 	private void UpdateMergedResources()
 	{
+		// Remove everything previously projected from the (old) source application before
+		// recomputing the source. When the content is cleared on app unload the source falls
+		// back to the host application, and the previous app's resource objects must not be
+		// retained by this control (see the tracking fields for the rationale).
+		foreach (var key in _copiedDirectResourceKeys)
+		{
+			Resources.Remove(key);
+		}
+
+		_copiedDirectResourceKeys.Clear();
+
+		foreach (var key in _copiedThemeDictionaryKeys)
+		{
+			Resources.ThemeDictionaries.Remove(key);
+		}
+
+		_copiedThemeDictionaryKeys.Clear();
+
+		// Clear existing merged dictionaries to avoid duplicates
+		Resources.MergedDictionaries.Clear();
+
 		var sourceApp = _sourceApplicationOverride
 			?? _contentApplication
 			?? Application.GetForInstance(Content)
@@ -73,9 +102,6 @@ public sealed partial class AlcContentHost : ContentControl
 		{
 			return;
 		}
-
-		// Clear existing merged dictionaries to avoid duplicates
-		Resources.MergedDictionaries.Clear();
 
 		// Merge all resource dictionaries from the source application
 		foreach (var resourceDictionary in sourceApp.Resources.MergedDictionaries)
@@ -89,6 +115,7 @@ public sealed partial class AlcContentHost : ContentControl
 			foreach (var themeDictionary in sourceApp.Resources.ThemeDictionaries)
 			{
 				Resources.ThemeDictionaries[themeDictionary.Key] = themeDictionary.Value;
+				_copiedThemeDictionaryKeys.Add(themeDictionary.Key);
 			}
 		}
 
@@ -98,6 +125,7 @@ public sealed partial class AlcContentHost : ContentControl
 		foreach (var key in sourceApp.Resources.Keys.Except(Resources.Keys).ToList())
 		{
 			Resources[key] = sourceApp.Resources[key];
+			_copiedDirectResourceKeys.Add(key);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -33,6 +33,7 @@ public sealed partial class AlcContentHost : ContentControl
 		VerticalContentAlignment = VerticalAlignment.Stretch;
 
 		Loaded += OnLoaded;
+		Unloaded += OnUnloaded;
 	}
 
 	/// <summary>
@@ -70,12 +71,23 @@ public sealed partial class AlcContentHost : ContentControl
 		UpdateMergedResources();
 	}
 
-	private void UpdateMergedResources()
+	private void OnUnloaded(object sender, RoutedEventArgs e)
 	{
-		// Remove everything previously projected from the (old) source application before
-		// recomputing the source. When the content is cleared on app unload the source falls
-		// back to the host application, and the previous app's resource objects must not be
-		// retained by this control (see the tracking fields for the rationale).
+		// When the host discards this control (e.g. the previewed app is torn down and the
+		// host's reference is set to null / it is removed from the tree) without first setting
+		// Content to null, release everything projected from the secondary application so its
+		// resource objects — potentially typed in the collectible ALC — are not retained by this
+		// control after it leaves the tree, which would otherwise pin the ALC after unload.
+		// A subsequent re-Loaded re-projects via UpdateMergedResources.
+		ClearProjectedResources();
+		Resources.MergedDictionaries.Clear();
+	}
+
+	// Removes everything this control projected from the source application (direct resources and
+	// theme-dictionary entries) and clears the tracking lists. Shared by UpdateMergedResources
+	// (before recomputing the source) and OnUnloaded (on teardown).
+	private void ClearProjectedResources()
+	{
 		foreach (var key in _copiedDirectResourceKeys)
 		{
 			Resources.Remove(key);
@@ -89,6 +101,15 @@ public sealed partial class AlcContentHost : ContentControl
 		}
 
 		_copiedThemeDictionaryKeys.Clear();
+	}
+
+	private void UpdateMergedResources()
+	{
+		// Remove everything previously projected from the (old) source application before
+		// recomputing the source. When the content is cleared on app unload the source falls
+		// back to the host application, and the previous app's resource objects must not be
+		// retained by this control (see the tracking fields for the rationale).
+		ClearProjectedResources();
 
 		// Clear existing merged dictionaries to avoid duplicates
 		Resources.MergedDictionaries.Clear();

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -22,8 +22,32 @@ public sealed partial class AlcContentHost : ContentControl
 	// when the secondary app's content is cleared (app unloading), the host must not keep
 	// referencing the previous app's resource objects — they may be typed in the secondary
 	// (collectible) AssemblyLoadContext and would otherwise pin it after unload.
+	//
+	// Direct resources are only ever copied for keys the host does not already have (see the
+	// Except filter in UpdateMergedResources), so releasing them is a plain Remove. Theme
+	// dictionaries, however, OVERWRITE the host's same-key entry, so each projection records
+	// the host's previous value (and whether one existed) to restore it on release rather than
+	// dropping a consumer-defined dictionary the projection had shadowed.
 	private readonly List<object> _copiedDirectResourceKeys = new();
-	private readonly List<object> _copiedThemeDictionaryKeys = new();
+	private readonly List<ProjectedThemeDictionary> _copiedThemeDictionaries = new();
+
+	// A theme-dictionary key this control projected from the source application, paired with the
+	// host's own value for that key before the projection overwrote it.
+	private readonly struct ProjectedThemeDictionary
+	{
+		public ProjectedThemeDictionary(object key, bool hadPreviousValue, object? previousValue)
+		{
+			Key = key;
+			HadPreviousValue = hadPreviousValue;
+			PreviousValue = previousValue;
+		}
+
+		public object Key { get; }
+
+		public bool HadPreviousValue { get; }
+
+		public object? PreviousValue { get; }
+	}
 
 	public AlcContentHost()
 	{
@@ -95,12 +119,21 @@ public sealed partial class AlcContentHost : ContentControl
 
 		_copiedDirectResourceKeys.Clear();
 
-		foreach (var key in _copiedThemeDictionaryKeys)
+		foreach (var projected in _copiedThemeDictionaries)
 		{
-			Resources.ThemeDictionaries.Remove(key);
+			if (projected.HadPreviousValue)
+			{
+				// Restore the host's own dictionary that the projection overwrote, rather than
+				// dropping a consumer-defined entry (e.g. a host "Light" dictionary).
+				Resources.ThemeDictionaries[projected.Key] = projected.PreviousValue!;
+			}
+			else
+			{
+				Resources.ThemeDictionaries.Remove(projected.Key);
+			}
 		}
 
-		_copiedThemeDictionaryKeys.Clear();
+		_copiedThemeDictionaries.Clear();
 	}
 
 	private void UpdateMergedResources()
@@ -135,8 +168,9 @@ public sealed partial class AlcContentHost : ContentControl
 		{
 			foreach (var themeDictionary in sourceApp.Resources.ThemeDictionaries)
 			{
+				var hadPreviousValue = Resources.ThemeDictionaries.TryGetValue(themeDictionary.Key, out var previousValue);
 				Resources.ThemeDictionaries[themeDictionary.Key] = themeDictionary.Value;
-				_copiedThemeDictionaryKeys.Add(themeDictionary.Key);
+				_copiedThemeDictionaries.Add(new ProjectedThemeDictionary(themeDictionary.Key, hadPreviousValue, hadPreviousValue ? previousValue : null));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
+++ b/src/Uno.UI/UI/Xaml/Window/AlcContentHost.cs
@@ -139,13 +139,24 @@ public sealed partial class AlcContentHost : ContentControl
 	private void UpdateMergedResources()
 	{
 		// Remove everything previously projected from the (old) source application before
-		// recomputing the source. When the content is cleared on app unload the source falls
-		// back to the host application, and the previous app's resource objects must not be
-		// retained by this control (see the tracking fields for the rationale).
+		// recomputing the source. When the content is cleared on app unload, the previous app's
+		// resource objects must not be retained by this control (see the tracking fields for the
+		// rationale); the null-Content guard below then keeps those projections released.
 		ClearProjectedResources();
 
 		// Clear existing merged dictionaries to avoid duplicates
 		Resources.MergedDictionaries.Clear();
+
+		// When the host clears Content (the secondary app's teardown path), there is no source
+		// to project from: leave the projections released and return so the host falls back to
+		// its own ambient resources. Re-projecting from Application.Current here would re-copy
+		// the host's own keys needlessly; more importantly, never re-resolving to a secondary
+		// app on a null Content guarantees no collectible-ALC-typed key is re-pinned after the
+		// content is cleared (the projection released above stays released).
+		if (Content is null && _sourceApplicationOverride is null)
+		{
+			return;
+		}
 
 		var sourceApp = _sourceApplicationOverride
 			?? _contentApplication


### PR DESCRIPTION
GitHub Issue (If applicable): closes #23429  ## PR Type  Bugfix  ## What is the current behavior?  `AlcContentHost` keeps a closed secondary app's state reachable from the host: projected resources stay merged into host scope, the projection is not released when the host element unloads, and host theme dictionaries shadowed during projection are not restored. Each of these roots the secondary app's collectible `AssemblyLoadContext` after unload.  ## What is the new behavior?  - Projected secondary-app resources are removed from host scope on teardown. - The projection's RESOURCE state (direct resources and theme-dictionary entries this control copied from the secondary app) is released on `Unloaded`. `Content` ownership intentionally stays with the host - the host assigns it and clears it during teardown - so a transient detach/reattach does not destroy content. - Host theme dictionaries shadowed by the projection are restored when it ends.  Tests: `Given_AlcContentHost` (Uno.UI.RuntimeTests) covers the three behaviors — each test fails against the previous behavior (resources remain merged / projection remains rooted / host theme stays shadowed) and passes with this change. Root chains were confirmed via `gcroot` analysis of full memory dumps of a host that cyclically loads and unloads collectible-ALC apps.  ## PR Checklist  - [x] Tested code with current [supported SDKs](../README.md#supported) - [x] Contains **NO** breaking changes  🤖 Generated with [Claude Code](https://claude.com/claude-code)