### PR TITLE
fix(wasm): Avoid stuck loading screen on startup

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
@@ -62,14 +62,21 @@ internal partial class BrowserRenderer
 
 	private void RenderFrame()
 	{
-		_pendingInvalidate = false;
-
 		// The RootElement may not be set yet during startup because the JavaScript
-		// requestAnimationFrame can fire before the app initialization completes.
+		// requestAnimationFrame can fire before app initialization completes. When that
+		// happens, re-arm another frame instead of dropping the pending request, otherwise
+		// the render pump stalls and the splash screen is never removed (#23586).
 		if (_host.RootElement is not { Visual.CompositionTarget: CompositionTarget compositionTarget })
 		{
+			if (_pendingInvalidate && _nativeInstance is not null)
+			{
+				NativeMethods.Invalidate(_nativeInstance);
+			}
+
 			return;
 		}
+
+		_pendingInvalidate = false;
 
 		_renderStopwatch.Restart();
 


### PR DESCRIPTION
**GitHub Issue:** closes #23586

## PR Type:

🐞 Bugfix

## What changed? 🚀

On the **Skia WebAssembly** target, apps frequently stayed on the bootstrap loading screen (stuck near 100%) on mobile — almost always on iOS, ~half the time on Android — and on desktop when the tab was backgrounded/minimized during load (requiring an F5). The app was fully running; only the **first frame never painted**, so the persistent bootstrap loader (kept alive until the app reports its first render) was never removed.

### Root cause

The Skia WebAssembly render pump is driven by `requestAnimationFrame`:
`InvalidateRender → requestAnimationFrame → RenderFrame`.

`BrowserRenderer.RenderFrame()` reset `_pendingInvalidate = false` at the very top, **then** early-returned when `RootElement` / `CompositionTarget` was not ready yet (which happens when a frame fires before app initialization completes — common on slower mobile startups and in throttled background tabs). The queued animation frame was therefore **consumed without painting and without rescheduling**.

Because `CompositionTarget.RenderRequested` is only cleared once a render actually happens, it stayed `true`, so the compositor never issued another `InvalidateRender`; and the render-request deduplication (`_pendingInvalidate`) meant nothing re-armed the pump. Splash removal is gated on the `FrameRendered` event, which never fired — so the loader stayed forever. A touch/drag/scroll/resize revived it only because the TypeScript `setCanvasSize() → invalidate()` path bypasses the deduplication.

This was a regression: `release/stable/6.5` contains neither the readiness guard (`d5c6aa12de`) nor the deduplication (`d2bfc671ad`). Before the dedup, every `InvalidateRender` queued its own frame, so a dropped tick self-healed on the next one.

### Fix

In `RenderFrame()`, move the `_pendingInvalidate = false` reset **below** the readiness guard, and in the not-ready branch **re-arm another animation frame** — but only while a render is genuinely pending (`_pendingInvalidate == true`), so the deduplication-bypassing TypeScript resize ticks can't cause a busy-loop. The pending request now survives until `RootElement` is ready, at which point it paints and removes the splash. This self-heals both the mobile first-load race and the desktop background-tab case (a re-armed frame stays queued across rAF throttling and runs on refocus), with no `visibilitychange` handler needed.

Verified against the other Skia hosts (Win32/X11/Android) — they use continuous frame-pacers and don't have this self-consuming one-shot, so they were never affected and remain unchanged.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

> 🧪 **Testing note:** the failure is a startup timing race; it reproduces deterministically by deferring the first few animation frames in DevTools before a hard reload:
> ```js
> const _r = requestAnimationFrame; let n = 0;
> window.requestAnimationFrame = cb => n++ < 3 ? setTimeout(() => _r(() => cb(performance.now())), 1500) : _r(cb);
> ```
> Without the fix the splash stays stuck; with it, the app paints once `RootElement` is ready. A deterministic automated test requires a small testable seam around the pump decision (extracted method + `InternalsVisibleTo`); happy to add it as a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
