### PR TITLE
fix(scrollviewer): Arm offset intent on scrollbar drag

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -595,7 +595,7 @@ public class Given_ItemsRepeater_FastScroll
 			$"the thumb drag to {draggedTo:F2} must hold instead of snapping back to the stale "
 			+ $"programmatic intent {armedIntent:F2}. Observed VerticalOffset={sut.Scroller.VerticalOffset:F2}.");
 #else
-		await Task.CompletedTask;
+		Assert.Inconclusive("not application for winui");
 #endif
 	}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -536,6 +536,64 @@ public class Given_ItemsRepeater_FastScroll
 		}
 	}
 
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+#if __ANDROID__ || __IOS__ || __WASM__
+	[Ignore("Fails due to async native scrolling.")]
+#endif
+	public async Task When_ProgrammaticScrollArmsIntent_Then_ThumbDragHolds()
+	{
+#if HAS_UNO
+		// Regression guard for the Skia "thumb scrolling does nothing after a programmatic scroll" bug.
+		//
+		// A programmatic ScrollToVerticalOffset arms an "offset intent" that the post-layout
+		// RecomputeOffsetsFromIntent keeps re-applying (clamped to the current ScrollableHeight) on
+		// every arrange. The scrollbar thumb-drag path (OnVerticalScrollBarScrolled -> ChangeViewCore)
+		// used to neither clear nor update that intent, so each thumb drag was instantly snapped back
+		// to the stale programmatic offset on the very next layout pass — the thumb appeared dead once
+		// any programmatic scroll had run.
+		//
+		// Unlike When_ScrollBarThumbDragged_..., this (a) arms an intent first and (b) drives the REAL
+		// OnVerticalScrollBarScrolled handler (not ChangeView, which arms the intent itself and so
+		// masks the bug). Both conditions are required to reproduce it.
+		var sut = CreateMixedTemplateSut(itemCount: 150, viewport: new Size(360, 600));
+		await LoadAsync(sut);
+
+		var scrollable = sut.Scroller.ScrollableHeight;
+		scrollable.Should().BeGreaterThan(400,
+			"the SUT must be tall enough that the armed intent and the thumb target are clearly distinct offsets.");
+
+		// 1. Programmatic scroll down (the repro does this in OnLoaded). Arms _verticalOffsetIntent.
+		var armedIntent = scrollable * 0.7;
+		sut.Scroller.ScrollToVerticalOffset(armedIntent);
+		await TestServices.WindowHelper.WaitForIdle();
+		sut.Scroller.VerticalOffset.Should().BeGreaterThan(scrollable * 0.5,
+			"the programmatic scroll should land near the requested offset before the drag.");
+
+		// 2. User drags the thumb UP to a much smaller offset. This goes through the real scrollbar
+		//    handler with ThumbTrack (immediate, no animation) — the exact path that regressed.
+		var draggedTo = scrollable * 0.1;
+		sut.Scroller.OnVerticalScrollBarScrolled(
+			sut.Scroller,
+			new Microsoft.UI.Xaml.Controls.Primitives.ScrollEventArgs
+			{
+				ScrollEventType = Microsoft.UI.Xaml.Controls.Primitives.ScrollEventType.ThumbTrack,
+				NewValue = draggedTo,
+			});
+
+		// 3. Force the layout pass that runs RecomputeOffsetsFromIntent. Before the fix this snapped
+		//    the offset straight back to armedIntent; after the fix the intent tracks the drag request.
+		sut.Scroller.UpdateLayout();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		sut.Scroller.VerticalOffset.Should().BeLessThan(scrollable * 0.3,
+			$"the thumb drag to {draggedTo:F2} must hold instead of snapping back to the stale "
+			+ $"programmatic intent {armedIntent:F2}. Observed VerticalOffset={sut.Scroller.VerticalOffset:F2}.");
+#else
+		await Task.CompletedTask;
+#endif
+	}
+
 	// ----- helpers -----
 
 	// Mixed-template sample SUT: mimics the studio.live multi-template subagent markdown UI's

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -572,9 +572,14 @@ public class Given_ItemsRepeater_FastScroll
 
 		// 2. User drags the thumb UP to a much smaller offset. This goes through the real scrollbar
 		//    handler with ThumbTrack (immediate, no animation) — the exact path that regressed.
