### PR TITLE
fix(alc): remove DisplayInformation registration when an ALC window closes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
@@ -1,6 +1,10 @@
 // The per-WindowId DisplayInformation registry (and its CreateForWindowIdForTests seam) is
 // compile-time excluded on Android (#if !ANDROID in DisplayInformation.cs) — Android's
-// DisplayInformation is a process singleton, not per-window — so these tests cannot exist there.
+// DisplayInformation is a process singleton, not per-window — so these tests cannot run there.
+// Two guards are needed: the #if !__ANDROID__ keeps a native-Android compilation clean, while the
+// class-level [PlatformCondition] excludes Skia-on-Android at runtime — that assembly is compiled
+// generically (so __ANDROID__ is not defined) yet loads the Android Uno.UWP, where the seam is
+// absent and the call would otherwise throw MissingMethodException.
 #if HAS_UNO && !__ANDROID__
 #nullable enable
 
@@ -24,6 +28,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Graphics;
 /// </summary>
 [TestClass]
 [RunsOnUIThread]
+[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Android)]
 public class Given_DisplayInformation_WindowIdMap
 {
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
@@ -1,0 +1,77 @@
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI;
+using Windows.Graphics.Display;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Graphics;
+
+/// <summary>
+/// The per-WindowId <see cref="DisplayInformation"/> registry has no removal path: a closed
+/// window's entry retains its native wrapper / window-implementation graph — and every
+/// window-event subscriber reachable from it — for the process lifetime. For a secondary-app
+/// window in a collectible AssemblyLoadContext this pins the whole ALC.
+/// <see cref="DisplayInformation.DestroyForWindowId"/> (called from ALC window close) removes the
+/// entry.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_DisplayInformation_WindowIdMap
+{
+	[TestMethod]
+	public void When_DestroyForWindowId_Then_Entry_Is_Released()
+	{
+		var windowId = new WindowId(0xD15F0); // synthetic id, never used by a real window
+
+		try
+		{
+			var weakInstance = CreateEntryAndDropStrongReference(windowId);
+
+			DisplayInformation.DestroyForWindowId(windowId);
+
+			for (var i = 0; i < 10 && weakInstance.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsFalse(
+				weakInstance.IsAlive,
+				"DestroyForWindowId must remove the static map entry; otherwise the closed window's " +
+				"DisplayInformation (and everything reachable from it) is retained for the process lifetime.");
+		}
+		finally
+		{
+			DisplayInformation.DestroyForWindowId(windowId);
+		}
+	}
+
+	[TestMethod]
+	public void When_DestroyForWindowId_Then_Subsequent_GetOrCreate_Returns_New_Instance()
+	{
+		var windowId = new WindowId(0xD15F1);
+
+		try
+		{
+			var first = DisplayInformation.GetOrCreateForWindowId(windowId);
+			Assert.AreSame(first, DisplayInformation.GetOrCreateForWindowId(windowId), "Pre-condition: the registry caches per WindowId");
+
+			DisplayInformation.DestroyForWindowId(windowId);
+
+			var second = DisplayInformation.GetOrCreateForWindowId(windowId);
+			Assert.AreNotSame(first, second, "After DestroyForWindowId, a fresh instance must be created for the id");
+		}
+		finally
+		{
+			DisplayInformation.DestroyForWindowId(windowId);
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference CreateEntryAndDropStrongReference(WindowId windowId)
+		=> new WeakReference(DisplayInformation.GetOrCreateForWindowId(windowId));
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
@@ -1,4 +1,7 @@
-#if HAS_UNO
+// The per-WindowId DisplayInformation registry (and its CreateForWindowIdForTests seam) is
+// compile-time excluded on Android (#if !ANDROID in DisplayInformation.cs) — Android's
+// DisplayInformation is a process singleton, not per-window — so these tests cannot exist there.
+#if HAS_UNO && !__ANDROID__
 #nullable enable
 
 using System;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
@@ -26,7 +26,11 @@ public class Given_DisplayInformation_WindowIdMap
 	[TestMethod]
 	public async Task When_DestroyForWindowId_Then_Entry_Is_Released()
 	{
-		var windowId = new WindowId(0xD15F0); // synthetic id, never used by a real window
+		// A synthetic id (no live window) is intentional: this exercises the registry lifetime
+		// invariant only. We register via CreateForWindowIdForTests rather than GetOrCreateForWindowId
+		// because the latter runs Initialize(), which on Skia resolves an IDisplayInformationExtension
+		// for a real AppWindow and throws for an id with no window.
+		var windowId = new WindowId(0xD15F0);
 
 		try
 		{
@@ -50,16 +54,18 @@ public class Given_DisplayInformation_WindowIdMap
 	[TestMethod]
 	public void When_DestroyForWindowId_Then_Subsequent_GetOrCreate_Returns_New_Instance()
 	{
+		// Synthetic id with no live window; see When_DestroyForWindowId_Then_Entry_Is_Released for
+		// why CreateForWindowIdForTests is used instead of GetOrCreateForWindowId.
 		var windowId = new WindowId(0xD15F1);
 
 		try
 		{
-			var first = DisplayInformation.GetOrCreateForWindowId(windowId);
-			Assert.AreSame(first, DisplayInformation.GetOrCreateForWindowId(windowId), "Pre-condition: the registry caches per WindowId");
+			var first = DisplayInformation.CreateForWindowIdForTests(windowId);
+			Assert.AreSame(first, DisplayInformation.CreateForWindowIdForTests(windowId), "Pre-condition: the registry caches per WindowId");
 
 			DisplayInformation.DestroyForWindowId(windowId);
 
-			var second = DisplayInformation.GetOrCreateForWindowId(windowId);
+			var second = DisplayInformation.CreateForWindowIdForTests(windowId);
 			Assert.AreNotSame(first, second, "After DestroyForWindowId, a fresh instance must be created for the id");
 		}
 		finally
@@ -70,6 +76,6 @@ public class Given_DisplayInformation_WindowIdMap
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
 	private static WeakReference CreateEntryAndDropStrongReference(WindowId windowId)
-		=> new WeakReference(DisplayInformation.GetOrCreateForWindowId(windowId));
+		=> new WeakReference(DisplayInformation.CreateForWindowIdForTests(windowId));
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Graphics/Given_DisplayInformation_WindowIdMap.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI;
+using Uno.UI.RuntimeTests.Helpers;
 using Windows.Graphics.Display;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_Graphics;
@@ -22,7 +24,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Graphics;
 public class Given_DisplayInformation_WindowIdMap
 {
 	[TestMethod]
-	public void When_DestroyForWindowId_Then_Entry_Is_Released()
+	public async Task When_DestroyForWindowId_Then_Entry_Is_Released()
 	{
 		var windowId = new WindowId(0xD15F0); // synthetic id, never used by a real window
 
@@ -32,14 +34,10 @@ public class Given_DisplayInformation_WindowIdMap
 
 			DisplayInformation.DestroyForWindowId(windowId);
 
-			for (var i = 0; i < 10 && weakInstance.IsAlive; i++)
-			{
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-			}
+			var collected = await TestHelper.TryWaitUntilCollected(weakInstance);
 
-			Assert.IsFalse(
-				weakInstance.IsAlive,
+			Assert.IsTrue(
+				collected,
 				"DestroyForWindowId must remove the static map entry; otherwise the closed window's " +
 				"DisplayInformation (and everything reachable from it) is retained for the process lifetime.");
 		}

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -279,6 +279,23 @@ partial class Window
 		// The native window was already closed during InitializeAlcWindowMode().
 		_appWindowMap.TryRemove(AppWindow, out _);
 
+		// The Window registered a DisplayInformation for its WindowId at construction; that
+		// static map has no other removal path, so it retains the closed window's
+		// implementation graph — including window-event subscribers from the secondary ALC
+		// (e.g. a designer client's Closed handler) — for the process lifetime, pinning
+		// the ALC: DisplayInformation → native wrapper → window implementation → Closed → client.
+		try
+		{
+			global::Windows.Graphics.Display.DisplayInformation.DestroyForWindowId(AppWindow.Id);
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Window).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+			{
+				typeof(Window).Log().Debug($"[ALC-CLEANUP] DisplayInformation.DestroyForWindowId error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
 		// Purge Type-keyed caches (DependencyProperty registry, Style caches, etc.)
 		// that hold references to types from the ALC being torn down. Without this,
 		// these statics prevent the GC from collecting the ALC after Unload().

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
@@ -81,6 +81,20 @@ namespace Windows.Graphics.Display
 			}
 		}
 
+		/// <summary>
+		/// Removes the <see cref="DisplayInformation"/> registered for a window once that window is
+		/// closed. Without this, the static map retains the closed window's native wrapper graph
+		/// (and every event subscriber reachable from it) for the process lifetime — for a
+		/// secondary-app window in a collectible AssemblyLoadContext, that pins the entire ALC.
+		/// </summary>
+		internal static void DestroyForWindowId(WindowId windowId)
+		{
+			lock (_windowIdMapLock)
+			{
+				_windowIdMap.Remove(windowId);
+			}
+		}
+
 		public static DisplayOrientations AutoRotationPreferences
 		{
 			get => _autoRotationPreferences;

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
@@ -44,6 +44,17 @@ namespace Windows.Graphics.Display
 		}
 
 #if !ANDROID
+		private DisplayInformation(WindowId windowId, bool skipExtensionInitialization)
+		{
+			WindowId = windowId;
+			if (!skipExtensionInitialization)
+			{
+				Initialize();
+			}
+		}
+#endif
+
+#if !ANDROID
 		internal WindowId WindowId { get; }
 #endif
 
@@ -80,6 +91,30 @@ namespace Windows.Graphics.Display
 				return displayInformation;
 			}
 		}
+
+#if !ANDROID
+		/// <summary>
+		/// Test-only seam that registers a <see cref="DisplayInformation"/> entry for an arbitrary
+		/// <see cref="WindowId"/> without resolving the platform windowing extension. On Skia the
+		/// regular <see cref="GetOrCreateForWindowId"/> path runs <see cref="Initialize"/>, which
+		/// resolves an <c>IDisplayInformationExtension</c> for a real <c>AppWindow</c> and throws for
+		/// an id with no live window. This lets the registry lifetime invariant (entry added, then
+		/// removed by <see cref="DestroyForWindowId"/> and collectible) be verified without a window.
+		/// </summary>
+		internal static DisplayInformation CreateForWindowIdForTests(WindowId windowId)
+		{
+			lock (_windowIdMapLock)
+			{
+				if (!_windowIdMap.TryGetValue(windowId, out var displayInformation))
+				{
+					displayInformation = new(windowId, skipExtensionInitialization: true);
+					_windowIdMap[windowId] = displayInformation;
+				}
+
+				return displayInformation;
+			}
+		}
+#endif
 
 		/// <summary>
 		/// Removes the <see cref="DisplayInformation"/> registered for a window once that window is


### PR DESCRIPTION
GitHub Issue (If applicable): closes #23433

## PR Type

Bugfix

## What is the current behavior?

The static per-WindowId `DisplayInformation` registry has no removal path. A closed window's entry retains the window's native wrapper and implementation graph — including its `Closed` event subscribers — for the process lifetime. For a secondary-app window in a collectible AssemblyLoadContext, that chain pins the entire ALC after unload (confirmed via `gcroot` on full memory dumps).

## What is the new behavior?

- `DisplayInformation.DestroyForWindowId(WindowId)` (internal) removes the registry entry.
- The ALC window close path (`CloseAlcWindow`) destroys the window's registration.

## Tests

`Given_DisplayInformation_WindowIdMap` (Uno.UI.RuntimeTests):
- `When_DestroyForWindowId_Then_Entry_Is_Released` — the registry entry becomes collectible (WeakReference dies). On master this fails: the entry is retained forever.
- `When_DestroyForWindowId_Then_Subsequent_GetOrCreate_Returns_New_Instance` — the registry recovers with a fresh instance for the same id.

## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)