### PR TITLE
bisect: win32render @ c101afda3e

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -176,6 +176,7 @@ DwmExtendFrameIntoClientArea
 DwmSetWindowAttribute
 DwmDefWindowProc
 DWM_SYSTEMBACKDROP_TYPE
+DwmFlush
 EmptyClipboard
 EnableMouseInPointer
 EndPaint

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -49,13 +49,7 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 			_displayInformation?.NotifyDpiChanged();
 		}
 
-		if (_refreshRate != oldRefreshRate)
-		{
-			if (FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
-			{
-				_framePacer.UpdateTargetFps(_refreshRate);
-			}
-		}
+		// _refreshRate is still tracked for display information consumers.
 	}
 
 	private unsafe (DisplayInfo, float) GetDisplayInfo()

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -49,7 +49,14 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 			_displayInformation?.NotifyDpiChanged();
 		}
 
-		// _refreshRate is still tracked for display information consumers.
+		if (_refreshRate != oldRefreshRate
+			&& FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
+		{
+			// Renderers that pace via VSync (GL wglSwapInterval, software DwmFlush) are
+			// already aligned to the refresh rate and treat this as a no-op. The software
+			// DwmFlush degraded fallback (FramePacer) uses it to retarget.
+			_renderer?.UpdateRefreshRate(_refreshRate);
+		}
 	}
 
 	private unsafe (DisplayInfo, float) GetDisplayInfo()

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -52,11 +52,8 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 		if (_refreshRate != oldRefreshRate
 			&& FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
 		{
-			// Presentation is paced on the render thread by hardware VSync (GL wglSwapInterval,
-			// software DwmFlush), which blocks until the monitor's actual refresh — so those
-			// renderers are already aligned and ignore this. Only the software DwmFlush degraded
-			// fallback paces with a software timer (FramePacer) instead of VSync, and so needs the
-			// new rate to stay aligned; that's the one path UpdateRefreshRate actually retargets.
+			// VSync-paced renderers are already aligned to the monitor's refresh and ignore this;
+			// only the software-timer-paced DwmFlush degraded fallback actually retargets.
 			_renderer?.UpdateRefreshRate(_refreshRate);
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Display/Win32WindowWrapper.DisplayInformation.cs
@@ -52,9 +52,11 @@ internal partial class Win32WindowWrapper : IDisplayInformationExtension
 		if (_refreshRate != oldRefreshRate
 			&& FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate)
 		{
-			// Renderers that pace via VSync (GL wglSwapInterval, software DwmFlush) are
-			// already aligned to the refresh rate and treat this as a no-op. The software
-			// DwmFlush degraded fallback (FramePacer) uses it to retarget.
+			// Presentation is paced on the render thread by hardware VSync (GL wglSwapInterval,
+			// software DwmFlush), which blocks until the monitor's actual refresh — so those
+			// renderers are already aligned and ignore this. Only the software DwmFlush degraded
+			// fallback paces with a software timer (FramePacer) instead of VSync, and so needs the
+			// new rate to stay aligned; that's the one path UpdateRefreshRate actually retargets.
 			_renderer?.UpdateRefreshRate(_refreshRate);
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -109,6 +109,9 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 	private unsafe void OnRenderingNegativePathReevaluated(object? sender, SKPath path)
 	{
+		Debug.Assert(Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess,
+			$"{nameof(OnRenderingNegativePathReevaluated)} must run on the UI thread.");
+
 		if (_presenter.Content is not Win32NativeWindow window)
 		{
 			return;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Threading;
+using SkiaSharp;
+using Uno.Foundation.Logging;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal partial class Win32WindowWrapper
+{
+	/// <summary>
+	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt).
+	/// The UI thread records SKPictures and signals this thread to present them.
+	/// This mirrors the pattern used by WPF (milcore render thread) and the
+	/// Uno Android GL thread.
+	/// </summary>
+	private sealed class RenderThread : IDisposable
+	{
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _frameSignal = new(false);
+		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly IRenderer _renderer;
+		private readonly Func<(SKPath clipPath, int width, int height)?> _drawFrame;
+		private readonly Action<SKPath> _onClipPathUpdated;
+		private readonly Action _onFramePresented;
+		private volatile bool _disposed;
+
+		internal RenderThread(
+			IRenderer renderer,
+			Func<(SKPath, int, int)?> drawFrame,
+			Action<SKPath> onClipPathUpdated,
+			Action onFramePresented)
+		{
+			_renderer = renderer;
+			_drawFrame = drawFrame;
+			_onClipPathUpdated = onClipPathUpdated;
+			_onFramePresented = onFramePresented;
+			_thread = new Thread(RenderLoop) { Name = "Uno Render Thread", IsBackground = true };
+			_thread.Start();
+		}
+
+		/// <summary>
+		/// Signals the render thread that a new frame is available for presentation.
+		/// Multiple calls while the thread is busy coalesce into a single wake-up
+		/// (AutoResetEvent semantics). Resets the present-completion event before
+		/// signaling so a subsequent <see cref="WaitForNextPresent"/> always observes
+		/// the next presentation, never a stale one from a prior frame.
+		/// </summary>
+		internal void SignalNewFrame()
+		{
+			_presentedEvent.Reset();
+			_frameSignal.Set();
+		}
+
+		/// <summary>
+		/// Blocks the calling thread until the render thread finishes presenting a frame.
+		/// Used by ShowCore to ensure the first frame is painted before the window is shown.
+		/// Returns true if a present completed within the timeout, false otherwise.
+		/// </summary>
+		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+		private void RenderLoop()
+		{
+			while (!_disposed)
+			{
+				_frameSignal.WaitOne();
+				if (_disposed)
+				{
+					break;
+				}
+
+				_renderer.StartPaint();
+				try
+				{
+					var result = _drawFrame();
+					if (result is { } frame)
+					{
+						var (clipPath, width, height) = frame;
+						_onClipPathUpdated(clipPath);
+						_renderer.CopyPixels(width, height); // SwapBuffers/BitBlt — may block for VSync
+
+						_presentedEvent.Set();
+						_onFramePresented();
+					}
+				}
+				catch (Exception ex)
+				{
+					typeof(RenderThread).LogError()?.Error($"Render thread error: {ex}");
+				}
+				finally
+				{
+					_renderer.EndPaint();
+				}
+			}
+		}
+
+		public void Dispose()
+		{
+			_disposed = true;
+			_frameSignal.Set(); // Unblock if waiting
+
+			// 250 ms covers a present (~16 ms at 60 Hz) plus slack. If that fails, the GPU
+			// is likely hung. Wait one more bounded interval (2 s) and then abandon: leaving
+			// the render thread (background, marked at construction) blocked is preferable
+			// to hanging the UI thread on window close. The leaked synchronization
+			// primitives and renderer outlive the thread, so the OS reclaims them at exit.
+			var joined = _thread.Join(timeout: TimeSpan.FromMilliseconds(250));
+			if (!joined)
+			{
+				typeof(RenderThread).LogWarn()?.Warn(
+					"Render thread did not exit within 250 ms during dispose; waiting up to 2 s more " +
+					"before abandoning. This usually indicates a stuck GPU present " +
+					"(SwapBuffers/BitBlt/DwmFlush blocked).");
+
+				joined = _thread.Join(timeout: TimeSpan.FromSeconds(2));
+				if (!joined)
+				{
+					typeof(RenderThread).LogError()?.Error(
+						"Render thread still alive after 2 s; abandoning to keep window close responsive. " +
+						"Leaking _frameSignal, _presentedEvent and renderer until process exit.");
+					return;
+				}
+			}
+
+			_frameSignal.Dispose();
+			_presentedEvent.Dispose();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -21,19 +21,16 @@ internal partial class Win32WindowWrapper
 		private readonly IRenderer _renderer;
 		private readonly Func<(SKPath clipPath, int width, int height)?> _drawFrame;
 		private readonly Action<SKPath> _onClipPathUpdated;
-		private readonly Action _onFramePresented;
 		private volatile bool _disposed;
 
 		internal RenderThread(
 			IRenderer renderer,
 			Func<(SKPath, int, int)?> drawFrame,
-			Action<SKPath> onClipPathUpdated,
-			Action onFramePresented)
+			Action<SKPath> onClipPathUpdated)
 		{
 			_renderer = renderer;
 			_drawFrame = drawFrame;
 			_onClipPathUpdated = onClipPathUpdated;
-			_onFramePresented = onFramePresented;
 			_thread = new Thread(RenderLoop) { Name = "Uno Render Thread", IsBackground = true };
 			_thread.Start();
 		}
@@ -68,9 +65,12 @@ internal partial class Win32WindowWrapper
 					break;
 				}
 
-				_renderer.StartPaint();
+				var startPaintSucceeded = false;
 				try
 				{
+					_renderer.StartPaint();
+					startPaintSucceeded = true;
+
 					var result = _drawFrame();
 					if (result is { } frame)
 					{
@@ -79,7 +79,6 @@ internal partial class Win32WindowWrapper
 						_renderer.CopyPixels(width, height); // SwapBuffers/BitBlt — may block for VSync
 
 						_presentedEvent.Set();
-						_onFramePresented();
 					}
 				}
 				catch (Exception ex)
@@ -88,7 +87,10 @@ internal partial class Win32WindowWrapper
 				}
 				finally
 				{
-					_renderer.EndPaint();
+					if (startPaintSucceeded)
+					{
+						_renderer.EndPaint();
+					}
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -8,10 +8,8 @@ namespace Uno.UI.Runtime.Skia.Win32;
 internal partial class Win32WindowWrapper
 {
 	/// <summary>
-	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt).
-	/// The UI thread records SKPictures and signals this thread to present them.
-	/// This mirrors the pattern used by WPF (milcore render thread) and the
-	/// Uno Android GL thread.
+	/// Dedicated render thread that owns Draw + CopyPixels (SwapBuffers/BitBlt), mirroring
+	/// WPF's milcore render thread. The UI thread records SKPictures and signals presents.
 	/// </summary>
 	private sealed class RenderThread : IDisposable
 	{
@@ -36,11 +34,9 @@ internal partial class Win32WindowWrapper
 		}
 
 		/// <summary>
-		/// Signals the render thread that a new frame is available for presentation.
-		/// Multiple calls while the thread is busy coalesce into a single wake-up
-		/// (AutoResetEvent semantics). Resets the present-completion event before
-		/// signaling so a subsequent <see cref="WaitForNextPresent"/> always observes
-		/// the next presentation, never a stale one from a prior frame.
+		/// Signals that a new frame is available; calls coalesce into a single wake-up. Resets
+		/// the present-completion event so <see cref="WaitForNextPresent"/> always observes the
+		/// next present, never a stale one.
 		/// </summary>
 		internal void SignalNewFrame()
 		{
@@ -49,9 +45,7 @@ internal partial class Win32WindowWrapper
 		}
 
 		/// <summary>
-		/// Blocks the calling thread until the render thread finishes presenting a frame.
-		/// Used by ShowCore to ensure the first frame is painted before the window is shown.
-		/// Returns true if a present completed within the timeout, false otherwise.
+		/// Blocks until the render thread presents a frame; false if the timeout elapsed first.
 		/// </summary>
 		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
 
@@ -98,23 +92,18 @@ internal partial class Win32WindowWrapper
 		public void Dispose() => DisposeAndTryJoin();
 
 		/// <summary>
-		/// Stops the render thread and waits for it to exit. Returns <c>true</c> if the
-		/// thread joined within the backstop, <c>false</c> if it had to be abandoned while
-		/// still potentially executing inside a native present (SwapBuffers/BitBlt/DwmFlush).
-		/// When this returns <c>false</c>, the caller MUST NOT dispose any renderer/surface
-		/// resources the abandoned thread might still be touching — doing so would free native
-		/// GPU resources out from under it and risk a use-after-free.
+		/// Stops the render thread. Returns <c>false</c> when the thread had to be abandoned
+		/// (stuck in a native present); the caller must then not dispose renderer/surface
+		/// resources the abandoned thread might still be touching.
 		/// </summary>
 		internal bool DisposeAndTryJoin()
 		{
 			_disposed = true;
 			_frameSignal.Set(); // Unblock if waiting
 
-			// 250 ms covers a present (~16 ms at 60 Hz) plus slack. If that fails, the GPU
-			// is likely hung. Wait one more bounded interval (2 s) and then abandon: leaving
-			// the render thread (background, marked at construction) blocked is preferable
-			// to hanging the UI thread on window close. The leaked synchronization
-			// primitives and renderer outlive the thread, so the OS reclaims them at exit.
+			// 250 ms covers a present (~16 ms at 60 Hz) plus slack; after one more bounded wait
+			// (2 s), abandon the background thread — leaking the renderer and synchronization
+			// primitives until process exit beats hanging the UI thread on window close.
 			var joined = _thread.Join(timeout: TimeSpan.FromMilliseconds(250));
 			if (!joined)
 			{

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.RenderThread.cs
@@ -95,7 +95,17 @@ internal partial class Win32WindowWrapper
 			}
 		}
 
-		public void Dispose()
+		public void Dispose() => DisposeAndTryJoin();
+
+		/// <summary>
+		/// Stops the render thread and waits for it to exit. Returns <c>true</c> if the
+		/// thread joined within the backstop, <c>false</c> if it had to be abandoned while
+		/// still potentially executing inside a native present (SwapBuffers/BitBlt/DwmFlush).
+		/// When this returns <c>false</c>, the caller MUST NOT dispose any renderer/surface
+		/// resources the abandoned thread might still be touching — doing so would free native
+		/// GPU resources out from under it and risk a use-after-free.
+		/// </summary>
+		internal bool DisposeAndTryJoin()
 		{
 			_disposed = true;
 			_frameSignal.Set(); // Unblock if waiting
@@ -119,12 +129,13 @@ internal partial class Win32WindowWrapper
 					typeof(RenderThread).LogError()?.Error(
 						"Render thread still alive after 2 s; abandoning to keep window close responsive. " +
 						"Leaking _frameSignal, _presentedEvent and renderer until process exit.");
-					return;
+					return false;
 				}
 			}
 
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
+			return true;
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
@@ -14,5 +14,14 @@ internal partial class Win32WindowWrapper
 		void CopyPixels(int width, int height);
 		bool IsSoftware();
 		void Reinitialize();
+
+		/// <summary>
+		/// Notifies the renderer of a screen refresh rate change. Renderers that pace
+		/// internally via VSync (GL via wglSwapInterval, software DwmFlush) are
+		/// inherently aligned to the refresh rate and can ignore this; renderers that
+		/// pace via a software timer (e.g. the software DwmFlush degraded fallback
+		/// FramePacer) can use it to retarget.
+		/// </summary>
+		void UpdateRefreshRate(double fps);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.IRenderer.cs
@@ -16,11 +16,8 @@ internal partial class Win32WindowWrapper
 		void Reinitialize();
 
 		/// <summary>
-		/// Notifies the renderer of a screen refresh rate change. Renderers that pace
-		/// internally via VSync (GL via wglSwapInterval, software DwmFlush) are
-		/// inherently aligned to the refresh rate and can ignore this; renderers that
-		/// pace via a software timer (e.g. the software DwmFlush degraded fallback
-		/// FramePacer) can use it to retarget.
+		/// Notifies the renderer of a screen refresh rate change. VSync-paced renderers ignore
+		/// this; software-timer-paced ones (e.g. the DwmFlush degraded fallback) retarget.
 		/// </summary>
 		void UpdateRefreshRate(double fps);
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -15,6 +15,9 @@ internal partial class Win32WindowWrapper
 {
 	private class GlRenderer : IRenderer
 	{
+		[UnmanagedFunctionPointer(CallingConvention.Winapi)]
+		private delegate int WglSwapIntervalEXT(int interval);
+
 		private readonly HWND _hwnd;
 		private readonly HDC _hdc;
 		private HGLRC _glContext; // recreated when window is extended into titlebar
@@ -103,6 +106,21 @@ internal partial class Win32WindowWrapper
 					version is null
 						? $"{nameof(PInvoke.glGetString)} failed with error code {PInvoke.glGetError().ToString("X", CultureInfo.InvariantCulture)}"
 						: $"OpenGL Version: {Marshal.PtrToStringUTF8((IntPtr)version)}");
+			}
+
+			// Enable VSync so SwapBuffers blocks until the next display refresh.
+			// Without this, some GPU drivers default to swap interval 0,
+			// causing SwapBuffers to return immediately and the render loop
+			// to spin at hundreds of fps.
+			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
+			if (wglSwapIntervalAddr != IntPtr.Zero)
+			{
+				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
+				if (wglSwapInterval(1) == 0)
+				{
+					typeof(GlRenderer).LogWarn()?.Warn(
+						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
+				}
 			}
 
 			var grGlInterface = GRGlInterface.Create();

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -139,6 +139,14 @@ internal partial class Win32WindowWrapper
 				return null;
 			}
 
+			// Detach the GL context from the calling thread before returning, so a downstream
+			// render thread can make it current. WglCurrentContextDisposable above doesn't
+			// restore to "no context" when there was none before, so we detach explicitly.
+			if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
+			{
+				typeof(GlRenderer).LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
+			}
+
 			return new GlRenderer(hwnd, hdc, glContext, grGlInterface, grContext);
 		}
 
@@ -208,5 +216,9 @@ internal partial class Win32WindowWrapper
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
 			_grContext = GRContext.CreateGl(_grGlInterface);
 		}
+
+		// VSync via wglSwapInterval(1) already paces SwapBuffers at the screen
+		// refresh rate, so no retargeting is needed here.
+		void IRenderer.UpdateRefreshRate(double fps) { }
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.OpenGl.cs
@@ -108,20 +108,7 @@ internal partial class Win32WindowWrapper
 						: $"OpenGL Version: {Marshal.PtrToStringUTF8((IntPtr)version)}");
 			}
 
