### PR TITLE
feat(skia): Add flag to skip visual tree painting

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -50,6 +50,10 @@ The rendering backend for the Skia renderer can be configured per platform. On d
 
 For details, see [Vulkan Rendering Backend](xref:Uno.Skia.Vulkan).
 
+## Skipping visual tree painting (Skia)
+
+Set `Uno.UI.FeatureConfiguration.Rendering.SkipVisualTreePainting` to `true` to skip painting of the visual tree entirely, producing frames with no visual output. Frame scheduling, rendering events, composition animations and `RenderTargetBitmap` keep working as usual. This is intended for scenarios where the visual output is of no interest (e.g. automated tests) to save CPU/GPU. Default: `false`.
+
 ## ComboBox
 
 ### Default preferred placement

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -31,6 +31,8 @@ public partial class Compositor
 
 	internal bool? IsSoftwareRenderer { get; set; }
 
+	internal static bool SkipVisualTreePainting { get; set; }
+
 	internal bool IsAnimating => _runningAnimations.Count > 0;
 
 	internal void RegisterAnimation(CompositionAnimation animation, CompositionObject host)
@@ -216,7 +218,12 @@ public partial class Compositor
 #if PRINT_FRAME_TIMES
 		var start = Stopwatch.GetTimestamp();
 #endif
-		rootVisual.RenderRootVisual(canvas, null);
+		// Skip only the paint walk: animations above still tick and transitions/frame
+		// re-requests below still run, so the scene stays live without producing pixels.
+		if (!SkipVisualTreePainting)
+		{
+			rootVisual.RenderRootVisual(canvas, null);
+		}
 #if PRINT_FRAME_TIMES
 		var span = Stopwatch.GetElapsedTime(start);
 		Console.WriteLine($"Rendered frame {_frameNumber++} in {span.TotalMilliseconds}ms");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_CompositionTarget.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_CompositionTarget.cs
@@ -1,0 +1,53 @@
+#if __SKIA__
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media;
+
+[TestClass]
+public class Given_CompositionTarget
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_SkipVisualTreePainting()
+	{
+		var border = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Red) };
+
+		Assert.IsFalse(FeatureConfiguration.Rendering.SkipVisualTreePainting);
+		FeatureConfiguration.Rendering.SkipVisualTreePainting = true;
+		try
+		{
+			await UITestHelper.Load(border);
+
+			var target = (CompositionTarget)border.Visual.CompositionTarget!;
+			var frameRendered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			Action onFrameRendered = () => frameRendered.TrySetResult();
+			target.FrameRendered += onFrameRendered;
+			try
+			{
+				// A property change must still schedule and produce a (blank) frame.
+				border.Background = new SolidColorBrush(Colors.Blue);
+				await Task.WhenAny(frameRendered.Task, Task.Delay(2000));
+				Assert.IsTrue(frameRendered.Task.IsCompleted, "The rendering pipeline should keep producing frames while painting is skipped.");
+			}
+			finally
+			{
+				target.FrameRendered -= onFrameRendered;
+			}
+
+			// RenderTargetBitmap-based screenshots don't go through the frame pipeline and must still capture actual content.
+			var screenshot = await UITestHelper.ScreenShot(border);
+			ImageAssert.HasColorAt(screenshot, 50, 50, Colors.Blue, tolerance: 5);
+		}
+		finally
+		{
+			FeatureConfiguration.Rendering.SkipVisualTreePainting = false;
+		}
+	}
+}
+#endif

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1102,6 +1102,24 @@ namespace Uno.UI
 			/// If null (default) use Metal if available, otherwise fallback to Software rendering.
 			/// </summary>
 			public static bool? UseMetalOnMacOS { get; set; }
+
+			/// <summary>
+			/// When true, painting of the visual tree is skipped entirely, producing frames with no
+			/// visual output. Frame scheduling, rendering events, composition animations and
+			/// <see cref="Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"/> keep working as usual.
+			/// Intended for scenarios where the visual output is of no interest (e.g. automated tests)
+			/// to save CPU/GPU. This flag is only effective on skia targets.
+			/// </summary>
+			public static bool SkipVisualTreePainting
+			{
+#if __SKIA__
+				get => Compositor.SkipVisualTreePainting;
+				set => Compositor.SkipVisualTreePainting = value;
+#else
+				get => false;
+				set { }
+#endif
+			}
 		}
 
 		public static class ElementRefHandle


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno-private/issues/2204

## PR Type:

✨ Feature

## What changed? 🚀

Adds `Uno.UI.FeatureConfiguration.Rendering.SkipVisualTreePainting` (default `false`, Skia targets only). When enabled, each frame skips the visual tree paint walk — the expensive per-frame work of recording the whole tree into an `SKPicture` — producing frames with no visual output. This saves CPU/GPU in scenarios where the visual output is of no interest, e.g. automated/runtime test runs.

The skip is placed inside `Compositor.RenderRootVisual`, around only the paint walk, so everything else keeps running as usual:

- Composition animations still tick (`RaiseAnimationFrame`) and background transitions still expire, including `Completed` events and scoped batches.
- Frame scheduling stays alive: `CompositionTarget.Render()`/`Draw()` still execute, so `FrameRendered`, the public `CompositionTarget.Rendering` event, and render-job execution still fire (an empty picture is recorded and replayed, which is nearly free).
- `RenderTargetBitmap` is unaffected — it records its own picture directly from the visual, so screenshot-based tests still capture real content.
- Native-element clip path and z-order tracking still run (separate walk, not part of the paint walk).

Transform matrices stay correct because they are pull-based: invalidation marks them dirty at mutation time and the `TotalMatrix` getter recomputes lazily at read time, so hit-testing, `TransformToVisual`, and automation bounds don't depend on the paint walk having run. Paint caches (`_picture`, picture-collapsing counters) are consumed only by the walk itself, so toggling the flag off mid-run self-heals: everything is still dirty and the next frame repaints fully.

Since `Compositor` (in `Uno.UI.Composition`) can't reference `FeatureConfiguration` (in `Uno.UI`), the public flag delegates to an internal static under `#if __SKIA__`, mirroring the existing `EnableVisualSubtreeSkippingOptimization` pattern; on non-Skia targets it's a no-op returning `false`.

Includes a runtime test (`Given_CompositionTarget.When_SkipVisualTreePainting`, passing on Skia Desktop) verifying that with the flag on, a property change still produces a frame and a screenshot still shows actual content, plus documentation in `feature-flags.md`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
