### PR TITLE
fix(diagnostics): release unregistered diagnostic views from DiagnosticsOverlay (pins collectible ALCs)

### DIFF
--- a/src/Uno.Foundation/Diagnostics/DiagnosticViewRegistry.cs
+++ b/src/Uno.Foundation/Diagnostics/DiagnosticViewRegistry.cs
@@ -46,6 +46,11 @@ internal static class DiagnosticViewRegistry
 			ref _registrations,
 			static (regs, defAlc) => regs.RemoveAll(r => IsFromNonDefaultAlc(r.View.GetType(), defAlc)),
 			defaultAlc);
+
+		// Notify listeners (e.g. DiagnosticsOverlay) that the registration set changed so they reconcile
+		// their materialized views and drop the ones just removed. Without this the overlay's add-only refresh
+		// keeps a now-unregistered collectible-ALC view materialized, pinning its LoaderAllocator (uno #23614).
+		Added?.Invoke(null, _registrations);
 	}
 
 	private static bool IsFromNonDefaultAlc(Type type, System.Runtime.Loader.AssemblyLoadContext defaultAlc)

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
@@ -61,6 +61,17 @@ public sealed partial class DiagnosticsOverlay
 	private void HideNotification()
 	{
 		VisualStateManager.GoToState(this, NotificationCollapsedStateName, true);
+
+		// Sever the presenter's Content/ContentTemplate: a notification raised by a diagnostic view
+		// can carry a DataTemplate (or content object) defined in that view's collectible
+		// AssemblyLoadContext. Collapsing the visual state alone leaves those references on the
+		// process-lifetime presenter, pinning the ALC (its generated resources → LoaderAllocator)
+		// after the view is gone (#23614). The presenter re-populates on the next Notify.
+		if (_notificationPresenter is { } presenter)
+		{
+			presenter.Content = null;
+			presenter.ContentTemplate = null;
+		}
 	}
 }
 #endif

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -507,6 +507,13 @@ public sealed partial class DiagnosticsOverlay : Control
 
 						_localRegistrations.Remove(view);
 					}
+
+					// A currently-displayed notification may have been raised by one of the views
+					// just removed and can hold a DataTemplate/content from its collectible ALC.
+					// Hide it so the presenter drops those references (HideNotification clears
+					// Content/ContentTemplate); otherwise a persistent (no-duration) notification
+					// keeps pinning the ALC after its view is gone (#23614).
+					HideNotification();
 				}
 
 				foreach (var element in _elements.Values)

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -445,6 +445,23 @@ public sealed partial class DiagnosticsOverlay : Control
 
 			if (isHidden || Visibility is not Visibility.Visible)
 			{
+				// Even while hidden we must reconcile REMOVALS: a view unregistered while the overlay is hidden
+				// (e.g. a collectible-ALC view dropped by ClearNonDefaultAlcRegistrations on ALC teardown) would
+				// otherwise stay materialized in _elements — pinning the collectible ALC — until the overlay is
+				// next shown. The add/reorder work below is correctly skipped while hidden.
+				lock (_updateGate)
+				{
+					var hiddenLive = new HashSet<IDiagnosticView>(DiagnosticViewRegistry
+						.Registrations
+						.Where(ShouldMaterialize)
+						.Select(reg => reg.View)
+						.Concat(_localRegistrations));
+					if (ReconcileMaterializedRemovals(hiddenLive))
+					{
+						HideNotification();
+					}
+				}
+
 				if (_overlayHost is { } h)
 				{
 					ShowHost(h, false);
@@ -489,30 +506,12 @@ public sealed partial class DiagnosticsOverlay : Control
 					}
 				}
 
-				// Reconcile REMOVALS: drop any materialized element whose view is no longer registered — e.g. a
-				// view registered from a collectible AssemblyLoadContext that was unregistered by
-				// DiagnosticViewRegistry.ClearNonDefaultAlcRegistrations on ALC teardown. The materialization loop
-				// above is add-only; without this the overlay keeps the view (and its DataTemplate → the ALC's
-				// generated resources → LoaderAllocator), pinning the collectible ALC forever (uno #23614).
-				if (_elements.Count > viewsThatShouldBeMaterialized.Count)
+				// Reconcile REMOVALS (add-only loop above): drop elements whose view is no longer live. A view
+				// just removed may have raised a currently-displayed notification holding its collectible-ALC
+				// DataTemplate/content, so hide it too (HideNotification clears Content/ContentTemplate) or a
+				// persistent no-duration notification keeps pinning the ALC after its view is gone (#23614).
+				if (ReconcileMaterializedRemovals(new HashSet<IDiagnosticView>(viewsThatShouldBeMaterialized)))
 				{
-					var live = new HashSet<IDiagnosticView>(viewsThatShouldBeMaterialized);
-					foreach (var view in _elements.Keys.Where(v => !live.Contains(v)).ToList())
-					{
-						if (_elements.Remove(view, out var stale))
-						{
-							_elementsPanel.Children.Remove(stale.Value);
-							stale.Dispose();
-						}
-
-						_localRegistrations.Remove(view);
-					}
-
-					// A currently-displayed notification may have been raised by one of the views
-					// just removed and can hold a DataTemplate/content from its collectible ALC.
-					// Hide it so the presenter drops those references (HideNotification clears
-					// Content/ContentTemplate); otherwise a persistent (no-duration) notification
-					// keeps pinning the ALC after its view is gone (#23614).
 					HideNotification();
 				}
 
