### PR TITLE
fix(ItemsView): drop leaking DEBUG layout-invalidation diagnostics

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsView/ItemsView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsView/ItemsView.cs
@@ -1164,21 +1164,10 @@ partial class ItemsView : Control
 		}
 	}
 
-#if DEBUG
-	void OnLayoutMeasureInvalidatedDbg(
-		Layout sender,
-		object args)
-	{
-		//ITEMSVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
-	}
-
-	void OnLayoutArrangeInvalidatedDbg(
-		Layout sender,
-		object args)
-	{
-		//ITEMSVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
-	}
-#endif
+	// NOTE: the DEBUG-only OnLayoutMeasureInvalidatedDbg / OnLayoutArrangeInvalidatedDbg handlers were
+	// removed together with their leaking subscription (see OnLayoutChangedDbg below). They were empty
+	// no-ops (trace calls commented out); if the diagnostics are ever restored, re-add them and
+	// subscribe via a WEAK handler so the shared default-Style Layout cannot pin every ItemsView.
 
 	void OnCompositionTargetRendering(
 		object sender,

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsView/ItemsView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsView/ItemsView.cs
@@ -1259,14 +1259,15 @@ partial class ItemsView : Control
 		m_layoutMeasureInvalidatedDbg.Disposable = null;
 		m_layoutArrangeInvalidatedDbg.Disposable = null;
 
-		if (Layout is { } layout)
-		{
-			layout.MeasureInvalidated += OnLayoutMeasureInvalidatedDbg;
-			m_layoutMeasureInvalidatedDbg.Disposable = new DisposableAction(() => layout.MeasureInvalidated -= OnLayoutMeasureInvalidatedDbg);
-
-			layout.ArrangeInvalidated += OnLayoutArrangeInvalidatedDbg;
-			m_layoutArrangeInvalidatedDbg.Disposable = new DisposableAction(() => layout.ArrangeInvalidated -= OnLayoutArrangeInvalidatedDbg);
-		}
+		// NOTE: These diagnostics used to subscribe to the Layout's MeasureInvalidated /
+		// ArrangeInvalidated events. Because Layout is frequently a single instance shared by the
+		// control's default Style (a Setter value lives for the whole process), and the handlers are
+		// instance methods (target = this ItemsView), the shared Layout retained every ItemsView ever
+		// created for the life of the app — a real leak in Debug builds, and under collectible
+		// AssemblyLoadContexts it pinned the entire app ALC. The handlers below are empty no-ops (their
+		// trace calls are commented out), so the subscription provided no value. It is intentionally
+		// not created. If the traces are ever restored, re-subscribe via a weak handler so a shared
+		// Layout cannot keep this ItemsView alive.
 	}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -711,6 +711,15 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 						ExpandNode(resetNode);
 					}
 
+					if (IsContentMode)
+					{
+						// Uno-specific: a Reset (e.g. ItemsSource collection Clear) removes the nodes but
+						// left their item -> node mappings behind, retaining every cleared item (and, when
+						// items come from a collectible AssemblyLoadContext, pinning that ALC) for the
+						// TreeView's lifetime. Drop mappings whose node is no longer attached to the origin.
+						PruneDetachedNodesFromItemMap();
+					}
+
 					break;
 				}
 
@@ -801,6 +810,38 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 
 					break;
 				}
+		}
+	}
+
+	/// <summary>
+	/// Uno-specific: removes <see cref="m_itemToNodeMap"/> entries whose node is no longer attached to
+	/// the origin node. The WinUI-derived collection-change handling only removes mappings on
+	/// <c>ItemRemoved</c> with an expanded parent; a <c>Reset</c> (collection Clear) or a removal under a
+	/// collapsed parent leaks the mapping — and with it the item — for the TreeView's lifetime.
+	/// </summary>
+	private void PruneDetachedNodesFromItemMap()
+	{
+		List<object> keysToRemove = null;
+		foreach (var pair in m_itemToNodeMap)
+		{
+			var node = pair.Value;
+			while (node.Parent is { } parent)
+			{
+				node = parent;
+			}
+
+			if (node != m_originNode)
+			{
+				(keysToRemove ??= new List<object>()).Add(pair.Key);
+			}
+		}
+
+		if (keysToRemove is not null)
+		{
+			foreach (var key in keysToRemove)
+			{
+				m_itemToNodeMap.Remove(key);
+			}
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -824,13 +824,7 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 		List<object> keysToRemove = null;
 		foreach (var pair in m_itemToNodeMap)
 		{
-			var node = pair.Value;
-			while (node.Parent is { } parent)
-			{
-				node = parent;
-			}
-
-			if (node != m_originNode)
+			if (IsDetachedFromOrigin(pair.Value))
 			{
 				(keysToRemove ??= new List<object>()).Add(pair.Key);
 			}
@@ -843,6 +837,35 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 				m_itemToNodeMap.Remove(key);
 			}
 		}
+
+		// The selection vectors are a second retention path with the same defect: a selected node
+		// removed via Reset stays in m_selectedNodes / m_selectedItems indefinitely, keeping the node
+		// and its item alive. Prune detached selected nodes; SelectedItemsVector.RemoveAt keeps the
+		// two vectors in sync (and raises the appropriate selection-change notifications).
+		for (var i = m_selectedNodes.Count - 1; i >= 0; i--)
+		{
+			if (IsDetachedFromOrigin(m_selectedNodes[i]))
+			{
+				if (i < m_selectedItems.Count)
+				{
+					m_selectedItems.RemoveAt(i);
+				}
+				else
+				{
+					m_selectedNodes.RemoveAt(i);
+				}
+			}
+		}
+	}
+
+	private bool IsDetachedFromOrigin(TreeViewNode node)
+	{
+		while (node.Parent is { } parent)
+		{
+			node = parent;
+		}
+
+		return node != m_originNode;
 	}
 
 	private void SelectedNodeChildrenChanged(TreeViewNode sender, object args)

