### PR TITLE
fix: Inset maximized client area to work area on Win32

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -152,6 +152,7 @@ AdjustWindowRectEx
 AdjustWindowRectExForDpi
 AddClipboardFormatListener
 BeginPaint
+ClientToScreen
 BitBlt
 ChoosePixelFormat
 CloseClipboard
@@ -230,12 +231,14 @@ GlobalUnlock
 InternetGetConnectedState
 InvalidateRect
 IsChild
+IsZoomed
 LoadCursor
 LoadRegTypeLib
 LocalFree
 MapWindowPoints
 MonitorFromWindow
 MonitorFromPoint
+MonitorFromRect
 OleInitialize
 OpenClipboard
 PeekMessage

--- a/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.NonClientPointer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.NonClientPointer.cs
@@ -115,7 +115,11 @@ partial class Win32WindowWrapper : INativeInputNonClientPointerSource
 			uRow = 2;
 		}
 
-		var titleBarHeightForDraggingRects = _hasTitleBar ? borderThickness.top : 0;
+		// Region rects are in physical client coordinates; map them to screen space using the actual client
+		// origin. When maximized, the client rect is inset from the window rect (see WM_NCCALCSIZE), so the
+		// window origin no longer coincides with the client origin and must not be used for this mapping.
+		var clientOrigin = default(System.Drawing.Point);
+		PInvoke.ClientToScreen(hWnd, ref clientOrigin);
 
 		bool hasCustomDragRects = false;
 		if (!onResizeBorder)
