### PR TITLE
fix: Raise WinUI-faithful ChildAdded/ChildRemoved UIA events

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -32,8 +32,23 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 	private readonly Win32SyntheticPaneProvider _innerPane;
 	private readonly ConditionalWeakTable<UIElement, Win32RawElementProvider> _providers = new();
 	private readonly ConditionalWeakTable<AutomationPeer, Win32RawElementProvider> _peerProviders = new();
-	private readonly HashSet<Win32RawElementProvider> _pendingStructureChanges = new();
+	// Pending StructureChanged events, coalesced onto the dispatcher. We record the specific
+	// add/remove/invalidate so the flush can emit the WinUI-faithful event type (ChildAdded on the
+	// added element, ChildRemoved on the container with the removed child's runtime id) rather than
+	// a blanket ChildrenInvalidated. See AutomationEventsHelper::StructureChangedEventInformation
+	// (microsoft-ui-xaml). Kind.Invalidated is the coarse fallback for peer-initiated changes.
+	private enum StructureChangeKind { Added, Removed, Invalidated }
+	private readonly record struct PendingStructureChange(
+		Win32RawElementProvider Container,
+		Win32RawElementProvider? Child,
+		StructureChangeKind Kind,
+		int[]? ChildRuntimeId);
+	private readonly List<PendingStructureChange> _pendingStructureChanges = new();
 	private bool _structureChangeFlushQueued;
+
+	// Matches WinUI's AP_BULK_CHILDREN_LIMIT: more than this many add/remove on one container in a
+	// single coalescing window collapses to a single ChildrenInvalidated/ChildrenBulk* event.
+	private const int BulkChildrenLimit = 20;
 
 	internal Win32RawElementProvider? RootProvider => _rootProvider;
 
