### PR TITLE
fix(TreeView): node selection causes random node to expand/collapse

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -1,24 +1,30 @@
 ﻿using System;
-using System.Linq;
-using Windows.UI;
-using System.Threading.Tasks;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Helpers;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TreeView = Microsoft.UI.Xaml.Controls.TreeView;
-using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Uno.UI;
-using MUXControlsTestApp.Utilities;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MUXControlsTestApp.Utilities;
+using Private.Infrastructure;
+using Uno.UI;
+using Uno.UI.Helpers;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
 using Windows.System;
+using Windows.UI;
+using TreeView = Microsoft.UI.Xaml.Controls.TreeView;
+using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
+
 
 #if HAS_UNO && !HAS_UNO_WINUI
 using Microsoft.UI.Xaml.Controls;
@@ -253,6 +259,69 @@ public class Given_TreeView
 			MUXTestPage.FindVisualChildrenByType<TextBlock>(SUT.myTree).Count(c => c.Text == "Child 21"));
 #endif
 	}
+
+	[TestMethod]
+	public async Task When_AsdAsd()
+	{
+		// We had an issue where in a treeview of mixed expanded/collapsed nodes,
+		// sometimes selecting a node could cause the viewport to shift and
+		// toggling the IsExpanded of the nodes above. Happens only with selection, and not scrolling...
+
+		// What happened was that TreeViewList::PrepareContainerForItemOverride syncs the IsExpanded state
+		// between the container and the internal node bi-directionally, and the container was associated to a stale item.
+
+		var sources = Enumerable.Range('A', 'Z' - 'A' + 1)
+			.Select(x => new TreeNodeVM(((char)x).ToString(), isExpanded: true)
+			{
+				Children = [..Enumerable.Range('A', 'Z' - 'A' + 1).Select(y =>
+					new TreeNodeVM($"{(char)x}{(char)y}")
+				)]
+			})
+			.ToArray();
+		var flattened = Flatten(sources).ToArray();
+
+		var SUT = new TreeView
+		{
+			Width = 150,
+			Height = 500,
+			SelectionMode = TreeViewSelectionMode.Single,
+			ItemsSource = sources,
+			ItemTemplate = XamlHelper.LoadXaml<DataTemplate>("""
+				<DataTemplate>
+					<TreeViewItem Height="50" ItemsSource="{Binding Children}" IsExpanded="{Binding IsExpanded, Mode=TwoWay}">
+						<TextBlock Text="{Binding Name}" />
+					</TreeViewItem>
+				</DataTemplate>
+			"""),
+		};
+		await UITestHelper.Load(SUT);
+		await TestServices.WindowHelper.WaitFor(() => IsWithinViewport(SUT.ContainerFromItem(sources[0])));
+
+		foreach (var c in "BCDEFGHI")
+		{
+			// select and wait for the selection BringIntoView to occur
+			var node = flattened.First(x => x.Name == $"{c}A");
+			SUT.SelectedItem = node;
+			await TestServices.WindowHelper.WaitForIdle();
+			await TestServices.WindowHelper.WaitFor(() => SUT.ContainerFromItem(node) is { });
+		}
+
+		Assert.IsTrue(sources.All(x => x.IsExpanded), "All top-level nodes should remain expanded.");
+
+		IEnumerable<TreeNodeVM> Flatten(IEnumerable<TreeNodeVM> nodes) =>
+			nodes.SelectMany(x => Flatten(x.Children).Prepend(x));
+		bool IsWithinViewport(DependencyObject x)
+		{
+			if (x is FrameworkElement fe)
+			{
+				var offset = fe.TransformToVisual(SUT).TransformPoint(default);
+
+				return 0 <= offset.Y && (offset.Y + fe.ActualHeight - 1.0) <= SUT.ActualHeight;
+			}
+
+			return false;
+		}
+	}
 }
 
 public class MyNode
@@ -262,6 +331,35 @@ public class MyNode
 	public bool IsDirectory { get; set; }
 
 	public ObservableCollection<MyNode> Children { get; } = new ObservableCollection<MyNode>();
