### PR TITLE
fix(alc): clear cross-ALC InheritanceContext associations on teardown (1/3)

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
@@ -1,0 +1,153 @@
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
+
+/// <summary>
+/// A shared (host-lifetime) resource consumed by a secondary-ALC element records that element as
+/// its InheritanceContext parent (<c>DependencyObjectStore._associatedParent</c>). Nothing
+/// un-associates it when the element's AssemblyLoadContext unloads, so the host resource pins the
+/// collectible ALC forever. These tests stage that association with an element whose type lives in
+/// a collectible (RunAndCollect) assembly and assert that
+/// <see cref="Application.CleanupNonDefaultAlcCaches"/> releases it.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_CollectibleAlcAssociations
+{
+	private const string ProbeBrushKey = "CollectibleAssociationProbeBrush";
+	private const string ProbeThemeBrushKey = "CollectibleAssociationProbeThemeBrush";
+
+	private ResourceDictionary? _stagedThemedDictionary;
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Application.Current.Resources.Remove(ProbeBrushKey);
+
+		if (_stagedThemedDictionary is not null)
+		{
+			Application.Current.Resources.MergedDictionaries.Remove(_stagedThemedDictionary);
+			_stagedThemedDictionary = null;
+		}
+	}
+
+	[TestMethod]
+	public void When_HostResourceAssociatedToCollectibleElement_Then_CleanupReleasesAssociation()
+	{
+		var weakElement = StageHostResourceAssociation();
+
+		Application.CleanupNonDefaultAlcCaches();
+
+		for (var i = 0; i < 10 && weakElement.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		Assert.IsFalse(
+			weakElement.IsAlive,
+			"The host-lifetime brush's InheritanceContext association must be cleared during ALC " +
+			"teardown cleanup; otherwise the brush pins the collectible element (and its entire " +
+			"AssemblyLoadContext) for the host resource's lifetime.");
+	}
+
+	[TestMethod]
+	public void When_ThemeDictionaryResourceAssociatedToCollectibleElement_Then_CleanupReleasesAssociation()
+	{
+		var weakElement = StageThemeDictionaryAssociation();
+
+		Application.CleanupNonDefaultAlcCaches();
+
+		for (var i = 0; i < 10 && weakElement.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		Assert.IsFalse(
+			weakElement.IsAlive,
+			"Associations recorded on resources inside (active) theme dictionaries must also be " +
+			"cleared during ALC teardown cleanup.");
+	}
+
+	// Staging happens in non-inlined frames so no test-method local keeps the element alive when
+	// the collection assertion runs.
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference StageHostResourceAssociation()
+	{
+		var brush = new SolidColorBrush(Colors.Red);
+		Application.Current.Resources[ProbeBrushKey] = brush;
+
+		var element = CreateCollectibleBorder();
+
+		// First consumption records the element as the brush's InheritanceContext parent.
+		element.Background = brush;
+
+		return new WeakReference(element);
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private WeakReference StageThemeDictionaryAssociation()
+	{
+		var brush = new SolidColorBrush(Colors.Blue);
+
+		// Register the probe under every theme key so resolution succeeds (and materializes the
+		// active-theme path) regardless of the test environment's active theme.
+		var themed = new ResourceDictionary();
+		foreach (var themeKey in new[] { "Light", "Dark", "Default" })
+		{
+			themed.ThemeDictionaries[themeKey] = new ResourceDictionary { [ProbeThemeBrushKey] = brush };
+		}
+
+		Application.Current.Resources.MergedDictionaries.Add(themed);
+		_stagedThemedDictionary = themed;
+
+		// Resolve through the theme set so the active-theme path is materialized.
+		Assert.IsTrue(themed.TryGetValue(ProbeThemeBrushKey, out var resolved), "Pre-condition: the themed brush must resolve");
+		Assert.AreSame(brush, resolved, "Pre-condition: resolution must yield the staged brush");
+
+		var element = CreateCollectibleBorder();
+		element.Background = brush;
+
+		return new WeakReference(element);
+	}
+
+	/// <summary>
+	/// Emits a <see cref="Border"/> subclass into a RunAndCollect (collectible) assembly — the
+	/// same collectibility shape as an element type from an unloaded secondary app, without
+	/// needing to stage a full secondary application.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static Border CreateCollectibleBorder()
+	{
+		if (!RuntimeFeature.IsDynamicCodeSupported)
+		{
+			Assert.Inconclusive("Reflection.Emit (RunAndCollect) is not supported on this target.");
+		}
+
+		var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+			new AssemblyName("CollectibleAssociationProbe"),
+			AssemblyBuilderAccess.RunAndCollect);
+		var typeBuilder = assemblyBuilder
+			.DefineDynamicModule("main")
+			.DefineType("CollectibleBorder", TypeAttributes.Public, typeof(Border));
+
+		var borderType = typeBuilder.CreateType()!;
+		Assert.IsTrue(borderType.Assembly.IsCollectible, "Pre-condition: the probe element type must be collectible");
+
+		return (Border)Activator.CreateInstance(borderType)!;
+	}
+}
+#endif

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AlcStateHelper.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AlcStateHelper.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Xaml.Core;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_AlcStateHelper
+	{
+		[TestMethod]
+		public void When_Alive_Then_Not_UnloadInitiated_And_When_Unloaded_Then_UnloadInitiated()
+		{
+			if (!RuntimeFeature.IsDynamicCodeSupported)
+			{
+				Assert.Inconclusive("Collectible AssemblyLoadContext is not supported on this target.");
+			}
+
+			var alc = new AssemblyLoadContext("AlcStateHelperProbe", isCollectible: true);
+
+			// valueIfUnknown is set to the OPPOSITE of the expected result so a failed read (e.g. the
+			// reflected _state field no longer resolving) would surface as a test failure, not a false pass.
+			Assert.IsFalse(
+				AlcStateHelper.IsUnloadInitiated(alc, valueIfUnknown: true),
+				"A live ALC must report that its unload has not been initiated.");
+
+			alc.Unload();
+
+			Assert.IsTrue(
+				AlcStateHelper.IsUnloadInitiated(alc, valueIfUnknown: false),
+				"An ALC whose Unload() has been called must report that its unload has been initiated.");
+		}
+	}
+}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -17,6 +17,21 @@ namespace Uno.UI
 {
 	public static class FeatureConfiguration
 	{
+		/// <summary>
+		/// Configuration for collectible AssemblyLoadContext (secondary-app) teardown.
+		/// </summary>
+		public static class Alc
+		{
+			/// <summary>
+			/// When true, a failure to read an <see cref="System.Runtime.Loader.AssemblyLoadContext"/>'s
+			/// unload state (e.g. a future runtime renaming the private state field) throws instead of
+			/// silently falling back. The fallback keeps teardown leak-safe, but it would also let a
+			/// broken read silently degrade every ALC cleanup scenario — enable this in tests/CI so such
+			/// a regression fails loudly rather than going unnoticed. Defaults to false.
+			/// </summary>
+			public static bool ThrowOnUnloadStateReadFailure { get; set; }
+		}
+
 		public static class ApiInformation
 		{
 			/// <summary>

--- a/src/Uno.UI/UI/Xaml/AlcStateHelper.cs
+++ b/src/Uno.UI/UI/Xaml/AlcStateHelper.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Uno.UI.Xaml.Core;
+
+/// <summary>
+/// Reads <see cref="AssemblyLoadContext"/> unload state. The runtime exposes no public unload-state
+/// API, so this reads the private <c>_state</c> field. Verified against .NET 9 and .NET 10: the field
+/// exists and <c>0 == Alive</c> (any other value means Unloading/Unloaded). If a future runtime renames
+/// the field this resolves to <c>null</c> and <see cref="IsUnloadInitiated"/> returns the caller-supplied
+/// fallback, so each call site keeps its own leak-safe default.
+/// </summary>
+internal static class AlcStateHelper
+{
+	private static readonly FieldInfo? _alcStateField =
+		typeof(AssemblyLoadContext).GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance);
+
+	/// <summary>
+	/// Whether <paramref name="alc"/>'s unload has been initiated (private state != Alive). Returns
+	/// <paramref name="valueIfUnknown"/> when the state cannot be read (field absent on a future runtime,
+	/// or the read throws).
+	/// </summary>
+	internal static bool IsUnloadInitiated(AssemblyLoadContext alc, bool valueIfUnknown)
+	{
+		if (_alcStateField is null)
+		{
+			if (global::Uno.UI.FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure)
+			{
+				throw new InvalidOperationException(
+					"AssemblyLoadContext unload-state field '_state' was not found; the runtime layout may have changed.");
+			}
+
+			return valueIfUnknown;
+		}
+
+		try
+		{
+			return (int)_alcStateField.GetValue(alc)! != 0;
+		}
+		catch (Exception) when (!global::Uno.UI.FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure)
+		{
+			return valueIfUnknown;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -371,6 +371,12 @@ partial class Application
 		// ResourceResolver — remove Func delegates whose Target is from a non-default ALC
 		ResourceResolver.ClearNonDefaultAlcRegistrations();
 
+		// Shared resources (theme brushes etc.) first consumed by a secondary-ALC element record
+		// it as their InheritanceContext parent (DependencyObjectStore._associatedParent); nothing
+		// clears that association on unload, so host-lifetime resources pin the collectible ALC.
+		// Sweep every dictionary reachable from the host application and the master theme set.
+		RunCleanupStep(nameof(ClearCollectibleResourceAssociations), ClearCollectibleResourceAssociations);
+
 		// ResourceDictionary — invalidate _keyNotFoundCache on the host Application.
 		// The cache accumulates ResourceKey entries with TypeKey referencing ALC types.
 		// These entries pin RuntimeType → LoaderAllocator → ALC.
@@ -395,6 +401,32 @@ partial class Application
 				typeof(Application).Log().Trace($"[ALC-SCAN] Error during deep scan: {ex.GetType().Name}: {ex.Message}");
 			}
 		}
+	}
+
+	// Runs a teardown cleanup step in isolation: teardown is best-effort, so a failing step must not
+	// abort the rest. A failure may indicate a real defect, so it is logged as a warning with the
+	// full exception.
+	private static void RunCleanupStep(string name, Action step)
+	{
+		try
+		{
+			step();
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Application).Log().IsEnabled(LogLevel.Warning))
+			{
+				typeof(Application).Log().Warn($"[ALC-CLEANUP] {name} failed", ex);
+			}
+		}
+	}
+
+	private static void ClearCollectibleResourceAssociations()
+	{
+#if !__NETSTD_REFERENCE__
+		Uno.UI.GlobalStaticResources.MasterDictionary.ClearCollectibleAssociatedParents();
+#endif
+		_current?.Resources?.ClearCollectibleAssociatedParents();
 	}
 
 	private static void ClearNonDefaultAlcApplications()

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 // fallback option for legacy DepObj from external library generated before templated-parent rework.
@@ -711,6 +711,7 @@ namespace Microsoft.UI.Xaml
 			if (_associatedParent == null)
 			{
 				_associatedParent = parent;
+				RegisterCollectibleParentAssociation(parent);
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
@@ -1,0 +1,174 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.UI.Xaml
+{
+	public partial class DependencyObjectStore
+	{
+		/// <summary>
+		/// Drops <see cref="_associatedParent"/> — and any DataContext it propagated into this store —
+		/// when the parent is owned by an unloading collectible ALC, is an unloaded
+		/// <see cref="FrameworkElement"/>, or is orphaned from the content-root coordinator, so a
+		/// host-lifetime resource cannot pin a secondary app's ALC. A live host element re-associates
+		/// on its next value assignment.
+		/// </summary>
+		internal void ClearCollectibleAssociatedParent()
+		{
+			var associationCleared = false;
+
+			// Two flavors of secondary-app parents: objects whose TYPE lives in the collectible
+			// ALC, and instances of SHARED types (Grid, Border, …) owned by the unloaded app —
+			// the latter are indistinguishable by type, but after unload they are detached
+			// (unloaded, parentless), so a detached-element association is also dropped. A live
+			// host element re-associates naturally on its next value assignment.
+			// IsLoaded == false also matches host elements that are merely unloaded at sweep time
+			// (e.g. a collapsed pane); clearing their association only resets InheritanceContext
+			// DataContext propagation for the shared resource, which re-establishes on the next
+			// value assignment — an acceptable cost for guaranteeing the unloaded app's detached
+			// elements (shared types, indistinguishable by ALC) release their hold. An element
+			// whose ContentRoot has been unregistered from the coordinator (a closed secondary
+			// app's tree — popups included, which keep IsLoaded) is orphaned and also released.
+			// The collectible branch is gated on the parent's ALC unload having actually been
+			// initiated: a still-live session-lifetime add-in ALC (e.g. a designer host) is also
+			// collectible, but its associations must be preserved until it really unloads.
+			var collectibleAndUnloading = false;
+			if (_associatedParent is { } collectibleCandidate && collectibleCandidate.GetType().IsCollectible)
+			{
+				var parentAlc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(collectibleCandidate.GetType().Assembly);
+				// Conservative when the unload state can't be read: do NOT clear, so a still-live add-in
+				// ALC's associations (and inherited DataContext) are never dropped on an unreadable state.
+				// FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure surfaces such a runtime change in dev.
+				collectibleAndUnloading = parentAlc is not null
+					&& global::Uno.UI.Xaml.Core.AlcStateHelper.IsUnloadInitiated(parentAlc, valueIfUnknown: false);
+			}
+
+			if (_associatedParent is { } parent
+				&& (collectibleAndUnloading
+					|| parent is FrameworkElement { IsLoaded: false }
+					|| (parent is FrameworkElement orphanCandidate && IsOrphanedFromContentRoots(orphanCandidate))))
+			{
+				_associatedParent = null;
+				associationCleared = true;
+			}
+
+			// The association may already have propagated the parent's DataContext into this
+			// store at Inheritance precedence; that propagated value (e.g. the secondary app's
+			// view model) survives the parent's removal and pins the value's ALC on its own.
+			if (associationCleared
+				|| GetValue(_dataContextProperty)?.GetType().IsCollectible == true)
+			{
+				ClearInheritedDataContext();
+			}
+		}
+
+		/// <summary>
+		/// Returns whether the element's visual tree no longer has a registered ContentRoot —
+		/// i.e. it belonged to a closed (secondary-app) tree whose root was unregistered from
+		/// the <see cref="Uno.UI.Xaml.Core.ContentRootCoordinator"/> on Window close.
+		/// </summary>
+		private static bool IsOrphanedFromContentRoots(FrameworkElement element)
+		{
+			try
+			{
+				var contentRoot = element.XamlRoot?.VisualTree?.ContentRoot;
+				if (contentRoot is null)
+				{
+					return true;
+				}
+
+				return !Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.ContentRoots.Contains(contentRoot);
+			}
+			catch (Exception)
+			{
+				// Fail leak-safe: if orphan state can't be determined, treat the element as orphaned
+				// so its association is cleared rather than left to pin a potentially-unloaded ALC.
+				return true;
+			}
+		}
+
+		// Stores that recorded a collectible-ALC object as their associated parent, grouped by
+		// that parent's ALC. Entries are swept (associated parent cleared) when the ALC unloads,
+		// so a host-lifetime shared resource can never outlive-pin a secondary app's ALC.
+		// CWT-keyed by the ALC so the registry itself never extends the ALC's lifetime.
+		private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<global::System.Runtime.Loader.AssemblyLoadContext, List<WeakReference<DependencyObjectStore>>> _collectibleParentAssociations = new();
+
+		private void RegisterCollectibleParentAssociation(object parent)
+		{
+			// Collectible-ALC association tracking is only meaningful when secondary ALCs exist.
+			// Gate on the substitutable Application.HasSecondaryApps so that, for the overwhelmingly
+			// common single-ALC app, this whole path stays off and is linkable away.
+			if (!Application.HasSecondaryApps)
+			{
+				return;
+			}
+
+			// Fast path: Type.IsCollectible is a cached runtime flag; non-collectible parents
+			// (the overwhelmingly common case) exit here without touching the registry.
+			if (!parent.GetType().IsCollectible)
+			{
+				return;
+			}
+
+			var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(parent.GetType().Assembly);
+			if (alc is null || !alc.IsCollectible)
+			{
+				return;
+			}
+
+			var list = _collectibleParentAssociations.GetValue(alc, static a =>
+			{
+				a.Unloading += static unloading =>
+				{
+					// ClearCollectibleAssociatedParent reads/writes DependencyProperty values, which is
+					// only valid on the UI thread. Unloading fires on whichever thread called
+					// AssemblyLoadContext.Unload(); marshal to the UI thread so the clear actually runs
+					// instead of being swallowed as an off-thread DP-access failure.
+					static void Sweep(global::System.Runtime.Loader.AssemblyLoadContext unloading)
+					{
+						if (_collectibleParentAssociations.TryGetValue(unloading, out var stores))
+						{
+							lock (stores)
+							{
+								foreach (var weakStore in stores)
+								{
+									if (weakStore.TryGetTarget(out var store))
+									{
+										try
+										{
+											store.ClearCollectibleAssociatedParent();
+										}
+										catch (global::System.Exception)
+										{
+											// Defensive: one store throwing must not abort the sweep for the rest.
+										}
+									}
+								}
+
+								stores.Clear();
+							}
+
+							_collectibleParentAssociations.Remove(unloading);
+						}
+					}
+
+					if (global::Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess)
+					{
+						Sweep(unloading);
+					}
+					else
+					{
+						global::Uno.UI.Dispatching.NativeDispatcher.Main.Enqueue(() => Sweep(unloading));
+					}
+				};
+				return new List<WeakReference<DependencyObjectStore>>();
+			});
+
+			lock (list)
+			{
+				list.Add(new WeakReference<DependencyObjectStore>(this));
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.alc.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.alc.cs
@@ -1,0 +1,49 @@
+using Uno.UI.DataBinding;
+
+namespace Microsoft.UI.Xaml
+{
+	public partial class ResourceDictionary
+	{
+		/// <summary>
+		/// Clears <c>DependencyObjectStore._associatedParent</c> references into collectible
+		/// AssemblyLoadContexts on every materialized value of this dictionary (recursing into
+		/// nested, merged and theme dictionaries). A shared resource (e.g. a theme brush) first
+		/// consumed by a secondary-ALC element records that element as its InheritanceContext
+		/// parent; nothing unassociates it when the element's ALC unloads, so the host-lifetime
+		/// resource pins the collectible ALC. Called during ALC teardown from
+		/// <see cref="Application.CleanupNonDefaultAlcCaches"/>. Lazy (unmaterialized) entries
+		/// have no store and are skipped without being materialized.
+		/// </summary>
+		internal void ClearCollectibleAssociatedParents()
+		{
+			foreach (var value in _values.Values)
+			{
+				// A nested ResourceDictionary is itself an IDependencyObjectStoreProvider, so it must be
+				// matched FIRST and recursed into — otherwise it falls into the provider branch below and
+				// the associations held by its own values are never swept.
+				if (value is ResourceDictionary nested)
+				{
+					nested.ClearCollectibleAssociatedParents();
+				}
+				else if (value is IDependencyObjectStoreProvider { Store: { } store })
+				{
+					store.ClearCollectibleAssociatedParent();
+				}
+			}
+
+			var mergedCount = _mergedDictionaries.Count;
+			for (var i = 0; i < mergedCount; i++)
+			{
+				_mergedDictionaries[i].ClearCollectibleAssociatedParents();
+			}
+
+			_themeDictionaries?.ClearCollectibleAssociatedParents();
+
+			// The MATERIALIZED active theme dictionary may be reachable only through this cache:
+			// when the theme entry in _themeDictionaries is still a lazy stub, the stub is skipped
+			// above and the materialized dictionary it produced — holding the live brushes whose
+			// stores record cross-ALC associations — would never be visited.
+			_activeThemeDictionary?.ClearCollectibleAssociatedParents();
+		}
+	}
+}


### PR DESCRIPTION
**GitHub Issue (If applicable):** closes #23437

> **Part 1 of 3** of the ALC window-teardown work, now split into a reviewable stack for easier review and future regression isolation:
> - **Part 1 (this PR)** — foundation + cross-ALC InheritanceContext associations
> - **Part 2 — #23495** — window events / orphaned composition targets (stacks on this)
> - **Part 3 — #23496** — Type-keyed cache pruning (stacks on Part 2)

## PR Type
🐞 Bugfix

## What changed? 🚀
A shared (host-lifetime) resource first consumed by a secondary-ALC element records that element as its InheritanceContext parent (`DependencyObjectStore._associatedParent`); nothing un-associates it when the element's ALC unloads, so the host resource pins the collectible ALC. `CleanupNonDefaultAlcCaches` now sweeps every dictionary reachable from the host application and the master theme set, clearing those associations.

Also adds the shared foundation used by Parts 2–3: `AlcStateHelper` (reads ALC unload state), `FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure`, and the `RunCleanupStep` best-effort step helper.

## PR Checklist ✅
- [x] 🧪 Runtime test added (`Given_CollectibleAlcAssociations`)
- [x] ❗ Contains **NO** breaking changes
