### PR TITLE
[WIP] fix: Cancel click on touch long-press menu

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
@@ -16,6 +16,17 @@ body {
     Remarks 2: If applied only on the root of the app, this won't break the scrolling (unlike if applied on all UIElement).
   */
   touch-action: none;
+  /*
+    Disable the browser's text-selection and long-press callout gestures.
+    On touch devices the browser starts a text-selection gesture on long-press (firing a haptic
+    buzz and showing selection/callout UI) before the cancelable 'contextmenu' event. Uno draws all
+    text and selection with Skia, so the browser selection is never useful and only conflicts with
+    the app's own gestures (e.g. press-and-hold to open a ContextFlyout). The hidden IME input
+    re-enables selection on itself so text editing keeps working.
+  */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .uno-root-element {

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
@@ -74,6 +74,10 @@
 			input.style.textShadow = "none";
 			input.style.overflow = "hidden";
 			input.style.pointerEvents = "none";
+			// Re-enable text selection on the IME input: the root disables it (uno.css) to suppress the
+			// browser's long-press selection gesture, but the input still needs it for editing/IME.
+			input.style.userSelect = "text";
+			(input.style as any).webkitUserSelect = "text";
 			input.style.zIndex = "99";
 			input.style.top = "0px";
 			input.style.left = "0px";

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
@@ -140,6 +140,10 @@
 			input.style.textShadow = "none";
 			input.style.overflow = "hidden";
 			input.style.pointerEvents = "none";
+			// Re-enable text selection on the IME input: the root disables it (uno.css) to suppress the
+			// browser's long-press selection gesture, but the input still needs it for editing/IME.
+			input.style.userSelect = "text";
+			(input.style as any).webkitUserSelect = "text";
 			input.style.zIndex = "99";
 			input.style.top = "0px";
 			input.style.left = "0px";

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.cs
@@ -420,7 +420,7 @@ public partial class Given_ContextRequested_Injection
 			finger.Release();
 			await TestServices.WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(0, clickCount, "Long press must NOT click the button - it should behave like a right-tap (issue #22229)");
+			Assert.AreEqual(0, clickCount, "Long press must NOT click the button - it should behave like a right-tap");
 		}
 		finally
 		{
@@ -446,7 +446,7 @@ public partial class Given_ContextRequested_Injection
 		// Simulate a context menu being shown on long-press by handling ContextRequested,
 		// without a flyout that steals focus. On a real touch device the context menu does
 		// not clear the button's pressed state via focus, so the pending Click must instead
-		// be cancelled by releasing the pointer capture (issue #22229).
+		// be cancelled by releasing the pointer capture.
 		button.ContextRequested += (s, e) =>
 		{
 			contextRequestedCount++;
@@ -476,7 +476,7 @@ public partial class Given_ContextRequested_Injection
 			finger.Release();
 			await TestServices.WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(0, clickCount, "Long press must NOT click the button once a context menu was shown (issue #22229)");
+			Assert.AreEqual(0, clickCount, "Long press must NOT click the button once a context menu was shown");
 		}
 		finally
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.cs
@@ -375,5 +375,114 @@ public partial class Given_ContextRequested_Injection
 		Assert.IsTrue(innerButton.Equals(capturedOriginalSource) || VisualTreeUtils.FindVisualParentByType<Button>(capturedOriginalSource as DependencyObject) == innerButton,
 			"OriginalSource should be the inner button where right-click occurred");
 	}
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22229")]
+	public async Task When_Touch_LongPress_Opens_ContextFlyout_Without_Click()
+	{
+		var clickCount = 0;
+		var flyoutOpened = false;
+
+		var flyout = new MenuFlyout();
+		flyout.Items.Add(new MenuFlyoutItem { Text = "Item" });
+		flyout.Opened += (s, e) => flyoutOpened = true;
+
+		var button = new Button
+		{
+			Content = "Long press me",
+			Width = 160,
+			Height = 60,
+			ContextFlyout = flyout
+		};
+		button.Click += (s, e) => clickCount++;
+
+		await UITestHelper.Load(button);
+
+		try
+		{
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init InputInjector");
+			using var finger = injector.GetFinger();
+
+			var center = button.GetAbsoluteBounds().GetCenter();
+
+			// Press and hold without releasing. The holding gesture (800ms) opens the
+			// ContextFlyout for touch, which must also cancel the pending Click on release.
+			finger.Press(center);
+
+			for (var i = 0; i < 60 && !flyoutOpened; i++)
+			{
+				await Task.Delay(50);
+				await TestServices.WindowHelper.WaitForIdle();
+			}
+
+			Assert.IsTrue(flyoutOpened, "Long press should open the ContextFlyout");
+
+			finger.Release();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, clickCount, "Long press must NOT click the button - it should behave like a right-tap (issue #22229)");
+		}
+		finally
+		{
+			flyout.Hide();
+			await TestServices.WindowHelper.WaitForIdle();
+		}
+	}
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22229")]
+	public async Task When_Touch_LongPress_ContextRequested_Handled_Does_Not_Click()
+	{
+		var clickCount = 0;
+		var contextRequestedCount = 0;
+
+		var button = new Button
+		{
+			Content = "Long press me",
+			Width = 160,
+			Height = 60
+		};
+
+		// Simulate a context menu being shown on long-press by handling ContextRequested,
+		// without a flyout that steals focus. On a real touch device the context menu does
+		// not clear the button's pressed state via focus, so the pending Click must instead
+		// be cancelled by releasing the pointer capture (issue #22229).
+		button.ContextRequested += (s, e) =>
+		{
+			contextRequestedCount++;
+			e.Handled = true;
+		};
+		button.Click += (s, e) => clickCount++;
+
+		await UITestHelper.Load(button);
+
+		try
+		{
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init InputInjector");
+			using var finger = injector.GetFinger();
+
+			var center = button.GetAbsoluteBounds().GetCenter();
+
+			finger.Press(center);
+
+			for (var i = 0; i < 60 && contextRequestedCount == 0; i++)
+			{
+				await Task.Delay(50);
+				await TestServices.WindowHelper.WaitForIdle();
+			}
+
+			Assert.AreEqual(1, contextRequestedCount, "Long press should raise ContextRequested");
+
+			finger.Release();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, clickCount, "Long press must NOT click the button once a context menu was shown (issue #22229)");
+		}
+		finally
+		{
+			await TestServices.WindowHelper.WaitForIdle();
+		}
+	}
+
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
@@ -29,6 +29,10 @@ internal partial class ContextMenuProcessor
 	private DispatcherTimer? _contextMenuTimer;
 	private Point _contextMenuOnHoldingTouchPoint = new(-1, -1);
 
