### PR TITLE
chore!: Remove iOS BypassCheckToCloseKeyboard

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs
@@ -5,11 +5,9 @@ using CoreGraphics;
 using Foundation;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using UIKit;
 using Uno.Collections;
-using Uno.Diagnostics.Eventing;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI.Extensions;
@@ -29,27 +27,13 @@ namespace Uno.UI.Controls;
 /// </summary>
 public partial class Window : UIWindow
 {
-	//Impediment # 19821 A way the bypass the processing done in the HitTest override when third party controls are used.
-	public static bool BypassCheckToCloseKeyboard { get; set; } = true;
-
-	private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
-
 	private static readonly WeakAttachedDictionary<UIView, string> _attachedProperties = new WeakAttachedDictionary<UIView, string>();
 	private const string NeedsKeyboardAttachedPropertyKey = "NeedsKeyboard";
 	private const int KeyboardMargin = 10;
 
-	public static class TraceProvider
-	{
-		public readonly static Guid Id = Guid.Parse("{64C590CE-CC02-4B48-BFC9-754A47571AC1}");
-
-		public const int Window_TouchStart = 1;
-		public const int Window_TouchStop = 2;
-	}
-
 	private UIView? _focusedView; // Not really the "focused", but the last view which was touched.
 	private WeakReference<UIScrollView?>? _scrollViewModifiedForKeyboard;
 	private InputPane _inputPane;
-	private EventProviderExtensions.DisposableEventActivity? _touchTrace;
 
 	internal event Action? FrameChanged;
 
@@ -170,56 +154,7 @@ public partial class Window : UIWindow
 
 	public override UIView? HitTest(CGPoint point, UIEvent? uievent)
 	{
-		if (!BypassCheckToCloseKeyboard && uievent is { Type: UIEventType.Touches })
-		{
-			_touchTrace = _trace.WriteEventActivity(TraceProvider.Window_TouchStart, TraceProvider.Window_TouchStop);
-
-			if (UIDevice.CurrentDevice.CheckSystemVersion(8, 0) && _inputPane.Visible && point.Y > _inputPane.OccludedRect.Y)
-			{
-				// For some strange reasons, on iOS 8, when the app is sent in background (while the keyboard is open ?) and then restored,
-				// when user re-opens the keyboard we will get some HitTest also for touches which are made upon the keyboard.
-				// In this case we have to send back the currently focused view in order to prevent EndEditing which will cause
-				// the keyboard to disappear and the feeling that touches are going "through the keyboard".
-
-				return _focusedView!;
-			}
-
-			var previouslyFocusedView = _focusedView;
-			var newlyFocusedView = base.HitTest(point, uievent);
-			_focusedView = newlyFocusedView;
-
-			if (_inputPane.Visible
-				&& !NeedsKeyboard(_focusedView!))
-			{
-				// Note: prefer call the IsWithinAWebView after the NeedsKeyboard since it is more power consuming.
-				if (IsWithinAWebView(_focusedView))
-				{
-					// As soon as we are in a WebView the NeedsKeyboard will always returns false. So here we will complete
-					// edition as soon as the user touch anywhere on the screen. This is acceptable since there are dedicated
-					// buttons on the keyboard to focus the next/previous fields of a form.
-					previouslyFocusedView?.EndEditing(true);
-				}
-				else if (previouslyFocusedView != null && IsFocusable(_focusedView))
-				{
-					// If not in a WebView or focusable button, stop editing on the whole window in order to close the keyboard even it the focused view
-					// is no more the one which requires the keyboard (e.g. swipe on another TextBox will not close the keyboard
-					// neither begin edit, but will "focus" it)
-					this.EndEditing(true); // Propagated to all children, will close the keyboard
-				}
-			}
-
-			return _focusedView ?? base.HitTest(point, uievent);
-		}
-		else
-		{
-			if (_touchTrace != null)
-			{
-				_touchTrace.Dispose();
-				_touchTrace = null;
-			}
-
-			return base.HitTest(point, uievent);
-		}
+		return base.HitTest(point, uievent);
 	}
 
 #if !__TVOS__
@@ -442,13 +377,5 @@ public partial class Window : UIWindow
 			view?.FindSuperviewOfType<UIWebView>(stopAt: this) != null ||
 			view?.FindSuperviewOfType<WKWebView>(stopAt: this) != null;
 #endif
-	}
-
-	private bool IsFocusable(UIView? view)
-	{
-		// Basic IsFocusable support that only works with buttons.
-		// This prevent the keyboard from being dismissed when tapping on a button that doesn't want focus.
-		return ((_focusedView as ButtonBase) ?? _focusedView?.FindFirstParent<ButtonBase>())?.IsFocusable
-			?? true; // if it's not a button, we fallback to the default behavior which is to dismiss the keyboard
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs
@@ -152,11 +152,6 @@ public partial class Window : UIWindow
 		}
 	}
 
