### PR TITLE
feat: Add host window-size override to AdaptiveTrigger

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml/AdaptiveTriggerTests/AdaptiveTrigger_WindowSizeOverride.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml/AdaptiveTriggerTests/AdaptiveTrigger_WindowSizeOverride.xaml
@@ -1,0 +1,94 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml.AdaptiveTriggerTests.AdaptiveTrigger_WindowSizeOverride"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid Padding="16" RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Style="{ThemeResource BodyTextBlockStyle}"
+            Text="This page hosts an AdaptiveTrigger (MinWindowWidth=720). With the override off, the trigger follows the window size — resize the window to flip it. Turn the override on to make every AdaptiveTrigger evaluate against the resizable item's size instead: use the slider to resize the item across the 720px breakpoint without touching the window. The override is global, so while it is on it also affects AdaptiveTriggers elsewhere in the app (e.g. the samples browser layout); it is cleared automatically when leaving this sample."
+            TextWrapping="Wrap" />
+
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="24">
+            <ToggleSwitch
+                x:Name="OverrideToggle"
+                Header="Use item size as window-size override"
+                Toggled="OnOverrideToggled" />
+            <Slider
+                x:Name="ItemWidthSlider"
+                Width="280"
+                Header="Item width"
+                Maximum="1000"
+                Minimum="300"
+                StepFrequency="10"
+                Value="500" />
+        </StackPanel>
+
+        <TextBlock
+            x:Name="StatusText"
+            Grid.Row="2"
+            Style="{ThemeResource BodyTextBlockStyle}" />
+
+        <Border
+            x:Name="ResizableItem"
+            Grid.Row="3"
+            Width="{Binding Value, ElementName=ItemWidthSlider}"
+            MinHeight="160"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Top"
+            BorderBrush="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+            BorderThickness="1"
+            SizeChanged="OnResizableItemSizeChanged">
+            <StackPanel
+                x:Name="ItemPanel"
+                Padding="12"
+                Orientation="Vertical"
+                Spacing="8">
+                <TextBlock
+                    x:Name="TriggerStateText"
+                    Style="{ThemeResource SubtitleTextBlockStyle}"
+                    Text="(no adaptive state active)" />
+                <TextBlock Style="{ThemeResource BodyTextBlockStyle}" Text="Text block 1 — stacks vertically when narrow." />
+                <TextBlock Style="{ThemeResource BodyTextBlockStyle}" Text="Text block 2 — flows horizontally when wide." />
+            </StackPanel>
+        </Border>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="AdaptiveStates">
+                <VisualState x:Name="NarrowState">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="TriggerStateText.Text" Value="Narrow (width &lt; 720)" />
+                        <Setter Target="ItemPanel.Orientation" Value="Vertical" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="WideState">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="720" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="TriggerStateText.Text" Value="Wide (width &gt;= 720)" />
+                        <Setter Target="ItemPanel.Orientation" Value="Horizontal" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml/AdaptiveTriggerTests/AdaptiveTrigger_WindowSizeOverride.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml/AdaptiveTriggerTests/AdaptiveTrigger_WindowSizeOverride.xaml.cs
@@ -1,0 +1,56 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+
+namespace UITests.Windows_UI_Xaml.AdaptiveTriggerTests;
+
+[Sample("Visual states", Description = "Demonstrates the Uno Platform-specific AdaptiveTrigger.SetWindowSizeOverride host hook: toggle the override and resize the item across the 720px breakpoint to flip the trigger without resizing the window.", IsManualTest = true, IgnoreInSnapshotTests = true)]
+public sealed partial class AdaptiveTrigger_WindowSizeOverride : Page
+{
+	public AdaptiveTrigger_WindowSizeOverride()
+	{
+		this.InitializeComponent();
+
+		Unloaded += OnUnloaded;
+		UpdateStatus();
+	}
+
+	private void OnUnloaded(object sender, RoutedEventArgs e)
+	{
+#if HAS_UNO
+		// The override is process-global — clear it so the rest of the app reverts to window bounds.
+		AdaptiveTrigger.SetWindowSizeOverride(null);
+#endif
+	}
+
+	private void OnOverrideToggled(object sender, RoutedEventArgs e) => ApplyOverride();
+
+	private void OnResizableItemSizeChanged(object sender, SizeChangedEventArgs e) => ApplyOverride();
+
+	private void ApplyOverride()
+	{
+#if HAS_UNO
+		if (OverrideToggle.IsOn)
+		{
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(ResizableItem.ActualWidth, ResizableItem.ActualHeight));
+		}
+		else
+		{
+			AdaptiveTrigger.SetWindowSizeOverride(null);
+		}
+#endif
+		UpdateStatus();
+	}
+
+	private void UpdateStatus()
+	{
+#if HAS_UNO
+		StatusText.Text = OverrideToggle.IsOn
+			? $"Override active: {ResizableItem.ActualWidth:F0} × {ResizableItem.ActualHeight:F0} — AdaptiveTriggers evaluate against the item size."
+			: "Override off — AdaptiveTriggers evaluate against the window bounds.";
+#else
+		StatusText.Text = "AdaptiveTrigger.SetWindowSizeOverride is Uno Platform-specific and is not available on Windows (WinUI).";
+#endif
+	}
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
@@ -17,6 +17,10 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			UnitTestsApp.App.EnsureApplication();
 		}
 
