### PR TITLE
fix(skia): suspend recycle-pooled element visuals

### DIFF
--- a/doc/articles/Uno-UI-Performance.md
+++ b/doc/articles/Uno-UI-Performance.md
@@ -164,6 +164,7 @@ You'll find below other known memory leak patterns on iOS Native:
   - It's possible to set `DebugSettings.EnableFrameRateCounter` in `App.OnLaunched` in order to view a top-left indicator. It indicates the current frames per second, as well as the time spent rendering a composition frame, in milliseconds.
   - If the indicator does not change, this means that the UI is not refreshing.
   - If it is, but nothing is changing visually, it could be that a XAML or Composition animation is still running, see the `ProgressRing` section in this document.
+- Elements recycled by an `ItemsRepeater` (or any `RecyclePool` consumer) stay parented in the visual tree until they are reused. Their visuals are automatically excluded from composition while pooled, so continuously-animating content they host (e.g. an indeterminate `ProgressRing`) cannot keep the render loop awake once its item is removed. When targeting Uno Platform versions without this behavior, stop animations in `ItemsRepeater.ElementClearing` and restore them on `ElementPrepared` — and note that re-activating cannot be left to bindings alone, as a reused element whose new item produces the same values does not re-fire them.
 - Avoid the use of SkiaSharp's `SKXamlCanvas`, instead use [`SKCanvasElement`](xref:Uno.Controls.SKCanvasElement) which is hardware accelerated.
 
 ## Advanced performance Tracing

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
@@ -1,0 +1,103 @@
+<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.Repeater.ItemsRepeater_RecycledSpinner"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Repeater"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <!--  Template 1: row hosting an active indeterminate ProgressRing (Lottie/AnimatedVisualPlayer on Skia)  -->
+        <DataTemplate x:Key="SpinnerRowTemplate" x:DataType="local:RecycledSpinnerItem">
+            <StackPanel
+                Height="40"
+                Padding="16,0"
+                Orientation="Horizontal"
+                Spacing="8">
+                <mux:ProgressRing
+                    Width="24"
+                    Height="24"
+                    VerticalAlignment="Center"
+                    IsActive="{Binding IsSpinning}" />
+                <TextBlock VerticalAlignment="Center" Text="{Binding Title}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <!--  Template 2: plain text row. Removing the spinner item leaves only rows of THIS template,
+              so the recycled spinner element is never reused (different template = different pool key).  -->
+        <DataTemplate x:Key="TextRowTemplate" x:DataType="local:RecycledSpinnerItem">
+            <TextBlock
+                Height="32"
+                Padding="16,0"
+                VerticalAlignment="Center"
+                Text="{Binding Title}" />
+        </DataTemplate>
+
+        <local:RecycledSpinnerTemplateSelector
+            x:Key="ItemTemplateSelector"
+            SpinnerTemplate="{StaticResource SpinnerRowTemplate}"
+            TextTemplate="{StaticResource TextRowTemplate}" />
+    </Page.Resources>
+
+    <Grid Padding="12" RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            MaxWidth="680"
+            HorizontalAlignment="Left"
+            Style="{ThemeResource BodyTextBlockStyle}"
+            TextWrapping="Wrap">
+            Repro: an active ProgressRing inside an ItemsRepeater item keeps the Skia render loop pinned after its item is removed.
+            Steps: (1) press "Measure CPU (2 s)" for a baseline while the spinner is visible (expected: high — the spinner is animating);
+            (2) press "Remove spinner item" — the spinner disappears, its element is recycled but never reused (remaining rows use a different template);
+            (3) press "Measure CPU (2 s)" again. Expected: near-idle. Actual: still ~100% of one core, indefinitely, with nothing animating on screen.
+            The mechanism line shows the recycled element is still parented, with its stale DataContext and an active ring.
+        </TextBlock>
+
+        <StackPanel
+            Grid.Row="1"
+            Orientation="Horizontal"
+            Spacing="6">
+            <Button
+                x:Name="RemoveSpinnerButton"
+                Click="OnRemoveSpinnerClick"
+                Content="Remove spinner item" />
+            <Button Click="OnResetClick" Content="Reset" />
+            <Button Click="OnMeasureCpuClick" Content="Measure CPU (2 s)" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2">
+            <TextBlock
+                x:Name="MechanismText"
+                FontSize="12"
+                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+            <TextBlock
+                x:Name="CpuText"
+                FontSize="12"
+                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+        </StackPanel>
+
+        <Border
+            Grid.Row="3"
+            VerticalAlignment="Stretch"
+            BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1">
+            <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                <mux:ItemsRepeater x:Name="Repeater" ItemTemplate="{StaticResource ItemTemplateSelector}">
+                    <mux:ItemsRepeater.Layout>
+                        <mux:StackLayout Orientation="Vertical" />
+                    </mux:ItemsRepeater.Layout>
+                </mux:ItemsRepeater>
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
@@ -63,7 +63,7 @@
             (2) press "Remove spinner item" — the spinner disappears, its element is recycled but never reused (remaining rows use a different template);
             (3) watch the frame probe. With the fix (pooled element visuals suspended): ~1–2 frames/s within ~1 s. On builds without the fix: still full frame rate, indefinitely, with nothing animating on screen.
             "Measure CPU (2 s)" is a secondary signal: it shows the same contrast only on software-rasterized targets (e.g. X11 without a GPU); GPU-accelerated desktops read near-idle CPU even while the render loop is pinned.
