### PR TITLE
feat!: Invoke hot-reload handler on every outcome

### DIFF
--- a/specs/045-hotreload-handler-all-outcomes/spec.md
+++ b/specs/045-hotreload-handler-all-outcomes/spec.md
@@ -1,0 +1,305 @@
+# Hot-Reload Handler: Invoke on Every Outcome (not success-only)
+
+## Overview & Objectives
+
+`HotReloadManager.ProcessSolutionChanged` only invokes `IHotReloadHandler` on the
+**success** path — the cycle that produces a non-empty metadata-update (EnC delta) set.
+Every other terminal outcome (`NoChanges`, `RudeEdit`, `Failed`) returns early **before**
+the handler is reached. As a result, anything a handler must do that is **not** carried by
+the IL/metadata delta — most importantly *side-effects derived from the
+`SolutionUpdateResult`* — is silently skipped on no-delta cycles.
+
+This spec proposes three changes to `ProcessSolutionChanged`:
+
+1. **Invoke the handler on every terminal outcome**, passing the `HotReloadOperationResult`
+   so handlers can react per-outcome — replacing the success-only `SendAsync`.
+2. **Commit `CurrentSolution = result.Solution` unconditionally**, before any early return,
+   so solution mutations the updater performed (e.g. rebound references) survive cycles that
+   don't emit a delta.
+3. **Wrap the handler invocation in `try`/`catch`** and report a handler failure through
+   `hotReload.Complete(Failed, …)` rather than letting it surface as a generic
+   `InternalError`.
+
+### Key objective
+
+Make the handler a faithful observer of the **whole** hot-reload cycle, so a custom
+`ISolutionUpdater` + `IHotReloadHandler` pair can perform delta-independent work
+(notably staging resolved package assemblies) on the cycle that actually produces that
+state — without resorting to predictive workarounds.
+
+---
+
+## Motivating scenario (generic)
+
+A downstream consumer hosts an inner application in a dedicated `AssemblyLoadContext` (ALC)
+and plugs a **custom `ISolutionUpdater`** into `HotReloadManager` via the third
+`CreateAsync` overload. That updater:
+
+- re-evaluates an edited `.csproj` when a `PackageReference` is added,
+- resolves the package (and its transitive graph), rebinds the resulting metadata/analyzer
+  references onto the solution, and
+- returns a `SolutionUpdateResult` **subtype** carrying the resolved packages (surfaced to
+  the handler through `HotReloadUpdate.SolutionUpdate`).
+
+The consumer's `IHotReloadHandler` then **stages** those resolved assemblies onto the inner
+app's ALC probe directory, so that when a later edit references a type from the new package,
+the ALC resolves it at runtime.
+
+### The gap
+
+Adding a `PackageReference` is a **references-only** change: it mutates the solution
+(new metadata references) but produces **no IL/metadata delta**. In
+`ProcessSolutionChanged`:
+
+- `result.Solution != originalSolution` (the references were rebound), so the
+  "no changes" check at **L167** passes.
+- `EmitSolutionUpdateAsync` (**L180**) returns an **empty** `updates` set (no delta).
+- The branch at **L188** (`rudeEdits.IsEmpty && updates.IsEmpty`) treats the cycle as
+  `NoChanges` (or `Failed` if there are compile errors) and **returns at L201**, *before*
+  the handler call at **L223**.
+
+So the resolved packages on `SolutionUpdateResult` **never reach the handler on the cycle
+that resolved them**. The handler runs only on the *next* cycle that emits a delta — by
+which point the updater typically reports zero newly-resolved packages. The assembly is bound
+to the compile workspace (code/XAML compiles) but is never staged onto the running app's
+probe path, so instantiating a type from the new package throws `FileNotFoundException` /
+`TargetInvocationException` at runtime.
+
+Today a consumer can only work around this by **carrying resolved packages forward** to a
+later delta-producing cycle. That workaround is a *prediction*: from inside `UpdateAsync`
+the updater cannot observe whether the cycle it is in will actually ship a delta downstream,
+so the carry/flush decision is necessarily heuristic. The proper fix is to let the handler
+see the no-delta cycle and act on it directly.
+
+---
+
+## Current behavior (reference)
+
+`src/Uno.HotReload/HotReloadManager.cs`, `ProcessSolutionChanged` (≈L143-226). Terminal
+exits, in order:
+
+| # | Location | Condition | Completion | Handler called? |
+|---|----------|-----------|------------|-----------------|
+| 1 | L161 | `result.Diagnostics` has errors | `Failed` | **no** |
+| 2 | L167 | `result.Solution == originalSolution` | `NoChanges` | **no** |
+| 3 | L188 | `rudeEdits.IsEmpty && updates.IsEmpty` | `NoChanges` / `Failed` | **no** |
+| 4 | L204 | `!rudeEdits.IsEmpty` | `RudeEdit` | **no** |
+| 5 | L217 | otherwise (delta present) | `Success` | **yes** (`SendAsync`) |
+
+`CurrentSolution = result.Solution` is assigned at **L177** — *after* exits 1 and 2, so those
+paths never commit the updated solution. The handler call (**L223**) is not guarded; a handler
+exception propagates to the `ProcessFileChanges` catch (**L134**) and is reported as
+`InternalError`.
+
+---
+
+## Proposed changes
+
+### 1. Invoke the handler on every terminal outcome, with the result code
+
+Replace the success-only method on `IHotReloadHandler`:
+
+```csharp
+// before
+ValueTask SendAsync(HotReloadUpdate update, CancellationToken ct);
+
+// after
+ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct);
+```
+
+`ProcessSolutionChanged` builds a `HotReloadUpdate` on **every** terminal path and invokes the
+handler with the computed `HotReloadOperationResult` before completing the operation:
+
+- `Deltas` is empty on every non-success path.
+- `Diagnostics` carries the rude-edit / compile diagnostics where applicable.
+- `SolutionUpdate` (hence `SolutionUpdate.Packages` for a custom subtype) is populated on all
+  paths reached after `UpdateAsync`.
+
+This lets a handler:
+
+- stage delta-independent state (e.g. resolved package assemblies) on a `NoChanges`
+  (no-delta) cycle — removing the need for any carry-forward heuristic in the consumer;
+- observe `RudeEdit` / `Failed` / `NoChanges` for its own state or UI (e.g. surface that an
+  edit did not apply).
+
+Handlers that only care about success guard at the top:
+
+```csharp
+public ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct)
+{
+    if (result is not HotReloadOperationResult.Success && update.SolutionUpdate is not /* subtype with work to do */)
+    {
+        return ValueTask.CompletedTask;
+    }
+    // …
+}
+```
+
+Outcomes that invoke the handler: `Success`, `NoChanges`, `RudeEdit`, `Failed`.
+`Aborted` / `InternalError` remain manager/transport-level (see §3).
+
+#### Sketch
+
+```csharp
+// after UpdateAsync + NotifyIgnored + the unconditional CurrentSolution commit (§2):
+
+HotReloadOperationResult outcome;
+var deltas = ImmutableArray<Update>.Empty;
+var diagnostics = ImmutableArray<Diagnostic>.Empty;
+
+if (result.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+{
+    outcome = HotReloadOperationResult.Failed;
+    diagnostics = result.Diagnostics;
+}
+else if (result.Solution == originalSolution)
+{
+    outcome = HotReloadOperationResult.NoChanges;
+}
+else
+{
+    var (updates, hotReloadDiagnostics) = await _watchService.EmitSolutionUpdateAsync(result.Solution, ct).ConfigureAwait(false);
+    var rudeEdits = hotReloadDiagnostics.RemoveAll(d => d.Severity == DiagnosticSeverity.Warning || !d.Descriptor.Id.StartsWith("ENC", StringComparison.Ordinal));
+
+    if (!rudeEdits.IsEmpty)
+    {
+        outcome = HotReloadOperationResult.RudeEdit;
+        diagnostics = hotReloadDiagnostics;
+    }
+    else if (updates.IsEmpty)
+    {
+        outcome = GetCompilationErrors(result.Solution, ct).IsEmpty
+            ? HotReloadOperationResult.NoChanges
+            : HotReloadOperationResult.Failed;
+        diagnostics = hotReloadDiagnostics;
+    }
+    else
+    {
+        outcome = HotReloadOperationResult.Success;
+        deltas = updates;
+        diagnostics = hotReloadDiagnostics;
+    }
+}
+
+var update = new HotReloadUpdate(files, changeSet, result, diagnostics, deltas);
+// → §3 wraps the handler call and completion
+```
+
+### 2. Commit `CurrentSolution = result.Solution` before any early return
+
+Hoist the assignment to immediately after `UpdateAsync` / `NotifyIgnored`, ahead of every
+terminal branch:
+
+```csharp
+var result = await _solutionUpdater.UpdateAsync(originalSolution, changeSet, ct).ConfigureAwait(false);
+hotReload.NotifyIgnored(result.IgnoredChanges.GetAllPaths());
+
+// Commit unconditionally: an updater may have rebound metadata/analyzer references
+// (e.g. newly resolved packages) onto result.Solution. If a cycle exits early without
+// committing, those references are lost and the next cycle restarts from the stale
+// originalSolution — dropping the resolved references from the workspace.
+workspace.CurrentSolution = result.Solution;
+```
+
+This generalizes the intent already stated by the comment at **L175-176** ("No matter if the
+build will succeed or not, we update the `_currentSolution`") to the early-exit paths.
+
+- The `result.Solution == originalSolution` branch becomes a no-op assignment; the condition
+  still compares against the **captured** `originalSolution`, so the branch is unchanged.
+- **Requirement on updaters:** `result.Solution` must be coherent even when `result.Diagnostics`
+  carries errors — an updater must not return a half-applied / destructive diff. (The built-in
+  `SolutionUpdater` and well-behaved custom updaters already skip the diff/apply when a project
+  re-evaluation errors, leaving the project at its previous references.)
+
+### 3. Guard the handler call; report handler failure as `Failed`
+
+The handler now performs real side-effects (staging assemblies, applying deltas — possibly
+across a thread/process boundary in worker-hosted scenarios). A handler exception should
+surface as a hot-reload **failure** for that operation, distinct from a manager-internal fault:
+
+```csharp
+try
+{
+    await _handler.OnHotReloadAsync(outcome, update, ct).ConfigureAwait(false);
+}
+catch (OperationCanceledException)
+{
+    throw; // cancellation is not a failure
+}
+catch (Exception e)
+{
+    await hotReload.Complete(HotReloadOperationResult.Failed, e, diagnostics).ConfigureAwait(false);
+    return;
+}
+
+await hotReload.Complete(outcome, diagnostics: diagnostics).ConfigureAwait(false);
+```
+
+- `OperationCanceledException` is caught first and rethrown (most-specific-first ordering).
+- Any other handler exception completes the operation as `Failed` carrying the exception, so
+  consumers observing operation results see a real failure rather than a clean reload. A
+  handler that throws while staging on a would-be `Success` cycle thus correctly yields
+  `Failed` — the reload did not take effect on the consumer side.
+- The outer `ProcessFileChanges` catch (**L134** → `InternalError`) is retained for genuine
+  manager-internal faults (e.g. `EmitSolutionUpdateAsync` throwing).
+
+---
+
+## Interface & migration
+
+- **Breaking change** to `IHotReloadHandler` (`SendAsync` → `OnHotReloadAsync`). Treat as a
+  MAJOR/MINOR per the repo's SemVer policy; provide migration notes.
+- Update `DelegateHotReloadHandler` to the new shape. The legacy `SendUpdatesAsync` delegate
+  (`(files, updates, ct)`) should keep firing **only on `Success`** so existing
+  `(files, updates)` consumers are unaffected:
+
+  ```csharp
+  public ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct)
+      => result is HotReloadOperationResult.Success
+          ? send(update.Files, update.Deltas, ct)
+          : ValueTask.CompletedTask;
+  ```
+
+- Update the `IHotReloadHandler` / `HotReloadUpdate` doc comments (they currently state
+  "success path only"). The decorator/chaining contract is unchanged.
+
+---
+
+## Risks & considerations
+
+- **Per-cycle cost.** The handler is now called once per cycle (incl. `NoChanges`), and a
+  `HotReloadUpdate` record is allocated on every path. A `result != Success` guard keeps
+  success-only handlers cheap; the extra allocation is negligible relative to a cycle.
+- **`EmitSolutionUpdateAsync` placement unchanged.** It is still only invoked once the solution
+  actually changed (after the `== originalSolution` check), so the no-IL-change cost profile
+  is preserved.
+- **Worker-hosted handlers.** Where the handler forwards across a worker→main boundary,
+  "handled" means "dispatched"; the `try`/`catch` covers dispatch failures. Downstream staging
+  failures on the far side remain the consumer's responsibility to surface.
+- **Outcome vs handler-failure precedence.** A handler exception completes the operation as
+  `Failed` regardless of the computed `outcome`; this is intentional (the side-effect failed).
+
+---
+
+## Test plan
+
+- `ProcessSolutionChanged` unit tests (driving the manager with a stub `IWatchHotReloadService`
+  and a recording `IHotReloadHandler`) asserting the handler is invoked with the expected
+  `HotReloadOperationResult` for each terminal path: `Success`, `NoChanges` (no solution change),
+  `NoChanges` (solution changed but no delta), `RudeEdit`, `Failed` (compile errors), `Failed`
+  (updater diagnostics).
+- A references-only change (solution mutated, empty `updates`) invokes the handler with
+  `NoChanges` and a `HotReloadUpdate` whose `SolutionUpdate` carries the updater's result.
+- After an early-exit cycle, `CurrentSolution` reflects `result.Solution` (regression for §2).
+- A throwing handler completes the operation as `Failed` with the exception (regression for §3);
+  a handler throwing `OperationCanceledException` propagates and does not complete as `Failed`.
+
+---
+
+## Out of scope
+
+- The set of `HotReloadOperationResult` values (unchanged).
+- The delta-emission / rude-edit classification logic (unchanged; only its branch structure is
+  reorganized to converge on a single handler call + completion).
+- Removing any of the early-return *conditions* — each remains a distinct outcome; only the
+  premature **handler bypass** is removed.

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -161,6 +161,8 @@ public class Given_HotReloadManager
 		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.RudeEdit);
 		harness.Handler.Calls.Should().ContainSingle();
 		harness.Handler.Calls[0].Result.Should().Be(HotReloadOperationResult.RudeEdit);
