### PR TITLE
feat(WebView2): expose OS-account SSO and additional browser arguments on Skia Desktop

### DIFF
--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -174,6 +174,37 @@ The flag defaults to `true` in `DEBUG` builds and `false` in `RELEASE` builds.
 > [!NOTE]
 > The legacy iOS-only `Uno.UI.FeatureConfiguration.WebView2.IsInspectable` property is now an obsolete alias for `EnableDevTools`.
 
+## Customizing the WebView2 environment (Windows)
+
+On Windows (Skia Desktop) the `WebView2` is backed by the Microsoft Edge WebView2 runtime. A couple of environment-level options can be configured through `Uno.UI.FeatureConfiguration.WebView2` during application startup, before any `WebView2` is materialized. These are Windows-only and have no effect on other targets or on the Windows App SDK target (use `CoreWebView2EnvironmentOptions` directly there).
+
+### Single sign-on with the OS primary account
+
+Set `AllowSingleSignOnUsingOSPrimaryAccount` to `true` to let the `WebView2` use the OS primary account (for example, the Microsoft Entra ID / Azure AD account the user is signed into Windows with) for single sign-on against supporting resources:
+
+```csharp
+public App()
+{
+    Uno.UI.FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount = true;
+    this.InitializeComponent();
+}
+```
+
+> [!NOTE]
+> In a heavily managed environment the flag is necessary but may not be sufficient: device-registration state and administrator policy can still gate Entra ID SSO. Confirm with the environment's administrators that WebView2 AAD SSO is permitted.
+
+### Additional browser arguments
+
+Set `AdditionalBrowserArguments` to pass extra command-line switches (such as proxy configuration or Chromium feature flags) to the underlying browser process, which is often required in locked-down environments:
+
+```csharp
+public App()
+{
+    Uno.UI.FeatureConfiguration.WebView2.AdditionalBrowserArguments = "--proxy-server=http://proxy.example:8080";
+    this.InitializeComponent();
+}
+```
+
 ## Linux specifics
 
 In order to use WebView2 on Linux, you'll need to install `libwebkit2gtk` and `libgtk3-0`:

