### PR TITLE
docs: Add native OS menu integration spec

### DIFF
--- a/specs/047-native-os-menu/contracts/INativeMenuExtension.md
+++ b/specs/047-native-os-menu/contracts/INativeMenuExtension.md
@@ -1,0 +1,352 @@
+# Contract: `INativeMenuExtension` — native menu projection seam
+
+**Feature:** 047-native-os-menu · **Status:** Draft · **Created:** 2026-06-30
+
+This contract defines the **projection seam** between the platform-neutral core model
+(`NativeMenu` / `NativeMenuItem`, in `Uno.UI`) and the per-platform Skia runtime hosts that
+own the actual native menu system (AppKit `NSMenu`, UIKit `UIMenuBuilder`, DBusMenu, …).
+
+It is the **only** boundary the core crosses to put a menu on screen. The core never references
+AppKit/UIKit/D-Bus/Win32 types; it resolves a host-supplied implementation through Uno's
+[ApiExtensibility](../../../doc/articles/uno-development/api-extensions.md) mechanism
+(platform-targeting rule 5), exactly as `IApplicationViewExtension`, `IInputPaneExtension`,
+`INativeWindowFactoryExtension` and friends already do.
+
+Related artifacts: [spec.md](../spec.md) · [research.md](../research.md) ·
+[data-model.md](../data-model.md) · [quickstart.md](../quickstart.md).
+
+---
+
+## 1. Purpose & placement
+
+| Layer | Project | Type |
+|-------|---------|------|
+| Contract (this seam) | `src/Uno.UI` (generic `netX.0`, all Skia targets) | `INativeMenuExtension` interface + `NativeMenuScope` |
+| macOS implementation | `src/Uno.UI.Runtime.Skia.MacOS` | `MacOSNativeMenuExtension` → `NSMenu` via `UnoNativeMac` ObjC |
+| iPadOS/iOS implementation | `src/Uno.UI.Runtime.Skia.AppleUIKit` | `AppleUIKitNativeMenuExtension` → `UIMenuBuilder` |
+| Linux implementation (post-v1) | `src/Uno.UI.Runtime.Skia.X11` | `X11NativeMenuExtension` → DBusMenu + Registrar |
+| Win32 implementation | `src/Uno.UI.Runtime.Skia.Wpf` / Win32 host | `Win32NativeMenuExtension` → **no-op**, `IsExported == false` |
+
+**Why a seam and not `#if`:** `Uno.UI` ships as one generic `netX.0` assembly for **all** Skia
+platforms (`RuntimeAssetsSelectorTask`). It cannot reference native menu APIs directly. The
+concrete impl lives in the per-platform `Uno.UI.Runtime.Skia.*` host and is injected at startup.
+This keeps the model testable, payload-light, and free of native references — and lets the
+Toolkit `AppMenuBar` ask one question (`IsExported`) to decide whether to render in-app or
+collapse.
+
+The seam is **core-owned** and host-implemented. Direction is strictly one-way: hosts depend on
+the core seam; the core never depends on a host.
+
+---
+
+## 2. Interface definition (proposed)
+
+```csharp
+#nullable enable
+
+using System;
+
+namespace Uno.UI.Xaml.Controls;
+
+/// <summary>
+/// Identifies the scope a native menu is attached to: the whole application
+/// (macOS NSApp.mainMenu / iPadOS app-global menu) or one specific window
+/// (macOS swap-on-key, Linux per-window). Window is null for the application scope.
+/// </summary>
+internal readonly struct NativeMenuScope
+{
+	private NativeMenuScope(Microsoft.UI.Xaml.Window? window) => Window = window;
+
+	/// <summary>The targeted window, or <c>null</c> for the application-wide menu.</summary>
+	public Microsoft.UI.Xaml.Window? Window { get; }
+
+	/// <summary>True when this scope targets the application-wide menu.</summary>
+	public bool IsApplication => Window is null;
+
+	/// <summary>The application-wide menu scope (macOS NSApp.mainMenu / iPadOS buildMenu).</summary>
+	public static NativeMenuScope Application => new(null);
+
+	/// <summary>A window-scoped menu (focused-window-wins; falls back to Application).</summary>
+	public static NativeMenuScope ForWindow(Microsoft.UI.Xaml.Window window) =>
+		new(window ?? throw new ArgumentNullException(nameof(window)));
+}
+
+/// <summary>
+/// Projection seam between the platform-neutral <see cref="NativeMenu"/> model in Uno.UI and
+/// the per-platform native menu system owned by a Skia runtime host. Resolved via
+/// <c>ApiExtensibility.CreateInstance&lt;INativeMenuExtension&gt;()</c>; registered by each host.
+/// All members are invoked on the UI/main thread (see §5).
+/// </summary>
+internal interface INativeMenuExtension
+{
+	/// <summary>
+	/// Projects (or clears) the menu for the given scope, performing a full rebuild of the
+	/// native menu tree. Passing <c>null</c> removes any native menu for that scope and, for the
+	/// application scope on macOS, restores the framework-guaranteed minimal app menu (§4.1).
+	/// Idempotent: calling with the same model is allowed and re-projects.
+	/// </summary>
+	/// <param name="scope">Application-wide or a specific window.</param>
+	/// <param name="menu">The menu to project, or <c>null</c> to clear.</param>
+	void SetMenu(NativeMenuScope scope, NativeMenu? menu);
+
+	/// <summary>
+	/// True when a native menu is currently shown by the OS on this platform (macOS menu bar,
+	/// iPadOS hardware-keyboard menu bar, Linux global menu when a registrar accepted us).
+	/// The Toolkit AppMenuBar reads this to decide in-app render (false) vs. collapse (true).
+	/// On Win32 this is always false. May change at runtime (Linux registrar appears/disappears);
+	/// see <see cref="IsExportedChanged"/>.
+	/// </summary>
+	bool IsExported { get; }
+
+	/// <summary>
+	/// True when this host can project native menus at all (capability gate). Distinct from
+	/// <see cref="IsExported"/>: a platform may support menus yet not currently show one (no menu
+	/// set, registrar absent). Win32 returns false; macOS/iPadOS return true.
+	/// </summary>
+	bool IsSupported { get; }
+
+	/// <summary>
+	/// Reports whether a given OS slot role projects to a real native slot on this platform.
+	/// Lets apps adapt (e.g. hide a "Services" item where unsupported). See §6.
+	/// Roles that are unsupported still render as plain labeled items where the host shows a menu.
+	/// </summary>
+	bool IsRoleSupported(NativeMenuItemRole role);
+
+	/// <summary>
+	/// Raised when <see cref="IsExported"/> transitions (e.g. a Linux global-menu registrar
+	/// appears/disappears, or a key window with/without a menu becomes focused). Raised on the
+	/// UI thread. The Toolkit AppMenuBar subscribes to re-evaluate its in-app vs. collapsed state.
+	/// </summary>
+	event EventHandler? IsExportedChanged;
+}
+```
+
+**Notes on the surface**
+
+- `internal` visibility matches the other extension seams (`IApplicationViewExtension`,
+  `IInputPaneExtension`). Public attachment is the `NativeMenu.SetMenu(...)` static API
+  ([data-model.md](../data-model.md)); this interface is the private plumbing behind it.
+- `NativeMenuScope` is a value type so the application scope needs no sentinel object. `Window`
+  is the WinUI/Uno `Microsoft.UI.Xaml.Window` (not a `DependencyObject`, hence the side-table in
+  the core — see §5 lifecycle).
+- The event uses `EventHandler` (never `event Action`), per repo convention.
+- The seam intentionally exposes **no** per-item / incremental methods. Updates are a coalesced
+  **full rebuild** (§5.3); native-side diffing is the host's private concern and is not modeled
+  here (iPadOS and DBusMenu are rebuild-only).
+
+---
+
+## 3. Registration & resolution
+
+### 3.1 Host registration
+
+Each Skia host registers its implementation during startup, alongside its other
+`ApiExtensibility.Register(...)` calls (e.g. `ExtensionsRegistrar.Register()` for AppleUIKit,
+`MacOSHost` for macOS). The factory receives the calling owner object (unused here):
+
+```csharp
+// src/Uno.UI.Runtime.Skia.MacOS — host startup
+ApiExtensibility.Register(
+	typeof(INativeMenuExtension),
+	_ => MacOSNativeMenuExtension.Instance);
+```
+
+```csharp
+// src/Uno.UI.Runtime.Skia.AppleUIKit/Hosting/ExtensionsRegistrar.cs — add to Register()
+ApiExtensibility.Register(
+	typeof(INativeMenuExtension),
+	_ => AppleUIKitNativeMenuExtension.Instance);
+```
+
+The extension is a **host singleton** (one native menu system per process), so the factory
+returns a shared `Instance` rather than allocating per call — matching the
+`AppleUIKitImeTextBoxExtension.Instance` / `…InputSource.Instance` style already in the
+AppleUIKit registrar. Win32 and X11 register their own singletons the same way.
+
+> Hosts that ship as packages can instead use the assembly-level
+> `[ApiExtension(typeof(INativeMenuExtension), typeof(MyImpl))]` attribute; `App.InitializeComponent()`
+> emits the equivalent `Register` call. In-repo Skia hosts use the explicit imperative form above.
+
+### 3.2 Core resolution
+
+The core resolves the extension lazily and caches it. Resolution failure (no host registered for
+this platform, or a host that opted out) is **not** an error — the core simply treats native
+menus as unavailable, and the Toolkit `AppMenuBar` renders fully in-app.
+
+```csharp
+// Core side-table type that backs NativeMenu.SetMenu / SetApplicationMenu.
+private static INativeMenuExtension? TryGetExtension()
+{
+	if (_resolved is null &&
+		!ApiExtensibility.CreateInstance<INativeMenuExtension>(typeof(NativeMenu), out _resolved))
+	{
+		_resolved = null; // No native host on this platform — in-app fallback only.
+	}
+
+	return _resolved;
+}
+```
+
+`NativeMenu.IsSupported` (public capability probe) returns `TryGetExtension()?.IsSupported ?? false`.
+`NativeMenu.IsRoleSupported(role)` forwards to the extension, defaulting to `false` when none.
+
+---
+
+## 4. Per-host responsibilities
+
+Each host translates the **same** neutral `NativeMenu` tree into its native vocabulary. The host
+owns: the native object lifetime, enable/visibility pushing, role→OS-slot wiring, icon
+translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Shared expectations:
+
+- `NativeMenuItem` effective-enabled = `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)`
+  is computed by the **core** and pushed; the host must disable native auto-validation so the
+  pushed state is authoritative (macOS `autoenablesItems = NO`).
+- Activation: host invokes the item's `Click` event **and** `Command.Execute(CommandParameter)`
+  on the UI thread when the native item fires.
+- `NativeMenu.Opening` fires before a submenu is shown (just-in-time population); `Closed` after
+  dismissal.
+
+### 4.1 Skia.MacOS — `NSMenu` (v1, primary)
+
+- Builds `NSMenu`/`NSMenuItem` trees through new `UnoNativeMac` ObjC exports (e.g.
+  `uno_app_set_main_menu`, `uno_window_set_main_menu`, plus build/update entry points). Replaces
+  and extends the **bootstrap** `NSMenu` currently created in
+  [`UNOApplication.m:95-124`](../../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m)
+  (Quit ⌘Q / Close Window ⌘W).
+- **Framework-guaranteed app menu:** the host ALWAYS ensures the bold app-name menu exists with at
+  least **Quit (⌘Q)** and **Hide**, placed first; developer top-level menus follow. A developer
+  top-level item with `Role = ApplicationMenu` merges its children (About, Settings, …) into that
+  app menu rather than adding a second one.
+- **OS-owned roles auto-wire to AppKit selectors:** `Quit → terminate:`, `Hide → hide:`,
+  `HideOthers → hideOtherApplications:`, `ShowAll → unhideAllApplications:`,
+  `About → orderFrontStandardAboutPanel:`, `Services →` the Services submenu,
+  `Minimize → performMiniaturize:`, `Zoom → performZoom:`,
+  `EnterFullScreen → toggleFullScreen:`, `Window →` the Window menu.
+  **Edit roles** (`Cut/Copy/Paste/Undo/Redo/SelectAll/Delete`) are **placement + standard label
+  only** — the developer supplies `Command` and enable logic (Uno is not a native first responder;
+  there is no responder-chain bridging).
+- `autoenablesItems = NO`; the core pushes effective-enabled and checked state.
+- **Per-window swap-on-key (v1):** on `windowDidBecomeKey`, swap `NSApp.mainMenu` to that window's
+  menu (if it set one) else the Application menu; on `windowDidResignKey`/close, restore. macOS
+  multi-window is supported. `IsExported` is `true` whenever a main menu is installed.
+- Live updates apply incrementally on the native side from a full rebuild request; macOS supports
+  live mutation.
+
+### 4.2 Skia.AppleUIKit — `UIMenuBuilder` (v1)
+
+- Overrides `BuildMenu(IUIMenuBuilder)` on
+  [`UnoUIApplicationDelegate`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs)
+  (a `UIResponder`; devs supply their own via `UseUIApplicationDelegate<T>` —
+  [`AppleUIKitHostBuilder.cs`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/Builder/AppleUIKitHostBuilder.cs)).
+  The host's `BuildMenu` reads the current model and emits `UIMenu`/`UICommand`/`UIKeyCommand`.
+- **App-wide only in v1.** Uno AppleUIKit is single-window/single-scene
+  ([`NativeWindowFactoryExtension.cs:16`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)),
+  so `SetMenu(ForWindow(w), …)` is treated as the application menu. Per-scene override is deferred
+  until Uno gains multi-scene; the seam already accommodates it via `NativeMenuScope`.
+- `SetMenu(...)` requests a rebuild via `UIMenuSystem.Main.SetNeedsRebuild()`; UIKit then calls
+  back into `BuildMenu`. Rebuild-only — no incremental diffing.
+- OS std items map to UIKit standard command identifiers where available (About/Settings via app
+  menu group, Services N/A on iPadOS); edit roles map to `UIResponderStandardEditActions` only
+  when the developer supplies a `Command`.
+- `IsExported` reflects "menu content provided"; **bar visibility is OS-controlled** (reveal on
+  ⌘-hold, hidden in full-screen) — there is no force-show API.
+
+### 4.3 Skia.X11 — DBusMenu (post-v1, designed-for)
+
+- Exports a `com.canonical.dbusmenu` server and registers it with
+  `com.canonical.AppMenu.Registrar` **keyed by the X11 window XID**. Per-window is the native model.
+- **Fail-silent:** if no registrar is present (Wayland, GNOME without the extension), registration
+  fails quietly, `IsExported` stays `false`, and the Toolkit `AppMenuBar` renders the real in-app
+  `MenuBar`. `IsExportedChanged` fires if a registrar appears/disappears at runtime.
+- Toggle/radio map to DBusMenu `toggle-type`; icons are partial (`icon-name` / `icon-data`);
+  shortcuts are panel-dependent. Updates re-export the menu (rebuild).
+
+### 4.4 Win32 — no-op
+
+- `IsSupported == false`, `IsExported == false`, `SetMenu` is a no-op, `IsRoleSupported` returns
+  `false` for all roles. No `HMENU`. The Toolkit `AppMenuBar` always renders the real in-app
+  `MenuBar` on Win32. (A native HMENU/ribbon path is explicitly out of scope; revisit post-v1.)
+
+---
+
+## 5. Threading, lifecycle & rebuild contract
+
+### 5.1 Threading
+
+- Native menu APIs are **main-thread** (AppKit/UIKit). Every `INativeMenuExtension` member is
+  invoked **on the UI thread**. The core marshals model mutations (which may arrive on any thread
+  via `DependencyProperty` callbacks / `INotifyCollectionChanged`) onto the dispatcher before
+  calling `SetMenu`. Hosts may assume main-thread affinity and must not re-marshal.
+
+### 5.2 Lifecycle
+
+- **Attachment:** `NativeMenu.SetMenu(window, menu)` / `SetApplicationMenu(menu)` store the
+  model in a core `ConditionalWeakTable` keyed by `Window` (Window is **not** a
+  `DependencyObject`), then call `extension.SetMenu(scope, menu)`.
+- **Window close → unregister:** when a window closes, the core calls
+  `extension.SetMenu(ForWindow(closingWindow), null)` and drops the side-table entry, so the host
+  releases the native menu and (macOS) stops swapping it on key. The `ConditionalWeakTable` lets a
+  collected window's entry GC naturally; explicit close is the deterministic path.
+- **App menu replace:** `SetApplicationMenu(newMenu)` replaces the previous application model and
+  re-projects; `SetApplicationMenu(null)` restores the framework-guaranteed minimal menu (macOS)
+  or clears (iPadOS).
+- **Re-attachment** of the same `NativeMenu` instance to a different scope is allowed; the core
+  detaches it from the old scope first (a menu projects to at most one scope at a time).
+
+### 5.3 Coalesced full-rebuild contract
+
+- The model is **observable**: `DependencyProperty` change callbacks on `NativeMenuItem` plus
+  `INotifyCollectionChanged` on `NativeMenu.Items`. Any change marks the owning menu **dirty**.
+- The core **coalesces** dirty notifications onto a single dispatcher post (one rebuild per frame,
+  not per property), then calls `extension.SetMenu(scope, menu)` **once** with the whole tree.
+- `SetMenu` performs a **full rebuild** of that scope's native menu (Avalonia-style reset). Hosts
+  must make this **idempotent** and safe to call repeatedly; they may diff internally but must not
+  require the core to send deltas.
+- **Just-in-time population:** `NativeMenu.Opening` is raised by the host immediately before a
+  submenu is displayed (maps to `NSMenuDelegate.menuNeedsUpdate`, DBusMenu `AboutToShow`, iPadOS
+  rebuild), letting handlers populate/refresh children right before they're shown. `Closed` fires
+  after dismissal.
+
+---
+
+## 6. Capability-probe semantics & Toolkit usage
+
+Three probes let both apps and the Toolkit adapt to the host:
+
+| Probe | Question | Win32 | macOS | iPadOS | Linux (registrar) |
+|-------|----------|:-----:|:-----:|:------:|:-----------------:|
+| `IsSupported` | Can this host project native menus at all? | ✗ | ✓ | ✓ | ✓ |
+| `IsExported` | Is a native menu **shown right now**? | ✗ | ✓ (menu installed) | ✓ (content provided) | ✓ only if registrar accepted |
+| `IsRoleSupported(role)` | Does this OS slot project natively? | ✗ all | per role (§4.1) | per role | per role |
+
+`IsSupported` vs `IsExported`: a platform can *support* menus yet not currently *show* one — no
+menu set, or (Linux) no registrar. The Toolkit decision hinges on **`IsExported`**, not
+`IsSupported`, because the in-app `MenuBar` must appear exactly when nothing native is on screen.
+
+### Toolkit `AppMenuBar` flow (Uno.Toolkit.UI)
+
+`AppMenuBar : MenuBar` uses the seam indirectly through the public `NativeMenu.SetMenu(...)` API:
+
+1. On load, translate its `MenuBarItem` / `MenuFlyoutItem` content (+ `AppMenu.Role` attached
+   property → `NativeMenuItem.Role`) into a `NativeMenu`, and call
+   `NativeMenu.SetMenu(window, translatedMenu)`.
+2. Read `NativeMenu.IsSupported` / the resolved extension's `IsExported`:
+   - **`IsExported == true`** (macOS, iPadOS, Linux-with-registrar): the native bar shows the menu —
+     **collapse to zero in-app footprint** (don't render the `MenuBar` chrome).
+   - **`IsExported == false`** (Win32, Wayland/GNOME-no-registrar): **render normally** as a real
+     in-app `MenuBar`.
+3. Subscribe to `IsExportedChanged` and re-evaluate step 2 (e.g. a Linux registrar appears, or a
+   key window's menu changes) so the in-app bar appears/disappears without a reload.
+
+This keeps the **core** free of any Toolkit dependency: the Toolkit consumes the seam; the seam
+never knows the Toolkit exists.
+
+---
+
+## 7. Out of scope for this contract
+
+- The public `NativeMenu` / `NativeMenuItem` model surface — see [data-model.md](../data-model.md).
+- The Toolkit `AppMenuBar` control and `AppMenu.Role` attached property — separate Toolkit issue.
+- Native-side ObjC/UIKit/D-Bus payload formats — host implementation detail behind `SetMenu`.
+- System-tray / notification-area menus — the model is shaped to allow reuse later (Avalonia
+  precedent) but no tray seam is defined in v1.

--- a/specs/047-native-os-menu/contracts/INativeMenuExtension.md
+++ b/specs/047-native-os-menu/contracts/INativeMenuExtension.md
@@ -239,17 +239,32 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
   (a `UIResponder`; devs supply their own via `UseUIApplicationDelegate<T>` —
   [`AppleUIKitHostBuilder.cs`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/Builder/AppleUIKitHostBuilder.cs)).
   The host's `BuildMenu` reads the current model and emits `UIMenu`/`UICommand`/`UIKeyCommand`.
+  The backend targets the **iPadOS 26 always-available, macOS-like system menu bar** — a
+  first-class menu bar that the OS reveals via swipe-from-top (also pointer-to-top, or Globe+M)
+  and that works **without a hardware keyboard**. The underlying `UIMenuBuilder` /
+  `UIResponder.buildMenu(with:)` API is unchanged; iPadOS 26 simply presents the same content as
+  an always-on bar. On earlier iPadOS (15–25) the identical content surfaces as the older
+  transient menu shown with a hardware keyboard (⌘-hold). We supply the content; the OS presents
+  it per version. iPhone shows no menu bar (`UIKeyCommand`s still work with a hardware keyboard).
+- **Discoverability:** the iPadOS 26 bar is meant to display **all** app commands, including
+  unavailable ones, so users can discover capabilities. The host therefore keeps disabled
+  commands **visible but disabled** (does not remove them), matching our push-based enablement —
+  prefer toggling `IsEnabled` over `IsVisible = false` / removal for menu commands.
 - **App-wide only in v1.** Uno AppleUIKit is single-window/single-scene
   ([`NativeWindowFactoryExtension.cs:16`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)),
   so `SetMenu(ForWindow(w), …)` is treated as the application menu. Per-scene override is deferred
   until Uno gains multi-scene; the seam already accommodates it via `NativeMenuScope`.
-- `SetMenu(...)` requests a rebuild via `UIMenuSystem.Main.SetNeedsRebuild()`; UIKit then calls
-  back into `BuildMenu`. Rebuild-only — no incremental diffing.
+- `SetMenu(...)` requests a rebuild via `UIMainMenuSystem.Shared.SetNeedsRebuild()` (the new
+  `UIMenuSystem` subclass that drives the iPad menu bar on iOS/iPadOS 26), falling back to
+  `UIMenuSystem.Main.SetNeedsRebuild()` on earlier OS; UIKit then calls back into `BuildMenu`.
+  Rebuild-only — no incremental diffing.
 - OS std items map to UIKit standard command identifiers where available (About/Settings via app
   menu group, Services N/A on iPadOS); edit roles map to `UIResponderStandardEditActions` only
   when the developer supplies a `Command`.
-- `IsExported` reflects "menu content provided"; **bar visibility is OS-controlled** (reveal on
-  ⌘-hold, hidden in full-screen) — there is no force-show API.
+- `IsExported` reflects "menu content provided" — the content is always supplied; **bar
+  visibility is OS-controlled** (on iPadOS 26 the always-available bar is OS-revealed via
+  swipe-from-top, no hardware keyboard needed; on earlier iPadOS the same content surfaces as the
+  transient hardware-keyboard menu) — there is no force-show API.
 
 ### 4.3 Skia.X11 — DBusMenu (post-v1, designed-for)
 

--- a/specs/047-native-os-menu/contracts/INativeMenuExtension.md
+++ b/specs/047-native-os-menu/contracts/INativeMenuExtension.md
@@ -175,12 +175,17 @@ menus as unavailable, and the Toolkit `AppMenuBar` renders fully in-app.
 
 ```csharp
 // Core side-table type that backs NativeMenu.SetMenu / SetApplicationMenu.
+private static INativeMenuExtension? _resolved;
+private static bool _resolveAttempted;
+
 private static INativeMenuExtension? TryGetExtension()
 {
-	if (_resolved is null &&
-		!ApiExtensibility.CreateInstance<INativeMenuExtension>(typeof(NativeMenu), out _resolved))
+	if (!_resolveAttempted)
 	{
-		_resolved = null; // No native host on this platform — in-app fallback only.
+		// A failed resolution is cached too: no native host on this platform means
+		// in-app fallback only, and retrying on every call would be pure overhead.
+		_resolveAttempted = true;
+		ApiExtensibility.CreateInstance<INativeMenuExtension>(typeof(NativeMenu), out _resolved);
 	}
 
 	return _resolved;

--- a/specs/047-native-os-menu/contracts/INativeMenuExtension.md
+++ b/specs/047-native-os-menu/contracts/INativeMenuExtension.md
@@ -25,7 +25,7 @@ Related artifacts: [spec.md](../spec.md) · [research.md](../research.md) ·
 | macOS implementation | `src/Uno.UI.Runtime.Skia.MacOS` | `MacOSNativeMenuExtension` → `NSMenu` via `UnoNativeMac` ObjC |
 | iPadOS/iOS implementation | `src/Uno.UI.Runtime.Skia.AppleUIKit` | `AppleUIKitNativeMenuExtension` → `UIMenuBuilder` |
 | Linux implementation (post-v1) | `src/Uno.UI.Runtime.Skia.X11` | `X11NativeMenuExtension` → DBusMenu + Registrar |
-| Win32 implementation | `src/Uno.UI.Runtime.Skia.Wpf` / Win32 host | `Win32NativeMenuExtension` → **no-op**, `IsExported == false` |
+| Win32 implementation | `src/Uno.UI.Runtime.Skia.Win32` | `Win32NativeMenuExtension` → **no-op**, `IsExported == false` |
 
 **Why a seam and not `#if`:** `Uno.UI` ships as one generic `netX.0` assembly for **all** Skia
 platforms (`RuntimeAssetsSelectorTask`). It cannot reference native menu APIs directly. The
@@ -90,8 +90,11 @@ internal interface INativeMenuExtension
 	void SetMenu(NativeMenuScope scope, NativeMenu? menu);
 
 	/// <summary>
-	/// True when a native menu is currently shown by the OS on this platform (macOS menu bar,
-	/// iPadOS menu bar, Linux global menu when a registrar accepted us).
+	/// True when a native menu is currently <b>visible to the user</b> on this platform (macOS
+	/// menu bar, the iPadOS 26 always-available bar, Linux global menu when a registrar accepted
+	/// us). Supplying menu content is NOT sufficient: where the OS shows no menu surface at all
+	/// (iPhone) or only a transient keyboard-gated one (iPadOS 15-25), this is <c>false</c>, so
+	/// the in-app fallback stays on screen.
 	/// On Win32 this is always false. May change at runtime (Linux registrar appears/disappears);
 	/// see <see cref="IsExportedChanged"/>.
 	/// Surfaced publicly as <c>NativeMenu.IsExported</c>, which is what the Toolkit AppMenuBar
@@ -232,7 +235,7 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
 - Builds `NSMenu`/`NSMenuItem` trees through new `UnoNativeMac` ObjC exports (e.g.
   `uno_app_set_main_menu`, `uno_window_set_main_menu`, plus build/update entry points). Replaces
   and extends the **bootstrap** `NSMenu` currently created in
-  [`UNOApplication.m:95-124`](../../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m)
+  [`UNOApplication.m:156-185`](../../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m)
   (Quit ⌘Q / Close Window ⌘W).
 - **Framework-guaranteed app menu:** the host ALWAYS ensures the bold app-name menu exists with at
   least **Quit (⌘Q)** and **Hide**, placed first; developer top-level menus follow. A developer
@@ -242,7 +245,13 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
   `HideOthers → hideOtherApplications:`, `ShowAll → unhideAllApplications:`,
   `About → orderFrontStandardAboutPanel:`, `Services →` the Services submenu,
   `Minimize → performMiniaturize:`, `Zoom → performZoom:`,
-  `EnterFullScreen → toggleFullScreen:`, `Window →` the Window menu.
+  `EnterFullScreen → toggleFullScreen:`. Note `performMiniaturize:`, `performZoom:` and
+  `toggleFullScreen:` are `NSWindow` methods reached through nil-target responder dispatch, not
+  `NSApplication` ones — the menu item carries a `nil` target and AppKit routes to the key window.
+- **Slot-container roles are not selectors:** `ApplicationMenu`, `Window` and `Help` mark *where*
+  a menu sits (and let AppKit adopt it as the Window/Help menu); their children supply the items.
+  They are listed separately from the auto-wired set in
+  [data-model.md](../data-model.md#nativemenuitemrole) and behave the same way here.
   **Edit roles** (`Cut/Copy/Paste/Undo/Redo/SelectAll/Delete`) are **placement + standard label
   only** — the developer supplies `Command` and enable logic (Uno is not a native first responder;
   there is no responder-chain bridging).
@@ -255,10 +264,20 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
 
 ### 4.2 Skia.AppleUIKit — `UIMenuBuilder` (v1)
 
-- Overrides `BuildMenu(IUIMenuBuilder)` on
-  [`UnoUIApplicationDelegate`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs)
-  (a `UIResponder`; devs supply their own via `UseUIApplicationDelegate<T>` —
-  [`AppleUIKitHostBuilder.cs`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/Builder/AppleUIKitHostBuilder.cs)).
+- Overrides `BuildMenu(IUIMenuBuilder)` on a **`UIResponder`** in the chain. ⚠️ **Not on
+  [`UnoUIApplicationDelegate`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs)**,
+  which earlier drafts of this contract assumed: it derives from `UIApplicationDelegate`, an
+  `NSObject`-derived class in .NET for iOS, **not** a `UIResponder`, so `BuildMenu` cannot be
+  overridden there. Host the override on a `UIApplication` subclass passed as the principal class
+  to `UIApplication.Main`
+  ([`AppleUIKitHost.cs:44`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/Hosting/AppleUIKitHost.cs)
+  currently passes `null` for it) or on
+  [`RootViewController`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs)
+  (a `UINavigationController`, hence a `UIResponder`). The former better matches an app-global
+  menu; **confirm on device which responder UIKit consults before finalising** — see
+  research.md §8.5. Developers still supply their own delegate via `UseUIApplicationDelegate<T>`
+  ([`AppleUIKitHostBuilder.cs`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/Builder/AppleUIKitHostBuilder.cs)),
+  which remains the hook for the scene-focus path.
   The host's `BuildMenu` reads the current model and emits `UIMenu`/`UICommand`/`UIKeyCommand`.
   The backend targets the **iPadOS 26 always-available, macOS-like system menu bar** — a
   first-class menu bar that the OS reveals via swipe-from-top (also pointer-to-top, or Globe+M)
@@ -279,13 +298,27 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
   `UIMenuSystem` subclass that drives the iPad menu bar on iOS/iPadOS 26), falling back to
   `UIMenuSystem.Main.SetNeedsRebuild()` on earlier OS; UIKit then calls back into `BuildMenu`.
   Rebuild-only — no incremental diffing.
+- **`NeedsUpdate` granularity differs from macOS and this is observable.** AppKit has a
+  per-submenu `menuNeedsUpdate:` that fires only for the menu about to open. UIKit has no
+  equivalent: `buildMenu(with:)` rebuilds the whole tree, so *every* menu's `NeedsUpdate` fires on
+  *every* rebuild, whether or not the user is opening that menu. A handler doing real work — the
+  quickstart's Recent-Files example touches the disk — therefore runs once per submenu open on
+  macOS but once per whole-tree rebuild on iPadOS. Hosts MUST document this, and handler authors
+  MUST keep `NeedsUpdate` cheap and idempotent. The in-flight guarantee in FR-016 applies to hosts
+  with a synchronous per-menu update callback (macOS, DBusMenu `AboutToShow`); on iPadOS the
+  guarantee is satisfied trivially because the handler runs during the rebuild that consumes it.
 - OS std items map to UIKit standard command identifiers where available (About/Settings via app
   menu group, Services N/A on iPadOS); edit roles map to `UIResponderStandardEditActions` only
   when the developer supplies a `Command`.
-- `IsExported` reflects "menu content provided" — the content is always supplied; **bar
-  visibility is OS-controlled** (on iPadOS 26 the always-available bar is OS-revealed via
-  swipe-from-top, no hardware keyboard needed; on earlier iPadOS the same content surfaces as the
-  transient hardware-keyboard menu) — there is no force-show API.
+- `IsExported` reflects whether the user can actually **see** a menu bar, not merely that content
+  was supplied. Content is always supplied; the surface is not. On **iPadOS 26** the bar is
+  always available (OS-revealed via swipe-from-top, no hardware keyboard) → `true`. On **iPadOS
+  15-25** the same content only surfaces as a transient ⌘-hold menu → `false`, because a user
+  with no hardware keyboard would otherwise be left with nothing. On **iPhone** there is no menu
+  bar at all → `false` (`UIKeyCommand` shortcuts still work). There is no force-show API.
+  Reporting `true` on those last two would make the Toolkit `AppMenuBar` collapse its in-app bar
+  and leave the app with **no menu whatsoever** — the same silent failure the Linux
+  `IsSupported` rule (§6) exists to prevent.
 
 ### 4.3 Skia.X11 — DBusMenu (post-v1, designed-for)
 
@@ -353,13 +386,20 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
 
 ## 6. Capability-probe semantics & Toolkit usage
 
-Three probes let both apps and the Toolkit adapt to the host:
+Four public probes let both apps and the Toolkit adapt to the host:
 
-| Probe | Question | Win32 | macOS | iPadOS | Linux, registrar present | Linux, no registrar |
-|-------|----------|:-----:|:-----:|:------:|:-----------------:|:---:|
-| `IsSupported` | Would a menu assigned **right now** be projected? | ✗ | ✓ | ✓ | ✓ | ✗ |
-| `IsExported` | Is a native menu **shown right now**? | ✗ | ✓ (menu installed) | ✓ (content provided) | ✓ only if registrar accepted | ✗ |
-| `IsRoleSupported(role)` | Does this OS slot project natively? | ✗ all | per role (§4.1) | per role | per role | ✗ all |
+| Probe | Question | Win32 | macOS | iPadOS 26 | iPadOS 15–25 | iPhone | Linux, registrar | Linux, none |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| `IsSupported` | Would a menu assigned **right now** be projected? | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| `IsExported` | Is a native menu **visible to the user right now**? | ✗ | ✓ (installed) | ✓ (always-available bar) | ✗ (⌘-hold only) | ✗ (no bar) | ✓ if accepted | ✗ |
+| `IsRoleSupported(role)` | Does this OS slot project natively? | ✗ all | per role (§4.1) | per role | per role | per role | per role | ✗ all |
+| `IsExportedChanged` | *(event)* fires when `IsExported` flips | — | on key-window swap | — | — | — | on registrar appear/disappear | — |
+
+Note the deliberate split on Apple: `IsSupported` is `true` across all three Apple columns —
+UIKit accepts and honours the menu content everywhere, and `UIKeyCommand` shortcuts work even on
+iPhone — while `IsExported` tracks whether a **bar is actually on screen**. An app choosing
+whether to *build* a menu wants the first; a control choosing whether to *hide its own* wants the
+second.
 
 **`IsSupported` is a "would it work right now" probe, not a "was this platform built with menus
 in mind" probe.** Linux without a DBusMenu registrar reports `IsSupported == false`, exactly like
@@ -384,10 +424,10 @@ because the in-app `MenuBar` must appear exactly when nothing native is on scree
    `NativeMenu.SetMenu(window, translatedMenu)`.
 2. Read the public `NativeMenu.IsExported` bridge (the Toolkit is a separate assembly and cannot
    see `INativeMenuExtension`):
-   - **`IsExported == true`** (macOS, iPadOS, Linux-with-registrar): the native bar shows the menu —
-     **collapse to zero in-app footprint** (don't render the `MenuBar` chrome).
-   - **`IsExported == false`** (Win32, Wayland/GNOME-no-registrar): **render normally** as a real
-     in-app `MenuBar`.
+   - **`IsExported == true`** (macOS, iPadOS 26, Linux-with-registrar): the native bar shows the
+     menu — **collapse to zero in-app footprint** (don't render the `MenuBar` chrome).
+   - **`IsExported == false`** (Win32, Wayland/GNOME-no-registrar, iPhone, iPadOS 15–25 with no
+     hardware keyboard): **render normally** as a real in-app `MenuBar`.
 3. Subscribe to `NativeMenu.IsExportedChanged` and re-evaluate step 2 (e.g. a Linux registrar
    appears, or a key window's menu changes) so the in-app bar appears/disappears without a reload.
 

--- a/specs/047-native-os-menu/contracts/INativeMenuExtension.md
+++ b/specs/047-native-os-menu/contracts/INativeMenuExtension.md
@@ -91,17 +91,22 @@ internal interface INativeMenuExtension
 
 	/// <summary>
 	/// True when a native menu is currently shown by the OS on this platform (macOS menu bar,
-	/// iPadOS hardware-keyboard menu bar, Linux global menu when a registrar accepted us).
-	/// The Toolkit AppMenuBar reads this to decide in-app render (false) vs. collapse (true).
+	/// iPadOS menu bar, Linux global menu when a registrar accepted us).
 	/// On Win32 this is always false. May change at runtime (Linux registrar appears/disappears);
 	/// see <see cref="IsExportedChanged"/>.
+	/// Surfaced publicly as <c>NativeMenu.IsExported</c>, which is what the Toolkit AppMenuBar
+	/// reads to decide in-app render (false) vs. collapse (true) — it lives in a different
+	/// assembly and cannot see this interface.
 	/// </summary>
 	bool IsExported { get; }
 
 	/// <summary>
-	/// True when this host can project native menus at all (capability gate). Distinct from
-	/// <see cref="IsExported"/>: a platform may support menus yet not currently show one (no menu
-	/// set, registrar absent). Win32 returns false; macOS/iPadOS return true.
+	/// True when assigning a menu on this host right now would actually project it — i.e. the
+	/// platform has a native menu system AND whatever it needs to accept a menu is in place.
+	/// On Linux this means a DBusMenu registrar is present: no registrar, no support. Win32
+	/// returns false; macOS/iPadOS return true.
+	/// Distinct from <see cref="IsExported"/> only in that a supported host may have no menu
+	/// assigned yet — support is about capability, export is about a menu being on screen.
 	/// </summary>
 	bool IsSupported { get; }
 
@@ -192,8 +197,19 @@ private static INativeMenuExtension? TryGetExtension()
 }
 ```
 
-`NativeMenu.IsSupported` (public capability probe) returns `TryGetExtension()?.IsSupported ?? false`.
-`NativeMenu.IsRoleSupported(role)` forwards to the extension, defaulting to `false` when none.
+The four public probes on `NativeMenu` all forward through `TryGetExtension()` and degrade to
+`false` when no host is registered, so callers outside `Uno.UI` never touch this `internal`
+interface:
+
+```csharp
+public static bool IsSupported => TryGetExtension()?.IsSupported ?? false;
+public static bool IsRoleSupported(NativeMenuItemRole role) =>
+	TryGetExtension()?.IsRoleSupported(role) ?? false;
+public static bool IsExported => TryGetExtension()?.IsExported ?? false;
+
+// Forwarded from the extension; no-ops (and never leaks a subscription) when none resolved.
+public static event EventHandler? IsExportedChanged;
+```
 
 ---
 
@@ -208,8 +224,8 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
   pushed state is authoritative (macOS `autoenablesItems = NO`).
 - Activation: host invokes the item's `Click` event **and** `Command.Execute(CommandParameter)`
   on the UI thread when the native item fires.
-- `NativeMenu.Opening` fires before a submenu is shown (just-in-time population); `Closed` after
-  dismissal.
+- `NativeMenu.NeedsUpdate` fires before a submenu is shown (just-in-time population), then
+  `Opening` as a content-settled notification, then `Closed` after dismissal.
 
 ### 4.1 Skia.MacOS — `NSMenu` (v1, primary)
 
@@ -276,8 +292,10 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
 - Exports a `com.canonical.dbusmenu` server and registers it with
   `com.canonical.AppMenu.Registrar` **keyed by the X11 window XID**. Per-window is the native model.
 - **Fail-silent:** if no registrar is present (Wayland, GNOME without the extension), registration
-  fails quietly, `IsExported` stays `false`, and the Toolkit `AppMenuBar` renders the real in-app
-  `MenuBar`. `IsExportedChanged` fires if a registrar appears/disappears at runtime.
+  fails quietly, **both `IsSupported` and `IsExported` stay `false`** (§6), and the Toolkit
+  `AppMenuBar` renders the real in-app `MenuBar`. The host tracks the registrar's bus name via a
+  `NameOwnerChanged` subscription — **never a poll** — and raises `IsExportedChanged` when it
+  appears or disappears at runtime.
 - Toggle/radio map to DBusMenu `toggle-type`; icons are partial (`icon-name` / `icon-data`);
   shortcuts are panel-dependent. Updates re-export the menu (rebuild).
 
@@ -322,10 +340,14 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
 - `SetMenu` performs a **full rebuild** of that scope's native menu (Avalonia-style reset). Hosts
   must make this **idempotent** and safe to call repeatedly; they may diff internally but must not
   require the core to send deltas.
-- **Just-in-time population:** `NativeMenu.Opening` is raised by the host immediately before a
+- **Just-in-time population:** `NativeMenu.NeedsUpdate` is raised by the host immediately before a
   submenu is displayed (maps to `NSMenuDelegate.menuNeedsUpdate`, DBusMenu `AboutToShow`, iPadOS
-  rebuild), letting handlers populate/refresh children right before they're shown. `Closed` fires
-  after dismissal.
+  rebuild), letting handlers populate/refresh children right before they're shown. The host must
+  raise it **synchronously, inside the native update callback**, and read `Items` *after* it
+  returns, so handler mutations land in the build already in flight rather than scheduling a
+  second one. `Opening` is raised afterwards as a notification only (maps to
+  `NSMenuDelegate.menuWillOpen`) and `Closed` after dismissal; mutations from those two are
+  ordinary model changes that go through the normal coalesced path.
 
 ---
 
@@ -333,15 +355,25 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
 
 Three probes let both apps and the Toolkit adapt to the host:
 
-| Probe | Question | Win32 | macOS | iPadOS | Linux (registrar) |
-|-------|----------|:-----:|:-----:|:------:|:-----------------:|
-| `IsSupported` | Can this host project native menus at all? | ✗ | ✓ | ✓ | ✓ |
-| `IsExported` | Is a native menu **shown right now**? | ✗ | ✓ (menu installed) | ✓ (content provided) | ✓ only if registrar accepted |
-| `IsRoleSupported(role)` | Does this OS slot project natively? | ✗ all | per role (§4.1) | per role | per role |
+| Probe | Question | Win32 | macOS | iPadOS | Linux, registrar present | Linux, no registrar |
+|-------|----------|:-----:|:-----:|:------:|:-----------------:|:---:|
+| `IsSupported` | Would a menu assigned **right now** be projected? | ✗ | ✓ | ✓ | ✓ | ✗ |
+| `IsExported` | Is a native menu **shown right now**? | ✗ | ✓ (menu installed) | ✓ (content provided) | ✓ only if registrar accepted | ✗ |
+| `IsRoleSupported(role)` | Does this OS slot project natively? | ✗ all | per role (§4.1) | per role | per role | ✗ all |
 
-`IsSupported` vs `IsExported`: a platform can *support* menus yet not currently *show* one — no
-menu set, or (Linux) no registrar. The Toolkit decision hinges on **`IsExported`**, not
-`IsSupported`, because the in-app `MenuBar` must appear exactly when nothing native is on screen.
+**`IsSupported` is a "would it work right now" probe, not a "was this platform built with menus
+in mind" probe.** Linux without a DBusMenu registrar reports `IsSupported == false`, exactly like
+Win32. This is the semantics developer-facing guidance depends on: `quickstart.md §8` branches
+straight on `IsSupported` to decide between assigning a native menu and showing an in-app menu
+bar, so if Linux-without-registrar reported `true` that `else` branch would never run, the
+`SetApplicationMenu` call would no-op against an absent registrar, and the app would end up with
+**no menu at all** — a silent failure. Because a registrar can appear or disappear mid-session,
+`IsSupported` can change at runtime on Linux and flips alongside `IsExportedChanged`.
+
+`IsSupported` vs `IsExported`: the difference is only whether a menu has actually been assigned
+and accepted. A supported host with no menu set reports `IsSupported == true`,
+`IsExported == false`. The Toolkit decision hinges on **`IsExported`**, not `IsSupported`,
+because the in-app `MenuBar` must appear exactly when nothing native is on screen.
 
 ### Toolkit `AppMenuBar` flow (Uno.Toolkit.UI)
 
@@ -350,13 +382,14 @@ menu set, or (Linux) no registrar. The Toolkit decision hinges on **`IsExported`
 1. On load, translate its `MenuBarItem` / `MenuFlyoutItem` content (+ `AppMenu.Role` attached
    property → `NativeMenuItem.Role`) into a `NativeMenu`, and call
    `NativeMenu.SetMenu(window, translatedMenu)`.
-2. Read `NativeMenu.IsSupported` / the resolved extension's `IsExported`:
+2. Read the public `NativeMenu.IsExported` bridge (the Toolkit is a separate assembly and cannot
+   see `INativeMenuExtension`):
    - **`IsExported == true`** (macOS, iPadOS, Linux-with-registrar): the native bar shows the menu —
      **collapse to zero in-app footprint** (don't render the `MenuBar` chrome).
    - **`IsExported == false`** (Win32, Wayland/GNOME-no-registrar): **render normally** as a real
      in-app `MenuBar`.
-3. Subscribe to `IsExportedChanged` and re-evaluate step 2 (e.g. a Linux registrar appears, or a
-   key window's menu changes) so the in-app bar appears/disappears without a reload.
+3. Subscribe to `NativeMenu.IsExportedChanged` and re-evaluate step 2 (e.g. a Linux registrar
+   appears, or a key window's menu changes) so the in-app bar appears/disappears without a reload.
 
 This keeps the **core** free of any Toolkit dependency: the Toolkit consumes the seam; the seam
 never knows the Toolkit exists.

--- a/specs/047-native-os-menu/contracts/INativeMenuExtension.md
+++ b/specs/047-native-os-menu/contracts/INativeMenuExtension.md
@@ -101,7 +101,7 @@ internal interface INativeMenuExtension
 	/// reads to decide in-app render (false) vs. collapse (true) — it lives in a different
 	/// assembly and cannot see this interface.
 	/// </summary>
-	bool IsExported { get; }
+	bool IsExported(NativeMenuScope scope);
 
 	/// <summary>
 	/// True when assigning a menu on this host right now would actually project it — i.e. the
@@ -121,11 +121,12 @@ internal interface INativeMenuExtension
 	bool IsRoleSupported(NativeMenuItemRole role);
 
 	/// <summary>
-	/// Raised when <see cref="IsExported"/> transitions (e.g. a Linux global-menu registrar
-	/// appears/disappears, or a key window with/without a menu becomes focused). Raised on the
-	/// UI thread. The Toolkit AppMenuBar subscribes to re-evaluate its in-app vs. collapsed state.
+	/// Raised when <see cref="IsExported"/> transitions for some scope (e.g. a Linux global-menu
+	/// registrar appears/disappears, or a key window with/without a menu becomes focused). Raised
+	/// on the UI thread; the args name the affected scope. The Toolkit AppMenuBar subscribes to
+	/// re-evaluate its in-app vs. collapsed state.
 	/// </summary>
-	event EventHandler? IsExportedChanged;
+	event EventHandler<NativeMenuExportedChangedEventArgs>? IsExportedChanged;
 }
 ```
 
@@ -137,7 +138,15 @@ internal interface INativeMenuExtension
 - `NativeMenuScope` is a value type so the application scope needs no sentinel object. `Window`
   is the WinUI/Uno `Microsoft.UI.Xaml.Window` (not a `DependencyObject`, hence the side-table in
   the core — see §5 lifecycle).
-- The event uses `EventHandler` (never `event Action`), per repo convention.
+- The event uses `EventHandler<T>` (never `event Action`), per repo convention.
+- **`IsExported` takes a scope rather than being a process-global flag.** Export genuinely differs
+  per window: DBusMenu registration is keyed by X11 window XID (§4.3) and the macOS bar reflects
+  the key window (§4.1), and macOS multi-window is in v1 scope. A single global answer would be
+  wrong the moment two windows differ, and widening it to take a `Window` afterwards would
+  respecify public surface.
+- **`IsSupported` is also runtime-varying** (a Linux registrar can appear or disappear), so
+  `IsExportedChanged` is specified to fire for both transitions rather than adding a second event;
+  callers re-read whichever probe they use.
 - The seam intentionally exposes **no** per-item / incremental methods. Updates are a coalesced
   **full rebuild** (§5.3); native-side diffing is the host's private concern and is not modeled
   here (iPadOS and DBusMenu are rebuild-only).
@@ -290,6 +299,13 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
   unavailable ones, so users can discover capabilities. The host therefore keeps disabled
   commands **visible but disabled** (does not remove them), matching our push-based enablement —
   prefer toggling `IsEnabled` over `IsVisible = false` / removal for menu commands.
+- **tvOS registers through this same host.**
+  [`ExtensionsRegistrar.cs`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/Hosting/ExtensionsRegistrar.cs)
+  is shared across iOS/iPadOS/tvOS (only the WebView registration is `#if !__TVOS__`), so the menu
+  extension will be registered on tvOS unless it opts out. tvOS has no menu bar: it MUST report
+  `IsSupported == false` and `IsExported(...) == false`, like Win32. The same applies to iPhone
+  for `IsExported` (see above) — the "Apple means a menu bar" assumption holds only for macOS and
+  iPadOS 26.
 - **App-wide only in v1.** Uno AppleUIKit is single-window/single-scene
   ([`NativeWindowFactoryExtension.cs:16`](../../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)),
   so `SetMenu(ForWindow(w), …)` is treated as the application menu. Per-scene override is deferred
@@ -331,6 +347,21 @@ translation, accelerator mapping, and the `Opening`/`Closed` event bridge. Share
   appears or disappears at runtime.
 - Toggle/radio map to DBusMenu `toggle-type`; icons are partial (`icon-name` / `icon-data`);
   shortcuts are panel-dependent. Updates re-export the menu (rebuild).
+- **Trust boundary — the exported object is reachable by every peer on the session bus.** This is
+  the one place in the design where an outside party can call into the app, and the spec must say
+  who is allowed to:
+  - **Activation:** a peer calling `Event(id, "clicked", …)` invokes the item's `Command`. On a
+    `Role=Quit` item that terminates the application; on any other item it runs app code with no
+    user gesture. The host MUST accept `Event` only from the registrar it registered with — the
+    `NameOwnerChanged` subscription above already tracks that unique bus name — and MUST validate
+    that the item id belongs to the currently exported tree.
+  - **Disclosure:** `GetLayout` / `GetGroupProperties` return every label, and labels commonly
+    contain document titles and file paths. Same caller restriction applies.
+  - **Reentrancy + DoS:** `AboutToShow` now runs application code (`NeedsUpdate`) synchronously on
+    the UI thread, so an unrestricted peer can drive app code at will. Rate-limit it in addition
+    to restricting the caller.
+  These are requirements on the post-v1 Linux host, but they are recorded here because they
+  constrain the seam's shape, not just its implementation.
 
 ### 4.4 Win32 — no-op
 

--- a/specs/047-native-os-menu/data-model.md
+++ b/specs/047-native-os-menu/data-model.md
@@ -400,7 +400,7 @@ effective menu for the system  =  GetMenu(focused/key window)  ??  GetApplicatio
 | Platform | Mechanism |
 |---|---|
 | macOS | Swap `NSApp.mainMenu` on `windowDidBecomeKey`, restore on resign (per-window supported v1; multi-window exists). |
-| iPadOS | `UIMenuSystem.main.setNeedsRebuild()` on scene-focus change; `buildMenu(with:)` reads the focused scene menu. **v1 = app-wide only** (Uno AppleUIKit is single-scene — [NativeWindowFactoryExtension.cs:16](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)); per-scene override deferred until multi-scene exists. |
+| iPadOS | `UIMainMenuSystem` (iOS/iPadOS 26) `setNeedsRebuild()` on scene-focus change, falling back to `UIMenuSystem.main` on earlier OS; `buildMenu(with:)` reads the focused scene menu. This drives the **always-available iPadOS 26 menu bar** (swipe from top; earlier OS = transient hardware-keyboard menu). **v1 = app-wide only** (Uno AppleUIKit is single-scene — [NativeWindowFactoryExtension.cs:16](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)); per-scene override deferred until multi-scene exists. |
 | Linux | Per-window is the native DBusMenu model. |
 | Windows | Per-window == per in-app control. |
 

--- a/specs/047-native-os-menu/data-model.md
+++ b/specs/047-native-os-menu/data-model.md
@@ -175,7 +175,7 @@ responder-chain bridging for edit roles).
 | `None` | ordinary item | ordinary item | ordinary item | ordinary item |
 | `ApplicationMenu` | bold app-name menu; children **merge** into the app menu | app section | n/a | label-only |
 | `About` | **auto-wired** `orderFrontStandardAboutPanel:` | system About | n/a | dev `Command` |
-| `Settings` | **auto-wired** Preferences slot (Cmd+,) | Settings slot | n/a | dev `Command` |
+| `Settings` | Preferences slot + standard label (Cmd+,) — **dev `Command`** | Settings slot | n/a | dev `Command` |
 | `Services` | **auto-wired** Services submenu | n/a | n/a | n/a |
 | `Hide` | **auto-wired** `hide:` (Cmd+H) | n/a | n/a | n/a |
 | `HideOthers` | **auto-wired** `hideOtherApplications:` | n/a | n/a | n/a |
@@ -194,11 +194,13 @@ responder-chain bridging for edit roles).
 | `Delete` | placement + label "Delete" — **dev `Command`** | placement + label | placement | label / dev `Command` |
 | `SelectAll` | placement + label "Select All" — **dev `Command`** | placement + label | placement | label / dev `Command` |
 
-**Auto-wired (macOS OS-owned):** `About`, `Settings`, `Services`, `Hide`, `HideOthers`, `ShowAll`,
+**Auto-wired (macOS OS-owned):** `About`, `Services`, `Hide`, `HideOthers`, `ShowAll`,
 `Quit`, `Minimize`, `Zoom`, `EnterFullScreen`. **Placement-only (dev supplies `Command`):** the
-edit roles `Undo`, `Redo`, `Cut`, `Copy`, `Paste`, `Delete`, `SelectAll`, plus `None`. **Slot
-containers:** `ApplicationMenu`, `Window`, `Help` (define a menu section/slot; children supply the
-actual items). On Windows/Linux in-app, OS-only roles **no-op unless a `Command` is supplied**;
+edit roles `Undo`, `Redo`, `Cut`, `Copy`, `Paste`, `Delete`, `SelectAll`, plus `Settings` and
+`None`. `Settings` is placement-only because AppKit ships no default implementation of
+`orderFrontPreferencesPanel:` — the role reserves the Preferences slot, its standard label and
+Cmd+, , but the app must supply the `Command`. **Slot containers:** `ApplicationMenu`, `Window`,
+`Help` (define a menu section/slot; children supply the actual items). On Windows/Linux in-app, OS-only roles **no-op unless a `Command` is supplied**;
 others render as normal labeled items. Apps probe support via `IsRoleSupported` (see seam).
 
 ```csharp

--- a/specs/047-native-os-menu/data-model.md
+++ b/specs/047-native-os-menu/data-model.md
@@ -1,0 +1,422 @@
+# Data Model: Native OS Menu Integration
+
+The "data model" is the **public API surface as a typed object model** — a lightweight,
+observable menu tree plus an attachment side-table and a per-host projection seam. The core
+types live in `Uno.UI` (namespace `Uno.UI.Xaml.Controls`); the declarative `AppMenuBar`
+control lives in `Uno.Toolkit.UI` and depends on the core seam (never the reverse).
+
+The tree is the cross-platform **source of truth**; each native host projects it to its own
+menu system (macOS `NSMenu`, iPadOS `UIMenuBuilder`, Linux `DBusMenu` post-v1) or renders an
+in-app fallback (Windows / Linux-no-registrar). Projection is a **full coalesced rebuild**,
+not incremental diffing.
+
+## Type hierarchy
+
+```
+DependencyObject
+└── NativeMenuItemBase                      (abstract; Parent back-reference)
+    ├── NativeMenu                          (a menu / submenu container)
+    │     └── Items : IList<NativeMenuItemBase>   (XAML content property, observable)
+    ├── NativeMenuItem                      (a leaf or submenu-owning command)
+    │     └── SubMenu : NativeMenu?               (nesting → submenu)
+    └── NativeMenuItemSeparator             (a divider)
+```
+
+- `NativeMenu` and `NativeMenuItem` are **not** `FrameworkElement`s — no visual tree, no
+  template, no measure/arrange. They are `DependencyObject`s so properties are
+  `DependencyProperty`-backed (change callbacks drive the dirty/rebuild flow) and so XAML can
+  declare the tree as a resource/object graph.
+- Nesting: a `NativeMenu`'s `Items` hold `NativeMenuItemBase`. A `NativeMenuItem` becomes a
+  submenu parent by setting `SubMenu` to a child `NativeMenu`. `Parent` is maintained by the
+  owning collection/property setter for upward dirty propagation.
+
+## Core types — `Uno.UI.Xaml.Controls`
+
+### `NativeMenuItemBase`
+
+| Member | Type | Default | Meaning |
+|---|---|---|---|
+| `Parent` | `NativeMenuItemBase?` | `null` | Back-reference to the owning `NativeMenu` (set by collection) or owning `NativeMenuItem` (for a `SubMenu`); used to propagate "dirty" up to the root menu being projected. |
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+public abstract partial class NativeMenuItemBase : DependencyObject
+{
+	internal NativeMenuItemBase? Parent { get; set; }
+}
+```
+
+### `NativeMenu`
+
+A container of items; also serves as a submenu and as the root assigned to a scope.
+
+| Member | Type | Default | Meaning | macOS | iPadOS | Linux | Windows |
+|---|---|---|---|---|---|---|---|
+| `Items` | `IList<NativeMenuItemBase>` | empty observable list | Ordered child items. **XAML content property.** Implements `INotifyCollectionChanged`; add/remove/move/reset marks the menu dirty. | `NSMenu` item array | menu children for `UIMenu` | DBusMenu child layout | in-app `MenuBarItem` children |
+| `Title` | `string?` | `null` | Optional title for the menu when used as a submenu/top-level header (the owning `NativeMenuItem.Text` usually supplies this; `Title` is the standalone form). | `NSMenu.title` | `UIMenu.title` | submenu label | header text |
+| `Opening` | `EventHandler<NativeMenuOpeningEventArgs>` | — | Raised just before the menu is shown — the just-in-time population hook. | `NSMenuDelegate.menuNeedsUpdate:` | `buildMenu(with:)` pass | DBus `AboutToShow` | flyout `Opening` |
+| `Closed` | `EventHandler<NativeMenuClosedEventArgs>` | — | Raised after the menu is dismissed. | `NSMenuDelegate.menuDidClose:` | (best-effort) | DBus closed | flyout `Closed` |
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+[ContentProperty(Name = nameof(Items))]
+public partial class NativeMenu : NativeMenuItemBase
+{
+	public IList<NativeMenuItemBase> Items { get; } // observable; INotifyCollectionChanged
+
+	[GeneratedDependencyProperty(DefaultValue = null)]
+	public string? Title { get; set; }
+
+	public event EventHandler<NativeMenuOpeningEventArgs>? Opening;
+	public event EventHandler<NativeMenuClosedEventArgs>? Closed;
+}
+
+public sealed partial class NativeMenuOpeningEventArgs : EventArgs;
+public sealed partial class NativeMenuClosedEventArgs : EventArgs;
+```
+
+**Observability:** `Items` raises `INotifyCollectionChanged`; every `DependencyProperty` on
+items raises its change callback. Both feed the same dirty/coalesce/rebuild pipeline (see
+[State & lifecycle](#state--lifecycle)).
+
+### `NativeMenuItem`
+
+A single command, a checkable item, or a submenu owner.
+
+| Member | Type | Default | Meaning | macOS | iPadOS | Linux | Windows |
+|---|---|---|---|---|---|---|---|
+| `Text` | `string` | `""` | Display label. Mnemonics per platform convention. | `NSMenuItem.title` | `UICommand`/`UIAction.title` | DBus `label` | item text |
+| `Icon` | `IconSource?` | `null` | Best-effort icon. Bitmap/Image → PNG bytes; Symbol/Font → rendered glyph; optional SF-Symbol name passthrough on Apple. | `NSMenuItem.image` (`NSImage`) | `UIImage` (SF Symbol preferred) | icon-name / icon-data (partial) | in-app `IconElement` |
+| `Command` | `ICommand?` | `null` | Invoked on activation. `XamlUICommand`/`StandardUICommand` auto-populate `Text`/`Icon`/`KeyboardAccelerators` via `CommandingHelpers`. | target/action invokes callback | `UIAction` handler | DBus `clicked` | `Click`/command |
+| `CommandParameter` | `object?` | `null` | Passed to `Command.Execute` / `CanExecute`. | — | — | — | — |
+| `KeyboardAccelerators` | `IList<KeyboardAccelerator>` | empty | Literal accelerators (modifiers reused as-is — no Ctrl→Cmd remap; see [Shortcuts](#shortcut-modifier-mapping)). | `keyEquivalent` + `keyEquivalentModifierMask` | `UIKeyCommand` | accelerator (partial) | in-app accelerator |
+| `IsEnabled` | `bool` | `true` | Author-set enabled flag. Effective-enabled = `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)` — **pushed**, authoritative. | `NSMenuItem.enabled` (`autoenablesItems=NO`) | `UIAction` `.disabled` attribute | DBus `enabled` | in-app `IsEnabled` |
+| `IsChecked` | `bool` | `false` | Check/toggle state (with `ToggleType`). | `NSMenuItem.state` on/off | `.on`/`.off`/`.mixed` | toggle-state | in-app check |
+| `ToggleType` | `ToggleType` | `None` | None / CheckBox / Radio (mirrors `RadioMenuFlyoutItem`). | framework-coordinated radio | inline single-selection | `toggle-type` checkmark/radio | in-app toggle |
+| `GroupName` | `string?` | `null` | Radio exclusivity group (only meaningful when `ToggleType == Radio`). | framework coordinates exclusivity | inline group section | radio group | in-app group |
+| `IsVisible` | `bool` | `true` | When false the item is omitted from the projected menu. | item removed on rebuild | `.hidden` attribute / omitted | omitted | collapsed |
+| `Role` | `NativeMenuItemRole` | `None` | OS standard-slot marker (placement + standard label; some OS-owned, see [enum table](#nativemenuitemrole)). | maps to selector / slot | maps to system command id | placement only | label only / no-op |
+| `SubMenu` | `NativeMenu?` | `null` | Child menu — makes this item a submenu. | `NSMenuItem.submenu` | nested `UIMenu` | child layout | nested `MenuFlyout` |
+| `Click` | `EventHandler<NativeMenuItemClickEventArgs>` | — | Raised on activation (WinUI/Avalonia parity), in addition to `Command`. | action callback | `UIAction` handler | `clicked` | `Click` |
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+public partial class NativeMenuItem : NativeMenuItemBase
+{
+	[GeneratedDependencyProperty(DefaultValue = "")]
+	public string Text { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = null)]
+	public IconSource? Icon { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = null)]
+	public ICommand? Command { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = null)]
+	public object? CommandParameter { get; set; }
+
+	public IList<KeyboardAccelerator> KeyboardAccelerators { get; }
+
+	[GeneratedDependencyProperty(DefaultValue = true)]
+	public bool IsEnabled { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = false)]
+	public bool IsChecked { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = ToggleType.None)]
+	public ToggleType ToggleType { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = null)]
+	public string? GroupName { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = true)]
+	public bool IsVisible { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = NativeMenuItemRole.None)]
+	public NativeMenuItemRole Role { get; set; }
+
+	[GeneratedDependencyProperty(DefaultValue = null)]
+	public NativeMenu? SubMenu { get; set; }
+
+	public event EventHandler<NativeMenuItemClickEventArgs>? Click;
+}
+
+public sealed partial class NativeMenuItemClickEventArgs : EventArgs;
+```
+
+### `NativeMenuItemSeparator`
+
+| Member | Type | Default | Meaning | macOS | iPadOS | Linux | Windows |
+|---|---|---|---|---|---|---|---|
+| *(no public members)* | — | — | A visual divider between item groups. | `NSMenuItem.separatorItem` | inline section boundary | DBus `type=separator` | in-app separator |
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+public sealed partial class NativeMenuItemSeparator : NativeMenuItemBase;
+```
+
+## Enums
+
+### `NativeMenuItemRole`
+
+THIN slot-markers. A role marks **where** an item sits in the OS-standard layout and supplies a
+**standard label**. Some roles are **OS-owned/auto-wired** on macOS (AppKit selector is attached
+automatically, no developer `Command` needed). All other roles are **placement-only**: the role
+sets placement + standard label, but the **developer must supply `Command` + enabled logic** on
+every platform (Uno draws its own controls and is not a native first responder — there is no
+responder-chain bridging for edit roles).
+
+| Role | macOS | iPadOS | Linux | Windows |
+|---|---|---|---|---|
+| `None` | ordinary item | ordinary item | ordinary item | ordinary item |
+| `ApplicationMenu` | bold app-name menu; children **merge** into the app menu | app section | n/a | label-only |
+| `About` | **auto-wired** `orderFrontStandardAboutPanel:` | system About | n/a | dev `Command` |
+| `Settings` | **auto-wired** Preferences slot (Cmd+,) | Settings slot | n/a | dev `Command` |
+| `Services` | **auto-wired** Services submenu | n/a | n/a | n/a |
+| `Hide` | **auto-wired** `hide:` (Cmd+H) | n/a | n/a | n/a |
+| `HideOthers` | **auto-wired** `hideOtherApplications:` | n/a | n/a | n/a |
+| `ShowAll` | **auto-wired** `unhideAllApplications:` | n/a | n/a | n/a |
+| `Quit` | **auto-wired** `terminate:` (Cmd+Q) | n/a | n/a | dev `Command` |
+| `Window` | Window menu slot | Window section | n/a | label-only |
+| `Minimize` | **auto-wired** `performMiniaturize:` (Cmd+M) | n/a | n/a | dev `Command` |
+| `Zoom` | **auto-wired** `performZoom:` | n/a | n/a | dev `Command` |
+| `EnterFullScreen` | **auto-wired** `toggleFullScreen:` | n/a | n/a | dev `Command` |
+| `Help` | Help menu slot (search field) | Help section | n/a | label-only |
+| `Undo` | placement + label "Undo" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+| `Redo` | placement + label "Redo" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+| `Cut` | placement + label "Cut" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+| `Copy` | placement + label "Copy" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+| `Paste` | placement + label "Paste" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+| `Delete` | placement + label "Delete" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+| `SelectAll` | placement + label "Select All" — **dev `Command`** | placement + label | placement | label / dev `Command` |
+
+**Auto-wired (macOS OS-owned):** `About`, `Settings`, `Services`, `Hide`, `HideOthers`, `ShowAll`,
+`Quit`, `Minimize`, `Zoom`, `EnterFullScreen`. **Placement-only (dev supplies `Command`):** the
+edit roles `Undo`, `Redo`, `Cut`, `Copy`, `Paste`, `Delete`, `SelectAll`, plus `None`. **Slot
+containers:** `ApplicationMenu`, `Window`, `Help` (define a menu section/slot; children supply the
+actual items). On Windows/Linux in-app, OS-only roles **no-op unless a `Command` is supplied**;
+others render as normal labeled items. Apps probe support via `IsRoleSupported` (see seam).
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+public enum NativeMenuItemRole
+{
+	None,
+	ApplicationMenu, About, Settings, Services, Hide, HideOthers, ShowAll, Quit,
+	Window, Minimize, Zoom, EnterFullScreen, Help,
+	Undo, Redo, Cut, Copy, Paste, Delete, SelectAll,
+}
+```
+
+### `ToggleType`
+
+| Value | Meaning | macOS | iPadOS | Linux | Windows |
+|---|---|---|---|---|---|
+| `None` | Not checkable (default) | plain item | plain action | normal | normal |
+| `CheckBox` | Independent on/off | `state` on/off checkmark | `.on`/`.off` | `toggle-type=checkmark` | check |
+| `Radio` | Mutually exclusive within `GroupName` | framework-coordinated exclusivity + state | inline single-selection section | `toggle-type=radio` | grouped radio |
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+public enum ToggleType
+{
+	None,
+	CheckBox,
+	Radio,
+}
+```
+
+## Attachment API
+
+`Window` and `Application` are **not** `DependencyObject`s in WinUI/Uno
+([Window.cs](../../src/Uno.UI/UI/Xaml/Window/Window.cs),
+[Application.cs](../../src/Uno.UI/UI/Xaml/Application.cs)) — so an Avalonia-style attached
+property on `Window`/`Application` does **not** port. Attachment is therefore **code-first
+setters**, with associations stored in a `ConditionalWeakTable` side-table (weak-keyed on the
+`Window`, so menus are released when the window is collected).
+
+| API | Scope | Storage | Meaning |
+|---|---|---|---|
+| `NativeMenu.SetMenu(Window window, NativeMenu? menu)` | window | `ConditionalWeakTable<Window, NativeMenu>` | Assign (or clear with `null`) the menu for a specific window. |
+| `NativeMenu.GetMenu(Window window)` → `NativeMenu?` | window | same | Read the window's assigned menu. |
+| `NativeMenu.SetApplicationMenu(NativeMenu? menu)` | app | static field | Assign (or clear) the app-wide fallback menu. |
+| `NativeMenu.GetApplicationMenu()` → `NativeMenu?` | app | static field | Read the app-wide menu. |
+
+```csharp
+namespace Uno.UI.Xaml.Controls;
+
+public partial class NativeMenu
+{
+	public static void SetMenu(Window window, NativeMenu? menu);
+	public static NativeMenu? GetMenu(Window window);
+
+	public static void SetApplicationMenu(NativeMenu? menu);
+	public static NativeMenu? GetApplicationMenu();
+}
+```
+
+The **tree itself can be declared in XAML** as a resource/object (via the `Items` content
+property), then assigned in code:
+
+```xml
+<NativeMenu x:Key="MainMenu" xmlns="using:Uno.UI.Xaml.Controls">
+	<NativeMenuItem Text="File">
+		<NativeMenuItem.SubMenu>
+			<NativeMenu>
+				<NativeMenuItem Text="New" Command="{x:Bind NewCommand}" />
+				<NativeMenuItemSeparator />
+				<NativeMenuItem Role="Quit" />
+			</NativeMenu>
+		</NativeMenuItem.SubMenu>
+	</NativeMenuItem>
+</NativeMenu>
+```
+
+```csharp
+var menu = (NativeMenu)Resources["MainMenu"];
+NativeMenu.SetMenu(MainWindow, menu);   // window-scoped
+// or NativeMenu.SetApplicationMenu(menu); // app-wide
+```
+
+## Toolkit layer — `Uno.Toolkit.UI`
+
+A separate follow-up deliverable in `unoplatform/uno.toolkit.ui` providing the declarative
+control. It **depends on** the core seam; the core never depends on it.
+
+### `AppMenuBar : MenuBar`
+
+| Aspect | Behavior |
+|---|---|
+| Base | `MenuBar` (reuses existing `MenuBarItem` / `MenuFlyoutItem` markup and Skia rendering). |
+| Windows / Linux-no-native | Renders as a **real in-app `MenuBar`** (normal visual footprint). |
+| Apple (macOS / iPadOS) | Reads its `MenuBarItem` / `MenuFlyout*` content, **translates** to a `NativeMenu`, calls `NativeMenu.SetMenu(window, translatedMenu)` (or `SetApplicationMenu`), then **collapses to zero in-app footprint**. |
+| Role declaration | OS role via the Toolkit attached property `AppMenu.Role` → mapped to `NativeMenuItem.Role`. |
+| Sync | Re-translates and re-projects when its declarative content changes (same dirty/rebuild flow). |
+
+### `AppMenu` attached property (Toolkit)
+
+| API | Type | Applies to | Meaning |
+|---|---|---|---|
+| `AppMenu.SetRole(DependencyObject, NativeMenuItemRole)` | `NativeMenuItemRole` | `MenuBarItem` / `MenuFlyoutItem` | Marks the OS standard-slot role; copied to the translated `NativeMenuItem.Role`. |
+| `AppMenu.GetRole(DependencyObject)` → `NativeMenuItemRole` | — | — | Read the role. |
+
+### `MenuFlyoutItem` → `NativeMenuItem` translation map
+
+| Source (`MenuBar` / `MenuFlyout*`) | Target (`NativeMenu*`) |
+|---|---|
+| `MenuBarItem` | `NativeMenuItem` with a `SubMenu` (`Text` ← `Title`) |
+| `MenuFlyoutSubItem` | `NativeMenuItem` with a `SubMenu` |
+| `MenuFlyoutItem` | `NativeMenuItem` (leaf) |
+| `ToggleMenuFlyoutItem` | `NativeMenuItem`, `ToggleType=CheckBox`, `IsChecked` ← `IsChecked` |
+| `RadioMenuFlyoutItem` | `NativeMenuItem`, `ToggleType=Radio`, `GroupName` ← `GroupName`, `IsChecked` ← `IsChecked` |
+| `MenuFlyoutSeparator` | `NativeMenuItemSeparator` |
+| `.Text` | `.Text` |
+| `.Icon` (`IconElement`) | `.Icon` (`IconSource`, best-effort) |
+| `.Command` / `.CommandParameter` | `.Command` / `.CommandParameter` |
+| `.KeyboardAccelerators` | `.KeyboardAccelerators` (literal, no remap) |
+| `.IsEnabled` | `.IsEnabled` |
+| `Visibility` | `.IsVisible` (`Visible` → `true`) |
+| `AppMenu.Role` (attached) | `.Role` |
+
+## Projection seam
+
+`INativeMenuExtension` is the per-host projection contract (core in `Uno.UI`, resolved via
+`ApiExtensibility.CreateInstance<INativeMenuExtension>()`, registered by each Skia host). It
+exposes `SetMenu(scope, NativeMenu?)`, an `IsExported` indicator (is a native menu actually
+shown?), and the capability probes `IsSupported` / `IsRoleSupported`. Full contract, host
+implementations (Skia.MacOS / Skia.AppleUIKit / Skia.X11-post-v1 / Win32-noop), and the
+`NativeMenu.IsSupported` / `IsRoleSupported` public probe surface are in
+[contracts/INativeMenuExtension.md](./contracts/INativeMenuExtension.md).
+
+## Shortcut modifier mapping
+
+Literal `KeyboardAccelerator.Modifiers` reused as-is (no menu-only Ctrl→Cmd remap — it would be
+incoherent with live key events). This matches Uno's existing macOS input mapping
+([UNOWindow.m:878-889](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m)).
+
+| `VirtualKeyModifiers` | macOS | iPadOS | Linux | Windows |
+|---|---|---|---|---|
+| `Windows` | Command (⌘) | Command (⌘) | Super | Win |
+| `Control` | Control (⌃) | Control (⌃) | Ctrl | Ctrl |
+| `Menu` | Option/Alt (⌥) | Option/Alt (⌥) | Alt | Alt |
+| `Shift` | Shift (⇧) | Shift (⇧) | Shift | Shift |
+
+Cross-platform "Cmd-on-Mac / Ctrl-on-Win" is achieved via per-platform markup, or an optional
+future `Primary`-modifier sugar (non-core follow-up; **not v1**).
+
+## State & lifecycle
+
+### Dirty → coalesce → full rebuild
+
+```
+DP change callback  ─┐
+INotifyCollectionChanged on Items ─┤→ mark affected root menu DIRTY
+Command.CanExecuteChanged ─┘            (propagate via Parent to the projected root)
+                                     │
+                                     ▼
+                          coalesce on the UI-thread dispatcher
+                          (one rebuild per frame, dedup multiple changes)
+                                     │
+                                     ▼
+                          INativeMenuExtension.SetMenu(scope, root)
+                          → FULL rebuild of that menu on the native main thread
+                          (no incremental native diffing — iPadOS & Linux are rebuild-only)
+```
+
+- **Threading:** native menu APIs are main-thread; all mutations marshal to the UI thread and
+  the coalesced rebuild posts to the dispatcher.
+- **Reset strategy:** any collection change (including `Reset`) triggers a full re-projection of
+  the affected menu (Avalonia-style), keeping all four backends on one simple code path.
+
+### `Opening` — lazy / just-in-time population
+
+`NativeMenu.Opening` fires immediately before the menu/submenu is shown, letting authors build
+or refresh children on demand. Maps to `NSMenuDelegate.menuNeedsUpdate:` (macOS), DBus
+`AboutToShow` (Linux), and a `buildMenu(with:)` rebuild pass (iPadOS). `Closed` fires on
+dismissal. x:Bind / MVVM flows naturally through the observable model.
+
+### Enablement (pushed, authoritative)
+
+```
+EffectiveEnabled = IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)
+```
+
+The model **observes `CanExecuteChanged`** and re-pushes. macOS sets `NSMenu.autoenablesItems =
+NO` so the pushed state is authoritative (no AppKit auto-validation). iPadOS uses the `.disabled`
+attribute; Linux/Windows push the enabled flag directly.
+
+### Scope state — focused-window-wins + Application fallback
+
+```
+effective menu for the system  =  GetMenu(focused/key window)  ??  GetApplicationMenu()
+```
+
+| Platform | Mechanism |
+|---|---|
+| macOS | Swap `NSApp.mainMenu` on `windowDidBecomeKey`, restore on resign (per-window supported v1; multi-window exists). |
+| iPadOS | `UIMenuSystem.main.setNeedsRebuild()` on scene-focus change; `buildMenu(with:)` reads the focused scene menu. **v1 = app-wide only** (Uno AppleUIKit is single-scene — [NativeWindowFactoryExtension.cs:16](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)); per-scene override deferred until multi-scene exists. |
+| Linux | Per-window is the native DBusMenu model. |
+| Windows | Per-window == per in-app control. |
+
+### macOS framework-guaranteed App menu
+
+The framework **always** ensures the bold app-name menu exists with at least **Quit (Cmd+Q)** and
+**Hide**; developer top-level menus (File/Edit/…) follow it. This replaces/extends the existing
+bootstrap `NSMenu` ([UNOApplication.m:95-124](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m),
+Quit Cmd+Q / Close Window Cmd+W).
+
+To customize, the developer declares a top-level `NativeMenuItem` with `Role=ApplicationMenu`;
+its children (**About**, **Settings**, etc.) **merge** into the app menu. No auto-injection of
+`Services` / `HideOthers` unless explicitly declared (consistent with thin roles).
+
+### Tray-readiness (not built v1)
+
+`NativeMenu` is intentionally scope-agnostic (a plain item tree, not bound to a window's visual
+tree), so a future system-tray / notification-area menu can reuse the same model and projection
+seam without API changes.

--- a/specs/047-native-os-menu/data-model.md
+++ b/specs/047-native-os-menu/data-model.md
@@ -55,7 +55,7 @@ arrives as an explicit `NativeMenuItemGroup : NativeMenuItemBase` with its own p
 table — never as an inferred meaning for a bare container. Adding a new sealed item subtype is
 additive and non-breaking, so deferring it costs nothing.
 
-### One parent per item
+### One parent per item — and no cycles
 
 An item belongs to exactly one menu. Adding an item that already has a `Parent` to a second
 `NativeMenu` (or assigning one `NativeMenu` as the `SubMenu` of two different items) throws
@@ -63,6 +63,35 @@ An item belongs to exactly one menu. Adding an item that already has a `Parent` 
 that dirty propagation walks. Re-parent by removing from the first owner first. Avalonia enforces
 the same invariant through a collection validator, having found that silent aliasing produces
 menus that update in one place and not the other.
+
+**Single-parent is not sufficient on its own — cycles must be rejected separately.** This
+compiles, gives every node exactly one parent, and so passes the aliasing check:
+
+```csharp
+menuA.Items.Add(itemA);
+itemA.SubMenu = menuA;      // ✗ must throw: menuA is now its own descendant
+```
+
+Nothing is aliased, yet the upward walk described above — "until it reaches a menu with no
+`Parent`" — never terminates, and projection recurses until the UI thread dies. The same
+mutation point that enforces single-parent MUST therefore also walk `Parent` from the prospective
+new owner and throw `InvalidOperationException` if the item being attached is already an ancestor
+of it. The walk is bounded by the existing depth, so the check is cheap.
+
+### `Items` is a `DependencyObjectCollection`
+
+`NativeMenu.Items` MUST be backed by
+[`DependencyObjectCollection<NativeMenuItemBase>`](../../src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs),
+not a hand-rolled observable list. That type already calls `SetParent` on every element it holds
+([`DependencyObjectCollection.cs:105-116`](../../src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs))
+precisely to keep **inheritance context** flowing.
+
+This is load-bearing, not a convenience: without a real parent chain a `DependencyObject` receives
+no inherited `DataContext`, so `{Binding}` on a `NativeMenuItem.Command` silently never resolves —
+which would quietly break the MVVM story this model is sold on, and the XAML sample below with it.
+The `Parent` back-references described above are the *menu-tree* relationships used for dirty
+propagation; they are additional to, and not a replacement for, the framework parent that
+`DependencyObjectCollection` maintains.
 
 ## Core types — `Uno.UI.Xaml.Controls`
 
@@ -77,9 +106,20 @@ namespace Uno.UI.Xaml.Controls;
 
 public abstract partial class NativeMenuItemBase : DependencyObject
 {
+	// Internal ctor: the hierarchy is closed. A third-party subtype would reach every host as
+	// an unknown node — exactly the divergence the NativeMenu/NativeMenuItemBase split removes —
+	// and would void the "adding a sealed subtype later is additive" guarantee above.
+	internal NativeMenuItemBase() { }
+
 	internal NativeMenu? Parent { get; set; }
 }
 ```
+
+> **Every `[GeneratedDependencyProperty]` below is shown with its
+> `public static DependencyProperty XProperty { get; } = CreateXProperty();` assignment.** Per
+> `.claude/rules/dependency-properties.md` that assignment is mandatory — omitting it mis-generates
+> silently — and defaults are written as `default(T)` rather than bare literals. Implementers copy
+> these blocks, so they are written in the form that compiles.
 
 The upward walk therefore alternates between the two branches — item → owning `NativeMenu`
 (`NativeMenuItemBase.Parent`) → owning `NativeMenuItem` (`NativeMenu.Parent`) → … — until it
@@ -110,6 +150,7 @@ public partial class NativeMenu : DependencyObject
 
 	[GeneratedDependencyProperty(DefaultValue = null)]
 	public string? Title { get; set; }
+	public static DependencyProperty TitleProperty { get; } = CreateTitleProperty();
 
 	public event EventHandler<NativeMenuNeedsUpdateEventArgs>? NeedsUpdate; // mutate here
 	public event EventHandler<NativeMenuOpeningEventArgs>? Opening;         // notify only
@@ -142,13 +183,13 @@ A single command, a checkable item, or a submenu owner.
 | Member | Type | Default | Meaning | macOS | iPadOS | Linux | Windows |
 |---|---|---|---|---|---|---|---|
 | `Text` | `string` | `""` | Display label. Mnemonics per platform convention. | `NSMenuItem.title` | `UICommand`/`UIAction.title` | DBus `label` | item text |
