### PR TITLE
fix: Throw for InlineUIContainer in TextBlock to match WinUI

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -129,6 +129,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await ImageAssert.AreNotEqualAsync(actual, different);
 		}
 
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23510")]
+		public void When_InlineUIContainer_Added_To_TextBlock_Throws()
+		{
+			var SUT = new TextBlock();
+			SUT.Inlines.Add(new Run { Text = "Before " });
+
+			// WinUI throws ArgumentException; Uno used to silently drop the container.
+			Assert.ThrowsExactly<ArgumentException>(() => SUT.Inlines.Add(new InlineUIContainer { Child = new Border() }));
+
+			// Same when inserted or assigned through the indexer.
+			Assert.ThrowsExactly<ArgumentException>(() => SUT.Inlines.Insert(0, new InlineUIContainer()));
+			Assert.ThrowsExactly<ArgumentException>(() => SUT.Inlines[0] = new InlineUIContainer());
+
+			// Nested inside a Span that already lives in the TextBlock must also throw.
+			var span = new Span();
+			SUT.Inlines.Add(span);
+			Assert.ThrowsExactly<ArgumentException>(() => span.Inlines.Add(new InlineUIContainer()));
+
+			// A Span already holding an InlineUIContainer must throw when added to the TextBlock.
+			var preBuilt = new Span();
+			preBuilt.Inlines.Add(new InlineUIContainer());
+			Assert.ThrowsExactly<ArgumentException>(() => SUT.Inlines.Add(preBuilt));
+
+			// The valid inlines remain untouched after the rejected additions.
+			Assert.AreEqual(2, SUT.Inlines.Count);
+			Assert.IsInstanceOfType(SUT.Inlines[0], typeof(Run));
+			Assert.IsInstanceOfType(SUT.Inlines[1], typeof(Span));
+		}
+
 #if __SKIA__
 		[TestMethod]
 		// It looks like CI might not have any installed fonts with Chinese characters which could cause the test to fail

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
@@ -255,26 +255,11 @@ namespace Microsoft.UI.Xaml.Documents
 				_collection.GetParent();
 #endif
 
-			while (current is not null)
-			{
-				switch (current)
-				{
-					case TextBlock:
-						return true;
-					// A RichTextBlock hosts its inlines through a Paragraph; InlineUIContainer is valid there.
-					case Paragraph:
-					case RichTextBlock:
-						return false;
-					// Walk up through Span/Hyperlink/etc. to find the owning control.
-					case Inline inline:
-						current = inline.GetParent();
-						break;
-					default:
-						return false;
-				}
-			}
-
-			return false;
+			// Walk up through Span/Hyperlink/etc. to find the owning control.
+			while (current is Inline inline)
+				current = inline.GetParent();
+	
+			return current is TextBlock;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
@@ -258,7 +258,7 @@ namespace Microsoft.UI.Xaml.Documents
 			// Walk up through Span/Hyperlink/etc. to find the owning control.
 			while (current is Inline inline)
 				current = inline.GetParent();
-	
+
 			return current is TextBlock;
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
@@ -154,7 +154,11 @@ namespace Microsoft.UI.Xaml.Documents
 #endif
 
 		/// <inheritdoc />
-		public void Add(Inline item) => _collection.Add(item);
+		public void Add(Inline item)
+		{
+			ValidateInline(item);
+			_collection.Add(item);
+		}
 
 		/// <inheritdoc />
 		public void Clear() => _collection.Clear();
@@ -178,7 +182,11 @@ namespace Microsoft.UI.Xaml.Documents
 		public int IndexOf(Inline item) => _collection.IndexOf(item);
 
 		/// <inheritdoc />
-		public void Insert(int index, Inline item) => _collection.Insert(index, item);
+		public void Insert(int index, Inline item)
+		{
+			ValidateInline(item);
+			_collection.Insert(index, item);
+		}
 
 		/// <inheritdoc />
 		public void RemoveAt(int index) => _collection.RemoveAt(index);
