### PR TITLE
feat(macos): Dedicated Metal render thread

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -1075,8 +1075,8 @@ namespace Uno.UI.Samples.Tests
 										// retry loop sits inside this method while "Running test" is logged outside
 										// it — so a test that fails twice and then passes is indistinguishable in the
 										// log from one that was simply slow. Say so.
-										Console.WriteLine(
-											$"[diag] retry {_currentRun.CurrentRepeatCount + 1}/{config.Attempts - 1} of {fullTestName} " +
+										_log?.Warn(
+											$"Retry {_currentRun.CurrentRepeatCount + 1}/{config.Attempts - 1} of {fullTestName} " +
 											$"after {sw.ElapsedMilliseconds}ms: {e.GetType().Name}: {e.Message?.Split('\n')[0]}");
 
 										// Count only the first time we retry this test.

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -1071,6 +1071,14 @@ namespace Uno.UI.Samples.Tests
 								{
 									if (_currentRun.CurrentRepeatCount < config.Attempts - 1)
 									{
+										// A retried test is reported as passed if a later attempt succeeds, and the
+										// retry loop sits inside this method while "Running test" is logged outside
+										// it — so a test that fails twice and then passes is indistinguishable in the
+										// log from one that was simply slow. Say so.
+										Console.WriteLine(
+											$"[diag] retry {_currentRun.CurrentRepeatCount + 1}/{config.Attempts - 1} of {fullTestName} " +
+											$"after {sw.ElapsedMilliseconds}ms: {e.GetType().Name}: {e.Message?.Split('\n')[0]}");
+
 										// Count only the first time we retry this test.
 										if (_currentRun.CurrentRepeatCount == 0)
 										{

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -333,6 +333,13 @@ internal static partial class NativeUno
 	internal static partial void uno_window_get_metal_handles(nint window, out nint device, out nint queue);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	[return: MarshalAs(UnmanagedType.I1)]
+	internal static partial bool uno_window_acquire_next_frame(nint window, out nint texture, out double width, out double height);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_present_frame(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_move(nint window, double x, double y);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -340,6 +340,9 @@ internal static partial class NativeUno
 	internal static partial void uno_window_present_frame(nint window);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_discard_frame(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_move(nint window, double x, double y);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -362,6 +362,9 @@ internal static partial class NativeUno
 	internal static partial void uno_window_get_metal_handles(nint window, out nint device, out nint queue);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial double uno_window_get_refresh_rate(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	[return: MarshalAs(UnmanagedType.I1)]
 	internal static partial bool uno_window_acquire_next_frame(nint window, out nint texture, out double width, out double height);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -369,6 +369,9 @@ internal static partial class NativeUno
 	internal static partial void uno_window_present_frame(nint window);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_discard_frame(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_move(nint window, double x, double y);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -362,6 +362,13 @@ internal static partial class NativeUno
 	internal static partial void uno_window_get_metal_handles(nint window, out nint device, out nint queue);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	[return: MarshalAs(UnmanagedType.I1)]
+	internal static partial bool uno_window_acquire_next_frame(nint window, out nint texture, out double width, out double height);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_present_frame(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_move(nint window, double x, double y);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
@@ -31,6 +32,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private readonly XamlRoot _xamlRoot;
 	private readonly DisplayInformation _displayInformation;
 	private readonly GRContext? _context;
+	private MacOSRenderThread? _metalRenderThread;
 	private SKBitmap? _bitmap;
 	private SKSurface? _surface;
 	private readonly RetainedLayer _retainedLayer = new();
@@ -61,6 +63,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					QueueHandle = queue,
 				};
 				_context = GRContext.CreateMetal(ctx);
+				InitializeMetalRenderThread();
 				break;
 			case RenderSurfaceType.Software:
 				break;
@@ -81,6 +84,60 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	{
 		_nativeWindowSize = new Size(nativeWidth, nativeHeight);
 		SizeChanged?.Invoke(this, _nativeWindowSize);
+	}
+
+	private void InitializeMetalRenderThread()
+	{
+		if (_context is null)
+		{
+			return;
+		}
+
+		_metalRenderThread = new MacOSRenderThread(_nativeWindow.Handle, _context, RenderThreadMetalDraw);
+	}
+
+	/// <summary>
+	/// Called on the render thread. Draws the recorded SKPicture into the Metal texture
+	/// acquired from the layer; the render loop flushes and presents after this returns.
+	/// </summary>
+	private void RenderThreadMetalDraw(double nativeWidth, double nativeHeight, nint texture)
+	{
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace($"Window {_nativeWindow.Handle} render thread drawing {nativeWidth}x{nativeHeight} texture: {texture}");
+		}
+
+		if (RootElement?.Visual.CompositionTarget is not CompositionTarget ct)
+		{
+			return;
+		}
+
+		// The texture differs every frame, so nothing here can be cached.
+		GRBackendRenderTarget? target = null;
+		SKSurface? surface = null;
+		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
+		{
+			target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
+			surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
+			return surface.Canvas;
+		});
+
+		// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
+		// main thread; this method runs on the render thread, so marshal the update there.
+		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+		if (clip != Volatile.Read(ref _lastSvgClipPath))
+		{
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				{
+					Volatile.Write(ref _lastSvgClipPath, clip);
+				}
+			}, NativeDispatcherPriority.Normal);
+		}
+
+		target?.Dispose();
+		surface?.Dispose();
 	}
 
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
@@ -285,7 +342,19 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		AccessibilityRouter.NotifyDisposed(this);
 	}
 
-	void IXamlRootHost.InvalidateRender() => NativeUno.uno_window_invalidate(_nativeWindow.Handle);
+	void IXamlRootHost.InvalidateRender()
+	{
+		if (_metalRenderThread is not null)
+		{
+			// Metal path: wake the dedicated render thread so draw + present run off the UI thread.
+			_metalRenderThread.SignalNewFrame();
+		}
+		else
+		{
+			// Software path: drive AppKit's display loop on the UI thread.
+			NativeUno.uno_window_invalidate(_nativeWindow.Handle);
+		}
+	}
 
 	void IXamlRootHost.ResignNativeFocus() => NativeUno.uno_window_resign_native_first_responder(_nativeWindow.Handle);
 
@@ -741,6 +810,9 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			var window = GetWindowHost(handle);
 			if (window is not null)
 			{
+				// Stop the render thread before tearing down the native window / GRContext.
+				window._metalRenderThread?.Dispose();
+				window._metalRenderThread = null;
 				Unregister(handle);
 				window._nativeWindow.Destroyed();
 				window.Closed?.Invoke(window, EventArgs.Empty);
@@ -793,6 +865,90 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		catch (Exception e)
 		{
 			Application.Current.RaiseRecoverableUnhandledException(e);
+		}
+	}
+
+	// --- Render thread ---
+
+	/// <summary>
+	/// Dedicated render thread for macOS Metal: acquires a drawable, draws the recorded
+	/// SKPicture, flushes, then presents — all off the UI thread so a slow present / VSync
+	/// wait never blocks input or layout. Mirrors the Win32 render thread and the iOS
+	/// CADisplayLink render thread.
+	/// </summary>
+	private sealed class MacOSRenderThread : IDisposable
+	{
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _frameSignal = new(false);
+		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly nint _windowHandle;
+		private readonly GRContext _context;
+		private readonly Action<double, double, nint> _drawFrame;
+		private volatile bool _disposed;
+
+		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame)
+		{
+			_windowHandle = windowHandle;
+			_context = context;
+			_drawFrame = drawFrame;
+			_thread = new Thread(RenderLoop) { Name = "Uno macOS Render Thread", IsBackground = true };
+			_thread.Start();
+		}
+
+		/// <summary>
+		/// Wakes the render thread to present a new frame. Calls made while it is busy
+		/// coalesce into a single wake-up.
+		/// </summary>
+		internal void SignalNewFrame() => _frameSignal.Set();
+
+		/// <summary>
+		/// Blocks until the render thread finishes presenting the current frame, or the timeout elapses.
+		/// </summary>
+		internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+		private void RenderLoop()
+		{
+			while (!_disposed)
+			{
+				_frameSignal.WaitOne();
+				if (_disposed)
+				{
+					break;
+				}
+
+				_presentedEvent.Reset();
+				try
+				{
+					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
+					{
+						_drawFrame(width, height, texture);
+
+						// submit: true commits the Metal command buffer before present (matches the iOS path).
+						_context.Flush(submit: true);
+
+						// Present the drawable; may block on VSync / drawable availability.
+						NativeUno.uno_window_present_frame(_windowHandle);
+					}
+				}
+				catch (Exception ex)
+				{
+					if (this.Log().IsEnabled(LogLevel.Error))
+					{
+						this.Log().Error($"macOS render thread error: {ex}");
+					}
+				}
+
+				_presentedEvent.Set();
+			}
+		}
+
+		public void Dispose()
+		{
+			_disposed = true;
+			_frameSignal.Set();
+			_thread.Join(TimeSpan.FromSeconds(2));
+			_frameSignal.Dispose();
+			_presentedEvent.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -38,7 +38,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private readonly RetainedLayer _retainedLayer = new();
 	private int _rowBytes;
 	private bool _initializationCompleted;
-	private string? _lastSvgClipPath;
+	// Written by the software/legacy draw paths on the main thread and by the Metal render thread.
+	private volatile string? _lastSvgClipPath;
 	private Size _nativeWindowSize;
 	private MacOSAccessibility? _accessibility;
 	private bool _accessibilityBuildQueued;
@@ -115,29 +116,34 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		// The texture differs every frame, so nothing here can be cached.
 		GRBackendRenderTarget? target = null;
 		SKSurface? surface = null;
-		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
+		try
 		{
-			target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
-			surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
-			return surface.Canvas;
-		});
-
-		// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
-		// main thread; this method runs on the render thread, so marshal the update there.
-		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
-		if (clip != Volatile.Read(ref _lastSvgClipPath))
-		{
-			NativeDispatcher.Main.Enqueue(() =>
+			var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
 			{
-				if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
-				{
-					Volatile.Write(ref _lastSvgClipPath, clip);
-				}
-			}, NativeDispatcherPriority.Normal);
-		}
+				target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
+				surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
+				return surface.Canvas;
+			});
 
-		target?.Dispose();
-		surface?.Dispose();
+			// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
+			// main thread; this method runs on the render thread, so marshal the update there.
+			var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+			if (clip != _lastSvgClipPath)
+			{
+				NativeDispatcher.Main.Enqueue(() =>
+				{
+					if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+					{
+						_lastSvgClipPath = clip;
+					}
+				}, NativeDispatcherPriority.Normal);
+			}
+		}
+		finally
+		{
+			surface?.Dispose();
+			target?.Dispose();
+		}
 	}
 
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
@@ -902,9 +908,15 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		internal void SignalNewFrame() => _frameSignal.Set();
 
 		/// <summary>
-		/// Blocks until the render thread finishes presenting the current frame, or the timeout elapses.
+		/// Blocks until the render thread finishes presenting the current frame, and returns
+		/// <see langword="false"/> if the timeout elapsed first.
 		/// </summary>
-		internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+		/// <remarks>
+		/// TODO: not wired up yet. It mirrors the Win32 render-thread contract, where the UI thread
+		/// waits for a present during a synchronous resize/show (Win32WindowWrapper.SynchronousRenderAndDraw),
+		/// which the macOS host still has to grow an equivalent of.
+		/// </remarks>
+		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
 
 		private void RenderLoop()
 		{
@@ -946,7 +958,22 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		{
 			_disposed = true;
 			_frameSignal.Set();
-			_thread.Join(TimeSpan.FromSeconds(2));
+
+			// A present blocked on an unavailable drawable (occluded/minimized window) can outlive the
+			// join. Disposing the primitives underneath the still-running thread would make its next
+			// _presentedEvent.Set() / _frameSignal.WaitOne() throw ObjectDisposedException, which is
+			// unhandled at the thread boundary and would take the process down. Leaking them is cheap:
+			// the thread is a background thread and dies with the process.
+			if (!_thread.Join(TimeSpan.FromSeconds(2)))
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn("macOS render thread did not exit within 2 seconds; leaving its synchronization primitives undisposed.");
+				}
+
+				return;
+			}
+
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -113,36 +113,37 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			return;
 		}
 
-		// The texture differs every frame, so nothing here can be cached.
-		GRBackendRenderTarget? target = null;
-		SKSurface? surface = null;
-		try
-		{
-			var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
-			{
-				target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
-				surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
-				return surface.Canvas;
-			});
+		// The app is drawn into a retained layer sized from the managed XamlRoot bounds, which can
+		// briefly disagree with the drawable size while a resize is in flight. Only the blit below
+		// targets the drawable, so the swapchain surface must use the texture's own dimensions.
+		// The layer also survives across frames, which is what keeps damage-region rendering usable
+		// even though the drawable rotates every frame.
+		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(
+			_retainedLayer.Surface?.Canvas,
+			size => _retainedLayer.EnsureSurface(_context!, (int)size.Width, (int)size.Height, SKColors.Transparent).Canvas);
 
-			// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
-			// main thread; this method runs on the render thread, so marshal the update there.
-			var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
-			if (clip != _lastSvgClipPath)
-			{
-				NativeDispatcher.Main.Enqueue(() =>
-				{
-					if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
-					{
-						_lastSvgClipPath = clip;
-					}
-				}, NativeDispatcherPriority.Normal);
-			}
-		}
-		finally
+		using (var target = new GRBackendRenderTarget((int)nativeWidth, (int)nativeHeight, new GRMtlTextureInfo(texture)))
+		using (var swapchainSurface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888))
 		{
-			surface?.Dispose();
-			target?.Dispose();
+			_retainedLayer.Present(swapchainSurface);
+		}
+
+		// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
+		// main thread; this method runs on the render thread, so marshal the update there.
+		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+		if (clip != _lastSvgClipPath)
+		{
+			_lastSvgClipPath = clip;
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				// if too early it's possible that the native element has not been arranged yet
+				// so the position and dimension of the element are not yet correct (0,0,0,0)
+				if (!NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				{
+					// Retry on the next frame that produces a clip path.
+					_lastSvgClipPath = null;
+				}
+			}, NativeDispatcherPriority.Normal);
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
 using Microsoft.UI.Input;
 using PointerEventArgs = global::Windows.UI.Core.PointerEventArgs;
 using PointerDeviceType = global::Windows.Devices.Input.PointerDeviceType;
@@ -17,6 +19,7 @@ using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
 using Uno.UI.Hosting;
+using Uno.UI.Runtime.Skia.Hosting;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.Graphics;
@@ -98,8 +101,33 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			return;
 		}
 
-		_metalRenderThread = new MacOSRenderThread(_nativeWindow.Handle, _context, RenderThreadMetalDraw);
+		var screenFps = NativeUno.uno_window_get_refresh_rate(_nativeWindow.Handle);
+		var targetFps = ResolveTargetFps(screenFps);
+
+		// Logged unconditionally at Information: on a CI agent this is the only record of what the
+		// render clock is actually running at, and a screen reporting an unexpected rate (or none)
+		// is the first thing to check when frames stall.
+		if (this.Log().IsEnabled(LogLevel.Information))
+		{
+			this.Log().Info(
+				$"macOS render thread starting for window {_nativeWindow.Handle}: " +
+				$"surface={MacSkiaHost.Current.RenderSurfaceType}, " +
+				$"screen refresh rate={(screenFps > 0 ? screenFps.ToString("0.##", CultureInfo.InvariantCulture) + "Hz" : "unknown")}, " +
+				$"pacing at {targetFps.ToString("0.##", CultureInfo.InvariantCulture)} fps.");
+		}
+
+		_metalRenderThread = new MacOSRenderThread(_nativeWindow.Handle, _context, RenderThreadMetalDraw, targetFps);
 	}
+
+	/// <summary>
+	/// Frame rate the render thread should be paced at: the screen's refresh rate when it is known
+	/// and <see cref="FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate"/> is set,
+	/// otherwise the configured rate.
+	/// </summary>
+	private static double ResolveTargetFps(double screenFps)
+		=> FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate && screenFps > 0
+			? screenFps
+			: FeatureConfiguration.CompositionTarget.FrameRate;
 
 	/// <summary>
 	/// Called on the render thread. Draws the recorded SKPicture into the Metal texture
@@ -369,8 +397,10 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	{
 		if (_metalRenderThread is not null)
 		{
-			// Metal path: wake the dedicated render thread so draw + present run off the UI thread.
-			_metalRenderThread.SignalNewFrame();
+			// Metal path: ask the dedicated render thread for a frame so draw + present run off the
+			// UI thread. The request is paced, so repeated invalidations inside one frame interval
+			// coalesce instead of each costing a drawable acquisition.
+			_metalRenderThread.RequestFrame();
 		}
 		else
 		{
@@ -865,6 +895,12 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			var window = GetWindowHost(handle);
 			window?.DisplayInformationExtension?.Update(width, height, scaleFactor);
 			window?.RasterizationScaleChanged?.Invoke(window, EventArgs.Empty);
+
+			if (window?._metalRenderThread is { } renderThread)
+			{
+				// Moving between screens can change the refresh rate (e.g. 120Hz laptop -> 60Hz external).
+				renderThread.UpdateTargetFps(ResolveTargetFps(NativeUno.uno_window_get_refresh_rate(handle)));
+			}
 		}
 		catch (Exception e)
 		{
@@ -900,41 +936,75 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	/// wait never blocks input or layout. Mirrors the Win32 render thread and the iOS
 	/// CADisplayLink render thread.
 	/// </summary>
+	/// <remarks>
+	/// Frame requests are paced by a <see cref="FramePacer"/>, exactly as X11 paces its render
+	/// thread. This is not an optimization: <c>nextDrawable</c> blocks for ~1s and then returns nil
+	/// once the layer's pool is exhausted, so an unpaced loop that acquires as fast as it is
+	/// signalled outruns the compositor and turns every frame into a one-second stall. Pacing keeps
+	/// acquisitions at most one per refresh interval, which is the rate the compositor recycles at.
+	/// A timer drives the pace rather than the display, so the render clock keeps ticking even when
+	/// the display does not (occluded window, headless CI agent).
+	/// </remarks>
 	private sealed class MacOSRenderThread : IDisposable
 	{
 		/// <summary>
-		/// Pause before retrying a frame the render loop could not present. nextDrawable already
-		/// blocks for up to ~1s before returning nil, so this only avoids a hot spin in the cases
-		/// where acquisition fails immediately (e.g. a zero-sized layer during window setup).
+		/// Consecutive unpresentable frames tolerated at the normal pace before retries start
+		/// backing off. Brief failures are expected (a zero-sized layer during window setup, a
+		/// drawable still held across a resize) and should recover within a frame or two.
 		/// </summary>
-		private const int FrameRetryDelayMs = 8;
+		private const int UnthrottledRetries = 3;
+
+		private const int InitialBackoffMs = 16;
+		private const int MaxBackoffMs = 1000;
+
+		/// <summary>Minimum interval between "still cannot present" warnings.</summary>
+		private const int FailureLogIntervalMs = 5000;
 
 		private readonly Thread _thread;
 		private readonly AutoResetEvent _frameSignal = new(false);
 		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly ManualResetEventSlim _shutdown = new(false);
+		private readonly FramePacer _framePacer;
 		private readonly nint _windowHandle;
 		private readonly GRContext _context;
 		private readonly Action<double, double, nint> _drawFrame;
 		private volatile bool _disposed;
 
-		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame)
+		// Render-thread only.
+		private int _consecutiveFailures;
+		private long _firstFailureTimestamp;
+		private long _lastFailureLogTimestamp;
+
+		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame, double targetFps)
 		{
 			_windowHandle = windowHandle;
 			_context = context;
 			_drawFrame = drawFrame;
+			_framePacer = new FramePacer(targetFps, () => _frameSignal.Set());
 			_thread = new Thread(RenderLoop) { Name = "Uno macOS Render Thread", IsBackground = true };
 			_thread.Start();
 		}
 
 		/// <summary>
-		/// Wakes the render thread to present a new frame. Calls made while it is busy
-		/// coalesce into a single wake-up. Resets the present-completion event first so a
-		/// <see cref="WaitForNextPresent"/> caller can never observe a previous present.
+		/// Asks for a frame. Requests made within the same frame interval coalesce into one
+		/// wake-up. Resets the present-completion event first so a <see cref="WaitForNextPresent"/>
+		/// caller can never observe a previous present.
 		/// </summary>
-		internal void SignalNewFrame()
+		internal void RequestFrame()
 		{
 			_presentedEvent.Reset();
-			_frameSignal.Set();
+			_framePacer.RequestFrame();
+		}
+
+		/// <summary>
+		/// Retargets the pace, e.g. when the window moves to a screen with a different refresh rate.
+		/// </summary>
+		internal void UpdateTargetFps(double fps)
+		{
+			if (fps > 0)
+			{
+				_framePacer.UpdateTargetFps(fps);
+			}
 		}
 
 		/// <summary>
@@ -956,6 +1026,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				{
 					break;
 				}
+
+				_framePacer.OnFrameStart();
 
 				var framePresented = false;
 				try
@@ -990,19 +1062,103 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					NativeUno.uno_window_discard_frame(_windowHandle);
 				}
 
