### PR TITLE
fix(x11): set _NET_WM_PID and WM_CLIENT_MACHINE on window creation

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -521,6 +521,31 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		IntPtr deleteWindow = X11Helper.GetAtom(display, X11Helper.WM_DELETE_WINDOW);
 		_ = XLib.XSetWMProtocols(RootX11Window.Display, RootX11Window.Window, new[] { deleteWindow }, 1);
 
+		// Advertise the process owning the window. Per EWMH, _NET_WM_PID is only valid alongside
+		// WM_CLIENT_MACHINE (the hostname the pid is valid on). Desktop environments use these to
+		// tie the window to its process, e.g. KDE Plasma's task manager matches audio streams to
+		// taskbar buttons by pid, and WMs can offer to kill an unresponsive window's process.
+		_ = XLib.XChangeProperty(
+			display,
+			RootX11Window.Window,
+			X11Helper.GetAtom(display, X11Helper._NET_WM_PID),
+			X11Helper.GetAtom(display, X11Helper.XA_CARDINAL),
+			32,
+			PropertyMode.Replace,
+			new IntPtr[] { (IntPtr)Environment.ProcessId },
+			1);
+
+		var hostname = System.Text.Encoding.ASCII.GetBytes(Environment.MachineName);
+		_ = XLib.XChangeProperty(
+			display,
+			RootX11Window.Window,
+			X11Helper.GetAtom(display, X11Helper.WM_CLIENT_MACHINE),
+			X11Helper.GetAtom(display, X11Helper.XA_STRING),
+			8,
+			PropertyMode.Replace,
+			hostname,
+			hostname.Length);
+
 		lock (_x11WindowToXamlRootHostMutex)
 		{
 			_firstWindowCreated = true;

--- a/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/X11Helper.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/X11Helper.cs
@@ -67,6 +67,9 @@ internal static partial class X11Helper
 	public const string _NET_WM_ACTION_MAXIMIZE_HORZ = "_NET_WM_ACTION_MAXIMIZE_HORZ";
 	public const string _NET_WM_ACTION_MAXIMIZE_VERT = "_NET_WM_ACTION_MAXIMIZE_VERT";
 	public const string _NET_WM_ICON = "_NET_WM_ICON";
+	public const string _NET_WM_PID = "_NET_WM_PID";
+	public const string WM_CLIENT_MACHINE = "WM_CLIENT_MACHINE";
+	public const string XA_STRING = "STRING";
 	public const string _MOTIF_WM_HINTS = "_MOTIF_WM_HINTS";
 	public const string TIMESTAMP = "TIMESTAMP";
 	public const string MULTIPLE = "MULTIPLE";


### PR DESCRIPTION
**GitHub Issue:** N/A. The behavior is described below; happy to open a tracking issue if preferred.

## PR Type:

Bugfix

## What changed?

The X11 backend never advertises which process owns its windows. This PR sets `_NET_WM_PID` (together with `WM_CLIENT_MACHINE`, which EWMH requires alongside it) on the top-level window at creation time, before the WM maps the window.

**Current behavior:** desktop environments cannot tie an Uno window to its process:

- On KDE Plasma, the task manager resolves the window to an empty app id. Plasma's audio-stream matcher then pairs that empty id with any audio stream lacking a portal app id. In practice this pins speech-dispatcher's idle dummy stream onto the app's taskbar button, so every Uno X11 app shows a spurious speaker/"playing audio" icon on its taskbar entry.
- Window managers can't offer their "this window is not responding, kill the owning process?" flow, since they don't know the pid.

**With this PR:** the window carries `_NET_WM_PID` and `WM_CLIENT_MACHINE` from creation (the properties are set in `CreateWindow`, so the WM sees them when it starts managing the window). The spurious speaker icon on Plasma is gone, and pid-based WM features work.

Implementation notes:

- `WM_CLIENT_MACHINE` is set to `Environment.MachineName`; per EWMH/ICCCM, `_NET_WM_PID` is only meaningful in combination with it.
- Uses the existing `XChangeProperty` bindings (format-32 `IntPtr[]` for the CARDINAL pid, format-8 `byte[]` for the STRING hostname); only three atom-name constants were added to `X11Helper`.
- Complements the existing `SetWMClass` call: `WM_CLASS` gives the window its app identity, `_NET_WM_PID` ties it to the process.

Validated on KDE Plasma (X11): setting these same properties on the window externally (an app-side `XChangeProperty` workaround in our app) removes the phantom audio indicator. This PR makes the backend set them itself, at creation time rather than post-hoc.

## PR Checklist

- [x] Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable): manually validated on KDE Plasma/X11 (see notes above); the properties are WM-facing and not observable from inside the app, so no runtime test was added.
- [ ] Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
