### PR TITLE
fix(hotreload): release collectible-ALC state when the owning context is torn down

### DIFF
--- a/specs/048-hotreload-collectible-alc-agent-teardown/spec.md
+++ b/specs/048-hotreload-collectible-alc-agent-teardown/spec.md
@@ -76,45 +76,56 @@ without relying on `Unloading`.
 
 ## Validation
 
-Red/fix/green (both tests fail on the pre-fix `Dispose`, which only detached the
-`AssemblyLoad` subscription):
+Seven `[TestMethod]`s in
+`Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs` cover the fix.
+Five of them (marked "Red before fix N") fail on the pre-fix agent `Dispose` bodies, which only
+detached the `AssemblyLoad` subscription and left the caches/statics populated; the other two
+(`AssemblyLoadSubscriptionDetached` and `SharedElementAgentUntouched`) are non-regression guards
+that stay green either way.
 
-- `Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs`
-  - `When_ElementUpdateAgentDisposed_Then_HandlerMapCleared` — after `ElementUpdateAgent.Dispose()`,
-    the `Type`-keyed `ElementHandlerActions` map is empty (the assembly-level
-    `[ElementMetadataUpdateHandlerAttribute]`s in the test assembly cause handlers to be
-    discovered at construction, so the map is non-empty before dispose). Red before fix 1;
-    green after.
-  - `When_HotReloadAgentDisposed_Then_DeltaAndAssemblyMapsCleared` — after
-    `HotReloadAgent.Dispose()`, `_deltas` (populated via the public `ApplyDeltas` path with a
-    random module id that matches no loaded module, so nothing is applied to the runtime) and
-    `_appliedAssemblies` (seeded via reflection, as it has no public writer) are both empty.
-    Red before fix 2; green after.
-  - `When_ElementUpdateAgentDisposed_Then_AssemblyLoadSubscriptionDetached` — guards the
-    process-wide `AppDomain.AssemblyLoad` unsubscription (observed through the runtime's
-    `AssemblyLoadContext.AssemblyLoad` backing field, which the `AppDomain` event forwards to).
-  - `When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased` — loads a real
-    copy of `Uno.UI.RemoteControl` into a collectible `AssemblyLoadContext` (the copy's
-    `_processorAlc` then resolves to that context, so the production gate is exercised, not
-    simulated), seeds the copy's static `_elementAgent`, and proves that a host-driven
-    `Dispose()` releases the static agent and detaches its `AssemblyLoad` subscription, and
-    that double-dispose is safe. Red before fix 4; green after.
-  - `When_DefaultContextProcessorDisposed_Then_SharedElementAgentUntouched` — proves the
-    default-context `Dispose()` behavior is unchanged: the shared element agent stays alive
-    and subscribed.
-  - `When_TearDownForAlcUnload_WithLiveInstance_Then_TearsDownWithoutRecursion` — drives the
-    `Unloading`-path teardown against a collectible copy with a live `_instance` whose
-    `Dispose()` now re-enters the static release, proving the flow neither recurses nor throws
-    on repeat.
+- `When_ElementUpdateAgentDisposed_Then_HandlerMapCleared` — after `ElementUpdateAgent.Dispose()`,
+  the `Type`-keyed `ElementHandlerActions` map is empty (the assembly-level
+  `[ElementMetadataUpdateHandlerAttribute]`s in the test assembly cause handlers to be
+  discovered at construction, so the map is non-empty before dispose). Red before fix 1;
+  green after.
+- `When_HotReloadAgentDisposed_Then_DeltaAndAssemblyMapsCleared` — after
+  `HotReloadAgent.Dispose()`, `_deltas` (populated via the public `ApplyDeltas` path with a
+  random module id that matches no loaded module, so nothing is applied to the runtime) and
+  `_appliedAssemblies` (seeded via reflection, as it has no public writer) are both empty.
+  Red before fix 2; green after.
+- `When_HotReloadAgentDisposed_Then_HandlerActionsCacheCleared` — after `HotReloadAgent.Dispose()`,
+  the `_handlerActions` cache (which captures handler delegates and `Type`s discovered by
+  scanning the owning context's assemblies) is null. Red before fix 2; green after.
+- `When_ElementUpdateAgentDisposed_Then_AssemblyLoadSubscriptionDetached` — guards the
+  process-wide `AppDomain.AssemblyLoad` unsubscription (observed through the runtime's
+  `AssemblyLoadContext.AssemblyLoad` backing field, which the `AppDomain` event forwards to).
+- `When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased` — loads a real
+  copy of `Uno.UI.RemoteControl` into a collectible `AssemblyLoadContext` (the copy's
+  `_processorAlc` then resolves to that context, so the production gate is exercised, not
+  simulated), seeds the copy's static `_elementAgent`, and proves that a host-driven
+  `Dispose()` releases the static agent and detaches its `AssemblyLoad` subscription, and
+  that double-dispose is safe. The collectible context is `Unload()`ed in a `finally` after the
+  assertions. Red before fix 4; green after.
+- `When_DefaultContextProcessorDisposed_Then_SharedElementAgentUntouched` — proves the
+  default-context `Dispose()` behavior is unchanged: the shared element agent stays alive
+  and subscribed.
+- `When_TearDownForAlcUnload_WithLiveInstance_Then_TearsDownWithoutRecursion` — drives the
+  `Unloading`-path teardown against a collectible copy with a live `_instance` whose
+  `Dispose()` now re-enters the static release, proving the flow neither recurses nor throws
+  on repeat. The collectible context is `Unload()`ed in a `finally` after the assertions.
 
 The agents' internals are exercised via `InternalsVisibleTo("Uno.UI.RemoteControl.DevServer.Tests")`,
 which already exists; the private `_appliedAssemblies`/`_deltas` counts are read reflectively
 to keep the test a true unit test with no UI scaffolding.
 
-Evidence: with the committed fix the two tests pass (2/2); reverting only the two `Dispose`
-bodies to the pre-fix expression form (`=> AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;`)
-makes both fail (2/2), one on the non-empty handler map and one on `_deltas` still holding a
-stashed delta.
+Evidence: with the committed fix all seven tests pass (7/7). Reverting only the two agent
+`Dispose` bodies to the pre-fix expression form (`=> AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;`)
+turns five assertions red — `HandlerMapCleared` on the non-empty handler map,
+`DeltaAndAssemblyMapsCleared` on `_deltas` still holding the stashed delta,
+`HandlerActionsCacheCleared` on the non-null cache, and the two collectible-context /
+teardown tests (`PerContextStaticsReleased`, `TearDownForAlcUnload_WithLiveInstance...`) on the
+released agent's `AssemblyLoad` subscription still being attached — while the two guards
+(`AssemblyLoadSubscriptionDetached`, `SharedElementAgentUntouched`) stay green.
 
 ## Notes / follow-ups
 

--- a/specs/048-hotreload-collectible-alc-agent-teardown/spec.md
+++ b/specs/048-hotreload-collectible-alc-agent-teardown/spec.md
@@ -1,0 +1,98 @@
+# 048 — Hot-Reload Client Agents Release Collectible-ALC State On Teardown
+
+Issue: #23704
+
+## Problem
+
+A downstream host loads previewed apps into their own collectible
+`AssemblyLoadContext`s (see spec 000). Each such context brings a per-context copy of
+`Uno.UI.RemoteControl`, so the hot-reload client agents defined in that assembly run once
+per context. When the host unloads a previewed app it calls `AssemblyLoadContext.Unload()`,
+but the context was never collected: the hot-reload client machinery left per-context state
+behind that kept the unloaded context reachable, leaking one full context per load/unload
+cycle.
+
+Heap-dump root-walks against a leaked context traced the pins to the two client agents:
+
+- **Process-wide `AppDomain.CurrentDomain.AssemblyLoad` subscription.** Both
+  `ElementUpdateAgent` and `HotReloadAgent` subscribe to `AssemblyLoad` at construction and
+  keep the delegate for their lifetime. The delegate target is the agent instance, which
+  captures the context's `AssemblyLoadContext` and its assemblies; because the event lives on
+  the process-immortal `AppDomain`, the whole per-context object graph stays reachable after
+  unload.
+- **Type/assembly-keyed caches.** `ElementUpdateAgent._elementHandlerActions` is keyed on the
+  context's element `Type`s; `HotReloadAgent._deltas` and `HotReloadAgent._appliedAssemblies`
+  hold the context's module ids and `Assembly` instances. A single retained collectible
+  `Type` or `Assembly` pins its `LoaderAllocator` and, through it, the entire previous app
+  graph.
+
+## Root cause
+
+The agents' `Dispose()` implementations only detached the `AssemblyLoad` subscription; they
+left the type- and assembly-keyed caches populated. There was also no path that disposed the
+agents when the owning collectible context was torn down, so nothing released the state a
+host teardown should have released.
+
+## Fix
+
+1. **`ElementUpdateAgent.Dispose()`
+   (Uno.UI.RemoteControl/HotReload/MetadataUpdater/ElementUpdaterAgent.cs):** in addition to
+   detaching the `AssemblyLoad` handler, now clears `_elementHandlerActions` so the context's
+   element `Type` keys are no longer retained.
+
+2. **`HotReloadAgent.Dispose()`
+   (Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs):** in addition to
+   detaching the `AssemblyLoad` handler, now clears `_deltas` and `_appliedAssemblies` so the
+   context's module ids and `Assembly` references are no longer retained.
+
+3. **Best-effort self-teardown
+   (Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs / .Agent.cs):** the
+   processor arms an `AssemblyLoadContext.Unloading` hook on its owning context, but only when
+   that context is collectible and not the default. On unload it disposes the processor (which
+   disposes its `HotReloadAgent`), disposes the shared `ElementUpdateAgent`, and clears the
+   per-context statics. A live (default-context) processor is never touched.
+
+## Caveat: `Unloading` is not raised on browser-wasm
+
+`AssemblyLoadContext.Unloading` was observed **not** to be raised on the browser-wasm runtime
+— collectible-context unload is unimplemented there (dotnet/runtime#34072). The `Unloading`
+hook is therefore best-effort and only helps on runtimes that raise the event. The
+**load-bearing** path for wasm hosts is the `Dispose()`-side cache clearing: a host that
+disposes the processor/agents during its own teardown genuinely releases the context, without
+relying on `Unloading`.
+
+## Validation
+
+Red/fix/green (both tests fail on the pre-fix `Dispose`, which only detached the
+`AssemblyLoad` subscription):
+
+- `Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs`
+  - `When_ElementUpdateAgentDisposed_Then_HandlerMapCleared` — after `ElementUpdateAgent.Dispose()`,
+    the `Type`-keyed `ElementHandlerActions` map is empty (the assembly-level
+    `[ElementMetadataUpdateHandlerAttribute]`s in the test assembly cause handlers to be
+    discovered at construction, so the map is non-empty before dispose). Red before fix 1;
+    green after.
+  - `When_HotReloadAgentDisposed_Then_DeltaAndAssemblyMapsCleared` — after
+    `HotReloadAgent.Dispose()`, `_deltas` (populated via the public `ApplyDeltas` path with a
+    random module id that matches no loaded module, so nothing is applied to the runtime) and
+    `_appliedAssemblies` (seeded via reflection, as it has no public writer) are both empty.
+    Red before fix 2; green after.
+
+The agents' internals are exercised via `InternalsVisibleTo("Uno.UI.RemoteControl.DevServer.Tests")`,
+which already exists; the private `_appliedAssemblies`/`_deltas` counts are read reflectively
+to keep the test a true unit test with no UI scaffolding.
+
+Evidence: with the committed fix the two tests pass (2/2); reverting only the two `Dispose`
+bodies to the pre-fix expression form (`=> AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;`)
+makes both fail (2/2), one on the non-empty handler map and one on `_deltas` still holding a
+stashed delta.
+
+## Notes / follow-ups
+
+- End-to-end, in a downstream host that repeatedly loads/unloads previewed apps in collectible
+  contexts, heap-dump root-walks previously showed the unloaded context pinned via
+  `HotReloadAgent`/`ElementUpdateAgent` (`AppDomain.AssemblyLoad`) and the processor statics;
+  with a host that disposes on teardown those referrers are gone and the managed context object
+  is collected.
+- Other collectible-ALC pins in the UI layer (parse-context, resource-dictionary caches,
+  resource `DataContext`) are addressed separately in spec 044.

--- a/specs/048-hotreload-collectible-alc-agent-teardown/spec.md
+++ b/specs/048-hotreload-collectible-alc-agent-teardown/spec.md
@@ -49,17 +49,30 @@ host teardown should have released.
    (Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs / .Agent.cs):** the
    processor arms an `AssemblyLoadContext.Unloading` hook on its owning context, but only when
    that context is collectible and not the default. On unload it disposes the processor (which
-   disposes its `HotReloadAgent`), disposes the shared `ElementUpdateAgent`, and clears the
-   per-context statics. A live (default-context) processor is never touched.
+   disposes its `HotReloadAgent`), then releases the per-context statics via the shared
+   `ReleasePerContextStatics()` helper (disposing the shared `ElementUpdateAgent` and clearing
+   the static references). A live (default-context) processor is never touched.
+
+4. **Host-driven `ClientHotReloadProcessor.Dispose()` releases the per-context statics
+   (Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs):** when the processor copy is
+   owned by a collectible non-default context, `Dispose()` — in addition to disposing its
+   `_agent` — clears the static `_instance` (when it references the disposing instance) and
+   calls `ReleasePerContextStatics()`. This makes an explicit host dispose sufficient on
+   runtimes where `Unloading` never fires (browser-wasm), instead of leaving the shared
+   `ElementUpdateAgent` subscribed to `AppDomain.AssemblyLoad` and pinning the context. The
+   flow is deliberately non-recursive (`Dispose()` never calls `TearDownForAlcUnload()`, and
+   the unload hook detaches `_instance` before disposing it) and idempotent (double-dispose
+   and dispose-then-unload are both safe). Default-context `Dispose()` behavior is unchanged —
+   a live host processor never tears down the shared element agent.
 
 ## Caveat: `Unloading` is not raised on browser-wasm
 
 `AssemblyLoadContext.Unloading` was observed **not** to be raised on the browser-wasm runtime
 — collectible-context unload is unimplemented there (dotnet/runtime#34072). The `Unloading`
 hook is therefore best-effort and only helps on runtimes that raise the event. The
-**load-bearing** path for wasm hosts is the `Dispose()`-side cache clearing: a host that
-disposes the processor/agents during its own teardown genuinely releases the context, without
-relying on `Unloading`.
+**load-bearing** path for wasm hosts is the `Dispose()`-side release (fixes 1, 2 and 4): a
+host that disposes the processor during its own teardown genuinely releases the context,
+without relying on `Unloading`.
 
 ## Validation
 
@@ -77,6 +90,22 @@ Red/fix/green (both tests fail on the pre-fix `Dispose`, which only detached the
     random module id that matches no loaded module, so nothing is applied to the runtime) and
     `_appliedAssemblies` (seeded via reflection, as it has no public writer) are both empty.
     Red before fix 2; green after.
+  - `When_ElementUpdateAgentDisposed_Then_AssemblyLoadSubscriptionDetached` — guards the
+    process-wide `AppDomain.AssemblyLoad` unsubscription (observed through the runtime's
+    `AssemblyLoadContext.AssemblyLoad` backing field, which the `AppDomain` event forwards to).
+  - `When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased` — loads a real
+    copy of `Uno.UI.RemoteControl` into a collectible `AssemblyLoadContext` (the copy's
+    `_processorAlc` then resolves to that context, so the production gate is exercised, not
+    simulated), seeds the copy's static `_elementAgent`, and proves that a host-driven
+    `Dispose()` releases the static agent and detaches its `AssemblyLoad` subscription, and
+    that double-dispose is safe. Red before fix 4; green after.
+  - `When_DefaultContextProcessorDisposed_Then_SharedElementAgentUntouched` — proves the
+    default-context `Dispose()` behavior is unchanged: the shared element agent stays alive
+    and subscribed.
+  - `When_TearDownForAlcUnload_WithLiveInstance_Then_TearsDownWithoutRecursion` — drives the
+    `Unloading`-path teardown against a collectible copy with a live `_instance` whose
+    `Dispose()` now re-enters the static release, proving the flow neither recurses nor throws
+    on repeat.
 
 The agents' internals are exercised via `InternalsVisibleTo("Uno.UI.RemoteControl.DevServer.Tests")`,
 which already exists; the private `_appliedAssemblies`/`_deltas` counts are read reflectively

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
@@ -156,6 +156,47 @@ public class HotReloadAgentDisposeTests
 	}
 
 	[TestMethod]
+	public void When_NonActiveCollectibleProcessorDisposed_Then_SharedStaticsPreserved()
+	{
+		// Arrange — a collectible context can host more than one processor (e.g. multiple
+		// RemoteControlClients). Only the active one (static _instance) owns the shared per-context
+		// statics; disposing a *non-active* processor must not tear the shared _elementAgent down
+		// from under the still-live active processor.
+		var (alc, copy, processorType) = LoadCollectibleProcessorCopy(
+			nameof(When_NonActiveCollectibleProcessorDisposed_Then_SharedStaticsPreserved));
+		var instanceField = GetStaticField(processorType, "_instance");
+		try
+		{
+			var elementAgentField = GetStaticField(processorType, "_elementAgent");
+			var elementAgent = CreateElementAgentIn(copy);
+			elementAgentField.SetValue(null, elementAgent);
+
+			// The active processor owns the statics; a second, non-active processor is what we dispose.
+			var activeProcessor = Activator.CreateInstance(processorType, new object?[] { null })!;
+			instanceField.SetValue(null, activeProcessor);
+			var nonActiveProcessor = (IDisposable)Activator.CreateInstance(processorType, new object?[] { null })!;
+
+			// Act
+			nonActiveProcessor.Dispose();
+
+			// Assert — the shared statics survive because the disposed processor is not the active one.
+			elementAgentField.GetValue(null).Should().BeSameAs(elementAgent,
+				"disposing a non-active collectible processor must not release the shared element agent");
+			instanceField.GetValue(null).Should().BeSameAs(activeProcessor,
+				"disposing a non-active processor must not clear the active _instance");
+			IsSubscribedToAssemblyLoad(elementAgent).Should().BeTrue(
+				"the shared element agent must stay subscribed while the active processor is alive");
+		}
+		finally
+		{
+			// Tear the active processor down (clears _instance and disposes the shared element agent,
+			// detaching its global AssemblyLoad subscription) so nothing pins the context past Unload.
+			(instanceField.GetValue(null) as IDisposable)?.Dispose();
+			alc.Unload();
+		}
+	}
+
+	[TestMethod]
 	public void When_DefaultContextProcessorDisposed_Then_SharedElementAgentUntouched()
 	{
 		// Arrange — this test assembly loads Uno.UI.RemoteControl into the default ALC, so the

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Uno.UI.RemoteControl.HotReload.MetadataUpdater;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.HotReload;
+
+/// <summary>
+/// Regression guards for the collectible-context teardown fix (issue #23704). Disposing the
+/// hot-reload client agents must release the per-context state that otherwise pins the owning
+/// collectible AssemblyLoadContext. The retained maps key on (or capture) types and assemblies
+/// from that context, so a host that previews apps in collectible contexts leaks one context per
+/// load/unload cycle until the agents are disposed. These tests fail against the pre-fix Dispose,
+/// which only detached the AppDomain.AssemblyLoad subscription and left the maps populated.
+/// </summary>
+[TestClass]
+public class HotReloadAgentDisposeTests
+{
+	[TestMethod]
+	public void When_ElementUpdateAgentDisposed_Then_HandlerMapCleared()
+	{
+		// Arrange — the assembly-level [ElementMetadataUpdateHandlerAttribute]s declared for these tests
+		// cause the agent to discover FrameworkElement handlers at construction.
+		var agent = new ElementUpdateAgent(_ => { }, (_, _) => { });
+		agent.ElementHandlerActions.Should().NotBeEmpty("handlers are discovered at construction");
+
+		// Act
+		agent.Dispose();
+
+		// Assert — the Type-keyed handler map is released so the collectible context's element types
+		// are no longer retained by this agent.
+		agent.ElementHandlerActions.Should().BeEmpty(
+			"Dispose must clear _elementHandlerActions so the owning collectible context is not pinned");
+	}
+
+	[TestMethod]
+	public void When_HotReloadAgentDisposed_Then_DeltaAndAssemblyMapsCleared()
+	{
+		// Arrange
+		var agent = new HotReloadAgent(_ => { });
+
+		// Populate _deltas through the public delta path. A random ModuleId matches no loaded module, so
+		// nothing is applied to the runtime — the delta is only stashed into the cache.
+		agent.ApplyDeltas(new[]
+		{
+			new UpdateDelta
+			{
+				ModuleId = Guid.NewGuid(),
+				MetadataDelta = Array.Empty<byte>(),
+				ILDelta = Array.Empty<byte>(),
+			},
+		});
+
+		// Seed _appliedAssemblies (no public path) so its clearing is also asserted.
+		var applied = (ConcurrentDictionary<Assembly, Assembly>)GetField(agent, "_appliedAssemblies").GetValue(agent)!;
+		var self = typeof(HotReloadAgentDisposeTests).Assembly;
+		applied.TryAdd(self, self);
+
+		Count(agent, "_deltas").Should().BeGreaterThan(0, "a delta was stashed");
+		Count(agent, "_appliedAssemblies").Should().BeGreaterThan(0, "an applied assembly was seeded");
+
+		// Act
+		agent.Dispose();
+
+		// Assert — both caches are released so the collectible context's modules/assemblies are no longer
+		// retained by this agent.
+		Count(agent, "_deltas").Should().Be(0, "Dispose must clear _deltas");
+		Count(agent, "_appliedAssemblies").Should().Be(0, "Dispose must clear _appliedAssemblies");
+	}
+
+	private static FieldInfo GetField(object target, string name) =>
+		target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+		?? throw new InvalidOperationException($"Field '{name}' not found on {target.GetType()}.");
+
+	private static int Count(object target, string fieldName) =>
+		((ICollection)GetField(target, fieldName).GetValue(target)!).Count;
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
@@ -69,6 +69,28 @@ public class HotReloadAgentDisposeTests
 		Count(agent, "_appliedAssemblies").Should().Be(0, "Dispose must clear _appliedAssemblies");
 	}
 
+	[TestMethod]
+	public void When_HotReloadAgentDisposed_Then_HandlerActionsCacheCleared()
+	{
+		// Arrange
+		var agent = new HotReloadAgent(_ => { });
+
+		// Populate the metadata-update-handler cache. Each action in UpdateHandlerActions is a delegate
+		// built from a MethodInfo on a handler Type discovered by scanning this context's assemblies, so a
+		// non-null cache captures delegates/Types owned by the owning collectible context and pins it.
+		var handlerField = GetField(agent, "_handlerActions");
+		handlerField.SetValue(agent, new HotReloadAgent.UpdateHandlerActions());
+		handlerField.GetValue(agent).Should().NotBeNull("the handler-action cache was seeded");
+
+		// Act
+		agent.Dispose();
+
+		// Assert — the cache is released so the collectible context's handler delegates/Types are no longer
+		// retained by this agent. Fails against the pre-fix Dispose, which left _handlerActions populated.
+		handlerField.GetValue(agent).Should().BeNull(
+			"Dispose must null _handlerActions so the owning collectible context is not pinned");
+	}
+
 	private static FieldInfo GetField(object target, string name) =>
 		target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
 		?? throw new InvalidOperationException($"Field '{name}' not found on {target.GetType()}.");

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
@@ -262,18 +262,51 @@ public class HotReloadAgentDisposeTests
 
 	/// <summary>
 	/// True when a delegate targeting <paramref name="target"/> is subscribed to
-	/// AppDomain.CurrentDomain.AssemblyLoad. On .NET the AppDomain event forwards to the internal
-	/// static AssemblyLoadContext.AssemblyLoad field-like event, whose backing field is read here.
+	/// <c>AppDomain.CurrentDomain.AssemblyLoad</c>. On .NET the AppDomain event forwards to the
+	/// internal static <c>AssemblyLoadContext.AssemblyLoad</c> field-like event; the agent's
+	/// subscription (whose delegate target is the agent) is the primary pin on the owning
+	/// collectible context, so detachment on Dispose is what these tests assert.
 	/// </summary>
+	/// <remarks>
+	/// The backing static field is a CoreCLR implementation detail whose name/layout can change
+	/// across runtime updates. Rather than binding to a single hard-coded name — which would make
+	/// the test fail on a runtime change even when the product behaviour is correct — the lookup
+	/// probes the known candidate field names and, if none resolve, fails with a clear diagnostic
+	/// (never an NRE) pointing at the layout change so the seam can be updated deliberately.
+	/// </remarks>
 	private static bool IsSubscribedToAssemblyLoad(object target)
 	{
-		var field = typeof(AssemblyLoadContext).GetField("AssemblyLoad", BindingFlags.NonPublic | BindingFlags.Static)
-			?? throw new InvalidOperationException(
-				"AssemblyLoadContext.AssemblyLoad backing field not found — the runtime's AppDomain.AssemblyLoad forwarding layout changed.");
-
+		var field = ResolveAssemblyLoadBackingField();
 		var subscribers = ((Delegate?)field.GetValue(null))?.GetInvocationList() ?? Array.Empty<Delegate>();
 
 		return subscribers.Any(d => ReferenceEquals(d.Target, target));
+	}
+
+	// Field-like events emit a backing field named after the event on most runtimes; the extra
+	// candidates cover the compiler-generated backing-field conventions in case that changes.
+	private static readonly string[] _assemblyLoadFieldCandidates =
+	[
+		"AssemblyLoad",
+		"<AssemblyLoad>k__BackingField",
+		"m_AssemblyLoad",
+	];
+
+	private static FieldInfo ResolveAssemblyLoadBackingField()
+	{
+		foreach (var candidate in _assemblyLoadFieldCandidates)
+		{
+			var field = typeof(AssemblyLoadContext).GetField(candidate, BindingFlags.NonPublic | BindingFlags.Static);
+			if (field is not null && typeof(Delegate).IsAssignableFrom(field.FieldType))
+			{
+				return field;
+			}
+		}
+
+		throw new InvalidOperationException(
+			"Could not resolve the static AssemblyLoadContext backing field for AppDomain.AssemblyLoad " +
+			$"(tried: {string.Join(", ", _assemblyLoadFieldCandidates)}). The runtime's AppDomain.AssemblyLoad " +
+			"forwarding layout has changed — update the candidate field names or switch this seam to a " +
+			"behavioural observation of the agent's AssemblyLoad reaction.");
 	}
 
 	private static FieldInfo GetField(object target, string name) =>

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.Loader;
+using Uno.UI.RemoteControl.HotReload;
 using Uno.UI.RemoteControl.HotReload.MetadataUpdater;
 
 namespace Uno.UI.RemoteControl.DevServer.Tests.HotReload;
@@ -11,8 +13,14 @@ namespace Uno.UI.RemoteControl.DevServer.Tests.HotReload;
 /// hot-reload client agents must release the per-context state that otherwise pins the owning
 /// collectible AssemblyLoadContext. The retained maps key on (or capture) types and assemblies
 /// from that context, so a host that previews apps in collectible contexts leaks one context per
-/// load/unload cycle until the agents are disposed. These tests fail against the pre-fix Dispose,
-/// which only detached the AppDomain.AssemblyLoad subscription and left the maps populated.
+/// load/unload cycle until the agents are disposed. The agent-level tests fail against the pre-fix
+/// Dispose, which only detached the AppDomain.AssemblyLoad subscription and left the maps populated.
+/// The processor-level tests load a real copy of Uno.UI.RemoteControl into a collectible
+/// AssemblyLoadContext (the copy's own <c>_processorAlc</c> then resolves to that context, so the
+/// production collectible gate is exercised, not simulated) and prove that a host-driven
+/// <see cref="ClientHotReloadProcessor.Dispose"/> — the load-bearing release path on browser-wasm,
+/// where <see cref="AssemblyLoadContext.Unloading"/> is not raised — also releases the static
+/// element agent, while a default-context processor never tears the shared agent down.
 /// </summary>
 [TestClass]
 public class HotReloadAgentDisposeTests
@@ -91,9 +99,171 @@ public class HotReloadAgentDisposeTests
 			"Dispose must null _handlerActions so the owning collectible context is not pinned");
 	}
 
+	[TestMethod]
+	public void When_ElementUpdateAgentDisposed_Then_AssemblyLoadSubscriptionDetached()
+	{
+		// Arrange
+		var agent = new ElementUpdateAgent(_ => { }, (_, _) => { });
+		IsSubscribedToAssemblyLoad(agent).Should().BeTrue(
+			"the agent subscribes to AppDomain.AssemblyLoad at construction");
+
+		// Act
+		agent.Dispose();
+
+		// Assert — the process-wide subscription is the primary pin on the owning collectible
+		// context (the delegate target is the agent, which captures the context's types).
+		IsSubscribedToAssemblyLoad(agent).Should().BeFalse(
+			"Dispose must detach the process-wide AppDomain.AssemblyLoad subscription");
+	}
+
+	[TestMethod]
+	public void When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased()
+	{
+		// Arrange — real collectible-context copy of the processor assembly (see class remarks).
+		var (copy, processorType) = LoadCollectibleProcessorCopy(
+			nameof(When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased));
+
+		var elementAgentField = GetStaticField(processorType, "_elementAgent");
+		var elementAgent = CreateElementAgentIn(copy);
+		elementAgentField.SetValue(null, elementAgent);
+		IsSubscribedToAssemblyLoad(elementAgent).Should().BeTrue(
+			"the seeded element agent subscribes to AppDomain.AssemblyLoad at construction");
+
+		var processor = (IDisposable)Activator.CreateInstance(processorType, new object?[] { null })!;
+
+		// Act — host-driven dispose, the load-bearing release path on runtimes where
+		// AssemblyLoadContext.Unloading is not raised (browser-wasm, dotnet/runtime#34072).
+		processor.Dispose();
+
+		// Assert — the per-context statics are released so nothing pins the collectible context.
+		elementAgentField.GetValue(null).Should().BeNull(
+			"Dispose on a collectible-context processor must release the static element agent");
+		IsSubscribedToAssemblyLoad(elementAgent).Should().BeFalse(
+			"the released agent's process-wide AppDomain.AssemblyLoad subscription must be detached");
+
+		// Double-dispose must be a safe no-op (idempotent teardown).
+		var secondDispose = () => processor.Dispose();
+		secondDispose.Should().NotThrow("the collectible teardown flow must be idempotent");
+	}
+
+	[TestMethod]
+	public void When_DefaultContextProcessorDisposed_Then_SharedElementAgentUntouched()
+	{
+		// Arrange — this test assembly loads Uno.UI.RemoteControl into the default ALC, so the
+		// processor under test runs the default-context (live host) Dispose path.
+		var elementAgentField = GetStaticField(typeof(ClientHotReloadProcessor), "_elementAgent");
+		elementAgentField.GetValue(null).Should().BeNull(
+			"test isolation — no other test should leave a shared element agent behind");
+
+		var agent = new ElementUpdateAgent(_ => { }, (_, _) => { });
+		try
+		{
+			elementAgentField.SetValue(null, agent);
+			var processor = new ClientHotReloadProcessor(null!);
+
+			// Act
+			processor.Dispose();
+
+			// Assert — a live host-context processor must never tear down the shared element agent.
+			elementAgentField.GetValue(null).Should().BeSameAs(agent,
+				"disposing a default-context processor must not release the shared element agent");
+			IsSubscribedToAssemblyLoad(agent).Should().BeTrue(
+				"the shared element agent must stay subscribed to AppDomain.AssemblyLoad");
+		}
+		finally
+		{
+			elementAgentField.SetValue(null, null);
+			agent.Dispose();
+		}
+	}
+
+	[TestMethod]
+	public void When_TearDownForAlcUnload_WithLiveInstance_Then_TearsDownWithoutRecursion()
+	{
+		// Arrange — separate collectible copy, with both the static instance and the static element
+		// agent populated, mirroring a fully-initialized processor at context-unload time.
+		var (copy, processorType) = LoadCollectibleProcessorCopy(
+			nameof(When_TearDownForAlcUnload_WithLiveInstance_Then_TearsDownWithoutRecursion));
+
+		var elementAgentField = GetStaticField(processorType, "_elementAgent");
+		var instanceField = GetStaticField(processorType, "_instance");
+		var elementAgent = CreateElementAgentIn(copy);
+		elementAgentField.SetValue(null, elementAgent);
+
+		var processor = Activator.CreateInstance(processorType, new object?[] { null })!;
+		instanceField.SetValue(null, processor);
+
+		var tearDown = processorType.GetMethod("TearDownForAlcUnload", BindingFlags.NonPublic | BindingFlags.Static)
+			?? throw new InvalidOperationException($"Method 'TearDownForAlcUnload' not found on {processorType}.");
+
+		// Act — the Unloading-path teardown disposes the instance, whose Dispose in turn releases
+		// the per-context statics; this must not recurse back into TearDownForAlcUnload (a recursive
+		// flow would overflow the stack and crash the test host here).
+		tearDown.Invoke(null, null);
+
+		// Assert
+		instanceField.GetValue(null).Should().BeNull("teardown must clear the static processor instance");
+		elementAgentField.GetValue(null).Should().BeNull("teardown must release the static element agent");
+		IsSubscribedToAssemblyLoad(elementAgent).Should().BeFalse(
+			"the released agent's process-wide AppDomain.AssemblyLoad subscription must be detached");
+
+		// Re-running the teardown (e.g. Unloading firing after an explicit host dispose) must be safe.
+		var secondTearDown = () => tearDown.Invoke(null, null);
+		secondTearDown.Should().NotThrow("the collectible teardown flow must be idempotent");
+	}
+
+	/// <summary>
+	/// Loads a fresh copy of the Uno.UI.RemoteControl assembly into a new collectible
+	/// AssemblyLoadContext, the way a downstream host loads previewed apps into their own
+	/// collectible contexts. The copy has its own statics, and its <c>_processorAlc</c> resolves
+	/// to the collectible context, so the production collectible gates are exercised for real.
+	/// </summary>
+	private static (Assembly Copy, Type ProcessorType) LoadCollectibleProcessorCopy(string name)
+	{
+		var alc = new AssemblyLoadContext(name, isCollectible: true);
+		var copy = alc.LoadFromAssemblyPath(typeof(ClientHotReloadProcessor).Assembly.Location);
+		var processorType = copy.GetType(typeof(ClientHotReloadProcessor).FullName!, throwOnError: true)!;
+
+		return (copy, processorType);
+	}
+
+	/// <summary>
+	/// Instantiates the given assembly copy's own ElementUpdateAgent type (the constructor
+	/// parameter types live in System.Private.CoreLib, so they are shared across contexts).
+	/// </summary>
+	private static object CreateElementAgentIn(Assembly copy)
+	{
+		var agentType = copy.GetType(typeof(ElementUpdateAgent).FullName!, throwOnError: true)!;
+
+		return Activator.CreateInstance(
+			agentType,
+			new Action<string>(_ => { }),
+			new Action<MethodInfo, Exception>((_, _) => { }))!;
+	}
+
+	/// <summary>
+	/// True when a delegate targeting <paramref name="target"/> is subscribed to
+	/// AppDomain.CurrentDomain.AssemblyLoad. On .NET the AppDomain event forwards to the internal
+	/// static AssemblyLoadContext.AssemblyLoad field-like event, whose backing field is read here.
+	/// </summary>
+	private static bool IsSubscribedToAssemblyLoad(object target)
+	{
+		var field = typeof(AssemblyLoadContext).GetField("AssemblyLoad", BindingFlags.NonPublic | BindingFlags.Static)
+			?? throw new InvalidOperationException(
+				"AssemblyLoadContext.AssemblyLoad backing field not found — the runtime's AppDomain.AssemblyLoad forwarding layout changed.");
+
+		var subscribers = ((Delegate?)field.GetValue(null))?.GetInvocationList() ?? Array.Empty<Delegate>();
+
+		return subscribers.Any(d => ReferenceEquals(d.Target, target));
+	}
+
 	private static FieldInfo GetField(object target, string name) =>
 		target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
 		?? throw new InvalidOperationException($"Field '{name}' not found on {target.GetType()}.");