-			// Enable VSync so SwapBuffers blocks until the next display refresh.
-			// Without this, some GPU drivers default to swap interval 0,
-			// causing SwapBuffers to return immediately and the render loop
-			// to spin at hundreds of fps.
-			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
-			if (wglSwapIntervalAddr != IntPtr.Zero)
-			{
-				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
-				if (wglSwapInterval(1) == 0)
-				{
-					typeof(GlRenderer).LogWarn()?.Warn(
-						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
-				}
-			}
+			TryEnableVSync();
 
 			var grGlInterface = GRGlInterface.Create();
 
@@ -139,15 +126,31 @@ internal partial class Win32WindowWrapper
 				return null;
 			}
 
-			// Detach the GL context from the calling thread before returning, so a downstream
-			// render thread can make it current. WglCurrentContextDisposable above doesn't
-			// restore to "no context" when there was none before, so we detach explicitly.
+			// Detach the GL context from the calling thread so the render thread can make it
+			// current later (WglCurrentContextDisposable doesn't restore to "no context").
 			if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
 			{
 				typeof(GlRenderer).LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
 			}
 
 			return new GlRenderer(hwnd, hdc, glContext, grGlInterface, grContext);
+		}
+
+		// Enable VSync so SwapBuffers blocks until the next display refresh; some drivers
+		// default to swap interval 0, letting the render loop spin at hundreds of fps.
+		// The swap interval is per-context, so re-apply this whenever an HGLRC is created.
+		private static void TryEnableVSync()
+		{
+			var wglSwapIntervalAddr = PInvoke.wglGetProcAddress("wglSwapIntervalEXT");
+			if (wglSwapIntervalAddr != IntPtr.Zero)
+			{
+				var wglSwapInterval = Marshal.GetDelegateForFunctionPointer<WglSwapIntervalEXT>(wglSwapIntervalAddr);
+				if (wglSwapInterval(1) == 0)
+				{
+					typeof(GlRenderer).LogWarn()?.Warn(
+						"Failed to enable VSync via wglSwapIntervalEXT; the render loop may run unthrottled on this driver.");
+				}
+			}
 		}
 
 		private static void ReleaseGlContext(HWND hwnd, HDC hdc, HGLRC glContext, GRGlInterface? grGlInterface, GRContext? grContext, GRBackendRenderTarget? renderTarget)
