### PR TITLE
feat(scrollview): Add ScrollStarting and ZoomStarting events

### DIFF
--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTracker.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTracker.cs
@@ -14,6 +14,7 @@ public partial class InteractionTracker : CompositionObject
 {
 	private InteractionTrackerState _state;
 	private Vector3 _position;
+	private float _scale = 1.0f;
 
 	private int _currentRequestId;
 
@@ -30,7 +31,7 @@ public partial class InteractionTracker : CompositionObject
 
 	public float MaxScale { get; set; } = 1.0f;
 
-	public float Scale { get; } = 1.0f;
+	public float Scale => _scale;
 
 	public Vector3 MinPosition { get; set; }
 
@@ -63,12 +64,48 @@ public partial class InteractionTracker : CompositionObject
 		if (_position != newPosition)
 		{
 			_position = newPosition;
+			var scale = _scale;
 			NativeDispatcher.Main.Enqueue(() =>
 			{
-				Owner?.ValuesChanged(this, new InteractionTrackerValuesChangedArgs(newPosition, Scale, requestId));
+				Owner?.ValuesChanged(this, new InteractionTrackerValuesChangedArgs(newPosition, scale, requestId));
 				OnPropertyChanged(nameof(Position), isSubPropertyChange: false);
 			});
 		}
+	}
+
+	internal void SetScale(float newScale, Vector3 centerPoint, int requestId)
+	{
+		var oldScale = _scale;
+		var scaleChanged = !oldScale.Equals(newScale);
+		var scaleRatio = oldScale == 0.0f ? 1.0f : newScale / oldScale;
+		var newPosition = scaleRatio * (_position + centerPoint) - centerPoint;
+
+		if (scaleChanged)
+		{
+			_scale = newScale;
+
+			// Scale-dependent expression animations update the position boundaries synchronously.
+			OnPropertyChanged(nameof(Scale), isSubPropertyChange: false);
+		}
+
+		newPosition = Vector3.Clamp(newPosition, MinPosition, MaxPosition);
+		var positionChanged = _position != newPosition;
+
+		if (!scaleChanged && !positionChanged)
+		{
+			return;
+		}
+
+		_position = newPosition;
+		NativeDispatcher.Main.Enqueue(() =>
+		{
+			Owner?.ValuesChanged(this, new InteractionTrackerValuesChangedArgs(newPosition, newScale, requestId));
+
+			if (positionChanged)
+			{
+				OnPropertyChanged(nameof(Position), isSubPropertyChange: false);
+			}
+		});
 	}
 
 	public int TryUpdatePositionWithAdditionalVelocity(Vector3 velocityInPixelsPerSecond)
@@ -123,6 +160,22 @@ public partial class InteractionTracker : CompositionObject
 
 	public int TryUpdatePositionBy(Vector3 amount, InteractionTrackerClampingOption option)
 		=> TryUpdatePosition(Position + amount, option);
+
+	/// <summary>
+	/// Tries to update the scale to the specified value.
+	/// </summary>
+	/// <param name="value">The new value for scale.</param>
+	/// <param name="centerPoint">The new center point.</param>
+	/// <returns>
+	/// The request identifier. Request identifiers start at 1 and increase with each try call
+	/// during the lifetime of the application.
+	/// </returns>
+	public int TryUpdateScale(float value, Vector3 centerPoint)
+	{
+		var id = Interlocked.Increment(ref _currentRequestId);
+		_state.TryUpdateScale(value, centerPoint, id);
+		return id;
+	}
 
 	private protected override void SetAnimatableProperty(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> subPropertyName, object? propertyValue)
 	{

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTracker.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTracker.cs
@@ -97,15 +97,14 @@ public partial class InteractionTracker : CompositionObject
 		}
 
 		_position = newPosition;
-		NativeDispatcher.Main.Enqueue(() =>
-		{
-			Owner?.ValuesChanged(this, new InteractionTrackerValuesChangedArgs(newPosition, newScale, requestId));
 
-			if (positionChanged)
-			{
-				OnPropertyChanged(nameof(Position), isSubPropertyChange: false);
-			}
-		});
+		if (positionChanged)
+		{
+			OnPropertyChanged(nameof(Position), isSubPropertyChange: false);
+		}
+
+		NativeDispatcher.Main.Enqueue(() =>
+			Owner?.ValuesChanged(this, new InteractionTrackerValuesChangedArgs(newPosition, newScale, requestId)));
 	}
 
 	public int TryUpdatePositionWithAdditionalVelocity(Vector3 velocityInPixelsPerSecond)

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerCustomAnimationState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerCustomAnimationState.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Numerics;
 using Windows.Foundation;
 
@@ -55,6 +56,13 @@ internal sealed class InteractionTrackerCustomAnimationState : InteractionTracke
 		}
 
 		_interactionTracker.SetPosition(value, requestId);
+		_interactionTracker.ChangeState(new InteractionTrackerIdleState(_interactionTracker, requestId));
+	}
+
+	internal override void TryUpdateScale(float value, Vector3 centerPoint, int requestId)
+	{
+		value = Math.Clamp(value, _interactionTracker.MinScale, _interactionTracker.MaxScale);
+		_interactionTracker.SetScale(value, centerPoint, requestId);
 		_interactionTracker.ChangeState(new InteractionTrackerIdleState(_interactionTracker, requestId));
 	}
 }

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerIdleState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerIdleState.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Numerics;
 using Windows.Foundation;
 

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerIdleState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerIdleState.cs
@@ -65,4 +65,10 @@ internal sealed class InteractionTrackerIdleState : InteractionTrackerState
 
 		_interactionTracker.SetPosition(value, requestId);
 	}
+
+	internal override void TryUpdateScale(float value, Vector3 centerPoint, int requestId)
+	{
+		value = Math.Clamp(value, _interactionTracker.MinScale, _interactionTracker.MaxScale);
+		_interactionTracker.SetScale(value, centerPoint, requestId);
+	}
 }

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerInertiaState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerInertiaState.cs
@@ -97,6 +97,13 @@ internal sealed class InteractionTrackerInertiaState : InteractionTrackerState
 		_interactionTracker.ChangeState(new InteractionTrackerIdleState(_interactionTracker, requestId));
 	}
 
+	internal override void TryUpdateScale(float value, Vector3 centerPoint, int requestId)
+	{
+		value = Math.Clamp(value, _interactionTracker.MinScale, _interactionTracker.MaxScale);
+		_interactionTracker.SetScale(value, centerPoint, requestId);
+		_interactionTracker.ChangeState(new InteractionTrackerIdleState(_interactionTracker, requestId));
+	}
+
 	public override void Dispose()
 	{
 		_handler.Stop();

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerInteractingState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerInteractingState.cs
@@ -55,4 +55,9 @@ internal sealed class InteractionTrackerInteractingState : InteractionTrackerSta
 	{
 		_interactionTracker.Owner?.RequestIgnored(_interactionTracker, new InteractionTrackerRequestIgnoredArgs(requestId));
 	}
+
+	internal override void TryUpdateScale(float value, Vector3 centerPoint, int requestId)
+	{
+		_interactionTracker.Owner?.RequestIgnored(_interactionTracker, new InteractionTrackerRequestIgnoredArgs(requestId));
+	}
 }

--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerState.cs
@@ -26,5 +26,6 @@ internal abstract class InteractionTrackerState : IDisposable
 	internal abstract void ReceivePointerWheel(int delta, bool isHorizontal);
 	internal abstract void TryUpdatePositionWithAdditionalVelocity(Vector3 velocityInPixelsPerSecond, int requestId);
 	internal abstract void TryUpdatePosition(Vector3 value, InteractionTrackerClampingOption option, int requestId);
+	internal abstract void TryUpdateScale(float value, Vector3 centerPoint, int requestId);
 	public virtual void Dispose() => _disposed = true;
 }

--- a/src/Uno.UI.Composition/Generated/3.0.0.0/Microsoft.UI.Composition.Interactions/InteractionTracker.cs
+++ b/src/Uno.UI.Composition/Generated/3.0.0.0/Microsoft.UI.Composition.Interactions/InteractionTracker.cs
@@ -152,13 +152,7 @@ namespace Microsoft.UI.Composition.Interactions
 		}
 #endif
 		// Skipping already declared method Microsoft.UI.Composition.Interactions.InteractionTracker.TryUpdatePositionWithAdditionalVelocity(System.Numerics.Vector3)
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public int TryUpdateScale(float value, global::System.Numerics.Vector3 centerPoint)
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.UI.Composition.Interactions.InteractionTracker", "TryUpdateScale(float value, Vector3 centerPoint)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Composition.Interactions.InteractionTracker.TryUpdateScale(System.Single, System.Numerics.Vector3)
 #if __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
 		public int TryUpdateScaleWithAnimation(global::Microsoft.UI.Composition.CompositionAnimation animation, global::System.Numerics.Vector3 centerPoint)

--- a/src/Uno.UI.Composition/Generated/3.0.0.0/Microsoft.UI.Composition.Interactions/InteractionTracker.cs
+++ b/src/Uno.UI.Composition/Generated/3.0.0.0/Microsoft.UI.Composition.Interactions/InteractionTracker.cs
@@ -152,7 +152,7 @@ namespace Microsoft.UI.Composition.Interactions
 		}
 #endif
 		// Skipping already declared method Microsoft.UI.Composition.Interactions.InteractionTracker.TryUpdatePositionWithAdditionalVelocity(System.Numerics.Vector3)
-		// Skipping already declared method Microsoft.UI.Composition.Interactions.InteractionTracker.TryUpdateScale(System.Single, System.Numerics.Vector3)
+		// Skipping already declared method Microsoft.UI.Composition.Interactions.InteractionTracker.TryUpdateScale(float, System.Numerics.Vector3)
 #if __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
 		public int TryUpdateScaleWithAnimation(global::Microsoft.UI.Composition.CompositionAnimation animation, global::System.Numerics.Vector3 centerPoint)

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollPresenter/ScrollPresenterViewChangeTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollPresenter/ScrollPresenterViewChangeTests.cs
@@ -1390,6 +1390,12 @@ partial class ScrollPresenterTests : MUXApiTestBase
 		UnoAutoResetEvent scrollPresenterLoadedEvent = new UnoAutoResetEvent(false);
 		UnoAutoResetEvent scrollPresenterViewChangeOperationEvent = new UnoAutoResetEvent(false);
 		ScrollPresenterOperation operation = null;
+		uint scrollStartingCount = 0u;
+		uint zoomStartingCount = 0u;
+		int scrollStartingCorrelationId = -1;
+		double scrollStartingHorizontalOffset = 0.0;
+		double scrollStartingVerticalOffset = 0.0;
+		float scrollStartingZoomFactor = 0.0f;
 
 		RunOnUIThread.Execute(() =>
 		{
@@ -1397,6 +1403,21 @@ partial class ScrollPresenterTests : MUXApiTestBase
 			scrollPresenter = new ScrollPresenter();
 
 			SetupDefaultUI(scrollPresenter, rectangleScrollPresenterContent, scrollPresenterLoadedEvent, false /*setAsContentRoot*/);
+
+			scrollPresenter.ScrollStarting += (sender, args) =>
+			{
+				Log.Comment($"ScrollStarting scrollStartingCount={++scrollStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
+				Verify.AreSame(scrollPresenter, sender);
+				scrollStartingCorrelationId = args.CorrelationId;
+				scrollStartingHorizontalOffset = args.HorizontalOffset;
+				scrollStartingVerticalOffset = args.VerticalOffset;
+				scrollStartingZoomFactor = args.ZoomFactor;
+			};
+
+			scrollPresenter.ZoomStarting += (sender, args) =>
+			{
+				Log.Comment($"ZoomStarting zoomStartingCount={++zoomStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
+			};
 
 			scrollPresenter.ViewChanged += (sender, args) =>
 			{
@@ -1428,6 +1449,16 @@ partial class ScrollPresenterTests : MUXApiTestBase
 			Verify.AreEqual(400.0, scrollPresenter.VerticalOffset);
 			Verify.AreEqual(1.0f, scrollPresenter.ZoomFactor);
 			Verify.AreEqual(ScrollPresenterViewChangeResult.Completed, operation.Result);
+			Verify.AreEqual(animate ? 0u : 1u, scrollStartingCount);
+			Verify.AreEqual(0u, zoomStartingCount);
+
+			if (!animate)
+			{
+				Verify.AreEqual(operation.CorrelationId, scrollStartingCorrelationId);
+				Verify.AreEqual(600.0, scrollStartingHorizontalOffset);
+				Verify.AreEqual(400.0, scrollStartingVerticalOffset);
+				Verify.AreEqual(1.0f, scrollStartingZoomFactor);
+			}
 		});
 	}
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollPresenter/ScrollPresenterViewChangeTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollPresenter/ScrollPresenterViewChangeTests.cs
@@ -1336,8 +1336,8 @@ partial class ScrollPresenterTests : MUXApiTestBase
 	}
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
 	[TestProperty("Description", "Requests a non-animated zoomFactor change before loading scrollPresenter.")]
-	[Ignore("Zoom is not yet supported in Uno.")]
 	public async Task SetZoomFactorBeforeLoading()
 	{
 		await ChangeZoomFactorBeforeLoading(false /*animate*/);
@@ -1345,7 +1345,7 @@ partial class ScrollPresenterTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Requests an animated zoomFactor change before loading scrollPresenter.")]
-	[Ignore("Zoom is not yet supported in Uno.")]
+	[Ignore("ScrollingAnimationMode.Enabled requires InteractionTracker's CustomAnimation state")]
 	public async Task AnimateZoomFactorBeforeLoading()
 	{
 		await ChangeZoomFactorBeforeLoading(true /*animate*/);
@@ -1469,6 +1469,12 @@ partial class ScrollPresenterTests : MUXApiTestBase
 		UnoAutoResetEvent scrollPresenterLoadedEvent = new UnoAutoResetEvent(false);
 		UnoAutoResetEvent scrollPresenterViewChangeOperationEvent = new UnoAutoResetEvent(false);
 		ScrollPresenterOperation operation = null;
+		uint scrollStartingCount = 0u;
+		uint zoomStartingCount = 0u;
+		int zoomStartingCorrelationId = -1;
+		double zoomStartingHorizontalOffset = 0.0;
+		double zoomStartingVerticalOffset = 0.0;
+		float zoomStartingZoomFactor = 0.0f;
 
 		RunOnUIThread.Execute(() =>
 		{
@@ -1476,6 +1482,21 @@ partial class ScrollPresenterTests : MUXApiTestBase
 			scrollPresenter = new ScrollPresenter();
 
 			SetupDefaultUI(scrollPresenter, rectangleScrollPresenterContent, scrollPresenterLoadedEvent, false /*setAsContentRoot*/);
+
+			scrollPresenter.ScrollStarting += (sender, args) =>
+			{
+				Log.Comment($"ScrollStarting scrollStartingCount={++scrollStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
+			};
+
+			scrollPresenter.ZoomStarting += (sender, args) =>
+			{
+				Log.Comment($"ZoomStarting zoomStartingCount={++zoomStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
+				Verify.AreSame(scrollPresenter, sender);
+				zoomStartingCorrelationId = args.CorrelationId;
+				zoomStartingHorizontalOffset = args.HorizontalOffset;
+				zoomStartingVerticalOffset = args.VerticalOffset;
+				zoomStartingZoomFactor = args.ZoomFactor;
+			};
 
 			scrollPresenter.ViewChanged += (sender, args) =>
 			{
@@ -1508,6 +1529,16 @@ partial class ScrollPresenterTests : MUXApiTestBase
 			Verify.IsLessThan(Math.Abs(scrollPresenter.VerticalOffset - 1050.0), 0.01);
 			Verify.AreEqual(8.0f, scrollPresenter.ZoomFactor);
 			Verify.AreEqual(ScrollPresenterViewChangeResult.Completed, operation.Result);
+			Verify.AreEqual(0u, scrollStartingCount);
+			Verify.AreEqual(animate ? 0u : 1u, zoomStartingCount);
+
+			if (!animate)
+			{
+				Verify.AreEqual(operation.CorrelationId, zoomStartingCorrelationId);
+				Verify.IsLessThan(Math.Abs(zoomStartingHorizontalOffset - 700.0), 0.01);
+				Verify.IsLessThan(Math.Abs(zoomStartingVerticalOffset - 1050.0), 0.01);
+				Verify.AreEqual(8.0f, zoomStartingZoomFactor);
+			}
 		});
 	}
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
@@ -583,7 +583,6 @@ public class ScrollViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
-	[Ignore("UNO: Zoom via InteractionTracker.TryUpdateScale is [NotImplemented] on Skia (it throws), so ScrollPresenter never reaches RaiseZoomStarting and ScrollView.ZoomStarting cannot fire at runtime. The forwarding wiring itself matches WinUI (ScrollStarting is covered by VerifyScrollStartingForwarding). Re-enable once the Skia InteractionTracker implements scale.")]
 	[TestProperty("Description", "Verifies ScrollView forwards ScrollPresenter ZoomStarting args.")]
 	public async Task VerifyZoomStartingForwarding()
 	{
@@ -595,6 +594,8 @@ public class ScrollViewTests : MUXApiTestBase
 		int zoomStartingCorrelationId = -1;
 		int zoomCompletedCorrelationId = -1;
 		int operationCorrelationId = -1;
+		double zoomStartingHorizontalOffset = 0.0;
+		double zoomStartingVerticalOffset = 0.0;
 		float zoomStartingZoomFactor = 0.0f;
 
 		RunOnUIThread.Execute(() =>
@@ -609,6 +610,8 @@ public class ScrollViewTests : MUXApiTestBase
 				Log.Comment($"ZoomStarting zoomStartingCount={++zoomStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
 				Verify.AreSame(scrollView, sender);
 				zoomStartingCorrelationId = args.CorrelationId;
+				zoomStartingHorizontalOffset = args.HorizontalOffset;
+				zoomStartingVerticalOffset = args.VerticalOffset;
 				zoomStartingZoomFactor = args.ZoomFactor;
 			};
 
@@ -643,6 +646,8 @@ public class ScrollViewTests : MUXApiTestBase
 			Verify.AreEqual(1u, zoomStartingCount);
 			Verify.AreEqual(operationCorrelationId, zoomStartingCorrelationId);
 			Verify.AreEqual(operationCorrelationId, zoomCompletedCorrelationId);
+			Verify.AreEqual(0.0, zoomStartingHorizontalOffset);
+			Verify.AreEqual(0.0, zoomStartingVerticalOffset);
 			Verify.AreEqual(2.0f, zoomStartingZoomFactor);
 		});
 	}

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
@@ -511,6 +511,7 @@ public class ScrollViewTests : MUXApiTestBase
 	}
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
 	[TestProperty("Description", "Verifies ScrollView forwards ScrollPresenter ScrollStarting args.")]
 	public async Task VerifyScrollStartingForwarding()
 	{
@@ -581,6 +582,7 @@ public class ScrollViewTests : MUXApiTestBase
 	}
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
 	[Ignore("UNO: Zoom via InteractionTracker.TryUpdateScale is [NotImplemented] on Skia (it throws), so ScrollPresenter never reaches RaiseZoomStarting and ScrollView.ZoomStarting cannot fire at runtime. The forwarding wiring itself matches WinUI (ScrollStarting is covered by VerifyScrollStartingForwarding). Re-enable once the Skia InteractionTracker implements scale.")]
 	[TestProperty("Description", "Verifies ScrollView forwards ScrollPresenter ZoomStarting args.")]
 	public async Task VerifyZoomStartingForwarding()

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
@@ -580,6 +580,71 @@ public class ScrollViewTests : MUXApiTestBase
 		});
 	}
 
+	[TestMethod]
+	[Ignore("UNO: Zoom via InteractionTracker.TryUpdateScale is [NotImplemented] on Skia (it throws), so ScrollPresenter never reaches RaiseZoomStarting and ScrollView.ZoomStarting cannot fire at runtime. The forwarding wiring itself matches WinUI (ScrollStarting is covered by VerifyScrollStartingForwarding). Re-enable once the Skia InteractionTracker implements scale.")]
+	[TestProperty("Description", "Verifies ScrollView forwards ScrollPresenter ZoomStarting args.")]
+	public async Task VerifyZoomStartingForwarding()
+	{
+		ScrollView scrollView = null;
+		Rectangle rectangleScrollViewContent = null;
+		UnoAutoResetEvent scrollViewLoadedEvent = new UnoAutoResetEvent(false);
+		UnoAutoResetEvent scrollViewZoomCompletedEvent = new UnoAutoResetEvent(false);
+		uint zoomStartingCount = 0u;
+		int zoomStartingCorrelationId = -1;
+		int zoomCompletedCorrelationId = -1;
+		int operationCorrelationId = -1;
+		float zoomStartingZoomFactor = 0.0f;
+
+		RunOnUIThread.Execute(() =>
+		{
+			rectangleScrollViewContent = new Rectangle();
+			scrollView = new ScrollView();
+
+			SetupDefaultUI(scrollView, rectangleScrollViewContent, scrollViewLoadedEvent);
+
+			scrollView.ZoomStarting += (sender, args) =>
+			{
+				Log.Comment($"ZoomStarting zoomStartingCount={++zoomStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
+				Verify.AreSame(scrollView, sender);
+				zoomStartingCorrelationId = args.CorrelationId;
+				zoomStartingZoomFactor = args.ZoomFactor;
+			};
+
+			scrollView.ZoomCompleted += (sender, args) =>
+			{
+				Log.Comment($"ZoomCompleted CorrelationId={args.CorrelationId}");
+				Verify.AreSame(scrollView, sender);
+				zoomCompletedCorrelationId = args.CorrelationId;
+				scrollViewZoomCompletedEvent.Set();
+			};
+		});
+
+		await WaitForEvent("Waiting for Loaded event", scrollViewLoadedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			operationCorrelationId = scrollView.ZoomTo(
+				2.0f,
+				global::System.Numerics.Vector2.Zero,
+				new ScrollingZoomOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
+
+			if (operationCorrelationId == -1)
+			{
+				scrollViewZoomCompletedEvent.Set();
+			}
+		});
+
+		await WaitForEvent("Waiting for ZoomCompleted event", scrollViewZoomCompletedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			Verify.AreEqual(1u, zoomStartingCount);
+			Verify.AreEqual(operationCorrelationId, zoomStartingCorrelationId);
+			Verify.AreEqual(operationCorrelationId, zoomCompletedCorrelationId);
+			Verify.AreEqual(2.0f, zoomStartingZoomFactor);
+		});
+	}
+
 	private void SetupDefaultUI(
 		ScrollView scrollView,
 		Rectangle rectangleScrollViewContent = null,

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Common;
@@ -649,6 +651,141 @@ public class ScrollViewTests : MUXApiTestBase
 			Verify.AreEqual(0.0, zoomStartingHorizontalOffset);
 			Verify.AreEqual(0.0, zoomStartingVerticalOffset);
 			Verify.AreEqual(2.0f, zoomStartingZoomFactor);
+		});
+	}
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
+	[TestProperty("Description", "Verifies successive ScrollBy requests expose the anticipated final offsets.")]
+	public async Task VerifySuccessiveScrollStartingValues()
+	{
+		ScrollView scrollView = null;
+		Rectangle rectangleScrollViewContent = null;
+		UnoAutoResetEvent scrollViewLoadedEvent = new UnoAutoResetEvent(false);
+		UnoAutoResetEvent scrollViewScrollCompletedEvent = new UnoAutoResetEvent(false);
+		List<int> scrollStartingCorrelationIds = new();
+		List<double> scrollStartingHorizontalOffsets = new();
+		List<double> scrollStartingVerticalOffsets = new();
+		List<int> scrollCompletedCorrelationIds = new();
+		int firstOperationCorrelationId = -1;
+		int secondOperationCorrelationId = -1;
+
+		RunOnUIThread.Execute(() =>
+		{
+			rectangleScrollViewContent = new Rectangle();
+			scrollView = new ScrollView();
+
+			SetupDefaultUI(scrollView, rectangleScrollViewContent, scrollViewLoadedEvent);
+
+			scrollView.ScrollStarting += (sender, args) =>
+			{
+				Verify.AreSame(scrollView, sender);
+				scrollStartingCorrelationIds.Add(args.CorrelationId);
+				scrollStartingHorizontalOffsets.Add(args.HorizontalOffset);
+				scrollStartingVerticalOffsets.Add(args.VerticalOffset);
+			};
+
+			scrollView.ScrollCompleted += (sender, args) =>
+			{
+				Verify.AreSame(scrollView, sender);
+				scrollCompletedCorrelationIds.Add(args.CorrelationId);
+				if (scrollCompletedCorrelationIds.Count == 2)
+				{
+					scrollViewScrollCompletedEvent.Set();
+				}
+			};
+		});
+
+		await WaitForEvent("Waiting for Loaded event", scrollViewLoadedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			var options = new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore);
+			firstOperationCorrelationId = scrollView.ScrollBy(10.0, 20.0, options);
+			secondOperationCorrelationId = scrollView.ScrollBy(5.0, 7.0, options);
+		});
+
+		await WaitForEvent("Waiting for ScrollCompleted events", scrollViewScrollCompletedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			Verify.AreEqual(2, scrollStartingCorrelationIds.Count);
+			Verify.AreEqual(firstOperationCorrelationId, scrollStartingCorrelationIds[0]);
+			Verify.AreEqual(secondOperationCorrelationId, scrollStartingCorrelationIds[1]);
+			Verify.AreEqual(10.0, scrollStartingHorizontalOffsets[0]);
+			Verify.AreEqual(20.0, scrollStartingVerticalOffsets[0]);
+			Verify.AreEqual(15.0, scrollStartingHorizontalOffsets[1]);
+			Verify.AreEqual(27.0, scrollStartingVerticalOffsets[1]);
+			Verify.AreEqual(2, scrollCompletedCorrelationIds.Count);
+			Verify.AreEqual(firstOperationCorrelationId, scrollCompletedCorrelationIds[0]);
+			Verify.AreEqual(secondOperationCorrelationId, scrollCompletedCorrelationIds[1]);
+			Verify.AreEqual(15.0, scrollView.HorizontalOffset);
+			Verify.AreEqual(27.0, scrollView.VerticalOffset);
+		});
+	}
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
+	[TestProperty("Description", "Verifies successive ZoomBy requests expose the anticipated final zoom factor.")]
+	public async Task VerifySuccessiveZoomStartingValues()
+	{
+		ScrollView scrollView = null;
+		Rectangle rectangleScrollViewContent = null;
+		UnoAutoResetEvent scrollViewLoadedEvent = new UnoAutoResetEvent(false);
+		UnoAutoResetEvent scrollViewZoomCompletedEvent = new UnoAutoResetEvent(false);
+		List<int> zoomStartingCorrelationIds = new();
+		List<float> zoomStartingZoomFactors = new();
+		List<int> zoomCompletedCorrelationIds = new();
+		int firstOperationCorrelationId = -1;
+		int secondOperationCorrelationId = -1;
+
+		RunOnUIThread.Execute(() =>
+		{
+			rectangleScrollViewContent = new Rectangle();
+			scrollView = new ScrollView();
+
+			SetupDefaultUI(scrollView, rectangleScrollViewContent, scrollViewLoadedEvent);
+
+			scrollView.ZoomStarting += (sender, args) =>
+			{
+				Verify.AreSame(scrollView, sender);
+				zoomStartingCorrelationIds.Add(args.CorrelationId);
+				zoomStartingZoomFactors.Add(args.ZoomFactor);
+			};
+
+			scrollView.ZoomCompleted += (sender, args) =>
+			{
+				Verify.AreSame(scrollView, sender);
+				zoomCompletedCorrelationIds.Add(args.CorrelationId);
+				if (zoomCompletedCorrelationIds.Count == 2)
+				{
+					scrollViewZoomCompletedEvent.Set();
+				}
+			};
+		});
+
+		await WaitForEvent("Waiting for Loaded event", scrollViewLoadedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			var options = new ScrollingZoomOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore);
+			firstOperationCorrelationId = scrollView.ZoomBy(1.0f, Vector2.Zero, options);
+			secondOperationCorrelationId = scrollView.ZoomBy(1.0f, Vector2.Zero, options);
+		});
+
+		await WaitForEvent("Waiting for ZoomCompleted events", scrollViewZoomCompletedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			Verify.AreEqual(2, zoomStartingCorrelationIds.Count);
+			Verify.AreEqual(firstOperationCorrelationId, zoomStartingCorrelationIds[0]);
+			Verify.AreEqual(secondOperationCorrelationId, zoomStartingCorrelationIds[1]);
+			Verify.AreEqual(2.0f, zoomStartingZoomFactors[0]);
+			Verify.AreEqual(3.0f, zoomStartingZoomFactors[1]);
+			Verify.AreEqual(2, zoomCompletedCorrelationIds.Count);
+			Verify.AreEqual(firstOperationCorrelationId, zoomCompletedCorrelationIds[0]);
+			Verify.AreEqual(secondOperationCorrelationId, zoomCompletedCorrelationIds[1]);
+			Verify.AreEqual(3.0f, scrollView.ZoomFactor);
 		});
 	}
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ScrollView/ScrollViewTests.cs
@@ -510,6 +510,76 @@ public class ScrollViewTests : MUXApiTestBase
 		}
 	}
 
+	[TestMethod]
+	[TestProperty("Description", "Verifies ScrollView forwards ScrollPresenter ScrollStarting args.")]
+	public async Task VerifyScrollStartingForwarding()
+	{
+		ScrollView scrollView = null;
+		Rectangle rectangleScrollViewContent = null;
+		UnoAutoResetEvent scrollViewLoadedEvent = new UnoAutoResetEvent(false);
+		UnoAutoResetEvent scrollViewScrollCompletedEvent = new UnoAutoResetEvent(false);
+		uint scrollStartingCount = 0u;
+		int scrollStartingCorrelationId = -1;
+		int scrollCompletedCorrelationId = -1;
+		int operationCorrelationId = -1;
+		double scrollStartingHorizontalOffset = 0.0;
+		double scrollStartingVerticalOffset = 0.0;
+		float scrollStartingZoomFactor = 0.0f;
+
+		RunOnUIThread.Execute(() =>
+		{
+			rectangleScrollViewContent = new Rectangle();
+			scrollView = new ScrollView();
+
+			SetupDefaultUI(scrollView, rectangleScrollViewContent, scrollViewLoadedEvent);
+
+			scrollView.ScrollStarting += (sender, args) =>
+			{
+				Log.Comment($"ScrollStarting scrollStartingCount={++scrollStartingCount} - HorizontalOffset={args.HorizontalOffset}, VerticalOffset={args.VerticalOffset}, ZoomFactor={args.ZoomFactor}");
+				Verify.AreSame(scrollView, sender);
+				scrollStartingCorrelationId = args.CorrelationId;
+				scrollStartingHorizontalOffset = args.HorizontalOffset;
+				scrollStartingVerticalOffset = args.VerticalOffset;
+				scrollStartingZoomFactor = args.ZoomFactor;
+			};
+
+			scrollView.ScrollCompleted += (sender, args) =>
+			{
+				Log.Comment($"ScrollCompleted CorrelationId={args.CorrelationId}");
+				Verify.AreSame(scrollView, sender);
+				scrollCompletedCorrelationId = args.CorrelationId;
+				scrollViewScrollCompletedEvent.Set();
+			};
+		});
+
+		await WaitForEvent("Waiting for Loaded event", scrollViewLoadedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			operationCorrelationId = scrollView.ScrollTo(
+				60.0,
+				70.0,
+				new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
+
+			if (operationCorrelationId == -1)
+			{
+				scrollViewScrollCompletedEvent.Set();
+			}
+		});
+
+		await WaitForEvent("Waiting for ScrollCompleted event", scrollViewScrollCompletedEvent);
+
+		RunOnUIThread.Execute(() =>
+		{
+			Verify.AreEqual(1u, scrollStartingCount);
+			Verify.AreEqual(operationCorrelationId, scrollStartingCorrelationId);
+			Verify.AreEqual(operationCorrelationId, scrollCompletedCorrelationId);
+			Verify.AreEqual(60.0, scrollStartingHorizontalOffset);
+			Verify.AreEqual(70.0, scrollStartingVerticalOffset);
+			Verify.AreEqual(1.0f, scrollStartingZoomFactor);
+		});
+	}
+
 	private void SetupDefaultUI(
 		ScrollView scrollView,
 		Rectangle rectangleScrollViewContent = null,

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker_Scale.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker_Scale.cs
@@ -1,0 +1,130 @@
+﻿#nullable enable
+
+using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Microsoft.UI.Composition.Interactions;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
+
+[TestClass]
+[RunsOnUIThread]
+[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
+public class Given_InteractionTracker_Scale
+{
+	[TestMethod]
+#if !HAS_COMPOSITION_API
+	[Ignore("Composition APIs are not supported on this platform.")]
+#endif
+	public async Task When_TryUpdateScale_AtOrigin()
+	{
+		var border = new Border
+		{
+			Width = 50,
+			Height = 50,
+		};
+
+		try
+		{
+			await UITestHelper.Load(border);
+
+			var owner = new TrackerOwner();
+			var tracker = InteractionTracker.CreateWithOwner(
+				ElementCompositionPreview.GetElementVisual(border).Compositor,
+				owner);
+			tracker.MinPosition = new Vector3(-1000.0f);
+			tracker.MaxPosition = new Vector3(1000.0f);
+			tracker.MinScale = 0.5f;
+			tracker.MaxScale = 4.0f;
+
+			var requestId = tracker.TryUpdateScale(2.0f, Vector3.Zero);
+			var args = await owner.ValuesChangedCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+			Assert.AreEqual(requestId, args.RequestId);
+			Assert.AreEqual(Vector3.Zero, args.Position);
+			Assert.AreEqual(2.0f, args.Scale);
+			Assert.AreEqual(Vector3.Zero, tracker.Position);
+			Assert.AreEqual(2.0f, tracker.Scale);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+#if !HAS_COMPOSITION_API
+	[Ignore("Composition APIs are not supported on this platform.")]
+#endif
+	public async Task When_TryUpdateScale_WithCenterPoint()
+	{
+		var border = new Border
+		{
+			Width = 50,
+			Height = 50,
+		};
+
+		try
+		{
+			await UITestHelper.Load(border);
+
+			var owner = new TrackerOwner();
+			var tracker = InteractionTracker.CreateWithOwner(
+				ElementCompositionPreview.GetElementVisual(border).Compositor,
+				owner);
+			tracker.MinPosition = new Vector3(-1000.0f);
+			tracker.MaxPosition = new Vector3(1000.0f);
+			tracker.MinScale = 0.5f;
+			tracker.MaxScale = 4.0f;
+
+			var centerPoint = new Vector3(10.0f, 20.0f, 0.0f);
+			var requestId = tracker.TryUpdateScale(2.0f, centerPoint);
+			var args = await owner.ValuesChangedCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+			Assert.AreEqual(requestId, args.RequestId);
+			Assert.AreEqual(centerPoint, args.Position);
+			Assert.AreEqual(2.0f, args.Scale);
+			Assert.AreEqual(centerPoint, tracker.Position);
+			Assert.AreEqual(2.0f, tracker.Scale);
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+
+	private sealed class TrackerOwner : IInteractionTrackerOwner
+	{
+		public TaskCompletionSource<InteractionTrackerValuesChangedArgs> ValuesChangedCompletion { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public void CustomAnimationStateEntered(InteractionTracker sender, InteractionTrackerCustomAnimationStateEnteredArgs args)
+		{
+		}
+
+		public void IdleStateEntered(InteractionTracker sender, InteractionTrackerIdleStateEnteredArgs args)
+		{
+		}
+
+		public void InertiaStateEntered(InteractionTracker sender, InteractionTrackerInertiaStateEnteredArgs args)
+		{
+		}
+
+		public void InteractingStateEntered(InteractionTracker sender, InteractionTrackerInteractingStateEnteredArgs args)
+		{
+		}
+
+		public void RequestIgnored(InteractionTracker sender, InteractionTrackerRequestIgnoredArgs args)
+		{
+		}
+
+		public void ValuesChanged(InteractionTracker sender, InteractionTrackerValuesChangedArgs args)
+		{
+			ValuesChangedCompletion.TrySetResult(args);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker_Scale.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker_Scale.cs
@@ -13,10 +13,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 
 [TestClass]
 [RunsOnUIThread]
-[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
 public class Given_InteractionTracker_Scale
 {
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
 #if !HAS_COMPOSITION_API
 	[Ignore("Composition APIs are not supported on this platform.")]
 #endif
@@ -41,14 +41,14 @@ public class Given_InteractionTracker_Scale
 			tracker.MinScale = 0.5f;
 			tracker.MaxScale = 4.0f;
 
-			var requestId = tracker.TryUpdateScale(2.0f, Vector3.Zero);
+			var requestId = tracker.TryUpdateScale(5.0f, Vector3.Zero);
 			var args = await owner.ValuesChangedCompletion.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
 			Assert.AreEqual(requestId, args.RequestId);
 			Assert.AreEqual(Vector3.Zero, args.Position);
-			Assert.AreEqual(2.0f, args.Scale);
+			Assert.AreEqual(4.0f, args.Scale);
 			Assert.AreEqual(Vector3.Zero, tracker.Position);
-			Assert.AreEqual(2.0f, tracker.Scale);
+			Assert.AreEqual(4.0f, tracker.Scale);
 		}
 		finally
 		{
@@ -57,6 +57,7 @@ public class Given_InteractionTracker_Scale
 	}
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23688")]
 #if !HAS_COMPOSITION_API
 	[Ignore("Composition APIs are not supported on this platform.")]
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/IScrollPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/IScrollPresenter.cs
@@ -98,6 +98,10 @@ internal interface IScrollPresenter
 
 	event TypedEventHandler<ScrollPresenter, ScrollingZoomCompletedEventArgs> ZoomCompleted;
 
+	event TypedEventHandler<ScrollPresenter, ScrollingScrollStartingEventArgs> ScrollStarting;
+
+	event TypedEventHandler<ScrollPresenter, ScrollingZoomStartingEventArgs> ZoomStarting;
+
 	int ScrollTo(double horizontalOffset, double verticalOffset);
 
 	int ScrollTo(double horizontalOffset, double verticalOffset, ScrollingScrollOptions options);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
@@ -6366,7 +6366,6 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		}
 
 		// Uno docs: ToArray call is to avoid modifying the collection while iterating.
-		// Uno: iterate a snapshot to allow Remove() inside the loop.
 		foreach (var interactionTrackerAsyncOperation in m_interactionTrackerAsyncOperations.ToArray())
 		{
 			bool isMatch = requestId == -1 || requestId == interactionTrackerAsyncOperation.GetRequestId();
@@ -6420,6 +6419,7 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 		// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
 
+		// Uno: iterate a snapshot to allow Remove() inside the loop.
 		foreach (var interactionTrackerAsyncOperation in m_interactionTrackerAsyncOperations.ToArray())
 		{
 			if (interactionTrackerAsyncOperation.IsDelayed())

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
@@ -6366,6 +6366,7 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		}
 
 		// Uno docs: ToArray call is to avoid modifying the collection while iterating.
+		// Uno: iterate a snapshot to allow Remove() inside the loop.
 		foreach (var interactionTrackerAsyncOperation in m_interactionTrackerAsyncOperations.ToArray())
 		{
 			bool isMatch = requestId == -1 || requestId == interactionTrackerAsyncOperation.GetRequestId();
@@ -7102,7 +7103,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 	{
 		if (dimension == ScrollPresenterDimension.HorizontalScroll)
 		{
-			if (m_anticipatedZoomedHorizontalOffset != zoomedOffset)
+			bool sameNaN = double.IsNaN(m_anticipatedZoomedHorizontalOffset) && double.IsNaN(zoomedOffset);
+			if (!sameNaN && m_anticipatedZoomedHorizontalOffset != zoomedOffset)
 			{
 				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedHorizontalOffset", m_anticipatedZoomedHorizontalOffset, zoomedOffset);
 
@@ -7112,7 +7114,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		else
 		{
 			MUX_ASSERT(dimension == ScrollPresenterDimension.VerticalScroll);
-			if (m_anticipatedZoomedVerticalOffset != zoomedOffset)
+			bool sameNaN = double.IsNaN(m_anticipatedZoomedVerticalOffset) && double.IsNaN(zoomedOffset);
+			if (!sameNaN && m_anticipatedZoomedVerticalOffset != zoomedOffset)
 			{
 				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedVerticalOffset", m_anticipatedZoomedVerticalOffset, zoomedOffset);
 
@@ -7123,7 +7126,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 	void UpdateAnticipatedZoomFactor(float zoomFactor)
 	{
-		if (m_anticipatedZoomFactor != zoomFactor)
+		bool sameNaN = float.IsNaN(m_anticipatedZoomFactor) && float.IsNaN(zoomFactor);
+		if (!sameNaN && m_anticipatedZoomFactor != zoomFactor)
 		{
 			// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"old/new anticipatedZoomFactor", m_anticipatedZoomFactor, zoomFactor);
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
@@ -236,6 +236,19 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 	public double ScrollableHeight => Math.Max(0.0, GetZoomedExtentHeight() - ViewportHeight);
 
+	// AnticipatedZoomedHorizontalOffset, AnticipatedZoomedVerticalOffset, AnticipatedZoomFactor, AnticipatedScrollableWidth and
+	// AnticipatedScrollableHeight return the anticipated view once all queued view change requests are completed. They are used to
+	// accumulate successive relative-to-current-view requests and to populate the ScrollStarting/ZoomStarting event args.
+	private double AnticipatedZoomedHorizontalOffset() => double.IsNaN(m_anticipatedZoomedHorizontalOffset) ? m_zoomedHorizontalOffset : m_anticipatedZoomedHorizontalOffset;
+
+	private double AnticipatedZoomedVerticalOffset() => double.IsNaN(m_anticipatedZoomedVerticalOffset) ? m_zoomedVerticalOffset : m_anticipatedZoomedVerticalOffset;
+
+	private float AnticipatedZoomFactor() => float.IsNaN(m_anticipatedZoomFactor) ? m_zoomFactor : m_anticipatedZoomFactor;
+
+	private double AnticipatedScrollableWidth() => Math.Max(0.0, m_unzoomedExtentWidth * AnticipatedZoomFactor() - ViewportWidth);
+
+	private double AnticipatedScrollableHeight() => Math.Max(0.0, m_unzoomedExtentHeight * AnticipatedZoomFactor() - ViewportHeight);
+
 	public IScrollController HorizontalScrollController
 	{
 		get => m_horizontalScrollController;
@@ -3908,6 +3921,11 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 							unhookCompositionTargetRendering = false;
 						}
 						m_interactionTrackerAsyncOperations.Remove(interactionTrackerAsyncOperation);
+
+						if (m_interactionTrackerAsyncOperations.Count == 0)
+						{
+							ResetAnticipatedView();
+						}
 					}
 					else
 					{
@@ -5867,6 +5885,9 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 			}
 		}
 
+		double anticipatedZoomedHorizontalOffset = double.NaN;
+		double anticipatedZoomedVerticalOffset = double.NaN;
+
 		switch (offsetsChange.ViewKind())
 		{
 #if ScrollPresenterViewKind_RelativeToEndOfInertiaView // UNO TODO
@@ -5880,10 +5901,14 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 #endif
 			case ScrollPresenterViewKind.RelativeToCurrentView:
 				{
+					anticipatedZoomedHorizontalOffset = AnticipatedZoomedHorizontalOffset();
+					anticipatedZoomedVerticalOffset = AnticipatedZoomedVerticalOffset();
+
 					if (snapPointsMode == ScrollingSnapPointsMode.Default || animationMode == ScrollingAnimationMode.Enabled)
 					{
-						zoomedHorizontalOffset += m_zoomedHorizontalOffset;
-						zoomedVerticalOffset += m_zoomedVerticalOffset;
+						// The new requested deltas are added to the prior deltas that have not been processed yet.
+						zoomedHorizontalOffset += anticipatedZoomedHorizontalOffset;
+						zoomedVerticalOffset += anticipatedZoomedVerticalOffset;
 					}
 					break;
 				}
@@ -5923,6 +5948,22 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 						m_latestInteractionTrackerRequest = m_interactionTracker.TryUpdatePositionBy(
 							new Vector3((float)zoomedHorizontalOffset, (float)zoomedVerticalOffset, 0.0f));
 						m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdatePositionBy;
+
+						if (zoomedHorizontalOffset != 0.0)
+						{
+							double newAnticipatedZoomedHorizontalOffset = zoomedHorizontalOffset + anticipatedZoomedHorizontalOffset;
+							newAnticipatedZoomedHorizontalOffset = Math.Max(0.0, newAnticipatedZoomedHorizontalOffset);
+							newAnticipatedZoomedHorizontalOffset = Math.Min(AnticipatedScrollableWidth(), newAnticipatedZoomedHorizontalOffset);
+							UpdateAnticipatedOffset(ScrollPresenterDimension.HorizontalScroll, newAnticipatedZoomedHorizontalOffset);
+						}
+
+						if (zoomedVerticalOffset != 0.0)
+						{
+							double newAnticipatedZoomedVerticalOffset = zoomedVerticalOffset + anticipatedZoomedVerticalOffset;
+							newAnticipatedZoomedVerticalOffset = Math.Max(0.0, newAnticipatedZoomedVerticalOffset);
+							newAnticipatedZoomedVerticalOffset = Math.Min(AnticipatedScrollableHeight(), newAnticipatedZoomedVerticalOffset);
+							UpdateAnticipatedOffset(ScrollPresenterDimension.VerticalScroll, newAnticipatedZoomedVerticalOffset);
+						}
 					}
 					else
 					{
@@ -5936,7 +5977,21 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 						m_latestInteractionTrackerRequest = m_interactionTracker.TryUpdatePosition(
 							new Vector3(targetPosition, 0.0f));
 						m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdatePosition;
+
+						double newAnticipatedZoomedHorizontalOffset = Math.Max(0.0, zoomedHorizontalOffset);
+						newAnticipatedZoomedHorizontalOffset = Math.Min(AnticipatedScrollableWidth(), newAnticipatedZoomedHorizontalOffset);
+						UpdateAnticipatedOffset(ScrollPresenterDimension.HorizontalScroll, newAnticipatedZoomedHorizontalOffset);
+
+						double newAnticipatedZoomedVerticalOffset = Math.Max(0.0, zoomedVerticalOffset);
+						newAnticipatedZoomedVerticalOffset = Math.Min(AnticipatedScrollableHeight(), newAnticipatedZoomedVerticalOffset);
+						UpdateAnticipatedOffset(ScrollPresenterDimension.VerticalScroll, newAnticipatedZoomedVerticalOffset);
 					}
+
+					RaiseScrollStarting(
+						offsetsChangeCorrelationId,
+						AnticipatedZoomedHorizontalOffset(),
+						AnticipatedZoomedVerticalOffset(),
+						AnticipatedZoomFactor());
 
 					if (isForAsyncOperation)
 					{
@@ -5957,6 +6012,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 							operationTrigger,
 							offsetsChangeCorrelationId));
 					m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdatePositionWithAnimation;
+
+					ResetAnticipatedView();
 					break;
 				}
 		}
@@ -6013,6 +6070,11 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 			m_interactionTracker.PositionInertiaDecayRate = new Vector3(horizontalInertiaDecayRate, verticalInertiaDecayRate, 0.0f);
 		}
+		else
+		{
+			// Restore the default 0.95 position inertia decay rate since it may have been overridden by a prior offset change with additional velocity.
+			m_interactionTracker.PositionInertiaDecayRate = null;
+		}
 
 #if DEBUG
 		// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_METH_STR, METH_NAME, this,
@@ -6022,6 +6084,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		m_latestInteractionTrackerRequest = m_interactionTracker.TryUpdatePositionWithAdditionalVelocity(
 			new Vector3(offsetsVelocity, 0.0f));
 		m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdatePositionWithAdditionalVelocity;
+
+		ResetAnticipatedView();
 	}
 
 	// Restores the default scroll inertia decay rate if no offset change with additional velocity operation is in progress.
@@ -6083,7 +6147,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 #endif
 			case ScrollPresenterViewKind.RelativeToCurrentView:
 				{
-					zoomFactor += m_zoomFactor;
+					// The new requested delta is added to the prior deltas that have not been processed yet.
+					zoomFactor += AnticipatedZoomFactor();
 					break;
 				}
 		}
@@ -6110,6 +6175,25 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 					m_latestInteractionTrackerRequest = m_interactionTracker.TryUpdateScale(zoomFactor, centerPoint);
 					m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdateScale;
 
+					double newAnticipatedZoomedHorizontalOffset = zoomFactor / AnticipatedZoomFactor() * (AnticipatedZoomedHorizontalOffset() + centerPoint.X) - centerPoint.X;
+					double newAnticipatedZoomedVerticalOffset = zoomFactor / AnticipatedZoomFactor() * (AnticipatedZoomedVerticalOffset() + centerPoint.Y) - centerPoint.Y;
+
+					UpdateAnticipatedZoomFactor(zoomFactor);
+
+					newAnticipatedZoomedHorizontalOffset = Math.Max(0.0, newAnticipatedZoomedHorizontalOffset);
+					newAnticipatedZoomedHorizontalOffset = Math.Min(AnticipatedScrollableWidth(), newAnticipatedZoomedHorizontalOffset);
+					UpdateAnticipatedOffset(ScrollPresenterDimension.HorizontalScroll, newAnticipatedZoomedHorizontalOffset);
+
+					newAnticipatedZoomedVerticalOffset = Math.Max(0.0, newAnticipatedZoomedVerticalOffset);
+					newAnticipatedZoomedVerticalOffset = Math.Min(AnticipatedScrollableHeight(), newAnticipatedZoomedVerticalOffset);
+					UpdateAnticipatedOffset(ScrollPresenterDimension.VerticalScroll, newAnticipatedZoomedVerticalOffset);
+
+					RaiseZoomStarting(
+						zoomFactorChangeCorrelationId,
+						newAnticipatedZoomedHorizontalOffset,
+						newAnticipatedZoomedVerticalOffset,
+						zoomFactor);
+
 					HookCompositionTargetRendering();
 					break;
 				}
@@ -6123,6 +6207,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 						GetZoomFactorAnimation(zoomFactor, centerPoint2D, zoomFactorChangeCorrelationId),
 						centerPoint);
 					m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdateScaleWithAnimation;
+
+					ResetAnticipatedView();
 					break;
 				}
 		}
@@ -6153,6 +6239,11 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 			m_interactionTracker.ScaleInertiaDecayRate = scaleInertiaDecayRate;
 		}
+		else
+		{
+			// Restore the default 0.985 zoomFactor inertia decay rate since it may have been overridden by a prior zoomFactor change with additional velocity.
+			m_interactionTracker.ScaleInertiaDecayRate = null;
+		}
 
 		Vector2 centerPoint2D = !nullableCenterPoint.HasValue ?
 			new Vector2((float)(m_viewportWidth / 2.0), (float)(m_viewportHeight / 2.0)) : nullableCenterPoint.Value;
@@ -6167,6 +6258,8 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 			zoomFactorVelocity,
 			centerPoint);
 		m_lastInteractionTrackerAsyncOperationType = InteractionTrackerAsyncOperationType.TryUpdateScaleWithAdditionalVelocity;
+
+		ResetAnticipatedView();
 	}
 
 	// Restores the default zoomFactor inertia decay rate if no zoomFactor change with additional velocity operation is in progress.
@@ -6298,6 +6391,11 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 					m_interactionTrackerAsyncOperations.Remove(interactionTrackerAsyncOperationRemoved);
 
+					if (m_interactionTrackerAsyncOperations.Count == 0)
+					{
+						ResetAnticipatedView();
+					}
+
 					switch (interactionTrackerAsyncOperationRemoved.GetOperationType())
 					{
 						case InteractionTrackerAsyncOperationType.TryUpdatePositionWithAdditionalVelocity:
@@ -6321,12 +6419,17 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 		// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
 
-		foreach (var interactionTrackerAsyncOperation in m_interactionTrackerAsyncOperations)
+		foreach (var interactionTrackerAsyncOperation in m_interactionTrackerAsyncOperations.ToArray())
 		{
 			if (interactionTrackerAsyncOperation.IsDelayed())
 			{
 				CompleteViewChange(interactionTrackerAsyncOperation, ScrollPresenterViewChangeResult.Interrupted);
 				m_interactionTrackerAsyncOperations.Remove(interactionTrackerAsyncOperation);
+
+				if (m_interactionTrackerAsyncOperations.Count == 0)
+				{
+					ResetAnticipatedView();
+				}
 			}
 		}
 	}
@@ -6992,6 +7095,94 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		else
 		{
 			return zoomFactorAnimation;
+		}
+	}
+
+	void UpdateAnticipatedOffset(ScrollPresenterDimension dimension, double zoomedOffset)
+	{
+		if (dimension == ScrollPresenterDimension.HorizontalScroll)
+		{
+			if (m_anticipatedZoomedHorizontalOffset != zoomedOffset)
+			{
+				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedHorizontalOffset", m_anticipatedZoomedHorizontalOffset, zoomedOffset);
+
+				m_anticipatedZoomedHorizontalOffset = zoomedOffset;
+			}
+		}
+		else
+		{
+			MUX_ASSERT(dimension == ScrollPresenterDimension.VerticalScroll);
+			if (m_anticipatedZoomedVerticalOffset != zoomedOffset)
+			{
+				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedVerticalOffset", m_anticipatedZoomedVerticalOffset, zoomedOffset);
+
+				m_anticipatedZoomedVerticalOffset = zoomedOffset;
+			}
+		}
+	}
+
+	void UpdateAnticipatedZoomFactor(float zoomFactor)
+	{
+		if (m_anticipatedZoomFactor != zoomFactor)
+		{
+			// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"old/new anticipatedZoomFactor", m_anticipatedZoomFactor, zoomFactor);
+
+			m_anticipatedZoomFactor = zoomFactor;
+		}
+	}
+
+	// Clears the last recorded anticipated view for the ScrollStarting/ZoomStarting events.
+	// Called in two classes of circumstances:
+	// - all queued view change requested were completed,
+	// - an animated view change request is handed off to the InteractionTracker.
+	void ResetAnticipatedView()
+	{
+		UpdateAnticipatedOffset(ScrollPresenterDimension.HorizontalScroll, double.NaN);
+		UpdateAnticipatedOffset(ScrollPresenterDimension.VerticalScroll, double.NaN);
+		UpdateAnticipatedZoomFactor(float.NaN);
+	}
+
+	void RaiseScrollStarting(
+		int offsetsChangeCorrelationId,
+		double anticipatedHorizontalOffset,
+		double anticipatedVerticalOffset,
+		float anticipatedZoomFactor)
+	{
+		if (ScrollStarting is not null)
+		{
+			var scrollStartingEventArgs = new ScrollingScrollStartingEventArgs();
+
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_INT, METH_NAME, this, offsetsChangeCorrelationId);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, anticipatedHorizontalOffset, anticipatedVerticalOffset);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_FLT, METH_NAME, this, anticipatedZoomFactor);
+
+			scrollStartingEventArgs.CorrelationId = offsetsChangeCorrelationId;
+			scrollStartingEventArgs.HorizontalOffset = anticipatedHorizontalOffset;
+			scrollStartingEventArgs.VerticalOffset = anticipatedVerticalOffset;
+			scrollStartingEventArgs.ZoomFactor = anticipatedZoomFactor;
+			ScrollStarting.Invoke(this, scrollStartingEventArgs);
+		}
+	}
+
+	void RaiseZoomStarting(
+		int zoomFactorChangeCorrelationId,
+		double anticipatedHorizontalOffset,
+		double anticipatedVerticalOffset,
+		float anticipatedZoomFactor)
+	{
+		if (ZoomStarting is not null)
+		{
+			var zoomStartingEventArgs = new ScrollingZoomStartingEventArgs();
+
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_INT, METH_NAME, this, zoomFactorChangeCorrelationId);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, anticipatedHorizontalOffset, anticipatedVerticalOffset);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_FLT, METH_NAME, this, anticipatedZoomFactor);
+
+			zoomStartingEventArgs.CorrelationId = zoomFactorChangeCorrelationId;
+			zoomStartingEventArgs.HorizontalOffset = anticipatedHorizontalOffset;
+			zoomStartingEventArgs.VerticalOffset = anticipatedVerticalOffset;
+			zoomStartingEventArgs.ZoomFactor = anticipatedZoomFactor;
+			ZoomStarting.Invoke(this, zoomStartingEventArgs);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollPresenter.cpp, commit b8cfb8490
 
 using System;
 using System.Collections.Generic;
@@ -236,9 +237,9 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 	public double ScrollableHeight => Math.Max(0.0, GetZoomedExtentHeight() - ViewportHeight);
 
-	// AnticipatedZoomedHorizontalOffset, AnticipatedZoomedVerticalOffset, AnticipatedZoomFactor, AnticipatedScrollableWidth and
-	// AnticipatedScrollableHeight return the anticipated view once all queued view change requests are completed. They are used to
-	// accumulate successive relative-to-current-view requests and to populate the ScrollStarting/ZoomStarting event args.
+	// AnticipatedZoomedHorizontalOffset, AnticipatedZoomedVerticalOffset and AnticipatedZoomFactor are
+	// used to evaluate the view for the ScrollStarting/ZoomStarting events raised when a ScrollTo, ScrollBy,
+	// ZoomTo or ZoomBy request is handed off to the InteractionTracker.
 	private double AnticipatedZoomedHorizontalOffset() => double.IsNaN(m_anticipatedZoomedHorizontalOffset) ? m_zoomedHorizontalOffset : m_anticipatedZoomedHorizontalOffset;
 
 	private double AnticipatedZoomedVerticalOffset() => double.IsNaN(m_anticipatedZoomedVerticalOffset) ? m_zoomedVerticalOffset : m_anticipatedZoomedVerticalOffset;