+		harness.Handler.Calls[0].Update.Diagnostics.Should().Contain(d => d.Id == "ENC0033",
+			"handler must receive the rude-edit diagnostics so consumers can surface them");
 	}
 
 	[TestMethod]
@@ -190,6 +192,8 @@ public class Given_HotReloadManager
 		harness.Handler.Calls.Should().ContainSingle(c => c.Result == HotReloadOperationResult.Failed);
 		emitCalled.Should().BeFalse("the updater-error path short-circuits before EmitSolutionUpdateAsync");
 		harness.Manager.CurrentSolution.Should().NotBeSameAs(original, "the rebound solution is committed even on the early Failed exit (§2)");
+		harness.Handler.Calls[0].Update.Diagnostics.Should().Contain(d => d.Id == "TEST0001",
+			"the updater error diagnostic must be forwarded to the handler so consumers see the failure reason");
 	}
 
 	[TestMethod]

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -77,7 +77,8 @@ public class Given_HotReloadManager
 		harness.Tracker.Current.Should().BeNull();
 		harness.Tracker.Last.Should().NotBeNull();
 		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Success);
-		harness.Handler.Updates.Should().HaveCount(1);
+		harness.Handler.Calls.Should().ContainSingle()
+			.Which.Result.Should().Be(HotReloadOperationResult.Success);
 	}
 
 	[TestMethod]
