### PR TITLE
fix(devserver): sync RemoteControl port for the launched project (MCP app-rename disconnect)

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
@@ -122,6 +122,16 @@ public class CsprojUserGeneratorTests
 	}
 
 	[TestMethod]
+	public void SetCsprojUserPortForProject_WithNonExistentCsproj_DoesNotCreateUserFile()
+	{
+		var csproj = Path.Combine(_tempRoot, "Ghost", "Ghost.csproj");
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(csproj, 62483);
+
+		File.Exists(csproj + ".user").Should().BeFalse();
+	}
+
+	[TestMethod]
 	public void TryGetConfiguredPort_WhenNoUserFile_ReturnsFalse()
 	{
 		var csproj = CreateProjectFile();

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RemoteControl.Host.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Helpers;
+
+[TestClass]
+public class CsprojUserGeneratorTests
+{
+	private string _tempRoot = string.Empty;
+
+	[TestInitialize]
+	public void Setup()
+	{
+		_tempRoot = Path.Combine(Path.GetTempPath(), "uno-csprojuser-tests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempRoot);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(_tempRoot))
+			{
+				Directory.Delete(_tempRoot, recursive: true);
+			}
+		}
+		catch
+		{
+			// Best-effort cleanup; a leaked temp dir must never fail a test.
+		}
+	}
+
+	private string CreateProjectFile(string name = "App")
+	{
+		var projectDir = Path.Combine(_tempRoot, name);
+		Directory.CreateDirectory(projectDir);
+		var csproj = Path.Combine(projectDir, name + ".csproj");
+		File.WriteAllText(csproj, "<Project Sdk=\"Uno.Sdk\" />");
+		return csproj;
+	}
+
+	[TestMethod]
+	public void SetCsprojUserPortForProject_WhenNoUserFile_CreatesItWithPort()
+	{
+		var csproj = CreateProjectFile();
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(csproj, 62483);
+
+		var userFile = csproj + ".user";
+		File.Exists(userFile).Should().BeTrue();
+		// The DevServer marks tooling-assigned ports with a trailing '#'.
+		File.ReadAllText(userFile).Should().Contain("<UnoRemoteControlPort>62483#</UnoRemoteControlPort>");
+	}
+
+	[TestMethod]
+	public void SetCsprojUserPortForProject_WhenUserFileExists_UpdatesPort()
+	{
+		var csproj = CreateProjectFile();
+		var userFile = csproj + ".user";
+		File.WriteAllText(userFile,
+			"""
+			<?xml version="1.0" encoding="utf-8"?>
+			<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+			  <PropertyGroup>
+			    <UnoRemoteControlPort>14300</UnoRemoteControlPort>
+			  </PropertyGroup>
+			</Project>
+			""");
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(csproj, 62483);
+
+		var updated = File.ReadAllText(userFile);
+		updated.Should().Contain("62483#");
+		updated.Should().NotContain("14300");
+	}
+
+	[TestMethod]
+	public void SetCsprojUserPortForProject_AcceptsUserPathDirectly()
+	{
+		var csproj = CreateProjectFile();
+		var userFile = csproj + ".user";
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(userFile, 55000);
+
+		File.Exists(userFile).Should().BeTrue();
+		File.ReadAllText(userFile).Should().Contain("55000#");
+	}
+
+	[TestMethod]
+	public void SetCsprojUserPortForProject_WithInvalidPort_Throws()
+	{
+		var csproj = CreateProjectFile();
+
+		var act = () => CsprojUserGenerator.SetCsprojUserPortForProject(csproj, 0);
+
+		act.Should().Throw<ArgumentOutOfRangeException>();
+	}
+
+	[TestMethod]
+	public void SetCsprojUserPortForProject_WithSolutionPath_DoesNothing()
+	{
+		var sln = Path.Combine(_tempRoot, "App.sln");
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(sln, 62483);
+
+		File.Exists(sln + ".user").Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void TryGetConfiguredPort_WhenNoUserFile_ReturnsFalse()
+	{
+		var csproj = CreateProjectFile();
+
+		var found = CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port);
+
+		found.Should().BeFalse();
+		port.Should().Be(0);
+	}
+
+	[TestMethod]
+	public void TryGetConfiguredPort_StripsTrailingHashMarker()
+	{
+		var csproj = CreateProjectFile();
+		CsprojUserGenerator.SetCsprojUserPortForProject(csproj, 62483);
+
+		var found = CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port);
+
+		found.Should().BeTrue();
+		port.Should().Be(62483);
+	}
+
+	[TestMethod]
+	public void TryGetConfiguredPort_ReadsPlainPortWithoutMarker()
+	{
+		var csproj = CreateProjectFile();
+		var userFile = csproj + ".user";
+		File.WriteAllText(userFile,
+			"""
+			<?xml version="1.0" encoding="utf-8"?>
+			<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+			  <PropertyGroup>
+			    <UnoRemoteControlPort>14300</UnoRemoteControlPort>
+			  </PropertyGroup>
+			</Project>
+			""");
+
+		var found = CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port);
+
+		found.Should().BeTrue();
+		port.Should().Be(14300);
+	}
+
+	[TestMethod]
+	public async Task SetCsprojUserPortForPath_WithProjectFile_WritesProjectUser()
+	{
+		var csproj = CreateProjectFile();
+
+		await CsprojUserGenerator.SetCsprojUserPortForPath(csproj, 62483);
+
+		File.Exists(csproj + ".user").Should().BeTrue();
+	}
+
+	[TestMethod]
+	public async Task SetCsprojUserPortForPath_WithDirectoryContainingProject_WritesProjectUser()
+	{
+		var csproj = CreateProjectFile();
+		var projectDir = Path.GetDirectoryName(csproj)!;
+
+		await CsprojUserGenerator.SetCsprojUserPortForPath(projectDir, 62483);
+
+		File.Exists(csproj + ".user").Should().BeTrue();
+		CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port).Should().BeTrue();
+		port.Should().Be(62483);
+	}
+
+	[TestMethod]
+	public void SetThenReadRoundTrips()
+	{
+		var csproj = CreateProjectFile("SomethingApp");
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(csproj, 51717);
+
+		CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port).Should().BeTrue();
+		port.Should().Be(51717);
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
@@ -43,6 +43,17 @@ public class CsprojUserGeneratorTests
 		return csproj;
 	}
 