@@ -5130,6 +5131,42 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		}
 	}
 
+	void UpdateAnticipatedOffset(ScrollPresenterDimension dimension, double zoomedOffset)
+	{
+		if (dimension == ScrollPresenterDimension.HorizontalScroll)
+		{
+			bool sameNaN = double.IsNaN(m_anticipatedZoomedHorizontalOffset) && double.IsNaN(zoomedOffset);
+			if (!sameNaN && m_anticipatedZoomedHorizontalOffset != zoomedOffset)
+			{
+				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedHorizontalOffset", m_anticipatedZoomedHorizontalOffset, zoomedOffset);
+
+				m_anticipatedZoomedHorizontalOffset = zoomedOffset;
+			}
+		}
+		else
+		{
+			MUX_ASSERT(dimension == ScrollPresenterDimension.VerticalScroll);
+			bool sameNaN = double.IsNaN(m_anticipatedZoomedVerticalOffset) && double.IsNaN(zoomedOffset);
+			if (!sameNaN && m_anticipatedZoomedVerticalOffset != zoomedOffset)
+			{
+				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedVerticalOffset", m_anticipatedZoomedVerticalOffset, zoomedOffset);
+
+				m_anticipatedZoomedVerticalOffset = zoomedOffset;
+			}
+		}
+	}
+
+	void UpdateAnticipatedZoomFactor(float zoomFactor)
+	{
+		bool sameNaN = float.IsNaN(m_anticipatedZoomFactor) && float.IsNaN(zoomFactor);
+		if (!sameNaN && m_anticipatedZoomFactor != zoomFactor)
+		{
+			// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"old/new anticipatedZoomFactor", m_anticipatedZoomFactor, zoomFactor);
+
+			m_anticipatedZoomFactor = zoomFactor;
+		}
+	}
+
 	void UpdateOffset(ScrollPresenterDimension dimension, double zoomedOffset)
 	{
 		if (dimension == ScrollPresenterDimension.HorizontalScroll)
@@ -6070,11 +6107,6 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 			m_interactionTracker.PositionInertiaDecayRate = new Vector3(horizontalInertiaDecayRate, verticalInertiaDecayRate, 0.0f);
 		}
-		else
-		{
-			// Restore the default 0.95 position inertia decay rate since it may have been overridden by a prior offset change with additional velocity.
-			m_interactionTracker.PositionInertiaDecayRate = null;
-		}
 
 #if DEBUG
 		// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_METH_STR, METH_NAME, this,
@@ -6239,11 +6271,6 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 
 			m_interactionTracker.ScaleInertiaDecayRate = scaleInertiaDecayRate;
 		}
-		else
-		{
-			// Restore the default 0.985 zoomFactor inertia decay rate since it may have been overridden by a prior zoomFactor change with additional velocity.
-			m_interactionTracker.ScaleInertiaDecayRate = null;
-		}
 
 		Vector2 centerPoint2D = !nullableCenterPoint.HasValue ?
 			new Vector2((float)(m_viewportWidth / 2.0), (float)(m_viewportHeight / 2.0)) : nullableCenterPoint.Value;
