### PR TITLE
chore: try building on macOS 26

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -56,7 +56,7 @@ variables:
   windowsScaledPool: 'Windows2025-20260406-1'
   linuxVMImage: 'ubuntu-24.04'
   linuxScaledPool: 'Ubuntu2404-20251016'
-  macOSVMImage: 'macOS-15'
+  macOSVMImage: 'macOS-26'
   macOSVMImage_UITests: 'macOS-14'
   xCodeRoot: '/Applications/Xcode_26.1.1.app'
   xCodeRoot_iOS_UITests: '/Applications/Xcode_15.3.app'


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/pull/23603

PR #23603 has one remaining blocking issue:
**Tests - Desktop Skia macOS > Runtime Tests > Run macOS Runtime Tests** regularly crashes on CI, frequently during/immediatley after the `Given_WebView2.When_ExecuteScriptAsync_Has_No_Result() or `Given_WebView2.When_ExecuteScriptAsync_Non_String() tests.

The question is *why*.

Additionally, there are (at least?) two *significant* changes in PR #23603: (1) it uses .NET 11 instead of .NET 10, and (2) it builds on macOS 26 instead of macOS 15.

Furthermore, crash cannot be reproduced locally on macOS 26 arm64 or on macOS 15 x64, while the crash *does* occur on macOS 26 x64.

Update CI to use macos-26.  This avoids the .NET 11 changes, narrowing things down to just the macOS 26 changes.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
🏗️ Build or CI related changes

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