--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -147,6 +147,33 @@ See [WebView2 → Enabling native developer tools](xref:Uno.Controls.WebView2#en
 > [!IMPORTANT]
 > On Apple platforms the OS only honors this flag for development-signed apps (DEBUG builds). The legacy iOS-only `IsInspectable` property is now an obsolete alias for `EnableDevTools`.
 
+### AllowSingleSignOnUsingOSPrimaryAccount
+
+Enables single sign-on using the OS primary account (for example, the Microsoft Entra ID / Azure AD account the user is signed into Windows with) when `WebView2` authenticates against supporting resources. This is **Windows (Skia Desktop) only**; it is a no-op on other targets and on the Windows App SDK target (configure SSO through `CoreWebView2EnvironmentOptions` there). Defaults to `false`. Set it during application startup, before any `WebView2` is materialized:
+
+```csharp
+public App()
+{
+    Uno.UI.FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount = true;
+    this.InitializeComponent();
+}
+```
+
+> [!NOTE]
+> The CoreWebView2 environment is shared process-wide per user-data folder, so this must be set before the first `WebView2` is created. In a managed tenant the flag may be necessary but not sufficient: device-registration state and administrator policy can still gate Entra ID SSO.
+
+### AdditionalBrowserArguments
+
+Additional command-line switches passed to the browser process backing `WebView2` (for example proxy configuration or Chromium feature flags), useful in locked-down or managed environments. **Windows (Skia Desktop) only**, applied when the environment is first created; a no-op elsewhere. Set it during application startup, before any `WebView2` is materialized:
+
+```csharp
+public App()
+{
+    Uno.UI.FeatureConfiguration.WebView2.AdditionalBrowserArguments = "--proxy-server=http://proxy.example:8080";
+    this.InitializeComponent();
+}
+```
+
 ## `ApplicationData`
 
 On Skia Desktop targets, it is possible to override the default `ApplicationData` folder locations using `WinRTFeatureConfiguration.ApplicationData` properties. For more information, see [related docs here](/articles/features/applicationdata.md#data-location-on-skia-desktop)

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentOptions.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentOptions.xaml
@@ -19,7 +19,7 @@
         <StackPanel Padding="12" Spacing="6">
             <TextBlock
                 FontWeight="SemiBold"
-                Text="WebView2 environment options (Windows / Skia Desktop)"
+                Text="WebView2 environment options (Skia Desktop on Windows)"
                 TextWrapping="Wrap" />
             <TextBlock
                 Foreground="{ThemeResource SystemBaseMediumColor}"

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentOptions.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentOptions.xaml
@@ -1,0 +1,49 @@
+﻿<Page
+    x:Class="SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests.WebView2_EnvironmentOptions"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    xmlns:not_win="http://uno.ui/not_win"
+    mc:Ignorable="d not_win">
+
+    <not_win:Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Padding="12" Spacing="6">
+            <TextBlock
+                FontWeight="SemiBold"
+                Text="WebView2 environment options (Windows / Skia Desktop)"
+                TextWrapping="Wrap" />
+            <TextBlock
+                Foreground="{ThemeResource SystemBaseMediumColor}"
+                Text="These options must be set during application startup, before any WebView2 is materialized. This sample reflects the current values. They are Windows-only and have no effect on other targets."
+                TextWrapping="Wrap" />
+            <TextBlock x:Name="SsoStatusText" TextWrapping="Wrap" />
+            <TextBlock x:Name="ArgsStatusText" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Border
+            Grid.Row="1"
+            Margin="12,0,12,12"
+            Padding="8"
+            Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
+            CornerRadius="4">
+            <TextBlock FontFamily="Consolas" TextWrapping="Wrap">
+                <Run Text="// In App.xaml.cs constructor, BEFORE InitializeComponent:" />
+                <LineBreak />
+                <Run Text="Uno.UI.FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount = true;" />
+                <LineBreak />
+                <Run Text="Uno.UI.FeatureConfiguration.WebView2.AdditionalBrowserArguments = &quot;--proxy-server=...&quot;;" />
+            </TextBlock>
+        </Border>
+
+        <mux:WebView2 Grid.Row="2" Source="https://platform.uno/" />
+    </not_win:Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentOptions.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentOptions.xaml.cs
@@ -1,0 +1,16 @@
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests
+{
+	[Sample("WebView", Name = "WebView2_EnvironmentOptions", Description = "Demonstrates the Windows-only Uno.UI.FeatureConfiguration.WebView2 environment options (AllowSingleSignOnUsingOSPrimaryAccount and AdditionalBrowserArguments), which must be set at application startup.")]
+	public sealed partial class WebView2_EnvironmentOptions : Page
+	{
+		public WebView2_EnvironmentOptions()
+		{
+			this.InitializeComponent();
+			SsoStatusText.Text = $"FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount = {Uno.UI.FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount}";
+			ArgsStatusText.Text = $"FeatureConfiguration.WebView2.AdditionalBrowserArguments = {Uno.UI.FeatureConfiguration.WebView2.AdditionalBrowserArguments ?? "(null)"}";
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -153,7 +153,18 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		NativeDispatcher.Main.EnqueueAsync(async () =>
 		{
 			var userDataFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "WebView2");
-			var env = await NativeWebView.CoreWebView2Environment.CreateAsync(userDataFolder: userDataFolder);
+			// These options must be applied at environment creation time; CoreWebView2EnvironmentOptions cannot be
+			// changed once the environment exists. They are surfaced through FeatureConfiguration.WebView2 because Uno
+			// owns this CreateAsync call (the app never sees the CoreWebView2Environment), so it's the only injection point.
+			var options = new NativeWebView.CoreWebView2EnvironmentOptions
+			{
+				AllowSingleSignOnUsingOSPrimaryAccount = FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount
+			};
+			if (!string.IsNullOrEmpty(FeatureConfiguration.WebView2.AdditionalBrowserArguments))
+			{
+				options.AdditionalBrowserArguments = FeatureConfiguration.WebView2.AdditionalBrowserArguments;
+			}
+			var env = await NativeWebView.CoreWebView2Environment.CreateAsync(userDataFolder: userDataFolder, options: options);
 			var controller = await env.CreateCoreWebView2ControllerAsync(_hwnd);
 
 			// Hide until NavigationCompleted to suppress the initial black frame.

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -844,7 +844,7 @@ namespace Uno.UI
 			public static bool AllowSingleSignOnUsingOSPrimaryAccount { get; set; }
 
 			/// <summary>
-			/// Additional command-line switches passed to the browser process backing the <see cref="WebView2"/>
+			/// Additional command-line switches passed to the browser process backing the <see cref="Microsoft.UI.Xaml.Controls.WebView2"/>
 			/// (for example proxy configuration or Chromium feature flags), useful in locked-down or managed environments.
 			/// </summary>
 			/// <remarks>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -827,6 +827,36 @@ namespace Uno.UI
 				= true;
 #endif
 
+			/// <summary>
+			/// Enables single sign-on using the OS primary account (for example the Microsoft Entra ID / Azure AD
+			/// account the user is signed into Windows with) when the <see cref="WebView2"/> authenticates against
+			/// supporting resources.
+			/// </summary>
+			/// <remarks>
+			/// <para><b>Windows (Skia Desktop) only.</b> The value is passed to the underlying CoreWebView2 environment
+			/// options when the environment is first created. It is a no-op on every other target, and on the Windows
+			/// App SDK (WinUI) target where SSO is configured through <c>CoreWebView2EnvironmentOptions</c> directly.</para>
+			/// <para>Must be set once during application startup, before any <c>WebView2</c> is materialized. The
+			/// CoreWebView2 environment is shared process-wide per user-data folder, so changing this after the first
+			/// <c>WebView2</c> is created has no effect (and creating a second environment with different options throws).</para>
+			/// <para>Defaults to <c>false</c>, matching the WebView2 default.</para>
+			/// </remarks>
+			public static bool AllowSingleSignOnUsingOSPrimaryAccount { get; set; }
+
+			/// <summary>
+			/// Additional command-line switches passed to the browser process backing the <see cref="WebView2"/>
+			/// (for example proxy configuration or Chromium feature flags), useful in locked-down or managed environments.
+			/// </summary>
+			/// <remarks>
+			/// <para><b>Windows (Skia Desktop) only.</b> The value is applied to the underlying CoreWebView2 environment
+			/// options when the environment is first created. It is a no-op on every other target, and on the Windows
+			/// App SDK (WinUI) target where <c>CoreWebView2EnvironmentOptions.AdditionalBrowserArguments</c> is used directly.</para>
+			/// <para>Must be set once during application startup, before any <c>WebView2</c> is materialized (see
+			/// <see cref="AllowSingleSignOnUsingOSPrimaryAccount"/> for why). Refer to the WebView2 documentation for the
+			/// list of supported switches.</para>
+			/// </remarks>
+			public static string AdditionalBrowserArguments { get; set; }
+
 #if __IOS__ || UNO_REFERENCE_API
 			/// <summary>
 			/// Sets whether the <see cref="WebView2"/> object is inspectable or not.

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -829,7 +829,7 @@ namespace Uno.UI
 
 			/// <summary>
 			/// Enables single sign-on using the OS primary account (for example the Microsoft Entra ID / Azure AD
-			/// account the user is signed into Windows with) when the <see cref="WebView2"/> authenticates against
+			/// account the user is signed into Windows with) when the <see cref="Microsoft.UI.Xaml.Controls.WebView2"/> authenticates against
 			/// supporting resources.
 			/// </summary>
 			/// <remarks>


### PR DESCRIPTION
**GitHub Issue:** closes #23514

fixes https://github.com/unoplatform/kahua-private/issues/502

## PR Type:

✨ Feature

## What changed? 🚀

Adds two `Uno.UI.FeatureConfiguration.WebView2` options so apps can configure the underlying CoreWebView2 environment on **Skia Desktop (Windows / Win32)**, where it previously couldn't be customized:

- **`AllowSingleSignOnUsingOSPrimaryAccount`** (bool, default `false`) — enables Microsoft Entra ID (Azure AD) single sign-on using the OS primary (work/school) account.
- **`AdditionalBrowserArguments`** (string) — extra command-line switches passed to the browser process (proxy configuration, Chromium feature flags, etc.).

Both must be set at application startup (before the first `WebView2` is materialized) and are consumed by the Win32 WebView host (`Win32NativeWebView`) when it creates the `CoreWebView2Environment` — previously created with only a user-data folder, so these options could not be supplied.

Scope: **Windows-only by nature** — macOS (WKWebView) and Linux (WebKitGTK) have no OS-account SSO equivalent. The properties are declared cross-platform but consumed only by the Win32 host (no-op elsewhere; on the Windows App SDK target, configure `CoreWebView2EnvironmentOptions` directly). No native-target changes.

Also includes:
- Docs: `doc/articles/feature-flags.md` and `doc/articles/controls/WebView.md`.
- A manual sample: `WebView2_EnvironmentOptions`.

### Validation

- **Compile:** Win32 Skia head builds clean.
- **Engine:** with SSO on, the WebView2 browser process launches with `--enable-features=msSingleSignOnOSForPrimaryAccount…`, and `AdditionalBrowserArguments` appear verbatim on the browser command line.
- **Behavior:** verified on an Entra-joined device with a clean-profile A/B against an Entra-protected resource — with the option **off** the WebView shows the interactive sign-in prompt; with it **on** the WebView silently authenticates via the OS account (PRT) and lands authenticated, no prompt.

> Automated runtime tests aren't viable for this on the Skia/Win32 lane (the existing `Given_WebView2` tests are platform-excluded there, and the CoreWebView2 environment is process-global per user-data folder), so validation is compile + manual as above.

## PR Checklist ✅

- [x] 🧪 Added a manual test sample (`WebView2_EnvironmentOptions`)
- [x] 📚 Docs have been added/updated
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
