### PR TITLE
refactor: drop RenderTargetBitmap.RenderSync

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.skia.cs
@@ -84,21 +84,6 @@ namespace Microsoft.UI.Xaml.Media.Imaging
 		}
 
 		/// <summary>
-		/// Renders synchronously on the UI thread using the software rasterizer. For internal
-		/// callers that cannot yield to the dispatcher — e.g. the drag visual must be captured
-		/// within the DragStarting sequence so DragEnter/DragOver still fire synchronously right
-		/// after it, matching WinUI. Must not be called while a RenderAsync is in flight on the
-		/// same instance.
-		/// </summary>
-		internal void RenderSync(UIElement element, int scaledWidth, int scaledHeight)
-		{
-			(_bufferSize, PixelWidth, PixelHeight) = PrepareRender(element, new Size(scaledWidth, scaledHeight)) is { } render
-				? RenderSoftware(element.Visual, render)
-				: (0, 0, 0);
-			InvalidateSource();
-		}
-
-		/// <summary>
 		/// Computes the render dimensions and sizes the pixel buffer accordingly; null when the
 		/// element has nothing to render.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -969,14 +969,11 @@ namespace Microsoft.UI.Xaml
 				//		 so we provide the ActualSize to request the image to be scaled back in logical pixels.
 
 				var target = new RenderTargetBitmap();
-#if __SKIA__
-				// RenderAsync completes during a later render pass; the drag visual must instead be
-				// captured without yielding so DragStarted/DragEnter below still fire synchronously
-				// within the DragStarting sequence (matching WinUI).
-				target.RenderSync(this, (int)ActualSize.X, (int)ActualSize.Y);
-#else
-				await target.RenderAsync(this, (int)ActualSize.X, (int)ActualSize.Y);
-#endif
+				// Deliberately not awaited: on Skia the render completes during a later render pass,
+				// and yielding here would break the synchronous DragStarting → DragStarted →
+				// DragEnter/DragOver sequence (matching WinUI). The drag view redraws itself when
+				// the bitmap's pixels arrive (InvalidateSource).
+				_ = target.RenderAsync(this, (int)ActualSize.X, (int)ActualSize.Y);
 
 				routedArgs.DragUI.Content = target;
 				routedArgs.DragUI.Anchor = -ptPosition;


### PR DESCRIPTION
**GitHub Issue:** related to #23636 (follow-up to #23637)

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

Follow-up to #23637: removes the `RenderTargetBitmap.RenderSync` special case that was added to keep the drag-visual capture synchronous.

The drag visual is now captured by starting a regular `RenderAsync` **without awaiting it**: the `DragStarting` → `DragStarted` → `DragEnter`/`DragOver` sequence stays synchronous (matching WinUI), `DragUI.Content` is set immediately, and the drag view redraws itself when the bitmap's pixels arrive one render pass later (`InvalidateSource` → the `DragView`'s `Image` re-opens its source). Not awaiting is also behavior-preserving on non-Skia platforms, where `RenderAsync` completes synchronously.

Net effect:
- `RenderTargetBitmap` has a single (async) render path again — the synchronous software-only entry point is gone.
- The drag visual is hardware-accelerated on GPU-rendered windows, like every other `RenderTargetBitmap` consumer.
- The drag visual may be empty for the first frame (~one vsync) until the pixels arrive.

Validation: `Given_RenderTargetBitmap`, `Given_Border`, and the four drag-and-drop runtime tests that regressed during #23637 (`When_DragEnter_Fires_Along_DragStarting`, `When_DragOver_Fires_Along_DragEnter_Drop`, `When_DragDrop_ItemsSource_Is_Subclass_Of_ObservableCollection`, `When_UpdateLayout_In_DragDropping`) were run on Skia Desktop (Win32) against both the Vulkan renderer (via SwiftShader) and the software renderer — 35 passed / 0 failed / 2 pre-existing inconclusive on each.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — covered by existing drag-and-drop and RenderTargetBitmap runtime tests
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)