+	private static void WriteUserFileWithPort(string csproj, string rawPortValue)
+		=> File.WriteAllText(csproj + ".user",
+			$"""
+			<?xml version="1.0" encoding="utf-8"?>
+			<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+			  <PropertyGroup>
+			    <UnoRemoteControlPort>{rawPortValue}</UnoRemoteControlPort>
+			  </PropertyGroup>
+			</Project>
+			""");
+
 	[TestMethod]
 	public void SetCsprojUserPortForProject_WhenNoUserFile_CreatesItWithPort()
 	{
@@ -186,5 +197,33 @@ public class CsprojUserGeneratorTests
 
 		CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port).Should().BeTrue();
 		port.Should().Be(51717);
+	}
+
+	[TestMethod]
+	[DataRow("0")]
+	[DataRow("-1")]
+	[DataRow("99999")]
+	[DataRow("not-a-number")]
+	public void TryGetConfiguredPort_WithInvalidOrOutOfRangeValue_ReturnsFalse(string rawPortValue)
+	{
+		var csproj = CreateProjectFile();
+		WriteUserFileWithPort(csproj, rawPortValue);
+
+		var found = CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port);
+
+		found.Should().BeFalse();
+		port.Should().Be(0);
+	}
+
+	[TestMethod]
+	public void TryGetConfiguredPort_TrimsWhitespaceAroundMarker()
+	{
+		var csproj = CreateProjectFile();
+		WriteUserFileWithPort(csproj, "62483 #");
+
+		var found = CsprojUserGenerator.TryGetConfiguredPort(csproj, out var port);
+
+		found.Should().BeTrue();
+		port.Should().Be(62483);
 	}
 }

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/CsprojUserGeneratorTests.cs
@@ -132,6 +132,27 @@ public class CsprojUserGeneratorTests
 	}
 
 	[TestMethod]