@@ -233,9 +234,10 @@ public class Given_HotReloadManager
 
 	[TestMethod]
 	[Description(
-		"Spec 045 §3: OperationCanceledException from the handler is not a hot-reload failure — it propagates " +
-		"to the manager-internal catch and must not complete the operation as Failed.")]
-	public async Task When_HandlerThrowsOperationCanceled_Then_NotCompletedAsFailed()
+		"Spec 045 §3: OperationCanceledException from the handler is not a hot-reload failure — it re-throws " +
+		"past the per-handler catch into the ProcessFileChanges manager-internal catch, which completes the " +
+		"operation as InternalError (carrying the exception), not Failed.")]
+	public async Task When_HandlerThrowsOperationCanceled_Then_CompletedAsInternalError()
 	{
 		using var harness = new HotReloadManagerHarness(
 			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
@@ -245,9 +247,62 @@ public class Given_HotReloadManager
 		var batch = ImmutableHashSet.Create("/work/Model.cs");
 		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
 
-		harness.Tracker.Last!.Result.Should().NotBe(
-			HotReloadOperationResult.Failed,
-			"cancellation is not a handler failure; it propagates to the manager-internal catch");
+		harness.Tracker.Last!.Result.Should().Be(
+			HotReloadOperationResult.InternalError,
+			"a handler cancellation is not a hot-reload failure; it re-throws into the manager-internal catch which records InternalError");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 045 idempotency contract (IHotReloadHandler.OnHotReloadAsync remarks): a single logical edit can " +
+		"drive the handler more than once. A host that re-runs a no-delta cycle (the no-changes auto-retry path, " +
+		"which re-enters ProcessSolutionChanged) re-invokes the handler with the same NoChanges outcome each time, " +
+		"so delta-independent side-effects must be idempotent. Re-processing the same no-delta batch is the " +
+		"observable proxy for that re-run: the handler is invoked once per cycle, never coalesced.")]
+	public async Task When_NoDeltaCycleReprocessed_Then_HandlerReinvokedPerCycle()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])));
+
+		var batch = ImmutableHashSet.Create("/work/App.csproj");
+
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Handler.Calls.Should().HaveCount(2, "each cycle re-invokes the handler — side-effects must be idempotent across re-runs of the same logical change");
+		harness.Handler.Calls.Should().OnlyContain(c => c.Result == HotReloadOperationResult.NoChanges);
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 045 §1: an emitted cycle that produces no metadata updates and no rude edits, but whose solution " +
+		"carries compilation errors, completes as Failed (not NoChanges) — the manager probes the committed " +
+		"solution's compilation via GetCompilationErrors. The handler is invoked with Failed so consumers see the " +
+		"blocked reload.")]
+	public async Task When_CompilationErrors_Then_HandlerInvokedWithFailed()
+	{
+		using var harness = new HotReloadManagerHarness(
+			// No metadata updates and no diagnostics: forces the updates-empty / no-rude-edit branch
+			// that probes the committed solution's compilation for blocking errors.
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
+			// Mutate the solution (so it isn't the NoChanges fast-path) by adding a document with a
+			// reference-independent syntax error (CS1513 '}' expected).
+			onUpdate: solution =>
+			{
+				var projectId = solution.ProjectIds[0];
+				var broken = solution.AddDocument(DocumentId.CreateNewId(projectId), "Broken.cs", "public class Broken {");
+				return new SolutionUpdateResult(broken, ChangeSet.IgnoreAll([]));
+			},
+			// GetCompilationErrors reads TryGetCompilation (the cached compilation), so the result
+			// solution's compilation must be computed before the manager probes it.
+			warmCompilation: true);
+
+		var batch = ImmutableHashSet.Create("/work/Broken.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Failed, "a solution that does not compile blocks the reload");
+		harness.Handler.Calls.Should().ContainSingle()
+			.Which.Result.Should().Be(HotReloadOperationResult.Failed);
 	}
 
 	private sealed record MarkerSolutionUpdateResult(Solution Solution, ChangeSet IgnoredChanges, string Marker)

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using AwesomeAssertions;
 using Microsoft.CodeAnalysis;
+using Uno.HotReload.Diffing;
 using Uno.HotReload.Tests.TestUtils;
 using Uno.HotReload.Tracking;
 
@@ -106,4 +107,149 @@ public class Given_HotReloadManager
 		pendingBatch.SetResult(batch);
 		await firstProcess.WaitAsync(_testTimeout);
 	}
