### PR TITLE
fix(android): Avoid white flash on first frame

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -44,6 +44,12 @@ namespace Microsoft.UI.Xaml
 		private bool _isContentViewSet;
 
 		/// <summary>
+		/// Set by the GL thread after the first Skia frame has been rendered.
+		/// Used to keep the splash screen visible until pixels are ready.
+		/// </summary>
+		internal volatile bool FirstFrameRendered;
+
+		/// <summary>
 		/// The windows model implies only one managed activity.
 		/// </summary>
 		internal static ApplicationActivity Instance { get; private set; } = null!;

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -43,10 +43,7 @@ namespace Microsoft.UI.Xaml
 		private static bool _started;
 		private bool _isContentViewSet;
 
-		/// <summary>
-		/// Set by the GL thread after the first Skia frame has been rendered.
-		/// Used to keep the splash screen visible until pixels are ready.
-		/// </summary>
+		// Set on the GL/Vulkan render thread after the first Skia frame; read on the main thread to gate splash-screen dismissal.
 		internal volatile bool FirstFrameRendered;
 
 		/// <summary>

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -43,9 +43,6 @@ namespace Microsoft.UI.Xaml
 		private static bool _started;
 		private bool _isContentViewSet;
 
-		// Set on the GL/Vulkan render thread after the first Skia frame; read on the main thread to gate splash-screen dismissal.
-		internal volatile bool FirstFrameRendered;
-
 		/// <summary>
 		/// The windows model implies only one managed activity.
 		/// </summary>
@@ -258,6 +255,9 @@ namespace Microsoft.UI.Xaml
 			base.OnCreate(bundle);
 
 			NativeWindowWrapper.Instance.OnActivityCreated();
+
+			// Hold the splash on the Skia path until the first Skia frame is presented (see the render views).
+			NativeWindowWrapper.Instance.ArmFirstFrameGate();
 
 			LayoutProvider = new LayoutProvider(this);
 			LayoutProvider.KeyboardChanged += OnKeyboardChanged;

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -43,9 +43,6 @@ namespace Microsoft.UI.Xaml
 		private static bool _started;
 		private bool _isContentViewSet;
 
-		// Set on the GL/Vulkan render thread after the first Skia frame; read on the main thread to gate splash-screen dismissal.
-		internal volatile bool FirstFrameRendered;
-
 		/// <summary>
 		/// The windows model implies only one managed activity.
 		/// </summary>
@@ -257,6 +254,9 @@ namespace Microsoft.UI.Xaml
 			base.OnCreate(bundle);
 
 			NativeWindowWrapper.Instance.OnActivityCreated();
+
+			// Hold the splash on the Skia path until the first Skia frame is presented (see the render views).
+			NativeWindowWrapper.Instance.ArmFirstFrameGate();
 
 			LayoutProvider = new LayoutProvider(this);
 			LayoutProvider.KeyboardChanged += OnKeyboardChanged;

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -18,6 +18,7 @@ using SkiaSharp;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
+using Uno.UI.Xaml.Controls;
 using Windows.Graphics.Display;
 
 namespace Uno.UI.Runtime.Skia.Android;
@@ -143,6 +144,8 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 		private readonly bool _hardwareAccelerated = FeatureConfiguration.Rendering.UseOpenGLOnSkiaAndroid;
 
+		private bool _firstFrameSignaled;
+
 		private GRContext? _context;
 		private GRGlFramebufferInfo _glInfo;
 		private GRBackendRenderTarget? _renderTarget;
@@ -222,9 +225,10 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 			_context!.Flush();
 
-			if (!ApplicationActivity.Instance.FirstFrameRendered)
+			if (!_firstFrameSignaled)
 			{
-				ApplicationActivity.Instance.FirstFrameRendered = true;
+				_firstFrameSignaled = true;
+				NativeWindowWrapper.Instance.NotifyFirstFrameRendered();
 				// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
 				ApplicationActivity.RelativeLayout?.Post(() =>
 					ApplicationActivity.RelativeLayout?.Invalidate());

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -221,6 +221,14 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 			}
 
 			_context!.Flush();
+
+			if (!ApplicationActivity.Instance.FirstFrameRendered)
+			{
+				ApplicationActivity.Instance.FirstFrameRendered = true;
+				// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
+				ApplicationActivity.RelativeLayout?.Post(() =>
+					ApplicationActivity.RelativeLayout?.Invalidate());
+			}
 		}
 
 		void IRenderer.OnSurfaceChanged(IGL10? gl, int width, int height)

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -18,6 +18,7 @@ using SkiaSharp;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
+using Uno.UI.Xaml.Controls;
 using Windows.Graphics.Display;
 
 namespace Uno.UI.Runtime.Skia.Android;
@@ -148,6 +149,8 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 		internal bool HardwareAccelerated => _hardwareAccelerated;
 
+		private bool _firstFrameSignaled;
+
 		private GRContext? _context;
 		private GRGlFramebufferInfo _glInfo;
 		private GRBackendRenderTarget? _renderTarget;
@@ -227,9 +230,10 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 			_context!.Flush();
 
-			if (!ApplicationActivity.Instance.FirstFrameRendered)
+			if (!_firstFrameSignaled)
 			{
-				ApplicationActivity.Instance.FirstFrameRendered = true;
+				_firstFrameSignaled = true;
+				NativeWindowWrapper.Instance.NotifyFirstFrameRendered();
 				// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
 				ApplicationActivity.RelativeLayout?.Post(() =>
 					ApplicationActivity.RelativeLayout?.Invalidate());

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -226,6 +226,14 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 			}
 
 			_context!.Flush();
+
+			if (!ApplicationActivity.Instance.FirstFrameRendered)
+			{
+				ApplicationActivity.Instance.FirstFrameRendered = true;
+				// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
+				ApplicationActivity.RelativeLayout?.Post(() =>
+					ApplicationActivity.RelativeLayout?.Invalidate());
+			}
 		}
 
 		void IRenderer.OnSurfaceChanged(IGL10? gl, int width, int height)

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -16,6 +16,7 @@ using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
 using Uno.UI.Runtime.Skia.Vulkan;
+using Uno.UI.Xaml.Controls;
 using Uno.WinUI.Runtime.Skia.Android.Platform.Vulkan;
 
 namespace Uno.UI.Runtime.Skia.Android;
@@ -34,6 +35,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 	private volatile bool _renderRequested;
 	private volatile bool _surfaceReady;
 	private volatile bool _disposed;
+	private bool _firstFrameSignaled;
 	private readonly ManualResetEventSlim _renderEvent = new(false);
 	private readonly object _renderLock = new();
 	private IntPtr _nativeWindow; // Must stay alive while Vulkan surfaces reference it
@@ -206,9 +208,10 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 				// Update the native layer host clip path
 				ApplicationActivity.NativeLayerHost!.Path = nativeClipPath;
 
-				if (!ApplicationActivity.Instance.FirstFrameRendered)
+				if (!_firstFrameSignaled)
 				{
-					ApplicationActivity.Instance.FirstFrameRendered = true;
+					_firstFrameSignaled = true;
+					NativeWindowWrapper.Instance.NotifyFirstFrameRendered();
 					// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
 					ApplicationActivity.RelativeLayout?.Post(() =>
 						ApplicationActivity.RelativeLayout?.Invalidate());

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -205,6 +205,14 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 
 				// Update the native layer host clip path
 				ApplicationActivity.NativeLayerHost!.Path = nativeClipPath;
+
+				if (!ApplicationActivity.Instance.FirstFrameRendered)
+				{
+					ApplicationActivity.Instance.FirstFrameRendered = true;
+					// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
+					ApplicationActivity.RelativeLayout?.Post(() =>
+						ApplicationActivity.RelativeLayout?.Invalidate());
+				}
 			});
 		}
 		catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -16,6 +16,7 @@ using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
 using Uno.UI.Runtime.Skia.Vulkan;
+using Uno.UI.Xaml.Controls;
 using Uno.WinUI.Runtime.Skia.Android.Platform.Vulkan;
 
 namespace Uno.UI.Runtime.Skia.Android;
@@ -34,6 +35,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 	private volatile bool _renderRequested;
 	private volatile bool _surfaceReady;
 	private volatile bool _disposed;
+	private bool _firstFrameSignaled;
 	private readonly ManualResetEventSlim _renderEvent = new(false);
 	private readonly object _renderLock = new();
 	private IntPtr _nativeWindow; // Must stay alive while Vulkan surfaces reference it
@@ -215,9 +217,10 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 				// Update the native layer host clip path
 				ApplicationActivity.NativeLayerHost!.Path = nativeClipPath;
 
-				if (!ApplicationActivity.Instance.FirstFrameRendered)
+				if (!_firstFrameSignaled)
 				{
-					ApplicationActivity.Instance.FirstFrameRendered = true;
+					_firstFrameSignaled = true;
+					NativeWindowWrapper.Instance.NotifyFirstFrameRendered();
 					// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
 					ApplicationActivity.RelativeLayout?.Post(() =>
 						ApplicationActivity.RelativeLayout?.Invalidate());

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -214,6 +214,14 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 
 				// Update the native layer host clip path
 				ApplicationActivity.NativeLayerHost!.Path = nativeClipPath;
+
+				if (!ApplicationActivity.Instance.FirstFrameRendered)
+				{
+					ApplicationActivity.Instance.FirstFrameRendered = true;
+					// Trigger OnPreDraw re-evaluation so the splash can dismiss once the first frame is on screen
+					ApplicationActivity.RelativeLayout?.Post(() =>
+						ApplicationActivity.RelativeLayout?.Invalidate());
+				}
 			});
 		}
 		catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
