### PR TITLE
refactor(dp)!: Clean up DependencyPropertyValuePrecedences enum

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2275,6 +2275,11 @@
 	  </Types>
 
 	  <Fields>
+		  <!-- DependencyPropertyValuePrecedences enum cleanup: obsolete/misused members removed and style levels renamed to match WinUI's BaseValueSource (#16356, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::TemplatedParent" reason="Removed unused TemplatedParent precedence (#16356, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::ExplicitStyle" reason="Renamed ExplicitStyle to Style to match WinUI BaseValueSourceStyle (#16356, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::ImplicitStyle" reason="Removed misused ImplicitStyle precedence; default styles now use BuiltInStyle (#16356, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::DefaultStyle" reason="Renamed DefaultStyle to BuiltInStyle to match WinUI BaseValueSourceBuiltInStyle (#16356, breaking changes for 7.0)" />
 		  <Member fullName="System.Int32 Microsoft.UI.Xaml.Controls.ScrollingInputKinds::value__" reason="WinUI sync: type restructured in WinAppSDK 1.8" />
 
 		  <!-- ====================================================================== -->

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
@@ -61,7 +61,7 @@ namespace Uno.UI.Samples.Controls
 			base.OnDataContextChanged();
 
 			// Workaround to #10396: The DataContext of ContentTemplate should be ContentControl.DataContext if ContentControl.Content is not set.
-			this.SetValue(ContentProperty, DataContext, DependencyPropertyValuePrecedences.DefaultStyle);
+			this.SetValue(ContentProperty, DataContext, DependencyPropertyValuePrecedences.BuiltInStyle);
 		}
 #endif
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_DependencyPropertyHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_DependencyPropertyHelper.cs
@@ -220,7 +220,7 @@ public partial class Given_DependencyPropertyHelper
 
 		// Assert
 		unsetValue.Should().Be("StyledTestValue");
-		precedence.Should().Be(DependencyPropertyValuePrecedences.ExplicitStyle);
+		precedence.Should().Be(DependencyPropertyValuePrecedences.Style);
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.UnitTests/BinderTests/Given_Binder.GeneratedAttached.cs
+++ b/src/Uno.UI.UnitTests/BinderTests/Given_Binder.GeneratedAttached.cs
@@ -51,7 +51,7 @@ namespace Uno.UI.Tests.BinderTests
 			Binder_GeneratedAttached_Attached.SetMyValue(SUT, 42);
 			Assert.AreEqual(42, Binder_GeneratedAttached_Attached.GetMyValue(SUT));
 
-			SUT.SetValue(Binder_GeneratedAttached_Attached.MyValueProperty, 43, DependencyPropertyValuePrecedences.ImplicitStyle);
+			SUT.SetValue(Binder_GeneratedAttached_Attached.MyValueProperty, 43, DependencyPropertyValuePrecedences.BuiltInStyle);
 			Assert.AreEqual(42, Binder_GeneratedAttached_Attached.GetMyValue(SUT));
 		}
 
@@ -65,7 +65,7 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual(42, Binder_GeneratedAttached_Attached.GetMyValue2(SUT));
 			Assert.AreEqual(1, SUT.Value2ChangedCallback);
 
-			SUT.SetValue(Binder_GeneratedAttached_Attached.MyValue2Property, 43, DependencyPropertyValuePrecedences.ImplicitStyle);
+			SUT.SetValue(Binder_GeneratedAttached_Attached.MyValue2Property, 43, DependencyPropertyValuePrecedences.BuiltInStyle);
 			Assert.AreEqual(42, Binder_GeneratedAttached_Attached.GetMyValue2(SUT));
 			Assert.AreEqual(1, SUT.Value2ChangedCallback);
 		}

--- a/src/Uno.UI.UnitTests/BinderTests/Given_Binder.LocalCache.cs
+++ b/src/Uno.UI.UnitTests/BinderTests/Given_Binder.LocalCache.cs
@@ -54,7 +54,7 @@ namespace Uno.UI.Tests.BinderTests
 			SUT.SetValue(BinderLocalCache_Data.MyValueProperty, 42);
 			Assert.AreEqual(42, SUT.MyValue);
 
-			SUT.SetValue(BinderLocalCache_Data.MyValueProperty, 43, DependencyPropertyValuePrecedences.ImplicitStyle);
+			SUT.SetValue(BinderLocalCache_Data.MyValueProperty, 43, DependencyPropertyValuePrecedences.BuiltInStyle);
 			Assert.AreEqual(42, SUT.MyValue);
 		}
 

--- a/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.cs
@@ -425,9 +425,67 @@ namespace Uno.UI.Tests.BinderTests
 			var testProperty = DependencyProperty.Register(nameof(When_Two_Precedences_Set_Then_Only_Highest_Returned), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("42"));
 
 			SUT.SetValue(testProperty, "Not42");
-			SUT.SetValue(testProperty, "ALowPriorityValue", DependencyPropertyValuePrecedences.ImplicitStyle);
+			SUT.SetValue(testProperty, "ALowPriorityValue", DependencyPropertyValuePrecedences.BuiltInStyle);
 
 			Assert.AreEqual("Not42", SUT.GetValue(testProperty));
+		}
+
+		[TestMethod]
+		public void When_Each_Precedence_Set_Then_Highest_Wins()
+		{
+			var testProperty = DependencyProperty.Register(nameof(When_Each_Precedence_Set_Then_Highest_Wins), typeof(string), typeof(MockDependencyObject), new PropertyMetadata("default"));
+			var SUT = new MockDependencyObject();
+
+			// No value set: the metadata default value is used.
+			Assert.AreEqual(DependencyPropertyValuePrecedences.DefaultValue, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("default", SUT.GetValue(testProperty));
+
+			// Set each precedence from weakest to strongest; each one must win over the previous,
+			// validating the ordinal ordering of the surviving precedences.
+			SUT.SetValue(testProperty, "builtInStyle", DependencyPropertyValuePrecedences.BuiltInStyle);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.BuiltInStyle, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("builtInStyle", SUT.GetValue(testProperty));
+
+			SUT.SetValue(testProperty, "style", DependencyPropertyValuePrecedences.Style);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.Style, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("style", SUT.GetValue(testProperty));
+
+			SUT.SetValue(testProperty, "local", DependencyPropertyValuePrecedences.Local);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.Local, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("local", SUT.GetValue(testProperty));
+
+			SUT.SetValue(testProperty, "animation", DependencyPropertyValuePrecedences.Animations);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.Animations, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("animation", SUT.GetValue(testProperty));
+
+			// Clearing the animation modifier falls back to the local value.
+			SUT.ClearValue(testProperty, DependencyPropertyValuePrecedences.Animations);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.Local, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("local", SUT.GetValue(testProperty));
+		}
+
+		[TestMethod]
+		public void When_BuiltInStyle_Set_Then_Takes_Precedence_Over_Inherited_Value()
+		{
+			var SUT = new MockDependencyObject();
+			var testProperty = DependencyProperty.Register(
+				nameof(When_BuiltInStyle_Set_Then_Takes_Precedence_Over_Inherited_Value),
+				typeof(string),
+				typeof(MockDependencyObject),
+				new PropertyMetadata("default"));
+
+			SUT.SetValue(testProperty, "inherited", DependencyPropertyValuePrecedences.Inheritance);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.Inheritance, SUT.GetCurrentHighestValuePrecedence(testProperty));
+
+			// BuiltInStyle (default style from Generic.xaml) must win over an inherited value, matching WinUI.
+			SUT.SetValue(testProperty, "builtInStyle", DependencyPropertyValuePrecedences.BuiltInStyle);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.BuiltInStyle, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("builtInStyle", SUT.GetValue(testProperty));
+
+			// Clearing the built-in style falls back to the inherited value.
+			SUT.ClearValue(testProperty, DependencyPropertyValuePrecedences.BuiltInStyle);
+			Assert.AreEqual(DependencyPropertyValuePrecedences.Inheritance, SUT.GetCurrentHighestValuePrecedence(testProperty));
+			Assert.AreEqual("inherited", SUT.GetValue(testProperty));
 		}
 
 		[TestMethod]