+		//    The sender is the vertical ScrollBar, matching the production wiring
+		//    (_verticalScrollbar.Scroll += OnVerticalScrollBarScrolled).
+		var verticalScrollBar = sut.Scroller.ElementVerticalScrollBar;
+		verticalScrollBar.Should().NotBeNull("the vertical scrollbar must be materialized to drive its Scroll handler.");
+
 		var draggedTo = scrollable * 0.1;
 		sut.Scroller.OnVerticalScrollBarScrolled(
-			sut.Scroller,
+			verticalScrollBar,
 			new Microsoft.UI.Xaml.Controls.Primitives.ScrollEventArgs
 			{
 				ScrollEventType = Microsoft.UI.Xaml.Controls.Primitives.ScrollEventType.ThumbTrack,

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -563,12 +563,21 @@ public class Given_ItemsRepeater_FastScroll
 		scrollable.Should().BeGreaterThan(400,
 			"the SUT must be tall enough that the armed intent and the thumb target are clearly distinct offsets.");
 
+		// The 0.7x/0.1x targets vs the 0.5x/0.3x thresholds are NOT a loose tolerance on a single value:
+		// they are regime markers. This is virtualized mixed-height content (no snap points), so
+		// ScrollableHeight is a running-average ESTIMATE that shifts as items realize/dematerialize, and
+		// RecomputeOffsetsFromIntent re-clamps the offset to that moving height every layout pass — the
+		// landed offset drifts off the request. The bug snaps back to ~armedIntent (0.7x); the fix holds
+		// near the drag target (0.1x). Asserting "> 0.5x then < 0.3x" cleanly separates "held" from
+		// "snapped back"; the 0.3x..0.5x gap is a deliberate dead-zone so estimation drift can't flip the
+		// result. Pinning exact offsets here would be flaky, not stricter.
+
 		// 1. Programmatic scroll down (the repro does this in OnLoaded). Arms _verticalOffsetIntent.
 		var armedIntent = scrollable * 0.7;
 		sut.Scroller.ScrollToVerticalOffset(armedIntent);
 		await TestServices.WindowHelper.WaitForIdle();
 		sut.Scroller.VerticalOffset.Should().BeGreaterThan(scrollable * 0.5,
-			"the programmatic scroll should land near the requested offset before the drag.");
+			"the programmatic scroll must land clearly in the lower half before the drag.");
 
 		// 2. User drags the thumb UP to a much smaller offset. This goes through the real scrollbar
 		//    handler with ThumbTrack (immediate, no animation) — the exact path that regressed.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -604,7 +604,7 @@ public class Given_ItemsRepeater_FastScroll
 			$"the thumb drag to {draggedTo:F2} must hold instead of snapping back to the stale "
 			+ $"programmatic intent {armedIntent:F2}. Observed VerticalOffset={sut.Scroller.VerticalOffset:F2}.");
 #else
-		Assert.Inconclusive("not application for winui");
+		Assert.Inconclusive("not applicable for winappsdk: no backdoor available");
 #endif
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1207,7 +1207,9 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		private void OnVerticalScrollBarScrolled(object sender, ScrollEventArgs e)
+		// internal (not private) so runtime tests can drive the exact scrollbar-drag path that the
+		// offset-intent recompute regressed (Skia ScrollViewer thumb-scroll after a programmatic scroll).
+		internal void OnVerticalScrollBarScrolled(object sender, ScrollEventArgs e)
 		{
 			// We animate only if the user clicked in the scroll bar, and disable otherwise
 			// (especially, we disable animation when dragging the thumb)
@@ -1223,6 +1225,14 @@ namespace Microsoft.UI.Xaml.Controls
 				ScrollEventType.SmallDecrement => (false, VerticalOffset - 16),
 				_ => (true, e.NewValue)
 			};
+
+			// A scrollbar interaction (thumb drag, paging, line step) is an explicit offset request —
+			// the WinUI equivalent of updating m_Offset via SetVerticalOffsetPrivate. Arm the intent so
+			// the post-layout RecomputeOffsetsFromIntent re-coerces toward THIS request rather than a
+			// stale programmatic intent left by an earlier ChangeView. Without this, ChangeViewCore
+			// (which never touches the intent) lets the recompute snap the offset straight back, so the
+			// thumb appears dead after any programmatic ScrollToVerticalOffset.
+			_verticalOffsetIntent = offset;
 
 			ChangeViewCore(
 				horizontalOffset: null,
@@ -1248,6 +1258,10 @@ namespace Microsoft.UI.Xaml.Controls
 				ScrollEventType.SmallDecrement => (false, HorizontalOffset - 16),
 				_ => (true, e.NewValue)
 			};