@@ -543,6 +542,30 @@ public sealed partial class DiagnosticsOverlay : Control
 			ShowHost(host, isVisible: visibleViews is not 0);
 			UpdatePlacement();
 		});
+	}
+
+	// Drops any materialized element whose view is no longer live — e.g. a view registered from a collectible
+	// AssemblyLoadContext that was unregistered by DiagnosticViewRegistry.ClearNonDefaultAlcRegistrations on ALC
+	// teardown. The materialization loop in EnqueueUpdate is add-only; without this the overlay keeps the view
+	// (and its DataTemplate -> the ALC's generated resources -> LoaderAllocator), pinning the collectible ALC
+	// forever (uno #23614). Caller holds _updateGate; tolerates a not-yet-applied _elementsPanel so it is safe to
+	// call from the hidden path. Returns true if anything was removed (the caller may then hide a stale notification).
+	private bool ReconcileMaterializedRemovals(HashSet<IDiagnosticView> live)
+	{
+		var removedAny = false;
+		foreach (var view in _elements.Keys.Where(v => !live.Contains(v)).ToList())
+		{
+			if (_elements.Remove(view, out var stale))
+			{
+				_elementsPanel?.Children.Remove(stale.Value);
+				stale.Dispose();
+				removedAny = true;
+			}
+
+			_localRegistrations.Remove(view);
+		}
+
+		return removedAny;
 	}
 
 	private static Popup CreateHost(XamlRoot root, DiagnosticsOverlay overlay)

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -476,7 +476,8 @@ public sealed partial class DiagnosticsOverlay : Control
 					.Select(reg => reg.View)
 					.Concat(_localRegistrations)
 					.OrderBy(r => (int)r.Position)
-					.Distinct();
+					.Distinct()
+					.ToList();
 
 				foreach (var view in viewsThatShouldBeMaterialized)
 				{
@@ -485,6 +486,26 @@ public sealed partial class DiagnosticsOverlay : Control
 					{
 						element = new DiagnosticElement(this, view, _context!);
 						_elementsPanel.Children.Add(element.Value);
+					}
+				}
+
+				// Reconcile REMOVALS: drop any materialized element whose view is no longer registered — e.g. a
+				// view registered from a collectible AssemblyLoadContext that was unregistered by
+				// DiagnosticViewRegistry.ClearNonDefaultAlcRegistrations on ALC teardown. The materialization loop
+				// above is add-only; without this the overlay keeps the view (and its DataTemplate → the ALC's
+				// generated resources → LoaderAllocator), pinning the collectible ALC forever (uno #23614).
+				if (_elements.Count > viewsThatShouldBeMaterialized.Count)
+				{
+					var live = new HashSet<IDiagnosticView>(viewsThatShouldBeMaterialized);
+					foreach (var view in _elements.Keys.Where(v => !live.Contains(v)).ToList())
+					{
+						if (_elements.Remove(view, out var stale))
+						{
+							_elementsPanel.Children.Remove(stale.Value);
+							stale.Dispose();
+						}
+
+						_localRegistrations.Remove(view);
 					}
 				}
 


### PR DESCRIPTION
Fixes #23614.

## Problem

`DiagnosticsOverlay` permanently retains an `IDiagnosticView` registered from a **collectible** `AssemblyLoadContext` after that ALC is unloaded, pinning its `LoaderAllocator`. A downstream host that previews plugins in per-plugin collectible ALCs leaks one ALC per unloaded plugin that registered a diagnostic view (e.g. via a `[ModuleInitializer]` calling `DiagnosticViewRegistry.Register`).

Two cooperating gaps:
1. The overlay's refresh is **add-only** — it materializes newly-registered views into `_elements` but never removes an element whose view is no longer registered.
2. `DiagnosticViewRegistry.ClearNonDefaultAlcRegistrations()` (called on ALC teardown) removes the registration but does **not** notify listeners, so the overlay never reconciles.

Result: the process-global per-window overlay (held by the static `_overlays` CWT) keeps the collectible view materialized → its `DataTemplate` → the ALC's generated resources → `RuntimeType` → `LoaderAllocator` → the ALC.

## Change

- **`DiagnosticsOverlay` refresh now reconciles removals**: any `_elements` entry whose view is no longer in the current registration set is removed, detached from the panel, disposed, and dropped from `_localRegistrations`.
- **`DiagnosticViewRegistry.ClearNonDefaultAlcRegistrations` now raises the change notification** so overlays reconcile and drop the just-removed views.

## Verification

Root-caused via `gcroot` on a leaked collectible ALC in a downstream host: the only external root on the retention path was the process-global `DiagnosticsOverlay` still holding the collectible `IDiagnosticView`; everything below it is the ALC's own graph. The reconciliation directly severs that edge on teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)