@@ -1459,7 +1517,7 @@ namespace Uno.UI.Tests.BinderTests
 				(o, e) =>
 				{
 					e.BypassesPropagation.Should().BeFalse();
-					e.NewPrecedence.Should().Be(DependencyPropertyValuePrecedences.ImplicitStyle);
+					e.NewPrecedence.Should().Be(DependencyPropertyValuePrecedences.BuiltInStyle);
 					button.Content = "Frogurt";
 				});
 
@@ -1512,7 +1570,7 @@ namespace Uno.UI.Tests.BinderTests
 				(dependencyObject, args) =>
 				{
 					args.NewPrecedence.Should().Be(DependencyPropertyValuePrecedences.Local);
-					args.NewValue.Should().Be(DependencyPropertyValuePrecedences.ExplicitStyle);
+					args.NewValue.Should().Be(DependencyPropertyValuePrecedences.Style);
 				});
 
 			using var _ = new AssertionScope();
@@ -1530,7 +1588,7 @@ namespace Uno.UI.Tests.BinderTests
 
 			// Local value is cleared, fallback to style value
 			sut.BorderThickness.Should().Be(new Thickness(10d), "After removing local value");
-			sut.Tag.Should().Be(DependencyPropertyValuePrecedences.ExplicitStyle, "After applying style");
+			sut.Tag.Should().Be(DependencyPropertyValuePrecedences.Style, "After applying style");
 
 			registration2.Dispose();
 
@@ -1582,7 +1640,7 @@ namespace Uno.UI.Tests.BinderTests
 				(dependencyObject, args) =>
 				{
 					args.NewPrecedence.Should().Be(DependencyPropertyValuePrecedences.Local);
-					args.NewValue.Should().Be(DependencyPropertyValuePrecedences.ExplicitStyle);
+					args.NewValue.Should().Be(DependencyPropertyValuePrecedences.Style);
 				});
 
 			using var _ = new AssertionScope();
@@ -1612,7 +1670,7 @@ namespace Uno.UI.Tests.BinderTests
 				Border.BorderThicknessProperty,
 				(dependencyObject, args) =>
 				{
-					args.NewPrecedence.Should().Be(DependencyPropertyValuePrecedences.ExplicitStyle);
+					args.NewPrecedence.Should().Be(DependencyPropertyValuePrecedences.Style);
 					args.NewValue.Should().Be(new Thickness(10d));
 					sut.Child = new Rectangle();
 				});

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.mux.cs
@@ -687,7 +687,7 @@ public partial class Slider
 		// TODO Uno specific: Set background of slider container to ensure touch events are captured, but allow it to be overwritten by bindings etc
 		if (_tpSliderContainer.Background == null)
 		{
-			_tpSliderContainer.SetValue(BackgroundProperty, SolidColorBrushHelper.Transparent, DependencyPropertyValuePrecedences.ImplicitStyle);
+			_tpSliderContainer.SetValue(BackgroundProperty, SolidColorBrushHelper.Transparent, DependencyPropertyValuePrecedences.BuiltInStyle);
 		}
 
 		// Attach the event handlers

--- a/src/Uno.UI/UI/Xaml/Controls/WrapPanel/WrapPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WrapPanel/WrapPanel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				if (GetTemplatedParent() is ItemsPresenter presenter &&
 					presenter.GetTemplatedParent() is GridView gv &&
-					gv.GetCurrentHighestValuePrecedence(Control.TemplateProperty) == DependencyPropertyValuePrecedences.ImplicitStyle)
+					gv.GetCurrentHighestValuePrecedence(Control.TemplateProperty) == DependencyPropertyValuePrecedences.BuiltInStyle)
 				{
 					// This is a workaround for our GridView using a WrapPanel instead of an ItemsWrapGrid (which we don't implement).
 					// The following is the implementation of ItemsWrapGrid::get_PhysicalOrientation from WinUI.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -412,9 +412,9 @@ namespace Microsoft.UI.Xaml
 		{
 			var precedence = dependencyObject.GetCurrentHighestValuePrecedence(property);
 			// TODO: Bring this closer to CFrameworkElement::IsPropertySetByStyle from WinUI.
-			if (precedence is DependencyPropertyValuePrecedences.DefaultStyle or DependencyPropertyValuePrecedences.ImplicitStyle or DependencyPropertyValuePrecedences.ExplicitStyle)
+			if (precedence is DependencyPropertyValuePrecedences.BuiltInStyle or DependencyPropertyValuePrecedences.Style)
 			{
-				return DependencyPropertyValuePrecedences.ExplicitStyle;
+				return DependencyPropertyValuePrecedences.Style;
 			}
 			else if (precedence == DependencyPropertyValuePrecedences.DefaultValue)
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -2219,21 +2219,19 @@ namespace Microsoft.UI.Xaml
 		private void ReevaluateBaseValue(DependencyPropertyDetails propertyDetails)
 		{
 			// When local value or style value are cleared, we want to re-evaluate base value and set the value with the right precedence.
-			// The new base value will either be Style (explicit or implicit) or DefaultStyle (aka built-in style)
+			// The new base value will either be an applied style (explicit or implicit) or the built-in style.
 			var actualInstance = ActualInstance;
 			if (actualInstance is FrameworkElement fe &&
 				fe.TryGetValueFromStyle(propertyDetails.Property, out var valueFromStyle) &&
 				valueFromStyle != DependencyProperty.UnsetValue)
 			{
-				// NOTE: ExplicitStyle here actually means ExplicitOrImplicitStyle. This will be fixed with https://github.com/unoplatform/uno/pull/15684/
-				SetValueInternal(valueFromStyle, DependencyPropertyValuePrecedences.ExplicitStyle, propertyDetails);
+				SetValueInternal(valueFromStyle, DependencyPropertyValuePrecedences.Style, propertyDetails);
 			}
 			else if (actualInstance is Control control &&
 				control.TryGetValueFromBuiltInStyle(propertyDetails.Property, out var valueFromBuiltInStyle) &&
 				valueFromBuiltInStyle != DependencyProperty.UnsetValue)
 			{
-				// NOTE: ImplicitStyle here actually means DefaultStyle. This will be fixed with https://github.com/unoplatform/uno/pull/15684/
-				SetValueInternal(valueFromBuiltInStyle, DependencyPropertyValuePrecedences.ImplicitStyle, propertyDetails);
+				SetValueInternal(valueFromBuiltInStyle, DependencyPropertyValuePrecedences.BuiltInStyle, propertyDetails);
 			}
 		}
 
@@ -2263,9 +2261,8 @@ namespace Microsoft.UI.Xaml
 			// TODO Uno Specific: The check is a bit different in WinUI, but should have the same effect.
 			bool hasLocalValue = !(
 				precedence == DependencyPropertyValuePrecedences.DefaultValue ||
-				precedence == DependencyPropertyValuePrecedences.DefaultStyle ||
-				precedence == DependencyPropertyValuePrecedences.ExplicitStyle ||
-				precedence == DependencyPropertyValuePrecedences.ImplicitStyle);
+				precedence == DependencyPropertyValuePrecedences.BuiltInStyle ||
+				precedence == DependencyPropertyValuePrecedences.Style);
 
 			return hasLocalValue;
 		}

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
@@ -22,30 +22,24 @@ namespace Microsoft.UI.Xaml
 		Local,
 
 		/// <summary>
-		/// Values inherited from the templated parent
+		/// Defined by an applied style, either explicitly assigned through the Style property or resolved as an implicit style.
 		/// </summary>
-		TemplatedParent,
+		/// <remarks>Corresponds to WinUI's <c>BaseValueSourceStyle</c>.</remarks>
+		Style,
 
 		/// <summary>
-		/// Defined when setting a style from the style property
+		/// Defined by the built-in (default) style from Generic.xaml.
 		/// </summary>
-		ExplicitStyle,
-
-		/// <summary>
-		/// Values defined by an implicitly defined style
-		/// </summary>
-		/// <remarks>On Uno, this is actually used for values set by the default style, to allow for them to correctly take precedence over inherited values.</remarks>
-		ImplicitStyle,
+		/// <remarks>
+		/// Corresponds to WinUI's <c>BaseValueSourceBuiltInStyle</c>. This takes precedence over inherited property
+		/// values so that setters not covered by an applied style are still honored.
+		/// </remarks>
+		BuiltInStyle,
 
 		/// <summary>
 		/// Defined by the inheritance of a FrameworkElement property of the same name
 		/// </summary>
 		Inheritance,