-            The mechanism line shows the recycled element is still parented, with its stale DataContext and an active ring.
+            The mechanism line shows the recycled element is still parented with an active ring — and, on Uno Platform, its stale DataContext (WinUI clears the DataContext on recycle).
         </TextBlock>
 
         <StackPanel

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
@@ -59,9 +59,10 @@
             Style="{ThemeResource BodyTextBlockStyle}"
             TextWrapping="Wrap">
             Repro for issue #23446: an active ProgressRing inside an ItemsRepeater item used to keep the Skia render loop pinned after its item was removed.
-            Steps: (1) press "Measure CPU (2 s)" for a baseline while the spinner is visible (expected: high — the spinner is animating);
+            Steps: (1) note the frame probe while the spinner is visible (expected: full frame rate — the spinner is animating);
             (2) press "Remove spinner item" — the spinner disappears, its element is recycled but never reused (remaining rows use a different template);
-            (3) press "Measure CPU (2 s)" again. With the fix (pooled element visuals suspended): near-idle within ~1 s. On builds without the fix: still ~100% of one core, indefinitely, with nothing animating on screen.
+            (3) watch the frame probe. With the fix (pooled element visuals suspended): ~1–2 frames/s within ~1 s. On builds without the fix: still full frame rate, indefinitely, with nothing animating on screen.
+            "Measure CPU (2 s)" is a secondary signal: it shows the same contrast only on software-rasterized targets (e.g. X11 without a GPU); GPU-accelerated desktops read near-idle CPU even while the render loop is pinned.
             The mechanism line shows the recycled element is still parented, with its stale DataContext and an active ring.
         </TextBlock>
 
@@ -77,7 +78,11 @@
             <Button Click="OnMeasureCpuClick" Content="Measure CPU (2 s)" />
         </StackPanel>
 
-        <StackPanel Grid.Row="2">
+        <StackPanel x:Name="DiagnosticsPanel" Grid.Row="2">
+            <TextBlock
+                x:Name="FramesText"
+                FontSize="12"
+                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
             <TextBlock
                 x:Name="MechanismText"
                 FontSize="12"

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
@@ -1,4 +1,4 @@
-<Page
+﻿<Page
     x:Class="UITests.Windows_UI_Xaml_Controls.Repeater.ItemsRepeater_RecycledSpinner"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -26,8 +26,10 @@
             </StackPanel>
         </DataTemplate>
 
-        <!--  Template 2: plain text row. Removing the spinner item leaves only rows of THIS template,
-              so the recycled spinner element is never reused (different template = different pool key).  -->
+        <!--
+            Template 2: plain text row. Removing the spinner item leaves only rows of THIS template,
+            so the recycled spinner element is never reused (different template = different pool key).
+        -->
         <DataTemplate x:Key="TextRowTemplate" x:DataType="local:RecycledSpinnerItem">
             <TextBlock
                 Height="32"

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
@@ -78,7 +78,7 @@
             <Button Click="OnMeasureCpuClick" Content="Measure CPU (2 s)" />
         </StackPanel>
 
-        <StackPanel x:Name="DiagnosticsPanel" Grid.Row="2">
+        <StackPanel Grid.Row="2">
             <TextBlock
                 x:Name="FramesText"
                 FontSize="12"

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml
@@ -58,10 +58,10 @@
             HorizontalAlignment="Left"
             Style="{ThemeResource BodyTextBlockStyle}"
             TextWrapping="Wrap">
-            Repro: an active ProgressRing inside an ItemsRepeater item keeps the Skia render loop pinned after its item is removed.
+            Repro for issue #23446: an active ProgressRing inside an ItemsRepeater item used to keep the Skia render loop pinned after its item was removed.
             Steps: (1) press "Measure CPU (2 s)" for a baseline while the spinner is visible (expected: high — the spinner is animating);
             (2) press "Remove spinner item" — the spinner disappears, its element is recycled but never reused (remaining rows use a different template);
