### PR TITLE
fix: Report UIA IsOffscreen for off-window popup content

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Uno.UI.RuntimeTests.Helpers;
 using static Private.Infrastructure.TestServices;
 
@@ -266,6 +267,118 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 			finally
 			{
 				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)] // IsOffscreen clipping is Skia-only.
+		public async Task When_Popup_Content_InWindow_IsOffscreen()
+		{
+			var target = new Button { Content = "Subject", Width = 120, Height = 40 };
+			var popup = new Popup
+			{
+				XamlRoot = WindowHelper.XamlRoot,
+				HorizontalOffset = 50,
+				VerticalOffset = 50,
+				Child = target,
+			};
+
+			try
+			{
+				popup.IsOpen = true;
+				await WindowHelper.WaitForLoaded(target);
+				await WindowHelper.WaitForIdle();
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(target);
+				Assert.IsNotNull(peer);
+
+				Assert.IsFalse(peer.IsOffscreen(), "In-window open popup content should be on-screen (false).");
+			}
+			finally
+			{
+				popup.IsOpen = false;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)] // IsOffscreen clipping is Skia-only.
+		public async Task When_Popup_Content_Outside_Window_IsOffscreen()
+		{
+			var target = new Button { Content = "Subject", Width = 120, Height = 40 };
+			var popup = new Popup
+			{
+				XamlRoot = WindowHelper.XamlRoot,
+				HorizontalOffset = 100000,
+				VerticalOffset = 100000,
+				Child = target,
+			};
+
+			try
+			{
+				popup.IsOpen = true;
+				await WindowHelper.WaitForLoaded(target);
+				await WindowHelper.WaitForIdle();
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(target);
+				Assert.IsNotNull(peer);
+
+				Assert.IsTrue(peer.IsOffscreen(), "Popup content far outside the window should be off-screen (true).");
+			}
+			finally
+			{
+				popup.IsOpen = false;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)] // IsOffscreen clipping is Skia-only.
+		public async Task When_Element_Scrolled_Out_Inside_Popup_IsOffscreen()
+		{
+			var target = new Button { Content = "Subject", Width = 120, Height = 40 };
+			var scrollViewer = new ScrollViewer
+			{
+				Width = 200,
+				Height = 200,
+				Content = new StackPanel
+				{
+					Children =
+					{
+						target,
+						new Border { Height = 1000 },
+					},
+				},
+			};
+			var popup = new Popup
+			{
+				XamlRoot = WindowHelper.XamlRoot,
+				HorizontalOffset = 50,
+				VerticalOffset = 50,
+				Child = scrollViewer,
+			};
+
+			try
+			{
+				popup.IsOpen = true;
+				await WindowHelper.WaitForLoaded(scrollViewer);
+				await WindowHelper.WaitForIdle();
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(target);
+				Assert.IsNotNull(peer);
+
+				Assert.IsFalse(peer.IsOffscreen(), "Element should be on-screen before scrolling (inside popup).");
+
+				scrollViewer.ChangeView(null, 500, null, disableAnimation: true);
+				await WindowHelper.WaitForEqual(500, () => scrollViewer.VerticalOffset);
+				await WindowHelper.WaitForIdle();
+
+				Assert.IsTrue(peer.IsOffscreen(), "Element scrolled out of a popup's ScrollViewer should be off-screen (true).");
+			}
+			finally
+			{
+				popup.IsOpen = false;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -859,6 +859,16 @@ namespace Microsoft.UI.Xaml
 				var right = Math.Min(globalBounds.Right, clip.Right);
 				var bottom = Math.Min(globalBounds.Bottom, clip.Bottom);
 
+				// Clip to the window viewport too: the composition tree roots at an infinite clip,
+				// so off-window content (e.g. a Popup/Flyout) is otherwise reported as on-screen.
+				if (XamlRoot?.Size is { Width: > 0, Height: > 0 } viewport)
+				{
+					left = Math.Max(left, 0);
+					top = Math.Max(top, 0);
+					right = Math.Min(right, viewport.Width);
+					bottom = Math.Min(bottom, viewport.Height);
+				}
+
 				return right > left && bottom > top
 					? new Rect(left, top, right - left, bottom - top)
 					: default;


### PR DESCRIPTION
**GitHub Issue:** closes #23502

related to https://github.com/unoplatform/kahua-private/issues/495

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia, UIA `IsOffscreen` derives "off-screen" by intersecting an element's root-space bounds with the effective ancestor clip (`UIElement.GetGlobalBoundsWithOptions` → `Visual.GetTotalClipRectInRootCoordinates()`). That clip walks the Composition `Visual.Parent` chain and applies an **infinite clip** at the root visual — so the **window viewport is never applied**. Only a real clip in the chain (e.g. a `ScrollViewer` viewport) could shrink the bounds. As a result, content positioned **outside the window** is never detected as off-screen. This surfaces with `Popup`/`Flyout` content, which is frequently placed by absolute offset (or overflows the window): such off-window content wrongly reported `IsOffscreen = false` in inspect.exe / Accessibility Insights on Skia Win32.

This PR clips the automation bounds to the element's `XamlRoot.Size` viewport (origin `(0,0)` in root coordinates) in `GetGlobalBoundsWithOptions`, after the existing ancestor-clip intersection. This mirrors WinUI, which clips automation bounds to the window. The clip resolves per-element against the element's own `XamlRoot`, so it is correct for both in-window popups and the windowed-popup model, and it flows to both `IsOffscreen` and the cross-platform `GetBoundingRectangleCore`.

Behavior, verified by runtime tests on Skia Desktop (the exact value the Win32 UIA provider forwards):

| Scenario | Before | After |
|---|---|---|
| Open popup content **inside** the window | `false` ✅ | `false` ✅ |
| Element scrolled out of a `ScrollViewer` **inside** a popup | `true` ✅ | `true` ✅ |
| Open popup content **outside** the window | `false` ❌ | `true` ✅ |

Three regression tests added to `Given_AutomationPeer` (Skia-only, since this clipping is Skia-specific); the existing `When_Element_Scrolled_Out_Of_ScrollViewer_IsOffscreen` and `When_AutomationPeer_Default_IsOffscreen` continue to pass (no regression).

## PR Checklist ✅

- [x] 🧪 Added Runtime tests (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the documentation template (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