+
+			// See OnVerticalScrollBarScrolled: arm the intent so the post-layout recompute re-coerces
+			// toward this scrollbar request instead of snapping back to a stale programmatic intent.
+			_horizontalOffsetIntent = offset;
 
 			ChangeViewCore(
 				horizontalOffset: offset,

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1207,8 +1207,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		// internal (not private) so runtime tests can drive the exact scrollbar-drag path that the
-		// offset-intent recompute regressed (Skia ScrollViewer thumb-scroll after a programmatic scroll).
+		// internal so runtime tests can drive the scrollbar-drag path directly.
 		internal void OnVerticalScrollBarScrolled(object sender, ScrollEventArgs e)
 		{
 			// We animate only if the user clicked in the scroll bar, and disable otherwise
@@ -1226,12 +1225,8 @@ namespace Microsoft.UI.Xaml.Controls
 				_ => (true, e.NewValue)
 			};
 
-			// A scrollbar interaction (thumb drag, paging, line step) is an explicit offset request —
-			// the WinUI equivalent of updating m_Offset via SetVerticalOffsetPrivate. Arm the intent so
-			// the post-layout RecomputeOffsetsFromIntent re-coerces toward THIS request rather than a
-			// stale programmatic intent left by an earlier ChangeView. Without this, ChangeViewCore
-			// (which never touches the intent) lets the recompute snap the offset straight back, so the
-			// thumb appears dead after any programmatic ScrollToVerticalOffset.
+			// Scrollbar interactions are explicit offset requests: arm the intent so the post-layout
+			// recompute coerces toward this offset instead of snapping back to a stale programmatic one.
 			_verticalOffsetIntent = offset;
 
 			ChangeViewCore(
@@ -1259,8 +1254,7 @@ namespace Microsoft.UI.Xaml.Controls
 				_ => (true, e.NewValue)
 			};
 
-			// See OnVerticalScrollBarScrolled: arm the intent so the post-layout recompute re-coerces
-			// toward this scrollbar request instead of snapping back to a stale programmatic intent.
+			// Arm the intent — see OnVerticalScrollBarScrolled.
 			_horizontalOffsetIntent = offset;
 
 			ChangeViewCore(


### PR DESCRIPTION
**GitHub Issue:** closes  https://github.com/unoplatform/kahua-private/issues/490

## PR Type:

🐞 Bugfix

## What changed? 🚀

On the Skia `ScrollViewer`, dragging the scrollbar **thumb** (and track-paging / line-steps) stopped moving the content after any programmatic scroll — e.g. a `ScrollToVerticalOffset(...)` / `ChangeView(...)`. Mouse-wheel and touch still worked; only the scrollbar interaction appeared dead.

**Root cause:** the offset-intent mechanism (introduced to fix the fast-wheel blank-territory bug) tracks the caller-requested offset (`_verticalOffsetIntent` / `_horizontalOffsetIntent`, mirroring WinUI `m_Offset`) and re-applies it every layout pass via `RecomputeOffsetsFromIntent()`. A programmatic scroll *arms* that intent. But `OnVerticalScrollBarScrolled` / `OnHorizontalScrollBarScrolled` pushed the new offset straight through `ChangeViewCore`, which never updates the intent — so the next layout pass coerced the offset right back to the **stale programmatic intent**, snapping the thumb back to where it was.

**Fix:** treat a scrollbar interaction as an explicit offset request (the WinUI equivalent of `SetVerticalOffsetPrivate` updating `m_Offset`) and arm `_verticalOffsetIntent` / `_horizontalOffsetIntent` to the requested offset before calling `ChangeViewCore`, so the post-layout recompute re-coerces toward *this* request instead of the stale one. Armed for all scrollbar event types (thumb drag, paging, line steps), matching WinUI parity and staying safe under realization-driven extent changes.

- `OnVerticalScrollBarScrolled` made `internal` (from `private`) so the regression test can drive the exact scrollbar-drag path.
- Added regression test `When_ProgrammaticScrollArmsIntent_Then_ThumbDragHolds` in `Given_ItemsRepeater_FastScroll` (fails before / passes after).

Validated against a standalone Skia-desktop repro (canvas-in-`ScrollViewer` with custom pointer handling): thumb drag now holds after a programmatic scroll.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
