### PR TITLE
ci: Skip native runtime tests on PRs

### DIFF
--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -116,7 +116,8 @@ stages:
 
 - stage: wasm_tests
   displayName: Tests - WebAssembly Native
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeWasm'], 'true')))
+  # Native targets are maintenance-only: native runtime tests run on branch builds (master/feature) only, never on PRs.
+  condition: and(succeededOrFailed(), ne(variables['Build.Reason'], 'PullRequest'))
   dependsOn:
     - Setup
 
@@ -140,7 +141,8 @@ stages:
 
 - stage: android_tests
   displayName: Tests - Android Native
-  condition: and(succeededOrFailed(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(stageDependencies.Setup.outputs['DetermineScope.SetScope.RequireNativeAndroid'], 'true')))
+  # Native targets are maintenance-only: native runtime tests run on branch builds (master/feature) only, never on PRs.
+  condition: and(succeededOrFailed(), ne(variables['Build.Reason'], 'PullRequest'))
   dependsOn:
     - Setup
 


### PR DESCRIPTION
**GitHub Issue:** N/A — CI configuration change (no associated issue)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Native targets are maintenance-only, so their runtime-test stages no longer run on pull requests — they now run **only on branch builds (master/feature merges)**.

In `build/ci/.azure-devops-stages.yml`, the two affected stage conditions changed from *"not a PR **or** the diff touched native files"* to *"not a PR"*:

| Stage | Before (on a PR) | After (on a PR) |
|-------|------------------|-----------------|
| `wasm_tests` (WebAssembly Native) | ran when a `.wasm.cs` file changed | **never runs** |
| `android_tests` (Android Native) | ran when a `.android.cs`/netcoremobile file changed | **never runs** |
| `ios_tests` (iOS Native) | already `condition: false` | unchanged (still off) |

The **Skia** runtime-test stages (the primary development target) continue to run on every PR — this change only affects the native stages. This trims PR CI time and cost while keeping full native coverage on master/feature builds.

Note: the `determine-test-scope.ps1` `RequireNative*` scope variables are intentionally left in place (they no longer gate the native stages on PRs); a follow-up can remove the now-dead determination if desired.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — _N/A, CI-only change_
- [ ] 📚 Docs have been added/updated — _N/A_
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — _N/A_
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
