### PR TITLE
fix(hot-reload): post-review fixes for the workspace target-framework change

### DIFF
--- a/specs/047-hotreload-workspace-single-tfm/spec.md
+++ b/specs/047-hotreload-workspace-single-tfm/spec.md
@@ -192,11 +192,14 @@ into the product (`Uno.HotReload/Utils/`) together with its unit tests; the DevS
 project (linked-source convention) validates the end-to-end behavior against multi-TFM
 fixtures.
 
-Known gap to address during the port: the classifier does not recognize
-`Microsoft.Windows.SDK.NET.Ref` (WinAppSDK `net10.0-windows10.x` heads resolve as plain
-`net10.0`). Windows targets do not use the dev-server metadata-updates path (VS native HR),
-but the mapping should either be added or the limitation asserted by a test so the filter
-never silently flushes a windows head that a future scenario would rely on.
+The classifier recognizes `Microsoft.Windows.SDK.NET.Ref` → `windows` (in `_platformPackPrefixes`,
+covered by `TryParseRefPackPath_WindowsSdkRefPack_ParsesPlatform`, with the WinAppSDK base pack
+covered by `TryParseRefPackPath_WindowsDesktopAppRef_BasePackRecognised`), so a WinAppSDK
+`net10.0-windows10.x` head resolves to `windows` rather than plain `net10.0`. Windows targets do not
+use the dev-server metadata-updates path (VS provides native hot reload), so this classification is a
+safety net: it keeps the filter from silently flushing a windows head a future scenario might rely on.
+No residual gap is known; should a windows ref-pack path outside the mapped prefix ever surface, add it
+to `_platformPackPrefixes` (with a fixture) rather than leaning on the plain-`net10.0` fallback.
 
 ### D6 — Diagnostics
 

--- a/src/Uno.HotReload.Tests/Utils/Given_TryGetTargetFramework.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_TryGetTargetFramework.cs
@@ -406,8 +406,8 @@ public sealed class Given_TryGetTargetFramework
 			parseOptions: parseOptions,
 			metadataReferences: metadataReferences);
 
-		var solution = workspace.AddProject(projectInfo);
-		return solution;
+		var project = workspace.AddProject(projectInfo);
+		return project;
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_GetRuntimeTargetFramework.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_GetRuntimeTargetFramework.cs
@@ -1,0 +1,38 @@
+using Uno.UI.RemoteControl.HotReload;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+/// <summary>
+/// Tests for the framework-version composition of the client's runtime target-framework
+/// descriptor (<see cref="ClientHotReloadProcessor.ResolveFrameworkVersion"/>) — the non-<c>#if</c>
+/// part of <c>GetRuntimeTargetFramework</c>, including the malformed/missing fallback that the
+/// rest of the suite (server-side parse/match/filter) does not cover.
+/// </summary>
+[TestClass]
+public class Given_GetRuntimeTargetFramework
+{
+	[TestMethod]
+	[DataRow(".NETCoreApp,Version=v10.0", 10, 0)]
+	[DataRow(".NETCoreApp,Version=v9.0", 9, 0)]
+	[DataRow(".NETCoreApp,Version=v8.0", 8, 0)]
+	public void When_ValidNetCoreAppMoniker_Then_VersionIsParsed(string frameworkName, int major, int minor)
+	{
+		var version = ClientHotReloadProcessor.ResolveFrameworkVersion(frameworkName);
+
+		version.Major.Should().Be(major);
+		version.Minor.Should().Be(minor);
+	}
+
+	[TestMethod]
+	[DataRow((string?)null)]              // no TargetFrameworkAttribute
+	[DataRow("")]                          // empty FrameworkName
+	[DataRow("not a framework name")]      // unparsable → ArgumentException
+	[DataRow(".NETCoreApp")]               // identifier only, no version → ArgumentException
+	[DataRow(".NETFramework,Version=v4.8")] // valid moniker, but not .NETCoreApp
+	public void When_MissingMalformedOrNonNetCoreApp_Then_FallsBackToRuntimeVersion(string? frameworkName)
+	{
+		var version = ClientHotReloadProcessor.ResolveFrameworkVersion(frameworkName);
+
+		version.Should().Be(Environment.Version);
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_GetRuntimeTargetFramework.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_GetRuntimeTargetFramework.cs
@@ -33,6 +33,6 @@ public class Given_GetRuntimeTargetFramework
 	{
 		var version = ClientHotReloadProcessor.ResolveFrameworkVersion(frameworkName);
 
-		version.Should().Be(Environment.Version);
+		version.Should().Be(ClientHotReloadProcessor.FallbackVersion);
 	}
 }

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -109,6 +109,14 @@ public static class CompilationWorkspaceProvider
 				workspace = null!;
 				await Task.Delay(5_000, ct);
 			}
