### PR TITLE
fix(alc): prune Type-keyed caches on teardown (3/3)

### DIFF
--- a/src/Uno.UI.UnitTests/ContentControlTests/Given_ContentControl_DefaultTemplateMemo.cs
+++ b/src/Uno.UI.UnitTests/ContentControlTests/Given_ContentControl_DefaultTemplateMemo.cs
@@ -1,0 +1,65 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Reflection.Emit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.ContentControlTests
+{
+	/// <summary>
+	/// <see cref="ContentControl"/> memoizes "does the default style for this DefaultStyleKey
+	/// type set a Template" per <see cref="Type"/>. Keys from a collectible
+	/// AssemblyLoadContext's controls pin the unloaded ALC through the memoization dictionary.
+	/// ALC teardown must drop the memo (it rebuilds lazily).
+	/// </summary>
+	[TestClass]
+	public class Given_ContentControl_DefaultTemplateMemo
+	{
+		[TestMethod]
+		public void When_CleanupNonDefaultAlcCaches_Then_DefaultTemplate_Memo_Is_Reset()
+		{
+			var field = typeof(ContentControl).GetField("HasDefaultTemplate", BindingFlags.NonPublic | BindingFlags.Static);
+			Assert.IsNotNull(field, "ContentControl.HasDefaultTemplate memo field must exist");
+
+			var before = (Func<Type, bool>)field!.GetValue(null)!;
+
+			// Populate the memo with a collectible Type key (the shape an unloaded secondary
+			// app's control type would have).
+			var collectibleType = EmitCollectibleControlType();
+			before(collectibleType);
+
+			Application.CleanupNonDefaultAlcCaches();
+
+			var after = (Func<Type, bool>)field.GetValue(null)!;
+			Assert.AreNotSame(
+				before,
+				after,
+				"ALC teardown must replace the memoized default-template lookup; the old memo's " +
+				"dictionary keys (collectible Types) pin the unloaded AssemblyLoadContext.");
+
+			// The fresh memo still answers lookups.
+			after(typeof(ContentControl));
+		}
+
+		private static Type EmitCollectibleControlType()
+		{
+			if (!RuntimeFeature.IsDynamicCodeSupported)
+			{
+				Assert.Inconclusive("Reflection.Emit (RunAndCollect) is not supported on this target.");
+			}
+
+			var typeBuilder = AssemblyBuilder
+				.DefineDynamicAssembly(new AssemblyName("CollectibleDefaultTemplateProbe"), AssemblyBuilderAccess.RunAndCollect)
+				.DefineDynamicModule("main")
+				.DefineType("CollectibleControl", TypeAttributes.Public, typeof(ContentControl));
+
+			var emitted = typeBuilder.CreateType()!;
+			Assert.IsTrue(emitted.Assembly.IsCollectible, "Pre-condition: the probe type must be collectible");
+			return emitted;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -389,6 +389,10 @@ partial class Application
 		// Sweep every dictionary reachable from the host application and the master theme set.
 		RunCleanupStep(nameof(ClearCollectibleResourceAssociations), ClearCollectibleResourceAssociations);
 
+		// ContentControl memoizes "does this DefaultStyleKey type have a default template" per
+		// Type; keys from the unloaded app's controls pin the ALC.
+		RunCleanupStep(nameof(Controls.ContentControl.ClearHasDefaultTemplateCache), Controls.ContentControl.ClearHasDefaultTemplateCache);
+
 		// Secondary-ALC code can subscribe to events on HOST visual-tree elements (e.g. a
 		// designer overlay tracking an ancestor's SizeChanged); those subscriptions are never
 		// removed when the secondary app unloads and each one pins the collectible ALC. Walk

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -469,7 +469,9 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Gets whether the default style for the given type sets a non-null Template.
 		/// </summary>
-		private static Func<Type, bool> HasDefaultTemplate =
+		private static Func<Type, bool> HasDefaultTemplate = CreateHasDefaultTemplateMemo();
+
+		private static Func<Type, bool> CreateHasDefaultTemplateMemo() =>
 			Funcs.CreateMemoized((Type type) =>
 				Style.GetDefaultStyleForType(type) is Style defaultStyle
 					&& defaultStyle
@@ -478,6 +480,13 @@ namespace Microsoft.UI.Xaml.Controls
 						.OfType<Setter>()
 						.Any(s => s.Property == TemplateProperty && s.Value != null)
 			);
+
+		/// <summary>
+		/// Drops the memoized per-Type default-template lookups. The memoization dictionary keys
+		/// are DefaultStyleKey types — for controls from a collectible AssemblyLoadContext those
+		/// keys pin the ALC after unload. Called from ALC teardown cleanup.
+		/// </summary>
+		internal static void ClearHasDefaultTemplateCache() => HasDefaultTemplate = CreateHasDefaultTemplateMemo();
 
 		/// <summary>
 		/// Creates a ContentControl which can be measured without being added to the visual tree (eg as container in virtualized lists).

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
@@ -56,8 +56,20 @@ namespace Microsoft.UI.Xaml
 			// The association may already have propagated the parent's DataContext into this
 			// store at Inheritance precedence; that propagated value (e.g. the secondary app's
 			// view model) survives the parent's removal and pins the value's ALC on its own.
-			if (associationCleared
-				|| GetValue(_dataContextProperty)?.GetType().IsCollectible == true)
+			// Drop it only when the association was cleared, or when the value itself belongs to
+			// a collectible ALC whose unload has begun — a value from a still-live add-in ALC
+			// must be preserved (mirrors the conservative _associatedParent gating above).
+			var dataContextFromUnloadingAlc = false;
+			if (!associationCleared
+				&& GetValue(_dataContextProperty) is { } dataContext
+				&& dataContext.GetType().IsCollectible)
+			{
+				var valueAlc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(dataContext.GetType().Assembly);
+				dataContextFromUnloadingAlc = valueAlc is not null
+					&& global::Uno.UI.Xaml.Core.AlcStateHelper.IsUnloadInitiated(valueAlc, valueIfUnknown: false);
+			}
+
+			if (associationCleared || dataContextFromUnloadingAlc)
 			{
 				ClearInheritedDataContext();
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.alc.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.alc.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using System;
+
+namespace Microsoft.UI.Xaml
+{
+	public sealed partial class DependencyProperty
+	{
+		private partial class TypeNullableDictionary
+		{
+			/// <summary>
+			/// Removes entries whose key <see cref="Type"/> belongs to a non-default
+			/// (collectible) <see cref="System.Runtime.Loader.AssemblyLoadContext"/>, so the
+			/// app-lifetime dictionary does not pin an unloaded secondary app's types.
+			/// </summary>
+			internal void RemoveNonDefaultAlcEntries()
+			{
+				var defaultAlc = global::System.Runtime.Loader.AssemblyLoadContext.Default;
+				var keysToRemove = new global::System.Collections.Generic.List<Type>();
+
+				foreach (Type key in _entries.Keys)
+				{
+					// Type.IsCollectible also catches generic instantiations over collectible
+					// type arguments, whose declaring assembly is a shared (default-ALC) one.
+					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.Assembly);
+					if (key.IsCollectible || (alc is not null && alc != defaultAlc))
+					{
+						keysToRemove.Add(key);
+					}
+				}
+
+				foreach (var key in keysToRemove)
+				{
+					_entries.Remove(key);
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.alc.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.alc.cs
@@ -20,10 +20,17 @@ namespace Microsoft.UI.Xaml
 
 				foreach (Type key in _entries.Keys)
 				{
-					// Type.IsCollectible also catches generic instantiations over collectible
-					// type arguments, whose declaring assembly is a shared (default-ALC) one.
+					// Type.IsCollectible is the fast path — it also catches generic instantiations
+					// over collectible type arguments, whose declaring assembly is a shared
+					// (default-ALC) one. Only fall back to the load-context lookup otherwise.
+					if (key.IsCollectible)
+					{
+						keysToRemove.Add(key);
+						continue;
+					}
+
 					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.Assembly);
-					if (key.IsCollectible || (alc is not null && alc != defaultAlc))
+					if (alc is not null && alc != defaultAlc)
 					{
 						keysToRemove.Add(key);
 					}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
@@ -16,13 +16,24 @@ namespace Microsoft.UI.Xaml
 		{
 			if (!_isTypeNullableDictionary.TryGetValue(type, out var isNullable))
 			{
-				_isTypeNullableDictionary.Add(type, isNullable = type.IsNullable());
+				isNullable = type.IsNullable();
+
+				// Never cache collectible types: the app-lifetime dictionary would pin the
+				// type's AssemblyLoadContext after unload — and teardown sweeps themselves can
+				// re-query such types, racing any clear-on-teardown approach. Type.IsCollectible
+				// (not Assembly.IsCollectible) also covers generic instantiations whose
+				// DEFINITION lives in a shared assembly (e.g. ObservableCollection<T> from
+				// CoreLib) but whose type ARGUMENT is collectible.
+				if (!type.IsCollectible)
+				{
+					_isTypeNullableDictionary.Add(type, isNullable);
+				}
 			}
 
 			return isNullable;
 		}
 
-		private class TypeNullableDictionary
+		private partial class TypeNullableDictionary
 		{
 			// This dictionary has a single static instance that is kept for the lifetime of the whole app.
 			// So we don't use pooling to not cause pool exhaustion by renting without returning.

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -61,6 +61,10 @@ namespace Microsoft.UI.Xaml
 			_registry.RemoveNonDefaultAlcEntries();
 			_getInheritedPropertiesForType.RemoveNonDefaultAlcEntries();
 			_getPropertyCache.RemoveNonDefaultAlcEntries();
+			_isTypeNullableDictionary.RemoveNonDefaultAlcEntries();
+
+			// The pooled lookup key retains the last-queried Type past the cache prunes.
+			_searchPropertyCacheEntry.Update(typeof(object), "");
 		}
 
 		private readonly PropertyMetadata _ownerTypeMetadata; // For perf consideration, we keep direct ref the metadata for the owner type

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.alc.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.alc.cs
@@ -1,0 +1,28 @@
+using System.Runtime.Loader;
+
+namespace Uno.UI
+{
+	public static partial class ResourceResolver
+	{
+		/// <summary>
+		/// Schedules removal of an ALC's scoped resource-dictionary registrations once that ALC
+		/// unloads. The <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/> values hold
+		/// <see cref="System.Func{TResult}"/>s over generated code in that ALC, so while the entry
+		/// lives the ALC's LoaderAllocator can't be collected — and during unload the runtime keeps
+		/// the ALC (the live key) rooted until the LoaderAllocator dies, pinning it forever.
+		/// Teardown cleanup runs BEFORE <c>Unload()</c> is initiated, so removal is driven by the
+		/// <see cref="AssemblyLoadContext.Unloading"/> event (subscribed once, when the ALC first
+		/// registers a scoped dictionary) to fire at the right moment.
+		/// </summary>
+		private static void ScheduleAlcScopedRegistrationCleanup(AssemblyLoadContext alc)
+		{
+			alc.Unloading += static unloading =>
+			{
+				lock (_alcDictionariesLock)
+				{
+					_registeredDictionariesByUriByAlc.Remove(unloading);
+				}
+			};
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -22,7 +22,7 @@ using System.Runtime.Loader;
 namespace Uno.UI
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static class ResourceResolver
+	public static partial class ResourceResolver
 	{
 		/// <summary>
 		/// The ambient ALC context for resource resolution. Set during App.xaml initialization
@@ -933,6 +933,7 @@ namespace Uno.UI
 					{
 						alcDict = new Dictionary<string, Func<ResourceDictionary>>(StringComparer.OrdinalIgnoreCase);
 						_registeredDictionariesByUriByAlc.Add(dictAlc, alcDict);
+						ScheduleAlcScopedRegistrationCleanup(dictAlc);
 					}
 					alcDict[uri] = dictionary;
 				}
@@ -978,6 +979,9 @@ namespace Uno.UI
 		{
 			RemoveNonDefaultAlcEntries(_registeredDictionariesByUri);
 			RemoveNonDefaultAlcEntries(_registeredDictionariesByFilepath);
+			// ALC-scoped registrations are removed via the AssemblyLoadContext.Unloading subscription
+			// set up in ScheduleAlcScopedRegistrationCleanup — this cleanup runs before Unload() is
+			// initiated, so it cannot rely on unload state here.
 		}
 
 		private static void RemoveNonDefaultAlcEntries(Dictionary<string, Func<ResourceDictionary>> dictionary)
@@ -1036,6 +1040,7 @@ namespace Uno.UI
 					{
 						alcDict = new Dictionary<string, Func<ResourceDictionary>>(StringComparer.OrdinalIgnoreCase);
 						_registeredDictionariesByUriByAlc.Add(alc, alcDict);
+						ScheduleAlcScopedRegistrationCleanup(alc);
 					}
 					alcDict[uri] = dictionary;
 				}

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -357,9 +357,11 @@ partial class Window
 		}
 
 		// Remove this window's ContentRoot from the process-wide ContentRootCoordinator.
-		// RemoveContentRoot has no other caller, so an ALC window's content root otherwise
-		// stays registered forever — and its Window.Closed subscribers (e.g. Hot Design's
-		// client host) keep the collectible ALC pinned via the coordinator's list:
+		// This is the only path that removes a window-owned content root — the teardown sweep
+		// in Application.PruneCollectibleAlcEventSubscriptions deliberately skips window roots —
+		// so an ALC window's content root otherwise stays registered forever, and its
+		// Window.Closed subscribers (e.g. Hot Design's client host) keep the collectible ALC
+		// pinned via the coordinator's list:
 		// CoreServices → ContentRootCoordinator → ContentRoot → XamlIslandRoot → Window →
 		// Closed handlers → per-ALC subscriber → LoaderAllocator.
 		var alcContentRoot = _windowImplementation.XamlRoot?.VisualTree?.ContentRoot;


### PR DESCRIPTION
> **Depends on #23438 (Part 1) and #23495 (Part 2).** This PR's branch is stacked, so it contains Parts 1–2 commits too — **review the last commit only**. Will be rebased onto master once #23438 and #23495 merge.

**GitHub Issue (If applicable):** closes #23437

> **Part 3 of 3** of the ALC window-teardown work, split out for reviewability and regression isolation. **Stacks on #23495 (Part 2)** — based on Part 2's branch; review only its own commit. Will be retargeted to `master` once Parts 1–2 merge. Merging this completes the set, so it closes the issue.

## PR Type
🐞 Bugfix

## What changed? 🚀
Type-keyed cache pruning during collectible-ALC teardown. Several process-lifetime caches are keyed by `Type` and pin an unloaded secondary app's types (and their `LoaderAllocator` → ALC): `ContentControl`'s default-template memo, `DependencyProperty`'s `TypeNullableDictionary` and pooled search key, and `ResourceResolver`'s ALC-scoped dictionary registrations. `CleanupNonDefaultAlcCaches` now clears each on teardown; entries re-cache on demand.

## PR Checklist ✅
- [x] 🧪 Unit test added (`Given_ContentControl_DefaultTemplateMemo`)
- [x] ❗ Contains **NO** breaking changes

