### PR TITLE
fix(ci): Serialize WASM+mobile template build to stop flaky wasm-opt OOM

### DIFF
--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -212,7 +212,12 @@ $projects =
     @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY\src\PackageCache"), @("macOS", "NetCore", "CleanNugetTemp","NoBuildClean")),
 
     # 5.6 Android/ios/Wasm+Skia
-    @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @("macOS", "NetCore")),
+    # /m:1 serializes the inner per-TFM builds. Without it, `dotnet build` (no -f) compiles all 5 TFMs
+    # in parallel, so the memory-heavy WASM native relink (wasm-opt -O2 over the SkiaSharp/HarfBuzz/ICU
+    # statics) runs concurrently with the android/ios/maccatalyst builds and intermittently aborts with
+    # SIGABRT under peak memory on the macOS agent (flaky Templates stage). Serializing removes that
+    # contention so wasm-opt runs on its own. See PR #23521.
+    @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @("/m:1"), @("macOS", "NetCore")),
 
     # 5.6 net-current runtime folder validation
     @(3, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @(), @("macOS", "NetCore")),

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -216,7 +216,7 @@ $projects =
     # in parallel, so the memory-heavy WASM native relink (wasm-opt -O2 over the SkiaSharp/HarfBuzz/ICU
     # statics) runs concurrently with the android/ios/maccatalyst builds and intermittently aborts with
     # SIGABRT under peak memory on the macOS agent (flaky Templates stage). Serializing removes that
-    # contention so wasm-opt runs on its own. See PR #23521.
+    # contention so wasm-opt runs on its own. See #23528.
     @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @("/m:1"), @("macOS", "NetCore")),
 
     # 5.6 net-current runtime folder validation


### PR DESCRIPTION
**GitHub Issue:** closes #23528

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`build/test-scripts/run-netcore-mobile-template-tests.ps1` now passes `/m:1` when building the
`uno56droidioswasmskia` project template, serializing its inner per-TFM builds.

## Why this is the correct fix (diagnosis → fix)

**Symptom (flaky):** `Tests - Templates` intermittently fails on the macOS agent while building
`uno56droidioswasmskia`, with `wasm-opt` aborting:
`emcc : error : '…/wasm-opt … -O2 … dotnet.native.wasm' failed (received SIGABRT (-6))`. It is *flaky*,
not a deterministic break — `Tests - Templates` passes on every recent `master` build, so it only
forces a stage re-run occasionally.

**Root cause:** that template is built with **no `-f`**, so `dotnet build` compiles **all of its TFMs
in parallel** (`android`/`ios`/`maccatalyst`/`browserwasm`/`desktop`). The loop's `$extraArgs` already
disables the costly *mobile* AOT/link and the *Uno* WASM IL-linker, but it does **not** affect the
**.NET WASM SDK native relink** (`wasm-opt -O2` over the SkiaSharp/HarfBuzz/ICU WASM statics), which is
memory-heavy and still runs. So `wasm-opt -O2` executes **concurrently** with the other TFM builds, and
under peak memory on the macOS agent it intermittently aborts (`SIGABRT`).

**Why `/m:1` is correct (not a band-aid):** limiting to one MSBuild node serializes the inner TFM
builds, so `wasm-opt` runs **without competing** with the other TFMs for memory. This removes the
contention *mechanism* rather than retrying past the symptom. It is scoped to the single multi-TFM
template that crashes; the only cost is a slightly longer build for that one template (the mobile TFMs
are already lightweight since AOT/link are disabled, so `wasm-opt` is the long pole regardless) — far
cheaper than the full-stage re-runs the flake currently triggers.

**Alternative considered:** lowering the WASM native-relink optimization (`wasm-opt -O1/-O0`) keeps full
parallelism and shrinks the memory spike, but `/m:1` is behaviour we are certain of; the lower-O path
can be a follow-up if more headroom is wanted.

## PR Checklist ✅

- [x] 🧪 N/A — CI build-script reliability fix (no product code; exercised by the `Tests - Templates` stage)
- [x] 📚 Rationale documented above and in #23528
- [x] 🖼️ N/A — no UI / screenshot impact
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests
