### PR TITLE
perf(wasm): improve dispatcher wake-up scheduling

### DIFF
--- a/src/Uno.UWP/js/Uno.Wasm.d.ts
+++ b/src/Uno.UWP/js/Uno.Wasm.d.ts
@@ -228,8 +228,10 @@ declare namespace Uno.UI.Dispatching {
     class NativeDispatcher {
         static _dispatcherCallback: any;
         static _isReady: boolean;
+        private static _schedule;
         static init(isReady: Promise<boolean>): void;
         static WakeUp(force: boolean): void;
+        private static createScheduler;
     }
 }
 declare namespace Windows.Gaming.Input {

--- a/src/Uno.UWP/ts/Windows/Dispatching/NativeDispatcher.ts
+++ b/src/Uno.UWP/ts/Windows/Dispatching/NativeDispatcher.ts
@@ -4,6 +4,8 @@
 
 		static _isReady: boolean;
 
+		private static _schedule: (callback: () => void) => void = NativeDispatcher.createScheduler();
+
 		public static init(isReady : Promise<boolean>) {
 
 			isReady.then(() => {
@@ -18,7 +20,7 @@
 		public static WakeUp(force: boolean) {
 
 			if (NativeDispatcher._isReady || force) {
-				(<any>window).setImmediate(() => {
+				NativeDispatcher._schedule(() => {
 					try {
 						NativeDispatcher._dispatcherCallback();
 					}
@@ -28,6 +30,47 @@
 					}
 				});
 			}
+		}
+
+		private static createScheduler(): (callback: () => void) => void {
+			const scheduler = (<any>globalThis).scheduler;
+
+			if (scheduler?.postTask instanceof Function) {
+				return callback => scheduler.postTask(() => {
+					try {
+						callback();
+					}
+					catch (e) {
+						window.setTimeout(() => { throw e; }, 0);
+					}
+				});
+			}
+
+			if (globalThis.MessageChannel instanceof Function) {
+				const channel = new MessageChannel();
+				const callbacks: (() => void)[] = [];
+
+				channel.port1.onmessage = () => {
+					const callback = callbacks.shift();
+
+					if (callback) {
+						callback();
+					}
+				};
+
+				return callback => {
+					callbacks.push(callback);
+					channel.port2.postMessage(undefined);
+				};
+			}
+
+			const setImmediate = (<any>window).setImmediate;
+
+			if (setImmediate instanceof Function) {
+				return callback => setImmediate(callback);
+			}
+
+			return callback => window.setTimeout(callback, 0);
 		}
 	}
 }

--- a/src/Uno.UWP/ts/Windows/Dispatching/NativeDispatcher.ts
+++ b/src/Uno.UWP/ts/Windows/Dispatching/NativeDispatcher.ts
@@ -33,7 +33,8 @@
 		}
 
 		private static createScheduler(): (callback: () => void) => void {
-			const scheduler = (<any>globalThis).scheduler;
+			const global = <any>globalThis;
+			const scheduler = global.scheduler;
 
 			if (scheduler?.postTask instanceof Function) {
 				return callback => scheduler.postTask(() => {
@@ -41,17 +42,25 @@
 						callback();
 					}
 					catch (e) {
-						window.setTimeout(() => { throw e; }, 0);
+						global.setTimeout(() => { throw e; }, 0);
 					}
 				});
 			}
 
-			if (globalThis.MessageChannel instanceof Function) {
-				const channel = new MessageChannel();
-				const callbacks: (() => void)[] = [];
+			if (global.MessageChannel instanceof Function) {
+				const channel = new global.MessageChannel();
+				const callbacks: { [id: number]: () => void } = {};
+				let readIndex = 0;
+				let writeIndex = 0;
 
 				channel.port1.onmessage = () => {
-					const callback = callbacks.shift();
+					const callback = callbacks[readIndex];
+					delete callbacks[readIndex++];
+
+					if (readIndex === writeIndex) {
+						readIndex = 0;
+						writeIndex = 0;
+					}
 
 					if (callback) {
 						callback();
@@ -59,18 +68,18 @@
 				};
 
 				return callback => {
-					callbacks.push(callback);
+					callbacks[writeIndex++] = callback;
 					channel.port2.postMessage(undefined);
 				};
 			}
 
-			const setImmediate = (<any>window).setImmediate;
+			const setImmediate = global.setImmediate;
 
 			if (setImmediate instanceof Function) {
 				return callback => setImmediate(callback);
 			}
 
-			return callback => window.setTimeout(callback, 0);
+			return callback => global.setTimeout(callback, 0);
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** closes #21272

## PR Type:

💬 Other... (Performance)

## What changed? 🚀

Updates the WASM native dispatcher wake-up path to avoid using the global `setImmediate` polyfill as the primary scheduler.

The dispatcher now uses:

- `scheduler.postTask`, when available
- a direct `MessageChannel` task fallback
- `setImmediate` only as the compatibility fallback
- `setTimeout(0)` as the final fallback

This keeps dispatcher callbacks on the browser task queue, avoiding the starvation risk called out in the issue for `queueMicrotask`, while removing the heavier `setImmediate` path from the common dispatcher scheduling flow.

Validation:

- `dotnet build src/Uno.UWP/Uno.Wasm.csproj -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true` passed.
- `dotnet build src/Uno.UI/Uno.UI.Wasm.csproj -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true` passed.
- `git diff --check` passed.
- `dotnet build src/Uno.UI-Wasm-only.slnf --no-restore -p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true` was attempted. It failed in this local environment because several projects had no restored assets, the .NET Framework 4.8 targeting pack is unavailable, and `Uno.UI.RuntimeTests.Wasm` hit an existing `WasmSemanticDomHelper.cs` compile error outside this change.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
