### PR TITLE
perf(dependencyobject): hold the inheritance-context associated parent weakly

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_CollectibleAlcAssociations.cs
@@ -68,6 +68,28 @@ public class Given_CollectibleAlcAssociations
 	}
 
 	[TestMethod]
+	public void When_SharedValueConsumerDetached_Then_CollectableWithoutCleanupSweep()
+	{
+		// Structural guard for the weak `_associatedParentRef`: with the parent held weakly, the
+		// consuming element must be collectable on its own once it is otherwise unreferenced — WITHOUT
+		// relying on the CleanupNonDefaultAlcCaches eviction sweep (which loses the race against
+		// residual activity). Note: this test intentionally does NOT call CleanupNonDefaultAlcCaches.
+		var weakElement = StageHostResourceAssociation();
+
+		for (var i = 0; i < 10 && weakElement.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		Assert.IsFalse(
+			weakElement.IsAlive,
+			"A shared value's InheritanceContext parent is held weakly, so the consuming element must " +
+			"be collected once unreferenced even without the ALC cleanup sweep. If it survives, the " +
+			"associated-parent field is pinning it strongly again.");
+	}
+
+	[TestMethod]
 	public void When_ThemeDictionaryResourceAssociatedToCollectibleElement_Then_CleanupReleasesAssociation()
 	{
 		var weakElement = StageThemeDictionaryAssociation();

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -714,7 +714,7 @@ namespace Microsoft.UI.Xaml
 			//		of ResourceDictionary and ContentControl.  It is ok to have multiple parents as long as
 			//		the first parent is a ResourceDictionary, or if the first parent is a ContentControl and there are at most
 			//		two parents.
-			// todo: if we are to implement that in the future, we should promote `object? _associatedParent` into a `List/HashSet<object?>? _associatedParents`
+			// todo: if we are to implement that in the future, we should promote the weak `_associatedParentRef` into a collection of weak references (e.g. `List<ManagedWeakReference>? _associatedParentRefs`)
 
 			// A previously-associated parent that has since been collected (weak target is null) no longer
 			// counts: the value is single-parent again, so re-associate rather than treating it as shared.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -38,7 +38,15 @@ namespace Microsoft.UI.Xaml
 	{
 		private readonly object _gate = new object();
 
-		private object? _associatedParent; // see note in AssociateParent(object)
+		// WEAK reference to the associated (inheritance-context) parent — see note in AssociateParent(object).
+		// A shareable value (IMultiParentShareableDependencyObject, e.g. a Brush) must NOT strongly pin the
+		// element that consumed it: shared/process-lifetime values (DependencyProperty metadata defaults,
+		// theme brushes, static resources) would otherwise retain every transient element they were ever set
+		// on until the property is overwritten — a leak for any long-running app, since visual-tree detach
+		// alone does not run UnassociateParent. This mirrors _mentorRef and WinUI's
+		// SetParentForInheritanceContextOnly (xref::weakref_ptr). The field is read only for multi-parent
+		// detection and teardown; DataContext inheritance is push-based via the parent's ChildrenBindable.
+		private ManagedWeakReference? _associatedParentRef;
 
 		private HashtableEx? _childrenBindableMap; // maps DependencyProperty to _childrenBindable[index]
 		private List<object?>? _childrenBindable;
@@ -708,20 +716,28 @@ namespace Microsoft.UI.Xaml
 			//		two parents.
 			// todo: if we are to implement that in the future, we should promote `object? _associatedParent` into a `List/HashSet<object?>? _associatedParents`
 
-			if (_associatedParent == null)
+			// A previously-associated parent that has since been collected (weak target is null) no longer
+			// counts: the value is single-parent again, so re-associate rather than treating it as shared.
+			var current = _associatedParentRef?.Target;
+			if (current is null)
 			{
-				_associatedParent = parent;
+				if (_associatedParentRef is not null)
+				{
+					WeakReferencePool.ReturnWeakReference(this, _associatedParentRef);
+				}
+
+				_associatedParentRef = WeakReferencePool.RentWeakReference(this, parent);
 				RegisterCollectibleParentAssociation(parent);
 			}
-			else
+			else if (!ReferenceEquals(current, parent))
 			{
-				// if there are multiple parents (would be if we count the previous one `_associatedParent` and the current one `parent`),
-				// it means that the current instance is shared across multiple owners/parents,
-				// which means that it should no longer participate in any dc propagation.
+				// A second, simultaneously-alive parent means the instance is shared across multiple
+				// owners/parents, so it should no longer participate in any dc propagation.
 				_inheritanceContextEnabled = false;
 
 				ClearInheritedDataContext();
-				_associatedParent = null;
+				WeakReferencePool.ReturnWeakReference(this, _associatedParentRef);
+				_associatedParentRef = null;
 			}
 		}
 		private void UnassociateParent(object? parent)
@@ -729,9 +745,10 @@ namespace Microsoft.UI.Xaml
 			if (parent == null) return;
 			if (!_inheritanceContextEnabled) return;
 
-			if (ReferenceEquals(_associatedParent, parent))
+			if (ReferenceEquals(_associatedParentRef?.Target, parent))
 			{
-				_associatedParent = null;
+				WeakReferencePool.ReturnWeakReference(this, _associatedParentRef!);
+				_associatedParentRef = null;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs
@@ -2,13 +2,14 @@
 
 using System;
 using System.Collections.Generic;
+using Uno.UI.DataBinding;
 
 namespace Microsoft.UI.Xaml
 {
 	public partial class DependencyObjectStore
 	{
 		/// <summary>
-		/// Drops <see cref="_associatedParent"/> — and any DataContext it propagated into this store —
+		/// Drops <see cref="_associatedParentRef"/> — and any DataContext it propagated into this store —
 		/// when the parent is owned by an unloading collectible ALC, is an unloaded
 		/// <see cref="FrameworkElement"/>, or is orphaned from the content-root coordinator, so a
 		/// host-lifetime resource cannot pin a secondary app's ALC. A live host element re-associates
@@ -33,8 +34,9 @@ namespace Microsoft.UI.Xaml
 			// The collectible branch is gated on the parent's ALC unload having actually been
 			// initiated: a still-live session-lifetime add-in ALC (e.g. a designer host) is also
 			// collectible, but its associations must be preserved until it really unloads.
+			var associatedParent = _associatedParentRef?.Target;
 			var collectibleAndUnloading = false;
-			if (_associatedParent is { } collectibleCandidate && collectibleCandidate.GetType().IsCollectible)
+			if (associatedParent is { } collectibleCandidate && collectibleCandidate.GetType().IsCollectible)
 			{
 				var parentAlc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(collectibleCandidate.GetType().Assembly);
 				// Conservative when the unload state can't be read: do NOT clear, so a still-live add-in
@@ -44,12 +46,17 @@ namespace Microsoft.UI.Xaml
 					&& global::Uno.UI.Xaml.Core.AlcStateHelper.IsUnloadInitiated(parentAlc, valueIfUnknown: false);
 			}
 
-			if (_associatedParent is { } parent
+			if (associatedParent is { } parent
 				&& (collectibleAndUnloading
 					|| parent is FrameworkElement { IsLoaded: false }
 					|| (parent is FrameworkElement orphanCandidate && IsOrphanedFromContentRoots(orphanCandidate))))
 			{
-				_associatedParent = null;
+				if (_associatedParentRef is not null)
+				{
+					WeakReferencePool.ReturnWeakReference(this, _associatedParentRef);
+					_associatedParentRef = null;
+				}
+
 				associationCleared = true;
 			}
 


### PR DESCRIPTION
**ALC pin-fix stack — PR 1 of 4 (uno).** Base: `master`. Next: U2 (weak Type-keyed caches) stacks on this branch.

Fixes #23627

## Spec

Fixes the strong-reference leak described in the linked issue: `DependencyObjectStore._associatedParent` (the inheritance-context "associated parent" set for every `IMultiParentShareableDependencyObject` value placed on an element) held the consuming element **strongly**, and was only cleared when the property value was replaced — never on visual-tree detach. Any shared/process-lifetime value (DP metadata default brush, theme brush, static resource) therefore retained the first element that ever consumed it, its whole parent chain, event subscriptions, and inherited `DataContext`; in a host loading plugin/preview apps into collectible AssemblyLoadContexts, this pinned the entire collectible ALC.

The field is read only for multi-parent detection and teardown — `DataContext` inheritance is push-based (parent → children via the parent's `ChildrenBindable`) and already uses the weak `_mentorRef`, which is explicitly modeled on WinUI's `SetParentForInheritanceContextOnly` / `xref::weakref_ptr`. This PR aligns the associated parent with that same weak model, so holding it weakly changes no inheritance behavior while removing the leak.

## Implementation

**`src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs`**
- Replaces `private object? _associatedParent` with `private ManagedWeakReference? _associatedParentRef`, with a doc comment explaining the weak-reference rationale and the WinUI mentor model it mirrors. Weak references are rented/returned through the existing `WeakReferencePool` — the same mechanism `_mentorRef` already uses.
- `AssociateParent`: dereferences the weak target once. If there is no *live* current parent (never associated, or the previous parent has been collected), it returns any stale pooled reference, rents a fresh one for the new parent, and calls `RegisterCollectibleParentAssociation(parent)` as before — a collected former parent no longer counts toward multi-parent detection, so the value is correctly treated as single-parent again. Multi-parent demotion (`_inheritanceContextEnabled = false` + `ClearInheritedDataContext`) now requires a second, **distinct, simultaneously-alive** parent (`!ReferenceEquals(current, parent)`); re-associating the same parent is a no-op instead of a spurious demotion. The pooled reference is returned when the field is cleared.
- `UnassociateParent`: compares the caller against `_associatedParentRef?.Target` and returns the pooled weak reference when clearing.

**`src/Uno.UI/UI/Xaml/DependencyObjectStore.alc.cs`**
- The existing association-teardown path (clearing the associated parent when it belongs to an unloading collectible ALC, is an unloaded `FrameworkElement`, or is orphaned from the content roots) now dereferences `_associatedParentRef?.Target` once, applies the same collectible-ALC/`IsLoaded`/orphan checks to the target, and returns the pooled weak reference when clearing. Adds `using Uno.UI.DataBinding;`.

No public API changes; both touched members are private implementation details of `DependencyObjectStore`.

## Test plan

Red/green (to be committed with this PR — not yet in the diff): new `src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_DependencyObjectStore_InheritanceContext.cs`, following `Given_BindingMemoryLeak.cs` conventions:

1. `When_Shared_Value_Associated_Then_Consuming_Element_Is_Collected` — a strongly-held `SolidColorBrush` is set as `Background` of a `Border` created in a `[NoInlining]` helper that only returns a `WeakReference`; after a forced-GC loop the border must be collected while the brush stays alive. **Fails before** this change (the brush's store roots the border), **passes after**.
2. `When_Associated_Parent_Collected_Then_Value_Is_Single_Parent_Again` — after the first associated parent is collected, associating a new parent must keep inheritance context enabled and propagate the new parent's `DataContext`. **Fails before** (the pinned first parent forces multi-parent demotion), **passes after**.

Additional verification: in a downstream designer-style host that loads preview apps into collectible ALCs, a ClrMD heap-dump crossing analysis attributed unloaded-ALC pins to the strong `_associatedParent` path from host-lifetime brushes; with this change those root paths are gone and the collectible ALC fully unloads and collects.

## Risks / rollback

- **Allocation**: weak references are pooled via the existing `WeakReferencePool` and only created for `IMultiParentShareableDependencyObject` values with inheritance context enabled — same cost profile as the pre-existing `_mentorRef`.
- **Intentional behavior deltas** (both matching WinUI's weak inheritance-context model): (1) a collected former parent no longer triggers multi-parent demotion — the value becomes single-parent again; (2) re-associating the same live parent no longer demotes. `_associatedParent` was never used for `DataContext` propagation itself, so live-tree inheritance behavior is unchanged.
- **Rollback**: single-commit revert; no persisted state, no API surface involved.