-				if (!framePresented && !_disposed)
+				if (framePresented)
 				{
-					// The frame request must not be lost. CompositionTarget.RequestNewFrame latches
-					// RenderRequested and only clears it once a frame is actually drawn, so it will not
-					// signal us again on its own: dropping this wake-up stops rendering for this window
-					// permanently, and anything awaiting a render (RenderTargetBitmap jobs, composition
-					// animations) would then never complete. AppKit gives the non-threaded path the same
-					// guarantee by re-invoking drawInMTKView: for as long as the view stays dirty, so
-					// re-arm to keep retrying until a frame gets through.
-					Thread.Sleep(FrameRetryDelayMs);
-					_frameSignal.Set();
+					OnFramePresented();
+				}
+				else if (!_disposed)
+				{
+					RetryFrame();
 				}
 			}
+		}
+
+		private void OnFramePresented()
+		{
+			if (_consecutiveFailures == 0)
+			{
+				return;
+			}
+
+			if (this.Log().IsEnabled(LogLevel.Information))
+			{
+				this.Log().Info(
+					$"macOS render thread presented a frame again after {_consecutiveFailures} failed " +
+					$"attempt(s) over {ElapsedMsSince(_firstFailureTimestamp)}ms.");
+			}
+
+			_consecutiveFailures = 0;
+			_lastFailureLogTimestamp = 0;
+		}
+
+		/// <summary>
+		/// Re-arms a frame that could not be presented. The request must not be dropped:
+		/// <see cref="CompositionTarget.RequestNewFrame"/> latches its render-requested flag and only
+		/// clears it once a frame is actually drawn, so it will not signal us again on its own, and
+		/// anything awaiting a render (RenderTargetBitmap jobs, composition animations) would hang.
+		/// Retries are paced, and back off once failures persist so a window that can never present
+		/// (minimized, or a compositor that stopped recycling drawables) does not spin the GPU.
+		/// </summary>
+		private void RetryFrame()
+		{
+			if (_consecutiveFailures == 0)
+			{
+				_firstFailureTimestamp = Stopwatch.GetTimestamp();
+			}
+
+			_consecutiveFailures++;
+			ReportPersistentFailure();
+
+			var backoff = BackoffDelayMs(_consecutiveFailures);
+			if (backoff > 0 && _shutdown.Wait(backoff))
+			{
+				// Disposed while backing off.
+				return;
+			}
+
+			_framePacer.RequestFrame();
+		}
+
+		private void ReportPersistentFailure()
+		{
+			if (!this.Log().IsEnabled(LogLevel.Warning))
+			{
+				return;
+			}
+
+			if (_consecutiveFailures <= UnthrottledRetries)
+			{
+				// Still inside the tolerated window — a frame or two of failure is routine.
+				return;
+			}
+
+			if (_consecutiveFailures > UnthrottledRetries + 1
+				&& ElapsedMsSince(_lastFailureLogTimestamp) < FailureLogIntervalMs)
+			{
+				return;
+			}
+
+			_lastFailureLogTimestamp = Stopwatch.GetTimestamp();
+			this.Log().Warn(
+				$"macOS render thread could not present {_consecutiveFailures} consecutive frame(s) over " +
+				$"{ElapsedMsSince(_firstFailureTimestamp)}ms for window {_windowHandle}: the layer vended no " +
+				$"drawable. Retrying with backoff; rendering for this window is stalled until one is available.");
+		}
+
+		private static long ElapsedMsSince(long timestamp)
+			=> timestamp == 0 ? 0 : (long)Stopwatch.GetElapsedTime(timestamp).TotalMilliseconds;
+
+		private static int BackoffDelayMs(int consecutiveFailures)
+		{
+			if (consecutiveFailures <= UnthrottledRetries)
+			{
+				// Still within the tolerated window: retry at the normal pace.
+				return 0;
+			}
+
+			// Double from InitialBackoffMs, capped — the shift is bounded so it cannot overflow.
+			var steps = Math.Min(consecutiveFailures - UnthrottledRetries - 1, 8);
+			return Math.Min(MaxBackoffMs, InitialBackoffMs << steps);
 		}
 
 		/// <summary>
@@ -1010,18 +1166,22 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		/// primitives. The join is intentionally unbounded, matching the Win32 render thread: the
 		/// loop only delays observing <see cref="_disposed"/> while a frame is in flight, and both
 		/// <c>nextDrawable</c> and the present complete in bounded time (a vsync wait, or ~1s and a
-		/// nil drawable when the window is occluded), so the thread always exits. The caller tears
-		/// down the native window and the <see cref="GRContext"/> right after this returns, and the
-		/// render thread is their sole other user, so it must be guaranteed stopped first.
+		/// nil drawable when the window is occluded), so the thread always exits. A retry backoff
+		/// waits on <see cref="_shutdown"/> rather than sleeping, so it is cut short here. The caller
+		/// tears down the native window and the <see cref="GRContext"/> right after this returns, and
+		/// the render thread is their sole other user, so it must be guaranteed stopped first.
 		/// </summary>
 		public void Dispose()
 		{
 			_disposed = true;
+			_shutdown.Set();
 			_frameSignal.Set();
 			_thread.Join();
 
+			_framePacer.Dispose();
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
+			_shutdown.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -960,6 +960,9 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		/// <summary>Minimum interval between "still cannot present" warnings.</summary>
 		private const int FailureLogIntervalMs = 5000;
 
+		/// <summary>A successful acquisition slower than this is worth reporting.</summary>
+		private const int SlowAcquireMs = 100;
+
 		private readonly Thread _thread;
 		private readonly AutoResetEvent _frameSignal = new(false);
 		private readonly ManualResetEventSlim _presentedEvent = new(false);
@@ -974,6 +977,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		private int _consecutiveFailures;
 		private long _firstFailureTimestamp;
 		private long _lastFailureLogTimestamp;
+		private long _lastAcquireLogTimestamp;
 
 		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame, double targetFps)
 		{
@@ -1051,7 +1055,14 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				var framePresented = false;
 				try
 				{
-					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
+					// Timed: whether nextDrawable blocks (and for how long) on a given machine is the
+					// single fact that separates "the render thread is stuck" from "the render thread is
+					// idle and something else is slow". Nothing else records it.
+					var acquireStart = Stopwatch.GetTimestamp();
+					var acquired = NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height);
+					ReportAcquire(acquired, ElapsedMsSince(acquireStart));
+
+					if (acquired)
 					{
 						_drawFrame(width, height, texture);
 
@@ -1136,6 +1147,34 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 
 			_framePacer.RequestFrame();
+		}
+
+		/// <summary>
+		/// Surfaces a drawable acquisition that failed, or succeeded but blocked. Both are reported the
+		/// first time and then at most once per <see cref="FailureLogIntervalMs"/>, so a pathological
+		/// agent shows up in the log immediately instead of only after several consecutive failures.
+		/// </summary>
+		private void ReportAcquire(bool acquired, long elapsedMs)
+		{
+			if (acquired && elapsedMs < SlowAcquireMs)
+			{
+				return;
+			}
+
+			if (!this.Log().IsEnabled(LogLevel.Warning))
+			{
+				return;
+			}
+
+			if (_lastAcquireLogTimestamp != 0 && ElapsedMsSince(_lastAcquireLogTimestamp) < FailureLogIntervalMs)
+			{
+				return;
+			}
+
+			_lastAcquireLogTimestamp = Stopwatch.GetTimestamp();
+			this.Log().Warn(
+				$"macOS drawable acquisition {(acquired ? "was slow" : "returned no drawable")} for window "
+				+ $"{_windowHandle}: nextDrawable took {elapsedMs}ms.");
 		}
 
 		private void ReportPersistentFailure()

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -153,6 +153,14 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
 	{
+		if (_metalRenderThread is not null)
+		{
+			// The render thread owns the GRContext and the retained layer on the Metal path. AppKit
+			// should not reach this (the view is paused), but bail out rather than risk drawing from
+			// the main thread concurrently with it.
+			return;
+		}
+
 		if (this.Log().IsEnabled(LogLevel.Trace))
 		{
 			this.Log().Trace($"Window {_nativeWindow.Handle} drawing {nativeWidth}x{nativeHeight} texture: {texture}");
@@ -909,18 +917,22 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 		/// <summary>
 		/// Wakes the render thread to present a new frame. Calls made while it is busy
-		/// coalesce into a single wake-up.
+		/// coalesce into a single wake-up. Resets the present-completion event first so a
+		/// <see cref="WaitForNextPresent"/> caller can never observe a previous present.
 		/// </summary>
-		internal void SignalNewFrame() => _frameSignal.Set();
+		internal void SignalNewFrame()
+		{
+			_presentedEvent.Reset();
+			_frameSignal.Set();
+		}
 
 		/// <summary>
 		/// Blocks until the render thread finishes presenting the current frame, and returns
 		/// <see langword="false"/> if the timeout elapsed first.
 		/// </summary>
 		/// <remarks>
-		/// TODO: not wired up yet. It mirrors the Win32 render-thread contract, where the UI thread
-		/// waits for a present during a synchronous resize/show (Win32WindowWrapper.SynchronousRenderAndDraw),
-		/// which the macOS host still has to grow an equivalent of.
+		/// Currently unused. It mirrors the Win32 render-thread contract, where the UI thread waits for
+		/// a present during a synchronous resize/show (Win32WindowWrapper.SynchronousRenderAndDraw).
 		/// </remarks>
 		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
 
@@ -934,7 +946,6 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					break;
 				}
 
-				_presentedEvent.Reset();
 				try
 				{
 					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
@@ -946,6 +957,9 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 						// Present the drawable; may block on VSync / drawable availability.
 						NativeUno.uno_window_present_frame(_windowHandle);
+
+						// Only a frame that actually reached the screen may release a waiter.
+						_presentedEvent.Set();
 					}
 				}
 				catch (Exception ex)
@@ -955,8 +969,6 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 						this.Log().Error($"macOS render thread error: {ex}");
 					}
 				}
