### PR TITLE
fix(binding): drop cached accessors for collectible DataContext types

### DIFF
--- a/src/Uno.UI.UnitTests/BinderTests/Given_BindingPath_CollectibleDataContext.cs
+++ b/src/Uno.UI.UnitTests/BinderTests/Given_BindingPath_CollectibleDataContext.cs
@@ -1,0 +1,128 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.DataBinding;
+
+namespace Uno.UI.Tests.BinderTests
+{
+	/// <summary>
+	/// A live binding keeps its reflection accessors cached when the DataContext goes null so a
+	/// same-typed rebind is cheap. For a DataContext type from a collectible AssemblyLoadContext
+	/// (an unloaded secondary app), the cached <c>ValueGetterHandler</c> closes over a
+	/// <c>RuntimeMethodInfo</c> of the dead type — pinning the entire ALC for as long as the
+	/// (host-lifetime) binding exists. The accessors must be dropped in that case, while the
+	/// cheap-rebind optimization stays intact for non-collectible types.
+	/// </summary>
+	[TestClass]
+	public partial class Given_BindingPath_CollectibleDataContext
+	{
+		[TestMethod]
+		public void When_DataContext_Of_Collectible_Type_Goes_Null_Then_Accessors_Are_Dropped()
+		{
+			var path = new BindingPath("Value", null);
+			var source = CreateCollectibleSource(out var sourceType);
+
+			path.DataContext = source;
+			Assert.AreEqual("probe", path.Value, "Pre-condition: the binding resolves the emitted property");
+
+			var item = GetSingleBindingItem(path);
+			Assert.IsNotNull(GetItemField(item, "_valueGetter"), "Pre-condition: the value getter is cached while bound");
+			Assert.AreSame(sourceType, GetItemField(item, "_dataContextType"), "Pre-condition: the DataContext type is cached while bound");
+
+			path.DataContext = null;
+
+			Assert.IsNull(
+				GetItemField(item, "_valueGetter"),
+				"The cached getter closes over a RuntimeMethodInfo of the collectible type and pins its ALC — it must be dropped when the DataContext goes null.");
+			Assert.IsNull(GetItemField(item, "_substituteValueGetter"), "The substitute getter must be dropped for a collectible DataContext type.");
+			Assert.IsNull(GetItemField(item, "_valueSetter"), "The setter must be dropped for a collectible DataContext type.");
+			Assert.IsNull(GetItemField(item, "_valueUnsetter"), "The unsetter must be dropped for a collectible DataContext type.");
+			Assert.IsNull(GetItemField(item, "_dataContextType"), "The cached DataContext type itself pins the ALC — it must be dropped.");
+		}
+
+		[TestMethod]
+		public void When_DataContext_Of_NonCollectible_Type_Goes_Null_Then_Accessors_Are_Kept()
+		{
+			var path = new BindingPath("Value", null);
+			var source = new PlainSource();
+
+			path.DataContext = source;
+			Assert.AreEqual("probe", path.Value, "Pre-condition: the binding resolves the property");
+
+			var item = GetSingleBindingItem(path);
+
+			path.DataContext = null;
+
+			Assert.AreSame(
+				typeof(PlainSource),
+				GetItemField(item, "_dataContextType"),
+				"For non-collectible DataContext types the accessors stay cached so a same-typed rebind is cheap.");
+		}
+
+		[TestMethod]
+		public void When_Same_Collectible_Type_Rebinds_Then_Value_Resolves_Again()
+		{
+			var path = new BindingPath("Value", null);
+
+			var source = CreateCollectibleSource(out _);
+			path.DataContext = source;
+			Assert.AreEqual("probe", path.Value, "Pre-condition: the binding resolves the emitted property");
+
+			path.DataContext = null;
+			path.DataContext = source;
+
+			Assert.AreEqual("probe", path.Value, "Rebinding the same collectible-typed source must rebuild the accessors");
+		}
+
+		private static object GetSingleBindingItem(BindingPath path)
+			=> typeof(BindingPath)
+				.GetField("_chain", BindingFlags.NonPublic | BindingFlags.Instance)!
+				.GetValue(path)!;
+
+		private static object? GetItemField(object bindingItem, string fieldName)
+			=> bindingItem.GetType()
+				.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+				.GetValue(bindingItem);
+
+		/// <summary>
+		/// Emits a type with a string property <c>Value</c> (returning "probe") into a
+		/// RunAndCollect (collectible) assembly — the same collectibility shape as a view model
+		/// from an unloaded secondary app.
+		/// </summary>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static object CreateCollectibleSource(out Type sourceType)
+		{
+			var typeBuilder = AssemblyBuilder
+				.DefineDynamicAssembly(new AssemblyName("CollectibleBindingSourceProbe"), AssemblyBuilderAccess.RunAndCollect)
+				.DefineDynamicModule("main")
+				.DefineType("CollectibleSource", TypeAttributes.Public);
+
+			var getter = typeBuilder.DefineMethod(
+				"get_Value",
+				MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+				typeof(string),
+				Type.EmptyTypes);
+			var il = getter.GetILGenerator();
+			il.Emit(OpCodes.Ldstr, "probe");
+			il.Emit(OpCodes.Ret);
+
+			typeBuilder
+				.DefineProperty("Value", PropertyAttributes.None, typeof(string), null)
+				.SetGetMethod(getter);
+
+			sourceType = typeBuilder.CreateType()!;
+			Assert.IsTrue(sourceType.Assembly.IsCollectible, "Pre-condition: the probe source type must be collectible");
+
+			return Activator.CreateInstance(sourceType)!;
+		}
+
+		public sealed class PlainSource
+		{
+			public string Value => "probe";
+		}
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
@@ -172,6 +172,22 @@ namespace Uno.UI.DataBinding
 					RaiseValueChanged(null);
 
 					_propertyChanged.Disposable = null;
+
+					// The cached reflection accessors are normally kept so a same-typed DataContext
+					// can rebind cheaply — but when the previous DataContext type lives in a
+					// collectible AssemblyLoadContext, the cached RuntimeMethodInfo closures would
+					// pin that ALC's LoaderAllocator long after the source is gone (e.g. a designer
+					// binding whose secondary-app source was unloaded). Drop them; a rebind to a
+					// live collectible source simply rebuilds the accessors.
+					if (_dataContextType?.Assembly.IsCollectible == true)
+					{
+						IsDependencyPropertyValueSet = false;
+						_valueGetter = null;
+						_substituteValueGetter = null;
+						_valueSetter = null;
+						_valueUnsetter = null;
+						_dataContextType = null;
+					}
 				}
 			}
 