@@ -272,26 +287,130 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 
 	protected override void OnChildAdded(UIElement parent, UIElement child, int? index)
 	{
-		// Raise structure changed event on the nearest ancestor that has a provider.
-		// Child providers will be lazily created when UIA navigates to them.
+		// A child entered the tree / the composition (PC) scene (e.g. a DataGrid cell flipped
+		// Collapsed->Visible when its column scrolled into view). Faithful to WinUI: when a UIA
+		// client is listening, this raises a ChildAdded event ON THE ADDED ELEMENT itself (with a
+		// null runtime id) — see CUIElement::EnterPCScene -> RegisterForStructureChangedEvent(Added)
+		// -> AutomationEventsHelper. A blanket ChildrenInvalidated on an ancestor (the prior
+		// behaviour) is invisible to screen readers like Narrator that key off ChildAdded to
+		// incorporate/announce a newly revealed element, so the revealed content was rendered but
+		// never surfaced to automation.
 		var ancestorProvider = FindNearestAncestorProvider(parent);
-		if (ancestorProvider is not null)
+		if (ancestorProvider is null)
 		{
-			RaiseStructureChanged(ancestorProvider);
+			return;
+		}
+
+		// Drop the cached children along the path so the next navigation rebuilds from current state.
+		ancestorProvider.InvalidateChildrenCache();
+
+		if (!Win32UIAutomationInterop.UiaClientsAreListening())
+		{
+			return;
+		}
+
+		// ChildAdded is associated with the added element, so we must materialize its provider.
+		// Gated above on a listening client to avoid COM-wrapper churn during normal layout.
+		var childProvider = GetOrCreateProvider(child);
+		if (childProvider is not null)
+		{
+			QueueStructureChange(new PendingStructureChange(ancestorProvider, childProvider, StructureChangeKind.Added, null));
+			return;
+		}
+
+		// The entering element has no automation peer of its own (e.g. a WCT DataGridCell whose
+		// only automation content is a flattened TextBlock descendant). Faithful to WinUI's
+		// EnterPCSceneRecursive, walk into the now-visible subtree and raise ChildAdded for each
+		// shallowest peer-bearing descendant — otherwise the revealed text (the cell value) would
+		// be announced by no event at all. Fall back to the coarse signal only if none is found.
+		var entering = new List<Win32RawElementProvider>();
+		CollectEnteringProviders(child, entering, 0);
+		if (entering.Count > 0)
+		{
+			foreach (var provider in entering)
+			{
+				QueueStructureChange(new PendingStructureChange(ancestorProvider, provider, StructureChangeKind.Added, null));
+			}
+		}
+		else
+		{
+			QueueStructureChange(new PendingStructureChange(ancestorProvider, null, StructureChangeKind.Invalidated, null));
+		}
+	}
+
+	/// <summary>
+	/// Collects the shallowest peer-bearing descendant providers of an element entering the scene,
+	/// recursing through peer-less (flattened) elements and skipping Collapsed branches. Mirrors the
+	/// flattening of <see cref="Win32RawElementProvider"/>'s child walk / WinUI EnterPCSceneRecursive.
+	/// </summary>
+	private void CollectEnteringProviders(UIElement element, List<Win32RawElementProvider> result, int depth)
+	{
+		if (depth > 64)
+		{
+			return;
+		}
+
+		foreach (var child in element.GetChildren())
+		{
+			if (child.Visibility == Visibility.Collapsed)
+			{
+				continue;
+			}
+
+			if (GetOrCreateProvider(child) is { } provider)
+			{
+				result.Add(provider);
+			}
+			else
+			{
+				CollectEnteringProviders(child, result, depth + 1);
+			}
 		}
 	}
 
 	protected override void OnChildRemoved(UIElement parent, UIElement child)
 	{
-		// Clean up cached providers for the removed subtree
+		// Capture the removed child's runtime id BEFORE cleanup — ChildRemoved carries it so a
+		// client can drop exactly that node. Only an already-existing provider is meaningful here.
+		var listening = Win32UIAutomationInterop.UiaClientsAreListening();
+		int[]? childRuntimeId = listening ? TryGetExistingProviderForElement(child)?.GetRuntimeId() : null;
+
+		// Clean up cached providers for the removed subtree.
 		CleanupProviders(child);
 
-		// Raise structure changed event on the nearest ancestor
+		// Faithful to WinUI: a child leaving the PC scene (e.g. a cell collapsing as its column
+		// scrolls off) raises ChildRemoved ON THE CONTAINER with the removed child's runtime id
+		// (CUIElement::LeavePCScene -> RegisterForStructureChangedEvent(Removed)).
 		var ancestorProvider = FindNearestAncestorProvider(parent);
-		if (ancestorProvider is not null)
+		if (ancestorProvider is null)
 		{
-			RaiseStructureChanged(ancestorProvider);
+			return;
 		}
+
+		ancestorProvider.InvalidateChildrenCache();
+
+		if (!listening)
+		{
+			return;
+		}
+
+		QueueStructureChange(childRuntimeId is not null
+			? new PendingStructureChange(ancestorProvider, null, StructureChangeKind.Removed, childRuntimeId)
+			: new PendingStructureChange(ancestorProvider, null, StructureChangeKind.Invalidated, null));
+	}
+
+	/// <summary>
+	/// Resolves an element's already-created provider (element- or peer-keyed) without creating one.
+	/// </summary>
+	private Win32RawElementProvider? TryGetExistingProviderForElement(UIElement element)
+	{
+		if (_providers.TryGetValue(element, out var provider))
+		{
+			return provider;
+		}
+
+		var peer = element.GetOrCreateAutomationPeer();
+		return peer is not null ? FindExistingProviderForPeer(peer, resolveEventsSource: true) : null;
 	}
 
 	protected override void OnSizeOrOffsetChanged(Visual visual)
@@ -336,7 +455,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 				// Clear cached peer lists so a stale provider cannot keep the
 				// removed subtree alive.
 				provider.InvalidateChildrenCache();