@@ -131,8 +135,8 @@ partial class Win32WindowWrapper : INativeInputNonClientPointerSource
 				foreach (var rect in region.Value)
 				{
 					var adjustedRect = new RectInt32(
-						rect.X + windowRectangle.left,
-						titleBarHeightForDraggingRects + rect.Y + windowRectangle.top,
+						rect.X + clientOrigin.X,
+						rect.Y + clientOrigin.Y,
 						rect.Width,
 						rect.Height);
 					if (adjustedRect.Contains(new PointInt32(ptMouse.X, ptMouse.Y)))

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32AutoHideTaskbar.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32AutoHideTaskbar.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Runtime.InteropServices;
+using Windows.Win32.Foundation;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+// Hand-written interop for the shell auto-hide taskbar query: CsWin32 cannot generate SHAppBarMessage /
+// APPBARDATA for an AnyCPU assembly (PInvoke005), so they are declared manually here.
+internal static class Win32AutoHideTaskbar
+{
+	public const uint ABE_LEFT = 0;
+	public const uint ABE_TOP = 1;
+	public const uint ABE_RIGHT = 2;
+	public const uint ABE_BOTTOM = 3;
+
+	private const uint ABM_GETAUTOHIDEBAREX = 0x0000000b;
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct APPBARDATA
+	{
+		public uint cbSize;
+		public IntPtr hWnd;
+		public uint uCallbackMessage;
+		public uint uEdge;
+		public RECT rc;
+		public IntPtr lParam;
+	}
+
+	[DllImport("shell32.dll")]
+	private static extern nuint SHAppBarMessage(uint dwMessage, ref APPBARDATA pData);
+
+	// Returns true when an auto-hide taskbar occupies the given edge of the monitor described by monitorRect.
+	public static bool ExistsOnEdge(uint edge, RECT monitorRect)
+	{
+		var data = new APPBARDATA
+		{
+			cbSize = (uint)Marshal.SizeOf<APPBARDATA>(),
+			uEdge = edge,
+			rc = monitorRect
+		};
+
+		// ABM_GETAUTOHIDEBAREX returns the auto-hide appbar's HWND for that monitor edge, or null when none.
+		return SHAppBarMessage(ABM_GETAUTOHIDEBAREX, ref data) != 0;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32AutoHideTaskbar.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32AutoHideTaskbar.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Runtime.InteropServices;
 using Windows.Win32.Foundation;

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32WindowWrapper.OverlappedPresenter.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32WindowWrapper.OverlappedPresenter.cs
@@ -180,7 +180,6 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 			PInvoke.AdjustWindowRectExForDpi(ref borderCaptionThickness, GetStyle(), false, 0, scaling);
 		}
 
-		borderCaptionThickness.left *= -1;
 		borderCaptionThickness.top *= -1;
 
 		bool hasSystemTitleBar = _hasTitleBar;

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32WindowWrapper.OverlappedPresenter.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Windowing/Win32WindowWrapper.OverlappedPresenter.cs
@@ -2,13 +2,13 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Windowing.Native;
-using Microsoft.UI.Xaml;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.UI.Hosting;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
+using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.WindowsAndMessaging;
 using MARGINS = Windows.Win32.UI.Controls.MARGINS;
 
@@ -18,9 +18,6 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 {
 	private OverlappedPresenterState? _pendingState;
 	private nuint _lastWindowSizeChange = 0;
-
-	private Thickness _offScreenMargins;
-	private Thickness _extendedMargins;
 
 	private bool _hasBorder;
 	private bool _hasTitleBar;
@@ -117,9 +114,6 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 			var margins = new MARGINS();
 			ApplyFrameExtension(margins);
 
-			_offScreenMargins = default;
-			_extendedMargins = default;
-
 			int cornerPreference = (int)DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_DEFAULT;
 			PInvoke.DwmSetWindowAttribute(_hwnd, DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(int));
 		}
@@ -167,7 +161,6 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 
 	private MARGINS UpdateClientAreaExtensionMargins()
 	{
-		RECT borderThickness = new RECT();
 		RECT borderCaptionThickness = new RECT();
 
 		var scaling = (uint)(RasterizationScale * PInvoke.USER_DEFAULT_SCREEN_DPI);
@@ -176,26 +169,17 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 		if (Environment.OSVersion.Version < new Version(10, 0, 14393))
 		{
 			PInvoke.AdjustWindowRectEx(ref borderCaptionThickness, GetStyle(), false, 0);
-			PInvoke.AdjustWindowRectEx(ref borderThickness, GetStyle() & ~WINDOW_STYLE.WS_CAPTION, false, 0);
 
 			borderCaptionThickness.top = (int)(borderCaptionThickness.top * relativeScaling);
 			borderCaptionThickness.right = (int)(borderCaptionThickness.right * relativeScaling);
 			borderCaptionThickness.left = (int)(borderCaptionThickness.left * relativeScaling);
 			borderCaptionThickness.bottom = (int)(borderCaptionThickness.bottom * relativeScaling);
-
-			borderThickness.top = (int)(borderThickness.top * relativeScaling);
-			borderThickness.right = (int)(borderThickness.right * relativeScaling);
-			borderThickness.left = (int)(borderThickness.left * relativeScaling);
-			borderThickness.bottom = (int)(borderThickness.bottom * relativeScaling);
 		}
 		else
 		{
 			PInvoke.AdjustWindowRectExForDpi(ref borderCaptionThickness, GetStyle(), false, 0, scaling);
-			PInvoke.AdjustWindowRectExForDpi(ref borderThickness, GetStyle() & ~WINDOW_STYLE.WS_CAPTION, false, 0, scaling);
 		}
 
-		borderThickness.left *= -1;
-		borderThickness.top *= -1;
 		borderCaptionThickness.left *= -1;
 		borderCaptionThickness.top *= -1;
 
@@ -220,25 +204,6 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 
 		margins.cyTopHeight = _window!.AppWindow.TitleBar.ExtendsContentIntoTitleBar ? borderCaptionThickness.top : defaultMargin;
 
-		if (State == OverlappedPresenterState.Maximized)
-		{
-			_extendedMargins = new Thickness(
-				0,
-				(borderCaptionThickness.top - borderThickness.top) / RasterizationScale,
-				0,
-				0);
-			_offScreenMargins = new Thickness(
-				borderThickness.left / RasterizationScale,
-				borderThickness.top / RasterizationScale,
-				borderThickness.right / RasterizationScale,
-				borderThickness.bottom / RasterizationScale);
-		}
-		else
-		{
-			_extendedMargins = new(0, borderCaptionThickness.top / RasterizationScale, 0, 0);
-			_offScreenMargins = default;
-		}
-
 		return margins;
 	}
 
@@ -252,6 +217,49 @@ internal partial class Win32WindowWrapper : INativeOverlappedPresenter
 		{
 			return (WINDOW_STYLE)PInvoke.GetWindowLong(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
 		}
+	}
+
+	// Insets a maximized custom-chrome window's proposed client rect back to the monitor work area. The OS
+	// positions a maximized resizable window so its resize frame overhangs the monitor on every edge; custom
+	// chrome draws into that area, so without correction the content and caption buttons spill off-screen.
+	// Clamping the proposed rect (rgrc[0], a screen-space WINDOW rect) to the work area makes the client exactly
+	// the visible, non-taskbar region - identical to a standard maximized window and to WinUI - with no
+	// frame-thickness/DPI math (which can be off by a pixel). The monitor comes from the proposed rect, so this
+	// is correct on a secondary monitor with a different DPI and during restore-from-minimized.
+	private unsafe void ApplyMaximizedClientInset(ref RECT client)
+	{
+		var monitor = PInvoke.MonitorFromRect(in client, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
+		if (monitor.Value == IntPtr.Zero)
+		{
+			return;
+		}
+
+		var monitorInfo = new MONITORINFO { cbSize = (uint)sizeof(MONITORINFO) };
+		if (!PInvoke.GetMonitorInfo(monitor, &monitorInfo))
+		{
+			return;
+		}
+
+		var work = monitorInfo.rcWork;
+		client.left = Math.Max(client.left, work.left);
+		client.top = Math.Max(client.top, work.top);
+		client.right = Math.Min(client.right, work.right);
+		client.bottom = Math.Min(client.bottom, work.bottom);
+
+		ReserveAutoHideTaskbarEdges(ref client, monitorInfo.rcMonitor);
+	}
+
+	// An auto-hide taskbar reserves no work area, so the work-area clamp above leaves the client flush with that
+	// monitor edge. A maximized window that fully covers the edge hosting an auto-hide taskbar is treated by
+	// Windows as a full-screen app and the bar can no longer be revealed, so keep the client 1px short of any
+	// such edge - matching the native WinUI windowing layer.
+	private void ReserveAutoHideTaskbarEdges(ref RECT client, RECT rcMonitor)
+	{
+		const int reserve = 1;
+		if (Win32AutoHideTaskbar.ExistsOnEdge(Win32AutoHideTaskbar.ABE_LEFT, rcMonitor)) { client.left += reserve; }
+		if (Win32AutoHideTaskbar.ExistsOnEdge(Win32AutoHideTaskbar.ABE_TOP, rcMonitor)) { client.top += reserve; }
+		if (Win32AutoHideTaskbar.ExistsOnEdge(Win32AutoHideTaskbar.ABE_RIGHT, rcMonitor)) { client.right -= reserve; }
+		if (Win32AutoHideTaskbar.ExistsOnEdge(Win32AutoHideTaskbar.ABE_BOTTOM, rcMonitor)) { client.bottom -= reserve; }
 	}
 
 	private void SetWindowStyle(WINDOW_STYLE style, bool on)

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -386,6 +386,19 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 			case PInvoke.WM_NCCALCSIZE:
 				if (wParam.Value == 1 && (!_hasBorder || !_hasTitleBar))
 				{
+					// Custom-chrome windows remove the system frame so content fills the whole window. When such
+					// a window is maximized, Windows still positions it so the resize frame overhangs the monitor
+					// on every edge; left uncorrected, content and the caption buttons would spill off-screen and
+					// the reported client size would exceed the visible area. Inset the proposed client rect back
+					// to the monitor work area so the chrome fills exactly the visible screen, matching WinUI.
+					// FullScreenPresenter is excluded: it also reports a maximized window but must own the whole
+					// monitor. IsZoomed reflects the live maximized state even before WM_SIZE arrives.
+					if (Window?.AppWindow?.Presenter is OverlappedPresenter && PInvoke.IsZoomed(hwnd))
+					{
+						// rgrc[0] is the first field of NCCALCSIZE_PARAMS, so lParam can be read as its RECT.
+						ref var client = ref *(RECT*)lParam.Value;
+						ApplyMaximizedClientInset(ref client);
+					}
 					return new LRESULT(IntPtr.Zero);
 				}
 				break;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
@@ -184,6 +184,50 @@ public class Given_AppWindow
 		}
 	}
 
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21745")]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
+	public async Task When_Maximized_With_Extended_TitleBar_Client_Is_Inset_From_Window()
+	{
+		AssertPositioningAndSizingSupport();
+
+		var newWindow = new Window();
+		newWindow.ExtendsContentIntoTitleBar = true;
+		var appWindow = newWindow.AppWindow;
+		var overlapped = (OverlappedPresenter)appWindow.Presenter;
+		var activated = false;
+		try
+		{
+			newWindow.Activated += (s, e) => activated = true;
+			newWindow.Activate();
+			await TestServices.WindowHelper.WaitFor(() => activated);
+
+			overlapped.Maximize();
+			await TestServices.WindowHelper.WaitForIdle();
+			await TestServices.WindowHelper.WaitFor(() => overlapped.State == OverlappedPresenterState.Maximized);
+
+			var size = appWindow.Size;             // outer window rect: overhangs the monitor when maximized
+			var clientSize = appWindow.ClientSize; // client rect: must be inset back onto the visible work area
+
+			// The maximized window rect overhangs the monitor by the resize frame on every edge. With the native
+			// overhang correction the client is inset back inside the window, so it must be strictly smaller than
+			// the window on both axes. Before the fix the client equalled the window (no inset), i.e. the chrome
+			// bled off-screen and these would have been equal.
+			clientSize.Width.Should().BeLessThan(size.Width);
+			clientSize.Height.Should().BeLessThan(size.Height);
+
+			// The inset equals the resize-frame thickness per side (a handful of DPI-scaled px), never the whole
+			// window - guard against a degenerate or grossly over-large inset.
+			(size.Width - clientSize.Width).Should().BeInRange(1, 120);
+			(size.Height - clientSize.Height).Should().BeInRange(1, 120);
+		}
+		finally
+		{
+			await TestServices.WindowHelper.WaitForIdle();
+			await TestServices.RunOnUIThread(() => newWindow.Close());
+		}
+	}
+
 	private void AssertPositioningAndSizingSupport()
 	{
 		if (!OperatingSystem.IsLinux() &&

--- a/src/Uno.UI/UI/Xaml/Window/WindowChrome.cs
+++ b/src/Uno.UI/UI/Xaml/Window/WindowChrome.cs
@@ -492,14 +492,8 @@ internal sealed partial class WindowChrome : ContentControl
 			Visibility.Visible :
 			Visibility.Collapsed;
 
-		// On Windows, maximized window stretches out of the bounds of the screen slightly.
-		// https://www.reddit.com/r/csharp/comments/921k9l/fixing_8_pixel_overhang_on_maximized_window_state/
-		var isClientAreaExtended = appWindowTitleBar.ExtendsContentIntoTitleBar || !hasPresenterTitleBar;
-		var shouldHavePadding =
-			OperatingSystem.IsWindows() &&
-			IsWindowMaximized() &&
-			isClientAreaExtended;
-		Padding = new(shouldHavePadding ? 4 : 0);
+		// The maximized-window overhang is corrected natively in the Win32 windowing layer (the client rect is
+		// inset back to the work area in WM_NCCALCSIZE), so the chrome simply fills the client area on all states.
 
 		ResizeCaptionButtons();
 	}


### PR DESCRIPTION
**GitHub Issue:** closes #21745

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Win32 (Skia), custom-chrome windows (`ExtendsContentIntoTitleBar = true`, or no presenter title bar) strip the system frame by returning `0` from `WM_NCCALCSIZE`, making the client area equal to the window rect. When such a window is **maximized**, Windows positions it so its resize frame overhangs the monitor on every edge (~8px/side at 100% DPI, more when scaled). The previous behaviour therefore let the content and caption buttons spill off-screen, and `AppWindow.ClientSize` / `Window.Bounds` / `XamlRoot.Bounds` over-reported. The only compensation was a hard-coded, DPI-unaware `WindowChrome.Padding = 4` fudge.

This moves the correction to the **native level**, so `WindowChrome` fills the full screen and the reported sizes match a maximized WinUI app on the same screen:

- **`WM_NCCALCSIZE`**: when the window is maximized (and not full-screen), clamp the proposed client rect to the monitor **work area** (`client = window ∩ rcWork`). This makes the client exactly the visible, non-taskbar region — identical to a standard maximized window and to WinUI — with no frame-thickness/DPI math (which is off by a pixel and caption-sensitive). The monitor is taken from the proposed rect, so it is correct on a secondary monitor and during restore-from-minimized.
- **Auto-hide taskbar**: an auto-hide taskbar reserves no work area, so a maximized window flush with its edge is treated as full-screen and the bar stops revealing. 1px is reserved on any edge hosting one (`SHAppBarMessage` / `ABM_GETAUTOHIDEBAREX`), matching the native WinUI windowing layer.
- Removed the `WindowChrome.Padding = 4` hack and the now-dead `_offScreenMargins` / `_extendedMargins`.
- **Caption/drag-region hit-testing** now maps region rects through the real client origin (`ClientToScreen`) instead of the window origin. The two coincided only while full-bleed; once the client is inset they diverged by the frame thickness, which would have misplaced the caption-button hit zones.

`FullScreenPresenter` (which also reports a maximized window via `SW_MAXIMIZE`) is explicitly excluded so it keeps owning the whole monitor. Standard windows (with a system title bar + border) are untouched — they fall through to `DefWindowProc` as before.

**Validation** (Skia Win32, `AppWindowPositionAndSize` sample, 150% DPI): with the title bar extended and the window maximized, the client area is now exactly the monitor work area (`dW=0, dH=0`) while the window rect overhangs by 2×frame; the caption buttons render at the true top-right corner and clicking the maximize/restore button correctly restores the window (confirming hit-test alignment). A runtime regression test (`Given_AppWindow.When_Maximized_With_Extended_TitleBar_Client_Is_Inset_From_Window`) asserts the client is inset from the overhanging window rect.

The approach was cross-checked against WPF (`SetWindowRgn` to `rcWork`), WinUI (client == work-area contract) and Avalonia (NCCALCSIZE inset).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