-            (3) press "Measure CPU (2 s)" again. Expected: near-idle. Actual: still ~100% of one core, indefinitely, with nothing animating on screen.
+            (3) press "Measure CPU (2 s)" again. With the fix (pooled element visuals suspended): near-idle within ~1 s. On builds without the fix: still ~100% of one core, indefinitely, with nothing animating on screen.
             The mechanism line shows the recycled element is still parented, with its stale DataContext and an active ring.
         </TextBlock>
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -1,0 +1,177 @@
+#nullable enable
+
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+using MuxProgressRing = Microsoft.UI.Xaml.Controls.ProgressRing;
+
+namespace UITests.Windows_UI_Xaml_Controls.Repeater;
+
+[Sample(
+	"ItemsRepeater",
+	IsManualTest = true,
+	Description =
+		"Repro for the recycled-spinner render-loop leak on Skia: an active ProgressRing inside an " +
+		"ItemsRepeater item keeps invalidating the canvas after its item is removed, because the recycled " +
+		"element stays parented with its stale DataContext and is never reused (the remaining items use a " +
+		"different template). Measure CPU before/after removal; after removal it should be near-idle but " +
+		"stays at ~100% of one core.")]
+public sealed partial class ItemsRepeater_RecycledSpinner : Page
+{
+	private readonly ObservableCollection<RecycledSpinnerItem> _items = new();
+
+	private UIElement? _recycledSpinnerElement;
+	private object? _spinnerDataContextAtRemoval;
+
+	public ItemsRepeater_RecycledSpinner()
+	{
+		InitializeComponent();
+		Repeater.ItemsSource = _items;
+		ResetItems();
+	}
+
+	private void ResetItems()
+	{
+		_items.Clear();
+		_items.Add(new RecycledSpinnerItem("A plain text row", IsSpinning: false));
+		_items.Add(new RecycledSpinnerItem("Working… (active spinner row)", IsSpinning: true));
+		_items.Add(new RecycledSpinnerItem("Another plain text row", IsSpinning: false));
+
+		_recycledSpinnerElement = null;
+		_spinnerDataContextAtRemoval = null;
+		MechanismText.Text = "Spinner row present and animating.";
+		CpuText.Text = string.Empty;
+		RemoveSpinnerButton.IsEnabled = true;
+	}
+
+	private void OnResetClick(object sender, RoutedEventArgs e) => ResetItems();
+
+	private async void OnRemoveSpinnerClick(object sender, RoutedEventArgs e)
+	{
+		try
+		{
+			var spinnerIndex = -1;
+			for (var i = 0; i < _items.Count; i++)
+			{
+				if (_items[i].IsSpinning)
+				{
+					spinnerIndex = i;
+					break;
+				}
+			}
+
+			if (spinnerIndex < 0)
+			{
+				MechanismText.Text = "No spinner item to remove — press Reset first.";
+				return;
+			}
+
+			// Capture the realized element before removal so the recycled element can be inspected after.
+			_recycledSpinnerElement = Repeater.TryGetElement(spinnerIndex);
+			_spinnerDataContextAtRemoval = (_recycledSpinnerElement as FrameworkElement)?.DataContext;
+
+			_items.RemoveAt(spinnerIndex);
+			RemoveSpinnerButton.IsEnabled = false;
+
+			// Let the repeater process the collection change and recycle the element.
+			await Task.Delay(500);
+
+			UpdateMechanismText();
+		}
+		catch (Exception ex)
+		{
+			MechanismText.Text = $"Removal failed: {ex.Message}";
+		}
+	}
+
+	private void UpdateMechanismText()
+	{
+		if (_recycledSpinnerElement is not { } element)
+		{
+			MechanismText.Text = "Spinner element was not realized before removal.";
+			return;
+		}
+
+		var isParented = VisualTreeHelper.GetParent(element) is not null;
+		var dataContextUnchanged = ReferenceEquals(
+			(element as FrameworkElement)?.DataContext,
+			_spinnerDataContextAtRemoval);
+		var ring = FindDescendant<MuxProgressRing>(element);
+
+		MechanismText.Text =
+			$"Recycled element after removal: stillParented={isParented}, " +
+			$"dataContextUnchanged={dataContextUnchanged}, " +
+			$"ringIsActive={(ring is null ? "ring not found" : ring.IsActive.ToString())} " +
+			"(expected by this bug: True / True / True — nothing visible, yet the ring keeps invalidating the canvas).";
+	}
+
+	private async void OnMeasureCpuClick(object sender, RoutedEventArgs e)
+	{
+		try
+		{
+			CpuText.Text = "Measuring CPU for 2 s…";
+
+			using var process = Process.GetCurrentProcess();
+			var cpuBefore = process.TotalProcessorTime;
+			var stopwatch = Stopwatch.StartNew();
+
+			await Task.Delay(2000);
+
+			process.Refresh();
+			stopwatch.Stop();
+			var coresUsed = (process.TotalProcessorTime - cpuBefore).TotalMilliseconds / stopwatch.Elapsed.TotalMilliseconds;
+
+			CpuText.Text =
+				$"Process CPU over {stopwatch.Elapsed.TotalMilliseconds:F0} ms: {coresUsed:P0} of one core " +
+				(coresUsed > 0.5 ? "— render loop is busy/pinned." : "— near idle.");
+		}
+		catch (Exception ex)
+		{
+			// Process CPU accounting is unavailable on some targets (e.g. WebAssembly);
+			// use the browser's performance tools / paint flashing there instead.
+			CpuText.Text = $"CPU measurement unavailable on this target ({ex.GetType().Name}). " +
+				"On WebAssembly use DevTools → Rendering → Paint flashing.";
+		}
+	}
+
+	private static T? FindDescendant<T>(DependencyObject root) where T : class, DependencyObject
+	{
+		var count = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < count; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is T typed)
+			{
+				return typed;
+			}
+
+			if (FindDescendant<T>(child) is { } nested)
+			{
+				return nested;
+			}
+		}
+
+		return null;
+	}
+}
+
+public sealed record RecycledSpinnerItem(string Title, bool IsSpinning);
+
+public sealed partial class RecycledSpinnerTemplateSelector : DataTemplateSelector
+{
+	public DataTemplate? SpinnerTemplate { get; set; }
+
+	public DataTemplate? TextTemplate { get; set; }
+
+	protected override DataTemplate SelectTemplateCore(object item)
+		=> (item is RecycledSpinnerItem { IsSpinning: true } ? SpinnerTemplate : TextTemplate)!;
+
+	protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+		=> SelectTemplateCore(item);
+}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -108,7 +108,8 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 			$"Recycled element after removal: stillParented={isParented}, " +
 			$"dataContextUnchanged={dataContextUnchanged}, " +
 			$"ringIsActive={(ring is null ? "ring not found" : ring.IsActive.ToString())} " +