@@ -214,6 +217,7 @@ internal partial class Win32WindowWrapper
 			ReleaseGlContext(_hwnd, new HDC(IntPtr.Zero), _glContext, null, _grContext, _renderTarget);
 			_glContext = PInvoke.wglCreateContext(_hdc);
 			using var makeCurrentDisposable = new Win32Helper.WglCurrentContextDisposable(_hdc, _glContext);
+			TryEnableVSync();
 			_grContext = GRContext.CreateGl(_grGlInterface);
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
@@ -13,7 +14,15 @@ internal partial class Win32WindowWrapper
 {
 	private class SoftwareRenderer(HWND hwnd) : IRenderer
 	{
+		// Pacing fallback when DwmFlush hangs/fails repeatedly (DWM paused, RDP reconnect,
+		// fast user switch, GPU TDR). After this many consecutive failures we stop calling
+		// DwmFlush and use a fixed sleep to keep the render loop bounded.
+		private const int DwmFlushFailureThreshold = 3;
+		private const int FallbackPacingMs = 16; // ~60 Hz
+
 		private HBITMAP _hBitmap;
+		private int _consecutiveDwmFlushFailures;
+		private bool _dwmFlushDegraded;
 
 		public void StartPaint() { }
 		public void EndPaint() { }
@@ -82,6 +91,46 @@ internal partial class Win32WindowWrapper
 
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
+
+			// Block until the DWM compositor's next VSync to pace frames.
+			// Without this, BitBlt returns instantly (unlike GL's SwapBuffers
+			// which blocks for VSync), causing the render loop to spin at
+			// hundreds of fps — wasting CPU and reporting misleading frame rates.
+			//
+			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung
+			// during RDP reconnect, fast user switch, or a GPU TDR), give up on
+			// DwmFlush and use a fixed sleep. We never re-enable DwmFlush in this
+			// renderer instance — once degraded, stay degraded for the lifetime of
+			// the window. Better to lose vsync alignment than to risk hanging the
+			// render thread on each frame.
+			if (_dwmFlushDegraded)
+			{
+				Thread.Sleep(FallbackPacingMs);
+				return;
+			}
+
+			var dwmFlushResult = PInvoke.DwmFlush();
+			if (dwmFlushResult.Failed)
+			{
+				_consecutiveDwmFlushFailures++;
+				this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
+
+				if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+				{
+					_dwmFlushDegraded = true;
+					this.LogWarn()?.Warn(
+						$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
+						$"falling back to {FallbackPacingMs} ms sleep-based pacing. " +
+						"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
+				}
+
+				// Pace the failing call so we don't spin at full speed.
+				Thread.Sleep(FallbackPacingMs);
+			}
+			else
+			{
+				_consecutiveDwmFlushFailures = 0;
+			}
 		}
 
 		bool IRenderer.IsSoftware() => true;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -1,28 +1,43 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Windows.Win32;
-using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.Gdi;
 using SkiaSharp;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI.Runtime.Skia.Hosting;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
 internal partial class Win32WindowWrapper
 {
-	private class SoftwareRenderer(HWND hwnd) : IRenderer
+	private class SoftwareRenderer : IRenderer
 	{
 		// Pacing fallback when DwmFlush hangs/fails repeatedly (DWM paused, RDP reconnect,
 		// fast user switch, GPU TDR). After this many consecutive failures we stop calling
-		// DwmFlush and use a fixed sleep to keep the render loop bounded.
+		// DwmFlush and pace via FramePacer instead.
 		private const int DwmFlushFailureThreshold = 3;
-		private const int FallbackPacingMs = 16; // ~60 Hz
+
+		private readonly HWND _hwnd;
+		private readonly FramePacer _framePacer;
+		private readonly AutoResetEvent _frameDeadlineReached = new(false);
 
 		private HBITMAP _hBitmap;
 		private int _consecutiveDwmFlushFailures;
 		private bool _dwmFlushDegraded;
+
+		public SoftwareRenderer(HWND hwnd)
+		{
+			_hwnd = hwnd;
+			// Self-correcting absolute-time pacer used as the fallback when DwmFlush is degraded.
+			// Initialized at FeatureConfiguration.CompositionTarget.FrameRate; retargeted to the
+			// screen refresh rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
+			_framePacer = new FramePacer(
+				FeatureConfiguration.CompositionTarget.FrameRate,
+				() => _frameDeadlineReached.Set());
+		}
 
 		public void StartPaint() { }
 		public void EndPaint() { }
@@ -59,7 +74,11 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.CopyPixels(int width, int height)
 		{
-			var paintDc = PInvoke.GetDC(hwnd);
+			// Anchor the absolute target tick at the start of every frame so a subsequent
+			// FramePacer.RequestFrame schedules wake-up at the next deadline (no drift).
+			_framePacer.OnFrameStart();
+
+			var paintDc = PInvoke.GetDC(_hwnd);
 			if (paintDc == new HDC(IntPtr.Zero))
 			{
 				this.LogError()?.Error($"{nameof(PInvoke.GetDC)} failed: {Win32Helper.GetErrorMessage()}");
@@ -69,7 +88,7 @@ internal partial class Win32WindowWrapper
 			{
 				var success = PInvoke.ReleaseDC(hwnd, lpPaint) == 1;
 				if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
-			}, hwnd, paintDc);
+			}, _hwnd, paintDc);
 
 			var bitmapDc = PInvoke.CreateCompatibleDC(paintDc);
 			if (bitmapDc == new HDC(IntPtr.Zero))
@@ -92,44 +111,49 @@ internal partial class Win32WindowWrapper
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
 
-			// Block until the DWM compositor's next VSync to pace frames.
-			// Without this, BitBlt returns instantly (unlike GL's SwapBuffers
-			// which blocks for VSync), causing the render loop to spin at
-			// hundreds of fps — wasting CPU and reporting misleading frame rates.
+			// Pace the frame. Normally DwmFlush blocks until the DWM compositor's next VSync
+			// (BitBlt itself returns instantly, so without pacing the render loop spins at
+			// hundreds of fps — wasting CPU and reporting misleading frame rates).
 			//
-			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung
-			// during RDP reconnect, fast user switch, or a GPU TDR), give up on
-			// DwmFlush and use a fixed sleep. We never re-enable DwmFlush in this
-			// renderer instance — once degraded, stay degraded for the lifetime of
-			// the window. Better to lose vsync alignment than to risk hanging the
+			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung during
+			// RDP reconnect, fast user switch, or a GPU TDR), give up on DwmFlush and pace via
+			// FramePacer's self-correcting absolute-time scheduling. We never re-enable
+			// DwmFlush in this renderer instance — once degraded, stay degraded for the
+			// lifetime of the window. Better to lose vsync alignment than to risk hanging the
 			// render thread on each frame.
-			if (_dwmFlushDegraded)
-			{
-				Thread.Sleep(FallbackPacingMs);
-				return;
-			}
+			var paceViaFramePacer = _dwmFlushDegraded;
 
-			var dwmFlushResult = PInvoke.DwmFlush();
-			if (dwmFlushResult.Failed)
+			if (!_dwmFlushDegraded)
 			{
-				_consecutiveDwmFlushFailures++;
-				this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
-
-				if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+				var dwmFlushResult = PInvoke.DwmFlush();
+				if (dwmFlushResult.Failed)
 				{
-					_dwmFlushDegraded = true;
-					this.LogWarn()?.Warn(
-						$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
-						$"falling back to {FallbackPacingMs} ms sleep-based pacing. " +
-						"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
-				}
+					_consecutiveDwmFlushFailures++;
+					this.LogError()?.Error($"{nameof(PInvoke.DwmFlush)} failed: {dwmFlushResult} (failure {_consecutiveDwmFlushFailures}/{DwmFlushFailureThreshold})");
 
-				// Pace the failing call so we don't spin at full speed.
-				Thread.Sleep(FallbackPacingMs);
+					if (_consecutiveDwmFlushFailures >= DwmFlushFailureThreshold)
+					{
+						_dwmFlushDegraded = true;
+						this.LogWarn()?.Warn(
+							$"{nameof(PInvoke.DwmFlush)} failed {DwmFlushFailureThreshold} times consecutively; " +
+							$"falling back to FramePacer-driven pacing at {_framePacer.TargetIntervalMs:F1} ms. " +
+							"Frame timing will not be vsync-aligned for the rest of this window's lifetime.");
+					}
+
+					// Pace this failed frame via FramePacer; subsequent frames will also use the
+					// degraded branch above and pace the same way.
+					paceViaFramePacer = true;
+				}
+				else
+				{
+					_consecutiveDwmFlushFailures = 0;
+				}
 			}
-			else
+
+			if (paceViaFramePacer)
 			{
-				_consecutiveDwmFlushFailures = 0;
+				_framePacer.RequestFrame();
+				_frameDeadlineReached.WaitOne();
 			}
 		}
 
@@ -137,8 +161,12 @@ internal partial class Win32WindowWrapper
 
 		void IRenderer.Reinitialize() { }
 
+		void IRenderer.UpdateRefreshRate(double fps) => _framePacer.UpdateTargetFps(fps);
+
 		void IDisposable.Dispose()
 		{
+			_framePacer.Dispose();
+			_frameDeadlineReached.Dispose();
 			var success = PInvoke.DeleteObject(_hBitmap) == 1;
 			if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.DeleteObject)} failed: {Win32Helper.GetErrorMessage()}"); }
 		}

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Software.cs
@@ -15,9 +15,8 @@ internal partial class Win32WindowWrapper
 {
 	private class SoftwareRenderer : IRenderer
 	{
-		// Pacing fallback when DwmFlush hangs/fails repeatedly (DWM paused, RDP reconnect,
-		// fast user switch, GPU TDR). After this many consecutive failures we stop calling
-		// DwmFlush and pace via FramePacer instead.
+		// After this many consecutive DwmFlush failures (DWM paused, RDP reconnect, fast user
+		// switch, GPU TDR), we stop calling DwmFlush and pace via FramePacer instead.
 		private const int DwmFlushFailureThreshold = 3;
 
 		private readonly HWND _hwnd;
@@ -31,9 +30,8 @@ internal partial class Win32WindowWrapper
 		public SoftwareRenderer(HWND hwnd)
 		{
 			_hwnd = hwnd;
-			// Self-correcting absolute-time pacer used as the fallback when DwmFlush is degraded.
-			// Initialized at FeatureConfiguration.CompositionTarget.FrameRate; retargeted to the
-			// screen refresh rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
+			// Fallback pacer used when DwmFlush is degraded; retargeted to the screen refresh
+			// rate via UpdateRefreshRate when SetFrameRateAsScreenRefreshRate is on.
 			_framePacer = new FramePacer(
 				FeatureConfiguration.CompositionTarget.FrameRate,
 				() => _frameDeadlineReached.Set());
@@ -98,8 +96,8 @@ internal partial class Win32WindowWrapper
 			}
 			using var bitmapDcDisposable = new DisposableStruct<HDC>(static bitmapDc =>
 			{
-				var success = PInvoke.DeleteObject(new HGDIOBJ(bitmapDc.Value)) == 1;
-				if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
+				var success = PInvoke.DeleteDC(bitmapDc);
+				if (!success) { typeof(Win32WindowWrapper).LogError()?.Error($"{nameof(PInvoke.DeleteDC)} failed: {Win32Helper.GetErrorMessage()}"); }
 			}, bitmapDc);
 
 			if (PInvoke.SelectObject(bitmapDc, _hBitmap) == 0)
@@ -111,16 +109,10 @@ internal partial class Win32WindowWrapper
 			var success2 = PInvoke.BitBlt(paintDc, 0, 0, width, height, bitmapDc, 0, 0, ROP_CODE.SRCCOPY);
 			if (!success2) { this.LogError()?.Error($"{nameof(PInvoke.BitBlt)} failed: {Win32Helper.GetErrorMessage()}"); }
 
-			// Pace the frame. Normally DwmFlush blocks until the DWM compositor's next VSync
-			// (BitBlt itself returns instantly, so without pacing the render loop spins at
-			// hundreds of fps — wasting CPU and reporting misleading frame rates).
-			//
-			// Fallback: after DwmFlushFailureThreshold consecutive failures (DWM hung during
-			// RDP reconnect, fast user switch, or a GPU TDR), give up on DwmFlush and pace via
-			// FramePacer's self-correcting absolute-time scheduling. We never re-enable
-			// DwmFlush in this renderer instance — once degraded, stay degraded for the
-			// lifetime of the window. Better to lose vsync alignment than to risk hanging the
-			// render thread on each frame.
+			// Pace the frame: DwmFlush blocks until the compositor's next VSync (BitBlt returns
+			// instantly, so the loop would otherwise spin unthrottled). After repeated failures,
+			// degrade permanently to FramePacer pacing — losing vsync alignment beats risking a
+			// hung render thread on every frame.
 			var paceViaFramePacer = _dwmFlushDegraded;
 
 			if (!_dwmFlushDegraded)

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.Vulkan.cs
@@ -152,5 +152,8 @@ internal partial class Win32WindowWrapper
 			_deviceLock = null;
 			_vulkanContext.Dispose();
 		}
+
+		// Vulkan presents through its own VSync-aware swapchain, so no retargeting is needed here.
+		public void UpdateRefreshRate(double fps) { }
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -1,38 +1,34 @@
 using System;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.OpenGL;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
-using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
-using Uno.UI.Runtime.Skia.Hosting;
-using Windows.Win32;
-using Windows.Win32.Foundation;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
 internal partial class Win32WindowWrapper
 {
-	private readonly FramePacer _framePacer;
-	private int _renderCount;
 	private SKSurface? _surface;
-	private bool _rendering;
+	private RenderThread? _renderThread;
 
 	public event EventHandler<SKPath>? RenderingNegativePathReevaluated; // not necessarily changed
 
-	private FramePacer CreateFramePacer()
-	{
-		return new FramePacer(
-			_refreshRate,
-			() => NativeDispatcher.Main.Enqueue(Render, NativeDispatcherPriority.High));
-	}
-
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
-		var success = PInvoke.InvalidateRect(_hwnd, default(RECT*), true);
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}"); }
+		// Mark the window dirty for WM_PAINT. This handles external repaints (window
+		// uncovering, restore from minimized) where Windows generates WM_PAINT.
+		// Like WPF (InvalidateRect in HwndTarget).
+		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
+		{
+			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
+		}
 
-		_framePacer.RequestFrame();
+		// Signal the render thread to present the current frame.
+		_renderThread?.SignalNewFrame();
 	}
 
 	private void ReinitializeRenderer()