--- a/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #if !NETFX_CORE
 using System;
@@ -179,7 +179,7 @@ namespace Uno.UI.DataBinding
 					// pin that ALC's LoaderAllocator long after the source is gone (e.g. a designer
 					// binding whose secondary-app source was unloaded). Drop them; a rebind to a
 					// live collectible source simply rebuilds the accessors.
-					if (_dataContextType?.Assembly.IsCollectible == true)
+					if (_dataContextType?.IsCollectible == true)
 					{
 						IsDependencyPropertyValueSet = false;
 						_valueGetter = null;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
@@ -31,6 +31,19 @@ namespace Uno.UI.DataBinding
 
 			internal GetPropertyTypeKey Clone() => new(_type!, _property!, _allowPrivateMembers, _cachedHashcode);
 
+			/// <summary>
+			/// Drops the last-queried key state. The pooled key instance is a static — without
+			/// this, it retains the last looked-up <see cref="Type"/> (potentially from a
+			/// collectible AssemblyLoadContext) past <c>ClearCaches</c>.
+			/// </summary>
+			internal void Reset()
+			{
+				_type = null;
+				_property = null;
+				_allowPrivateMembers = false;
+				_cachedHashcode = 0;
+			}
+
 			internal void Update(Type type, string property, bool allowPrivateMembers)
 			{
 				_type = type;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
@@ -18,6 +18,10 @@ namespace Uno.UI.DataBinding
 
 			internal GetPropertyTypeKey()
 			{
+				// Seed non-null state: Clone() relies on _type/_property being non-null, and the
+				// pooled instance can be swapped (ClearCaches) while a racing GetPropertyType call
+				// is between Update() and Clone().
+				Update(typeof(object), string.Empty, allowPrivateMembers: false);
 			}
 
 			private GetPropertyTypeKey(Type type, string property, bool allowPrivateMembers, int cachedHashcode)
@@ -30,19 +34,6 @@ namespace Uno.UI.DataBinding
 			}
 
 			internal GetPropertyTypeKey Clone() => new(_type!, _property!, _allowPrivateMembers, _cachedHashcode);
-
-			/// <summary>
-			/// Drops the last-queried key state. The pooled key instance is a static — without
-			/// this, it retains the last looked-up <see cref="Type"/> (potentially from a
-			/// collectible AssemblyLoadContext) past <c>ClearCaches</c>.
-			/// </summary>
-			internal void Reset()
-			{
-				_type = null;
-				_property = null;
-				_allowPrivateMembers = false;
-				_cachedHashcode = 0;
-			}
 
 			internal void Update(Type type, string property, bool allowPrivateMembers)
 			{

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #if !NETFX_CORE
 using System;
@@ -77,10 +77,8 @@ namespace Uno.UI.DataBinding
 			_getPropertyType.Clear();
 
 			// The pooled lookup key retains the last-queried Type past the dictionary clears.
-			// Swap rather than mutate: an in-flight GetPropertyType call may be between Update()
-			// and Clone() on the old instance, and Clone() relies on non-null fields — a fresh
-			// instance keeps that invariant (its constructor seeds typeof(object)) while the old
-			// key, and the Type it retained, become unreachable.
+			// Swap rather than mutate: an in-flight GetPropertyType call may hold the old
+			// instance, and Clone() relies on non-null fields.
 			_getPropertyTypeKey = new GetPropertyTypeKey();
 		}
 
@@ -145,13 +143,17 @@ namespace Uno.UI.DataBinding
 
 		public static Type? GetPropertyType(Type type, string property, bool allowPrivateMembers)
 		{
-			_getPropertyTypeKey.Update(type, property, allowPrivateMembers);
+			// Capture the pooled key into a local: ClearCaches() swaps the static field, and a
+			// single lookup must never mix the old and the new instance (Update on one, Clone on
+			// the other would insert a stale or seeded key into the freshly cleared table).
+			var key = _getPropertyTypeKey;
+			key.Update(type, property, allowPrivateMembers);
 
 			object? result;
 
-			if (!_getPropertyType.TryGetValue(_getPropertyTypeKey, out result))
+			if (!_getPropertyType.TryGetValue(key, out result))
 			{
-				_getPropertyType.Add(_getPropertyTypeKey.Clone(), result = InternalGetPropertyType(type, property, allowPrivateMembers));
+				_getPropertyType.Add(key.Clone(), result = InternalGetPropertyType(type, property, allowPrivateMembers));
 			}
 
 			return Unsafe.As<Type>(result);

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -75,6 +75,9 @@ namespace Uno.UI.DataBinding
 			_getSubstituteValueGetter.Clear();
 			_getValueUnsetter.Clear();
 			_getPropertyType.Clear();
+
+			// The pooled lookup key retains the last-queried Type past the dictionary clears.
+			_getPropertyTypeKey.Reset();
 		}
 
 		/// <summary>

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -77,7 +77,11 @@ namespace Uno.UI.DataBinding
 			_getPropertyType.Clear();
 
 			// The pooled lookup key retains the last-queried Type past the dictionary clears.
-			_getPropertyTypeKey.Reset();
+			// Swap rather than mutate: an in-flight GetPropertyType call may be between Update()
+			// and Clone() on the old instance, and Clone() relies on non-null fields — a fresh
+			// instance keeps that invariant (its constructor seeds typeof(object)) while the old
+			// key, and the Type it retained, become unreachable.
+			_getPropertyTypeKey = new GetPropertyTypeKey();
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #23435

## PR Type

Bugfix

## What is the current behavior?

A live binding whose DataContext goes null keeps its cached reflection accessors and DataContext type for cheap same-typed rebinds. For a collectible-AssemblyLoadContext DataContext type (an unloaded secondary app's object), the cached `ValueGetterHandler` closes over a `RuntimeMethodInfo` of the dead type and pins the whole ALC for as long as the host-lifetime binding exists. `BindingPropertyHelper`'s pooled static lookup key also retains the last-queried `Type` past `ClearCaches()`.

## What is the new behavior?

- `BindingItem` drops the cached accessors and `_dataContextType` in the DataContext-null branch when the previous type's assembly is collectible; rebinding rebuilds them. Non-collectible types keep the existing optimization.
- `BindingPropertyHelper.ClearCaches()` also resets the pooled `GetPropertyTypeKey`.

## Tests

`Given_BindingPath_CollectibleDataContext` (Uno.UI.UnitTests), using a property source emitted into a RunAndCollect (collectible) assembly:

- `When_DataContext_Of_Collectible_Type_Goes_Null_Then_Accessors_Are_Dropped` — **fails on master** (accessors and type stay cached), passes with this change.
- `When_DataContext_Of_NonCollectible_Type_Goes_Null_Then_Accessors_Are_Kept` — guards the cheap-rebind optimization.
- `When_Same_Collectible_Type_Rebinds_Then_Value_Resolves_Again` — rebinding rebuilds the accessors.

Red/green verified locally: with the test only (product code at master), the first test fails; with the fix, all three pass.

## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)