-
-		/// <summary>
-		/// Defined by the default style from Generic.xaml
-		/// </summary>
-		DefaultStyle,
 
 		/// <summary>
 		/// Defined on the dependency property metadata

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -512,7 +512,7 @@ namespace Microsoft.UI.Xaml
 		{
 			var oldActiveStyle = _activeStyle;
 			UpdateActiveStyle();
-			OnStyleChanged(oldActiveStyle, _activeStyle, DependencyPropertyValuePrecedences.ExplicitStyle);
+			OnStyleChanged(oldActiveStyle, _activeStyle, DependencyPropertyValuePrecedences.Style);
 		}
 
 		/// <summary>
@@ -667,7 +667,7 @@ namespace Microsoft.UI.Xaml
 		/// Apply the default style for this element, if one is defined.
 		/// </summary>
 		/// <remarks>
-		/// The default app-wide style is always applied (using the lower priority ImplicitStyle) so that setters that are not
+		/// The default app-wide style is always applied (using the lower priority BuiltInStyle) so that setters that are not
 		/// set by a tree-provided style are still applied. (e.g. a tree-provided implicit style may only change the Foreground of a Button,
 		/// and the Template property still needs to be applied for the template to work).
 		/// </remarks>
@@ -682,9 +682,9 @@ namespace Microsoft.UI.Xaml
 
 			var style = Style.GetDefaultStyleForInstance(this, GetDefaultStyleKey());
 
-			// Although this is the default style, we use the ImplicitStyle enum value (which is otherwise unused) to ensure that it takes precedence
-			//over inherited property values. UWP's precedence system is simpler than WPF's, from which the enum is derived.
-			OnStyleChanged(null, style, DependencyPropertyValuePrecedences.ImplicitStyle);
+			// The default style is applied at BuiltInStyle precedence so that it takes precedence over inherited
+			// property values. UWP's precedence system is simpler than WPF's, from which the enum is derived.
+			OnStyleChanged(null, style, DependencyPropertyValuePrecedences.BuiltInStyle);
 #if DEBUG
 			AppliedDefaultStyle = style;
 #endif

--- a/src/Uno.UI/UI/Xaml/Internal/DependencyPropertyHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/DependencyPropertyHelper.cs
@@ -166,15 +166,14 @@ internal static class DependencyPropertyHelper
 		if (obj is FrameworkElement fe && fe.TryGetValueFromStyle(dependencyProperty, out var valueFromStyle))
 		{
 			// .TryGetValueFromStyle() will return false if the value is UnsetValue
-			return (valueFromStyle, DependencyPropertyValuePrecedences.ExplicitStyle);
+			return (valueFromStyle, DependencyPropertyValuePrecedences.Style);
 		}
 
 		// 2nd: Check built-in style value, if any
-		if (obj is Control control && control.TryGetValueFromBuiltInStyle(dependencyProperty, out var valueFromImplicitStyle))
+		if (obj is Control control && control.TryGetValueFromBuiltInStyle(dependencyProperty, out var valueFromBuiltInStyle))
 		{
 			// .TryGetValueFromBuiltInStyle() will return false if the value is UnsetValue
-			// NOTE: ExplicitStyle here actually means ExplicitOrImplicitStyle. This will be fixed with https://github.com/unoplatform/uno/pull/15684/
-			return (valueFromImplicitStyle, DependencyPropertyValuePrecedences.ImplicitStyle);
+			return (valueFromBuiltInStyle, DependencyPropertyValuePrecedences.BuiltInStyle);
 		}
 
 		if (obj is IDependencyObjectStoreProvider { Store: { } store })

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -126,7 +126,7 @@ namespace Microsoft.UI.Xaml
 			// In DependencyObject::EvaluateBaseValue (DependencyObject.cpp file), the value is updated to that returned from GetValueFromStyle
 			// Then, baseValueSource is updated from BaseValueSourceBuiltInStyle to BaseValueSourceStyle
 			// The OverrideLocalPrecedence call below is the equivalent of the baseValueSource update.