@@ -42,45 +38,66 @@ internal partial class Win32WindowWrapper
 		_surface = null;
 	}
 
-	private void Render()
+	private void InitializeRenderThread()
 	{
-		if (_rendererDisposed || _rendering)
+		// TryCreateGlRenderer leaves the GL context current on the UI thread
+		// (WglCurrentContextDisposable doesn't restore to "no context" when there
+		// was none before). Detach it so the render thread can make it current.
+		// No-op for the software renderer (no GL context to detach).
+		if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
 		{
-			return;
+			this.LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
 		}
 
-		_framePacer.OnFrameStart();
-
-		this.LogTrace()?.Trace($"Render {this._renderCount++}");
-
-		_renderer.StartPaint();
-		using var paintDisposable = new DisposableStruct<IRenderer>(static r => r.EndPaint(), _renderer);
-
-		// In some cases, if a call to a synchronization method such as Monitor.Enter or Task.Wait()
-		// happens inside Paint(), the dotnet runtime can itself call WndProc, which can lead to
-		// Paint() becoming reentrant which can cause crashes.
-		_rendering = true;
-		try
-		{
-			var nativeElementClipPath = ((CompositionTarget)((IXamlRootHost)this).RootElement!.Visual.CompositionTarget!).OnNativePlatformFrameRequested(_surface?.Canvas, size =>
+		_renderThread = new RenderThread(
+			_renderer,
+			drawFrame: DrawFrame,
+			onClipPathUpdated: clipPath =>
 			{
-				_surface?.Dispose();
-				_surface = _renderer.UpdateSize((int)size.Width, (int)size.Height);
-				return _surface.Canvas;
-			});
-			RenderingNegativePathReevaluated?.Invoke(this, nativeElementClipPath);
-		}
-		finally
+				NativeDispatcher.Main.Enqueue(() =>
+					RenderingNegativePathReevaluated?.Invoke(this, clipPath),
+					NativeDispatcherPriority.Normal);
+			},
+			onFramePresented: () => { });
+	}
+
+	/// <summary>
+	/// Called on the render thread. Replays the last recorded SKPicture to
+	/// the canvas and returns the clip path and client dimensions for CopyPixels.
+	/// Returns null when there is no frame to present yet — this avoids a wasted
+	/// CopyPixels (BitBlt + DwmFlush, or SwapBuffers presenting an uninitialised
+	/// back buffer) for WM_PAINT messages that arrive before the first synchronous
+	/// render.
+	/// </summary>
+	private unsafe (SKPath clipPath, int width, int height)? DrawFrame()
+	{
+		var ct = ((IXamlRootHost)this).RootElement?.Visual.CompositionTarget as CompositionTarget;
+		if (ct is null || _rendererDisposed)
 		{
-			_rendering = false;
+			return null;
+		}
+
+		var clipPath = ct.OnNativePlatformFrameRequested(_surface?.Canvas, size =>
+		{
+			_surface?.Dispose();
+			_surface = _renderer.UpdateSize((int)size.Width, (int)size.Height);
+			return _surface.Canvas;
+		});
+
+		// _surface is created lazily inside the resizeFunc only when there's an actual
+		// frame to draw. If it's still null, the CompositionTarget has not recorded
+		// anything yet — nothing to present.
+		if (_surface is null)
+		{
+			return null;
 		}
 
 		if (!PInvoke.GetClientRect(_hwnd, out RECT clientRect))
 		{
 			this.LogError()?.Error($"{nameof(PInvoke.GetClientRect)} failed: {Win32Helper.GetErrorMessage()}");
-			return;
+			return null;
 		}
-		// this may call WM_ERASEBKGND
-		_renderer.CopyPixels(clientRect.Width, clientRect.Height);
+
+		return (clipPath, clientRect.Width, clientRect.Height);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -1,7 +1,6 @@
 using System;
 using Windows.Win32;
 using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.OpenGL;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
 using Uno.Foundation.Logging;
@@ -40,15 +39,6 @@ internal partial class Win32WindowWrapper
 
 	private void InitializeRenderThread()
 	{
-		// TryCreateGlRenderer leaves the GL context current on the UI thread
-		// (WglCurrentContextDisposable doesn't restore to "no context" when there
-		// was none before). Detach it so the render thread can make it current.
-		// No-op for the software renderer (no GL context to detach).
-		if (!PInvoke.wglMakeCurrent(default, HGLRC.Null))
-		{
-			this.LogError()?.Error($"{nameof(PInvoke.wglMakeCurrent)} (detach) failed: {Win32Helper.GetErrorMessage()}");
-		}
-
 		_renderThread = new RenderThread(
 			_renderer,
 			drawFrame: DrawFrame,
@@ -57,8 +47,7 @@ internal partial class Win32WindowWrapper
 				NativeDispatcher.Main.Enqueue(() =>
 					RenderingNegativePathReevaluated?.Invoke(this, clipPath),
 					NativeDispatcherPriority.Normal);
-			},
-			onFramePresented: () => { });
+			});
 	}
 
 	/// <summary>

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -19,9 +19,7 @@ internal partial class Win32WindowWrapper
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
 		// Mark the window dirty and let Windows coalesce it into a WM_PAINT, whose handler