+
+	// ── Spec 045: invoke the handler on every terminal outcome ──
+
+	[TestMethod]
+	[Description(
+		"Spec 045 §1: a cycle that mutates the solution but emits no delta (e.g. a references-only " +
+		"PackageReference add) now invokes the handler with NoChanges, carrying the updater's result — " +
+		"so a handler can stage delta-independent state on the no-delta cycle, not via a carry-forward.")]
+	public async Task When_NoDeltaCycle_Then_HandlerInvokedWithNoChanges()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])));
+
+		var batch = ImmutableHashSet.Create("/work/App.csproj");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.NoChanges);
+		harness.Handler.Calls.Should().HaveCount(1, "the handler is invoked on every terminal outcome, not just Success");
+		harness.Handler.Calls[0].Result.Should().Be(HotReloadOperationResult.NoChanges);
+		harness.Handler.Calls[0].Update.Deltas.Should().BeEmpty("there is no delta on a NoChanges cycle");
+		harness.Handler.Calls[0].Update.SolutionUpdate.Should().NotBeNull("the updater's result is visible to the handler on the no-delta cycle");
+	}
+
+	[TestMethod]
+	[Description("Spec 045 §1: a successful delta cycle invokes the handler with Success and the deltas.")]
+	public async Task When_DeltaCycle_Then_HandlerInvokedWithSuccessAndDeltas()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
+				([HotReloadManagerHarness.CreateEmptyUpdate()], [])));
+
+		var batch = ImmutableHashSet.Create("/work/Model.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Handler.Calls.Should().HaveCount(1);
+		harness.Handler.Calls[0].Result.Should().Be(HotReloadOperationResult.Success);
+		harness.Handler.Calls[0].Update.Deltas.Should().HaveCount(1);
+	}
+
+	[TestMethod]
+	[Description("Spec 045 §1: a rude edit invokes the handler with RudeEdit so handlers can observe a non-applied edit.")]
+	public async Task When_RudeEdit_Then_HandlerInvokedWithRudeEdit()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
+				([], [HotReloadManagerHarness.CreateRudeEditDiagnostic()])));
+
+		var batch = ImmutableHashSet.Create("/work/Model.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.RudeEdit);
+		harness.Handler.Calls.Should().ContainSingle();
+		harness.Handler.Calls[0].Result.Should().Be(HotReloadOperationResult.RudeEdit);
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 045 §1+§2: when the updater reports an error diagnostic the handler is invoked with Failed, " +
+		"and the (rebound) solution is committed before the early exit so later cycles don't restart from " +
+		"the stale solution. The error path short-circuits before EmitSolutionUpdateAsync.")]
+	public async Task When_UpdaterReportsError_Then_HandlerInvokedWithFailed_AndSolutionCommitted()
+	{
+		var emitCalled = false;
+		using var harness = new HotReloadManagerHarness(
+			_ =>
+			{
+				emitCalled = true;
+				return Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], []));
+			},
+			onUpdate: solution => new SolutionUpdateResult(
+				solution.WithProjectAssemblyName(solution.ProjectIds[0], "Rebound"),
+				ChangeSet.IgnoreAll([]),
+				[HotReloadManagerHarness.CreateErrorDiagnostic()]));
+
+		var original = harness.Manager.CurrentSolution;
+		var batch = ImmutableHashSet.Create("/work/App.csproj");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Failed);
+		harness.Handler.Calls.Should().ContainSingle(c => c.Result == HotReloadOperationResult.Failed);
+		emitCalled.Should().BeFalse("the updater-error path short-circuits before EmitSolutionUpdateAsync");
+		harness.Manager.CurrentSolution.Should().NotBeSameAs(original, "the rebound solution is committed even on the early Failed exit (§2)");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 045 motivating scenario: a references-only change returns a SolutionUpdateResult subtype " +
+		"(carrying e.g. resolved packages); the handler receives it via HotReloadUpdate.SolutionUpdate on " +
+		"the no-delta cycle and can downcast — removing the consumer's carry-forward workaround.")]
+	public async Task When_ReferencesOnlyChange_Then_HandlerSeesSubtypeOnNoChanges()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
+			onUpdate: solution => new MarkerSolutionUpdateResult(
+				solution.WithProjectAssemblyName(solution.ProjectIds[0], "WithPackage"),
+				ChangeSet.IgnoreAll([]),
+				"resolved-package"));
+
+		var batch = ImmutableHashSet.Create("/work/App.csproj");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Handler.Calls.Should().ContainSingle();
+		harness.Handler.Calls[0].Result.Should().Be(HotReloadOperationResult.NoChanges);
+		harness.Handler.Calls[0].Update.SolutionUpdate.Should().BeOfType<MarkerSolutionUpdateResult>()
+			.Which.Marker.Should().Be("resolved-package");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 045 §3: a handler exception completes the operation as Failed carrying the exception, even on " +
+		"a would-be Success cycle — the reload did not take effect on the consumer side.")]
+	public async Task When_HandlerThrows_Then_OperationCompletesFailed()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
+				([HotReloadManagerHarness.CreateEmptyUpdate()], [])));
+		harness.Handler.ThrowAfterRecording = new InvalidOperationException("staging failed");
+
+		var batch = ImmutableHashSet.Create("/work/Model.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Failed, "a handler failure fails the operation (§3)");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 045 §3: OperationCanceledException from the handler is not a hot-reload failure — it propagates " +
+		"to the manager-internal catch and must not complete the operation as Failed.")]
+	public async Task When_HandlerThrowsOperationCanceled_Then_NotCompletedAsFailed()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(
+				([HotReloadManagerHarness.CreateEmptyUpdate()], [])));
+		harness.Handler.ThrowAfterRecording = new OperationCanceledException();
+
+		var batch = ImmutableHashSet.Create("/work/Model.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().NotBe(
+			HotReloadOperationResult.Failed,
+			"cancellation is not a handler failure; it propagates to the manager-internal catch");
+	}
+
+	private sealed record MarkerSolutionUpdateResult(Solution Solution, ChangeSet IgnoredChanges, string Marker)
+		: SolutionUpdateResult(Solution, IgnoredChanges, []);
 }

--- a/src/Uno.HotReload.Tests/TestUtils/HotReloadManagerHarness.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/HotReloadManagerHarness.cs
@@ -19,7 +19,8 @@ internal sealed class HotReloadManagerHarness : IDisposable
 
 	public HotReloadManagerHarness(
 		Func<int, Task<(ImmutableArray<Update> Updates, ImmutableArray<Diagnostic> Diagnostics)>> onEmit,
-		Func<Solution, SolutionUpdateResult>? onUpdate = null)
+		Func<Solution, SolutionUpdateResult>? onUpdate = null,
+		bool warmCompilation = false)
 	{
 		_workspace = new AdhocWorkspace();
 		var project = _workspace.AddProject("TestProject", LanguageNames.CSharp);
@@ -36,7 +37,10 @@ internal sealed class HotReloadManagerHarness : IDisposable
 		var update = onUpdate ?? (solution => new SolutionUpdateResult(
 			solution.WithProjectAssemblyName(projectId, $"TestProject{Interlocked.Increment(ref _updateCount)}"),
 			ChangeSet.IgnoreAll([])));
-		var updater = new StubSolutionUpdater(update);
+		// warmCompilation forces the result solution's compilation to be computed (cached) so the
+		// manager's GetCompilationErrors — which reads TryGetCompilation, not GetCompilationAsync — can
+		// observe compile errors a test injected via a broken document (the StubWatchService never compiles).
+		var updater = new StubSolutionUpdater(update, warmCompilation);
 
 		Manager = new HotReloadManager(
 			_workspace,
@@ -103,18 +107,6 @@ internal sealed class HotReloadManagerHarness : IDisposable
 			}
 		}
 
-		/// <summary>The updates only (back-compat with success-oriented assertions).</summary>
-		public IReadOnlyList<HotReloadUpdate> Updates
-		{
-			get
-			{
-				lock (_gate)
-				{
-					return _calls.ConvertAll(c => c.Update);
-				}
-			}
-		}
-
 		public ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct)
 		{
 			lock (_gate)
@@ -150,9 +142,20 @@ internal sealed class HotReloadManagerHarness : IDisposable
 			=> ValueTask.FromResult(ChangeSet.IgnoreAll([]));
 	}
 
-	private sealed class StubSolutionUpdater(Func<Solution, SolutionUpdateResult> update) : ISolutionUpdater
+	private sealed class StubSolutionUpdater(Func<Solution, SolutionUpdateResult> update, bool warm) : ISolutionUpdater
 	{
-		public ValueTask<SolutionUpdateResult> UpdateAsync(Solution solution, ChangeSet changeSet, CancellationToken ct)
-			=> ValueTask.FromResult(update(solution));
+		public async ValueTask<SolutionUpdateResult> UpdateAsync(Solution solution, ChangeSet changeSet, CancellationToken ct)
+		{
+			var result = update(solution);
+			if (warm)
+			{
+				foreach (var project in result.Solution.Projects)
+				{
+					await project.GetCompilationAsync(ct).ConfigureAwait(false);
+				}
+			}
+
+			return result;
+		}
 	}
 }

--- a/src/Uno.HotReload.Tests/TestUtils/HotReloadManagerHarness.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/HotReloadManagerHarness.cs
@@ -17,7 +17,9 @@ internal sealed class HotReloadManagerHarness : IDisposable
 	private readonly AdhocWorkspace _workspace;
 	private int _updateCount;
 
