### PR TITLE
fix(wasm): skip a11y focus sync for elements without a semantic peer

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Accessibility/WebAssemblyAccessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Accessibility/WebAssemblyAccessibility.cs
@@ -1744,11 +1744,6 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 						this.Log().Trace($"[A11y] AUTOMATION EVENT: AutomationFocusChanged handle={focusElement.Visual.Handle} element={focusElement.GetType().Name}");
 					}
 
-					// Only sync focus to the browser DOM when the element actually has a
-					// semantic peer. The peer may have been pruned (non-semantic element) or
-					// removed while a virtualized item was recycled; focusing a handle that is
-					// not in the semantic DOM is a no-op the JS layer can only resolve by
-					// retrying once and then warning that the element was not found.
 					if (HasSemanticElement(focusElement.Visual.Handle))
 					{
 						NativeMethods.FocusSemanticElement(focusElement.Visual.Handle);
@@ -1848,9 +1843,6 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 	}
 	protected override void SetNativeFocus(nint handle)
 	{
-		// Skip handles with no semantic DOM peer (pruned/removed elements) — focusing
-		// them is a no-op that the JS layer resolves by warning after a failed retry.
-		// See the AutomationFocusChanged case in OnAutomationEvent.
 		if (HasSemanticElement(handle))
 		{
 			NativeMethods.FocusSemanticElement(handle);

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Accessibility/WebAssemblyAccessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Accessibility/WebAssemblyAccessibility.cs
@@ -1743,7 +1743,16 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 					{
 						this.Log().Trace($"[A11y] AUTOMATION EVENT: AutomationFocusChanged handle={focusElement.Visual.Handle} element={focusElement.GetType().Name}");
 					}
-					NativeMethods.FocusSemanticElement(focusElement.Visual.Handle);
+
+					// Only sync focus to the browser DOM when the element actually has a
+					// semantic peer. The peer may have been pruned (non-semantic element) or
+					// removed while a virtualized item was recycled; focusing a handle that is
+					// not in the semantic DOM is a no-op the JS layer can only resolve by
+					// retrying once and then warning that the element was not found.
+					if (HasSemanticElement(focusElement.Visual.Handle))
+					{
+						NativeMethods.FocusSemanticElement(focusElement.Visual.Handle);
+					}
 				}
 				break;
 
@@ -1838,7 +1847,15 @@ internal partial class WebAssemblyAccessibility : SkiaAccessibilityBase
 		}
 	}
 	protected override void SetNativeFocus(nint handle)
-		=> NativeMethods.FocusSemanticElement(handle);
+	{
+		// Skip handles with no semantic DOM peer (pruned/removed elements) — focusing
+		// them is a no-op that the JS layer resolves by warning after a failed retry.
+		// See the AutomationFocusChanged case in OnAutomationEvent.
+		if (HasSemanticElement(handle))
+		{
+			NativeMethods.FocusSemanticElement(handle);
+		}
+	}
 	protected override void OnNativeStructureChanged() { }
 
 	internal void SyncTextBoxValueAndSelection(TextBox textBox)


### PR DESCRIPTION
**GitHub Issue:** related https://github.com/unoplatform/studio.live/issues/2620

## PR Type

Bug fix.

## What is the current behavior?

On the Skia WebAssembly browser target, the accessibility bridge floods the browser console with:

```
[A11y] focusSemanticElement: element NOT FOUND handle=NNNN (after retry)
```

`WebAssemblyAccessibility.OnAutomationEvent` (the `AutomationFocusChanged` case) and `SetNativeFocus` call `NativeMethods.FocusSemanticElement(handle)` for handles whose semantic DOM peer was **pruned** (a non-semantic element) or **removed while a virtualized item was recycled**. The JS layer retries once after a `requestAnimationFrame` and, finding nothing, warns. `FocusSynchronizer.OnXamlGotFocus` already guards this path (resolves to a semantic handle first and skips when there is none); these two call sites did not.

## What is the new behavior?

Guard both call sites with the existing `HasSemanticElement(handle)` check — the same pattern already used by `SyncTextBoxValueAndSelection`. Focusing a handle absent from the semantic DOM is a no-op, so skipping it changes no observable behavior; it only removes the futile call and its retry/warning. Elements that have a semantic peer (including the semantics root) are unaffected.

The JS-side `debugWarn` gating that already merged silences the *log*; this addresses the *cause* so the futile focus call is not issued in the first place.

## PR Checklist

- [x] Existing behavior preserved for elements with a semantic peer.
- [ ] CI build/tests (local full build is blocked by an unrelated pre-existing source-generator issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)