+
+	private static FieldInfo GetStaticField(Type type, string name) =>
+		type.GetField(name, BindingFlags.Static | BindingFlags.NonPublic)
+		?? throw new InvalidOperationException($"Static field '{name}' not found on {type}.");
 
 	private static int Count(object target, string fieldName) =>
 		((ICollection)GetField(target, fieldName).GetValue(target)!).Count;

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/HotReloadAgentDisposeTests.cs
@@ -120,30 +120,39 @@ public class HotReloadAgentDisposeTests
 	public void When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased()
 	{
 		// Arrange — real collectible-context copy of the processor assembly (see class remarks).
-		var (copy, processorType) = LoadCollectibleProcessorCopy(
+		var (alc, copy, processorType) = LoadCollectibleProcessorCopy(
 			nameof(When_CollectibleContextProcessorDisposed_Then_PerContextStaticsReleased));
+		try
+		{
+			var elementAgentField = GetStaticField(processorType, "_elementAgent");
+			var elementAgent = CreateElementAgentIn(copy);
+			elementAgentField.SetValue(null, elementAgent);
+			IsSubscribedToAssemblyLoad(elementAgent).Should().BeTrue(
+				"the seeded element agent subscribes to AppDomain.AssemblyLoad at construction");
 
-		var elementAgentField = GetStaticField(processorType, "_elementAgent");
-		var elementAgent = CreateElementAgentIn(copy);
-		elementAgentField.SetValue(null, elementAgent);
-		IsSubscribedToAssemblyLoad(elementAgent).Should().BeTrue(
-			"the seeded element agent subscribes to AppDomain.AssemblyLoad at construction");
+			var processor = (IDisposable)Activator.CreateInstance(processorType, new object?[] { null })!;
 
-		var processor = (IDisposable)Activator.CreateInstance(processorType, new object?[] { null })!;
+			// Act — host-driven dispose, the load-bearing release path on runtimes where
+			// AssemblyLoadContext.Unloading is not raised (browser-wasm, dotnet/runtime#34072).
+			processor.Dispose();
 
-		// Act — host-driven dispose, the load-bearing release path on runtimes where
-		// AssemblyLoadContext.Unloading is not raised (browser-wasm, dotnet/runtime#34072).
-		processor.Dispose();
+			// Assert — the per-context statics are released so nothing pins the collectible context.
+			elementAgentField.GetValue(null).Should().BeNull(
+				"Dispose on a collectible-context processor must release the static element agent");
+			IsSubscribedToAssemblyLoad(elementAgent).Should().BeFalse(
+				"the released agent's process-wide AppDomain.AssemblyLoad subscription must be detached");
 
-		// Assert — the per-context statics are released so nothing pins the collectible context.
-		elementAgentField.GetValue(null).Should().BeNull(
-			"Dispose on a collectible-context processor must release the static element agent");
-		IsSubscribedToAssemblyLoad(elementAgent).Should().BeFalse(
-			"the released agent's process-wide AppDomain.AssemblyLoad subscription must be detached");
-
-		// Double-dispose must be a safe no-op (idempotent teardown).
-		var secondDispose = () => processor.Dispose();
-		secondDispose.Should().NotThrow("the collectible teardown flow must be idempotent");
+			// Double-dispose must be a safe no-op (idempotent teardown).
+			var secondDispose = () => processor.Dispose();
+			secondDispose.Should().NotThrow("the collectible teardown flow must be idempotent");
+		}
+		finally
+		{
+			// The collectible context has to outlive the teardown assertions above (the test
+			// verifies the processor releases what pins it), so it is unloaded only here — mirroring
+			// the try/finally Unload() idiom used by the sibling cross-ALC tests.
+			alc.Unload();
+		}
 	}
 
 	[TestMethod]
@@ -182,34 +191,42 @@ public class HotReloadAgentDisposeTests
 	{
 		// Arrange — separate collectible copy, with both the static instance and the static element
 		// agent populated, mirroring a fully-initialized processor at context-unload time.
-		var (copy, processorType) = LoadCollectibleProcessorCopy(
+		var (alc, copy, processorType) = LoadCollectibleProcessorCopy(
 			nameof(When_TearDownForAlcUnload_WithLiveInstance_Then_TearsDownWithoutRecursion));
+		try
+		{
+			var elementAgentField = GetStaticField(processorType, "_elementAgent");
+			var instanceField = GetStaticField(processorType, "_instance");
+			var elementAgent = CreateElementAgentIn(copy);
+			elementAgentField.SetValue(null, elementAgent);
 
-		var elementAgentField = GetStaticField(processorType, "_elementAgent");
-		var instanceField = GetStaticField(processorType, "_instance");
-		var elementAgent = CreateElementAgentIn(copy);
-		elementAgentField.SetValue(null, elementAgent);
+			var processor = Activator.CreateInstance(processorType, new object?[] { null })!;
+			instanceField.SetValue(null, processor);
 
-		var processor = Activator.CreateInstance(processorType, new object?[] { null })!;
-		instanceField.SetValue(null, processor);
+			var tearDown = processorType.GetMethod("TearDownForAlcUnload", BindingFlags.NonPublic | BindingFlags.Static)
+				?? throw new InvalidOperationException($"Method 'TearDownForAlcUnload' not found on {processorType}.");
 
-		var tearDown = processorType.GetMethod("TearDownForAlcUnload", BindingFlags.NonPublic | BindingFlags.Static)
-			?? throw new InvalidOperationException($"Method 'TearDownForAlcUnload' not found on {processorType}.");
+			// Act — the Unloading-path teardown disposes the instance, whose Dispose in turn releases
+			// the per-context statics; this must not recurse back into TearDownForAlcUnload (a recursive
+			// flow would overflow the stack and crash the test host here).
+			tearDown.Invoke(null, null);
 
-		// Act — the Unloading-path teardown disposes the instance, whose Dispose in turn releases
-		// the per-context statics; this must not recurse back into TearDownForAlcUnload (a recursive
-		// flow would overflow the stack and crash the test host here).
-		tearDown.Invoke(null, null);
+			// Assert
+			instanceField.GetValue(null).Should().BeNull("teardown must clear the static processor instance");
+			elementAgentField.GetValue(null).Should().BeNull("teardown must release the static element agent");
+			IsSubscribedToAssemblyLoad(elementAgent).Should().BeFalse(
+				"the released agent's process-wide AppDomain.AssemblyLoad subscription must be detached");
 
-		// Assert
-		instanceField.GetValue(null).Should().BeNull("teardown must clear the static processor instance");
-		elementAgentField.GetValue(null).Should().BeNull("teardown must release the static element agent");
-		IsSubscribedToAssemblyLoad(elementAgent).Should().BeFalse(
-			"the released agent's process-wide AppDomain.AssemblyLoad subscription must be detached");
-
-		// Re-running the teardown (e.g. Unloading firing after an explicit host dispose) must be safe.
-		var secondTearDown = () => tearDown.Invoke(null, null);
-		secondTearDown.Should().NotThrow("the collectible teardown flow must be idempotent");
+			// Re-running the teardown (e.g. Unloading firing after an explicit host dispose) must be safe.
+			var secondTearDown = () => tearDown.Invoke(null, null);
+			secondTearDown.Should().NotThrow("the collectible teardown flow must be idempotent");
+		}
+		finally
+		{
+			// Unload the collectible context only after the teardown assertions — it must stay alive
+			// while the test verifies what pins it, mirroring the sibling cross-ALC tests' try/finally.
+			alc.Unload();
+		}
 	}
 
 	/// <summary>
@@ -217,14 +234,16 @@ public class HotReloadAgentDisposeTests
 	/// AssemblyLoadContext, the way a downstream host loads previewed apps into their own
 	/// collectible contexts. The copy has its own statics, and its <c>_processorAlc</c> resolves
 	/// to the collectible context, so the production collectible gates are exercised for real.
+	/// The context is returned so the caller can <see cref="AssemblyLoadContext.Unload"/> it in a
+	/// <c>finally</c> after the teardown assertions, matching the sibling cross-ALC tests' idiom.
 	/// </summary>
-	private static (Assembly Copy, Type ProcessorType) LoadCollectibleProcessorCopy(string name)
+	private static (AssemblyLoadContext Alc, Assembly Copy, Type ProcessorType) LoadCollectibleProcessorCopy(string name)
 	{
 		var alc = new AssemblyLoadContext(name, isCollectible: true);
 		var copy = alc.LoadFromAssemblyPath(typeof(ClientHotReloadProcessor).Assembly.Location);
 		var processorType = copy.GetType(typeof(ClientHotReloadProcessor).FullName!, throwOnError: true)!;
 
-		return (copy, processorType);
+		return (alc, copy, processorType);
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -53,6 +53,11 @@ namespace Uno.UI.RemoteControl.HotReload
 		{
 			_instance = this;
 
+			// If this processor copy is owned by a collectible previewed-app context, arm a best-effort
+			// teardown for when that context unloads so its process-wide AssemblyLoad subscriptions are
+			// released (no-op for the default/host context).
+			ArmCollectibleAlcTeardown();
+
 			// Subscribe the drain dispatcher so that pause-handle releases that
 			// drain pending types end up actually applying them through the
 			// standard visual-tree update path.

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -129,6 +129,20 @@ namespace Uno.UI.RemoteControl.HotReload
 			}
 
 			_elementAgent = null;
+
+#if HAS_UNO_WINUI
+			// Detach the first-activation diagnostics handler before dropping the window reference.
+			// The handler is a static method on this collectible-context copy of the processor; if the
+			// host Window outlives the context (it does — the window is owned by the host), its Activated
+			// event would keep that method — and through it this context — alive after unload. The handler
+			// self-detaches on first activation, but only once RootElement.XamlRoot is available, so a
+			// context torn down before that (or with the indicator disabled) would otherwise still be pinned.
+			if (CurrentWindow is not null)
+			{
+				CurrentWindow.Activated -= ShowDiagnosticsOnFirstActivation;
+			}
+#endif
+
 			CurrentWindow = null;
 		}
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -117,7 +117,11 @@ namespace Uno.UI.RemoteControl.HotReload
 
 			try
 			{
-				instance?.Dispose();
+				// Dispose() lives in the base partial file, which some consumers (e.g. Uno.UI.Toolkit)
+				// link WITHOUT: cast through IDisposable so this binds in the full assembly (where the
+				// type is IDisposable) and compiles-to-no-op in those partial embeds. Harmless there:
+				// the teardown only runs for a collectible context, which such embeds never have.
+				(instance as IDisposable)?.Dispose();
 			}
 			catch (Exception e)
 			{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -91,10 +91,11 @@ namespace Uno.UI.RemoteControl.HotReload
 
 		/// <summary>
 		/// Releases this collectible context's per-context hot-reload state: disposes the processor instance
-		/// (which disposes its <c>_agent</c> and detaches that agent's AssemblyLoad subscription), disposes
-		/// the shared element-update agent (detaching its AssemblyLoad subscription and clearing its
-		/// Type-keyed handler map), and clears the static references. No-op for the default (host) context or
-		/// a non-collectible owner, so a live processor is never torn down.
+		/// (which disposes its <c>_agent</c>, detaches that agent's AssemblyLoad subscription, and — for a
+		/// collectible owner — releases the per-context statics), then calls
+		/// <see cref="ReleasePerContextStatics"/> to cover a context that never initialized a processor
+		/// instance. No-op for the default (host) context or a non-collectible owner, so a live processor is
+		/// never torn down.
 		/// </summary>
 		private static void TearDownForAlcUnload()
 		{
@@ -108,17 +109,38 @@ namespace Uno.UI.RemoteControl.HotReload
 				_log.Trace("Tearing down hot-reload state for the collectible processor load context unload.");
 			}
 
+			// Detach the instance BEFORE disposing it: for a collectible owner Dispose() re-enters the
+			// static teardown through ReleasePerContextStatics() (never through this method, keeping the
+			// flow non-recursive), and clearing the reference first keeps the whole path idempotent.
+			var instance = _instance;
+			_instance = null;
+
 			try
 			{
-				_instance?.Dispose();
+				instance?.Dispose();
 			}
 			catch (Exception e)
 			{
 				_log.Error("Failed to dispose the hot-reload processor during collectible context teardown.", e);
 			}
 
-			_instance = null;
+			// Dispose() above already released the statics when an instance existed; this covers a context
+			// whose statics were populated without a processor instance ever being initialized.
+			ReleasePerContextStatics();
+		}
 
+		/// <summary>
+		/// Releases the per-context static hot-reload state that would otherwise pin a collectible owning
+		/// context: disposes the shared element-update agent (detaching its process-wide
+		/// <see cref="AppDomain.AssemblyLoad"/> subscription and clearing its Type-keyed handler map) and
+		/// clears the static references. Idempotent and never calls back into
+		/// <see cref="TearDownForAlcUnload"/>, so it is safe to invoke from both the
+		/// <see cref="AssemblyLoadContext.Unloading"/> teardown and an explicit host-driven
+		/// <see cref="Dispose"/> (the load-bearing release path on browser-wasm, where Unloading is not
+		/// raised — dotnet/runtime#34072).
+		/// </summary>
+		private static void ReleasePerContextStatics()
+		{
 			try
 			{
 				_elementAgent?.Dispose();

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -49,6 +49,89 @@ namespace Uno.UI.RemoteControl.HotReload
 		}
 #endif
 
+		// Guards single-arming of the collectible-context Unloading teardown below.
+		private static bool _alcTeardownArmed;
+
+		static ClientHotReloadProcessor()
+		{
+			// Arm at type initialization: in a collectible-context copy the metadata-updater
+			// initialization path may never run (e.g. when the dev-server connection is unavailable),
+			// yet the per-context statics above still get populated and would pin the context.
+			ArmCollectibleAlcTeardown();
+		}
+
+		/// <summary>
+		/// When this processor copy is owned by a collectible load context (the case where a downstream
+		/// host loads previewed apps into their own collectible <see cref="AssemblyLoadContext"/>s, each
+		/// loading its own copy of this assembly), arm a teardown that runs when that context unloads.
+		/// The per-context static state here — the processor instance, its <c>_agent</c>, and the shared
+		/// <c>_elementAgent</c> — each hold a process-wide <see cref="AppDomain.AssemblyLoad"/> subscription
+		/// that otherwise keeps the whole context alive after unload. NOTE: <see cref="AssemblyLoadContext.Unloading"/>
+		/// was observed NOT to be raised on the browser-wasm runtime, where collectible-context unload is
+		/// unimplemented (dotnet/runtime#34072) — there this hook never fires. It is therefore best-effort for
+		/// runtimes that do raise the event; a host that needs deterministic release must still dispose the
+		/// processor explicitly on teardown (the load-bearing part is that <c>Dispose()</c> on the agents now
+		/// clears their Type/delta maps and detaches their <see cref="AppDomain.AssemblyLoad"/> subscriptions).
+		/// </summary>
+		private static void ArmCollectibleAlcTeardown()
+		{
+			if (_alcTeardownArmed || _processorAlc == AssemblyLoadContext.Default || !_processorAlc.IsCollectible)
+			{
+				return;
+			}
+
+			_alcTeardownArmed = true;
+			_processorAlc.Unloading += static _ => TearDownForAlcUnload();
+
+			if (_log.IsEnabled(LogLevel.Trace))
+			{
+				_log.Trace("Armed Unloading teardown for the collectible processor load context.");
+			}
+		}
+
+		/// <summary>
+		/// Releases this collectible context's per-context hot-reload state: disposes the processor instance
+		/// (which disposes its <c>_agent</c> and detaches that agent's AssemblyLoad subscription), disposes
+		/// the shared element-update agent (detaching its AssemblyLoad subscription and clearing its
+		/// Type-keyed handler map), and clears the static references. No-op for the default (host) context or
+		/// a non-collectible owner, so a live processor is never torn down.
+		/// </summary>
+		private static void TearDownForAlcUnload()
+		{
+			if (_processorAlc == AssemblyLoadContext.Default || !_processorAlc.IsCollectible)
+			{
+				return;
+			}
+
+			if (_log.IsEnabled(LogLevel.Trace))
+			{
+				_log.Trace("Tearing down hot-reload state for the collectible processor load context unload.");
+			}
+
+			try
+			{
+				_instance?.Dispose();
+			}
+			catch (Exception e)
+			{
+				_log.Error("Failed to dispose the hot-reload processor during collectible context teardown.", e);
+			}
+
+			_instance = null;
+
+			try
+			{
+				_elementAgent?.Dispose();
+			}
+			catch (Exception e)
+			{
+				_log.Error("Failed to dispose the element-update agent during collectible context teardown.", e);
+			}
+
+			_elementAgent = null;
+			CurrentWindow = null;
+		}
+
 		private static async IAsyncEnumerable<TMatch> EnumerateHotReloadInstances<TMatch>(
 			object? instance,
 			Func<FrameworkElement, string, Task<TMatch?>> predicate,

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.Loader;
 using System.Threading.Tasks;
 using Uno.Foundation.Logging;
 using Uno.UI.RemoteControl.HotReload.Messages;
@@ -31,6 +32,23 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 	{
 		_agent?.Dispose();
 		_agent = null;
+
+		// On runtimes where AssemblyLoadContext.Unloading is not raised for collectible contexts
+		// (browser-wasm, dotnet/runtime#34072) an explicit host-driven Dispose is the load-bearing
+		// release path, so when this processor copy is owned by a collectible context also release
+		// the per-context statics — most importantly the shared ElementUpdateAgent, whose
+		// process-wide AppDomain.AssemblyLoad subscription would otherwise pin the context after
+		// unload. The default/non-collectible case is deliberately left untouched: disposing a
+		// host-context processor must never tear down the shared element agent.
+		if (_processorAlc != AssemblyLoadContext.Default && _processorAlc.IsCollectible)
+		{
+			if (ReferenceEquals(_instance, this))
+			{
+				_instance = null;
+			}
+
+			ReleasePerContextStatics();
+		}
 	}
 
 	string IClientProcessor.Scope => WellKnownScopes.HotReload;

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -42,12 +42,20 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 		// host-context processor must never tear down the shared element agent.
 		if (_processorAlc != AssemblyLoadContext.Default && _processorAlc.IsCollectible)
 		{
+			// Only the active processor (or a context whose metadata updater never initialized an
+			// instance, so _instance is null and nothing live depends on the statics) may release
+			// the shared per-context statics. Disposing a non-active processor — e.g. a second
+			// RemoteControlClient in the same collectible context — must not tear down the shared
+			// _elementAgent out from under the still-live active processor.
 			if (ReferenceEquals(_instance, this))
 			{
 				_instance = null;
+				ReleasePerContextStatics();
 			}
-
-			ReleasePerContextStatics();
+			else if (_instance is null)
+			{
+				ReleasePerContextStatics();
+			}
 		}
 	}
 

--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/ElementUpdaterAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/ElementUpdaterAgent.cs
@@ -416,6 +416,13 @@ internal sealed class ElementUpdateAgent : IDisposable
 	}
 
 	public void Dispose()
-		=> AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;
+	{
+		// Release the process-wide AssemblyLoad subscription that otherwise keeps this agent — and,
+		// through its captured load context, that context's assemblies — alive for the life of the host.
+		AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;
+
+		// Drop the Type-keyed handler map so a collectible context's element types are not retained.
+		_elementHandlerActions.Clear();
+	}
 
 }

--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
@@ -361,7 +361,15 @@ internal sealed class HotReloadAgent : IDisposable
 	}
 
 	public void Dispose()
