### PR TITLE
test: Document HotReload When_HotReload_Succeeds CI-flake diagnosis (#23529)

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
@@ -22,13 +22,13 @@ public class Given_HotReloadResilience : BaseTestClass
 	/// per-element error isolation or handler try/catch is broken, the
 	/// ReloadCompleted callback would not fire or would report uiUpdated=false.
 	/// </summary>
+	[TestMethod]
 	// FLAKY IN CI ONLY (passes locally 8/8; ~12/15 Windows-Skia CI builds fail with
 	// "tb1 should exist"). Under CI load, page.FindName("tb1") is not resolved at ReloadCompleted
 	// time. Not a simple timing race — polling for the element did not help (build 219526) — and
 	// "tb1" is not in HR_Frame_Pages_Page1's static XAML, so the element depends entirely on the
 	// hot-reload pipeline. Root cause is in the DevServer/HotReload reload behavior under CI
 	// conditions; needs that subsystem's investigation. https://github.com/unoplatform/uno/issues/9080
-	[TestMethod]
 	public async Task When_HotReload_Succeeds_Then_ReloadCompleted_ReportsSuccess()
 	{
 		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
@@ -22,6 +22,12 @@ public class Given_HotReloadResilience : BaseTestClass
 	/// per-element error isolation or handler try/catch is broken, the
 	/// ReloadCompleted callback would not fire or would report uiUpdated=false.
 	/// </summary>
+	// FLAKY IN CI ONLY (passes locally 8/8; ~12/15 Windows-Skia CI builds fail with
+	// "tb1 should exist"). Under CI load, page.FindName("tb1") is not resolved at ReloadCompleted
+	// time. Not a simple timing race — polling for the element did not help (build 219526) — and
+	// "tb1" is not in HR_Frame_Pages_Page1's static XAML, so the element depends entirely on the
+	// hot-reload pipeline. Root cause is in the DevServer/HotReload reload behavior under CI
+	// conditions; needs that subsystem's investigation. https://github.com/unoplatform/uno/issues/9080
 	[TestMethod]
 	public async Task When_HotReload_Succeeds_Then_ReloadCompleted_ReportsSuccess()
 	{


### PR DESCRIPTION
**GitHub Issue:** #23529 (diagnostic breadcrumb — intentionally does **not** close it; the underlying flake remains for DevServer/HotReload follow-up. Umbrella: #9080)

## PR Type:

📚 Documentation content changes (in-test diagnostic comment; no behaviour change)

## What changed? 🚀

Adds a comment above `Given_HotReloadResilience.When_HotReload_Succeeds_Then_ReloadCompleted_ReportsSuccess`
recording the CI-flake diagnosis. No code/behaviour change — the test still runs everywhere with its
assertions untouched.

## Why this is the right (interim) action

**Symptom:** `Given_HotReloadWorkspace.When_HotReloadScenario` fails ~12/15 recent `master` builds on
Windows Skia; the failing inner sub-test asserts `"tb1 should exist"`.

**Diagnosis (documented at the test + in #23529):**
- Passes **8/8 locally** (Skia Desktop, after building the DevServer Host + HRApp) → it does **not**
  reproduce in a healthy/unloaded environment ⇒ a CI **load/timing** flake.
- **Not a timing race:** polling for the element before asserting did **not** help (CI build 219526 —
  same `tb1` failure), so adding waits is not the fix.
- The asserted element (`tb1`, `Hello`→`World`) is **not in `HR_Frame_Pages_Page1`'s static XAML** — it
  depends entirely on the hot-reload pipeline producing it; under CI load `page.FindName("tb1")` does
  not resolve the reloaded element.

**Why only a breadcrumb here:** the real fix lives in the DevServer/HotReload reload pipeline
(namescope/instance resolution of reloaded content under load), which cannot be reproduced or validated
from a normal dev environment and is outside the scope of a test change. Per the debugging-discipline
rules (reproduce-first, validate-at-runtime, no blind patching), this PR records the precise diagnosis
for the owning subsystem rather than guessing at an unvalidatable fix. #23529 stays open for that fix.

## PR Checklist ✅

- [x] 🧪 N/A — comment-only; the test and its assertions are unchanged
- [x] 📚 Diagnosis documented at the test and in #23529
- [x] 🖼️ N/A
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests
