### PR TITLE
ci(ios): trust the facebook/fb tap formula required by newer Homebrew

### DIFF
--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -1,4 +1,31 @@
 #!/bin/bash
+# ===========================================================================
+# ios-uitest-run.sh — CI (Azure DevOps) entry point that runs the SamplesApp
+# UI test suites against an iOS Simulator on a macOS hosted agent.
+#
+# What it does:
+#   1. Picks the NUnit test filter from $UITEST_SNAPSHOTS_ONLY /
+#      $UITEST_AUTOMATED_GROUP (snapshot groups, automated groups 1-5,
+#      RuntimeTests, Benchmarks).
+#   2. Waits for the target simulator runtime/device to exist and boots it.
+#   3. Installs the pre-built SamplesApp bundle on the simulator with `idb`
+#      (Meta's iOS Development Bridge, https://github.com/facebook/idb):
+#      `xcrun simctl install` was historically unreliable for this
+#      (see microsoft/appcenter#2389), idb is the dependable path.
+#   4. Runs the tests through the NUnit console, transforms the results and
+#      maintains the failed-tests re-run list for retry stages.
+#
+# Tooling / supply-chain notes (idb):
+#   - `idb-companion` comes from Meta's Homebrew tap `facebook/fb`
+#     (github.com/facebook/homebrew-fb). The formula pins the binary artifact
+#     of facebook/idb release v1.1.8 together with its sha256, so what gets
+#     installed is reproducible byte-for-byte; the tap itself has been
+#     dormant since 2022.
+#   - Newer Homebrew refuses formulas from third-party taps unless explicitly
+#     trusted (`brew trust`) — see the install section below.
+#   - `fb-idb` (the Python client) is installed from PyPI via pipx, pinned to
+#     Python 3.12 (asyncio breakage under 3.14) but not version-pinned.
+# ===========================================================================
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -169,6 +196,15 @@ then
 	# 2) Install helpers
 	brew list --versions pipx >/dev/null 2>&1 || brew install pipx
 	brew tap facebook/fb >/dev/null 2>&1 || true
+	# Newer Homebrew on the runner images gates third-party taps: installing
+	# idb-companion fails with "Refusing to load formula facebook/fb/idb-companion
+	# from untrusted tap facebook/fb" unless explicitly trusted. Trust only the
+	# formula we need (least privilege); fall back to tap-level trust for brew
+	# versions that only support that form. Older brews have no `trust` command
+	# at all — best effort, the install below still surfaces any real failure.
+	brew trust --formula facebook/fb/idb-companion >/dev/null 2>&1 \
+		|| brew trust facebook/fb >/dev/null 2>&1 \
+		|| true
 	brew list --versions idb-companion >/dev/null 2>&1 || brew install idb-companion
 
 	# 3) Install fb-idb under Python 3.12


### PR DESCRIPTION
**GitHub Issue:** no tracking issue — CI-infrastructure hotfix (all iOS UI test stages failing since the runner-image update last night).

## PR Type:

- 🏗️ Build or CI related changes

## What is the current behavior? 🤔

Every iOS UI test stage fails at the idb install step since the macOS runner images picked up a newer Homebrew that gates formulas from third-party taps behind an explicit trust step:

```
Installing idb (fb-idb + idb-companion) pinned to Python 3.12
Error: Refusing to load formula facebook/fb/idb-companion from untrusted tap facebook/fb.
Run `brew trust --formula facebook/fb/idb-companion` or `brew trust facebook/fb` to trust it.
```

No repository change is involved — the tap `facebook/homebrew-fb` has been dormant since 2022 and its `idb-companion` formula pins the sha256 of the facebook/idb v1.1.8 release artifact, so the installed binary is unchanged; only the Homebrew policy on the runners moved.

## What is the new behavior? 🚀

`build/test-scripts/ios-uitest-run.sh` trusts the required formula before installing it:

- `brew trust --formula facebook/fb/idb-companion` — least privilege: only the one formula this script installs is trusted, not the whole tap;
- falls back to `brew trust facebook/fb` for Homebrew versions that only support tap-level trust;
- no-ops (`|| true`) on older Homebrew that has no `trust` command — and if trusting genuinely fails, the `brew install idb-companion` right after still surfaces the real error.

Also adds a header comment documenting what this script does (CI entry point running the SamplesApp UI test suites on an iOS Simulator), why it uses idb (Meta's iOS Development Bridge — `xcrun simctl install` was historically unreliable, see microsoft/appcenter#2389), and the supply-chain notes for the tap (sha256-pinned artifact, dormant tap, fb-idb from PyPI not version-pinned).

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

- Single file, +36 lines, no behavioral change on runners where the older Homebrew accepts the tap as before.
- The same script is byte-identical on `release/stable/6.6`, so this commit cherry-picks cleanly there — needed to unblock in-flight PRs targeting that branch (e.g. #23638).
- Suggested follow-up (not in this PR): version-pin `pipx install fb-idb` — it is currently unpinned from PyPI, the one remaining moving part in this install block.