### PR TITLE
test(datepicker): Guard 2-year range year column (#23589)

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/DatePickerIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/DatePickerIntegrationTests.cs
@@ -845,6 +845,67 @@ namespace Microsoft.UI.Tests.Controls.DatePickerTests
 		}
 
 		[TestMethod]
+		// Opening and inspecting the picker flyout is unreliable on Android in CI (see When_Time_Zone, #9080).
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI | RuntimeTestPlatforms.Android)]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23589")]
+		public async Task When_Year_Range_Spans_Two_Years_Year_Should_Not_Loop()
+		{
+			// #23589: a small range (MinYear != MaxYear but too few years to fill the column) must show each
+			// year exactly once, like WinUI. Before the year column stopped looping it repeated the two years
+			// (…2026, 2025, 2026, 2025…). Use midday-UTC bounds so the local-time years are stable in every
+			// time zone, mirroring the issue's `MinYear = Now.AddYears(-1)`, `MaxYear = Now`.
+			var datePicker = await SetupDatePickerTest();
+
+			await RunOnUIThread.ExecuteAsync(() =>
+			{
+				datePicker.MinYear = new DateTimeOffset(2025, 6, 24, 12, 0, 0, TimeSpan.Zero);
+				datePicker.MaxYear = new DateTimeOffset(2026, 6, 24, 12, 0, 0, TimeSpan.Zero);
+				datePicker.SelectedDate = new DateTimeOffset(2026, 6, 24, 12, 0, 0, TimeSpan.Zero);
+			});
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await DateTimePickerHelper.OpenDateTimePicker(datePicker);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var yearTexts = new global::System.Collections.Generic.List<string>();
+			await RunOnUIThread.ExecuteAsync(() =>
+			{
+				var presenter = GetDatePickerFlyoutPresenter();
+				Assert.IsNotNull(presenter, "DatePickerFlyoutPresenter should be open");
+
+				var yearSelector = VisualTreeUtils.FindVisualChildByName(presenter, "YearLoopingSelector") as LoopingSelector;
+				Assert.IsNotNull(yearSelector, "YearLoopingSelector should be found");
+
+				var scrollViewer = VisualTreeUtils.FindVisualChildByName(yearSelector, "ScrollViewer") as ScrollViewer;
+				Assert.IsNotNull(scrollViewer, "ScrollViewer should be found");
+
+				var panel = scrollViewer.Content as LoopingSelectorPanel;
+				Assert.IsNotNull(panel, "LoopingSelectorPanel should be found");
+
+				// Count realized year items by their populated PrimaryText (recycled/offscreen shells stay
+				// as children with empty text), same approach as the multi-year test.
+				foreach (var child in panel.Children)
+				{
+					if (child is ContentControl cc && cc.Content is DatePickerFlyoutItem item && !string.IsNullOrEmpty(item.PrimaryText))
+					{
+						yearTexts.Add(item.PrimaryText);
+					}
+				}
+			});
+
+			// Exactly the two selectable years, each realized once (a looping column would realize the
+			// short list many times over, producing duplicates).
+			Assert.AreEqual(2, yearTexts.Count,
+				$"Year selector should show the two years once each, but showed: [{string.Join(", ", yearTexts)}]");
+			var distinctYears = new global::System.Collections.Generic.HashSet<string>(yearTexts);
+			Assert.AreEqual(2, distinctYears.Count,
+				$"Year selector should not repeat years, but showed: [{string.Join(", ", yearTexts)}]");
+
+			await ControlHelper.ClickFlyoutCloseButton(datePicker, false /* isAccept */);
+			await TestServices.WindowHelper.WaitForIdle();
+		}
+
+		[TestMethod]
 		[Ignore]
 		public async Task ValidateFlyoutPositioningForRightToLeftCalendar()
 		{


### PR DESCRIPTION
**GitHub Issue:** related to #23589
patches https://github.com/unoplatform/uno/pull/23544

## PR Type:

🐞 Bugfix

## What changed? 🚀

Issue #23589 reports the `DatePicker` year column looping (…2026, 2025, 2026, 2025…) when a small year range is set (`MinYear = Now.AddYears(-1)`, `MaxYear = Now`), whereas WinUI shows each year exactly once and does not loop the year column.

This is the same root cause as #23538 (the year `LoopingSelector` was created with `ShouldLoop = true`), which was already corrected to `ShouldLoop = false` in PR #23544 to match WinUI (`put_ShouldLoop(false)`). That fix is item-count independent, so it also resolves #23589's multi-year (`MinYear != MaxYear`) case — no product code change is required here.

The two tests added in #23544 covered only the single-year range (`MinYear == MaxYear`, asserts exactly one year) and a wide 31-year range (asserts the column is populated). The specific #23589 scenario — a range with **more than one year but too few to fill the viewport** — was left uncovered, and is exactly the case that would still loop if the fix were ever regressed.

This PR adds a targeted regression test, `When_Year_Range_Spans_Two_Years_Year_Should_Not_Loop`, that opens the flyout for a 2-year range and asserts the year column realizes **exactly two distinct years, each once** (no looping duplicates). Bounds use midday-UTC instants so the local-time years are stable across time zones.

Runtime-verified: passes on Skia Desktop.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