-		=> AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;
+	{
+		// Release the process-wide AssemblyLoad subscription that otherwise keeps this agent — and,
+		// through its captured load context, that context's assemblies — alive for the life of the host.
+		AppDomain.CurrentDomain.AssemblyLoad -= _assemblyLoad;
+
+		// Drop cached delta/assembly references so a collectible context's assemblies are not retained.
+		_deltas.Clear();
+		_appliedAssemblies.Clear();
+	}
 
 	private static Guid? TryGetModuleId(Assembly loadedAssembly)
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
@@ -369,6 +369,11 @@ internal sealed class HotReloadAgent : IDisposable
 		// Drop cached delta/assembly references so a collectible context's assemblies are not retained.
 		_deltas.Clear();
 		_appliedAssemblies.Clear();
+
+		// Drop the cached metadata-update-handler actions. Each action is a delegate created from a
+		// MethodInfo on a handler Type discovered by scanning this context's assemblies, so the cache
+		// captures delegates/Types owned by a collectible context and would otherwise pin it.
+		_handlerActions = null;
 	}
 
 	private static Guid? TryGetModuleId(Assembly loadedAssembly)


### PR DESCRIPTION
Closes #23704

## What

When `Uno.UI.RemoteControl` is loaded into a **collectible `AssemblyLoadContext`** (e.g. a host that loads previewed apps into their own collectible contexts, each bringing a per-context copy of this assembly), the hot-reload machinery leaves state behind that pins the unloaded context indefinitely:

- `ElementUpdateAgent` and `HotReloadAgent` hold **process-wide `AppDomain.CurrentDomain.AssemblyLoad` subscriptions**; via the delegate, the whole per-context object graph stays reachable after unload.
- `ElementUpdateAgent._elementHandlerActions` (Type-keyed) and `HotReloadAgent._deltas`/`_appliedAssemblies` retain the context's types/assemblies even after `Dispose()`.
- The per-context statics (`_instance`, `_elementAgent`, `CurrentWindow`) are never cleared.

## Fix

- `ElementUpdateAgent.Dispose()` / `HotReloadAgent.Dispose()` now also clear their Type/delta maps in addition to detaching the `AssemblyLoad` subscription — a host-driven dispose now releases everything.
- `ClientHotReloadProcessor` arms a **best-effort** teardown on its owning context's `Unloading` (only when that context is collectible and not the default): it disposes the processor instance (which disposes its `HotReloadAgent`), disposes the shared `ElementUpdateAgent`, and clears the per-context statics. A live (default-context) processor is never touched.

## Caveat encoded in the code

`AssemblyLoadContext.Unloading` was observed **not** to be raised on the browser-wasm runtime (collectible-context unload is unimplemented there — see dotnet/runtime#34072), so the `Unloading` hook is best-effort for runtimes that raise it. The load-bearing part for wasm hosts is the `Dispose()`-side map clearing: a host that disposes the processor/agents during its own teardown now genuinely releases the context.

## Verification

In a downstream host that repeatedly loads/unloads previewed apps in collectible contexts, heap-dump root-walks previously showed the unloaded context pinned via `HotReloadAgent`/`ElementUpdateAgent` (`AppDomain.AssemblyLoad`) and the processor statics; with this change (host disposing on teardown) those referrers are gone and the managed context object is collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)