### PR TITLE
feat(win32): WebView2Aot backend for <WebView2/>

### DIFF
--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -390,3 +390,30 @@ When using the WebView2 and running on WinAppSDK, make sure to create an `x64` o
 - In the Visual Studio configuration manager, create an `x64` or `ARM64` solution configuration
 - Assign it to the Uno Platform project
 - Debug your application using the configuration relevant to your current environment
+
+## Windows Specifics
+
+Starting with Uno 7, WebView2 has two separate backends on Windows:
+
+- Microsoft.Web.WebView2
+- WebView2Aot
+
+The WebView2Aot backend is required in order to use WebView2 with [Native AOT](xref:Uno.Features.NativeAOT) on Windows.
+
+The WebView2Aot backend is the default when `net10.0-desktop` or later is the target framework.
+
+If you encounter issues with the WebView2 control on Windows when targeting .NET 10 or later, please file an issue. The previous Microsoft.Web.WebView2 backend can be used by setting the `UNO_WEBVIEW2_BACKEND` environment variable to `microsoft.web.webview2`, for example within `Main()`:
+
+```csharp
+public partial class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        Environment.SetEnvironmentVariable("UNO_WEBVIEW2_BACKEND", "microsoft.web.webview2");
+        var host = UnoPlatformHostBuilder.Create()
+            // …
+            ;
+    }
+}
+```

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -156,6 +156,7 @@
 		<PackageReference Update="CommunityToolkit.Mvvm" Version="$(CommunityToolkitMvvmVersion)" />
 		<PackageReference Update="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 		<PackageReference Update="Microsoft.Web.WebView2" Version="1.0.2592.51" Condition="'$(MSBuildProjectName)' != 'Uno.WinAppSDKSyncGenerator.References'" />
+		<PackageReference Update="WebView2Aot" Version="1.5.0" />
 
 		<PackageReference Update="Basic.Reference.Assemblies.Net100" Version="1.8.4" />
 	</ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.Win32/BannedSymbols.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32/BannedSymbols.txt
