### PR TITLE
ci: migrate labeler.yml to actions/labeler v5+ schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,83 +1,109 @@
 # https://github.com/actions/labeler
+# Config schema is v5+ (actions/labeler@v6): each label maps to a list of match
+# objects keyed by `changed-files` + a match strategy (`any-glob-to-any-file`).
 
 area/automation:
-  - src/SamplesApp/*
-  - src/SamplesApp/**/*
-  - src/Uno.UI.UnitTests/*
-  - src/Uno.UI.UnitTests/**/*
-  - src/Uno.UI.Wasm.Tests/*
-  - src/Uno.UI.Wasm.Tests/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/SamplesApp/*
+          - src/SamplesApp/**/*
+          - src/Uno.UI.UnitTests/*
+          - src/Uno.UI.UnitTests/**/*
+          - src/Uno.UI.Wasm.Tests/*
+          - src/Uno.UI.Wasm.Tests/**/*
 
 area/build:
-  - build/*
-  - build/**/*
-  - '**/*.yml'
-  - src/Uno.UI.TestComparer/*
-  - src/Uno.UI.TestComparer/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - build/*
+          - build/**/*
+          - '**/*.yml'
+          - src/Uno.UI.TestComparer/*
+          - src/Uno.UI.TestComparer/**/*
 
 area/code-generation:
-  - src/SourceGenerators/*
-  - src/SourceGenerators/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/SourceGenerators/*
+          - src/SourceGenerators/**/*
 
 kind/documentation:
-  - README.*
-  - doc/**
-  - '**/*.md'
-  - '**/*.MD'
-  - '**/*.txt'
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.*
+          - doc/**
+          - '**/*.md'
+          - '**/*.MD'
+          - '**/*.txt'
 
 area/skia ✏️:
-  - '**/*.skia.cs'
-  - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/*
-  - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/**/*
-  - src/Uno.UI.Runtime.Skia.Tizen/*
-  - src/Uno.UI.Runtime.Skia.Tizen/**/*
-  - src/Uno.UI.Runtime.Skia.Android/*
-  - src/Uno.UI.Runtime.Skia.Android/**/*
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/*
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.skia.cs'
+          - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/*
+          - src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/**/*
+          - src/Uno.UI.Runtime.Skia.Tizen/*
+          - src/Uno.UI.Runtime.Skia.Tizen/**/*
+          - src/Uno.UI.Runtime.Skia.Android/*
+          - src/Uno.UI.Runtime.Skia.Android/**/*
+          - src/Uno.UI.Runtime.Skia.AppleUIKit/*
+          - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
 
 area/solution-templates:
-  - src/SolutionTemplate/*
-  - src/SolutionTemplate/**/*
-  - src/UnoItemTemplate/*
-  - src/UnoItemTemplate/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/SolutionTemplate/*
+          - src/SolutionTemplate/**/*
+          - src/UnoItemTemplate/*
+          - src/UnoItemTemplate/**/*
 
 area/sdk:
-  - src/Uno.Sdk/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Uno.Sdk/*
 
 platform/android 🤖:
-  - src/Uno.UI.BindingHelper.Android/*
-  - src/Uno.UI.BindingHelper.Android/**/*
-  - '**/*.Android.cs'
-  - '**/*.Xamarin.cs'
-  - src/Uno.UI.Runtime.Skia.Android/*
-  - src/Uno.UI.Runtime.Skia.Android/**/*
-  
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Uno.UI.BindingHelper.Android/*
+          - src/Uno.UI.BindingHelper.Android/**/*
+          - '**/*.Android.cs'
+          - '**/*.Xamarin.cs'
+          - src/Uno.UI.Runtime.Skia.Android/*
+          - src/Uno.UI.Runtime.Skia.Android/**/*
+
 platform/wasm 🌐:
-  - '**/*.wasm.cs'
-  - src/Uno.UI.Wasm/*
-  - src/Uno.UI.Wasm/**/*
-  - src/Uno.Foundation.Runtime.WebAssembly/*
-  - src/Uno.Foundation.Runtime.WebAssembly/**/*
-  - src/Uno.UI.Runtime.WebAssembly/*
-  - src/Uno.UI.Runtime.WebAssembly/**/*
-  - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/*
-  - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.wasm.cs'
+          - src/Uno.UI.Wasm/*
+          - src/Uno.UI.Wasm/**/*
+          - src/Uno.Foundation.Runtime.WebAssembly/*
+          - src/Uno.Foundation.Runtime.WebAssembly/**/*
+          - src/Uno.UI.Runtime.WebAssembly/*
+          - src/Uno.UI.Runtime.WebAssembly/**/*
+          - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/*
+          - src/Uno.UI.Runtime.Skia.WebAssembly.Browser/**/*
 
 platform/ios 🍎:
-  - '**/*.iOS.cs'
-  - '**/*.UIKit.cs'
-  - '**/*.iOSmacOS.cs'
-  - '**/*.Apple.cs'
-  - '**/*.Xamarin.cs'
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/*
-  - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.iOS.cs'
+          - '**/*.UIKit.cs'
+          - '**/*.iOSmacOS.cs'
+          - '**/*.Apple.cs'
+          - '**/*.Xamarin.cs'
+          - src/Uno.UI.Runtime.Skia.AppleUIKit/*
+          - src/Uno.UI.Runtime.Skia.AppleUIKit/**/*
 
 platform/macos 🍏:
-  - src/Uno.UI.Runtime.Skia.MacOS/*
-  - src/Uno.UI.Runtime.Skia.MacOS/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Uno.UI.Runtime.Skia.MacOS/*
+          - src/Uno.UI.Runtime.Skia.MacOS/**/*
 
 platform/x11 🐧:
-  - src/Uno.UI.Runtime.Skia.X11/*
-  - src/Uno.UI.Runtime.Skia.X11/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/Uno.UI.Runtime.Skia.X11/*
+          - src/Uno.UI.Runtime.Skia.X11/**/*


### PR DESCRIPTION
**GitHub Issue:** closes #23475

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The `Pull Request Labeler` workflow pins `actions/labeler@v6.1.0`, but `.github/labeler.yml` was still written in the pre-v5 schema (each label mapped to a flat list of glob strings). v6 requires each label to be a list of match objects keyed by `changed-files` + a match strategy, so it aborted on the first entry:

```
Error: found unexpected type for label 'area/automation' (should be array of config options)
```

As a result the `triage` check failed on **every** PR.

This migrates each label to the v5+ schema (`changed-files` → `any-glob-to-any-file`). **Glob patterns are preserved verbatim — no change to labeling scope**, purely a format migration. Validated that the file parses to the expected schema shape.

## PR Checklist ✅

- [x] 🧪 N/A — CI configuration change; validated by the labeler run on merge to the base branch (the labeler reads its config from the base via `pull_request_target`, so it self-validates once merged).
- [x] 📚 N/A — no public API/behavior change.
- [x] 🖼️ N/A — no UI change.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests
