### PR TITLE
chore!: Remove no-op WASM RethrowNativeExceptions config

### DIFF
--- a/src/Uno.Foundation/FoundationFeatureConfiguration.cs
+++ b/src/Uno.Foundation/FoundationFeatureConfiguration.cs
@@ -29,20 +29,4 @@ public static class FoundationFeatureConfiguration
 		[DefaultValue(_defaultAllowNegativeWidthHeight)]
 		public static bool AllowNegativeWidthHeight { get; set; } = _defaultAllowNegativeWidthHeight;
 	}
-
-#if __WASM__
-	public static class Runtime
-	{
-		/// <summary>
-		/// [Deprecated] Indicates if exception thrown in javascript should be rethrown in managed code.
-		/// </summary>
-		[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-		public static bool RethrowNativeExceptions
-		{
-			// Obsolete, remove in next major
-			get => true;
-			set { }
-		}
-	}
-#endif
 }


### PR DESCRIPTION
**GitHub Issue:** #8339

Part of the breaking-changes rollout epic (#8339). Reference only — this PR must not auto-close the umbrella epic.

## PR Type:

💬 Other... (Deliberate breaking removal of a deprecated, no-op public API)

## What changed? 🚀

Removed the WASM-only, `EditorBrowsable`-hidden, no-op `FoundationFeatureConfiguration.Runtime.RethrowNativeExceptions` property, along with its now-empty `Runtime` nested class.

The property was a pure no-op (getter always returned `true`, setter did nothing) and was already explicitly tagged `// Obsolete, remove in next major`. It was wrapped in `#if __WASM__`, and `RethrowNativeExceptions` was the only member of the `Runtime` class, so removing the property leaves the class empty — the entire `#if __WASM__ ... Runtime { ... } ... #endif` block is therefore deleted.

A repo-wide grep confirms there are no consumers of either `RethrowNativeExceptions` or `FoundationFeatureConfiguration.Runtime` (only matches are this property's own definition and the breaking-changes spec/assessment files describing this removal).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, pure removal of a no-op API with no behavior to test.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A, no UI impact.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- breaking change description -->
**Breaking change:** The public property `Uno.FoundationFeatureConfiguration.Runtime.RethrowNativeExceptions` (and the `Runtime` nested class) is removed. This API existed only on the WASM target, was hidden from IntelliSense (`EditorBrowsableState.Never`), and had no effect (the getter was hardcoded to `true` and the setter was empty).

**Migration path:** Delete any references to `FoundationFeatureConfiguration.Runtime.RethrowNativeExceptions`. Since the property was a no-op, removing the code has no behavioral impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
