### PR TITLE
fix: Clear caption-button hover when leaving into caption

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.NonClientPointer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.NonClientPointer.cs
@@ -174,16 +174,20 @@ partial class Win32WindowWrapper : INativeInputNonClientPointerSource
 		_ => Win32NonClientHitTestKind.HTCLIENT
 	};
 
-	private bool ShouldRedirectNonClientInput(HWND hWnd, WPARAM wParam, IntPtr lParam)
-	{
-		var hitTestResult = NonClientAreaHitTest(hWnd, wParam, lParam);
-
-		return hitTestResult
+	// A caption button (min/max/close/...) whose pointer input is redirected into the matching XAML button.
+	private static bool IsCaptionButton(Win32NonClientHitTestKind hitTest)
+		=> hitTest
 			is Win32NonClientHitTestKind.HTMINBUTTON
 			or Win32NonClientHitTestKind.HTMAXBUTTON
 			or Win32NonClientHitTestKind.HTCLOSE
 			or Win32NonClientHitTestKind.HTHELP
 			or Win32NonClientHitTestKind.HTMENU
 			or Win32NonClientHitTestKind.HTSYSMENU;
-	}
+
+	// The whole title bar: the caption buttons plus the caption/drag area to their left.
+	private static bool IsOverTitleBar(Win32NonClientHitTestKind hitTest)
+		=> IsCaptionButton(hitTest) || hitTest is Win32NonClientHitTestKind.HTCAPTION;
+
+	private bool ShouldRedirectNonClientInput(HWND hWnd, WPARAM wParam, IntPtr lParam)
+		=> IsCaptionButton(NonClientAreaHitTest(hWnd, wParam, lParam));
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -432,6 +432,17 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				}
 				break;
 			case PInvoke.WM_NCPOINTERUPDATE:
+				// Redirect pointer moves over the whole title bar (caption drag area + caption buttons) into XAML,
+				// not just over the buttons. Caption-button hover (PointerOver) is driven by these redirected
+				// moves; without redirecting caption moves, sliding off a button sideways into the drag area
+				// delivers no move at the new position, so the button stays stuck in the hovered state.
+				if (!handled
+					&& IsOverTitleBar(NonClientAreaHitTest(hWnd, wParam, lParam)))
+				{
+					OnPointer(msg, wParam, hWnd);
+					handled = true;
+				}
+				break;
 			case PInvoke.WM_NCPOINTERDOWN:
 			case PInvoke.WM_NCPOINTERUP:
 				if (!handled


### PR DESCRIPTION
**GitHub Issue:** closes #23563

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Win32 (Skia), a custom-chrome caption button (e.g. **Minimize**) stayed stuck in its hovered (`PointerOver`) state when the pointer slid off it **sideways into the caption drag area**.

Caption-button hover is driven by redirected non-client pointer moves. In `TryHandleCustomCaptionMessage`, `WM_NCPOINTERUPDATE` was only redirected to XAML when the pointer was **over a button** (`HTMINBUTTON/HTMAXBUTTON/HTCLOSE/...`). Moving left off the (leftmost) Minimize button lands on the caption drag area (`HTCAPTION`), which was *not* redirected, so XAML never received a move at the new position and the button's pointer-over state was never cleared. Moving **down** (into the client → `WM_POINTERUPDATE`) or **right** (onto the next button → already redirected) worked, which is why only the sideways/left direction was broken.

The fix redirects `WM_NCPOINTERUPDATE` over the **whole title bar** (caption drag area + caption buttons), not just over the buttons, so a move is always delivered to XAML when the pointer slides off a button — clearing the hover. `WM_NCPOINTERDOWN`/`WM_NCPOINTERUP` stay gated to the buttons, so window dragging (handled by `DwmDefWindowProc`) and the snap-layout flyout are unaffected.

**Validation** (Skia Win32, `AppWindowPositionAndSize` sample with the title bar extended, driven by injected mouse moves): the Minimize button highlights on hover and correctly returns to its baseline appearance when the pointer moves left into the caption — verified by sampling the button's pixel color (baseline → hovered → back to baseline) and by tracing the redirected non-client pointer messages.

A committed runtime test is not included because the behavior depends on real Win32 non-client pointer messages (`WM_NCPOINTERUPDATE` with `HTCAPTION`/`HTMINBUTTON` hit-testing), which the cross-platform runtime-test harness cannot synthesize; it was validated manually as described above.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