-				_pendingStructureChanges.Remove(provider);
+				_pendingStructureChanges.RemoveAll(p => ReferenceEquals(p.Container, provider) || ReferenceEquals(p.Child, provider));
 
 				_providers.Remove(current);
 				if (provider.RepresentedPeer is { } representedPeer)
@@ -379,13 +498,26 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		return _rootProvider;
 	}
 
+	/// <summary>
+	/// Coarse StructureChanged (ChildrenInvalidated) for peer-initiated changes where we don't know
+	/// the specific added/removed child (e.g. a peer raising AutomationEvents.StructureChanged).
+	/// </summary>
 	private void RaiseStructureChanged(Win32RawElementProvider provider)
 	{
-		// Invalidate the children cache so the next navigation rebuilds the list
+		// Invalidate the children cache (cascading) so the next navigation rebuilds the list.
 		provider.InvalidateChildrenCache();
+		QueueStructureChange(new PendingStructureChange(provider, null, StructureChangeKind.Invalidated, null));
+	}
 
-		// Coalesce rapid StructureChanged events into a single deferred dispatch.
-		_pendingStructureChanges.Add(provider);
+	/// <summary>
+	/// Records a pending StructureChanged and schedules a coalesced flush on the dispatcher.
+	/// Deferring rather than raising synchronously avoids UIA re-entering GetChildren while a peer
+	/// is still computing its children (WCT's DataGridItemAutomationPeer.GetChildrenCore calls
+	/// OwningRowPeer.InvalidatePeer() from inside that very call).
+	/// </summary>
+	private void QueueStructureChange(PendingStructureChange change)
+	{
+		_pendingStructureChanges.Add(change);
 		if (_structureChangeFlushQueued)
 		{
 			return;
@@ -396,36 +528,103 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		{
 			_structureChangeFlushQueued = false;
 
-			// Short-circuit the flush if the window was closed while this callback
-			// was queued (edge case "Window close during dispatch").
+			// Short-circuit the flush if the window was closed while this callback was queued.
 			if (IsDisposed)
 			{
 				_pendingStructureChanges.Clear();
 				return;
 			}
 
-			foreach (var pending in _pendingStructureChanges)
-			{
-				RaiseStructureChangedCore(pending);
-			}
-			_pendingStructureChanges.Clear();
+			FlushStructureChanges();
 		});
 	}
 
