### PR TITLE
fix(sdk): align Linux SkiaSharp native asset on desktop

### DIFF
--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -131,3 +131,25 @@ for($i = 0; $i -lt $projects.Length; $i++)
         dotnet clean $release "$projectPath"
     }
 }
+
+# Regression guard for issue #23658: overriding SkiaSharpVersion on a desktop head must retarget
+# SkiaSharp.NativeAssets.Linux too. The base SkiaSharp package pulls its Win32/macOS native assets
+# but not the Linux one, so without the Uno.Sdk injecting it the Linux native stays at the runtime
+# packs' floor while managed SkiaSharp moves up — a silent mismatch that crashes Skia Desktop on Linux.
+if ($TestGroup -eq '1')
+{
+    $skiaAlignProject = "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj"
+    $skiaAlignVersion = "4.148.0"
+    $skiaAlignAssets = "5.6/uno56netcurrent/uno56netcurrent/obj/project.assets.json"
+
+    Write-Host "Validating SkiaSharp.NativeAssets.Linux aligns with an overridden SkiaSharpVersion ($skiaAlignVersion) - issue #23658"
+    dotnet restore $skiaAlignProject "-p:SkiaSharpVersion=$skiaAlignVersion" "-p:RestoreConfigFile=$env:NUGET_CI_CONFIG" -p:EnableWindowsTargeting=true -bl:binlogs/skiasharp-linux-alignment/restore.binlog
+    Assert-ExitCodeIsZero
+
+    $assets = Get-Content $skiaAlignAssets -Raw
+    if ($assets -notmatch [regex]::Escape("SkiaSharp.NativeAssets.Linux/$skiaAlignVersion"))
+    {
+        throw "SkiaSharp.NativeAssets.Linux did not resolve to $skiaAlignVersion to match the overridden managed SkiaSharp. The Uno.Sdk must inject the Linux native asset for desktop heads (issue #23658)."
+    }
+    Write-Host "SkiaSharp.NativeAssets.Linux correctly aligned to $skiaAlignVersion"
+}

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Desktop.targets
@@ -30,5 +30,13 @@
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Runtime.Skia.MacOS" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Runtime.Skia.Win32" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Runtime.Skia.X11" ProjectSystem="true" />
+
+		<!--
+			The managed SkiaSharp package auto-references its Win32/macOS native assets but not the Linux one,
+			which only arrives as a transitive floor from the X11 / FrameBuffer runtime packs above. Inject it
+			so overriding SkiaSharpVersion retargets the Linux native asset too; otherwise a managed SkiaSharp
+			bumped past Uno's floor keeps the old libSkiaSharp on Linux and crashes Skia Desktop at startup.
+		-->
+		<_UnoProjectSystemPackageReference Include="SkiaSharp.NativeAssets.Linux" ProjectSystem="true" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
**GitHub Issue:** closes #23658

## PR Type:

🐞 Bugfix

## What changed? 🚀

On a Skia Desktop single-project head (`net*-desktop`), overriding `<SkiaSharpVersion>` above the version the Uno.Sdk ships did **not** retarget `SkiaSharp.NativeAssets.Linux`. Managed `SkiaSharp` and the Win32/macOS native assets moved to the requested version, but the Linux native `libSkiaSharp.so` stayed at the transitive floor referenced by the `Uno.WinUI.Runtime.Skia.X11` / `Uno.WinUI.Runtime.Skia.Linux.FrameBuffer` runtime packs — a **silent** managed/native ABI mismatch that crashed Skia Desktop on Linux at startup (no build or restore diagnostic).

**Root cause:** the base `SkiaSharp` package auto-depends on `SkiaSharp.NativeAssets.Win32` and `.macOS` (in every desktop/generic TFM group, at its own version), so those self-align on a managed bump — but it has **no `SkiaSharp.NativeAssets.Linux` dependency** in any group (Linux native is opt-in). Meanwhile the Uno.Sdk only injected the Linux native asset for the legacy `*.Skia.Linux.FrameBuffer` head, never for the modern single-project desktop head. With no top-level reference to bind to, `SkiaSharpVersion` (and the documented `PackageReference Update` fallback) had nothing to retarget, so the transitive floor won.

**Fix:** inject `SkiaSharp.NativeAssets.Linux` as an implicit package for executable desktop heads — in the same `$(_IsExecutable)` item group that already pulls the X11/FrameBuffer runtime packs. Because the package is already part of the Uno.Sdk `SkiaSharp` version group, `SkiaSharpVersion` now retargets it *in one place*, making the *Using the Skia Desktop* docs' promise actually hold, and mirroring both the legacy FrameBuffer head and SkiaSharp's own Win32/macOS behavior. This also aligns the default (non-overridden) case, where the Linux native previously resolved one patch below managed.

**Validation:**

- **NuGet-resolution repro (root cause + fix mechanism):** a minimal `Uno.WinUI.Runtime.Skia.X11 6.5.237` + `SkiaSharp 4.148.0` project resolves managed + `NativeAssets.Win32` + `NativeAssets.macOS` to `4.148.0` while `NativeAssets.Linux` stays at `3.119.0`, with **no** restore warning/error. Adding a top-level `SkiaSharp.NativeAssets.Linux 4.148.0` reference — exactly what this change injects — realigns it to `4.148.0`.
- **Code review:** the injection mirrors the existing `Uno.Implicit.Packages.ProjectSystem.Legacy.targets` pattern, and `ImplicitPackagesResolver` already routes `SkiaSharpVersion` into the `SkiaSharp` group so the injected reference is emitted at the overridden version.
- The full Uno.Sdk-pack + consumer-restore end-to-end was not run in this environment (heavy Sdk packaging pipeline); happy to run it on request.

> Related latent gaps tracked for follow-up (out of scope here to keep the backport minimal): `HarfBuzzSharp.NativeAssets.Linux` shares the same floor mechanism, and the WebAssembly native asset is structurally similar (managed `SkiaSharp` has no wasm dependency).

## PR Checklist ✅

- [ ] 🧪 Added Runtime/UI tests or a manual sample — build-system (MSBuild targets) change; there is no runtime-test harness for implicit-package resolution, so it is validated via the NuGet-resolution repro above.
- [ ] 📚 Docs updated — the existing *Using the Skia Desktop* → "Upgrading to a later version of SkiaSharp" guidance becomes accurate with this fix; no doc change required.
- [x] ❗ Contains **NO** breaking changes.