-			"(expected by this bug: True / True / True — nothing visible, yet the ring keeps invalidating the canvas).";
+			"(expected on Uno Platform/Skia: True / True / True — nothing visible, yet the ring keeps invalidating the canvas; " +
+			"on WinUI: True / False / True — WinUI clears the DataContext on recycle, yet the ring stays active there too, at no render cost).";
 	}
 
 	private async void OnMeasureCpuClick(object sender, RoutedEventArgs e)

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -140,7 +140,7 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 		}
 	}
 
-	private static T? FindDescendant<T>(DependencyObject root) where T : class, DependencyObject
+	private static T? FindDescendant<T>(DependencyObject root) where T : class
 	{
 		var count = VisualTreeHelper.GetChildrenCount(root);
 		for (var i = 0; i < count; i++)

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -10,11 +10,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.Samples.Controls;
 using MuxProgressRing = Microsoft.UI.Xaml.Controls.ProgressRing;
-#if __SKIA__
-using Windows.Foundation;
-using SkiaSharp;
-using Uno.WinUI.Graphics2DSK;
-#endif
 
 namespace UITests.Windows_UI_Xaml_Controls.Repeater;
 
@@ -32,15 +27,13 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 {
 	private readonly ObservableCollection<RecycledSpinnerItem> _items = new();
 
-	private const string FrameProbeUnavailableText =
-		"Frame probe not available on this target — observe frame production externally (e.g. PresentMon).";
-
 	private UIElement? _recycledSpinnerElement;
 	private object? _spinnerDataContextAtRemoval;
 
 #if __SKIA__
-	private FrameProbe? _frameProbe;
-	private long _lastFramesPainted;
+	private CompositionTarget? _frameSource;
+	private long _framesRendered;
+	private long _lastFramesRendered;
 #endif
 
 	public ItemsRepeater_RecycledSpinner()
@@ -54,45 +47,48 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 	private void InitializeFrameProbe()
 	{
 #if __SKIA__
-		if (SKCanvasElement.IsSupportedOnCurrentPlatform())
+		// Counts composed frames passively via the Uno-internal CompositionTarget.FrameRendered,
+		// raised at the end of every frame render. Element-level paints can't be used as the
+		// signal (per-visual picture caching replays unchanged visuals without repainting them),
+		// and the public CompositionTarget.Rendering forces the render loop to keep producing
+		// frames while subscribed.
+		Loaded += (_, _) =>
 		{
-			// A passive probe: its RenderOverride runs once per composed frame, so sampling the
-			// counter at 1 Hz reads ~1-2 frames/s when the render loop idles (the once-a-second
-			// text update itself causes a frame) vs the full frame rate while the loop is awake.
-			_frameProbe = new FrameProbe { Width = 8, Height = 8 };
-			DiagnosticsPanel.Children.Insert(0, _frameProbe);
+			if (_frameSource is null && XamlRoot?.VisualTree.ContentRoot.CompositionTarget is { } target)
+			{
+				_frameSource = target;
+				target.FrameRendered += OnFrameRendered;
+			}
+		};
+		Unloaded += (_, _) =>
+		{
+			if (_frameSource is { } target)
+			{
+				_frameSource = null;
+				target.FrameRendered -= OnFrameRendered;
+			}
+		};
 
-			var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-			timer.Tick += OnFrameTimerTick;
-			timer.Start();
-			Unloaded += (_, _) => timer.Stop();
-			return;
-		}
+		var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+		timer.Tick += OnFrameTimerTick;
+		timer.Start();
+		Unloaded += (_, _) => timer.Stop();
+#else
+		FramesText.Text = "Frame probe not available on this target — observe frame production externally (e.g. PresentMon).";
 #endif
-		FramesText.Text = FrameProbeUnavailableText;
 	}
 
 #if __SKIA__
+	private void OnFrameRendered() => _framesRendered++;
+
 	private void OnFrameTimerTick(object? sender, object e)
 	{
-		if (_frameProbe is not { } probe)
-		{
-			return;
-		}
+		var rendered = _framesRendered;
+		var delta = rendered - _lastFramesRendered;
+		_lastFramesRendered = rendered;
 
-		var painted = probe.FramesPainted;
-		var delta = painted - _lastFramesPainted;
-		_lastFramesPainted = painted;
-
-		FramesText.Text = $"Frames painted in the last second: {delta} " +
+		FramesText.Text = $"Frames rendered in the last second: {delta} " +
 			(delta > 10 ? "— render loop is awake." : "— render loop is idle.");
-	}
-
-	private sealed partial class FrameProbe : SKCanvasElement
-	{
-		public long FramesPainted { get; private set; }
-
-		protected override void RenderOverride(SKCanvas canvas, Size area) => FramesPainted++;
 	}
 #endif
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -188,7 +188,7 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 			CpuText.Text =
 				$"Process CPU over {stopwatch.Elapsed.TotalMilliseconds:F0} ms: {coresUsed:P0} of one core " +
 				(coresUsed > 0.5 ? "— render loop is busy/pinned." : "— near idle.") +
-				" CPU only tracks the render loop on software-rasterized targets; on GPU-accelerated desktops rely on the frame probe.";
+				" CPU only tracks the render loop on software-rasterized targets; on GPU-accelerated desktops use the frame readout above instead.";
 		}
 		catch (Exception ex)
 		{

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -17,11 +17,11 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater;
 	"ItemsRepeater",
 	IsManualTest = true,
 	Description =
-		"Repro for the recycled-spinner render-loop leak on Skia: an active ProgressRing inside an " +
-		"ItemsRepeater item keeps invalidating the canvas after its item is removed, because the recycled " +
+		"Repro for the recycled-spinner render-loop leak on Skia (#23446): an active ProgressRing inside an " +
+		"ItemsRepeater item kept invalidating the canvas after its item was removed, because the recycled " +
 		"element stays parented with its stale DataContext and is never reused (the remaining items use a " +
-		"different template). Measure CPU before/after removal; after removal it should be near-idle but " +
-		"stays at ~100% of one core.")]
+		"different template). Measure CPU before/after removal: with the pooled-visual suspension fix it " +
+		"drops to near-idle within ~1 s; on builds without the fix it stays at ~100% of one core.")]
 public sealed partial class ItemsRepeater_RecycledSpinner : Page
 {
 	private readonly ObservableCollection<RecycledSpinnerItem> _items = new();
@@ -108,7 +108,8 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 			$"Recycled element after removal: stillParented={isParented}, " +
 			$"dataContextUnchanged={dataContextUnchanged}, " +
 			$"ringIsActive={(ring is null ? "ring not found" : ring.IsActive.ToString())} " +
-			"(expected on Uno Platform/Skia: True / True / True — nothing visible, yet the ring keeps invalidating the canvas; " +
+			"(expected on Uno Platform/Skia: True / True / True — with the fix the pooled visual is suspended, so the render loop idles; " +
+			"on builds without the fix the ring keeps invalidating the canvas with nothing visible; " +
 			"on WinUI: True / False / True — WinUI clears the DataContext on recycle, yet the ring stays active there too, at no render cost).";
 	}
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/Repeater/ItemsRepeater_RecycledSpinner.xaml.cs
@@ -10,6 +10,11 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.Samples.Controls;
 using MuxProgressRing = Microsoft.UI.Xaml.Controls.ProgressRing;
