### PR TITLE
docs: Update 6.6 external docs pins (stable branches)

### DIFF
--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -26,19 +26,21 @@ If your app references these legacy namespaces, remove or migrate those usages b
 
 This change was introduced in [PR #22377](https://github.com/unoplatform/uno/pull/22377).
 
-<!-- REVIEW (draft PR): the two items below were surfaced from the 6.6 changelog as candidate
-     migration notes. Each needs validation before merge — confirm accuracy and remove this
-     comment along with any item that does not apply. -->
-
 ### Mouse wheel direction on Linux Framebuffer
 
-On the Linux Framebuffer target, the default mouse wheel scroll direction has been reversed to align with the other platforms. If your app relied on the previous behavior, set the `ReverseMouseWheel` option when configuring the Framebuffer host to restore it.
+On the Linux Framebuffer target, the default mouse wheel scroll direction is now inverted from the raw device values, so scrolling behaves consistently with the other targets. If your app relied on the previous direction, call `ReverseMouseWheel()` on the Framebuffer host builder to restore it.
 
 This change was introduced in [PR #22924](https://github.com/unoplatform/uno/pull/22924).
 
-### Uno.Extensions MVUX generated view model naming
+### Uno.Extensions MVUX bindable generation tool
 
-Uno.Extensions 7.2 (shipped with Uno Platform 6.6) updates the MVUX code generator. Generated inner view model types are renamed (for example, `_ViewModel` becomes `_Model`). If your code references these generated bindable types directly, update those references.
+Uno.Extensions 7.2 (shipped with Uno Platform 6.6) changes the default MVUX bindable generation tool from version 2 to version 3 (a Hot Reload-friendly generator). This changes the generated bindable view model naming convention — the doubled `ViewViewModel` suffix is dropped (for example, a `MainModel` now generates `MainViewModel`).
+
+If your code or XAML references the generated bindable types directly, update those references to the new names. To keep the previous generator, pin its version at the assembly level:
+
+```csharp
+[assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(2)]
+```
 
 This change was introduced in [Uno.Extensions PR #3055](https://github.com/unoplatform/uno.extensions/pull/3055).
 

--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -8,7 +8,7 @@ To upgrade to the latest version of Uno Platform, [follow our guide](xref:Uno.De
 
 ## Uno Platform 6.6
 
-Uno Platform 6.6 contains a single breaking change, related to the removal of legacy Windows Phone namespaces.
+Uno Platform 6.6 contains a breaking change related to the removal of legacy Windows Phone namespaces, along with a few platform behavior changes to be aware of when upgrading.
 
 ### Visual Studio, Visual Studio Code, and Rider
 
@@ -25,6 +25,22 @@ As part of the migration of the API surface to a generated model aligned with th
 If your app references these legacy namespaces, remove or migrate those usages before upgrading.
 
 This change was introduced in [PR #22377](https://github.com/unoplatform/uno/pull/22377).
+
+<!-- REVIEW (draft PR): the two items below were surfaced from the 6.6 changelog as candidate
+     migration notes. Each needs validation before merge — confirm accuracy and remove this
+     comment along with any item that does not apply. -->
+
+### Mouse wheel direction on Linux Framebuffer
+
+On the Linux Framebuffer target, the default mouse wheel scroll direction has been reversed to align with the other platforms. If your app relied on the previous behavior, set the `ReverseMouseWheel` option when configuring the Framebuffer host to restore it.
+
+This change was introduced in [PR #22924](https://github.com/unoplatform/uno/pull/22924).
+
+### Uno.Extensions MVUX generated view model naming
+
+Uno.Extensions 7.2 (shipped with Uno Platform 6.6) updates the MVUX code generator. Generated inner view model types are renamed (for example, `_ViewModel` becomes `_Model`). If your code references these generated bindable types directly, update those references.
+
+This change was introduced in [Uno.Extensions PR #3055](https://github.com/unoplatform/uno.extensions/pull/3055).
 
 ## Uno Platform 6.5
 

--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -34,9 +34,9 @@ This change was introduced in [PR #22924](https://github.com/unoplatform/uno/pul
 
 ### Uno.Extensions MVUX bindable generation tool
 
-Uno.Extensions 7.2 (shipped with Uno Platform 6.6) changes the default MVUX bindable generation tool from version 2 to version 3 (a Hot Reload-friendly generator). This changes the generated bindable view model naming convention — the doubled `ViewViewModel` suffix is dropped (for example, a `MainModel` now generates `MainViewModel`).
+Uno.Extensions 7.2 (shipped with Uno Platform 6.6) changes the default MVUX bindable generation tool from version 2 to version 3, which improves Hot Reload support. Typical MVUX code is unaffected, because navigation and bindings reference your model type rather than the generated bindable. However, the *name* of the generated bindable view model changes: version 2 generated `Bindable{ModelName}` (for example, `BindableMainModel`), while version 3 generates `{Name}ViewModel` (for example, `MainModel` generates `MainViewModel`).
 
-If your code or XAML references the generated bindable types directly, update those references to the new names. To keep the previous generator, pin its version at the assembly level:
+If your code references the generated bindable type by name directly, update those references. To keep the previous generator, pin its version at the assembly level:
 
 ```csharp
 [assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(2)]

--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -6,6 +6,26 @@ uid: Uno.Development.MigratingFromPreviousReleases
 
 To upgrade to the latest version of Uno Platform, [follow our guide](xref:Uno.Development.UpgradeUnoNuget).
 
+## Uno Platform 6.6
+
+Uno Platform 6.6 contains a single breaking change, related to the removal of legacy Windows Phone namespaces.
+
+### Visual Studio, Visual Studio Code, and Rider
+
+When upgrading to Uno Platform 6.6, make sure to update your IDE extension or plugin to the latest stable version to ensure the Uno Platform development tooling connects properly.
+
+- [Visual Studio extension](https://aka.platform.uno/vs-extension-marketplace)
+- [Visual Studio Code extension](https://aka.platform.uno/vscode-extension-marketplace)
+- [Rider plugin](https://aka.platform.uno/rider-extension-marketplace)
+
+### Removal of legacy Windows.Phone namespaces
+
+As part of the migration of the API surface to a generated model aligned with the Windows App SDK, Uno Platform 6.6 removes the legacy `Windows.Phone` namespaces inherited from the Windows Phone API set. Only the types that were already implemented remain available.
+
+If your app references these legacy namespaces, remove or migrate those usages before upgrading.
+
+This change was introduced in [PR #22377](https://github.com/unoplatform/uno/pull/22377).
+
 ## Uno Platform 6.5
 
 Uno Platform 6.5 does not contain breaking changes that require attention when upgrading

--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -10,19 +10,19 @@ Set-PSDebug -Trace 1
 # Each entry: repo name -> @{ ref = '<commit|branch>'; dest = '<sub-folder>'? }
 $external_docs = @{
     # use either commit, or branch name to use its latest commit
-    "uno.wasm.bootstrap" = @{ ref="817a4fe1a2e333c22e08477c5ee738d3f144cc8d" }  #latest main commit
-    "uno.themes"         = @{ ref="02f3c86ec8d7426950460f2739b501a660e1ccd3" }  #latest master commit
-    "uno.toolkit.ui"     = @{ ref="b8ebddb96cc030156aa765d0706ee978d4b3f5e2" }  #latest main commit
-    "uno.check"          = @{ ref="ff69cd013f9c84da278cffdac8f4644363d5361d" }  #latest main commit
-    "uno.xamlmerge.task" = @{ ref="081dcfa44b5ce24ac0948675e5ee6b781e2107bc" }  #latest main commit
-    "figma-docs"         = @{ ref="842a2792282b88586a337381b2b3786e779973b4" }  #latest main commit
-    "uno.resizetizer"    = @{ ref="e422ad9f26cf21ed02c339e717e0dd0189bb566e" }  #latest main commit
-    "uno.uitest"         = @{ ref="94d027295b779e28064aebf99aeaee2b393ad558" }  #latest master commit
-    "uno.extensions"     = @{ ref="0e9983942842aa28bb4849b2cb133b6480eb54c2" }  #latest main commit
-    "workshops"          = @{ ref="3515c29e03dea36cf2206d797d1bf9f8620370e3" }  #latest master commit
-    "uno.samples"        = @{ ref="1d9ea60a7aec335e1d034446c631b93f605f06b8" }  #latest master commit
-    "uno.chefs"          = @{ ref="d54bceea13406bca23e870a89ecee469813c69b3" }  #latest main commit
-    "hd-docs"            = @{ ref="ec0553b7a2d000cc0138c020215f313a04ec8807"; dest="studio/Hot Design" } #latest main commit
+    "uno.wasm.bootstrap" = @{ ref="1e8ff08053827b2801f58b35ef6b15d26e47e1b8" } #latest release/stable/10.0 branch commit
+    "uno.themes"         = @{ ref="1f70ae895eba4cea1658e4c8d05c99b9ad051893" } #latest release/stable/6.1 branch commit
+    "uno.toolkit.ui"     = @{ ref="347d5a141e692a17c446b39b7a7e899806da1d59" } #latest release/stable/8.4 branch commit
+    "uno.check"          = @{ ref="79d3dfce8fa13e86c0f37d0538087d8450fe4e91" } #latest release/stable/1.34 branch commit
+    "uno.xamlmerge.task" = @{ ref="377ce2d9fdeab0d4f0b94a61e008731a40b10220" } #latest release/stable/1.33 branch commit
+    "figma-docs"         = @{ ref="842a2792282b88586a337381b2b3786e779973b4" } #latest main commit
+    "uno.resizetizer"    = @{ ref="e422ad9f26cf21ed02c339e717e0dd0189bb566e" } #latest main commit
+    "uno.uitest"         = @{ ref="94d027295b779e28064aebf99aeaee2b393ad558" } #latest master commit
+    "uno.extensions"     = @{ ref="55cdc2fe9920b495925eaa171196067b6a695a03" } #latest release/stable/7.2 branch commit
+    "workshops"          = @{ ref="3515c29e03dea36cf2206d797d1bf9f8620370e3" } #latest master commit
+    "uno.samples"        = @{ ref="e593c241f9d00eb21ca20f67fd3639e1b12f8dd9" } #latest master commit
+    "uno.chefs"          = @{ ref="d54bceea13406bca23e870a89ecee469813c69b3" } #latest main commit
+    "hd-docs"            = @{ ref="c4c2f891544ae17b846b8fd24a90edd974ae6938"; dest="studio/Hot Design" } #latest main commit
     "studio-docs"        = @{ ref="3b86af4dac3e7a21c41b619960d14848ce95e2fd" }  #latest main commit
 }
 


### PR DESCRIPTION
## Summary

Docs updates for the `release/stable/6.6` branch, including migration notes.

Updates `doc/import_external_docs.ps1` so the 6.6 docs build imports external docs from the appropriate **stable branches** (matching how 6.5 was set up).

Per the 6.6 release branch matrix (unoplatform/private#1076), no new stable branch was cut for most of these repos, so they keep the **same pins as 6.5**. The only repo with a new 6.6 stable branch among the imported docs is **uno.extensions**, which advances `release/stable/7.1` → `release/stable/7.2`.

| Repo | Branch | Note |
|------|--------|------|
| uno.wasm.bootstrap | release/stable/10.0 | same as 6.5 |
| uno.themes | release/stable/6.1 | same as 6.5 |
| uno.toolkit.ui | release/stable/8.4 | same as 6.5 |
| uno.check | **release/stable/1.34** | **new 1.34 stable** | 
| uno.xamlmerge.task | release/stable/1.33 | same as 6.5 |
| uno.extensions | **release/stable/7.2** | **new 6.6 stable** |
| figma-docs, uno.resizetizer, uno.chefs, hd-docs, studio-docs | main | same as 6.5 |
| uno.uitest, workshops, uno.samples | master | same as 6.5 |

Verified the script parses cleanly.

Related to https://github.com/unoplatform/private/issues/1076