-
-				_presentedEvent.Set();
 			}
 		}
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -149,6 +149,14 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
 	{
+		if (_metalRenderThread is not null)
+		{
+			// The render thread owns the GRContext and the retained layer on the Metal path. AppKit
+			// should not reach this (the view is paused), but bail out rather than risk drawing from
+			// the main thread concurrently with it.
+			return;
+		}
+
 		if (this.Log().IsEnabled(LogLevel.Trace))
 		{
 			this.Log().Trace($"Window {_nativeWindow.Handle} drawing {nativeWidth}x{nativeHeight} texture: {texture}");
@@ -904,18 +912,22 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 		/// <summary>
 		/// Wakes the render thread to present a new frame. Calls made while it is busy
-		/// coalesce into a single wake-up.
+		/// coalesce into a single wake-up. Resets the present-completion event first so a
+		/// <see cref="WaitForNextPresent"/> caller can never observe a previous present.
 		/// </summary>
-		internal void SignalNewFrame() => _frameSignal.Set();
+		internal void SignalNewFrame()
+		{
+			_presentedEvent.Reset();
+			_frameSignal.Set();
+		}
 
 		/// <summary>
 		/// Blocks until the render thread finishes presenting the current frame, and returns
 		/// <see langword="false"/> if the timeout elapsed first.
 		/// </summary>
 		/// <remarks>
-		/// TODO: not wired up yet. It mirrors the Win32 render-thread contract, where the UI thread
-		/// waits for a present during a synchronous resize/show (Win32WindowWrapper.SynchronousRenderAndDraw),
-		/// which the macOS host still has to grow an equivalent of.
+		/// Currently unused. It mirrors the Win32 render-thread contract, where the UI thread waits for
+		/// a present during a synchronous resize/show (Win32WindowWrapper.SynchronousRenderAndDraw).
 		/// </remarks>
 		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
 
@@ -929,7 +941,6 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					break;
 				}
 
-				_presentedEvent.Reset();
 				try
 				{
 					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
@@ -941,6 +952,9 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 						// Present the drawable; may block on VSync / drawable availability.
 						NativeUno.uno_window_present_frame(_windowHandle);
+
+						// Only a frame that actually reached the screen may release a waiter.
+						_presentedEvent.Set();
 					}
 				}
 				catch (Exception ex)
@@ -950,8 +964,6 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 						this.Log().Error($"macOS render thread error: {ex}");
 					}
 				}
-
-				_presentedEvent.Set();
 			}
 		}
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -897,6 +897,13 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	/// </summary>
 	private sealed class MacOSRenderThread : IDisposable
 	{
+		/// <summary>
+		/// Pause before retrying a frame the render loop could not present. nextDrawable already
+		/// blocks for up to ~1s before returning nil, so this only avoids a hot spin in the cases
+		/// where acquisition fails immediately (e.g. a zero-sized layer during window setup).
+		/// </summary>
+		private const int FrameRetryDelayMs = 8;
+
 		private readonly Thread _thread;
 		private readonly AutoResetEvent _frameSignal = new(false);
 		private readonly ManualResetEventSlim _presentedEvent = new(false);
@@ -945,6 +952,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					break;
 				}
 
+				var framePresented = false;
 				try
 				{
 					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
@@ -959,6 +967,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 						// Only a frame that actually reached the screen may release a waiter.
 						_presentedEvent.Set();
+						framePresented = true;
 					}
 				}
 				catch (Exception ex)
@@ -969,6 +978,24 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					{
 						this.Log().Error($"macOS render thread error: {ex}");
 					}
+
+					// The drawable is only released by uno_window_present_frame, which we did not reach.
+					// Drop it explicitly, otherwise repeated failures exhaust the layer's drawable pool
+					// and every later nextDrawable call blocks then returns nil.
+					NativeUno.uno_window_discard_frame(_windowHandle);
+				}
+
+				if (!framePresented && !_disposed)
+				{
+					// The frame request must not be lost. CompositionTarget.RequestNewFrame latches
+					// RenderRequested and only clears it once a frame is actually drawn, so it will not
+					// signal us again on its own: dropping this wake-up stops rendering for this window
+					// permanently, and anything awaiting a render (RenderTargetBitmap jobs, composition
+					// animations) would then never complete. AppKit gives the non-threaded path the same
+					// guarantee by re-invoking drawInMTKView: for as long as the view stays dirty, so
+					// re-arm to keep retrying until a frame gets through.
+					Thread.Sleep(FrameRetryDelayMs);
+					_frameSignal.Set();
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -42,7 +42,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private readonly RetainedLayer _retainedLayer = new();
 	private int _rowBytes;
 	private bool _initializationCompleted;
-	private string? _lastSvgClipPath;
+	// Written by the software/legacy draw paths on the main thread and by the Metal render thread.
+	private volatile string? _lastSvgClipPath;
 	private Size _nativeWindowSize;
 	private MacOSAccessibility? _accessibility;
 	private bool _accessibilityBuildQueued;
@@ -119,29 +120,34 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		// The texture differs every frame, so nothing here can be cached.
 		GRBackendRenderTarget? target = null;
 		SKSurface? surface = null;
-		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
+		try
 		{
-			target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
-			surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
-			return surface.Canvas;
-		});
-
-		// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
-		// main thread; this method runs on the render thread, so marshal the update there.
-		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
-		if (clip != Volatile.Read(ref _lastSvgClipPath))
-		{
-			NativeDispatcher.Main.Enqueue(() =>
+			var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
 			{
-				if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
-				{
-					Volatile.Write(ref _lastSvgClipPath, clip);
-				}
-			}, NativeDispatcherPriority.Normal);
-		}
+				target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
+				surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
+				return surface.Canvas;
+			});
 
-		target?.Dispose();
-		surface?.Dispose();
+			// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
+			// main thread; this method runs on the render thread, so marshal the update there.
+			var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+			if (clip != _lastSvgClipPath)
+			{
+				NativeDispatcher.Main.Enqueue(() =>
+				{
+					if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+					{
+						_lastSvgClipPath = clip;
+					}
+				}, NativeDispatcherPriority.Normal);
+			}
+		}
+		finally
+		{
+			surface?.Dispose();
+			target?.Dispose();
+		}
 	}
 
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
@@ -907,9 +913,15 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		internal void SignalNewFrame() => _frameSignal.Set();
 
 		/// <summary>
-		/// Blocks until the render thread finishes presenting the current frame, or the timeout elapses.
+		/// Blocks until the render thread finishes presenting the current frame, and returns
+		/// <see langword="false"/> if the timeout elapsed first.
 		/// </summary>
-		internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+		/// <remarks>
+		/// TODO: not wired up yet. It mirrors the Win32 render-thread contract, where the UI thread
+		/// waits for a present during a synchronous resize/show (Win32WindowWrapper.SynchronousRenderAndDraw),
+		/// which the macOS host still has to grow an equivalent of.
+		/// </remarks>
+		internal bool WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
 
 		private void RenderLoop()
 		{
@@ -951,7 +963,22 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		{
 			_disposed = true;
 			_frameSignal.Set();
-			_thread.Join(TimeSpan.FromSeconds(2));
+
+			// A present blocked on an unavailable drawable (occluded/minimized window) can outlive the
+			// join. Disposing the primitives underneath the still-running thread would make its next
+			// _presentedEvent.Set() / _frameSignal.WaitOne() throw ObjectDisposedException, which is
+			// unhandled at the thread boundary and would take the process down. Leaking them is cheap:
+			// the thread is a background thread and dies with the process.
+			if (!_thread.Join(TimeSpan.FromSeconds(2)))
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn("macOS render thread did not exit within 2 seconds; leaving its synchronization primitives undisposed.");
+				}
+
+				return;
+			}
+
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -133,14 +133,18 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
 		if (clip != _lastSvgClipPath)
 		{
+			// Written before the enqueue so a subsequent render-thread frame producing the same clip
+			// doesn't queue a duplicate update while this one is still pending. MetalDraw can write
+			// on success instead because it already runs on the main thread.
 			_lastSvgClipPath = clip;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
 				// if too early it's possible that the native element has not been arranged yet
 				// so the position and dimension of the element are not yet correct (0,0,0,0)
-				if (!NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				if (!NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip) && _lastSvgClipPath == clip)
 				{
-					// Retry on the next frame that produces a clip path.
+					// Retry on the next frame, unless a newer clip was recorded meanwhile — that one
+					// has its own pending update and must not be forced to re-apply.
 					_lastSvgClipPath = null;
 				}
 			}, NativeDispatcherPriority.Normal);
@@ -959,6 +963,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				}
 				catch (Exception ex)
 				{
+					// Intentionally broad: the loop must survive any per-frame Skia or interop failure.
+					// Letting an exception escape would end the thread and stop rendering permanently.
 					if (this.Log().IsEnabled(LogLevel.Error))
 					{
 						this.Log().Error($"macOS render thread error: {ex}");
@@ -967,25 +973,20 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 		}
 
+		/// <summary>
+		/// Stops the render thread, waits for it to exit, then releases its synchronization
+		/// primitives. The join is intentionally unbounded, matching the Win32 render thread: the
+		/// loop only delays observing <see cref="_disposed"/> while a frame is in flight, and both
+		/// <c>nextDrawable</c> and the present complete in bounded time (a vsync wait, or ~1s and a
+		/// nil drawable when the window is occluded), so the thread always exits. The caller tears
+		/// down the native window and the <see cref="GRContext"/> right after this returns, and the
+		/// render thread is their sole other user, so it must be guaranteed stopped first.
+		/// </summary>
 		public void Dispose()
 		{
 			_disposed = true;
 			_frameSignal.Set();
-
-			// A present blocked on an unavailable drawable (occluded/minimized window) can outlive the
-			// join. Disposing the primitives underneath the still-running thread would make its next
-			// _presentedEvent.Set() / _frameSignal.WaitOne() throw ObjectDisposedException, which is
-			// unhandled at the thread boundary and would take the process down. Leaking them is cheap:
-			// the thread is a background thread and dies with the process.
-			if (!_thread.Join(TimeSpan.FromSeconds(2)))
-			{
-				if (this.Log().IsEnabled(LogLevel.Warning))
-				{
-					this.Log().Warn("macOS render thread did not exit within 2 seconds; leaving its synchronization primitives undisposed.");
-				}
-
-				return;
-			}
+			_thread.Join();
 
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -137,14 +137,18 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
 		if (clip != _lastSvgClipPath)
 		{
+			// Written before the enqueue so a subsequent render-thread frame producing the same clip
+			// doesn't queue a duplicate update while this one is still pending. MetalDraw can write
+			// on success instead because it already runs on the main thread.
 			_lastSvgClipPath = clip;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
 				// if too early it's possible that the native element has not been arranged yet
 				// so the position and dimension of the element are not yet correct (0,0,0,0)
-				if (!NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				if (!NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip) && _lastSvgClipPath == clip)
 				{
-					// Retry on the next frame that produces a clip path.
+					// Retry on the next frame, unless a newer clip was recorded meanwhile — that one
+					// has its own pending update and must not be forced to re-apply.
 					_lastSvgClipPath = null;
 				}
 			}, NativeDispatcherPriority.Normal);
@@ -964,6 +968,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				}
 				catch (Exception ex)
 				{
+					// Intentionally broad: the loop must survive any per-frame Skia or interop failure.
+					// Letting an exception escape would end the thread and stop rendering permanently.
 					if (this.Log().IsEnabled(LogLevel.Error))
 					{
 						this.Log().Error($"macOS render thread error: {ex}");
@@ -972,25 +978,20 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 		}
 
+		/// <summary>
+		/// Stops the render thread, waits for it to exit, then releases its synchronization
+		/// primitives. The join is intentionally unbounded, matching the Win32 render thread: the
+		/// loop only delays observing <see cref="_disposed"/> while a frame is in flight, and both
+		/// <c>nextDrawable</c> and the present complete in bounded time (a vsync wait, or ~1s and a
+		/// nil drawable when the window is occluded), so the thread always exits. The caller tears
+		/// down the native window and the <see cref="GRContext"/> right after this returns, and the
+		/// render thread is their sole other user, so it must be guaranteed stopped first.
+		/// </summary>
 		public void Dispose()
 		{
 			_disposed = true;
 			_frameSignal.Set();
-
-			// A present blocked on an unavailable drawable (occluded/minimized window) can outlive the
-			// join. Disposing the primitives underneath the still-running thread would make its next
-			// _presentedEvent.Set() / _frameSignal.WaitOne() throw ObjectDisposedException, which is
-			// unhandled at the thread boundary and would take the process down. Leaking them is cheap:
-			// the thread is a background thread and dies with the process.
-			if (!_thread.Join(TimeSpan.FromSeconds(2)))
-			{
-				if (this.Log().IsEnabled(LogLevel.Warning))
-				{
-					this.Log().Warn("macOS render thread did not exit within 2 seconds; leaving its synchronization primitives undisposed.");
-				}
-
-				return;
-			}
+			_thread.Join();
 
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -6,6 +6,7 @@ using KeyEventArgs = global::Windows.UI.Core.KeyEventArgs;
 using CharacterReceivedEventArgs = global::Windows.UI.Core.CharacterReceivedEventArgs;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
@@ -35,6 +36,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private readonly XamlRoot _xamlRoot;
 	private readonly DisplayInformation _displayInformation;
 	private readonly GRContext? _context;
+	private MacOSRenderThread? _metalRenderThread;
 	private SKBitmap? _bitmap;
 	private SKSurface? _surface;
 	private readonly RetainedLayer _retainedLayer = new();
@@ -65,6 +67,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					QueueHandle = queue,
 				};
 				_context = GRContext.CreateMetal(ctx);
+				InitializeMetalRenderThread();
 				break;
 			case RenderSurfaceType.Software:
 				break;
@@ -85,6 +88,60 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	{
 		_nativeWindowSize = new Size(nativeWidth, nativeHeight);
 		SizeChanged?.Invoke(this, _nativeWindowSize);
+	}
+
+	private void InitializeMetalRenderThread()
+	{
+		if (_context is null)
+		{
+			return;
+		}
+
+		_metalRenderThread = new MacOSRenderThread(_nativeWindow.Handle, _context, RenderThreadMetalDraw);
+	}
+
+	/// <summary>
+	/// Called on the render thread. Draws the recorded SKPicture into the Metal texture
+	/// acquired from the layer; the render loop flushes and presents after this returns.
+	/// </summary>
+	private void RenderThreadMetalDraw(double nativeWidth, double nativeHeight, nint texture)
+	{
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace($"Window {_nativeWindow.Handle} render thread drawing {nativeWidth}x{nativeHeight} texture: {texture}");
+		}
+
+		if (RootElement?.Visual.CompositionTarget is not CompositionTarget ct)
+		{
+			return;
+		}
+
+		// The texture differs every frame, so nothing here can be cached.
+		GRBackendRenderTarget? target = null;
+		SKSurface? surface = null;
+		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
+		{
+			target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
+			surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
+			return surface.Canvas;
+		});
+
+		// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
+		// main thread; this method runs on the render thread, so marshal the update there.
+		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+		if (clip != Volatile.Read(ref _lastSvgClipPath))
+		{
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				{
+					Volatile.Write(ref _lastSvgClipPath, clip);
+				}
+			}, NativeDispatcherPriority.Normal);
+		}
+
+		target?.Dispose();
+		surface?.Dispose();
 	}
 
 	private void MetalDraw(double nativeWidth, double nativeHeight, nint texture)
@@ -289,7 +346,19 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		AccessibilityRouter.NotifyDisposed(this);
 	}
 
-	void IXamlRootHost.InvalidateRender() => NativeUno.uno_window_invalidate(_nativeWindow.Handle);
+	void IXamlRootHost.InvalidateRender()
+	{
+		if (_metalRenderThread is not null)
+		{
+			// Metal path: wake the dedicated render thread so draw + present run off the UI thread.
+			_metalRenderThread.SignalNewFrame();
+		}
+		else
+		{
+			// Software path: drive AppKit's display loop on the UI thread.
+			NativeUno.uno_window_invalidate(_nativeWindow.Handle);
+		}
+	}
 
 	void IXamlRootHost.ResignNativeFocus() => NativeUno.uno_window_resign_native_first_responder(_nativeWindow.Handle);
 
@@ -746,6 +815,9 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			var window = GetWindowHost(handle);
 			if (window is not null)
 			{
+				// Stop the render thread before tearing down the native window / GRContext.
+				window._metalRenderThread?.Dispose();
+				window._metalRenderThread = null;
 				Unregister(handle);
 				window._nativeWindow.Destroyed();
 				window.Closed?.Invoke(window, EventArgs.Empty);
@@ -798,6 +870,90 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		catch (Exception e)
 		{
 			Application.Current.RaiseRecoverableUnhandledException(e);
+		}
+	}
+
+	// --- Render thread ---
+
+	/// <summary>
+	/// Dedicated render thread for macOS Metal: acquires a drawable, draws the recorded
+	/// SKPicture, flushes, then presents — all off the UI thread so a slow present / VSync
+	/// wait never blocks input or layout. Mirrors the Win32 render thread and the iOS
+	/// CADisplayLink render thread.
+	/// </summary>
+	private sealed class MacOSRenderThread : IDisposable
+	{
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _frameSignal = new(false);
+		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly nint _windowHandle;
+		private readonly GRContext _context;
+		private readonly Action<double, double, nint> _drawFrame;
+		private volatile bool _disposed;
+
+		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame)
+		{
+			_windowHandle = windowHandle;
+			_context = context;
+			_drawFrame = drawFrame;
+			_thread = new Thread(RenderLoop) { Name = "Uno macOS Render Thread", IsBackground = true };
+			_thread.Start();
+		}
+
+		/// <summary>
+		/// Wakes the render thread to present a new frame. Calls made while it is busy
+		/// coalesce into a single wake-up.
+		/// </summary>
+		internal void SignalNewFrame() => _frameSignal.Set();
+
+		/// <summary>
+		/// Blocks until the render thread finishes presenting the current frame, or the timeout elapses.
+		/// </summary>
+		internal void WaitForNextPresent(TimeSpan timeout) => _presentedEvent.Wait(timeout);
+
+		private void RenderLoop()
+		{
+			while (!_disposed)
+			{
+				_frameSignal.WaitOne();
+				if (_disposed)
+				{
+					break;
+				}
+
+				_presentedEvent.Reset();
+				try
+				{
+					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
+					{
+						_drawFrame(width, height, texture);
+
+						// submit: true commits the Metal command buffer before present (matches the iOS path).
+						_context.Flush(submit: true);
+
+						// Present the drawable; may block on VSync / drawable availability.
+						NativeUno.uno_window_present_frame(_windowHandle);
+					}
+				}
+				catch (Exception ex)
+				{
+					if (this.Log().IsEnabled(LogLevel.Error))
+					{
+						this.Log().Error($"macOS render thread error: {ex}");
+					}
+				}
+
+				_presentedEvent.Set();
+			}
+		}
+
+		public void Dispose()
+		{
+			_disposed = true;
+			_frameSignal.Set();
+			_thread.Join(TimeSpan.FromSeconds(2));
+			_frameSignal.Dispose();
+			_presentedEvent.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -902,6 +902,13 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	/// </summary>
 	private sealed class MacOSRenderThread : IDisposable
 	{
+		/// <summary>
+		/// Pause before retrying a frame the render loop could not present. nextDrawable already
+		/// blocks for up to ~1s before returning nil, so this only avoids a hot spin in the cases
+		/// where acquisition fails immediately (e.g. a zero-sized layer during window setup).
+		/// </summary>
+		private const int FrameRetryDelayMs = 8;
+
 		private readonly Thread _thread;
 		private readonly AutoResetEvent _frameSignal = new(false);
 		private readonly ManualResetEventSlim _presentedEvent = new(false);
@@ -950,6 +957,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					break;
 				}
 
+				var framePresented = false;
 				try
 				{
 					if (NativeUno.uno_window_acquire_next_frame(_windowHandle, out var texture, out var width, out var height))
@@ -964,6 +972,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 						// Only a frame that actually reached the screen may release a waiter.
 						_presentedEvent.Set();
+						framePresented = true;
 					}
 				}
 				catch (Exception ex)
@@ -974,6 +983,24 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					{
 						this.Log().Error($"macOS render thread error: {ex}");
 					}
+
+					// The drawable is only released by uno_window_present_frame, which we did not reach.
+					// Drop it explicitly, otherwise repeated failures exhaust the layer's drawable pool
+					// and every later nextDrawable call blocks then returns nil.
+					NativeUno.uno_window_discard_frame(_windowHandle);
+				}
+
+				if (!framePresented && !_disposed)
+				{
+					// The frame request must not be lost. CompositionTarget.RequestNewFrame latches
+					// RenderRequested and only clears it once a frame is actually drawn, so it will not
+					// signal us again on its own: dropping this wake-up stops rendering for this window
+					// permanently, and anything awaiting a render (RenderTargetBitmap jobs, composition
+					// animations) would then never complete. AppKit gives the non-threaded path the same
+					// guarantee by re-invoking drawInMTKView: for as long as the view stays dirty, so
+					// re-arm to keep retrying until a frame gets through.
+					Thread.Sleep(FrameRetryDelayMs);
+					_frameSignal.Set();
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -104,7 +104,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		var screenFps = NativeUno.uno_window_get_refresh_rate(_nativeWindow.Handle);
 		var targetFps = ResolveTargetFps(screenFps);
 
-		// Logged unconditionally at Information: on a CI agent this is the only record of what the
+		// Information rather than Trace on purpose: on a CI agent this is the only record of what the
 		// render clock is actually running at, and a screen reporting an unexpected rate (or none)
 		// is the first thing to check when frames stall.
 		if (this.Log().IsEnabled(LogLevel.Information))
@@ -980,9 +980,28 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			_windowHandle = windowHandle;
 			_context = context;
 			_drawFrame = drawFrame;
-			_framePacer = new FramePacer(targetFps, () => _frameSignal.Set());
+			_framePacer = new FramePacer(targetFps, SignalFrameDue);
 			_thread = new Thread(RenderLoop) { Name = "Uno macOS Render Thread", IsBackground = true };
 			_thread.Start();
+		}
+
+		/// <summary>
+		/// Pacer callback: the frame deadline has arrived, so let the render loop run.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="Dispose"/> stops the pacer before disposing the events, but a timer callback
+		/// already in flight can still land afterwards — swallow that rather than let it surface as
+		/// an unhandled exception on a timer thread during window teardown.
+		/// </remarks>
+		private void SignalFrameDue()
+		{
+			try
+			{
+				_frameSignal.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+			}
 		}
 
 		/// <summary>

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -117,36 +117,37 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			return;
 		}
 
-		// The texture differs every frame, so nothing here can be cached.
-		GRBackendRenderTarget? target = null;
-		SKSurface? surface = null;
-		try
-		{
-			var nativeElementClipPath = ct.OnNativePlatformFrameRequested(null, size =>
-			{
-				target = new GRBackendRenderTarget((int)size.Width, (int)size.Height, new GRMtlTextureInfo(texture));
-				surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
-				return surface.Canvas;
-			});
+		// The app is drawn into a retained layer sized from the managed XamlRoot bounds, which can
+		// briefly disagree with the drawable size while a resize is in flight. Only the blit below
+		// targets the drawable, so the swapchain surface must use the texture's own dimensions.
+		// The layer also survives across frames, which is what keeps damage-region rendering usable
+		// even though the drawable rotates every frame.
+		var nativeElementClipPath = ct.OnNativePlatformFrameRequested(
+			_retainedLayer.Surface?.Canvas,
+			size => _retainedLayer.EnsureSurface(_context!, (int)size.Width, (int)size.Height, SKColors.Transparent).Canvas);
 
-			// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
-			// main thread; this method runs on the render thread, so marshal the update there.
-			var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
-			if (clip != _lastSvgClipPath)
-			{
-				NativeDispatcher.Main.Enqueue(() =>
-				{
-					if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
-					{
-						_lastSvgClipPath = clip;
-					}
-				}, NativeDispatcherPriority.Normal);
-			}
-		}
-		finally
+		using (var target = new GRBackendRenderTarget((int)nativeWidth, (int)nativeHeight, new GRMtlTextureInfo(texture)))
+		using (var swapchainSurface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888))
 		{
-			surface?.Dispose();
-			target?.Dispose();
+			_retainedLayer.Present(swapchainSurface);
+		}
+
+		// uno_window_clip_svg mutates AppKit view layers, which must be touched only on the
+		// main thread; this method runs on the render thread, so marshal the update there.
+		var clip = nativeElementClipPath.IsEmpty ? null : nativeElementClipPath.ToSvgPathData();
+		if (clip != _lastSvgClipPath)
+		{
+			_lastSvgClipPath = clip;
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				// if too early it's possible that the native element has not been arranged yet
+				// so the position and dimension of the element are not yet correct (0,0,0,0)
+				if (!NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+				{
+					// Retry on the next frame that produces a clip path.
+					_lastSvgClipPath = null;
+				}
+			}, NativeDispatcherPriority.Normal);
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -44,7 +44,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private SKSurface? _surface;
 	private readonly RetainedLayer _retainedLayer = new();
 	private int _rowBytes;
-	private bool _initializationCompleted;
+	private volatile bool _initializationCompleted;
 	// Written by the software/legacy draw paths on the main thread and by the Metal render thread.
 	private volatile string? _lastSvgClipPath;
 	private Size _nativeWindowSize;
@@ -142,6 +142,30 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 		if (RootElement?.Visual.CompositionTarget is not CompositionTarget ct)
 		{
+			return;
+		}
+
+		// FIXME: we get the first (native) updates for window sizes before we have completed the (managed)
+		// host initialization — https://github.com/unoplatform/uno-private/issues/319
+		// The non-threaded path re-delivers the size from every draw until the managed host has subscribed
+		// to SizeChanged. Without that here, a size that arrives too early is simply lost and XamlRoot.Bounds
+		// stays 0x0 — and CoreServices.RequestAdditionalFrame silently does nothing while bounds are zero
+		// (CoreServices.cs:67), so UpdateLayout and RaiseLoadedEvent never run for that window. Every
+		// WaitForLoaded against it then burns its full timeout, three times over, and the test fails.
+		if (!_initializationCompleted)
+		{
+			// UpdateWindowSize raises SizeChanged into the managed tree, so it must run on the UI thread.
+			NativeDispatcher.Main.Enqueue(() =>
+			{
+				var scale = (float)_xamlRoot.RasterizationScale;
+				UpdateWindowSize(nativeWidth / scale, nativeHeight / scale);
+				_initializationCompleted = SizeChanged is not null;
+
+				// Nothing else will ask for the next frame while we are still bootstrapping, and the
+				// request is paced, so this cannot spin.
+				_metalRenderThread?.RequestFrame();
+			}, NativeDispatcherPriority.Normal);
+
 			return;
 		}
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
@@ -16,10 +16,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable) id<MTLCommandQueue> queue;
 
+/// Holds the drawable acquired by uno_window_acquire_next_frame until
+/// uno_window_present_frame is called. Only accessed from the render thread.
+@property (nullable) id<CAMetalDrawable> currentFrameDrawable;
+
 @end
 
 typedef void (*metal_draw_fn_ptr)(void* /* window */, double /* width */, double /* height */, void* _Nullable /* texture */);
 metal_draw_fn_ptr uno_get_metal_draw_callback(void);
 void uno_set_draw_callback(metal_draw_fn_ptr p);
+
+/// Acquires the next drawable from the window's CAMetalLayer and returns its texture handle and size.
+/// The drawable is held by the delegate until uno_window_present_frame is called.
+/// Returns false if no drawable is available. Called from the managed render thread.
+bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull texture, double* width, double* height);
+
+/// Presents the previously acquired drawable via a Metal command buffer.
+/// Must be called after uno_window_acquire_next_frame returned true. Called from the managed render thread.
+void uno_window_present_frame(NSWindow* window);
 
 NS_ASSUME_NONNULL_END

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
@@ -34,5 +34,8 @@ bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull 
 /// Presents the previously acquired drawable via a Metal command buffer.
 /// Must be called after uno_window_acquire_next_frame returned true. Called from the managed render thread.
 void uno_window_present_frame(NSWindow* window);
+/// Releases the drawable acquired by uno_window_acquire_next_frame without presenting it.
+/// Called from the managed render thread when the frame could not be drawn.
+void uno_window_discard_frame(NSWindow* window);
 
 NS_ASSUME_NONNULL_END

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.h
@@ -14,11 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nonnull instancetype)initWithMetalKitView:(nonnull MTKView *)mtkView;
 
-@property (nullable) id<MTLCommandQueue> queue;
+@property (nonatomic, strong, nullable) id<MTLCommandQueue> queue;
 
 /// Holds the drawable acquired by uno_window_acquire_next_frame until
 /// uno_window_present_frame is called. Only accessed from the render thread.
-@property (nullable) id<CAMetalDrawable> currentFrameDrawable;
+@property (nonatomic, strong, nullable) id<CAMetalDrawable> currentFrameDrawable;
 
 @end
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -34,6 +34,14 @@
 
 - (void)drawInMTKView:(nonnull MTKView *)view
 {
+    // A paused view is driven by the managed render thread, which owns the GRContext. AppKit can
+    // still call this (occlusion changes, backing-store redraws), so bail out rather than touch the
+    // GRContext from the main thread concurrently with the render thread.
+    if (view.isPaused)
+    {
+        return;
+    }
+
 #if DEBUG
     NSLog (@"drawInMTKView: %f %f", view.drawableSize.width, view.drawableSize.height);
 #endif

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -99,3 +99,63 @@
 }
 
 @end
+
+// --- Render thread drawable lifecycle functions ---
+// Called from the managed render thread (a background thread). These use
+// CAMetalLayer.nextDrawable directly instead of MTKView.currentDrawable, which is only
+// valid during drawInMTKView: callbacks on the main thread. nextDrawable is thread-safe.
+// See: https://developer.apple.com/documentation/quartzcore/cametallayer
+
+bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* width, double* height)
+{
+    @autoreleasepool {
+        if (window == nil) return false;
+
+        MTKView* view = (MTKView*)window.contentViewController.view;
+        if (view == nil || ![view isKindOfClass:[MTKView class]]) return false;
+
+        UNOWindow* unoWindow = (UNOWindow*)window;
+        UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+        if (delegate == nil) return false;
+
+        // nextDrawable is thread-safe (unlike MTKView.currentDrawable). It blocks up to ~1s
+        // if all drawables are in use (occluded/minimized window); with maximumDrawableCount=2
+        // set in uno_window_create that is rare, and a nil return is handled by the caller.
+        CAMetalLayer* metalLayer = (CAMetalLayer*)view.layer;
+
+        id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
+        if (drawable == nil) return false;
+
+        // Hold the drawable until present (strong property retains via ARC).
+        delegate.currentFrameDrawable = drawable;
+
+        *texture = (__bridge void*)drawable.texture;
+        CGSize size = metalLayer.drawableSize;
+        *width = size.width;
+        *height = size.height;
+        return true;
+    }
+}
+
+void uno_window_present_frame(NSWindow* window)
+{
+    @autoreleasepool {
+        if (window == nil) return;
+
+        UNOWindow* unoWindow = (UNOWindow*)window;
+        UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+        if (delegate == nil) return;
+
+        id<CAMetalDrawable> drawable = delegate.currentFrameDrawable;
+        if (drawable == nil) return;
+
+        id<MTLCommandBuffer> commandBuffer = [delegate.queue commandBuffer];
+        [commandBuffer presentDrawable:drawable];
+        [commandBuffer commit];
+
+        // Release the drawable as soon as possible after committing; the command buffer
+        // retains it internally for presentation.
+        // See: https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/Drawables.html
+        delegate.currentFrameDrawable = nil;
+    }
+}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -103,6 +103,15 @@
 #if DEBUG
     NSLog (@"drawableSizeWillChange: %p %f x %f @ %gx", view.window, size.width, size.height, scale);
 #endif
