### PR TITLE
refactor(binding)!: Remove no-op Clear/RestoreBindings (BC49)

### DIFF
--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -98,7 +98,7 @@ _Danger 2. Cross-target but low blast radius: delete always-on/off flags (inline
 - [ ] **BC33** — Remove `UseInvalidate(Measure/Arrange)Path` flags  `d2·M`
   - Hard-delete both flags; inline the always-true dirty-path branch.
   - Files: `src/Uno.UI/FeatureConfiguration.cs`, `src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs`, `src/Uno.UI/UI/Xaml/UIElement.skia.cs`
-- [ ] **BC49** — Remove empty `RestoreBindings`/`ClearBindings`  `d2·S` · #13046
+- [x] **BC49** — Remove empty `RestoreBindings`/`ClearBindings`  `d2·S` · #13046
   - Hard-delete.
   - Files: `src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs`, `src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs`, `src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/FrameworkElementUIKitMixinGenerator.cs`
 - [ ] **BC70** — Remove no-op `AdjustArrange`  `d2·S` · #14478

--- a/src/Uno.UI/UI/Xaml/DependencyObject.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.cs
@@ -78,20 +78,6 @@ namespace Microsoft.UI.Xaml
 		// the __Store getter via __InitializeBinder().
 		private protected void InitializeBinder() { }
 
-		/// <summary>
-		/// Obsolete method kept for binary compatibility
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public void ClearBindings() => __Store.ClearBindings();
-
-		/// <summary>
-		/// Obsolete method kept for binary compatibility
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public void RestoreBindings() => __Store.RestoreBindings();
-
 		ManagedWeakReference IWeakReferenceProvider.WeakReference
 			=> _selfWeakReference ??= WeakReferencePool.RentSelfWeakReference(this);
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -204,34 +204,6 @@ namespace Microsoft.UI.Xaml
 		internal DependencyProperty? DataContextProperty => _dataContextProperty;
 
 		/// <summary>
-		/// Restores the bindings that may have been cleared by <see cref="ClearBindings()"/>.
-		/// </summary>
-		/// <remarks>
-		/// Calling this method will specifically restore <see cref="UI.Xaml.Data.Binding.ElementName"/>
-		/// and <see cref="UI.Xaml.Data.Binding.Source"/> bindings, which are not restored as part of the
-		/// normal <see cref="DataContext"/> change flow.
-		/// </remarks>
-		public void RestoreBindings()
-		{
-
-		}
-
-		/// <summary>
-		/// Clears the bindings for the current binder.
-		/// </summary>
-		/// <remarks>
-		/// This method is used as an out-of-band replacement for setting the DataContext to null, which
-		/// in the case of two-way bindings, would send the fallback value if it has been set.
-		/// This method may also clear <see cref="UI.Xaml.Data.Binding.ElementName"/>
-		/// and <see cref="UI.Xaml.Data.Binding.Source"/> bindings, which need to be restored
-		/// using the <see cref="RestoreBindings()"/> method.
-		/// </remarks>
-		public void ClearBindings()
-		{
-
-		}
-
-		/// <summary>
 		/// Suspends the processing the <see cref="DataContext"/> until <see cref="ResumeBindings"/> is called.
 		/// </summary>
 		public void SuspendBindings()


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/uno-private/issues/2125

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

> ⚠️ Contains a **breaking change** (`refactor!`) — removes public API. See the breaking-changes section below.

## What changed? 🚀

Implements **BC49** from breaking-changes Phase 3 (#8339, tracked publicly as #13046): removes the empty no-op `RestoreBindings()` / `ClearBindings()` methods that were surfaced on every `DependencyObject`.

- Deletes the empty `DependencyObjectStore.ClearBindings()` / `RestoreBindings()` methods from `DependencyObjectStore.Binder.cs`.
- Stops `DependencyObjectGenerator` emitting the matching public `[EditorBrowsable(Never)]` wrappers on every `DependencyObject`. They existed only "for binary compatibility" and merely forwarded to the now-deleted store methods.
- Updates the `DependencyObjectGenerator` golden test to match the regenerated output.
- Registers the removal in `build/PackageDiffIgnore.xml` (6.5 set) with a regex over every declaring type, since the wrappers were generated per-type.

The native `SyncBinder` caller that once used `ClearBindings()` is already gone with the native-rendering drop, and a repo-wide search finds no other callers.

**On default settings runtime behavior is unchanged** — both methods had empty bodies, so nothing observable happened even when they were (rarely) called.

## PR Checklist ✅

- [x] 🧪 `Given_DependencyObjectGenerator` generator tests pass (2/2) — the golden reflects the regenerated output exactly.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

### Breaking changes & migration

- **`ClearBindings()` / `RestoreBindings()` (BC49):** the public no-op `ClearBindings()` / `RestoreBindings()` methods emitted on every `DependencyObject` are removed. Both were empty `[EditorBrowsable(Never)]` shims kept only for binary compatibility. This is a binary break, and a source break only for the rare consumer that explicitly called these do-nothing methods. Migration: remove the call — it never did anything.

### Validation evidence

- **Runtime (unit tests):** `Given_DependencyObjectGenerator` — 2 passed / 0 failed (validates the generator change and the golden byte-for-byte).
- **Compile:** `Uno.UI.Skia` (net10.0) builds clean — 0 warnings, 0 errors — regenerating every `DependencyObject` mixin without the wrappers.
- **Not validated locally (CI-gated):** native heads (iOS/Android) were not built locally; the change is in shared code and a repo-wide grep found zero remaining references to the removed identifiers. The `PackageDiff` allow-list runs CI-only.