@@ -6283,6 +6310,17 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		}
 
 		m_interactionTracker.ScaleInertiaDecayRate = null;
+	}
+
+	// Clears the last recorded anticipated view for the ScrollStarting/ZoomStarting events.
+	// Called in two classes of circumstances:
+	// - all queued view change requested were completed,
+	// - an animated view change request is handed off to the InteractionTracker.
+	void ResetAnticipatedView()
+	{
+		UpdateAnticipatedOffset(ScrollPresenterDimension.HorizontalScroll, double.NaN);
+		UpdateAnticipatedOffset(ScrollPresenterDimension.VerticalScroll, double.NaN);
+		UpdateAnticipatedZoomFactor(float.NaN);
 	}
 
 	void CompleteViewChange(
@@ -7026,6 +7064,50 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		StateChanged?.Invoke(this, null);
 	}
 
+	void RaiseScrollStarting(
+		int offsetsChangeCorrelationId,
+		double anticipatedHorizontalOffset,
+		double anticipatedVerticalOffset,
+		float anticipatedZoomFactor)
+	{
+		if (ScrollStarting is not null)
+		{
+			var scrollStartingEventArgs = new ScrollingScrollStartingEventArgs();
+
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_INT, METH_NAME, this, offsetsChangeCorrelationId);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, anticipatedHorizontalOffset, anticipatedVerticalOffset);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_FLT, METH_NAME, this, anticipatedZoomFactor);
+
+			scrollStartingEventArgs.SetCorrelationId(offsetsChangeCorrelationId);
+			scrollStartingEventArgs.SetHorizontalOffset(anticipatedHorizontalOffset);
+			scrollStartingEventArgs.SetVerticalOffset(anticipatedVerticalOffset);
+			scrollStartingEventArgs.SetZoomFactor(anticipatedZoomFactor);
+			ScrollStarting.Invoke(this, scrollStartingEventArgs);
+		}
+	}
+
+	void RaiseZoomStarting(
+		int zoomFactorChangeCorrelationId,
+		double anticipatedHorizontalOffset,
+		double anticipatedVerticalOffset,
+		float anticipatedZoomFactor)
+	{
+		if (ZoomStarting is not null)
+		{
+			var zoomStartingEventArgs = new ScrollingZoomStartingEventArgs();
+
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_INT, METH_NAME, this, zoomFactorChangeCorrelationId);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, anticipatedHorizontalOffset, anticipatedVerticalOffset);
+			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_FLT, METH_NAME, this, anticipatedZoomFactor);
+
+			zoomStartingEventArgs.SetCorrelationId(zoomFactorChangeCorrelationId);
+			zoomStartingEventArgs.SetHorizontalOffset(anticipatedHorizontalOffset);
+			zoomStartingEventArgs.SetVerticalOffset(anticipatedVerticalOffset);
+			zoomStartingEventArgs.SetZoomFactor(anticipatedZoomFactor);
+			ZoomStarting.Invoke(this, zoomStartingEventArgs);
+		}
+	}
+
 	void RaiseViewChanged()
 	{
 		ViewChanged?.Invoke(this, null);
@@ -7096,97 +7178,6 @@ public partial class ScrollPresenter : FrameworkElement, IScrollAnchorProvider, 
 		else
 		{
 			return zoomFactorAnimation;
-		}
-	}
-
-	void UpdateAnticipatedOffset(ScrollPresenterDimension dimension, double zoomedOffset)
-	{
-		if (dimension == ScrollPresenterDimension.HorizontalScroll)
-		{
-			bool sameNaN = double.IsNaN(m_anticipatedZoomedHorizontalOffset) && double.IsNaN(zoomedOffset);
-			if (!sameNaN && m_anticipatedZoomedHorizontalOffset != zoomedOffset)
-			{
-				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedHorizontalOffset", m_anticipatedZoomedHorizontalOffset, zoomedOffset);
-
-				m_anticipatedZoomedHorizontalOffset = zoomedOffset;
-			}
-		}
-		else
-		{
-			MUX_ASSERT(dimension == ScrollPresenterDimension.VerticalScroll);
-			bool sameNaN = double.IsNaN(m_anticipatedZoomedVerticalOffset) && double.IsNaN(zoomedOffset);
-			if (!sameNaN && m_anticipatedZoomedVerticalOffset != zoomedOffset)
-			{
-				// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL_DBL, METH_NAME, this, L"old/new anticipatedZoomedVerticalOffset", m_anticipatedZoomedVerticalOffset, zoomedOffset);
-
-				m_anticipatedZoomedVerticalOffset = zoomedOffset;
-			}
-		}
-	}
-
-	void UpdateAnticipatedZoomFactor(float zoomFactor)
-	{
-		bool sameNaN = float.IsNaN(m_anticipatedZoomFactor) && float.IsNaN(zoomFactor);
-		if (!sameNaN && m_anticipatedZoomFactor != zoomFactor)
-		{
-			// SCROLLPRESENTER_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"old/new anticipatedZoomFactor", m_anticipatedZoomFactor, zoomFactor);
-
-			m_anticipatedZoomFactor = zoomFactor;
-		}
-	}
-
-	// Clears the last recorded anticipated view for the ScrollStarting/ZoomStarting events.
-	// Called in two classes of circumstances:
-	// - all queued view change requested were completed,
-	// - an animated view change request is handed off to the InteractionTracker.
-	void ResetAnticipatedView()
-	{
-		UpdateAnticipatedOffset(ScrollPresenterDimension.HorizontalScroll, double.NaN);
-		UpdateAnticipatedOffset(ScrollPresenterDimension.VerticalScroll, double.NaN);
-		UpdateAnticipatedZoomFactor(float.NaN);
-	}
-
-	void RaiseScrollStarting(
-		int offsetsChangeCorrelationId,
-		double anticipatedHorizontalOffset,
-		double anticipatedVerticalOffset,
-		float anticipatedZoomFactor)
-	{
-		if (ScrollStarting is not null)
-		{
-			var scrollStartingEventArgs = new ScrollingScrollStartingEventArgs();
-
-			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_INT, METH_NAME, this, offsetsChangeCorrelationId);
-			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, anticipatedHorizontalOffset, anticipatedVerticalOffset);
-			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_FLT, METH_NAME, this, anticipatedZoomFactor);
-
-			scrollStartingEventArgs.CorrelationId = offsetsChangeCorrelationId;
-			scrollStartingEventArgs.HorizontalOffset = anticipatedHorizontalOffset;
-			scrollStartingEventArgs.VerticalOffset = anticipatedVerticalOffset;
-			scrollStartingEventArgs.ZoomFactor = anticipatedZoomFactor;
-			ScrollStarting.Invoke(this, scrollStartingEventArgs);
-		}
-	}
-
-	void RaiseZoomStarting(
-		int zoomFactorChangeCorrelationId,
-		double anticipatedHorizontalOffset,
-		double anticipatedVerticalOffset,
-		float anticipatedZoomFactor)
-	{
-		if (ZoomStarting is not null)
-		{
-			var zoomStartingEventArgs = new ScrollingZoomStartingEventArgs();
-
-			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_INT, METH_NAME, this, zoomFactorChangeCorrelationId);
-			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, anticipatedHorizontalOffset, anticipatedVerticalOffset);
-			// SCROLLPRESENTER_TRACE_INFO(*this, TRACE_MSG_METH_FLT, METH_NAME, this, anticipatedZoomFactor);
-
-			zoomStartingEventArgs.CorrelationId = zoomFactorChangeCorrelationId;
-			zoomStartingEventArgs.HorizontalOffset = anticipatedHorizontalOffset;
-			zoomStartingEventArgs.VerticalOffset = anticipatedVerticalOffset;
-			zoomStartingEventArgs.ZoomFactor = anticipatedZoomFactor;
-			ZoomStarting.Invoke(this, zoomStartingEventArgs);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.h.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollPresenter.h, commit b8cfb8490
 
 using System.Collections.Generic;
 using System.Numerics;
@@ -108,18 +109,17 @@ public partial class ScrollPresenter : FrameworkElement
 	private float m_animationRestartZoomFactor = 1.0f;
 	private float m_endOfInertiaZoomFactor = 1.0f;
 	private float m_zoomFactor = 1.0f;
+	private float m_anticipatedZoomFactor = float.NaN;
 	private float m_contentLayoutOffsetX = 0.0f;
 	private float m_contentLayoutOffsetY = 0.0f;
 	private double m_zoomedHorizontalOffset = 0.0;
 	private double m_zoomedVerticalOffset = 0.0;
+	private double m_anticipatedZoomedHorizontalOffset = double.NaN;
+	private double m_anticipatedZoomedVerticalOffset = double.NaN;
 	private double m_unzoomedExtentWidth = 0.0;
 	private double m_unzoomedExtentHeight = 0.0;
 	private double m_viewportWidth = 0.0;
 	private double m_viewportHeight = 0.0;
-	// Anticipated view recorded for the ScrollStarting/ZoomStarting events. NaN means no anticipated value, in which case the current value is used.
-	private float m_anticipatedZoomFactor = float.NaN;
-	private double m_anticipatedZoomedHorizontalOffset = double.NaN;
-	private double m_anticipatedZoomedVerticalOffset = double.NaN;
 	private bool m_horizontalSnapPointsNeedViewportUpdates = false; // True when at least one horizontal snap point is not near aligned.
 	private bool m_verticalSnapPointsNeedViewportUpdates = false; // True when at least one vertical snap point is not near aligned.
 	private bool m_isAnchorElementDirty = true; // False when m_anchorElement is up-to-date, True otherwise.

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenter.h.cs
@@ -116,6 +116,10 @@ public partial class ScrollPresenter : FrameworkElement
 	private double m_unzoomedExtentHeight = 0.0;
 	private double m_viewportWidth = 0.0;
 	private double m_viewportHeight = 0.0;
+	// Anticipated view recorded for the ScrollStarting/ZoomStarting events. NaN means no anticipated value, in which case the current value is used.
+	private float m_anticipatedZoomFactor = float.NaN;
+	private double m_anticipatedZoomedHorizontalOffset = double.NaN;
+	private double m_anticipatedZoomedVerticalOffset = double.NaN;
 	private bool m_horizontalSnapPointsNeedViewportUpdates = false; // True when at least one horizontal snap point is not near aligned.
 	private bool m_verticalSnapPointsNeedViewportUpdates = false; // True when at least one vertical snap point is not near aligned.
 	private bool m_isAnchorElementDirty = true; // False when m_anchorElement is up-to-date, True otherwise.

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenterPrimitives.idl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenterPrimitives.idl.cs
@@ -186,6 +186,8 @@ public partial class ScrollPresenter :
 	public event TypedEventHandler<ScrollPresenter, ScrollingZoomCompletedEventArgs> ZoomCompleted;
 	public event TypedEventHandler<ScrollPresenter, ScrollingBringingIntoViewEventArgs> BringingIntoView;
 	public event TypedEventHandler<ScrollPresenter, ScrollingAnchorRequestedEventArgs> AnchorRequested;