-		// signals the render thread to present. Presenting here too would double-present the
-		// same content (and re-block on VSync for GL), so WM_PAINT is the single present path,
-		// like WPF's HwndTarget (InvalidateRect here, present on WM_PAINT).
+		// signals the render thread — the single present path, like WPF's HwndTarget.
 		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
 		{
 			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
@@ -49,12 +47,9 @@ internal partial class Win32WindowWrapper
 	}
 
 	/// <summary>
-	/// Called on the render thread. Replays the last recorded SKPicture to
-	/// the canvas and returns the clip path and client dimensions for CopyPixels.
-	/// Returns null when there is no frame to present yet — this avoids a wasted
-	/// CopyPixels (BitBlt + DwmFlush, or SwapBuffers presenting an uninitialised
-	/// back buffer) for WM_PAINT messages that arrive before the first synchronous
-	/// render.
+	/// Called on the render thread. Replays the last recorded SKPicture and returns the clip
+	/// path and client dimensions for CopyPixels, or null when there is no frame to present
+	/// yet (avoids presenting an uninitialised back buffer before the first render).
 	/// </summary>
 	private unsafe (SKPath clipPath, int width, int height)? DrawFrame()
 	{
@@ -71,9 +66,8 @@ internal partial class Win32WindowWrapper
 			return _surface.Canvas;
 		});
 