-| `Icon` | `IconSource?` | `null` | Best-effort icon. Bitmap/Image → PNG bytes; Symbol/Font → rendered glyph; optional SF-Symbol name passthrough on Apple. | `NSMenuItem.image` (`NSImage`) | `UIImage` (SF Symbol preferred) | icon-name / icon-data (partial) | in-app `IconElement` |
+| `Icon` | `IconSource?` | `null` | Best-effort icon. Bitmap/Image → PNG bytes; Symbol/Font → rendered glyph; optional SF-Symbol name passthrough on Apple. **Translation result is cached on (`IconSource`, scale) and computed when `Icon` changes, never per rebuild** — re-encoding every icon in the tree on each coalesced tick would make an `IsEnabled` toggle arbitrarily expensive. | `NSMenuItem.image` (`NSImage`) | `UIImage` (SF Symbol preferred) | icon-name / icon-data (partial) | in-app `IconElement` |
 | `Command` | `ICommand?` | `null` | Invoked on activation. `XamlUICommand`/`StandardUICommand` auto-populate `Text`/`Icon`/`KeyboardAccelerators` via `CommandingHelpers`. | target/action invokes callback | `UIAction` handler | DBus `clicked` | `Click`/command |
 | `CommandParameter` | `object?` | `null` | Passed to `Command.Execute` / `CanExecute`. | — | — | — | — |
 | `KeyboardAccelerators` | `IList<KeyboardAccelerator>` | empty | Literal accelerators (modifiers reused as-is — no Ctrl→Cmd remap; see [Shortcuts](#shortcut-modifier-mapping)). | `keyEquivalent` + `keyEquivalentModifierMask` | `UIKeyCommand` | accelerator (partial) | in-app accelerator |
 | `IsEnabled` | `bool` | `true` | Author-set enabled flag. Effective-enabled = `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)` — **pushed**, authoritative. | `NSMenuItem.enabled` (`autoenablesItems=NO`) | `UIAction` `.disabled` attribute | DBus `enabled` | in-app `IsEnabled` |
 | `IsChecked` | `bool` | `false` | Check/toggle state (with `ToggleType`). | `NSMenuItem.state` on/off | `.on`/`.off`/`.mixed` | toggle-state | in-app check |
-| `ToggleType` | `ToggleType` | `None` | None / CheckBox / Radio (mirrors `RadioMenuFlyoutItem`). | framework-coordinated radio | inline single-selection | `toggle-type` checkmark/radio | in-app toggle |
+| `ToggleType` | `NativeMenuItemToggleType` | `None` | None / CheckBox / Radio (mirrors `RadioMenuFlyoutItem`). | framework-coordinated radio | inline single-selection | `toggle-type` checkmark/radio | in-app toggle |
 | `GroupName` | `string?` | `null` | Radio exclusivity group (only meaningful when `ToggleType == Radio`). | framework coordinates exclusivity | inline group section | radio group | in-app group |
 | `IsVisible` | `bool` | `true` | When false the item is omitted from the projected menu. | item removed on rebuild | `.hidden` attribute / omitted | omitted | collapsed |
 | `Role` | `NativeMenuItemRole` | `None` | OS standard-slot marker (placement + standard label; some OS-owned, see [enum table](#nativemenuitemrole)). | maps to selector / slot | maps to system command id | placement only | label only / no-op |
@@ -180,8 +221,9 @@ public partial class NativeMenuItem : NativeMenuItemBase
 	[GeneratedDependencyProperty(DefaultValue = false)]
 	public bool IsChecked { get; set; }
 
-	[GeneratedDependencyProperty(DefaultValue = ToggleType.None)]
-	public ToggleType ToggleType { get; set; }
+	[GeneratedDependencyProperty(DefaultValue = NativeMenuItemToggleType.None)]
+	public NativeMenuItemToggleType ToggleType { get; set; }
+	public static DependencyProperty ToggleTypeProperty { get; } = CreateToggleTypeProperty();
 
 	[GeneratedDependencyProperty(DefaultValue = null)]
 	public string? GroupName { get; set; }
@@ -269,7 +311,7 @@ public enum NativeMenuItemRole
 }
 ```
 
-### `ToggleType`
+### `NativeMenuItemToggleType`
 
 | Value | Meaning | macOS | iPadOS | Linux | Windows |
 |---|---|---|---|---|---|
@@ -280,7 +322,7 @@ public enum NativeMenuItemRole
 ```csharp
 namespace Uno.UI.Xaml.Controls;
 
-public enum ToggleType
+public enum NativeMenuItemToggleType
 {
 	None,
 	CheckBox,
@@ -314,8 +356,9 @@ forward to the resolved extension and degrade to `false` when no host is registe
 |---|---|---|
 | `NativeMenu.IsSupported` | `bool` | Will a menu assigned right now actually be projected on this platform? See [capability semantics](./contracts/INativeMenuExtension.md#6-capability-semantics). |
 | `NativeMenu.IsRoleSupported(NativeMenuItemRole role)` | `bool` | Does this role map to a real OS slot here? |
-| `NativeMenu.IsExported` | `bool` | Is a native menu currently on screen for this app? |
-| `NativeMenu.IsExportedChanged` | `EventHandler?` | Raised when `IsExported` flips. Raised on the UI thread. |
+| `NativeMenu.IsExported` | `bool` | Is a native menu currently on screen for the app-wide scope? |
+| `NativeMenu.IsExported(Window)` | `bool` | Same question for one window. Required because export is genuinely per-window: on Linux the DBusMenu registrar is keyed by X11 window XID, and on macOS the bar reflects the key window. A process-global answer is wrong as soon as two windows differ — and v1 supports macOS multi-window. |
+| `NativeMenu.IsExportedChanged` | `EventHandler<NativeMenuExportedChangedEventArgs>?` | Raised when export state flips; the args carry the affected `Window` (`null` = app scope). |
 
 ```csharp
 namespace Uno.UI.Xaml.Controls;
@@ -332,7 +375,19 @@ public partial class NativeMenu
 	public static bool IsRoleSupported(NativeMenuItemRole role);
 
 	public static bool IsExported { get; }
-	public static event EventHandler? IsExportedChanged;
+	public static bool IsExported(Window window);
+
+	// Explicit add/remove, NOT a field-like event: a field-like declaration would compile while
+	// forwarding to nothing (never raised), and would root every subscriber for the process
+	// lifetime. The accessors attach to / detach from the resolved extension and hold subscribers
+	// weakly, so an unloaded AppMenuBar is collectable.
+	public static event EventHandler<NativeMenuExportedChangedEventArgs>? IsExportedChanged;
+}
+
+public sealed partial class NativeMenuExportedChangedEventArgs : EventArgs
+{
+	/// <summary>The affected window, or null when the application-wide scope changed.</summary>
+	public Window? Window { get; }
 }
 ```
 
@@ -351,7 +406,7 @@ property), then assigned in code:
 	<NativeMenuItem Text="File">
 		<NativeMenuItem.SubMenu>
 			<NativeMenu>
-				<NativeMenuItem Text="New" Command="{x:Bind NewCommand}" />
+				<NativeMenuItem Text="New" Command="{Binding New, Source={StaticResource Commands}}" />
 				<NativeMenuItemSeparator />
 				<NativeMenuItem Role="Quit" />
 			</NativeMenu>
@@ -359,6 +414,16 @@ property), then assigned in code:
 	</NativeMenuItem>
 </NativeMenu>
 ```
+
+> **No `{x:Bind}` and no `x:Name` in a resource dictionary.** `x:Bind` compiles against a root
+> element's code-behind, which a `ResourceDictionary` does not have, and `x:Name` emits no field
+> there. Reference commands through `{StaticResource}`/`{Binding Source=...}` as above, or attach
+> them in code after pulling the resource. Plain `{Binding}` against an inherited `DataContext`
+> works once `Items` is a `DependencyObjectCollection`.
+>
+> **A menu declared this way is a shared instance.** `{StaticResource}` hands back the same object
+> every time, and the one-parent invariant means the second attach throws. Assign a resource menu
+> to exactly one scope, or declare it `x:Shared="False"` to get a fresh instance per lookup.
 
 ```csharp
 var menu = (NativeMenu)Resources["MainMenu"];
@@ -455,8 +520,29 @@ Command.CanExecuteChanged ─┘            (propagate via Parent to the project
 
 - **Threading:** native menu APIs are main-thread; all mutations marshal to the UI thread and
   the coalesced rebuild posts to the dispatcher.
-- **Reset strategy:** any collection change (including `Reset`) triggers a full re-projection of
-  the affected menu (Avalonia-style), keeping all four backends on one simple code path.
+- **Reset strategy:** any *structural* change (including `Reset`) triggers a full re-projection of
+  the affected menu, keeping all four backends on one simple code path.
+
+#### Structure-dirty vs state-dirty
+
+Not every change deserves a rebuild, and treating them alike is the difference between a menu that
+costs nothing and one that pegs the UI thread:
+
+| Dirt | Trigger | Projection |
+|---|---|---|
+| **Structure** | `Items` add/remove/move/reset, `SubMenu` assigned, `IsVisible`, `Text`, `Icon`, `Role`, accelerators | full coalesced rebuild of the affected menu |
+| **State** | `IsEnabled`, `IsChecked`, and every `Command.CanExecuteChanged` | in-place push to the existing native items — **never** a rebuild |
+
+`CanExecuteChanged` is the reason this split is mandatory rather than an optimisation. A
+`RelayCommand` that re-raises it on every keystroke or selection change is entirely ordinary, and
+routing that into the structural path means a whole-tree walk plus a full native reconstruction
+**every frame, indefinitely, on the UI thread** — for a menu the user is not even looking at.
+State-only dirt maps to `NSMenuItem.enabled`/`.state` on macOS, `setNeedsRevalidate()` on iPadOS
+and a property update on DBusMenu, all of which exist precisely for this.
+
+Two further requirements on the pipeline: a change that does not alter the effective value MUST
+short-circuit before marking anything dirty, and dirt MUST be scoped to the affected menu rather
+than always escalating to the projected root.
 
 ### `NeedsUpdate` — lazy / just-in-time population
 

--- a/specs/047-native-os-menu/data-model.md
+++ b/specs/047-native-os-menu/data-model.md
@@ -408,13 +408,15 @@ control. It **depends on** the core seam; the core never depends on it.
 
 ## Projection seam
 
-`INativeMenuExtension` is the per-host projection contract (core in `Uno.UI`, resolved via
-`ApiExtensibility.CreateInstance<INativeMenuExtension>()`, registered by each Skia host). It
-exposes `SetMenu(scope, NativeMenu?)`, an `IsExported` indicator (is a native menu actually
-shown?), and the capability probes `IsSupported` / `IsRoleSupported`. Full contract, host
-implementations (Skia.MacOS / Skia.AppleUIKit / Skia.X11-post-v1 / Win32-noop), and the
-`NativeMenu.IsSupported` / `IsRoleSupported` public probe surface are in
-[contracts/INativeMenuExtension.md](./contracts/INativeMenuExtension.md).
+`INativeMenuExtension` is the `internal` per-host projection contract (core in `Uno.UI`, resolved
+via `ApiExtensibility.CreateInstance<INativeMenuExtension>()`, registered by each Skia host).
+The public face of it is the four statics in
+[Public capability surface](#public-capability-surface) above.
+
+The seam's own members, its host implementations (Skia.MacOS / Skia.AppleUIKit / Skia.X11-post-v1
+/ Win32-noop) and the capability semantics are specified once, in
+[contracts/INativeMenuExtension.md](./contracts/INativeMenuExtension.md) — deliberately not
+restated here, because the previous restatement of the member list drifted out of date.
 
 ## Shortcut modifier mapping
 
@@ -497,7 +499,7 @@ effective menu for the system  =  GetMenu(focused/key window)  ??  GetApplicatio
 
 The framework **always** ensures the bold app-name menu exists with at least **Quit (Cmd+Q)** and
 **Hide**; developer top-level menus (File/Edit/…) follow it. This replaces/extends the existing
-bootstrap `NSMenu` ([UNOApplication.m:95-124](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m),
+bootstrap `NSMenu` ([UNOApplication.m:156-185](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m),
 Quit Cmd+Q / Close Window Cmd+W).
 
 To customize, the developer declares a top-level `NativeMenuItem` with `Role=ApplicationMenu`;

--- a/specs/047-native-os-menu/data-model.md
+++ b/specs/047-native-os-menu/data-model.md
@@ -14,12 +14,13 @@ not incremental diffing.
 
 ```
 DependencyObject
+├── NativeMenu                              (a menu / submenu container — NOT an item)
+│     ├── Items : IList<NativeMenuItemBase> (XAML content property, observable)
+│     └── Parent : NativeMenuItem?          (the item that owns this as its SubMenu)
 └── NativeMenuItemBase                      (abstract; Parent back-reference)
-    ├── NativeMenu                          (a menu / submenu container)
-    │     └── Items : IList<NativeMenuItemBase>   (XAML content property, observable)
-    ├── NativeMenuItem                      (a leaf or submenu-owning command)
-    │     └── SubMenu : NativeMenu?               (nesting → submenu)
-    └── NativeMenuItemSeparator             (a divider)
+      ├── NativeMenuItem                    (a leaf or submenu-owning command)
+      │     └── SubMenu : NativeMenu?       (nesting → submenu)
+      └── NativeMenuItemSeparator           (a divider)
 ```
 
 - `NativeMenu` and `NativeMenuItem` are **not** `FrameworkElement`s — no visual tree, no
@@ -30,22 +31,59 @@ DependencyObject
   submenu parent by setting `SubMenu` to a child `NativeMenu`. `Parent` is maintained by the
   owning collection/property setter for upward dirty propagation.
 
+### `NativeMenu` is deliberately **not** a `NativeMenuItemBase`
+
+A menu is a *container*, not a thing that can sit in a list of items. Keeping the two branches
+separate is a load-bearing decision, not an accident of layout:
+
+```csharp
+parentMenu.Items.Add(new NativeMenu());   // ✗ does not compile — NativeMenu is not a
+                                          //   NativeMenuItemBase. Nest via NativeMenuItem.SubMenu.
+```
+
+Were `NativeMenu` an item, that line would compile and produce an item with no label, no
+command and no defined projection — each host would then invent its own answer (drop it? splice
+its children inline? render an empty row?) and the four backends would diverge. The type system
+removes the question instead of documenting an answer to it. This mirrors Avalonia, whose
+`NativeMenu` likewise derives from `AvaloniaObject` rather than `NativeMenuItemBase`
+([`NativeMenu.cs`](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/NativeMenu.cs)).
+
+**Grouping is a separate feature, not an emergent one.** If a future version wants
+inline/sectioned groups (a run of items fenced by separators, as in AppKit inline sections,
+`UIMenu.Options.displayInline` on Apple, or Flutter's dedicated `PlatformMenuItemGroup`), that
+arrives as an explicit `NativeMenuItemGroup : NativeMenuItemBase` with its own platform-support
+table — never as an inferred meaning for a bare container. Adding a new sealed item subtype is
+additive and non-breaking, so deferring it costs nothing.
+
+### One parent per item
+
+An item belongs to exactly one menu. Adding an item that already has a `Parent` to a second
+`NativeMenu` (or assigning one `NativeMenu` as the `SubMenu` of two different items) throws
+`InvalidOperationException` at mutation time rather than silently corrupting the back-references
+that dirty propagation walks. Re-parent by removing from the first owner first. Avalonia enforces
+the same invariant through a collection validator, having found that silent aliasing produces
+menus that update in one place and not the other.
+
 ## Core types — `Uno.UI.Xaml.Controls`
 
 ### `NativeMenuItemBase`
 
 | Member | Type | Default | Meaning |
 |---|---|---|---|
-| `Parent` | `NativeMenuItemBase?` | `null` | Back-reference to the owning `NativeMenu` (set by collection) or owning `NativeMenuItem` (for a `SubMenu`); used to propagate "dirty" up to the root menu being projected. |
+| `Parent` | `NativeMenu?` | `null` | Back-reference to the owning `NativeMenu`, set by that menu's `Items` collection; used to propagate "dirty" up to the root menu being projected. Non-`null` exactly while the item is in a menu — see [One parent per item](#one-parent-per-item). |
 
 ```csharp
 namespace Uno.UI.Xaml.Controls;
 
 public abstract partial class NativeMenuItemBase : DependencyObject
 {
-	internal NativeMenuItemBase? Parent { get; set; }
+	internal NativeMenu? Parent { get; set; }
 }
 ```
+
+The upward walk therefore alternates between the two branches — item → owning `NativeMenu`
+(`NativeMenuItemBase.Parent`) → owning `NativeMenuItem` (`NativeMenu.Parent`) → … — until it
+reaches a menu with no `Parent`, which is the root that was handed to a scope.
 
 ### `NativeMenu`
 
@@ -54,28 +92,44 @@ A container of items; also serves as a submenu and as the root assigned to a sco
 | Member | Type | Default | Meaning | macOS | iPadOS | Linux | Windows |
 |---|---|---|---|---|---|---|---|
 | `Items` | `IList<NativeMenuItemBase>` | empty observable list | Ordered child items. **XAML content property.** Implements `INotifyCollectionChanged`; add/remove/move/reset marks the menu dirty. | `NSMenu` item array | menu children for `UIMenu` | DBusMenu child layout | in-app `MenuBarItem` children |
+| `Parent` | `NativeMenuItem?` | `null` | Back-reference to the `NativeMenuItem` whose `SubMenu` this is; `null` for a root menu handed to a scope. |
 | `Title` | `string?` | `null` | Optional title for the menu when used as a submenu/top-level header (the owning `NativeMenuItem.Text` usually supplies this; `Title` is the standalone form). | `NSMenu.title` | `UIMenu.title` | submenu label | header text |
-| `Opening` | `EventHandler<NativeMenuOpeningEventArgs>` | — | Raised just before the menu is shown — the just-in-time population hook. | `NSMenuDelegate.menuNeedsUpdate:` | `buildMenu(with:)` pass | DBus `AboutToShow` | flyout `Opening` |
+| `NeedsUpdate` | `EventHandler<NativeMenuNeedsUpdateEventArgs>` | — | **The just-in-time population hook.** Raised before the menu is shown, at the point where mutating `Items` is still safe and will be picked up by the in-flight build. | `NSMenuDelegate.menuNeedsUpdate:` | `buildMenu(with:)` pass | DBus `AboutToShow` | before flyout opens |
+| `Opening` | `EventHandler<NativeMenuOpeningEventArgs>` | — | Notification that the menu is about to appear, after its content is settled. **Do not mutate the menu here** — use `NeedsUpdate`. | `NSMenuDelegate.menuWillOpen:` | (best-effort) | DBus opened | flyout `Opening` |
 | `Closed` | `EventHandler<NativeMenuClosedEventArgs>` | — | Raised after the menu is dismissed. | `NSMenuDelegate.menuDidClose:` | (best-effort) | DBus closed | flyout `Closed` |
 
 ```csharp
 namespace Uno.UI.Xaml.Controls;
 
 [ContentProperty(Name = nameof(Items))]
-public partial class NativeMenu : NativeMenuItemBase
+public partial class NativeMenu : DependencyObject
 {
 	public IList<NativeMenuItemBase> Items { get; } // observable; INotifyCollectionChanged
+
+	internal NativeMenuItem? Parent { get; set; }
 
 	[GeneratedDependencyProperty(DefaultValue = null)]
 	public string? Title { get; set; }
 
-	public event EventHandler<NativeMenuOpeningEventArgs>? Opening;
+	public event EventHandler<NativeMenuNeedsUpdateEventArgs>? NeedsUpdate; // mutate here
+	public event EventHandler<NativeMenuOpeningEventArgs>? Opening;         // notify only
 	public event EventHandler<NativeMenuClosedEventArgs>? Closed;
 }
 
+public sealed partial class NativeMenuNeedsUpdateEventArgs : EventArgs;
 public sealed partial class NativeMenuOpeningEventArgs : EventArgs;
 public sealed partial class NativeMenuClosedEventArgs : EventArgs;
 ```
+
+**Why `NeedsUpdate` and `Opening` are separate events.** They fire at different points in the
+native open sequence and only the first one can safely change the menu. AppKit draws the
+distinction directly (`menuNeedsUpdate:` is the documented place to add or remove items;
+`menuWillOpen:` runs once layout is committed), and DBusMenu's `AboutToShow` is a request for
+content that expects a "did anything change?" answer. Collapsing both into one event invites
+authors to repopulate `Items` from the notification-only phase, which re-enters the
+dirty→coalesce→rebuild pipeline (see [State & lifecycle](#state--lifecycle)) from inside the
+platform's menu-tracking run loop. Avalonia ships the same three-event split — `NeedsUpdate`,
+`Opening`, `Closed` — with the same "do not update the menu in `Opening`" guidance.
 
 **Observability:** `Items` raises `INotifyCollectionChanged`; every `DependencyProperty` on
 items raises its change callback. Both feed the same dirty/coalesce/rebuild pipeline (see
@@ -199,7 +253,7 @@ responder-chain bridging for edit roles).
 edit roles `Undo`, `Redo`, `Cut`, `Copy`, `Paste`, `Delete`, `SelectAll`, plus `Settings` and
 `None`. `Settings` is placement-only because AppKit ships no default implementation of
 `orderFrontPreferencesPanel:` — the role reserves the Preferences slot, its standard label and
-Cmd+, , but the app must supply the `Command`. **Slot containers:** `ApplicationMenu`, `Window`,
+Cmd+, but the app must supply the `Command`. **Slot containers:** `ApplicationMenu`, `Window`,
 `Help` (define a menu section/slot; children supply the actual items). On Windows/Linux in-app, OS-only roles **no-op unless a `Command` is supplied**;
 others render as normal labeled items. Apps probe support via `IsRoleSupported` (see seam).
 
@@ -250,6 +304,19 @@ setters**, with associations stored in a `ConditionalWeakTable` side-table (weak
 | `NativeMenu.SetApplicationMenu(NativeMenu? menu)` | app | static field | Assign (or clear) the app-wide fallback menu. |
 | `NativeMenu.GetApplicationMenu()` → `NativeMenu?` | app | static field | Read the app-wide menu. |
 
+### Public capability surface
+
+`INativeMenuExtension` is `internal`, matching the other extension seams. Everything a caller
+outside `Uno.UI` needs is therefore re-exposed as **public statics on `NativeMenu`**, which
+forward to the resolved extension and degrade to `false` when no host is registered:
+
+| API | Type | Meaning |
+|---|---|---|
+| `NativeMenu.IsSupported` | `bool` | Will a menu assigned right now actually be projected on this platform? See [capability semantics](./contracts/INativeMenuExtension.md#6-capability-semantics). |
+| `NativeMenu.IsRoleSupported(NativeMenuItemRole role)` | `bool` | Does this role map to a real OS slot here? |
+| `NativeMenu.IsExported` | `bool` | Is a native menu currently on screen for this app? |
+| `NativeMenu.IsExportedChanged` | `EventHandler?` | Raised when `IsExported` flips. Raised on the UI thread. |
+
 ```csharp
 namespace Uno.UI.Xaml.Controls;
 
@@ -260,8 +327,21 @@ public partial class NativeMenu
 
 	public static void SetApplicationMenu(NativeMenu? menu);
 	public static NativeMenu? GetApplicationMenu();
+
+	public static bool IsSupported { get; }
+	public static bool IsRoleSupported(NativeMenuItemRole role);
+
+	public static bool IsExported { get; }
+	public static event EventHandler? IsExportedChanged;
 }
 ```
+
+`IsExported` and `IsExportedChanged` are **required public surface, not conveniences.** The
+Toolkit `AppMenuBar` decides between rendering in-app and collapsing to zero footprint purely on
+`IsExported`, and it ships from `Uno.Toolkit.UI` — a different assembly in a different
+repository, which cannot see an `internal` interface. The alternatives are an
+`[InternalsVisibleTo]` coupling (which the `ApiExtensibility` design exists specifically to
+avoid) or polling on a timer. Both are worse, so the bridge is part of the v1 contract.
 
 The **tree itself can be declared in XAML** as a resource/object (via the `Items` content
 property), then assigned in code:
@@ -376,12 +456,19 @@ Command.CanExecuteChanged ─┘            (propagate via Parent to the project
 - **Reset strategy:** any collection change (including `Reset`) triggers a full re-projection of
   the affected menu (Avalonia-style), keeping all four backends on one simple code path.
 
-### `Opening` — lazy / just-in-time population
+### `NeedsUpdate` — lazy / just-in-time population
 
-`NativeMenu.Opening` fires immediately before the menu/submenu is shown, letting authors build
-or refresh children on demand. Maps to `NSMenuDelegate.menuNeedsUpdate:` (macOS), DBus
-`AboutToShow` (Linux), and a `buildMenu(with:)` rebuild pass (iPadOS). `Closed` fires on
-dismissal. x:Bind / MVVM flows naturally through the observable model.
+`NativeMenu.NeedsUpdate` fires immediately before the menu/submenu is shown, letting authors
+build or refresh children on demand. Maps to `NSMenuDelegate.menuNeedsUpdate:` (macOS), DBus
+`AboutToShow` (Linux), and a `buildMenu(with:)` rebuild pass (iPadOS). `Opening` then fires as a
+notification once the content is settled, and `Closed` on dismissal. x:Bind / MVVM flows
+naturally through the observable model.
+
+Mutations made from a `NeedsUpdate` handler are applied **synchronously to the build already in
+flight** — they do not schedule a second coalesced rebuild, so populating a submenu here costs
+one projection, not two. Mutations from `Opening` or `Closed` are ordinary model changes: they
+go through the normal dirty→coalesce path and therefore land on the *next* rebuild, which is
+why they must not be used for population.
 
 ### Enablement (pushed, authoritative)
 

--- a/specs/047-native-os-menu/quickstart.md
+++ b/specs/047-native-os-menu/quickstart.md
@@ -332,7 +332,10 @@ automatically.
 > Window↔menu associations are stored in a `ConditionalWeakTable` side-table (because
 > `Window` is not a `DependencyObject`), so they do not keep windows alive.
 
-> **iPadOS v1 = app-wide only.** Uno AppleUIKit is single-scene today
+> **iPadOS v1 = app-wide only.** On iPadOS 26 the same `NativeMenu` model surfaces in the
+> always-available, macOS-like system menu bar (swipe down from the top of the screen — no
+> hardware keyboard required), built via `UIMenuBuilder`/`UIMainMenuSystem`. Uno AppleUIKit is
+> single-scene today
 > ([NativeWindowFactoryExtension.cs](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)),
 > so `SetMenu(window, ...)` resolves to the app-global menu there. Per-scene override is
 > designed-for and lands when Uno gains multi-scene. On Windows, per-window == per-control
@@ -486,7 +489,7 @@ What shows where, at a glance:
 
 | Capability | macOS | iPadOS | Linux (DBusMenu) | Windows |
 |------------|-------|--------|------------------|---------|
-| App-wide menu | Yes (`NSApp.mainMenu`) | Yes (`buildMenu`) | No (per-window only) | No native (in-app) |
+| App-wide menu | Yes (`NSApp.mainMenu`) | Yes — always-available bar on iPadOS 26 (`UIMenuBuilder`/`UIMainMenuSystem`) | No (per-window only) | No native (in-app) |
 | Per-window menu | Yes (swap on key) | No in v1 (single-scene) | Yes (the only model) | Per-control (in-app) |
 | Submenu / separator / checkable | Yes | Yes | Yes | Yes (in-app) |
 | Radio | Framework-coordinated | Inline single-selection | `toggle-type=radio` | In-app |
@@ -499,3 +502,7 @@ What shows where, at a glance:
 > **Rule of thumb:** build one `NativeMenu` tree, attach it once, and probe
 > `IsSupported` / `IsRoleSupported` only where you need to adapt the surrounding UI. The
 > projection seam handles the rest per host.
+
+> **iPadOS discoverability tip:** on the iPadOS 26 menu bar, keep unavailable commands
+> **visible but disabled** (toggle `IsEnabled`, don't remove them) so users can discover
+> what the app can do.

--- a/specs/047-native-os-menu/quickstart.md
+++ b/specs/047-native-os-menu/quickstart.md
@@ -1,0 +1,501 @@
+# Quickstart: Native OS Menu Integration
+
+Practical, copy-pasteable recipes for defining application- and window-scoped menus that
+project to each platform's native menu system (macOS `NSMenu`, iPadOS `UIMenuBuilder`),
+with an in-app fallback where there is none (Windows, Linux-no-registrar).
+
+The core model lives in namespace **`Uno.UI.Xaml.Controls`** ([NativeMenu](../../src/Uno.UI),
+[NativeMenuItem](../../src/Uno.UI), etc.). The declarative `AppMenuBar` control lives in the
+separate **`Uno.Toolkit.UI`** package (see [section 7](#7-the-toolkit-appmenubar-control)).
+
+> **Skia targets only.** v1 ships macOS + iPadOS. Linux (DBusMenu) and Windows are
+> designed-for extension points. Where there is no native menu, the model is inert
+> (`NativeMenu.IsSupported == false`) and you fall back to the in-app `AppMenuBar`.
+
+Quick mental model:
+
+- **The tree is just data.** `NativeMenu` / `NativeMenuItem` are lightweight
+  `DependencyObject`s (not `FrameworkElement`s). You build the tree, then *attach* it.
+- **Attachment is code-first.** `Window` and `Application` are **not** `DependencyObject`s
+  in WinUI/Uno, so there is no attached property on them. You call
+  `NativeMenu.SetApplicationMenu(...)` or `NativeMenu.SetMenu(window, ...)`.
+- **The model is observable.** Mutate `Items` or any property and the native menu
+  re-projects automatically (coalesced full rebuild).
+
+---
+
+## 1. App-wide menu, code-first
+
+Build a `NativeMenu` tree in code and attach it app-wide. The framework **always**
+guarantees the bold app-name menu with at least **Quit (Cmd+Q)** and **Hide** on macOS, so
+you only declare your own top-level menus (File, Edit, ...).
+
+```csharp
+using System;
+using System.Windows.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Uno.UI.Xaml.Controls;
+
+public sealed partial class App : Application
+{
+	protected override void OnLaunched(LaunchActivatedEventArgs args)
+	{
+		// ... window bootstrap ...
+		InstallMenu();
+	}
+
+	private void InstallMenu()
+	{
+		NativeMenu menu = new();
+
+		// --- Optional: customize the macOS application menu (the bold app-name slot). ---
+		// Children of a Role=ApplicationMenu item MERGE into the OS app menu. Quit is
+		// already guaranteed; here we add About + Settings. OS-owned roles (About) auto-wire
+		// to the AppKit selector; Settings is yours to handle via Command.
+		NativeMenuItem appMenu = new() { Role = NativeMenuItemRole.ApplicationMenu };
+		appMenu.SubMenu = new NativeMenu
+		{
+			Items =
+			{
+				new NativeMenuItem { Text = "About MyApp", Role = NativeMenuItemRole.About },
+				new NativeMenuItemSeparator(),
+				new NativeMenuItem
+				{
+					Text = "Settings...",
+					Role = NativeMenuItemRole.Settings,
+					Command = ShowSettingsCommand,
+				},
+			},
+		};
+		menu.Items.Add(appMenu);
+
+		// --- File menu ---
+		NativeMenuItem file = new() { Text = "File" };
+		file.SubMenu = new NativeMenu
+		{
+			Items =
+			{
+				new NativeMenuItem { Text = "New", Command = NewCommand },
+				new NativeMenuItem { Text = "Open...", Command = OpenCommand },
+				new NativeMenuItemSeparator(),
+				new NativeMenuItem { Text = "Close", Command = CloseCommand },
+			},
+		};
+		menu.Items.Add(file);
+
+		// --- Edit menu (role-placed; YOU supply the Command on every platform — Uno draws
+		// its own controls and is not a native first responder, so there is no responder
+		// chain to bridge). ---
+		NativeMenuItem edit = new() { Text = "Edit" };
+		edit.SubMenu = new NativeMenu
+		{
+			Items =
+			{
+				new NativeMenuItem { Role = NativeMenuItemRole.Undo, Command = UndoCommand },
+				new NativeMenuItem { Role = NativeMenuItemRole.Redo, Command = RedoCommand },
+				new NativeMenuItemSeparator(),
+				new NativeMenuItem { Role = NativeMenuItemRole.Cut, Command = CutCommand },
+				new NativeMenuItem { Role = NativeMenuItemRole.Copy, Command = CopyCommand },
+				new NativeMenuItem { Role = NativeMenuItemRole.Paste, Command = PasteCommand },
+			},
+		};
+		menu.Items.Add(edit);
+
+		// Attach app-wide. Quit (Cmd+Q) is guaranteed even if you never declared it.
+		NativeMenu.SetApplicationMenu(menu);
+	}
+
+	// ... your ICommand fields (see section 3) ...
+}
+```
+
+> `Role` items that you do not give a `Text` fall back to the **standard OS label** for
+> that role (e.g. `Cut`/`Copy`/`Paste`). Set `Text` to override. OS-only roles with no
+> `Command` no-op on Windows/Linux in-app.
+
+---
+
+## 2. App-wide menu, declared in XAML as a resource, assigned in code
+
+The tree itself **can** be declared in XAML (its content property is `Items`), then
+assigned via the code-first setter. This keeps the menu shape readable and `x:Bind`-able.
+Declare it as a resource so it is not added to the visual tree.
+
+```xml
+<!-- App.xaml -->
+<Application
+	x:Class="MyApp.App"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:menu="using:Uno.UI.Xaml.Controls">
+	<Application.Resources>
+		<menu:NativeMenu x:Key="AppMenu" x:Name="AppMenu">
+			<menu:NativeMenuItem Role="ApplicationMenu">
+				<menu:NativeMenuItem.SubMenu>
+					<menu:NativeMenu>
+						<menu:NativeMenuItem Text="About MyApp" Role="About" />
+						<menu:NativeMenuItemSeparator />
+						<menu:NativeMenuItem Text="Settings..." Role="Settings" Command="{x:Bind ShowSettingsCommand}" />
+					</menu:NativeMenu>
+				</menu:NativeMenuItem.SubMenu>
+			</menu:NativeMenuItem>
+
+			<menu:NativeMenuItem Text="File">
+				<menu:NativeMenuItem.SubMenu>
+					<menu:NativeMenu>
+						<menu:NativeMenuItem Text="New" Command="{x:Bind NewCommand}" />
+						<menu:NativeMenuItem Text="Open..." Command="{x:Bind OpenCommand}" />
+						<menu:NativeMenuItemSeparator />
+						<menu:NativeMenuItem Text="Close" Command="{x:Bind CloseCommand}" />
+					</menu:NativeMenu>
+				</menu:NativeMenuItem.SubMenu>
+			</menu:NativeMenuItem>
+		</menu:NativeMenu>
+	</Application.Resources>
+</Application>
+```
+
+```csharp
+// App.xaml.cs — pull the resource and attach it.
+protected override void OnLaunched(LaunchActivatedEventArgs args)
+{
+	// ... window bootstrap ...
+
+	NativeMenu menu = (NativeMenu)Resources["AppMenu"];
+	NativeMenu.SetApplicationMenu(menu);
+}
+```
+
+> The menu tree is data, so declaring it in `Application.Resources` (or a page's resources)
+> never renders it into the visual tree — it is only realized when projected to the native
+> menu by the setter.
+
+---
+
+## 3. Commands & shortcuts
+
+Items execute via **`Command` (ICommand) + `CommandParameter`** *and* a **`Click` event**
+(use whichever you prefer; both are supported for WinUI/Avalonia parity). Reusing a
+`XamlUICommand` / `StandardUICommand` auto-populates `Text`, `Icon`, and the accelerator.
+
+```csharp
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Uno.UI.Xaml.Controls;
+
+// (a) Plain ICommand + an explicit accelerator.
+NativeMenuItem save = new()
+{
+	Text = "Save",
+	Command = SaveCommand,
+};
+// Cmd+S on macOS, Ctrl+S on Windows — see the literal-modifier note below.
+save.KeyboardAccelerators.Add(new KeyboardAccelerator
+{
+	Key = VirtualKey.S,
+	Modifiers = VirtualKeyModifiers.Windows, // Command on Mac (see note)
+});
+
+// (b) StandardUICommand — Label / Icon / accelerator come for free.
+NativeMenuItem paste = new()
+{
+	Command = new StandardUICommand(StandardUICommandKind.Paste),
+};
+
+// (c) Click event instead of (or in addition to) a Command.
+NativeMenuItem ping = new() { Text = "Ping" };
+ping.Click += OnPingClicked;
+
+void OnPingClicked(object? sender, EventArgs e) => Debug.WriteLine("pong");
+```
+
+### Literal modifiers — no Control→Command remap
+
+Shortcuts reuse `KeyboardAccelerator` modifiers **literally**, matching Uno's live macOS key
+mapping ([UNOWindow.m:878-889](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m)).
+There is deliberately **no** menu-only remap (that would be incoherent with the key events
+your app already receives):
+
+| `VirtualKeyModifiers` | macOS | Windows / Linux |
+|-----------------------|-------|-----------------|
+| `Windows`             | **Command (⌘)** | Windows key |
+| `Control`             | Control (⌃) | **Ctrl** |
+| `Menu`                | Option/Alt (⌥) | Alt |
+| `Shift`               | Shift (⇧) | Shift |
+
+So a cross-platform "primary" shortcut (Cmd on Mac, Ctrl on Win) needs **per-platform
+markup** today:
+
+```csharp
+var primary = OperatingSystem.IsMacOS()
+	? VirtualKeyModifiers.Windows   // ⌘
+	: VirtualKeyModifiers.Control;  // Ctrl
+
+save.KeyboardAccelerators.Add(new KeyboardAccelerator { Key = VirtualKey.S, Modifiers = primary });
+```
+
+> An optional `Primary`-modifier sugar (write once, maps per platform) is a possible future
+> follow-up — it is **not** part of v1.
+
+---
+
+## 4. Checkable + radio items
+
+Use `ToggleType` (`None` / `CheckBox` / `Radio`) with `IsChecked`, and `GroupName` for radio
+exclusivity (mirrors `RadioMenuFlyoutItem`). On macOS the framework coordinates radio
+exclusivity itself and pushes the state; Linux uses native `toggle-type=radio`; iPadOS uses
+inline single-selection.
+
+```csharp
+using Uno.UI.Xaml.Controls;
+
+NativeMenu view = new();
+
+// Checkable toggle.
+NativeMenuItem statusBar = new()
+{
+	Text = "Show Status Bar",
+	ToggleType = ToggleType.CheckBox,
+	IsChecked = true,
+	Command = ToggleStatusBarCommand,
+};
+view.Items.Add(statusBar);
+
+view.Items.Add(new NativeMenuItemSeparator());
+
+// Radio group — exactly one checked across the shared GroupName.
+view.Items.Add(new NativeMenuItem
+{
+	Text = "Small",
+	ToggleType = ToggleType.Radio,
+	GroupName = "TextSize",
+	Command = SetSizeCommand,
+	CommandParameter = "small",
+});
+view.Items.Add(new NativeMenuItem
+{
+	Text = "Medium",
+	ToggleType = ToggleType.Radio,
+	GroupName = "TextSize",
+	IsChecked = true,
+	Command = SetSizeCommand,
+	CommandParameter = "medium",
+});
+view.Items.Add(new NativeMenuItem
+{
+	Text = "Large",
+	ToggleType = ToggleType.Radio,
+	GroupName = "TextSize",
+	Command = SetSizeCommand,
+	CommandParameter = "large",
+});
+```
+
+> Effective-enabled is **pushed**: `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)`.
+> macOS sets `NSMenu.autoenablesItems = NO` so your pushed enabled/checked state is
+> authoritative — toggle `IsChecked` / `IsEnabled` on the model and it reflects natively.
+
+---
+
+## 5. Per-window / per-document menu
+
+Attach a menu to a specific `Window` with `NativeMenu.SetMenu(window, menu)`. This is ideal
+for document windows that need a different File menu per open document.
+
+```csharp
+using Microsoft.UI.Xaml;
+using Uno.UI.Xaml.Controls;
+
+void OpenDocumentWindow(Document doc)
+{
+	Window window = new();
+	// ... set window content ...
+
+	NativeMenu menu = BuildMenuFor(doc);
+	NativeMenu.SetMenu(window, menu);   // window-scoped
+
+	window.Activate();
+}
+
+// Read it back later:
+NativeMenu? current = NativeMenu.GetMenu(window);
+```
+
+**Key-window-wins.** The system menu reflects the **focused (key) window's** menu if it set
+one; otherwise it falls back to the **Application-level** menu from
+`SetApplicationMenu(...)`. On macOS the backend swaps `NSApp.mainMenu` on
+`windowDidBecomeKey` and restores on resign, so activating different windows swaps the menu
+automatically.
+
+> Window↔menu associations are stored in a `ConditionalWeakTable` side-table (because
+> `Window` is not a `DependencyObject`), so they do not keep windows alive.
+
+> **iPadOS v1 = app-wide only.** Uno AppleUIKit is single-scene today
+> ([NativeWindowFactoryExtension.cs](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs)),
+> so `SetMenu(window, ...)` resolves to the app-global menu there. Per-scene override is
+> designed-for and lands when Uno gains multi-scene. On Windows, per-window == per-control
+> in-app.
+
+---
+
+## 6. Dynamic updates + lazy submenu population
+
+The model is observable: mutate any property or the `Items` collection
+(`INotifyCollectionChanged`) and the affected menu is marked dirty, coalesced on the
+dispatcher, and re-projected via a **full rebuild** of that menu. `x:Bind`/MVVM flows
+naturally.
+
+```csharp
+// Just mutate — the native menu re-projects on the next dispatcher tick.
+saveItem.IsEnabled = document.HasUnsavedChanges;
+recentMenu.Items.Add(new NativeMenuItem { Text = path, Command = OpenRecentCommand, CommandParameter = path });
+recentMenu.Items.Clear();
+```
+
+For **just-in-time** population (e.g. a Recent Files list you do not want to rebuild on every
+change), handle the **`Opening`** event on the submenu's `NativeMenu`. It maps to
+`NSMenuDelegate.menuNeedsUpdate` on macOS, DBus `AboutToShow` on Linux, and the rebuild pass
+on iPadOS.
+
+```csharp
+using System;
+using Uno.UI.Xaml.Controls;
+
+NativeMenuItem recent = new() { Text = "Open Recent" };
+NativeMenu recentMenu = new();
+recent.SubMenu = recentMenu;
+
+// Populate fresh each time the submenu is about to open.
+recentMenu.Opening += OnRecentOpening;
+
+void OnRecentOpening(object? sender, EventArgs e)
+{
+	recentMenu.Items.Clear();
+
+	foreach (string path in _recentFilesService.GetRecent())
+	{
+		recentMenu.Items.Add(new NativeMenuItem
+		{
+			Text = System.IO.Path.GetFileName(path),
+			Command = OpenRecentCommand,
+			CommandParameter = path,
+		});
+	}
+
+	if (recentMenu.Items.Count == 0)
+	{
+		recentMenu.Items.Add(new NativeMenuItem { Text = "No Recent Files", IsEnabled = false });
+	}
+}
+```
+
+> There is also a `Closed` event on `NativeMenu` if you need teardown. Native menu APIs are
+> main-thread; the coalesced rebuild posts to the UI dispatcher for you, so you can mutate
+> the model from the UI thread freely.
+
+---
+
+## 7. The Toolkit `AppMenuBar` control
+
+If you prefer a **declarative XAML control** over the code-first setters, use
+**`AppMenuBar : MenuBar`** from the **`Uno.Toolkit.UI`** package (namespace
+`Uno.Toolkit.UI`). It is the same `MenuBar`/`MenuFlyoutItem` vocabulary you already know:
+
+- On **Windows / Linux-no-native**: it renders as a **real in-app `MenuBar`**.
+- On **Apple (macOS / iPadOS)**: it reads its `MenuBarItem` / `MenuFlyoutItem` content,
+  translates to a `NativeMenu`, projects to the native menu, and **collapses to a zero-size
+  in-app footprint**.
+
+Map OS standard slots with the attached property **`AppMenu.Role`** (Toolkit), which maps to
+`NativeMenuItem.Role`.
+
+```xml
+<!-- MainPage.xaml — requires the Uno.Toolkit.UI NuGet package -->
+<Page
+	x:Class="MyApp.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:utu="using:Uno.Toolkit.UI">
+
+	<Grid>
+		<utu:AppMenuBar>
+			<MenuBarItem Title="File">
+				<MenuFlyoutItem Text="New" Command="{x:Bind NewCommand}" />
+				<MenuFlyoutItem Text="Open..." Command="{x:Bind OpenCommand}" />
+				<MenuFlyoutSeparator />
+				<MenuFlyoutItem Text="Close" Command="{x:Bind CloseCommand}" />
+			</MenuBarItem>
+
+			<MenuBarItem Title="Edit">
+				<!-- Role marks the OS slot + standard label; YOU supply the Command. -->
+				<MenuFlyoutItem utu:AppMenu.Role="Undo" Command="{x:Bind UndoCommand}" />
+				<MenuFlyoutItem utu:AppMenu.Role="Redo" Command="{x:Bind RedoCommand}" />
+				<MenuFlyoutSeparator />
+				<MenuFlyoutItem utu:AppMenu.Role="Cut" Command="{x:Bind CutCommand}" />
+				<MenuFlyoutItem utu:AppMenu.Role="Copy" Command="{x:Bind CopyCommand}" />
+				<MenuFlyoutItem utu:AppMenu.Role="Paste" Command="{x:Bind PasteCommand}" />
+			</MenuBarItem>
+		</utu:AppMenuBar>
+
+		<!-- ... rest of your page ... -->
+	</Grid>
+</Page>
+```
+
+> Under the hood `AppMenuBar` calls the core seam `NativeMenu.SetMenu(window, translatedMenu)`
+> for you. The dependency direction is one-way: the Toolkit control depends on the core seam,
+> never the reverse.
+
+---
+
+## 8. Capability probe
+
+Adapt your UI to what the current platform actually supports. `NativeMenu.IsSupported` tells
+you whether a native menu exists here at all; `IsRoleSupported(role)` probes a specific OS
+slot (Flutter-borrowed).
+
+```csharp
+using Uno.UI.Xaml.Controls;
+
+if (NativeMenu.IsSupported)
+{
+	// macOS / iPadOS: project to the native menu bar.
+	NativeMenu.SetApplicationMenu(BuildNativeMenu());
+}
+else
+{
+	// Windows / Linux-no-registrar: show the in-app AppMenuBar (or your own MenuBar).
+	ShowInAppMenuBar();
+}
+
+// Only offer "Quit" in your own UI where the OS does NOT own a Quit slot.
+bool osHasQuit = NativeMenu.IsRoleSupported(NativeMenuItemRole.Quit);
+```
+
+> On Win32 the native extension is a no-op (`IsExported == false`); the in-app `AppMenuBar`
+> renders the real `MenuBar`. On Linux, native projection is available only when a DBusMenu
+> registrar is present (else fall back in-app).
+
+---
+
+## 9. Platform behavior cheat-sheet
+
+What shows where, at a glance:
+
+| Capability | macOS | iPadOS | Linux (DBusMenu) | Windows |
+|------------|-------|--------|------------------|---------|
+| App-wide menu | Yes (`NSApp.mainMenu`) | Yes (`buildMenu`) | No (per-window only) | No native (in-app) |
+| Per-window menu | Yes (swap on key) | No in v1 (single-scene) | Yes (the only model) | Per-control (in-app) |
+| Submenu / separator / checkable | Yes | Yes | Yes | Yes (in-app) |
+| Radio | Framework-coordinated | Inline single-selection | `toggle-type=radio` | In-app |
+| Icon | Yes | Yes | Partial (icon-name/data) | In-app |
+| Shortcut | Yes | Yes | Partial (panel-dependent) | In-app accelerators |
+| Enable/disable + visibility | Yes (pushed) | Yes (pushed) | Yes (pushed) | Yes (in-app) |
+| Dynamic update | Live | Rebuild-only | Re-export | In-app |
+| OS std items (About/Quit/Services) | Yes | Yes | No | No |
+
+> **Rule of thumb:** build one `NativeMenu` tree, attach it once, and probe
+> `IsSupported` / `IsRoleSupported` only where you need to adapt the surrounding UI. The
+> projection seam handles the rest per host.

--- a/specs/047-native-os-menu/quickstart.md
+++ b/specs/047-native-os-menu/quickstart.md
@@ -131,7 +131,7 @@ Declare it as a resource so it is not added to the visual tree.
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:menu="using:Uno.UI.Xaml.Controls">
 	<Application.Resources>
-		<menu:NativeMenu x:Key="AppMenu" x:Name="AppMenu">
+		<menu:NativeMenu x:Key="AppMenu">
 			<menu:NativeMenuItem Role="ApplicationMenu">
 				<menu:NativeMenuItem.SubMenu>
 					<menu:NativeMenu>
@@ -208,7 +208,7 @@ NativeMenuItem paste = new()
 NativeMenuItem ping = new() { Text = "Ping" };
 ping.Click += OnPingClicked;
 
-void OnPingClicked(object? sender, EventArgs e) => Debug.WriteLine("pong");
+void OnPingClicked(object? sender, NativeMenuItemClickEventArgs e) => Debug.WriteLine("pong");
 ```
 
 ### Literal modifiers — no Control→Command remap
@@ -373,7 +373,7 @@ recent.SubMenu = recentMenu;
 // Populate fresh each time the submenu is about to open.
 recentMenu.Opening += OnRecentOpening;
 
-void OnRecentOpening(object? sender, EventArgs e)
+void OnRecentOpening(object? sender, NativeMenuOpeningEventArgs e)
 {
 	recentMenu.Items.Clear();
 

--- a/specs/047-native-os-menu/quickstart.md
+++ b/specs/047-native-os-menu/quickstart.md
@@ -4,9 +4,13 @@ Practical, copy-pasteable recipes for defining application- and window-scoped me
 project to each platform's native menu system (macOS `NSMenu`, iPadOS `UIMenuBuilder`),
 with an in-app fallback where there is none (Windows, Linux-no-registrar).
 
-The core model lives in namespace **`Uno.UI.Xaml.Controls`** ([NativeMenu](../../src/Uno.UI),
-[NativeMenuItem](../../src/Uno.UI), etc.). The declarative `AppMenuBar` control lives in the
-separate **`Uno.Toolkit.UI`** package (see [section 7](#7-the-toolkit-appmenubar-control)).
+The core model lives in namespace **`Uno.UI.Xaml.Controls`** — `NativeMenu`, `NativeMenuItem`,
+`NativeMenuItemSeparator` and friends; see [data-model.md](./data-model.md) for the full type
+reference. The declarative `AppMenuBar` control lives in the separate **`Uno.Toolkit.UI`**
+package (see [section 7](#7-the-toolkit-appmenubar-control)).
+
+> **These types do not exist yet.** This document describes a proposed API; the spec is the
+> source of truth until the implementation lands.
 
 > **Skia targets only.** v1 ships macOS + iPadOS. Linux (DBusMenu) and Windows are
 > designed-for extension points. Where there is no native menu, the model is inert
@@ -181,6 +185,7 @@ Items execute via **`Command` (ICommand) + `CommandParameter`** *and* a **`Click
 `XamlUICommand` / `StandardUICommand` auto-populates `Text`, `Icon`, and the accelerator.
 
 ```csharp
+using System.Diagnostics;
 using Microsoft.UI.Xaml.Input;
 using Windows.System;
 using Uno.UI.Xaml.Controls;
@@ -229,6 +234,10 @@ So a cross-platform "primary" shortcut (Cmd on Mac, Ctrl on Win) needs **per-pla
 markup** today:
 
 ```csharp
+using System;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+
 var primary = OperatingSystem.IsMacOS()
 	? VirtualKeyModifiers.Windows   // ⌘
 	: VirtualKeyModifiers.Control;  // Ctrl
@@ -358,12 +367,13 @@ recentMenu.Items.Clear();
 ```
 
 For **just-in-time** population (e.g. a Recent Files list you do not want to rebuild on every
-change), handle the **`Opening`** event on the submenu's `NativeMenu`. It maps to
+change), handle the **`NeedsUpdate`** event on the submenu's `NativeMenu`. It maps to
 `NSMenuDelegate.menuNeedsUpdate` on macOS, DBus `AboutToShow` on Linux, and the rebuild pass
 on iPadOS.
 
 ```csharp
 using System;
+using System.IO;
 using Uno.UI.Xaml.Controls;
 
 NativeMenuItem recent = new() { Text = "Open Recent" };
@@ -371,9 +381,9 @@ NativeMenu recentMenu = new();
 recent.SubMenu = recentMenu;
 
 // Populate fresh each time the submenu is about to open.
-recentMenu.Opening += OnRecentOpening;
+recentMenu.NeedsUpdate += OnRecentNeedsUpdate;
 
-void OnRecentOpening(object? sender, NativeMenuOpeningEventArgs e)
+void OnRecentNeedsUpdate(object? sender, NativeMenuNeedsUpdateEventArgs e)
 {
 	recentMenu.Items.Clear();
 
@@ -394,9 +404,13 @@ void OnRecentOpening(object? sender, NativeMenuOpeningEventArgs e)
 }
 ```
 
-> There is also a `Closed` event on `NativeMenu` if you need teardown. Native menu APIs are
-> main-thread; the coalesced rebuild posts to the UI dispatcher for you, so you can mutate
-> the model from the UI thread freely.
+> **Populate from `NeedsUpdate`, not `Opening`.** `NativeMenu` also raises `Opening` (the menu
+> is about to appear, content already settled) and `Closed` (dismissed) — use those for
+> notification and teardown only. Mutations made from `NeedsUpdate` land in the build already
+> in flight; the same mutations from `Opening` go through the normal coalesced rebuild and so
+> show up only the *next* time the menu opens. Native menu APIs are main-thread; the coalesced
+> rebuild posts to the UI dispatcher for you, so you can mutate the model from the UI thread
+> freely.
 
 ---
 
@@ -455,9 +469,10 @@ Map OS standard slots with the attached property **`AppMenu.Role`** (Toolkit), w
 
 ## 8. Capability probe
 
-Adapt your UI to what the current platform actually supports. `NativeMenu.IsSupported` tells
-you whether a native menu exists here at all; `IsRoleSupported(role)` probes a specific OS
-slot (Flutter-borrowed).
+Adapt your UI to what the current platform actually supports. `NativeMenu.IsSupported` answers
+**"would a menu I assign right now actually be projected?"** — so it is `false` not only on
+Windows but also on a Linux desktop with no DBusMenu registrar, which is exactly the branch you
+need. `IsRoleSupported(role)` probes a specific OS slot (Flutter-borrowed).
 
 ```csharp
 using Uno.UI.Xaml.Controls;
@@ -477,9 +492,26 @@ else
 bool osHasQuit = NativeMenu.IsRoleSupported(NativeMenuItemRole.Quit);
 ```
 
-> On Win32 the native extension is a no-op (`IsExported == false`); the in-app `AppMenuBar`
+> On Win32 the native extension is a no-op (`IsSupported == false`); the in-app `AppMenuBar`
 > renders the real `MenuBar`. On Linux, native projection is available only when a DBusMenu
 > registrar is present (else fall back in-app).
+
+**`IsSupported` vs `IsExported`.** `IsSupported` is about the *host*: can it project at all?
+`IsExported` is about *right now*: is a native menu on screen? Assign a menu on macOS and both
+are `true`; assign nothing and `IsSupported` is still `true` while `IsExported` is `false`.
+Most apps only need `IsSupported`, as above. Reach for `IsExported` when your own UI has to
+appear exactly when the native menu does not — which is what the Toolkit `AppMenuBar` does:
+
+```csharp
+void SyncInAppMenuVisibility() =>
+	InAppMenuBar.Visibility = NativeMenu.IsExported ? Visibility.Collapsed : Visibility.Visible;
+
+NativeMenu.IsExportedChanged += (_, _) => SyncInAppMenuVisibility();
+SyncInAppMenuVisibility();
+```
+
+A Linux registrar can appear or disappear mid-session, so both flags can change at runtime —
+subscribe rather than probing once at startup.
 
 ---
 

--- a/specs/047-native-os-menu/quickstart.md
+++ b/specs/047-native-os-menu/quickstart.md
@@ -124,8 +124,13 @@ public sealed partial class App : Application
 ## 2. App-wide menu, declared in XAML as a resource, assigned in code
 
 The tree itself **can** be declared in XAML (its content property is `Items`), then
-assigned via the code-first setter. This keeps the menu shape readable and `x:Bind`-able.
-Declare it as a resource so it is not added to the visual tree.
+assigned via the code-first setter. This keeps the menu shape readable. Declare it as a
+resource so it is not added to the visual tree.
+
+> **Neither `{x:Bind}` nor `x:Name` works inside a resource dictionary.** `x:Bind` compiles
+> against a root element's code-behind, and a `ResourceDictionary` has none; `x:Name` emits no
+> field there either. Declare the commands as resources and reference them with
+> `{StaticResource}`, as below. (`{Binding}` also works once the menu has a `DataContext`.)
 
 ```xml
 <!-- App.xaml -->
@@ -133,15 +138,22 @@ Declare it as a resource so it is not added to the visual tree.
 	x:Class="MyApp.App"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:menu="using:Uno.UI.Xaml.Controls">
+	xmlns:menu="using:Uno.UI.Xaml.Controls"
+	xmlns:vm="using:MyApp.Commands">
 	<Application.Resources>
+		<!-- Commands as resources, so the menu can reference them with {StaticResource}. -->
+		<vm:AppCommands x:Key="Commands" />
+
 		<menu:NativeMenu x:Key="AppMenu">
 			<menu:NativeMenuItem Role="ApplicationMenu">
 				<menu:NativeMenuItem.SubMenu>
 					<menu:NativeMenu>
 						<menu:NativeMenuItem Text="About MyApp" Role="About" />
 						<menu:NativeMenuItemSeparator />
-						<menu:NativeMenuItem Text="Settings..." Role="Settings" Command="{x:Bind ShowSettingsCommand}" />
+						<menu:NativeMenuItem
+							Text="Settings..."
+							Role="Settings"
+							Command="{Binding ShowSettings, Source={StaticResource Commands}}" />
 					</menu:NativeMenu>
 				</menu:NativeMenuItem.SubMenu>
 			</menu:NativeMenuItem>
@@ -149,10 +161,10 @@ Declare it as a resource so it is not added to the visual tree.
 			<menu:NativeMenuItem Text="File">
 				<menu:NativeMenuItem.SubMenu>
 					<menu:NativeMenu>
-						<menu:NativeMenuItem Text="New" Command="{x:Bind NewCommand}" />
-						<menu:NativeMenuItem Text="Open..." Command="{x:Bind OpenCommand}" />
+						<menu:NativeMenuItem Text="New" Command="{Binding New, Source={StaticResource Commands}}" />
+						<menu:NativeMenuItem Text="Open..." Command="{Binding Open, Source={StaticResource Commands}}" />
 						<menu:NativeMenuItemSeparator />
-						<menu:NativeMenuItem Text="Close" Command="{x:Bind CloseCommand}" />
+						<menu:NativeMenuItem Text="Close" Command="{Binding Close, Source={StaticResource Commands}}" />
 					</menu:NativeMenu>
 				</menu:NativeMenuItem.SubMenu>
 			</menu:NativeMenuItem>
@@ -175,6 +187,10 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
 > The menu tree is data, so declaring it in `Application.Resources` (or a page's resources)
 > never renders it into the visual tree — it is only realized when projected to the native
 > menu by the setter.
+>
+> **A resource menu is a shared instance.** `{StaticResource}` returns the same object on every
+> lookup, and an item belongs to exactly one menu, so attaching the same resource menu to two
+> scopes throws. Attach it once, or mark it `x:Shared="False"` for a fresh instance per lookup.
 
 ---
 

--- a/specs/047-native-os-menu/research.md
+++ b/specs/047-native-os-menu/research.md
@@ -292,12 +292,17 @@ the entire menu tree. The builder lets you **insert / replace / remove** `UIMenu
 
 ### 5.2 Rebuild-only updates (A3)
 
-There is **no live mutation**. To change the menu you call
-**`UIMenuSystem.main.setNeedsRebuild()`** (or `setNeedsRevalidate()` for enabled-state-only),
-and UIKit calls `buildMenu(with:)` again to reconstruct the tree. This is the canonical
-**rebuild-only** platform and the reason Uno's common update path is a full rebuild. Uno's
-observable model marks dirty → coalesces → calls `setNeedsRebuild()`, and the
-`buildMenu` override reads the current `NativeMenu` to emit `UIMenu`/`UICommand`s.
+There is **no live mutation**. To change the menu you request a rebuild on the menu system
+(`setNeedsRebuild()`, or `setNeedsRevalidate()` for enabled-state-only), and UIKit calls
+`buildMenu(with:)` again to reconstruct the tree. iOS/iPadOS 26 adds **`UIMainMenuSystem`**
+— a new `UIMenuSystem` subclass that represents the iPad menu bar — so the Uno backend
+requests the rebuild on **`UIMainMenuSystem.shared`** where available, falling back to
+**`UIMenuSystem.main`** on earlier OS. This is the canonical **rebuild-only** platform and
+the reason Uno's common update path is a full rebuild. Uno's observable model marks dirty →
+coalesces → requests the rebuild, and the `buildMenu` override reads the current
+`NativeMenu` to emit `UIMenu`/`UICommand`s. The `UIMenuBuilder` API itself is **unchanged**
+and remains the correct seam (iOS/iPadOS 26 only enhanced it with new convenience methods,
+faster construction, and better diagnostics).
 
 ### 5.3 Validation
 
@@ -308,12 +313,24 @@ is the enabled-only fast path.
 
 ### 5.4 When the bar appears
 
-- The menu bar is shown when a **hardware keyboard** is attached (iPad) — it is *not*
-  always visible. On **iPhone** there is no menu bar at all (the menu system surfaces only
-  via key commands / edit menus).
-- **iPadOS 26** moves to a **reveal-on-demand** menu bar (hover/gesture at the top edge),
-  hidden during full-screen. **Bar visibility is OS-controlled** — there is deliberately
-  **no force-show API** in the Uno design; the app contributes *content* only.
+- **iPadOS 26 brings the macOS menu bar to iPad as an always-available, first-class system
+  menu bar** — it does **not** require a hardware keyboard. Users reveal it by **swiping
+  down from the top of the screen** (also by moving the pointer to the top edge, or via
+  Globe+M), and it works on any iPad regardless of input device. This is a real macOS-like
+  menu bar, not a transient Cmd-hold HUD. **Bar visibility is OS-controlled** — there is
+  deliberately **no force-show API** in the Uno design; the app contributes *content* only.
+- **Version nuance.** The same `UIMenuBuilder` content surfaces differently per OS version:
+  on **iPadOS 26+** it is the always-available menu bar above; on **earlier iPadOS (15–25)**
+  the identical content is presented as the older **transient menu shown with a hardware
+  keyboard** (Cmd-hold). We supply the content once; the OS presents it per version.
+- On **iPhone** there is no menu bar at all (`UIKeyCommand`s still work with a hardware
+  keyboard, but the menu system does not surface a bar).
+- **Discoverability convention.** Because the iPadOS 26 menu bar is meant to advertise an
+  app's full capability surface, it should display **all** app commands — **including
+  currently-unavailable ones**. Keep disabled commands **visible but disabled** (do not
+  remove them) so users discover what the app can do. This aligns cleanly with Uno's
+  push-based enablement (A2): prefer toggling `IsEnabled` over `IsVisible=false`/removal for
+  menu commands.
 
 ### 5.5 Catalyst unification & Uno reach
 

--- a/specs/047-native-os-menu/research.md
+++ b/specs/047-native-os-menu/research.md
@@ -495,7 +495,7 @@ host registers a concrete impl at startup.
   [`ExtensionsRegistrar.cs:31-38`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/Hosting/ExtensionsRegistrar.cs)
   via `ApiExtensibility.Register(typeof(IXxxExtension), o => new …Extension())`.
 - macOS registers in
-  [`MacSkiaHost.cs:197-205`](../../src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs)
+  [`MacOSWindowHost.cs:196-204`](../../src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs)
   (and `MacSkiaHost.cs:66`) the same way. The macOS `NSMenu` impl additionally needs new
   native exports in the UnoNativeMac ObjC layer (e.g. `uno_window_set_main_menu` /
   `uno_app_set_main_menu` + build/update entry points).

--- a/specs/047-native-os-menu/research.md
+++ b/specs/047-native-os-menu/research.md
@@ -1,0 +1,555 @@
+# Research: Native OS Menu Integration
+
+**Date**: 2026-06-30
+**Branch**: `047-native-os-menu`
+**Issue**: unoplatform/uno#22172 (core model + projection seam)
+**Scope**: Apple-first, design-for-all. v1 = macOS (NSMenu) + iPadOS (UIMenuBuilder); Linux (DBusMenu) + Windows are post-v1 extension points. Skia targets only.
+
+> **Evidence level.** Native-platform sections (macOS / iPadOS / Linux / Windows) are
+> grounded in the platform vendor documentation and the prior-art codebases
+> (Avalonia, Flutter) named below; treat them as *design research*, not Uno runtime
+> validation. The **Uno inventory (§8)** is the load-bearing part for implementation:
+> every integration point there was traced in the live source and is cited with a
+> relative `../../src/...` link and a line number. No native menu code exists in Uno
+> today, so there is nothing to runtime-validate yet.
+
+This document consolidates the investigation behind the [final design decisions](./spec.md):
+the cross-platform asymmetries that force the shape of the model, the two prior-art
+frameworks that solved the same problem (Avalonia and Flutter), the four target
+platforms' native menu systems, and the existing Uno surfaces the design reuses.
+
+---
+
+## 1. Executive summary — the load-bearing asymmetries
+
+A "native menu" means something structurally different on each OS. Four asymmetries
+dominate every design decision; everything in the spec is a response to one of them.
+
+| # | Asymmetry | macOS | iPadOS | Linux (DBusMenu) | Windows |
+|---|-----------|-------|--------|------------------|---------|
+| **A1** | **Scope: app vs window** | One **app-wide** menu (`NSApp.mainMenu`), swapped per key window | One **app-global** menu (`buildMenu`), single-scene | **Per-window only** (keyed by window XID) | Per-control (in-app), no OS global menu |
+| **A2** | **Validation: pull vs push** | Pull (`autoenablesItems` + `validateMenuItem:`) — *we override to push* | Pull (per-responder `validate(_:)`) — *we override to push* | Push (exporter sets enabled/visible) | Push (in-app control state) |
+| **A3** | **Update: live vs rebuild** | **Live** (mutate `NSMenuItem` in place; `NSMenuDelegate` JIT) | **Rebuild-only** (`setNeedsRebuild` → full `buildMenu`) | **Re-export** (push whole layout) | Live (in-app DP changes) |
+| **A4** | **OS standard items** | **Yes** (About/Quit/Services/Hide auto-wire to AppKit selectors) | **Yes** (system-provided `UICommand`/identifiers) | **No** | **No** |
+
+The design's responses, one-to-one:
+
+- **A1 → both-scope attachment + focused-window-wins fallback.** The API exposes
+  *both* `SetMenu(Window, …)` (window-scoped) and `SetApplicationMenu(…)` (app-wide);
+  the system menu reflects the focused window's menu if it set one, else the
+  Application menu (spec decision 6). macOS honors per-window by swapping
+  `NSApp.mainMenu` on `windowDidBecomeKey`; iPadOS is single-scene today, so v1 is
+  app-wide only, with per-scene deferred until Uno gains multi-scene.
+- **A2 → push-only enablement.** Because pull-validation (the responder chain) assumes
+  the menu's target is a native first responder, and **Uno draws its own controls and
+  is never a first responder**, the design pushes effective-enabled state
+  (`IsEnabled && (Command?.CanExecute(p) ?? true)`) and disables native auto-validation
+  (`NSMenu.autoenablesItems = NO`). This is the single most important correctness
+  constraint and it is why `Role` does *not* bridge edit commands to the responder chain.
+- **A3 → observable model + coalesced full rebuild.** The model is observable (DP change
+  callbacks + `INotifyCollectionChanged` on `Items`); any change marks the menu dirty,
+  coalesces on the dispatcher, and re-projects via a **full rebuild** (the lowest common
+  denominator: iPadOS and Linux are rebuild-only). A `NativeMenu.Opening` event covers
+  JIT submenu population where the platform supports it.
+- **A4 → thin slot-marker `Role` enum.** Only Apple platforms have OS-owned items, so
+  `Role` is a *placement marker*, not a behavior bridge. On macOS the framework wires the
+  OS-owned slots (About/Quit/Services/Hide) to AppKit selectors; everywhere else a role
+  sets placement + a standard label only, and the developer always supplies the
+  `Command`. On Windows/Linux in-app, OS-only roles no-op unless a `Command` is given.
+
+A fifth, smaller asymmetry — **shortcut modifier semantics** — is resolved by *not*
+remapping: KeyboardAccelerator modifiers are reused literally, matching Uno's existing
+live-key mapping (§8.3), so a menu accelerator and a live key event agree.
+
+---
+
+## 2. Avalonia analysis (primary prior art)
+
+Avalonia ships the closest analog to what Uno needs: a lightweight, code-first native
+menu model with an in-app fallback control, projecting to macOS / Linux and storing-only
+on Windows. The Uno design borrows Avalonia's *shape* wholesale and diverges only where
+Uno's type system (Window/Application not being DependencyObjects) forces it.
+
+### 2.1 The model
+
+- **`NativeMenu` / `NativeMenuItem` / `NativeMenuItemSeparator`**, all derived from
+  `AvaloniaObject` (Avalonia's DependencyObject equivalent) — **not** `Control`/visual
+  elements. They are a pure data model, exactly the "lightweight DO, not FrameworkElement"
+  choice in Uno spec decision 1.
+- `NativeMenuItem` carries `Header`, `Icon`, `Command`, `CommandParameter`, `Gesture`
+  (the accelerator), `IsEnabled`, `IsChecked`, `ToggleType` (`{None, CheckBox, Radio}`),
+  and a nested `Menu` (submenu). This is a near-exact superset match to Uno's
+  `NativeMenuItem`; Uno adds `Role`, `GroupName`, `IsVisible`, and uses the existing
+  `IconSource`/`KeyboardAccelerator` vocabulary instead of Avalonia's own.
+- Items are an **observable collection** (`NativeMenuItemsCollection : AvaloniaList`),
+  which is what makes the live-update strategy possible. Uno mirrors this with
+  `INotifyCollectionChanged` on `NativeMenu.Items`.
+
+### 2.2 Both-scope attachment
+
+Avalonia attaches the menu via a **`NativeMenu.Menu` attached property** set on
+**both** a `TopLevel` (window-scoped) **and** the `Application` (app-wide) — because in
+Avalonia *both are AvaloniaObjects*. The exporter reads whichever applies, with the
+window menu taking precedence. **This is the one place Uno cannot copy Avalonia
+verbatim**: in WinUI/Uno, `Window` and `Application` are **not** DependencyObjects
+(verified §8.1–8.2), so an attached-property-on-Window/Application does not port. Uno
+keeps the *both-scope* semantics but switches the mechanism to **code-first static
+setters** backed by a `ConditionalWeakTable` side-table (spec decision 3). The menu
+*tree* can still be authored in XAML as a resource and then assigned in code.
+
+### 2.3 The exporter seam and `MenuTarget`
+
+Avalonia projects through an `ITopLevelNativeMenuExporter` / per-backend exporter, with a
+`NativeMenuExporterDefaultRoots`/`MenuTarget` enum of **`Application | Window | TrayIcon |
+Dock`**. This validates two Uno decisions:
+
+- The **projection seam** abstraction (Uno's `INativeMenuExtension` with a `scope`
+  argument) is the right altitude — Avalonia proved a single exporter interface can serve
+  app, window, tray, and dock targets.
+- **Tray-ready shaping.** Because the *same* `NativeMenu` model feeds a `TrayIcon` in
+  Avalonia, Uno deliberately shapes `NativeMenu` so a future system-tray / notification-area
+  menu can reuse it (spec "tray-ready", not built v1).
+
+### 2.4 Per-backend behavior Uno mirrors
+
+- **macOS** (`AvaloniaNativeMenuExporter` → `IAvnMenu`): distinguishes
+  `SetAppMenu` (the app-wide bold-name menu) from per-window `SetMainMenu`, and
+  `PopulateStandardOSXMenuItems` **auto-injects** a baseline app menu (About/Hide/Quit
+  wired to native actions) when the developer doesn't supply one. Uno adopts the same
+  "framework-guaranteed minimal app menu with at least Quit + Hide" rule (spec decision 8),
+  and the same App-menu-customization-by-role approach (declare a top-level item with
+  `Role=ApplicationMenu` whose children merge into the app menu).
+- **Linux** (`DBusMenuExporter`): exports `com.canonical.dbusmenu` and registers with
+  `com.canonical.AppMenu.Registrar`, **failing silently** when no registrar is present
+  (Wayland/GNOME). Uno copies the fail-silent contract and the in-app fallback elsewhere
+  (spec decision Linux backend, post-v1).
+- **Windows**: the menu is **store-only / no-op** (no HMENU); the in-app `NativeMenuBar`
+  renders instead. Uno's Win32 impl is identically a no-op with `IsExported = false`.
+
+### 2.5 The in-app fallback control
+
+Avalonia's **`NativeMenuBar`** is a real templated control that, on platforms with a
+native exporter, **collapses to zero size** (it has exported its content) and on
+platforms without one **renders an in-app menu bar**. This is exactly the
+**`AppMenuBar : MenuBar`** behavior in the Uno **Toolkit** (separate repo/issue): render
+normally where there's no native menu, translate-and-collapse on Apple. The split — model
++ seam in core, declarative control in Toolkit — keeps the dependency one-way.
+
+### 2.6 Full-rebuild update strategy
+
+Avalonia's exporters do **not** incrementally diff; a model change triggers a
+`QueueReset` that re-exports the whole (sub)menu. Uno adopts the identical
+coalesced-full-rebuild strategy (spec decision 7), because the rebuild-only platforms
+(iPadOS, Linux) make incremental native diffing pointless as a common path.
+
+**What Uno borrows from Avalonia:** the model + in-app-control pairing; both-scope
+attachment semantics (mechanism changed to setters); the single exporter seam with a
+scope/target argument; `ICommand` + `CanExecute` execution; tray-ready model shaping;
+fail-silent registrar on Linux; framework-guaranteed minimal macOS app menu; and the
+coalesced full-rebuild update model.
+
+---
+
+## 3. Flutter analysis (secondary prior art)
+
+Flutter solved a narrower version of the same problem and contributes two specific ideas:
+the **portable role enum** and the **capability probe**.
+
+### 3.1 The model
+
+Flutter's `PlatformMenuBar` widget takes a tree of:
+
+- **`PlatformMenu`** — a submenu with a label and children.
+- **`PlatformMenuItem`** — a leaf with `label`, `onSelected` callback, and
+  `shortcut` (a `MenuSerializableShortcut`).
+- **`PlatformMenuItemGroup`** — a group rendered with separators around it (the
+  separator concept, expressed as grouping rather than an explicit separator item).
+- **`PlatformProvidedMenuItem`** — an **OS-provided** item selected from a fixed enum
+  (`PlatformProvidedMenuItemType`: `about`, `quit`, `servicesSubmenu`, `hide`,
+  `hideOtherApplications`, `showAllApplications`, `startSpeaking`, `toggleFullScreen`,
+  `minimizeWindow`, `zoomWindow`, `arrangeWindowsInFront`, …).
+
+`PlatformProvidedMenuItem` is the direct ancestor of Uno's **`NativeMenuItemRole`** enum:
+a portable, OS-agnostic *marker* for a slot the OS owns, where the framework supplies the
+wiring. Uno generalizes it from "provided item type" to a `Role` *property* on a normal
+`NativeMenuItem` (so a role item can still carry a developer `Command` on non-Apple
+platforms), but the enum membership is essentially the Flutter set plus the edit roles.
+
+### 3.2 Channel + platform reach
+
+- Projection goes over the **`flutter/menu` platform channel**; the menu tree is
+  serialized to a channel message and the platform side builds the native menu.
+- **macOS is the only platform with a real native menu** in Flutter. On every other
+  platform `PlatformMenuBar` **silently degrades** (renders nothing / no-ops) — there is
+  no in-app fallback in the framework itself. Uno improves on this by pairing the model
+  with the Toolkit `AppMenuBar` in-app fallback so non-native platforms still get a menu.
+
+### 3.3 Capability probe
+
+Flutter exposes `PlatformProvidedMenuItem.hasMenu` and per-item availability so an app can
+ask "does this platform provide this item?" and adapt its tree. Uno borrows this as
+**`NativeMenu.IsSupported`** (is there *any* native menu here?) and
+**`IsRoleSupported(NativeMenuItemRole)`** (is *this* OS slot available?), so apps can
+branch their menu construction (spec "capability probe").
+
+**What Uno borrows from Flutter:** the portable role-enum concept (`PlatformProvidedMenuItem`
+→ `NativeMenuItemRole`) and the capability-probe API. Uno explicitly *rejects* Flutter's
+"silent degrade, no fallback" choice in favor of Avalonia's in-app fallback.
+
+---
+
+## 4. macOS — NSMenu / NSMenuItem (primary v1 target)
+
+### 4.1 App-wide structure
+
+macOS has exactly one menu bar at the top of the screen, owned by the application:
+`NSApplication.mainMenu` (`NSApp.mainMenu`). Its structure is rigid:
+
+- `mainMenu` is an `NSMenu` whose **items are the top-level bar entries** (the bold
+  app-name menu, then File, Edit, View, … Help).
+- **Each** top-level `NSMenuItem` has **no action of its own**; it carries a `submenu`
+  (`NSMenuItem.submenu`, an `NSMenu`) that holds the actual commands.
+- The **first** top-level item is special: it is the **application menu** (rendered with
+  the app's name in bold), conventionally About / Settings… / Services / Hide / Quit.
+- macOS auto-positions a few menus by convention (the Services submenu, the Window menu
+  via `NSApp.windowsMenu`, the Help search menu) when they are tagged appropriately.
+
+### 4.2 Items, shortcuts, state, image
+
+- `NSMenuItem.title` — the label. `NSMenuItem.separatorItem` — the separator.
+- **Shortcut** = `keyEquivalent` (a string, e.g. `"q"`) + `keyEquivalentModifierMask`
+  (an `NSEventModifierFlags` bitmask: `.command`, `.option`, `.control`, `.shift`). This
+  maps cleanly from a Uno `KeyboardAccelerator` (`Key` + `Modifiers`), and — critically —
+  the modifier mapping is the **same direction** Uno already uses for live key events
+  (§8.3): `VirtualKeyModifiers.Windows` ⇄ `.command`.
+- **Checked/mixed** = `NSMenuItem.state` (`.on` / `.off` / `.mixed`). There is **no
+  native radio-group type**; radio exclusivity is coordinated by the app — the framework
+  sets `.on` on the selected item and `.off` on its `GroupName` peers. (Avalonia does the
+  same.)
+- **Icon** = `NSMenuItem.image` (an `NSImage`). Uno translates `IconSource` best-effort to
+  PNG bytes → `NSImage`, with an optional SF-Symbol-name passthrough for Apple.
+- **Submenu/enabled/visibility** = `submenu`, `isEnabled`, `isHidden`.
+
+### 4.3 Validation — why Uno pushes state (A2)
+
+By default `NSMenu.autoenablesItems == YES`: AppKit **pulls** each item's enabled state by
+walking the responder chain and asking the target whether it responds to the item's
+`action` (and consulting `validateMenuItem:` / `NSMenuItemValidation`). This presupposes
+the menu's target is a live native responder. **Uno renders its own controls and is not a
+native first responder**, so pull-validation would disable everything. The design therefore
+sets **`NSMenu.autoenablesItems = NO`** and **pushes** the effective-enabled state computed
+in managed code (`IsEnabled && CanExecute`), observing `CanExecuteChanged`. This is the
+macOS embodiment of asymmetry A2 and the reason `Role` does not bridge edit commands.
+
+### 4.4 OS-owned items (A4)
+
+A handful of standard items are wired to AppKit selectors on `NSApp` / first responder:
+`terminate:` (Quit), `hide:` (Hide), `hideOtherApplications:`, `unhideAllApplications:`
+(Show All), `orderFrontStandardAboutPanel:` (About), and the Services submenu
+(`NSApp.servicesMenu`). For these, Uno's framework auto-wires the selector when a role is
+present (no developer Command needed). The existing bootstrap menu
+(`UNOApplication.m:95-124`) already does this for Quit (`terminate:`) and Close
+(`performClose:`); the seam **replaces/extends** that menu rather than coexisting with it.
+
+### 4.5 Dynamic updates
+
+macOS supports both **live mutation** (change `title`/`state`/`isEnabled` on an existing
+`NSMenuItem` and it reflects immediately) and **JIT population** via `NSMenuDelegate`:
+`menuNeedsUpdate:` (called before a menu is displayed) and `numberOfItems` /
+`menu:updateItem:atIndex:shouldCancel:`. Uno maps `NativeMenu.Opening` to
+`menuNeedsUpdate:` for just-in-time submenu population. Despite macOS supporting live
+mutation, Uno still uses the coalesced full-rebuild as the *common* path (A3) and reserves
+live-mutate as a possible macOS optimization.
+
+### 4.6 Limitations
+
+- One menu bar per app — per-window is emulated by **swapping** `NSApp.mainMenu` on
+  `windowDidBecomeKey:` and restoring on resign (multi-window is real on macOS, so this is
+  a v1 requirement, not a future).
+- Custom-view menu items (`NSMenuItem.view`) exist but are **out of scope**.
+- The app menu's bold name comes from the bundle, not the menu — the first item's title is
+  effectively ignored for display.
+
+---
+
+## 5. iPadOS / Mac Catalyst — UIMenuBuilder / UIMenu / UICommand
+
+### 5.1 App-global build model
+
+UIKit's menu system is **app-global and declarative-by-rebuild**. The app delegate (a
+`UIResponder`) overrides **`buildMenu(with: UIMenuBuilder)`**; UIKit calls it to construct
+the entire menu tree. The builder lets you **insert / replace / remove** `UIMenu`s and
+`UICommand`s relative to **system identifiers** (`UIMenu.Identifier`,
+`UICommand`/`UIKeyCommand`), e.g. insert a child menu `before:`/`after:` `.file`, or remove
+`.format`. The app supplies content; UIKit owns layout and the system slots.
+
+- **`UIMenu`** — a submenu (title, image, children, options like `.displayInline` for
+  separator-style grouping and single-selection inline groups).
+- **`UICommand`** — a leaf (title, image, `action:` selector, `propertyList`); **`UIKeyCommand`**
+  is a `UICommand` subclass that adds `input` + `modifierFlags` (the shortcut).
+- **System-provided items** come from standard identifiers (About, Services, Hide, Quit on
+  Catalyst; edit commands) — the A4 "OS standard items" for this platform.
+
+### 5.2 Rebuild-only updates (A3)
+
+There is **no live mutation**. To change the menu you call
+**`UIMenuSystem.main.setNeedsRebuild()`** (or `setNeedsRevalidate()` for enabled-state-only),
+and UIKit calls `buildMenu(with:)` again to reconstruct the tree. This is the canonical
+**rebuild-only** platform and the reason Uno's common update path is a full rebuild. Uno's
+observable model marks dirty → coalesces → calls `setNeedsRebuild()`, and the
+`buildMenu` override reads the current `NativeMenu` to emit `UIMenu`/`UICommand`s.
+
+### 5.3 Validation
+
+Per-responder validation via `validate(_ command: UICommand)` / `canPerformAction(_:withSender:)`
+along the responder chain — the same pull model as macOS, and Uno overrides it the same
+way (push effective state into the emitted `UICommand`s during the rebuild). `setNeedsRevalidate()`
+is the enabled-only fast path.
+
+### 5.4 When the bar appears
+
+- The menu bar is shown when a **hardware keyboard** is attached (iPad) — it is *not*
+  always visible. On **iPhone** there is no menu bar at all (the menu system surfaces only
+  via key commands / edit menus).
+- **iPadOS 26** moves to a **reveal-on-demand** menu bar (hover/gesture at the top edge),
+  hidden during full-screen. **Bar visibility is OS-controlled** — there is deliberately
+  **no force-show API** in the Uno design; the app contributes *content* only.
+
+### 5.5 Catalyst unification & Uno reach
+
+Mac Catalyst uses the same `UIMenuBuilder` API but renders into a real macOS `NSMenu`,
+unifying the iPad and Mac-Catalyst code path. For Uno, the seam lives in
+**`UnoUIApplicationDelegate.BuildMenu(IUIMenuBuilder)`** — the delegate is already a
+`UIResponder` that can override `BuildMenu`, and devs already override the delegate via
+`UseUIApplicationDelegate<T>` (§8.4–8.5).
+
+### 5.6 Limitations
+
+- **App-global only in Uno v1**: Uno AppleUIKit is single-window/single-scene today
+  (§8.6), so per-scene menu override is deferred until Uno gains multi-scene. The model
+  accommodates it (scope argument) but the backend projects app-wide.
+- Rebuild-only — no in-place item mutation; every change is a full reconstruct.
+- Icons map to `UIImage` (incl. SF Symbols by name); shortcuts to `UIKeyCommand`.
+
+---
+
+## 6. Linux — DBusMenu (com.canonical.dbusmenu) [post-v1]
+
+### 6.1 The native models
+
+Linux has **no single OS menu API**; the de-facto "global menu" is a desktop-shell
+convention exported over D-Bus:
+
+- **`com.canonical.dbusmenu`** (the Unity/Ubuntu-era "dbusmenu" protocol, still used by KDE
+  Plasma's global menu and the appmenu-gtk module) — the app exports a menu layout object;
+  the shell renders it. Registration is via **`com.canonical.AppMenu.Registrar`**, keyed by
+  the **X11 window XID**, so it is fundamentally **per-window** (asymmetry A1: Linux is the
+  one platform whose *only* model is per-window).
+- **`org.gtk.Menus` + `org.gtk.Actions`** — GTK's own exported-menu/action protocol, an
+  alternative used by some GNOME apps. (Avalonia uses dbusmenu; Uno's recommended strategy
+  follows suit for breadth of shell support.)
+
+### 6.2 The fragmentation problem
+
+- **GNOME removed the global app menu** (the old top-bar app menu was deprecated and
+  dropped); GNOME Shell does not render a dbusmenu global menu by default.
+- **KDE Plasma supports it** (Global Menu widget) via dbusmenu.
+- **Wayland gap**: registration is XID-keyed and X11-centric; under Wayland there is no
+  stable surface→XID, so the dbusmenu/registrar path is effectively **X11-only**.
+
+### 6.3 Capabilities
+
+Submenu / separator / checkable / **radio (native `toggle-type=radio`)** are all
+supported; icons are **partial** (icon-name or icon-data, no rich rendering); shortcuts are
+**panel-dependent** (the shell may or may not render the accelerator). Updates are
+**re-export** (push the whole layout; `AboutToShow` provides JIT population — the Linux
+analog of `NativeMenu.Opening`). Enable/disable + visibility are **push** (A2: Linux pushes).
+**No OS-standard items** (A4: Linux has no About/Quit/Services slots).
+
+### 6.4 Recommended strategy
+
+Export **DBusMenu on X11**, register with `com.canonical.AppMenu.Registrar`, and **fail
+silently** when no registrar is present (Wayland, GNOME, no panel) — exactly Avalonia's
+contract. Where there is no registrar, fall back to the **in-app `AppMenuBar`**. This is
+**post-v1**: the seam (`INativeMenuExtension`) is designed so a `Skia.X11` impl can be
+added without touching the core model.
+
+---
+
+## 7. Windows / WinUI
+
+### 7.1 No OS global menu
+
+Windows has **no application-global menu bar**. The legacy native construct is the Win32
+**`HMENU`** attached to a top-level `HWND` (`SetMenu`) — strictly **per-window**, drawn in
+the non-client area, and stylistically inconsistent with modern Fluent apps. **WinUI does
+not use HMENU**; it provides the **in-app `MenuBar`** control (a normal templated control in
+the client area).
+
+### 7.2 The command/menu surface Uno already has
+
+Uno already implements the full WinUI in-app menu + commanding stack that the design
+reuses (verified §8.7):
+
+- **`MenuBar` / `MenuBarItem` / `MenuFlyout` / `MenuFlyoutItem` / `MenuFlyoutSubItem` /
+  `ToggleMenuFlyoutItem` / `RadioMenuFlyoutItem` / `MenuFlyoutSeparator`** — Skia-rendered,
+  the in-app rendering target for `AppMenuBar` on Windows/Linux-no-native.
+- **`XamlUICommand` / `StandardUICommand` (+ `StandardUICommandKind`)** — the commanding
+  vocabulary, with `CommandingHelpers` auto-populating Label/Icon/KeyboardAccelerator from
+  a command onto a menu item.
+- **`KeyboardAccelerator`** (`Key` + `VirtualKeyModifiers`) — the accelerator type reused
+  literally (no Ctrl→Cmd remap).
+- **`IconSource` / `IconElement`** family (`BitmapIconSource`, `ImageIconSource`,
+  `SymbolIconSource`, `FontIconSource`, `PathIconSource`) — the icon vocabulary, translated
+  best-effort to native images on Apple/Linux.
+
+### 7.3 Recommendation
+
+Win32 impl is a **no-op** with `IsExported = false`; the in-app `AppMenuBar` renders the
+real `MenuBar`. **No HMENU** — it would be per-window, non-Fluent, and a styling dead-end.
+Windows is a designed-for extension point (the seam exists) but ships as in-app only.
+
+---
+
+## 8. Uno inventory (verified integration points)
+
+Every claim here was traced in the live source. No native-menu integration exists today —
+this is greenfield on top of the surfaces below.
+
+### 8.1 `Window` is **not** a DependencyObject
+
+[`Window.cs`](../../src/Uno.UI/UI/Xaml/Window/Window.cs) — `Window` does not derive from
+`DependencyObject`. Consequence: Avalonia's `NativeMenu.Menu` attached-property-on-window
+**does not port**; window-scoped attachment must be a static setter
+(`NativeMenu.SetMenu(Window, …)`) backed by a `ConditionalWeakTable<Window, NativeMenu>`.
+
+### 8.2 `Application` is **not** a DependencyObject
+
+[`Application.cs`](../../src/Uno.UI/UI/Xaml/Application.cs) — likewise. App-wide attachment
+is `NativeMenu.SetApplicationMenu(…)` into a static side-table, not an attached property.
+
+### 8.3 Existing bootstrap NSMenu (macOS)
+
+[`UNOApplication.m:95-124`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m) —
+on launch, if `app.mainMenu == nil`, Uno builds a minimal menu: an app menu with **Quit
+(`terminate:`, Cmd+Q)** and a File menu with **Close Window (`performClose:`, Cmd+W)**. The
+projection seam **replaces/extends** `app.mainMenu`; this confirms the "framework-guaranteed
+minimal app menu" baseline already exists and just needs to be driven by the model.
+
+### 8.4 macOS modifier mapping (shortcut direction)
+
+[`UNOWindow.m:874-890`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m) —
+`get_modifiers` maps live `NSEventModifierFlags` to `VirtualKeyModifiers`:
+`Command → Windows`, `Control → Control`, `Option → Menu` (Alt), `Shift → Shift`. This is the
+**same direction** the menu accelerator translation must use; a menu-only remap would be
+incoherent with live key events. This is the evidence behind spec decision 5 (reuse
+KeyboardAccelerator modifiers literally; `VirtualKeyModifiers.Windows` = Cmd).
+
+### 8.5 iPadOS `BuildMenu` seam
+
+[`UnoUIApplicationDelegate.cs:11-12`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs) —
+`UnoUIApplicationDelegate : UIApplicationDelegate` is a `UIResponder`, so it can override
+**`BuildMenu(IUIMenuBuilder)`**. It already observes `UIScene` activation notifications
+(lines 27-43), which the per-scene-focus path would hook when multi-scene lands. This is the
+iPadOS projection seam.
+
+### 8.6 `UseUIApplicationDelegate<T>` override hook
+
+[`AppleUIKitHostBuilder.cs:22-28`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/Builder/AppleUIKitHostBuilder.cs) —
+devs supply a custom delegate type via `UseUIApplicationDelegate<T>()` (where
+`T : UnoUIApplicationDelegate`), so the framework's `BuildMenu` override composes with
+app-supplied delegates.
+
+### 8.7 Single-window TODO (multi-scene gap)
+
+[`NativeWindowFactoryExtension.cs:16-17`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/NativeWindowFactoryExtension.cs) —
+`SupportsMultipleWindows => false` with an explicit TODO: *"While supported by the OS, we
+currently only support single window. Later switch to … SupportsMultipleScenes."* This is
+the concrete reason iPadOS v1 is **app-wide menu only**; per-scene override is deferred but
+the design accommodates it.
+
+### 8.8 ApiExtensibility registration pattern
+
+The projection seam follows the established `ApiExtensibility` pattern (platform-targeting
+rule 5): the core resolves `ApiExtensibility.CreateInstance<INativeMenuExtension>()`; each
+host registers a concrete impl at startup.
+
+- AppleUIKit registers in
+  [`ExtensionsRegistrar.cs:31-38`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/Hosting/ExtensionsRegistrar.cs)
+  via `ApiExtensibility.Register(typeof(IXxxExtension), o => new …Extension())`.
+- macOS registers in
+  [`MacSkiaHost.cs:197-205`](../../src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs)
+  (and `MacSkiaHost.cs:66`) the same way. The macOS `NSMenu` impl additionally needs new
+  native exports in the UnoNativeMac ObjC layer (e.g. `uno_window_set_main_menu` /
+  `uno_app_set_main_menu` + build/update entry points).
+
+### 8.9 Reusable commanding / menu / icon types
+
+[`CommandingHelpers.cs`](../../src/Uno.UI/UI/Xaml/Controls/MenuFlyout/CommandingHelpers.cs)
+already bridges `XamlUICommand`/`StandardUICommand` → menu-item Label/Icon/KeyboardAccelerator
+(the same auto-populate the native model wants). `StandardUICommand` /
+[`StandardUICommandKind`](../../src/Uno.UI/UI/Xaml/Input/StandardUICommandKind.cs),
+`XamlUICommand`, `KeyboardAccelerator`, the `MenuBar`/`MenuFlyout*` family, and the
+`IconSource`/`IconElement` family are all implemented and reusable — the design adds **no new
+commanding or icon vocabulary**, only the `NativeMenu`/`NativeMenuItem` data model and the
+`Role`/`ToggleType` enums.
+
+---
+
+## 9. Cross-platform capability matrix
+
+Rows are capabilities; cells are the native behavior. "in-app" = handled by the in-app
+`AppMenuBar`/`MenuBar` fallback, not a native menu.
+
+| Capability | macOS | iPadOS | Linux (DBusMenu) | Windows |
+|------------|-------|--------|------------------|---------|
+| **App-wide menu** | Yes (`NSApp.mainMenu`) | Yes (`buildMenu`) | No (per-window only) | No native |
+| **Per-window menu** | Yes (swap on key) | No (single-scene v1) | Yes (the only model) | per-control (in-app) |
+| **Submenu** | Yes | Yes | Yes | in-app |
+| **Separator** | Yes | Yes (inline group) | Yes | in-app |
+| **Checkable** | Yes (`state`) | Yes (on/off/mixed) | Yes | in-app |
+| **Radio** | Framework-coordinated | Inline single-selection | `toggle-type=radio` | in-app |
+| **Icon** | Yes (`NSImage`) | Yes (`UIImage`/SF) | Partial (name/data) | in-app |
+| **Shortcut** | Yes (`keyEquivalent`) | Yes (`UIKeyCommand`) | Partial (panel-dependent) | in-app accelerators |
+| **Enable / disable** | Yes (push) | Yes (push) | Yes (push) | Yes (push) |
+| **Visibility** | Yes (`isHidden`) | Yes | Yes | Yes |
+| **Dynamic update** | Live + JIT | Rebuild-only | Re-export | Live (in-app) |
+| **OS std items** | Yes | Yes | No | No |
+| **Custom-view items** | Yes (out of scope) | No | No | No |
+| **`IsExported`** | true | true | true (X11+registrar) / false | **false** |
+
+---
+
+## 10. Design implications — findings → decisions
+
+| Finding | Design decision (spec §) |
+|---------|--------------------------|
+| Model must be a portable data tree, not visuals; Avalonia & Flutter both use non-visual models | **Lightweight `NativeMenu`/`NativeMenuItem` : DependencyObject** (decision 1), reusing existing `XamlUICommand`/`KeyboardAccelerator`/`IconSource` vocabulary (§7.2, §8.9) |
+| Window & Application are **not** DOs (§8.1–8.2), so Avalonia's attached-property-on-window does not port | **Code-first static setters** `SetMenu(Window,…)`/`SetApplicationMenu(…)` over a `ConditionalWeakTable` (decision 3) |
+| A1: app-scope (macOS/iPadOS) vs window-scope (Linux/macOS-multiwindow) | **Both-scope API + focused-window-wins fallback** (decision 6); macOS swaps `NSApp.mainMenu` on key; iPadOS app-wide v1 (§5.6, §8.7) |
+| A2: pull-validation assumes native first responder, which Uno never is (§4.3, §5.3) | **Push effective-enabled** (`IsEnabled && CanExecute`), `autoenablesItems=NO`; `Role` does **not** bridge edit commands to the responder chain (decision 4, BANKED enablement) |
+| A4: only Apple has OS-owned items (§4.4, §5.1); Flutter's `PlatformProvidedMenuItem` enum | **Thin slot-marker `NativeMenuItemRole` enum** (decision 4); macOS auto-wires AppKit selectors, others render role as a labeled item + dev `Command` |
+| A3: iPadOS & Linux are rebuild-only (§5.2, §6.3); Avalonia uses `QueueReset` | **Observable model + coalesced full rebuild** + `NativeMenu.Opening` JIT (decision 7) |
+| macOS bootstrap menu already guarantees Quit/Close (§8.3); Avalonia `PopulateStandardOSXMenuItems` | **Framework-guaranteed minimal app menu** (Quit+Hide); customize via `Role=ApplicationMenu` child merge (decision 8) |
+| Modifier mapping is already `Command→Windows` for live keys (§8.4) | **Reuse `KeyboardAccelerator` modifiers literally**, no Ctrl→Cmd remap (decision 5) |
+| Seam must serve macOS/iPadOS now, Linux/Windows later; Avalonia's single exporter + `MenuTarget` | **`INativeMenuExtension`** over `ApiExtensibility` with a `scope` arg + `IsSupported`/`IsRoleSupported` probe (§8.8); Win32 no-op `IsExported=false`, Linux fail-silent post-v1 |
+| Flutter silently degrades with no fallback; Avalonia's `NativeMenuBar` collapses/renders | **Toolkit `AppMenuBar : MenuBar`** renders in-app where no native menu, translates+collapses on Apple (decision 2) — separate repo, one-way dependency on the core seam |
+| Avalonia reuses the model for `TrayIcon`/`Dock` (§2.3) | **Tray-ready model shaping** (BANKED), not built v1 |
+
+---
+
+## 11. Assumptions
+
+- **A-1**: Uno AppleUIKit remains single-scene through v1; multi-scene per-window menu
+  override is deferred (§8.7). The model's scope argument is forward-compatible.
+- **A-2**: macOS multi-window is in scope for v1 (swap-on-key is a requirement, not a
+  future), since macOS multi-window already exists in Uno.
+- **A-3**: Linux and Windows native backends are **post-v1**; only the seam and the in-app
+  fallback path are designed (not shipped) for them.
+- **A-4**: Icon translation is **documented best-effort** — bitmap/image sources translate
+  cleanly; symbol/font sources are rendered-glyph best-effort with an SF-Symbol passthrough
+  on Apple. Apps should not assume pixel-fidelity icons in native menus.
+- **A-5**: Native menu APIs are main-thread; all model mutations marshal to the UI thread
+  before the coalesced rebuild posts to the dispatcher.
+- **A-6**: Accessibility (VoiceOver), dark-mode appearance, and RTL mirroring are inherited
+  from the OS for free as a benefit of projecting to native menus — no Uno work required.

--- a/specs/047-native-os-menu/research.md
+++ b/specs/047-native-os-menu/research.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-06-30
 **Branch**: `047-native-os-menu`
-**Issue**: unoplatform/uno#22172 (core model + projection seam)
+**Issue**: [unoplatform/uno#22172](https://github.com/unoplatform/uno/issues/22172) (core model + projection seam)
 **Scope**: Apple-first, design-for-all. v1 = macOS (NSMenu) + iPadOS (UIMenuBuilder); Linux (DBusMenu) + Windows are post-v1 extension points. Skia targets only.
 
 > **Evidence level.** Native-platform sections (macOS / iPadOS / Linux / Windows) are
@@ -49,7 +49,7 @@ The design's responses, one-to-one:
 - **A3 → observable model + coalesced full rebuild.** The model is observable (DP change
   callbacks + `INotifyCollectionChanged` on `Items`); any change marks the menu dirty,
   coalesces on the dispatcher, and re-projects via a **full rebuild** (the lowest common
-  denominator: iPadOS and Linux are rebuild-only). A `NativeMenu.Opening` event covers
+  denominator: iPadOS and Linux are rebuild-only). A `NativeMenu.NeedsUpdate` event covers
   JIT submenu population where the platform supports it.
 - **A4 → thin slot-marker `Role` enum.** Only Apple platforms have OS-owned items, so
   `Role` is a *placement marker*, not a behavior bridge. On macOS the framework wires the
@@ -76,6 +76,19 @@ Uno's type system (Window/Application not being DependencyObjects) forces it.
   `AvaloniaObject` (Avalonia's DependencyObject equivalent) — **not** `Control`/visual
   elements. They are a pure data model, exactly the "lightweight DO, not FrameworkElement"
   choice in Uno spec decision 1.
+- **The container is not an item.** `NativeMenu : AvaloniaObject` sits *beside* the item
+  hierarchy, not inside it: only `NativeMenuItem` and `NativeMenuItemSeparator` derive from
+  `NativeMenuItemBase`, and nesting goes through `NativeMenuItem.Menu`. Consequently
+  `parentMenu.Items.Add(new NativeMenu())` does not compile. Each type carries the back-reference
+  it actually needs — `NativeMenuItemBase.Parent` is a `NativeMenu`, `NativeMenu.Parent` is a
+  `NativeMenuItem` — so splitting the branches costs nothing in the dirty-propagation model.
+  Uno adopts this verbatim (spec decision 1, FR-001); an inline/section group, if ever wanted,
+  is a separate explicit type rather than an inferred meaning for a bare container.
+- **One parent per item, enforced.** Avalonia's items collection runs an
+  `IAvaloniaListItemValidator` that throws `InvalidOperationException` when an item that already
+  has a `Parent` is added elsewhere. Uno mirrors this (FR-001a): silent aliasing yields menus
+  that update in one place and not the other, because the back-reference chain the dirty walk
+  follows has only one slot.
 - `NativeMenuItem` carries `Header`, `Icon`, `Command`, `CommandParameter`, `Gesture`
   (the accelerator), `IsEnabled`, `IsChecked`, `ToggleType` (`{None, CheckBox, Radio}`),
   and a nested `Menu` (submenu). This is a near-exact superset match to Uno's
@@ -84,6 +97,14 @@ Uno's type system (Window/Application not being DependencyObjects) forces it.
 - Items are an **observable collection** (`NativeMenuItemsCollection : AvaloniaList`),
   which is what makes the live-update strategy possible. Uno mirrors this with
   `INotifyCollectionChanged` on `NativeMenu.Items`.
+- **Three menu events, not two.** Avalonia separates `NeedsUpdate` (the documented place to add,
+  remove or modify items before the menu is shown) from `Opening` (explicitly annotated *"Do not
+  update the menu in this event; use NeedsUpdate"*) and `Closed`. The split tracks the native
+  sequence — AppKit's `menuNeedsUpdate:` runs while content is still mutable, `menuWillOpen:`
+  after layout is committed, and DBusMenu's `AboutToShow` is a content request that expects a
+  "did anything change?" answer. Uno adopts the same three-event split (FR-016 / FR-016a);
+  collapsing them invites authors to repopulate from inside the platform's menu-tracking run
+  loop, which re-enters the dirty→coalesce→rebuild pipeline at its worst possible moment.
 
 ### 2.2 Both-scope attachment
 
@@ -142,9 +163,10 @@ Avalonia's exporters do **not** incrementally diff; a model change triggers a
 coalesced-full-rebuild strategy (spec decision 7), because the rebuild-only platforms
 (iPadOS, Linux) make incremental native diffing pointless as a common path.
 
-**What Uno borrows from Avalonia:** the model + in-app-control pairing; both-scope
-attachment semantics (mechanism changed to setters); the single exporter seam with a
-scope/target argument; `ICommand` + `CanExecute` execution; tray-ready model shaping;
+**What Uno borrows from Avalonia:** the model + in-app-control pairing; the container-is-not-an-item
+type split and its one-parent-per-item invariant; the `NeedsUpdate`/`Opening`/`Closed` event
+separation; both-scope attachment semantics (mechanism changed to setters); the single exporter
+seam with a scope/target argument; `ICommand` + `CanExecute` execution; tray-ready model shaping;
 fail-silent registrar on Linux; framework-guaranteed minimal macOS app menu; and the
 coalesced full-rebuild update model.
 
@@ -152,8 +174,8 @@ coalesced full-rebuild update model.
 
 ## 3. Flutter analysis (secondary prior art)
 
-Flutter solved a narrower version of the same problem and contributes two specific ideas:
-the **portable role enum** and the **capability probe**.
+Flutter solved a narrower version of the same problem and contributes three specific ideas:
+the **portable role enum**, the **capability probe**, and **grouping as an explicit type**.
 
 ### 3.1 The model
 
@@ -164,6 +186,13 @@ Flutter's `PlatformMenuBar` widget takes a tree of:
   `shortcut` (a `MenuSerializableShortcut`).
 - **`PlatformMenuItemGroup`** — a group rendered with separators around it (the
   separator concept, expressed as grouping rather than an explicit separator item).
+  Note the shape: Flutter *does* let a menu be an item (`PlatformMenu extends
+  PlatformMenuItem`), but grouping is still a **dedicated type** that serializes to
+  divider → members → divider, never an inferred meaning for a bare `PlatformMenu`. So both
+  prior-art frameworks refuse to let "container appearing where an item is expected" mean
+  something implicitly — Avalonia forbids it in the type system, Flutter names it. Uno follows
+  Avalonia's stricter option and reserves a future explicit `NativeMenuItemGroup` for the
+  feature Flutter spells out here (see §2.1 and FR-001).
 - **`PlatformProvidedMenuItem`** — an **OS-provided** item selected from a fixed enum
   (`PlatformProvidedMenuItemType`: `about`, `quit`, `servicesSubmenu`, `hide`,
   `hideOtherApplications`, `showAllApplications`, `startSpeaking`, `toggleFullScreen`,
@@ -256,7 +285,7 @@ present (no developer Command needed). The existing bootstrap menu
 macOS supports both **live mutation** (change `title`/`state`/`isEnabled` on an existing
 `NSMenuItem` and it reflects immediately) and **JIT population** via `NSMenuDelegate`:
 `menuNeedsUpdate:` (called before a menu is displayed) and `numberOfItems` /
-`menu:updateItem:atIndex:shouldCancel:`. Uno maps `NativeMenu.Opening` to
+`menu:updateItem:atIndex:shouldCancel:`. Uno maps `NativeMenu.NeedsUpdate` to
 `menuNeedsUpdate:` for just-in-time submenu population. Despite macOS supporting live
 mutation, Uno still uses the coalesced full-rebuild as the *common* path (A3) and reserves
 live-mutate as a possible macOS optimization.
@@ -380,7 +409,7 @@ Submenu / separator / checkable / **radio (native `toggle-type=radio`)** are all
 supported; icons are **partial** (icon-name or icon-data, no rich rendering); shortcuts are
 **panel-dependent** (the shell may or may not render the accelerator). Updates are
 **re-export** (push the whole layout; `AboutToShow` provides JIT population — the Linux
-analog of `NativeMenu.Opening`). Enable/disable + visibility are **push** (A2: Linux pushes).
+analog of `NativeMenu.NeedsUpdate`). Enable/disable + visibility are **push** (A2: Linux pushes).
 **No OS-standard items** (A4: Linux has no About/Quit/Services slots).
 
 ### 6.4 Recommended strategy
@@ -546,7 +575,7 @@ Rows are capabilities; cells are the native behavior. "in-app" = handled by the 
 | A1: app-scope (macOS/iPadOS) vs window-scope (Linux/macOS-multiwindow) | **Both-scope API + focused-window-wins fallback** (decision 6); macOS swaps `NSApp.mainMenu` on key; iPadOS app-wide v1 (§5.6, §8.7) |
 | A2: pull-validation assumes native first responder, which Uno never is (§4.3, §5.3) | **Push effective-enabled** (`IsEnabled && CanExecute`), `autoenablesItems=NO`; `Role` does **not** bridge edit commands to the responder chain (decision 4, BANKED enablement) |
 | A4: only Apple has OS-owned items (§4.4, §5.1); Flutter's `PlatformProvidedMenuItem` enum | **Thin slot-marker `NativeMenuItemRole` enum** (decision 4); macOS auto-wires AppKit selectors, others render role as a labeled item + dev `Command` |
-| A3: iPadOS & Linux are rebuild-only (§5.2, §6.3); Avalonia uses `QueueReset` | **Observable model + coalesced full rebuild** + `NativeMenu.Opening` JIT (decision 7) |
+| A3: iPadOS & Linux are rebuild-only (§5.2, §6.3); Avalonia uses `QueueReset` | **Observable model + coalesced full rebuild** + `NativeMenu.NeedsUpdate` JIT (decision 7) |
 | macOS bootstrap menu already guarantees Quit/Close (§8.3); Avalonia `PopulateStandardOSXMenuItems` | **Framework-guaranteed minimal app menu** (Quit+Hide); customize via `Role=ApplicationMenu` child merge (decision 8) |
 | Modifier mapping is already `Command→Windows` for live keys (§8.4) | **Reuse `KeyboardAccelerator` modifiers literally**, no Ctrl→Cmd remap (decision 5) |
 | Seam must serve macOS/iPadOS now, Linux/Windows later; Avalonia's single exporter + `MenuTarget` | **`INativeMenuExtension`** over `ApiExtensibility` with a `scope` arg + `IsSupported`/`IsRoleSupported` probe (§8.8); Win32 no-op `IsExported=false`, Linux fail-silent post-v1 |

--- a/specs/047-native-os-menu/research.md
+++ b/specs/047-native-os-menu/research.md
@@ -222,6 +222,26 @@ ask "does this platform provide this item?" and adapt its tree. Uno borrows this
 Linux with no registrar, per FR-026a) and **`IsRoleSupported(NativeMenuItemRole)`** (is *this*
 OS slot available?), so apps can branch their menu construction (spec "capability probe").
 
+### 3.4 Considered and rejected: project `MenuFlyout*` directly
+
+The obvious alternative to a parallel model is to project WinUI's existing
+`MenuFlyout`/`MenuFlyoutItem`/`MenuFlyoutSubItem`/`MenuFlyoutSeparator` tree straight to the native
+menu, with no new types at all. It was rejected, and the reason is a hard blocker rather than a
+preference: those are **templated `Control`s** — `MenuFlyoutItemBase : Control` — so they carry a
+visual tree, a template, and measure/arrange, and they only exist meaningfully once realized in a
+`Popup`. A macOS application menu has no Uno window behind it and may be projected before any
+content is loaded, so there is nothing to realize them into. Reusing them would mean instantiating
+a full control tree purely to read `Text`/`Command` off it.
+
+The cost of the parallel model is real and worth stating plainly: two menu object models in one
+framework, two spellings of a role, and a translation layer (FR-025) that must be kept in sync.
+The mitigation is that the translation is mechanical and lives in exactly one place — the Toolkit
+`AppMenuBar` — so app authors who prefer the familiar markup never see the second model.
+
+Worth noting for shape: WinUI itself puts the container **outside** the item hierarchy
+(`MenuFlyout : FlyoutBase`, not `MenuFlyoutItemBase`), which is the same split adopted in §2.1
+above. The new hierarchy is therefore closer to WinUI's own than the original draft was.
+
 **What Uno borrows from Flutter:** the portable role-enum concept (`PlatformProvidedMenuItem`
 → `NativeMenuItemRole`) and the capability-probe API. Uno explicitly *rejects* Flutter's
 "silent degrade, no fallback" choice in favor of Avalonia's in-app fallback.

--- a/specs/047-native-os-menu/research.md
+++ b/specs/047-native-os-menu/research.md
@@ -78,7 +78,8 @@ Uno's type system (Window/Application not being DependencyObjects) forces it.
   choice in Uno spec decision 1.
 - **The container is not an item.** `NativeMenu : AvaloniaObject` sits *beside* the item
   hierarchy, not inside it: only `NativeMenuItem` and `NativeMenuItemSeparator` derive from
-  `NativeMenuItemBase`, and nesting goes through `NativeMenuItem.Menu`. Consequently
+  `NativeMenuItemBase`, and nesting goes through Avalonia's `NativeMenuItem.Menu` (Uno spells the
+  same relationship `NativeMenuItem.SubMenu`). Consequently
   `parentMenu.Items.Add(new NativeMenu())` does not compile. Each type carries the back-reference
   it actually needs — `NativeMenuItemBase.Parent` is a `NativeMenu`, `NativeMenu.Parent` is a
   `NativeMenuItem` — so splitting the branches costs nothing in the dirty-propagation model.
@@ -217,9 +218,9 @@ platforms), but the enum membership is essentially the Flutter set plus the edit
 
 Flutter exposes `PlatformProvidedMenuItem.hasMenu` and per-item availability so an app can
 ask "does this platform provide this item?" and adapt its tree. Uno borrows this as
-**`NativeMenu.IsSupported`** (is there *any* native menu here?) and
-**`IsRoleSupported(NativeMenuItemRole)`** (is *this* OS slot available?), so apps can
-branch their menu construction (spec "capability probe").
+**`NativeMenu.IsSupported`** (would a menu assigned *right now* be projected? — so `false` on
+Linux with no registrar, per FR-026a) and **`IsRoleSupported(NativeMenuItemRole)`** (is *this*
+OS slot available?), so apps can branch their menu construction (spec "capability probe").
 
 **What Uno borrows from Flutter:** the portable role-enum concept (`PlatformProvidedMenuItem`
 → `NativeMenuItemRole`) and the capability-probe API. Uno explicitly *rejects* Flutter's
@@ -277,7 +278,7 @@ A handful of standard items are wired to AppKit selectors on `NSApp` / first res
 (Show All), `orderFrontStandardAboutPanel:` (About), and the Services submenu
 (`NSApp.servicesMenu`). For these, Uno's framework auto-wires the selector when a role is
 present (no developer Command needed). The existing bootstrap menu
-(`UNOApplication.m:95-124`) already does this for Quit (`terminate:`) and Close
+(`UNOApplication.m:156-185`) already does this for Quit (`terminate:`) and Close
 (`performClose:`); the seam **replaces/extends** that menu rather than coexisting with it.
 
 ### 4.5 Dynamic updates
@@ -305,8 +306,8 @@ live-mutate as a possible macOS optimization.
 
 ### 5.1 App-global build model
 
-UIKit's menu system is **app-global and declarative-by-rebuild**. The app delegate (a
-`UIResponder`) overrides **`buildMenu(with: UIMenuBuilder)`**; UIKit calls it to construct
+UIKit's menu system is **app-global and declarative-by-rebuild**. A `UIResponder` in the
+chain overrides **`buildMenu(with: UIMenuBuilder)`**; UIKit calls it to construct
 the entire menu tree. The builder lets you **insert / replace / remove** `UIMenu`s and
 `UICommand`s relative to **system identifiers** (`UIMenu.Identifier`,
 `UICommand`/`UIKeyCommand`), e.g. insert a child menu `before:`/`after:` `.file`, or remove
@@ -364,10 +365,8 @@ is the enabled-only fast path.
 ### 5.5 Catalyst unification & Uno reach
 
 Mac Catalyst uses the same `UIMenuBuilder` API but renders into a real macOS `NSMenu`,
-unifying the iPad and Mac-Catalyst code path. For Uno, the seam lives in
-**`UnoUIApplicationDelegate.BuildMenu(IUIMenuBuilder)`** — the delegate is already a
-`UIResponder` that can override `BuildMenu`, and devs already override the delegate via
-`UseUIApplicationDelegate<T>` (§8.4–8.5).
+unifying the iPad and Mac-Catalyst code path. Where the Uno seam lives is **not** settled by
+this research — see §8.5, which corrects an earlier assumption in this document.
 
 ### 5.6 Limitations
 
@@ -476,7 +475,7 @@ is `NativeMenu.SetApplicationMenu(…)` into a static side-table, not an attache
 
 ### 8.3 Existing bootstrap NSMenu (macOS)
 
-[`UNOApplication.m:95-124`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m) —
+[`UNOApplication.m:156-185`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m) —
 on launch, if `app.mainMenu == nil`, Uno builds a minimal menu: an app menu with **Quit
 (`terminate:`, Cmd+Q)** and a File menu with **Close Window (`performClose:`, Cmd+W)**. The
 projection seam **replaces/extends** `app.mainMenu`; this confirms the "framework-guaranteed
@@ -484,7 +483,7 @@ minimal app menu" baseline already exists and just needs to be driven by the mod
 
 ### 8.4 macOS modifier mapping (shortcut direction)
 
-[`UNOWindow.m:874-890`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m) —
+[`UNOWindow.m:875-891`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m) —
 `get_modifiers` maps live `NSEventModifierFlags` to `VirtualKeyModifiers`:
 `Command → Windows`, `Control → Control`, `Option → Menu` (Alt), `Shift → Shift`. This is the
 **same direction** the menu accelerator translation must use; a menu-only remap would be
@@ -493,11 +492,31 @@ KeyboardAccelerator modifiers literally; `VirtualKeyModifiers.Windows` = Cmd).
 
 ### 8.5 iPadOS `BuildMenu` seam
 
+> ⚠️ **Corrects an earlier draft of this spec.** Earlier revisions asserted that
+> `UnoUIApplicationDelegate` is a `UIResponder` and could therefore host `BuildMenu`. Verified
+> against the source, that is **false**, and the iPadOS seam has to move.
+
 [`UnoUIApplicationDelegate.cs:11-12`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs) —
-`UnoUIApplicationDelegate : UIApplicationDelegate` is a `UIResponder`, so it can override
-**`BuildMenu(IUIMenuBuilder)`**. It already observes `UIScene` activation notifications
-(lines 27-43), which the per-scene-focus path would hook when multi-scene lands. This is the
-iPadOS projection seam.
+`UnoUIApplicationDelegate : UIApplicationDelegate`. In .NET for iOS, `UIApplicationDelegate` is
+an `NSObject`-derived **class**, not a `UIResponder` (Apple's ObjC templates make the delegate a
+`UIResponder` conforming to the `UIApplicationDelegate` *protocol*; the .NET binding does not).
+`buildMenu(with:)` is a `UIResponder` method, so it **cannot** be overridden on the delegate.
+
+Two candidate hosts exist in the current code, both real `UIResponder`s:
+
+1. **A `UIApplication` subclass** passed as the principal class to `UIApplication.Main` —
+   [`AppleUIKitHost.cs:44`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/Hosting/AppleUIKitHost.cs)
+   currently passes `null` there, so this slot is free. `UIApplication : UIResponder` and sits at
+   the top of the chain, which matches an **app-global** menu.
+2. **`RootViewController`**
+   ([`RootViewController.cs:24`](../../src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs),
+   a `UINavigationController` and therefore a `UIResponder`), which is already the window's root.
+
+Option 1 is the better architectural fit for an app-wide menu. **Which responder UIKit actually
+consults for the main menu must be confirmed on a device or simulator before implementation** —
+nothing in this repo settles it, and no `BuildMenu` override exists in the tree today. The
+delegate still matters for the scene-focus path: it observes `UIScene` activation notifications
+(lines 27-43), which per-scene focus would hook when multi-scene lands.
 
 ### 8.6 `UseUIApplicationDelegate<T>` override hook
 

--- a/specs/047-native-os-menu/spec.md
+++ b/specs/047-native-os-menu/spec.md
@@ -1,0 +1,543 @@
+# Feature Specification: Cross-Platform Native OS Menu Integration
+
+**Feature Branch**: `047-native-os-menu`
+**Created**: 2026-06-30
+**Status**: Draft
+**Input**: "Cross-platform apps should feel native. Desktop and tablet operating systems
+expose a system menu (the macOS top-of-screen menu bar, the iPadOS hardware-keyboard menu
+bar, the Linux global menu on some desktop environments). Uno Platform has no native OS
+menu integration today. Provide a unified API to define application- and window-scoped
+menus that project to each platform's native menu system, with an in-app fallback control
+where there is none." (issue intent, paraphrased neutrally)
+
+## Context
+
+Applications built with Uno Platform draw their own UI on every target, but on desktop and
+tablet operating systems the *menu* is special: it lives outside the app's render surface
+(the macOS bar at the top of the screen, the iPadOS bar revealed by a hardware keyboard,
+the Linux global menu on supporting desktop environments). To feel native, a cross-platform
+app must populate that OS-owned menu, not draw its own bar in the window. Uno Platform offers
+no way to do this today. This feature introduces a lightweight, code-first menu model
+(`NativeMenu` / `NativeMenuItem`) and a projection seam that maps it onto each platform's
+native menu system, falling back to an in-app menu where no native menu exists. The work is
+**Apple-first, design-for-all**: v1 ships macOS (`NSMenu`) and iPadOS (`UIMenuBuilder`,
+app-wide) on the Skia targets only, with Linux (DBusMenu) and Windows as designed-for
+extension points delivered post-v1. The verified Uno integration points and the
+cross-framework comparison that informed these decisions are recorded in
+[research.md](./research.md); the model shape is in [data-model.md](./data-model.md) and the
+projection contract in [contracts/INativeMenuExtension.md](./contracts/INativeMenuExtension.md).
+
+The work is split across **two repositories**, with a strict one-way dependency:
+
+- **Core** (this feature) — the non-UI `NativeMenu` model, the code-first attachment setters,
+  the `INativeMenuExtension` projection seam, and the per-host native implementations
+  (Skia.MacOS, Skia.AppleUIKit). Namespace `Uno.UI.Xaml.Controls`.
+- **Toolkit** (a separate follow-up feature) — the declarative `AppMenuBar : MenuBar`
+  control. It consumes the core seam; the core never depends on the Toolkit. Namespace
+  `Uno.Toolkit.UI`.
+
+## Terminology
+
+- **Native menu** — a menu owned and rendered by the operating system (macOS `NSMenu`,
+  iPadOS `UIMenu` tree, Linux DBusMenu), as opposed to a control Uno draws itself.
+- **App-wide menu** — a single menu that represents the whole application (macOS
+  `NSApp.mainMenu`, iPadOS `buildMenu`). Set via `SetApplicationMenu`.
+- **Window-scoped menu** — a menu associated with one window/scene that the OS shows when
+  that window is focused. Set via `SetMenu(window, …)`.
+- **Projection seam** — the `INativeMenuExtension` abstraction (resolved per Skia host via
+  `ApiExtensibility`) that translates the `NativeMenu` model into the host's native menu
+  system. Each host registers one concrete implementation.
+- **Role** — a thin slot-marker (`NativeMenuItemRole`) that tells the OS *where* a standard
+  item belongs (e.g. the App menu's Quit slot, the Edit menu's Copy slot) and supplies a
+  standard label. OS-owned roles auto-wire to native selectors; all other roles only set
+  placement and label — the developer still supplies the `Command`.
+- **In-app fallback** — on a target with no native menu (Windows, Wayland/GNOME with no
+  global-menu registrar), the declarative `AppMenuBar` renders as a real in-app `MenuBar`
+  instead of projecting; the core seam reports `IsExported = false` and the setters no-op.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - An app-wide menu that feels native on macOS (Priority: P1)
+
+A developer building a macOS app declares an application menu with the usual top-level
+entries (File, Edit, View, Help) and assigns it once at startup. The familiar bold
+app-name menu (with Quit ⌘Q and Hide) appears automatically to the left of the
+developer's menus, and the whole bar lives in the macOS menu bar at the top of the screen —
+not inside the window.
+
+**Why this priority**: This is the headline scenario and the reason the feature exists —
+an app that does not populate the macOS menu bar does not feel like a Mac app. It is the
+smallest end-to-end slice that proves the model, the setter, and the macOS projection seam
+together.
+
+**Independent Test**: Build a macOS Skia app, construct a `NativeMenu` with File/Edit/Help
+top-level items, call `NativeMenu.SetApplicationMenu(menu)`, run the app, and assert (via
+the macOS automation/inspection layer) that `NSApp.mainMenu` contains a leading bold
+app-name menu with Quit (⌘Q) and Hide, followed by the three developer menus in order.
+
+**Acceptance Scenarios**:
+
+1. **Given** no menu has been set, **When** a macOS Skia app launches, **Then** the
+   framework-guaranteed app menu still exists with at least Quit (⌘Q) and Hide, and Quit
+   terminates the app via the AppKit selector.
+2. **Given** a `NativeMenu` with File/Edit/Help top-level items, **When**
+   `SetApplicationMenu(menu)` is called, **Then** the macOS menu bar shows the bold app-name
+   menu followed by File, Edit, Help in declaration order.
+3. **Given** a top-level `NativeMenuItem` with `Role=ApplicationMenu` and child items
+   (About, Settings…), **When** the menu is set, **Then** those children merge into the
+   bold app-name menu rather than producing a separate top-level menu.
+4. **Given** an item with `Role=Quit` or `Role=Hide` and no `Command`, **When** it is
+   activated, **Then** the OS performs the standard action (`terminate:` / `hide:`) with no
+   developer code.
+
+---
+
+### User Story 2 - Commands and shortcuts wired through existing Uno vocabulary (Priority: P1)
+
+A developer attaches behavior to menu items using the command/shortcut types they already
+use elsewhere in Uno: an `ICommand` (or `XamlUICommand` / `StandardUICommand`) for the
+action and `KeyboardAccelerator`s for the shortcut. Selecting the item — or pressing its
+shortcut — runs the command, and the item enables/disables itself based on
+`CanExecute`.
+
+**Why this priority**: A menu that cannot run anything is a label. Reusing the existing
+command and accelerator vocabulary is what makes the menu useful without inventing a new
+execution model, and the literal-modifier shortcut rule must be locked in v1 to stay
+coherent with Uno's live key-event mapping.
+
+**Independent Test**: Create a `NativeMenuItem` with a `Command` whose `CanExecute` is
+toggled by a flag and a `KeyboardAccelerator` (e.g. `S` + `Windows` modifier). Project it,
+then assert the native item shows ⌘S on macOS, runs the command on activation and on the
+shortcut, and greys out when `CanExecute` returns false.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `NativeMenuItem` with `Command` set, **When** the item is activated (click or
+   shortcut), **Then** `Command.Execute(CommandParameter)` runs.
+2. **Given** a `NativeMenuItem` with a `Click` handler instead of a command, **When** it is
+   activated, **Then** the `Click` event fires (WinUI/Avalonia parity).
+3. **Given** a `KeyboardAccelerator` of `Key=S, Modifiers=Windows`, **When** the menu is
+   projected on macOS, **Then** the item displays and responds to ⌘S; on a future Windows
+   in-app bar the same literal modifiers render as Ctrl+S — no Control→Command remap is
+   applied anywhere.
+4. **Given** an item whose `Command.CanExecute(CommandParameter)` is `false` (or
+   `IsEnabled=false`), **When** the menu is shown, **Then** the native item is disabled, and
+   it re-enables when `CanExecuteChanged` next reports `true`.
+5. **Given** an item populated from a `StandardUICommand`, **When** projected, **Then** its
+   label, icon, and accelerator come from the command (via the existing commanding helpers)
+   without the developer setting them explicitly.
+
+---
+
+### User Story 3 - Per-window / per-document menu on macOS (key-window-wins) (Priority: P2)
+
+A multi-window macOS app gives each window (e.g. each open document) its own menu. As the
+user switches between windows, the macOS menu bar updates to reflect the focused window's
+menu; a window that sets no menu inherits the application-level menu.
+
+**Why this priority**: macOS genuinely supports per-window menus and document-style apps
+expect them, but it builds on US1 (the app-wide path must exist first) and is only
+meaningful once more than one window is open, so it ranks below the core app-wide slice.
+
+**Independent Test**: Open two macOS windows, call `SetMenu(windowA, menuA)` and leave
+windowB without a window menu while an application menu is set. Focus each window in turn
+and assert the menu bar reflects `menuA` for windowA and the application menu for windowB.
+
+**Acceptance Scenarios**:
+
+1. **Given** `SetMenu(window, menu)` on a focused window, **When** the window is key,
+   **Then** `NSApp.mainMenu` reflects that window's menu.
+2. **Given** windowA has a window menu and windowB does not, **When** focus moves from A to
+   B, **Then** the bar swaps to windowB's effective menu — the Application-level menu — and
+   swaps back when A regains focus.
+3. **Given** a window menu is cleared with `SetMenu(window, null)`, **When** that window is
+   focused, **Then** the bar falls back to the Application-level menu.
+
+---
+
+### User Story 4 - Declarative `AppMenuBar` that is native on Apple, in-app elsewhere (Priority: P2)
+
+A developer authors a single declarative `AppMenuBar` in XAML (a `MenuBar` subclass in the
+Toolkit) with `MenuBarItem`/`MenuFlyoutItem` content. On macOS/iPadOS it projects to the
+native menu and leaves no in-app footprint; on Windows (and Linux without a global menu) the
+same markup renders as a real in-app `MenuBar`. OS slots are marked with the Toolkit
+`AppMenu.Role` attached property.
+
+**Why this priority**: This is the ergonomic, markup-first surface most developers will
+actually use, and it exercises the whole core seam end-to-end (translation + projection +
+collapse). It ranks P2 because it lives in the Toolkit and depends on the core model and
+seam shipping first; the core is independently valuable without it.
+
+**Independent Test**: Author one `AppMenuBar` XAML with File/Edit items and an item carrying
+`AppMenu.Role="Quit"`. Run it on macOS and assert it projects to `NSApp.mainMenu` with zero
+in-app bar height; run it on Windows and assert a real `MenuBar` renders and the Quit item
+behaves as a normal labeled item (no-op unless a command is supplied).
+
+**Acceptance Scenarios**:
+
+1. **Given** an `AppMenuBar` on macOS/iPadOS, **When** the page loads, **Then** its content
+   is translated to a `NativeMenu`, projected via `NativeMenu.SetMenu(window, …)`, and the
+   control collapses to zero in-app footprint.
+2. **Given** the same `AppMenuBar` on Windows, **When** the page loads, **Then** it renders
+   as a normal in-app `MenuBar` with the declared items.
+3. **Given** an item with `AppMenu.Role="Quit"`, **When** projected on macOS, **Then** it
+   maps to `NativeMenuItem.Role=Quit` and auto-wires to terminate; on Windows it renders as
+   a normal labeled item that no-ops unless a `Command` is supplied.
+4. **Given** an `AppMenuBar` on a Linux desktop with no global-menu registrar, **When** the
+   page loads, **Then** it falls back to the in-app `MenuBar`.
+
+---
+
+### User Story 5 - Dynamic updates and lazy submenu population (Priority: P3)
+
+A developer mutates the menu at runtime — adds or removes items, toggles `IsEnabled`,
+flips `IsChecked`, changes `Text` — and the native menu reflects the change. For
+expensive or context-dependent submenus (e.g. a Recent Files list), the developer fills the
+submenu just-in-time in response to an `Opening` event.
+
+**Why this priority**: Live menus and just-in-time population matter for real apps but are an
+enhancement over a correct static menu; they ride on the observable model that the earlier
+stories already establish.
+
+**Independent Test**: Bind a `NativeMenuItem.IsChecked` to a view-model property, toggle it,
+and assert the native item's check state updates after one coalesced rebuild. Separately,
+subscribe to `Opening`, populate `SubMenu.Items` in the handler, open the submenu, and assert
+the freshly added items appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a projected menu, **When** any model property changes or an item is added/removed
+   from `Items`, **Then** the affected menu is marked dirty, coalesced on the dispatcher, and
+   re-projected via a full rebuild of that menu.
+2. **Given** a submenu with an `Opening` handler, **When** the user opens it, **Then**
+   `Opening` fires (mapped to `menuNeedsUpdate` / iPadOS rebuild) before the submenu is shown,
+   and items added in the handler appear.
+3. **Given** several rapid mutations within one dispatcher tick, **When** they are processed,
+   **Then** they coalesce into a single native rebuild (no per-change native churn).
+4. **Given** a radio group (`ToggleType=Radio` + `GroupName`), **When** one item is checked,
+   **Then** the others in the group uncheck (framework-coordinated on macOS).
+
+---
+
+### User Story 6 - iPadOS app-wide menu via the hardware keyboard (Priority: P3)
+
+A user with a hardware keyboard attached to an iPad presses and holds the Command key (or
+focuses the menu bar) and sees the app's menu in the iPadOS menu bar, with the developer's
+items and working keyboard shortcuts.
+
+**Why this priority**: iPadOS is part of the Apple-first v1 promise, but it is app-wide-only
+in v1 (Uno AppleUIKit is single-scene today), the bar is OS-revealed rather than always
+visible, and it reaches fewer users than the macOS bar — so it ranks P3 while still shipping
+in v1.
+
+**Independent Test**: Run an iPadOS Skia app with an application menu set, attach a hardware
+keyboard, reveal the menu bar, and assert the developer's top-level items and shortcuts are
+present and invoke their commands. Verify `IsSupported` reports `true` on iPadOS.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application menu set via `SetApplicationMenu`, **When** the iPadOS app's
+   `BuildMenu(IUIMenuBuilder)` runs, **Then** the menu reflects the model's items.
+2. **Given** a hardware keyboard, **When** the user reveals the menu bar, **Then** the
+   developer's items and their shortcuts appear; activating one runs its command.
+3. **Given** a model change, **When** it is coalesced, **Then** the app requests a menu
+   rebuild (`setNeedsRebuild`) and the next `BuildMenu` reflects the change.
+4. **Given** no menu has been set, **When** the app runs, **Then** no developer items appear
+   and `IsSupported` still reports `true` (a native menu system is present).
+
+---
+
+### Edge Cases
+
+- **No native menu present (Windows, Wayland/GNOME without a registrar)** → the core setters
+  no-op, `IsExported`/`IsSupported` report `false`, and the declarative `AppMenuBar` renders
+  as a real in-app `MenuBar`. Nothing is silently lost.
+- **Multiple windows on macOS** → the bar always reflects the key window's menu, falling back
+  to the application menu when the focused window set none; closing the key window re-resolves
+  the bar for the next key window.
+- **Menu set before vs. after launch** → a menu assigned before the native host is ready is
+  applied once the host initializes; a menu assigned after launch projects immediately (next
+  coalesced tick). Either ordering yields the same final native menu.
+- **Unsupported role on a platform** → `IsRoleSupported(role)` reports `false`; the item still
+  renders as a normal labeled item where it can, and OS-only roles (About/Quit/Services/Hide)
+  no-op on platforms without that slot unless a `Command` is supplied.
+- **Icon that cannot be translated** → icon translation is best-effort; an icon that cannot be
+  rendered to the native form is dropped and the item shows text only (never an error).
+- **Rapid mutation** → many model changes within one dispatcher tick coalesce into a single
+  full rebuild of the affected menu; no incremental native diffing is attempted.
+- **Radio group with none checked** → all items in the group render unchecked; checking one
+  unchecks the rest.
+- **`Opening` handler throws / is slow** → submenu population is best-effort; a failed handler
+  leaves the previously-projected submenu content rather than crashing the menu.
+- **iPadOS in full-screen / no hardware keyboard** → the menu bar is OS-controlled and may be
+  hidden; the app exposes content only and offers no force-show API.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Core model (P1)**
+
+- **FR-001**: The system MUST provide a lightweight menu model in namespace
+  `Uno.UI.Xaml.Controls`, rooted at `NativeMenuItemBase : DependencyObject` with a `Parent`
+  reference, comprising `NativeMenu`, `NativeMenuItem`, and `NativeMenuItemSeparator`. These
+  are `DependencyObject`s, **not** `FrameworkElement`s.
+- **FR-002**: `NativeMenu` MUST expose an observable `Items` collection (`IList<NativeMenuItemBase>`,
+  the XAML content property) raising `INotifyCollectionChanged`, plus `Opening` and `Closed`
+  events (typed `EventHandler` / `EventHandler<T>`, never `Action`).
+- **FR-003**: `NativeMenuItem` MUST expose `Text` (string), `Icon` (`IconSource`),
+  `Command` (`ICommand`), `CommandParameter` (object), a `KeyboardAccelerators` collection,
+  `IsEnabled` (bool), `IsChecked` (bool), `ToggleType` (`ToggleType { None, CheckBox, Radio }`),
+  `GroupName` (string), `IsVisible` (bool), `Role` (`NativeMenuItemRole`), `SubMenu`
+  (`NativeMenu`), and a `Click` event.
+- **FR-004**: The system MUST reuse the existing Uno command/icon/shortcut vocabulary —
+  `XamlUICommand` / `StandardUICommand` auto-populate label, icon, and accelerator via the
+  existing commanding helpers; `IconSource` and `KeyboardAccelerator` are reused as-is.
+- **FR-005**: The model MUST be declarable in XAML as a resource/object (via the content
+  property) so that the tree itself can be authored in markup even though attachment is
+  code-first.
+
+**Attachment setters (P1)**
+
+- **FR-006**: The system MUST provide code-first attachment APIs — `NativeMenu.SetMenu(Window, NativeMenu?)`
+  / `NativeMenu.GetMenu(Window)` for window-scoped menus and
+  `NativeMenu.SetApplicationMenu(NativeMenu?)` / `NativeMenu.GetApplicationMenu()` for the
+  app-wide menu — because `Window` and `Application` are not `DependencyObject`s and an
+  attached-property-on-Window design does not port.
+- **FR-007**: Window-scoped associations MUST be stored in a side table keyed by `Window`
+  (a `ConditionalWeakTable`) so the menu does not leak the window and is released with it.
+
+**Role behavior (P1/P2)**
+
+- **FR-008**: `NativeMenuItemRole` MUST be a thin slot-marker enum
+  (`None, ApplicationMenu, About, Settings, Services, Hide, HideOthers, ShowAll, Quit, Window,
+  Minimize, Zoom, EnterFullScreen, Help, Undo, Redo, Cut, Copy, Paste, Delete, SelectAll`);
+  a role marks an OS slot and supplies a standard label, it does not itself carry behavior.
+- **FR-009**: On macOS, OS-owned roles (About, Quit, Services, Hide, HideOthers, ShowAll,
+  Minimize, Zoom, EnterFullScreen) MUST auto-wire to the corresponding AppKit selector
+  (`terminate:`, `hide:`, `orderFrontStandardAboutPanel:`, the Services submenu, etc.) with
+  no developer command.
+- **FR-010**: Edit-family and all non-OS-owned roles (Cut, Copy, Paste, Delete, SelectAll,
+  Undo, Redo, …) MUST set placement and a standard label only; the **developer MUST supply
+  the `Command` and enabled logic** on every platform — the system MUST NOT bridge to the
+  native responder chain (Uno draws its own controls and is not a native first responder).
+- **FR-011**: On in-app targets (Windows, Linux fallback), role items MUST render as normal
+  labeled items; OS-only roles MUST no-op unless a `Command` is supplied.
+
+**Shortcuts (P1)**
+
+- **FR-012**: Shortcuts MUST use literal `KeyboardAccelerator` modifiers with **no**
+  Control→Command remap: `VirtualKeyModifiers.Windows` = Command (⌘), `Control` = Ctrl,
+  `Menu` = Option/Alt, `Shift` = Shift — matching Uno's existing macOS live-input modifier
+  mapping. A menu-only remap is explicitly rejected as incoherent with live key events. A
+  cross-platform "Primary" modifier sugar is a non-core future follow-up, not v1.
+
+**Scope rule (P2)**
+
+- **FR-013**: The effective system menu MUST follow a focused-window/scene-wins rule with an
+  Application-level fallback: the OS menu reflects the key/focused window's menu if it set one,
+  otherwise the Application-level menu. macOS MUST swap `NSApp.mainMenu` on
+  `windowDidBecomeKey` and restore on resign (per-window supported in v1). iPadOS MUST request
+  a rebuild (`UIMenuSystem.main.setNeedsRebuild()`) on scene-focus change, but because Uno
+  AppleUIKit is single-scene today, **iPadOS v1 is app-wide only** — per-scene override is
+  deferred until Uno gains multi-scene (the design accommodates it).
+
+**Observable updates (P2/P3)**
+
+- **FR-014**: The model MUST be observable end-to-end: `DependencyProperty` change callbacks
+  plus `INotifyCollectionChanged` on `Items`. Any change MUST mark the affected menu dirty.
+- **FR-015**: Dirty menus MUST be coalesced on the dispatcher and re-projected via a **full
+  rebuild** of that menu (reset strategy). The system MUST NOT attempt incremental native
+  diffing (iPadOS and Linux are rebuild-only).
+- **FR-016**: `NativeMenu` MUST raise `Opening` before a (sub)menu is shown, enabling
+  just-in-time population — mapped to `NSMenuDelegate.menuNeedsUpdate` on macOS, DBus
+  `AboutToShow` on Linux, and the iPadOS rebuild — and `Closed` when it dismisses.
+- **FR-017**: Effective-enabled state MUST be pushed (not pulled): effective-enabled =
+  `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)`, observing
+  `CanExecuteChanged`. macOS MUST set `NSMenu.autoenablesItems = NO` so the pushed state is
+  authoritative.
+- **FR-018**: Toggle/radio state MUST mirror `RadioMenuFlyoutItem` semantics: `ToggleType`
+  + `IsChecked` + `GroupName`. macOS MUST coordinate radio exclusivity itself (no native
+  radio group) and set the check state; Linux MUST use native `toggle-type=radio`; iPadOS MUST
+  use on/off/mixed with inline single-selection.
+
+**Framework-guaranteed macOS App menu (P1)**
+
+- **FR-019**: The framework MUST always ensure the bold app-name menu exists with at least
+  Quit (⌘Q) and Hide, placed before the developer's top-level menus. To customize it, the
+  developer declares a top-level `NativeMenuItem` with `Role=ApplicationMenu` whose children
+  (About, Settings, …) merge into the app menu. Services/HideOthers MUST NOT be auto-injected
+  unless requested (consistent with thin roles). This replaces/extends the existing bootstrap
+  `NSMenu` (Quit ⌘Q / Close Window ⌘W).
+
+**Projection seam (P1)**
+
+- **FR-020**: The system MUST define `INativeMenuExtension` in `Uno.UI` exposing
+  `SetMenu(scope, NativeMenu?)`, a `bool IsExported` probe (is a native menu actually shown?),
+  and capability probes `IsSupported` / `IsRoleSupported(NativeMenuItemRole)`. It MUST be
+  registered per Skia host and resolved via
+  `ApiExtensibility.CreateInstance<INativeMenuExtension>()`.
+- **FR-021**: The Skia.MacOS implementation MUST project to `NSMenu` through the UnoNativeMac
+  ObjC layer via new native exports (e.g. `uno_window_set_main_menu` / `uno_app_set_main_menu`
+  plus menu build/update entry points), and MUST swap the menu on window-key changes for
+  multi-window support.
+- **FR-022**: The Skia.AppleUIKit implementation MUST project to `UIMenuBuilder` by overriding
+  `UnoUIApplicationDelegate.BuildMenu(IUIMenuBuilder)` (the delegate is a `UIResponder` and is
+  overridable by developers via `UseUIApplicationDelegate<T>`), app-wide in v1.
+- **FR-023**: The Win32 implementation MUST be a no-op with `IsExported = false` (no HMENU);
+  the in-app `AppMenuBar` renders the real `MenuBar` there.
+- **FR-024**: A Skia.X11 implementation projecting to a DBusMenu server
+  (`com.canonical.dbusmenu`) registered with `com.canonical.AppMenu.Registrar` keyed by X11
+  window XID, failing silently with the in-app fallback when no registrar is present, is a
+  **post-v1** designed-for extension point and is **out of scope for v1**.
+
+**Toolkit `AppMenuBar` control (P2)**
+
+- **FR-025**: The declarative `AppMenuBar : MenuBar` control (Toolkit, namespace
+  `Uno.Toolkit.UI`, separate follow-up feature) MUST render as a real in-app `MenuBar` on
+  Windows / Linux-without-native, and on Apple MUST read its `MenuBarItem` / `MenuFlyoutItem`
+  content, translate it to a `NativeMenu`, project via the core `NativeMenu.SetMenu(window, …)`,
+  and collapse to zero in-app footprint. OS slots MUST be expressible via a Toolkit
+  `AppMenu.Role` attached property that maps to `NativeMenuItem.Role`. The Toolkit MUST depend
+  on the core seam and the core MUST NOT depend on the Toolkit.
+
+**Capability probe & fallback (P2)**
+
+- **FR-026**: The system MUST expose `NativeMenu.IsSupported` (is any native menu available
+  here?) and `IsRoleSupported(NativeMenuItemRole)` so apps can adapt their UI per platform.
+- **FR-027**: On a target with no native menu, the core setters MUST no-op and report
+  `IsExported = false`; no exception is thrown and the model is retained so a later
+  Toolkit/in-app consumer can still render it.
+
+**Icons (P2)**
+
+- **FR-028**: Icon translation MUST be best-effort and documented as such: bitmap/image
+  `IconSource` → PNG bytes → native image; symbol/font `IconSource` → rendered glyph image
+  best-effort; with an optional SF-Symbol-name passthrough hatch for Apple. An icon that cannot
+  be translated MUST be dropped (text-only item), never surfaced as an error.
+
+**Threading (P1)**
+
+- **FR-029**: Native menu APIs are main-thread-only; all model mutations and projection work
+  MUST marshal to the UI thread, and the coalesced rebuild MUST be posted to the dispatcher.
+
+**Forward-shaping (P3)**
+
+- **FR-030**: The model SHOULD be shaped so a future system-tray / notification-area menu can
+  reuse `NativeMenu` unchanged. The tray surface itself is **not** built in v1.
+
+### Key Entities
+
+See [data-model.md](./data-model.md) for full property tables and relationships.
+
+- **`NativeMenuItemBase`** — abstract base (`DependencyObject`) with a `Parent` back-reference.
+- **`NativeMenu`** — a menu/submenu: observable `Items`, `Opening`/`Closed` events.
+- **`NativeMenuItem`** — a single command/checkable/submenu item (the entity carrying `Text`,
+  `Command`, `Role`, accelerators, toggle state, `SubMenu`).
+- **`NativeMenuItemSeparator`** — a visual divider.
+- **`NativeMenuItemRole` / `ToggleType`** — the thin slot-marker and toggle enums.
+- **`INativeMenuExtension`** — the projection seam (see
+  [contracts/INativeMenuExtension.md](./contracts/INativeMenuExtension.md)).
+- **Attachment side-table** — the `ConditionalWeakTable<Window, NativeMenu>` plus the
+  application-menu slot backing the setters.
+
+## Cross-Platform Capability Matrix
+
+| Capability | macOS | iPadOS | Linux (DBusMenu) | Windows |
+|---|---|---|---|---|
+| App-wide menu | Yes (`NSApp.mainMenu`) | Yes (`buildMenu`) | No (per-window only) | No native |
+| Per-window menu | Yes (swap on key) | No in v1 (single scene) | Yes (the only model) | Per-control (in-app) |
+| Submenu / separator / checkable | Yes | Yes | Yes | Yes (in-app) |
+| Radio | Framework-coordinated | Inline single-selection | `toggle-type=radio` | In-app |
+| Icon | Yes | Yes | Partial (icon-name / icon-data) | In-app |
+| Shortcut | Yes | Yes | Partial (panel-dependent) | In-app accelerators |
+| Enable/disable + visibility | Yes (pull-validated, we push) | Yes (pull-validated, we push) | Yes (push) | Yes (push) |
+| Dynamic update | Live | Rebuild-only | Re-export | In-app |
+| OS standard items (About/Quit/Services) | Yes | Yes | No | No |
+| Custom-view items | Yes (out of scope) | No | No | No |
+
+## Scope & Phasing
+
+**v1 (this feature + its Toolkit follow-up)** — the core `NativeMenu` model, the code-first
+setters, the `INativeMenuExtension` seam, the **macOS** (`NSMenu`) and **iPadOS** (app-wide
+`UIMenuBuilder`) implementations, the Win32 no-op (in-app fallback), and the declarative
+`AppMenuBar` control in the Toolkit. **Skia targets only** (Uno's Skia-first policy); legacy
+native iOS/macOS targets are maintenance-only and out of scope.
+
+**Post-v1 (designed-for extension points)** — the Linux DBusMenu implementation
+(`com.canonical.dbusmenu` + AppMenu registrar, X11-keyed, fail-silent with in-app fallback on
+Wayland/GNOME), Windows polish, iPadOS multi-scene per-scene override (gated on Uno gaining
+multi-scene support), and the system-tray / notification-area menu reuse of `NativeMenu`.
+
+**Two-repo coordination** — the core (unoplatform/uno) ships the model and seam first; the
+Toolkit `AppMenuBar` (unoplatform/uno.toolkit.ui) is a separate follow-up that depends on the
+shipped core seam. The dependency is strictly one-way (Toolkit → core).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A macOS Skia app that sets an application menu shows that menu in the OS menu
+  bar at the top of the screen, with the framework-guaranteed app-name menu (Quit ⌘Q, Hide)
+  leading — verified by an inspection-level test.
+- **SC-002**: With no menu set, a freshly launched macOS app still has a working Quit (⌘Q)
+  and Hide in the app menu.
+- **SC-003**: A menu item with a `Command` runs that command on click and on its
+  `KeyboardAccelerator`, and disables itself when `CanExecute` is false — verified by a test,
+  with literal modifiers ( `Windows` → ⌘ on macOS) and no remap.
+- **SC-004**: On a focused-window switch on macOS, the menu bar reflects the key window's menu
+  within one focus cycle, falling back to the application menu for windows with none.
+- **SC-005**: A model change (add/remove item, toggle check, change text/enabled) is reflected
+  in the native menu after a single coalesced rebuild, and N rapid changes within one
+  dispatcher tick produce exactly one native rebuild.
+- **SC-006**: An `Opening` handler that populates a submenu results in the new items appearing
+  the first time the submenu is opened.
+- **SC-007**: On a target with no native menu (Windows), the core setters no-op,
+  `IsSupported`/`IsExported` report `false`, and the declarative `AppMenuBar` renders a real
+  in-app `MenuBar` with the same items.
+- **SC-008**: The same `AppMenuBar` markup yields a native menu (zero in-app footprint) on
+  macOS/iPadOS and an in-app `MenuBar` on Windows, with no per-platform markup change.
+- **SC-009**: On iPadOS with a hardware keyboard, the app's items and shortcuts appear in the
+  OS menu bar and invoke their commands, and `IsSupported` reports `true`.
+- **SC-010**: `IsRoleSupported` correctly reports which roles a given platform honors, so an
+  app can hide or relabel items it cannot project.
+- **SC-011**: No regression to existing Uno menu controls (`MenuBar`, `MenuFlyout*`) or to the
+  existing macOS bootstrap behavior beyond the intended app-menu replacement.
+
+## Assumptions
+
+- The existing Uno types are reused as the foundation: `MenuBar`/`MenuBarItem`/`MenuFlyout*`,
+  `XamlUICommand`/`StandardUICommand`, `KeyboardAccelerator`, and the `IconSource`/`IconElement`
+  family are all implemented and available.
+- `Window` and `Application` are **not** `DependencyObject`s in Uno/WinUI (verified), which is
+  why attachment is code-first via setters rather than attached properties.
+- Uno's macOS live-input modifier mapping (Command→Windows, Control→Control, Option→Menu,
+  Shift→Shift) is the contract that the literal-modifier shortcut rule must stay coherent with.
+- Uno AppleUIKit is single-window/single-scene today; iPadOS per-scene override is deferred
+  until multi-scene support lands, and the model is shaped to accommodate it without breaking
+  changes.
+- The `ApiExtensibility` per-host registration pattern is the supported way to resolve a
+  platform implementation from `Uno.UI`.
+- Icon translation fidelity is best-effort by design; SF-Symbol passthrough is the highest-
+  fidelity Apple path.
+- WinUI/AppKit/Avalonia references may be consulted for native menu semantics (roles, radio
+  coordination, lazy population), with WinUI naming preferred where applicable.
+
+## Open Questions / Risks
+
+- **[NEEDS CLARIFICATION]** Linux global-menu availability is desktop-environment-dependent
+  (KDE/Unity expose a registrar; GNOME/Wayland generally do not). The post-v1 Linux path must
+  fail silently to the in-app fallback, but the exact detection heuristic (registrar presence
+  on the bus) needs confirming when that phase begins.
+- **Icon translation fidelity** — symbol/font glyph rendering to a native image is best-effort
+  and may not match the native look exactly; the SF-Symbol passthrough mitigates this on Apple
+  but has no Windows/Linux analogue.
+- **iPadOS multi-scene timing** — per-scene menus depend on Uno gaining multi-scene support;
+  the v1 design is app-wide-only and must not bake in single-scene assumptions that block the
+  later override.
+- **Optional "Primary" modifier sugar** — a cross-platform Cmd-on-Mac / Ctrl-on-Windows
+  convenience modifier is deliberately deferred to a non-core follow-up; v1 stays on literal
+  modifiers to remain coherent with live key events. Whether/when to add it is open.
+- **Custom-view menu items** (arbitrary views inside a macOS menu item) are explicitly out of
+  scope for v1; reconfirm there is no early demand before the model would need to accommodate
+  them.

--- a/specs/047-native-os-menu/spec.md
+++ b/specs/047-native-os-menu/spec.md
@@ -4,8 +4,9 @@
 **Created**: 2026-06-30
 **Status**: Draft
 **Input**: "Cross-platform apps should feel native. Desktop and tablet operating systems
-expose a system menu (the macOS top-of-screen menu bar, the iPadOS hardware-keyboard menu
-bar, the Linux global menu on some desktop environments). Uno Platform has no native OS
+expose a system menu (the macOS top-of-screen menu bar, the always-available iPadOS 26
+menu bar revealed by swiping from the top of the screen, the Linux global menu on some
+desktop environments). Uno Platform has no native OS
 menu integration today. Provide a unified API to define application- and window-scoped
 menus that project to each platform's native menu system, with an in-app fallback control
 where there is none." (issue intent, paraphrased neutrally)
@@ -14,8 +15,9 @@ where there is none." (issue intent, paraphrased neutrally)
 
 Applications built with Uno Platform draw their own UI on every target, but on desktop and
 tablet operating systems the *menu* is special: it lives outside the app's render surface
-(the macOS bar at the top of the screen, the iPadOS bar revealed by a hardware keyboard,
-the Linux global menu on supporting desktop environments). To feel native, a cross-platform
+(the macOS bar at the top of the screen, the always-available iPadOS 26 bar revealed by
+swiping down from the top of the screen, the Linux global menu on supporting desktop
+environments). To feel native, a cross-platform
 app must populate that OS-owned menu, not draw its own bar in the window. Uno Platform offers
 no way to do this today. This feature introduces a lightweight, code-first menu model
 (`NativeMenu` / `NativeMenuItem`) and a projection seam that maps it onto each platform's
@@ -219,29 +221,35 @@ the freshly added items appear.
 
 ---
 
-### User Story 6 - iPadOS app-wide menu via the hardware keyboard (Priority: P3)
+### User Story 6 - First-class app-wide menu on the always-available iPadOS 26 menu bar (Priority: P2)
 
-A user with a hardware keyboard attached to an iPad presses and holds the Command key (or
-focuses the menu bar) and sees the app's menu in the iPadOS menu bar, with the developer's
-items and working keyboard shortcuts.
+A user on iPadOS 26 swipes down from the top of the screen (or moves the pointer to the top,
+or presses Globe+M) and sees the app's menu in the always-available, macOS-like iPadOS menu
+bar — no hardware keyboard required — with the developer's items and working keyboard
+shortcuts. The bar lists all of the app's commands, including those that are currently
+unavailable, so the user can discover what the app can do.
 
-**Why this priority**: iPadOS is part of the Apple-first v1 promise, but it is app-wide-only
-in v1 (Uno AppleUIKit is single-scene today), the bar is OS-revealed rather than always
-visible, and it reaches fewer users than the macOS bar — so it ranks P3 while still shipping
-in v1.
+**Why this priority**: iPadOS 26 brings the macOS menu bar to iPad as a first-class,
+always-available surface, so this is a first-class Apple target rather than a niche one. It
+is app-wide-only in v1 (Uno AppleUIKit is single-scene today), and it ranks just below macOS
+only because macOS is the canonical/reference desktop menu — not because iPadOS is niche.
 
-**Independent Test**: Run an iPadOS Skia app with an application menu set, attach a hardware
-keyboard, reveal the menu bar, and assert the developer's top-level items and shortcuts are
-present and invoke their commands. Verify `IsSupported` reports `true` on iPadOS.
+**Independent Test**: Run an iPadOS 26 Skia app with an application menu set, reveal the
+always-available menu bar by swiping down from the top of the screen (no hardware keyboard
+needed), and assert the developer's top-level items and shortcuts are present and invoke
+their commands. Verify `IsSupported` reports `true` on iPadOS.
 
 **Acceptance Scenarios**:
 
 1. **Given** an application menu set via `SetApplicationMenu`, **When** the iPadOS app's
    `BuildMenu(IUIMenuBuilder)` runs, **Then** the menu reflects the model's items.
-2. **Given** a hardware keyboard, **When** the user reveals the menu bar, **Then** the
-   developer's items and their shortcuts appear; activating one runs its command.
+2. **Given** an iPadOS 26 device, **When** the user reveals the menu bar by swiping down from
+   the top of the screen (no hardware keyboard), **Then** the developer's items and their
+   shortcuts appear — including currently-unavailable commands shown visible-but-disabled —
+   and activating an enabled one runs its command.
 3. **Given** a model change, **When** it is coalesced, **Then** the app requests a menu
-   rebuild (`setNeedsRebuild`) and the next `BuildMenu` reflects the change.
+   rebuild on `UIMainMenuSystem` where available (falling back to `UIMenuSystem.main`) via
+   `setNeedsRebuild`, and the next `BuildMenu` reflects the change.
 4. **Given** no menu has been set, **When** the app runs, **Then** no developer items appear
    and `IsSupported` still reports `true` (a native menu system is present).
 
@@ -269,8 +277,10 @@ present and invoke their commands. Verify `IsSupported` reports `true` on iPadOS
   unchecks the rest.
 - **`Opening` handler throws / is slow** → submenu population is best-effort; a failed handler
   leaves the previously-projected submenu content rather than crashing the menu.
-- **iPadOS in full-screen / no hardware keyboard** → the menu bar is OS-controlled and may be
-  hidden; the app exposes content only and offers no force-show API.
+- **iPadOS in full-screen / no hardware keyboard** → on iPadOS 26 the always-available menu
+  bar is still reachable by swiping down from the top of the screen even with no hardware
+  keyboard attached; its visibility remains OS-controlled (the app exposes content only and
+  offers no force-show API).
 
 ## Requirements *(mandatory)*
 
@@ -338,9 +348,11 @@ present and invoke their commands. Verify `IsSupported` reports `true` on iPadOS
   Application-level fallback: the OS menu reflects the key/focused window's menu if it set one,
   otherwise the Application-level menu. macOS MUST swap `NSApp.mainMenu` on
   `windowDidBecomeKey` and restore on resign (per-window supported in v1). iPadOS MUST request
-  a rebuild (`UIMenuSystem.main.setNeedsRebuild()`) on scene-focus change, but because Uno
-  AppleUIKit is single-scene today, **iPadOS v1 is app-wide only** — per-scene override is
-  deferred until Uno gains multi-scene (the design accommodates it).
+  a rebuild on the always-available macOS-like menu bar (`UIMainMenuSystem.setNeedsRebuild()`
+  on iOS/iPadOS 26 where available, falling back to `UIMenuSystem.main.setNeedsRebuild()` on
+  earlier OS) on scene-focus change, but because Uno AppleUIKit is single-scene today,
+  **iPadOS v1 is app-wide only** — per-scene override is deferred until Uno gains multi-scene
+  (the design accommodates it).
 
 **Observable updates (P2/P3)**
 
@@ -383,7 +395,20 @@ present and invoke their commands. Verify `IsSupported` reports `true` on iPadOS
   multi-window support.
 - **FR-022**: The Skia.AppleUIKit implementation MUST project to `UIMenuBuilder` by overriding
   `UnoUIApplicationDelegate.BuildMenu(IUIMenuBuilder)` (the delegate is a `UIResponder` and is
-  overridable by developers via `UseUIApplicationDelegate<T>`), app-wide in v1.
+  overridable by developers via `UseUIApplicationDelegate<T>`), populating the always-available
+  macOS-like iPadOS 26 menu bar, app-wide in v1. Rebuilds MUST be driven on `UIMainMenuSystem`
+  (the iOS/iPadOS 26 `UIMenuSystem` subclass for the iPad menu bar) where available, falling
+  back to `UIMenuSystem.main` on earlier OS. Per the single-scene caveat above, iPadOS v1 is
+  app-wide only.
+- **FR-022a**: For discoverability on the iPadOS menu bar, the system MUST keep an app's
+  commands **visible but disabled** when they are currently unavailable rather than removing
+  them, so users can discover the app's capabilities — aligning with the push-based enablement
+  rule (prefer toggling `IsEnabled` over `IsVisible=false`/removal for menu commands). The
+  always-available macOS-like menu bar requires **iPadOS 26+**; on earlier iPadOS (15–25) the
+  same `UIMenuBuilder` content surfaces as the older transient menu shown with a hardware
+  keyboard (Cmd-hold), and on iPhone no menu bar is shown (the same `UIKeyCommand` shortcuts
+  still work with a hardware keyboard). Uno supplies the content; the OS presents it per
+  version.
 - **FR-023**: The Win32 implementation MUST be a no-op with `IsExported = false` (no HMENU);
   the in-app `AppMenuBar` renders the real `MenuBar` there.
 - **FR-024**: A Skia.X11 implementation projecting to a DBusMenu server
@@ -497,8 +522,9 @@ shipped core seam. The dependency is strictly one-way (Toolkit → core).
   in-app `MenuBar` with the same items.
 - **SC-008**: The same `AppMenuBar` markup yields a native menu (zero in-app footprint) on
   macOS/iPadOS and an in-app `MenuBar` on Windows, with no per-platform markup change.
-- **SC-009**: On iPadOS with a hardware keyboard, the app's items and shortcuts appear in the
-  OS menu bar and invoke their commands, and `IsSupported` reports `true`.
+- **SC-009**: On the always-available iPadOS 26 menu bar (revealed by swiping from the top of
+  the screen, no hardware keyboard required), the app's items and shortcuts appear in the OS
+  menu bar and invoke their commands, and `IsSupported` reports `true`.
 - **SC-010**: `IsRoleSupported` correctly reports which roles a given platform honors, so an
   app can hide or relabel items it cannot project.
 - **SC-011**: No regression to existing Uno menu controls (`MenuBar`, `MenuFlyout*`) or to the
@@ -513,9 +539,13 @@ shipped core seam. The dependency is strictly one-way (Toolkit → core).
   why attachment is code-first via setters rather than attached properties.
 - Uno's macOS live-input modifier mapping (Command→Windows, Control→Control, Option→Menu,
   Shift→Shift) is the contract that the literal-modifier shortcut rule must stay coherent with.
-- Uno AppleUIKit is single-window/single-scene today; iPadOS per-scene override is deferred
-  until multi-scene support lands, and the model is shaped to accommodate it without breaking
-  changes.
+- iPadOS 26 brings the always-available, macOS-like system menu bar to iPad (revealed by
+  swiping down from the top of the screen, pointer-to-top, or Globe+M, with no hardware
+  keyboard required); on earlier iPadOS (15–25) the same `UIMenuBuilder` content instead
+  surfaces as the older transient menu shown with a hardware keyboard. Uno AppleUIKit is
+  single-window/single-scene today; iPadOS per-scene override is deferred until multi-scene
+  support lands, and the model is shaped to accommodate it without breaking changes (iPadOS v1
+  is app-wide only).
 - The `ApiExtensibility` per-host registration pattern is the supported way to resolve a
   platform implementation from `Uno.UI`.
 - Icon translation fidelity is best-effort by design; SF-Symbol passthrough is the highest-

--- a/specs/047-native-os-menu/spec.md
+++ b/specs/047-native-os-menu/spec.md
@@ -331,6 +331,9 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   Undo, Redo, …) MUST set placement and a standard label only; the **developer MUST supply
   the `Command` and enabled logic** on every platform — the system MUST NOT bridge to the
   native responder chain (Uno draws its own controls and is not a native first responder).
+  `Settings` is placement-only for the same reason: it reserves the macOS Preferences slot,
+  its standard label and Cmd+, , but AppKit ships no default `orderFrontPreferencesPanel:`
+  implementation, so the developer MUST supply the `Command`.
 - **FR-011**: On in-app targets (Windows, Linux fallback), role items MUST render as normal
   labeled items; OS-only roles MUST no-op unless a `Command` is supplied.
 

--- a/specs/047-native-os-menu/spec.md
+++ b/specs/047-native-os-menu/spec.md
@@ -327,7 +327,7 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   and `Closed` events (typed `EventHandler` / `EventHandler<T>`, never `Action`).
 - **FR-003**: `NativeMenuItem` MUST expose `Text` (string), `Icon` (`IconSource`),
   `Command` (`ICommand`), `CommandParameter` (object), a `KeyboardAccelerators` collection,
-  `IsEnabled` (bool), `IsChecked` (bool), `ToggleType` (`ToggleType { None, CheckBox, Radio }`),
+  `IsEnabled` (bool), `IsChecked` (bool), `ToggleType` (`NativeMenuItemToggleType { None, CheckBox, Radio }` — qualified, because an unqualified `ToggleType` would squat a very generic identifier in a shared public namespace and breaks symmetry with `NativeMenuItemRole`),
   `GroupName` (string), `IsVisible` (bool), `Role` (`NativeMenuItemRole`), `SubMenu`
   (`NativeMenu`), and a `Click` event.
 - **FR-004**: The system MUST reuse the existing Uno command/icon/shortcut vocabulary —
@@ -391,9 +391,19 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 
 - **FR-014**: The model MUST be observable end-to-end: `DependencyProperty` change callbacks
   plus `INotifyCollectionChanged` on `Items`. Any change MUST mark the affected menu dirty.
-- **FR-015**: Dirty menus MUST be coalesced on the dispatcher and re-projected via a **full
-  rebuild** of that menu (reset strategy). The system MUST NOT attempt incremental native
-  diffing (iPadOS and Linux are rebuild-only).
+- **FR-015**: **Structural** dirt (item added/removed/moved, `SubMenu` assigned, `Text`, `Icon`,
+  `Role`, `IsVisible`, accelerators) MUST be coalesced on the dispatcher and re-projected via a
+  **full rebuild** of the affected menu. The system MUST NOT attempt incremental native diffing
+  for structure (iPadOS and Linux are rebuild-only).
+- **FR-015a**: **State** dirt — `IsEnabled`, `IsChecked`, and every `Command.CanExecuteChanged` —
+  MUST be pushed in place to the existing native items and MUST NOT trigger a rebuild. A
+  `RelayCommand` re-raising `CanExecuteChanged` per keystroke is ordinary, and routing that into
+  the structural path means a whole-tree walk plus a full native reconstruction every frame,
+  indefinitely, on the UI thread. Hosts map state dirt to `NSMenuItem.enabled`/`.state`,
+  `setNeedsRevalidate()` on iPadOS, and a DBusMenu property update.
+- **FR-015b**: A change whose effective value is unchanged MUST short-circuit before marking
+  anything dirty, and dirt MUST be scoped to the affected menu rather than always escalating to
+  the projected root.
 - **FR-016**: `NativeMenu` MUST raise `NeedsUpdate` before a (sub)menu is shown, enabling
   just-in-time population — mapped to `NSMenuDelegate.menuNeedsUpdate` on macOS, DBus
   `AboutToShow` on Linux, and the iPadOS rebuild. Mutations made from a `NeedsUpdate` handler
@@ -407,7 +417,7 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)`, observing
   `CanExecuteChanged`. macOS MUST set `NSMenu.autoenablesItems = NO` so the pushed state is
   authoritative.
-- **FR-018**: Toggle/radio state MUST mirror `RadioMenuFlyoutItem` semantics: `ToggleType`
+- **FR-018**: Toggle/radio state MUST mirror `RadioMenuFlyoutItem` semantics: `NativeMenuItemToggleType`
   + `IsChecked` + `GroupName`. macOS MUST coordinate radio exclusivity itself (no native
   radio group) and set the check state; Linux MUST use native `toggle-type=radio`; iPadOS MUST
   use on/off/mixed with inline single-selection.
@@ -419,13 +429,20 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   developer declares a top-level `NativeMenuItem` with `Role=ApplicationMenu` whose children
   (About, Settings, …) merge into the app menu. Services/HideOthers MUST NOT be auto-injected
   unless requested (consistent with thin roles). This replaces/extends the existing bootstrap
-  `NSMenu` (Quit ⌘Q / Close Window ⌘W).
+  `NSMenu` ([`UNOApplication.m:156-185`](../../src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m)).
+- **FR-019a**: The guaranteed menu MUST also preserve **Close Window (⌘W)**. The bootstrap
+  `NSMenu` being replaced ships a File menu containing `performClose:` bound to ⌘W (verified at
+  `UNOApplication.m:175-181`), so a guarantee of only Quit + Hide would **silently remove ⌘W from
+  every existing macOS app that sets no menu** — a regression SC-011 forbids. Either the
+  framework-guaranteed menu retains the File ▸ Close Window item, or a `CloseWindow` role is added
+  and auto-wired to `performClose:`; a developer-declared File menu then merges with it the way
+  `Role=ApplicationMenu` children merge into the app menu.
 
 **Projection seam (P1)**
 
 - **FR-020**: The system MUST define `INativeMenuExtension` in `Uno.UI` exposing
-  `SetMenu(scope, NativeMenu?)`, a `bool IsExported` probe (is a native menu actually shown?),
-  an `IsExportedChanged` event, and capability probes `IsSupported` /
+  `SetMenu(scope, NativeMenu?)`, a scope-taking `IsExported(scope)` probe (is a native menu
+  actually visible for that scope?), an `IsExportedChanged` event carrying the affected scope, and capability probes `IsSupported` /
   `IsRoleSupported(NativeMenuItemRole)`. It MUST be `internal` (matching the other extension
   seams), registered per Skia host, and resolved via
   `ApiExtensibility.CreateInstance<INativeMenuExtension>()`, with a **cached** resolution that
@@ -482,8 +499,11 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 **Capability probe & fallback (P2)**
 
 - **FR-026**: The system MUST expose, as **public statics on `NativeMenu`**,
-  `IsSupported`, `IsRoleSupported(NativeMenuItemRole)`, `IsExported` and an
-  `IsExportedChanged` event, each forwarding to the resolved extension and degrading to
+  `IsSupported`, `IsRoleSupported(NativeMenuItemRole)`, `IsExported`, a window-scoped
+  `IsExported(Window)` overload, and an `IsExportedChanged` event (declared with explicit
+  `add`/`remove` accessors that attach to the resolved extension and hold subscribers weakly — a
+  field-like declaration would compile while forwarding to nothing and would root every subscriber
+  for the process lifetime), each forwarding to the resolved extension and degrading to
   `false` when none is registered. `IsExported`/`IsExportedChanged` MUST be public because the
   Toolkit `AppMenuBar` decides collapse-vs-render on them from a **different assembly**, which
   cannot see the `internal` `INativeMenuExtension`.
@@ -502,6 +522,21 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   `IconSource` → PNG bytes → native image; symbol/font `IconSource` → rendered glyph image
   best-effort; with an optional SF-Symbol-name passthrough hatch for Apple. An icon that cannot
   be translated MUST be dropped (text-only item), never surfaced as an error.
+- **FR-028a**: Translation results MUST be **cached** on (`IconSource`, scale) and recomputed only
+  when `Icon` changes — never once per projection. Re-encoding every icon in the tree on each
+  coalesced rebuild would make an `IsEnabled` toggle cost the whole icon set.
+- **FR-028b**: Icon translation MUST bound its inputs: a maximum decoded dimension and byte size,
+  enforced before decode, with oversized sources dropped per FR-028 rather than decoded. Decoding
+  MUST NOT block the projection call, and an `IconSource` that would require **fetching a remote
+  URI MUST NOT be resolved during a rebuild** — rebuilds can be triggered externally (DBusMenu
+  `AboutToShow`, a UIKit rebuild pass), so remote fetch there is both a stall and an
+  externally-triggerable network request.
+- **FR-028c**: `NativeMenuItem.Text` MUST be treated as a **literal label**, not markup: no
+  mnemonic interpretation beyond the documented per-platform convention, control characters and
+  bidirectional-override characters stripped, and a bounded maximum length. Menu labels routinely
+  carry untrusted content (file names, document titles, user-supplied strings); without this a
+  crafted name can reorder rendered text to impersonate a framework-guaranteed item such as
+  Quit.
 
 **Threading (P1)**
 
@@ -561,7 +596,7 @@ See [data-model.md](./data-model.md) for full property tables and relationships.
 - **`NativeMenuItem`** — a single command/checkable/submenu item (the entity carrying `Text`,
   `Command`, `Role`, accelerators, toggle state, `SubMenu`).
 - **`NativeMenuItemSeparator`** — a visual divider.
-- **`NativeMenuItemRole` / `ToggleType`** — the thin slot-marker and toggle enums.
+- **`NativeMenuItemRole` / `NativeMenuItemToggleType`** — the thin slot-marker and toggle enums.
 - **`INativeMenuExtension`** — the projection seam (see
   [contracts/INativeMenuExtension.md](./contracts/INativeMenuExtension.md)).
 - **Attachment side-table** — the `ConditionalWeakTable<Window, NativeMenu>` plus the

--- a/specs/047-native-os-menu/spec.md
+++ b/specs/047-native-os-menu/spec.md
@@ -195,7 +195,7 @@ behaves as a normal labeled item (no-op unless a command is supplied).
 A developer mutates the menu at runtime — adds or removes items, toggles `IsEnabled`,
 flips `IsChecked`, changes `Text` — and the native menu reflects the change. For
 expensive or context-dependent submenus (e.g. a Recent Files list), the developer fills the
-submenu just-in-time in response to an `Opening` event.
+submenu just-in-time in response to a `NeedsUpdate` event.
 
 **Why this priority**: Live menus and just-in-time population matter for real apps but are an
 enhancement over a correct static menu; they ride on the observable model that the earlier
@@ -203,7 +203,7 @@ stories already establish.
 
 **Independent Test**: Bind a `NativeMenuItem.IsChecked` to a view-model property, toggle it,
 and assert the native item's check state updates after one coalesced rebuild. Separately,
-subscribe to `Opening`, populate `SubMenu.Items` in the handler, open the submenu, and assert
+subscribe to `NeedsUpdate`, populate `SubMenu.Items` in the handler, open the submenu, and assert
 the freshly added items appear.
 
 **Acceptance Scenarios**:
@@ -211,7 +211,7 @@ the freshly added items appear.
 1. **Given** a projected menu, **When** any model property changes or an item is added/removed
    from `Items`, **Then** the affected menu is marked dirty, coalesced on the dispatcher, and
    re-projected via a full rebuild of that menu.
-2. **Given** a submenu with an `Opening` handler, **When** the user opens it, **Then**
+2. **Given** a submenu with a `NeedsUpdate` handler, **When** the user opens it, **Then**
    `Opening` fires (mapped to `menuNeedsUpdate` / iPadOS rebuild) before the submenu is shown,
    and items added in the handler appear.
 3. **Given** several rapid mutations within one dispatcher tick, **When** they are processed,
@@ -275,7 +275,7 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   full rebuild of the affected menu; no incremental native diffing is attempted.
 - **Radio group with none checked** → all items in the group render unchecked; checking one
   unchecks the rest.
-- **`Opening` handler throws / is slow** → submenu population is best-effort; a failed handler
+- **`NeedsUpdate` handler throws / is slow** → submenu population is best-effort; a failed handler
   leaves the previously-projected submenu content rather than crashing the menu.
 - **iPadOS in full-screen / no hardware keyboard** → on iPadOS 26 the always-available menu
   bar is still reachable by swiping down from the top of the screen even with no hardware
@@ -289,12 +289,21 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 **Core model (P1)**
 
 - **FR-001**: The system MUST provide a lightweight menu model in namespace
-  `Uno.UI.Xaml.Controls`, rooted at `NativeMenuItemBase : DependencyObject` with a `Parent`
-  reference, comprising `NativeMenu`, `NativeMenuItem`, and `NativeMenuItemSeparator`. These
-  are `DependencyObject`s, **not** `FrameworkElement`s.
+  `Uno.UI.Xaml.Controls`, comprising `NativeMenu` (the container) plus the item hierarchy
+  `NativeMenuItemBase` → {`NativeMenuItem`, `NativeMenuItemSeparator`}. All are
+  `DependencyObject`s, **not** `FrameworkElement`s. `NativeMenu` MUST NOT derive from
+  `NativeMenuItemBase`, so that adding a bare menu to another menu's `Items` is a
+  **compile-time** error rather than undefined behavior; nesting goes through
+  `NativeMenuItem.SubMenu`. Both branches carry an internal `Parent` back-reference
+  (`NativeMenuItemBase.Parent` → owning `NativeMenu`; `NativeMenu.Parent` → owning
+  `NativeMenuItem`) for upward dirty propagation.
+- **FR-001a**: An item MUST belong to at most one menu. Adding an item that already has a
+  `Parent` to a second `NativeMenu`, or assigning one `NativeMenu` as the `SubMenu` of two
+  items, MUST throw `InvalidOperationException` at mutation time rather than silently
+  aliasing the back-references that dirty propagation walks.
 - **FR-002**: `NativeMenu` MUST expose an observable `Items` collection (`IList<NativeMenuItemBase>`,
-  the XAML content property) raising `INotifyCollectionChanged`, plus `Opening` and `Closed`
-  events (typed `EventHandler` / `EventHandler<T>`, never `Action`).
+  the XAML content property) raising `INotifyCollectionChanged`, plus `NeedsUpdate`, `Opening`
+  and `Closed` events (typed `EventHandler` / `EventHandler<T>`, never `Action`).
 - **FR-003**: `NativeMenuItem` MUST expose `Text` (string), `Icon` (`IconSource`),
   `Command` (`ICommand`), `CommandParameter` (object), a `KeyboardAccelerators` collection,
   `IsEnabled` (bool), `IsChecked` (bool), `ToggleType` (`ToggleType { None, CheckBox, Radio }`),
@@ -332,7 +341,7 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   the `Command` and enabled logic** on every platform — the system MUST NOT bridge to the
   native responder chain (Uno draws its own controls and is not a native first responder).
   `Settings` is placement-only for the same reason: it reserves the macOS Preferences slot,
-  its standard label and Cmd+, , but AppKit ships no default `orderFrontPreferencesPanel:`
+  its standard label and Cmd+, but AppKit ships no default `orderFrontPreferencesPanel:`
   implementation, so the developer MUST supply the `Command`.
 - **FR-011**: On in-app targets (Windows, Linux fallback), role items MUST render as normal
   labeled items; OS-only roles MUST no-op unless a `Command` is supplied.
@@ -364,9 +373,15 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 - **FR-015**: Dirty menus MUST be coalesced on the dispatcher and re-projected via a **full
   rebuild** of that menu (reset strategy). The system MUST NOT attempt incremental native
   diffing (iPadOS and Linux are rebuild-only).
-- **FR-016**: `NativeMenu` MUST raise `Opening` before a (sub)menu is shown, enabling
+- **FR-016**: `NativeMenu` MUST raise `NeedsUpdate` before a (sub)menu is shown, enabling
   just-in-time population — mapped to `NSMenuDelegate.menuNeedsUpdate` on macOS, DBus
-  `AboutToShow` on Linux, and the iPadOS rebuild — and `Closed` when it dismisses.
+  `AboutToShow` on Linux, and the iPadOS rebuild. Mutations made from a `NeedsUpdate` handler
+  MUST be picked up by the build already in flight rather than scheduling a second rebuild.
+- **FR-016a**: `NativeMenu` MUST additionally raise `Opening` once content is settled and the
+  menu is about to appear (`NSMenuDelegate.menuWillOpen`), and `Closed` when it dismisses.
+  These two are notifications: mutations from them are ordinary model changes that take effect
+  on the next coalesced rebuild. The separation MUST be documented, because a single event
+  doing both jobs invites repopulation from inside the platform's menu-tracking run loop.
 - **FR-017**: Effective-enabled state MUST be pushed (not pulled): effective-enabled =
   `IsEnabled && (Command?.CanExecute(CommandParameter) ?? true)`, observing
   `CanExecuteChanged`. macOS MUST set `NSMenu.autoenablesItems = NO` so the pushed state is
@@ -389,9 +404,11 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 
 - **FR-020**: The system MUST define `INativeMenuExtension` in `Uno.UI` exposing
   `SetMenu(scope, NativeMenu?)`, a `bool IsExported` probe (is a native menu actually shown?),
-  and capability probes `IsSupported` / `IsRoleSupported(NativeMenuItemRole)`. It MUST be
-  registered per Skia host and resolved via
-  `ApiExtensibility.CreateInstance<INativeMenuExtension>()`.
+  an `IsExportedChanged` event, and capability probes `IsSupported` /
+  `IsRoleSupported(NativeMenuItemRole)`. It MUST be `internal` (matching the other extension
+  seams), registered per Skia host, and resolved via
+  `ApiExtensibility.CreateInstance<INativeMenuExtension>()`, with a **cached** resolution that
+  also caches the "no host" outcome. Public access goes through `NativeMenu` (FR-026).
 - **FR-021**: The Skia.MacOS implementation MUST project to `NSMenu` through the UnoNativeMac
   ObjC layer via new native exports (e.g. `uno_window_set_main_menu` / `uno_app_set_main_menu`
   plus menu build/update entry points), and MUST swap the menu on window-key changes for
@@ -431,8 +448,17 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 
 **Capability probe & fallback (P2)**
 
-- **FR-026**: The system MUST expose `NativeMenu.IsSupported` (is any native menu available
-  here?) and `IsRoleSupported(NativeMenuItemRole)` so apps can adapt their UI per platform.
+- **FR-026**: The system MUST expose, as **public statics on `NativeMenu`**,
+  `IsSupported`, `IsRoleSupported(NativeMenuItemRole)`, `IsExported` and an
+  `IsExportedChanged` event, each forwarding to the resolved extension and degrading to
+  `false` when none is registered. `IsExported`/`IsExportedChanged` MUST be public because the
+  Toolkit `AppMenuBar` decides collapse-vs-render on them from a **different assembly**, which
+  cannot see the `internal` `INativeMenuExtension`.
+- **FR-026a**: `IsSupported` MUST mean "a menu assigned right now would actually be
+  projected", not "this platform has a menu architecture". On Linux with no DBusMenu registrar
+  it MUST therefore report `false`, so that a `if (IsSupported) … else …` fallback branch is
+  correct as written. `IsSupported` MAY change at runtime where a registrar can appear or
+  disappear.
 - **FR-027**: On a target with no native menu, the core setters MUST no-op and report
   `IsExported = false`; no exception is thrown and the model is retained so a later
   Toolkit/in-app consumer can still render it.
@@ -458,8 +484,11 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 
 See [data-model.md](./data-model.md) for full property tables and relationships.
 
-- **`NativeMenuItemBase`** — abstract base (`DependencyObject`) with a `Parent` back-reference.
-- **`NativeMenu`** — a menu/submenu: observable `Items`, `Opening`/`Closed` events.
+- **`NativeMenu`** — a menu/submenu container (`DependencyObject`, **not** an item): observable
+  `Items`, a `Parent` back-reference to the owning `NativeMenuItem`, and the
+  `NeedsUpdate`/`Opening`/`Closed` events.
+- **`NativeMenuItemBase`** — abstract base for things that can sit *in* a menu
+  (`DependencyObject`) with a `Parent` back-reference to the owning `NativeMenu`.
 - **`NativeMenuItem`** — a single command/checkable/submenu item (the entity carrying `Text`,
   `Command`, `Role`, accelerators, toggle state, `SubMenu`).
 - **`NativeMenuItemSeparator`** — a visual divider.
@@ -518,7 +547,7 @@ shipped core seam. The dependency is strictly one-way (Toolkit → core).
 - **SC-005**: A model change (add/remove item, toggle check, change text/enabled) is reflected
   in the native menu after a single coalesced rebuild, and N rapid changes within one
   dispatcher tick produce exactly one native rebuild.
-- **SC-006**: An `Opening` handler that populates a submenu results in the new items appearing
+- **SC-006**: A `NeedsUpdate` handler that populates a submenu results in the new items appearing
   the first time the submenu is opened.
 - **SC-007**: On a target with no native menu (Windows), the core setters no-op,
   `IsSupported`/`IsExported` report `false`, and the declarative `AppMenuBar` renders a real

--- a/specs/047-native-os-menu/spec.md
+++ b/specs/047-native-os-menu/spec.md
@@ -212,8 +212,11 @@ the freshly added items appear.
    from `Items`, **Then** the affected menu is marked dirty, coalesced on the dispatcher, and
    re-projected via a full rebuild of that menu.
 2. **Given** a submenu with a `NeedsUpdate` handler, **When** the user opens it, **Then**
-   `Opening` fires (mapped to `menuNeedsUpdate` / iPadOS rebuild) before the submenu is shown,
-   and items added in the handler appear.
+   `NeedsUpdate` fires (mapped to `menuNeedsUpdate` / iPadOS rebuild) before the submenu is
+   shown, and items added in the handler appear in **that** opening.
+2a. **Given** a submenu with an `Opening` handler that mutates `Items`, **When** the user opens
+   it, **Then** those mutations do **not** appear in the current opening — `Opening` is
+   notification-only and the change lands on the next coalesced rebuild (FR-016a).
 3. **Given** several rapid mutations within one dispatcher tick, **When** they are processed,
    **Then** they coalesce into a single native rebuild (no per-change native churn).
 4. **Given** a radio group (`ToggleType=Radio` + `GroupName`), **When** one item is checked,
@@ -251,7 +254,8 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
    rebuild on `UIMainMenuSystem` where available (falling back to `UIMenuSystem.main`) via
    `setNeedsRebuild`, and the next `BuildMenu` reflects the change.
 4. **Given** no menu has been set, **When** the app runs, **Then** no developer items appear
-   and `IsSupported` still reports `true` (a native menu system is present).
+   and `IsSupported` still reports `true` (a menu assigned now would be projected — support
+   is about capability, not about a menu being on screen; see FR-026a).
 
 ---
 
@@ -276,7 +280,24 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 - **Radio group with none checked** → all items in the group render unchecked; checking one
   unchecks the rest.
 - **`NeedsUpdate` handler throws / is slow** → submenu population is best-effort; a failed handler
-  leaves the previously-projected submenu content rather than crashing the menu.
+  is caught at the native boundary and logged (FR-031), leaving the previously-projected submenu
+  content rather than crashing the menu. A slow handler blocks the native menu-tracking loop — do
+  I/O before the menu opens, not inside the handler.
+- **A `NeedsUpdate` handler mutates a *different* menu** → out-of-scope mutations do not join the
+  in-flight build (FR-016 covers only the menu being built). They are deferred and applied after
+  menu tracking ends, since a dispatcher post made during macOS `NSEventTrackingRunLoopMode`
+  would otherwise be delayed or dropped unpredictably.
+- **⌘C with a focused `TextBox` and a `Role=Copy` menu item** → **open behavioral question, must
+  be settled before the macOS implementation lands.** AppKit dispatches `keyEquivalent` matching
+  *before* the app's normal key path, so a menu item carrying ⌘C can intercept the keystroke that
+  today reaches Uno's own text handling. The three possible outcomes are: the menu item's
+  `Command` runs *instead* of the built-in copy (silently breaking a `TextBox`), both run
+  (double-fire), or the accelerator never reaches the item. FR-010 says the developer supplies
+  the `Command`, which means an Edit menu built the obvious way could regress copy/paste in every
+  text control in the app. Resolution requires running it on macOS; the answer then belongs in
+  FR-010 as either a documented limitation or a framework-supplied default for the edit roles.
+- **Tree mutated from a background thread** → throws (FR-029). The model has `DependencyObject`
+  thread affinity; silently marshalling would hide a real bug in the caller.
 - **iPadOS in full-screen / no hardware keyboard** → on iPadOS 26 the always-available menu
   bar is still reachable by swiping down from the top of the screen even with no hardware
   keyboard attached; its visibility remains OS-controlled (the app exposes content only and
@@ -414,9 +435,16 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   plus menu build/update entry points), and MUST swap the menu on window-key changes for
   multi-window support.
 - **FR-022**: The Skia.AppleUIKit implementation MUST project to `UIMenuBuilder` by overriding
-  `UnoUIApplicationDelegate.BuildMenu(IUIMenuBuilder)` (the delegate is a `UIResponder` and is
-  overridable by developers via `UseUIApplicationDelegate<T>`), populating the always-available
-  macOS-like iPadOS 26 menu bar, app-wide in v1. Rebuilds MUST be driven on `UIMainMenuSystem`
+  `BuildMenu(IUIMenuBuilder)` on a **`UIResponder`** in the chain, populating the
+  always-available macOS-like iPadOS 26 menu bar, app-wide in v1. **`UnoUIApplicationDelegate`
+  is not a valid host for this override:** it derives from `UIApplicationDelegate`, which in
+  .NET for iOS is an `NSObject`-derived class and *not* a `UIResponder`, so `BuildMenu` cannot
+  be overridden on it (Apple's ObjC templates make the delegate a `UIResponder` conforming to
+  the `UIApplicationDelegate` protocol; the .NET binding does not). The implementation MUST
+  instead host the override on a `UIApplication` subclass supplied as the principal class to
+  `UIApplication.Main` — the argument currently passed as `null` — or on `RootViewController`.
+  Which responder UIKit consults for the main menu MUST be confirmed on device before the
+  implementation is finalised; see research.md §8.5. Rebuilds MUST be driven on `UIMainMenuSystem`
   (the iOS/iPadOS 26 `UIMenuSystem` subclass for the iPad menu bar) where available, falling
   back to `UIMenuSystem.main` on earlier OS. Per the single-scene caveat above, iPadOS v1 is
   app-wide only.
@@ -435,6 +463,11 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
   (`com.canonical.dbusmenu`) registered with `com.canonical.AppMenu.Registrar` keyed by X11
   window XID, failing silently with the in-app fallback when no registrar is present, is a
   **post-v1** designed-for extension point and is **out of scope for v1**.
+- **FR-024a**: DBusMenu is a **per-window** protocol — there is no Linux app-wide menu surface.
+  When Linux lands, `SetApplicationMenu(menu)` MUST therefore be projected by exporting that
+  menu for **every** window that has no window-scoped menu of its own, and for each new window as
+  it opens. It MUST NOT no-op: the app-wide setter is the headline v1 API, and silently ignoring
+  it on one platform is the failure mode FR-026a exists to prevent.
 
 **Toolkit `AppMenuBar` control (P2)**
 
@@ -472,8 +505,44 @@ their commands. Verify `IsSupported` reports `true` on iPadOS.
 
 **Threading (P1)**
 
-- **FR-029**: Native menu APIs are main-thread-only; all model mutations and projection work
-  MUST marshal to the UI thread, and the coalesced rebuild MUST be posted to the dispatcher.
+- **FR-029**: Native menu APIs are main-thread-only. The model is `DependencyObject`-based and
+  therefore has UI-thread affinity: **mutating the tree off the UI thread MUST throw** with a
+  message naming the offending member, rather than being silently marshalled. Projection work
+  and the coalesced rebuild MUST be posted to the UI dispatcher. (Earlier drafts described the
+  core as marshalling arbitrary off-thread mutations; that is not implementable against
+  `DependencyObject` affinity and would hide a real threading bug.)
+
+**Failure handling & diagnosability (P1)**
+
+- **FR-031**: No managed exception may unwind into a native frame. The host MUST wrap in
+  `try`/`catch`: item activation (`Click` **and** `Command.Execute`), every model-raised event
+  (`NeedsUpdate`, `Opening`, `Closed`), and the projection call itself — all of which run inside
+  an AppKit/UIKit/D-Bus callback where an escaping exception terminates the process. A caught
+  exception MUST be logged at `Error` and swallowed at the boundary. This applies with force to
+  `NeedsUpdate`, which is raised synchronously inside the native update callback (FR-016) and
+  where the one-parent invariant (FR-001a) can itself throw.
+- **FR-032**: Every path that silently does nothing MUST log, guarded by
+  `this.Log().IsEnabled(...)` per the repo logging conventions, so that "I set a menu and nothing
+  appeared" is diagnosable without a debugger:
+  | Path | Level |
+  |---|---|
+  | Extension resolution found no host for this platform | `Debug` (once) |
+  | `SetMenu` called while `IsSupported == false` | `Warning` |
+  | Linux registrar absent, or lost at runtime | `Information` |
+  | A role unsupported on this host (FR-011) | `Debug` |
+  | An icon that could not be translated (FR-028) | `Debug` |
+  | A `NeedsUpdate` / `Opening` / `Closed` handler threw (FR-031) | `Error` |
+  | Activation handler or `Command.Execute` threw (FR-031) | `Error` |
+- **FR-033**: Teardown MUST be deterministic. Closing a window MUST cancel any pending coalesced
+  rebuild for that scope, clear its native menu, and drop its side-table entry. Detaching an item
+  or menu from the tree MUST unsubscribe its `CanExecuteChanged` handler, so a removed item can
+  no longer dirty a menu it has left. `SetApplicationMenu(null)` MUST release the previously
+  retained tree — the static application-menu field otherwise roots the whole model, its
+  commands, and anything they capture, for the life of the process.
+- **FR-034**: `NativeMenu.IsExportedChanged` is a **static** event; the Toolkit `AppMenuBar`
+  subscribes per control instance. The implementation MUST NOT strongly root subscribers for the
+  process lifetime — either a weak subscription or a documented detach-on-unload contract is
+  required, otherwise every `AppMenuBar` ever created leaks.
 
 **Forward-shaping (P3)**
 
@@ -532,11 +601,31 @@ shipped core seam. The dependency is strictly one-way (Toolkit → core).
 
 ## Success Criteria *(mandatory)*
 
+### Validation plan
+
+The spec previously named no home for any of this. Concretely:
+
+| What | Where | Target |
+|---|---|---|
+| Model invariants — one-parent-per-item throw (FR-001a), `Parent` wiring, dirty propagation, coalescing (one rebuild per N changes), `NeedsUpdate`-in-flight vs `Opening`-next-rebuild ordering (FR-016/016a) | `Uno.UI.UnitTests` — no visual tree needed, the model is not a `FrameworkElement` | all |
+| Capability probes degrading with no host registered (FR-026/026a) | `Uno.UI.UnitTests` with no extension registered | all |
+| Command execution, `CanExecute` → effective-enabled, accelerator invocation (FR-017, SC-003) | `Uno.UI.RuntimeTests` | Skia Desktop |
+| Native menu actually installed and correct (SC-001, SC-002, SC-004) | `Uno.UI.RuntimeTests` **plus** the test-only `UnoNativeMac` read-back export named in SC-001 | macOS only |
+| A `SamplesApp` sample exercising roles, toggles, radio groups, submenus, lazy population and the capability probes | `src/SamplesApp/SamplesApp.Samples` | all; visual on Skia |
+| iPadOS 26 bar behaviour (SC-009), Linux registrar appear/disappear, ⌘C precedence | **manual, on device** — no automated mechanism is proposed | iPadOS / Linux / macOS |
+
+The last row is the honest limit: the iPadOS bar and the DBusMenu registrar cannot be exercised
+in CI today, so those criteria are signed off by manual verification, not by a green build.
+
 ### Measurable Outcomes
 
 - **SC-001**: A macOS Skia app that sets an application menu shows that menu in the OS menu
   bar at the top of the screen, with the framework-guaranteed app-name menu (Quit ⌘Q, Hide)
-  leading — verified by an inspection-level test.
+  leading. **Verification mechanism:** managed tests cannot read `NSApp.mainMenu`, so this
+  requires a test-only `UnoNativeMac` export that serialises the installed menu tree (titles,
+  key equivalents, enabled/checked state) back to managed code. That export is part of the
+  deliverable, not an afterthought — without it SC-001, SC-002 and SC-004 have no automated
+  mechanism at all.
 - **SC-002**: With no menu set, a freshly launched macOS app still has a working Quit (⌘Q)
   and Hide in the app menu.
 - **SC-003**: A menu item with a `Command` runs that command on click and on its
@@ -549,11 +638,19 @@ shipped core seam. The dependency is strictly one-way (Toolkit → core).
   dispatcher tick produce exactly one native rebuild.
 - **SC-006**: A `NeedsUpdate` handler that populates a submenu results in the new items appearing
   the first time the submenu is opened.
-- **SC-007**: On a target with no native menu (Windows), the core setters no-op,
-  `IsSupported`/`IsExported` report `false`, and the declarative `AppMenuBar` renders a real
-  in-app `MenuBar` with the same items.
-- **SC-008**: The same `AppMenuBar` markup yields a native menu (zero in-app footprint) on
-  macOS/iPadOS and an in-app `MenuBar` on Windows, with no per-platform markup change.
+- **SC-007** *(Toolkit deliverable — `unoplatform/uno.toolkit.ui`)*: On a target with no native
+  menu (Windows), the core setters no-op, `IsSupported`/`IsExported` report `false`, and the
+  declarative `AppMenuBar` renders a real in-app `MenuBar` with the same items.
+- **SC-008** *(Toolkit deliverable — `unoplatform/uno.toolkit.ui`)*: The same `AppMenuBar` markup
+  yields a native menu (zero in-app footprint) on macOS/iPadOS 26 and an in-app `MenuBar` on
+  Windows, with no per-platform markup change.
+
+> **What ships from *this* repo.** SC-001…SC-006 and SC-009…SC-011 are satisfied by the core
+> alone. SC-007 and SC-008 depend on `AppMenuBar`, which is a **separate deliverable in a
+> separate repository**. A developer who installs only Uno Platform therefore gets the code-first
+> `NativeMenu` tree — a real native menu on macOS and iPadOS 26, and *no* menu at all on Windows,
+> since the in-app fallback is the Toolkit control. That is an accepted v1 outcome, not an
+> oversight, but it means "the feature is done" is only true across both repositories.
 - **SC-009**: On the always-available iPadOS 26 menu bar (revealed by swiping from the top of
   the screen, no hardware keyboard required), the app's items and shortcuts appear in the OS
   menu bar and invoke their commands, and `IsSupported` reports `true`.


### PR DESCRIPTION
**GitHub Issue:** #22172 (specification — does **not** close the feature; implementation is tracked separately)

## PR Type:

📚 Documentation content changes

## Executive summary 👔

Uno Platform apps render their own UI on every device, but today they **cannot populate the operating system's own menu** — the macOS menu bar at the top of the screen, the iPad menu bar, or the Linux global menu. That gap is why Uno desktop/tablet apps can feel "not quite native."

This PR adds the **design specification** for a new **Native OS Menu API**. It is **documentation only — no product code changes** — and its purpose is to lock in the agreed shape of the feature so implementation can proceed with confidence and community/team review (as the issue requested).

**What the feature will let developers do:** define one menu (File / Edit / View …) once, in code or XAML, and have it appear as the *real* native menu on each platform — the macOS app menu, the iPadOS 26 menu bar — automatically falling back to an in-app menu on Windows/Linux where the OS has no system menu.

**Scope & sequencing — Apple-first, design-for-all:**
- **Ship first:** macOS and iPadOS native menus.
- **Designed-for-later:** Linux global menu and Windows, with the extension points already defined so they slot in *without breaking changes*.
- **Two repositories:** the core menu model + platform plumbing lands here in `unoplatform/uno`; the optional declarative `AppMenuBar` control is a follow-up in `unoplatform/uno.toolkit.ui` (one-way dependency, Toolkit → core).

**Why this approach:** it reuses Uno Platform's existing command, shortcut, and icon building blocks (no new concepts for developers to learn), mirrors the proven Avalonia/Flutter patterns, and keeps the public surface small and forward-compatible.

**Risk:** none to existing apps — this is a net-new, opt-in capability, and this PR changes documentation only.

## TL;DR — the API at a glance ⚡

**Core** (`Uno.UI`, namespace `Uno.UI.Xaml.Controls`) — a lightweight, observable menu model (`DependencyObject`s, not `FrameworkElement`s): `NativeMenu`, `NativeMenuItem`, `NativeMenuItemSeparator`, plus the `NativeMenuItemRole` (thin OS-slot markers) and `ToggleType` enums. Attachment is **code-first** because `Window`/`Application` aren't `DependencyObject`s:

```csharp
var menu = new NativeMenu
{
    Items =
    {
        new NativeMenuItem { Text = "File", SubMenu = new NativeMenu
        {
            Items =
            {
                new NativeMenuItem { Text = "New",  Command = NewCommand },
                new NativeMenuItem { Text = "Open", Command = OpenCommand },
                new NativeMenuItemSeparator(),
                new NativeMenuItem { Role = NativeMenuItemRole.Quit },   // auto-wired on macOS
            }
        }},
    },
};

NativeMenu.SetApplicationMenu(menu);      // app-wide    (macOS app menu / iPadOS bar)
// or NativeMenu.SetMenu(window, menu);   // window-scoped (focused-window-wins)
```

**Toolkit** (`Uno.Toolkit.UI`, follow-up) — `AppMenuBar : MenuBar`: author once in familiar XAML; renders a real in-app `MenuBar` on Windows, projects to the native menu on Apple (collapsing its in-app footprint):

```xml
<utu:AppMenuBar>
  <MenuBarItem Title="File">
    <MenuFlyoutItem Text="New" Command="{x:Bind NewCommand}" />
    <MenuFlyoutItem utu:AppMenu.Role="Quit" />
  </MenuBarItem>
</utu:AppMenuBar>
```

**Where one definition shows up:**

| macOS | iPadOS 26 | Windows | Linux |
|---|---|---|---|
| `NSMenu` (top-of-screen bar) | always-available menu bar (swipe-from-top, no keyboard needed) | in-app `MenuBar` | global menu (DBusMenu) where available, else in-app |

**Reused building blocks:** `ICommand` / `XamlUICommand` / `StandardUICommand`, `KeyboardAccelerator` (literal modifiers — `Windows` = ⌘ on Apple), `IconSource`.
**Projection seam:** `INativeMenuExtension` resolved via `ApiExtensibility` → `NSMenu` (macOS) · `UIMenuBuilder` + `UIMainMenuSystem` (iPadOS) · DBusMenu (Linux, post-v1) · no-op/in-app (Windows).
**Behavior:** focused-window-wins + app-level fallback · framework-guaranteed macOS App menu (Quit ⌘Q) · observable model → coalesced full rebuild + `Opening` lazy population · push-based enable/check state.

## What changed? 🚀

Adds a complete spec under `specs/047-native-os-menu/`:

| File | Contents |
|---|---|
| `spec.md` | Prioritized user stories, 30+ functional requirements, cross-platform capability matrix, scope/phasing, success criteria |
| `research.md` | Avalonia & Flutter analysis + macOS / iPadOS / Linux / Windows native-menu API findings + verified Uno integration points |
| `data-model.md` | The `NativeMenu` / `NativeMenuItem` type model, role & toggle enums, code-first attachment setters, the `AppMenuBar` translation map |
| `contracts/INativeMenuExtension.md` | The platform projection seam (interface, registration, per-host responsibilities, threading/rebuild contract) |
| `quickstart.md` | Copy-pasteable developer recipes |

Key design decisions captured: a lightweight `NativeMenu` model (not a heavy templated control); code-first attachment (`Window`/`Application` are not `DependencyObject`s, so attached properties don't apply); thin OS-slot "roles"; literal keyboard-accelerator modifiers (consistent with Uno Platform's existing input mapping); focused-window-wins scoping; and an `ApiExtensibility`-based projection seam (macOS → `NSMenu`, iPadOS → `UIMenuBuilder` / `UIMainMenuSystem`).

No source code, tests, or public API surface are changed by this PR.

## PR Checklist ✅

- [ ] 🧪 Added Runtime/UI tests or a manual sample — **N/A** (specification only, no code)
- [x] 📚 Docs added/updated — this PR **is** the design specification
- [ ] 🖼️ Validated `Screenshots Compare Test Run` — **N/A** (no UI changes)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