-	private void RaiseStructureChangedCore(Win32RawElementProvider provider)
+	/// <summary>
+	/// Emits the queued StructureChanged events, grouped per container and applying WinUI's bulk
+	/// thresholding (AutomationEventsHelper::StructureChangedEventInformation::RaiseStructureChangedEvent):
+	/// up to <see cref="BulkChildrenLimit"/> changes per container emit individual ChildAdded (on the
+	/// added element) / ChildRemoved (on the container, carrying the child runtime id); beyond that
+	/// they collapse to ChildrenBulkAdded / ChildrenBulkRemoved / ChildrenInvalidated on the container.
+	/// </summary>
+	private void FlushStructureChanges()
+	{
+		var groups = new Dictionary<Win32RawElementProvider, (List<Win32RawElementProvider> Added, List<int[]> Removed, bool Invalidated)>(ReferenceEqualityComparer.Instance);
+
+		foreach (var change in _pendingStructureChanges)
+		{
+			if (!groups.TryGetValue(change.Container, out var group))
+			{
+				group = (new List<Win32RawElementProvider>(), new List<int[]>(), false);
+			}
+
+			switch (change.Kind)
+			{
+				case StructureChangeKind.Added when change.Child is not null:
+					group.Added.Add(change.Child);
+					break;
+				case StructureChangeKind.Removed when change.ChildRuntimeId is not null:
+					group.Removed.Add(change.ChildRuntimeId);
+					break;
+				default:
+					group.Invalidated = true;
+					break;
+			}
+
+			groups[change.Container] = group;
+		}
+
+		_pendingStructureChanges.Clear();
+
+		foreach (var (container, group) in groups)
+		{
+			var total = group.Added.Count + group.Removed.Count;
+
+			// Too many changes (or an explicit coarse request) -> a single ChildrenInvalidated.
+			if (group.Invalidated || total > BulkChildrenLimit)
+			{
+				RaiseStructureChangedCore(container, StructureChangeType.ChildrenInvalidated, null);
+				continue;
+			}
+
+			if (group.Added.Count >= BulkChildrenLimit)
+			{
+				RaiseStructureChangedCore(container, StructureChangeType.ChildrenBulkAdded, null);
+			}
+			else
+			{
+				// ChildAdded is raised on the added element itself, with a null runtime id.
+				foreach (var child in group.Added)
+				{
+					RaiseStructureChangedCore(child, StructureChangeType.ChildAdded, null);
+				}
+			}
+
+			if (group.Removed.Count >= BulkChildrenLimit)
+			{
+				RaiseStructureChangedCore(container, StructureChangeType.ChildrenBulkRemoved, null);
+			}
+			else
+			{
+				// ChildRemoved is raised on the container, carrying the removed child's runtime id.
+				foreach (var removedRuntimeId in group.Removed)
+				{
+					RaiseStructureChangedCore(container, StructureChangeType.ChildRemoved, removedRuntimeId);
+				}
+			}
+		}
+	}
+
+	private void RaiseStructureChangedCore(Win32RawElementProvider provider, StructureChangeType type, int[]? runtimeId)
 	{
 		try
 		{
-			_ = Win32UIAutomationInterop.UiaRaiseStructureChangedEvent(
-				provider,
-				StructureChangeType.ChildrenInvalidated,
-				provider.GetRuntimeId());
+			_ = Win32UIAutomationInterop.UiaRaiseStructureChangedEvent(provider, type, runtimeId);
 		}
 		catch (Exception ex)
 		{
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
-				this.Log().Debug($"RaiseStructureChanged failed: {ex.Message}");
+				this.Log().Debug($"RaiseStructureChanged ({type}) failed: {ex.Message}");
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -46,8 +46,10 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 	private readonly List<PendingStructureChange> _pendingStructureChanges = new();
 	private bool _structureChangeFlushQueued;
 
-	// Matches WinUI's AP_BULK_CHILDREN_LIMIT: more than this many add/remove on one container in a
-	// single coalescing window collapses to a single ChildrenInvalidated/ChildrenBulk* event.
+	// Matches WinUI's AP_BULK_CHILDREN_LIMIT. Within one coalescing window, per container:
+	// if total add+remove exceeds this, collapse to a single ChildrenInvalidated; otherwise a
+	// per-type count that reaches this emits ChildrenBulkAdded/ChildrenBulkRemoved, and below it
+	// individual ChildAdded/ChildRemoved.
 	private const int BulkChildrenLimit = 20;
 
 	internal Win32RawElementProvider? RootProvider => _rootProvider;
@@ -296,10 +298,6 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		// incorporate/announce a newly revealed element, so the revealed content was rendered but
 		// never surfaced to automation.
 		var ancestorProvider = FindNearestAncestorProvider(parent);
-		if (ancestorProvider is null)
-		{
-			return;
-		}
 
 		// Drop the cached children along the path so the next navigation rebuilds from current state.
 		ancestorProvider.InvalidateChildrenCache();
@@ -382,11 +380,6 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		// scrolls off) raises ChildRemoved ON THE CONTAINER with the removed child's runtime id
 		// (CUIElement::LeavePCScene -> RegisterForStructureChangedEvent(Removed)).
 		var ancestorProvider = FindNearestAncestorProvider(parent);
-		if (ancestorProvider is null)
-		{
-			return;
-		}
-
 		ancestorProvider.InvalidateChildrenCache();
 
 		if (!listening)
@@ -409,7 +402,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 			return provider;
 		}
 
-		var peer = element.GetOrCreateAutomationPeer();
+		var peer = element.CachedAutomationPeer;
 		return peer is not null ? FindExistingProviderForPeer(peer, resolveEventsSource: true) : null;
 	}
 
