### PR TITLE
refactor!: Remove EventsBubblingInManagedCode DP (BC04)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2515,6 +2515,10 @@
 		       FrameworkElement keeps them, so its members are never reported as removed and are unaffected by these patterns. -->
 		  <Member fullName="System\.Object .+(::|\.)DataContext\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
 		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)DataContextProperty\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+
+		  <!-- Uno-only native-bubbling knob (no WinUI counterpart); meaningless once native bubbling is gone on Skia. -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.UIElement::EventsBubblingInManagedCodeProperty()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Xaml.RoutedEventFlag Microsoft.UI.Xaml.UIElement::EventsBubblingInManagedCode()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
 	  </Properties>
 
 	  <Methods>
@@ -2887,6 +2891,11 @@
 		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)get_DataContextProperty\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
 		  <Member fullName="System\.Void .+(::|\.)add_DataContextChanged\(.+\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
 		  <Member fullName="System\.Void .+(::|\.)remove_DataContextChanged\(.+\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+
+		  <!-- EventsBubblingInManagedCode accessors: paired with the removed DP (see <Properties> above). Uno-only native-bubbling knob with no WinUI counterpart. -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.UIElement.get_EventsBubblingInManagedCodeProperty()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Xaml.RoutedEventFlag Microsoft.UI.Xaml.UIElement.get_EventsBubblingInManagedCode()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.UIElement.set_EventsBubblingInManagedCode(Uno.UI.Xaml.RoutedEventFlag value)" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
 	  </Methods>
 
 	  <Events>

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -68,24 +68,12 @@ This article covers some of the finer technical details of Uno Platform's routed
 
 ## Native bubbling vs Managed bubbling
 
-A special property named `EventsBubblingInManagedCode` is used to determine how properties are propagated through
-the platform. This value of this property is inherited in the visual tree.
+On the native targets (native Android Views, iOS/UIKit, WASM DOM), routed events that originate from the
+platform bubble natively by default (except for those which can't bubble natively like `LostFocus` on iOS or
+`KeyDown` on Android). Bubbling natively improves interoperability with native UI elements in the visual tree
+by letting the platform propagate the events, at the cost of more interop between managed and unmanaged code.
 
