### PR TITLE
fix: Resolve duplicate materializedProvider local in ResourceDictionary

### DIFF
--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -588,10 +588,10 @@ namespace Microsoft.UI.Xaml
 					{
 						ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 					}
-					else if (newValue is IDependencyObjectStoreProvider materializedProvider)
+					else if (newValue is IDependencyObjectStoreProvider storeProvider)
 					{
 						// Resources do not inherit DataContext (see DependencyObjectStore.IsResourceDictionaryItem).
-						materializedProvider.Store.IsResourceDictionaryItem = true;
+						storeProvider.Store.IsResourceDictionaryItem = true;
 					}
 
 					if (!FeatureConfiguration.ResourceDictionary.IncludeUnreferencedDictionaries)


### PR DESCRIPTION
**GitHub Issue:** closes #23499

## PR Type:

🐞 Bugfix

## What changed? 🚀

Fixes a **CS0136** build break in `ResourceDictionary.cs` that fails CI (and local `master` builds) for the Skia and Reference `net10.0` targets:

```
src/Uno.UI/UI/Xaml/ResourceDictionary.cs(591,58): error CS0136: A local or parameter named 'materializedProvider' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
```

This is a merge-time collision, not a defect in either change on its own. Two independently-merged PRs each introduced a pattern variable named `materializedProvider`:

- `fix(theming): resolve binding & resource ThemeResource against owner theme` (`84a8eadd1f`) — `if (value is IDependencyObjectStoreProvider materializedProvider ...)` in the **enclosing block scope**, after the `try/finally`.
- `fix(alc): resources must not inherit DataContext from their host subtree` (`58a07c27d2`) — `else if (newValue is IDependencyObjectStoreProvider materializedProvider)` inside the nested **`finally` block**.

A pattern variable in the enclosing block has scope spanning the rest of that block, so the inner-scope (`finally`) declaration collides with it even though it appears textually earlier. Each branch compiled cleanly in isolation; the conflict only surfaced once both landed on `master`.

This PR renames the `finally`-block occurrence to `storeProvider`. The two are independent casts to `IDependencyObjectStoreProvider` of different values (`newValue` vs `value`), so the rename is a pure scoping fix with **no behavioral change**.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A: compile-only fix, covered by the existing build; behavior unchanged.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A.
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