@@ -484,7 +477,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		}
 	}
 
-	private Win32RawElementProvider? FindNearestAncestorProvider(UIElement element)
+	private Win32RawElementProvider FindNearestAncestorProvider(UIElement element)
 	{
 		UIElement? current = element;
 		while (current is not null)
@@ -524,7 +517,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		}
 
 		_structureChangeFlushQueued = true;
-		_dispatcherQueue.TryEnqueue(() =>
+		if (!_dispatcherQueue.TryEnqueue(() =>
 		{
 			_structureChangeFlushQueued = false;
 
@@ -536,7 +529,10 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 			}
 
 			FlushStructureChanges();
-		});
+		}))
+		{
+			_structureChangeFlushQueued = false;
+		}
 	}
 
 	/// <summary>

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -389,6 +389,8 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 
 		QueueStructureChange(childRuntimeId is not null
 			? new PendingStructureChange(ancestorProvider, null, StructureChangeKind.Removed, childRuntimeId)
+			// TODO Uno: mirror CollectEnteringProviders for peer-less removals so shallow peer-bearing descendants
+			// can emit ChildRemoved instead of falling back to ChildrenInvalidated.
 			: new PendingStructureChange(ancestorProvider, null, StructureChangeKind.Invalidated, null));
 	}
 
@@ -532,6 +534,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		}))
 		{
 			_structureChangeFlushQueued = false;
+			_pendingStructureChanges.Clear();
 		}
 	}
 
@@ -582,7 +585,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 				continue;
 			}
 
-			if (group.Added.Count >= BulkChildrenLimit)
+			if (group.Added.Count >= BulkChildrenLimit) // deliberate >=: exactly BulkChildrenLimit → BulkAdded (total > limit → Invalidated above)
 			{
 				RaiseStructureChangedCore(container, StructureChangeType.ChildrenBulkAdded, null);
 			}
@@ -595,7 +598,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 				}
 			}
 
-			if (group.Removed.Count >= BulkChildrenLimit)
+			if (group.Removed.Count >= BulkChildrenLimit) // deliberate >=: exactly BulkChildrenLimit → BulkRemoved (total > limit → Invalidated above)
 			{
 				RaiseStructureChangedCore(container, StructureChangeType.ChildrenBulkRemoved, null);
 			}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -307,6 +307,15 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 			return;
 		}
 
+		// If UIA has not materialized any provider between the changed parent and the root, there
+		// is no specific accessible container to update. Keep the root-level signal coarse instead
+		// of eagerly creating peers for every element added anywhere in the app.
+		if (ReferenceEquals(ancestorProvider, _rootProvider))
+		{
+			QueueStructureChange(new PendingStructureChange(ancestorProvider, null, StructureChangeKind.Invalidated, null));
+			return;
+		}
+
 		// ChildAdded is associated with the added element, so we must materialize its provider.
 		// Gated above on a listening client to avoid COM-wrapper churn during normal layout.
 		var childProvider = GetOrCreateProvider(child);

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32Accessibility.cs
@@ -331,7 +331,7 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 		// shallowest peer-bearing descendant — otherwise the revealed text (the cell value) would
 		// be announced by no event at all. Fall back to the coarse signal only if none is found.
 		var entering = new List<Win32RawElementProvider>();