@@ -28,6 +28,10 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 	private readonly DisplayInformation _displayInformation;
 	private bool _contentViewAttachedToWindow;
 
+	// Armed by the Skia render path so splash dismissal waits for the first Skia frame; cleared once that frame is
+	// on screen. Native Android never arms it, so its splash keeps dismissing as soon as content is attached.
+	private volatile bool _awaitingFirstFrame;
+
 	private Rect _previousTrueVisibleBounds;
 
 	public NativeWindowWrapper()
@@ -268,6 +272,12 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 #pragma warning restore 618
 	}
 
+	// Called on the Skia path (in ApplicationActivity.OnCreate) so the splash is held until the first Skia frame.
+	internal void ArmFirstFrameGate() => _awaitingFirstFrame = true;
+
+	// Called on the GL/Vulkan render thread once the first Skia frame has been presented.
+	internal void NotifyFirstFrameRendered() => _awaitingFirstFrame = false;
+
 	private void AddPreDrawListener()
 	{
 		if (Uno.UI.ContextHelper.Current is Android.App.Activity activity &&
@@ -303,7 +313,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		public bool OnPreDraw()
 		{
 			if (_windowWrapper._contentViewAttachedToWindow
-				&& MUX.ApplicationActivity.Instance?.FirstFrameRendered == true)
+				&& !_windowWrapper._awaitingFirstFrame)
 			{
 				_windowWrapper.RemovePreDrawListener();
 				return true;

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
@@ -302,7 +302,8 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 		public bool OnPreDraw()
 		{
-			if (_windowWrapper._contentViewAttachedToWindow)
+			if (_windowWrapper._contentViewAttachedToWindow
+				&& MUX.ApplicationActivity.Instance?.FirstFrameRendered == true)
 			{
 				_windowWrapper.RemovePreDrawListener();
 				return true;

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -356,7 +356,8 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 		public bool OnPreDraw()
 		{
-			if (_windowWrapper._contentViewAttachedToWindow)
+			if (_windowWrapper._contentViewAttachedToWindow
+				&& MUX.ApplicationActivity.Instance?.FirstFrameRendered == true)
 			{
 				_windowWrapper.RemovePreDrawListener();
 				return true;

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -28,6 +28,10 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 	private readonly DisplayInformation _displayInformation;
 	private bool _contentViewAttachedToWindow;
 
+	// Armed by the Skia render path so splash dismissal waits for the first Skia frame; cleared once that frame is
+	// on screen. Native Android never arms it, so its splash keeps dismissing as soon as content is attached.
+	private volatile bool _awaitingFirstFrame;
+
 	private Rect _previousTrueVisibleBounds;
 
 	public NativeWindowWrapper()
@@ -322,6 +326,12 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 #pragma warning restore 618
 	}
 
+	// Called on the Skia path (in ApplicationActivity.OnCreate) so the splash is held until the first Skia frame.
+	internal void ArmFirstFrameGate() => _awaitingFirstFrame = true;
+
+	// Called on the GL/Vulkan render thread once the first Skia frame has been presented.
+	internal void NotifyFirstFrameRendered() => _awaitingFirstFrame = false;
+
 	private void AddPreDrawListener()
 	{
 		if (Uno.UI.ContextHelper.Current is Android.App.Activity activity &&
@@ -357,7 +367,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		public bool OnPreDraw()
 		{
 			if (_windowWrapper._contentViewAttachedToWindow
-				&& MUX.ApplicationActivity.Instance?.FirstFrameRendered == true)
+				&& !_windowWrapper._awaitingFirstFrame)
 			{
 				_windowWrapper.RemovePreDrawListener();
 				return true;


### PR DESCRIPTION
Avoids the white flash between Android splash-screen dismissal and the first Skia paint.

The splash is held (`OnPreDraw` keeps returning `false`) until the GL thread has flushed the first Skia frame. A `volatile bool FirstFrameRendered` is set on the GL thread after the first `_context.Flush()`, which posts an invalidation so `OnPreDraw` re-evaluates and dismisses the splash only once pixels are actually ready.

### Validation
- **Compile:** `Uno.UI.Runtime.Skia.Android.csproj` (net10.0-android) builds clean — 0 errors (pre-existing XA0101 `@(Content)` warning only).
- **Runtime:** pending device / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBAigLEAf3csGwnWE22Yr5
