### PR TITLE
feat!: UserControl inherits from Control

### DIFF
--- a/specs/050-breaking-changes-rollup/bc14-usercontrol-to-control.md
+++ b/specs/050-breaking-changes-rollup/bc14-usercontrol-to-control.md
@@ -31,9 +31,9 @@ WinUI hierarchy is **`Control` → `UserControl` → `Page`**, with `UserControl
 - `x is ContentControl` checks and `ContentControl`-typed casts against a `UserControl`/`Page` **flip from `true` to `false`** — can silently change behaviour in framework and app code.
 - Re-implementing content hosting without `ContentPresenter` is non-trivial: focus, automation peers, and visual-state hosting all currently lean on the `ContentControl` path.
 
-## Open decision (needs maintainer confirmation)
+## Decision (resolved)
 
-Commit to WinUI parity (accept that `ContentTemplate`/`ContentTemplateSelector`/`ContentTransitions` vanish from `UserControl`/`Page`, and `is ContentControl` flips), **or** keep the extra `ContentControl` for back-compat? This is the single highest-risk break in the epic — get explicit sign-off before starting.
+**Commit to WinUI parity.** `ContentTemplate`/`ContentTemplateSelector`/`ContentTransitions` and the `object`-typed `Content` setter are removed from `UserControl`/`Page`; `Content` is typed `UIElement`; `is ContentControl` against a `UserControl`/`Page` flips to `false`. The back-compat alternative (keeping the extra `ContentControl`) was rejected.
 
 ## Affected files (starting set)
 
@@ -47,4 +47,17 @@ Commit to WinUI parity (accept that `ContentTemplate`/`ContentTemplateSelector`/
 
 ## Sequencing
 
-Do **BC38 (Background → Control)** first so the `Background` relocation onto `Control` is not redone during this re-parenting. Independent of the DataContext / DependencyObject items. Own stabilized PR; never batch.
+Originally planned after **BC38 (Background → Control)**. In practice BC14 is **independent of BC38**: `Background` is declared on `FrameworkElement`, so `UserControl` keeps inheriting it through `FrameworkElement` → `Control` → `UserControl` regardless of BC38; if BC38 lands later it relocates `Background` onto `Control` without disturbing this change. Independent of the DataContext / DependencyObject items. Own stabilized PR; never batch.
+
+## Implementation (as landed)
+
+`UserControl : Control` with its own `UIElement`-typed `Content` (`[GeneratedDependencyProperty]`, `AffectsMeasure | ValueDoesNotInheritDataContext`). Single-child hosting is done directly via `AddChild`/`RemoveChild` in `OnContentChanged` — these primitives exist on every platform, so no per-platform partial and no `ContentPresenter`/template plumbing is needed. `Control`'s existing single-child `MeasureOverride`/`ArrangeOverride` (`FindFirstChild`/`ArrangeFirstChild`) handles layout, so `UserControl` adds none. `Page` inherits the new base unchanged (its `OnBackgroundChanged` override still works). The generated `UserControl`/`Page` stubs already matched the target shape (stub skips `Content`/`ContentProperty`), so no regeneration was required — confirmed by a clean full-samples build.
+
+Consumer adaptation was minimal: `IFrameworkElement.FindName` gained a `UserControl.Content` branch (covers `Page`), and hot reload's `SwapViews` gained a `UserControl` parent path. The other `is ContentControl` sites (AriaMapper, FocusManager, VisualStateUtil, WASM a11y) correctly stop matching `UserControl`/`Page` and needed no code change.
+
+Files changed: `…/Controls/UserControl/UserControl.cs`, `…/Controls/UserControl/UserControl.Properties.cs` (new), `…/UI/Xaml/IFrameworkElement.cs`, `Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs`, plus `Uno.UI.RuntimeTests/.../Given_UserControl.cs` (new). `ContentControl.cs` and the generated stubs were **not** touched.
+
+## Validation status
+
+- **Done (Skia Desktop, runtime):** `Given_UserControl` (5/5) plus a regression batch of **407/0** across `Given_Control`, `Given_ContentControl` (incl. FindName), `Given_ContentPresenter`, `Given_Frame` (navigation), `Given_VisualStateManager`, `Given_FocusManager`, `Given_FrameworkElement`. Full-samples Skia build clean (Uno.UI, RemoteControl, SamplesApp).
+- **Pending (PR-stabilization):** WinUI-parity run (`/winui-runtime-tests`), SamplesApp light/dark visual sweep (layout-equivalence headline risk), WASM Skia head, HotReload app-harness tests.

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_StreamSource.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_StreamSource.xaml.cs
@@ -42,21 +42,12 @@ namespace Uno.UI.Samples.UITests.ImageBrushTestControl
 
 			this.RunWhileLoaded(async ct =>
 			{
-				using var httpClient = new HttpClient();
 				const string imageUrl = "https://uno-assets.platform.uno/tests/images/uno-overalls.jpg";
-				var data = await httpClient.GetByteArrayAsync(imageUrl);
 
-				BitmapImage bitmapImage;
-				MySource = bitmapImage = new BitmapImage();
-
-#if WINAPPSDK
-				using var stream = new MemoryStream(data).AsRandomAccessStream();
-#else
-				using var stream = new MemoryStream(data);
-#endif
-				await bitmapImage.SetSourceAsync(stream);
-				MySource = bitmapImage;
-
+				// Subscribe before assigning MySource below. The brushes bind to MySource via x:Bind,
+				// and assigning an already-decoded BitmapImage can raise ImageOpened/ImageFailed
+				// synchronously. Subscribing afterwards would miss those events, so _tcs would never
+				// complete and IWaitableSample.SamplePreparedTask would hang the snapshot run.
 				imageBrush1.ImageOpened += ImageOpened;
 				imageBrush1.ImageFailed += ImageFailed;
 				imageBrush2.ImageOpened += ImageOpened;
@@ -69,6 +60,20 @@ namespace Uno.UI.Samples.UITests.ImageBrushTestControl
 				imageBrush5.ImageFailed += ImageFailed;
 				imageBrush6.ImageOpened += ImageOpened;
 				imageBrush6.ImageFailed += ImageFailed;
+
+				using var httpClient = new HttpClient();
+				var data = await httpClient.GetByteArrayAsync(imageUrl);
+
+				BitmapImage bitmapImage;
+				MySource = bitmapImage = new BitmapImage();
+
+#if WINAPPSDK
+				using var stream = new MemoryStream(data).AsRandomAccessStream();
+#else
+				using var stream = new MemoryStream(data);
+#endif
+				await bitmapImage.SetSourceAsync(stream);
+				MySource = bitmapImage;
 			});
 		}
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -357,7 +357,15 @@ namespace SampleControl.Presentation
 
 							if (control is IWaitableSample waitableSample)
 							{
-								await waitableSample.SamplePreparedTask;
+								// Cap the wait so a sample that never signals readiness can't stall the
+								// whole screenshot run until the CI job timeout. A timeout yields one bad
+								// screenshot for this sample instead of hanging every remaining sample.
+								var timeoutTask = Task.Delay(TimeSpan.FromMinutes(2), ct);
+								if (await Task.WhenAny(waitableSample.SamplePreparedTask, timeoutTask) == timeoutTask)
+								{
+									Console.WriteLine($"Timed out waiting for sample {fileName} to be prepared (IWaitableSample.SamplePreparedTask).");
+									_log.Error($"Timed out waiting for sample {fileName} to be prepared (IWaitableSample.SamplePreparedTask).");
+								}
 							}
 
 #if HAS_UNO

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Remove_Sibling/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Remove_Sibling/0/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Remove_Sibling/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Remove_Sibling/1/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Remove_Sibling/2/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Remove_Sibling/2/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Sibling/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Sibling/0/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Sibling/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Add_Sibling/1/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Move_Sibling/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Move_Sibling/0/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Move_Sibling/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Move_Sibling/1/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Remove_Sibling/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Remove_Sibling/0/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Remove_Sibling/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplates_With_Nested_Remove_Sibling/1/p1/MainPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class MainPage : Page
 }
 
 [Microsoft.UI.Xaml.Markup.ContentProperty(Name = nameof(Template1))]
-public class MyControl
+public class MyControl : global::Microsoft.UI.Xaml.Controls.Control
 {
 	public DataTemplate Template1 { get; set; }
 	public DataTemplate Template2 { get; set; }

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -135,6 +135,7 @@ namespace Uno.UI.RemoteControl.HotReload
 #if !WINUI
 			var parentAsContentControl = oldView.GetVisualTreeParent() as ContentControl;
 			parentAsContentControl = parentAsContentControl ?? (oldView.GetVisualTreeParent() as ContentPresenter)?.FindFirstParent<ContentControl>();
+			var parentAsUserControl = oldView.GetVisualTreeParent() as UserControl;
 #else
 			var parentAsContentControl = VisualTreeHelper.GetParent(oldView) as ContentControl;
 			parentAsContentControl = parentAsContentControl ?? (VisualTreeHelper.GetParent(oldView) as ContentPresenter)?.FindFirstParent<ContentControl>();
@@ -148,6 +149,12 @@ namespace Uno.UI.RemoteControl.HotReload
 			{
 				parentAsContentControl.Content = newView;
 			}
+#if !WINUI
+			else if ((parentAsUserControl?.Content as FrameworkElement) == oldView)
+			{
+				parentAsUserControl.Content = newView;
+			}
+#endif
 			else if (newView is Page newPage && oldView is Page oldPage)
 			{
 				// In the case of Page, swapping the actual page is not supported, so we

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_UserControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_UserControl.cs
@@ -49,8 +49,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreSame(child, VisualTreeHelper.GetChild(userControl, 0));
 
 			// And it must be measured/arranged through Control's single-child layout.
-			Assert.AreEqual(100, child.ActualWidth);
-			Assert.AreEqual(50, child.ActualHeight);
+			// Tolerance accommodates sub-pixel layout rounding on fractional-DPI heads (e.g. WASM browser).
+			Assert.AreEqual(100, child.ActualWidth, 1d);
+			Assert.AreEqual(50, child.ActualHeight, 1d);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_UserControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_UserControl.cs
@@ -1,0 +1,95 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_UserControl
+	{
+		[TestMethod]
+		public void When_Inheritance_Then_Matches_WinUI_Hierarchy()
+		{
+			var userControl = new UserControl();
+			Assert.IsInstanceOfType(userControl, typeof(Control));
+			Assert.IsNotInstanceOfType(userControl, typeof(ContentControl));
+
+			var page = new Page();
+			Assert.IsInstanceOfType(page, typeof(UserControl));
+			Assert.IsInstanceOfType(page, typeof(Control));
+			Assert.IsNotInstanceOfType(page, typeof(ContentControl));
+		}
+
+		[TestMethod]
+		public void When_ContentProperty_Then_Typed_UIElement()
+		{
+			Assert.AreEqual(typeof(UIElement), typeof(UserControl).GetProperty(nameof(UserControl.Content)).PropertyType);
+		}
+
+		[TestMethod]
+		public async Task When_Content_Set_Then_Hosted_Without_ContentPresenter()
+		{
+			var child = new Border { Width = 100, Height = 50 };
+			var userControl = new UserControl { Content = child };
+
+			TestServices.WindowHelper.WindowContent = userControl;
+			await TestServices.WindowHelper.WaitForLoaded(userControl);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// The content must be the direct, single visual child — no ContentPresenter layer.
+			Assert.AreEqual(1, VisualTreeHelper.GetChildrenCount(userControl));
+			Assert.AreSame(child, VisualTreeHelper.GetChild(userControl, 0));
+
+			// And it must be measured/arranged through Control's single-child layout.
+			Assert.AreEqual(100, child.ActualWidth);
+			Assert.AreEqual(50, child.ActualHeight);
+		}
+
+		[TestMethod]
+		public async Task When_Content_Reassigned_Then_Child_Swapped()
+		{
+			var first = new Border { Width = 100, Height = 50 };
+			var second = new Border { Width = 80, Height = 40 };
+			var userControl = new UserControl { Content = first };
+
+			TestServices.WindowHelper.WindowContent = userControl;
+			await TestServices.WindowHelper.WaitForLoaded(userControl);
+
+			Assert.AreSame(first, VisualTreeHelper.GetChild(userControl, 0));
+
+			userControl.Content = second;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, VisualTreeHelper.GetChildrenCount(userControl));
+			Assert.AreSame(second, VisualTreeHelper.GetChild(userControl, 0));
+
+			userControl.Content = null;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, VisualTreeHelper.GetChildrenCount(userControl));
+		}
+
+		[TestMethod]
+		public async Task When_DataContext_Then_Flows_Through_Visual_Tree()
+		{
+			var textBlock = new TextBlock();
+			textBlock.SetBinding(TextBlock.TextProperty, new Binding());
+			var userControl = new UserControl { Content = textBlock, DataContext = "hello" };
+
+			TestServices.WindowHelper.WindowContent = userControl;
+			await TestServices.WindowHelper.WaitForLoaded(userControl);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("hello", textBlock.DataContext);
+			Assert.AreEqual("hello", textBlock.Text);
+		}
+	}
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1004,7 +1004,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		public void When_Color_Thickness_GridLength_As_String()
 		{
 			var s = GetContent(nameof(When_Color_Thickness_GridLength_As_String));
-			var r = Microsoft.UI.Xaml.Markup.XamlReader.Load(s) as ContentControl;
+			var r = Microsoft.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
 
 			Assert.AreEqual(Microsoft.UI.Colors.Red, r.Resources["Color01"]);
 			Assert.AreEqual(Microsoft.UI.Colors.Blue, (r.Resources["scb01"] as SolidColorBrush).Color);

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/UserControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/UserControl.cs
@@ -3,7 +3,6 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Controls
 {
-	[global::Microsoft.UI.Xaml.Markup.ContentPropertyAttribute(Name = "Content")]
 #if false || false
 	[global::Uno.NotImplemented]
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/UserControl/UserControl.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/UserControl/UserControl.Properties.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+using Uno.UI.Xaml;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class UserControl
+{
+	// Content is hosted as a real visual child, so DataContext flows through the visual tree.
+	// Don't propagate it again as a property (ValueDoesNotInheritDataContext avoids double-propagation).
+	[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext)]
+	public static DependencyProperty ContentProperty { get; } = CreateContentProperty();
+
+	public UIElement Content
+	{
+		get => GetContentValue();
+		set => SetContentValue(value);
+	}
+
+	private static UIElement? GetContentDefaultValue() => null;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/UserControl/UserControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/UserControl/UserControl.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.UI.Xaml.Markup;
 
 namespace Microsoft.UI.Xaml.Controls
 {
+	[ContentProperty(Name = nameof(Content))]
 	public partial class UserControl : Control
 	{
 		public UserControl()

--- a/src/Uno.UI/UI/Xaml/Controls/UserControl/UserControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/UserControl/UserControl.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public partial class UserControl : ContentControl
+	public partial class UserControl : Control
 	{
 		public UserControl()
 		{
@@ -12,5 +12,18 @@ namespace Microsoft.UI.Xaml.Controls
 
 		// This mimics UWP
 		private protected override Type GetDefaultStyleKey() => null;
+
+		private void OnContentChanged(UIElement oldContent, UIElement newContent)
+		{
+			if (oldContent is not null)
+			{
+				RemoveChild(oldContent);
+			}
+
+			if (newContent is not null)
+			{
+				AddChild(newContent);
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
@@ -167,6 +167,12 @@ namespace Microsoft.UI.Xaml
 				content = innerContent;
 			}
 			else if (!hasAnyChildren &&
+				e is UserControl userControl &&
+				userControl.Content is IFrameworkElement userControlContent)
+			{
+				content = userControlContent;
+			}
+			else if (!hasAnyChildren &&
 				e is Controls.Primitives.Popup popup)
 			{
 				content = popup.Child as IFrameworkElement;


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno-private#2054

Part of the breaking-changes rollup epic #8339 (item **BC14**).

## PR Type:

✨ Feature (breaking change — see migration note below)

## What changed? 🚀

Reparents `UserControl` from `ContentControl` directly onto `Control`, matching the WinUI hierarchy `Control` → `UserControl` → `Page`. Uno previously inserted an extra `ContentControl` layer (`Control` → `ContentControl` → `UserControl` → `Page`).

- **`UserControl : Control`** with its own `UIElement`-typed `Content` (`[GeneratedDependencyProperty]`, `AffectsMeasure | ValueDoesNotInheritDataContext`). Single-child hosting is done directly via `AddChild`/`RemoveChild` in `OnContentChanged` — no `ContentPresenter`/`ContentTemplate` plumbing. `Control`'s existing single-child layout (`FindFirstChild`/`ArrangeFirstChild`) handles measure/arrange, so `UserControl` adds no layout overrides and no per-platform partial.
- **`Page`** inherits the new base unchanged; its `OnBackgroundChanged` override still works.
- **Consumer adaptation** (minimal): `IFrameworkElement.FindName` gained a `UserControl.Content` branch (covers `Page`); hot reload's `SwapViews` gained a `UserControl` parent path. Other `is ContentControl` sites correctly stop matching `UserControl`/`Page` (the WinUI-aligned behavior) and needed no change.
- The generated `UserControl`/`Page` stubs already matched the target shape, so no regeneration was required.

Benefits: true WinUI parity for the most-subclassed control, lighter/faster visual trees (a `ContentPresenter`/template layer dropped from every `UserControl` and `Page`), and `Content` correctly typed `UIElement`.

### Validation

- New `Given_UserControl` runtime tests (hierarchy, `UIElement` `Content`, ContentPresenter-less single-child rendering, reassignment/removal, DataContext-through-tree).
- **Skia Desktop**: `Given_UserControl` 5/5; regression batch across `Given_Control`/`Given_ContentControl` (incl. FindName)/`Given_ContentPresenter`/`Given_Frame` (navigation)/`Given_VisualStateManager`/`Given_FocusManager`/`Given_FrameworkElement` = 407 passed / 0 failed.
- **WASM (Skia head)**: `Given_UserControl` 5/5 (assertion relaxed for the WASM fractional-DPI device-pixel grid).
- **Native WinUI (WinAppSDK)**: `Given_UserControl` 5/5 — confirms parity with the reference implementation.
- Local visual sweep (light + dark) of `UserControl`/`Page` content hosting — background/border/padding/centered content render correctly; theming cascades through the directly-hosted child.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests (`Given_UserControl`), validated on Skia Desktop, WASM, and native WinUI
- [x] 📚 Impact spec reconciled (`specs/050-breaking-changes-rollup/bc14-usercontrol-to-control.md`)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results (to review once CI runs)
- [ ] ❗ Contains **NO** breaking changes — **this PR is intentionally breaking** (see below)
- [x] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration

`UserControl` and `Page` no longer inherit `ContentControl`:

- `ContentTemplate`, `ContentTemplateSelector`, `ContentTransitions`, and the `object`-typed `Content` setter are **removed** from `UserControl`/`Page`. `Content` is now typed `UIElement` (matching WinUI). Code/XAML setting those members on a `UserControl`/`Page` must be updated.
- `x is ContentControl` / `ContentControl`-typed casts against a `UserControl`/`Page` now evaluate `false`. Code relying on this must target `Control`/`UserControl` (or the concrete type) instead.

This matches WinUI exactly, so apps already written against the WinUI surface are unaffected. Ships last in its own stabilized PR per the epic plan; never batched.