+#if __SKIA__
+using Windows.Foundation;
+using SkiaSharp;
+using Uno.WinUI.Graphics2DSK;
+#endif
 
 namespace UITests.Windows_UI_Xaml_Controls.Repeater;
 
@@ -20,21 +25,76 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater;
 		"Repro for the recycled-spinner render-loop leak on Skia (#23446): an active ProgressRing inside an " +
 		"ItemsRepeater item kept invalidating the canvas after its item was removed, because the recycled " +
 		"element stays parented with its stale DataContext and is never reused (the remaining items use a " +
-		"different template). Measure CPU before/after removal: with the pooled-visual suspension fix it " +
-		"drops to near-idle within ~1 s; on builds without the fix it stays at ~100% of one core.")]
+		"different template). Watch the frame probe before/after removal: with the pooled-visual suspension " +
+		"fix it drops to ~1-2 frames/s within ~1 s; on builds without the fix the render loop stays at full " +
+		"frame rate indefinitely. CPU shows the same contrast only on software-rasterized targets.")]
 public sealed partial class ItemsRepeater_RecycledSpinner : Page
 {
 	private readonly ObservableCollection<RecycledSpinnerItem> _items = new();
 
+	private const string FrameProbeUnavailableText =
+		"Frame probe not available on this target — observe frame production externally (e.g. PresentMon).";
+
 	private UIElement? _recycledSpinnerElement;
 	private object? _spinnerDataContextAtRemoval;
+
+#if __SKIA__
+	private FrameProbe? _frameProbe;
+	private long _lastFramesPainted;
+#endif
 
 	public ItemsRepeater_RecycledSpinner()
 	{
 		InitializeComponent();
 		Repeater.ItemsSource = _items;
 		ResetItems();
+		InitializeFrameProbe();
 	}
+
+	private void InitializeFrameProbe()
+	{
+#if __SKIA__
+		if (SKCanvasElement.IsSupportedOnCurrentPlatform())
+		{
+			// A passive probe: its RenderOverride runs once per composed frame, so sampling the
+			// counter at 1 Hz reads ~1-2 frames/s when the render loop idles (the once-a-second
+			// text update itself causes a frame) vs the full frame rate while the loop is awake.
+			_frameProbe = new FrameProbe { Width = 8, Height = 8 };
+			DiagnosticsPanel.Children.Insert(0, _frameProbe);
+
+			var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+			timer.Tick += OnFrameTimerTick;
+			timer.Start();
+			Unloaded += (_, _) => timer.Stop();
+			return;
+		}
+#endif
+		FramesText.Text = FrameProbeUnavailableText;
+	}
+
+#if __SKIA__
+	private void OnFrameTimerTick(object? sender, object e)
+	{
+		if (_frameProbe is not { } probe)
+		{
+			return;
+		}
+
+		var painted = probe.FramesPainted;
+		var delta = painted - _lastFramesPainted;
+		_lastFramesPainted = painted;
+
+		FramesText.Text = $"Frames painted in the last second: {delta} " +
+			(delta > 10 ? "— render loop is awake." : "— render loop is idle.");
+	}
+
+	private sealed partial class FrameProbe : SKCanvasElement
+	{
+		public long FramesPainted { get; private set; }
+
+		protected override void RenderOverride(SKCanvas canvas, Size area) => FramesPainted++;
+	}
+#endif
 
 	private void ResetItems()
 	{
@@ -131,7 +191,8 @@ public sealed partial class ItemsRepeater_RecycledSpinner : Page
 
 			CpuText.Text =
 				$"Process CPU over {stopwatch.Elapsed.TotalMilliseconds:F0} ms: {coresUsed:P0} of one core " +
-				(coresUsed > 0.5 ? "— render loop is busy/pinned." : "— near idle.");
+				(coresUsed > 0.5 ? "— render loop is busy/pinned." : "— near idle.") +
+				" CPU only tracks the render loop on software-rasterized targets; on GPU-accelerated desktops rely on the frame probe.";
 		}
 		catch (Exception ex)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -613,6 +613,78 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				=> Create(new ObservableCollection<string>(Enumerable.Range(0, itemsCount).Select(i => $"Item #{i}")), viewport: viewport);
 		}
 
