### PR TITLE
fix(theming): re-expose ResourceDictionary theme-scope API

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Theme_Materialization.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Theme_Materialization.cs
@@ -1043,9 +1043,12 @@ public class Given_Theme_Materialization
 	[TestMethod]
 	public void When_Phase4_Global_Theme_Stack_Removed_Guard()
 	{
-		// tests.md §B: Phase 4 deleted the process-global requested-theme stack and the band-aid push API.
-		// This reflection guard fails if PushRequestedThemeForSubTree (or the _requestedThemeForSubTree stack)
-		// is reintroduced — preventing a regression back to global-ambient theme selection. Sibling/context
+		// tests.md §B: Phase 4 deleted the process-global requested-theme stack and the internal band-aid
+		// push API. This reflection guard fails if the internal PushRequestedThemeForSubTree feeder (or the
+		// Themes._requestedThemeForSubTree stack) is reintroduced — preventing a regression back to
+		// global-ambient theme selection. The public PushRequestedThemeForSubTreeByName is intentionally
+		// kept: it is the sanctioned owner-less scope over the core requested-theme-for-subtree slot for
+		// external markup packages, not the removed global stack (see ResourceDictionary). Sibling/context
 		// isolation without the stack is covered by Given_ElementTheme's "Context Isolation" tests; non-FE
 		// owner theming by When_ThemeResource_On_NonFE_DependencyObject_*.
 		const BindingFlags allStatic = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
@@ -1053,14 +1056,72 @@ public class Given_Theme_Materialization
 
 		var resourceDictionary = typeof(ResourceDictionary);
 		Assert.IsNull(resourceDictionary.GetMethod("PushRequestedThemeForSubTree", allStatic),
-			"ResourceDictionary.PushRequestedThemeForSubTree must not be reintroduced (Phase 4 removed the global theme stack).");
-		Assert.IsNull(resourceDictionary.GetMethod("PushRequestedThemeForSubTreeByName", allStatic),
-			"ResourceDictionary.PushRequestedThemeForSubTreeByName must not be reintroduced.");
+			"ResourceDictionary.PushRequestedThemeForSubTree (internal band-aid feeder) must not be reintroduced.");
 
 		var themes = resourceDictionary.GetNestedType("Themes", BindingFlags.NonPublic);
 		Assert.IsNotNull(themes, "ResourceDictionary.Themes should still exist (it holds the app-level Active theme).");
 		Assert.IsNull(themes.GetField("_requestedThemeForSubTree", allMembers),
 			"Themes._requestedThemeForSubTree stack must not be reintroduced.");
+	}
+
+	// ---- Public by-name theme scope bridge (Uno.Extensions.Markup / C# Markup contract) ----
+
+	[TestMethod]
+	// Native (non-enhanced-lifecycle) targets do not read the core requested-theme-for-subtree slot, so the
+	// bridge is a balanced no-op there; the resolution-outcome assertions only hold on enhanced targets.
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid | RuntimeTestPlatforms.NativeIOS)]
+	public async Task When_PushRequestedThemeForSubTreeByName_Scopes_Resolution()
+	{
+		// Contract for external markup packages (Uno.Extensions.Markup / C# Markup): a balanced
+		// Push/PopRequestedThemeForSubTreeByName scopes {ThemeResource} resolution to the named base theme
+		// for an owner-less lookup, and nests LIFO. The theming rewrite (uno#23416) removed this public API;
+		// this guards the re-exposed bridge over the core requested-theme-for-subtree slot.
+		using var _ = ThemeHelper.UseSystemThemeOverride(ApplicationTheme.Light);
+		await WindowHelper.WaitForIdle();
+
+		var dict = (ResourceDictionary)XamlReader.Load(
+			"""
+			<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+				<ResourceDictionary.ThemeDictionaries>
+					<ResourceDictionary x:Key="Light">
+						<SolidColorBrush x:Key="SentinelBrush" Color="#FF111111" />
+					</ResourceDictionary>
+					<ResourceDictionary x:Key="Dark">
+						<SolidColorBrush x:Key="SentinelBrush" Color="#FFEEEEEE" />
+					</ResourceDictionary>
+				</ResourceDictionary.ThemeDictionaries>
+			</ResourceDictionary>
+			""");
+
+		static Color? Sentinel(ResourceDictionary d)
+			=> d.TryGetValue("SentinelBrush", out var v) && v is SolidColorBrush b ? (Color?)b.Color : null;
+
+		Assert.AreEqual(LightSentinel, Sentinel(dict), "Baseline (no scope) resolves the app Light theme.");
+
+		ResourceDictionary.PushRequestedThemeForSubTreeByName("Dark");
+		try
+		{
+			Assert.AreEqual(DarkSentinel, Sentinel(dict), "A Dark scope selects the Dark sub-dictionary.");
+
+			ResourceDictionary.PushRequestedThemeForSubTreeByName("Light");
+			try
+			{
+				Assert.AreEqual(LightSentinel, Sentinel(dict), "A nested Light scope selects Light.");
+			}
+			finally
+			{
+				ResourceDictionary.PopRequestedThemeForSubTreeByName();
+			}
+
+			Assert.AreEqual(DarkSentinel, Sentinel(dict), "Popping the nested scope restores the outer Dark scope.");
+		}
+		finally
+		{
+			ResourceDictionary.PopRequestedThemeForSubTreeByName();
+		}
+
+		Assert.AreEqual(LightSentinel, Sentinel(dict), "Popping the last scope restores the app Light theme.");
 	}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -1295,6 +1295,56 @@ namespace Microsoft.UI.Xaml
 
 		internal static object GetStaticResourceAliasPassthrough(string resourceKey, XamlParseContext parseContext) => new StaticResourceAliasRedirect(resourceKey, parseContext);
 
