### PR TITLE
fix(listview): Fixed layout measure issue by respecting max size

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -234,12 +234,21 @@ namespace Microsoft.UI.Xaml
 			}
 
 			var remainingTries = MaxLayoutIterations;
+			var hasMaxWidth = false;
+
+			// Check whether this element has an explicit MaxWidth constraint.
+			if (this is FrameworkElement frameworkElement)
+			{
+				var (_, maxSize) = frameworkElement.GetMinMax();
+				hasMaxWidth = maxSize.Width is not double.PositiveInfinity;
+			}
 
 			// remember whether we need to set this value back
 			var wasInNonClippingTree = IsInNonClippingTree;
-			// once entering a tree that is non-clipping, we don't get out of it
-			// remember this for down-stream
-			IsInNonClippingTree = IsNonClippingSubtree || wasInNonClippingTree;
+			// Once measure enters a non-clipping subtree, descendants normally remain in
+			// non-clipping mode. However, when a user-defined MaxWidth is present, the
+			// desired size must still respect that maximum constraint.
+			IsInNonClippingTree = (IsNonClippingSubtree || wasInNonClippingTree) && !hasMaxWidth;
 
 			while (--remainingTries > 0)
 			{


### PR DESCRIPTION
**GitHub Issue:** closes #21463

## PR Type: 🐞 Bugfix

## What changed? 🚀

This PR fixes a layout measure issue that can happen when an element is measured inside a `ListView` subtree while horizontal scrolling is enabled.

Previously, once layout entered a non-clipping subtree, that state continued to propagate to downstream elements. This allowed some elements to measure larger than their explicit width constraint, causing incorrect desired size calculations and visible clipping in controls such as [`TableView`](https://github.com/w-ahmad/WinUI.TableView) cells.

The measure logic now checks whether the current `FrameworkElement` has an explicit width constraint. When it is present, the non-clipping measure behavior is not propagated further for that element.

This keeps the existing non-clipping behavior for scrolling scenarios, while ensuring elements with an explicit width constraint remain bounded by that constraint.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)