+    // A paused view never runs the draw cycle that would apply the new size to its CAMetalLayer, so
+    // nextDrawable would keep vending textures at the previous size. Applying it here (main thread,
+    // before the managed resize) keeps the drawable in step with the window.
+    CAMetalLayer* metalLayer = (CAMetalLayer*)view.layer;
+    if (view.isPaused && [metalLayer isKindOfClass:[CAMetalLayer class]] && !CGSizeEqualToSize(metalLayer.drawableSize, size))
+    {
+        metalLayer.drawableSize = size;
+    }
+
     uno_get_resize_callback()((__bridge void*) view.window, size.width / scale, size.height / scale);
 }
 
@@ -140,10 +149,13 @@ bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* wid
         // Hold the drawable until present (strong property retains via ARC).
         delegate.currentFrameDrawable = drawable;
 
-        *texture = (__bridge void*)drawable.texture;
-        CGSize size = metalLayer.drawableSize;
-        *width = size.width;
-        *height = size.height;
+        // Report the texture's own dimensions rather than the layer's drawableSize: the two can
+        // disagree while a resize is in flight, and the managed side sizes its render target from
+        // these values, so they must describe the texture it is actually drawing into.
+        id<MTLTexture> drawableTexture = drawable.texture;
+        *texture = (__bridge void*)drawableTexture;
+        *width = drawableTexture.width;
+        *height = drawableTexture.height;
         return true;
     }
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -163,6 +163,23 @@ bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* wid
     }
 }
 
+/// Releases the drawable acquired by uno_window_acquire_next_frame without presenting it.
+/// Used when the managed render thread fails to draw the frame: the drawable would otherwise
+/// stay retained and repeated failures would exhaust the layer's pool, making every later
+/// nextDrawable call block and then return nil.
+void uno_window_discard_frame(NSWindow* window)
+{
+    @autoreleasepool {
+        if (window == nil) return;
+
+        UNOWindow* unoWindow = (UNOWindow*)window;
+        UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
+        if (delegate == nil) return;
+
+        delegate.currentFrameDrawable = nil;
+    }
+}
+
 void uno_window_present_frame(NSWindow* window)
 {
     @autoreleasepool {

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -119,10 +119,13 @@ bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* wid
     @autoreleasepool {
         if (window == nil) return false;
 
-        MTKView* view = (MTKView*)window.contentViewController.view;
-        if (view == nil || ![view isKindOfClass:[MTKView class]]) return false;
-
         UNOWindow* unoWindow = (UNOWindow*)window;
+        // The rendering view is a subview of the container returned by contentViewController.view,
+        // so it must be reached through renderingView rather than the content view itself.
+        NSView* renderingView = unoWindow.renderingView;
+        if (![renderingView isKindOfClass:[MTKView class]]) return false;
+
+        MTKView* view = (MTKView*)renderingView;
         UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
         if (delegate == nil) return false;
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -105,7 +105,10 @@
 #endif
     // A paused view never runs the draw cycle that would apply the new size to its CAMetalLayer, so
     // nextDrawable would keep vending textures at the previous size. Applying it here (main thread,
-    // before the managed resize) keeps the drawable in step with the window.
+    // before the managed resize) keeps the drawable in step with the window. CAMetalLayer allows
+    // drawableSize to be set from any thread; if the render thread acquires a drawable between this
+    // write and the managed resize it simply presents one more frame at the old size, which stays
+    // self-consistent because uno_window_acquire_next_frame reports the texture's own dimensions.
     CAMetalLayer* metalLayer = (CAMetalLayer*)view.layer;
     if (view.isPaused && [metalLayer isKindOfClass:[CAMetalLayer class]] && !CGSizeEqualToSize(metalLayer.drawableSize, size))
     {

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -141,9 +141,9 @@ bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* wid
         UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
         if (delegate == nil) return false;
 
-        // nextDrawable is thread-safe (unlike MTKView.currentDrawable). It blocks up to ~1s
-        // if all drawables are in use (occluded/minimized window); with maximumDrawableCount=2
-        // set in uno_window_create that is rare, and a nil return is handled by the caller.
+        // nextDrawable is thread-safe (unlike MTKView.currentDrawable). It blocks for up to ~1s
+        // and then returns nil when every drawable in the layer's pool is still held by the
+        // compositor, so the caller must pace its acquisitions rather than retry in a tight loop.
         CAMetalLayer* metalLayer = (CAMetalLayer*)view.layer;
 
         id<CAMetalDrawable> drawable = [metalLayer nextDrawable];

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -345,6 +345,14 @@ void uno_set_window_close_callbacks(window_should_close_fn_ptr shouldClose, wind
 
 void uno_window_get_metal_handles(UNOWindow* window, void*_Nonnull* _Nonnull device, void*_Nonnull* _Nonnull queue);
 
+/// Acquires the next drawable from the window's CAMetalLayer (texture handle + size).
+/// Called from the managed render thread.
+bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull texture, double* width, double* height);
+
+/// Presents the previously acquired drawable via a Metal command buffer.
+/// Called from the managed render thread after drawing is complete.
+void uno_window_present_frame(NSWindow* window);
+
 typedef void (*window_did_change_screen_fn_ptr)(NSWindow* window, uint32 width, uint32 height, CGFloat backingScaleFactor);
 window_did_change_screen_fn_ptr uno_get_window_did_change_screen_callback(void);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -352,6 +352,10 @@ bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull 
 /// Presents the previously acquired drawable via a Metal command buffer.
 /// Called from the managed render thread after drawing is complete.
 void uno_window_present_frame(NSWindow* window);
+/// Releases the drawable acquired by uno_window_acquire_next_frame without presenting it.
+/// Called from the managed render thread when the frame could not be drawn.
+void uno_window_discard_frame(NSWindow* window);
+
 
 typedef void (*window_did_change_screen_fn_ptr)(NSWindow* window, uint32 width, uint32 height, CGFloat backingScaleFactor);
 window_did_change_screen_fn_ptr uno_get_window_did_change_screen_callback(void);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -345,6 +345,10 @@ void uno_set_window_close_callbacks(window_should_close_fn_ptr shouldClose, wind
 
 void uno_window_get_metal_handles(UNOWindow* window, void*_Nonnull* _Nonnull device, void*_Nonnull* _Nonnull queue);
 
+/// Refresh rate, in frames per second, of the screen currently showing the window.
+/// Returns 0 when it cannot be determined, in which case the caller keeps its configured rate.
+double uno_window_get_refresh_rate(NSWindow* window);
+
 /// Acquires the next drawable from the window's CAMetalLayer (texture handle + size).
 /// Called from the managed render thread.
 bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull texture, double* width, double* height);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -326,8 +326,10 @@ NSWindow* uno_window_create(double width, double height)
         v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
-        // Double-buffering (2 drawables) instead of the default triple-buffering reduces
-        // present latency by one VSync; the render thread is already paced by the UI thread.
+        // Double-buffering (2 drawables) instead of the default triple-buffering reduces present
+        // latency by one VSync, at the cost of headroom: when a frame overruns a VSync interval
+        // (GC pause, slow first frame, resize) there is no spare drawable, so nextDrawable blocks
+        // right away. Raise back to 3 if stutter under load is observed.
         CAMetalLayer* metalLayer = (CAMetalLayer*)v.layer;
         metalLayer.maximumDrawableCount = 2;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -320,8 +320,16 @@ NSWindow* uno_window_create(double width, double height)
     id device = uno_application_get_metal_device();
     if (device) {
         UNOMetalFlippedView *v = [[UNOMetalFlippedView alloc] initWithFrame:size device:device];
-        v.enableSetNeedsDisplay = YES;
+        // Disable MTKView auto-draw; frames are driven by the managed render thread via
+        // uno_window_acquire_next_frame / uno_window_present_frame.
+        v.paused = YES;
+        v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+        // Double-buffering (2 drawables) instead of the default triple-buffering reduces
+        // present latency by one VSync; the render thread is already paced by the UI thread.
+        CAMetalLayer* metalLayer = (CAMetalLayer*)v.layer;
+        metalLayer.maximumDrawableCount = 2;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];
         v.delegate = window.metalViewDelegate;
         window.renderingView = v;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -327,8 +327,10 @@ NSWindow* uno_window_create(double width, double height)
         v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
-        // Double-buffering (2 drawables) instead of the default triple-buffering reduces
-        // present latency by one VSync; the render thread is already paced by the UI thread.
+        // Double-buffering (2 drawables) instead of the default triple-buffering reduces present
+        // latency by one VSync, at the cost of headroom: when a frame overruns a VSync interval
+        // (GC pause, slow first frame, resize) there is no spare drawable, so nextDrawable blocks
+        // right away. Raise back to 3 if stutter under load is observed.
         CAMetalLayer* metalLayer = (CAMetalLayer*)v.layer;
         metalLayer.maximumDrawableCount = 2;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -321,8 +321,16 @@ NSWindow* uno_window_create(double width, double height)
     id device = uno_application_get_metal_device();
     if (device) {
         UNOMetalFlippedView *v = [[UNOMetalFlippedView alloc] initWithFrame:size device:device];
-        v.enableSetNeedsDisplay = YES;
+        // Disable MTKView auto-draw; frames are driven by the managed render thread via
+        // uno_window_acquire_next_frame / uno_window_present_frame.
+        v.paused = YES;
+        v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+        // Double-buffering (2 drawables) instead of the default triple-buffering reduces
+        // present latency by one VSync; the render thread is already paced by the UI thread.
+        CAMetalLayer* metalLayer = (CAMetalLayer*)v.layer;
+        metalLayer.maximumDrawableCount = 2;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];
         v.delegate = window.metalViewDelegate;
         window.renderingView = v;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -327,12 +327,13 @@ NSWindow* uno_window_create(double width, double height)
         v.enableSetNeedsDisplay = NO;
         v.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
-        // Double-buffering (2 drawables) instead of the default triple-buffering reduces present
-        // latency by one VSync, at the cost of headroom: when a frame overruns a VSync interval
-        // (GC pause, slow first frame, resize) there is no spare drawable, so nextDrawable blocks
-        // right away. Raise back to 3 if stutter under load is observed.
+        // Keep the default triple-buffering (3 drawables). Dropping to 2 saves one VSync of
+        // present latency but leaves no headroom: when a frame overruns a VSync interval (GC
+        // pause, slow first frame, resize, or a CPU-constrained CI agent) there is no spare
+        // drawable, so nextDrawable blocks for ~1s and then returns nil. Losing frames that way
+        // is far more costly than the latency it saves.
         CAMetalLayer* metalLayer = (CAMetalLayer*)v.layer;
-        metalLayer.maximumDrawableCount = 2;
+        metalLayer.maximumDrawableCount = 3;
         window.metalViewDelegate = [[UNOMetalViewDelegate alloc] initWithMetalKitView:v];
         v.delegate = window.metalViewDelegate;
         window.renderingView = v;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -1026,6 +1026,30 @@ void uno_set_ime_active(UNOWindow* window, bool active)
     }
 }
 
+double uno_window_get_refresh_rate(NSWindow* window)
+{
+    NSScreen* screen = window.screen;
+    if (screen == nil)
+    {
+        // An off-screen window (never ordered front, or on a headless agent) has no screen;
+        // fall back to the main screen so the render loop still gets a sane pace.
+        screen = NSScreen.mainScreen;
+    }
+    if (screen == nil)
+    {
+        return 0;
+    }
+    if (@available(macOS 12.0, *))
+    {
+        NSInteger fps = screen.maximumFramesPerSecond;
+        if (fps > 0)
+        {
+            return (double)fps;
+        }
+    }
+    return 0;
+}
+
 void uno_window_get_metal_handles(UNOWindow* window, void** device, void** queue)
 {
     *device = (__bridge void *)(uno_application_get_metal_device());

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -153,10 +153,38 @@ namespace Private.Infrastructure
 				return spRootFrameAsCC.Content as Page;
 			}
 
+			/// <summary>
+			/// Longest a pair of idle round-trips may take before it is worth reporting. Reaching the
+			/// idle queue should cost microseconds; anything near a second means the dispatcher is not
+			/// servicing Idle work, which is invisible today because WaitFor only re-checks its
+			/// deadline between awaits and so never times out on it.
+			/// </summary>
+			private const int SlowIdleMs = 500;
+
+			private static long _lastSlowIdleLogTimestamp;
+
 			internal static async Task WaitForIdle()
 			{
+				var start = Stopwatch.GetTimestamp();
+
 				await RootElementDispatcher.RunIdleAsync(_ => { /* Empty to wait for the idle queue to be reached */ });
 				await RootElementDispatcher.RunIdleAsync(_ => { /* Empty to wait for the idle queue to be reached */ });
+
+				var elapsedMs = (long)Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+				if (elapsedMs < SlowIdleMs)
+				{
+					return;
+				}
+
+				// Throttled: a stalled run would otherwise emit this on every wait.
+				var last = _lastSlowIdleLogTimestamp;
+				if (last != 0 && Stopwatch.GetElapsedTime(last).TotalMilliseconds < 5000)
+				{
+					return;
+				}
+
+				_lastSlowIdleLogTimestamp = Stopwatch.GetTimestamp();
+				Console.WriteLine($"[diag] WaitForIdle took {elapsedMs}ms — the Idle queue is not being serviced promptly.");
 			}
 
 			/// <summary>

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Diagnostics;
+using Uno.Foundation.Logging;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -184,7 +185,7 @@ namespace Private.Infrastructure
 				}
 
 				_lastSlowIdleLogTimestamp = Stopwatch.GetTimestamp();
-				Console.WriteLine($"[diag] WaitForIdle took {elapsedMs}ms — the Idle queue is not being serviced promptly.");
+				typeof(WindowHelper).Log().Warn($"WaitForIdle took {elapsedMs}ms — the Idle queue is not being serviced promptly.");
 			}
 
 			/// <summary>