+	public void SetCsprojUserPortForProject_WithNonProjectUserPath_IsIgnored()
+	{
+		// The contract is .csproj/.csproj.user only; unrelated MSBuild user files must never be touched.
+		// Not created when absent...
+		var missing = Path.Combine(_tempRoot, "App.sln.user");
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(missing, 62483);
+
+		File.Exists(missing).Should().BeFalse();
+
+		// ...and not modified when it already exists.
+		var existing = Path.Combine(_tempRoot, "Other.sln.user");
+		const string original = "<Project />";
+		File.WriteAllText(existing, original);
+
+		CsprojUserGenerator.SetCsprojUserPortForProject(existing, 62483);
+
+		File.ReadAllText(existing).Should().Be(original);
+	}
+
+	[TestMethod]
 	public void TryGetConfiguredPort_WhenNoUserFile_ReturnsFalse()
 	{
 		var csproj = CreateProjectFile();

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -103,9 +103,11 @@ public static class CsprojUserGenerator
 	/// </summary>
 	/// <remarks>
 	/// This is the resilient entry point for tooling (e.g. the MCP <c>uno_app_start</c> flow) that only knows the
-	/// project being launched, not necessarily its solution. It guarantees the launched project's embedded
-	/// <c>UnoRemoteControlPort</c> can be made to match the running DevServer even across renames or multi-solution
-	/// workspaces, where solution-based synchronization alone silently misses the project.
+	/// project being launched, not necessarily its solution. For the strongest guarantee across renames or
+	/// multi-solution workspaces — where solution-based synchronization alone silently misses the project — pass the
+	/// launched project's <c>.csproj</c> path directly, which syncs exactly that project. When a directory is supplied
+	/// and it contains one or more solutions, only the projects referenced by those solutions are updated; a launched
+	/// project that none of them reference would still be missed, so prefer passing its project path in that case.
 	/// </remarks>
 	/// <param name="path">A solution file, a project file, or a directory containing either.</param>
 	/// <param name="port">The port number to assign. Must be between 1 and 65535.</param>

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -125,9 +125,25 @@ public static class CsprojUserGenerator
 
 		if (Directory.Exists(path))
 		{
-			var solutions = Directory.EnumerateFiles(path, "*.sln")
-				.Concat(Directory.EnumerateFiles(path, "*.slnx"))
-				.ToList();
+			List<string> solutions;
+			List<string> projects;
+			try
+			{
+				solutions = Directory.EnumerateFiles(path, "*.sln")
+					.Concat(Directory.EnumerateFiles(path, "*.slnx"))
+					.ToList();
+
+				// Only look for projects when the directory has no solution to drive the sync.
+				projects = solutions.Count > 0
+					? new List<string>()
+					: Directory.EnumerateFiles(path, "*.csproj").ToList();
+			}
+			catch (Exception ex) when (ex is UnauthorizedAccessException or DirectoryNotFoundException or IOException)
+			{
+				// Best effort: a directory we cannot enumerate (access denied, IO error, or removed mid-scan) must
+				// not crash this public tooling API and abort the DevServer flow. Mirrors SolutionFileFinder.
+				return;
+			}
 
 			if (solutions.Count > 0)
 			{
@@ -139,7 +155,7 @@ public static class CsprojUserGenerator
 				return;
 			}
 
-			foreach (var project in Directory.EnumerateFiles(path, "*.csproj"))
+			foreach (var project in projects)
 			{
 				SetCsprojUserPortForProject(project, port);
 			}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -59,6 +59,160 @@ public static class CsprojUserGenerator
 		GenerateCsprojUserOrRetrievePortWhenAvailable(unique, port);
 	}
 
+	/// <summary>
+	/// Sets the Uno Remote Control port for a single project's <c>.csproj.user</c> file, creating the file if it does
+	/// not yet exist. Unlike <see cref="SetCsprojUserPort(string, int)"/>, this does not require the project to be part
+	/// of a solution — which makes it safe to call for a freshly created or renamed project whose owning solution may
+	/// not yet reference it (a common cause of the running app failing to connect back to the DevServer).
+	/// </summary>
+	/// <param name="projectPath">Full path to the project's <c>.csproj</c> (or its <c>.csproj.user</c>) file.</param>
+	/// <param name="port">The port number to assign. Must be between 1 and 65535.</param>
+	public static void SetCsprojUserPortForProject(string projectPath, int port)
+	{
+		if (string.IsNullOrWhiteSpace(projectPath))
+		{
+			return;
+		}
+
+		if (port is <= 0 or > ushort.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(port), port, "Port must be between 1 and 65535.");
+		}
+
+		var csprojUserPath = ResolveCsprojUserPath(projectPath);
+		if (csprojUserPath is null)
+		{
+			return; // Not a project file we know how to handle (e.g. a solution was passed by mistake).
+		}
+
+		GenerateCsprojUserOrRetrievePortWhenAvailable(new[] { csprojUserPath }, port);
+	}
+
+	/// <summary>
+	/// Sets the Uno Remote Control port for whatever the supplied path points at: a solution (.sln/.slnx) updates every
+	/// referenced project, a project (.csproj) updates that project only, and a directory updates the solutions it
+	/// contains — or, failing that, the projects it contains. Anything else is ignored.
+	/// </summary>
+	/// <remarks>
+	/// This is the resilient entry point for tooling (e.g. the MCP <c>uno_app_start</c> flow) that only knows the
+	/// project being launched, not necessarily its solution. It guarantees the launched project's embedded
+	/// <c>UnoRemoteControlPort</c> can be made to match the running DevServer even across renames or multi-solution
+	/// workspaces, where solution-based synchronization alone silently misses the project.
+	/// </remarks>
+	/// <param name="path">A solution file, a project file, or a directory containing either.</param>
+	/// <param name="port">The port number to assign. Must be between 1 and 65535.</param>
+	public static async Task SetCsprojUserPortForPath(string path, int port)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			return;
+		}
+
+		if (Directory.Exists(path))
+		{
+			var solutions = Directory.EnumerateFiles(path, "*.sln")
+				.Concat(Directory.EnumerateFiles(path, "*.slnx"))
+				.ToList();
+
+			if (solutions.Count > 0)
+			{
+				foreach (var solution in solutions)
+				{
+					await SetCsprojUserPort(solution, port);
+				}
+
+				return;
+			}
+
+			foreach (var project in Directory.EnumerateFiles(path, "*.csproj"))
+			{
+				SetCsprojUserPortForProject(project, port);
+			}
+
+			return;
+		}
+
+		var extension = Path.GetExtension(path);
+		if (string.Equals(extension, ".sln", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(extension, ".slnx", StringComparison.OrdinalIgnoreCase))
+		{
+			await SetCsprojUserPort(path, port);
+		}
+		else if (string.Equals(extension, ".csproj", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(extension, ".user", StringComparison.OrdinalIgnoreCase))
+		{
+			SetCsprojUserPortForProject(path, port);
+		}
+	}
+
+	/// <summary>
+	/// Reads the Uno Remote Control port currently configured in a project's <c>.csproj.user</c> file, if any.
+	/// Intended for fail-fast validation before launch: a caller can compare the returned value against the running
+	/// DevServer port and surface a clear error instead of letting the app connect to a dead port and time out.
+	/// </summary>
+	/// <param name="projectPath">Full path to the project's <c>.csproj</c> (or its <c>.csproj.user</c>) file.</param>
+	/// <param name="port">When this method returns <see langword="true"/>, the configured port; otherwise 0.</param>
+	/// <returns><see langword="true"/> if a valid port was found; otherwise <see langword="false"/>.</returns>
+	public static bool TryGetConfiguredPort(string projectPath, out int port)
+	{
+		port = 0;
+
+		if (string.IsNullOrWhiteSpace(projectPath))
+		{
+			return false;
+		}
+
+		var csprojUserPath = ResolveCsprojUserPath(projectPath);
+		if (csprojUserPath is null || !File.Exists(csprojUserPath))
+		{
+			return false;
+		}
+
+		try
+		{
+			var document = XDocument.Load(csprojUserPath);
+			var ns = document.Root?.GetDefaultNamespace() ?? XNamespace.None;
+
+			var value = document.Root?
+				.Elements(ns + "PropertyGroup")
+				.Elements(ns + "UnoRemoteControlPort")
+				.FirstOrDefault()?.Value;
+
+			if (string.IsNullOrWhiteSpace(value))
+			{
+				return false;
+			}
+
+			// The DevServer marks tooling-assigned ports with a trailing '#'; strip it before parsing.
+			value = value.TrimEnd('#').Trim();
+
+			return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out port);
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Maps a project path to its <c>.csproj.user</c> counterpart, or returns <see langword="null"/> when the path is
+	/// not a project file (e.g. a solution was supplied by mistake).
+	/// </summary>
+	private static string? ResolveCsprojUserPath(string projectPath)
+	{
+		if (projectPath.EndsWith(".user", StringComparison.OrdinalIgnoreCase))
+		{
+			return projectPath;
+		}
+
+		if (projectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+		{
+			return projectPath + ".user";
+		}
+
+		return null;
+	}
+
 	private static async Task<List<string>> GetCsprojUserPathsFromSolutionAsync(string solutionPath)
 	{
 		var result = new List<string>();

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -188,10 +188,18 @@ public static class CsprojUserGenerator
 				return false;
 			}
 
-			// The DevServer marks tooling-assigned ports with a trailing '#'; strip it before parsing.
-			value = value.TrimEnd('#').Trim();
+			// The DevServer marks tooling-assigned ports with a trailing '#'. Trim surrounding whitespace first so the
+			// marker is stripped even when the value is written as e.g. "62483 #", then trim again for a clean parse.
+			value = value.Trim().TrimEnd('#').Trim();
 
-			return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out port);
+			if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+				&& parsed is > 0 and <= ushort.MaxValue)
+			{
+				port = parsed;
+				return true;
+			}
+
+			return false;
 		}
 		catch
 		{

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -108,6 +108,11 @@ public static class CsprojUserGenerator
 			return;
 		}
 
