### PR TITLE
fix(linux): X11NativeWebView exports GDK_BACKEND=x11

### DIFF
--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -53,6 +53,9 @@ public class X11NativeWebView : INativeWebView
 
 	private bool _dontRaiseNextNavigationCompleted;
 
+	[DllImport("libc", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+	private static extern int setenv(string name, string value, int overwrite);
+
 	[DllImport("libwebkit2gtk-4.1.so", CallingConvention = CallingConvention.Cdecl)]
 	private static extern IntPtr webkit_uri_request_get_http_headers(IntPtr request);
 
@@ -66,6 +69,15 @@ public class X11NativeWebView : INativeWebView
 	{
 		try
 		{
+			if (setenv("GDK_BACKEND", "x11", 0) != 0)
+			{
+				int errno = Marshal.GetLastWin32Error();
+				if (typeof(X11NativeWebView).Log().IsEnabled(LogLevel.Error))
+				{
+					typeof(X11NativeWebView).Log().Error($"setenv(3) failed; errno={errno}");
+				}
+			}
+
 			// webkit2gtk-4.1 adds support for exposing libsoup objects, most importantly in webkit_uri_request_get_http_headers.
 			// Gtk# by default loads libwebkit2gtk-4.0 (+ libsoup-2.0), but we want libwebkit2gtk-4.1 (+ libsoup-3.0), so what
 			// we do is that before WebKitGtk# makes its dlopen calls, we load libwebkit2gtk-4.1 and put it where the handle to


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/uno/issues/23159

Context: https://github.com/dotnet/runtime/issues/4538#issuecomment-180527782
Context: https://github.com/unoplatform/uno/blob/ffbb0c0ed47679ede7c67effaa979e7a9934ed33/doc/articles/controls/WebView.md?plain=1#L198-L206

Use of WebView2 on Linux Wayland requires that the `GDK_BACKEND` environment variable be set, lest Bad Things Happen™.

On the ignorable side, the bad things are simply messages written to stdout.  For example, build and run SamplesApp.Skia.Generic:

	dotnet build -c Release -f net10.0 src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
	LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libfreetype.so.6.20.1 \
	  dotnet src/SamplesApp/SamplesApp.Skia.Generic/bin/Release/net10.0/SamplesApp.Skia.Generic.dll

(The $LD_PRELOAD is needed to avoid [a *different* problem][0], which should get fixed by updating SkiaSharp; see #23598.)

Once SamplesApp.Skia.Generic has launched:

 1. Click the "checkbox list" icon on the top-left to show the RuntimeTests panel.
 2. In the "Enter test filter here" textbox, enter `When_ExecuteScriptAsync`.
 3. Click the ▶️ Run button

Console output will contain messages such as:

	(SamplesApp.Skia.Generic:25303): Gdk-CRITICAL **: 09:20:32.946: gdk_x11_window_get_xid: assertion 'GDK_IS_X11_WINDOW (window)' failed
	…
	fail: Uno.UI.WebView.Skia.X11.X11NativeWebView[0]
	      SetScrollingEnabled is not supported on the X11 target.
	…
	warn: Uno.WinUI.Runtime.Skia.X11.X11ApplicationHost[0]
	      X11 protocol error — ErrorCode: 3, RequestCode: X_UnmapWindow, MinorCode: 0, ResourceId: 0x0, Serial: 428

However, the tests *pass* and the app *doesn't crash*.

Enter #23159: if we build Uno.Gallery for *Native AOT* and hit the WebView2 logic, we see the same `Gdk-CRITICAL` message, *and also* these messages:

	fail: Uno.WinUI.Runtime.Skia.X11.X11NativeOverlappedPresenter[0]
	      Couldn't get OverlappedPresenterState: _NET_WM_STATE does not exist on the window. Make sure you use an EWMH-compliant WM.
	fail: Uno.WinUI.Runtime.Skia.X11.X11NativeOverlappedPresenter[0]
	      Couldn't get OverlappedPresenterState: _NET_WM_STATE does not exist on the window. Make sure you use an EWMH-compliant WM.

followed by a *hard crash*:

	(Uno.Gallery:8586): Gdk-CRITICAL **: 14:46:16.851: gdk_x11_window_get_xid: assertion 'GDK_IS_X11_WINDOW (window)' failed
	X Error of failed request:  BadWindow (invalid Window parameter)
	  Major opcode of failed request:  3 (X_GetWindowAttributes)
	  Resource id in failed request:  0x0
	  Serial number of failed request:  103
	  Current serial number in output stream:  104

The workaround for this, as documented in
`doc/articles/controls/WebView.md`, is to export the `GDK_BACKEND` environment variable to `x11`:

	export GDK_BACKEND=x11
	dotnet …

This works, but requires reading documentation (who does that?!).

The ideal fix would be to have `X11NativeWebProvider` export the environment variable during app startup.  The problem is that the "obvious" way to do this:

	Environment.SetEnvironmentVariable("GDK_BACKEND", "x11");

[*does not work*][1]

> we will not support the case where a user wants to modify the
> environment from managed code and expects to see those changes
> reflected in a native library they PInvoke to, or vice versa.

Since we *need* native code in `libgdk*` et al to see the `GDK_BACKEND` environment variable, we can't use
`Environment.SetEnvironmentVariable()` to do so.

Instead, P/Invoke into **setenv**(3).  This allows us to set the `GDK_BACKEND` environment variable on the native side, allowing `libdk*` et al to see the value we set and behave accordingly.

With this fix in place, `SamplesApp.Skia.Generic.dll` no longer produces the `Gdk-CRITICAL` or X11 protocol error messages.

[0]: https://github.com/unoplatform/uno/issues/20532#issuecomment-4244174397
[1]: https://github.com/dotnet/runtime/issues/4538#issuecomment-180527782

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
