### PR TITLE
docs: Bump studio-docs pin to 3b86af4 (partial backport of #23425)

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -23,7 +23,7 @@ $external_docs = @{
     "uno.samples"        = @{ ref="8098a452951c9f73cbcf8d0ac1348f029820e53a" } #latest master commit
     "uno.chefs"          = @{ ref="06f4f8042595473557f00cdfa622788273d3a131" } #latest main commit
     "hd-docs"            = @{ ref="03df0e2a08dde9527b72ac58e1fe3b2d402a38e3"; dest="studio/Hot Design" } #latest main commit
-    "studio-docs"        = @{ ref="97f349bc1cb3b0ecb9cfdc2fa86c5aac137ba4ee" }  #latest main commit
+    "studio-docs"        = @{ ref="3b86af4dac3e7a21c41b619960d14848ce95e2fd" }  #latest main commit
 }
 
 $uno_git_url = "https://github.com/unoplatform/"


### PR DESCRIPTION
**GitHub Issue:** N/A — documentation / tooling change (exempt per template)

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Partial backport of #23425 to `release/stable/6.5`.

Bumps the `studio-docs` external-docs pin in `doc/import_external_docs.ps1`
(`97f349b` → `3b86af4`) so the 6.5 documentation build pulls the same latest
Studio docs `main` content as master. `studio-docs` tracks `main` (there is no
per-release stable variant), so 6.5 and master should reference the same commit.

**Not backported:** the `docs-build` agent skill (`.claude/skills/docs-build/SKILL.md`
and its `AGENTS.md` entry) from #23425. It is master-only developer tooling that
ships in nothing and has no effect on the built 6.5 docs output, so it is kept off
the stable branch to avoid divergence.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample (N/A — docs/tooling only)
- [x] 📚 Docs have been added/updated
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results (N/A)
- [x] ❗ Contains **NO** breaking changes

Related to #23425