--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -840,22 +840,23 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 
 		// The selection vectors are a second retention path with the same defect: a selected node
 		// removed via Reset stays in m_selectedNodes / m_selectedItems indefinitely, keeping the node
-		// and its item alive. Prune detached selected nodes; SelectedItemsVector.RemoveAt keeps the
-		// two vectors in sync (and raises the appropriate selection-change notifications).
+		// and its item alive. Prune detached selected nodes the same way the ItemRemoved/Reset cases
+		// above do — via SelectedTreeNodeVector.RemoveAtCore, which keeps m_selectedItems in sync and
+		// records the unselect (TrackItemUnselected). Removing from m_selectedItems directly would
+		// bypass that tracking (RemoveAtCore then can't correlate the already-removed item), so
+		// SelectionChanged would not be raised in multi-select mode. Batch the removals inside
+		// Begin/EndSelectionChanges so a single aggregate SelectionChanged is raised.
+		BeginSelectionChanges();
 		for (var i = m_selectedNodes.Count - 1; i >= 0; i--)
 		{
-			if (IsDetachedFromOrigin(m_selectedNodes[i]))
+			var selectNode = m_selectedNodes[i];
+			if (IsDetachedFromOrigin(selectNode))
 			{
-				if (i < m_selectedItems.Count)
-				{
-					m_selectedItems.RemoveAt(i);
-				}
-				else
-				{
-					m_selectedNodes.RemoveAt(i);
-				}
+				m_selectedNodes.RemoveAtCore(i);
+				selectNode.ChildrenChanged -= SelectedNodeChildrenChanged;
 			}
 		}
+		EndSelectionChanges();
 	}
 
 	private bool IsDetachedFromOrigin(TreeViewNode node)


### PR DESCRIPTION
**ALC pin-fix stack — PR 3 of 4 (uno).** Base: `dev/nr/alc-weak-type-keyed-caches`. Next: U4 (TreeView prune) stacks on this branch.

Fixes #23631

## Spec

In Debug builds, `ItemsView.OnLayoutChangedDbg()` (`#if DEBUG`) subscribed instance-method handlers to `Layout.MeasureInvalidated` / `Layout.ArrangeInvalidated`. The default style assigns `Layout` from a `<Setter>` whose value is a single shared `<controls:StackLayout />` that lives for the whole process, so the subscription made that shared object strongly retain every `ItemsView` ever created:

- a permanent per-control leak in every Debug-built app, and
- an ALC pin for hosts that load plugin/preview apps into collectible `AssemblyLoadContext`s: the retained `ItemsView` holds `DataContext` / `ItemsSource` / template objects from the collectible ALC, so `AssemblyLoadContext.Unload()` never completes (GC-root path confirmed with ClrMD: default-style `StackLayout` → `MeasureInvalidated` invocation list → `ItemsView` → app-ALC objects).

The revokers were only disposed when `LayoutProperty` changed again — never on teardown ( `~ItemsView()` and `OnUnloaded` don't touch them, and the finalizer can't run while the rooted Layout references the control; `Unloaded` also doesn't fire when a tree is discarded wholesale). Both handlers are empty no-ops — their trace calls are commented out — so the subscription had zero diagnostic value. Removing it is strictly a leak fix with no behavior change.

## Implementation

- `src/Uno.UI/UI/Xaml/Controls/ItemsView/ItemsView.cs` (+9/−8): in the `#if DEBUG` `OnLayoutChangedDbg()`, removed the `if (Layout is { } layout)` block that subscribed `OnLayoutMeasureInvalidatedDbg` / `OnLayoutArrangeInvalidatedDbg` and created the `DisposableAction` revokers. Replaced it with a comment explaining why the subscription is intentionally not created (shared style-Setter `Layout` outlives the control; instance-method handlers retain the control; `OnUnloaded` is not a reliable teardown hook) and instructing that any future restoration of the traces must use a weak handler. The `m_layoutMeasureInvalidatedDbg.Disposable = null;` / `m_layoutArrangeInvalidatedDbg.Disposable = null;` resets are kept, as are the (now-unsubscribed) no-op handler methods, minimizing divergence from the WinUI reference source.

## Test plan

- **Red/green (existing test, no new code needed)**: `Given_FrameworkElement_And_Leak.When_Add_Remove` with the `[ActivatableDataRow(typeof(ItemsView), 15)]` row (`src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs:115`). It materializes 15 `ItemsView` instances under the default (and UWP) styles, removes them, GC-pressures for up to 30 s, and asserts every tracked `WeakReference` dies. On a **Debug**-configuration `Uno.UI` build this row fails before this change (all instances retained by the shared default-style `StackLayout`) and passes after. Note the bug is `#if DEBUG`-only, so Release legs compile it out — which is why this row was always green on Release CI.
- **ALC scenario verification**: reproduced and verified in a downstream host that loads preview apps into collectible ALCs — before the fix, ClrMD dump analysis showed the unloaded app ALC pinned via `StackLayout.MeasureInvalidated → ItemsView`; after the fix that root path is gone and the ALC weak reference collects.

## Risks / rollback

- **Risk**: effectively none — the removed handlers were empty no-ops (trace bodies commented out), so no diagnostic output is lost and no runtime behavior changes in Debug or Release. The change is confined to `#if DEBUG` code.
- **Rollback**: revert the single commit. If the layout-invalidation traces are ever wanted again, re-subscribe via a weak event handler so a shared `Layout` cannot retain the `ItemsView` (called out in the in-code comment).
