### PR TITLE
fix(hot-reload): log unrecognized client frame at Debug not Error

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -66,9 +66,13 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 				break;
 
 			default:
-				if (this.Log().IsEnabled(LogLevel.Error))
+				// An unrecognized frame name does not indicate a client error: a frame can be
+				// relayed over a scope this processor participates in while being addressed to a
+				// different consumer (for example host-only diagnostics frames). Log at Debug so a
+				// benign, expected frame does not surface as a red error in the console.
+				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
-					this.Log().LogError($"Received unknown frame [{frame.Scope}/{frame.Name}]");
+					this.Log().LogDebug($"Received unknown frame [{frame.Scope}/{frame.Name}]");
 				}
 				break;
 		}


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/studio.live/issues/2620


## PR Type:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

The hot-reload client logged every frame whose Name it does not handle at Error. A frame can legitimately arrive on a scope this client participates in while being addressed to a different consumer (e.g. host-only diagnostics frames relayed over a shared scope). Those are benign and expected, so surfacing them as red console errors is misleading. Log them at Debug.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)