+		[TestCleanup]
+		public void Cleanup()
+			=> AdaptiveTrigger.SetWindowSizeOverride(null);
+
 		[TestMethod]
 		public void When_SingleActiveState()
 		{
@@ -211,6 +215,139 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 
 				return result;
 			}
+		}
+
+		[TestMethod]
+		public void When_SizeOverride_WinsOverWindow()
+		{
+			// Real window is large enough to satisfy the trigger.
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var border = new Border();
+			border.ForceLoaded();
+
+			var sut = new AdaptiveTrigger { MinWindowHeight = 100, MinWindowWidth = 100 };
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			VisualStateManager.SetVisualStateGroups(border, new List<VisualStateGroup>() { group });
+
+			group.CurrentState.Should().Be(state);
+
+			// A simulated (smaller) size overrides the real window, so the trigger goes inactive even
+			// though the window itself never changed — the "host resizes the content" scenario.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50));
+			group.CurrentState.Should().Be(null);
+		}
+
+		[TestMethod]
+		public void When_SizeOverride_ReevaluatesOnChange()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var border = new Border();
+			border.ForceLoaded();
+
+			var sut = new AdaptiveTrigger { MinWindowHeight = 100, MinWindowWidth = 100 };
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			VisualStateManager.SetVisualStateGroups(border, new List<VisualStateGroup>() { group });
+
+			// Start below the threshold via the override -> inactive.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50));
+			group.CurrentState.Should().Be(null);
+
+			// Growing the override above the threshold re-evaluates without any window/XamlRoot change.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200));
+			group.CurrentState.Should().Be(state);
+		}
+
+		[TestMethod]
+		public void When_SizeOverride_SetBeforeAttach_AppliesOnAttach()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			// The override is set before the trigger ever attaches — the primary host scenario where a
+			// simulated form factor is active while new pages load.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50));
+
+			var border = new Border();
+			border.ForceLoaded();
+
+			var sut = new AdaptiveTrigger { MinWindowHeight = 100, MinWindowWidth = 100 };
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			VisualStateManager.SetVisualStateGroups(border, new List<VisualStateGroup>() { group });
+
+			// The freshly attached trigger must evaluate against the pre-existing override, not the window.
+			group.CurrentState.Should().Be(null);
+
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200));
+			group.CurrentState.Should().Be(state);
+		}
+
+		[TestMethod]
+		public void When_SizeOverride_FailsMinWindowHeightOnly()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var border = new Border();
+			border.ForceLoaded();
+
+			var sut = new AdaptiveTrigger { MinWindowHeight = 100, MinWindowWidth = 100 };
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			VisualStateManager.SetVisualStateGroups(border, new List<VisualStateGroup>() { group });
+
+			// The override width satisfies the trigger but its height does not — both constraints must be
+			// evaluated against the override, not just the width.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 50));
+			group.CurrentState.Should().Be(null);
+		}
+
+		[TestMethod]
+		public void When_SizeOverride_Cleared_RevertsToWindow()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var border = new Border();
+			border.ForceLoaded();
+
+			var sut = new AdaptiveTrigger { MinWindowHeight = 100, MinWindowWidth = 100 };
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			VisualStateManager.SetVisualStateGroups(border, new List<VisualStateGroup>() { group });
+
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50));
+			group.CurrentState.Should().Be(null);
+
+			// Clearing the override reverts evaluation to the real window size (1000x1000) -> active.
+			AdaptiveTrigger.SetWindowSizeOverride(null);
+			group.CurrentState.Should().Be(state);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -1,4 +1,8 @@
+using System;
+using System.ComponentModel;
 using Uno.Disposables;