-		CollectEnteringProviders(child, entering, 0);
+		CollectEnteringProviders(child, entering);
 		if (entering.Count > 0)
 		{
 			foreach (var provider in entering)
@@ -347,30 +347,65 @@ internal sealed class Win32Accessibility : SkiaAccessibilityBase
 
 	/// <summary>
 	/// Collects the shallowest peer-bearing descendant providers of an element entering the scene,
-	/// recursing through peer-less (flattened) elements and skipping Collapsed branches. Mirrors the
+	/// traversing through peer-less (flattened) elements and skipping Collapsed branches. Mirrors the
 	/// flattening of <see cref="Win32RawElementProvider"/>'s child walk / WinUI EnterPCSceneRecursive.
 	/// </summary>
-	private void CollectEnteringProviders(UIElement element, List<Win32RawElementProvider> result, int depth)
+	private void CollectEnteringProviders(UIElement element, List<Win32RawElementProvider> result)
 	{
-		if (depth > 64)
-		{
-			return;
-		}
+		TraverseDescendants(
+			element,
+			static current => current.GetChildren(),
+			child =>
+			{
+				if (child.Visibility == Visibility.Collapsed)
+				{
+					return false;
+				}
 
-		foreach (var child in element.GetChildren())
+				if (GetOrCreateProvider(child) is { } provider)
+				{
+					result.Add(provider);
+					return false;
+				}
+
+				return true;
+			});
+	}
+
+	private static void TraverseDescendants(
+		UIElement root,
+		Func<UIElement, IEnumerable<UIElement>> getChildren,
+		Func<UIElement, bool> shouldDescend)
+	{
+		var pending = new Stack<UIElement>();
+		var visited = new HashSet<UIElement>(ReferenceEqualityComparer.Instance) { root };
+		var children = new List<UIElement>();
+
+		PushChildren(root);
+
+		while (pending.Count > 0)
 		{
-			if (child.Visibility == Visibility.Collapsed)
+			var child = pending.Pop();
+			if (!visited.Add(child))
 			{
 				continue;
 			}
 
-			if (GetOrCreateProvider(child) is { } provider)
+			if (shouldDescend(child))
 			{
-				result.Add(provider);
+				PushChildren(child);
 			}
-			else
+		}
+
+		void PushChildren(UIElement parent)
+		{
+			children.Clear();
+			children.AddRange(getChildren(parent));
+
+			// Reverse the push order so the LIFO traversal preserves visual-tree order.
+			for (var i = children.Count - 1; i >= 0; i--)
 			{
-				CollectEnteringProviders(child, result, depth + 1);
+				pending.Push(children[i]);
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32UIAutomationInterop.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32UIAutomationInterop.cs
@@ -345,6 +345,14 @@ internal static class Win32UIAutomationInterop
 		StructureChangeType structureChangeType,
 		[MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_I4)] int[]? runtimeId);
 
+	// Returns true when one or more UIA clients are listening for events. WinUI gates the
+	// StructureChanged registration (CUIElement::EnterPCScene / LeavePCScene) on the equivalent
+	// UIAClientsAreListening check, so we only materialize child providers + raise ChildAdded/
+	// ChildRemoved when a client actually cares — avoiding COM-wrapper churn during normal layout.
+	[DllImport("uiautomationcore.dll")]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	internal static extern bool UiaClientsAreListening();
+
 	[DllImport("uiautomationcore.dll")]
 	internal static extern int UiaRaiseNotificationEvent(
 		[MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
@@ -1,0 +1,85 @@
+#if __SKIA__
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation;
+
+[TestClass]
+[RunsOnUIThread]
+[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
+public class Given_Win32Accessibility
+{
+	[TestMethod]
+	public void When_Traversing_Deep_Cyclic_Descendants()
+	{
+		var accessibilityType = FindType("Uno.UI.Runtime.Skia.Win32.Win32Accessibility")
+			?? throw new InvalidOperationException("Win32Accessibility type not found.");
+		var traverse = accessibilityType.GetMethod(
+			"TraverseDescendants",
+			BindingFlags.Static | BindingFlags.NonPublic)
+			?? throw new InvalidOperationException("Win32Accessibility.TraverseDescendants not found.");
+
+		var root = new Grid();
+		var descendants = new Grid[128];
+		var target = new Button();
+		for (var i = 0; i < descendants.Length; i++)
+		{
+			descendants[i] = new Grid();
+		}
+
+		var graph = new Dictionary<UIElement, IReadOnlyList<UIElement>>(ReferenceEqualityComparer.Instance)
+		{
+			[root] = new[] { descendants[0] },
+		};
+
+		for (var i = 0; i < descendants.Length - 1; i++)
+		{
+			graph[descendants[i]] = new[] { descendants[i + 1] };
+		}
+
+		graph[descendants[^1]] = new UIElement[] { descendants[32], target };
+
+		var visited = new HashSet<UIElement>(ReferenceEqualityComparer.Instance);
+		IEnumerable<UIElement> GetChildren(UIElement element) =>
+			graph.TryGetValue(element, out var children) ? children : Array.Empty<UIElement>();
+		bool Visit(UIElement element)
+		{
+			Assert.IsTrue(visited.Add(element), "Each descendant must be visited at most once.");
+			return !ReferenceEquals(element, target);
+		}
+
+		traverse.Invoke(
+			null,
+			new object[]
+			{
+				root,
+				(Func<UIElement, IEnumerable<UIElement>>)GetChildren,
+				(Func<UIElement, bool>)Visit,
+			});
+
+		Assert.IsTrue(visited.Contains(target), "Deep descendants after a cycle must still be reached.");
+		Assert.AreEqual(descendants.Length + 1, visited.Count);
+	}
+
+	private static Type? FindType(string fullName)
+	{
+		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+		{
+			var type = assembly.GetType(fullName, throwOnError: false);
+			if (type is not null)
+			{
+				return type;
+			}
+		}
+
+		return null;
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XYFocusBubbling.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XYFocusBubbling.cs
@@ -8,6 +8,8 @@
 // equivalent, so the whole fixture is Uno-only and excluded from the native WinAppSDK build.
 #if HAS_UNO
 
+using System.Threading.Tasks;
+using Private.Infrastructure;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -20,7 +22,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Input;
 public class Given_XYFocusBubbling
 {
 	[TestMethod]
-	public void VerifyXYFocusPropertyRetrieval()
+	public async Task VerifyXYFocusPropertyRetrieval()
 	{
 		var element = new Control();
 
@@ -34,10 +36,24 @@ public class Given_XYFocusBubbling
 		element.SetValue(UIElement.XYFocusDownProperty, elementDown);
 		element.SetValue(UIElement.XYFocusUpProperty, elementUp);
 
-		Assert.AreEqual(elementLeft, GetDirectionOverride(element, null, FocusNavigationDirection.Left));
-		Assert.AreEqual(elementRight, GetDirectionOverride(element, null, FocusNavigationDirection.Right));
-		Assert.AreEqual(elementUp, GetDirectionOverride(element, null, FocusNavigationDirection.Up));
-		Assert.AreEqual(elementDown, GetDirectionOverride(element, null, FocusNavigationDirection.Down));
+		// GetDirectionOverride only returns an override target that is a valid focus candidate,
+		// which now requires live-tree membership - so the override targets must be loaded.
+		var root = new StackPanel { Children = { element, elementLeft, elementRight, elementUp, elementDown } };
+		TestServices.WindowHelper.WindowContent = root;
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(root, x => x.IsLoaded);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(elementLeft, GetDirectionOverride(element, null, FocusNavigationDirection.Left));
+			Assert.AreEqual(elementRight, GetDirectionOverride(element, null, FocusNavigationDirection.Right));
+			Assert.AreEqual(elementUp, GetDirectionOverride(element, null, FocusNavigationDirection.Up));
+			Assert.AreEqual(elementDown, GetDirectionOverride(element, null, FocusNavigationDirection.Down));
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
 	}
 
 	[TestMethod]
@@ -48,7 +64,7 @@ public class Given_XYFocusBubbling
 	}
 
 	[TestMethod]
-	public void VerifyCorrectOverrideChosenWhenTargetElementHasOverride()
+	public async Task VerifyCorrectOverrideChosenWhenTargetElementHasOverride()
 	{
 		var element = new Control();
 		var candidate = new Control();
@@ -61,12 +77,25 @@ public class Given_XYFocusBubbling
 		parent.SetValue(UIElement.XYFocusRightProperty, directionOverrideOfParent);
 		element.SetValue(UIElement.XYFocusRightProperty, overrideElement);
 
-		var retrieved = TryXYFocusBubble(element, candidate, null, FocusNavigationDirection.Right);
-		Assert.AreEqual(overrideElement, retrieved);
+		// The override targets must be live-tree focus candidates to be chosen.
+		var root = new StackPanel { Children = { parent, overrideElement, directionOverrideOfParent } };
+		TestServices.WindowHelper.WindowContent = root;
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(root, x => x.IsLoaded);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var retrieved = TryXYFocusBubble(element, candidate, null, FocusNavigationDirection.Right);
+			Assert.AreEqual(overrideElement, retrieved);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
 	}
 
 	[TestMethod]
-	public void VerifyCorrectOverrideChosenWhenBubbling()
+	public async Task VerifyCorrectOverrideChosenWhenBubbling()
 	{
 		var element = new Control();
 		var candidate = new Control();
@@ -77,8 +106,20 @@ public class Given_XYFocusBubbling
 
 		parent.SetValue(UIElement.XYFocusRightProperty, directionOverrideOfParent);
 
-		var retrieved = TryXYFocusBubble(element, candidate, null, FocusNavigationDirection.Right);
-		Assert.AreEqual(directionOverrideOfParent, retrieved);
+		var root = new StackPanel { Children = { parent, directionOverrideOfParent } };
+		TestServices.WindowHelper.WindowContent = root;
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(root, x => x.IsLoaded);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var retrieved = TryXYFocusBubble(element, candidate, null, FocusNavigationDirection.Right);
+			Assert.AreEqual(directionOverrideOfParent, retrieved);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XYFocusTreeWalker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XYFocusTreeWalker.cs
@@ -10,6 +10,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Private.Infrastructure;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -31,7 +33,7 @@ public partial class Given_XYFocusTreeWalker
 	}
 
 	[TestMethod]
-	public void VerifyFindElement()
+	public async Task VerifyFindElement()
 	{
 		var root = new XYFocusCUIElement();
 
@@ -40,13 +42,25 @@ public partial class Given_XYFocusTreeWalker
 
 		root.Children.Add(candidate);
 
-		var candidateList = FindElements(root, current, null, true, false);
-		Assert.HasCount(1, candidateList);
-		Assert.AreEqual(candidate, candidateList[0].Element);
+		// Candidates must be in the live visual tree to count as focusable (WinUI's IsActive() gate).
+		TestServices.WindowHelper.WindowContent = root;
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(root, x => x.IsLoaded);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var candidateList = FindElements(root, current, null, true, false);
+			Assert.HasCount(1, candidateList);
+			Assert.AreEqual(candidate, candidateList[0].Element);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
 	}
 
 	[TestMethod]
-	public void VerifyFindElementIgnoresNonFocusableChildren()
+	public async Task VerifyFindElementIgnoresNonFocusableChildren()
 	{
 		var root = new XYFocusCUIElement();
 
@@ -58,9 +72,20 @@ public partial class Given_XYFocusTreeWalker
 		root.Children.Add(candidate);
 		root.Children.Add(nonFocusableCandidate);
 
-		var candidateList = FindElements(root, current, null, true, false);
-		Assert.HasCount(1, candidateList);
-		Assert.AreEqual(candidate, candidateList[0].Element);
+		TestServices.WindowHelper.WindowContent = root;
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(root, x => x.IsLoaded);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var candidateList = FindElements(root, current, null, true, false);
+			Assert.HasCount(1, candidateList);
+			Assert.AreEqual(candidate, candidateList[0].Element);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
 	}
 
 	[Ignore("https://github.com/unoplatform/uno/issues/17399 — needs a focusable Panel subclass to mirror the unit-test mock's `_children` parent-child semantics; ContentControl.Content is not picked up by the focus walker without an applied template.")]


### PR DESCRIPTION
**GitHub Issue:** part of https://github.com/unoplatform/kahua-private/issues/493

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