@@ -187,7 +195,77 @@ namespace Microsoft.UI.Xaml.Documents
 		public Inline this[int index]
 		{
 			get => (Inline)_collection[index];
-			set => _collection[index] = value;
+			set
+			{
+				ValidateInline(value);
+				_collection[index] = value;
+			}
+		}
+
+		/// <summary>
+		/// WinUI only supports <see cref="InlineUIContainer"/> within a <see cref="RichTextBlock"/>; adding one to a
+		/// <see cref="TextBlock"/> throws. We match that contract instead of silently dropping the element. See uno#23510.
+		/// </summary>
+		private void ValidateInline(Inline item)
+		{
+			// Check the (cheap) item shape first so the common Run-add path avoids the owner walk entirely.
+			if (ContainsInlineUIContainer(item) && IsOwnedByTextBlock())
+			{
+				throw new ArgumentException(
+					"InlineUIContainer is not supported in a TextBlock. It can only be used within a RichTextBlock.");
+			}
+		}
+
+		private static bool ContainsInlineUIContainer(Inline item)
+		{
+			if (item is InlineUIContainer)
+			{
+				return true;
+			}
+
+			if (item is Span span)
+			{
+				foreach (var child in span.Inlines)
+				{
+					if (ContainsInlineUIContainer(child))
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		private bool IsOwnedByTextBlock()
+		{
+			var current =
+#if __WASM__
+				(object)_collection.Owner;
+#else
+				_collection.GetParent();
+#endif
+
+			while (current is not null)
+			{
+				switch (current)
+				{
+					case TextBlock:
+						return true;
+					// A RichTextBlock hosts its inlines through a Paragraph; InlineUIContainer is valid there.
+					case Paragraph:
+					case RichTextBlock:
+						return false;
+					// Walk up through Span/Hyperlink/etc. to find the owning control.
+					case Inline inline:
+						current = inline.GetParent();
+						break;
+					default:
+						return false;
+				}
+			}
+
+			return false;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
@@ -156,7 +156,7 @@ namespace Microsoft.UI.Xaml.Documents
 		/// <inheritdoc />
 		public void Add(Inline item)
 		{
-			ValidateInline(item);
+			ValidateInline(item, nameof(item));
 			_collection.Add(item);
 		}
 
@@ -184,7 +184,7 @@ namespace Microsoft.UI.Xaml.Documents
 		/// <inheritdoc />
 		public void Insert(int index, Inline item)
 		{
-			ValidateInline(item);
+			ValidateInline(item, nameof(item));
 			_collection.Insert(index, item);
 		}
 
@@ -197,7 +197,7 @@ namespace Microsoft.UI.Xaml.Documents
 			get => (Inline)_collection[index];
 			set
 			{
-				ValidateInline(value);
+				ValidateInline(value, nameof(value));
 				_collection[index] = value;
 			}
 		}
@@ -206,13 +206,22 @@ namespace Microsoft.UI.Xaml.Documents
 		/// WinUI only supports <see cref="InlineUIContainer"/> within a <see cref="RichTextBlock"/>; adding one to a
 		/// <see cref="TextBlock"/> throws. We match that contract instead of silently dropping the element. See uno#23510.
 		/// </summary>
-		private void ValidateInline(Inline item)
+		private void ValidateInline(Inline item, string paramName)
 		{
-			// Check the (cheap) item shape first so the common Run-add path avoids the owner walk entirely.
-			if (ContainsInlineUIContainer(item) && IsOwnedByTextBlock())
+			// Only an InlineUIContainer (or a Span that may nest one) can ever be invalid; a plain Run/LineBreak
+			// is always fine, so it skips both the owner walk and the Span recursion.
+			if (item is not (InlineUIContainer or Span))
+			{
+				return;
+			}
+
+			// Resolve ownership before recursing: a Paragraph/RichTextBlock-owned collection always allows the
+			// container, so there is no need to scan Span content in rich-text scenarios.
+			if (IsOwnedByTextBlock() && ContainsInlineUIContainer(item))
 			{
 				throw new ArgumentException(
-					"InlineUIContainer is not supported in a TextBlock. It can only be used within a RichTextBlock.");
+					"InlineUIContainer is not supported in a TextBlock. It can only be used within a RichTextBlock.",
+					paramName);
 			}
 		}
 


### PR DESCRIPTION
**GitHub Issue:** closes #23510

## PR Type:

🐞 Bugfix

## What changed? 🚀

`InlineUIContainer` is only valid inside a `RichTextBlock` (via a `Paragraph`); in WinUI, adding one to a `TextBlock`'s `Inlines` throws an `ArgumentException`. Uno instead **silently dropped** the container — `InlineCollection.TraversedTree` only treats `Run`/`LineBreak` as renderable leaves, so the element was accepted into the collection but never rendered and never reported.

This PR aligns the behavior with WinUI: adding an `InlineUIContainer` to a `TextBlock`-owned `InlineCollection` now throws `ArgumentException` instead of failing silently.

- Validation runs from `InlineCollection.Add`, `Insert`, and the indexer setter.
- It throws when the item being added **contains** an `InlineUIContainer` — directly, or nested inside a `Span`/`Hyperlink` — **and** the collection is ultimately owned by a `TextBlock` (resolved by walking up the parent chain).
- A `Paragraph`/`RichTextBlock` owner is explicitly allowed, so the rich-text path is never affected.
- The cheap item-shape check runs first, so the common `Run`-add path does a single type check and skips the owner walk — no behavior change for any existing content type.

**Behavior note:** code that previously added an `InlineUIContainer` to a `TextBlock` got a non-functional silent drop; it now throws, matching WinUI. This is the resolution requested in the issue, not an API change.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