+}
+
+public class TreeNodeVM : INotifyPropertyChanged
+{
+	public event PropertyChangedEventHandler PropertyChanged;
+
+	private string _name;
+	private bool _isExpanded;
+	public string Name { get => _name; set => SetAndRaisePropertyChanged(ref _name, value); }
+	public bool IsExpanded { get => _isExpanded; set => SetAndRaisePropertyChanged(ref _isExpanded, value); }
+
+	public TreeNodeVM(string name, bool isExpanded = false)
+	{
+		_name = name;
+		_isExpanded = isExpanded;
+	}
+
+	public ObservableCollection<TreeNodeVM> Children { get; init; } = new();
+
+	public override string ToString() => $"[{(IsExpanded ? "+" : "-")}]{Name}";
+
+	private void SetAndRaisePropertyChanged<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+	{
+		if (!EqualityComparer<T>.Default.Equals(field, value))
+		{
+			field = value;
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
 }
 
 public class FSObjectTemplateSelector : DataTemplateSelector

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -261,7 +259,7 @@ public class Given_TreeView
 	}
 
 	[TestMethod]
-	public async Task When_AsdAsd()
+	public async Task When_SelectNode_DoesNotToggle_OtherNodesExpansion()
 	{
 		// We had an issue where in a treeview of mixed expanded/collapsed nodes,
 		// sometimes selecting a node could cause the viewport to shift and

--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewList.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewList.cs
@@ -343,6 +343,12 @@ public partial class TreeViewList : ListView
 
 	protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
 	{
+#if HAS_UNO
+		// Uno: we are moving PrepareContainerForItemOverride to the top, because otherwise
+		// the container will still be associated with the old item's state
+		base.PrepareContainerForItemOverride(element, item);
+#endif
+
 		var itemNode = NodeFromContainer(element);
 		TreeViewNode itemNodeImplNoRef = itemNode;
 		TreeViewItem itemContainer = (TreeViewItem)element;
@@ -359,9 +365,6 @@ public partial class TreeViewList : ListView
 			{
 				DispatcherQueue.TryEnqueue(() =>
 				{
-#if !HAS_UNO // Uno Specific: this is actually a bug in WinUI, copy WinUI's fix when https://github.com/microsoft/microsoft-ui-xaml/issues/9549 is resolved
-					itemNode.IsExpanded = itemContainer.IsExpanded;
-#else
 					// The "source of truth" for IsExpanded should come from the (likely recycled) container only if
 					// it has a binding on IsExpanded. Otherwise, the container doesn't know anything and we should
 					// use the IsExpanded value of the Node (which remembers the last value of IsExpanded before
@@ -375,7 +378,6 @@ public partial class TreeViewList : ListView
 					{
 						itemContainer.IsExpanded = itemNode.IsExpanded;
 					}
-#endif
 				});
 			}
 		}
@@ -390,7 +392,9 @@ public partial class TreeViewList : ListView
 		templateSettings.ExpandedGlyphVisibility = itemNode.IsExpanded ? Visibility.Visible : Visibility.Collapsed;
 		templateSettings.CollapsedGlyphVisibility = !itemNode.IsExpanded ? Visibility.Visible : Visibility.Collapsed;
 
+#if !HAS_UNO
 		base.PrepareContainerForItemOverride(element, item);
+#endif
 
 		if (selectionState != itemNodeImplNoRef.SelectionState)
 		{


### PR DESCRIPTION
**GitHub Issue:** closes #23451, closes unoplatform/kahua-private#473

## PR Type:

🐞 Bugfix

## What changed? 🚀

In a `TreeView` with TwoWay-bound `IsExpanded`, changing `SelectedItem` (which triggers `BringIntoView` and container recycling) could corrupt the `IsExpanded` state of unrelated nodes.

**Root cause:** `TreeViewList.PrepareContainerForItemOverride` reads the container's `IsExpanded` to sync it into the `TreeViewNode`. On Uno, `base.PrepareContainerForItemOverride` — which re-associates the container with the new item — was called *after* that sync. So the sync ran while the container still pointed at the *old* item, writing the old node's expanded state into the wrong slot.

**Fix:** Move `base.PrepareContainerForItemOverride(element, item)` to the top of the override (under `#if HAS_UNO`) so the container is correctly associated with the new item before any `IsExpanded` sync logic runs. The existing `#if !HAS_UNO` WinUI bug note (tracking `microsoft-ui-xaml#9549`) was also cleaned up since it is no longer needed separately from the fixed flow.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)