-	public HotReloadManagerHarness(Func<int, Task<(ImmutableArray<Update> Updates, ImmutableArray<Diagnostic> Diagnostics)>> onEmit)
+	public HotReloadManagerHarness(
+		Func<int, Task<(ImmutableArray<Update> Updates, ImmutableArray<Diagnostic> Diagnostics)>> onEmit,
+		Func<Solution, SolutionUpdateResult>? onUpdate = null)
 	{
 		_workspace = new AdhocWorkspace();
 		var project = _workspace.AddProject("TestProject", LanguageNames.CSharp);
@@ -28,10 +30,13 @@ internal sealed class HotReloadManagerHarness : IDisposable
 
 		var projectId = project.Id;
 		var detector = new StubChangesDetector();
-		// Each pass must yield a different solution snapshot, otherwise the
-		// manager short-circuits with NoChanges before reaching the emitter.
-		var updater = new StubSolutionUpdater(solution =>
-			solution.WithProjectAssemblyName(projectId, $"TestProject{Interlocked.Increment(ref _updateCount)}"));
+		// Default updater: each pass yields a different solution snapshot, otherwise the manager
+		// short-circuits with NoChanges before reaching the emitter. Tests pass onUpdate to control
+		// the result (mutate or not, attach diagnostics, return a SolutionUpdateResult subtype).
+		var update = onUpdate ?? (solution => new SolutionUpdateResult(
+			solution.WithProjectAssemblyName(projectId, $"TestProject{Interlocked.Increment(ref _updateCount)}"),
+			ChangeSet.IgnoreAll([])));
+		var updater = new StubSolutionUpdater(update);
 
 		Manager = new HotReloadManager(
 			_workspace,
@@ -53,6 +58,17 @@ internal sealed class HotReloadManagerHarness : IDisposable
 	public static Update CreateEmptyUpdate()
 		=> new(Guid.NewGuid(), [], [], [], []);
 
+	public static Diagnostic CreateErrorDiagnostic(string id = "TEST0001")
+		=> Diagnostic.Create(
+			new DiagnosticDescriptor(
+				id,
+				"Updater error",
+				"Simulated updater failure (e.g. csproj re-evaluation error)",
+				"Build",
+				DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			Location.None);
+
 	public static Diagnostic CreateRudeEditDiagnostic()
 		=> Diagnostic.Create(
 			new DiagnosticDescriptor(
@@ -69,25 +85,46 @@ internal sealed class HotReloadManagerHarness : IDisposable
 
 	internal sealed class RecordingHandler : IHotReloadHandler
 	{
-		private readonly List<HotReloadUpdate> _updates = [];
+		private readonly List<(HotReloadOperationResult Result, HotReloadUpdate Update)> _calls = [];
 		private readonly Lock _gate = new();
 
+		/// <summary>When set, the handler throws this after recording the call (to test §3 failure handling).</summary>
+		public Exception? ThrowAfterRecording { get; set; }
+
+		/// <summary>Every (outcome, update) the manager handed to the handler, in order.</summary>
+		public IReadOnlyList<(HotReloadOperationResult Result, HotReloadUpdate Update)> Calls
+		{
+			get
+			{
+				lock (_gate)
+				{
+					return [.. _calls];
+				}
+			}
+		}
+
+		/// <summary>The updates only (back-compat with success-oriented assertions).</summary>
 		public IReadOnlyList<HotReloadUpdate> Updates
 		{
 			get
 			{
 				lock (_gate)
 				{
-					return [.. _updates];
+					return _calls.ConvertAll(c => c.Update);
 				}
 			}
 		}
 
-		public ValueTask SendAsync(HotReloadUpdate update, CancellationToken ct)
+		public ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct)
 		{
 			lock (_gate)
 			{
-				_updates.Add(update);
+				_calls.Add((result, update));
+			}
+
+			if (ThrowAfterRecording is { } ex)
+			{
+				throw ex;
 			}
 
 			return ValueTask.CompletedTask;
@@ -113,9 +150,9 @@ internal sealed class HotReloadManagerHarness : IDisposable
 			=> ValueTask.FromResult(ChangeSet.IgnoreAll([]));
 	}
 
-	private sealed class StubSolutionUpdater(Func<Solution, Solution> mutate) : ISolutionUpdater
+	private sealed class StubSolutionUpdater(Func<Solution, SolutionUpdateResult> update) : ISolutionUpdater
 	{
 		public ValueTask<SolutionUpdateResult> UpdateAsync(Solution solution, ChangeSet changeSet, CancellationToken ct)
-			=> ValueTask.FromResult(new SolutionUpdateResult(mutate(solution), ChangeSet.IgnoreAll([])));
+			=> ValueTask.FromResult(update(solution));
 	}
 }

--- a/src/Uno.HotReload/DelegateHotReloadHandler.cs
+++ b/src/Uno.HotReload/DelegateHotReloadHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.HotReload.Tracking;
 
 namespace Uno.HotReload;
 
@@ -22,6 +23,11 @@ public delegate ValueTask SendUpdatesAsync(ImmutableHashSet<string> files, Immut
 /// </summary>
 public sealed class DelegateHotReloadHandler(SendUpdatesAsync send) : IHotReloadHandler
 {
-	public ValueTask SendAsync(HotReloadUpdate update, CancellationToken ct)
-		=> send(update.Files, update.Deltas, ct);
+	// The handler is now invoked on every terminal outcome, but the legacy (files, updates)
+	// delegate only carries deltas — fire it on Success only so existing consumers are unaffected
+	// by no-delta (NoChanges / RudeEdit / Failed) cycles.
+	public ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct)
+		=> result is HotReloadOperationResult.Success
+			? send(update.Files, update.Deltas, ct)
+			: ValueTask.CompletedTask;
 }

--- a/src/Uno.HotReload/Diffing/ISolutionUpdater.cs
+++ b/src/Uno.HotReload/Diffing/ISolutionUpdater.cs
@@ -38,6 +38,18 @@ public interface ISolutionUpdater
 	/// state changed, otherwise an unnecessary
 	/// <c>EmitSolutionUpdateAsync</c> roundtrip is incurred per cycle.
 	/// </para>
+	/// <para>
+	/// Coherence-under-error contract: <see cref="SolutionUpdateResult.Solution"/> must be a
+	/// <strong>coherent</strong> snapshot even when <see cref="SolutionUpdateResult.Diagnostics"/>
+	/// reports an error. An updater applies only the edits it can apply safely; when it cannot
+	/// proceed (e.g. a <c>.csproj</c> re-evaluation fails) it returns the solution at its
+	/// last-known-good state — typically the previous references, never a half-applied or
+	/// destructive diff — together with the error diagnostics. The manager commits
+	/// <c>result.Solution</c> <em>unconditionally</em>, ahead of the error short-circuit, so the
+	/// safely-applied edits survive across cycles; a half-applied snapshot would persist into and
+	/// poison the next cycle. The built-in updater honors this by skipping the diff/apply entirely
+	/// when a project re-evaluation errors, leaving the project at its prior references.
+	/// </para>
 	/// </remarks>
 	ValueTask<SolutionUpdateResult> UpdateAsync(
 		Solution solution,

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -172,6 +172,7 @@ public sealed class HotReloadManager : IDisposable
 		{
 			// Updater encountered a fatal condition (typically a csproj re-evaluation error). The
 			// manager — not the updater — owns the operation lifecycle, so we carry the diagnostics.
+			_tracker.Output($"Hot reload failed: solution updater reported {result.Diagnostics.Count(d => d.Severity == DiagnosticSeverity.Error)} error diagnostic(s).");
 			outcome = HotReloadOperationResult.Failed;
 			diagnostics = result.Diagnostics;
 		}
@@ -183,44 +184,53 @@ public sealed class HotReloadManager : IDisposable
 		else
 		{
 			// Compile the solution and get deltas.
-			var (updates, hotReloadDiagnostics) = await _watchService.EmitSolutionUpdateAsync(result.Solution, ct).ConfigureAwait(false);
-			// hotReloadDiagnostics currently includes semantic Warnings and Errors for types being updated. We want to limit rude edits to the class
+			var (updates, emitDiagnostics) = await _watchService.EmitSolutionUpdateAsync(result.Solution, ct).ConfigureAwait(false);
+			// emitDiagnostics currently includes semantic Warnings and Errors for types being updated. We want to limit rude edits to the class
 			// of unrecoverable errors that a user cannot fix and requires an app rebuild.
-			var rudeEdits = hotReloadDiagnostics.RemoveAll(d => d.Severity == DiagnosticSeverity.Warning || !d.Descriptor.Id.StartsWith("ENC", StringComparison.Ordinal));
+			var rudeEdits = emitDiagnostics.RemoveAll(d => d.Severity <= DiagnosticSeverity.Warning || !d.Descriptor.Id.StartsWith("ENC", StringComparison.Ordinal));
 
 			_tracker.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
 
-			if (!rudeEdits.IsEmpty)
-			{
-				// Rude edit.
-				_tracker.Output("Unable to apply hot reload because of a rude edit.");
-				foreach (var diagnostic in hotReloadDiagnostics)
-				{
-					_tracker.Verbose(CSharpDiagnosticFormatter.Instance.Format(diagnostic, CultureInfo.InvariantCulture));
-				}
+			// Emit (EnC) diagnostics carry on every outcome of this branch; deltas are populated on Success only.
+			diagnostics = emitDiagnostics;
 
-				outcome = HotReloadOperationResult.RudeEdit;
-				diagnostics = hotReloadDiagnostics;
-			}
-			else if (updates.IsEmpty)
+			switch (rudeEdits.IsEmpty, updates.IsEmpty)
 			{
-				if (GetCompilationErrors(result.Solution, ct).IsEmpty)
-				{
+				// A rude edit is unrecoverable: the user must rebuild. Surface every diagnostic.
+				case (false, _):
+					_tracker.Output("Unable to apply hot reload because of a rude edit.");
+					foreach (var diagnostic in emitDiagnostics)
+					{
+						_tracker.Verbose(CSharpDiagnosticFormatter.Instance.Format(diagnostic, CultureInfo.InvariantCulture));
+					}
+
+					outcome = HotReloadOperationResult.RudeEdit;
+					break;
+
+				// Metadata updates were produced and are applicable.
+				case (true, false):
+					outcome = HotReloadOperationResult.Success;
+					deltas = updates;
+					break;
+
+				// No metadata updates, but the solution does not compile: the reload is blocked, not a no-op.
+				// FIXME (out of this PR's scope): these compilation errors are only pushed to _tracker (console)
+				// from inside GetCompilationErrors — they are NOT carried onto the operation/handler diagnostics
+				// bag, so a structured consumer sees Failed without the reason (asymmetric with rude edits, which
+				// flow via emitDiagnostics). Side-effecting logging inside a Get... is also smelly. Carrying them
+				// would mean aggregating updater + emit + compilation diagnostics, which can duplicate the same
+				// CSxxxx (emit already reports a broken changed file that the full sweep re-finds) — so it needs a
+				// dedup (by Id+location) before it can be done cleanly. Revisit separately.
+				case (true, true) when GetCompilationErrors(result.Solution, ct) is { IsEmpty: false } compilationErrors:
+					_tracker.Output($"Hot reload blocked by {compilationErrors.Length} compilation error(s).");
+					outcome = HotReloadOperationResult.Failed;
+					break;
+
+				// (true, true) with a clean compile: genuinely nothing to apply.
+				default:
 					_tracker.Output("No hot reload changes to apply.");
 					outcome = HotReloadOperationResult.NoChanges;
-				}
-				else
-				{
-					outcome = HotReloadOperationResult.Failed;
-				}
-
-				diagnostics = hotReloadDiagnostics;
-			}
-			else
-			{
-				outcome = HotReloadOperationResult.Success;
-				deltas = updates;
-				diagnostics = hotReloadDiagnostics;
+					break;
 			}
 		}
 
@@ -241,6 +251,10 @@ public sealed class HotReloadManager : IDisposable
 		}
 		catch (Exception e)
 		{
+			// Mirror the manager-internal catch (ProcessFileChanges) so a handler-side failure (e.g. a
+			// staging error) is traceable in the console, not only via the operation's result.
+			_tracker.Warn($"Hot reload handler failed ({e.Message}).");
+			_tracker.Verbose(e.ToString());
 			await hotReload.Complete(HotReloadOperationResult.Failed, e, diagnostics).ConfigureAwait(false);
 			return;
 		}

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -154,75 +154,98 @@ public sealed class HotReloadManager : IDisposable
 		// before any short-circuit so the report reflects skipped inputs.
 		hotReload.NotifyIgnored(result.IgnoredChanges.GetAllPaths());
 
-		// Updater encountered a fatal condition (typically a csproj re-evaluation
-		// error). The manager — not the updater — owns the operation lifecycle, so
-		// we complete the operation here with the diagnostics and skip the rest of
-		// the cycle.
-		if (result.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-		{
-			await hotReload.Complete(HotReloadOperationResult.Failed, diagnostics: result.Diagnostics).ConfigureAwait(false);
-			return;
-		}
-
-		if (result.Solution == originalSolution)
-		{
-			_tracker.Output($"No changes found in {string.Join(",", files.Select(Path.GetFileName))}");
-
-			await hotReload.Complete(HotReloadOperationResult.NoChanges).ConfigureAwait(false);
-			return;
-		}
-
-		// No matter if the build will succeed or not, we update the _currentSolution.
-		// Files needs to be updated again to fix the compilation errors.
+		// Commit unconditionally, ahead of every terminal branch (spec 045 §2): an updater may have
+		// rebound metadata/analyzer references (e.g. newly resolved packages) onto result.Solution.
+		// If a cycle exited early without committing, those references would be lost and the next
+		// cycle would restart from the stale originalSolution. The == originalSolution branch below
+		// still compares against the captured snapshot, so its NoChanges decision is unchanged.
 		workspace.CurrentSolution = result.Solution;
 
-		// Compile the solution and get deltas
-		var (updates, hotReloadDiagnostics) = await _watchService.EmitSolutionUpdateAsync(result.Solution, ct).ConfigureAwait(false);
-		// hotReloadDiagnostics currently includes semantic Warnings and Errors for types being updated. We want to limit rude edits to the class
-		// of unrecoverable errors that a user cannot fix and requires an app rebuild.
-		var rudeEdits = hotReloadDiagnostics.RemoveAll(d => d.Severity == DiagnosticSeverity.Warning || !d.Descriptor.Id.StartsWith("ENC", StringComparison.Ordinal));
+		// Converge every terminal outcome onto a single handler call + completion (spec 045 §1) so a
+		// handler can perform delta-independent work (e.g. staging resolved package assemblies) on a
+		// no-delta cycle, not only on Success. Deltas are non-empty only on Success.
+		HotReloadOperationResult outcome;
+		var deltas = ImmutableArray<Update>.Empty;
+		var diagnostics = ImmutableArray<Diagnostic>.Empty;
 
-		_tracker.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
-		sw.Stop();
-
-		if (rudeEdits.IsEmpty && updates.IsEmpty)
+		if (result.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
 		{
-			var compilationErrors = GetCompilationErrors(result.Solution, ct);
-			if (compilationErrors.IsEmpty)
+			// Updater encountered a fatal condition (typically a csproj re-evaluation error). The
+			// manager — not the updater — owns the operation lifecycle, so we carry the diagnostics.
+			outcome = HotReloadOperationResult.Failed;
+			diagnostics = result.Diagnostics;
+		}
+		else if (result.Solution == originalSolution)
+		{
+			_tracker.Output($"No changes found in {string.Join(",", files.Select(Path.GetFileName))}");
+			outcome = HotReloadOperationResult.NoChanges;
+		}
+		else
+		{
+			// Compile the solution and get deltas.
+			var (updates, hotReloadDiagnostics) = await _watchService.EmitSolutionUpdateAsync(result.Solution, ct).ConfigureAwait(false);
+			// hotReloadDiagnostics currently includes semantic Warnings and Errors for types being updated. We want to limit rude edits to the class
+			// of unrecoverable errors that a user cannot fix and requires an app rebuild.
+			var rudeEdits = hotReloadDiagnostics.RemoveAll(d => d.Severity == DiagnosticSeverity.Warning || !d.Descriptor.Id.StartsWith("ENC", StringComparison.Ordinal));
+
+			_tracker.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
+
+			if (!rudeEdits.IsEmpty)
 			{
-				_tracker.Output("No hot reload changes to apply.");
-				await hotReload.Complete(HotReloadOperationResult.NoChanges).ConfigureAwait(false);
+				// Rude edit.
+				_tracker.Output("Unable to apply hot reload because of a rude edit.");
+				foreach (var diagnostic in hotReloadDiagnostics)
+				{
+					_tracker.Verbose(CSharpDiagnosticFormatter.Instance.Format(diagnostic, CultureInfo.InvariantCulture));
+				}
+
+				outcome = HotReloadOperationResult.RudeEdit;
+				diagnostics = hotReloadDiagnostics;
+			}
+			else if (updates.IsEmpty)
+			{
+				if (GetCompilationErrors(result.Solution, ct).IsEmpty)
+				{
+					_tracker.Output("No hot reload changes to apply.");
+					outcome = HotReloadOperationResult.NoChanges;
+				}
+				else
+				{
+					outcome = HotReloadOperationResult.Failed;
+				}
+
+				diagnostics = hotReloadDiagnostics;
 			}
 			else
 			{
-				await hotReload.Complete(HotReloadOperationResult.Failed, diagnostics: hotReloadDiagnostics).ConfigureAwait(false);
+				outcome = HotReloadOperationResult.Success;
+				deltas = updates;
+				diagnostics = hotReloadDiagnostics;
 			}
-
-			return;
 		}
 
-		if (!rudeEdits.IsEmpty)
+		sw.Stop();
+
+		// The handler now runs real side-effects (staging assemblies, applying deltas — possibly
+		// across a worker→main boundary). A handler exception is a hot-reload failure for THIS
+		// operation, distinct from a manager-internal fault (spec 045 §3). Cancellation is not a
+		// failure and propagates to the ProcessFileChanges catch.
+		var update = new HotReloadUpdate(files, changeSet, result, diagnostics, deltas);
+		try
 		{
-			// Rude edit.
-			_tracker.Output("Unable to apply hot reload because of a rude edit.");
-			foreach (var diagnostic in hotReloadDiagnostics)
-			{
-				_tracker.Verbose(CSharpDiagnosticFormatter.Instance.Format(diagnostic, CultureInfo.InvariantCulture));
-			}
-
-			await hotReload.Complete(HotReloadOperationResult.RudeEdit, diagnostics: hotReloadDiagnostics).ConfigureAwait(false);
+			await _handler.OnHotReloadAsync(outcome, update, ct).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception e)
+		{
+			await hotReload.Complete(HotReloadOperationResult.Failed, e, diagnostics).ConfigureAwait(false);
 			return;
 		}
 
-		var update = new HotReloadUpdate(
-			files,
-			changeSet,
-			result,
-			hotReloadDiagnostics,
-			updates);
-		await _handler.SendAsync(update, ct).ConfigureAwait(false);
-
-		await hotReload.Complete(HotReloadOperationResult.Success).ConfigureAwait(false);
+		await hotReload.Complete(outcome, diagnostics: diagnostics).ConfigureAwait(false);
 	}
 
 	/// <summary>

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -214,13 +214,8 @@ public sealed class HotReloadManager : IDisposable
 					break;
 
 				// No metadata updates, but the solution does not compile: the reload is blocked, not a no-op.
-				// FIXME (out of this PR's scope): these compilation errors are only pushed to _tracker (console)
-				// from inside GetCompilationErrors — they are NOT carried onto the operation/handler diagnostics
-				// bag, so a structured consumer sees Failed without the reason (asymmetric with rude edits, which
-				// flow via emitDiagnostics). Side-effecting logging inside a Get... is also smelly. Carrying them
-				// would mean aggregating updater + emit + compilation diagnostics, which can duplicate the same
-				// CSxxxx (emit already reports a broken changed file that the full sweep re-finds) — so it needs a
-				// dedup (by Id+location) before it can be done cleanly. Revisit separately.
+				// FIXME: GetCompilationErrors side-effects into _tracker but doesn't populate `diagnostics`;
+				// consumers see Failed without the reason (asymmetric with rude edits). Needs dedup before fixing.
 				case (true, true) when GetCompilationErrors(result.Solution, ct) is { IsEmpty: false } compilationErrors:
 					_tracker.Output($"Hot reload blocked by {compilationErrors.Length} compilation error(s).");
 					outcome = HotReloadOperationResult.Failed;

--- a/src/Uno.HotReload/HotReloadUpdate.cs
+++ b/src/Uno.HotReload/HotReloadUpdate.cs
@@ -5,9 +5,10 @@ using Uno.HotReload.Diffing;
 namespace Uno.HotReload;
 
 /// <summary>
-/// Payload handed to <see cref="IHotReloadHandler.SendAsync"/> after a
-/// successful hot-reload cycle. Carries every piece of state the manager has
-/// at the point where deltas are ready to be shipped to consumers.
+/// Payload handed to <see cref="IHotReloadHandler.OnHotReloadAsync"/> on every terminal
+/// hot-reload cycle outcome. Carries every piece of state the manager has at the point the
+/// outcome is decided. <see cref="Deltas"/> is non-empty only on a <c>Success</c> cycle;
+/// <see cref="SolutionUpdate"/> is populated on every path reached after the solution update.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Uno.HotReload/IHotReloadHandler.cs
+++ b/src/Uno.HotReload/IHotReloadHandler.cs
@@ -27,10 +27,20 @@ public interface IHotReloadHandler
 	/// <c>SolutionUpdateResult</c> subtype's payload is visible on no-delta cycles too).
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// Handlers that only act on a successful delta should guard on <paramref name="result"/> at the
 	/// top and return early. A thrown exception (other than <see cref="System.OperationCanceledException"/>,
 	/// which propagates) completes the operation as <see cref="HotReloadOperationResult.Failed"/> — the
 	/// reload did not take effect on the consumer side.
+	/// </para>
+	/// <para>
+	/// <b>Idempotency:</b> a single logical edit may invoke this method more than once. When a host
+	/// enables no-changes auto-retry (re-running the cycle when a <see cref="HotReloadOperationResult.NoChanges"/>
+	/// outcome is unexpected), every retry attempt re-invokes the handler with the recomputed outcome.
+	/// Delta-independent side-effects (e.g. staging resolved package assemblies derived from
+	/// <see cref="HotReloadUpdate.SolutionUpdate"/>) must therefore be idempotent — applying the same
+	/// update twice must be harmless.
+	/// </para>
 	/// </remarks>
 	ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct);
 }

--- a/src/Uno.HotReload/IHotReloadHandler.cs
+++ b/src/Uno.HotReload/IHotReloadHandler.cs
@@ -1,25 +1,36 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.HotReload.Tracking;
 
 namespace Uno.HotReload;
 
 /// <summary>
-/// Consumer end of the hot-reload pipeline. Receives the full
-/// <see cref="HotReloadUpdate"/> after a successful cycle and is responsible
-/// for shipping the deltas (and any subtype-specific side-effects) downstream.
+/// Consumer end of the hot-reload pipeline. Invoked by <see cref="HotReloadManager"/> on
+/// <b>every</b> terminal cycle outcome — with the computed <see cref="HotReloadOperationResult"/>
+/// and the full <see cref="HotReloadUpdate"/> — so a handler can react per-outcome, including
+/// performing delta-independent side-effects (e.g. staging resolved package assemblies) on a
+/// no-delta cycle that mutated the solution but emitted no IL/metadata delta.
 /// </summary>
 /// <remarks>
-/// Implementations may chain (decorator pattern): a wrapping handler can
-/// inspect the update, perform side-effects (e.g. stage resolved NuGet
-/// packages onto disk), then delegate to an inner handler for the actual
-/// delta transport.
+/// Implementations may chain (decorator pattern): a wrapping handler can inspect the update,
+/// perform side-effects, then delegate to an inner handler for the actual delta transport.
 /// </remarks>
 public interface IHotReloadHandler
 {
 	/// <summary>
-	/// Process the post-validated <paramref name="update"/>. Called by
-	/// <see cref="HotReloadManager"/> on the success path only — handlers
-	/// never see <c>NoChanges</c>, <c>RudeEdit</c>, or <c>Failed</c> cycles.
+	/// Process a completed hot-reload cycle. Called for each terminal outcome —
+	/// <see cref="HotReloadOperationResult.Success"/>, <see cref="HotReloadOperationResult.NoChanges"/>,
+	/// <see cref="HotReloadOperationResult.RudeEdit"/> and <see cref="HotReloadOperationResult.Failed"/>.
+	/// <paramref name="update"/>'s <see cref="HotReloadUpdate.Deltas"/> is non-empty only on
+	/// <see cref="HotReloadOperationResult.Success"/>; its <see cref="HotReloadUpdate.SolutionUpdate"/>
+	/// is populated on every path reached after the solution update (so a custom
+	/// <c>SolutionUpdateResult</c> subtype's payload is visible on no-delta cycles too).
 	/// </summary>
-	ValueTask SendAsync(HotReloadUpdate update, CancellationToken ct);
+	/// <remarks>
+	/// Handlers that only act on a successful delta should guard on <paramref name="result"/> at the
+	/// top and return early. A thrown exception (other than <see cref="System.OperationCanceledException"/>,
+	/// which propagates) completes the operation as <see cref="HotReloadOperationResult.Failed"/> — the
+	/// reload did not take effect on the consumer side.
+	/// </remarks>
+	ValueTask OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct);
 }

--- a/src/Uno.HotReload/IHotReloadHandler.cs
+++ b/src/Uno.HotReload/IHotReloadHandler.cs
@@ -29,9 +29,11 @@ public interface IHotReloadHandler
 	/// <remarks>
 	/// <para>
 	/// Handlers that only act on a successful delta should guard on <paramref name="result"/> at the
-	/// top and return early. A thrown exception (other than <see cref="System.OperationCanceledException"/>,
-	/// which propagates) completes the operation as <see cref="HotReloadOperationResult.Failed"/> — the
-	/// reload did not take effect on the consumer side.
+	/// top and return early. A thrown exception completes the operation as
+	/// <see cref="HotReloadOperationResult.Failed"/> — the reload did not take effect on the consumer side.
+	/// <see cref="System.OperationCanceledException"/> is the exception: it is re-thrown from this hook and
+	/// the manager reports the operation as <see cref="HotReloadOperationResult.InternalError"/> (not
+	/// <see cref="HotReloadOperationResult.Failed"/>), since cancellation is not a hot-reload failure.
 	/// </para>
 	/// <para>
 	/// <b>Idempotency:</b> a single logical edit may invoke this method more than once. When a host


### PR DESCRIPTION
**GitHub Issue:** closes #<!-- TODO: link the associated issue before marking ready -->

## PR Type:

✨ Feature

## What changed? 🚀

`HotReloadManager.ProcessSolutionChanged` previously invoked `IHotReloadHandler` only on the
**success** path (a non-empty metadata-update / EnC delta set). Every other terminal outcome
(`NoChanges`, `RudeEdit`, `Failed`) returned early **before** reaching the handler, so a custom
`ISolutionUpdater` + `IHotReloadHandler` pair could not perform delta-independent work — e.g.
staging resolved package assemblies — on the cycle that actually produced that state. (Adding a
`PackageReference` is a references-only change: it mutates the solution but emits no delta.)

This PR implements spec `045-hotreload-handler-all-outcomes`:

- **Invokes the handler on every terminal outcome**, passing the `HotReloadOperationResult` —
  `IHotReloadHandler.SendAsync(update)` becomes `OnHotReloadAsync(result, update, ct)`. Deltas
  are non-empty only on `Success`.
- **Commits `CurrentSolution = result.Solution` unconditionally** before any early return, so
  references an updater rebound (e.g. newly resolved packages) survive no-delta cycles instead of
  being lost on the next cycle.
- **Guards the handler call**: a handler exception completes the operation as `Failed` (carrying
  the exception); `OperationCanceledException` propagates unchanged.
- `DelegateHotReloadHandler` now fires the legacy `(files, updates)` delegate on `Success`
  only, so existing consumers are unaffected by the new no-delta invocations.

## PR Checklist ✅

- [x] 🧪 Added tests (`Given_HotReloadManager`: handler invoked with the expected outcome for each
  terminal path — Success / NoChanges / RudeEdit / Failed; unconditional solution commit; a
  `SolutionUpdateResult` subtype surfaced to the handler on a no-delta cycle; throwing-handler →
  `Failed` and `OperationCanceledException` → not `Failed`).
- [ ] 📚 Docs have been added/updated following the documentation template (XML doc comments on
  `IHotReloadHandler` / `HotReloadUpdate` updated; no article changes).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results (N/A — no UI surface changed).
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional).

**Breaking change & migration:** `IHotReloadHandler.SendAsync(HotReloadUpdate, CancellationToken)`
is renamed to `OnHotReloadAsync(HotReloadOperationResult result, HotReloadUpdate update, CancellationToken ct)`
and is invoked on **every** terminal outcome (not only `Success`). Migration: rename the method,
add the `HotReloadOperationResult result` parameter, and — if the handler only acted on a
successful delta — guard with `if (result is not HotReloadOperationResult.Success) return`.
`DelegateHotReloadHandler` already encapsulates this for `(files, updates)` consumers.