### PR TITLE
fix(android): Replace deprecated SharedPreferences API

### DIFF
--- a/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Android.Content;
-using Android.Preferences;
 using Uno;
 using Uno.UI;
 using Windows.Foundation.Collections;
@@ -26,7 +25,10 @@ namespace Windows.Storage
 			}
 
 			private ISharedPreferences CreatePreferences()
-				=> PreferenceManager.GetDefaultSharedPreferences(ApplicationData.GetAndroidAppContext())!;
+			{
+				var context = ApplicationData.GetAndroidAppContext();
+				return context.GetSharedPreferences(context.PackageName + "_preferences", FileCreationMode.Private)!;
+			}
 
 			public object this[string key]
 			{


### PR DESCRIPTION
**GitHub Issue:** closes #1833

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Android, `ApplicationDataContainer` backs `ApplicationData.Current.LocalSettings` / `RoamingSettings` with Android `SharedPreferences`. It obtained the store via `Android.Preferences.PreferenceManager.GetDefaultSharedPreferences(context)`, which has been **deprecated since API 29** (Android 10) — issue #1833.

This replaces that call with the explicit, non-deprecated equivalent:

```csharp
private ISharedPreferences CreatePreferences()
{
    var context = ApplicationData.GetAndroidAppContext();
    return context.GetSharedPreferences(context.PackageName + "_preferences", FileCreationMode.Private)!;
}
```

This is byte-for-byte the store the deprecated API resolves to internally — Android's `getDefaultSharedPreferences(context)` is implemented as `context.getSharedPreferences(context.getPackageName() + "_preferences", MODE_PRIVATE)`. Consequences:

- **Data is preserved.** The on-disk backing file (`<package>_preferences.xml`) and all keys are unchanged, so existing users' persisted settings survive an app upgrade — no silent orphaning.
- **Both `LocalSettings` and `RoamingSettings` are covered**, since both resolve to the same `SharedPreferencesPropertySet`.
- **No new dependency.** The `AndroidX.Preference` alternative was intentionally avoided; the explicit call needs nothing beyond `Android.Content` (already imported).

The now-unused `using Android.Preferences;` was removed.

**Validation:**
- *Compile*: `Uno.UWP` `net10.0-android` target builds clean — 0 warnings, 0 errors.
- *Runtime*: the existing (non-gated) `Given_ApplicationDataContainer` runtime-test suite exercises set/get/remove/enumerate through the changed `SharedPreferencesPropertySet` on native Android. No new test was added — the swap is a framework-contract equivalence, so continuity does not require a dedicated test.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — covered by existing `Given_ApplicationDataContainer`; no new test needed for a like-for-like API swap.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, internal implementation only.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no visual change.
- [x] ❗ Contains **NO** breaking changes — `CreatePreferences()` is a private implementation detail; no public API surface changes.
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