+	// Uno specific: the touch pointer that triggered the holding gesture, so its capture can be
+	// released once the context menu is shown (see ReleaseContextMenuHoldingPointerCapture).
+	private uint _contextMenuOnHoldingPointerId;
+
 	public ContextMenuProcessor(ContentRoot contentRoot)
 	{
 		_contentRoot = contentRoot ?? throw new ArgumentNullException(nameof(contentRoot));
@@ -95,6 +99,32 @@ internal partial class ContextMenuProcessor
 		if (args.Handled && isTouchInput)
 		{
 			_isContextMenuOnHolding = true;
+
+			// A context menu was shown in response to a touch press-and-hold. WinUI suppresses the
+			// pending Click/Tapped because opening the menu's popup steals the OS pointer capture
+			// (raising PointerCaptureLost on the pressing element). Uno's popups don't steal capture,
+			// so release it explicitly here, matching that behavior across all targets.
+			ReleaseContextMenuHoldingPointerCapture();
+		}
+	}
+
+	/// <summary>
+	/// Releases the explicit pointer capture held for the touch pointer that triggered the holding
+	/// gesture, raising PointerCaptureLost so the pressing element (e.g. a Button) clears its pressed
+	/// state and does not raise Click/Tapped on release (issue #22229).
+	/// </summary>
+	private void ReleaseContextMenuHoldingPointerCapture()
+	{
+		if (PointerCapture.Any(out var captures))
+		{
+			foreach (var capture in captures)
+			{
+				if (capture.Pointer.PointerId == _contextMenuOnHoldingPointerId
+					&& capture.ExplicitTarget is { } captureTarget)
+				{
+					captureTarget.ReleasePointerCaptureForContextMenu(capture.Pointer);
+				}
+			}
 		}
 	}
 
