### PR TITLE
refactor(animation)!: Remove ColorKeyFrameCollection shadows (BC67)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2538,6 +2538,8 @@
 		  <Member fullName="System\.Boolean .+(::|\.)IsStoreInitialized\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
 		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyObject .+(::|\.)TemplatedParent\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
 		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)TemplatedParentProperty\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <!-- ColorKeyFrameCollection carried a binary-compat 'new'-shadow block (Size/Count/IsReadOnly/indexer) that its zero-shadow siblings Double/ObjectKeyFrameCollection never had; the get-only base DependencyObjectCollection<T> members show through with identical behavior. Accessor methods are paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.ColorKeyFrameCollection(::|\.)(Size|Count|IsReadOnly|Item)\(.*\)" reason="Removed ColorKeyFrameCollection binary-compat shadow members; provided by base DependencyObjectCollection&lt;T&gt; (BC67, breaking changes for 7.0)" isRegex="true" />
 	  </Properties>
 
 	  <Methods>
@@ -2950,6 +2952,9 @@
 
 		  <!-- Interop helper whose only purpose was marshalling IJSObject arguments; removed with the IJSObject mechanism. -->
 		  <Member fullName="System.String Uno.Foundation.WebAssemblyRuntime.InvokeJSWithInterop(System.FormattableString formattable)" reason="Removed legacy WASM IJSObject DOM-interop API (BC02, breaking changes for 7.0)" />
+
+		  <!-- ColorKeyFrameCollection shadow-block accessors/methods (paired with the <Properties> entry above); base DependencyObjectCollection<T> still satisfies IList<ColorKeyFrame>. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.ColorKeyFrameCollection(::|\.)(get_Size|GetEnumerator|Add|Clear|Contains|CopyTo|Remove|get_Count|set_Count|get_IsReadOnly|set_IsReadOnly|IndexOf|Insert|RemoveAt|get_Item|set_Item)\(.*\)" reason="Removed ColorKeyFrameCollection binary-compat shadow members; provided by base DependencyObjectCollection&lt;T&gt; (BC67, breaking changes for 7.0)" isRegex="true" />
 	  </Methods>
 
 	  <Events>

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -54,7 +54,7 @@ _Danger 1. The safe vanguard: deletions scoped to native targets being dropped, 
 - [ ] **BC35** — Remove `IgnoreINPCSameReferences` flag  `d1·S`
   - Hard-delete the flag; inline the always-taken branch.
   - Files: `src/Uno.UI/FeatureConfiguration.cs`, `src/Uno.UI/DataBinding/BindingPath.BindingItem.cs`
-- [ ] **BC67** — Remove `ColorKeyFrameCollection` throwing shadow setters  `d1·S`
+- [x] **BC67** — Remove `ColorKeyFrameCollection` throwing shadow setters  `d1·S`
   - Delete the entire `new`-shadow back-compat block to match `DoubleKeyFrameCollection`/`ObjectKeyFrameCollection`.
   - Files: `src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs`, `src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs`, `src/Uno.UI/UI/Xaml/Media/Animation/DoubleKeyFrameCollection.cs`
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Microsoft.UI.Xaml.Media.Animation
 {
@@ -7,45 +6,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
 	{
 		public ColorKeyFrameCollection() : base(null, false)
 		{
-		}
-
-		// Following members are for binary backward compatibility. They can be safely remove in an eventual "breaking" new version.
-		public new uint Size => base.Size;
-
-		public new IEnumerator<ColorKeyFrame> GetEnumerator() => base.GetEnumerator();
-
-		public new void Add(ColorKeyFrame item) => base.Add(item);
-
-		public new void Clear() => base.Clear();
-
-		public new bool Contains(ColorKeyFrame item) => base.Contains(item);
-
-		public new void CopyTo(ColorKeyFrame[] array, int arrayIndex) => base.CopyTo(array, arrayIndex);
-
-		public new bool Remove(ColorKeyFrame item) => base.Remove(item);
-
-		public new int Count
-		{
-			get => base.Count;
-			set => throw new NotSupportedException();
-		}
-
-		public new bool IsReadOnly
-		{
-			get => base.IsReadOnly;
-			set => throw new NotSupportedException();
-		}
-
-		public new int IndexOf(ColorKeyFrame item) => base.IndexOf(item);
-
-		public new void Insert(int index, ColorKeyFrame item) => base.Insert(index, item);
-
-		public new void RemoveAt(int index) => base.RemoveAt(index);
-
-		public new ColorKeyFrame this[int index]
-		{
-			get => base[index];
-			set => base[index] = value;
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/uno-private/issues/2125

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

> ⚠️ Contains a **breaking change** (`refactor!`) — removes public API. See the breaking-changes section below.

## What changed? 🚀

Implements **BC67** from breaking-changes Phase 3 (#8339): removes the binary-compatibility `new`-shadow block from `ColorKeyFrameCollection`.

- Deletes the whole `new`-shadow member block (`Size`, `GetEnumerator`, `Add`, `Clear`, `Contains`, `CopyTo`, `Remove`, `Count`, `IsReadOnly`, `IndexOf`, `Insert`, `RemoveAt`, indexer) from `ColorKeyFrameCollection.cs`. The `Count` / `IsReadOnly` setters only threw `NotSupportedException`; the rest merely forwarded to the base.
- The get-only base `DependencyObjectCollection<ColorKeyFrame>` members now show through with identical behavior and still satisfy `IList<ColorKeyFrame>` — matching the zero-shadow sibling collections `DoubleKeyFrameCollection` / `ObjectKeyFrameCollection`.
- Registers the removed members in `build/PackageDiffIgnore.xml` (6.5 set), in both `<Properties>` and `<Methods>` (the diff tool reports the shadowed declared members even though the base provides them — see the existing "indexer provided by base class" entries).

The file's own comment marked this block as removable "in an eventual breaking new version"; the only in-repo user (`ColorAnimationUsingKeyFrames`) constructs/casts the type and never calls the shadowed setters.

**On default settings runtime behavior is unchanged** — reads go to the identical base members; only the throw-only setters and the redundant forwarders are gone.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

### Breaking changes & migration

- **`ColorKeyFrameCollection` shadow members (BC67):** the type's `new`-shadow members are removed. This is a binary break; the members remain source-compatible for any realistic consumer because the identical base `DependencyObjectCollection<ColorKeyFrame>` members show through. The only observable prior difference — the `Count` / `IsReadOnly` setters throwing `NotSupportedException` — is gone: those become the get-only base properties (a compile error to assign, as on the sibling collections). Migration: none for normal use.

### Validation evidence

- **Compile:** `Uno.UI.Skia` (net10.0) builds clean — 0 warnings, 0 errors — confirming the base satisfies `IList<ColorKeyFrame>` without the shadows.
- **Code review:** the sole in-repo user (`ColorAnimationUsingKeyFrames`) only constructs/casts the type; a repo-wide search finds no caller of the removed setters.
- **Not validated locally (CI-gated):** native heads (iOS/Android) were not built locally; the change is in shared code with no platform guards. The `PackageDiff` allow-list runs CI-only.
