### PR TITLE
chore(sdk): bump Uno.UI.App.Mcp to 1.3.0-dev.36

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -428,7 +428,7 @@
 	},
 	{
 		"group": "AppMcp",
-		"version": "1.2.0-dev.41",
+		"version": "1.3.0-dev.36",
 		"packages": [
 			"Uno.UI.App.Mcp"
 		]


### PR DESCRIPTION
## Summary

Bumps the `AppMcp` package group in the Uno.Sdk manifest to the latest `Uno.UI.App.Mcp` dev build: `1.2.0-dev.41` → `1.3.0-dev.36`.

> Note: the `dev` suffix is lower (41 → 36) but the version is newer — the `1.3.0-dev` line restarted its counter after the `release/stable/1.2` branch was cut in the app-mcp repo.

Package: https://www.nuget.org/packages/Uno.UI.App.Mcp/1.3.0-dev.36

## Changes

- `src/Uno.Sdk/packages.json` — `AppMcp` group version `1.2.0-dev.41` → `1.3.0-dev.36`
