### PR TITLE
fix(wasm): Map forward mouse button to XButton2

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
@@ -326,8 +326,8 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 			HtmlPointerButtonUpdate.Right => PointerUpdateKind.RightButtonReleased,
 			HtmlPointerButtonUpdate.X1 when props.IsXButton1Pressed => PointerUpdateKind.XButton1Pressed,
 			HtmlPointerButtonUpdate.X1 => PointerUpdateKind.XButton1Released,
-			HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed => PointerUpdateKind.XButton1Pressed,
-			HtmlPointerButtonUpdate.X2 => PointerUpdateKind.XButton1Released,
+			HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed => PointerUpdateKind.XButton2Pressed,
+			HtmlPointerButtonUpdate.X2 => PointerUpdateKind.XButton2Released,
 			_ => PointerUpdateKind.Other
 		};
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input/Given_BrowserPointerInputSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input/Given_BrowserPointerInputSource.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using Windows.UI.Core;
+using Windows.UI.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Input;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_BrowserPointerInputSource
+{
+	// Values mirror the private HtmlPointerEvent / HtmlPointerButtonsState / HtmlPointerButtonUpdate
+	// enums in BrowserPointerInputSource, which themselves match the DOM PointerEvent contract.
+	private const int PointerDown = 1 << 2;
+	private const int PointerUp = 1 << 3;
+	private const int ButtonsX1 = 8; // back button held
+	private const int ButtonsX2 = 16; // forward button held
+	private const int UpdateX1 = 3; // back button updated
+	private const int UpdateX2 = 4; // forward button updated
+
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Wasm)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23509")]
+	[DataRow(PointerDown, ButtonsX2, UpdateX2, PointerUpdateKind.XButton2Pressed, DisplayName = "Forward button down => XButton2Pressed")]
+	[DataRow(PointerUp, 0, UpdateX2, PointerUpdateKind.XButton2Released, DisplayName = "Forward button up => XButton2Released")]
+	[DataRow(PointerDown, ButtonsX1, UpdateX1, PointerUpdateKind.XButton1Pressed, DisplayName = "Back button down => XButton1Pressed")]
+	[DataRow(PointerUp, 0, UpdateX1, PointerUpdateKind.XButton1Released, DisplayName = "Back button up => XButton1Released")]
+	public void When_XButton_Then_Reports_Matching_UpdateKind(int @event, int buttons, int buttonUpdate, PointerUpdateKind expected)
+	{
+		var actual = RaiseNativePointerEvent((byte)@event, buttons, buttonUpdate);
+
+		Assert.AreEqual(expected, actual);
+	}
+
+	private static PointerUpdateKind RaiseNativePointerEvent(byte @event, int buttons, int buttonUpdate)
+	{
+		var type =
+			Type.GetType("Uno.UI.Runtime.BrowserPointerInputSource, Uno.UI")
+			?? Type.GetType("Uno.UI.Runtime.Skia.BrowserPointerInputSource, Uno.UI.Runtime.Skia.WebAssembly.Browser");
+
+		Assert.IsNotNull(type, "BrowserPointerInputSource type was not found in the loaded WASM assemblies.");
+
+		// Bypass the constructor: it calls into JS to register the source, which we don't want from a test.
+		var source = RuntimeHelpers.GetUninitializedObject(type);
+
+		PointerEventArgs? captured = null;
+		TypedEventHandler<object, PointerEventArgs> handler = (_, e) => captured = e;
+
+		var pressed = type.GetEvent("PointerPressed")!;
+		var released = type.GetEvent("PointerReleased")!;
+		pressed.AddEventHandler(source, handler);
+		released.AddEventHandler(source, handler);
+
+		try
+		{
+			var onNativeEvent = type.GetMethod("OnNativeEvent", BindingFlags.NonPublic | BindingFlags.Static)!;
+			onNativeEvent.Invoke(null, new object[]
+			{
+				source,
+				@event,
+				/* timestamp */ 0d,
+				/* deviceType */ (int)Windows.Devices.Input.PointerDeviceType.Mouse,
+				/* pointerId */ 1d,
+				/* x */ 0d,
+				/* y */ 0d,
+				/* ctrl */ false,
+				/* shift */ false,
+				buttons,
+				buttonUpdate,
+				/* pressure */ 0.5d,
+				/* wheelDeltaX */ 0d,
+				/* wheelDeltaY */ 0d,
+				/* hasRelatedTarget */ false,
+			});
+		}
+		finally
+		{
+			pressed.RemoveEventHandler(source, handler);
+			released.RemoveEventHandler(source, handler);
+		}
+
+		Assert.IsNotNull(captured, "BrowserPointerInputSource did not raise a pointer event.");
+
+		return captured!.CurrentPoint.Properties.PointerUpdateKind;
+	}
+}

--- a/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
+++ b/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
@@ -359,8 +359,8 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 			HtmlPointerButtonUpdate.Right => PointerUpdateKind.RightButtonReleased,
 			HtmlPointerButtonUpdate.X1 when props.IsXButton1Pressed => PointerUpdateKind.XButton1Pressed,
 			HtmlPointerButtonUpdate.X1 => PointerUpdateKind.XButton1Released,
-			HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed => PointerUpdateKind.XButton1Pressed,
-			HtmlPointerButtonUpdate.X2 => PointerUpdateKind.XButton1Released,
+			HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed => PointerUpdateKind.XButton2Pressed,
+			HtmlPointerButtonUpdate.X2 => PointerUpdateKind.XButton2Released,
 			_ => PointerUpdateKind.Other
 		};
 


### PR DESCRIPTION
**GitHub Issue:** closes #23509

## PR Type:

🐞 Bugfix

## What changed? 🚀

On WebAssembly, pressing the **forward** mouse button reported as `XButton1` (the *back* button) in `PointerPressed`/`PointerReleased`, instead of `XButton2`. This made the forward button trigger "go back" behavior in apps.

Root cause was a copy-paste typo in `BrowserPointerInputSource.ToUpdateKind`: the `HtmlPointerButtonUpdate.X2` (forward) switch arm correctly guarded on `IsXButton2Pressed`, but returned `XButton1Pressed`/`XButton1Released`. The TypeScript layer forwards the DOM `event.button` value verbatim, so the defect was purely in the C# mapping.

The same typo existed in both WASM input sources, so both are fixed:
- `src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs` (native WASM / DOM renderer)
- `src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs` (Skia-on-WASM)

Both now map `X2 → XButton2Pressed`/`XButton2Released`.

A WASM-only runtime test (`Given_BrowserPointerInputSource`) invokes the native `OnNativeEvent` entry point and asserts the resulting `PointerUpdateKind` for the forward (X2) and back (X1) buttons on press and release. The standard `InputInjector` harness cannot cover this path — mouse injection is `[NotImplemented("__WASM__")]` and dispatches `PointerEventArgs` directly to the `InputManager`, bypassing `BrowserPointerInputSource`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
