### PR TITLE
fix(macos): Don't override dock icon for bundled apps

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowNative.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowNative.cs
@@ -81,7 +81,12 @@ internal class MacOSWindowNative
 	// FIXME: should be shared with GTK and X11 hosts with a delegate to set the icon from a filename
 	private void UpdateWindowPropertiesFromPackage()
 	{
-		if (Windows.ApplicationModel.Package.Current.Logo is { } uri)
+		// When running from a macOS .app bundle, the OS renders the dock icon from the
+		// bundle's Assets.car / CFBundleIconName, including the appearance-aware (Liquid
+		// Glass) variants. Calling setApplicationIconImage: would clobber those, so only
+		// set the icon programmatically when unbundled (e.g. development runs) to avoid
+		// the generic executable icon.
+		if (!NativeUno.uno_application_is_bundled() && Windows.ApplicationModel.Package.Current.Logo is { } uri)
 		{
 			var basePath = uri.OriginalString.Replace('\\', IOPath.DirectorySeparatorChar);
 			var iconPath = IOPath.Combine(Windows.ApplicationModel.Package.Current.InstalledPath, basePath);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowNative.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowNative.cs
@@ -81,11 +81,8 @@ internal class MacOSWindowNative
 	// FIXME: should be shared with GTK and X11 hosts with a delegate to set the icon from a filename
 	private void UpdateWindowPropertiesFromPackage()
 	{
-		// When running from a macOS .app bundle, the OS renders the dock icon from the
-		// bundle's Assets.car / CFBundleIconName, including the appearance-aware (Liquid
-		// Glass) variants. Calling setApplicationIconImage: would clobber those, so only
-		// set the icon programmatically when unbundled (e.g. development runs) to avoid
-		// the generic executable icon.
+		// Only set the icon when unbundled (e.g. dev runs); a bundle already carries
+		// its own appearance-aware icon that setApplicationIconImage: would clobber.
 		if (!NativeUno.uno_application_is_bundled() && Windows.ApplicationModel.Package.Current.Logo is { } uri)
 		{
 			var basePath = uri.OriginalString.Replace('\\', IOPath.DirectorySeparatorChar);


### PR DESCRIPTION
**GitHub Issue:** closes #23072

## PR Type:

🐞 Bugfix

## What changed? 🚀

On macOS Tahoe (macOS 26), Uno's native layer called `[NSApp setApplicationIconImage:]` at startup for every app, overriding the dock icon that macOS had already rendered from the bundle's `Assets.car` / `CFBundleIconName`. Because the override loads a flat PNG via `[NSImage imageNamed:]` (default appearance variant), it clobbered the appearance-aware (Liquid Glass) light/dark/tinted/clear variants — producing a visible mid-launch icon "flip".

This change gates the runtime icon override on the already-existing `uno_application_is_bundled()` flag in `MacOSWindowNative.UpdateWindowPropertiesFromPackage()`:

- **Bundled `.app`** → skip the override. macOS renders the dock icon from the bundle's `Assets.car` / `CFBundleIconName` with full appearance-aware variants. No more flip.
- **Unbundled** (e.g. `dotnet run`, development) → unchanged. Uno still sets the icon programmatically so the app doesn't fall back to the generic executable icon.

The window-title fallback at the end of the method is unaffected and still runs in both cases.

This supersedes the issue's manual workaround (stripping `CFBundleIconName` + `Assets.car`), which is not viable for Mac App Store builds (ITMS-90546 requires `Assets.car`). With this fix, bundled apps keep `Assets.car` and get the correct Liquid Glass icon.

Note: a bundle that ships a `Package.appxmanifest` `Logo` but no bundle icon info would now fall back to the generic icon rather than the manifest logo — this is the intended "trust the bundle" behavior, and the Uno macOS packaging normally emits the bundle icon anyway.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