+		if (port is <= 0 or > ushort.MaxValue)
+		{
+			throw new ArgumentOutOfRangeException(nameof(port), port, "Port must be between 1 and 65535.");
+		}
+
 		if (Directory.Exists(path))
 		{
 			var solutions = Directory.EnumerateFiles(path, "*.sln")

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -85,6 +85,14 @@ public static class CsprojUserGenerator
 			return; // Not a project file we know how to handle (e.g. a solution was passed by mistake).
 		}
 
+		// Mirror SetCsprojUserPort's existence check: do not materialize a .csproj.user for a .csproj that does not
+		// exist (typo / stale path), which would otherwise leave stray user files behind. A directly supplied .user
+		// path is still honored, since creating it on demand is the whole point for a freshly launched project.
+		if (projectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) && !File.Exists(projectPath))
+		{
+			return;
+		}
+
 		GenerateCsprojUserOrRetrievePortWhenAvailable(new[] { csprojUserPath }, port);
 	}
 

--- a/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/CsprojUserGenerator.cs
@@ -170,7 +170,7 @@ public static class CsprojUserGenerator
 			await SetCsprojUserPort(path, port);
 		}
 		else if (string.Equals(extension, ".csproj", StringComparison.OrdinalIgnoreCase)
-			|| string.Equals(extension, ".user", StringComparison.OrdinalIgnoreCase))
+			|| path.EndsWith(".csproj.user", StringComparison.OrdinalIgnoreCase))
 		{
 			SetCsprojUserPortForProject(path, port);
 		}