-		// _surface is created lazily inside the resizeFunc only when there's an actual
-		// frame to draw. If it's still null, the CompositionTarget has not recorded
-		// anything yet — nothing to present.
+		// _surface is created lazily inside resizeFunc; still null means the CompositionTarget
+		// has not recorded anything yet — nothing to present.
 		if (_surface is null)
 		{
 			return null;

--- a/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Rendering/Win32WindowWrapper.Rendering.cs
@@ -18,16 +18,14 @@ internal partial class Win32WindowWrapper
 
 	unsafe void IXamlRootHost.InvalidateRender()
 	{
-		// Mark the window dirty for WM_PAINT. This handles external repaints (window
-		// uncovering, restore from minimized) where Windows generates WM_PAINT.
-		// Like WPF (InvalidateRect in HwndTarget).
+		// Mark the window dirty and let Windows coalesce it into a WM_PAINT, whose handler
+		// signals the render thread to present. Presenting here too would double-present the
+		// same content (and re-block on VSync for GL), so WM_PAINT is the single present path,
+		// like WPF's HwndTarget (InvalidateRect here, present on WM_PAINT).
 		if (!PInvoke.InvalidateRect(_hwnd, default(RECT*), false))
 		{
 			this.LogError()?.Error($"{nameof(PInvoke.InvalidateRect)} failed: {Win32Helper.GetErrorMessage()}");
 		}
-
-		// Signal the render thread to present the current frame.
-		_renderThread?.SignalNewFrame();
 	}
 
 	private void ReinitializeRenderer()

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -495,15 +495,31 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		_renderThread?.Dispose();
+		// DisposeAndTryJoin returns false only when the render thread was abandoned because it
+		// would not exit within the backstop (e.g. stuck in a native present). In that case the
+		// thread may still be executing inside _renderer.CopyPixels, so disposing the renderer or
+		// its cached surface here would free native GPU resources out from under it.
+		var renderThreadJoined = _renderThread?.DisposeAndTryJoin() ?? true;
 		_renderThread = null;
-		// Dispose the cached SKSurface before the renderer: on Vulkan it references
-		// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
-		// and the render thread has already been joined, so no background access remains.
-		_surface?.Dispose();
-		_surface = null;
-		_renderer.Dispose();
-		_rendererDisposed = true;
+		if (renderThreadJoined)
+		{
+			// Dispose the cached SKSurface before the renderer: on Vulkan it references
+			// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
+			// and the render thread has exited, so no background access remains.
+			_surface?.Dispose();
+			_surface = null;
+			_renderer.Dispose();
+			_rendererDisposed = true;
+		}
+		else
+		{
+			// Leak the renderer and cached surface for the remaining lifetime of the process
+			// rather than risk a use-after-free on the abandoned render thread; the OS reclaims
+			// them at exit.
+			this.LogError()?.Error(
+				"Render thread was abandoned during dispose; leaking the renderer and cached surface " +
+				"until process exit to avoid a use-after-free on native GPU resources.");
+		}
 		_backgroundDisposable?.Dispose();
 		DestroyIcons();
 		XamlRootMap.Unregister(XamlRoot!);

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -104,7 +104,6 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 
 		Win32Host.RegisterWindow(_hwnd);
 
-		_framePacer = CreateFramePacer();
 		_renderer = FeatureConfiguration.Rendering.UseVulkanOnWin32
 			? (IRenderer?)VulkanRenderer.TryCreateVulkanRenderer(_hwnd)
 				?? (FeatureConfiguration.Rendering.UseOpenGLOnWin32 ?? true
@@ -113,6 +112,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 			: FeatureConfiguration.Rendering.UseOpenGLOnWin32 ?? true
 				? (IRenderer?)GlRenderer.TryCreateGlRenderer(_hwnd) ?? new SoftwareRenderer(_hwnd)
 				: new SoftwareRenderer(_hwnd);
+
+		InitializeRenderThread();
 
 		RegisterForBackgroundColor();
 
@@ -282,13 +283,16 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// This call is necessary when part of the window is outside the bounds of the screen and is then moved inside.
-				// In that case, the part that was outside the screen will remain unpainted until the next Render call, probably
-				// since Windows discards that part of the framebuffer thinking that that part will be drawn again during the
-				// WM_PAINT message that follows the movement of the window. However, we ignore WM_PAINT and depend on InvalidateRender
-				// and our render timer.
-				SynchronousRenderAndDraw(false);
+				// When the window moves and part of it was off-screen, Windows discards that part of
+				// the framebuffer. Signal the render thread to re-blit the exposed area.
+				_renderThread?.SignalNewFrame();
 				return new LRESULT(0);
+			case PInvoke.WM_PAINT:
+				// Signal the render thread to re-blit the current frame. WM_PAINT is generated
+				// when the window is uncovered, restored, or otherwise needs repainting.
+				// DefWindowProc calls BeginPaint/EndPaint to validate the update region.
+				_renderThread?.SignalNewFrame();
+				break;
 			case PInvoke.WM_GETMINMAXINFO:
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_GETMINMAXINFO)} message.");
 				if (Window?.AppWindow?.Presenter is OverlappedPresenter overlappedPresenter)
