### PR TITLE
test: Fix flaky NavigationView toggle test on WinUI

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -225,7 +225,13 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			Assert.AreEqual(300, templateSettings.PaneToggleButtonWidth, "Updated PaneToggleButtonWidth");
 			Assert.AreEqual(292, templateSettings.SmallerPaneToggleButtonWidth, "Updated SmallerPaneToggleButtonWidth");
 			Assert.AreEqual(292, toggleButton.MinWidth, "Updated toggle MinWidth");
-			Assert.IsTrue(toggleButton.ActualWidth > initialActualWidth + 50, $"Toggle button should grow: {initialActualWidth} -> {toggleButton.ActualWidth}");
+
+			// On native WinUI the binding-driven MinWidth updates before the button is re-arranged,
+			// so ActualWidth catches up asynchronously - poll instead of asserting immediately.
+			await WindowHelper.WaitFor(
+				() => toggleButton.ActualWidth > initialActualWidth + 50,
+				timeoutMS: 3000,
+				message: $"Toggle button should grow from {initialActualWidth}, was {toggleButton.ActualWidth}");
 		}
 
 		[TestMethod]


### PR DESCRIPTION
**GitHub Issue:** closes #23561

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Given_NavigationView.When_CompactPaneLength_Changed_PaneToggleButton_Updates` was flaky on **native WinUI (winappsdk)** — it intermittently failed with `Toggle button should grow: 200 -> 200` (only on WinUI, not Skia Desktop).

**Root cause (test timing, not a product bug):** the test runs against Microsoft's own `NavigationView` on WinUI, which is the reference implementation, so its behavior is correct by definition. After `CompactPaneLength` changes, the value flows source → `TemplateSettings` → binding → `TogglePaneButton.MinWidth` synchronously, but the re-arrange that updates `ActualWidth` happens asynchronously. A single `WaitForIdle()` sometimes returned before that arrange pass flushed. The failure state was internally inconsistent (`MinWidth=292` while `ActualWidth=200`), confirming the layout simply hadn't settled — the value arrives, just late.

**Fix:** the upstream `TemplateSettings`/`MinWidth` assertions stay eager (they settle first, preserving the granular diagnostic), and only the racy `ActualWidth` check is replaced with a polling `WindowHelper.WaitFor(...)` (3s timeout). This corrects a wrong timing assumption in the test — a root-cause fix, not defensive hardening.

**Validation:** built the WinAppSDK SamplesApp MSIX and ran the test against native WinUI — **9/9 consecutive passes** (1 initial + 8 reruns). Previously it flaked on this path.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