@@ -166,4 +196,9 @@ internal partial class ContextMenuProcessor
 	/// Sets the touch point for context menu on holding gesture.
 	/// </summary>
 	public void SetContextMenuOnHoldingTouchPoint(Point point) => _contextMenuOnHoldingTouchPoint = point;
+
+	/// <summary>
+	/// Sets the touch pointer id that triggered the holding gesture.
+	/// </summary>
+	public void SetContextMenuOnHoldingPointer(uint pointerId) => _contextMenuOnHoldingPointerId = pointerId;
 }

--- a/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
@@ -31,7 +31,8 @@ internal partial class ContextMenuProcessor
 
 	// Uno specific: the touch pointer that triggered the holding gesture, so its capture can be
 	// released once the context menu is shown (see ReleaseContextMenuHoldingPointerCapture).
-	private uint _contextMenuOnHoldingPointerId;
+	// Nullable as 0 is a valid pointer id (e.g. first finger on an Android device with deviceId 0).
+	private uint? _contextMenuOnHoldingPointerId;
 
 	public ContextMenuProcessor(ContentRoot contentRoot)
 	{
@@ -111,15 +112,21 @@ internal partial class ContextMenuProcessor
 	/// <summary>
 	/// Releases the explicit pointer capture held for the touch pointer that triggered the holding
 	/// gesture, raising PointerCaptureLost so the pressing element (e.g. a Button) clears its pressed
-	/// state and does not raise Click/Tapped on release (issue #22229).
+	/// state and does not raise Click/Tapped on release.
 	/// </summary>
 	private void ReleaseContextMenuHoldingPointerCapture()
 	{
+		// No holding pointer was recorded (e.g. ContextRequested raised without a holding gesture).
+		if (_contextMenuOnHoldingPointerId is not { } holdingPointerId)
+		{
+			return;
+		}
+
 		if (PointerCapture.Any(out var captures))
 		{
 			foreach (var capture in captures)
 			{
-				if (capture.Pointer.PointerId == _contextMenuOnHoldingPointerId
+				if (capture.Pointer.PointerId == holdingPointerId
 					&& capture.ExplicitTarget is { } captureTarget)
 				{
 					captureTarget.ReleasePointerCaptureForContextMenu(capture.Pointer);

--- a/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
@@ -29,6 +29,10 @@ internal partial class ContextMenuProcessor
 	private DispatcherTimer? _contextMenuTimer;
 	private Point _contextMenuOnHoldingTouchPoint = new(-1, -1);
 
+	// Uno specific: the touch pointer that triggered the holding gesture, so its capture can be
+	// released once the context menu is shown (see ReleaseContextMenuHoldingPointerCapture).
+	private uint _contextMenuOnHoldingPointerId;
+
 	public ContextMenuProcessor(ContentRoot contentRoot)
 	{
 		_contentRoot = contentRoot ?? throw new ArgumentNullException(nameof(contentRoot));
@@ -98,6 +102,32 @@ internal partial class ContextMenuProcessor
 		if (args.Handled && isTouchInput && !args.PreventContextMenuOnHolding)
 		{
 			_isContextMenuOnHolding = true;
+
+			// A context menu was shown in response to a touch press-and-hold. WinUI suppresses the
+			// pending Click/Tapped because opening the menu's popup steals the OS pointer capture
+			// (raising PointerCaptureLost on the pressing element). Uno's popups don't steal capture,
+			// so release it explicitly here, matching that behavior across all targets.
+			ReleaseContextMenuHoldingPointerCapture();
+		}
+	}
+
+	/// <summary>
+	/// Releases the explicit pointer capture held for the touch pointer that triggered the holding
+	/// gesture, raising PointerCaptureLost so the pressing element (e.g. a Button) clears its pressed
+	/// state and does not raise Click/Tapped on release (issue #22229).
+	/// </summary>
+	private void ReleaseContextMenuHoldingPointerCapture()
+	{
+		if (PointerCapture.Any(out var captures))
+		{
+			foreach (var capture in captures)
+			{
+				if (capture.Pointer.PointerId == _contextMenuOnHoldingPointerId
+					&& capture.ExplicitTarget is { } captureTarget)
+				{
+					captureTarget.ReleasePointerCaptureForContextMenu(capture.Pointer);
+				}
+			}
 		}
 	}
 
@@ -169,4 +199,9 @@ internal partial class ContextMenuProcessor
 	/// Sets the touch point for context menu on holding gesture.
 	/// </summary>
 	public void SetContextMenuOnHoldingTouchPoint(Point point) => _contextMenuOnHoldingTouchPoint = point;
+
+	/// <summary>
+	/// Sets the touch pointer id that triggered the holding gesture.
+	/// </summary>
+	public void SetContextMenuOnHoldingPointer(uint pointerId) => _contextMenuOnHoldingPointerId = pointerId;
 }

--- a/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
@@ -31,7 +31,8 @@ internal partial class ContextMenuProcessor
 
 	// Uno specific: the touch pointer that triggered the holding gesture, so its capture can be
 	// released once the context menu is shown (see ReleaseContextMenuHoldingPointerCapture).
-	private uint _contextMenuOnHoldingPointerId;
+	// Nullable as 0 is a valid pointer id (e.g. first finger on an Android device with deviceId 0).
+	private uint? _contextMenuOnHoldingPointerId;
 
 	public ContextMenuProcessor(ContentRoot contentRoot)
 	{
@@ -114,15 +115,21 @@ internal partial class ContextMenuProcessor
 	/// <summary>
 	/// Releases the explicit pointer capture held for the touch pointer that triggered the holding
 	/// gesture, raising PointerCaptureLost so the pressing element (e.g. a Button) clears its pressed
-	/// state and does not raise Click/Tapped on release (issue #22229).
+	/// state and does not raise Click/Tapped on release.
 	/// </summary>
 	private void ReleaseContextMenuHoldingPointerCapture()
 	{
+		// No holding pointer was recorded (e.g. ContextRequested raised without a holding gesture).
+		if (_contextMenuOnHoldingPointerId is not { } holdingPointerId)
+		{
+			return;
+		}
+
 		if (PointerCapture.Any(out var captures))
 		{
 			foreach (var capture in captures)
 			{
-				if (capture.Pointer.PointerId == _contextMenuOnHoldingPointerId
+				if (capture.Pointer.PointerId == holdingPointerId
 					&& capture.ExplicitTarget is { } captureTarget)
 				{
 					captureTarget.ReleasePointerCaptureForContextMenu(capture.Pointer);

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1653,7 +1653,7 @@ namespace Microsoft.UI.Xaml
 		/// Releases the explicit pointer capture and raises an <em>unhandled</em> PointerCaptureLost so the
 		/// pressing control clears its pressed state. Used when a context menu is shown on a touch press-and-hold:
 		/// WinUI clears the pressed state via the OS pointer-capture-changed raised when the menu's popup steals
-		/// capture, but Uno's popups don't, so we do it explicitly (issue #22229).
+		/// capture, but Uno's popups don't, so we do it explicitly.
 		/// </summary>
 		/// <remarks>
 		/// The capture tracks the args from the PointerPressed, which the pressing control marks as Handled.

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -483,6 +483,9 @@ namespace Microsoft.UI.Xaml
 						// but ContextRequestedEventArgs.TryGetPosition expects global coordinates.
 						var globalPosition = that.TransformToVisual(null).TransformPoint(args.Position);
 						contentRoot.InputManager.ContextMenuProcessor.SetContextMenuOnHoldingTouchPoint(globalPosition);
+						// Record the pointer so that, once the context menu is actually shown, its capture
+						// can be released to cancel the pending Click/Tapped on the pressing element.
+						contentRoot.InputManager.ContextMenuProcessor.SetContextMenuOnHoldingPointer(args.PointerId);
 						contentRoot.InputManager.ContextMenuProcessor.ProcessContextRequestOnHoldingGesture(src);
 					}
 					else if (args.HoldingState == HoldingState.Canceled)
@@ -1644,6 +1647,33 @@ namespace Microsoft.UI.Xaml
 			}
 
 			Release(PointerCaptureKind.Explicit);
+		}
+
+		/// <summary>
+		/// Releases the explicit pointer capture and raises an <em>unhandled</em> PointerCaptureLost so the
+		/// pressing control clears its pressed state. Used when a context menu is shown on a touch press-and-hold:
+		/// WinUI clears the pressed state via the OS pointer-capture-changed raised when the menu's popup steals
+		/// capture, but Uno's popups don't, so we do it explicitly (issue #22229).
+		/// </summary>
+		/// <remarks>
+		/// The capture tracks the args from the PointerPressed, which the pressing control marks as Handled.
+		/// PointerCaptureLost reuses those args, so we reset Handled first - otherwise the control's class handler
+		/// (which only runs for unhandled events) never clears the pressed state.
+		/// </remarks>
+		internal void ReleasePointerCaptureForContextMenu(Pointer pointer)
+		{
+			if (PointerCapture.TryGet(pointer, out var capture))
+			{
+				foreach (var target in capture.GetTargets(PointerCaptureKind.Explicit))
+				{
+					if (target.LastDispatched is { } lastDispatched)
+					{
+						lastDispatched.Handled = false;
+					}
+				}
+			}
+
+			ReleasePointerCapture(pointer);
 		}
 		#endregion
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -473,6 +473,9 @@ namespace Microsoft.UI.Xaml
 						// but ContextRequestedEventArgs.TryGetPosition expects global coordinates.
 						var globalPosition = that.TransformToVisual(null).TransformPoint(args.Position);
 						contentRoot.InputManager.ContextMenuProcessor.SetContextMenuOnHoldingTouchPoint(globalPosition);
+						// Record the pointer so that, once the context menu is actually shown, its capture
+						// can be released to cancel the pending Click/Tapped on the pressing element.
+						contentRoot.InputManager.ContextMenuProcessor.SetContextMenuOnHoldingPointer(args.PointerId);
 						contentRoot.InputManager.ContextMenuProcessor.ProcessContextRequestOnHoldingGesture(src);
 					}
 					else if (args.HoldingState == HoldingState.Canceled)
@@ -1615,6 +1618,33 @@ namespace Microsoft.UI.Xaml
 			}
 
 			Release(PointerCaptureKind.Explicit);
+		}
+
+		/// <summary>
+		/// Releases the explicit pointer capture and raises an <em>unhandled</em> PointerCaptureLost so the
+		/// pressing control clears its pressed state. Used when a context menu is shown on a touch press-and-hold:
+		/// WinUI clears the pressed state via the OS pointer-capture-changed raised when the menu's popup steals
+		/// capture, but Uno's popups don't, so we do it explicitly (issue #22229).
+		/// </summary>
+		/// <remarks>
+		/// The capture tracks the args from the PointerPressed, which the pressing control marks as Handled.
+		/// PointerCaptureLost reuses those args, so we reset Handled first - otherwise the control's class handler
+		/// (which only runs for unhandled events) never clears the pressed state.
+		/// </remarks>
+		internal void ReleasePointerCaptureForContextMenu(Pointer pointer)
+		{
+			if (PointerCapture.TryGet(pointer, out var capture))
+			{
+				foreach (var target in capture.GetTargets(PointerCaptureKind.Explicit))
+				{
+					if (target.LastDispatched is { } lastDispatched)
+					{
+						lastDispatched.Handled = false;
+					}
+				}
+			}
+
+			ReleasePointerCapture(pointer);
 		}
 		#endregion
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1624,7 +1624,7 @@ namespace Microsoft.UI.Xaml
 		/// Releases the explicit pointer capture and raises an <em>unhandled</em> PointerCaptureLost so the
 		/// pressing control clears its pressed state. Used when a context menu is shown on a touch press-and-hold:
 		/// WinUI clears the pressed state via the OS pointer-capture-changed raised when the menu's popup steals
-		/// capture, but Uno's popups don't, so we do it explicitly (issue #22229).
+		/// capture, but Uno's popups don't, so we do it explicitly.
 		/// </summary>
 		/// <remarks>
 		/// The capture tracks the args from the PointerPressed, which the pressing control marks as Handled.


### PR DESCRIPTION
On Skia targets, long-pressing a control (e.g. a Button) with a
ContextFlyout both opened the menu AND raised Click, instead of
behaving like a right-tap. WinUI suppresses the click because opening
the menu's popup steals the OS pointer capture (PointerCaptureLost);
Uno's in-canvas popups don't, so the pressed state was never cleared.

When a context menu is shown on a touch press-and-hold, release the
pressing element's pointer capture and raise an unhandled
PointerCaptureLost so the control clears its pressed state and does not
click on release.

fixes #22229

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WQEkhvePgnJMns2KhVNUxr**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
