### PR TITLE
docs(skia): document SkiaSharpVersion property and SkiaSharp 4 upgrade

### DIFF
--- a/doc/articles/features/using-skia-desktop.md
+++ b/doc/articles/features/using-skia-desktop.md
@@ -67,16 +67,31 @@ YourAppNamespace.App.ConfigureFilters(); // Enable tracing of the Skia host
 
 ## Upgrading to a later version of SkiaSharp
 
-By default, Uno Platform comes with a set of **SkiaSharp** dependencies.
+By default, the [Uno.Sdk](xref:Uno.Features.Uno.Sdk) brings a tested set of **SkiaSharp** dependencies that match the native libraries it ships. To move to a different SkiaSharp version, override the `SkiaSharpVersion` MSBuild property in your project. This retargets the SkiaSharp packages the Uno.Sdk manages, including the platform native-asset packages, to the same version in one place:
 
-If you want to upgrade **SkiaSharp** to a later version, you'll need to specify all packages individually in your project as follows:
+```xml
+<PropertyGroup>
+   <SkiaSharpVersion>4.148.0</SkiaSharpVersion>
+</PropertyGroup>
+```
+
+> [!NOTE]
+> A SkiaSharp version mismatch between the managed packages and the bundled native libraries surfaces at runtime, not at build time. Prefer the `SkiaSharpVersion` property so every managed and native SkiaSharp package stays aligned. For the versions the Uno.Sdk manages, see [Using the Uno.Sdk](xref:Uno.Features.Uno.Sdk).
+
+### SkiaSharp 4
+
+SkiaSharp 4.0 reached general availability as `4.148.0`, and Uno Platform is a co-maintainer of SkiaSharp. SkiaSharp 4 support is opt-in: set `SkiaSharpVersion` to a `4.x` version as shown above. SkiaSharp 4 turns several long-deprecated APIs into compile errors (for example, text APIs that moved from `SKPaint` to `SKFont`), so a project moving from `3.x` may need small code changes before it builds.
+
+### Pinning packages individually
+
+If you need to control individual packages instead of using the `SkiaSharpVersion` property, reference every **SkiaSharp** and **HarfBuzzSharp** package, including the native-asset packages for each target you build, at the same version. Use `Update` so you retarget the references the Uno.Sdk already provides:
 
 ```xml
 <ItemGroup>
-   <PackagReference Include="SkiaSharp" Version="3.119.0" />
-   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
-   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="3.119.0" />
-   <PackagReference Include="HarfBuzzSharp" Version="8.3.1.1" />
+   <PackageReference Update="SkiaSharp" Version="4.148.0" />
+   <PackageReference Update="SkiaSharp.NativeAssets.Linux" Version="4.148.0" />
+   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="4.148.0" />
+   <PackageReference Update="HarfBuzzSharp" Version="8.3.1.1" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
### GitHub Issue (If applicable): n/a

### PR Type
Documentation

### What is the current behavior?
The "Upgrading to a later version of SkiaSharp" section in `using-skia-desktop.md` only documents pinning each SkiaSharp package individually, pinned to `3.119.0`, and the sample has typos (`PackagReference`). It does not mention the `SkiaSharpVersion` Uno.Sdk MSBuild property or SkiaSharp 4.

### What is the new behavior?
Rewrites the section to:

- Lead with the `SkiaSharpVersion` MSBuild property (already supported by the Uno.Sdk via `ImplicitPackagesResolver` and listed in `Sdk.props.buildschema.json` / `using-the-uno-sdk.md`), which retargets the managed and native SkiaSharp packages together. This is the path that avoids the runtime managed/native version mismatch.
- Add a short **SkiaSharp 4** subsection: GA is `4.148.0`, Uno Platform is a co-maintainer, support is opt-in, and the obsolete-to-error change (text APIs moved from `SKPaint` to `SKFont`) may require small code changes when moving from `3.x`.
- Keep an individual-pin fallback, corrected to use `Update` consistently and to include the native-asset packages.

Docs-only change. No code paths affected.

### Checklist
- [x] Documentation only
- [x] Verified `SkiaSharpVersion` is a supported Uno.Sdk property
- [ ] Maintainer review of wording / placement
