### PR TITLE
fix(macos): Skip native window creation for secondary ALC windows

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -1551,6 +1551,25 @@ public class Given_AlcContentHost
 	}
 
 	/// <summary>
+	/// A macOS hosted-ALC window has no native window (DesktopWindow.Initialize skips it), so the
+	/// Window ctor must skip DisplayInformation.GetOrCreateForWindowId for it. Otherwise the macOS
+	/// DisplayInformation extension subscribes to MacOSWindowNative.NativeWindowReady and never
+	/// unsubscribes (no native window is coming) — pinning the extension/DisplayInformation (and the
+	/// collectible ALC) and binding to the next unrelated native window that gets created.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaMacOS)]
+	public async Task When_MacOSAlcWindow_Then_NoDisplayInformationRegistered()
+	{
+		var (_, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
+
+		Assert.IsFalse(
+			Windows.Graphics.Display.DisplayInformation.IsRegisteredForWindowId(alcWindow.AppWindow.Id),
+			"A macOS hosted-ALC window must not register a DisplayInformation — doing so leaves " +
+			"MacOSDisplayInformationExtension subscribed to NativeWindowReady forever, pinning the ALC.");
+	}
+
+	/// <summary>
 	/// Boots the AlcApp test application into a secondary ALC, assuming the caller has already set up
 	/// <see cref="WindowHelper.ContentHostOverride"/> and the window content. Returns the registered
 	/// secondary <see cref="Application"/>. Use <see cref="StartSecondaryAlcAppAsync"/> instead when the

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -1478,7 +1478,7 @@ public class Given_AlcContentHost
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_ContentHostOverride_Set_Then_NativeWindowNotCreated()
 	{
-		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
+		var (_, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
 
 		// The ALC window should NOT have a native window wrapper — DesktopWindow.Initialize()
 		// must skip native window creation when ContentHostOverride is set on macOS.

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -80,7 +80,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)] // Disabled on macOS for unknown core dump
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcContentHost_Then_ResourcesInherited()
 	{
 		var contentHost = await StartSecondaryAlcAppAsync();
@@ -98,7 +98,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)] // Disabled on macOS for unknown core dump
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcContentHost_Then_MergedDictionariesInherited()
 	{
 		var contentHost = await StartSecondaryAlcAppAsync();
@@ -120,7 +120,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)] // Disabled on macOS for unknown core dump
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_SecondaryAlcApp_Then_ContentHosted()
 	{
 		var contentHost = await StartSecondaryAlcAppAsync();
@@ -276,7 +276,7 @@ public class Given_AlcContentHost
 	/// &lt;ResourceDictionary Source="AppResources.xaml"/&gt;) would resolve to the primary ALC's dictionary.
 	/// </summary>
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcAppXaml_HasSourceDictionary_Then_ResolvesToAlcSpecificDictionary()
 	{
 		var contentHost = await StartSecondaryAlcAppAsync();
@@ -311,7 +311,7 @@ public class Given_AlcContentHost
 	/// ALC-scoped registry via ResourceResolver.CurrentResolutionAlc.
 	/// </summary>
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcAppXaml_HasSubdirectorySourceDictionary_Then_ResolvesCorrectly()
 	{
 		var contentHost = await StartSecondaryAlcAppAsync();
@@ -752,7 +752,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Activate_Then_ActivatedEventRaised()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -774,7 +774,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Activate_WithFrameNavigation_Then_ActivatedEventRaised()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync(new[] { "--use-frame" });
@@ -796,7 +796,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_ActivatedRegisteredBeforeContent_Then_ActivatedEventRaised()
 	{
 		var (_, alcWindow) = await StartSecondaryAlcAppWithWindowAsync(new[] { "--defer-content" });
@@ -821,7 +821,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_ActivatedRegisteredBeforeContent_WithFrameNavigation_Then_ActivatedEventRaised()
 	{
 		var (_, alcWindow) = await StartSecondaryAlcAppWithWindowAsync(new[] { "--defer-content", "--use-frame" });
@@ -846,7 +846,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Then_VisibleReturnsHostVisibility()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -856,7 +856,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Then_BoundsMatchesHostBounds()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -872,7 +872,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_HostSizeChanges_Then_SizeChangedEventRaised()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -898,7 +898,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Close_Then_ClosedEventRaised()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -915,7 +915,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Close_Then_ContentClearedFromHost()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -929,7 +929,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Close_Then_VisibilityChangedEventRaised()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -950,7 +950,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Close_Then_VisibleReturnsFalse()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -963,7 +963,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_ClosedEventHandled_Then_CloseIsCancelled()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -981,7 +981,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_ActivateAfterClose_Then_ThrowsException()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -1002,7 +1002,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcWindow_Then_NotInApplicationHelperWindows()
 	{
 		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
@@ -1013,7 +1013,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_AlcContentHost_Then_FrameContentNavigates()
 	{
 		var contentHost = await StartSecondaryAlcAppAsync(new[] { "--use-frame" });
@@ -1029,7 +1029,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_SecondaryAlcApp_Then_AlcWindowModeEnabled()
 	{
 		// This test verifies that the ALC window is properly set up in ALC mode.
@@ -1064,7 +1064,7 @@ public class Given_AlcContentHost
 	}
 
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
 	public async Task When_SecondaryAlcApp_Then_KeyboardInputStillWorks()
 	{
 		// This test verifies that keyboard input continues to work after loading a secondary ALC app.
@@ -1464,6 +1464,90 @@ public class Given_AlcContentHost
 				Application.Current.SetExplicitRequestedTheme(null);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Validates that on macOS, when ContentHostOverride is set, DesktopWindow.Initialize()
+	/// skips native window creation entirely. This prevents the MacOSWindowHost.Register
+	/// duplicate key error that occurred when the secondary app's Window tried to create
+	/// a native window that conflicted with the host's window. Win32/X11 are intentionally
+	/// excluded — they continue to set up XamlRoot/RootElement because their
+	/// DisplayInformation extensions dereference them.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaMacOS)]
+	public async Task When_ContentHostOverride_Set_Then_NativeWindowNotCreated()
+	{
+		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
+
+		// The ALC window should NOT have a native window wrapper — DesktopWindow.Initialize()
+		// must skip native window creation when ContentHostOverride is set on macOS.
+		var nativeWrapperProperty = typeof(Window).GetProperty("NativeWrapper",
+			BindingFlags.NonPublic | BindingFlags.Instance);
+		Assert.IsNotNull(nativeWrapperProperty, "Window.NativeWrapper property should exist");
+
+		var nativeWrapper = nativeWrapperProperty!.GetValue(alcWindow);
+		Assert.IsNull(nativeWrapper,
+			"ALC window should NOT have a NativeWindowWrapper when ContentHostOverride is set on macOS. " +
+			"DesktopWindow.Initialize() must skip native window creation in hosted ALC scenarios on macOS.");
+	}
+
+	/// <summary>
+	/// Validates that setting Window.Content to null does not throw in hosted ALC mode.
+	/// Window.Content redirects via ContentHostOverride before reaching DesktopWindow.Content,
+	/// so the assignment is satisfied by the host on all platforms regardless of whether
+	/// WindowChrome was created (skipped on macOS, present on Win32/X11).
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)]
+	public async Task When_AlcWindow_ContentSetToNull_Then_DoesNotThrow()
+	{
+		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
+
+		Assert.IsNotNull(contentHost.Content, "Content should be set before clearing");
+
+		// Setting content to null should not throw. Window.Content setter redirects via
+		// ContentHostOverride before reaching DesktopWindow.Content.
+		alcWindow.Content = null;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Content host should be cleared
+		Assert.IsNull(contentHost.Content,
+			"ContentHostOverride content should be null after setting Window.Content = null");
+	}
+
+	/// <summary>
+	/// Validates that a secondary ALC app can be fully loaded on macOS without native window
+	/// registration collisions. This is an end-to-end test that the DesktopWindow.Initialize()
+	/// skip prevents the MacOSWindowHost.Register duplicate key ArgumentException.
+	/// </summary>
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaMacOS)]
+	public async Task When_SecondaryAlcApp_OnMacOS_Then_LoadsWithoutNativeWindowConflict()
+	{
+		var (contentHost, alcWindow) = await StartSecondaryAlcAppWithWindowAsync();
+
+		// Verify the app loaded successfully — content is hosted
+		Assert.IsNotNull(contentHost.Content,
+			"Secondary ALC content should be loaded without native window conflicts on macOS");
+
+		// Verify the ALC window is operating in ALC mode
+		var isAlcWindowProperty = typeof(Window).GetProperty("IsAlcWindow",
+			BindingFlags.NonPublic | BindingFlags.Instance);
+		Assert.IsNotNull(isAlcWindowProperty, "IsAlcWindow property should exist");
+		Assert.IsTrue((bool)isAlcWindowProperty!.GetValue(alcWindow)!,
+			"Window should be in ALC mode on macOS");
+
+		// Verify Activate does not throw (it should be a no-op in ALC mode)
+		alcWindow.Activate();
+
+		// Verify the main app's window is still functional
+		var mainWindow = Uno.UI.ApplicationHelper.Windows.FirstOrDefault();
+		Assert.IsNotNull(mainWindow, "Main app window should still exist");
+		var mainNativeWrapper = typeof(Window).GetProperty("NativeWrapper",
+			BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(mainWindow);
+		Assert.IsNotNull(mainNativeWrapper,
+			"Main app window should still have its NativeWindowWrapper intact");
 	}
 
 	/// <summary>

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
@@ -48,7 +48,7 @@ internal class DesktopWindow : BaseWindowImplementation
 			{
 				// On macOS hosted ALC scenarios the chrome is intentionally not created;
 				// content is redirected at the Window.Content level via ContentHostOverride.
-				if (Window.ContentHostOverride is not null && OperatingSystem.IsMacOS())
+				if (OperatingSystem.IsMacOS() && Window.ContentHostOverride is not null && Window.IsAlcWindow)
 				{
 					return;
 				}

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
@@ -21,6 +21,16 @@ internal class DesktopWindow : BaseWindowImplementation
 
 	public override void Initialize()
 	{
+		// macOS-only: the secondary ALC scenario collides with MacOSWindowHost's
+		// native window registration. Skipping native window/chrome/XamlSource here
+		// avoids the duplicate registration. Win32/X11 require XamlRoot/RootElement
+		// to be set up (DisplayInformation extensions dereference them), so they
+		// must continue through the normal Initialize path.
+		if (Window.ContentHostOverride is not null && OperatingSystem.IsMacOS())
+		{
+			return;
+		}
+
 		_windowChrome = new WindowChrome(Window);
 		_windowChrome.ApplyStylingForMinMaxCloseButtons();
 		_desktopWindowXamlSource = new DesktopWindowXamlSource();
@@ -41,6 +51,13 @@ internal class DesktopWindow : BaseWindowImplementation
 		{
 			if (_windowChrome is null)
 			{
+				// On macOS hosted ALC scenarios the chrome is intentionally not created;
+				// content is redirected at the Window.Content level via ContentHostOverride.
+				if (Window.ContentHostOverride is not null && OperatingSystem.IsMacOS())
+				{
+					return;
+				}
+
 				throw new InvalidOperationException(
 					"Window content is being set before the application is initialized." +
 					"Instead, set the window content later - e.g. in OnLaunched.");

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
@@ -21,12 +21,7 @@ internal class DesktopWindow : BaseWindowImplementation
 
 	public override void Initialize()
 	{
-		// macOS-only: the secondary ALC scenario collides with MacOSWindowHost's
-		// native window registration. Skipping native window/chrome/XamlSource here
-		// avoids the duplicate registration. Win32/X11 require XamlRoot/RootElement
-		// to be set up (DisplayInformation extensions dereference them), so they
-		// must continue through the normal Initialize path.
-		if (Window.ContentHostOverride is not null && OperatingSystem.IsMacOS())
+		if (OperatingSystem.IsMacOS() && Window.ContentHostOverride is not null && Window.IsAlcWindow)
 		{
 			return;
 		}

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
@@ -21,7 +21,7 @@ internal class DesktopWindow : BaseWindowImplementation
 
 	public override void Initialize()
 	{
-		if (OperatingSystem.IsMacOS() && Window.ContentHostOverride is not null && Window.IsAlcWindow)
+		if (Window.IsMacOSHostedAlcWindow)
 		{
 			return;
 		}
@@ -48,7 +48,7 @@ internal class DesktopWindow : BaseWindowImplementation
 			{
 				// On macOS hosted ALC scenarios the chrome is intentionally not created;
 				// content is redirected at the Window.Content level via ContentHostOverride.
-				if (OperatingSystem.IsMacOS() && Window.ContentHostOverride is not null && Window.IsAlcWindow)
+				if (Window.IsMacOSHostedAlcWindow)
 				{
 					return;
 				}

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -419,6 +419,16 @@ partial class Window
 	internal bool IsAlcWindow => _isWindowFromSecondaryAlc || _alcState is not null;
 
 	/// <summary>
+	/// True for a hosted secondary-ALC window on macOS. <see cref="Uno.UI.Xaml.Controls.DesktopWindow.Initialize"/>
+	/// skips native window creation in this case (it would collide with MacOSWindowHost's native-window
+	/// registration), so the window has no native backing — callers that depend on one must skip their work
+	/// too (the native window itself, and the DisplayInformation registration whose macOS extension subscribes
+	/// to <c>MacOSWindowNative.NativeWindowReady</c> and would never unsubscribe).
+	/// </summary>
+	internal bool IsMacOSHostedAlcWindow
+		=> OperatingSystem.IsMacOS() && ContentHostOverride is not null && IsAlcWindow;
+
+	/// <summary>
 	/// Checks if the given content element is from a secondary AssemblyLoadContext.
 	/// When value is null, returns false to allow clearing content.
 	/// </summary>

--- a/src/Uno.UI/UI/Xaml/Window/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.cs
@@ -122,7 +122,14 @@ public partial class Window
 		}
 
 		// We set up the DisplayInformation instance after Initialize so that we have an actual window to bind to.
-		global::Windows.Graphics.Display.DisplayInformation.GetOrCreateForWindowId(AppWindow.Id);
+		// A macOS hosted-ALC window has no native window (Initialize skips it), so skip this too: the macOS
+		// DisplayInformation extension subscribes to MacOSWindowNative.NativeWindowReady and only unsubscribes
+		// when a native window is created — which never happens here — leaking the extension (pinning the ALC)
+		// and letting it bind to the next unrelated native window.
+		if (!IsMacOSHostedAlcWindow)
+		{
+			global::Windows.Graphics.Display.DisplayInformation.GetOrCreateForWindowId(AppWindow.Id);
+		}
 	}
 
 	internal INativeWindowWrapper? NativeWrapper => _windowImplementation.NativeWindowWrapper;

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
@@ -130,6 +130,19 @@ namespace Windows.Graphics.Display
 			}
 		}
 
+		/// <summary>
+		/// Whether a <see cref="DisplayInformation"/> is currently registered for the given
+		/// <see cref="WindowId"/>, without creating one. Used to verify that windows which never
+		/// get a native window (e.g. a macOS hosted-ALC window) don't register one.
+		/// </summary>
+		internal static bool IsRegisteredForWindowId(WindowId windowId)
+		{
+			lock (_windowIdMapLock)
+			{
+				return _windowIdMap.ContainsKey(windowId);
+			}
+		}
+
 		public static DisplayOrientations AutoRotationPreferences
 		{
 			get => _autoRotationPreferences;


### PR DESCRIPTION
**GitHub Issue:** closes #

## PR Type:

🐞 Bugfix

## What changed? 🚀

In the hosted secondary-ALC scenario on **macOS** desktop, the secondary app's `new Window()` still went through `DesktopWindow.Initialize()` → `BaseWindowImplementation.InitializeNativeWindow()` → `NativeWindowFactory.CreateWindow()`, creating a real native macOS window and registering it in `MacOSWindowHost`. Because the secondary window collided with the host app's already-registered window, this raised a duplicate-key `ArgumentException`, leaving the inner app in a broken state (no DevServer bridge, no screenshots, blank UI). This was also the root cause of the "unknown core dump" that previously forced these ALC runtime tests to be disabled on macOS.

This PR makes `DesktopWindow.Initialize()` return early — skipping native window, chrome, and `XamlSource` creation — when `Window.ContentHostOverride` is set **and** the platform is macOS. Content redirection to the `AlcContentHost` is already handled by `Window.Content` at the framework level, so no native window is needed. The skip is intentionally scoped to macOS: Win32/X11 must continue through the normal `Initialize` path because their `DisplayInformation` extensions dereference `XamlRoot`/`RootElement`. The `Content` setter is also guarded to gracefully handle the intentionally-null `WindowChrome` in hosted mode.

With the collision fixed, macOS is re-enabled across the existing ALC runtime tests, plus three new tests covering the skip behavior directly:

- `When_ContentHostOverride_Set_Then_NativeWindowNotCreated`
- `When_AlcWindow_ContentSetToNull_Then_DoesNotThrow`
- `When_SecondaryAlcApp_OnMacOS_Then_LoadsWithoutNativeWindowConflict`

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