+	public event TypedEventHandler<ScrollPresenter, ScrollingScrollStartingEventArgs> ScrollStarting;
+	public event TypedEventHandler<ScrollPresenter, ScrollingZoomStartingEventArgs> ZoomStarting;
 
 	public new static DependencyProperty BackgroundProperty { get; } = DependencyProperty.Register(
 		nameof(Background),

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenterPrimitives.idl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollPresenterPrimitives.idl.cs
@@ -1,4 +1,8 @@
-﻿using System.Numerics;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollPresenterPrimitives.idl, commit b8cfb8490
+
+using System.Numerics;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference ScrollingScrollStartingEventArgs.cpp, commit b8cfb8490
+// MUX Reference ScrollPresenter.idl, commit b8cfb8490
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -10,33 +10,4 @@ namespace Microsoft.UI.Xaml.Controls;
 /// </summary>
 public sealed partial class ScrollingScrollStartingEventArgs
 {
-	internal ScrollingScrollStartingEventArgs()
-	{
-		// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
-	}
-
-	// ~ScrollingScrollStartingEventArgs()
-	// {
-	//     SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
-	// }
-
-	/// <summary>
-	/// Gets the correlation identifier associated with the imminent scroll offsets change.
-	/// </summary>
-	public int CorrelationId { get; internal set; } = -1;
-
-	/// <summary>
-	/// Gets the anticipated horizontal offset once all queued offset changes are completed.
-	/// </summary>
-	public double HorizontalOffset { get; internal set; }
-
-	/// <summary>
-	/// Gets the anticipated vertical offset once all queued offset changes are completed.
-	/// </summary>
-	public double VerticalOffset { get; internal set; }
-
-	/// <summary>
-	/// Gets the anticipated zoom factor once all queued view changes are completed.
-	/// </summary>
-	public float ZoomFactor { get; internal set; }
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollingScrollStartingEventArgs.cpp, commit b8cfb8490
+
+namespace Microsoft.UI.Xaml.Controls;
+
+/// <summary>
+/// Provides data for the <see cref="ScrollView.ScrollStarting"/> and
+/// Microsoft.UI.Xaml.Controls.Primitives.ScrollPresenter.ScrollStarting events.
+/// </summary>
+public sealed partial class ScrollingScrollStartingEventArgs
+{
+	internal ScrollingScrollStartingEventArgs()
+	{
+		// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	}
+
+	// ~ScrollingScrollStartingEventArgs()
+	// {
+	//     SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	// }
+
+	/// <summary>
+	/// Gets the correlation identifier associated with the imminent scroll offsets change.
+	/// </summary>
+	public int CorrelationId { get; internal set; } = -1;
+
+	/// <summary>
+	/// Gets the anticipated horizontal offset once all queued offset changes are completed.
+	/// </summary>
+	public double HorizontalOffset { get; internal set; }
+
+	/// <summary>
+	/// Gets the anticipated vertical offset once all queued offset changes are completed.
+	/// </summary>
+	public double VerticalOffset { get; internal set; }
+
+	/// <summary>
+	/// Gets the anticipated zoom factor once all queued view changes are completed.
+	/// </summary>
+	public float ZoomFactor { get; internal set; }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.h.mux.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollingScrollStartingEventArgs.h, commit b8cfb8490
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class ScrollingScrollStartingEventArgs
+{
+	internal ScrollingScrollStartingEventArgs()
+	{
+		// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	}
+
+#if HAS_UNO
+	// TODO Uno: The original C++ destructor only traces destruction, so Uno does not add a finalizer.
+	// Original destructor logic (not executed):
+	// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+#endif
+
+	private int m_correlationId = -1;
+	private double m_horizontalOffset;
+	private double m_verticalOffset;
+	private float m_zoomFactor;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingScrollStartingEventArgs.mux.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollingScrollStartingEventArgs.cpp, commit b8cfb8490
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class ScrollingScrollStartingEventArgs
+{
+	/// <summary>
+	/// Gets the correlation identifier associated with the imminent scroll offsets change.
+	/// </summary>
+	public int CorrelationId => m_correlationId;
+
+	internal void SetCorrelationId(int correlationId) => m_correlationId = correlationId;
+
+	/// <summary>
+	/// Gets the anticipated horizontal offset once all queued offset changes are completed.
+	/// </summary>
+	public double HorizontalOffset => m_horizontalOffset;
+
+	internal void SetHorizontalOffset(double horizontalOffset) => m_horizontalOffset = horizontalOffset;
+
+	/// <summary>
+	/// Gets the anticipated vertical offset once all queued offset changes are completed.
+	/// </summary>
+	public double VerticalOffset => m_verticalOffset;
+
+	internal void SetVerticalOffset(double verticalOffset) => m_verticalOffset = verticalOffset;
+
+	/// <summary>
+	/// Gets the anticipated zoom factor once all queued view changes are completed.
+	/// </summary>
+	public float ZoomFactor => m_zoomFactor;
+
+	internal void SetZoomFactor(float zoomFactor) => m_zoomFactor = zoomFactor;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference ScrollingZoomStartingEventArgs.cpp, commit b8cfb8490
+// MUX Reference ScrollPresenter.idl, commit b8cfb8490
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -10,33 +10,4 @@ namespace Microsoft.UI.Xaml.Controls;
 /// </summary>
 public sealed partial class ScrollingZoomStartingEventArgs
 {
-	internal ScrollingZoomStartingEventArgs()
-	{
-		// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
-	}
-
-	// ~ScrollingZoomStartingEventArgs()
-	// {
-	//     SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
-	// }
-
-	/// <summary>
-	/// Gets the correlation identifier associated with the imminent zoom factor change.
-	/// </summary>
-	public int CorrelationId { get; internal set; } = -1;
-
-	/// <summary>
-	/// Gets the anticipated horizontal offset once all queued view changes are completed.
-	/// </summary>
-	public double HorizontalOffset { get; internal set; }
-
-	/// <summary>
-	/// Gets the anticipated vertical offset once all queued view changes are completed.
-	/// </summary>
-	public double VerticalOffset { get; internal set; }
-
-	/// <summary>
-	/// Gets the anticipated zoom factor once all queued zoom factor changes are completed.
-	/// </summary>
-	public float ZoomFactor { get; internal set; }
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollingZoomStartingEventArgs.cpp, commit b8cfb8490
+
+namespace Microsoft.UI.Xaml.Controls;
+
+/// <summary>
+/// Provides data for the <see cref="ScrollView.ZoomStarting"/> and
+/// Microsoft.UI.Xaml.Controls.Primitives.ScrollPresenter.ZoomStarting events.
+/// </summary>
+public sealed partial class ScrollingZoomStartingEventArgs
+{
+	internal ScrollingZoomStartingEventArgs()
+	{
+		// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	}
+
+	// ~ScrollingZoomStartingEventArgs()
+	// {
+	//     SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	// }
+
+	/// <summary>
+	/// Gets the correlation identifier associated with the imminent zoom factor change.
+	/// </summary>
+	public int CorrelationId { get; internal set; } = -1;
+
+	/// <summary>
+	/// Gets the anticipated horizontal offset once all queued view changes are completed.
+	/// </summary>
+	public double HorizontalOffset { get; internal set; }
+
+	/// <summary>
+	/// Gets the anticipated vertical offset once all queued view changes are completed.
+	/// </summary>
+	public double VerticalOffset { get; internal set; }
+
+	/// <summary>
+	/// Gets the anticipated zoom factor once all queued zoom factor changes are completed.
+	/// </summary>
+	public float ZoomFactor { get; internal set; }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.h.mux.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollingZoomStartingEventArgs.h, commit b8cfb8490
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class ScrollingZoomStartingEventArgs
+{
+	internal ScrollingZoomStartingEventArgs()
+	{
+		// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	}
+
+#if HAS_UNO
+	// TODO Uno: The original C++ destructor only traces destruction, so Uno does not add a finalizer.
+	// Original destructor logic (not executed):
+	// SCROLLPRESENTER_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+#endif
+
+	private int m_correlationId = -1;
+	private double m_horizontalOffset;
+	private double m_verticalOffset;
+	private float m_zoomFactor;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollPresenter/ScrollingZoomStartingEventArgs.mux.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollingZoomStartingEventArgs.cpp, commit b8cfb8490
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class ScrollingZoomStartingEventArgs
+{
+	/// <summary>
+	/// Gets the correlation identifier associated with the imminent zoom factor change.
+	/// </summary>
+	public int CorrelationId => m_correlationId;
+
+	internal void SetCorrelationId(int correlationId) => m_correlationId = correlationId;
+
+	/// <summary>
+	/// Gets the anticipated horizontal offset once all queued view changes are completed.
+	/// </summary>
+	public double HorizontalOffset => m_horizontalOffset;
+
+	internal void SetHorizontalOffset(double horizontalOffset) => m_horizontalOffset = horizontalOffset;
+
+	/// <summary>
+	/// Gets the anticipated vertical offset once all queued view changes are completed.
+	/// </summary>
+	public double VerticalOffset => m_verticalOffset;
+
+	internal void SetVerticalOffset(double verticalOffset) => m_verticalOffset = verticalOffset;
+
+	/// <summary>
+	/// Gets the anticipated zoom factor once all queued zoom factor changes are completed.
+	/// </summary>
+	public float ZoomFactor => m_zoomFactor;
+
+	internal void SetZoomFactor(float zoomFactor) => m_zoomFactor = zoomFactor;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollBarController.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollBarController.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX reference ScrollBarController.cpp, tag winui3/release/1.4.2
+// MUX Reference ScrollBarController.cpp, commit b8cfb8490
 
 using System;
 using System.Numerics;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollBarController.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollBarController.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference ScrollBarController.cpp, commit b8cfb8490
+// MUX reference ScrollBarController.cpp, tag winui3/release/1.4.2
 
 using System;
 using System.Numerics;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollView.cpp, commit b8cfb8490
 
 using System;
 using System.Collections.Generic;
@@ -55,7 +56,7 @@ public partial class ScrollView : Control, IScrollView
 		UnhookCompositionTargetRendering();
 		UnhookScrollPresenterEvents(true /*isForDestructor*/);
 		UnhookScrollViewEvents();
-		ResetHideIndicatorsTimer(true /*isForDestructor*/);
+		ResetHideIndicatorsTimer();
 	}
 
 	#region IScrollView
@@ -713,14 +714,9 @@ public partial class ScrollView : Control, IScrollView
 	}
 
 	// Invoked by ScrollViewTestHooks
-	internal void ScrollControllersAutoHidingChanged()
+	internal void ScrollControllersAutoHidingChangedDbg()
 	{
 		UpdateScrollControllersAutoHiding(true /*forceUpdate*/);
-	}
-
-	internal ScrollPresenter GetScrollPresenterPart()
-	{
-		return m_scrollPresenter as ScrollPresenter;
 	}
 
 	internal void ValidateAnchorRatio(double value)
@@ -854,7 +850,9 @@ public partial class ScrollView : Control, IScrollView
 
 		if (AreScrollControllersAutoHiding())
 		{
-			HideIndicators();
+			// As this control may be in the process of being discarded,
+			// use tracker_ref's safe_get() instead of get() to avoid crashes.
+			HideIndicators(true /*useTransitions*/, true /*useSafeGet*/);
 		}
 	}
 
@@ -925,6 +923,30 @@ public partial class ScrollView : Control, IScrollView
 			//SCROLLVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
 
 			ZoomAnimationStarting.Invoke(this, args);
+		}
+	}
+
+	private void OnScrollPresenterScrollStarting(
+		object sender,
+		ScrollingScrollStartingEventArgs args)
+	{
+		if (ScrollStarting is not null)
+		{
+			//SCROLLVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
+
+			ScrollStarting.Invoke(this, args);
+		}
+	}
+
+	private void OnScrollPresenterZoomStarting(
+		object sender,
+		ScrollingZoomStartingEventArgs args)
+	{
+		if (ZoomStarting is not null)
+		{
+			//SCROLLVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
+
+			ZoomStarting.Invoke(this, args);
 		}
 	}
 
@@ -1085,17 +1107,14 @@ public partial class ScrollView : Control, IScrollView
 		}
 	}
 
-	private void ResetHideIndicatorsTimer(bool isForDestructor = false, bool restart = false)
+	private void ResetHideIndicatorsTimer(bool restart = false)
 	{
-		// UNO TODO
-		var hideIndicatorsTimer = m_hideIndicatorsTimer; //.safe_get(isForDestructor /*useSafeGet*/);
-
-		if (hideIndicatorsTimer is not null && hideIndicatorsTimer.IsEnabled)
+		if (m_hideIndicatorsTimer is not null && m_hideIndicatorsTimer.IsEnabled)
 		{
-			hideIndicatorsTimer.Stop();
+			m_hideIndicatorsTimer.Stop();
 			if (restart)
 			{
-				hideIndicatorsTimer.Start();
+				m_hideIndicatorsTimer.Start();
 			}
 		}
 	}
@@ -1273,6 +1292,8 @@ public partial class ScrollView : Control, IScrollView
 			scrollPresenter.ZoomCompleted += OnScrollPresenterZoomCompleted;
 			scrollPresenter.BringingIntoView += OnScrollPresenterBringingIntoView;
 			scrollPresenter.AnchorRequested += OnScrollPresenterAnchorRequested;
+			scrollPresenter.ScrollStarting += OnScrollPresenterScrollStarting;
+			scrollPresenter.ZoomStarting += OnScrollPresenterZoomStarting;
 
 			DependencyObject scrollPresenterAsDO = scrollPresenter as DependencyObject;
 
@@ -1362,6 +1383,8 @@ public partial class ScrollView : Control, IScrollView
 			scrollPresenter.ZoomCompleted -= OnScrollPresenterZoomCompleted;
 			scrollPresenter.BringingIntoView -= OnScrollPresenterBringingIntoView;
 			scrollPresenter.AnchorRequested -= OnScrollPresenterAnchorRequested;
+			scrollPresenter.ScrollStarting -= OnScrollPresenterScrollStarting;
+			scrollPresenter.ZoomStarting -= OnScrollPresenterZoomStarting;
 
 			DependencyObject scrollPresenterAsDO = scrollPresenter as DependencyObject;
 
@@ -1673,10 +1696,14 @@ public partial class ScrollView : Control, IScrollView
 		return (IgnoredInputKinds & inputKind) == inputKind;
 	}
 
-	private bool AreAllScrollControllersCollapsed()
+	private bool AreAllScrollControllersCollapsed(bool useSafeGet = false)
 	{
-		return !SharedHelpers.IsAncestor(m_horizontalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/) &&
-			!SharedHelpers.IsAncestor(m_verticalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/);
+		// UNO TODO: m_*ScrollControllerElement are plain fields, so safe_get(useSafeGet) is not needed.
+		return
+			(m_horizontalScrollControllerElement is null ||
+			 !SharedHelpers.IsAncestor(m_horizontalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/)) &&
+			(m_verticalScrollControllerElement is null ||
+			 !SharedHelpers.IsAncestor(m_verticalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/));
 	}
 
 	private bool AreBothScrollControllersVisible()
@@ -1727,13 +1754,14 @@ public partial class ScrollView : Control, IScrollView
 	}
 
 	private void HideIndicators(
-		bool useTransitions = true)
+		bool useTransitions = true,
+		bool useSafeGet = false)
 	{
 		//SCROLLVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, useTransitions, m_keepIndicatorsShowing);
 
 		MUX_ASSERT(AreScrollControllersAutoHiding());
 
-		if (!AreAllScrollControllersCollapsed() && !m_keepIndicatorsShowing)
+		if (!AreAllScrollControllersCollapsed(useSafeGet) && !m_keepIndicatorsShowing)
 		{
 			GoToState(s_noIndicatorStateName, useTransitions);
 
@@ -1766,6 +1794,10 @@ public partial class ScrollView : Control, IScrollView
 			{
 				hideIndicatorsTimer = new DispatcherTimer();
 				hideIndicatorsTimer.Interval = new TimeSpan(ticks: s_noIndicatorCountdown);
+				// TODO Uno: WinUI captures a weak reference to `this` here (make_weak) and resolves it
+				// on tick to avoid a use-after-free if a tick is dispatched after the ScrollView is
+				// destroyed (e.g. window closed before Stop() takes effect). In Uno the managed GC
+				// prevents dereferencing freed memory, so the direct handler hookup is kept.
 				hideIndicatorsTimer.Tick += OnHideIndicatorsTimerTick;
 				m_hideIndicatorsTimer = hideIndicatorsTimer;
 			}
@@ -1842,7 +1874,7 @@ public partial class ScrollView : Control, IScrollView
 				return;
 			}
 
-			ResetHideIndicatorsTimer(false /*isForDestructor*/, true /*restart*/);
+			ResetHideIndicatorsTimer(true /*restart*/);
 
 			// Mouse indicators dominate if they are already showing or if we have set the flag to prefer them.
 			if (m_preferMouseIndicators || m_showingMouseIndicators || !areScrollControllersAutoHiding)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.cs
@@ -56,7 +56,7 @@ public partial class ScrollView : Control, IScrollView
 		UnhookCompositionTargetRendering();
 		UnhookScrollPresenterEvents(true /*isForDestructor*/);
 		UnhookScrollViewEvents();
-		ResetHideIndicatorsTimer();
+		ResetHideIndicatorsTimer(true /*isForDestructor*/);
 	}
 
 	#region IScrollView
@@ -714,9 +714,14 @@ public partial class ScrollView : Control, IScrollView
 	}
 
 	// Invoked by ScrollViewTestHooks
-	internal void ScrollControllersAutoHidingChangedDbg()
+	internal void ScrollControllersAutoHidingChanged()
 	{
 		UpdateScrollControllersAutoHiding(true /*forceUpdate*/);
+	}
+
+	internal ScrollPresenter GetScrollPresenterPart()
+	{
+		return m_scrollPresenter as ScrollPresenter;
 	}
 
 	internal void ValidateAnchorRatio(double value)
@@ -850,9 +855,7 @@ public partial class ScrollView : Control, IScrollView
 
 		if (AreScrollControllersAutoHiding())
 		{
-			// As this control may be in the process of being discarded,
-			// use tracker_ref's safe_get() instead of get() to avoid crashes.
-			HideIndicators(true /*useTransitions*/, true /*useSafeGet*/);
+			HideIndicators();
 		}
 	}
 
@@ -1107,14 +1110,17 @@ public partial class ScrollView : Control, IScrollView
 		}
 	}
 