-This value is set to `RoutedEventFlag.None` by default, so all routed events are bubbling natively by default
-(except for those which can't bubble natively like `LostFocus` on iOS or `KeyDown` on Android).
-
-Bubbling natively will improve interoperability with native UI elements in the visual tree by letting the
-platform propagate the events. But this will cause more interop between managed and unmanaged code.
-
-You can control which events are bubbling in managed code by using the `EventsBubblingInManagedCode`
-dependency property. The value of this property is inherited to children. Example:
-
-```csharp
-  // Make sure PointerPressed and PointerReleased are always bubbling in
-  // managed code when they are originating from myControl and its children.
-  myControl.EventsBubblingInManagedCode =
-      RoutedEventFlag.PointerPressed | RoutedEventFlag.PointerReleased;
-```
+On the Skia targets there is no native visual tree, so every routed event bubbles in managed code.
 
 ### Limitations of managed bubbling
 

--- a/src/Uno.UI.UnitTests/RoutedEventTests/Given_TappedRoutedEvent.cs
+++ b/src/Uno.UI.UnitTests/RoutedEventTests/Given_TappedRoutedEvent.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.Xaml;
 
 namespace Uno.UI.Tests.RoutedEventTests
 {
@@ -295,47 +294,6 @@ namespace Uno.UI.Tests.RoutedEventTests
 			// Here the "platform" is eating the native bubbling event, so no handlers should receive it.
 
 			events.Should().HaveCount(0);
-		}
-
-		[TestMethod]
-		public void When_SubscribingUsingAddHandler_WithHandlesToo_And_BubblingInNativeCode_SetToBubbleInManaged_EatenByPlatform()
-		{
-			var events = new List<(object sender, TappedRoutedEventArgs args)>();
-
-			var child2 = new Border
-			{
-				Name = "child2"
-			};
-			var child1 = new Border
-			{
-				Child = child2,
-				Name = "child1"
-			};
-			var root = new Border
-			{
-				Child = child1,
-				Name = "root",
-				EventsBubblingInManagedCode = RoutedEventFlag.Tapped
-			};
-
-			void OnTapped(object snd, TappedRoutedEventArgs evt)
-			{
-				events.Add((snd, evt));
-				evt.Handled = true;
-			}
-
-			root.AddHandler(UIElement.TappedEvent, (TappedEventHandler)OnTapped, true);
-			child1.AddHandler(UIElement.TappedEvent, (TappedEventHandler)OnTapped, true);
-
-			root.Measure(new Size(1, 1));
-
-			var evt1 = new TappedRoutedEventArgs()
-			{
-				CanBubbleNatively = true
-			};
-			child2.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeTrue();
-
-			events.Should().HaveCount(2); // bubbling in managed code
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -197,54 +197,6 @@ namespace Microsoft.UI.Xaml
 			internal bool HandledEventsToo { get; }
 		}
 
-		#region EventsBubblingInManagedCode DependencyProperty
-
-		public static DependencyProperty EventsBubblingInManagedCodeProperty { get; } = DependencyProperty.Register(
-			"EventsBubblingInManagedCode",
-			typeof(RoutedEventFlag),
-			typeof(UIElement),
-			new FrameworkPropertyMetadata(
-				RoutedEventFlag.None,
-				FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals)
-			{
-				CoerceValueCallback = CoerceRoutedEventFlag
-			}
-		);
-
-		public RoutedEventFlag EventsBubblingInManagedCode
-		{
-			get => (RoutedEventFlag)GetValue(EventsBubblingInManagedCodeProperty);
-			set => SetValue(EventsBubblingInManagedCodeProperty, value);
-		}
-
-		#endregion
-
-		private static object CoerceRoutedEventFlag(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences precedence)
-		{
-			var @this = (UIElement)dependencyObject;
-
-			// ReadLocalValue will read an outdated value for the precedence currently being set
-			var localValue = precedence is DependencyPropertyValuePrecedences.Local ?
-				baseValue :
-				@this.ReadLocalValue(EventsBubblingInManagedCodeProperty);
-
-			var inheritedValue = precedence is DependencyPropertyValuePrecedences.Inheritance ?
-				baseValue :
-				((IDependencyObjectStoreProvider)@this).Store.ReadInheritedValueOrDefaultValue(EventsBubblingInManagedCodeProperty);
-
-			var combinedFlag = RoutedEventFlag.None;
-			if (localValue is RoutedEventFlag local)
-			{
-				combinedFlag |= local;
-			}
-			if (inheritedValue is RoutedEventFlag inherited)
-			{
-				combinedFlag |= inherited;
-			}
-
-			return combinedFlag;
-		}
-
 		private readonly Dictionary<RoutedEvent, List<RoutedEventHandlerInfo>> _eventHandlerStore
 			= new Dictionary<RoutedEvent, List<RoutedEventHandlerInfo>>();
 
@@ -707,8 +659,8 @@ namespace Microsoft.UI.Xaml
 				return isHandled;
 			}
 