+#if __SKIA__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Item_Removed_Then_Pooled_Element_Visual_Suspended_Until_Reuse()
+		{
+			// A recycle-pooled element stays parented until it is reused. On the Skia composition
+			// path its visual must be suspended while pooled: otherwise it keeps rendering at its
+			// stale position, and continuously-animating content it hosts (e.g. an indeterminate
+			// ProgressRing) keeps invalidating the canvas so the render loop never idles.
+			// Two templates are used so that removing the "probe" item recycles its element
+			// without anything reusing it (the remaining items resolve to the other template).
+			var probeTemplate = new DataTemplate(() => new Border
+			{
+				Width = 80,
+				Height = 40,
+				Background = new SolidColorBrush(Colors.Red),
+			});
+			var textTemplate = new DataTemplate(() => new TextBlock { Text = "text", Height = 30 });
+			var source = new ObservableCollection<string> { "probe-1", "plain-1", "plain-2" };
+			var repeater = new ItemsRepeater
+			{
+				ItemsSource = source,
+				ItemTemplate = new ProbeTemplateSelector { ProbeTemplate = probeTemplate, TextTemplate = textTemplate },
+			};
+
+			TestServices.WindowHelper.WindowContent = new Grid
+			{
+				Width = 200,
+				Height = 300,
+				Children = { repeater },
+			};
+			await TestServices.WindowHelper.WaitForLoaded(repeater);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var probe = repeater.TryGetElement(0);
+			Assert.IsNotNull(probe, "The probe item must be realized.");
+			Assert.IsFalse(probe.IsVisualSuspendedForRecyclePooling, "A realized element must not be suspended.");
+			Assert.IsTrue(probe.Visual.IsVisible, "A realized element's visual must be composed.");
+
+			// Recycle: nothing reuses the element (remaining items use the other template).
+			source.RemoveAt(0);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsNotNull(VisualTreeHelper.GetParent(probe), "Premise: a pooled element stays parented until reuse.");
+			Assert.IsTrue(probe.IsVisualSuspendedForRecyclePooling, "A pooled element must be suspended.");
+			Assert.IsFalse(probe.Visual.IsVisible, "A pooled element's visual must not be composed.");
+			Assert.AreEqual(Visibility.Visible, probe.Visibility, "Suspension must not touch the public Visibility.");
+
+			// Reuse: a new probe item resolves to the same template, so the pool hands the element back.
+			source.Insert(0, "probe-2");
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var reused = repeater.TryGetElement(0);
+			Assert.AreSame(probe, reused, "The pooled element is expected to be reused for a same-template item.");
+			Assert.IsFalse(probe.IsVisualSuspendedForRecyclePooling, "A reused element must not be suspended.");
+			Assert.IsTrue(probe.Visual.IsVisible, "A reused element's visual must be composed again.");
+		}
+
+		private sealed class ProbeTemplateSelector : DataTemplateSelector
+		{
+			public required DataTemplate ProbeTemplate { get; set; }
+
+			public required DataTemplate TextTemplate { get; set; }
+
+			protected override DataTemplate SelectTemplateCore(object item)
+				=> item is string s && s.StartsWith("probe", StringComparison.Ordinal) ? ProbeTemplate : TextTemplate;
+
+			protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+				=> SelectTemplateCore(item);
+		}
+#endif
+
 		private record SUT<T>(Border Root, ScrollViewer Scroller, ItemsRepeater Repeater, ObservableCollection<T> Source)
 		{
 			public int Materialized => Repeater.Children.Count(elt => elt.ActualOffset.X >= 0);

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.cs
@@ -50,6 +50,14 @@ namespace Microsoft.UI.Xaml.Controls
 			var winrtOwner = owner;
 			var winrtOwnerAsPanel = EnsureOwnerIsPanelOrNull(winrtOwner);
 
+#if __SKIA__
+			// Uno specific: a pooled element stays parented (and would stay composed) until it is
+			// reused. Suspend its visual so it neither renders at its stale position nor keeps the
+			// render loop awake through continuously-animating content (e.g. an indeterminate
+			// ProgressRing self-invalidating the canvas every frame). Restored in TryGetElementCore.
+			element.IsVisualSuspendedForRecyclePooling = true;
+#endif
+
 			ElementInfo elementInfo = new ElementInfo(element, winrtOwnerAsPanel);
 
 			if (m_elements.TryGetValue(winrtKey, out var infos))
@@ -111,6 +119,11 @@ namespace Microsoft.UI.Xaml.Controls
 							panel.Children.RemoveAt(childIndex);
 						}
 					}