+using Uno.Foundation.Logging;
+using Windows.Foundation;
 
 using WindowSizeChangedEventArgs = Microsoft.UI.Xaml.WindowSizeChangedEventArgs;
 
@@ -8,25 +12,72 @@ namespace Microsoft.UI.Xaml
 	{
 		private readonly SerialDisposable _sizeChangedSubscription = new SerialDisposable();
 
+		private static Size? _windowSizeOverride;
+
+		// Raised when the global window-size override set through SetWindowSizeOverride changes, so that
+		// every live AdaptiveTrigger re-evaluates its active state (the same role XamlRoot.Changed plays).
+		private static event EventHandler WindowSizeOverrideChanged;
+
 		public AdaptiveTrigger()
 		{
 		}
 
 		public XamlRoot XamlRoot => XamlRoot.GetForElement(this);
 
-		private void OnXamlRootChanged(object sender, XamlRootChangedEventArgs e) => UpdateState();
-
-		private void UpdateState()
+		/// <summary>
+		/// Overrides the size that every <see cref="AdaptiveTrigger"/> uses to evaluate its active state,
+		/// instead of the hosting window's <see cref="Microsoft.UI.Xaml.XamlRoot"/> bounds. Passing
+		/// <c>null</c> reverts to the default behavior (the window bounds).
+		/// </summary>
+		/// <remarks>
+		/// This is an Uno-specific host-extensibility hook with no WinUI equivalent. It mirrors the Uno
+		/// Toolkit's <c>ResponsiveHelper.SetOverrideSizeProvider</c>, so a host that simulates a form factor
+		/// by resizing the previewed content — rather than the window — can make platform adaptive triggers
+		/// re-evaluate against that simulated size. The override is global, matching the Toolkit's own
+		/// global responsive size source. Call it on the UI thread: it synchronously re-evaluates every
+		/// live trigger, driving visual-state changes on their owner elements.
+		/// </remarks>
+		/// <param name="size">The simulated window size, or <c>null</c> to clear the override.</param>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetWindowSizeOverride(Size? size)
 		{
-			if (XamlRoot is not { } xamlRoot)
+			if (_windowSizeOverride == size)
 			{
 				return;
 			}
 
-			var size = xamlRoot.Bounds;
+			if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(AdaptiveTrigger).Log().Debug($"Window-size override {(size is { } s ? $"set to {s}" : "cleared")}");
+			}
 
-			var w = size.Width;
-			var h = size.Height;
+			_windowSizeOverride = size;
+			WindowSizeOverrideChanged?.Invoke(null, EventArgs.Empty);
+		}
+
+		private void OnXamlRootChanged(object sender, XamlRootChangedEventArgs e) => UpdateState();
+
+		private void OnWindowSizeOverrideChanged(object sender, EventArgs e) => UpdateState();
+
+		private void UpdateState()
+		{
+			double w, h;
+			if (_windowSizeOverride is { } overrideSize)
+			{
+				w = overrideSize.Width;
+				h = overrideSize.Height;
+			}
+			else if (XamlRoot is { } xamlRoot)
+			{
+				var bounds = xamlRoot.Bounds;
+				w = bounds.Width;
+				h = bounds.Height;
+			}
+			else
+			{
+				return;
+			}
+
 			var mw = MinWindowWidth;
 			var mh = MinWindowHeight;
 
@@ -106,12 +157,20 @@ namespace Microsoft.UI.Xaml
 
 		private void AttachSizeChanged()
 		{
+			// Only subscribe while a XamlRoot exists (the trigger is in a live tree): subscribing the static
+			// override event any earlier would root never-loaded triggers for the process lifetime.
 			if (XamlRoot is { } xamlRoot)
 			{
 				xamlRoot.Changed += OnXamlRootChanged;
+				WindowSizeOverrideChanged += OnWindowSizeOverrideChanged;
+
 				UpdateState();
 
-				_sizeChangedSubscription.Disposable = Disposable.Create(() => xamlRoot.Changed -= OnXamlRootChanged);
+				_sizeChangedSubscription.Disposable = Disposable.Create(() =>
+				{
+					xamlRoot.Changed -= OnXamlRootChanged;
+					WindowSizeOverrideChanged -= OnWindowSizeOverrideChanged;
+				});
 			}
 		}
 


### PR DESCRIPTION
**GitHub Issue:** closes #23444

## PR Type:

✨ Feature

## What changed? 🚀

`AdaptiveTrigger` evaluated its active state only against the hosting window's `XamlRoot.Bounds` and re-evaluated only on `XamlRoot.Changed`. A host that simulates a form factor by resizing the *previewed content* rather than the window could not make platform adaptive breakpoints re-evaluate — they kept reporting the real window size, so `<AdaptiveTrigger MinWindowWidth="…">` layouts looked different when previewed than when run standalone.

This adds an opt-in, global size override on `AdaptiveTrigger`, analogous to the Uno Toolkit `ResponsiveHelper.SetOverrideSizeProvider` seam:

```csharp
AdaptiveTrigger.SetWindowSizeOverride(new Size(width, height)); // evaluate against a simulated size
AdaptiveTrigger.SetWindowSizeOverride(null);                    // revert to XamlRoot.Bounds
```

- When set, `UpdateState()` evaluates against the override instead of `XamlRoot.Bounds`, and **every live `AdaptiveTrigger` re-evaluates** when the override changes (wired through the same subscription lifecycle as `XamlRoot.Changed` — the static event is only subscribed while the trigger has a `XamlRoot`, so never-loaded triggers are not rooted by it).
- Setting the same value again is a no-op (no app-wide re-evaluation storm); passing `null` reverts to the default window-bounds behavior.
- A guarded Debug log traces override set/clear for diagnosability; the XML remarks document the UI-thread requirement.
- The hook is `[EditorBrowsable(EditorBrowsableState.Never)]` (host-extensibility, no WinUI equivalent) and the change is purely additive — no behavior change unless a host opts in.

Added unit tests in `Given_AdaptiveTrigger` (19 total pass locally):
- `When_SizeOverride_WinsOverWindow` — a smaller override deactivates the trigger even though the window is large.
- `When_SizeOverride_ReevaluatesOnChange` — growing the override above the threshold re-activates without any window/`XamlRoot` change.
- `When_SizeOverride_SetBeforeAttach_AppliesOnAttach` — a trigger loaded while an override is already active evaluates against it immediately (the primary host scenario).
- `When_SizeOverride_FailsMinWindowHeightOnly` — both constraints are checked against the override, not just the width.
- `When_SizeOverride_Cleared_RevertsToWindow` — clearing reverts to the real window size.

Added a manual SamplesApp sample (`AdaptiveTrigger_WindowSizeOverride`, category *Visual states*): a `ToggleSwitch` applies a slider-resizable item's size as the override, so the page's `AdaptiveTrigger (MinWindowWidth=720)` flips by resizing the item across the breakpoint without resizing the window; the override is cleared on toggle-off and when leaving the sample.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (unit tests — all 19 in `Given_AdaptiveTrigger` pass locally — plus the `AdaptiveTrigger_WindowSizeOverride` manual sample)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (host-extensibility hook marked `EditorBrowsable(Never)`; not part of the public IntelliSense surface)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
