### PR TITLE
fix(TreeView): prune item-to-node map on collection Reset

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -711,6 +711,15 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 						ExpandNode(resetNode);
 					}
 
+					if (IsContentMode)
+					{
+						// Uno-specific: a Reset (e.g. ItemsSource collection Clear) removes the nodes but
+						// left their item -> node mappings behind, retaining every cleared item (and, when
+						// items come from a collectible AssemblyLoadContext, pinning that ALC) for the
+						// TreeView's lifetime. Drop mappings whose node is no longer attached to the origin.
+						PruneDetachedNodesFromItemMap();
+					}
+
 					break;
 				}
 
@@ -801,6 +810,38 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 
 					break;
 				}
+		}
+	}
+
+	/// <summary>
+	/// Uno-specific: removes <see cref="m_itemToNodeMap"/> entries whose node is no longer attached to
+	/// the origin node. The WinUI-derived collection-change handling only removes mappings on
+	/// <c>ItemRemoved</c> with an expanded parent; a <c>Reset</c> (collection Clear) or a removal under a
+	/// collapsed parent leaks the mapping — and with it the item — for the TreeView's lifetime.
+	/// </summary>
+	private void PruneDetachedNodesFromItemMap()
+	{
+		List<object> keysToRemove = null;
+		foreach (var pair in m_itemToNodeMap)
+		{
+			var node = pair.Value;
+			while (node.Parent is { } parent)
+			{
+				node = parent;
+			}
+
+			if (node != m_originNode)
+			{
+				(keysToRemove ??= new List<object>()).Add(pair.Key);
+			}
+		}
+
+		if (keysToRemove is not null)
+		{
+			foreach (var key in keysToRemove)
+			{
+				m_itemToNodeMap.Remove(key);
+			}
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -824,13 +824,7 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 		List<object> keysToRemove = null;
 		foreach (var pair in m_itemToNodeMap)
 		{
-			var node = pair.Value;
-			while (node.Parent is { } parent)
-			{
-				node = parent;
-			}
-
-			if (node != m_originNode)
+			if (IsDetachedFromOrigin(pair.Value))
 			{
 				(keysToRemove ??= new List<object>()).Add(pair.Key);
 			}
@@ -843,6 +837,35 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 				m_itemToNodeMap.Remove(key);
 			}
 		}
+
+		// The selection vectors are a second retention path with the same defect: a selected node
+		// removed via Reset stays in m_selectedNodes / m_selectedItems indefinitely, keeping the node
+		// and its item alive. Prune detached selected nodes; SelectedItemsVector.RemoveAt keeps the
+		// two vectors in sync (and raises the appropriate selection-change notifications).
+		for (var i = m_selectedNodes.Count - 1; i >= 0; i--)
+		{
+			if (IsDetachedFromOrigin(m_selectedNodes[i]))
+			{
+				if (i < m_selectedItems.Count)
+				{
+					m_selectedItems.RemoveAt(i);
+				}
+				else
+				{
+					m_selectedNodes.RemoveAt(i);
+				}
+			}
+		}
+	}
+
+	private bool IsDetachedFromOrigin(TreeViewNode node)
+	{
+		while (node.Parent is { } parent)
+		{
+			node = parent;
+		}
+
+		return node != m_originNode;
 	}
 
 	private void SelectedNodeChildrenChanged(TreeViewNode sender, object args)

--- a/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -840,22 +840,23 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 
 		// The selection vectors are a second retention path with the same defect: a selected node
 		// removed via Reset stays in m_selectedNodes / m_selectedItems indefinitely, keeping the node
-		// and its item alive. Prune detached selected nodes; SelectedItemsVector.RemoveAt keeps the
-		// two vectors in sync (and raises the appropriate selection-change notifications).
+		// and its item alive. Prune detached selected nodes the same way the ItemRemoved/Reset cases
+		// above do — via SelectedTreeNodeVector.RemoveAtCore, which keeps m_selectedItems in sync and
+		// records the unselect (TrackItemUnselected). Removing from m_selectedItems directly would
+		// bypass that tracking (RemoveAtCore then can't correlate the already-removed item), so
+		// SelectionChanged would not be raised in multi-select mode. Batch the removals inside
+		// Begin/EndSelectionChanges so a single aggregate SelectionChanged is raised.
+		BeginSelectionChanges();
 		for (var i = m_selectedNodes.Count - 1; i >= 0; i--)
 		{
-			if (IsDetachedFromOrigin(m_selectedNodes[i]))
+			var selectNode = m_selectedNodes[i];
+			if (IsDetachedFromOrigin(selectNode))
 			{
-				if (i < m_selectedItems.Count)
-				{
-					m_selectedItems.RemoveAt(i);
-				}
-				else
-				{
-					m_selectedNodes.RemoveAt(i);
-				}
+				m_selectedNodes.RemoveAtCore(i);
+				selectNode.ChildrenChanged -= SelectedNodeChildrenChanged;
 			}
 		}
+		EndSelectionChanges();
 	}
 
 	private bool IsDetachedFromOrigin(TreeViewNode node)


### PR DESCRIPTION
**ALC pin-fix stack — PR 4 of 4 (uno).** Base: `dev/nr/alc-itemsview-debug-layout-leak`. Top of the uno stack.

Fixes #23633

