### PR TITLE
fix(wasm): drop StorageFolder persistent-mount debug log

### DIFF
--- a/src/Uno.UWP/ts/Windows/Storage/StorageFolder.js
+++ b/src/Uno.UWP/ts/Windows/Storage/StorageFolder.js
@@ -47,7 +47,6 @@ var Windows;
                     StorageFolder.onStorageInitialized();
                     return;
                 }
-                console.debug("Making persistent: " + path);
                 FS.mkdir(path);
                 FS.mount(IDBFS, {}, path);
             }

--- a/src/Uno.UWP/ts/Windows/Storage/StorageFolder.ts
+++ b/src/Uno.UWP/ts/Windows/Storage/StorageFolder.ts
@@ -61,8 +61,6 @@ namespace Windows.Storage {
 				return;
 			}
 
-			console.debug("Making persistent: " + path);
-
 			FS.mkdir(path);
 
 			FS.mount(IDBFS, {}, path);


### PR DESCRIPTION
**GitHub Issue:** closes #

## PR Type:

🐞 Bugfix

## What changed? 🚀

`StorageFolder` logged the IDBFS mount path at `console.debug`
(`Making persistent: <path>`) on every persistent-folder initialization.
This is non-actionable diagnostic noise that appears in the browser console
of every WebAssembly app using IndexedDB persistence.

This PR removes the log statement from both the TypeScript source
(`StorageFolder.ts`) and the committed generated JavaScript
(`StorageFolder.js`), keeping the two in sync. No behavior changes — the
`FS.mkdir` / `FS.mount` mount logic is untouched.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)