### PR TITLE
fix: Restore CornerRadius converters to system resources

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/Priority01/CornerRadius_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/Priority01/CornerRadius_themeresources.xaml
@@ -14,6 +14,8 @@
       <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
+  <!-- These converters are also defined in Uno.UI (Controls/Primitives/CornerRadius_converters.xaml) so they
+       reach the system MasterDictionary for Uno.UI control templates; keep the two copies in sync. See uno#23567. -->
   <primitives:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="Top" />
   <primitives:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right" />
   <primitives:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="Bottom" />

--- a/src/Uno.UI.FluentTheme/Resources/Priority01/CornerRadius_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/Priority01/CornerRadius_themeresources.xaml
@@ -14,6 +14,8 @@
       <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
+  <!-- These converters are also defined in Uno.UI (Controls/Primitives/CornerRadius_converters.xaml) so they
+       reach the system MasterDictionary for Uno.UI control templates; keep the two copies in sync. See uno#23567. -->
   <primitives:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="Top" />
   <primitives:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right" />
   <primitives:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="Bottom" />

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls_Primitives/Given_CornerRadiusFilterConverter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls_Primitives/Given_CornerRadiusFilterConverter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Private.Infrastructure;
@@ -77,7 +78,7 @@ public class Given_CornerRadiusFilterConverter
 		// there (see CornerRadius_converters.xaml) — a dropped or typo'd key would otherwise ship unguarded.
 		foreach (var key in _converterKeys)
 		{
-			var converter = global::Uno.UI.ResourceResolver.GetSystemResource<global::Microsoft.UI.Xaml.Data.IValueConverter>(key);
+			var converter = ResourceResolver.GetSystemResource<IValueConverter>(key);
 			Assert.IsNotNull(converter, $"{key} is not reachable as a system resource.");
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls_Primitives/Given_CornerRadiusFilterConverter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls_Primitives/Given_CornerRadiusFilterConverter.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls_Primitives;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_CornerRadiusFilterConverter
+{
+	// The 12 framework converters that must be reachable as system resources (see uno#23567).
+	private static readonly string[] _converterKeys =
+	{
+		"TopCornerRadiusFilterConverter",
+		"RightCornerRadiusFilterConverter",
+		"BottomCornerRadiusFilterConverter",
+		"LeftCornerRadiusFilterConverter",
+		"TopLeftCornerRadiusDoubleValueConverter",
+		"BottomRightCornerRadiusDoubleValueConverter",
+		"TopThicknessFilterConverter",
+		"BottomThicknessFilterConverter",
+		"LeftThicknessFilterConverter",
+		"RightThicknessFilterConverter",
+		"TabViewLeftInsetCornerConverter",
+		"TabViewRightInsetCornerConverter",
+	};
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23567")]
+	public async Task When_CornerRadius_Binding_Converter_Sets_Rectangle_Radius()
+	{
+		// End-to-end / WinUI-parity guard: ProgressBar binds Rectangle.RadiusX/RadiusY to its CornerRadius via
+		// {StaticResource TopLeft/BottomRightCornerRadiusDoubleValueConverter}; verify the converters resolve and
+		// produce the right radii. (When_CornerRadius_Converters_Are_System_Resources is the precise #23567
+		// fails-before/passes-after guard; this is the rendering-level companion.)
+		var progressBar = new ProgressBar
+		{
+			Width = 200,
+			Maximum = 100,
+			Value = 50,
+			CornerRadius = new CornerRadius(8, 8, 4, 4),
+		};
+
+		try
+		{
+			await UITestHelper.Load(progressBar);
+
+			var rectangles = new List<Rectangle>();
+			CollectRectangles(progressBar, rectangles);
+
+			// TopLeftValue -> RadiusX (8), BottomRightValue -> RadiusY (4).
+			Assert.IsTrue(
+				rectangles.Any(r => Math.Abs(r.RadiusX - 8) < 0.5 && Math.Abs(r.RadiusY - 4) < 0.5),
+				$"Expected an indicator Rectangle with RadiusX≈8 / RadiusY≈4 from the CornerRadius converters. " +
+				$"Found radii: {string.Join(", ", rectangles.Select(r => $"({r.RadiusX},{r.RadiusY})"))}.");
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+
+#if HAS_UNO
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23567")]
+	public void When_CornerRadius_Converters_Are_System_Resources()
+	{
+		// The converters are consumed as Binding.Converter via {StaticResource} from Uno.UI control templates,
+		// whose one-time static resolve can only reach the system MasterDictionary. All of them must be present
+		// there (see CornerRadius_converters.xaml) — a dropped or typo'd key would otherwise ship unguarded.
+		foreach (var key in _converterKeys)
+		{
+			var converter = global::Uno.UI.ResourceResolver.GetSystemResource<global::Microsoft.UI.Xaml.Data.IValueConverter>(key);
+			Assert.IsNotNull(converter, $"{key} is not reachable as a system resource.");
+		}
+	}
+#endif
+
+	private static void CollectRectangles(DependencyObject root, List<Rectangle> result)
+	{
+		var count = VisualTreeHelper.GetChildrenCount(root);
+		for (var i = 0; i < count; i++)
+		{
+			var child = VisualTreeHelper.GetChild(root, i);
+			if (child is Rectangle rectangle)
+			{
+				result.Add(rectangle);
+			}
+
+			CollectRectangles(child, result);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CornerRadius_converters.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CornerRadius_converters.xaml
@@ -1,0 +1,28 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!--
+	Keep these converters in a Uno.UI page so they merge into the system MasterDictionary. Uno.UI control
+	templates reference them as a Binding.Converter via {StaticResource ...}, resolved once and eagerly against
+	the Uno.UI parse context — a path that only reaches the system MasterDictionary, never the FluentTheme assembly.
+	A copy also lives in the FluentTheme dictionaries (CornerRadius_themeresources.xaml) for the app-merge scope;
+	keep the two in sync. Theme-scoped *values* (ControlCornerRadius/OverlayCornerRadius) stay only in FluentTheme
+	so HasKey doesn't report them in every control's dictionary. See uno#23567.
+-->
+<ResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
+	<primitives:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="Top" />
+	<primitives:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right" />
+	<primitives:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="Bottom" />
+	<primitives:CornerRadiusFilterConverter x:Key="LeftCornerRadiusFilterConverter" Filter="Left" />
+	<primitives:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter" Filter="TopLeftValue" />
+	<primitives:CornerRadiusFilterConverter x:Key="BottomRightCornerRadiusDoubleValueConverter" Filter="BottomRightValue" />
+
+	<primitives:CornerRadiusToThicknessConverter x:Key="TopThicknessFilterConverter" ConversionKind="FilterLeftAndRightFromTop" />
+	<primitives:CornerRadiusToThicknessConverter x:Key="BottomThicknessFilterConverter" ConversionKind="FilterLeftAndRightFromBottom" />
+	<primitives:CornerRadiusToThicknessConverter x:Key="LeftThicknessFilterConverter" ConversionKind="FilterTopAndBottomFromLeft" />
+	<primitives:CornerRadiusToThicknessConverter x:Key="RightThicknessFilterConverter" ConversionKind="FilterTopAndBottomFromRight" />
+
+	<primitives:CornerRadiusToThicknessConverter x:Key="TabViewLeftInsetCornerConverter" ConversionKind="FilterLeftFromBottomLeft" Multiplier="-1" />
+	<primitives:CornerRadiusToThicknessConverter x:Key="TabViewRightInsetCornerConverter" ConversionKind="FilterRightFromBottomRight" Multiplier="-1" />
+</ResourceDictionary>


### PR DESCRIPTION
**GitHub Issue:** closes #23567

## PR Type:

🐞 Bugfix

## What changed? 🚀

Control templates round a `Rectangle`'s corners by binding `Rectangle.RadiusX`/`RadiusY` (both `double`) to a `CornerRadius` through `Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}` / `BottomRightCornerRadiusDoubleValueConverter` (used by ProgressBar, ItemContainer, ColorPicker/ColorSpectrum, SelectorBar, …).

At runtime those converters failed to resolve, so the binding fell back to the default `DoubleConverter`, which throws when handed a `CornerRadius`:

```
warn: Uno.UI.ResourceResolver[0] Couldn't statically resolve resource TopLeftCornerRadiusDoubleValueConverter
fail: Microsoft.UI.Xaml.Data.BindingExpression[0] DoubleConverter cannot convert from Microsoft.UI.Xaml.CornerRadius.
```

**Root cause.** A `Binding.Converter={StaticResource …}` is resolved **once, eagerly**, against the **Uno.UI** parse context, whose only system lookup path is the framework `MasterDictionary` (built solely from Uno.UI pages). DP-targeted `{StaticResource}`/`{ThemeResource}` self-heal because they defer and re-resolve against the visual-tree scope at load time, but a `Binding.Converter` is a plain CLR property with no `DependencyObject` to attach a deferred reference to. Commit `734fbbbb7c` ("fix: Correct `CornerRadius` theme resources") moved the whole `CornerRadius_themeresources.xaml` — both the theme-scoped values **and** the theme-independent converters — out of Uno.UI into `Uno.UI.FluentTheme.v2`. After that move the converters were no longer in the `MasterDictionary`, so the eager resolve returned `null`. WinUI never hits this because it statically flattens templates + theme resources into a single physical dictionary, making the converter an in-scope sibling.

**Fix.** Re-add a Uno.UI page (`Controls/Primitives/CornerRadius_converters.xaml`) containing **only** the converters (no `ThemeDictionaries`), so they merge back into the system `MasterDictionary` and the Uno.UI-context static resolve finds them again. The theme-scoped `ControlCornerRadius`/`OverlayCornerRadius` stay in FluentTheme.v2 — keeping them out of system resources is what `734fbbbb7c` actually needed (so `HasKey` doesn't report them in every control's dictionary). A sync cross-reference comment is added on both copies to prevent future drift.

**Tests.** A new runtime test (`Given_CornerRadiusFilterConverter`):
- `When_CornerRadius_Converters_Are_System_Resources` — deterministic guard that all 12 converters are reachable as system resources (fails before this change, passes after).
- `When_CornerRadius_Binding_Converter_Sets_Rectangle_Radius` — end-to-end / WinUI-parity check that a `ProgressBar`'s indicator `Rectangle` gets `RadiusX`/`RadiusY` from the converters.

**Validation.** Skia desktop: build clean; the converter warning and the `DoubleConverter` binding failure are gone after the fix; regression set (`Given_ResourceDictionary` + `Given_ProgressBar`) 14/14 green. The `MasterDictionary` is built by the same TFM-agnostic source generator for all targets, so the behavior is identical on WASM/native.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5wrUiF87pnz6T3vBw71e7
