### PR TITLE
fix: Widen members to public for WinUI API parity

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeaterScrollHost.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeaterScrollHost.cs
@@ -226,9 +226,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 		#region IScrollAnchorProvider / IRepeaterScrollingSurface
 
-		internal double HorizontalAnchorRatio { get; set; }
+		public double HorizontalAnchorRatio { get; set; }
 
-		internal double VerticalAnchorRatio { get; set; }
+		public double VerticalAnchorRatio { get; set; }
 
 		UIElement IRepeaterScrollingSurface.AnchorElement => GetAnchorElement(out _);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsSourceView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsSourceView.cs
@@ -50,7 +50,7 @@ public partial class ItemsSourceView : INotifyCollectionChanged
 	public string KeyFromIndex(int index)
 		=> KeyFromIndexCore(index);
 
-	internal int IndexOf(object item)
+	public int IndexOf(object item)
 		=> IndexOfCore(item);
 	#endregion
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/SnapPoint.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/SnapPoint.cs
@@ -611,9 +611,9 @@ public partial class RepeatedScrollSnapPoint : ScrollSnapPointBase
 
 	public double Interval { get; }
 
-	private double Start { get; }
+	public double Start { get; }
 
-	private double End { get; }
+	public double End { get; }
 
 	internal override ExpressionAnimation CreateRestingPointExpression(
 		double ignoredValue,

--- a/src/Uno.UWP/Graphics/PointInt32.cs
+++ b/src/Uno.UWP/Graphics/PointInt32.cs
@@ -5,7 +5,7 @@ namespace Windows.Graphics;
 /// </summary>
 public partial struct PointInt32
 {
-	internal PointInt32(int x, int y)
+	public PointInt32(int x, int y)
 	{
 		X = x;
 		Y = y;

--- a/src/Uno.UWP/Graphics/RectInt32.cs
+++ b/src/Uno.UWP/Graphics/RectInt32.cs
@@ -7,7 +7,7 @@ namespace Windows.Graphics;
 /// </summary>
 public partial struct RectInt32
 {
-	internal RectInt32(int x, int y, int width, int height)
+	public RectInt32(int x, int y, int width, int height)
 	{
 		X = x;
 		Y = y;

--- a/src/Uno.UWP/Graphics/SizeInt32.cs
+++ b/src/Uno.UWP/Graphics/SizeInt32.cs
@@ -7,7 +7,7 @@ namespace Windows.Graphics;
 /// </summary>
 public partial struct SizeInt32
 {
-	internal SizeInt32(int width, int height)
+	public SizeInt32(int width, int height)
 	{
 		Width = width;
 		Height = height;


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno-private#2201

## PR Type:

🐞 Bugfix

## What changed? 🚀

Some `Microsoft.UI.Xaml.*` / `Windows.*` members were declared **narrower than the WinAppSDK reference surface** — the same class of defect as #23653 (`Hyperlink.UnderlineStyleProperty` was `internal` while its CLR wrapper was `public`), which silently blocks external use (binding, `ClearValue`, styles, animations, construction, direct reads) even though the containing type is public.

The **entire Uno WinRT-facing surface** was audited (see method below); **8 genuine narrowings** were found and fixed:

**`Uno.UI` (`Microsoft.UI.Xaml.*`)**

| Member | Change |
|---|---|
| `ItemsRepeaterScrollHost.HorizontalAnchorRatio` | `internal` → `public` |
| `ItemsRepeaterScrollHost.VerticalAnchorRatio` | `internal` → `public` |
| `RepeatedScrollSnapPoint.Start` | `private` → `public` |
| `RepeatedScrollSnapPoint.End` | `private` → `public` |
| `ItemsSourceView.IndexOf(object)` | `internal` → `public` |

**`Uno.UWP` (`Windows.Graphics.*`)**

| Member | Change |
|---|---|
| `PointInt32(int, int)` ctor | `internal` → `public` |
| `RectInt32(int, int, int, int)` ctor | `internal` → `public` |
| `SizeInt32(int, int)` ctor | `internal` → `public` |

In every case the sibling members were already public (`Offset`/`Interval` on `RepeatedScrollSnapPoint`; `GetAt`/`IndexFromKey`/`KeyFromIndex` on `ItemsSourceView`; the public `X`/`Y`/`Width`/`Height` fields on the `*Int32` structs), so these were accidental narrowings. `new PointInt32(x, y)` / `new SizeInt32(w, h)` are the idiomatic forms used throughout the `AppWindow` / windowing APIs and now compile against Uno as they do against WinAppSDK.

### How they were found

The whole public/protected surface of `Uno.UI`, `Uno.UWP`, `Uno.Foundation`, `Uno.UI.Composition` and `Uno.UI.Dispatching` was diffed against the **WinAppSDK 2.1 reference assemblies** (`Microsoft.WinUI.dll`, `Microsoft.Windows.SDK.NET.dll`, `Microsoft.InteractiveExperiences` + `Microsoft.Windows.*` projections — the same set the sync generator references), reflected via `MetadataLoadContext`. Every member Uno declares narrower than the reference exposes was flagged, then verified against the WinUI **IDL** / MS Learn. This generalizes the recurring #23653 shape to all member kinds (fields, properties, events, methods, constructors) across every WinRT-facing assembly.

`Uno.Foundation` and `Uno.UI.Dispatching` were **clean** (zero findings). All remaining flagged constructors were investigated and **ruled out as WinRT projection artifacts** — the projected `Foo(DerivedComposed)` composability constructor on unsealed base types (`Visual`, `CompositionBrush`, `AppWindowPresenter`, `InfoBar*EventArgs`, …) and abstract-base constructors, which match only by parameter count and are not real developer API — and left untouched.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests — n/a: these are **accessibility-only** changes with no runtime behavior; correctness was validated by re-diffing each rebuilt Uno assembly against the reference (all eight resolved, no regressions).
- [x] 📚 Docs — n/a (no API behavior change).
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a (no visual change).
- [x] ❗ Contains **NO** breaking changes — widening accessibility is additive and source/binary compatible.
- [ ] 👀 Reviewed 2 other open pull requests
