### PR TITLE
refactor(input)!: Remove PointerPoint op_Explicit shim (BC43)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2938,6 +2938,9 @@
 		  <Member fullName="System\.Void .+(::|\.)RestoreBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
 		  <Member fullName="System\.Void .+(::|\.)ResumeBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
 		  <Member fullName="System\.Void .+(::|\.)SuspendBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+
+		  <!-- op_Explicit binary-compat shim on PointerPoint; hand-emitted only to keep old binaries linking after the explicit-to-implicit conversion change. The implicit operators remain. -->
+		  <Member fullName="Windows.UI.Input.PointerPoint Microsoft.UI.Input.PointerPoint.op_Explicit(Microsoft.UI.Input.PointerPoint muxPointerPoint)" reason="Removed op_Explicit binary-compat shim on Microsoft.UI.Input.PointerPoint (BC43, breaking changes for 7.0)" />
 	  </Methods>
 
 	  <Events>

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -110,7 +110,7 @@ _Danger 2. Cross-target but low blast radius: delete always-on/off flags (inline
 - [ ] **BC07** — Remove redundant bootstrapper meta-packages ⚠️  `d2·M` · PR #17788
   - **Verify** not already removed, then hard-delete the meta-packages.
   - Files: `build/Uno.UI.Build.csproj`, `build/nuget/Uno.WinUI.Skia.X11.nuspec`, `build/nuget/Uno.WinUI.Skia.MacOS.nuspec`
-- [ ] **BC43** — Remove `PointerPoint.op_Explicit` shim  `d2·S`
+- [x] **BC43** — Remove `PointerPoint.op_Explicit` shim  `d2·S`
   - Hard-delete.
   - Files: `src/Uno.UI/UI/Input/WinRT/PointerPoint.cs`, `src/Uno.ReferenceImplComparer/Program.cs`
 - [ ] **BC18** — Remove `UseLegacyHitTest` flag  `d2·S`

--- a/src/Uno.UI/UI/Input/WinRT/PointerPoint.cs
+++ b/src/Uno.UI/UI/Input/WinRT/PointerPoint.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
@@ -56,15 +55,6 @@ namespace Windows.UI.Input
 
 			Properties = new PointerPointProperties(point.Properties);
 		}
-
-		// Historically, we had explicit conversion only.
-		// In the work for InteractionTracker, we needed an implicit conversion to avoid a breaking change.
-		// The compiler doesn't allow to define both. (https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0557)
-		// And changing the explicit conversion operator to implicit conversion operator is a binary breaking change.
-		// We manually add this method to avoid this binary breaking change.
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static global::Windows.UI.Input.PointerPoint op_Explicit(Microsoft.UI.Input.PointerPoint muxPointerPoint)
-			=> muxPointerPoint;
 
 		public static implicit operator global::Windows.UI.Input.PointerPoint(Microsoft.UI.Input.PointerPoint muxPointerPoint)
 		{


### PR DESCRIPTION
**GitHub Issue:** unoplatform/uno-private#2125

## PR Type:

💬 Other... — breaking change (binary-compat shim removal), part of the Uno 7.0 breaking-changes epic.

## What changed? 🚀

Removes the hand-emitted `op_Explicit` binary-compatibility shim on `Microsoft.UI.Input.PointerPoint` (BC43), leaving only the implicit conversion operators:

- Deletes the `public static PointerPoint op_Explicit(PointerPoint)` method in `src/Uno.UI/UI/Input/WinRT/PointerPoint.cs`. It was a manually-declared static method (name-matching the C# explicit-conversion operator) that existed **solely** to keep the historical `op_Explicit` IL symbol alive after the conversion was switched from explicit to implicit during the InteractionTracker work. C# forbids declaring both implicit and explicit conversions between the same two types ([CS0557](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0557)), so the raw method was hand-emitted next to the implicit operator and hidden with `[EditorBrowsable(Never)]`.
- `build/PackageDiffIgnore.xml` records the removed public member under the `6.5` baseline so the API-diff gate accepts the intentional binary break.
- Marks BC43 done in the rollup checklist (`specs/050-breaking-changes-rollup/spec.md`).

**No behavioral change:** the two `implicit operator` conversions between MUX and WUX `PointerPoint` remain. Uno-internal explicit-cast call sites (e.g. `PointerRoutedEventArgs`) already bind to the implicit operator, and there are no in-repo callers of the literal `op_Explicit` method (the only other reference is a generic `op_Implicit`/`op_Explicit` name check in `Uno.ReferenceImplComparer`, which needs no change).

**Validation:** `Uno.UI.Skia` (net10.0) builds clean (0 warnings, 0 errors). The package-diff gate itself only runs in CI against the released baseline; the ignore entry was format-verified against the tool's `SignatureExtensions.ToSignature` and the existing entries.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, removal of an unused, hidden binary-compat shim with no behavioral surface.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, binary-only break with no source migration action (see below); already covered by the migration guide's blanket "recompile every library against 7.0" guidance.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Breaking change — impact & migration path

**Impact:** Pure binary-compatibility break, **not** a source break. The only thing affected is a third-party binary compiled against an older Uno that emitted an IL `call` to the literal `op_Explicit` method — it would throw `MissingMethodException` at runtime. That symbol was `[EditorBrowsable(Never)]` and depending on it directly is extremely rare (practically near-zero real-world impact). C# source that casts a MUX `PointerPoint` to a WUX `PointerPoint` — whether via explicit-cast syntax or implicitly — still compiles unchanged through the implicit operator.

**Migration:** Recompile against 7.0. No source changes required. Binary compatibility is expected to break at a major version anyway.