+		// Per-thread stack of active by-name scopes, so a Pop disposes the scope opened by its matching
+		// Push. LIFO and thread-local: the paired calls are balanced within a single synchronous resolution.
+		[ThreadStatic]
+		private static Stack<Uno.UI.Xaml.Core.CoreServices.RequestedThemeForSubTreeScope> _byNameThemeScopes;
+
+		/// <summary>
+		/// Scopes {ThemeResource} resolution to the named base theme ("Light"/"Dark") until the matching
+		/// <see cref="PopRequestedThemeForSubTreeByName"/>. Infrastructure entry point for external markup
+		/// packages (e.g. Uno.Extensions.Markup) that resolve theme resources with no owning element; not
+		/// intended for application code.
+		/// </summary>
+		/// <remarks>
+		/// Routes to the core requested-theme-for-subtree slot that the resolution leaf reads
+		/// (GetActiveTheme → CoreServices.GetRequestedThemeForSubTree), the same single slot WinUI's
+		/// CCoreServices::LookupThemeResource(theme, key) scopes. This is not the removed process-global
+		/// Themes stack — it is an owner-less scope over the core slot. On targets without the core slot
+		/// (native, or before a CoreServices instance exists) it is a balanced no-op.
+		/// </remarks>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void PushRequestedThemeForSubTreeByName(string theme)
+		{
+			var scopes = _byNameThemeScopes ??= new();
+			scopes.Push(
+				Uno.UI.Xaml.Core.CoreServices.HasInstance
+					? Uno.UI.Xaml.Core.CoreServices.Instance.ScopeRequestedThemeForSubTree(ThemeFromSubTreeName(theme))
+					: default);
+		}
+
+		/// <summary>
+		/// Restores the theme scoped by the matching <see cref="PushRequestedThemeForSubTreeByName"/>.
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void PopRequestedThemeForSubTreeByName()
+		{
+			if (_byNameThemeScopes is { Count: > 0 } scopes)
+			{
+				scopes.Pop().Dispose();
+			}
+		}
+
+		// The core slot carries only the base Light/Dark theme (high contrast is composed separately at the
+		// resolution leaf). "Default" (a request with no specific base theme) and any other name map to None,
+		// so resolution falls back to the app/OS base theme — matching how WinUI resolves a Default request.
+		private static Theme ThemeFromSubTreeName(string theme) => theme switch
+		{
+			"Light" => Theme.Light,
+			"Dark" => Theme.Dark,
+			_ => Theme.None,
+		};
+
 		// The single theme read of the resolution leaf: every theme sub-dictionary selection
 		// (GetActiveThemeDictionary, lazy materialization) keys on this ambient.
 #if UNO_HAS_ENHANCED_LIFECYCLE


### PR DESCRIPTION
**GitHub Issue:** unoplatform/uno.csharpmarkup#886

<!-- Cross-repo: the failing canary and issue live in unoplatform/uno.csharpmarkup; the fix belongs here in unoplatform/uno. GitHub does not auto-close across repos, so the linked issue is closed manually once the dev feed rebuilds green. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

The WinUI-theming rewrite (#23416, commit `d9ac0bc`) removed the public API `ResourceDictionary.PushRequestedThemeForSubTreeByName` / `PopRequestedThemeForSubTreeByName`. The external **Uno.Extensions.Markup** (C# Markup) package calls these from `ThemeBindingProvider` (`#if !WINDOWS`), so its **C# Markup Canary** build has failed against the Uno **dev feed** every day since 2026-06-19 (`CS0117`). Shipping **6.6.x is unaffected** — the rewrite was not backported to `release/stable/6.6`, which still carries the old API.

This restores the two public methods, but instead of resurrecting the process-global theme stack the rewrite deliberately deleted, it routes them to the rewrite's **kept** core requested-theme-for-subtree slot:

- `PushRequestedThemeForSubTreeByName` / `PopRequestedThemeForSubTreeByName` are re-added as `public static` `[EditorBrowsable(Never)]` on `ResourceDictionary`, bridging paired Push/Pop to `CoreServices.ScopeRequestedThemeForSubTree` via a `[ThreadStatic]` LIFO scope stack.
- `GetActiveTheme()` already reads that core slot on enhanced-lifecycle targets (Skia/WASM), so C# Markup's owner-less `{ThemeResource}` lookups resolve under the scoped theme. On native targets without the slot, the pair is a **balanced no-op** (native UI is maintenance-only; behaviour there already changed with the merged rewrite, nothing newly broken).
- Theme-name mapping: `"Light"`/`"Dark"` → theme; `"Default"` and any other name → `None` (app/OS base theme), matching how WinUI resolves a `Default` request.
- The Phase-4 leak-guard (`When_Phase4_Global_Theme_Stack_Removed_Guard`) is reconciled: it still forbids the internal band-aid feeder and the `Themes._requestedThemeForSubTree` stack, while permitting the sanctioned public bridge.

No C# Markup change is required — merging this and letting the dev feed rebuild turns the canary green.

**Validation**
- New fail-before/pass-after runtime test `When_PushRequestedThemeForSubTreeByName_Scopes_Resolution` (scoped Dark/Light resolution + LIFO nesting + restore).
- `Uno.UI.Skia` and `SamplesApp.Skia.Generic` (Release) build with 0 warnings / 0 errors.
- 2/2 theming runtime tests pass on Skia Desktop.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the documentation template (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uQu4HgPkKwZcodsBhsRC4
