### PR TITLE
chore!: Remove ColorKeyFrameCollection shadow setters

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.UI.Xaml.Media.Animation
@@ -7,45 +7,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
 	{
 		public ColorKeyFrameCollection() : base(null, false)
 		{
-		}
-
-		// Following members are for binary backward compatibility. They can be safely remove in an eventual "breaking" new version.
-		public new uint Size => base.Size;
-
-		public new IEnumerator<ColorKeyFrame> GetEnumerator() => base.GetEnumerator();
-
-		public new void Add(ColorKeyFrame item) => base.Add(item);
-
-		public new void Clear() => base.Clear();
-
-		public new bool Contains(ColorKeyFrame item) => base.Contains(item);
-
-		public new void CopyTo(ColorKeyFrame[] array, int arrayIndex) => base.CopyTo(array, arrayIndex);
-
-		public new bool Remove(ColorKeyFrame item) => base.Remove(item);
-
-		public new int Count
-		{
-			get => base.Count;
-			set => throw new NotSupportedException();
-		}
-
-		public new bool IsReadOnly
-		{
-			get => base.IsReadOnly;
-			set => throw new NotSupportedException();
-		}
-
-		public new int IndexOf(ColorKeyFrame item) => base.IndexOf(item);
-
-		public new void Insert(int index, ColorKeyFrame item) => base.Insert(index, item);
-
-		public new void RemoveAt(int index) => base.RemoveAt(index);
-
-		public new ColorKeyFrame this[int index]
-		{
-			get => base[index];
-			set => base[index] = value;
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Reference only — #8339 is the umbrella breaking-changes epic and must not auto-close. -->

## PR Type:

💬 Other... (deliberate binary-breaking removal of legacy back-compat shadow members)

## What changed? 🚀

`ColorKeyFrameCollection` carried a leftover "binary backward compatibility" block of `new` shadow members that simply re-declared the surface already provided by its base `DependencyObjectCollection<ColorKeyFrame>` (`Size`, `GetEnumerator`, `Add`, `Clear`, `Contains`, `CopyTo`, `Remove`, `IndexOf`, `Insert`, `RemoveAt`, `this[int]`), plus `Count` and `IsReadOnly` whose **setters threw `NotSupportedException`**.

The sibling collections `DoubleKeyFrameCollection` and `ObjectKeyFrameCollection` have no such block, and the base `DependencyObjectCollection<T>` already exposes get-only `Count`/`IsReadOnly` that satisfy `IList<ColorKeyFrame>`/`ICollection<ColorKeyFrame>`. This PR removes the entire shadow block so `ColorKeyFrameCollection` matches its siblings and WinUI's plain get-only collection members.

The only in-repo consumer, `ColorAnimationUsingKeyFrames`, constructs the type and assigns it through a dependency property — it never calls the (now-removed) shadowed setters. `Uno.WinAppSDKSyncGenerator` references are tooling-only.

This is part of the breaking-changes rollout epic (#8339).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A: pure removal of redundant members; existing Color keyframe animation runtime tests exercise the base collection surface and run in CI.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A: no rendering change
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- Breaking change description -->
**Breaking change:** This is **binary-breaking only**. The removed members were `new` shadows that hid identical base members (or threw on set). Source-level consumers that read `Count`/`IsReadOnly` or use any `IList<ColorKeyFrame>` member continue to compile and behave identically against the base implementation; no realistic consumer relied on the throwing setters. Existing compiled binaries that bound to the shadow members must recompile. **Migration:** recompile against the updated assembly — no source changes are required for normal usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
