### PR TITLE
fix(dp): DependencyProperty.Register returns existing property on exact-duplicate registration

### DIFF
--- a/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
@@ -402,9 +402,12 @@ namespace Uno.UI.Tests.BinderTests
 			// twice (the official WinUI Gallery relies on this). Match that by returning the
 			// already-registered property instead of throwing.
 			var testProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
-			var secondProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+			var secondProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("99"));
 
 			Assert.AreSame(testProperty, secondProperty);
+
+			// The first registration wins: the second registration's metadata is discarded.
+			Assert.AreEqual("42", testProperty.GetMetadata(typeof(MockDependencyObject)).DefaultValue);
 		}
 
 		[TestMethod]
@@ -419,9 +422,21 @@ namespace Uno.UI.Tests.BinderTests
 		public void When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing()
 		{
 			var testProperty = DependencyProperty.RegisterAttached(nameof(When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
-			var secondProperty = DependencyProperty.RegisterAttached(nameof(When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+			var secondProperty = DependencyProperty.RegisterAttached(nameof(When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("99"));
 
 			Assert.AreSame(testProperty, secondProperty);
+
+			// The first registration wins: the second registration's metadata is discarded.
+			Assert.AreEqual("42", testProperty.GetMetadata(typeof(MockDependencyObject)).DefaultValue);
+		}
+
+		[TestMethod]
+		public void When_Property_Registered_Then_RegisterAttached_With_Same_Type_Then_Fail()
+		{
+			// Same name and property type, but a different attached-ness, is a genuine conflict:
+			// returning the existing property would hand the caller a wrong IsAttached flag.
+			var testProperty = DependencyProperty.Register(nameof(When_Property_Registered_Then_RegisterAttached_With_Same_Type_Then_Fail), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+			Assert.ThrowsExactly<InvalidOperationException>(() => DependencyProperty.RegisterAttached(nameof(When_Property_Registered_Then_RegisterAttached_With_Same_Type_Then_Fail), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42")));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
@@ -396,6 +396,7 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23554")]
 		public void When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing()
 		{
 			// WinUI does not throw when the same (name, ownerType, propertyType) is registered
@@ -411,6 +412,7 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23554")]
 		public void When_Property_RegisterTwice_With_Different_Type_Then_Fail()
 		{
 			// A same-name registration with a different property type is still a genuine conflict.
@@ -419,6 +421,7 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23554")]
 		public void When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing()
 		{
 			var testProperty = DependencyProperty.RegisterAttached(nameof(When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
@@ -431,6 +434,7 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23554")]
 		public void When_Property_Registered_Then_RegisterAttached_With_Same_Type_Then_Fail()
 		{
 			// Same name and property type, but a different attached-ness, is a genuine conflict:

--- a/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
@@ -396,11 +396,32 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
-		public void When_Property_RegisterTwice_then_Fail()
+		public void When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing()
 		{
-			var SUT = new MockDependencyObject();
-			var testProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_then_Fail), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
-			Assert.ThrowsExactly<InvalidOperationException>(() => DependencyProperty.Register(nameof(When_Property_RegisterTwice_then_Fail), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42")));
+			// WinUI does not throw when the same (name, ownerType, propertyType) is registered
+			// twice (the official WinUI Gallery relies on this). Match that by returning the
+			// already-registered property instead of throwing.
+			var testProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+			var secondProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+
+			Assert.AreSame(testProperty, secondProperty);
+		}
+
+		[TestMethod]
+		public void When_Property_RegisterTwice_With_Different_Type_Then_Fail()
+		{
+			// A same-name registration with a different property type is still a genuine conflict.
+			var testProperty = DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Different_Type_Then_Fail), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+			Assert.ThrowsExactly<InvalidOperationException>(() => DependencyProperty.Register(nameof(When_Property_RegisterTwice_With_Different_Type_Then_Fail), typeof(int), typeof(MockDependencyObject), new PropertyMetadata(42)));
+		}
+
+		[TestMethod]
+		public void When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing()
+		{
+			var testProperty = DependencyProperty.RegisterAttached(nameof(When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+			var secondProperty = DependencyProperty.RegisterAttached(nameof(When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
+
+			Assert.AreSame(testProperty, secondProperty);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -163,8 +163,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="typeMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If a non-attached property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type, or an attached property, has already been declared for the ownerType</exception>
 		public static DependencyProperty Register(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -225,8 +225,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="defaultMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If an attached property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type, or a non-attached property, has already been declared for the ownerType</exception>
 		public static DependencyProperty RegisterAttached(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -438,16 +438,12 @@ namespace Microsoft.UI.Xaml
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
 			DependencyProperty newProperty)
 		{
-			// WinUI does not validate or de-duplicate registrations: every call to
-			// MetadataAPI::RegisterDependencyProperty creates a fresh DP, so registering the
-			// same (name, ownerType, propertyType) twice is allowed there. The official WinUI
-			// Gallery relies on this (ControlExample and SampleCodePresenter both register
-			// "Substitutions" on typeof(ControlExample)). To stay faithful while keeping Uno's
-			// (ownerType, name) registry unique, return the already-registered property on an
-			// exact duplicate instead of throwing. A same-name registration with a different
-			// propertyType is still a genuine conflict and keeps throwing.
+			// WinUI does not de-duplicate registrations (MetadataAPI::RegisterDependencyProperty creates a fresh
+			// DP each time) and apps rely on it, so an exact duplicate returns the already-registered property
+			// instead of throwing. A different propertyType or attached-ness is still a genuine conflict.
 			if (_registry.TryGetValue(ownerType, name, out var existingProperty) &&
-				existingProperty!.Type == propertyType)
+				existingProperty!.Type == propertyType &&
+				existingProperty.IsAttached == newProperty.IsAttached)
 			{
 				return existingProperty;
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -163,8 +163,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="typeMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
 		public static DependencyProperty Register(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -175,19 +175,7 @@ namespace Microsoft.UI.Xaml
 
 			var newProperty = new DependencyProperty(name, propertyType, ownerType, typeMetadata, attached: false);
 
-			try
-			{
-				RegisterProperty(ownerType, name, newProperty);
-			}
-			catch (ArgumentException e)
-			{
-				throw new InvalidOperationException(
-					"The dependency property {0} already exists in type {1}".InvariantCultureFormat(name, ownerType),
-					e
-				);
-			}
-
-			return newProperty;
+			return RegisterProperty(ownerType, name, propertyType, newProperty);
 		}
 
 		private static PropertyMetadata FixMetadataIfNeeded(
@@ -237,8 +225,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="defaultMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
 		public static DependencyProperty RegisterAttached(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -249,19 +237,7 @@ namespace Microsoft.UI.Xaml
 
 			var newProperty = new DependencyProperty(name, propertyType, ownerType, defaultMetadata, attached: true);
 
-			try
-			{
-				RegisterProperty(ownerType, name, newProperty);
-			}
-			catch (ArgumentException e)
-			{
-				throw new InvalidOperationException(
-					"The dependency property {0} already exists in type {1}".InvariantCultureFormat(name, ownerType),
-					e
-				);
-			}
-
-			return newProperty;
+			return RegisterProperty(ownerType, name, propertyType, newProperty);
 		}
 
 		/// <summary>
@@ -456,11 +432,41 @@ namespace Microsoft.UI.Xaml
 			return result;
 		}
 
-		private static void RegisterProperty(Type ownerType, string name, DependencyProperty newProperty)
+		private static DependencyProperty RegisterProperty(
+			Type ownerType,
+			string name,
+			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
+			DependencyProperty newProperty)
 		{
+			// WinUI does not validate or de-duplicate registrations: every call to
+			// MetadataAPI::RegisterDependencyProperty creates a fresh DP, so registering the
+			// same (name, ownerType, propertyType) twice is allowed there. The official WinUI
+			// Gallery relies on this (ControlExample and SampleCodePresenter both register
+			// "Substitutions" on typeof(ControlExample)). To stay faithful while keeping Uno's
+			// (ownerType, name) registry unique, return the already-registered property on an
+			// exact duplicate instead of throwing. A same-name registration with a different
+			// propertyType is still a genuine conflict and keeps throwing.
+			if (_registry.TryGetValue(ownerType, name, out var existingProperty) &&
+				existingProperty!.Type == propertyType)
+			{
+				return existingProperty;
+			}
+
 			ResetGetPropertyCache(ownerType, name);
 
-			_registry.Add(ownerType, name, newProperty);
+			try
+			{
+				_registry.Add(ownerType, name, newProperty);
+			}
+			catch (ArgumentException e)
+			{
+				throw new InvalidOperationException(
+					"The dependency property {0} already exists in type {1}".InvariantCultureFormat(name, ownerType),
+					e
+				);
+			}
+
+			return newProperty;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -170,13 +170,7 @@ namespace Microsoft.UI.Xaml
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type ownerType,
 			PropertyMetadata typeMetadata)
-		{
-			typeMetadata = FixMetadataIfNeeded(propertyType, typeMetadata);
-
-			var newProperty = new DependencyProperty(name, propertyType, ownerType, typeMetadata, attached: false);
-
-			return RegisterProperty(ownerType, name, propertyType, newProperty);
-		}
+			=> RegisterProperty(ownerType, name, propertyType, typeMetadata, attached: false);
 
 		private static PropertyMetadata FixMetadataIfNeeded(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
@@ -232,13 +226,7 @@ namespace Microsoft.UI.Xaml
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type ownerType,
 			PropertyMetadata defaultMetadata)
-		{
-			defaultMetadata = FixMetadataIfNeeded(propertyType, defaultMetadata);
-
-			var newProperty = new DependencyProperty(name, propertyType, ownerType, defaultMetadata, attached: true);
-
-			return RegisterProperty(ownerType, name, propertyType, newProperty);
-		}
+			=> RegisterProperty(ownerType, name, propertyType, defaultMetadata, attached: true);
 
 		/// <summary>
 		/// Registers a attachable dependency property on the specified <paramref name="ownerType"/>.
@@ -433,20 +421,24 @@ namespace Microsoft.UI.Xaml
 		}
 
 		private static DependencyProperty RegisterProperty(
-			Type ownerType,
+			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type ownerType,
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
-			DependencyProperty newProperty)
+			PropertyMetadata typeMetadata,
+			bool attached)
 		{
 			// WinUI does not de-duplicate registrations (MetadataAPI::RegisterDependencyProperty creates a fresh
 			// DP each time) and apps rely on it, so an exact duplicate returns the already-registered property
 			// instead of throwing. A different propertyType or attached-ness is still a genuine conflict.
+			// Checked before the property is created, so a duplicate neither allocates nor burns a unique id.
 			if (_registry.TryGetValue(ownerType, name, out var existingProperty) &&
 				existingProperty!.Type == propertyType &&
-				existingProperty.IsAttached == newProperty.IsAttached)
+				existingProperty.IsAttached == attached)
 			{
 				return existingProperty;
 			}
+
+			var newProperty = new DependencyProperty(name, propertyType, ownerType, FixMetadataIfNeeded(propertyType, typeMetadata), attached);
 
 			ResetGetPropertyCache(ownerType, name);
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -157,8 +157,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="typeMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If a non-attached property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type, or an attached property, has already been declared for the ownerType</exception>
 		public static DependencyProperty Register(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -219,8 +219,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="defaultMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If an attached property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type, or a non-attached property, has already been declared for the ownerType</exception>
 		public static DependencyProperty RegisterAttached(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -432,16 +432,12 @@ namespace Microsoft.UI.Xaml
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
 			DependencyProperty newProperty)
 		{
-			// WinUI does not validate or de-duplicate registrations: every call to
-			// MetadataAPI::RegisterDependencyProperty creates a fresh DP, so registering the
-			// same (name, ownerType, propertyType) twice is allowed there. The official WinUI
-			// Gallery relies on this (ControlExample and SampleCodePresenter both register
-			// "Substitutions" on typeof(ControlExample)). To stay faithful while keeping Uno's
-			// (ownerType, name) registry unique, return the already-registered property on an
-			// exact duplicate instead of throwing. A same-name registration with a different
-			// propertyType is still a genuine conflict and keeps throwing.
+			// WinUI does not de-duplicate registrations (MetadataAPI::RegisterDependencyProperty creates a fresh
+			// DP each time) and apps rely on it, so an exact duplicate returns the already-registered property
+			// instead of throwing. A different propertyType or attached-ness is still a genuine conflict.
 			if (_registry.TryGetValue(ownerType, name, out var existingProperty) &&
-				existingProperty!.Type == propertyType)
+				existingProperty!.Type == propertyType &&
+				existingProperty.IsAttached == newProperty.IsAttached)
 			{
 				return existingProperty;
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -157,8 +157,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="typeMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
 		public static DependencyProperty Register(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -169,19 +169,7 @@ namespace Microsoft.UI.Xaml
 
 			var newProperty = new DependencyProperty(name, propertyType, ownerType, typeMetadata, attached: false);
 
-			try
-			{
-				RegisterProperty(ownerType, name, newProperty);
-			}
-			catch (ArgumentException e)
-			{
-				throw new InvalidOperationException(
-					"The dependency property {0} already exists in type {1}".InvariantCultureFormat(name, ownerType),
-					e
-				);
-			}
-
-			return newProperty;
+			return RegisterProperty(ownerType, name, propertyType, newProperty);
 		}
 
 		private static PropertyMetadata FixMetadataIfNeeded(
@@ -231,8 +219,8 @@ namespace Microsoft.UI.Xaml
 		/// <param name="propertyType">The type of the property</param>
 		/// <param name="ownerType">The owner type of the property</param>
 		/// <param name="defaultMetadata">The metadata to use when creating the property</param>
-		/// <returns>A dependency property instance</returns>
-		/// <exception cref="InvalidOperationException">A property with the same name has already been declared for the ownerType</exception>
+		/// <returns>A dependency property instance. If a property with the same name and property type has already been registered for the ownerType, that existing instance is returned.</returns>
+		/// <exception cref="InvalidOperationException">A property with the same name but a different property type has already been declared for the ownerType</exception>
 		public static DependencyProperty RegisterAttached(
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
@@ -243,19 +231,7 @@ namespace Microsoft.UI.Xaml
 
 			var newProperty = new DependencyProperty(name, propertyType, ownerType, defaultMetadata, attached: true);
 
-			try
-			{
-				RegisterProperty(ownerType, name, newProperty);
-			}
-			catch (ArgumentException e)
-			{
-				throw new InvalidOperationException(
-					"The dependency property {0} already exists in type {1}".InvariantCultureFormat(name, ownerType),
-					e
-				);
-			}
-
-			return newProperty;
+			return RegisterProperty(ownerType, name, propertyType, newProperty);
 		}
 
 		/// <summary>
@@ -450,11 +426,41 @@ namespace Microsoft.UI.Xaml
 			return result;
 		}
 
-		private static void RegisterProperty(Type ownerType, string name, DependencyProperty newProperty)
+		private static DependencyProperty RegisterProperty(
+			Type ownerType,
+			string name,
+			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
+			DependencyProperty newProperty)
 		{
+			// WinUI does not validate or de-duplicate registrations: every call to
+			// MetadataAPI::RegisterDependencyProperty creates a fresh DP, so registering the
+			// same (name, ownerType, propertyType) twice is allowed there. The official WinUI
+			// Gallery relies on this (ControlExample and SampleCodePresenter both register
+			// "Substitutions" on typeof(ControlExample)). To stay faithful while keeping Uno's
+			// (ownerType, name) registry unique, return the already-registered property on an
+			// exact duplicate instead of throwing. A same-name registration with a different
+			// propertyType is still a genuine conflict and keeps throwing.
+			if (_registry.TryGetValue(ownerType, name, out var existingProperty) &&
+				existingProperty!.Type == propertyType)
+			{
+				return existingProperty;
+			}
+
 			ResetGetPropertyCache(ownerType, name);
 
-			_registry.Add(ownerType, name, newProperty);
+			try
+			{
+				_registry.Add(ownerType, name, newProperty);
+			}
+			catch (ArgumentException e)
+			{
+				throw new InvalidOperationException(
+					"The dependency property {0} already exists in type {1}".InvariantCultureFormat(name, ownerType),
+					e
+				);
+			}
+
+			return newProperty;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -164,13 +164,7 @@ namespace Microsoft.UI.Xaml
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type ownerType,
 			PropertyMetadata typeMetadata)
-		{
-			typeMetadata = FixMetadataIfNeeded(propertyType, typeMetadata);
-
-			var newProperty = new DependencyProperty(name, propertyType, ownerType, typeMetadata, attached: false);
-
-			return RegisterProperty(ownerType, name, propertyType, newProperty);
-		}
+			=> RegisterProperty(ownerType, name, propertyType, typeMetadata, attached: false);
 
 		private static PropertyMetadata FixMetadataIfNeeded(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
@@ -226,13 +220,7 @@ namespace Microsoft.UI.Xaml
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type ownerType,
 			PropertyMetadata defaultMetadata)
-		{
-			defaultMetadata = FixMetadataIfNeeded(propertyType, defaultMetadata);
-
-			var newProperty = new DependencyProperty(name, propertyType, ownerType, defaultMetadata, attached: true);
-
-			return RegisterProperty(ownerType, name, propertyType, newProperty);
-		}
+			=> RegisterProperty(ownerType, name, propertyType, defaultMetadata, attached: true);
 
 		/// <summary>
 		/// Registers a attachable dependency property on the specified <paramref name="ownerType"/>.
@@ -427,20 +415,24 @@ namespace Microsoft.UI.Xaml
 		}
 
 		private static DependencyProperty RegisterProperty(
-			Type ownerType,
+			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type ownerType,
 			string name,
 			[DynamicallyAccessedMembers(BindableType.TypeRequirements)] Type propertyType,
-			DependencyProperty newProperty)
+			PropertyMetadata typeMetadata,
+			bool attached)
 		{
 			// WinUI does not de-duplicate registrations (MetadataAPI::RegisterDependencyProperty creates a fresh
 			// DP each time) and apps rely on it, so an exact duplicate returns the already-registered property
 			// instead of throwing. A different propertyType or attached-ness is still a genuine conflict.
+			// Checked before the property is created, so a duplicate neither allocates nor burns a unique id.
 			if (_registry.TryGetValue(ownerType, name, out var existingProperty) &&
 				existingProperty!.Type == propertyType &&
-				existingProperty.IsAttached == newProperty.IsAttached)
+				existingProperty.IsAttached == attached)
 			{
 				return existingProperty;
 			}
+
+			var newProperty = new DependencyProperty(name, propertyType, ownerType, FixMetadataIfNeeded(propertyType, typeMetadata), attached);
 
 			ResetGetPropertyCache(ownerType, name);
 


### PR DESCRIPTION
**GitHub Issue:** closes #23554

## PR Type:

🐞 Bugfix

## What changed? 🚀

`DependencyProperty.Register` / `RegisterAttached` threw `InvalidOperationException` ("…already exists in type…") when the same dependency property was registered twice with the **same `name`, `ownerType`, and `propertyType`**. WinUI does not throw here — the official WinUI Gallery registers `"Substitutions"` on `typeof(ControlExample)` from **both** `ControlExample` and `SampleCodePresenter`, and it runs fine on WinUI. On Uno the second registration threw a `TypeInitializationException`, taking down every feature that used those types.

I verified WinUI's behavior against the WinUI source — `microsoft/microsoft-ui-xaml`, `dxaml/xcp/dxaml/lib/MetadataAPI.cpp` (`MetadataAPI::RegisterDependencyProperty`): WinUI never validates or de-duplicates; every call allocates a fresh DP (there's even a `// TODO: Validate that people don't register the same DP multiple times…` comment). Allocating a brand-new DP each time is unsafe in Uno because its lookup relies on a unique `(ownerType, name)` registry, so this PR reproduces WinUI's **observable** behavior conservatively:

- `RegisterProperty` (now shared by `Register` and `RegisterAttached`) returns the **already-registered** `DependencyProperty` when an exact duplicate `(name, ownerType, propertyType)` is registered, instead of throwing.
- A same `(name, ownerType)` registration with a **different `propertyType`** is still a genuine conflict and keeps throwing `InvalidOperationException`.
- The previously-duplicated duplicate-key try/catch in `Register`/`RegisterAttached` is consolidated into `RegisterProperty`.

### ⚠️ Reviewer note (behavior change)

There was an existing test `When_Property_RegisterTwice_then_Fail` that **asserted the throw** on an exact duplicate — i.e. Uno intentionally threw before. To match WinUI it is repurposed to `When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing` (`Assert.AreSame`). The genuine-conflict case (different `propertyType`) is still covered by a new test. Please confirm this is the desired semantics. Nothing should rely on a DP *registration throwing*, so this is a permissive change rather than a functional break.

## Tests

`src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs`:
- `When_Property_RegisterTwice_With_Same_Type_Then_Returns_Existing` — exact duplicate returns the same instance.
- `When_Property_RegisterTwice_With_Different_Type_Then_Fail` — different `propertyType` still throws.
- `When_AttachedProperty_RegisterTwice_With_Same_Type_Then_Returns_Existing` — same for `RegisterAttached`.

`dotnet test src/Uno.UI.UnitTests --filter FullyQualifiedName~Given_DependencyProperty` → **127/127 passed**.

## PR Checklist ✅

- [x] 🧪 Added unit tests
- [ ] 📚 Docs (n/a — XML doc comments updated on `Register`/`RegisterAttached`)
- [ ] 🖼️ Screenshots compare (n/a)
- [x] ❗ Contains **NO** breaking changes (permissive change — see reviewer note above; genuine conflicts still throw)