@@ -308,16 +312,14 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				if (_forcePaintOnNextEraseBkgndOrNcPaint)
 				{
 					_forcePaintOnNextEraseBkgndOrNcPaint = false;
-					// This call is necessary to avoid an initial blank frame during window startup.
-					// This follows from the SynchronousRenderAndDraw call in ShowCore
-					// The render timer might already be running. This is fine. The CompositionTarget
-					// contract allows calling OnNativePlatformFrameRequested multiple times.
-					Render();
+					// Signal the render thread to re-blit. The first frame was already painted
+					// by ShowCore (which waited for present), so the framebuffer has content.
+					_renderThread?.SignalNewFrame();
 					return new LRESULT(1);
 				}
 				else
 				{
-					// Paiting on WM_ERASEBKGND causes severe flickering in hosted native windows so we
+					// Painting on WM_ERASEBKGND causes severe flickering in hosted native windows so we
 					// only do it the first time when we really need to
 					return new LRESULT(0);
 				}
@@ -401,8 +403,18 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 			OnWindowSizeOrLocationChanged(); // In case the window size has changed but WM_SIZE is not fired yet. This happens specifically if the window is starting maximized using _pendingState
 			XamlRoot!.VisualTree.RootElement.UpdateLayout(); // relayout in response to the new window size
 		}