+
+#if __SKIA__
+					// Uno specific: undo the composition suspension applied in PutElementCore.
+					elementInfo.Element.IsVisualSuspendedForRecyclePooling = false;
+#endif
 
 					return elementInfo.Element;
 				}

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -422,8 +422,45 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
+		private bool _isVisualSuspendedForRecyclePooling;
+
+		/// <summary>
+		/// Excludes this element's visual from composition while the element sits, still parented,
+		/// in a recycle pool (<see cref="Microsoft.UI.Xaml.Controls.RecyclePool"/> keeps cleared
+		/// elements attached to their parent until they are reused). Without this, a pooled element
+		/// keeps rendering at its stale position — and continuously-animating content it hosts
+		/// (e.g. an indeterminate ProgressRing) keeps invalidating the canvas every frame, so the
+		/// render loop never idles. This is internal composition state only: the element's public
+		/// <see cref="Visibility"/> is not touched.
+		/// </summary>
+		internal bool IsVisualSuspendedForRecyclePooling
+		{
+			get => _isVisualSuspendedForRecyclePooling;
+			set
+			{
+				if (_isVisualSuspendedForRecyclePooling == value)
+				{
+					return;
+				}
+
+				_isVisualSuspendedForRecyclePooling = value;
+
+				if (value)
+				{
+					Visual.IsVisible = false;
+				}
+				else if (Visibility == Visibility.Visible)
+				{
+					// Restore eagerly rather than waiting for the reuse arrange: Arrange()
+					// early-outs when the slot and layout flags are unchanged, in which case
+					// ShowVisual would never run and the reused element would stay invisible.
+					Visual.IsVisible = true;
+				}
+			}
+		}
+
 		partial void ShowVisual()
-			=> Visual.IsVisible = true;
+			=> Visual.IsVisible = !_isVisualSuspendedForRecyclePooling;
 
 		partial void HideVisual()
 			=> Visual.IsVisible = false;


### PR DESCRIPTION
## What

On the Skia composition path, an element recycled by `ItemsRepeater` (via `RecyclePool`) stays **parented and composed** until it is reused. If it hosts continuously-animating content — e.g. an indeterminate `ProgressRing`, whose Lottie re-invalidates the canvas from its own `Render()` — the render loop never idles again after the item is removed: ~100% of one core, full-canvas repaints, with nothing visible on screen.

Fixes #23446.

## How

"Elements in the pool are not composed", encapsulated in the pool itself:

- `RecyclePool.PutElementCore` suspends the element's visual; `TryGetElementCore` restores it on reuse — covering every pool consumer and every reuse path.
- The suspension is a new internal `UIElement.IsVisualSuspendedForRecyclePooling` (Skia-only) that drives `Visual.IsVisible` **without touching the element's public `Visibility`** — no app-observable state changes, no interference with bindings or visual states.
- The restore is eager rather than left to the reuse arrange (which can early-out and skip `ShowVisual`), and `ShowVisual` respects the flag so an arrange while pooled cannot resurrect the visual.
- Intentionally **not** done: detaching pooled elements (WinUI-parity behavior the pool relies on for cheap reuse) or clearing their DataContext. Note: current WinUI *does* clear the DataContext on recycle when the repeater set it ([`ViewManager::ClearElementToElementFactory` / `MustClearDataContext`](https://github.com/microsoft/microsoft-ui-xaml/blob/d4aeb088aeeb17e023e83e00bc8e95ee20733059/controls/dev/Repeater/ViewManager.cpp#L144-L167)) — Uno's Repeater port predates that change. That is a separate parity gap (tracked in #23624), and measurably not a fix for this bug: running the repro sample on the WinAppSDK head (real WinUI) reports `stillParented=True / dataContextUnchanged=False / ringIsActive=True` — the pooled ring keeps animating on WinUI even after the clear; WinUI just renders it for free.

## Validation

- **Repro**: `ItemsRepeater_RecycledSpinner` SamplesApp sample — two templates so the removed spinner element is recycled but never reused; includes a mechanism readout, a passive frames-per-second probe (the primary render-loop signal — full frame rate while pinned vs ~1–2 frames/s once idle), and an in-app CPU meter (meaningful on software-rasterized targets only; GPU-accelerated desktops read near-idle CPU even while the loop is pinned).
- **Measured on Skia X11** (external 1 Hz sampling of `/proc/<pid>/stat`):

  | Phase | Before | After |
  |---|---|---|
  | Spinner visible (animating) | ~1.4 cores | ~1.3 cores |
  | After spinner item removed | **~1.4 cores, forever** | **0.00 cores within ~1 s** |
  | Spinner item re-added (element reused) | — | ~1.3 cores (spinner animates again) |

  Control: the same app idling on a static `ItemsRepeater` sample measures 0.00 cores.
- **Runtime test**: `When_Item_Removed_Then_Pooled_Element_Visual_Suspended_Until_Reuse` — realized → composed; pooled → still parented, suspended, public `Visibility` untouched; reused → same element instance, composed again. Fails without the `RecyclePool` change, passes with it.
- **Existing suites**: Repeater + MUX repeater runtime tests pass (108/108).

## Docs

`Uno-UI-Performance.md` (Skia specifics) documents the new behavior, plus the `ElementClearing`/`ElementPrepared` workaround guidance for earlier versions — including the trap that re-activation on reuse cannot be left to bindings (no re-fire when the new item produces identical values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

