### PR TITLE
fix(macos): Follow system accent color

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SystemAccentColorSample.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SystemAccentColorSample.xaml
@@ -161,6 +161,24 @@
                 </NavigationView.MenuItems>
             </NavigationView>
 
+            <!--  Explicit RequestedTheme subtree: must also follow the accent (enhanced lifecycle)  -->
+            <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="Subtree with explicit RequestedTheme=Light" />
+            <Border
+                Padding="12"
+                Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}"
+                CornerRadius="4"
+                RequestedTheme="Light">
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                    <Border
+                        Width="80"
+                        Height="56"
+                        Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+                        CornerRadius="4" />
+                    <Button Content="Accent button" Style="{StaticResource AccentButtonStyle}" />
+                    <ToggleSwitch Header="Toggle" IsOn="True" />
+                </StackPanel>
+            </Border>
+
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SystemAccentColorSample.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SystemAccentColorSample.xaml
@@ -1,0 +1,166 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_ViewManagement.SystemAccentColorSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <ScrollViewer Padding="16">
+        <StackPanel Spacing="16">
+
+            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="System accent color" />
+            <TextBlock Text="The swatches show the values returned by UISettings.GetColorValue. The controls below use the SystemAccentColor theme resources. On macOS, change the accent color in System Settings → Appearance and everything should update live." TextWrapping="Wrap" />
+            <Button Click="OnRefreshClick" Content="Refresh values" />
+
+            <!--  Raw UISettings.GetColorValue swatches (set from code-behind)  -->
+            <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="UISettings.GetColorValue" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="Dark3Swatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Dark3" />
+                    <TextBlock
+                        x:Name="Dark3Hex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="Dark2Swatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Dark2" />
+                    <TextBlock
+                        x:Name="Dark2Hex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="Dark1Swatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Dark1" />
+                    <TextBlock
+                        x:Name="Dark1Hex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="AccentSwatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Accent" />
+                    <TextBlock
+                        x:Name="AccentHex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="Light1Swatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Light1" />
+                    <TextBlock
+                        x:Name="Light1Hex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="Light2Swatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Light2" />
+                    <TextBlock
+                        x:Name="Light2Hex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+                <StackPanel Width="92" Spacing="4">
+                    <Border
+                        x:Name="Light3Swatch"
+                        Height="56"
+                        CornerRadius="4" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Light3" />
+                    <TextBlock
+                        x:Name="Light3Hex"
+                        HorizontalAlignment="Center"
+                        Style="{StaticResource CaptionTextBlockStyle}" />
+                </StackPanel>
+            </StackPanel>
+
+            <!--  Controls driven by the SystemAccentColor theme resources  -->
+            <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="Theme resources &amp; controls" />
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <Border
+                    Width="80"
+                    Height="56"
+                    Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+                    CornerRadius="4" />
+                <Border
+                    Width="80"
+                    Height="56"
+                    Background="{ThemeResource SystemControlHighlightAccentBrush}"
+                    CornerRadius="4" />
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <Button Content="Accent button" Style="{StaticResource AccentButtonStyle}" />
+                <ToggleSwitch Header="Toggle" IsOn="True" />
+            </StackPanel>
+
+            <Slider
+                Width="240"
+                HorizontalAlignment="Left"
+                Maximum="100"
+                Value="60" />
+            <ProgressBar
+                Width="240"
+                HorizontalAlignment="Left"
+                Maximum="100"
+                Value="60" />
+
+            <!--  NavigationView selection indicator: the canonical accent-color regression (issue #6767)  -->
+            <NavigationView
+                Height="160"
+                IsBackButtonVisible="Collapsed"
+                IsSettingsVisible="False"
+                PaneDisplayMode="Top">
+                <NavigationView.MenuItems>
+                    <NavigationViewItem Content="Home" IsSelected="True" />
+                    <NavigationViewItem Content="Documents" />
+                    <NavigationViewItem Content="Settings" />
+                </NavigationView.MenuItems>
+            </NavigationView>
+
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SystemAccentColorSample.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SystemAccentColorSample.xaml.cs
@@ -1,0 +1,56 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.ViewManagement;
+
+namespace UITests.Windows_UI_ViewManagement;
+
+[Sample("Windows.UI.ViewManagement",
+	Name = "SystemAccentColor",
+	Description = "Shows that SystemAccentColor and the accent brushes follow the OS accent color. "
+		+ "On macOS, open System Settings → Appearance and change the accent color while this "
+		+ "sample is visible: the swatches and the controls below should update live.",
+	IsManualTest = true,
+	IgnoreInSnapshotTests = true)]
+public sealed partial class SystemAccentColorSample : Page
+{
+	private readonly UISettings _uiSettings = new();
+
+	public SystemAccentColorSample()
+	{
+		this.InitializeComponent();
+
+		_uiSettings.ColorValuesChanged += OnColorValuesChanged;
+		Unloaded += OnUnloaded;
+
+		UpdateColors();
+	}
+
+	private void OnUnloaded(object sender, RoutedEventArgs e)
+		=> _uiSettings.ColorValuesChanged -= OnColorValuesChanged;
+
+	private void OnRefreshClick(object sender, RoutedEventArgs e) => UpdateColors();
+
+	private void OnColorValuesChanged(UISettings sender, object args)
+		=> this.DispatcherQueue.TryEnqueue(UpdateColors);
+
+	private void UpdateColors()
+	{
+		SetSwatch(AccentSwatch, AccentHex, UIColorType.Accent);
+		SetSwatch(Light1Swatch, Light1Hex, UIColorType.AccentLight1);
+		SetSwatch(Light2Swatch, Light2Hex, UIColorType.AccentLight2);
+		SetSwatch(Light3Swatch, Light3Hex, UIColorType.AccentLight3);
+		SetSwatch(Dark1Swatch, Dark1Hex, UIColorType.AccentDark1);
+		SetSwatch(Dark2Swatch, Dark2Hex, UIColorType.AccentDark2);
+		SetSwatch(Dark3Swatch, Dark3Hex, UIColorType.AccentDark3);
+	}
+
+	private void SetSwatch(Border swatch, TextBlock hex, UIColorType type)
+	{
+		var color = _uiSettings.GetColorValue(type);
+		swatch.Background = new SolidColorBrush(color);
+		hex.Text = $"#{color.A:X2}{color.R:X2}{color.G:X2}{color.B:X2}";
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
@@ -55,6 +55,7 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 		MacOSNativeWindowFactoryExtension.Register();
 		MacOSSystemThemeHelperExtension.Register();
 		MacOSTextScaleFactorExtension.Register();
+		MacOSAccentColorExtension.Register();
 		MacOSNativeOpenGLWrapper.Register();
 		MacOSNativeWebViewProvider.Register();
 		MacOSMediaPlayerExtension.Register();

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -206,6 +206,12 @@ internal static partial class NativeUno
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial double uno_get_text_scale_factor();
 
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static unsafe partial void uno_set_accent_color_change_callback(delegate* unmanaged[Cdecl]<void> callback);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial uint uno_get_accent_color();
+
 	// IME (Input Method Editor) callbacks
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static unsafe partial void uno_set_ime_callbacks(

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/ViewManagement/MacOSAccentColorExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/ViewManagement/MacOSAccentColorExtension.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Uno.Foundation.Extensibility;
+using Uno.Foundation.Logging;
+using Windows.UI;
+using Windows.UI.ViewManagement;
+
+namespace Uno.UI.Runtime.Skia.MacOS;
+
+internal class MacOSAccentColorExtension : IAccentColorExtension
+{
+	private static readonly MacOSAccentColorExtension _instance = new();
+
+	public event EventHandler? AccentColorChanged;
+
+	public static unsafe void Register()
+	{
+		ApiExtensibility.Register(typeof(IAccentColorExtension), _ => _instance);
+		NativeUno.uno_set_accent_color_change_callback(&Update);
+	}
+
+	public Color GetAccentColor()
+	{
+		var argb = NativeUno.uno_get_accent_color();
+		return Color.FromArgb(
+			(byte)((argb >> 24) & 0xFF),
+			(byte)((argb >> 16) & 0xFF),
+			(byte)((argb >> 8) & 0xFF),
+			(byte)(argb & 0xFF));
+	}
+
+	[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+	internal static void Update()
+	{
+		if (typeof(MacOSAccentColorExtension).Log().IsEnabled(LogLevel.Trace))
+		{
+			typeof(MacOSAccentColorExtension).Log().Trace($"MacOSAccentColorExtension.AccentColorChanged {_instance.GetAccentColor()}");
+		}
+
+		_instance.AccentColorChanged?.Invoke(_instance, EventArgs.Empty);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.h
@@ -18,6 +18,11 @@ text_scale_factor_change_fn_ptr uno_get_text_scale_factor_change_callback(void);
 void uno_set_text_scale_factor_change_callback(text_scale_factor_change_fn_ptr p);
 double uno_get_text_scale_factor(void);
 
+typedef void (*accent_color_change_fn_ptr)(void);
+accent_color_change_fn_ptr uno_get_accent_color_change_callback(void);
+void uno_set_accent_color_change_callback(accent_color_change_fn_ptr p);
+uint32 uno_get_accent_color(void);
+
 bool uno_app_initialize(bool *supportsMetal);
 NSWindow* uno_app_get_main_window(void);
 
@@ -48,6 +53,7 @@ void uno_application_quit(void);
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender;
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary<NSKeyValueChangeKey, id> *)change context:(nullable void *)context;
 - (void)textScalePreferenceChanged:(NSNotification *)notification;
+- (void)systemColorsChanged:(NSNotification *)notification;
 
 @end
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m
@@ -7,6 +7,7 @@
 static UNOApplicationDelegate *ad;
 static system_theme_change_fn_ptr system_theme_change;
 static text_scale_factor_change_fn_ptr text_scale_factor_change;
+static accent_color_change_fn_ptr accent_color_change;
 static id<MTLDevice> device;
 
 // KVO context pointers (values are not read — only compared for identity).
@@ -68,6 +69,35 @@ double uno_get_text_scale_factor(void)
     return 1.0;
 }
 
+inline accent_color_change_fn_ptr uno_get_accent_color_change_callback(void)
+{
+    return accent_color_change;
+}
+
+void uno_set_accent_color_change_callback(accent_color_change_fn_ptr p)
+{
+    accent_color_change = p;
+}
+
+// Returns NSColor.controlAccentColor (macOS 10.14+) as 32-bit ARGB; the system resolves
+// "multicolor"/"graphite"/etc. to a concrete RGB.
+uint32 uno_get_accent_color(void)
+{
+    NSColor *raw = [NSColor controlAccentColor];
+    NSColor *rgb = [raw colorUsingColorSpace:[NSColorSpace sRGBColorSpace]];
+    if (rgb == nil) {
+        // Fallback to the Uno default accent (#FF3399FF), matching UISettings' managed fallback.
+        return 0xFF3399FF;
+    }
+    CGFloat r = 0, g = 0, b = 0, a = 0;
+    [rgb getRed:&r green:&g blue:&b alpha:&a];
+    uint32_t ar = (uint32_t)(a * 255.0);
+    uint32_t rr = (uint32_t)(r * 255.0);
+    uint32_t gr = (uint32_t)(g * 255.0);
+    uint32_t br = (uint32_t)(b * 255.0);
+    return (ar << 24) | (rr << 16) | (gr << 8) | br;
+}
+
 bool uno_app_initialize(bool *metal)
 {
     NSApplication *app = [NSApplication sharedApplication];
@@ -90,6 +120,12 @@ bool uno_app_initialize(bool *metal)
                                                 forKeyPath:@"UIPreferredContentSizeCategoryName"
                                                    options:NSKeyValueObservingOptionNew
                                                    context:kTextScaleFactorContext];
+
+        // Accent color changes post NSSystemColorsDidChangeNotification.
+        [[NSNotificationCenter defaultCenter] addObserver:ad
+                                                 selector:@selector(systemColorsChanged:)
+                                                     name:NSSystemColorsDidChangeNotification
+                                                   object:nil];
 
 
         if (app.mainMenu == nil) {
@@ -280,6 +316,19 @@ void uno_application_quit(void)
 #endif
     dispatch_async(dispatch_get_main_queue(), ^{
         text_scale_factor_change_fn_ptr cb = uno_get_text_scale_factor_change_callback();
+        if (cb != NULL) {
+            cb();
+        }
+    });
+}
+
+- (void)systemColorsChanged:(NSNotification *)notification
+{
+#if DEBUG
+    NSLog(@"UNOApplicationDelegate.systemColorsChanged %@", notification.name);
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{
+        accent_color_change_fn_ptr cb = uno_get_accent_color_change_callback();
         if (cb != NULL) {
             cb();
         }

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Globalization;
 using Windows.ApplicationModel.Core;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Data;
 using Uno.UI.Dispatching;
 using Uno.UI.Xaml.Core;
 using Windows.Globalization;
@@ -236,6 +237,47 @@ namespace Microsoft.UI.Xaml
 			{
 				CoreServices.Instance.UpdateFontScale(global::Windows.UI.ViewManagement.UISettings.GetTextScaleFactorValue());
 			};
+
+			InitializeSystemAccentColor();
+		}
+
+		private global::Windows.UI.ViewManagement.UISettings? _accentColorUISettings;
+
+		/// <summary>Mirrors the OS accent color into the SystemAccentColor* theme resources where the platform exposes it (e.g. macOS); no-op otherwise.</summary>
+		private void InitializeSystemAccentColor()
+		{
+			// Notify ColorValuesChanged listeners when the OS accent changes.
+			global::Windows.UI.ViewManagement.UISettings.ObserveAccentColorChanges();
+
+			if (!global::Windows.UI.ViewManagement.UISettings.HasAccentColorExtension)
+			{
+				return;
+			}
+
+			// UISettings only raises events while the instance is alive, so keep a strong reference.
+			_accentColorUISettings = new global::Windows.UI.ViewManagement.UISettings();
+			_accentColorUISettings.ColorValuesChanged += (_, _) => UpdateSystemAccentColorResources();
+
+			UpdateSystemAccentColorResources();
+		}
+
+		/// <summary>Copies the OS accent color and its shades into the SystemAccentColor* resources and refreshes ThemeResource bindings.</summary>
+		private void UpdateSystemAccentColorResources()
+		{
+			if (_accentColorUISettings is not { } settings)
+			{
+				return;
+			}
+
+			Resources["SystemAccentColor"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.Accent);
+			Resources["SystemAccentColorLight1"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentLight1);
+			Resources["SystemAccentColorLight2"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentLight2);
+			Resources["SystemAccentColorLight3"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentLight3);
+			Resources["SystemAccentColorDark1"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentDark1);
+			Resources["SystemAccentColorDark2"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentDark2);
+			Resources["SystemAccentColorDark3"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentDark3);
+
+			OnResourcesChanged(ResourceUpdateReason.ThemeResource);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -277,7 +277,11 @@ namespace Microsoft.UI.Xaml
 			Resources["SystemAccentColorDark2"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentDark2);
 			Resources["SystemAccentColorDark3"] = settings.GetColorValue(global::Windows.UI.ViewManagement.UIColorType.AccentDark3);
 
-			OnResourcesChanged(ResourceUpdateReason.ThemeResource);
+			// The accent resources are theme-independent, so a plain ThemeResource update would miss
+			// subtrees with an explicit RequestedTheme under UNO_HAS_ENHANCED_LIFECYCLE (skipped by
+			// PropagateResourcesChanged, and NotifyThemeChanged early-outs when the theme is unchanged).
+			// PropagatesThroughTree forces the refresh through the whole tree.
+			OnResourcesChanged(ResourceUpdateReason.PropagatesThroughTree);
 		}
 	}
 

--- a/src/Uno.UWP/UI/ViewManagement/UISettings.cs
+++ b/src/Uno.UWP/UI/ViewManagement/UISettings.cs
@@ -68,6 +68,22 @@ namespace Windows.UI.ViewManagement
 
 		static partial void ObserveTextScaleFactorChangesPlatform();
 
+		/// <summary>Starts observing OS accent color changes; raises <see cref="ColorValuesChanged"/> on change (Skia desktop). No-op elsewhere.</summary>
+		internal static void ObserveAccentColorChanges()
+		{
+			ObserveAccentColorChangesPlatform();
+		}
+
+		static partial void ObserveAccentColorChangesPlatform();
+
+		/// <summary>True when the platform provides the OS accent color (e.g. macOS); otherwise the default SystemAccentColor resources are kept.</summary>
+		internal static bool HasAccentColorExtension =>
+#if __SKIA__
+			GetAccentColorExtension() is not null;
+#else
+			false;
+#endif
+
 #pragma warning disable 67 // Event is never used — used by platform-specific partials
 		internal static event global::System.EventHandler TextScaleFactorChangedInternal;
 #pragma warning restore 67
@@ -79,6 +95,28 @@ namespace Windows.UI.ViewManagement
 		public Color GetColorValue(UIColorType desiredColor)
 		{
 			var systemTheme = SystemThemeHelper.SystemTheme;
+#if __SKIA__
+			if (desiredColor is UIColorType.Accent
+				or UIColorType.AccentDark1 or UIColorType.AccentDark2 or UIColorType.AccentDark3
+				or UIColorType.AccentLight1 or UIColorType.AccentLight2 or UIColorType.AccentLight3)
+			{
+				if (GetAccentColorExtension() is { } extension)
+				{
+					var accent = extension.GetAccentColor();
+					return desiredColor switch
+					{
+						UIColorType.Accent => accent,
+						UIColorType.AccentDark1 => AdjustLightness(accent, -0.15),
+						UIColorType.AccentDark2 => AdjustLightness(accent, -0.30),
+						UIColorType.AccentDark3 => AdjustLightness(accent, -0.45),
+						UIColorType.AccentLight1 => AdjustLightness(accent, 0.15),
+						UIColorType.AccentLight2 => AdjustLightness(accent, 0.30),
+						UIColorType.AccentLight3 => AdjustLightness(accent, 0.45),
+						_ => accent,
+					};
+				}
+			}
+#endif
 			return desiredColor switch
 			{
 				UIColorType.Background =>
@@ -97,6 +135,72 @@ namespace Windows.UI.ViewManagement
 				_ => Colors.Transparent
 			};
 		}
+
+#if __SKIA__
+		private static Color AdjustLightness(Color color, double delta)
+		{
+			// Simple HSL-based shade derivation for the AccentDark/Light variants
+			// since macOS only exposes a single accentColor.
+			var r = color.R / 255.0;
+			var g = color.G / 255.0;
+			var b = color.B / 255.0;
+
+			var max = global::System.Math.Max(r, global::System.Math.Max(g, b));
+			var min = global::System.Math.Min(r, global::System.Math.Min(g, b));
+			var l = (max + min) / 2.0;
+
+			double h = 0, s = 0;
+			if (max != min)
+			{
+				var d = max - min;
+				s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
+				if (max == r)
+				{
+					h = (g - b) / d + (g < b ? 6 : 0);
+				}
+				else if (max == g)
+				{
+					h = (b - r) / d + 2;
+				}
+				else
+				{
+					h = (r - g) / d + 4;
+				}
+				h /= 6.0;
+			}
+
+			l = global::System.Math.Clamp(l + delta, 0.0, 1.0);
+
+			double r1, g1, b1;
+			if (s == 0)
+			{
+				r1 = g1 = b1 = l;
+			}
+			else
+			{
+				var q = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
+				var p = 2.0 * l - q;
+				r1 = HueToRgb(p, q, h + 1.0 / 3.0);
+				g1 = HueToRgb(p, q, h);
+				b1 = HueToRgb(p, q, h - 1.0 / 3.0);
+			}
+
+			return Color.FromArgb(color.A,
+				(byte)global::System.Math.Round(r1 * 255),
+				(byte)global::System.Math.Round(g1 * 255),
+				(byte)global::System.Math.Round(b1 * 255));
+		}
+
+		private static double HueToRgb(double p, double q, double t)
+		{
+			if (t < 0) t += 1;
+			if (t > 1) t -= 1;
+			if (t < 1.0 / 6.0) return p + (q - p) * 6.0 * t;
+			if (t < 1.0 / 2.0) return q;
+			if (t < 2.0 / 3.0) return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+			return p;
+		}
+#endif
 
 		[NotImplemented]
 		public uint CaretBlinkRate

--- a/src/Uno.UWP/UI/ViewManagement/UISettings.skia.cs
+++ b/src/Uno.UWP/UI/ViewManagement/UISettings.skia.cs
@@ -13,9 +13,21 @@ internal interface ITextScaleFactorExtension
 	double GetTextScaleFactor();
 }
 
+/// <summary>
+/// Extension interface for Skia platforms to provide the OS accent color.
+/// </summary>
+internal interface IAccentColorExtension
+{
+	event global::System.EventHandler AccentColorChanged;
+	Color GetAccentColor();
+}
+
 public partial class UISettings
 {
 	private static ITextScaleFactorExtension? _textScaleFactorExtension;
+	private static IAccentColorExtension? _accentColorExtension;
+	private static bool _accentColorExtensionChecked;
+	private static bool _accentColorChangesObserved;
 
 	public double TextScaleFactor => GetTextScaleFactorValue();
 
@@ -31,6 +43,17 @@ public partial class UISettings
 		return _textScaleFactorExtension;
 	}
 
+	internal static IAccentColorExtension? GetAccentColorExtension()
+	{
+		if (!_accentColorExtensionChecked)
+		{
+			ApiExtensibility.CreateInstance(typeof(UISettings), out _accentColorExtension);
+			_accentColorExtensionChecked = true;
+		}
+
+		return _accentColorExtension;
+	}
+
 	static partial void ObserveTextScaleFactorChangesPlatform()
 	{
 		if (GetTextScaleFactorExtension() is { } extension)
@@ -39,6 +62,20 @@ public partial class UISettings
 			{
 				TextScaleFactorChangedInternal?.Invoke(null, global::System.EventArgs.Empty);
 			};
+		}
+	}
+
+	static partial void ObserveAccentColorChangesPlatform()
+	{
+		if (_accentColorChangesObserved)
+		{
+			return;
+		}
+
+		if (GetAccentColorExtension() is { } extension)
+		{
+			_accentColorChangesObserved = true;
+			extension.AccentColorChanged += (_, _) => OnColorValuesChanged();
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** closes #22645

## PR Type:

🐞 Bugfix

## What changed? 🚀

On macOS (Skia), `SystemAccentColor` and the accent brushes did not follow the accent color selected in **System Settings → Appearance** — they stayed on the hard-coded default (regression of #6767, e.g. the NavigationView selection indicator).

This PR makes the macOS head read and track the OS accent color:

- **Native** (`UnoNativeMac`): `uno_get_accent_color` reads `NSColor.controlAccentColor` (sRGB → ARGB), and an observer on `NSSystemColorsDidChangeNotification` raises a managed callback when the accent changes.
- **Extension**: `IAccentColorExtension` / `MacOSAccentColorExtension` (registered in `MacSkiaHost`), wired through `UISettings`.
- **`UISettings.GetColorValue`** returns the OS accent for `Accent` and the six `AccentDark/Light` variants (variants derived by HSL lightness offsets, since macOS exposes a single accent color).
- **Theme-resource bridge** (`Application.skia.cs`): mirrors the resolved accent into the `SystemAccentColor*` application resources and refreshes `ThemeResource` bindings, so framework controls follow the accent — not just the `UISettings` API. This is **gated on the platform actually providing an accent extension**, so Windows/Linux Skia keep the framework defaults (no behavior change there).
- Accent changes are also propagated as `UISettings.ColorValuesChanged`, and updates apply live (no restart).

A manual sample is added under **Windows.UI.ViewManagement → SystemAccentColor** showing the raw `GetColorValue` swatches, accent-driven controls, and a `NavigationView` selection indicator, all updating live.

> Note: the native `.dylib` (`libUnoNativeMac`) is rebuilt by CI/maintainers on macOS via the existing `BuildUnoNativeMac` target; it is git-ignored, so there is nothing native to commit.

### Validation

- **Compile**: `Uno.UWP` + `Uno.UI` + `Uno.UI.Runtime.Skia.MacOS` (net10.0) build clean; native dylib rebuilt with the new exports.
- **Runtime (macOS)**: verified live — changing the System Settings accent (Orange, etc.) updates the sample swatches and the accent Button / ToggleSwitch / Slider / NavigationView indicator immediately.

## PR Checklist ✅

- [x] 🧪 Added a manual test sample (`SystemAccentColorSample`)
- [ ] 📚 Docs have been added/updated following the documentation template (n/a)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
