### PR TITLE
fix(alc): stop static Type-keyed caches pinning collectible AssemblyLoadContexts

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -478,7 +478,8 @@ namespace Microsoft.UI.Xaml.Controls
 		private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<Type, global::System.Runtime.CompilerServices.StrongBox<bool>> _hasDefaultTemplateCache = new();
 
 		private static bool ComputeHasDefaultTemplate(Type? type)
-			=> Style.GetDefaultStyleForType(type!) is Style defaultStyle
+			=> type is not null
+				&& Style.GetDefaultStyleForType(type) is Style defaultStyle
 				&& defaultStyle
 					.Flatten(s => s.BasedOn!)
 					.SelectMany(s => s.Setters)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -469,15 +469,30 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Gets whether the default style for the given type sets a non-null Template.
 		/// </summary>
-		private static Func<Type, bool> HasDefaultTemplate =
-			Funcs.CreateMemoized((Type type) =>
-				Style.GetDefaultStyleForType(type) is Style defaultStyle
-					&& defaultStyle
-						.Flatten(s => s.BasedOn!)
-						.SelectMany(s => s.Setters)
-						.OfType<Setter>()
-						.Any(s => s.Property == TemplateProperty && s.Value != null)
-			);
+		// Memoized per type, but keyed through a ConditionalWeakTable rather than a Dictionary<Type,bool>.
+		// This static, process-lifetime cache is queried with the type of every ContentControl that is
+		// measured — including control types loaded into a collectible AssemblyLoadContext (plugin/preview
+		// hosting). A strong Dictionary key would retain such a type's RuntimeType -> LoaderAllocator and
+		// pin the entire ALC for the process lifetime. Type identity is canonical, so weak-keyed
+		// memoization is equivalent for lookup while letting a collectible type be collected once unused.
+		private static readonly global::System.Runtime.CompilerServices.ConditionalWeakTable<Type, global::System.Runtime.CompilerServices.StrongBox<bool>> _hasDefaultTemplateCache = new();
+
+		private static bool ComputeHasDefaultTemplate(Type? type)
+			=> Style.GetDefaultStyleForType(type!) is Style defaultStyle
+				&& defaultStyle
+					.Flatten(s => s.BasedOn!)
+					.SelectMany(s => s.Setters)
+					.OfType<Setter>()
+					.Any(s => s.Property == TemplateProperty && s.Value != null);
+
+		// A ConditionalWeakTable key must be non-null (unlike the previous Dictionary-based memoize, which
+		// special-cased a null key). GetDefaultStyleKey() can be null, so compute directly in that case.
+		private static readonly Func<Type, bool> HasDefaultTemplate = static type =>
+			type is null
+				? ComputeHasDefaultTemplate(type)
+				: _hasDefaultTemplateCache.GetValue(
+					type,
+					static t => new global::System.Runtime.CompilerServices.StrongBox<bool>(ComputeHasDefaultTemplate(t))).Value;
 
 		/// <summary>
 		/// Creates a ContentControl which can be measured without being added to the visual tree (eg as container in virtualized lists).

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.FrameworkPropertiesForType.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.FrameworkPropertiesForType.cs
@@ -19,15 +19,18 @@ namespace Microsoft.UI.Xaml
 	{
 		private class FrameworkPropertiesForTypeDictionary
 		{
-			// This dictionary has a single static instance that is kept for the lifetime of the whole app.
-			// So we don't use pooling to not cause pool exhaustion by renting without returning.
-			private readonly HashtableEx _entries = new HashtableEx(usePooling: false);
+			// Single process-lifetime instance, keyed by owner Type through a ConditionalWeakTable (weak
+			// keys) so a collectible-ALC control type is not pinned here (Type -> RuntimeType ->
+			// LoaderAllocator). Eviction alone loses the race to the unloading app's residual DP activity;
+			// weak identity keys remove the pin structurally. Type identity is canonical, so weak-keyed
+			// lookup is equivalent to the previous strong table.
+			private readonly ConditionalWeakTable<Type, DependencyProperty[]> _entries = new();
 
 			internal bool TryGetValue(Type key, out DependencyProperty[]? result)
 			{
 				if (_entries.TryGetValue(key, out var value))
 				{
-					result = (DependencyProperty[])value!;
+					result = value;
 
 					return true;
 				}
@@ -37,25 +40,23 @@ namespace Microsoft.UI.Xaml
 			}
 
 			internal void Add(Type key, DependencyProperty[] value)
-				=> _entries.Add(key, value);
+				=> _entries.AddOrUpdate(key, value);
 
 			internal void Clear() => _entries.Clear();
 
 			/// <summary>
-			/// Removes entries whose Type key belongs to a non-default ALC.
+			/// Eagerly removes entries whose Type key belongs to a non-default ALC (weak keys also let
+			/// them be collected once the type is otherwise unreferenced).
 			/// </summary>
 			internal void RemoveNonDefaultAlcEntries()
 			{
 				var keysToRemove = new List<Type>();
-				foreach (var key in _entries.Keys)
+				foreach (var entry in _entries)
 				{
-					if (key is Type t)
+					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(entry.Key.Assembly);
+					if (alc is not null && alc != global::System.Runtime.Loader.AssemblyLoadContext.Default)
 					{
-						var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(t.Assembly);
-						if (alc is not null && alc != global::System.Runtime.Loader.AssemblyLoadContext.Default)
-						{
-							keysToRemove.Add(t);
-						}
+						keysToRemove.Add(entry.Key);
 					}
 				}
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.NameToProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.NameToProperty.cs
@@ -45,7 +45,21 @@ namespace Microsoft.UI.Xaml
 			}
 
 			internal void Add(PropertyCacheEntry key, DependencyProperty? dependencyProperty)
-				=> _entries.Add(key, dependencyProperty);
+			{
+				// Do not cache entries whose owner type is from a collectible (non-default) ALC. The key is
+				// a composite (CachedType + name), so it cannot be weak-keyed like the Type-keyed caches;
+				// caching it here would retain the type (via DependencyProperty._ownerType) and pin its
+				// ALC, and the eviction sweep loses the race to the unloading app re-populating it. Such
+				// lookups re-resolve through the (weak-keyed) registry — cheap and pin-free. Framework
+				// (default-ALC) types are cached as before.
+				var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.CachedType.Assembly);
+				if (alc is not null && alc != global::System.Runtime.Loader.AssemblyLoadContext.Default)
+				{
+					return;
+				}
+
+				_entries.Add(key, dependencyProperty);
+			}
 
 			internal void Remove(PropertyCacheEntry propertyCacheEntry)
 				=> _entries.Remove(propertyCacheEntry);

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.PropertiesRegistry.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.PropertiesRegistry.cs
@@ -22,9 +22,16 @@ namespace Microsoft.UI.Xaml
 		{
 			public static DependencyPropertyRegistry Instance { get; } = new DependencyPropertyRegistry();
 
-			// This dictionary has a single static instance that is kept for the lifetime of the whole app.
-			// So we don't use pooling to not cause pool exhaustion by renting without returning.
-			private readonly HashtableEx _entries = new HashtableEx(FastTypeComparer.Default, usePooling: false);
+			// Single process-lifetime instance. The OUTER map is keyed by owner Type through a
+			// ConditionalWeakTable (weak keys) rather than a strong HashtableEx: the owner type of a
+			// control loaded into a collectible AssemblyLoadContext (plugin / preview hosting) would
+			// otherwise be retained here (Type -> RuntimeType -> LoaderAllocator), pinning the whole ALC.
+			// The per-type eviction sweep (RemoveNonDefaultAlcEntries) cannot win the race against the
+			// unloading app's residual DP activity re-populating the entry; weak identity keys remove the
+			// pin structurally. Type identity is canonical, so weak-keyed lookup is equivalent to the
+			// previous FastTypeComparer-keyed table. Inner per-type tables (keyed by property name) stay
+			// strong HashtableEx and are collected together with their weakly-held type key.
+			private readonly ConditionalWeakTable<Type, HashtableEx> _entries = new();
 
 			private DependencyPropertyRegistry()
 			{
@@ -32,15 +39,12 @@ namespace Microsoft.UI.Xaml
 
 			internal bool TryGetValueByName(string type, string name, out DependencyProperty? result)
 			{
-				foreach (Type key in _entries.Keys)
+				foreach (var entry in _entries)
 				{
-					if (key.Name == type && TryGetTypeTable(key, out var typeTable))
+					if (entry.Key.Name == type && entry.Value.TryGetValue(name, out var propertyObject))
 					{
-						if (typeTable!.TryGetValue(name, out var propertyObject))
-						{
-							result = (DependencyProperty)propertyObject!;
-							return true;
-						}
+						result = (DependencyProperty)propertyObject!;
+						return true;
 					}
 				}
 
@@ -68,7 +72,7 @@ namespace Microsoft.UI.Xaml
 				if (!TryGetTypeTable(type, out var typeTable))
 				{
 					typeTable = new HashtableEx(usePooling: false);
-					_entries[type] = typeTable;
+					_entries.AddOrUpdate(type, typeTable);
 				}
 
 				typeTable!.Add(name, property);
@@ -91,9 +95,9 @@ namespace Microsoft.UI.Xaml
 
 			internal bool TryGetTypeTable(Type type, out HashtableEx? table)
 			{
-				if (_entries.TryGetValue(type, out var dictionaryObject))
+				if (_entries.TryGetValue(type, out var typeTable))
 				{
-					table = (HashtableEx)dictionaryObject!;
+					table = typeTable;
 					return true;
 				}
 
@@ -102,17 +106,19 @@ namespace Microsoft.UI.Xaml
 			}
 
 			/// <summary>
-			/// Removes all entries whose Type key belongs to a non-default (collectible) ALC.
+			/// Eagerly removes entries whose Type key belongs to a non-default (collectible) ALC. The
+			/// weak keys already let such entries be collected once the type is otherwise unreferenced;
+			/// this drops them promptly on ALC teardown rather than waiting for the next GC.
 			/// </summary>
 			internal void RemoveNonDefaultAlcEntries()
 			{
 				var keysToRemove = new List<Type>();
-				foreach (Type key in _entries.Keys)
+				foreach (var entry in _entries)
 				{
-					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.Assembly);
+					var alc = global::System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(entry.Key.Assembly);
 					if (alc is not null && alc != global::System.Runtime.Loader.AssemblyLoadContext.Default)
 					{
-						keysToRemove.Add(key);
+						keysToRemove.Add(entry.Key);
 					}
 				}
 

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -21,19 +21,28 @@ namespace Microsoft.UI.Xaml
 		public delegate Style StyleProviderHandler();
 
 		private readonly static Dictionary<Type, StyleProviderHandler> _lookup = new(Uno.Core.Comparison.FastTypeComparer.Default);
-		private readonly static Dictionary<Type, Style> _defaultStyleCache = new(Uno.Core.Comparison.FastTypeComparer.Default);
 		private readonly static Dictionary<Type, StyleProviderHandler> _nativeLookup = new(Uno.Core.Comparison.FastTypeComparer.Default);
-		private readonly static Dictionary<Type, Style> _nativeDefaultStyleCache = new(Uno.Core.Comparison.FastTypeComparer.Default);
+
+		// Resolved default styles are cached per type through a ConditionalWeakTable rather than a
+		// Dictionary<Type,Style>. This cache is process-lifetime and is queried during rendering with the
+		// type of every styled control — including control types from a collectible AssemblyLoadContext
+		// (plugin / preview hosting). A strong Dictionary key retains that type's RuntimeType ->
+		// LoaderAllocator and pins the whole ALC; the eviction sweep (ClearCachesForNonDefaultAlc) cannot
+		// win the race against a render that re-populates the entry after unload. Weak (identity) keys let
+		// a collectible type be collected once otherwise unreferenced, structurally removing the pin. A
+		// StrongBox wraps the value so a legitimately-null resolved style can still be cached.
+		private readonly static global::System.Runtime.CompilerServices.ConditionalWeakTable<Type, global::System.Runtime.CompilerServices.StrongBox<Style?>> _defaultStyleCache = new();
+		private readonly static global::System.Runtime.CompilerServices.ConditionalWeakTable<Type, global::System.Runtime.CompilerServices.StrongBox<Style?>> _nativeDefaultStyleCache = new();
 
 		/// <summary>
 		/// Removes entries from the style caches whose Type key belongs to a non-default ALC.
 		/// </summary>
 		internal static void ClearCachesForNonDefaultAlc()
 		{
+			// The default-style caches are ConditionalWeakTables (weak type keys) and self-clean, so only
+			// the strongly-keyed provider lookups need explicit eviction here.
 			RemoveNonDefaultAlcEntries(_lookup);
-			RemoveNonDefaultAlcEntries(_defaultStyleCache);
 			RemoveNonDefaultAlcEntries(_nativeLookup);
-			RemoveNonDefaultAlcEntries(_nativeDefaultStyleCache);
 		}
 
 		private static void RemoveNonDefaultAlcEntries<TValue>(Dictionary<Type, TValue> dictionary)
@@ -350,16 +359,18 @@ namespace Microsoft.UI.Xaml
 			var lookup = useUWPDefaultStyles ? _lookup
 				: _nativeLookup;
 
-			if (!styleCache.TryGetValue(type, out Style? style))
+			Style? style = null;
+			if (styleCache.TryGetValue(type, out var cachedBox))
 			{
-				if (lookup.TryGetValue(type, out var styleProvider))
-				{
-					style = styleProvider();
+				style = cachedBox.Value;
+			}
+			else if (lookup.TryGetValue(type, out var styleProvider))
+			{
+				style = styleProvider();
 
-					styleCache[type] = style;
+				styleCache.AddOrUpdate(type, new global::System.Runtime.CompilerServices.StrongBox<Style?>(style));
 
-					lookup.Remove(type); // The lookup won't be used again now that the style itself is cached
-				}
+				lookup.Remove(type); // The lookup won't be used again now that the style itself is cached
 			}
 
 			if (style is null && instance is Control { DefaultStyleResourceUri: { } defaultStyleResourceUri })

--- a/src/Uno.UI/UI/Xaml/UIElementGeneratedProxy.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementGeneratedProxy.cs
@@ -1,44 +1,54 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Uno.UI.Xaml;
 
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class UIElementGeneratedProxy
 {
-	private static readonly Dictionary<Type, RoutedEventFlag> _implementedRoutedEvents = new();
+	// Keyed by control Type through a ConditionalWeakTable (weak keys): a control type from a collectible
+	// AssemblyLoadContext (plugin / preview hosting) must not be pinned here (Type -> RuntimeType ->
+	// LoaderAllocator). A miss here would be misread as "implements no routed events", so the entry must
+	// still be cached (not skipped) — weak keys keep caching while letting a collectible type collect once
+	// otherwise unreferenced. StrongBox wraps the enum value (CWT values must be reference types).
+	private static readonly ConditionalWeakTable<Type, StrongBox<RoutedEventFlag>> _implementedRoutedEvents = new();
 
 	public static RoutedEventFlag RegisterImplementedRoutedEvents(Type type, RoutedEventFlag routedEventFlags)
 	{
-		lock (_implementedRoutedEvents)
-		{
-			_implementedRoutedEvents[type] = routedEventFlags;
-			return routedEventFlags;
-		}
+		_implementedRoutedEvents.AddOrUpdate(type, new StrongBox<RoutedEventFlag>(routedEventFlags));
+		return routedEventFlags;
 	}
 
-	internal static bool TryGetImplementedRoutedEvents(Type type, out RoutedEventFlag routedEventFlags) =>
-		_implementedRoutedEvents.TryGetValue(type, out routedEventFlags);
+	internal static bool TryGetImplementedRoutedEvents(Type type, out RoutedEventFlag routedEventFlags)
+	{
+		if (_implementedRoutedEvents.TryGetValue(type, out var box))
+		{
+			routedEventFlags = box.Value;
+			return true;
+		}
+
+		routedEventFlags = default;
+		return false;
+	}
 
 	internal static void ClearCachesForNonDefaultAlc()
 	{
-		lock (_implementedRoutedEvents)
+		// Weak keys self-clean; eagerly drop collectible-ALC entries on teardown too.
+		var keysToRemove = new List<Type>();
+		foreach (var entry in _implementedRoutedEvents)
 		{
-			var keysToRemove = new List<Type>();
-			foreach (var key in _implementedRoutedEvents.Keys)
+			var alc = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(entry.Key.Assembly);
+			if (alc is not null && alc != System.Runtime.Loader.AssemblyLoadContext.Default)
 			{
-				var alc = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(key.Assembly);
-				if (alc is not null && alc != System.Runtime.Loader.AssemblyLoadContext.Default)
-				{
-					keysToRemove.Add(key);
-				}
+				keysToRemove.Add(entry.Key);
 			}
+		}
 
-			foreach (var key in keysToRemove)
-			{
-				_implementedRoutedEvents.Remove(key);
-			}
+		foreach (var key in keysToRemove)
+		{
+			_implementedRoutedEvents.Remove(key);
 		}
 	}
 }


### PR DESCRIPTION
**ALC pin-fix stack — PR 2 of 4 (uno).** Base: `dev/nr/alc-weak-associated-parent`. Next: U3 (ItemsView DEBUG) stacks on this branch.

Fixes #23629

