### PR TITLE
ci: Align docs artifact names with docs (partial backport of #23086)

### DIFF
--- a/build/ci/docs/.azure-devops-docs.yml
+++ b/build/ci/docs/.azure-devops-docs.yml
@@ -47,12 +47,12 @@ jobs:
     retryCountOnTaskFailure: 3
     inputs:
       targetPath: $(build.artifactstagingdirectory)
-      ArtifactName: DocumentationArtifacts
+      ArtifactName: docs
 
   - task: PublishBuildArtifacts@1
     condition: always()
     retryCountOnTaskFailure: 3
     inputs:
       PathtoPublish: $(Agent.TempDirectory)/unobinlog
-      ArtifactName: DocumentationBuildLogs
+      ArtifactName: docs-logs
       ArtifactType: Container


### PR DESCRIPTION
**GitHub Issue:** N/A — CI / build infrastructure change (exempt per template)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Renames the docs build artifacts on `release/stable/6.5` to match master/6.6:

| Before (6.5) | After (this PR) |
|---|---|
| `DocumentationArtifacts` | `docs` |
| `DocumentationBuildLogs` | `docs-logs` |

(2-line change in `build/ci/docs/.azure-devops-docs.yml`.)

## Why

The docs release for 6.5 fails on the **Upload site files** step with:

```
az storage blob upload-batch ... -s ".../docs/docs/doc/_site" ...
ERROR: incorrect usage: source must be an existing directory
```

Root cause — a naming mismatch between the build and the shared release pipeline:

- The build artifact was renamed `DocumentationArtifacts` → `docs` (and `DocumentationBuildLogs` → `docs-logs`) on **master/6.6** in #23086. This was **not** backported to 6.5, so 6.5 still publishes `DocumentationArtifacts`.
- The shared docs release definition (*Uno.UI Docs*, def 81) was later updated so the **Upload site files** source path reads `.../docs/docs/doc/_site` (artifact-source alias `docs` + artifact name `docs`).
- The release downloads each build's artifact to `<alias>/<artifactName>`. For master/6.6 that is `docs/docs/...` (matches). For 6.5 it is `docs/DocumentationArtifacts/...`, so the upload's `docs/docs/doc/_site` path does not exist → failure.

This PR aligns 6.5's published artifact names with the convention master/6.6 already use, so the release download lands at `docs/docs/...` and the upload resolves. No release-pipeline change is required (the download step adapts to whatever the build publishes).

## Validation

- **Parity check**: the two `ArtifactName` values now match `release/stable/6.6` exactly (`docs`, `docs-logs`).

Related to #23086