-	public override UIView? HitTest(CGPoint point, UIEvent? uievent)
-	{
-		return base.HitTest(point, uievent);
-	}
-
 #if !__TVOS__
 	private void OnKeyboardWillShow(object? sender, UIKeyboardEventArgs e)
 	{


### PR DESCRIPTION
**GitHub Issue:** #8339

Part of the breaking-changes rollout epic (#8339). Reference only — this PR is not intended to close the umbrella epic.

## PR Type:

💬 Other... (deliberate breaking removal of an iOS/tvOS-only public surface)

## What changed? 🚀

Removes the public static `Uno.UI.Controls.Window.BypassCheckToCloseKeyboard` property and its now-dead keyboard-dismissal branch from the native UIKit `UIWindow.HitTest` override (`src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs`, compiled only for `__APPLE_UIKIT__`).

The property defaulted to `true`, which made the guarded branch `if (!BypassCheckToCloseKeyboard && uievent is { Type: UIEventType.Touches })` permanently inert: it was never entered, so the override always fell through to the `else` branch and (with `_touchTrace` always `null`) simply returned `base.HitTest(point, uievent)`. After this change, the override cleanly returns `base.HitTest(point, uievent)` — identical observable behavior, no dead code.

Cleanup of members that became unused solely as a result of removing the branch (each verified unreferenced before removal):

- Field `_touchTrace`, field `_trace`, and the nested `TraceProvider` class (touch-trace plumbing used only by the removed branch).
- Private helper `IsFocusable` (its only call site was the removed branch).
- Usings `Uno.Diagnostics.Eventing` (sole consumers were the trace plumbing) and `Microsoft.UI.Xaml.Controls.Primitives` (sole consumer was `ButtonBase` inside `IsFocusable`).

Intentionally kept: the public `SetNeedsKeyboard` API and its read-side helpers (`NeedsKeyboard`, `GetNeedsKeyboard`, `_attachedProperties`), because `SetNeedsKeyboard` is still consumed (`src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.UIKit.cs`). Also kept `IsWithinAWebView`, which is still used by `MakeFocusedViewVisible`.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, removal of dead native-only code; no behavior change.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

> **Breaking change — impact & migration path:** The public static `Uno.UI.Controls.Window.BypassCheckToCloseKeyboard` property (iOS/tvOS) is removed (hard removal, no deprecation shim). It had no functional effect with its default value of `true` — the keyboard-dismissal-on-touch logic it gated was already dead — so removing it does not change runtime behavior. Migration: delete any references to `Uno.UI.Controls.Window.BypassCheckToCloseKeyboard` in consuming code; no replacement is required.

### Validation

- **Compile (negative control):** `Uno.UI.Skia.csproj` (`net10.0`, `UnoFastDevBuild=true`) builds clean (0 errors; only pre-existing MSB3836 binding-redirect warnings). Note: the edited file is iOS/tvOS-only (`.UIKit.cs`) and is **not** part of any Skia compilation — this build only proves no shared cross-platform code was touched.
- **Code review:** the removed `if` branch was unreachable (guard always false by default), so the override's behavior is unchanged.
- **Consumer grep:** repo-wide search for `BypassCheckToCloseKeyboard` finds zero consumers outside the removed definition (only references are in the rollout spec docs). Removed touch-trace/`IsFocusable` members confirmed unreferenced; `SetNeedsKeyboard` kept because `TextBox.UIKit.cs` still calls it.
- iOS/tvOS compilation is validated by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
