### PR TITLE
fix(alc): prune window events and orphaned composition targets on teardown (2/3)

### DIFF
--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -35,6 +35,57 @@ namespace Uno.UI.Dispatching
 
 		private readonly Dictionary<object, (Action? renderAction, int normalItemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
 
+		/// <summary>
+		/// Removes composition-target render registrations matching the predicate. Nothing else
+		/// ever removes entries, so a closed secondary-app window's CompositionTarget otherwise
+		/// stays registered forever — pinning its visual tree (and its collectible
+		/// AssemblyLoadContext) through this process-lifetime dispatcher.
+		/// </summary>
+		internal void RemoveCompositionTargets(Predicate<object> shouldRemove)
+		{
+			ArgumentNullException.ThrowIfNull(shouldRemove);
+
+			// The predicate is caller-provided: evaluate it OUTSIDE the gate so arbitrary work
+			// (or a predicate that re-enters dispatcher APIs taking the gate) cannot deadlock or
+			// extend the lock's hold time.
+			object[] snapshot;
+			lock (_gate)
+			{
+				snapshot = new object[_compositionTargets.Keys.Count];
+				_compositionTargets.Keys.CopyTo(snapshot, 0);
+			}
+
+			List<object>? toRemove = null;
+			foreach (var key in snapshot)
+			{
+				if (shouldRemove(key))
+				{
+					(toRemove ??= new()).Add(key);
+				}
+			}
+
+			if (toRemove is not null)
+			{
+				lock (_gate)
+				{
+					foreach (var key in toRemove)
+					{
+						// A pending renderAction was counted in _globalCount by EnqueueRender and is
+						// normally decremented when TryGetRenderAction consumes it. Removing the entry
+						// here would skip that decrement, leaving _globalCount permanently elevated and
+						// breaking the 0→1 transition future scheduling relies on — so account for it.
+						if (_compositionTargets.TryGetValue(key, out var details)
+							&& details.renderAction is not null)
+						{
+							Interlocked.Decrement(ref _globalCount);
+						}
+
+						_compositionTargets.Remove(key);
+					}
+				}
+			}
+		}
+
 		private NativeDispatcherPriority _currentPriority;
 
 		private int _globalCount;

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
@@ -1,0 +1,153 @@
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
+
+/// <summary>
+/// A shared (host-lifetime) resource consumed by a secondary-ALC element records that element as
+/// its InheritanceContext parent (<c>DependencyObjectStore._associatedParent</c>). Nothing
+/// un-associates it when the element's AssemblyLoadContext unloads, so the host resource pins the
+/// collectible ALC forever. These tests stage that association with an element whose type lives in
+/// a collectible (RunAndCollect) assembly and assert that
+/// <see cref="Application.CleanupNonDefaultAlcCaches"/> releases it.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_CollectibleAlcAssociations
+{
+	private const string ProbeBrushKey = "CollectibleAssociationProbeBrush";
+	private const string ProbeThemeBrushKey = "CollectibleAssociationProbeThemeBrush";
+
+	private ResourceDictionary? _stagedThemedDictionary;
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Application.Current.Resources.Remove(ProbeBrushKey);
+
+		if (_stagedThemedDictionary is not null)
+		{
+			Application.Current.Resources.MergedDictionaries.Remove(_stagedThemedDictionary);
+			_stagedThemedDictionary = null;
+		}
+	}
+
+	[TestMethod]
+	public void When_HostResourceAssociatedToCollectibleElement_Then_CleanupReleasesAssociation()
+	{
+		var weakElement = StageHostResourceAssociation();
+
+		Application.CleanupNonDefaultAlcCaches();
+
+		for (var i = 0; i < 10 && weakElement.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		Assert.IsFalse(
+			weakElement.IsAlive,
+			"The host-lifetime brush's InheritanceContext association must be cleared during ALC " +
+			"teardown cleanup; otherwise the brush pins the collectible element (and its entire " +
+			"AssemblyLoadContext) for the host resource's lifetime.");
+	}
+
+	[TestMethod]
+	public void When_ThemeDictionaryResourceAssociatedToCollectibleElement_Then_CleanupReleasesAssociation()
+	{
+		var weakElement = StageThemeDictionaryAssociation();
+
+		Application.CleanupNonDefaultAlcCaches();
+
+		for (var i = 0; i < 10 && weakElement.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		Assert.IsFalse(
+			weakElement.IsAlive,
+			"Associations recorded on resources inside (active) theme dictionaries must also be " +
+			"cleared during ALC teardown cleanup.");
+	}
+
+	// Staging happens in non-inlined frames so no test-method local keeps the element alive when
+	// the collection assertion runs.
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference StageHostResourceAssociation()
+	{
+		var brush = new SolidColorBrush(Colors.Red);
+		Application.Current.Resources[ProbeBrushKey] = brush;
+
+		var element = CreateCollectibleBorder();
+
+		// First consumption records the element as the brush's InheritanceContext parent.
+		element.Background = brush;
+
+		return new WeakReference(element);
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private WeakReference StageThemeDictionaryAssociation()
+	{
+		var brush = new SolidColorBrush(Colors.Blue);
+
+		// Register the probe under every theme key so resolution succeeds (and materializes the
+		// active-theme path) regardless of the test environment's active theme.
+		var themed = new ResourceDictionary();
+		foreach (var themeKey in new[] { "Light", "Dark", "Default" })
+		{
+			themed.ThemeDictionaries[themeKey] = new ResourceDictionary { [ProbeThemeBrushKey] = brush };
+		}
+
+		Application.Current.Resources.MergedDictionaries.Add(themed);
+		_stagedThemedDictionary = themed;
+
+		// Resolve through the theme set so the active-theme path is materialized.
+		Assert.IsTrue(themed.TryGetValue(ProbeThemeBrushKey, out var resolved), "Pre-condition: the themed brush must resolve");
+		Assert.AreSame(brush, resolved, "Pre-condition: resolution must yield the staged brush");
+
+		var element = CreateCollectibleBorder();
+		element.Background = brush;
+
+		return new WeakReference(element);
+	}
+
+	/// <summary>
+	/// Emits a <see cref="Border"/> subclass into a RunAndCollect (collectible) assembly — the
+	/// same collectibility shape as an element type from an unloaded secondary app, without
+	/// needing to stage a full secondary application.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static Border CreateCollectibleBorder()
+	{
+		if (!RuntimeFeature.IsDynamicCodeSupported)
+		{
+			Assert.Inconclusive("Reflection.Emit (RunAndCollect) is not supported on this target.");
+		}
+
+		var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+			new AssemblyName("CollectibleAssociationProbe"),
+			AssemblyBuilderAccess.RunAndCollect);
+		var typeBuilder = assemblyBuilder
+			.DefineDynamicModule("main")
+			.DefineType("CollectibleBorder", TypeAttributes.Public, typeof(Border));
+
+		var borderType = typeBuilder.CreateType()!;
+		Assert.IsTrue(borderType.Assembly.IsCollectible, "Pre-condition: the probe element type must be collectible");
+
+		return (Border)Activator.CreateInstance(borderType)!;
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
@@ -23,6 +23,11 @@ namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
 /// </summary>
 [TestClass]
 [RunsOnUIThread]
+// The association clearing runs identically on every Skia target, but the assertion depends on GC
+// reclaiming the now-unreferenced collectible element within a bounded GC.Collect() loop. The WASM
+// and UIKit (Mono) runtimes have non-deterministic/conservative GC and don't reliably reclaim it, so
+// the assertion is unreliable there. Coverage stays on CoreCLR-backed Skia (Desktop/Android) + WinAppSDK.
+[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm | RuntimeTestPlatforms.SkiaUIKit)]
 public class Given_CollectibleAlcAssociations
 {
 	private const string ProbeBrushKey = "CollectibleAssociationProbeBrush";

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_WindowCollectibleEventPrune.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_WindowCollectibleEventPrune.cs
@@ -1,0 +1,113 @@
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Private.Infrastructure;
+using Windows.Foundation;
+
+namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
+
+/// <summary>
+/// Window-level events (Activated / SizeChanged / VisibilityChanged / Closed) live on the window
+/// implementation object, which is not part of any visual tree — a secondary-ALC subscriber on
+/// the HOST window survives unload (the visual-tree event prune never reaches it) and pins its
+/// AssemblyLoadContext. The ALC teardown cleanup must prune window-level subscriptions whose
+/// targets are collectible.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_WindowCollectibleEventPrune
+{
+	[TestMethod]
+	public void When_Collectible_Subscriber_On_Window_Closed_Then_Cleanup_Prunes_It()
+	{
+		var window = TestServices.WindowHelper.CurrentTestWindow;
+		Assert.IsNotNull(window, "Pre-condition: a test window must be available");
+
+		// Only the event subscription itself may hold the target strongly — the test keeps just
+		// a WeakReference, so the assertion measures whether the prune removed the subscription.
+		var weakTarget = SubscribeCollectibleHandler(window!);
+		try
+		{
+			Application.CleanupNonDefaultAlcCaches();
+
+			for (var i = 0; i < 10 && weakTarget.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsFalse(
+				weakTarget.IsAlive,
+				"ALC teardown cleanup must prune window-level event subscriptions whose target " +
+				"lives in a collectible assembly; otherwise the host window pins the unloaded ALC.");
+		}
+		finally
+		{
+			// Failure path only: the subscription is still attached, so the target is still
+			// reachable — re-create an equivalent delegate from the weak target to detach it and
+			// not leak into later tests. On the success path the target is gone and this no-ops.
+			if (weakTarget.Target is { } survivingTarget)
+			{
+				var method = survivingTarget.GetType().GetMethod("OnClosed")!;
+				window!.Closed -= (TypedEventHandler<object, WindowEventArgs>)Delegate.CreateDelegate(
+					typeof(TypedEventHandler<object, WindowEventArgs>),
+					survivingTarget,
+					method);
+			}
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference SubscribeCollectibleHandler(Window window)
+	{
+		var target = CreateCollectibleHandlerTarget(out var method);
+		var handler = (TypedEventHandler<object, WindowEventArgs>)Delegate.CreateDelegate(
+			typeof(TypedEventHandler<object, WindowEventArgs>),
+			target,
+			method);
+
+		window.Closed += handler;
+
+		return new WeakReference(target);
+	}
+
+	/// <summary>
+	/// Emits a handler type with an instance method compatible with
+	/// <see cref="TypedEventHandler{TSender, TResult}"/> of (object, WindowEventArgs) into a
+	/// RunAndCollect (collectible) assembly — the same collectibility shape as an unloaded
+	/// secondary app's subscriber.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static object CreateCollectibleHandlerTarget(out MethodInfo method)
+	{
+		if (!RuntimeFeature.IsDynamicCodeSupported)
+		{
+			Assert.Inconclusive("Reflection.Emit (RunAndCollect) is not supported on this target.");
+		}
+
+		var typeBuilder = AssemblyBuilder
+			.DefineDynamicAssembly(new AssemblyName("CollectibleWindowHandlerProbe"), AssemblyBuilderAccess.RunAndCollect)
+			.DefineDynamicModule("main")
+			.DefineType("CollectibleHandler", TypeAttributes.Public);
+
+		var methodBuilder = typeBuilder.DefineMethod(
+			"OnClosed",
+			MethodAttributes.Public | MethodAttributes.HideBySig,
+			typeof(void),
+			new[] { typeof(object), typeof(WindowEventArgs) });
+		methodBuilder.GetILGenerator().Emit(OpCodes.Ret);
+
+		var handlerType = typeBuilder.CreateType()!;
+		Assert.IsTrue(handlerType.Assembly.IsCollectible, "Pre-condition: the probe handler type must be collectible");
+
+		method = handlerType.GetMethod("OnClosed")!;
+		return Activator.CreateInstance(handlerType)!;
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_WindowCollectibleEventPrune.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_WindowCollectibleEventPrune.cs
@@ -21,6 +21,11 @@ namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
 /// </summary>
 [TestClass]
 [RunsOnUIThread]
+// The prune runs identically on every Skia target, but the assertion depends on GC reclaiming the
+// now-unreferenced collectible target within a bounded GC.Collect() loop. The WASM and UIKit (Mono)
+// runtimes have non-deterministic/conservative GC and don't reliably reclaim it, so the assertion is
+// unreliable there. Coverage stays on CoreCLR-backed Skia (Desktop/Android) + WinAppSDK.
+[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm | RuntimeTestPlatforms.SkiaUIKit)]
 public class Given_WindowCollectibleEventPrune
 {
 	[TestMethod]

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AlcStateHelper.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AlcStateHelper.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Xaml.Core;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_AlcStateHelper
+	{
+		[TestMethod]
+		public void When_Alive_Then_Not_UnloadInitiated_And_When_Unloaded_Then_UnloadInitiated()
+		{
+			if (!RuntimeFeature.IsDynamicCodeSupported)
+			{
+				Assert.Inconclusive("Collectible AssemblyLoadContext is not supported on this target.");
+			}
+
+			var alc = new AssemblyLoadContext("AlcStateHelperProbe", isCollectible: true);
+
+			// valueIfUnknown is set to the OPPOSITE of the expected result so a failed read (e.g. the
+			// reflected _state field no longer resolving) would surface as a test failure, not a false pass.
+			Assert.IsFalse(
+				AlcStateHelper.IsUnloadInitiated(alc, valueIfUnknown: true),
+				"A live ALC must report that its unload has not been initiated.");
+
+			alc.Unload();
+
+			Assert.IsTrue(
+				AlcStateHelper.IsUnloadInitiated(alc, valueIfUnknown: false),
+				"An ALC whose Unload() has been called must report that its unload has been initiated.");
+		}
+	}
+}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -17,6 +17,21 @@ namespace Uno.UI
 {
 	public static class FeatureConfiguration
 	{
+		/// <summary>
+		/// Configuration for collectible AssemblyLoadContext (secondary-app) teardown.
+		/// </summary>
+		public static class Alc
+		{
+			/// <summary>
+			/// When true, a failure to read an <see cref="System.Runtime.Loader.AssemblyLoadContext"/>'s
+			/// unload state (e.g. a future runtime renaming the private state field) throws instead of
+			/// silently falling back. The fallback keeps teardown leak-safe, but it would also let a
+			/// broken read silently degrade every ALC cleanup scenario — enable this in tests/CI so such
+			/// a regression fails loudly rather than going unnoticed. Defaults to false.
+			/// </summary>
+			public static bool ThrowOnUnloadStateReadFailure { get; set; }
+		}
+
 		public static class ApiInformation
 		{
 			/// <summary>

--- a/src/Uno.UI/UI/Xaml/AlcStateHelper.cs
+++ b/src/Uno.UI/UI/Xaml/AlcStateHelper.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Uno.UI.Xaml.Core;
+
+/// <summary>
+/// Reads <see cref="AssemblyLoadContext"/> unload state. The runtime exposes no public unload-state
+/// API, so this reads the private <c>_state</c> field. Verified against .NET 9 and .NET 10: the field
+/// exists and <c>0 == Alive</c> (any other value means Unloading/Unloaded). If a future runtime renames
+/// the field this resolves to <c>null</c> and <see cref="IsUnloadInitiated"/> returns the caller-supplied
+/// fallback, so each call site keeps its own leak-safe default.
+/// </summary>
+internal static class AlcStateHelper
+{
+	private static readonly FieldInfo? _alcStateField =
+		typeof(AssemblyLoadContext).GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance);
+
+	/// <summary>
+	/// Whether <paramref name="alc"/>'s unload has been initiated (private state != Alive). Returns
+	/// <paramref name="valueIfUnknown"/> when the state cannot be read (field absent on a future runtime,
+	/// or the read throws).
+	/// </summary>
+	internal static bool IsUnloadInitiated(AssemblyLoadContext alc, bool valueIfUnknown)
+	{
+		if (_alcStateField is null)
+		{
+			if (global::Uno.UI.FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure)
+			{
+				throw new InvalidOperationException(
+					"AssemblyLoadContext unload-state field '_state' was not found; the runtime layout may have changed.");
+			}
+
+			return valueIfUnknown;
+		}
+
+		try
+		{
+			return (int)_alcStateField.GetValue(alc)! != 0;
+		}
+		catch (Exception) when (!global::Uno.UI.FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure)
+		{
+			return valueIfUnknown;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -371,6 +371,12 @@ partial class Application
 		// ResourceResolver — remove Func delegates whose Target is from a non-default ALC
 		ResourceResolver.ClearNonDefaultAlcRegistrations();
 
+		// Shared resources (theme brushes etc.) first consumed by a secondary-ALC element record
+		// it as their InheritanceContext parent (DependencyObjectStore._associatedParent); nothing
+		// clears that association on unload, so host-lifetime resources pin the collectible ALC.
+		// Sweep every dictionary reachable from the host application and the master theme set.
+		RunCleanupStep(nameof(ClearCollectibleResourceAssociations), ClearCollectibleResourceAssociations);
+
 		// ResourceDictionary — invalidate _keyNotFoundCache on the host Application.
 		// The cache accumulates ResourceKey entries with TypeKey referencing ALC types.
 		// These entries pin RuntimeType → LoaderAllocator → ALC.
@@ -395,6 +401,32 @@ partial class Application
 				typeof(Application).Log().Trace($"[ALC-SCAN] Error during deep scan: {ex.GetType().Name}: {ex.Message}");
 			}
 		}
+	}
+
+	// Runs a teardown cleanup step in isolation: teardown is best-effort, so a failing step must not
+	// abort the rest. A failure may indicate a real defect, so it is logged as a warning with the
+	// full exception.
+	private static void RunCleanupStep(string name, Action step)
+	{
+		try
+		{
+			step();
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Application).Log().IsEnabled(LogLevel.Warning))
+			{
+				typeof(Application).Log().Warn($"[ALC-CLEANUP] {name} failed", ex);
+			}
+		}
+	}
+
+	private static void ClearCollectibleResourceAssociations()
+	{
+#if !__NETSTD_REFERENCE__
+		Uno.UI.GlobalStaticResources.MasterDictionary.ClearCollectibleAssociatedParents();
+#endif
+		_current?.Resources?.ClearCollectibleAssociatedParents();
 	}
 
 	private static void ClearNonDefaultAlcApplications()

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -31,6 +31,18 @@ partial class Application
 	/// </summary>
 	internal long AlcRegistrationId;
 
+	// Per-type cache of delegate-typed instance fields, to keep the teardown tree walk cheap.
+	// Concurrent: the cleanup can be triggered from multiple teardown paths at once
+	// (Window.CloseAlcWindows, Application.RemoveAlcApplication, host sweeps).
+	private static readonly global::System.Collections.Concurrent.ConcurrentDictionary<Type, global::System.Reflection.FieldInfo[]> _delegateFieldsCache = new();
+
+	// Set while pruning a single content root's tree to record whether that tree contained an
+	// element from an unloading ALC (so an orphaned root can be removed). [ThreadStatic] because ALC
+	// teardown sweeps can run concurrently on multiple threads; the flag is transient per-walk state
+	// and must stay thread-local, otherwise one walk would observe another's result.
+	[ThreadStatic]
+	private static bool _treeContainsUnloadingAlcElement;
+
 	private static void SetCurrentApplication(Application app)
 	{
 		if (app is null)
@@ -377,6 +389,22 @@ partial class Application
 		// Sweep every dictionary reachable from the host application and the master theme set.
 		RunCleanupStep(nameof(ClearCollectibleResourceAssociations), ClearCollectibleResourceAssociations);
 
+		// Secondary-ALC code can subscribe to events on HOST visual-tree elements (e.g. a
+		// designer overlay tracking an ancestor's SizeChanged); those subscriptions are never
+		// removed when the secondary app unloads and each one pins the collectible ALC. Walk
+		// every live content root and prune delegate fields of invocation-list entries whose
+		// target or method lives in a collectible ALC.
+		RunCleanupStep(nameof(PruneCollectibleAlcEventSubscriptions), PruneCollectibleAlcEventSubscriptions);
+
+		// The delegate-field cache is keyed by Type; a collectible key (including a host generic
+		// instantiated over a collectible argument) pins its ALC. Drop them — re-cached on demand.
+		RunCleanupStep(nameof(PruneCollectibleDelegateFieldsCache), PruneCollectibleDelegateFieldsCache);
+
+		// NativeDispatcher render registrations are never removed; prune entries whose
+		// CompositionTarget's ContentRoot is no longer registered (a closed secondary-app
+		// surface). Runs AFTER the tree prune above so orphaned roots are already unregistered.
+		RunCleanupStep(nameof(PruneOrphanedCompositionTargets), PruneOrphanedCompositionTargets);
+
 		// ResourceDictionary — invalidate _keyNotFoundCache on the host Application.
 		// The cache accumulates ResourceKey entries with TypeKey referencing ALC types.
 		// These entries pin RuntimeType → LoaderAllocator → ALC.
@@ -427,6 +455,289 @@ partial class Application
 		Uno.UI.GlobalStaticResources.MasterDictionary.ClearCollectibleAssociatedParents();
 #endif
 		_current?.Resources?.ClearCollectibleAssociatedParents();
+	}
+
+	// The delegate-field cache (keyed by Type) outlives a teardown; a collectible key — including a
+	// host generic instantiated over a collectible argument — pins its ALC. Drop every collectible
+	// key on teardown; entries are cheap to rebuild on demand.
+	private static void PruneCollectibleDelegateFieldsCache()
+	{
+		foreach (var key in _delegateFieldsCache.Keys)
+		{
+			if (key.IsCollectible)
+			{
+				_delegateFieldsCache.TryRemove(key, out _);
+			}
+		}
+	}
+
+	private static void PruneOrphanedCompositionTargets()
+	{
+		var rootCoordinator = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator;
+		Uno.UI.Dispatching.NativeDispatcher.Main.RemoveCompositionTargets(target =>
+			target is Media.CompositionTarget compositionTarget
+			&& !rootCoordinator.ContentRoots.Contains(compositionTarget.ContentRoot));
+	}
+
+	/// <summary>
+	/// Whether the type's collectibility means "owned by a dying AssemblyLoadContext". This is
+	/// the discriminator for DESTRUCTIVE prunes: <see cref="Type.IsCollectible"/> alone also
+	/// matches session-lifetime add-in ALCs (e.g. a designer host) whose live subscriptions must
+	/// survive a secondary app's teardown.
+	/// </summary>
+	/// <remarks>
+	/// A collectible type whose load context resolves to the default ALC (or unknown) is only
+	/// genuinely owned by a dying context when its DEFINITION is dynamic/RunAndCollect. A
+	/// constructed generic such as <c>HostType&lt;TAddIn&gt;</c> reports <see cref="Type.IsCollectible"/>
+	/// == <see langword="true"/> merely because a generic ARGUMENT is collectible, even though the
+	/// definition lives in the non-collectible host assembly; pruning delegate fields off such a
+	/// host type would wrongly strip live host subscriptions. We therefore re-evaluate constructed
+	/// generics against their generic type DEFINITION.
+	/// </remarks>
+	private static bool IsFromUnloadInitiatedAlc(Type type)
+	{
+		if (!type.IsCollectible)
+		{
+			return false;
+		}
+
+		// For a constructed generic, collectibility can stem solely from a generic ARGUMENT while
+		// the DEFINITION is host-owned. Judge by the definition so HostType<TAddIn> is not pruned
+		// just because TAddIn is collectible. (Non-constructed types fall through to direct checks.)
+		if (type.IsConstructedGenericType)
+		{
+			var definition = type.GetGenericTypeDefinition();
+
+			// A host-defined definition (default/null ALC, non-dynamic assembly) is NOT prunable via
+			// this path: its collectibility is borrowed from the argument, not the definition itself.
+			var definitionAlc = AssemblyLoadContext.GetLoadContext(definition.Assembly);
+			if ((definitionAlc is null || definitionAlc == AssemblyLoadContext.Default)
+				&& !definition.Assembly.IsDynamic)
+			{
+				return false;
+			}
+
+			// Otherwise judge the definition's own load context like any other type.
+			type = definition;
+		}
+
+		var alc = AssemblyLoadContext.GetLoadContext(type.Assembly);
+		if (alc is null || alc == AssemblyLoadContext.Default)
+		{
+			// Default/unknown ALC is only "dying" when the assembly is a dynamic/RunAndCollect
+			// builder (which legitimately maps to a collectible context). A genuinely static
+			// host assembly that is collectible here would be a false positive, so guard on it.
+			return type.Assembly.IsDynamic;
+		}
+
+		// Conservative when the unload state can't be read: do NOT treat the ALC as dying, so this
+		// destructive prune never strips handlers off a still-live (e.g. session add-in) ALC. A
+		// runtime that breaks the state read is surfaced in dev via
+		// FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure rather than by silent over-pruning.
+		return global::Uno.UI.Xaml.Core.AlcStateHelper.IsUnloadInitiated(alc, valueIfUnknown: false);
+	}
+
+	/// <summary>
+	/// Walks every live content root's visual tree and removes, from each element's delegate
+	/// fields (compiler-generated event backing fields included), any invocation-list entry
+	/// whose target or declaring method lives in a collectible AssemblyLoadContext. Such
+	/// subscriptions are made by secondary-ALC code on host elements and are never undone when
+	/// the secondary app unloads — each one pins the unloaded ALC. Runs only during ALC teardown.
+	/// </summary>
+	[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "ALC cleanup reflection over live instances")]
+	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ALC cleanup reflection over live instances")]
+	private static void PruneCollectibleAlcEventSubscriptions()
+	{
+		// Window-owned content roots are NEVER removed here, no matter what their trees contain:
+		// the host main window's tree legitimately hosts a previewed app's (collectible-typed)
+		// content, and unregistering the host root would take down the host window.
+		var windows = global::Uno.UI.ApplicationHelper.WindowsInternal.ToArray();
+		var windowRoots = new HashSet<object>();
+		foreach (var window in windows)
+		{
+			if (window.WindowImplementation?.XamlRoot?.VisualTree?.ContentRoot is { } windowRoot)
+			{
+				windowRoots.Add(windowRoot);
+			}
+		}
+
+		var coordinator = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator;
+		var roots = coordinator.ContentRoots;
+		// Reverse iteration: RemoveContentRoot below mutates this collection, so walking from the end
+		// keeps the remaining indices valid as entries are removed.
+		for (var i = roots.Count - 1; i >= 0; i--)
+		{
+			if (i < roots.Count && roots[i] is { } root && root.VisualTree?.RootElement is { } rootElement)
+			{
+				_treeContainsUnloadingAlcElement = false;
+				PruneCollectibleAlcEventSubscriptions(rootElement);
+
+				// A non-window content root whose tree contains unloading-ALC elements belongs to
+				// a dead secondary app's surface (e.g. a designer popup island) — the window's
+				// own root is removed at CloseAlcWindow, but popup/island roots otherwise stay
+				// registered forever and pin the ALC through the coordinator.
+				if (_treeContainsUnloadingAlcElement && !windowRoots.Contains(root))
+				{
+					coordinator.RemoveContentRoot(root);
+				}
+			}
+		}
+
+		// Window-level events (Activated / SizeChanged / VisibilityChanged / Closed) live on the
+		// window implementation object, which is not part of any visual tree — a secondary-ALC
+		// subscriber on the HOST window (e.g. a designer client hooking Closed) is never undone
+		// by the tree walk above and would pin its ALC.
+		foreach (var window in windows)
+		{
+			try
+			{
+				PruneCollectibleDelegateFields(window);
+				if (window.WindowImplementation is { } windowImplementation)
+				{
+					PruneCollectibleDelegateFields(windowImplementation);
+				}
+			}
+			catch (Exception)
+			{
+				// One window refusing reflection must not abort pruning of the remaining windows.
+			}
+		}
+	}
+
+	private static void PruneCollectibleAlcEventSubscriptions(DependencyObject element)
+	{
+		if (IsFromUnloadInitiatedAlc(element.GetType()))
+		{
+			_treeContainsUnloadingAlcElement = true;
+		}
+
+		try
+		{
+			PruneCollectibleDelegateFields(element);
+		}
+		catch (Exception)
+		{
+			// One element refusing reflection must not abort the sweep of the rest of the tree.
+		}
+
+		// Element-level Resources dictionaries are not reachable from Application.Resources or
+		// the master theme set; their shared values can hold InheritanceContext associations
+		// into the unloaded app's elements just like app-level resources do.
+		try
+		{
+			if (element is FrameworkElement { Resources: { } elementResources })
+			{
+				elementResources.ClearCollectibleAssociatedParents();
+			}
+		}
+		catch (Exception)
+		{
+		}
+
+		// FrameworkElement content (e.g. a ContentControl's value) is normally also a visual
+		// child, but prune the Content DP value explicitly in case the visual link differs
+		// during teardown.
+		try
+		{
+			if (element is Controls.ContentControl { Content: DependencyObject contentChild })
+			{
+				PruneCollectibleDelegateFields(contentChild);
+			}
+		}
+		catch (Exception)
+		{
+		}
+
+		try
+		{
+			var childCount = Media.VisualTreeHelper.GetChildrenCount(element);
+			for (var i = 0; i < childCount; i++)
+			{
+				PruneCollectibleAlcEventSubscriptions(Media.VisualTreeHelper.GetChild(element, i));
+			}
+		}
+		catch (Exception)
+		{
+			// A subtree that cannot be enumerated mid-teardown must not abort the rest of the sweep.
+		}
+	}
+
+	[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "ALC cleanup reflection over live instances")]
+	[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "ALC cleanup reflection over live instances")]
+	internal static void PruneCollectibleDelegateFields(object instance, AssemblyLoadContext dyingAlc = null)
+	{
+		var type = instance.GetType();
+		if (IsFromUnloadInitiatedAlc(type))
+		{
+			// Instances genuinely owned by the dying ALC die with it, so there is nothing to prune.
+			// Type.IsCollectible alone would also skip host-lifetime instances that are collectible
+			// only via a generic argument (e.g. HostType<TAddIn>), leaving dying-ALC handlers attached.
+			return;
+		}
+
+		var fields = _delegateFieldsCache.GetOrAdd(type, static t =>
+		{
+			var list = new List<global::System.Reflection.FieldInfo>();
+			for (var current = t; current is not null && current != typeof(object); current = current.BaseType)
+			{
+				foreach (var field in current.GetFields(global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.Public | global::System.Reflection.BindingFlags.NonPublic | global::System.Reflection.BindingFlags.DeclaredOnly))
+				{
+					if (typeof(Delegate).IsAssignableFrom(field.FieldType))
+					{
+						list.Add(field);
+					}
+				}
+			}
+
+			return list.ToArray();
+		});
+
+		if (fields.Length == 0)
+		{
+			return;
+		}
+
+		foreach (var field in fields)
+		{
+			try
+			{
+				if (field.GetValue(instance) is not Delegate current)
+				{
+					continue;
+				}
+
+				Delegate updated = current;
+				foreach (var invocation in current.GetInvocationList())
+				{
+					// Destructive prune: only remove subscriptions whose owner is DYING — the
+					// explicitly provided ALC (known at ALC-window close, before Unload() is
+					// initiated) or an ALC whose unload has begun. A merely-collectible target
+					// can belong to a live session-lifetime add-in ALC and must survive.
+					var ownerType = invocation.Target?.GetType() ?? invocation.Method.DeclaringType;
+					if (ownerType is null)
+					{
+						continue;
+					}
+
+					var prune = IsFromUnloadInitiatedAlc(ownerType)
+						|| (dyingAlc is not null && ownerType.IsCollectible && AssemblyLoadContext.GetLoadContext(ownerType.Assembly) == dyingAlc);
+
+					if (prune)
+					{
+						updated = Delegate.Remove(updated, invocation);
+					}
+				}
+
+				if (!ReferenceEquals(updated, current))
+				{
+					field.SetValue(instance, updated);
+				}
+			}
+			catch (Exception)
+			{
+				// A single inaccessible field must not abort pruning of the remaining fields.
+			}
+		}
 	}
 
 	private static void ClearNonDefaultAlcApplications()

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 // fallback option for legacy DepObj from external library generated before templated-parent rework.
@@ -711,6 +711,7 @@ namespace Microsoft.UI.Xaml
 			if (_associatedParent == null)
 			{
 				_associatedParent = parent;
+				RegisterCollectibleParentAssociation(parent);
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
@@ -1,0 +1,174 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.UI.Xaml
+{
+	public partial class DependencyObjectStore
+	{
+		/// <summary>
+		/// Drops <see cref="_associatedParent"/> — and any DataContext it propagated into this store —
+		/// when the parent is owned by an unloading collectible ALC, is an unloaded
+		/// <see cref="FrameworkElement"/>, or is orphaned from the content-root coordinator, so a
+		/// host-lifetime resource cannot pin a secondary app's ALC. A live host element re-associates
+		/// on its next value assignment.
+		/// </summary>
+		internal void ClearCollectibleAssociatedParent()
+		{
+			var associationCleared = false;
+
+			// Two flavors of secondary-app parents: objects whose TYPE lives in the collectible
+			// ALC, and instances of SHARED types (Grid, Border, …) owned by the unloaded app —
+			// the latter are indistinguishable by type, but after unload they are detached
+			// (unloaded, parentless), so a detached-element association is also dropped. A live
+			// host element re-associates naturally on its next value assignment.
+			// IsLoaded == false also matches host elements that are merely unloaded at sweep time
+			// (e.g. a collapsed pane); clearing their association only resets InheritanceContext
+			// DataContext propagation for the shared resource, which re-establishes on the next
+			// value assignment — an acceptable cost for guaranteeing the unloaded app's detached
+			// elements (shared types, indistinguishable by ALC) release their hold. An element
+			// whose ContentRoot has been unregistered from the coordinator (a closed secondary
+			// app's tree — popups included, which keep IsLoaded) is orphaned and also released.
+			// The collectible branch is gated on the parent's ALC unload having actually been
+			// initiated: a still-live session-lifetime add-in ALC (e.g. a designer host) is also
+			// collectible, but its associations must be preserved until it really unloads.
+			var collectibleAndUnloading = false;
+			if (_associatedParent is { } collectibleCandidate && collectibleCandidate.GetType().IsCollectible)
+			{
+				var parentAlc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(collectibleCandidate.GetType().Assembly);
+				// Conservative when the unload state can't be read: do NOT clear, so a still-live add-in
+				// ALC's associations (and inherited DataContext) are never dropped on an unreadable state.
+				// FeatureConfiguration.Alc.ThrowOnUnloadStateReadFailure surfaces such a runtime change in dev.
+				collectibleAndUnloading = parentAlc is not null
+					&& global::Uno.UI.Xaml.Core.AlcStateHelper.IsUnloadInitiated(parentAlc, valueIfUnknown: false);
+			}
+
+			if (_associatedParent is { } parent
+				&& (collectibleAndUnloading
+					|| parent is FrameworkElement { IsLoaded: false }
+					|| (parent is FrameworkElement orphanCandidate && IsOrphanedFromContentRoots(orphanCandidate))))
+			{
+				_associatedParent = null;
+				associationCleared = true;
+			}
+
+			// The association may already have propagated the parent's DataContext into this
+			// store at Inheritance precedence; that propagated value (e.g. the secondary app's
+			// view model) survives the parent's removal and pins the value's ALC on its own.
+			if (associationCleared
+				|| GetValue(_dataContextProperty)?.GetType().IsCollectible == true)
+			{
+				ClearInheritedDataContext();
+			}
+		}
+
+		/// <summary>
+		/// Returns whether the element's visual tree no longer has a registered ContentRoot —
+		/// i.e. it belonged to a closed (secondary-app) tree whose root was unregistered from
+		/// the <see cref="Uno.UI.Xaml.Core.ContentRootCoordinator"/> on Window close.
+		/// </summary>
+		private static bool IsOrphanedFromContentRoots(FrameworkElement element)
+		{
+			try
+			{
+				var contentRoot = element.XamlRoot?.VisualTree?.ContentRoot;
+				if (contentRoot is null)
+				{
+					return true;
+				}
+
+				return !Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.ContentRoots.Contains(contentRoot);
+			}
+			catch (Exception)
+			{
+				// Fail leak-safe: if orphan state can't be determined, treat the element as orphaned
+				// so its association is cleared rather than left to pin a potentially-unloaded ALC.
+				return true;
+			}
+		}
+
+		// Stores that recorded a collectible-ALC object as their associated parent, grouped by
+		// that parent's ALC. Entries are swept (associated parent cleared) when the ALC unloads,
+		// so a host-lifetime shared resource can never outlive-pin a secondary app's ALC.
+		// CWT-keyed by the ALC so the registry itself never extends the ALC's lifetime.
+		private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<global::System.Runtime.Loader.AssemblyLoadContext, List<WeakReference<DependencyObjectStore>>> _collectibleParentAssociations = new();
+
+		private void RegisterCollectibleParentAssociation(object parent)
+		{
+			// Collectible-ALC association tracking is only meaningful when secondary ALCs exist.
+			// Gate on the substitutable Application.HasSecondaryApps so that, for the overwhelmingly
+			// common single-ALC app, this whole path stays off and is linkable away.
+			if (!Application.HasSecondaryApps)
+			{
+				return;
+			}
+
+			// Fast path: Type.IsCollectible is a cached runtime flag; non-collectible parents
+			// (the overwhelmingly common case) exit here without touching the registry.
+			if (!parent.GetType().IsCollectible)
+			{
+				return;
+			}
+
+			var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(parent.GetType().Assembly);
+			if (alc is null || !alc.IsCollectible)
+			{
+				return;
+			}
+
+			var list = _collectibleParentAssociations.GetValue(alc, static a =>
+			{
+				a.Unloading += static unloading =>
+				{
+					// ClearCollectibleAssociatedParent reads/writes DependencyProperty values, which is
+					// only valid on the UI thread. Unloading fires on whichever thread called
+					// AssemblyLoadContext.Unload(); marshal to the UI thread so the clear actually runs
+					// instead of being swallowed as an off-thread DP-access failure.
+					static void Sweep(global::System.Runtime.Loader.AssemblyLoadContext unloading)
+					{
+						if (_collectibleParentAssociations.TryGetValue(unloading, out var stores))
+						{
+							lock (stores)
+							{
+								foreach (var weakStore in stores)
+								{
+									if (weakStore.TryGetTarget(out var store))
+									{
+										try
+										{
+											store.ClearCollectibleAssociatedParent();
+										}
+										catch (global::System.Exception)
+										{
+											// Defensive: one store throwing must not abort the sweep for the rest.
+										}
+									}
+								}
+
+								stores.Clear();
+							}
+
+							_collectibleParentAssociations.Remove(unloading);
+						}
+					}
+
+					if (global::Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess)
+					{
+						Sweep(unloading);
+					}
+					else
+					{
+						global::Uno.UI.Dispatching.NativeDispatcher.Main.Enqueue(() => Sweep(unloading));
+					}
+				};
+				return new List<WeakReference<DependencyObjectStore>>();
+			});
+
+			lock (list)
+			{
+				list.Add(new WeakReference<DependencyObjectStore>(this));
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.alc.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.alc.cs
@@ -1,0 +1,49 @@
+using Uno.UI.DataBinding;
+
+namespace Microsoft.UI.Xaml
+{
+	public partial class ResourceDictionary
+	{
+		/// <summary>
+		/// Clears <c>DependencyObjectStore._associatedParent</c> references into collectible
+		/// AssemblyLoadContexts on every materialized value of this dictionary (recursing into
+		/// nested, merged and theme dictionaries). A shared resource (e.g. a theme brush) first
+		/// consumed by a secondary-ALC element records that element as its InheritanceContext
+		/// parent; nothing unassociates it when the element's ALC unloads, so the host-lifetime
+		/// resource pins the collectible ALC. Called during ALC teardown from
+		/// <see cref="Application.CleanupNonDefaultAlcCaches"/>. Lazy (unmaterialized) entries
+		/// have no store and are skipped without being materialized.
+		/// </summary>
+		internal void ClearCollectibleAssociatedParents()
+		{
+			foreach (var value in _values.Values)
+			{
+				// A nested ResourceDictionary is itself an IDependencyObjectStoreProvider, so it must be
+				// matched FIRST and recursed into — otherwise it falls into the provider branch below and
+				// the associations held by its own values are never swept.
+				if (value is ResourceDictionary nested)
+				{
+					nested.ClearCollectibleAssociatedParents();
+				}
+				else if (value is IDependencyObjectStoreProvider { Store: { } store })
+				{
+					store.ClearCollectibleAssociatedParent();
+				}
+			}
+
+			var mergedCount = _mergedDictionaries.Count;
+			for (var i = 0; i < mergedCount; i++)
+			{
+				_mergedDictionaries[i].ClearCollectibleAssociatedParents();
+			}
+
+			_themeDictionaries?.ClearCollectibleAssociatedParents();
+
+			// The MATERIALIZED active theme dictionary may be reachable only through this cache:
+			// when the theme entry in _themeDictionaries is still a lazy stub, the stub is skipped
+			// above and the materialized dictionary it produced — holding the live brushes whose
+			// stores record cross-ALC associations — would never be visited.
+			_activeThemeDictionary?.ClearCollectibleAssociatedParents();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -298,6 +298,21 @@ partial class Window
 
 		state.IsClosed = true;
 
+		// Capture the dying ALC BEFORE the content reference is cleared: at window-close time the
+		// secondary app's Unload() has not been initiated yet, so the delegate prune below cannot
+		// discriminate by unload state and needs the ALC identity explicitly. OwnerAssemblyLoadContext
+		// is authoritative — it stays correct even when the secondary app rooted a shared framework
+		// type (Frame, Grid, …) whose own type resolves to the default ALC. Fall back to the content
+		// type's ALC only when the owner was never captured.
+		var dyingAlc = OwnerAssemblyLoadContext;
+		if (dyingAlc is null
+			&& _secondaryAlcContent is { } secondaryContent
+			&& AssemblyLoadContext.GetLoadContext(secondaryContent.GetType().Assembly) is { IsCollectible: true } contentAlc
+			&& contentAlc != AssemblyLoadContext.Default)
+		{
+			dyingAlc = contentAlc;
+		}
+
 		// Clear content from host
 		var host = ContentHostOverride;
 		if (host is not null && ReferenceEquals(host.Content, _secondaryAlcContent))
@@ -338,6 +353,38 @@ partial class Window
 			if (typeof(Window).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 			{
 				typeof(Window).Log().Debug($"[ALC-CLEANUP] DisplayInformation.DestroyForWindowId error: {ex.GetType().Name}: {ex.Message}");
+			}
+		}
+
+		// Remove this window's ContentRoot from the process-wide ContentRootCoordinator.
+		// RemoveContentRoot has no other caller, so an ALC window's content root otherwise
+		// stays registered forever — and its Window.Closed subscribers (e.g. Hot Design's
+		// client host) keep the collectible ALC pinned via the coordinator's list:
+		// CoreServices → ContentRootCoordinator → ContentRoot → XamlIslandRoot → Window →
+		// Closed handlers → per-ALC subscriber → LoaderAllocator.
+		var alcContentRoot = _windowImplementation.XamlRoot?.VisualTree?.ContentRoot;
+		if (alcContentRoot is not null)
+		{
+			Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.RemoveContentRoot(alcContentRoot);
+		}
+
+		// WindowId-keyed statics (DisplayInformation, CoreDragDropManager's map, input managers,
+		// …) can retain the closed window's implementation graph. Rather than chasing every
+		// registry, strip the window-event subscriptions whose targets live in the collectible
+		// ALC (Closed/Activated/SizeChanged/VisibilityChanged on the implementation object).
+		// This window was removed from ApplicationHelper at InitializeAlcWindowMode, so the
+		// ALC-teardown window sweep in Application.CleanupNonDefaultAlcCaches never visits it —
+		// prune here, after RaiseClosed.
+		try
+		{
+			Application.PruneCollectibleDelegateFields(this, dyingAlc);
+			Application.PruneCollectibleDelegateFields(_windowImplementation, dyingAlc);
+		}
+		catch (Exception ex)
+		{
+			if (typeof(Window).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+			{
+				typeof(Window).Log().Debug($"[ALC-CLEANUP] window delegate prune error: {ex.GetType().Name}: {ex.Message}");
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.cs
@@ -127,6 +127,8 @@ public partial class Window
 
 	internal INativeWindowWrapper? NativeWrapper => _windowImplementation.NativeWindowWrapper;
 
+	internal IWindowImplementation WindowImplementation => _windowImplementation;
+
 	internal static Window GetFromAppWindow(AppWindow appWindow)
 	{
 		if (!_appWindowMap.TryGetValue(appWindow, out var window))


### PR DESCRIPTION
> **Depends on #23438 (Part 1).** This PR's branch is stacked on Part 1, so it contains Part 1's commit too — **review the last commit only**. Will be rebased onto master once #23438 merges.

**GitHub Issue (If applicable):** Part of #23437

> **Part 2 of 3** of the ALC window-teardown work, split out for reviewability and regression isolation. **Stacks on #23438 (Part 1)** — this PR is based on Part 1's branch, so review only its own commit. Will be retargeted to `master` once Part 1 merges.

## PR Type
🐞 Bugfix

## What changed? 🚀
Window-level event and render pruning during collectible-ALC teardown. Secondary-ALC code subscribes to events on host visual-tree elements and on the window implementation; those handlers are never removed when the secondary app unloads, and each pins the collectible ALC. This walks every live content root and prunes delegate-field invocation entries whose owner lives in an *unload-initiated* ALC (`IsFromUnloadInitiatedAlc`, which re-evaluates constructed generics against their definition so host types are never stripped), prunes the Type-keyed delegate cache, prunes orphaned `NativeDispatcher` composition targets, and clears window-level subscriptions at close time using the authoritative `OwnerAssemblyLoadContext`.

## PR Checklist ✅
- [x] 🧪 Runtime test added (`Given_WindowCollectibleEventPrune`)
- [x] ❗ Contains **NO** breaking changes