-			// [6] & [7] Will the event bubbling natively or in managed code?
-			var isBubblingInManagedCode = IsBubblingInManagedCode(routedEvent, args);
+			// [6] Will the event bubbling natively or in managed code?
+			var isBubblingInManagedCode = IsBubblingInManagedCode(args);
 			if (!isBubblingInManagedCode)
 			{
 				return false; // [8] Return for native bubbling
@@ -964,21 +916,10 @@ namespace Microsoft.UI.Xaml
 		private static bool IsHandled(RoutedEventArgs args)
 			=> args is IHandleableRoutedEventArgs { Handled: true };
 
-		private bool IsBubblingInManagedCode(RoutedEvent routedEvent, RoutedEventArgs args)
-		{
-			if (args == null || !args.CanBubbleNatively) // [6] From platform?
-			{
-				// Not from platform
-
-				return true; // -> [10] bubble in managed to parents
-			}
-
-			// [7] Event set to bubble in managed code?
-			var eventsBubblingInManagedCode = EventsBubblingInManagedCode;
-			var flag = routedEvent.Flag;
-
-			return eventsBubblingInManagedCode.HasFlag(flag);
-		}
+		// [6] Events that didn't originate from the platform always bubble in managed code to parents ([10]);
+		// events still flagged as bubbling natively are returned for native bubbling ([8]).
+		private static bool IsBubblingInManagedCode(RoutedEventArgs args)
+			=> args is null || !args.CanBubbleNatively;
 
 #pragma warning disable IDE0055 // Fix formatting: Current formatting is readable and rule expectation is unclear
 		private void InvokeHandlers(IList<RoutedEventHandlerInfo> handlers, RoutedEventArgs args, ref bool isHandled)


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/uno-private/issues/2125

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

> ⚠️ Contains a **breaking change** (`refactor!`) — removes public API. See the breaking-changes section below.

## What changed? 🚀

Implements **BC04** from breaking-changes Phase 3 (#8339): removes the public Uno-only `UIElement.EventsBubblingInManagedCode` dependency property — a native-bubbling knob with no WinUI counterpart that let apps force specific routed events to bubble in managed code on the native targets.

- Removes the static `EventsBubblingInManagedCodeProperty`, the instance `EventsBubblingInManagedCode` accessor, and the `CoerceRoutedEventFlag` coerce callback from `UIElement.RoutedEvents.cs`.
- Simplifies the sole consumer to `IsBubblingInManagedCode(args) => args is null || !args.CanBubbleNatively` (the `routedEvent` parameter is no longer needed).
- Keeps the native-bubbling plumbing (`CanBubbleNatively`) intact so the native heads keep behaving as-is.
- Removes the one unit test that exercised the removed override, and trims the doc prose for the removed knob (the flowchart, the numbered flow steps, and the "Limitations of … bubbling" sections stay — they describe the still-present `CanBubbleNatively` mechanism).
- Registers the public-API removal in `build/PackageDiffIgnore.xml` (6.6 set, matching the baseline already used for this branch's breaking-change entries).

**On default settings runtime behavior is unchanged.** The property defaulted to `RoutedEventFlag.None`, so `None.HasFlag(realFlag)` was already `false` and `IsBubblingInManagedCode` deferred to native bubbling whenever `CanBubbleNatively`. The simplified helper returns `false` in exactly that same case — only the app-settable override is gone.

## PR Checklist ✅

- [x] 🧪 The affected unit test slice (`Given_TappedRoutedEvent`) passes — 10 passed / 0 failed, including the 3 surviving `CanBubbleNatively=true` scenarios that prove the default path is intact.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- Breaking change impact & migration path -->
### Breaking changes & migration

- **`EventsBubblingInManagedCode` (BC04):** the public `UIElement.EventsBubblingInManagedCode` DP (and `EventsBubblingInManagedCodeProperty`) is removed. It only had an effect on the native targets (native Android Views, iOS/UIKit, WASM DOM) for forcing native-originated routed events to bubble in managed code; on Skia it was already a no-op. Migration: there is no replacement — the default behavior (native bubbling when the platform supports it, otherwise managed bubbling) is preserved automatically. Apps that set the property purely to influence native interop should remove the assignment.

### Validation evidence

- **Compile:** `Uno.UI.UnitTests` (Uno.UI Reference flavor) builds clean — 0 warnings, 0 errors.
- **Runtime (unit tests):** `Given_TappedRoutedEvent` — 10 passed / 0 failed.
- **Not validated locally (CI-gated):** native heads (iOS/Android) were not built locally. The change is in shared, unguarded code and a repo-wide grep found zero platform-specific references to the removed API, so native compilation is expected to be safe; the `PackageDiff` allow-list runs CI-only.