-	private void ResetHideIndicatorsTimer(bool restart = false)
+	private void ResetHideIndicatorsTimer(bool isForDestructor = false, bool restart = false)
 	{
-		if (m_hideIndicatorsTimer is not null && m_hideIndicatorsTimer.IsEnabled)
+		// UNO TODO
+		var hideIndicatorsTimer = m_hideIndicatorsTimer; //.safe_get(isForDestructor /*useSafeGet*/);
+
+		if (hideIndicatorsTimer is not null && hideIndicatorsTimer.IsEnabled)
 		{
-			m_hideIndicatorsTimer.Stop();
+			hideIndicatorsTimer.Stop();
 			if (restart)
 			{
-				m_hideIndicatorsTimer.Start();
+				hideIndicatorsTimer.Start();
 			}
 		}
 	}
@@ -1696,14 +1702,10 @@ public partial class ScrollView : Control, IScrollView
 		return (IgnoredInputKinds & inputKind) == inputKind;
 	}
 
-	private bool AreAllScrollControllersCollapsed(bool useSafeGet = false)
+	private bool AreAllScrollControllersCollapsed()
 	{
-		// UNO TODO: m_*ScrollControllerElement are plain fields, so safe_get(useSafeGet) is not needed.
-		return
-			(m_horizontalScrollControllerElement is null ||
-			 !SharedHelpers.IsAncestor(m_horizontalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/)) &&
-			(m_verticalScrollControllerElement is null ||
-			 !SharedHelpers.IsAncestor(m_verticalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/));
+		return !SharedHelpers.IsAncestor(m_horizontalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/) &&
+			!SharedHelpers.IsAncestor(m_verticalScrollControllerElement as DependencyObject /*child*/, this /*parent*/, true /*checkVisibility*/);
 	}
 
 	private bool AreBothScrollControllersVisible()
@@ -1754,14 +1756,13 @@ public partial class ScrollView : Control, IScrollView
 	}
 
 	private void HideIndicators(
-		bool useTransitions = true,
-		bool useSafeGet = false)
+		bool useTransitions = true)
 	{
 		//SCROLLVIEW_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, useTransitions, m_keepIndicatorsShowing);
 
 		MUX_ASSERT(AreScrollControllersAutoHiding());
 
-		if (!AreAllScrollControllersCollapsed(useSafeGet) && !m_keepIndicatorsShowing)
+		if (!AreAllScrollControllersCollapsed() && !m_keepIndicatorsShowing)
 		{
 			GoToState(s_noIndicatorStateName, useTransitions);
 
@@ -1794,10 +1795,6 @@ public partial class ScrollView : Control, IScrollView
 			{
 				hideIndicatorsTimer = new DispatcherTimer();
 				hideIndicatorsTimer.Interval = new TimeSpan(ticks: s_noIndicatorCountdown);
-				// TODO Uno: WinUI captures a weak reference to `this` here (make_weak) and resolves it
-				// on tick to avoid a use-after-free if a tick is dispatched after the ScrollView is
-				// destroyed (e.g. window closed before Stop() takes effect). In Uno the managed GC
-				// prevents dereferencing freed memory, so the direct handler hookup is kept.
 				hideIndicatorsTimer.Tick += OnHideIndicatorsTimerTick;
 				m_hideIndicatorsTimer = hideIndicatorsTimer;
 			}
@@ -1874,7 +1871,7 @@ public partial class ScrollView : Control, IScrollView
 				return;
 			}
 
-			ResetHideIndicatorsTimer(true /*restart*/);
+			ResetHideIndicatorsTimer(false /*isForDestructor*/, true /*restart*/);
 
 			// Mouse indicators dominate if they are already showing or if we have set the flag to prefer them.
 			if (m_preferMouseIndicators || m_showingMouseIndicators || !areScrollControllersAutoHiding)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.h.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollView.h, commit b8cfb8490
 
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -61,6 +62,8 @@ public partial class ScrollView : Control
 	// event_token m_scrollPresenterStateChangedToken{};
 	// event_token m_scrollPresenterScrollAnimationStartingToken{};
 	// event_token m_scrollPresenterZoomAnimationStartingToken{};
+	// event_token m_scrollPresenterScrollStartingToken{};
+	// event_token m_scrollPresenterZoomStartingToken{};
 	// event_token m_scrollPresenterViewChangedToken{};
 	// event_token m_scrollPresenterScrollCompletedToken{};
 	// event_token m_scrollPresenterZoomCompletedToken{};

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.idl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollView.idl.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.UI.Xaml.Markup;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollView.idl, commit b8cfb8490
+
+using Microsoft.UI.Xaml.Markup;
 using Windows.Foundation;
 
 namespace Microsoft.UI.Xaml.Controls;
@@ -22,4 +26,8 @@ public partial class ScrollView : Control
 	public event TypedEventHandler<ScrollView, ScrollingZoomCompletedEventArgs> ZoomCompleted;
 	public event TypedEventHandler<ScrollView, ScrollingBringingIntoViewEventArgs> BringingIntoView;
 	public event TypedEventHandler<ScrollView, ScrollingAnchorRequestedEventArgs> AnchorRequested;
+
+	public event TypedEventHandler<ScrollView, ScrollingScrollStartingEventArgs> ScrollStarting;
+
+	public event TypedEventHandler<ScrollView, ScrollingZoomStartingEventArgs> ZoomStarting;
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollViewTestHooks.cpp, commit b8cfb8490
 
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollViewTestHooks.cpp, commit b8cfb8490
 
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -52,17 +53,7 @@ internal partial class ScrollViewTestHooks
 				hooks.m_autoHideScrollControllersMap.Add(scrollView, value);
 			}
 
-			scrollView.ScrollControllersAutoHidingChanged();
+			scrollView.ScrollControllersAutoHidingChangedDbg();
 		}
-	}
-
-	public ScrollPresenter GetScrollPresenterPart(ScrollView scrollView)
-	{
-		if (scrollView is not null)
-		{
-			return scrollView.GetScrollPresenterPart();
-		}
-
-		return null;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference ScrollViewTestHooks.cpp, commit b8cfb8490
-
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 
@@ -53,7 +51,17 @@ internal partial class ScrollViewTestHooks
 				hooks.m_autoHideScrollControllersMap.Add(scrollView, value);
 			}
 
-			scrollView.ScrollControllersAutoHidingChangedDbg();
+			scrollView.ScrollControllersAutoHidingChanged();
 		}
+	}
+
+	public ScrollPresenter GetScrollPresenterPart(ScrollView scrollView)
+	{
+		if (scrollView is not null)
+		{
+			return scrollView.GetScrollPresenterPart();
+		}
+
+		return null;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.h.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.h.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference ScrollViewTestHooks.h, commit b8cfb8490
-
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/ScrollViewTestHooks.h.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ScrollViewTestHooks.h, commit b8cfb8490
 
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;


### PR DESCRIPTION
**GitHub Issue:** closes #23688

## PR Type:

✨ Feature

## What changed? 🚀

Ports the WinUI `ScrollStarting` and `ZoomStarting` event flow to `ScrollPresenter` and forwards both events through `ScrollView`.

The port:

- exposes the WinUI-compatible event args and event surface;
- tracks anticipated offsets and zoom factors across queued `ScrollTo`, `ScrollBy`, `ZoomTo`, and `ZoomBy` requests;
- implements non-animated `InteractionTracker.TryUpdateScale` on Skia, including scale clamping and center-point-preserving position updates, so `ZoomStarting` now fires at runtime;
- preserves request correlation IDs and validates single and successive request forwarding with runtime tests.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
