### PR TITLE
perf(wasm): Defer scrollbar thumb scrolling

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -608,6 +608,44 @@ public class Given_ItemsRepeater_FastScroll
 #endif
 	}
 
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22495")]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Wasm)]
+	public async Task When_BrowserScrollBarThumbTracked_Then_OffsetIsDeferredUntilDispatcher()
+	{
+#if HAS_UNO
+		var sut = CreateMixedTemplateSut(itemCount: 150, viewport: new Size(360, 600));
+		await LoadAsync(sut);
+
+		var scrollable = sut.Scroller.ScrollableHeight;
+		scrollable.Should().BeGreaterThan(400,
+			"the SUT must be tall enough for the deferred scrollbar thumb-track request to be observable.");
+
+		var verticalScrollBar = sut.Scroller.ElementVerticalScrollBar;
+		verticalScrollBar.Should().NotBeNull("the vertical scrollbar must be materialized to drive its Scroll handler.");
+
+		var initialOffset = sut.Scroller.VerticalOffset;
+		var target = scrollable * 0.5;
+
+		sut.Scroller.OnVerticalScrollBarScrolled(
+			verticalScrollBar,
+			new Microsoft.UI.Xaml.Controls.Primitives.ScrollEventArgs
+			{
+				ScrollEventType = Microsoft.UI.Xaml.Controls.Primitives.ScrollEventType.ThumbTrack,
+				NewValue = target,
+			});
+
+		sut.Scroller.VerticalOffset.Should().BeApproximately(initialOffset, OffsetTolerance,
+			"browser-hosted scrollbar thumb tracking should queue the content scroll instead of blocking the pointer move handler.");
+
+		await TestServices.WindowHelper.WaitFor(
+			() => sut.Scroller.VerticalOffset > scrollable * 0.3,
+			message: $"Timed out waiting for deferred thumb-track offset near {target:F2}. Current offset={sut.Scroller.VerticalOffset:F2}.");
+#else
+		Assert.Inconclusive("not applicable for winappsdk: no backdoor available");
+#endif
+	}
+
 	// ----- helpers -----
 
 	// Mixed-template sample SUT: mimics the studio.live multi-template subagent markdown UI's

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1210,6 +1210,16 @@ namespace Microsoft.UI.Xaml.Controls
 		// internal so runtime tests can drive the scrollbar-drag path directly.
 		internal void OnVerticalScrollBarScrolled(object sender, ScrollEventArgs e)
 		{
+			if (e.ScrollEventType == ScrollEventType.ThumbTrack && TryDeferScrollbarThumbTrack(isVertical: true, e.NewValue))
+			{
+				return;
+			}
+
+			if (e.ScrollEventType == ScrollEventType.EndScroll)
+			{
+				FlushDeferredScrollbarThumbTrackChanges();
+			}
+
 			// We animate only if the user clicked in the scroll bar, and disable otherwise
 			// (especially, we disable animation when dragging the thumb)
 
@@ -1239,6 +1249,16 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void OnHorizontalScrollBarScrolled(object sender, ScrollEventArgs e)
 		{
+			if (e.ScrollEventType == ScrollEventType.ThumbTrack && TryDeferScrollbarThumbTrack(isVertical: false, e.NewValue))
+			{
+				return;
+			}
+
+			if (e.ScrollEventType == ScrollEventType.EndScroll)
+			{
+				FlushDeferredScrollbarThumbTrackChanges();
+			}
+
 			// We animate only if the user clicked in the scroll bar, and disable otherwise
 			// (especially, we disable animation when dragging the thumb)
 
@@ -1264,6 +1284,91 @@ namespace Microsoft.UI.Xaml.Controls
 				disableAnimation: immediate,
 				shouldSnap: true);
 		}
+
+#if __WASM__ || __SKIA__
+		private bool _isScrollbarThumbTrackFlushQueued;
+		private double? _deferredVerticalScrollbarThumbTrackOffset;
+		private double? _deferredHorizontalScrollbarThumbTrackOffset;
+
+		private static bool ShouldDeferScrollbarThumbTrack()
+			=> OperatingSystem.IsBrowser();
+
+		private bool TryDeferScrollbarThumbTrack(bool isVertical, double offset)
+		{
+			if (!ShouldDeferScrollbarThumbTrack())
+			{
+				return false;
+			}
+
+			// Browser pointer events run synchronously; defer content scrolling so thumb drags
+			// do not block pointermove dispatch on expensive virtualized layout work.
+			if (isVertical)
+			{
+				_deferredVerticalScrollbarThumbTrackOffset = offset;
+			}
+			else
+			{
+				_deferredHorizontalScrollbarThumbTrackOffset = offset;
+			}
+
+			if (!_isScrollbarThumbTrackFlushQueued)
+			{
+				_isScrollbarThumbTrackFlushQueued = true;
+
+				var dispatcherQueue = global::Windows.System.DispatcherQueue.GetForCurrentThread();
+				if (dispatcherQueue is null || !dispatcherQueue.TryEnqueue(FlushDeferredScrollbarThumbTrackChanges))
+				{
+					FlushDeferredScrollbarThumbTrackChanges();
+				}
+			}
+
+			return true;
+		}
+
+		private void FlushDeferredScrollbarThumbTrackChanges()
+		{
+			if (!ShouldDeferScrollbarThumbTrack() || !_isScrollbarThumbTrackFlushQueued)
+			{
+				return;
+			}
+
+			_isScrollbarThumbTrackFlushQueued = false;
+
+			var verticalOffset = _deferredVerticalScrollbarThumbTrackOffset;
+			var horizontalOffset = _deferredHorizontalScrollbarThumbTrackOffset;
+			_deferredVerticalScrollbarThumbTrackOffset = null;
+			_deferredHorizontalScrollbarThumbTrackOffset = null;
+
+			if (verticalOffset is { } vertical)
+			{
+				_verticalOffsetIntent = vertical;
+				ChangeViewCore(
+					horizontalOffset: null,
+					verticalOffset: vertical,
+					zoomFactor: null,
+					disableAnimation: true,
+					shouldSnap: true);
+			}
+
+			if (horizontalOffset is { } horizontal)
+			{
+				_horizontalOffsetIntent = horizontal;
+				ChangeViewCore(
+					horizontalOffset: horizontal,
+					verticalOffset: null,
+					zoomFactor: null,
+					disableAnimation: true,
+					shouldSnap: true);
+			}
+		}
+#else
+		private static bool TryDeferScrollbarThumbTrack(bool isVertical, double offset)
+			=> false;
+
+		private static void FlushDeferredScrollbarThumbTrackChanges()
+		{
+		}
+#endif
 		#endregion
 
 		// Presenter to Control, i.e. OnPresenterScrolled

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1217,7 +1217,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (e.ScrollEventType == ScrollEventType.EndScroll)
 			{
-				FlushDeferredScrollbarThumbTrackChanges();
+				if (FlushDeferredScrollbarThumbTrackChanges())
+				{
+					return;
+				}
 			}
 
 			// We animate only if the user clicked in the scroll bar, and disable otherwise