-		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.OnRenderFrameOpportunity(); // force an early render
-		Render();
+		// Force an early SKPicture record so the render thread has fresh content to present.
+		(XamlRoot?.Content?.Visual.CompositionTarget as CompositionTarget)?.OnRenderFrameOpportunity();
+		// Signal the render thread and wait briefly for the present to land.
+		// Bounded so an unresponsive GPU does not stall WM_SIZE / WM_MOVE / ShowCore.
+		_renderThread?.SignalNewFrame();
+		var presentCompleted = _renderThread?.WaitForNextPresent(TimeSpan.FromMilliseconds(100));
+		if (presentCompleted == false)
+		{
+			this.LogWarn()?.Warn(
+				"Timed out waiting for the next present during synchronous render; " +
+				"the window may be shown before the first frame is displayed.");
+		}
 	}
 
 	private static System.Drawing.Point PointFromLParam(LPARAM lParam)
@@ -483,7 +495,13 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		_framePacer.Dispose();
+		_renderThread?.Dispose();
+		_renderThread = null;
+		// Dispose the cached SKSurface before the renderer: on Vulkan it references
+		// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
+		// and the render thread has already been joined, so no background access remains.
+		_surface?.Dispose();
+		_surface = null;
 		_renderer.Dispose();
 		_rendererDisposed = true;
 		_backgroundDisposable?.Dispose();

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -283,9 +283,9 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// When the window moves and part of it was off-screen, Windows discards that part of
-				// the framebuffer. Signal the render thread to re-blit the exposed area.
-				_renderThread?.SignalNewFrame();
+				// No present here: under DWM the window's backing surface survives the move, and
+				// any region that genuinely needs repainting is invalidated by the OS, which posts
+				// a WM_PAINT that signals the render thread.
 				return new LRESULT(0);
 			case PInvoke.WM_PAINT:
 				// Signal the render thread to re-blit the current frame. WM_PAINT is generated

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -283,14 +283,12 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				this.LogTrace()?.Trace($"WndProc received a {nameof(PInvoke.WM_MOVE)} message.");
 				UpdateDisplayInfo();
 				OnWindowSizeOrLocationChanged();
-				// No present here: under DWM the window's backing surface survives the move, and
-				// any region that genuinely needs repainting is invalidated by the OS, which posts
-				// a WM_PAINT that signals the render thread.
+				// No present here: the DWM backing surface survives the move, and the OS
+				// invalidates any region needing repaint via WM_PAINT.
 				return new LRESULT(0);
 			case PInvoke.WM_PAINT:
-				// Signal the render thread to re-blit the current frame. WM_PAINT is generated
-				// when the window is uncovered, restored, or otherwise needs repainting.
-				// DefWindowProc calls BeginPaint/EndPaint to validate the update region.
+				// Signal the render thread to re-blit the current frame; DefWindowProc
+				// validates the update region via BeginPaint/EndPaint.
 				_renderThread?.SignalNewFrame();
 				break;
 			case PInvoke.WM_GETMINMAXINFO:
@@ -495,17 +493,14 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 
 		Win32Host.UnregisterWindow(_hwnd);
-		// DisposeAndTryJoin returns false only when the render thread was abandoned because it
-		// would not exit within the backstop (e.g. stuck in a native present). In that case the
-		// thread may still be executing inside _renderer.CopyPixels, so disposing the renderer or
-		// its cached surface here would free native GPU resources out from under it.
+		// An abandoned render thread (stuck in a native present) may still be executing inside
+		// _renderer.CopyPixels — disposing the renderer/surface then would be a use-after-free.
 		var renderThreadJoined = _renderThread?.DisposeAndTryJoin() ?? true;
 		_renderThread = null;
 		if (renderThreadJoined)
 		{
-			// Dispose the cached SKSurface before the renderer: on Vulkan it references
-			// GPU resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs)
-			// and the render thread has exited, so no background access remains.
+			// Dispose the cached SKSurface before the renderer: on Vulkan it references GPU
+			// resources owned by _renderer (see Win32WindowWrapper.Rendering.Vulkan.cs).
 			_surface?.Dispose();
 			_surface = null;
 			_renderer.Dispose();
@@ -513,9 +508,6 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 		else
 		{
-			// Leak the renderer and cached surface for the remaining lifetime of the process
-			// rather than risk a use-after-free on the abandoned render thread; the OS reclaims
-			// them at exit.
 			this.LogError()?.Error(
 				"Render thread was abandoned during dispose; leaking the renderer and cached surface " +
 				"until process exit to avoid a use-after-free on native GPU resources.");


### PR DESCRIPTION
**Temporary diagnostic PR — DO NOT MERGE, DO NOT REVIEW.**

Purpose: bisect the Win32 Skia-Desktop **runtime-test timeout/stall** regression seen on PR #23216 (`dev/mazi/win32render`).

This branch is the PR branch truncated at commit `c101afda3e` ("chore(win32): Condense verbose comments", 2026-06-11), i.e. **before** these 5 commits:
- `a2df03d148` refactor(win32): Join render thread on dispose without timeout
- `695c07ed51` fix(win32): Throttle Vulkan rendering to vsync
- `9cf9b880d5` feat(win32): Honor custom FrameRate when not following refresh
- `1dfb60b1e5` fix(win32): Avoid GL render target double-dispose on reinit
- `68f5fe9269` fix(win32): Restore bounded render thread join on dispose

**If the Win32 (Skia Desktop / Windows) Runtime Tests job completes quickly and green here**, the runtime-test hang was introduced **after** `c101afda3e` (i.e. in one of the 5 commits above). If it still hangs, the regression predates this commit (the render thread itself).

Will be deleted once the bisection is done.