### PR TITLE
refactor(layout)!: Remove no-op AdjustArrange (BC70)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2956,6 +2956,9 @@
 
 		  <!-- ColorKeyFrameCollection shadow-block accessors/methods (paired with the <Properties> entry above); base DependencyObjectCollection<T> still satisfies IList<ColorKeyFrame>. -->
 		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.ColorKeyFrameCollection(::|\.)(get_Size|GetEnumerator|Add|Clear|Contains|CopyTo|Remove|get_Count|set_Count|get_IsReadOnly|set_IsReadOnly|IndexOf|Insert|RemoveAt|get_Item|set_Item)\(.*\)" reason="Removed ColorKeyFrameCollection binary-compat shadow members; provided by base DependencyObjectCollection&lt;T&gt; (BC67, breaking changes for 7.0)" isRegex="true" />
+
+		  <!-- No-op AdjustArrange(Size) (always returned its input) declared on the internal IFrameworkElement; publicly surfaced only as this implicit implementation on FrameworkElement. The lone caller in the legacy Layouter path is inlined. -->
+		  <Member fullName="Windows.Foundation.Size Microsoft.UI.Xaml.FrameworkElement.AdjustArrange(Windows.Foundation.Size finalSize)" reason="Removed no-op AdjustArrange (BC70, breaking changes for 7.0)" />
 	  </Methods>
 
 	  <Events>

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -101,7 +101,7 @@ _Danger 2. Cross-target but low blast radius: delete always-on/off flags (inline
 - [x] **BC49** — Remove empty `RestoreBindings`/`ClearBindings`  `d2·S` · #13046
   - Hard-delete.
   - Files: `src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs`, `src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs`, `src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/FrameworkElementUIKitMixinGenerator.cs`
-- [ ] **BC70** — Remove no-op `AdjustArrange`  `d2·S` · #14478
+- [x] **BC70** — Remove no-op `AdjustArrange`  `d2·S` · #14478
   - Hard-delete.
   - Files: `src/Uno.UI/UI/Xaml/IFrameworkElement.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.Interface.skia.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.Interface.reference.cs`
 - [x] **BC72** — Delete `Uno.UWP` `Vector2Extensions`  `d2·S`

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
@@ -111,8 +111,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		public event SizeChangedEventHandler SizeChanged { add { } remove { } }
 #endif
 
-		public Size AdjustArrange(Size finalSize) => finalSize;
-
 		public void ApplyBindingPhase(int phase) { }
 
 		public void CreationComplete() { }

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -712,9 +712,6 @@ namespace Microsoft.UI.Xaml.Controls
 				// Calculate Create layoutFrame and apply child's margins
 				var layoutFrame = new Rect(x, y, width, height).DeflateBy(childMargin);
 
-				// Give opportunity to element to alter arranged size
-				layoutFrame.Size = frameworkElement.AdjustArrange(layoutFrame.Size);
-
 				// Calculate clipped frame.
 				var clippedFrameWithParentOrigin =
 					layoutFrame

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.reference.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.reference.cs
@@ -59,11 +59,6 @@ namespace Microsoft.UI.Xaml
 			throw new NotImplementedException();
 		}
 
-		public Size AdjustArrange(Size finalSize)
-		{
-			return finalSize;
-		}
-
 		public object FindName(string name)
 			=> IFrameworkElementHelper.FindName(this, this, name);
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.skia.cs
@@ -57,11 +57,6 @@ namespace Microsoft.UI.Xaml
 		{
 		}
 
-		public Size AdjustArrange(Size finalSize)
-		{
-			return finalSize;
-		}
-
 		[NotImplemented]
 		public int? RenderPhase
 		{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
@@ -76,8 +76,6 @@ namespace Microsoft.UI.Xaml
 
 		Uri BaseUri { get; }
 
-		_Size AdjustArrange(_Size finalSize);
-
 		int? RenderPhase { get; set; }
 
 		void ApplyBindingPhase(int phase);


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/uno-private/issues/2125

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

> ⚠️ Contains a **breaking change** (`refactor!`) — removes public API. See the breaking-changes section below.

## What changed? 🚀

Implements **BC70** from breaking-changes Phase 3 (#8339, tracked publicly as #14478): removes the no-op `AdjustArrange(Size)` member.

- Deletes the `AdjustArrange` declaration from the internal `IFrameworkElement` interface and both implementations (`FrameworkElement.Interface.skia.cs`, `FrameworkElement.Interface.reference.cs`), each of which just returned its input.
- Inlines the sole call site in the legacy `Layouter` arrange path (a no-op assignment `layoutFrame.Size = frameworkElement.AdjustArrange(layoutFrame.Size)`).
- Drops the `AdjustArrange` stub from the `NativeViewIFrameworkElement` test double.
- Registers the publicly-surfaced `FrameworkElement.AdjustArrange` in `build/PackageDiffIgnore.xml` (6.5 set).

The companion `AdjustArrangePartial` hook (which had zero implementations) and the native mixin emitters that once exposed a `public virtual AdjustArrange` on the native heads are already gone with the native-rendering drop, leaving only the pieces removed here.

**On default settings runtime behavior is unchanged** — `AdjustArrange` always returned its input unchanged, so inlining the call is behavior-preserving on every target.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

### Breaking changes & migration

- **`AdjustArrange(Size)` (BC70):** declared on the internal `IFrameworkElement`, it was publicly surfaced only as the implicit `FrameworkElement.AdjustArrange(Size)` implementation. That public method is removed (binary break). It was a pure no-op that always returned its input, so there is no behavioral replacement. Migration: none — the only theoretical break was a native-iOS subclass calling/overriding the public-virtual member, and that native target is being dropped this major version.

### Validation evidence

- **Compile:** `Uno.UI.Skia` + `Uno.UI.Reference` + `Uno.UI.RuntimeTests.Skia` (net10.0) all build clean — 0 warnings, 0 errors.
- **Code review:** `AdjustArrange` is a no-op on every implementation, so inlining the call site is behavior-preserving; a repo-wide grep finds zero remaining references to the identifier.
- **Not validated locally (CI-gated):** native heads (iOS/Android) were not built locally; the native `AdjustArrange` implementation came from mixin generators that no longer exist, so this removes an interface member whose native impl source is already gone. The `PackageDiff` allow-list runs CI-only.