@@ -362,8 +363,8 @@ namespace Private.Infrastructure
 
 				// The runner retries a failed test twice without logging it, so a WaitFor that times out
 				// three times shows up only as a test that took ~3x its timeout and "passed". Name it.
-				Console.WriteLine(
-					$"[diag] WaitFor timed out after {stopwatch.ElapsedMilliseconds}ms and {iterations} idle " +
+				typeof(WindowHelper).Log().Warn(
+					$"WaitFor timed out after {stopwatch.ElapsedMilliseconds}ms and {iterations} idle " +
 					$"round-trip(s) at {callerMemberName}():{lineNumber} — {message}");
 
 				throw new AssertFailedException("Timed out waiting for condition to be met. " + message);

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -347,8 +347,10 @@ namespace Private.Infrastructure
 				}
 
 				var stopwatch = Stopwatch.StartNew();
+				var iterations = 0;
 				while (stopwatch.ElapsedMilliseconds < timeoutMS)
 				{
+					iterations++;
 					await WaitForIdle();
 					if (condition())
 					{
@@ -357,6 +359,12 @@ namespace Private.Infrastructure
 				}
 
 				message ??= $"{callerMemberName}():{lineNumber}";
+
+				// The runner retries a failed test twice without logging it, so a WaitFor that times out
+				// three times shows up only as a test that took ~3x its timeout and "passed". Name it.
+				Console.WriteLine(
+					$"[diag] WaitFor timed out after {stopwatch.ElapsedMilliseconds}ms and {iterations} idle " +
+					$"round-trip(s) at {callerMemberName}():{lineNumber} — {message}");
 
 				throw new AssertFailedException("Timed out waiting for condition to be met. " + message);
 			}


### PR DESCRIPTION
Moves macOS Metal rendering (draw + GPU flush + present) off the UI thread onto a dedicated render thread, mirroring the existing Win32, X11, and iOS render threads. macOS was the **only** Skia host still drawing on the UI/main thread, so a slow present or VSync wait directly stalled input and layout.

Driven entirely by master's existing **per-host** contract — `InvalidateRender()` wakes the render thread, which draws the recorded `SKPicture` via `OnNativePlatformFrameRequested` and presents. **No shared-scheduler changes** (no `OnFramePresented` / `SupportsRenderThrottle`).

### What changed
- `MacOSRenderThread` (mirrors Win32's `RenderThread`): an `AutoResetEvent`-signalled loop that acquires a drawable, draws, `Flush(submit: true)`, then presents.
- `InvalidateRender` → `SignalNewFrame()` on the Metal path (software path unchanged).
- Native acquire/present split using **`CAMetalLayer.nextDrawable`** (thread-safe, unlike `MTKView.currentDrawable` which is main-thread-only), wrapped in `@autoreleasepool`; `paused=YES; enableSetNeedsDisplay=NO`; `maximumDrawableCount = 2`.
- A paused `MTKView` never runs the draw cycle that applies a new drawable size to its `CAMetalLayer`, so `drawableSizeWillChange:` now applies it explicitly, and `uno_window_acquire_next_frame` reports the acquired texture's own dimensions rather than the layer's `drawableSize` (the two can disagree mid-resize).
- Clip-path (`uno_window_clip_svg`) updates marshalled to the main thread (AppKit layer mutation).

### Measured impact

Workload: `Performance_1000ButtonsContinuousRendering` (1000 buttons + forever `ColorAnimation`). Both builds are the same merged master, differing only in `src/Uno.UI.Runtime.Skia.MacOS/`. `sample` at 1 ms, two independent runs (40 s + 25 s), Apple M4, 120 Hz display.

**UI thread availability**

| Main thread | master | this PR |
|---|---|---|
| Busy | 62.1 – 64.8 % | **7.6 – 8.2 %** |
| Idle (free for input/layout) | 35.2 – 37.9 % | **91.8 – 92.4 %** |

**Where master's main-thread time went** (inclusive, % of main-thread samples)

| Frame | master | this PR |
|---|---|---|
| `drawInMTKView` | 39.1 % | **0 %** |
| `currentDrawable` | 39.1 % | **0 %** |
| `MetalDraw` (managed) | 38.9 % | **0 %** |

`drawInMTKView` (12840 samples) ≈ `currentDrawable` (12831) — essentially all of that 39 % is the blocking drawable/VSync wait, which is exactly what this PR removes from the UI thread.

**Throughput — no regression, better worst case**

| FPS | master | this PR |
|---|---|---|
| Median | 120 | 120 |
| Mean | 114.7 | **118.5** |
| Min | 61 | **85** |

Both saturate the 120 Hz display; the PR is better on mean and notably better on worst-case frame time. Process CPU was also lower (~22–27 % vs ~29–37 %).

### Validation

Validated on macOS 26.2 / Xcode 26.2 / Apple M4 with a locally built `libUnoNativeMac.dylib`, running `SamplesApp.Skia.Generic`:

- **Rendering correctness** — glyph/text rendering pixel-diffed against master on `Icons/FontIconControlTest`: **0 differing pixels** across the full content area (the only delta was title-bar chrome from window focus state).
- **Native element clipping** — `ContentPresenter/ContentPresenter_NativeEmbedding_ZIndex` (overlapping WebViews, animated Z-order): identical clip geometry to master (3 distinct clip paths, 1 update/sec matching the animation, no redundant re-application).
- **AcrylicBrush** — framebuffer sampling works from the render thread, including live slider-driven tint updates.
- **MediaPlayerElement** — video playback with transport controls composited over the native layer, including resize during playback.
- **Resize** — grow and shrink, at both 1x and 2x backing scale.
- **Fullscreen** enter/exit, **minimize/restore**.
- **Render thread idle behaviour** — blocked on `__psynch_cvwait` in 1729/1735 samples (99.7 %), ~1 % process CPU while idle; no spin when the window is occluded/minimized and `nextDrawable` returns nil.
- **Shutdown** — clean, no `ObjectDisposedException`, no crash reports.

### Not covered
- A live drag between two displays with different backing scale factors. The scale-change path was exercised by running at both 1x and 2x (same `drawableSizeWillChange:` funnel), but a hot display switch is untested.
- Intel (x86_64) hardware — validated on Apple Silicon only. The dylib builds universal.