@@ -1256,7 +1259,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (e.ScrollEventType == ScrollEventType.EndScroll)
 			{
-				FlushDeferredScrollbarThumbTrackChanges();
+				if (FlushDeferredScrollbarThumbTrackChanges())
+				{
+					return;
+				}
 			}
 
 			// We animate only if the user clicked in the scroll bar, and disable otherwise
@@ -1316,7 +1322,10 @@ namespace Microsoft.UI.Xaml.Controls
 				_isScrollbarThumbTrackFlushQueued = true;
 
 				var dispatcherQueue = global::Windows.System.DispatcherQueue.GetForCurrentThread();
-				if (dispatcherQueue is null || !dispatcherQueue.TryEnqueue(FlushDeferredScrollbarThumbTrackChanges))
+				if (dispatcherQueue is null || !dispatcherQueue.TryEnqueue(() =>
+					{
+						FlushDeferredScrollbarThumbTrackChanges();
+					}))
 				{
 					FlushDeferredScrollbarThumbTrackChanges();
 				}
@@ -1325,11 +1334,11 @@ namespace Microsoft.UI.Xaml.Controls
 			return true;
 		}
 
-		private void FlushDeferredScrollbarThumbTrackChanges()
+		private bool FlushDeferredScrollbarThumbTrackChanges()
 		{
 			if (!ShouldDeferScrollbarThumbTrack() || !_isScrollbarThumbTrackFlushQueued)
 			{
-				return;
+				return false;
 			}
 
 			_isScrollbarThumbTrackFlushQueued = false;
@@ -1342,32 +1351,28 @@ namespace Microsoft.UI.Xaml.Controls
 			if (verticalOffset is { } vertical)
 			{
 				_verticalOffsetIntent = vertical;
-				ChangeViewCore(
-					horizontalOffset: null,
-					verticalOffset: vertical,
-					zoomFactor: null,
-					disableAnimation: true,
-					shouldSnap: true);
 			}
 
 			if (horizontalOffset is { } horizontal)
 			{
 				_horizontalOffsetIntent = horizontal;
-				ChangeViewCore(
-					horizontalOffset: horizontal,
-					verticalOffset: null,
-					zoomFactor: null,
-					disableAnimation: true,
-					shouldSnap: true);
 			}
+
+			ChangeViewCore(
+				horizontalOffset: horizontalOffset,
+				verticalOffset: verticalOffset,
+				zoomFactor: null,
+				disableAnimation: true,
+				shouldSnap: true);
+
+			return true;
 		}
 #else
 		private static bool TryDeferScrollbarThumbTrack(bool isVertical, double offset)
 			=> false;
 
-		private static void FlushDeferredScrollbarThumbTrackChanges()
-		{
-		}
+		private static bool FlushDeferredScrollbarThumbTrackChanges()
+			=> false;
 #endif
 		#endregion
 


### PR DESCRIPTION
**GitHub Issue:** closes #22495

## PR Type:

🐞 Bugfix

## What changed? 🚀

Defers browser-hosted `ScrollViewer` scrollbar `ThumbTrack` content scrolling so expensive virtualized layout work no longer runs synchronously inside the pointer move handler during thumb dragging.

This keeps the scrollbar thumb drag path responsive on Wasm Skia while preserving final offset application through the dispatcher. A WASM runtime regression test covers the deferred scrollbar thumb-track path.

Validation performed locally:

- `git diff --check`
- `dotnet build src/Uno.UI/Uno.UI.Skia.csproj --no-restore -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true`
- `dotnet build src/Uno.UI/Uno.UI.Wasm.csproj --no-restore -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true`
- `dotnet build src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Skia.csproj --no-restore -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true`

Note: `Uno.UI.RuntimeTests.Wasm.csproj` restore succeeds, but its build currently fails in existing unrelated `WasmSemanticDomHelper.cs` usage of `UIElement.Visual`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

