### PR TITLE
fix: recover layout when MeasureOverride throws

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Layouter_MeasureException.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Layouter_MeasureException.cs
@@ -1,0 +1,96 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	// An element whose MeasureOverride throws must not be permanently prevented from being measured
+	// again. The layouter sets the per-element MeasuringSelf flag before calling MeasureCore; if that
+	// flag is not cleared when MeasureCore throws, InvalidateMeasure() becomes a no-op for that element
+	// (and the dirtiness never propagates to its ancestors), so its DesiredSize can never be updated
+	// again — a transient measure exception turns into a permanent layout freeze for the subtree.
+	[TestClass]
+	[RunsOnUIThread]
+	public partial class Given_Layouter_MeasureException
+	{
+		private partial class ThrowingMeasureControl : FrameworkElement
+		{
+			public bool ThrowOnMeasure { get; set; }
+			public Size MeasureResult { get; set; } = new Size(100, 100);
+
+			protected override Size MeasureOverride(Size availableSize)
+			{
+				if (ThrowOnMeasure)
+				{
+					throw new InvalidOperationException("Simulated MeasureOverride failure");
+				}
+
+				return MeasureResult;
+			}
+		}
+
+		[TestMethod]
+		public void When_MeasureThrowsOnce_Then_Recovers_On_Reinvalidate()
+		{
+			var sut = new ThrowingMeasureControl { MeasureResult = new Size(100, 100) };
+
+			sut.Measure(new Size(1000, 1000));
+			Assert.AreEqual(new Size(100, 100), sut.DesiredSize, "baseline measure should produce 100x100");
+
+			// A measure that throws must not leave the element permanently un-measurable.
+			sut.ThrowOnMeasure = true;
+			sut.InvalidateMeasure();
+			Assert.ThrowsExactly<InvalidOperationException>(() => sut.Measure(new Size(1000, 1000)));
+
+			// Stop throwing, request a new size, re-invalidate, measure again.
+			sut.ThrowOnMeasure = false;
+			sut.MeasureResult = new Size(300, 300);
+			sut.InvalidateMeasure();
+			sut.Measure(new Size(1000, 1000));
+
+			Assert.AreEqual(new Size(300, 300), sut.DesiredSize, "element must re-measure after the throwing pass");
+		}
+
+		[TestMethod]
+		public async System.Threading.Tasks.Task When_ChildThrows_DuringResize_Then_Parent_Recovers()
+		{
+			var child = new ThrowingMeasureControl { MeasureResult = new Size(50, 50) };
+			var parent = new Grid { Width = 1920, Height = 1080 };
+			parent.Children.Add(child);
+
+			try
+			{
+				await UITestHelper.Load(parent);
+				await WindowHelper.WaitForIdle();
+
+				Assert.AreEqual(1920d, parent.ActualWidth, 1d, "baseline parent width");
+
+				// Resize down while the child throws on the resulting measure (the exception is observed
+				// by the layout pass).
+				child.ThrowOnMeasure = true;
+				parent.Width = 390;
+				parent.Height = 844;
+				parent.InvalidateMeasure();
+				await WindowHelper.WaitForIdle();
+
+				// The child stops throwing and the parent is resized again; it must re-measure.
+				child.ThrowOnMeasure = false;
+				parent.Width = 768;
+				parent.Height = 1024;
+				parent.InvalidateMeasure();
+				await WindowHelper.WaitForIdle();
+
+				Assert.AreEqual(768d, parent.ActualWidth, 1d, "parent must re-measure to the new width after the child stops throwing");
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Layouter_MeasureException.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Layouter_MeasureException.cs
@@ -35,6 +35,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public void When_MeasureThrowsOnce_Then_Recovers_On_Reinvalidate()
 		{
 			var sut = new ThrowingMeasureControl { MeasureResult = new Size(100, 100) };
@@ -57,6 +58,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public async System.Threading.Tasks.Task When_ChildThrows_DuringResize_Then_Parent_Recovers()
 		{
 			var child = new ThrowingMeasureControl { MeasureResult = new Size(50, 50) };
@@ -70,13 +72,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 				Assert.AreEqual(1920d, parent.ActualWidth, 1d, "baseline parent width");
 
-				// Resize down while the child throws on the resulting measure (the exception is observed
-				// by the layout pass).
+				// Resize down while the child throws, forcing a synchronous layout pass so the
+				// exception is deterministically observed rather than swallowed by the dispatcher.
 				child.ThrowOnMeasure = true;
 				parent.Width = 390;
 				parent.Height = 844;
-				parent.InvalidateMeasure();
-				await WindowHelper.WaitForIdle();
+				Assert.ThrowsExactly<InvalidOperationException>(() => parent.UpdateLayout());
 
 				// The child stops throwing and the parent is resized again; it must re-measure.
 				child.ThrowOnMeasure = false;

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -249,8 +249,19 @@ namespace Microsoft.UI.Xaml
 						}
 
 						SetLayoutFlags(LayoutFlag.MeasuringSelf);
-						MeasureCore(availableSize);
-						ClearLayoutFlags(LayoutFlag.MeasuringSelf);
+						try
+						{
+							MeasureCore(availableSize);
+						}
+						finally
+						{
+							// Clear MeasuringSelf even if MeasureCore throws. Otherwise the flag stays
+							// set and InvalidateMeasure() permanently no-ops for this element (see the
+							// guard in InvalidateMeasure), which freezes its DesiredSize until the
+							// process restarts — a transient measure exception becomes a permanent
+							// layout lock for the whole subtree.
+							ClearLayoutFlags(LayoutFlag.MeasuringSelf);
+						}
 						InvalidateArrange();
 					}
 #if DEBUG

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -255,11 +255,7 @@ namespace Microsoft.UI.Xaml
 						}
 						finally
 						{
-							// Clear MeasuringSelf even if MeasureCore throws. Otherwise the flag stays
-							// set and InvalidateMeasure() permanently no-ops for this element (see the
-							// guard in InvalidateMeasure), which freezes its DesiredSize until the
-							// process restarts — a transient measure exception becomes a permanent
-							// layout lock for the whole subtree.
+							// Clear even on throw, otherwise InvalidateMeasure() permanently no-ops and the subtree's layout freezes.
 							ClearLayoutFlags(LayoutFlag.MeasuringSelf);
 						}
 						InvalidateArrange();

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -190,6 +190,25 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
+		/// <remarks>
+		/// Isolates the try/finally into its own method so the hot measure path in <c>DoMeasure</c>
+		/// stays free of exception handling (an EH-containing method can't be inlined and is slower
+		/// on WebAssembly — see https://github.com/dotnet/runtime/issues/56309). The finally is
+		/// mandatory: if MeasuringSelf is left set, InvalidateMeasure() permanently no-ops and the
+		/// subtree's layout freezes.
+		/// </remarks>
+		private void MeasureCoreClearingMeasuringSelf(Size availableSize)
+		{
+			try
+			{
+				MeasureCore(availableSize);
+			}
+			finally
+			{
+				ClearLayoutFlags(LayoutFlag.MeasuringSelf);
+			}
+		}
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private void DoMeasure(Size availableSize)
 		{
@@ -249,15 +268,7 @@ namespace Microsoft.UI.Xaml
 						}
 
 						SetLayoutFlags(LayoutFlag.MeasuringSelf);
-						try
-						{
-							MeasureCore(availableSize);
-						}
-						finally
-						{
-							// Clear even on throw, otherwise InvalidateMeasure() permanently no-ops and the subtree's layout freezes.
-							ClearLayoutFlags(LayoutFlag.MeasuringSelf);
-						}
+						MeasureCoreClearingMeasuringSelf(availableSize);
 						InvalidateArrange();
 					}
 #if DEBUG


### PR DESCRIPTION
**GitHub Issue:** closes #23449

## PR Type:

🐞 Bugfix

## What changed? 🚀

When a control's `MeasureOverride` throws, the element was left permanently unable to be measured again: its `DesiredSize` froze at the last successful value and never updated, `InvalidateMeasure()`/`UpdateLayout()` had no effect, and the freeze propagated to ancestors (a parent with an explicit size could no longer resize). The state persisted for the lifetime of the element.

Cause: `DoMeasure` (in `UIElement.Layout.crossruntime.cs`) set `LayoutFlag.MeasuringSelf` before calling `MeasureCore` and cleared it afterwards, but not in a `finally`. On a throw the flag stayed set, and `InvalidateMeasure()` early-returns whenever `MeasuringSelf` is set — so the element could never be marked measure-dirty again.

This PR clears `MeasuringSelf` in a `finally`, so a transient measure exception no longer permanently disables layout: once the throwing condition is resolved and the element is re-invalidated, it measures normally again.

Added runtime tests (`Given_Layouter_MeasureException`):
- `When_MeasureThrowsOnce_Then_Recovers_On_Reinvalidate` — a single element recovers after a throwing measure.
- `When_ChildThrows_DuringResize_Then_Parent_Recovers` — a parent with an explicit `Width` re-measures after a child throws during a resize.

Both fail before the change and pass after (validated on Skia Desktop).

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the documentation template (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
