### PR TITLE
perf(android): avoid resource enumerator boxing

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -62,7 +62,7 @@ namespace Microsoft.UI.Xaml
 
 			if (this.Resources is not null)
 			{
-				foreach (var resource in Resources.Values)
+				foreach (var resource in Resources.ValuesInternal)
 				{
 					if (resource is FrameworkElement resourceAsFrameworkElement)
 					{
@@ -115,7 +115,7 @@ namespace Microsoft.UI.Xaml
 		{
 			if (this.Resources is not null)
 			{
-				foreach (var resource in this.Resources.Values)
+				foreach (var resource in this.Resources.ValuesInternal)
 				{
 					if (resource is FrameworkElement fe)
 					{


### PR DESCRIPTION
**GitHub Issue:** closes #16814

## PR Type:

💬 Other... (Performance)

## What changed? 🚀

Updates the Android FrameworkElement resource load/unload walks to enumerate `ResourceDictionary.ValuesInternal` instead of the public `Values` collection.

The Skia/WASM resource enter/leave paths already use `ValuesInternal` to avoid struct enumerator boxing. Android still used the public `ICollection<object>` surface, which boxes the `SpecializedResourceDictionary.ValueCollection.Enumerator` when resources are walked during load/unload.

This keeps the behavior unchanged while removing that avoidable allocation from the Android visual-tree/resource path.

Validation:

- `git diff --check` passed.
- `dotnet build src/Uno.UI/Uno.UI.netcoremobile.csproj -p:UnoTargetFrameworkOverride=net10.0-android -p:UnoFastDevBuild=true` was attempted, but this local environment does not have the Android workload installed (`NETSDK1147`).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