@@ -239,7 +239,9 @@ public static class CsprojUserGenerator
 	/// </summary>
 	private static string? ResolveCsprojUserPath(string projectPath)
 	{
-		if (projectPath.EndsWith(".user", StringComparison.OrdinalIgnoreCase))
+		// Only the .csproj/.csproj.user contract is supported. Accepting any ".user" path would let unrelated
+		// MSBuild user files (e.g. *.sln.user) receive an <UnoRemoteControlPort>, so restrict to .csproj.user.
+		if (projectPath.EndsWith(".csproj.user", StringComparison.OrdinalIgnoreCase))
 		{
 			return projectPath;
 		}


### PR DESCRIPTION
## Problem

Renaming an Uno app — or launching a project that isn't the workspace's resolved solution — breaks the `uno-app` MCP: the app launches but never connects to the DevServer, so `uno_app_get_screenshot` / `uno_app_element_peer_action` time out (30s) and tools report `No connected app instance`. Reproduced deterministically on Uno.Sdk 6.5.36.

Relates to #23679.

## Root cause

The launched app's embedded `UnoRemoteControlPort` (emitted by `RemoteControlGenerator`) comes from `<project>.csproj.user`, which the DevServer synchronizes only via `CsprojUserGenerator.SetCsprojUserPort(solution, port)`. That method:

- is **solution-only** and silently no-ops for anything that isn't a `.sln`/`.slnx`, and
- is always called with the **workspace-resolved** solution (`SolutionFileFinder.FindSolutionFiles(_currentDirectory)`; keyed per-solution in `AmbientRegistry`), **never the project actually launched**.

So when the launched project isn't part of that one resolved solution (after a rename, or in a nested / multi-solution workspace), its `.csproj.user` is never claimed → the app embeds a stale/placeholder port with no DevServer listening → the connection times out.

Verified with an A/B/A reproduction: the same app connects when its `.csproj.user` port matches the running DevServer and times out when it doesn't (only the port changed).

## Change

Adds project-aware, solution-independent APIs to `CsprojUserGenerator`:

- **`SetCsprojUserPortForProject(projectPath, port)`** — writes/updates a single `<project>.csproj.user` directly (no solution required).
- **`SetCsprojUserPortForPath(path, port)`** — dispatches by solution / project / directory, so callers can pass whatever they have.
- **`TryGetConfiguredPort(projectPath, out port)`** — reads back the configured port (stripping the `#` tooling marker) for fail-fast pre-launch validation.

New `CsprojUserGeneratorTests`. `Uno.UI.RemoteControl.Host` and the test project build clean; all tests pass.

## Remaining wiring (follow-up, in-repo)

This PR only adds the helpers — the port sync is entirely in this repo (not the HotDesign add-in). All three `SetCsprojUserPort(solution, …)` call sites are still unchanged and remain keyed on the workspace-resolved solution:

- `Uno.UI.RemoteControl.Host/Program.Command.cs` (host bootstrap)
- `Uno.UI.DevServer.Cli/StartCommandHandler.cs` (`start`)
- `Uno.UI.DevServer.Cli/Mcp/DevServerMonitor.cs` (MCP monitor)

To make the fix effective end-to-end, the sync needs to cover the launched project, e.g.:

```csharp
await CsprojUserGenerator.SetCsprojUserPortForPath(projectOrWorkspacePath, devServerPort);
// optional fail-fast instead of a 30s silent timeout:
if (!CsprojUserGenerator.TryGetConfiguredPort(projectPath, out var p) || p != devServerPort) { /* clear error */ }
```

Equivalently, pass `-p:UnoRemoteControlPort={devServerPort}` on the launch build (documented in `Uno.AppLaunch.targets`). Exact integration point TBD — see discussion.

## Notes

Draft: opening for review of the API shape and to agree on the integration point above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4pLj92NMJaWmNR2q9rV7p
