### PR TITLE
fix: require live-tree membership for UIElement focusability

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager_DetachedElements.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager_DetachedElements.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
+{
+	/// <summary>
+	/// WinUI parity: focus interactions with elements that are not (or no longer) in the live visual tree.
+	/// On WinUI, CUIElement::IsFocusable() requires IsActive() (element in the live tree), so Focus() on a
+	/// detached element fails and focus-candidate searches skip detached subtrees.
+	/// </summary>
+	[TestClass]
+	public class Given_FocusManager_DetachedElements
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Focus_Detached_Element_Should_Fail()
+		{
+			var okButton = new Button { Content = "OK" };
+			var dialogPanel = new StackPanel { Children = { okButton } };
+			var topBarButton = new Button { Content = "TopBar" };
+			var root = new StackPanel { Children = { topBarButton, dialogPanel } };
+
+			TestServices.WindowHelper.WindowContent = root;
+			await TestServices.WindowHelper.WaitForLoaded(root);
+
+			Assert.IsTrue(okButton.Focus(FocusState.Programmatic));
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.AreEqual(okButton, FocusManager.GetFocusedElement(root.XamlRoot));
+
+			root.Children.Remove(dialogPanel);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreNotEqual(okButton, FocusManager.GetFocusedElement(root.XamlRoot), "Focus must move off an element that left the visual tree");
+
+			var focusedAfterDetach = FocusManager.GetFocusedElement(root.XamlRoot);
+
+			var refocusResult = okButton.Focus(FocusState.Programmatic);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(refocusResult, "Focus() must fail for an element outside the live visual tree");
+			Assert.AreEqual(focusedAfterDetach, FocusManager.GetFocusedElement(root.XamlRoot), "Focused element must not change when focusing a detached element");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_FindFirstFocusableElement_On_Detached_Subtree_Should_Be_Null()
+		{
+			var okButton = new Button { Content = "OK" };
+			var dialogPanel = new StackPanel { Children = { okButton } };
+			var topBarButton = new Button { Content = "TopBar" };
+			var root = new StackPanel { Children = { topBarButton, dialogPanel } };
+
+			TestServices.WindowHelper.WindowContent = root;
+			await TestServices.WindowHelper.WaitForLoaded(root);
+
+			Assert.IsNotNull(FocusManager.FindFirstFocusableElement(dialogPanel));
+
+			root.Children.Remove(dialogPanel);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsNull(FocusManager.FindFirstFocusableElement(dialogPanel), "A detached subtree must not yield focus candidates");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Focus_Stolen_By_Detached_Element_Tab_Should_Stay_In_Cycle_Scope()
+		{
+			var okButton = new Button { Content = "OK" };
+			var cyclePanel = new StackPanel
+			{
+				TabFocusNavigation = KeyboardNavigationMode.Cycle,
+				Children = { okButton }
+			};
+			var topBarButton1 = new Button { Content = "TopBar1" };
+			var topBarButton2 = new Button { Content = "TopBar2" };
+			var strayButton = new Button { Content = "Stray" };
+			var strayPanel = new StackPanel { Children = { strayButton } };
+			var root = new StackPanel { Children = { topBarButton1, topBarButton2, strayPanel, cyclePanel } };
+
+			TestServices.WindowHelper.WindowContent = root;
+			await TestServices.WindowHelper.WaitForLoaded(root);
+
+			Assert.IsTrue(okButton.Focus(FocusState.Programmatic));
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.AreEqual(okButton, FocusManager.GetFocusedElement(root.XamlRoot));
+
+			// Simulate an app behavior (e.g. a deferred auto-focus) focusing an element
+			// of a view that has already been removed from the tree. On WinUI this is a no-op.
+			root.Children.Remove(strayPanel);
+			await TestServices.WindowHelper.WaitForIdle();
+			strayButton.Focus(FocusState.Programmatic);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(okButton, FocusManager.GetFocusedElement(root.XamlRoot), "Focus must remain on the dialog button");
+
+			await TestServices.KeyboardHelper.Tab();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// The Cycle scope contains a single focusable element, so Tab must wrap back to it.
+			Assert.AreEqual(okButton, FocusManager.GetFocusedElement(root.XamlRoot), "Tab must stay inside the TabFocusNavigation=Cycle scope");
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Documents/Hyperlink.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/Hyperlink.mux.cs
@@ -20,8 +20,10 @@ namespace Microsoft.UI.Xaml.Documents
 			var element = GetContainingFrameworkElement();
 			return
 				element != null &&
-				// Concept of IsActive is currently not present in Uno
-				//element.IsActive && IsActive &&
+#if __CROSSRUNTIME__
+				// WinUI checks element.IsActive && IsActive; the TextElement side has no Uno equivalent yet.
+				element.IsActiveOrAttachedUnderActiveAncestor() &&
+#endif
 				element is not Control { IsEnabled: false } &&
 				element.Visibility == Visibility.Visible &&
 				element.AreAllAncestorsVisible() &&

--- a/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
@@ -139,11 +139,42 @@ namespace Microsoft.UI.Xaml
 		}
 
 		internal virtual bool IsFocusable =>
-					/*IsActive() &&*/ //TODO Uno: No concept of IsActive in Uno yet.
+#if __CROSSRUNTIME__
+					// WinUI: CUIElement::IsFocusable requires IsActive() (the element is in the live tree),
+					// so focusing a detached element fails and focus-candidate searches skip detached subtrees.
+					IsActiveOrAttachedUnderActiveAncestor() &&
+#endif
 					IsVisible() &&
 					(IsEnabled() || ((this as FrameworkElement)?.AllowFocusWhenDisabled == true)) &&
 					(IsTabStop || IsFocusableForFocusEngagement()) &&
 					AreAllAncestorsVisible();
+
+#if __CROSSRUNTIME__
+		// WinUI's IsActive() equivalent for focusability. Uno's enhanced lifecycle activates freshly attached
+		// children one lifecycle step after they get a live parent (WinUI enters them synchronously during the
+		// same call), so an element attached under an active ancestor must count as active to keep same-tick
+		// focus working (e.g. ComboBox focusing its item container right when the dropdown opens).
+		internal bool IsActiveOrAttachedUnderActiveAncestor()
+		{
+			if (IsActiveInVisualTree)
+			{
+				return true;
+			}
+
+			var parent = this.GetUIElementAdjustedParentInternal(true /*public parents only*/);
+			while (parent is not null)
+			{
+				if (parent.IsActiveInVisualTree)
+				{
+					return true;
+				}
+
+				parent = parent.GetUIElementAdjustedParentInternal(true /*public parents only*/);
+			}
+
+			return false;
+		}
+#endif
 
 		internal virtual bool IsFocusableForFocusEngagement() => false;
 


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

TEMP, looking into implementing is active.

WinUI's CUIElement::IsFocusable requires IsActive() (element in the live visual tree), but Uno's port had that check commented out. This let Focus() and FindFirstFocusableElement succeed against detached elements, so a stale deferred focus call (e.g. from app code reacting to a view that already left the tree) could steal focus out of a TabFocusNavigation="Cycle" scope with no way back in.

Add IsActiveOrAttachedUnderActiveAncestor(), checked under __CROSSRUNTIME__ in UIElement.IsFocusable and Hyperlink.IsFocusable. The ancestor walk (not a bare IsActiveInVisualTree check) is required because Uno's enhanced lifecycle activates freshly attached children one tick after they get a live parent, while WinUI enters them synchronously - a bare check regresses same-tick focus scenarios like a ComboBox focusing its item container right when the dropdown opens.

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