-			if (baseValueSource == DependencyPropertyValuePrecedences.ImplicitStyle &&
+			if (baseValueSource == DependencyPropertyValuePrecedences.BuiltInStyle &&
 				dependencyObject is FrameworkElement fe &&
 				fe.GetActiveStyle() is { } activeStyle &&
 				// Make sure to only consider active style if it was explicit.
@@ -150,7 +150,7 @@ namespace Microsoft.UI.Xaml
 				return;
 			}
 
-			Debug.Assert(precedence is DependencyPropertyValuePrecedences.ImplicitStyle or DependencyPropertyValuePrecedences.ExplicitStyle);
+			Debug.Assert(precedence is DependencyPropertyValuePrecedences.BuiltInStyle or DependencyPropertyValuePrecedences.Style);
 
 			IDisposable? localPrecedenceDisposable = null;
 
@@ -177,7 +177,7 @@ namespace Microsoft.UI.Xaml
 							{
 								if (TryGetAdjustedSetter(precedence, o, _flattenedSetters[i], out var adjustedSetter))
 								{
-									using (o.OverrideLocalPrecedence(DependencyPropertyValuePrecedences.ExplicitStyle))
+									using (o.OverrideLocalPrecedence(DependencyPropertyValuePrecedences.Style))
 									{
 										adjustedSetter.ApplyTo(o);
 									}


### PR DESCRIPTION
**GitHub Issue:** closes #16356

## PR Type:

💬 Other — breaking API cleanup (refactoring with public enum surface removal)

## What changed? 🚀

Cleans up the public `DependencyPropertyValuePrecedences` enum, converging it on WinUI's `BaseValueSource` model and removing legacy/misused members.

**Before**, the enum carried levels that diverged from WinUI and were used inconsistently:
- an applied style (implicit *or* explicit) was stored at `ExplicitStyle`;
- the built-in (Generic.xaml) default style *misused* the otherwise-unused `ImplicitStyle` level;
- `DefaultStyle` was effectively vestigial and sat *below* `Inheritance`;
- `TemplatedParent` had no readers anywhere.

**After**, aligned with WinUI's `BaseValueSource`:

| Removed / renamed | Now |
|---|---|
| `ExplicitStyle` | **`Style`** — an applied implicit *or* explicit style (WinUI `BaseValueSourceStyle`) |
| `DefaultStyle` | **`BuiltInStyle`** — the Generic.xaml default style (WinUI `BaseValueSourceBuiltInStyle`), reordered **above** `Inheritance` to reflect its real runtime precedence |
| `ImplicitStyle` | **removed** — default-style storage now uses the correctly-named `BuiltInStyle` |
| `TemplatedParent` | **removed** — no readers; the separate templated-parent mechanism is tracked independently |

All readers across the DP value-resolution system are repointed onto the surviving values: `DependencyObjectStore`, `DependencyPropertyHelper`, `Style`, `FrameworkElement`, `DependencyObjectExtensions`, plus the `WrapPanel`/`Slider` call sites. There is **no behavioural change for real scenarios** — default styles already took precedence over inheritance at runtime (via the misused `ImplicitStyle` slot); this PR simply makes the enum say what the system actually does, and gives the levels their WinUI-aligned names.

## PR Checklist ✅

- [x] 🧪 Added unit tests exercising each surviving precedence level and the `BuiltInStyle`-over-`Inheritance` ordering (`Given_DependencyProperty.When_Each_Precedence_Set_Then_Highest_Wins`, `When_BuiltInStyle_Set_Then_Takes_Precedence_Over_Inherited_Value`); existing style/precedence and binder tests updated for the new names.
- [ ] 📚 Docs — n/a (internal precedence semantics, no public documentation surface).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional).

## Breaking change

**Source-breaking**, intentionally scoped to the 7.0 breaking-changes window (this PR targets `feature/breakingchanges`).

The public enum members `DependencyPropertyValuePrecedences.TemplatedParent`, `.ImplicitStyle`, `.ExplicitStyle` and `.DefaultStyle` are removed (hard removal — no `[EditorBrowsable]`-hidden aliases). Migration for any code referencing them:

- `ExplicitStyle` → `Style`
- `ImplicitStyle` / `DefaultStyle` → `BuiltInStyle`
- `TemplatedParent` → no replacement (it had no readers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