+			catch
+			{
+				// Non-retried failure (the final attempt, or any other exception type): dispose the
+				// partially-created workspace before surfacing the exception — same lingering MSBuild
+				// evaluation-node concern as the retry path above.
+				workspace?.Dispose();
+				throw;
+			}
 		}
 
 		return workspace;

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -102,7 +102,11 @@ public static class CompilationWorkspaceProvider
 			catch (InvalidOperationException) when (i > 1)
 			{
 				// When we load the workspace right after the app was started, it happens that it "app build" is not yet completed, preventing us to open the project.
-				// We retry a few times to let the build complete.
+				// We retry a few times to let the build complete. Dispose the failed workspace first:
+				// MSBuildWorkspace hosts MSBuild evaluation nodes (real OS resources), so a workspace
+				// left behind on a failed attempt would linger for the server's lifetime.
+				workspace?.Dispose();
+				workspace = null!;
 				await Task.Delay(5_000, ct);
 			}
 		}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -153,22 +153,12 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 	// Internal (rather than private) to allow validation from runtime tests via InternalsVisibleTo.
 	internal static string GetRuntimeTargetFramework(System.Reflection.Assembly appAssembly)
 	{
-		Version? frameworkVersion = null;
-		try
-		{
-			if (appAssembly.GetCustomAttributes(typeof(System.Runtime.Versioning.TargetFrameworkAttribute), false)
-					is [System.Runtime.Versioning.TargetFrameworkAttribute { FrameworkName: { Length: > 0 } frameworkName }, ..]
-				&& new System.Runtime.Versioning.FrameworkName(frameworkName) is { Identifier: ".NETCoreApp" } parsed)
-			{
-				frameworkVersion = parsed.Version;
-			}
-		}
-		catch (Exception)
-		{
-			// Malformed attribute — fall back to the runtime version below.
-		}
+		var frameworkName = appAssembly.GetCustomAttributes(typeof(System.Runtime.Versioning.TargetFrameworkAttribute), false)
+			is [System.Runtime.Versioning.TargetFrameworkAttribute { FrameworkName: { Length: > 0 } name }, ..]
+			? name
+			: null;
 
-		frameworkVersion ??= Environment.Version;
+		var frameworkVersion = ResolveFrameworkVersion(frameworkName);
 
 		// The platform MUST be probed at runtime, not from compile-time symbols: the skia flavor
 		// of this assembly is compiled for the plain `netX.0` TFM yet serves every skia-rendering
@@ -186,6 +176,32 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 			: "skia";
 
 		return $"net{frameworkVersion.Major}.{frameworkVersion.Minor}-{platform}";
+	}
+
+	/// <summary>
+	/// Parses the .NETCoreApp framework version out of a
+	/// <see cref="System.Runtime.Versioning.TargetFrameworkAttribute.FrameworkName"/> value
+	/// (e.g. <c>".NETCoreApp,Version=v10.0"</c> → <c>10.0</c>), falling back to
+	/// <see cref="Environment.Version"/> when the value is absent, malformed, or not a
+	/// .NETCoreApp moniker. Kept free of the platform <c>#if</c> in
+	/// <see cref="GetRuntimeTargetFramework"/> so the fallback is unit-testable.
+	/// </summary>
+	internal static Version ResolveFrameworkVersion(string? frameworkName)
+	{
+		try
+		{
+			if (frameworkName is { Length: > 0 }
+				&& new System.Runtime.Versioning.FrameworkName(frameworkName) is { Identifier: ".NETCoreApp" } parsed)
+			{
+				return parsed.Version;
+			}
+		}
+		catch (ArgumentException)
+		{
+			// Malformed FrameworkName — fall back to the runtime version below.
+		}
+
+		return Environment.Version;
 	}
 
 	private void ConfigureHotReloadMode()

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -179,10 +179,16 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 	}
 
 	/// <summary>
+	/// The framework version reported when the application's target framework cannot be resolved
+	/// (absent, malformed, or a non-.NETCoreApp moniker) — the version of the running .NET runtime.
+	/// </summary>
+	internal static Version FallbackVersion => Environment.Version;
+
+	/// <summary>
 	/// Parses the .NETCoreApp framework version out of a
 	/// <see cref="System.Runtime.Versioning.TargetFrameworkAttribute.FrameworkName"/> value
 	/// (e.g. <c>".NETCoreApp,Version=v10.0"</c> → <c>10.0</c>), falling back to
-	/// <see cref="Environment.Version"/> when the value is absent, malformed, or not a
+	/// <see cref="FallbackVersion"/> when the value is absent, malformed, or not a
 	/// .NETCoreApp moniker. Kept free of the platform <c>#if</c> in
 	/// <see cref="GetRuntimeTargetFramework"/> so the fallback is unit-testable.
 	/// </summary>
@@ -201,7 +207,7 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 			// Malformed FrameworkName — fall back to the runtime version below.
 		}
 
-		return Environment.Version;
+		return FallbackVersion;
 	}
 
 	private void ConfigureHotReloadMode()


### PR DESCRIPTION
**GitHub Issue:** _Follow-up to #23692 — no separate issue._

## PR Type:

🐞 Bugfix

## What changed? 🚀

Post-review follow-ups to the hot-reload workspace target-framework change (#23692), split into their
own PR so the parent's build isn't re-triggered while it waits on the release.

- **Workspace leak (fix).** `CompilationWorkspaceProvider.CreateWorkspaceAsync` retries `OpenProjectAsync`
  a few times; a failed attempt now disposes its `MSBuildWorkspace` before retrying, instead of leaving
  an MSBuild evaluation host (real OS resources) behind for the server's lifetime.
- **Testable runtime-TFM version parsing.** The non-`#if` part of the client's `GetRuntimeTargetFramework`
  is extracted into `ResolveFrameworkVersion(string?)`, with the `catch` narrowed to `ArgumentException`.
  New unit tests cover the missing / malformed / non-`.NETCoreApp` fallback to `Environment.Version`.
- **Test-helper naming.** Rename a misleading `solution` local — `AdhocWorkspace.AddProject` returns a `Project`.
- **Spec.** The Windows ref-pack is already classified (`Microsoft.Windows.SDK.NET.Ref` → `windows`, with
  tests), so the stale "known gap" note is dropped.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — unit tests for the runtime-TFM version fallback.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — internal spec note only; no user-facing docs.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no UI change.
- [x] ❗ Contains **NO** breaking changes — additive helper + internal fixes only.
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)