### PR TITLE
fix(ci): migrate labeler config to actions/labeler v5 schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,83 +1,107 @@
 # https://github.com/actions/labeler
 
 area/automation:
-  - src/SamplesApp/*
-  - src/SamplesApp/**/*
-  - src/Uno.UI.UnitTests/*
-  - src/Uno.UI.UnitTests/**/*
-  - src/Uno.UI.Wasm.Tests/*
-  - src/Uno.UI.Wasm.Tests/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/SamplesApp/*
+      - src/SamplesApp/**/*
+      - src/Uno.UI.UnitTests/*
+      - src/Uno.UI.UnitTests/**/*
+      - src/Uno.UI.Wasm.Tests/*
+      - src/Uno.UI.Wasm.Tests/**/*
 
 area/build:
-  - build/*
-  - build/**/*
-  - '**/*.yml'
-  - src/Uno.UI.TestComparer/*
-  - src/Uno.UI.TestComparer/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - build/*
+      - build/**/*
+      - '**/*.yml'
+      - src/Uno.UI.TestComparer/*
+      - src/Uno.UI.TestComparer/**/*
 
 area/code-generation:
-  - src/SourceGenerators/*
-  - src/SourceGenerators/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/SourceGenerators/*
+      - src/SourceGenerators/**/*
 
 kind/documentation:
-  - README.*
-  - doc/**
-  - '**/*.md'
-  - '**/*.MD'
-  - '**/*.txt'
+  - changed-files:
+    - any-glob-to-any-file:
+      - README.*
+      - doc/**
+      - '**/*.md'
+      - '**/*.MD'
+      - '**/*.txt'
 
 area/skia ✏️:
-  - '**/*.skia.cs'
-  - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/*
-  - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/**/*
-  - src/Uno.UI.Runtime.Skia.Tizen/*
-  - src/Uno.UI.Runtime.Skia.Tizen/**/*
-  - src/Uno.UI.Runtime.Skia.Android/*
-  - src/Uno.UI.Runtime.Skia.Android/**/*
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/*
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.skia.cs'
+      - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/*
+      - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/**/*
+      - src/Uno.UI.Runtime.Skia.Tizen/*
+      - src/Uno.UI.Runtime.Skia.Tizen/**/*
+      - src/Uno.UI.Runtime.Skia.Android/*
+      - src/Uno.UI.Runtime.Skia.Android/**/*
+      - src/Uno.UI.Runtime.Skia.AppleUIKit/*
+      - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
 
 area/solution-templates:
-  - src/SolutionTemplate/*
-  - src/SolutionTemplate/**/*
-  - src/UnoItemTemplate/*
-  - src/UnoItemTemplate/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/SolutionTemplate/*
+      - src/SolutionTemplate/**/*
+      - src/UnoItemTemplate/*
+      - src/UnoItemTemplate/**/*
 
 area/sdk:
-  - src/Uno.Sdk/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/Uno.Sdk/*
 
 platform/android 🤖:
-  - src/Uno.UI.BindingHelper.Android/*
-  - src/Uno.UI.BindingHelper.Android/**/*
-  - '**/*.Android.cs'
-  - '**/*.Xamarin.cs'
-  - src/Uno.UI.Runtime.Skia.Android/*
-  - src/Uno.UI.Runtime.Skia.Android/**/*
-  
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/Uno.UI.BindingHelper.Android/*
+      - src/Uno.UI.BindingHelper.Android/**/*
+      - '**/*.Android.cs'
+      - '**/*.Xamarin.cs'
+      - src/Uno.UI.Runtime.Skia.Android/*
+      - src/Uno.UI.Runtime.Skia.Android/**/*
+
 platform/wasm 🌐:
-  - '**/*.wasm.cs'
-  - src/Uno.UI.Wasm/*
-  - src/Uno.UI.Wasm/**/*
-  - src/Uno.Foundation.Runtime.WebAssembly/*
-  - src/Uno.Foundation.Runtime.WebAssembly/**/*
-  - src/Uno.UI.Runtime.WebAssembly/*
-  - src/Uno.UI.Runtime.WebAssembly/**/*
-  - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/*
-  - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.wasm.cs'
+      - src/Uno.UI.Wasm/*
+      - src/Uno.UI.Wasm/**/*
+      - src/Uno.Foundation.Runtime.WebAssembly/*
+      - src/Uno.Foundation.Runtime.WebAssembly/**/*
+      - src/Uno.UI.Runtime.WebAssembly/*
+      - src/Uno.UI.Runtime.WebAssembly/**/*
+      - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/*
+      - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/**/*
 
 platform/ios 🍎:
-  - '**/*.iOS.cs'
-  - '**/*.UIKit.cs'
-  - '**/*.iOSmacOS.cs'
-  - '**/*.Apple.cs'
-  - '**/*.Xamarin.cs'
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/*
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.iOS.cs'
+      - '**/*.UIKit.cs'
+      - '**/*.iOSmacOS.cs'
+      - '**/*.Apple.cs'
+      - '**/*.Xamarin.cs'
+      - src/Uno.UI.Runtime.Skia.AppleUIKit/*
+      - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
 
 platform/macos 🍏:
-  - src/Uno.UI.Runtime.Skia.MacOS/*
-  - src/Uno.UI.Runtime.Skia.MacOS/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/Uno.UI.Runtime.Skia.MacOS/*
+      - src/Uno.UI.Runtime.Skia.MacOS/**/*
 
 platform/x11 🐧:
-  - src/Uno.UI.Runtime.Skia.X11/*
-  - src/Uno.UI.Runtime.Skia.X11/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/Uno.UI.Runtime.Skia.X11/*
+      - src/Uno.UI.Runtime.Skia.X11/**/*


### PR DESCRIPTION
**GitHub Issue:** closes #23475

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The **Pull Request Labeler** workflow was bumped to `actions/labeler@v6.1.0`, but `.github/labeler.yml` was still in the pre-v5 config format (a flat list of globs per label). `actions/labeler` v5 introduced a breaking schema change, so the action now fails on every PR with:

```
##[error]Error: found unexpected type for label 'area/automation' (should be array of config options)
```

This PR migrates `.github/labeler.yml` to the v5/v6 schema, nesting each label's globs under `changed-files` → `any-glob-to-any-file`:

```yaml
# before (v4)            # after (v5/v6)
area/automation:         area/automation:
  - src/SamplesApp/*       - changed-files:
                             - any-glob-to-any-file:
                               - src/SamplesApp/*
```

All 12 labels and every glob (including the emoji label names) are preserved exactly — `any-glob-to-any-file` keeps the original OR-semantics, so labeling behavior is unchanged once the action can parse the config.

> Note: the workflow runs on `pull_request_target`, which uses the base branch's copy of the config, so the fix takes effect for PRs opened after this merges to `master`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample] — N/A (CI configuration change)
- [x] 📚 Docs have been added/updated — N/A
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