@@ -1,0 +1,1 @@
+M:DirectN.PWSTR.From(System.String); instead of `PWSTR.From(s)`, use `fixed(char* p = s) new PWSTR(p)`

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Helpers.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Helpers.cs
@@ -1,0 +1,117 @@
+
+#if NET10_0_OR_GREATER
+using System;
+using System.IO;
+using System.Runtime.InteropServices.Marshalling;
+
+using Windows.Storage.Streams;
+
+using DirectN;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal static class AotStreamHelpers
+{
+	internal static unsafe IRandomAccessStream ConvertIStream(IStream stream)
+	{
+		var ms = new MemoryStream();
+		var buffer = new byte[4096];
+		fixed (byte* pBuffer = buffer)
+		{
+			while (true)
+			{
+				uint bytesRead = 0;
+				stream.Read((nint)pBuffer, (uint)buffer.Length, (nint)(&bytesRead)).ThrowOnError();
+				if (bytesRead == 0) break;
+				ms.Write(buffer, 0, (int)bytesRead);
+			}
+		}
+		var ras = new InMemoryRandomAccessStream();
+		var dataWriter = new DataWriter(ras);
+		dataWriter.WriteBytes(ms.ToArray());
+		dataWriter.StoreAsync().AsTask().Wait();
+		ras.Seek(0);
+		return ras;
+	}
+
+	internal static byte[] ReadIRandomAccessStream(IRandomAccessStream? stream)
+	{
+		if (stream is null) return Array.Empty<byte>();
+		using var ms = new MemoryStream();
+		stream.AsStreamForRead().CopyTo(ms);
+		return ms.ToArray();
+	}
+}
+
+
+[GeneratedComClass]
+internal sealed partial class ByteArrayIStream : IStream, ISequentialStream
+{
+	private readonly byte[] _data;
+	private long _position;
+
+	public ByteArrayIStream(byte[] data) => _data = data;
+
+	public unsafe HRESULT Read(nint pv, uint cb, nint pcbRead)
+	{
+		int count = (int)Math.Min((long)cb, _data.Length - _position);
+		if (count <= 0)
+		{
+			if (pcbRead != nint.Zero) *(uint*)pcbRead = 0;
+			return Constants.S_OK;
+		}
+		fixed (byte* src = _data)
+		{
+			System.Runtime.CompilerServices.Unsafe.CopyBlock((byte*)pv, src + _position, (uint)count);
+		}
+		_position += count;
+		if (pcbRead != nint.Zero) *(uint*)pcbRead = (uint)count;
+		return Constants.S_OK;
+	}
+
+	public unsafe HRESULT Write(nint pv, uint cb, nint pcbWritten)
+	{
+		if (pcbWritten != nint.Zero) *(uint*)pcbWritten = 0;
+		return Constants.E_NOTIMPL;
+	}
+
+	public unsafe HRESULT Seek(long dlibMove, STREAM_SEEK dwOrigin, nint plibNewPosition)
+	{
+		_position = dwOrigin switch
+		{
+			STREAM_SEEK.STREAM_SEEK_SET => dlibMove,
+			STREAM_SEEK.STREAM_SEEK_CUR => _position + dlibMove,
+			STREAM_SEEK.STREAM_SEEK_END => _data.Length + dlibMove,
+			_ => _position
+		};
+		_position = Math.Clamp(_position, 0, _data.Length);
+		if (plibNewPosition != nint.Zero) *(ulong*)plibNewPosition = (ulong)_position;
+		return Constants.S_OK;
+	}
+
+	public HRESULT SetSize(ulong libNewSize) => Constants.E_NOTIMPL;
+
+	public HRESULT CopyTo(IStream pstm, ulong cb, nint pcbRead, nint pcbWritten) => Constants.E_NOTIMPL;
+
+	public HRESULT Commit(uint grfCommitFlags) => Constants.S_OK;
+
+	public HRESULT Revert() => Constants.S_OK;
+
+	public HRESULT LockRegion(ulong libOffset, ulong cb, uint dwLockType) => Constants.E_NOTIMPL;
+
+	public HRESULT UnlockRegion(ulong libOffset, ulong cb, uint dwLockType) => Constants.E_NOTIMPL;
+
+	public HRESULT Stat(out STATSTG pstatstg, uint grfStatFlag)
+	{
+		pstatstg = new STATSTG { cbSize = (ulong)_data.Length };
+		return Constants.S_OK;
+	}
+
+	public HRESULT Clone(out IStream ppstm)
+	{
+		ppstm = null!;
+		return Constants.E_NOTIMPL;
+	}
+}
+
+#endif // NET10_0_OR_GREATER

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Request.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Request.cs
@@ -1,0 +1,267 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Microsoft.Web.WebView2.Core;
+
+using Windows.Foundation;
+using Windows.Storage.Streams;
+
+using DirectN;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+// --- AOT-specific WebResourceRequested wrappers ---
+// These implement the same INative* interfaces as Win32NativeWebView.WebResourceRequested.cs
+// for the NET10+ NativeAOT code path, working directly with WebView2Aot COM interfaces.
+
+internal sealed class AotWebResourceRequestedEventArgsWrapper : INativeWebResourceRequestedEventArgs
+{
+	private readonly WebView2.ICoreWebView2WebResourceRequestedEventArgs _args;
+	private readonly WebView2.ICoreWebView2WebResourceRequestedEventArgs2? _args2;
+
+	public AotWebResourceRequestedEventArgsWrapper(WebView2.ICoreWebView2WebResourceRequestedEventArgs args)
+	{
+		_args = args;
+		_args2 = args as WebView2.ICoreWebView2WebResourceRequestedEventArgs2;
+		_args.get_Request(out var request).ThrowOnError();
+		Request = new AotWebResourceRequest(request);
+	}
+
+	public INativeWebResourceRequest Request { get; }
+
+	public INativeWebResourceResponse? Response
+	{
+		get
+		{
+			_args.get_Response(out var response).ThrowOnError();
+			return response is null ? null : new AotWebResourceResponse(response);
+		}
+		set
+		{
+			if (value is AotWebResourceResponse wr)
+			{
+				_args.put_Response(wr.NativeResponse).ThrowOnError();
+			}
+			else
+			{
+				_args.put_Response(null!).ThrowOnError();
+			}
+		}
+	}
+
+	public CoreWebView2WebResourceContext ResourceContext
+	{
+		get
+		{
+			WebView2.COREWEBVIEW2_WEB_RESOURCE_CONTEXT context = default;
+			_args.get_ResourceContext(ref context).ThrowOnError();
+			return (CoreWebView2WebResourceContext)(int)context;
+		}
+	}
+
+	public CoreWebView2WebResourceRequestSourceKinds RequestedSourceKind
+	{
+		get
+		{
+			if (_args2 is null) return default;
+			WebView2.COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS kinds = default;
+			_args2.get_RequestedSourceKind(ref kinds).ThrowOnError();
+			return (CoreWebView2WebResourceRequestSourceKinds)(int)kinds;
+		}
+	}
+
+	public Deferral GetDeferral()
+	{
+		_args.GetDeferral(out var deferral).ThrowOnError();
+		return new Deferral(() => deferral.Complete());
+	}
+}
+
+internal sealed class AotWebResourceRequest : INativeWebResourceRequest
+{
+	private readonly WebView2.ICoreWebView2WebResourceRequest _request;
+
+	public AotWebResourceRequest(WebView2.ICoreWebView2WebResourceRequest request)
+	{
+		_request = request;
+		_request.get_Headers(out var headers).ThrowOnError();
+		Headers = new AotHttpRequestHeaders(headers);
+	}
+
+	public unsafe string Uri
+	{
+		get { _request.get_Uri(out var v).ThrowOnError(); return v.ToString()!; }
+		set { fixed (char* p_value = value) _request.put_Uri(new PWSTR(p_value)).ThrowOnError(); }
+	}
+
+	public unsafe string Method
+	{
+		get { _request.get_Method(out var v).ThrowOnError(); return v.ToString()!; }
+		set { fixed (char* p_value = value) _request.put_Method(new PWSTR(p_value)).ThrowOnError(); }
+	}
+
+	public IRandomAccessStream Content
+	{
+		get
+		{
+			_request.get_Content(out var stream).ThrowOnError();
+			return stream is null ? new InMemoryRandomAccessStream() : AotStreamHelpers.ConvertIStream(stream);
+		}
+		set
+		{
+			var bytes = AotStreamHelpers.ReadIRandomAccessStream(value);
+			_request.put_Content(bytes.Length > 0 ? new ByteArrayIStream(bytes) : null!).ThrowOnError();
+		}
+	}
+
+	public INativeHttpRequestHeaders Headers { get; }
+}
+
+internal sealed class AotHttpRequestHeaders : INativeHttpRequestHeaders
+{
+	private readonly WebView2.ICoreWebView2HttpRequestHeaders _headers;
+
+	public AotHttpRequestHeaders(WebView2.ICoreWebView2HttpRequestHeaders headers) => _headers = headers;
+
+	public unsafe string GetHeader(string name)
+	{
+		fixed (char* p_name = name)
+		{
+			_headers.GetHeader(new PWSTR(p_name), out var value).ThrowOnError();
+			return value.ToString()!;
+		}
+	}
+
+	public unsafe INativeHttpHeadersCollectionIterator GetHeaders(string name)
+	{
+		fixed (char* p_name = name)
+		{
+			_headers.GetHeaders(new PWSTR(p_name), out var iter).ThrowOnError();
+			return new AotHttpHeadersCollectionIterator(iter);
+		}
+	}
+
+	public unsafe bool Contains(string name)
+	{
+		BOOL result = default;
+		fixed (char* p_name = name)
+			_headers.Contains(new PWSTR(p_name), ref result).ThrowOnError();
+		return result.Value != 0;
+	}
+
+	public unsafe void SetHeader(string name, string value)
+	{
+		fixed (char* p_name = name, p_value = value)
+			_headers.SetHeader(new PWSTR(p_name), new PWSTR(p_value)).ThrowOnError();
+	}
+
+	public unsafe void RemoveHeader(string name)
+	{
+		fixed (char* p_name = name)
+			_headers.RemoveHeader(new PWSTR(p_name)).ThrowOnError();
+	}
+
+	public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+	{
+		_headers.GetIterator(out var iter).ThrowOnError();
+		return new AotHeadersEnumerator(iter);
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal sealed class AotHttpHeadersCollectionIterator : INativeHttpHeadersCollectionIterator
+{
+	private readonly WebView2.ICoreWebView2HttpHeadersCollectionIterator _iterator;
+	private bool _hasCurrent;
+	private KeyValuePair<string, string> _current;
+
+	public AotHttpHeadersCollectionIterator(WebView2.ICoreWebView2HttpHeadersCollectionIterator iterator)
+	{
+		_iterator = iterator;
+		BOOL hasCurrent = default;
+		_iterator.get_HasCurrentHeader(ref hasCurrent).ThrowOnError();
+		_hasCurrent = hasCurrent.Value != 0;
+		if (_hasCurrent) LoadCurrent();
+	}
+
+	private void LoadCurrent()
+	{
+		_iterator.GetCurrentHeader(out var name, out var value).ThrowOnError();
+		_current = new(name.ToString()!, value.ToString()!);
+	}
+
+	public object Current => _current;
+	public bool HasCurrent => _hasCurrent;
+
+	public bool MoveNext()
+	{
+		if (!_hasCurrent) return false;
+		BOOL hasNext = default;
+		_iterator.MoveNext(ref hasNext).ThrowOnError();
+		_hasCurrent = hasNext.Value != 0;
+		if (_hasCurrent) LoadCurrent();
+		return _hasCurrent;
+	}
+
+	public uint GetMany(object items)
+	{
+		if (items is not KeyValuePair<string, string>[] array) return 0;
+		uint count = 0;
+		while (count < array.Length && _hasCurrent)
+		{
+			array[count++] = _current;
+			MoveNext();
+		}
+		return count;
+	}
+}
+
+internal sealed class AotHeadersEnumerator : IEnumerator<KeyValuePair<string, string>>
+{
+	private readonly WebView2.ICoreWebView2HttpHeadersCollectionIterator _iterator;
+	private bool _started;
+	private bool _hasCurrent;
+	private KeyValuePair<string, string> _current;
+
+	public AotHeadersEnumerator(WebView2.ICoreWebView2HttpHeadersCollectionIterator iterator)
+	{
+		_iterator = iterator;
+		BOOL hasCurrent = default;
+		_iterator.get_HasCurrentHeader(ref hasCurrent).ThrowOnError();
+		_hasCurrent = hasCurrent.Value != 0;
+	}
+
+	public KeyValuePair<string, string> Current => _current;
+	object IEnumerator.Current => _current;
+
+	public bool MoveNext()
+	{
+		if (!_started)
+		{
+			_started = true;
+			if (!_hasCurrent) return false;
+			_iterator.GetCurrentHeader(out var name, out var value).ThrowOnError();
+			_current = new(name.ToString()!, value.ToString()!);
+			BOOL hasNext = default;
+			_iterator.MoveNext(ref hasNext).ThrowOnError();
+			_hasCurrent = hasNext.Value != 0;
+			return true;
+		}
+
+		if (!_hasCurrent) return false;
+		_iterator.GetCurrentHeader(out var n, out var v).ThrowOnError();
+		_current = new(n.ToString()!, v.ToString()!);
+		BOOL hn = default;
+		_iterator.MoveNext(ref hn).ThrowOnError();
+		_hasCurrent = hn.Value != 0;
+		return true;
+	}
+
+	public void Reset() => throw new NotSupportedException();
+	public void Dispose() { }
+}
+
+#endif // NET10_0_OR_GREATER

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Response.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Response.cs
@@ -1,0 +1,101 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+using Microsoft.Web.WebView2.Core;
+
+using Windows.Storage.Streams;
+
+using DirectN;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal sealed class AotWebResourceResponse : INativeWebResourceResponse
+{
+	internal WebView2.ICoreWebView2WebResourceResponse NativeResponse { get; }
+
+	public AotWebResourceResponse(WebView2.ICoreWebView2WebResourceResponse response)
+	{
+		NativeResponse = response;
+		response.get_Headers(out var headers).ThrowOnError();
+		Headers = new AotHttpResponseHeaders(headers);
+	}
+
+	public IRandomAccessStream Content
+	{
+		get
+		{
+			NativeResponse.get_Content(out var stream).ThrowOnError();
+			return stream is null ? new InMemoryRandomAccessStream() : AotStreamHelpers.ConvertIStream(stream);
+		}
+		set
+		{
+			var bytes = AotStreamHelpers.ReadIRandomAccessStream(value);
+			NativeResponse.put_Content(bytes.Length > 0 ? new ByteArrayIStream(bytes) : null!).ThrowOnError();
+		}
+	}
+
+	public INativeHttpResponseHeaders Headers { get; }
+
+	public int StatusCode
+	{
+		get { int v = default; NativeResponse.get_StatusCode(ref v).ThrowOnError(); return v; }
+		set => NativeResponse.put_StatusCode(value).ThrowOnError();
+	}
+
+	public unsafe string ReasonPhrase
+	{
+		get { NativeResponse.get_ReasonPhrase(out var v).ThrowOnError(); return v.ToString()!; }
+		set { fixed (char* p_value = value) NativeResponse.put_ReasonPhrase(new PWSTR(p_value)).ThrowOnError(); }
+	}
+}
+
+internal sealed class AotHttpResponseHeaders : INativeHttpResponseHeaders
+{
+	private readonly WebView2.ICoreWebView2HttpResponseHeaders _headers;
+
+	public AotHttpResponseHeaders(WebView2.ICoreWebView2HttpResponseHeaders headers) => _headers = headers;
+
+	public unsafe void AppendHeader(string name, string value)
+	{
+		fixed (char* p_name = name, p_value = value)
+			_headers.AppendHeader(new PWSTR(p_name), new PWSTR(p_value)).ThrowOnError();
+	}
+
+	public unsafe bool Contains(string name)
+	{
+		BOOL result = default;
+		fixed (char* p_name = name)
+			_headers.Contains(new PWSTR(p_name), ref result).ThrowOnError();
+		return result.Value != 0;
+	}
+
+	public unsafe string GetHeader(string name)
+	{
+		fixed (char* p_name = name)
+		{
+			_headers.GetHeader(new PWSTR(p_name), out var value).ThrowOnError();
+			return value.ToString()!;
+		}
+	}
+
+	public unsafe object GetHeaders(string name)
+	{
+		fixed (char* p_name = name)
+		{
+			_headers.GetHeaders(new PWSTR(p_name), out var iter).ThrowOnError();
+			return new AotHttpHeadersCollectionIterator(iter);
+		}
+	}
+
+	public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+	{
+		_headers.GetIterator(out var iter).ThrowOnError();
+		return new AotHeadersEnumerator(iter);
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+#endif // NET10_0_OR_GREATER

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
@@ -1,0 +1,493 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.Web.WebView2.Core;
+
+using Windows.Storage;
+using Windows.Win32;
+
+using DirectN;
+
+using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
+using Uno.UI.Xaml.Controls;
+
+using WebView2Utilities = WebView2.Utilities.WebView2Utilities;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsVirtualHostMapping, ISupportsWebResourceRequested
+{
+	private readonly CoreWebView2 _coreWebView;
+	private readonly WebView2.ICoreWebView2_22 _nativeWebView;
+	private readonly WebView2.ICoreWebView2Controller _controller;
+
+	private Dictionary<ulong, string> _navigationIdToUriMap = new();
+	private string _documentTitle = string.Empty;
+
+	public Win32NativeAotWebView(CoreWebView2 owner, ContentPresenter presenter)
+	: base(presenter)
+	{
+		_coreWebView = owner;
+
+		ForwardBackgroundToPresenter();
+
+		var tcs = new TaskCompletionSource<(WebView2.ICoreWebView2Controller controller, WebView2.ICoreWebView2_22 webView)>();
+		NativeDispatcher.Main.EnqueueAsync(async () =>
+		{
+			try
+			{
+				WebView2Utilities.Initialize(Assembly.GetEntryAssembly());
+				var userDataFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "WebView2");
+
+				// These options must be applied at environment creation time; CoreWebView2EnvironmentOptions cannot be
+				// changed once the environment exists. They are surfaced through FeatureConfiguration.WebView2 because Uno
+				// owns this CreateAsync call (the app never sees the CoreWebView2Environment), so it's the only injection point.
+				var options = new WebView2.CoreWebView2EnvironmentOptions();
+				options.put_AllowSingleSignOnUsingOSPrimaryAccount(
+					FeatureConfiguration.WebView2.AllowSingleSignOnUsingOSPrimaryAccount ? BOOL.TRUE : BOOL.FALSE
+				).ThrowOnError();
+				var additionalBrowserArguments = FeatureConfiguration.WebView2.AdditionalBrowserArguments;
+				if (!string.IsNullOrEmpty(additionalBrowserArguments))
+				{
+					unsafe
+					{
+						fixed (char* p_args = additionalBrowserArguments)
+						{
+							options.put_AdditionalBrowserArguments(new PWSTR(p_args)).ThrowOnError();
+						}
+					}
+				}
+
+				CreateCoreWebView2Environment(userDataFolder, options, new WebView2.Utilities.CoreWebView2CreateCoreWebView2EnvironmentCompletedHandler((errorCode, environment) =>
+				{
+					if (errorCode.IsError)
+					{
+						tcs.TrySetException(errorCode.GetException() ?? new InvalidOperationException("Failed to create CoreWebView2 environment."));
+						return;
+					}
+
+					environment.CreateCoreWebView2Controller(new DirectN.HWND((IntPtr)Hwnd.Value), new WebView2.Utilities.CoreWebView2CreateCoreWebView2ControllerCompletedHandler((controllerError, controller) =>
+					{
+						if (controllerError.IsError)
+						{
+							tcs.TrySetException(controllerError.GetException() ?? new InvalidOperationException("Failed to create CoreWebView2 controller."));
+							return;
+						}
+
+						controller.get_CoreWebView2(out var coreWebView).ThrowOnError();
+						tcs.TrySetResult((controller, (WebView2.ICoreWebView2_22)coreWebView));
+					})).ThrowOnError();
+				}));
+			}
+			catch (Exception e)
+			{
+				tcs.TrySetException(e);
+			}
+		});
+
+		while (!tcs.Task.IsCompleted)
+		{
+			Win32EventLoop.RunOnce();
+		}
+
+		(_controller, _nativeWebView) = tcs.Task.Result;
+
+		_controller.put_IsVisible(BOOL.FALSE).ThrowOnError();
+		_controller.put_Bounds(new DirectN.RECT { left = 0, top = 0, right = 500, bottom = 500 }).ThrowOnError();
+
+		_nativeWebView.get_Settings(out var settings).ThrowOnError();
+		settings.put_IsScriptEnabled(BOOL.TRUE).ThrowOnError();
+		settings.put_IsWebMessageEnabled(BOOL.TRUE).ThrowOnError();
+		settings.put_AreDefaultScriptDialogsEnabled(BOOL.TRUE).ThrowOnError();
+		settings.put_AreDevToolsEnabled(FeatureConfiguration.WebView2.EnableDevTools ? BOOL.TRUE : BOOL.FALSE).ThrowOnError();
+
+		var weakRef = new WeakReference<Win32NativeAotWebView>(this);
+		var eventToken = new WebView2.EventRegistrationToken();
+
+		_nativeWebView.add_NavigationCompleted(
+		new WebView2.Utilities.CoreWebView2NavigationCompletedEventHandler((_, args) =>
+		{
+			if (weakRef.TryGetTarget(out var target)) target.NativeWebView_NavigationCompleted(args);
+		}),
+		ref eventToken).ThrowOnError();
+
+		_nativeWebView.add_NewWindowRequested(
+		new WebView2.Utilities.CoreWebView2NewWindowRequestedEventHandler((_, args) =>
+		{
+			if (weakRef.TryGetTarget(out var target)) target.NativeWebView_NewWindowRequested(args);
+		}),
+		ref eventToken).ThrowOnError();
+
+		_nativeWebView.add_SourceChanged(
+			new WebView2.Utilities.CoreWebView2SourceChangedEventHandler((_, args) =>
+			{
+				if (weakRef.TryGetTarget(out var target)) target.NativeWebView_SourceChanged(args);
+			}),
+			ref eventToken
+		).ThrowOnError();
+
+		_nativeWebView.add_WebMessageReceived(
+			new WebView2.Utilities.CoreWebView2WebMessageReceivedEventHandler((_, args) =>
+			{
+				if (weakRef.TryGetTarget(out var target)) target.NativeWebView_WebMessageReceived(args);
+			}),
+			ref eventToken
+		).ThrowOnError();
+
+		_nativeWebView.add_NavigationStarting(
+			new WebView2.Utilities.CoreWebView2NavigationStartingEventHandler((_, args) =>
+			{
+				if (weakRef.TryGetTarget(out var target)) target.NativeWebView_NavigationStarting(args);
+			}),
+			ref eventToken
+		).ThrowOnError();
+
+		_nativeWebView.add_HistoryChanged(
+			new WebView2.Utilities.CoreWebView2HistoryChangedEventHandler((_, _) =>
+			{
+				if (weakRef.TryGetTarget(out var target)) target.CoreWebView2_HistoryChanged();
+			}),
+			ref eventToken
+		).ThrowOnError();
+
+		_nativeWebView.add_DocumentTitleChanged(
+			new WebView2.Utilities.CoreWebView2DocumentTitleChangedEventHandler((_, _) =>
+			{
+				if (weakRef.TryGetTarget(out var target)) target.UpdateDocumentTitle();
+			}),
+			ref eventToken
+		).ThrowOnError();
+
+		_nativeWebView.add_WebResourceRequested(
+			new WebView2.Utilities.CoreWebView2WebResourceRequestedEventHandler((_, args) =>
+			{
+				if (weakRef.TryGetTarget(out var target)) target.NativeWebView2_WebResourceRequested(args);
+			}),
+			ref eventToken
+		).ThrowOnError();
+
+		UpdateDocumentTitle();
+	}
+
+	private void ForwardBackgroundToPresenter()
+	{
+		if (_coreWebView.Owner is Microsoft.UI.Xaml.Controls.WebView2 view)
+		{
+			Presenter.SetBinding(FrameworkElement.BackgroundProperty, new Binding()
+			{
+				Path = new(nameof(view.Background)),
+				Source = view,
+				Mode = BindingMode.OneWay
+			});
+		}
+	}
+
+	protected override void OnWindowSizeChanged()
+	{
+		if (_controller is not null)
+		{
+			PInvoke.GetClientRect(Hwnd, out var bounds);
+			_controller.put_Bounds(new DirectN.RECT { left = bounds.left, top = bounds.top, right = bounds.right, bottom = bounds.bottom }).ThrowOnError();
+		}
+	}
+
+	public event EventHandler<CoreWebView2WebResourceRequestedEventArgs>? WebResourceRequested;
+
+	private void NativeWebView2_WebResourceRequested(WebView2.ICoreWebView2WebResourceRequestedEventArgs e)
+	{
+		WebResourceRequested?.Invoke(this, new(new AotWebResourceRequestedEventArgsWrapper(e)));
+	}
+
+	public override string DocumentTitle => _documentTitle;
+
+	private void SetDocumentTitle(string value)
+	{
+		if (_documentTitle != value)
+		{
+			_documentTitle = value;
+			_coreWebView.OnDocumentTitleChanged();
+		}
+	}
+
+	private void NativeWebView_SourceChanged(WebView2.ICoreWebView2SourceChangedEventArgs e)
+	{
+		_nativeWebView.get_Source(out var source).ThrowOnError();
+		_coreWebView.Source = source.ToString();
+	}
+
+	private void NativeWebView_WebMessageReceived(WebView2.ICoreWebView2WebMessageReceivedEventArgs e)
+	{
+		e.get_WebMessageAsJson(out var json).ThrowOnError();
+		_coreWebView.RaiseWebMessageReceived(json.ToString()!);
+	}
+
+	private void NativeWebView_NavigationStarting(WebView2.ICoreWebView2NavigationStartingEventArgs e)
+	{
+		e.get_Uri(out var uriPwstr).ThrowOnError();
+		var uriString = uriPwstr.ToString();
+
+		if (uriString is null)
+		{
+			return;
+		}
+
+		bool cancel;
+		if (Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out var uri))
+		{
+			_coreWebView.RaiseNavigationStarting(uri, out cancel);
+		}
+		else
+		{
+			_coreWebView.RaiseNavigationStarting(uriString, out cancel);
+		}
+
+		BOOL canGoBack = default;
+		BOOL canGoForward = default;
+		_nativeWebView.get_CanGoBack(ref canGoBack).ThrowOnError();
+		_nativeWebView.get_CanGoForward(ref canGoForward).ThrowOnError();
+		_coreWebView.SetHistoryProperties(canGoBack.Value != 0, canGoForward.Value != 0);
+
+		e.put_Cancel(cancel ? BOOL.TRUE : BOOL.FALSE).ThrowOnError();
+
+		ulong navigationId = default;
+		e.get_NavigationId(ref navigationId).ThrowOnError();
+		_navigationIdToUriMap[navigationId] = uriString;
+	}
+
+	private void NativeWebView_NavigationCompleted(WebView2.ICoreWebView2NavigationCompletedEventArgs e)
+	{
+		_controller.put_IsVisible(BOOL.TRUE).ThrowOnError();
+
+		ulong navigationId = default;
+		e.get_NavigationId(ref navigationId).ThrowOnError();
+
+		if (!_navigationIdToUriMap.TryGetValue(navigationId, out var uriString) && this.Log().IsEnabled(LogLevel.Error))
+		{
+			this.Log().LogError("Got NavigationCompleted for unknown navigation id");
+		}
+
+		_navigationIdToUriMap.Remove(navigationId);
+
+		BOOL isSuccess = default;
+		e.get_IsSuccess(ref isSuccess).ThrowOnError();
+
+		WebView2.COREWEBVIEW2_WEB_ERROR_STATUS webErrorStatus = default;
+		e.get_WebErrorStatus(ref webErrorStatus).ThrowOnError();
+
+		int httpStatusCode = 0;
+		if (e is WebView2.ICoreWebView2NavigationCompletedEventArgs2 e2)
+		{
+			e2.get_HttpStatusCode(ref httpStatusCode).ThrowOnError();
+		}
+
+		if (Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out var uri))
+		{
+			if (webErrorStatus == WebView2.COREWEBVIEW2_WEB_ERROR_STATUS.COREWEBVIEW2_WEB_ERROR_STATUS_CONNECTION_ABORTED)
+			{
+				_coreWebView.RaiseUnsupportedUriSchemeIdentified(uri, out _);
+			}
+			_coreWebView.RaiseNavigationCompleted(uri, isSuccess.Value != 0, httpStatusCode, (CoreWebView2WebErrorStatus)(int)webErrorStatus, shouldSetSource: false);
+		}
+		else
+		{
+			_coreWebView.RaiseNavigationCompleted(null, isSuccess.Value != 0, httpStatusCode, (CoreWebView2WebErrorStatus)(int)webErrorStatus, shouldSetSource: false);
+		}
+	}
+
+	private void NativeWebView_NewWindowRequested(WebView2.ICoreWebView2NewWindowRequestedEventArgs e)
+	{
+		e.get_Uri(out var uriPwstr).ThrowOnError();
+		_coreWebView.RaiseNewWindowRequested(
+		uriPwstr.ToString()!,
+		CoreWebView2.BlankUri,
+		out var handled);
+		e.put_Handled(handled ? BOOL.TRUE : BOOL.FALSE).ThrowOnError();
+	}
+
+	private void UpdateDocumentTitle()
+	{
+		_nativeWebView.get_DocumentTitle(out var title).ThrowOnError();
+		SetDocumentTitle(title.ToString()!);
+	}
+
+	private void CoreWebView2_HistoryChanged()
+	{
+		BOOL canGoBack = default;
+		BOOL canGoForward = default;
+		_nativeWebView.get_CanGoBack(ref canGoBack).ThrowOnError();
+		_nativeWebView.get_CanGoForward(ref canGoForward).ThrowOnError();
+		_coreWebView.SetHistoryProperties(canGoBack.Value != 0, canGoForward.Value != 0);
+		_coreWebView.RaiseHistoryChanged();
+	}
+
+	public override unsafe Task<string?> ExecuteScriptAsync(string script, CancellationToken token)
+	{
+		var tcs = new TaskCompletionSource<string?>();
+		fixed (char* p_script = script)
+			_nativeWebView.ExecuteScript(new PWSTR(p_script), new WebView2.Utilities.CoreWebView2ExecuteScriptCompletedHandler((errorCode, result) =>
+			{
+				if (errorCode.IsError)
+					tcs.TrySetException(errorCode.GetException() ?? new InvalidOperationException("ExecuteScript failed."));
+				else
+					tcs.TrySetResult(result.ToString());
+			})).ThrowOnError();
+		return tcs.Task;
+	}
+
+	public override void GoBack()
+		=> _nativeWebView.GoBack().ThrowOnError();
+
+	public override void GoForward()
+		=> _nativeWebView.GoForward().ThrowOnError();
+
+	public override Task<string?> InvokeScriptAsync(string script, string[]? arguments, CancellationToken token)
+	{
+		if (arguments is null || arguments.Length == 0)
+		{
+			return ExecuteScriptAsync($"{script}()", token);
+		}
+
+		var adjustedScript = new StringBuilder(script);
+		adjustedScript.Append('(');
+
+		for (int i = 0; i < arguments.Length; i++)
+		{
+			adjustedScript.Append('"');
+			adjustedScript.Append(arguments[i]);
+			adjustedScript.Append('"');
+
+			if (i < arguments.Length - 1)
+			{
+				adjustedScript.Append(',');
+			}
+		}
+
+		adjustedScript.Append(')');
+		return ExecuteScriptAsync(adjustedScript.ToString(), token);
+	}
+
+	public override unsafe void ProcessNavigation(Uri uri)
+	{
+		var uriString = uri.ToString();
+		fixed (char* p_uri = uriString)
+			_nativeWebView.Navigate(new PWSTR(p_uri)).ThrowOnError();
+	}
+
+	public override unsafe void ProcessNavigation(string html)
+	{
+		fixed (char* p_html = html)
+			_nativeWebView.NavigateToString(new PWSTR(p_html)).ThrowOnError();
+	}
+
+	public override void ProcessNavigation(HttpRequestMessage httpRequestMessage) => ProcessNavigationCore(httpRequestMessage);
+
+	private unsafe void ProcessNavigationCore(HttpRequestMessage httpRequestMessage)
+	{
+		var builder = new StringBuilder();
+		foreach (var header in httpRequestMessage.Headers)
+		{
+			if (header.Key != "Host")
+			{
+				builder.Append(header.Key + ": " + string.Join(", ", header.Value) + "\r\n");
+			}
+		}
+
+		_nativeWebView.get_Environment(out var environment).ThrowOnError();
+		var env2 = (WebView2.ICoreWebView2Environment2)environment;
+
+		var bodyStream = httpRequestMessage.Content?.ReadAsStream() ?? Stream.Null;
+		IStream? bodyIStream = null;
+		if (bodyStream != Stream.Null)
+		{
+			var ms = new MemoryStream();
+			bodyStream.CopyTo(ms);
+			bodyIStream = new ByteArrayIStream(ms.ToArray());
+		}
+
+		var requestUri = httpRequestMessage.RequestUri!.ToString();
+		var requestMethod = httpRequestMessage.Method.Method;
+		var requestHeaders = builder.ToString();
+		fixed (char* p_requestUri = requestUri, p_requestMethod = requestMethod, p_requestHeaders = requestHeaders)
+		{
+			env2.CreateWebResourceRequest(
+				new PWSTR(p_requestUri),
+				new PWSTR(p_requestMethod),
+				bodyIStream!,
+				new PWSTR(p_requestHeaders),
+				out var request).ThrowOnError();
+
+			_nativeWebView.NavigateWithWebResourceRequest(request).ThrowOnError();
+		}
+	}
+
+	public override void Reload()
+		=> _nativeWebView.Reload().ThrowOnError();
+
+	public override void SetScrollingEnabled(bool isScrollingEnabled)
+	{
+	}
+
+	public override void Stop()
+		=> _nativeWebView.Stop().ThrowOnError();
+
+	public unsafe void ClearVirtualHostNameToFolderMapping(string hostName)
+	{
+		fixed (char* p_hostName = hostName)
+			_nativeWebView.ClearVirtualHostNameToFolderMapping(new PWSTR(p_hostName)).ThrowOnError();
+	}
+
+	public unsafe void SetVirtualHostNameToFolderMapping(string hostName, string folderPath, CoreWebView2HostResourceAccessKind accessKind)
+	{
+		fixed (char* p_hostName = hostName, p_folderPath = folderPath)
+			_nativeWebView.SetVirtualHostNameToFolderMapping(
+				new PWSTR(p_hostName),
+				new PWSTR(p_folderPath),
+				(WebView2.COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND)(int)accessKind
+			).ThrowOnError();
+	}
+
+	public unsafe void AddWebResourceRequestedFilter(string uri, CoreWebView2WebResourceContext resourceContext, CoreWebView2WebResourceRequestSourceKinds requestSourceKinds)
+	{
+		fixed (char* p_uri = uri)
+			_nativeWebView.AddWebResourceRequestedFilterWithRequestSourceKinds(
+				new PWSTR(p_uri),
+				(WebView2.COREWEBVIEW2_WEB_RESOURCE_CONTEXT)(int)resourceContext,
+				(WebView2.COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS)(int)requestSourceKinds
+			).ThrowOnError();
+	}
+
+	public unsafe void RemoveWebResourceRequestedFilter(string uri, CoreWebView2WebResourceContext resourceContext, CoreWebView2WebResourceRequestSourceKinds requestSourceKinds)
+	{
+		fixed (char* p_uri = uri)
+			_nativeWebView.RemoveWebResourceRequestedFilterWithRequestSourceKinds(
+				new PWSTR(p_uri),
+				(WebView2.COREWEBVIEW2_WEB_RESOURCE_CONTEXT)(int)resourceContext,
+				(WebView2.COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS)(int)requestSourceKinds
+			).ThrowOnError();
+	}
+
+	private static unsafe void CreateCoreWebView2Environment(string userDataFolder, WebView2.ICoreWebView2EnvironmentOptions options, WebView2.ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler handler)
+	{
+		fixed (char* p_userDataFolder = userDataFolder)
+			WebView2.Functions.CreateCoreWebView2EnvironmentWithOptions(
+				default,
+				new PWSTR(p_userDataFolder),
+				options,
+				handler
+			).ThrowOnError();
+	}
+}
+
+#endif

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebView.cs
@@ -1,13 +1,10 @@
 extern alias mswebview2;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,21 +15,52 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.Web.WebView2.Core;
 using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
-using Uno.UI.NativeElementHosting;
 using Uno.UI.Xaml.Controls;
 using Windows.Storage;
 using Windows.Win32;
-using Windows.Win32.Foundation;
-using Windows.Win32.UI.WindowsAndMessaging;
 using NativeWebView = mswebview2::Microsoft.Web.WebView2.Core;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
-// Heavily inspired/copied from WpfNativeWebView
-
 internal class Win32NativeWebViewProvider(CoreWebView2 owner) : INativeWebViewProvider
 {
 	public INativeWebView CreateNativeWebView(ContentPresenter contentPresenter)
+	{
+		var backend = Environment.GetEnvironmentVariable("UNO_WEBVIEW2_BACKEND")?.ToLowerInvariant();
+		switch (backend?.Trim())
+		{
+#if NET10_0_OR_GREATER
+			case "webview2aot":
+				return CreateWin32NativeAotWebView(contentPresenter);
+#endif // NET10_0_OR_GREATER
+			case "microsoft.web.webview2":
+				return CreateWin32NativeWebView(contentPresenter);
+			case "":
+			case null:
+				break;
+			default:
+				typeof(Win32Host).LogError()?.Error($"Unsupported `UNO_WEBVIEW2_BACKEND` value `{backend}`! {SupportedUnoWebview2BackendValues}");
+				break;
+		}
+		return CreateDefaultWebView(contentPresenter);
+	}
+
+#if NET10_0_OR_GREATER
+	private const string SupportedUnoWebview2BackendValues = "Supported values: `webview2aot`, `microsoft.web.webview2`.";
+
+	private INativeWebView CreateWin32NativeAotWebView(ContentPresenter contentPresenter)
+		=> new Win32NativeAotWebView(owner, contentPresenter);
+
+	private INativeWebView CreateDefaultWebView(ContentPresenter contentPresenter)
+		=> CreateWin32NativeAotWebView(contentPresenter);
+#else // !NET10_0_OR_GREATER
+	private const string SupportedUnoWebview2BackendValues = "Supported value: `microsoft.web.webview2`.";
+
+	private INativeWebView CreateDefaultWebView(ContentPresenter contentPresenter)
+		=> CreateWin32NativeWebView(contentPresenter);
+#endif // !NET10_0_OR_GREATER
+
+	private INativeWebView CreateWin32NativeWebView(ContentPresenter contentPresenter)
 	{
 		try
 		{
@@ -47,109 +75,22 @@ internal class Win32NativeWebViewProvider(CoreWebView2 owner) : INativeWebViewPr
 	}
 }
 
-internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHostMapping, ISupportsWebResourceRequested
+internal partial class Win32NativeWebView : Win32NativeWebViewBase, ISupportsVirtualHostMapping, ISupportsWebResourceRequested
 {
-	private const string WindowClassName = "UnoPlatformWebViewWindow";
-	private const uint SC_MASK = 0xFFF0; // Mask to extract system command from wParam
-
-	// _windowClass must be statically stored, otherwise lpfnWndProc will get collected and the CLR will throw some weird exceptions
-	// ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-	private static readonly WNDCLASSEXW _windowClass;
-
-	// This is necessary to be able to direct the very first WndProc call of a window to the correct window wrapper.
-	// That first call is inside CreateWindow, so we don't have a HWND yet. The alternative would be to create a new
-	// window class (and a new WndProc) per window, but that sounds excessive.
-	private static WeakReference<Win32NativeWebView>? _webViewForNextCreateWindow;
-	private static readonly Dictionary<HWND, WeakReference<Win32NativeWebView>> _hwndToWebView = new();
-
-	private readonly ContentPresenter _presenter;
-	private readonly HWND _hwnd;
 	private readonly CoreWebView2 _coreWebView;
 	private readonly NativeWebView.CoreWebView2 _nativeWebView;
-
+	private readonly NativeWebView.CoreWebView2Controller _controller;
 	private Dictionary<ulong, string> _navigationIdToUriMap = new();
 	private string _documentTitle = string.Empty;
-	private readonly NativeWebView.CoreWebView2Controller _controller;
-
-	private HWND ParentHwnd => (_presenter.XamlRoot?.HostWindow?.NativeWindow as Win32NativeWindow)?.Hwnd is IntPtr hwnd ? (HWND)hwnd : HWND.Null;
-
-	static unsafe Win32NativeWebView()
-	{
-		using var lpClassName = new Win32Helper.NativeNulTerminatedUtf16String(WindowClassName);
-
-		_windowClass = new WNDCLASSEXW
-		{
-			cbSize = (uint)Marshal.SizeOf<WNDCLASSEXW>(),
-			lpfnWndProc = &WndProc,
-			hInstance = Win32Helper.GetHInstance(),
-			lpszClassName = lpClassName,
-			style = WNDCLASS_STYLES.CS_HREDRAW | WNDCLASS_STYLES.CS_VREDRAW // https://learn.microsoft.com/en-us/windows/win32/winmsg/window-class-styles
-		};
-
-		var classAtom = PInvoke.RegisterClassEx(_windowClass);
-		if (classAtom is 0)
-		{
-			throw new InvalidOperationException($"{nameof(PInvoke.RegisterClassEx)} failed: {Win32Helper.GetErrorMessage()}");
-		}
-	}
 
 	public Win32NativeWebView(CoreWebView2 owner, ContentPresenter presenter)
+	: base(presenter)
 	{
-		_presenter = presenter;
 		_coreWebView = owner;
 
 		ForwardBackgroundToPresenter();
 
-		using var lpClassName = new Win32Helper.NativeNulTerminatedUtf16String(WindowClassName);
-
-		_webViewForNextCreateWindow = new WeakReference<Win32NativeWebView>(this);
-		unsafe
-		{
-			_hwnd = PInvoke.CreateWindowEx(
-				0,
-				lpClassName,
-				new PCWSTR(),
-				WINDOW_STYLE.WS_CHILDWINDOW | WINDOW_STYLE.WS_VISIBLE,
-				PInvoke.CW_USEDEFAULT,
-				PInvoke.CW_USEDEFAULT,
-				PInvoke.CW_USEDEFAULT,
-				PInvoke.CW_USEDEFAULT,
-				ParentHwnd,
-				HMENU.Null,
-				Win32Helper.GetHInstance(),
-				null);
-		}
-		_webViewForNextCreateWindow = null;
-
-		if (_hwnd == HWND.Null)
-		{
-			throw new InvalidOperationException($"{nameof(PInvoke.CreateWindowEx)} failed: {Win32Helper.GetErrorMessage()}");
-		}
-
-		unsafe
-		{
-			// disable window maximize/minimize/restore animations to avoid visual glitches during initial window setup
-			BOOL fDisable = true;
-			var hr = PInvoke.DwmSetWindowAttribute(_hwnd, Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, &fDisable, (uint)Marshal.SizeOf(fDisable));
-			if (hr.Failed && this.Log().IsEnabled(LogLevel.Error))
-			{
-				this.Log().Error($"{nameof(PInvoke.DwmSetWindowAttribute)} failed for {Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED}: 0x{hr.Value:X8}");
-			}
-		}
-
-		if (this.Log().IsEnabled(LogLevel.Trace))
-		{
-			this.Log().Trace("Created web view window.");
-		}
-
-		var success = PInvoke.RegisterTouchWindow(_hwnd, 0);
-		if (!success && this.Log().IsEnabled(LogLevel.Error))
-		{
-			this.Log().Error($"{nameof(PInvoke.RegisterTouchWindow)} failed: {Win32Helper.GetErrorMessage()}");
-		}
-
 		var tcs = new TaskCompletionSource<NativeWebView.CoreWebView2Controller>();
-		// ReSharper disable once AsyncVoidLambda
 		NativeDispatcher.Main.EnqueueAsync(async () =>
 		{
 			var userDataFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "WebView2");
@@ -165,19 +106,12 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 				options.AdditionalBrowserArguments = FeatureConfiguration.WebView2.AdditionalBrowserArguments;
 			}
 			var env = await NativeWebView.CoreWebView2Environment.CreateAsync(userDataFolder: userDataFolder, options: options);
-			var controller = await env.CreateCoreWebView2ControllerAsync(_hwnd);
-
-			// Hide until NavigationCompleted to suppress the initial black frame.
+			var controller = await env.CreateCoreWebView2ControllerAsync(Hwnd);
 			controller.IsVisible = false;
 
-			// Avoid setting DefaultBackgroundColor unless it exactly matches the background behind the
-			// WebView — a mismatch worsens the flash rather than hiding it.
-			// In the general case, it is actually beneficial to leave it out, since it won't be seen.
-			if (_presenter.Background is SolidColorBrush { Color: { } color })
+			if (Presenter.Background is SolidColorBrush { Color: { } color })
 			{
-				// note: DefaultBackgroundColor does not accept color with non-255 alpha.
-				// > System.ArgumentException: Value does not fall within the expected range.
-				controller.DefaultBackgroundColor = Color.FromArgb(Byte.MaxValue, color.R, color.G, color.B);
+				controller.DefaultBackgroundColor = Color.FromArgb(byte.MaxValue, color.R, color.G, color.B);
 			}
 
 			tcs.SetResult(controller);
@@ -197,8 +131,6 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		_nativeWebView.Settings.AreDevToolsEnabled = FeatureConfiguration.WebView2.EnableDevTools;
 		_controller.Bounds = new Rectangle(0, 0, 500, 500);
 
-		// This dance with weak refs is necessary because there seems like _nativeWebView when it has a ref back
-		// to this.
 		_nativeWebView.NavigationCompleted += EventHandlerBuilder<NativeWebView.CoreWebView2NavigationCompletedEventArgs>(static (@this, o, a) => @this.NativeWebView_NavigationCompleted(o, a));
 		_nativeWebView.NewWindowRequested += EventHandlerBuilder<NativeWebView.CoreWebView2NewWindowRequestedEventArgs>(static (@this, o, a) => @this.NativeWebView_NewWindowRequested(o, a));
 		_nativeWebView.SourceChanged += EventHandlerBuilder<NativeWebView.CoreWebView2SourceChangedEventArgs>(static (@this, o, a) => @this.NativeWebView_SourceChanged(o, a));
@@ -208,20 +140,27 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		_nativeWebView.DocumentTitleChanged += EventHandlerBuilder<object>(static (@this, o, a) => @this.OnNativeTitleChanged(o, a));
 		_nativeWebView.WebResourceRequested += NativeWebView2_WebResourceRequested;
 		UpdateDocumentTitle();
-
-		presenter.Content = new Win32NativeWindow(_hwnd);
 	}
 
 	private void ForwardBackgroundToPresenter()
 	{
-		if (_coreWebView.Owner is WebView2 view && _presenter is { } cp)
+		if (_coreWebView.Owner is Microsoft.UI.Xaml.Controls.WebView2 view)
 		{
-			cp.SetBinding(FrameworkElement.BackgroundProperty, new Binding()
+			Presenter.SetBinding(FrameworkElement.BackgroundProperty, new Binding()
 			{
 				Path = new(nameof(view.Background)),
 				Source = view,
 				Mode = BindingMode.OneWay
 			});
+		}
+	}
+
+	protected override void OnWindowSizeChanged()
+	{
+		if (_controller is not null)
+		{
+			PInvoke.GetClientRect(Hwnd, out var bounds);
+			_controller.Bounds = bounds;
 		}
 	}
 
@@ -244,107 +183,15 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		};
 	}
 
-	~Win32NativeWebView()
+	public override string DocumentTitle
+	=> _documentTitle;
+
+	private void SetDocumentTitle(string value)
 	{
-		_presenter.DispatcherQueue.TryEnqueue(() =>
+		if (_documentTitle != value)
 		{
-			var success = PInvoke.DestroyWindow(_hwnd);
-			if (!success && this.Log().IsEnabled(LogLevel.Error))
-			{
-				this.Log().Error($"{nameof(PInvoke.DestroyWindow)} failed: {Win32Helper.GetErrorMessage()}");
-			}
-
-			lock (_hwndToWebView)
-			{
-				_hwndToWebView.Remove(_hwnd);
-			}
-		});
-	}
-
-	[UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
-	private static LRESULT WndProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
-	{
-		lock (_hwndToWebView)
-		{
-			if (_webViewForNextCreateWindow is { } webView)
-			{
-				_hwndToWebView[hwnd] = webView;
-			}
-			else if (!_hwndToWebView.TryGetValue(hwnd, out webView))
-			{
-				throw new Exception($"{nameof(WndProc)} was fired on a {nameof(HWND)} before it was added to, or after it was removed from, {nameof(_hwndToWebView)}.");
-			}
-			if (webView.TryGetTarget(out var target))
-			{
-				return target.WndProcInner(hwnd, msg, wParam, lParam);
-			}
-			return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
-		}
-	}
-
-	private LRESULT WndProcInner(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
-	{
-		Debug.Assert(_hwnd == HWND.Null || hwnd == _hwnd); // the null check is for when this method gets called inside CreateWindow before setting _hwnd
-
-		switch (msg)
-		{
-			// ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-			case PInvoke.WM_SIZE when _controller is not null:
-				PInvoke.GetClientRect(_hwnd, out var bounds);
-				_controller.Bounds = bounds;
-				return new LRESULT(0);
-			case PInvoke.WM_SYSCOMMAND:
-				// When Alt+F4 is pressed on a focused WebView2, Windows sends WM_SYSCOMMAND with SC_CLOSE
-				// to the WebView2's child window. We need to forward this to the parent window to close
-				// the entire application instead of just the WebView2 control.
-				var syscommand = (uint)wParam.Value & SC_MASK;
-				if (syscommand == PInvoke.SC_CLOSE)
-				{
-					var parentHwnd = ParentHwnd;
-					if (parentHwnd != HWND.Null)
-					{
-						PInvoke.SendMessage(parentHwnd, msg, wParam, lParam);
-						return new LRESULT(0);
-					}
-				}
-				break;
-			case PInvoke.WM_CLOSE:
-				// Prevent the WebView2 window from being closed directly. Instead, forward to the parent
-				// window so the entire application can close properly.
-				{
-					var parentHwnd = ParentHwnd;
-					if (parentHwnd != HWND.Null)
-					{
-						PInvoke.SendMessage(parentHwnd, msg, wParam, lParam);
-						return new LRESULT(0);
-					}
-				}
-				break;
-			case PInvoke.WM_MOUSEACTIVATE:
-				// A WS_CHILD window's DefWindowProc only calls SetFocus, not SetForegroundWindow.
-				// Explicitly foreground the Uno top-level so clicking an inactive WebView2 brings the app forward.
-				{
-					var parentHwnd = ParentHwnd;
-					if (parentHwnd != HWND.Null)
-					{
-						PInvoke.SetForegroundWindow(parentHwnd);
-					}
-					return new LRESULT((nint)PInvoke.MA_ACTIVATE);
-				}
-		}
-		return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
-	}
-
-	public string DocumentTitle
-	{
-		get => _documentTitle;
-		private set
-		{
-			if (_documentTitle != value)
-			{
-				_documentTitle = value;
-				_coreWebView.OnDocumentTitleChanged();
-			}
+			_documentTitle = value;
+			_coreWebView.OnDocumentTitleChanged();
 		}
 	}
 
@@ -362,7 +209,7 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 	{
 		if (e.Uri is null)
 		{
-			return; // this is what the Wpf version does
+			return;
 		}
 
 		bool cancel;
@@ -392,10 +239,6 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		}
 
 		_navigationIdToUriMap.Remove(e.NavigationId);
-		// The source is set through NativeWebView_SourceChanged
-		// Note that when using NavigateToString on WinUI, the NavigationCompleted event on WinUI has uri containing base64 of the passed string, while source becomes about:blank.
-		// On WPF, we already have the same behavior for free. _coreWebView.Source becomes about:blank and the event arguments of NavigationCompleted contains the base64 value.
-		// So, we should skip setting the source from base64.
 		if (Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out var uri))
 		{
 			if (e.WebErrorStatus == NativeWebView.CoreWebView2WebErrorStatus.ConnectionAborted)
@@ -424,7 +267,7 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 
 	private void UpdateDocumentTitle()
 	{
-		DocumentTitle = _nativeWebView.DocumentTitle;
+		SetDocumentTitle(_nativeWebView.DocumentTitle);
 	}
 
 	private void CoreWebView2_HistoryChanged(object? sender, object e)
@@ -433,16 +276,16 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		_coreWebView.RaiseHistoryChanged();
 	}
 
-	public Task<string?> ExecuteScriptAsync(string script, CancellationToken token)
+	public override Task<string?> ExecuteScriptAsync(string script, CancellationToken token)
 		=> _nativeWebView.ExecuteScriptAsync(script);
 
-	public void GoBack()
+	public override void GoBack()
 		=> _nativeWebView.GoBack();
 
-	public void GoForward()
+	public override void GoForward()
 		=> _nativeWebView.GoForward();
 
-	public Task<string?> InvokeScriptAsync(string script, string[]? arguments, CancellationToken token)
+	public override Task<string?> InvokeScriptAsync(string script, string[]? arguments, CancellationToken token)
 	{
 		if (arguments is null || arguments.Length == 0)
 		{
@@ -468,19 +311,17 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		return ExecuteScriptAsync(adjustedScript.ToString(), token);
 	}
 
-	public void ProcessNavigation(Uri uri) => _nativeWebView.Navigate(uri.ToString());
+	public override void ProcessNavigation(Uri uri) => _nativeWebView.Navigate(uri.ToString());
 
-	public void ProcessNavigation(string html) => _nativeWebView.NavigateToString(html);
+	public override void ProcessNavigation(string html) => _nativeWebView.NavigateToString(html);
 
-	public void ProcessNavigation(HttpRequestMessage httpRequestMessage) => ProcessNavigationCore(httpRequestMessage);
+	public override void ProcessNavigation(HttpRequestMessage httpRequestMessage) => ProcessNavigationCore(httpRequestMessage);
 
 	private void ProcessNavigationCore(HttpRequestMessage httpRequestMessage)
 	{
 		var builder = new StringBuilder();
 		foreach (var header in httpRequestMessage.Headers)
 		{
-			// https://github.com/MicrosoftEdge/WebView2Feedback/issues/2250#issuecomment-1201765363
-			// WebView2 doesn't like when you try to set some headers manually
 			if (header.Key != "Host")
 			{
 				builder.Append(header.Key + ": " + string.Join(", ", header.Value) + "\r\n");
@@ -491,14 +332,14 @@ internal partial class Win32NativeWebView : INativeWebView, ISupportsVirtualHost
 		_nativeWebView.NavigateWithWebResourceRequest(request);
 	}
 
-	public void Reload()
+	public override void Reload()
 		=> _nativeWebView.Reload();
 
-	public void SetScrollingEnabled(bool isScrollingEnabled)
+	public override void SetScrollingEnabled(bool isScrollingEnabled)
 	{
 	}
 
-	public void Stop()
+	public override void Stop()
 		=> _nativeWebView.Stop();
 
 	public void ClearVirtualHostNameToFolderMapping(string hostName)

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebViewBase.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeWebViewBase.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Xaml.Controls;
+using Uno.Foundation.Logging;
+using Uno.UI.NativeElementHosting;
+using Uno.UI.Xaml.Controls;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal abstract class Win32NativeWebViewBase : INativeWebView
+{
+	private const string WindowClassName = "UnoPlatformWebViewWindow";
+	private const uint SC_MASK = 0xFFF0;
+
+	private static readonly WNDCLASSEXW _windowClass;
+	private static WeakReference<Win32NativeWebViewBase>? _webViewForNextCreateWindow;
+	private static readonly Dictionary<HWND, WeakReference<Win32NativeWebViewBase>> _hwndToWebView = new();
+
+	protected ContentPresenter Presenter { get; }
+	protected HWND Hwnd { get; }
+	protected HWND ParentHwnd => (Presenter.XamlRoot?.HostWindow?.NativeWindow as Win32NativeWindow)?.Hwnd is IntPtr hwnd ? (HWND)hwnd : HWND.Null;
+
+	static unsafe Win32NativeWebViewBase()
+	{
+		using var lpClassName = new Win32Helper.NativeNulTerminatedUtf16String(WindowClassName);
+
+		_windowClass = new WNDCLASSEXW
+		{
+			cbSize = (uint)Marshal.SizeOf<WNDCLASSEXW>(),
+			lpfnWndProc = &WndProc,
+			hInstance = Win32Helper.GetHInstance(),
+			lpszClassName = lpClassName,
+			style = WNDCLASS_STYLES.CS_HREDRAW | WNDCLASS_STYLES.CS_VREDRAW
+		};
+
+		var classAtom = PInvoke.RegisterClassEx(_windowClass);
+		if (classAtom is 0)
+		{
+			throw new InvalidOperationException($"{nameof(PInvoke.RegisterClassEx)} failed: {Win32Helper.GetErrorMessage()}");
+		}
+	}
+
+	protected Win32NativeWebViewBase(ContentPresenter presenter)
+	{
+		Presenter = presenter;
+
+		using var lpClassName = new Win32Helper.NativeNulTerminatedUtf16String(WindowClassName);
+
+		_webViewForNextCreateWindow = new WeakReference<Win32NativeWebViewBase>(this);
+		unsafe
+		{
+			Hwnd = PInvoke.CreateWindowEx(
+			0,
+			lpClassName,
+			new PCWSTR(),
+			WINDOW_STYLE.WS_CHILDWINDOW | WINDOW_STYLE.WS_VISIBLE,
+			PInvoke.CW_USEDEFAULT,
+			PInvoke.CW_USEDEFAULT,
+			PInvoke.CW_USEDEFAULT,
+			PInvoke.CW_USEDEFAULT,
+			ParentHwnd,
+			HMENU.Null,
+			Win32Helper.GetHInstance(),
+			null);
+		}
+		_webViewForNextCreateWindow = null;
+
+		if (Hwnd == HWND.Null)
+		{
+			throw new InvalidOperationException($"{nameof(PInvoke.CreateWindowEx)} failed: {Win32Helper.GetErrorMessage()}");
+		}
+
+		unsafe
+		{
+			BOOL fDisable = true;
+			var hr = PInvoke.DwmSetWindowAttribute(Hwnd, Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, &fDisable, (uint)Marshal.SizeOf(fDisable));
+			if (hr.Failed && this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"{nameof(PInvoke.DwmSetWindowAttribute)} failed for {Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED}: 0x{hr.Value:X8}");
+			}
+		}
+
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace("Created web view window.");
+		}
+
+		var success = PInvoke.RegisterTouchWindow(Hwnd, 0);
+		if (!success && this.Log().IsEnabled(LogLevel.Error))
+		{
+			this.Log().Error($"{nameof(PInvoke.RegisterTouchWindow)} failed: {Win32Helper.GetErrorMessage()}");
+		}
+
+		presenter.Content = new Win32NativeWindow(Hwnd);
+	}
+
+	~Win32NativeWebViewBase()
+	{
+		Presenter.DispatcherQueue.TryEnqueue(() =>
+		{
+			var success = PInvoke.DestroyWindow(Hwnd);
+			if (!success && this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"{nameof(PInvoke.DestroyWindow)} failed: {Win32Helper.GetErrorMessage()}");
+			}
+
+			lock (_hwndToWebView)
+			{
+				_hwndToWebView.Remove(Hwnd);
+			}
+		});
+	}
+
+	[UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+	private static LRESULT WndProc(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
+	{
+		lock (_hwndToWebView)
+		{
+			if (_webViewForNextCreateWindow is { } webView)
+			{
+				_hwndToWebView[hwnd] = webView;
+			}
+			else if (!_hwndToWebView.TryGetValue(hwnd, out webView))
+			{
+				var logger = typeof(Win32NativeWebViewBase).Log();
+				if (logger.IsEnabled(LogLevel.Error))
+				{
+					logger.Error($"{nameof(Win32NativeWebViewBase)}.{nameof(WndProc)} received message {msg} for unknown {nameof(HWND)}={hwnd}.");
+				}
+				return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+			}
+
+			if (webView.TryGetTarget(out var target))
+			{
+				return target.WndProcInner(hwnd, msg, wParam, lParam);
+			}
+
+			return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+		}
+	}
+
+	private LRESULT WndProcInner(HWND hwnd, uint msg, WPARAM wParam, LPARAM lParam)
+	{
+		switch (msg)
+		{
+			case PInvoke.WM_SIZE:
+				OnWindowSizeChanged();
+				return new LRESULT(0);
+			case PInvoke.WM_SYSCOMMAND:
+				var syscommand = (uint)wParam.Value & SC_MASK;
+				if (syscommand == PInvoke.SC_CLOSE)
+				{
+					var parentHwnd = ParentHwnd;
+					if (parentHwnd != HWND.Null)
+					{
+						PInvoke.SendMessage(parentHwnd, msg, wParam, lParam);
+						return new LRESULT(0);
+					}
+				}
+				break;
+			case PInvoke.WM_CLOSE:
+				{
+					var parentHwnd = ParentHwnd;
+					if (parentHwnd != HWND.Null)
+					{
+						PInvoke.SendMessage(parentHwnd, msg, wParam, lParam);
+						return new LRESULT(0);
+					}
+				}
+				break;
+			case PInvoke.WM_MOUSEACTIVATE:
+				// A WS_CHILD window's DefWindowProc only calls SetFocus, not SetForegroundWindow.
+				// Explicitly foreground the Uno top-level so clicking an inactive WebView2 brings the app forward.
+				{
+					var parentHwnd = ParentHwnd;
+					if (parentHwnd != HWND.Null)
+					{
+						PInvoke.SetForegroundWindow(parentHwnd);
+					}
+					return new LRESULT((nint)PInvoke.MA_ACTIVATE);
+				}
+		}
+
+		return PInvoke.DefWindowProc(hwnd, msg, wParam, lParam);
+	}
+
+	protected abstract void OnWindowSizeChanged();
+
+	public abstract string DocumentTitle { get; }
+	public abstract void GoBack();
+	public abstract void GoForward();
+	public abstract void Stop();
+	public abstract void Reload();
+	public abstract void ProcessNavigation(Uri uri);
+	public abstract void ProcessNavigation(string html);
+	public abstract void ProcessNavigation(System.Net.Http.HttpRequestMessage httpRequestMessage);
+	public abstract System.Threading.Tasks.Task<string?> ExecuteScriptAsync(string script, System.Threading.CancellationToken token);
+	public abstract System.Threading.Tasks.Task<string?> InvokeScriptAsync(string script, string[]? arguments, System.Threading.CancellationToken token);
+	public abstract void SetScrollingEnabled(bool isScrollingEnabled);
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Uno.UI.Runtime.Skia.Win32.csproj
+++ b/src/Uno.UI.Runtime.Skia.Win32/Uno.UI.Runtime.Skia.Win32.csproj
@@ -32,6 +32,15 @@
 		<PackageReference Include="Uno.icu-win" />
 	</ItemGroup>
 
+	<ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net10.0'))">
+		<PackageReference Include="WebView2Aot" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
+		<AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.Skia.csproj" />
 		<ProjectReference Include="..\Uno.UI.Runtime.Skia.Win32.Support\Uno.UI.Runtime.Skia.Win32.Support.csproj" PrivateAssets="all" />


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/uno/issues/23142

Context: https://github.com/MicrosoftEdge/WebView2Feedback/issues/5238
Context: https://github.com/smourier/WebView2Aot
Context: https://github.com/smourier/DirectNAot/issues/9

On Windows, the <WebView2/> XAML control is implemented in terms of the [Microsoft.Web.WebView2 NuGet package][0].

The problem: Microsoft.Web.WebView2, when used for "normal" .NET, uses COM Interop.  Native AOT does not support COM interop. The result is that things fail, a'la
MicrosoftEdge/WebView2Feedback#5238 (which is for WinForms, but the same fundamental idea).

In the case of #23142, if we build Uno.Gallery for Native AOT:

	git clone https://github.com/unoplatform/Uno.Gallery.git
	cd Uno.Gallery
	git checkout 54a08b1587aa020a5651d61eb3a3023a79e89d72
	sed -i '' 's/"Uno.Sdk": ".*"/"Uno.Sdk": "6.6.0-dev.216"/g' global.json
	dotnet publish -c Release -r win-arm64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop `
	  -bl Uno.Gallery/Uno.Gallery.csproj -p:SelfContained=true -p:UseSkiaRendering=true `
	  -p:SkiaPublishAot=true -p:IsAotCompatible=true

Run it:

	.\Uno.Gallery\bin\Release\net10.0-desktop\win-arm64\publish\Uno.Gallery.exe | Out-Default

and access the **UI components > WebView** entry in the left tree, then the console contains the following output:

	fail: Uno.UI.Dispatching.NativeDispatcher[0]
	      NativeDispatcher unhandled exception
	      System.NotSupportedException: COM Interop requires ComWrapper instance registered for marshalling.
	         at System.Runtime.InteropServices.ComWrappers.ComInterfaceForObject(Object) + 0xa4
	         at System.Runtime.InteropServices.ComWrappers.ComInterfaceForObject(Object, Guid) + 0x24
	         at Microsoft.Web.WebView2.Core.CoreWebView2Environment.CreateCoreWebView2EnvironmentWithOptions(String, String, ICoreWebView2EnvironmentOptions, ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler) + 0xdc
	         at Microsoft.Web.WebView2.Core.CoreWebView2Environment.<CreateAsync>d__102.MoveNext() + 0xe4
	      --- End of stack trace from previous location ---
	         at Uno.UI.Runtime.Skia.Win32.Win32NativeWebView.<>c__DisplayClass15_0.<<-ctor>b__0>d.MoveNext() + 0x60
	      --- End of stack trace from previous location ---
	         at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object state) + 0x1c
	         at Uno.UI.Dispatching.NativeDispatcher.RunAction(NativeDispatcher, Action) + 0x8c

The Microsoft.Web.WebView2 package *does* support Native AOT, but *only if* you're building for WinRT.  (Uno is not built on WinRT.)

A way to use Microsoft.Web.WebView2 while supporting Native AOT in a "normal" (non-WinRT) Windows environment is to instead use smourier/WebView2Aot, in the [WebView2Aot NuGet package][1]. WebView2Aot uses the [DirectN AOT generator][2] to emit Native AOT- compatible COM interop infrastrucure.

Update `Uno.UI.Runtime.Skia.Win32` as follows:

 1. Split out the "native" bits of `Win32NativeWebView` into `Win32NativeWebViewBase.cs`.  (Anything dealing with a Windows WndProc, etc.)

 2. Update `Win32NativeWebView` to inherit `Win32NativeWebViewBase`.

 3. Add a new `Win32NativeAotWebView` type, which also inherits from `Win32NativeWebViewBase`.  This implements `<WebView2/>` support in terms of WebView2Aot.

However, WebView2Aot requires .NET 10.  Consequently, `Uno.UI.Runtime.Skia.Win32.csproj` should only reference WebView2Aot when targeting .NET 10 and later, and `Win32NativeAotWebView` can only exist in .NET 10 and later.

Additionally, this is a potential significant change.  We want WebView2Aot to be the default in all Windows configurations for consistency -- nobody wants to debug a scenario of "WebView2 works when I'm not building for Native AOT!" -- but there should be a way to use the previous Microsoft.Web.WebView2 implementation in case WebView2Aot breaks things, or for testing, or…

Update `Win32NativeWebViewProvider` as follows:

 1. When built for .NET 9, only Win32NativerWebView / the Microsoft.Web.WebView2 backend is supported.

 2. When built for .NET 10+, the new WebView2Aot backend is used by default.  This can be overridden by setting the `UNO_WEBVIEW2_BACKEND` environment variable to `microsoft.web.webview2`.

    `UNO_WEBVIEW2_BACKEND` can also be set to `webview2aot` to be explicit.

The `UNO_WEBVIEW2_BACKEND` environment variable is always read, and will log an error message when using an unsupported value, e.g. when `UNO_WEBVIEW2_BACKEND=webview2aot` on .NET 9.

Aside: add BannedApiAnalyzers to `Uno.UI.Runtime.Skia.Win32.csproj` which make it an error to use `PWSTR.From(string)`. See also smourier/DirectNAot#9.

[0]: https://www.nuget.org/packages/Microsoft.Web.WebView2
[1]: https://www.nuget.org/packages/WebView2Aot
[2]: https://github.com/smourier/DirectNAot

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
