### PR TITLE
refactor!: Remove native-only FeatureConfiguration flags

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2922,6 +2922,7 @@
 		  <!-- Native-only FeatureConfiguration knobs removed with the native renderers (#2052, breaking changes for 7.0). -->
 		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors::UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
 		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/WebView2::IsInspectable()" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/AndroidSettings::IsEdgeToEdgeEnabled()" reason="Removed AndroidSettings.IsEdgeToEdgeEnabled flag; edge-to-edge is now unconditional on Skia-Android (#2052, breaking changes for 7.0)" />
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
@@ -2931,6 +2932,8 @@
 		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Cursors.set_UseHandForInteraction(System.Boolean value)" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
 		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/WebView2.get_IsInspectable()" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
 		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/WebView2.set_IsInspectable(System.Boolean value)" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/AndroidSettings.get_IsEdgeToEdgeEnabled()" reason="Removed AndroidSettings.IsEdgeToEdgeEnabled flag; edge-to-edge is now unconditional on Skia-Android (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/AndroidSettings.set_IsEdgeToEdgeEnabled(System.Boolean value)" reason="Removed AndroidSettings.IsEdgeToEdgeEnabled flag; edge-to-edge is now unconditional on Skia-Android (#2052, breaking changes for 7.0)" />
 		  <!-- NavigationView API surface aligned to the WinUI IDL: get-only properties and a non-activatable args type. -->
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationView.set_SettingsItem(System.Object value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_CompactPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2919,15 +2919,18 @@
 	  <Properties>
 		  <!-- StackLayout.DisableVirtualization is a plain CLR property in WinUI (backed by internal IsVirtualizationEnabledProperty); the DisableVirtualizationProperty DP is not part of the WinUI surface. -->
 		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout::DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
-		  <!-- Native-only FeatureConfiguration knob removed with the native renderers (#2052, breaking changes for 7.0). -->
+		  <!-- Native-only FeatureConfiguration knobs removed with the native renderers (#2052, breaking changes for 7.0). -->
 		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors::UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/WebView2::IsInspectable()" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
 		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout.get_DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
-		  <!-- Cursors.UseHandForInteraction accessors: paired with the removed property (see <Properties> above). Native-only knob removed with the native renderers (#2052). -->
+		  <!-- Cursors.UseHandForInteraction / WebView2.IsInspectable accessors: paired with the removed properties (see <Properties> above). Native-only knobs removed with the native renderers (#2052). -->
 		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors.get_UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
 		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Cursors.set_UseHandForInteraction(System.Boolean value)" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/WebView2.get_IsInspectable()" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/WebView2.set_IsInspectable(System.Boolean value)" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
 		  <!-- NavigationView API surface aligned to the WinUI IDL: get-only properties and a non-activatable args type. -->
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationView.set_SettingsItem(System.Object value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_CompactPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2919,10 +2919,15 @@
 	  <Properties>
 		  <!-- StackLayout.DisableVirtualization is a plain CLR property in WinUI (backed by internal IsVirtualizationEnabledProperty); the DisableVirtualizationProperty DP is not part of the WinUI surface. -->
 		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout::DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
+		  <!-- Native-only FeatureConfiguration knob removed with the native renderers (#2052, breaking changes for 7.0). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors::UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
 		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout.get_DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
+		  <!-- Cursors.UseHandForInteraction accessors: paired with the removed property (see <Properties> above). Native-only knob removed with the native renderers (#2052). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors.get_UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Cursors.set_UseHandForInteraction(System.Boolean value)" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
 		  <!-- NavigationView API surface aligned to the WinUI IDL: get-only properties and a non-activatable args type. -->
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationView.set_SettingsItem(System.Object value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_CompactPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -168,8 +168,12 @@ then
 
 	# 2) Install helpers
 	brew list --versions pipx >/dev/null 2>&1 || brew install pipx
+	# Homebrew 6.0 stopped auto-tapping untrusted taps and refuses to load their
+	# formulae without an explicit trust, so trust facebook/fb and install the
+	# fully-qualified formula (a bare "idb-companion" now resolves to the wrong cask).
 	brew tap facebook/fb >/dev/null 2>&1 || true
-	brew list --versions idb-companion >/dev/null 2>&1 || brew install idb-companion
+	brew trust facebook/fb >/dev/null 2>&1 || true
+	brew list --versions idb-companion >/dev/null 2>&1 || brew install facebook/fb/idb-companion
 
 	# 3) Install fb-idb under Python 3.12
 	pipx uninstall fb-idb >/dev/null 2>&1 || true

--- a/doc/articles/controls/CommandBar.md
+++ b/doc/articles/controls/CommandBar.md
@@ -159,7 +159,6 @@ Gets or sets a brush that describes the foreground color.
 - This is typically used to change the Content`'s text color.
 - Only supports `SolidColorBrush`.
 - Setting this property will not affect any of the `CommandBar's` `AppBarButton` tint Color. If you need to change the `AppBarButton` tint, this is possible by setting the `ShowAsMonochrome` property to true as well as setting the Foreground`SolidColorBrush`on the`BitmapIcon`.
-- On`Android`, you can also enable a feature that will allow that the`SolidColorBrush`set on your `CommandBar` `Foreground` to update your`AppBarButton`s Tint. To enable this, set on your `App.xml.cs` the `FeatureConfiguration.AppBarButton.EnableBitmapIconTint` to **true**.
 
 ### PrimaryCommands
 

--- a/doc/articles/controls/TimePicker.md
+++ b/doc/articles/controls/TimePicker.md
@@ -73,12 +73,3 @@ If you wish to customize the overlay color, add the following to your top-level 
 <SolidColorBrush x:Key="TimePickerLightDismissOverlayBackground"
                  Color="Pink" />
 ```
-
-Since **iOS14** the native `TimePicker` changed the way it's presented. By default iOS14 devices will display this new style.  You can still force the previous style (the one found in iOS13 or earlier) by adding the following at your `App.cs` or `App.xaml.cs` class:
-
-```csharp
-Uno.UI.FeatureConfiguration.TimePicker.UseLegacyStyle = true;
-```
-
-> [!IMPORTANT]
-> This feature flag is required and will only affect iOS 14 devices. As of **iOS 15**, the preferred style for the DatePicker is again the one found in iOS13 and earlier.

--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -170,9 +170,6 @@ The flag defaults to `true` in `DEBUG` builds and `false` in `RELEASE` builds.
 
 > [!IMPORTANT]
 > On Apple platforms the OS gates inspection to apps signed with the get-task-allow entitlement (DEBUG / development builds). Setting the flag in a RELEASE build has no visible effect.
->
-> [!NOTE]
-> The legacy iOS-only `Uno.UI.FeatureConfiguration.WebView2.IsInspectable` property is now an obsolete alias for `EnableDevTools`.
 
 ## Customizing the WebView2 environment (Windows)
 

--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -6,21 +6,6 @@ uid: Uno.Development.FeatureFlags
 
 Uno provides a set of feature flags that can be set early in an app's startup to control its behavior. Some of these flags are for backward compatibility, some of them provide fine-grained customizability of a particular feature, and some of them allow to toggle between more 'WinUI-like' and more 'native-like' behavior in a particular context.
 
-## Legacy clipping (Android)
-
-Historically, Uno has been relying on the default platform's behavior for clipping, which is quite different from WinUI compositing behavior.
-
-This behavior can be controlled by `Uno.UI.FeatureConfiguration.UIElement.UseLegacyClipping`, which now defaults to false.
-
-If legacy clipping is enabled, clipping is applied on the assigned children bounds instead of the parent bounds.
-
-## ListView scrolling (Android and iOS)
-
-On iOS and Android platforms specifically, `ListView.ScrollIntoView` performs an animated scrolling instead of an instant scrolling than other platforms.
-
-This feature can be toggled with `Uno.UI.FeatureConfiguration.ListViewBase.AnimateScrollIntoView`.
-Alternatively, `Uno.UI.Helpers.ListViewHelper` offers two extension methods, `InstantScrollToIndex` and `SmoothScrollToIndex`, to perform a specific type of scrolling irrespective of the flag set.
-
 ## WinUI styles default
 
 By default, Uno favors the default WinUI XAML styles over the native styles for Button, Slider, ComboBox, etc...
@@ -56,21 +41,11 @@ For details, see [Vulkan Rendering Backend](xref:Uno.Skia.Vulkan).
 
 By default, `ComboBox` popup is placed in such a way that the currently selected item is centered above the `ComboBox`. If you want to adjust this behavior on non-Windows targets, set the `Uno.UI.FeatureConfiguration.ComboBox.DefaultDropDownPreferredPlacement` property.
 
-### Allow popup under translucent status bar
-
-By default, the `ComboBox` popup will not extend under the status bar even if it is set as translucent. If you want to change this behavior, set the `Uno.UI.FeatureConfiguration.ComboBox.AllowPopupUnderTranslucentStatusBar` property to `true`. This property is Android-specific.
-
 ## Popups
 
 ### Constraining by visible bounds
 
 By default we don't constrain popups by the visible bounds of the application view on Skia renderer targets. This is different from native renderer where popups are automatically padded by the visible bounds, which ensures the popup does not flow below the system UI (e.g. mobile device status bar or navigation bar). The `ConstrainByVisibleBounds` property allows you to control this behavior. Please note that in case the property is set to `false` (which is the default for Skia renderer), you are responsible for ensuring the content of your popups has appropriate padding around its content. This can be achieved using the [`SafeArea` control in Uno Toolkit](xref:Toolkit.Controls.SafeArea).
-
-### Native popups (Android)
-
-On Android, it is possible to use a native popup implementation, which is integrated into the system for `Popup`- and `Flyout`-derived UI. Prior to Uno Platform 3.5, native popups were used by default. On Uno Platform 3.5 or later, we made the managed implementation the default.
-
-If you require native popups for your use case, set the `Uno.UI.FeatureConfiguration.Popup.UseNativePopup` to `true`.
 
 ### Light Dismiss Default
 
@@ -145,7 +120,7 @@ public App()
 See [WebView2 → Enabling native developer tools](xref:Uno.Controls.WebView2#enabling-native-developer-tools) for the per-platform inspection workflow.
 
 > [!IMPORTANT]
-> On Apple platforms the OS only honors this flag for development-signed apps (DEBUG builds). The legacy iOS-only `IsInspectable` property is now an obsolete alias for `EnableDevTools`.
+> On Apple platforms the OS only honors this flag for development-signed apps (DEBUG builds).
 
 ### AllowSingleSignOnUsingOSPrimaryAccount
 
@@ -186,12 +161,6 @@ In order for calls to fail on uses of this method, set the `Uno.UI.FeatureConfig
 
 ## Android Settings
 
-### `IsEdgeToEdgeEnabled`
+### Edge-to-edge UI
 
-This flag controls the [edge-to-edge UI behavior](https://developer.android.com/develop/ui/views/layout/edge-to-edge) on Android. When set to `true` it makes the system UI (status bar and navigation bar) transparent, and lets the application expand below these overlays. To ensure all UI is still accessible for the user, proper safe area padding/margin needs to be applied. To achieve this, use the [`SafeArea` control in Uno Toolkit](xref:Toolkit.Controls.SafeArea). The default value is `true` for apps targeting .NET 9 or targeting Android SDK 35 and newer, defaults to `false` otherwise. For apps targeting SDK 35+ and running on Android 15 and newer, edge-to-edge is always enforced by the OS, so it cannot be disabled.
-
-```csharp
-#if __ANDROID__
-var isEdgeToEdge = FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled;
-#endif
-```
+On Android, the [edge-to-edge UI behavior](https://developer.android.com/develop/ui/views/layout/edge-to-edge) is always enabled: the system UI (status bar and navigation bar) is transparent and the application expands below these overlays. To ensure all UI remains accessible to the user, apply proper safe area padding/margin using the [`SafeArea` control in Uno Toolkit](xref:Toolkit.Controls.SafeArea).

--- a/doc/articles/features/cursors.md
+++ b/doc/articles/features/cursors.md
@@ -16,13 +16,3 @@ public void ChangeCursor(InputCursor cursor)
 Note that you must perform this action on the UI thread. For more details on how to use `ProtectedCursor`, follow this [discussion](https://github.com/microsoft/WindowsAppSDK/discussions/1816).
 
 Note that the legacy `CoreWindow.PointerCursor` API is no longer supported.
-
-## Changing the default cursor for button-based controls on WASM
-
-To provide a web-like feel of Uno Platform WebAssembly apps, we use the "hand" cursor for "interactive" controls (currently including controls derived from `ButtonBase` and `ToggleSwitch` control). This makes the experience feel familiar to users. If you want your application to feel more like a native application, you can set the `FeatureConfiguration.Cursors.UseHandForInteraction` to `false`:
-
-```csharp
-Uno.UI.FeatureConfiguration.Cursors.UseHandForInteraction = false;
-```
-
-Make sure to set this property early in the application lifecycle, before the window content is first set, for example at the beginning of the `Main` method in `Program.cs`, which is located in the WASM project.

--- a/doc/articles/features/native-frame-nav.md
+++ b/doc/articles/features/native-frame-nav.md
@@ -65,7 +65,6 @@ Method|Return Type|Description
 - Android: Tapping the CommandBar's back button, system back button, or performing the sweep gesture will trigger `SystemNavigationManager.BackRequested`. It's the responsibility of the application's navigation controller to eventually call `Frame.GoBack()`.
 - iOS: Tapping the back button automatically triggers a back navigation on the native `UINavigationController` (which is part of the native `Frame` implementation). The `Frame` will raise the `Navigated` event, and its state will automatically be updated to reflect the navigation. The navigation can't be intercepted or canceled.
 - all non-Windows platforms: `Uno.UI.FeatureConfiguration.Page.IsPoolingEnabled` can be set to enable reuse of `Page` instances. Enabling this allows the pages in the forward stack to be recycled when stack is modified, which can improve performance of `Frame` navigation.
-- Android: On mobile, the pages in the back stack are still preserved in the visual tree for performance reasons. This feature can be disabled on Android by setting `Uno.UI.FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages = true`.
 - WASM: `SystemNavigationManager.AppViewBackButtonVisibility` needs to be set to `Visible` to intercept the browser back navigation. The intercepted event is forwarded to `SystemNavigationManager.BackRequested`. It's the responsibility of the application's navigation controller to eventually call `Frame.GoBack()`.
 
 ## Additional Resources

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -99,14 +99,22 @@ Skia/WinUI behavior:
   `UIElement.AlwaysClipNativeChildren`, `ScrollViewer.AndroidScrollbarFadeDelay`,
   `WebView.ForceSoftwareRendering`, `PointerRoutedEventArgs.AllowRelativeTimeStamp`,
   `TextBlock.IsJavaStringCachedEnabled` / `JavaStringCachedCapacity`,
-  `AndroidSettings.IsEdgeToEdgeEnabled`.
+  `AppBarButton.EnableBitmapIconTint`, `TimePickerFlyout.UseLegacyTimeSetting`,
+  `NavigationView.EnableUno19516Workaround`, `AndroidSettings.IsEdgeToEdgeEnabled`.
 - **iOS:** `Image.LegacyIosAlignment`,
-  `FrameworkElement.IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews`.
+  `FrameworkElement.IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews`,
+  `CommandBar.AllowNativePresenterContent`, `DatePicker.UseLegacyStyle`,
+  `TimePicker.UseLegacyStyle`.
 - **WebAssembly:** `Interop.ForceJavascriptInterop`, `UIElement.AssignDOMXamlName`,
-  `UIElement.AssignDOMXamlProperties`, `TextBlock.IsMeasureCacheEnabled`.
+  `UIElement.AssignDOMXamlProperties`, `TextBlock.IsMeasureCacheEnabled`,
+  `Cursors.UseHandForInteraction` (the "hand" cursor for interactive controls is
+  now never used).
 - **Native (Android + iOS):** `ListViewBase.AnimateScrollIntoView`.
 - **Native styling:** `Style.UseUWPDefaultStyles`, `Style.ConfigureNativeFrameNavigation()`.
 - **Skia overlay:** `TextBox.UseOverlayOnSkia`.
+
+`WebView2.IsInspectable` is also removed; it was an obsolete alias, so switch to
+`WebView2.EnableDevTools` instead.
 
 If a single codebase must target both pre-7.0 and 7.0, guard the calls with `#if`.
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/SetProtectedCursor.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/SetProtectedCursor.xaml
@@ -23,7 +23,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Margin="20">
-            <TextBlock Text="Tests for all platforms. Note for Wasm, Uno.UI.FeatureConfiguration.Cursors.UseHandForInteraction will need to be set to false to match the expected behavior." />
+            <TextBlock Text="Tests for all platforms." />
             <TextBlock Text="- Test 1: Hover the Button. Expected behavior: Cursor should show SizeWestEast cursor." />
             <TextBlock Text="- Test 2: Hover the Button and move to hover the yellow area. Expected behavior: Cursor should show SizeWestEast cursor the entire time." />
             <TextBlock Text="- Test 3: Hover the Button and move to hover the blue area. Expected behavior: Cursor should show SizeWestEast cursor first then show back the default Arrow cursor when hovering the blue area." />
@@ -32,7 +32,7 @@
             <TextBlock Text="- Test 6: Hover the pink Border and move to hover the yellow area. Expected behavior: Cursor should show Wait cursor the entire time." />
             <TextBlock Text="- Test 7: Hover the pink Border and move to hover the blue area. Expected behavior: Cursor should show Wait cursor first then show back the default Arrow cursor when hovering the blue area." />
             <TextBlock Text="- Test 8: Hover the pink border, press and keep pressing when moving to hover the blue area. Expected behavior: Cursor should show Wait cursor the entire time." />
-            <TextBlock Margin="0,10,0,0" Text="Tests for Wasm only. Uno.UI.FeatureConfiguration.Cursors.UseHandForInteraction will need to be set to true to match the expected behavior." />
+            <TextBlock Margin="0,10,0,0" Text="Tests for Wasm only." />
             <TextBlock Text="- Test 1: Hover the Button. Expected behavior: Cursor should show Hand cursor." />
             <TextBlock Text="- Test 2: Hover the Button and move to hover the yellow area. Expected behavior: Cursor should show Hand cursor the entire time." />
             <TextBlock Text="- Test 3: Hover the Button and move to hover the blue area. Expected behavior: Cursor should show Hand cursor first then show back the default Arrow cursor when hovering the blue area." />

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_TextBox.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_TextBox.xaml
@@ -2,13 +2,12 @@
     x:Class="UITests.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_TextBox"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:android="http://platform.uno/android"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ContentDialogTests"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="300"
     d:DesignWidth="400"
-    mc:Ignorable="d android">
+    mc:Ignorable="d">
 
     <StackPanel Padding="20">
         <TextBlock>
@@ -18,14 +17,7 @@
                 2. Once the dialog is open, press inside the text box so that the software keyboard appears. The dialog should adjust in size so that the buttons are still visible above the keyboard.
                 This test only needs to be run on platforms with touch input.
             </Run>
-            <Run Text=" On Android, the test should be done twice, once with native popups enabled and once with managed popups instead." />
         </TextBlock>
-        <android:CheckBox
-            x:Name="EnableNativeCheckBox"
-            Margin="5"
-            Checked="OnEnableNativeCheckedChanged"
-            Content="Enable native popups?"
-            Unchecked="OnEnableNativeCheckedChanged" />
         <Button
             Margin="5"
             Click="ShowContentDialog"

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_TextBox.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_TextBox.xaml.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable CS0169
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,38 +20,9 @@ namespace UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 	[Sample("Dialogs", IsManualTest = true, IgnoreInSnapshotTests = true)]
 	public sealed partial class ContentDialog_TextBox : UserControl
 	{
-#if __ANDROID__
-		private bool _initialEnableNativePopups;
-#endif
-
 		public ContentDialog_TextBox()
 		{
 			this.InitializeComponent();
-			Loaded += OnLoaded;
-			Unloaded += OnUnloaded;
-		}
-
-		private void OnLoaded(object sender, RoutedEventArgs e)
-		{
-#if __ANDROID__
-			_initialEnableNativePopups = Uno.UI.FeatureConfiguration.Popup.UseNativePopup;
-			EnableNativeCheckBox.IsChecked = _initialEnableNativePopups;
-#endif
-		}
-
-		private void OnUnloaded(object sender, RoutedEventArgs e)
-		{
-#if __ANDROID__
-			Uno.UI.FeatureConfiguration.Popup.UseNativePopup = _initialEnableNativePopups;
-#endif
-		}
-
-		private void OnEnableNativeCheckedChanged(object sender, object args)
-		{
-#if __ANDROID__
-			var isChecked = EnableNativeCheckBox.IsChecked ?? _initialEnableNativePopups;
-			Uno.UI.FeatureConfiguration.Popup.UseNativePopup = isChecked;
-#endif
 		}
 
 		private async void ShowContentDialog(object sender, object args)

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -140,7 +140,6 @@ partial class App
 
 #if __ANDROID__
 						Windows.ApplicationModel.Core.CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
-						Uno.UI.FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay = TimeSpan.Zero;
 #endif
 
 #if HAS_UNO

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -583,7 +583,6 @@ namespace SamplesApp
 		static void ConfigureFeatureFlags()
 		{
 #if __APPLE_UIKIT__
-			Uno.UI.FeatureConfiguration.CommandBar.AllowNativePresenterContent = true;
 			WinRTFeatureConfiguration.Focus.EnableExperimentalKeyboardFocus = true;
 #endif
 #if HAS_UNO

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -585,8 +585,6 @@ namespace SamplesApp
 #if __APPLE_UIKIT__
 			Uno.UI.FeatureConfiguration.CommandBar.AllowNativePresenterContent = true;
 			WinRTFeatureConfiguration.Focus.EnableExperimentalKeyboardFocus = true;
-			Uno.UI.FeatureConfiguration.DatePicker.UseLegacyStyle = true;
-			Uno.UI.FeatureConfiguration.TimePicker.UseLegacyStyle = true;
 #endif
 #if HAS_UNO
 			Uno.UI.FeatureConfiguration.TextBox.UseOverlayOnSkia = false;

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -247,10 +247,9 @@ namespace Microsoft.UI.Xaml
 
 		protected override void OnCreate(Bundle? bundle)
 		{
-			if (FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled)
-			{
-				EdgeToEdge.Enable(this);
-			}
+			// Once the app targets SDK 35+, edge-to-edge is enforced.
+			// Calling EdgeToEdge.Enable keeps this behavior consistent on earlier SDK levels too.
+			EdgeToEdge.Enable(this);
 
 			base.OnCreate(bundle);
 

--- a/src/Uno.UI.RuntimeTests/Helpers/FeatureConfigurationHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/FeatureConfigurationHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Disposables;
 using Microsoft.UI.Xaml;
 
@@ -32,17 +31,6 @@ namespace Uno.UI.RuntimeTests.Helpers
 				FrameworkTemplatePool.InternalIsPoolingEnabled = originallyEnabled;
 				FrameworkTemplatePool.Instance.SetPlatformProvider(null);
 			});
-#endif
-		}
-
-		public static IDisposable UseListViewAnimations()
-		{
-#if __ANDROID__
-			var originalSetting = FeatureConfiguration.NativeListViewBase.RemoveItemAnimator;
-			FeatureConfiguration.NativeListViewBase.RemoveItemAnimator = false;
-			return Disposable.Create(() => FeatureConfiguration.NativeListViewBase.RemoveItemAnimator = originalSetting);
-#else
-			return null;
 #endif
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Helpers/FeatureConfigurationHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/FeatureConfigurationHelper.cs
@@ -45,19 +45,5 @@ namespace Uno.UI.RuntimeTests.Helpers
 			return null;
 #endif
 		}
-
-		/// <summary>
-		/// On Android, ensure that native popups are used for the duration of the test. On other platforms this is a no-op.
-		/// </summary>
-		public static IDisposable UseNativePopups()
-		{
-#if !__ANDROID__
-			return null;
-#else
-			Assert.IsFalse(FeatureConfiguration.Popup.UseNativePopup);
-			FeatureConfiguration.Popup.UseNativePopup = true;
-			return Disposable.Create(() => FeatureConfiguration.Popup.UseNativePopup = false);
-#endif
-		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
@@ -19,11 +19,6 @@ public class Given_StatusBar
 	[RequiresFullWindow]
 	public async Task StatusBar_Background_Value_ShouldDisplaceRenderArea()
 	{
-		if (!FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled)
-		{
-			Assert.Inconclusive("This test is only relevant when Edge2Edge is enabled.");
-		}
-
 		var sb = StatusBar.GetForCurrentView();
 		var av = ApplicationView.GetForCurrentView();
 		if (sb.OccludedRect.Height == 0 || av.IsFullScreenMode)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -807,17 +807,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// Fails because keyboard does not appear when TextBox is programmatically focussed, or appearance is not correctly registered - https://github.com/unoplatform/uno/issues/7995
 		[Ignore()]
 		[TestMethod]
-		public async Task When_Soft_Keyboard_And_VisibleBounds_Native()
-		{
-			using (FeatureConfigurationHelper.UseNativePopups())
-			{
-				await When_Soft_Keyboard_And_VisibleBounds();
-			}
-		}
-
-		// Fails because keyboard does not appear when TextBox is programmatically focussed, or appearance is not correctly registered - https://github.com/unoplatform/uno/issues/7995
-		[Ignore()]
-		[TestMethod]
 		public async Task When_Soft_Keyboard_And_VisibleBounds_Managed()
 		{
 			await When_Soft_Keyboard_And_VisibleBounds();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -1931,14 +1931,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		private static void VerifyRelativeContentPosition(Windows.Foundation.Point position, HorizontalPosition horizontalPosition, VerticalPosition verticalPosition, FrameworkElement content, double minimumTargetOffset, FrameworkElement target)
 		{
 			var contentScreenBounds = content.GetOnScreenBounds();
-#if __ANDROID__
-			if (FeatureConfiguration.Popup.UseNativePopup)
-			{
-				// Adjust for status bar height, which is omitted from TransformToVisual() for elements inside of a native popup.
-				var rootViewBounds = ((FrameworkElement)Window.Current.Content).GetOnScreenBounds();
-				contentScreenBounds.Y += rootViewBounds.Y;
-			}
-#endif
 			var contentCenter = contentScreenBounds.GetCenter();
 			var targetScreenBounds = target.GetOnScreenBounds();
 			var targetCenter = targetScreenBounds.GetCenter();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
-using Uno.Disposables;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.GridPages;
@@ -668,69 +667,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var redBounds = ImageAssert.GetColorBounds(bitmap, Colors.Red, tolerance: 5);
 			Assert.AreEqual(new Rect(new Point(41, 125), new Size(117, 114)), redBounds);
 		}
-
-#if __ANDROID__
-		[TestMethod]
-		[RunsOnUIThread]
-		public async Task When_Grid_Remeasure()
-		{
-			// uno#12315: rows/columns of Grid can sometimes fail to re-measure due to android measure caching
-			// causing incorrect measure/arrange for views belonging to that rows/columns.
-
-			// ensure the flag is active, and will be restored after test
-			var flag = FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure;
-			using var restore = Disposable.Create(() => FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure = flag);
-			FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure = true;
-
-			var setup = XamlHelper.LoadXaml<Border>("""
-				<Border BorderThickness="5" BorderBrush="Red">
-					<Grid x:Name="SutGrid" Height="400" Width="600">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="*" />
-						</Grid.RowDefinitions>
-
-						<StackPanel>
-							<!--<Button x:Name="ToggleVisibility" Content="ON|OFF" Style="{StaticResource BasicButtonStyle}" />-->
-							<Border x:Name="TogglableBorder" Height="50" Background="SkyBlue" />
-						</StackPanel>
-
-						<ListView x:Name="SutLV" Grid.Row="1" ItemsSource="{Binding}" />
-						<TextBlock Grid.Row="1" Text="TEXT MUST BE HERE" HorizontalAlignment="Center" VerticalAlignment="Bottom" />
-					</Grid>
-				</Border>
-				""");
-			setup.DataContext = Enumerable.Range(0, 50);
-
-			var grid = setup.FindFirstDescendant<Grid>(x => x.Name == "SutGrid");
-			var togglableBorder = setup.FindFirstDescendant<Border>(x => x.Name == "TogglableBorder");
-			var lv = setup.FindFirstDescendant<ListView>(x => x.Name == "SutLV");
-
-			TestServices.WindowHelper.WindowContent = setup;
-			await TestServices.WindowHelper.WaitForLoaded(setup);
-			await TestServices.WindowHelper.WaitForIdle();
-
-			var initial = lv.ActualHeight;
-
-			// On first cycle, everything will be normal.
-			togglableBorder.Visibility = Visibility.Collapsed; // C = 1
-			await TestServices.WindowHelper.WaitForIdle();
-			Assert.IsGreaterThan(initial, lv.ActualHeight, $"C1: SutLV should've expanded with the border collapsed: Lv.ActualHeight>initial --> ({lv.ActualHeight}>{initial})");
-			togglableBorder.Visibility = Visibility.Visible; // C = 2
-			await TestServices.WindowHelper.WaitForIdle();
-			Assert.IsTrue(DoubleUtil.AreWithinTolerance(lv.ActualHeight, initial, 0.1), $"C2: SutLV should've returned to initial size with the border visible: Lv.ActualHeight==initial --> ({lv.ActualHeight}=={initial})");
-
-			// On the following cycles, everything should still be normal.
-			// [Android:] However, in context of uno12315, it would fail on C4,C6,C8...
-			// due to measure caching of Android.Views.View.Measure inside the measure pass of Grid.
-			togglableBorder.Visibility = Visibility.Collapsed; // C = 3
-			await TestServices.WindowHelper.WaitForIdle();
-			Assert.IsGreaterThan(initial, lv.ActualHeight, $"C3: SutLV should've expanded with the border collapsed: Lv.ActualHeight>initial --> ({lv.ActualHeight}>{initial})");
-			togglableBorder.Visibility = Visibility.Visible; // C = 4
-			await TestServices.WindowHelper.WaitForIdle();
-			Assert.IsTrue(DoubleUtil.AreWithinTolerance(lv.ActualHeight, initial, 0.1), $"C4: SutLV should've returned to initial size with the border visible: Lv.ActualHeight==initial --> ({lv.ActualHeight}=={initial})");
-		}
-#endif
 
 		private static void AddChild(Grid parent, FrameworkElement child, int row, int col, int? rowSpan = null, int? colSpan = null)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -3138,62 +3138,59 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Item_Removed_And_Relayout_NV286()
 		{
-			using (FeatureConfigurationHelper.UseListViewAnimations())
+			var source = new ObservableCollection<string>();
+			var index = 0;
+			for (int i = 0; i < 5; i++)
 			{
-				var source = new ObservableCollection<string>();
-				var index = 0;
-				for (int i = 0; i < 5; i++)
-				{
-					InsertAnItem();
-				}
-
-				var SUT = new ListView
-				{
-					HorizontalAlignment = HorizontalAlignment.Left,
-					Width = 300,
-					Height = 180,
-					Background = new SolidColorBrush(Colors.Beige),
-					ItemsSource = source,
-					ItemTemplate = NV286_Template
-				};
-
-				var errorCatchGrid = new ErrorCatchGrid
-				{
-					Children =
-					{
-						SUT
-					}
-				};
-
-				WindowHelper.WindowContent = errorCatchGrid;
-				await WindowHelper.WaitForLoaded(SUT);
-				await WindowHelper.WaitForNonNull(() => SUT.ContainerFromIndex(3));
-
-				source.RemoveAt(source.Count - 1);
 				InsertAnItem();
-				InsertAnItem();
+			}
 
-				await Task.Delay(5); // The key to reproing the bug is to trigger a relayout asynchronously, while the disappear animation is still in flight
-				var viewToModify = SUT.ContainerFromIndex(3) as ListViewItem;
-				Assert.IsNotNull(viewToModify);
-				var border = viewToModify.FindFirstDescendant<Border>(b => b.Name == "ItemBorder");
-				Assert.IsNotNull(border);
-				border.Width += 20;
+			var SUT = new ListView
+			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				Width = 300,
+				Height = 180,
+				Background = new SolidColorBrush(Colors.Beige),
+				ItemsSource = source,
+				ItemTemplate = NV286_Template
+			};
 
-				await WindowHelper.WaitForIdle();
-
-				if (errorCatchGrid.Exception is { } e)
+			var errorCatchGrid = new ErrorCatchGrid
+			{
+				Children =
 				{
-					throw e;
+					SUT
 				}
+			};
 
-				// If all goes well, the app will not crash when the removed item finishes animating
+			WindowHelper.WindowContent = errorCatchGrid;
+			await WindowHelper.WaitForLoaded(SUT);
+			await WindowHelper.WaitForNonNull(() => SUT.ContainerFromIndex(3));
 
-				void InsertAnItem()
-				{
-					index++;
-					source.Insert(0, $"Item {index}");
-				}
+			source.RemoveAt(source.Count - 1);
+			InsertAnItem();
+			InsertAnItem();
+
+			await Task.Delay(5); // The key to reproing the bug is to trigger a relayout asynchronously, while the disappear animation is still in flight
+			var viewToModify = SUT.ContainerFromIndex(3) as ListViewItem;
+			Assert.IsNotNull(viewToModify);
+			var border = viewToModify.FindFirstDescendant<Border>(b => b.Name == "ItemBorder");
+			Assert.IsNotNull(border);
+			border.Width += 20;
+
+			await WindowHelper.WaitForIdle();
+
+			if (errorCatchGrid.Exception is { } e)
+			{
+				throw e;
+			}
+
+			// If all goes well, the app will not crash when the removed item finishes animating
+
+			void InsertAnItem()
+			{
+				index++;
+				source.Insert(0, $"Item {index}");
 			}
 		}
 
@@ -3678,39 +3675,37 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			const int ITEMS_TO_ADD = 6;
 			const int INDEX_TO_DELETE = 3;
-			using (FeatureConfigurationHelper.UseListViewAnimations())
+
+			var source = Enumerable.Range(0, ITEMS_TO_ADD).Select(a => new DefaultItem { Name = $"Item {a}", Value = a * a }).ToArray();
+
+			var SUT = new ListView
 			{
-				var source = Enumerable.Range(0, ITEMS_TO_ADD).Select(a => new DefaultItem { Name = $"Item {a}", Value = a * a }).ToArray();
+				Width = 200,
+				Height = 300,
+				ItemTemplate = DefaultItemTemplate
+			};
 
-				var SUT = new ListView
-				{
-					Width = 200,
-					Height = 300,
-					ItemTemplate = DefaultItemTemplate
-				};
+			var model = new When_Deleting_Item_DataContext(source);
+			SUT.DataContext = model;
+			SUT.SetBinding(ItemsControl.ItemsSourceProperty, new Binding { Path = new PropertyPath(nameof(model.Items)), Mode = BindingMode.OneWay });
 
-				var model = new When_Deleting_Item_DataContext(source);
-				SUT.DataContext = model;
-				SUT.SetBinding(ItemsControl.ItemsSourceProperty, new Binding { Path = new PropertyPath(nameof(model.Items)), Mode = BindingMode.OneWay });
+			WindowHelper.WindowContent = SUT;
 
-				WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
 
-				await WindowHelper.WaitForLoaded(SUT);
+			Assert.AreEqual(ITEMS_TO_ADD, SUT.Items.Count);
 
-				Assert.AreEqual(ITEMS_TO_ADD, SUT.Items.Count);
+			var container = SUT.ContainerFromIndex(INDEX_TO_DELETE) as ContentControl;
 
-				var container = SUT.ContainerFromIndex(INDEX_TO_DELETE) as ContentControl;
+			model.Items.RemoveAt(INDEX_TO_DELETE);
 
-				model.Items.RemoveAt(INDEX_TO_DELETE);
+			// Ensure the container has properly been cleaned
+			// up after being removed.
+			Assert.IsNull(container.Content);
 
-				// Ensure the container has properly been cleaned
-				// up after being removed.
-				Assert.IsNull(container.Content);
+			Assert.IsNull(container.GetBindingExpression(ContentControl.ContentProperty));
 
-				Assert.IsNull(container.GetBindingExpression(ContentControl.ContentProperty));
-
-				Assert.HasCount(5, SUT.Items);
-			}
+			Assert.HasCount(5, SUT.Items);
 		}
 
 #if __SKIA__ || __WASM__

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -250,13 +250,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreEqual(32, menuBarItemBounds.Height, 1);
 
 				var expectedY = 39.0;
-#if __ANDROID__
-				if (!FeatureConfiguration.Popup.UseNativePopup)
-				{
-					// If using managed popup, the expected offset must be adjusted for the status bar
-					expectedY += menuBarBounds.Y;
-				}
-#endif
 
 				Assert.AreEqual(5, flyoutItemBounds.X, 3);
 				Assert.AreEqual(expectedY, flyoutItemBounds.Y, 3);
@@ -268,17 +261,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 #if __ANDROID__
-		[TestMethod]
-		[RequiresFullWindow]
-		[Ignore("Flaky #9080")]
-		public async Task Verify_MenuBarItem_Bounds_Native_Popups()
-		{
-			using (FeatureConfigurationHelper.UseNativePopups())
-			{
-				await Verify_MenuBarItem_Bounds();
-			}
-		}
-
 		[TestMethod]
 		[RequiresFullWindow]
 		public async Task Verify_MenuBarItem_Bounds_Managed_Popups()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -43,23 +43,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			}
 		}
 
-#if __ANDROID__
-		[TestMethod]
-		public async Task Check_Can_Reach_Main_Visual_Tree_Alternate_Mode()
-		{
-			var originalConfig = FeatureConfiguration.Popup.UseNativePopup;
-			FeatureConfiguration.Popup.UseNativePopup = !originalConfig;
-			try
-			{
-				await Check_Can_Reach_Main_Visual_Tree();
-			}
-			finally
-			{
-				FeatureConfiguration.Popup.UseNativePopup = originalConfig;
-			}
-		}
-#endif
-
 		[TestMethod]
 		public void When_IsLightDismissEnabled_Default()
 		{

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -616,14 +616,6 @@ namespace Uno.UI
 			/// </summary>
 			public static bool UseInvalidateArrangePath { get; set; } = true;
 
-#if __ANDROID__
-			/// <summary>
-			/// On Android, rollback the clipping to the previous behavior, which was to apply the clipping
-			/// on the assigned children bounds instead of the parent bounds. 
-			/// </summary>
-			public static bool UseLegacyClipping { get; set; }
-#endif
-
 			/// <summary>
 			/// Enable the visualization of clipping bounds (intended for diagnostic purposes).
 			/// </summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -744,32 +744,6 @@ namespace Uno.UI
 			public static bool FailOnUnknownProperties { get; set; }
 		}
 
-		public static class DatePicker
-		{
-#if __APPLE_UIKIT__
-			/// <summary>
-			/// Gets or set whether the <see cref="Microsoft.UI.Xaml.Controls.DatePicker" /> rendered matches the Legacy Style or not.
-			/// </summary>
-			/// <remarks>
-			/// Important: This flag will only have an impact on iOS 14 devices
-			/// </remarks>
-			public static bool UseLegacyStyle { get; set; }
-#endif
-		}
-
-		public static class TimePicker
-		{
-#if __APPLE_UIKIT__
-			/// <summary>
-			/// Gets or set whether the TimePicker rendered matches the Legacy Style or not.
-			/// </summary>
-			/// <remarks>
-			/// Important: This flag will only have an impact on iOS 14 devices
-			/// </remarks>
-			public static bool UseLegacyStyle { get; set; }
-#endif
-		}
-
 		public static class TimePickerFlyout
 		{
 #if __ANDROID__

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -107,14 +107,6 @@ namespace Uno.UI
 			/// referencing the ** type ** ComboBox in any way.
 			/// </remarks>
 			public static Uno.UI.Xaml.Controls.DropDownPlacement DefaultDropDownPreferredPlacement { get; set; } = Uno.UI.Xaml.Controls.DropDownPlacement.Auto;
-
-#if __ANDROID__
-			/// <summary>
-			/// Gets or sets a value indicating whether the ComboBox popup should be allowed
-			/// to be displayed under translucent status bar on Android. Defaults to false.
-			/// </summary>
-			public static bool AllowPopupUnderTranslucentStatusBar { get; set; }
-#endif
 		}
 
 		public static class CompositionTarget

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -380,18 +380,6 @@ namespace Uno.UI
 			/// the default value at the UWP default of 4.0.
 			/// </summary>
 			public static double? DefaultCacheLength { get; set; } = 1.0;
-
-#if __APPLE_UIKIT__ || __ANDROID__
-			/// <summary>
-			/// Sets a flag indicating whether <see cref="Microsoft.UI.Xaml.Controls.ListViewBase.ScrollIntoView(object)"/> will be animated smoothly or instant.
-			/// </summary>
-			/// <remarks>
-			/// Regardless of the value set, <see cref="Uno.UI.Helpers.ListViewHelper.InstantScrollToIndex(Microsoft.UI.Xaml.Controls.ListViewBase, int)"/>
-			/// and <see cref="Uno.UI.Helpers.ListViewHelper.SmoothScrollToIndex(Microsoft.UI.Xaml.Controls.ListViewBase, int)"/>
-			/// can be used to force a specific behavior.
-			/// </remarks>
-			public static bool AnimateScrollIntoView { get; set; } = true;
-#endif
 		}
 
 #if __ANDROID__

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -979,15 +979,5 @@ namespace Uno.UI
 		}
 #endif
 
-		public static class NavigationView
-		{
-#if __ANDROID__
-			/// <summary>
-			/// Workaround for unoplatform/uno#19516 where toggling IsBackButtonVisible would stop NVIs from updating their layout/size when expanded/collapsed.
-			/// </summary>
-			public static bool EnableUno19516Workaround { get; set; } = true;
-#endif
-		}
-
 	}
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -540,18 +540,6 @@ namespace Uno.UI
 			/// on iOS versions prior to 26.
 			/// </remarks>
 			public static bool DisableNumberPadPopover { get; set; }
-
-#if __ANDROID__
-			/// <summary>
-			/// The legacy <see cref="Microsoft.UI.Xaml.Controls.TextBox.InputScope"/> prevents invalid input on hardware keyboard.
-			/// This property defaults to <see langword="false"/> matching UWP, where InputScope only affects the keyboard layout,
-			/// but doesn't do any validation.
-			/// </summary>
-			/// <remarks>
-			/// This is available on Android only
-			/// </remarks>
-			public static bool UseLegacyInputScope { get; set; }
-#endif
 		}
 
 		public static class ScrollViewer

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -648,17 +648,6 @@ namespace Uno.UI
 			/// </remarks>
 			public static bool AssignDOMXamlProperties { get; set; }
 
-#if __ANDROID__
-			/// <summary>
-			/// When this is set, non-UIElements will always be clipped to their bounds (<see cref="Android.Views.ViewGroup.ClipChildren"/> will
-			/// always be set to true on their parent).
-			/// </summary>
-			/// <remarks>
-			/// This is true by default as most native views assume that they will be clipped, and can display incorrectly otherwise.
-			/// </remarks>
-			public static bool AlwaysClipNativeChildren { get; set; } = true;
-#endif
-
 			/// <summary>
 			/// For non-holding pointer events, use CompleteGesture when bubbling gesture events.
 			/// This defaults to false, which prevents the specific event instead of calling CompleteGesture

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -565,15 +565,6 @@ namespace Uno.UI
 			/// <remarks>This is effective only for managed scrollbars (WASM, macOS and Skia for now)</remarks>
 			public static TimeSpan? DefaultAutoHideDelay { get; set; }
 
-#if __ANDROID__
-			/// <summary>
-			/// This value defines an optional delay to be set for native ScrollBar thumbs to disapear. The
-			/// platform default is 300ms, which can make the thumbs appear on screenshots, changing this value
-			/// to <see cref="TimeSpan.Zero"/> makes those disapear faster.
-			/// </summary>
-			public static TimeSpan? AndroidScrollbarFadeDelay { get; set; }
-#endif
-
 			/// <summary>
 			/// Defines the delay of after which the ScrollViewer starts to move to snap points. The default value is 250ms.
 			/// </summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -341,13 +341,6 @@ namespace Uno.UI
 
 		public static class Popup
 		{
-#if __ANDROID__
-			/// <summary>
-			/// Use a native popup to display the popup content. Otherwise use the <see cref="PopupRoot"/>.
-			/// </summary>
-			public static bool UseNativePopup { get; set; }
-#endif
-
 			/// <summary>
 			/// By default, light dismiss is disabled in UWP/WinUI unless
 			/// <see cref="Microsoft.UI.Xaml.Controls.Primitives.Popup.IsLightDismissEnabled"/> is explicitly set to true.

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -710,21 +710,6 @@ namespace Uno.UI
 			/// </remarks>
 			public static string AdditionalBrowserArguments { get; set; }
 
-#if __IOS__ || UNO_REFERENCE_API
-			/// <summary>
-			/// Sets whether the <see cref="WebView2"/> object is inspectable or not.
-			/// </summary>
-			/// <remarks>
-			/// On iOS and Catalyst this means that developers can use the Safari Web Developers tools to debug apps with <see cref="WebView2"/>
-			/// Important: It will only work when the app runs in Debug mode.
-			/// </remarks>
-			[System.Obsolete("Use " + nameof(EnableDevTools) + " instead. This cross-platform flag controls the same behavior on all targets.")]
-			public static bool IsInspectable
-			{
-				get => EnableDevTools;
-				set => EnableDevTools = value;
-			}
-#endif
 		}
 
 		public static class Xaml

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -922,35 +922,5 @@ namespace Uno.UI
 #endif
 		}
 
-#if __ANDROID__ || UNO_REFERENCE_API
-		public static class AndroidSettings
-		{
-#if NET9_0_OR_GREATER
-			private static bool _isEdgeToEdgeEnabled = true;
-#else
-			private static bool _isEdgeToEdgeEnabled;
-#endif
-
-			/// <summary>
-			/// Gets or sets a value indicating whether the app should use the "edge-to-edge" experience
-			/// <see href="https://developer.android.com/develop/ui/views/layout/edge-to-edge" />.
-			/// When enabled, the system UI becomes transparent and the app's UI flows behind it.
-			/// Use Uno Toolkit SafeArea to accomodate for it.
-			/// This flag has no effect on Android 15 and newer, where the edge-to-edge experience
-			/// is enforced by the OS.
-			/// </summary>
-			/// <remarks>True by default in apps targeting .NET 9 and newer, false otherwise.</remarks>
-			public static bool IsEdgeToEdgeEnabled
-			{
-#if __ANDROID__
-				get => _isEdgeToEdgeEnabled || (int)Android.OS.Build.VERSION.SdkInt >= 35;
-#else
-				get => _isEdgeToEdgeEnabled;
-#endif
-				set => _isEdgeToEdgeEnabled = value;
-			}
-		}
-#endif
-
 	}
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -744,23 +744,6 @@ namespace Uno.UI
 			public static bool FailOnUnknownProperties { get; set; }
 		}
 
-		public static class TimePickerFlyout
-		{
-#if __ANDROID__
-			/// <summary>
-			/// Gets or sets whether the <see cref="Microsoft.UI.Xaml.Controls.TimePickerFlyout"/> uses legacy time setting.
-			/// Legacy time setting is about preserving days, seconds, and milliseconds of
-			/// <see cref="Microsoft.UI.Xaml.Controls.TimePickerFlyout.Time"/>.
-			/// </summary>
-			/// <remarks>
-			/// This flag defaults to <see langword="false"/> to match UWP behavior, where a value set from UI is
-			/// only hours and minutes, and any previously set (programmatically) days, seconds, or milliseconds are cleared.
-			/// This flag is Android only.
-			/// </remarks>
-			public static bool UseLegacyTimeSetting { get; set; }
-#endif
-		}
-
 		public static class CommandBar
 		{
 #if __APPLE_UIKIT__

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -670,20 +670,6 @@ namespace Uno.UI
 			public static bool ApplySettersBeforeTransition { get; set; }
 		}
 
-		public static class WebView
-		{
-#if __ANDROID__
-			/// <summary>
-			/// Prevent the WebView from using hardware rendering.
-			/// This was previously the default behavior in Uno to work around a keyboard-related visual glitch in Android 5.0 (http://stackoverflow.com/questions/27172217/android-systemui-glitches-in-lollipop), however it prevents video and 3d content from being rendered.
-			/// </summary>
-			/// <remarks>
-			/// See this for more info: https://github.com/unoplatform/uno/blob/26c5cc5992cae3c8c25adf51eb77ca4b0dd34e93/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs#L251_L255
-			/// </remarks>
-			public static bool ForceSoftwareRendering { get; set; }
-#endif
-		}
-
 		public static class WebView2
 		{
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -744,22 +744,6 @@ namespace Uno.UI
 			public static bool FailOnUnknownProperties { get; set; }
 		}
 
-		public static class CommandBar
-		{
-#if __APPLE_UIKIT__
-			/// <summary>
-			/// Gets or Set whether the AllowNativePresenterContent feature is on or off.
-			/// </summary>
-			/// <remarks>
-			/// This feature is used in the context of the sample application to test NavigationBars outside of a NativeFramePresenter for
-			/// UI Testing. In general cases, this should not happen as the bar may be moved back to to this presenter while
-			/// another page is already visible, making this bar overlay on top of another.
-			/// </remarks>
-			/// <returns>True if this feature is on, False otherwise</returns>
-			public static bool AllowNativePresenterContent { get; set; }
-#endif
-		}
-
 		public static class AppBarButton
 		{
 #if __ANDROID__

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -382,31 +382,6 @@ namespace Uno.UI
 			public static double? DefaultCacheLength { get; set; } = 1.0;
 		}
 
-#if __ANDROID__
-		public static class NativeListViewBase
-		{
-			/// <summary>
-			/// Sets this value to remove item animation for <see cref="UnoRecyclerView"/>. This prevents <see cref="UnoRecyclerView"/>
-			/// from crashing when pressured: Tmp detached view should be removed from RecyclerView before it can be recycled
-			/// </summary>
-			public static bool RemoveItemAnimator { get; set; } = true;
-
-			/// <summary>
-			/// Indicates if a full recycling pass should be achieved on drop (re-order) on a ListView instead of a simple layout pass.
-			/// </summary>
-			/// <remarks>
-			/// This flag should be kept to 'false' if you turned <see cref="RemoveItemAnimator"/> to 'false'.
-			/// Forcing a recycling pass with ItemAnimator is known to cause a flicker of the whole list.
-			/// </remarks>
-			public static bool ForceRecycleOnDrop { get; set; }
-
-			/// <summary>
-			/// Sets a value indicating whether the item snapping will be implemented by the native <see cref="AndroidX.RecyclerView.Widget.SnapHelper"/> or by Uno.
-			/// </summary>
-			public static bool UseNativeSnapHelper { get; set; } = true;
-		}
-#endif
-
 		public static class Page
 		{
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -271,15 +271,6 @@ namespace Uno.UI
 			/// will not, which is how WinUI behaves. Set to true if you have code written for earlier versions of Uno that relies upon the old behavior.
 			/// </summary>
 			public static bool UseLegacyHitTest { get; set; }
-
-#if __APPLE_UIKIT__
-			/// <summary>
-			/// When true, propagate the NeedsLayout on superview even if the element is in its LayoutSubViews() (i.e. Arrange()).
-			/// This is known to cause a layout cycle when a child invalidates itself during arrange (e.g. ItemsRepeater).
-			/// Default value is false, setting it to true will restore the behavior of uno v4.7 and earlier.
-			/// </summary>
-			public static bool IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews { get; set; }
-#endif
 		}
 
 		public static class FrameworkTemplate

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -744,23 +744,6 @@ namespace Uno.UI
 			public static bool FailOnUnknownProperties { get; set; }
 		}
 
-		public static class AppBarButton
-		{
-#if __ANDROID__
-			/// <summary>
-			/// Gets or set whether the EnableBitmapIconTint feature is on or off.
-			/// </summary>
-			/// <remarks>
-			/// This Feature will allow any <see cref="Microsoft.UI.Xaml.Controls.AppBarButton"/>
-			/// inside a <see cref="Microsoft.UI.Xaml.Controls.CommandBar"/> to use the Foreground <see cref="SolidColorBrush"/>
-			/// as their tint Color.
-			/// <para/>Default value is False.
-			/// </remarks>
-			/// <returns>True if this feature is on, False otherwise</returns>
-			public static bool EnableBitmapIconTint { get; set; }
-#endif
-		}
-
 		public static class Cursors
 		{
 #if UNO_REFERENCE_API

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -744,18 +744,6 @@ namespace Uno.UI
 			public static bool FailOnUnknownProperties { get; set; }
 		}
 
-		public static class Cursors
-		{
-#if UNO_REFERENCE_API
-			/// <summary>
-			/// Gets or sets a value indicating whether "interactive" controls like
-			/// Buttons and ToggleSwitches use the pointer cursor in WebAssembly
-			/// to emulate a "web-like" feel. Default is <see langword="true"/>.
-			/// </summary>
-			public static bool UseHandForInteraction { get; set; } = true;
-#endif
-		}
-
 		public static class Timeline
 		{
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -591,17 +591,6 @@ namespace Uno.UI
 			public static int ShowDuration { get; set; } = 5000;
 		}
 
-		public static class NativeFramePresenter
-		{
-#if __ANDROID__
-			/// <summary>
-			/// Determines if pages in the backstack are kept in the visual tree.
-			/// Defaults to false for performance considerations.
-			/// </summary>
-			public static bool AndroidUnloadInactivePages { get; set; }
-#endif
-		}
-
 		public static class UIElement
 		{
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -402,22 +402,6 @@ namespace Uno.UI
 #endif
 		}
 
-		public static class PointerRoutedEventArgs
-		{
-#if __ANDROID__
-			/// <summary>
-			/// Defines if the PointerPoint.Timestamp retrieved from PointerRoutedEventArgs.GetCurrentPoint(relativeTo)
-			/// or PointerRoutedEventArgs.GetIntermediatePoints(relativeTo) can be relative using the Android's
-			/// "SystemClock.uptimeMillis()" or if they must be converted into an absolute scale
-			/// (using the "elapsedRealtime()", cf. https://developer.android.com/reference/android/os/SystemClock).
-			/// Disabling it negatively impacts the performance it requires to compute the "sleep time"
-			/// (i.e. [real elapsed time] - [up time]) for each event (as the up time is paused when device is in deep sleep).
-			/// By default this is `true`.
-			/// </summary>
-			public static bool AllowRelativeTimeStamp { get; set; } = true;
-#endif
-		}
-
 		public static class ManipulationRoutedEventArgs
 		{
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -259,26 +259,6 @@ namespace Uno.UI
 
 		public static class FrameworkElement
 		{
-#if __ANDROID__
-			/// <summary>
-			/// Controls the propagation of <see cref="Microsoft.UI.Xaml.FrameworkElement.Loaded"/> and
-			/// <see cref="Microsoft.UI.Xaml.FrameworkElement.Unloaded"/> events through managed
-			/// or native visual tree traversal.
-			/// </summary>
-			/// <remarks>
-			/// This setting impacts significantly the loading performance of controls on Android.
-			/// Setting it to true avoids the use of costly Java->C# interop.
-			/// </remarks>
-			public static bool AndroidUseManagedLoadedUnloaded { get; set; } = true;
-#endif
-
-#if __ANDROID__
-			/// <summary>
-			/// Invalidate native android measure cache when measure-spec has changed since last measure.
-			/// </summary>
-			public static bool InvalidateNativeCacheOnRemeasure { get; set; } = true;
-#endif
-
 			/// <summary>
 			/// When false, skips the FrameworkElement Loading/Loaded/Unloaded exception handling. This can be
 			/// disabled to improve application performance on WebAssembly. See See #7005 for additional details.

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
@@ -29,12 +29,3 @@ If you wish to customize the overlay color, add the following to your top-level 
 <SolidColorBrush x:Key="DatePickerLightDismissOverlayBackground"
 		Color="Pink" />
 ```
-
-Since **iOS14** the native `DatePicker` changed the way it's presented. By default iOS14 devices will display this new style.  You can still force the previous style (the one found in iOS13 or earlier) by adding the following at your `App.xaml.cs` class:
-
-```csharp
-Uno.UI.FeatureConfiguration.DatePicker.UseLegacyStyle = true;
-```
-
-> [!IMPORTANT]
-> This feature flag is required and will only affect iOS 14 devices. As of **iOS 15**, the preferred style for the DatePicker is again the one found in iOS13 and earlier.

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -4442,18 +4442,6 @@ public partial class NavigationView : ContentControl
 				backButton.UpdateLayout();
 			}
 
-#if __ANDROID__
-			// workaround for unoplatform/uno#19516 where toggling IsBackButtonVisible would stop NVIs from updating their layout/size when expanded/collapsed.
-			if (global::Uno.UI.FeatureConfiguration.NavigationView.EnableUno19516Workaround &&
-				m_appliedTemplate && IsLoaded)
-			{
-				foreach (var ir in this.EnumerateDescendants().OfType<ItemsRepeater>())
-				{
-					ir.InvalidateMeasure();
-				}
-			}
-#endif
-
 			UpdatePaneLayout();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
@@ -57,13 +57,7 @@ partial class NativeTimePickerFlyout : TimePickerFlyout
 				minutes = minutes * MinuteIncrement;
 			}
 
-#if ANDROID_SKIA
 			var time = new TimeSpan(0, hourOfDay, minutes, 0);
-#else
-			var time = FeatureConfiguration.TimePickerFlyout.UseLegacyTimeSetting
-				? new TimeSpan(Time.Days, hourOfDay, minutes, Time.Seconds, Time.Milliseconds)
-				: new TimeSpan(0, hourOfDay, minutes, 0);
-#endif
 			SaveTime(time.RoundToMinuteInterval(MinuteIncrement));
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
@@ -62,17 +62,6 @@ internal partial class NativeWebViewWrapper : INativeWebView
 			ViewGroup.LayoutParams.MatchParent,
 			ViewGroup.LayoutParams.MatchParent);
 #endif
-
-#if !ANDROID_SKIA // We only have the flag for Android native. We can add it to Skia if needed.
-		if (FeatureConfiguration.WebView.ForceSoftwareRendering)
-		{
-			//SetLayerType disables hardware acceleration for a single view.
-			//_owner is required to remove glitching issues particularly when having a keyboard pop-up with a webview present.
-			//http://developer.android.com/guide/topics/graphics/hardware-accel.html
-			//http://stackoverflow.com/questions/27172217/android-systemui-glitches-in-lollipop
-			_webView.SetLayerType(LayerType.Software, null);
-		}
-#endif
 	}
 
 	public string DocumentTitle

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -63,20 +63,6 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 	internal void OnNativeClosed() => RaiseClosing();
 
-	internal bool IsStatusBarTranslucent()
-	{
-		if (!(ContextHelper.Current is Activity activity))
-		{
-			throw new Exception("Cannot check NavigationBar translucent property. Activity is not defined yet.");
-		}
-
-		return activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus)
-			|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.LayoutNoLimits)
-
-			//  Both TranslucentStatus and LayoutNoLimits are false when EdgeToEdge is set (default mode in net9).
-			|| FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled;
-	}
-
 	internal void RaiseNativeSizeChanged()
 	{
 		var (windowSize, visibleBounds) = GetVisualBounds();
@@ -140,58 +126,33 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		var decorView = activity.Window.DecorView;
 		var fitsSystemWindows = decorView.FitsSystemWindows;
 
-		if (FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled)
+		var insets = windowInsets?.GetInsets(insetsTypes).ToThickness() ?? default;
+
+		if (this.Log().IsEnabled(LogLevel.Debug))
 		{
-			var insets = windowInsets?.GetInsets(insetsTypes).ToThickness() ?? default;
+			this.Log().LogDebug($"Insets: {insets}");
+		}
 
-			if (this.Log().IsEnabled(LogLevel.Debug))
-			{
-				this.Log().LogDebug($"Insets: {insets}");
-			}
+		if (StatusBar.GetForCurrentView().BackgroundColor is { } && (int)Android.OS.Build.VERSION.SdkInt >= 35)
+		{
+			// quick refresher:
+			// - windowBounds: size of the rendered area, its location is ignored/unused
+			// - visibleBounds: area WITHIN windowBounds that isn't occluded/blocked by system overlays (status-bar, navigation-bar, etc.)
+			//		^ since VB calculated from WB, it is important that WB doesn't have an location/offset to be inherited by VB.
 
-			if (StatusBar.GetForCurrentView().BackgroundColor is { } && (int)Android.OS.Build.VERSION.SdkInt >= 35)
-			{
-				// quick refresher:
-				// - windowBounds: size of the rendered area, its location is ignored/unused
-				// - visibleBounds: area WITHIN windowBounds that isn't occluded/blocked by system overlays (status-bar, navigation-bar, etc.)
-				//		^ since VB calculated from WB, it is important that WB doesn't have an location/offset to be inherited by VB.
+			// see: StatusBar.SetStatusBarBackgroundColor (StatusBar.Android.cs)
+			// Setting a non-null StatusBar.Background in v35, will add a padding to the decor-view.
+			// This will move down the coordinates system for both windowBounds and visibleBounds,
+			// their zero(0,0) will be (0, inset.top) on the physical display.
 
-				// see: StatusBar.SetStatusBarBackgroundColor (StatusBar.Android.cs)
-				// Setting a non-null StatusBar.Background in v35, will add a padding to the decor-view.
-				// This will move down the coordinates system for both windowBounds and visibleBounds,
-				// their zero(0,0) will be (0, inset.top) on the physical display.
-
-				var size = GetWindowSize();
-				windowBounds = new Rect(0, 0, size.Width, size.Height - insets.Top); // exclude top inset from rendering area
-				visibleBounds = windowBounds.DeflateBy(insets with { Top = 0 }); // apply the rest of the insets, skipping Top that is already excluded
-			}
-			else
-			{
-				windowBounds = new Rect(default, GetWindowSize());
-				visibleBounds = windowBounds.DeflateBy(insets);
-			}
+			var size = GetWindowSize();
+			windowBounds = new Rect(0, 0, size.Width, size.Height - insets.Top); // exclude top inset from rendering area
+			visibleBounds = windowBounds.DeflateBy(insets with { Top = 0 }); // apply the rest of the insets, skipping Top that is already excluded
 		}
 		else
 		{
-			var opaqueInsetsTypes = insetsTypes;
-			if (IsStatusBarTranslucent())
-			{
-				opaqueInsetsTypes &= ~WindowInsetsCompat.Type.StatusBars();
-			}
-			if (IsNavigationBarTranslucent())
-			{
-				opaqueInsetsTypes &= ~WindowInsetsCompat.Type.NavigationBars();
-			}
-
-			var insets = windowInsets?.GetInsets(insetsTypes).ToThickness() ?? default;
-			var opaqueInsets = windowInsets?.GetInsets(opaqueInsetsTypes).ToThickness() ?? default;
-			var translucentInsets = insets.Minus(opaqueInsets);
-
-			// The native display size does not include any insets, so we remove the "opaque" insets under which we cannot draw anything
-			windowBounds = new Rect(default, GetWindowSize().Subtract(opaqueInsets));
-
-			// The visible bounds is the windows bounds on which we remove also translucentInsets
-			visibleBounds = windowBounds.DeflateBy(translucentInsets);
+			windowBounds = new Rect(default, GetWindowSize());
+			visibleBounds = windowBounds.DeflateBy(insets);
 		}
 
 		if (this.Log().IsEnabled(LogLevel.Debug))
@@ -203,18 +164,6 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		var visibleBoundsLogical = visibleBounds.PhysicalToLogicalPixels();
 
 		return (windowBoundsLogical.Size, visibleBoundsLogical);
-	}
-
-	private bool IsNavigationBarTranslucent()
-	{
-		if (!(ContextHelper.Current is Activity activity))
-		{
-			throw new Exception("Cannot check NavigationBar translucent property. Activity is not defined yet.");
-		}
-
-		var flags = activity.Window.Attributes.Flags;
-		return flags.HasFlag(WindowManagerFlags.TranslucentNavigation)
-			|| flags.HasFlag(WindowManagerFlags.LayoutNoLimits);
 	}
 
 	private WindowInsetsCompat GetWindowInsets(Activity activity)
@@ -238,21 +187,18 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		// Only apply theming if the app hasn't explicitly set a foreground
 		if (StatusBar.GetForCurrentView().ForegroundColor is null)
 		{
-			if (FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled)
+			// In edge-to-edge experience we want to adjust the theming of status bar to match the app theme.
+			if (Microsoft.UI.Xaml.Application.Current is { } application &&
+				(ContextHelper.TryGetCurrent(out var context)) &&
+				context is Activity activity &&
+				activity.Window?.DecorView is { FitsSystemWindows: false } decorView)
 			{
-				// In edge-to-edge experience we want to adjust the theming of status bar to match the app theme.
-				if (Microsoft.UI.Xaml.Application.Current is { } application &&
-					(ContextHelper.TryGetCurrent(out var context)) &&
-					context is Activity activity &&
-					activity.Window?.DecorView is { FitsSystemWindows: false } decorView)
-				{
-					var requestedTheme = application.RequestedTheme;
+				var requestedTheme = application.RequestedTheme;
 
-					var insetsController = WindowCompat.GetInsetsController(activity.Window, decorView);
+				var insetsController = WindowCompat.GetInsetsController(activity.Window, decorView);
 
-					// "appearance light" refers to status bar set to light theme == dark foreground
-					insetsController.AppearanceLightStatusBars = requestedTheme == Microsoft.UI.Xaml.ApplicationTheme.Light;
-				}
+				// "appearance light" refers to status bar set to light theme == dark foreground
+				insetsController.AppearanceLightStatusBars = requestedTheme == Microsoft.UI.Xaml.ApplicationTheme.Light;
 			}
 		}
 	}


### PR DESCRIPTION
**GitHub Issue:** Part of #8339

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

> ⚠️ This PR contains **breaking changes** (public API removals). See the migration note below.

## What changed? 🚀

Uno Platform 7.0 drops the native UI renderers (native Android `View`, iOS/tvOS `UIView`, WASM DOM). This PR hard-removes every `FeatureConfiguration` flag that existed **only** to tune those native renderers, and inlines the surviving Skia/WinUI behavior at each call site. With the native heads gone, these flags configured code paths that no longer compile in any shipping assembly — misleading API surface that is shed in the 7.0 clean break.

Cross-target / legacy flags (those with a Skia `#else` branch, or unconditional flags) are explicitly **out of scope** here and handled separately.

### Flags removed (one `refactor!` commit each, three grouped where atomic)

**Native-symbol-only (deleted; native call sites collapsed):**

- `ComboBox.AllowPopupUnderTranslucentStatusBar`
- `FrameworkElement.AndroidUseManagedLoadedUnloaded`
- `FrameworkElement.InvalidateNativeCacheOnRemeasure`
- `FrameworkElement.IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews`
- `Popup.UseNativePopup`
- `ListViewBase.AnimateScrollIntoView`
- `NativeListViewBase.{RemoveItemAnimator, ForceRecycleOnDrop, UseNativeSnapHelper}`
- `PointerRoutedEventArgs.AllowRelativeTimeStamp`
- `TextBox.UseLegacyInputScope`
- `ScrollViewer.AndroidScrollbarFadeDelay`
- `UIElement.UseLegacyClipping`
- `UIElement.AlwaysClipNativeChildren`
- `WebView.ForceSoftwareRendering`
- `NativeFramePresenter.AndroidUnloadInactivePages`
- `DatePicker.UseLegacyStyle`
- `TimePicker.UseLegacyStyle`
- `TimePickerFlyout.UseLegacyTimeSetting`
- `CommandBar.AllowNativePresenterContent`
- `AppBarButton.EnableBitmapIconTint`
- `NavigationView.EnableUno19516Workaround`

**Present on the Skia/Reference public surface (default inlined; `PackageDiffIgnore.xml` entries added):**
- `Cursors.UseHandForInteraction` — the "hand" cursor for interactive controls is now always used.
- `WebView2.IsInspectable` — was an obsolete alias; use `WebView2.EnableDevTools` instead.
- `AndroidSettings.IsEdgeToEdgeEnabled` — edge-to-edge is now **unconditional** on Skia-Android (`EdgeToEdge.Enable(...)` inlined in `ApplicationActivity.OnCreate`).

Empty container classes are kept to avoid additional type-removal API breaks. The one orphaned `*.Android.cs` consumer of a removed flag (`NativeWindowWrapper.Android.cs`, which read `AndroidSettings.IsEdgeToEdgeEnabled`, uncompiled) is collapsed to the always-on edge-to-edge path so no dead flag reference lingers; the remaining orphaned `*.Android.cs`/`*.iOS.cs` files are left for the broader native-drop cleanup.

### Migration

The migration guide (`doc/articles/migrating-to-uno-7.md`) lists every removed flag with its replacement/behavior. In short: delete the calls — behavior is the unified Skia/WinUI behavior; for `WebView2.IsInspectable`, switch to `WebView2.EnableDevTools`. Feature-flag prose in the docs was trimmed accordingly.

## PR Checklist ✅

- [x] 🧪 Existing Popup/Flyout/MenuFlyout/ContentDialog runtime tests and samples updated to drop the removed native-only branches (no new behavior to test — this is a removal).
- [x] 📚 Docs updated (`feature-flags.md`, `migrating-to-uno-7.md`, control docs, sample prose).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)

> **Breaking change impact & migration path:** Public API removals of the `FeatureConfiguration` members listed above. These flags only affected the now-removed native renderers; apps on Skia get the unified WinUI behavior. Remove any calls to the removed members (and switch `WebView2.IsInspectable` → `WebView2.EnableDevTools`). For codebases targeting both pre-7.0 and 7.0, guard the calls with `#if`. Full per-flag guidance is in `doc/articles/migrating-to-uno-7.md`.

### Validation

- ✅ `Uno.UI.Skia` (net10.0) — build succeeded, 0 warnings / 0 errors (primary gate).
- ✅ `Uno.UI.Reference` (net10.0) — build succeeded, 0 / 0.
- ✅ XamlStyler format check on the two changed SamplesApp XAML files — PASS.
- ✅ Unit tests — 4001 passed / 23 skipped; the 13 failures are pre-existing, host-culture/ICU-dependent `When_Calendar` date-format assertions, unrelated to this change (diff touches no globalization code).
- ⏳ Mobile-Skia heads (Android/iOS, which compile the `#if __APPLE_UIKIT__`/`#if __ANDROID__` sample & test edits) not built locally — Android restore hit a pre-existing workload issue and iOS needs a Mac; relying on CI for those TFMs.
