### PR TITLE
perf(skia): Reuse shared empty clip SKPath

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -54,6 +54,10 @@ public partial class CompositionTarget
 	// _frameGate, like the frame slot itself.
 	private readonly Stack<SKPath> _damageSnapshotPool = new();
 
+	// Returned as the native-element clip path when there's no recorded frame yet. The clip path is
+	// borrowed read-only by hosts (never mutated or disposed), so a single shared instance is safe.
+	private static readonly SKPath _emptyPath = new();
+
 	// only set on the UI thread and under _frameGate, only read under _frameGate
 	private (IntPtr frame, SKPath nativeElementClipPath, SKPath damage)? _lastRenderedFrame;
 	// only set and read under _xamlRootBoundsGate
@@ -228,7 +232,7 @@ public partial class CompositionTarget
 
 		if (lastRenderedFrameNullable is not { } lastRenderedFrame)
 		{
-			return new SKPath();
+			return _emptyPath;
 		}
 		else
 		{


### PR DESCRIPTION
Reuse a single shared empty `SKPath` for the native-element clip path when no frame has been recorded yet, instead of allocating a `new SKPath()` on every such `Draw` call.

The returned clip path is borrowed read-only by hosts (the non-empty branches already return shared frame-owned / cached paths, and consumers such as the Win32 `RenderingNegativePathReevaluated` handler only read it to compute a clip region — never mutate or dispose it), so a single shared instance is safe.

### Validation
- **Compile:** `Uno.UI.Skia.csproj` (net10.0) builds clean — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBAigLEAf3csGwnWE22Yr5
