### PR TITLE
Remove DO finalizers

### DIFF
--- a/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -378,6 +378,40 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 		}
 
 		[TestMethod]
+		public void When_Store_Populated_Then_Owner_Collected()
+		{
+			// The property details collection holds its owning DependencyObject strongly, so the two
+			// form a reference cycle. That is only safe while the collection never escapes its owner:
+			// the cycle is then unreachable as a unit and the tracing GC reclaims it whole. This pins
+			// that invariant - if the collection (or a closure capturing it) is ever handed to a
+			// longer-lived structure, the owner stops being collectable and this fails.
+			WeakReference ownerWR, childWR;
+
+			void Create()
+			{
+				var owner = new MyObject();
+				var child = new SubObject();
+
+				// Populate the store, and give the owner an inheriting child so it also mints the
+				// pooled self weak reference - the other per-instance state this branch made lazy.
+				owner.SubObject = child;
+				owner.DataContext = new object();
+
+				ownerWR = new WeakReference(owner);
+				childWR = new WeakReference(child);
+			}
+
+			Create();
+
+			GC.Collect(2, GCCollectionMode.Forced);
+			GC.WaitForPendingFinalizers();
+			GC.Collect(2, GCCollectionMode.Forced);
+
+			Assert.IsNull(ownerWR.Target);
+			Assert.IsNull(childWR.Target);
+		}
+
+		[TestMethod]
 		public void When_ControlTemplate_And_Animation()
 		{
 			var SUT = new ContentControl() { Tag = 42 };

--- a/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI.UnitTests/DependencyProperty/Given_DependencyPropertyDetailsCollection.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+using System;
+using System.Numerics;
+using System.Reflection;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.Tests;
+
+[TestClass]
+public partial class Given_DependencyPropertyDetailsCollection
+{
+	private const int PaddedPropertyCount = 256;
+
+	// DependencyProperty.UniqueId comes from a process-wide counter, so the bucket index of any given
+	// property depends on what the rest of the run registered first. Pad it well past the array pool's
+	// 16-element minimum bucket, otherwise the sizing assertion below holds no matter what is rented.
+	private static readonly DependencyProperty _highIdProperty = RegisterPaddedProperties();
+
+	private static DependencyProperty RegisterPaddedProperties()
+	{
+		DependencyProperty last = null!;
+
+		for (var i = 0; i < PaddedPropertyCount; i++)
+		{
+			last = DependencyProperty.Register($"Pad{i}", typeof(int), typeof(PaddedObject), new PropertyMetadata(0));
+		}
+
+		return last;
+	}
+
+	[TestMethod]
+	public void When_Property_Has_High_UniqueId_Then_Offsets_Are_Not_Over_Rented()
+	{
+		PaddedObject SUT = new();
+		SUT.SetValue(_highIdProperty, 42);
+
+		var offsets = GetEntryOffsets(SUT);
+
+		// The offsets array is indexed by the bucket index alone, so it only ever needs bucketIndex + 1 slots.
+		var bucketIndex = _highIdProperty.UniqueId >> 4;
+		var needed = bucketIndex + 1;
+
+		// ArrayPool rounds a request up to a power-of-two bucket (16 minimum) and may satisfy it from one
+		// bucket above that, hence the doubling.
+		var tolerated = Math.Max(16, (int)BitOperations.RoundUpToPowerOf2((uint)needed)) * 2;
+
+		Assert.IsTrue(
+			offsets.Length <= tolerated,
+			$"Offsets array is over-rented: {offsets.Length} slots for bucket index {bucketIndex} "
+			+ $"(needs {needed}, tolerated {tolerated}) = {offsets.Length * sizeof(short)} bytes per DependencyObject.");
+	}
+
+	[TestMethod]
+	public void When_Offsets_Grow_Then_Every_Covered_Bucket_Stays_Addressable()
+	{
+		PaddedObject SUT = new();
+
+		// Grow from the highest bucket downwards, so the array is sized once from the top and then written
+		// at every lower index it claims to cover.
+		for (var i = PaddedPropertyCount - 1; i >= 0; i -= 16)
+		{
+			SUT.SetValue(GetPaddedProperty(i), i);
+		}
+
+		for (var i = PaddedPropertyCount - 1; i >= 0; i -= 16)
+		{
+			Assert.AreEqual(i, SUT.GetValue(GetPaddedProperty(i)));
+		}
+	}
+
+	[TestMethod]
+	public void When_Offsets_Grow_Upwards_Then_Earlier_Buckets_Survive()
+	{
+		PaddedObject SUT = new();
+
+		// The opposite order: each step resizes and copies the previous offsets forward.
+		for (var i = 0; i < PaddedPropertyCount; i += 16)
+		{
+			SUT.SetValue(GetPaddedProperty(i), i);
+		}
+
+		for (var i = 0; i < PaddedPropertyCount; i += 16)
+		{
+			Assert.AreEqual(i, SUT.GetValue(GetPaddedProperty(i)));
+		}
+	}
+
+	private static DependencyProperty GetPaddedProperty(int index)
+	{
+		// Static field access, so the padded registrations above are guaranteed to have run.
+		_ = _highIdProperty;
+
+		return DependencyProperty.GetProperty(typeof(PaddedObject), $"Pad{index}")!;
+	}
+
+	private static short[] GetEntryOffsets(DependencyObject o)
+	{
+		var properties = typeof(DependencyObject)
+			.GetField("_properties", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.GetValue(o)!;
+
+		return (short[])properties.GetType()
+			.GetField("_entryOffsets", BindingFlags.Instance | BindingFlags.NonPublic)!
+			.GetValue(properties)!;
+	}
+}
+
+public partial class PaddedObject : DependencyObject
+{
+}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -139,9 +139,9 @@ namespace Uno.UI
 		public static class DependencyObject
 		{
 			/// <summary>
-			/// When set to true, the <see cref="DependencyObject"/> will create hard references
-			/// instead of weak references for some highly used fields, in common cases to improve the
-			/// overall performance.
+			/// When set to true, a loaded <see cref="DependencyObject"/> holds its parent through a hard
+			/// reference instead of a weak one, to improve the overall performance. The reference is
+			/// released when the element is unloaded.
 			/// </summary>
 			public static bool IsStoreHardReferenceEnabled { get; set; }
 				= true;

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
@@ -222,11 +222,13 @@ namespace Microsoft.UI.Xaml
 			_properties.ResumeBindings();
 		}
 
+		// Currently unreferenced: the finalizer that called this was removed. Kept (with _gate) so the
+		// finalizer removal stays the only behavioral diff — see the EXPERIMENT note in DependencyObject.Store.cs.
 		private void BinderDispose()
 		{
 			lock (_gate)
 			{
-				// Guard the dispose as it may be invoked from both a finalizer and the dispatcher.
+				// Guard the dispose against concurrent invocation.
 				if (_isDisposed)
 				{
 					return;

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
@@ -33,7 +33,6 @@ namespace Microsoft.UI.Xaml
 {
 	public partial class DependencyObject
 	{
-		private readonly object _gate = new object();
 
 		private object? _associatedParent; // see note in AssociateParent(object)
 
@@ -220,44 +219,6 @@ namespace Microsoft.UI.Xaml
 		{
 			_bindingsSuspended = false;
 			_properties.ResumeBindings();
-		}
-
-		// Currently unreferenced: the finalizer that called this was removed. Kept (with _gate) so the
-		// finalizer removal stays the only behavioral diff — see the EXPERIMENT note in DependencyObject.Store.cs.
-		private void BinderDispose()
-		{
-			lock (_gate)
-			{
-				// Guard the dispose against concurrent invocation.
-				if (_isDisposed)
-				{
-					return;
-				}
-
-				_isDisposed = true;
-			}
-
-			_properties.Dispose();
-			_childrenBindableMap?.Dispose();
-			_mentoredChildrenMap?.Dispose();
-
-			if (_mentorRef is not null)
-			{
-				WeakReferencePool.ReturnWeakReference(this, _mentorRef);
-				_mentorRef = null;
-			}
-
-			if (_mentoredChildren is not null)
-			{
-				for (int i = 0; i < _mentoredChildren.Count; i++)
-				{
-					if (_mentoredChildren[i] is { } childRef)
-					{
-						WeakReferencePool.ReturnWeakReference(this, childRef);
-					}
-				}
-				_mentoredChildren = null;
-			}
 		}
 
 		private void OnDataContextChanged(object? providedDataContext, object? actualDataContext, DependencyPropertyValuePrecedences precedence)

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
@@ -26,7 +26,6 @@ namespace Microsoft.UI.Xaml
 {
 	public partial class DependencyObject
 	{
-		private readonly object _gate = new object();
 
 		private object? _associatedParent; // see note in AssociateParent(object)
 
@@ -197,44 +196,6 @@ namespace Microsoft.UI.Xaml
 		{
 			_bindingsSuspended = false;
 			_properties.ResumeBindings();
-		}
-
-		// Currently unreferenced: the finalizer that called this was removed. Kept (with _gate) so the
-		// finalizer removal stays the only behavioral diff — see the EXPERIMENT note in DependencyObject.Store.cs.
-		private void BinderDispose()
-		{
-			lock (_gate)
-			{
-				// Guard the dispose against concurrent invocation.
-				if (_isDisposed)
-				{
-					return;
-				}
-
-				_isDisposed = true;
-			}
-
-			_properties.Dispose();
-			_childrenBindableMap?.Dispose();
-			_mentoredChildrenMap?.Dispose();
-
-			if (_mentorRef is not null)
-			{
-				WeakReferencePool.ReturnWeakReference(this, _mentorRef);
-				_mentorRef = null;
-			}
-
-			if (_mentoredChildren is not null)
-			{
-				for (int i = 0; i < _mentoredChildren.Count; i++)
-				{
-					if (_mentoredChildren[i] is { } childRef)
-					{
-						WeakReferencePool.ReturnWeakReference(this, childRef);
-					}
-				}
-				_mentoredChildren = null;
-			}
 		}
 
 		private void OnDataContextChanged(object? providedDataContext, object? actualDataContext, DependencyPropertyValuePrecedences precedence)

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Binder.cs
@@ -199,11 +199,13 @@ namespace Microsoft.UI.Xaml
 			_properties.ResumeBindings();
 		}
 
+		// Currently unreferenced: the finalizer that called this was removed. Kept (with _gate) so the
+		// finalizer removal stays the only behavioral diff — see the EXPERIMENT note in DependencyObject.Store.cs.
 		private void BinderDispose()
 		{
 			lock (_gate)
 			{
-				// Guard the dispose as it may be invoked from both a finalizer and the dispatcher.
+				// Guard the dispose against concurrent invocation.
 				if (_isDisposed)
 				{
 					return;

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -242,6 +242,9 @@ namespace Microsoft.UI.Xaml
 		// DependencyObject off the finalization queue. It is not load-bearing — pooled weak handles are
 		// freed by ManagedGCHandle's own finalizer; BinderDispose only recycled pooled weak refs/arrays.
 		// BinderDispose is kept (now unreferenced) so this is the ONLY behavioral diff vs the base.
+		// Consequence: nothing sets _isDisposed any more, so IsDisposed stays false and its callers
+		// (EventManager/CustomEventManager) are inert. They are kept for the same reason; if this
+		// experiment is promoted, drop BinderDispose, _gate, IsDisposed and its guards together.
 
 		/// <summary>
 		/// Determines if the dependency object automatically registers for inherited

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -238,13 +238,10 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		// Every DependencyObject is finalizable so pooled weak references and property details are
-		// returned when it is collected without an explicit teardown. BinderDispose is idempotent and
-		// guards against the finalizer/dispatcher race.
-		~DependencyObject()
-		{
-			BinderDispose();
-		}
+		// EXPERIMENT (dev/mazi/dostore-nofinalizer): the finalizer is intentionally removed to take
+		// DependencyObject off the finalization queue. It is not load-bearing — pooled weak handles are
+		// freed by ManagedGCHandle's own finalizer; BinderDispose only recycled pooled weak refs/arrays.
+		// BinderDispose is kept (now unreferenced) so this is the ONLY behavioral diff vs the base.
 
 		/// <summary>
 		/// Determines if the dependency object automatically registers for inherited

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -234,13 +234,10 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		// Every DependencyObject is finalizable so pooled weak references and property details are
-		// returned when it is collected without an explicit teardown. BinderDispose is idempotent and
-		// guards against the finalizer/dispatcher race.
-		~DependencyObject()
-		{
-			BinderDispose();
-		}
+		// EXPERIMENT (dev/mazi/dostore-nofinalizer): the finalizer is intentionally removed to take
+		// DependencyObject off the finalization queue. It is not load-bearing — pooled weak handles are
+		// freed by ManagedGCHandle's own finalizer; BinderDispose only recycled pooled weak refs/arrays.
+		// BinderDispose is kept (now unreferenced) so this is the ONLY behavioral diff vs the base.
 
 		/// <summary>
 		/// Determines if the dependency object automatically registers for inherited

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -238,6 +238,9 @@ namespace Microsoft.UI.Xaml
 		// DependencyObject off the finalization queue. It is not load-bearing — pooled weak handles are
 		// freed by ManagedGCHandle's own finalizer; BinderDispose only recycled pooled weak refs/arrays.
 		// BinderDispose is kept (now unreferenced) so this is the ONLY behavioral diff vs the base.
+		// Consequence: nothing sets _isDisposed any more, so IsDisposed stays false and its callers
+		// (EventManager/CustomEventManager) are inert. They are kept for the same reason; if this
+		// experiment is promoted, drop BinderDispose, _gate, IsDisposed and its guards together.
 
 		/// <summary>
 		/// Determines if the dependency object automatically registers for inherited

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -221,7 +221,7 @@ namespace Microsoft.UI.Xaml
 			_originalObjectType = effectiveOwner.GetType();
 			_dataContextProperty = effectiveOwner is FrameworkElement ? FrameworkElement.DataContextProperty : null;
 
-			_properties = new DependencyPropertyDetailsCollection(SelfWeakReference, _dataContextProperty);
+			_properties = new DependencyPropertyDetailsCollection(this, _dataContextProperty);
 
 			__InitializeBinder();
 
@@ -1939,9 +1939,6 @@ namespace Microsoft.UI.Xaml
 		{
 			var propertyMetadata = property.Metadata;
 
-			// We can reuse the weak reference, otherwise capture the weak reference to this instance.
-			var instanceRef = SelfWeakReference;
-
 			if (propertyMetadata is FrameworkPropertyMetadata frameworkPropertyMetadata)
 			{
 				if (frameworkPropertyMetadata.Options.HasLogicalChild())
@@ -1975,7 +1972,9 @@ namespace Microsoft.UI.Xaml
 					var localChildrenStores = _childrenStores;
 					for (var storeIndex = 0; storeIndex < localChildrenStores.Count; storeIndex++)
 					{
-						CallChildCallback(localChildrenStores[storeIndex], instanceRef, property, newValue);
+						// SelfWeakReference is minted lazily here: a leaf object with no inheriting
+						// children never reaches this and so never rents a weak self-handle.
+						CallChildCallback(localChildrenStores[storeIndex], SelfWeakReference, property, newValue);
 					}
 				}
 			}
@@ -2033,7 +2032,7 @@ namespace Microsoft.UI.Xaml
 			for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
 			{
 				var callback = currentCallbacks[callbackIndex];
-				callback.Invoke(instanceRef, property, eventArgs);
+				callback.Invoke(SelfWeakReference, property, eventArgs);
 			}
 
 			// Cleanup to avoid leaks

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -1969,11 +1969,15 @@ namespace Microsoft.UI.Xaml
 				if (frameworkPropertyMetadata.Options.HasInherits())
 				{
 					var localChildrenStores = _childrenStores;
-					for (var storeIndex = 0; storeIndex < localChildrenStores.Count; storeIndex++)
+					if (localChildrenStores.Count > 0)
 					{
-						// SelfWeakReference is minted lazily here: a leaf object with no inheriting
-						// children never reaches this and so never rents a weak self-handle.
-						CallChildCallback(localChildrenStores[storeIndex], SelfWeakReference, property, newValue);
+						// Minted only once we know there is an inheriting child: a leaf object never
+						// reaches this and so never rents a weak self-handle.
+						var instanceRef = SelfWeakReference;
+						for (var storeIndex = 0; storeIndex < localChildrenStores.Count; storeIndex++)
+						{
+							CallChildCallback(localChildrenStores[storeIndex], instanceRef, property, newValue);
+						}
 					}
 				}
 			}
@@ -2028,10 +2032,14 @@ namespace Microsoft.UI.Xaml
 
 			// Raise the property change for generic handlers
 			var currentCallbacks = _genericCallbacks.Data;
-			for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
+			if (currentCallbacks.Length > 0)
 			{
-				var callback = currentCallbacks[callbackIndex];
-				callback.Invoke(SelfWeakReference, property, eventArgs);
+				var instanceRef = SelfWeakReference;
+				for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
+				{
+					var callback = currentCallbacks[callbackIndex];
+					callback.Invoke(instanceRef, property, eventArgs);
+				}
 			}
 
 			// Cleanup to avoid leaks

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -2294,8 +2294,6 @@ namespace Microsoft.UI.Xaml
 			if (FeatureConfiguration.DependencyObject.IsStoreHardReferenceEnabled)
 			{
 				_hardParentRef = Parent;
-
-				_properties.TryEnableHardReferences();
 			}
 		}
 
@@ -2307,8 +2305,6 @@ namespace Microsoft.UI.Xaml
 			if (FeatureConfiguration.DependencyObject.IsStoreHardReferenceEnabled)
 			{
 				_hardParentRef = null;
-
-				_properties.DisableHardReferences();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -1965,11 +1965,15 @@ namespace Microsoft.UI.Xaml
 				if (frameworkPropertyMetadata.Options.HasInherits())
 				{
 					var localChildrenStores = _childrenStores;
-					for (var storeIndex = 0; storeIndex < localChildrenStores.Count; storeIndex++)
+					if (localChildrenStores.Count > 0)
 					{
-						// SelfWeakReference is minted lazily here: a leaf object with no inheriting
-						// children never reaches this and so never rents a weak self-handle.
-						CallChildCallback(localChildrenStores[storeIndex], SelfWeakReference, property, newValue);
+						// Minted only once we know there is an inheriting child: a leaf object never
+						// reaches this and so never rents a weak self-handle.
+						var instanceRef = SelfWeakReference;
+						for (var storeIndex = 0; storeIndex < localChildrenStores.Count; storeIndex++)
+						{
+							CallChildCallback(localChildrenStores[storeIndex], instanceRef, property, newValue);
+						}
 					}
 				}
 			}
@@ -2024,10 +2028,14 @@ namespace Microsoft.UI.Xaml
 
 			// Raise the property change for generic handlers
 			var currentCallbacks = _genericCallbacks.Data;
-			for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
+			if (currentCallbacks.Length > 0)
 			{
-				var callback = currentCallbacks[callbackIndex];
-				callback.Invoke(SelfWeakReference, property, eventArgs);
+				var instanceRef = SelfWeakReference;
+				for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
+				{
+					var callback = currentCallbacks[callbackIndex];
+					callback.Invoke(instanceRef, property, eventArgs);
+				}
 			}
 
 			// Cleanup to avoid leaks

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -2298,8 +2298,6 @@ namespace Microsoft.UI.Xaml
 			if (FeatureConfiguration.DependencyObject.IsStoreHardReferenceEnabled)
 			{
 				_hardParentRef = Parent;
-
-				_properties.TryEnableHardReferences();
 			}
 		}
 
@@ -2311,8 +2309,6 @@ namespace Microsoft.UI.Xaml
 			if (FeatureConfiguration.DependencyObject.IsStoreHardReferenceEnabled)
 			{
 				_hardParentRef = null;
-
-				_properties.DisableHardReferences();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -648,8 +648,8 @@ namespace Microsoft.UI.Xaml
 
 					if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 					{
-						var name = (SelfWeakReference.Target as IFrameworkElement)?.Name ?? SelfWeakReference.Target?.GetType().Name;
-						var hashCode = SelfWeakReference.Target?.GetHashCode();
+						var name = (this as IFrameworkElement)?.Name ?? GetType().Name;
+						var hashCode = GetHashCode();
 
 						this.Log().Debug(
 							$"SetValue on [{name}/{hashCode:X8}] for [{property.Name}] to [{newValue}] (req:{value} reqp:{precedence} p:{previousValue} pp:{previousPrecedence} np:{newPrecedence})"
@@ -941,7 +941,7 @@ namespace Microsoft.UI.Xaml
 			if (FeatureConfiguration.DependencyProperty.ValidatePropertyOwnerOnReadWrite)
 			{
 				var isFrameworkElement = _originalObjectType.Is(typeof(FrameworkElement));
-				var isMixinFrameworkElement = SelfWeakReference.Target is IFrameworkElement && !isFrameworkElement;
+				var isMixinFrameworkElement = this is IFrameworkElement && !isFrameworkElement;
 
 				if (
 					!_originalObjectType.Is(property.OwnerType)

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -644,8 +644,8 @@ namespace Microsoft.UI.Xaml
 
 					if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 					{
-						var name = (SelfWeakReference.Target as IFrameworkElement)?.Name ?? SelfWeakReference.Target?.GetType().Name;
-						var hashCode = SelfWeakReference.Target?.GetHashCode();
+						var name = (this as IFrameworkElement)?.Name ?? GetType().Name;
+						var hashCode = GetHashCode();
 
 						this.Log().Debug(
 							$"SetValue on [{name}/{hashCode:X8}] for [{property.Name}] to [{newValue}] (req:{value} reqp:{precedence} p:{previousValue} pp:{previousPrecedence} np:{newPrecedence})"
@@ -937,7 +937,7 @@ namespace Microsoft.UI.Xaml
 			if (FeatureConfiguration.DependencyProperty.ValidatePropertyOwnerOnReadWrite)
 			{
 				var isFrameworkElement = _originalObjectType.Is(typeof(FrameworkElement));
-				var isMixinFrameworkElement = SelfWeakReference.Target is IFrameworkElement && !isFrameworkElement;
+				var isMixinFrameworkElement = this is IFrameworkElement && !isFrameworkElement;
 
 				if (
 					!_originalObjectType.Is(property.OwnerType)

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -57,8 +57,6 @@ namespace Microsoft.UI.Xaml
 
 		private static readonly IEventProvider _trace = Tracing.Get(DependencyObjectTraceProvider.Id);
 
-		private bool _isDisposed;
-
 		private readonly DependencyPropertyDetailsCollection _properties;
 		private ResourceBindingCollection? _resourceBindings;
 		private ThemeResourceMap? _themeResources;
@@ -99,8 +97,6 @@ namespace Microsoft.UI.Xaml
 		/// The theme last to apply theme bindings on this object and its children.
 		/// </summary>
 		private SpecializedResourceDictionary.ResourceKey? _themeLastUsed;
-
-		internal bool IsDisposed => _isDisposed;
 
 		private InheritedPropertiesDisposable? InheritedProperties
 		{
@@ -238,13 +234,9 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		// EXPERIMENT (dev/mazi/dostore-nofinalizer): the finalizer is intentionally removed to take
-		// DependencyObject off the finalization queue. It is not load-bearing — pooled weak handles are
-		// freed by ManagedGCHandle's own finalizer; BinderDispose only recycled pooled weak refs/arrays.
-		// BinderDispose is kept (now unreferenced) so this is the ONLY behavioral diff vs the base.
-		// Consequence: nothing sets _isDisposed any more, so IsDisposed stays false and its callers
-		// (EventManager/CustomEventManager) are inert. They are kept for the same reason; if this
-		// experiment is promoted, drop BinderDispose, _gate, IsDisposed and its guards together.
+		// DependencyObject is deliberately not finalizable: it is the most-instantiated type in the
+		// framework, and nothing it owns needs finalization. The pooled weak handles it rents are freed
+		// by ManagedGCHandle's own finalizer, and the property details it holds are plain managed state.
 
 		/// <summary>
 		/// Determines if the dependency object automatically registers for inherited

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -57,8 +57,6 @@ namespace Microsoft.UI.Xaml
 
 		private static readonly IEventProvider _trace = Tracing.Get(DependencyObjectTraceProvider.Id);
 
-		private bool _isDisposed;
-
 		private readonly DependencyPropertyDetailsCollection _properties;
 		private ResourceBindingCollection? _resourceBindings;
 		private ThemeResourceMap? _themeResources;
@@ -99,8 +97,6 @@ namespace Microsoft.UI.Xaml
 		/// The theme last to apply theme bindings on this object and its children.
 		/// </summary>
 		private SpecializedResourceDictionary.ResourceKey? _themeLastUsed;
-
-		internal bool IsDisposed => _isDisposed;
 
 		private InheritedPropertiesDisposable? InheritedProperties
 		{
@@ -234,13 +230,9 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		// EXPERIMENT (dev/mazi/dostore-nofinalizer): the finalizer is intentionally removed to take
-		// DependencyObject off the finalization queue. It is not load-bearing — pooled weak handles are
-		// freed by ManagedGCHandle's own finalizer; BinderDispose only recycled pooled weak refs/arrays.
-		// BinderDispose is kept (now unreferenced) so this is the ONLY behavioral diff vs the base.
-		// Consequence: nothing sets _isDisposed any more, so IsDisposed stays false and its callers
-		// (EventManager/CustomEventManager) are inert. They are kept for the same reason; if this
-		// experiment is promoted, drop BinderDispose, _gate, IsDisposed and its guards together.
+		// DependencyObject is deliberately not finalizable: it is the most-instantiated type in the
+		// framework, and nothing it owns needs finalization. The pooled weak handles it rents are freed
+		// by ManagedGCHandle's own finalizer, and the property details it holds are plain managed state.
 
 		/// <summary>
 		/// Determines if the dependency object automatically registers for inherited

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -221,7 +221,7 @@ namespace Microsoft.UI.Xaml
 			_originalObjectType = effectiveOwner.GetType();
 			_dataContextProperty = effectiveOwner is FrameworkElement ? FrameworkElement.DataContextProperty : null;
 
-			_properties = new DependencyPropertyDetailsCollection(SelfWeakReference, _dataContextProperty);
+			_properties = new DependencyPropertyDetailsCollection(this, _dataContextProperty);
 
 #if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 			TemplatedParentScope.UpdateTemplatedParentIfNeeded(this, store: this);
@@ -1943,9 +1943,6 @@ namespace Microsoft.UI.Xaml
 		{
 			var propertyMetadata = property.Metadata;
 
-			// We can reuse the weak reference, otherwise capture the weak reference to this instance.
-			var instanceRef = SelfWeakReference;
-
 			if (propertyMetadata is FrameworkPropertyMetadata frameworkPropertyMetadata)
 			{
 				if (frameworkPropertyMetadata.Options.HasLogicalChild())
@@ -1979,7 +1976,9 @@ namespace Microsoft.UI.Xaml
 					var localChildrenStores = _childrenStores;
 					for (var storeIndex = 0; storeIndex < localChildrenStores.Count; storeIndex++)
 					{
-						CallChildCallback(localChildrenStores[storeIndex], instanceRef, property, newValue);
+						// SelfWeakReference is minted lazily here: a leaf object with no inheriting
+						// children never reaches this and so never rents a weak self-handle.
+						CallChildCallback(localChildrenStores[storeIndex], SelfWeakReference, property, newValue);
 					}
 				}
 			}
@@ -2037,7 +2036,7 @@ namespace Microsoft.UI.Xaml
 			for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
 			{
 				var callback = currentCallbacks[callbackIndex];
-				callback.Invoke(instanceRef, property, eventArgs);
+				callback.Invoke(SelfWeakReference, property, eventArgs);
 			}
 
 			// Cleanup to avoid leaks

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -422,7 +422,7 @@ namespace Microsoft.UI.Xaml
 			Debug.Assert(property.Metadata is FrameworkPropertyMetadata);
 			var propMethodCall = Unsafe.As<FrameworkPropertyMetadata>(property.Metadata).PropMethodCall;
 			Debug.Assert(propMethodCall is not null);
-			return propMethodCall(ActualInstance!, isGet: true, valueToSet: null);
+			return propMethodCall(ActualInstance, isGet: true, valueToSet: null);
 		}
 
 		private void SetValueViaMethodCall(DependencyProperty property, object? value)
@@ -431,7 +431,7 @@ namespace Microsoft.UI.Xaml
 			Debug.Assert(property.Metadata is FrameworkPropertyMetadata);
 			var propMethodCall = Unsafe.As<FrameworkPropertyMetadata>(property.Metadata).PropMethodCall;
 			Debug.Assert(propMethodCall is not null);
-			_ = propMethodCall(ActualInstance!, isGet: false, valueToSet: value);
+			_ = propMethodCall(ActualInstance, isGet: false, valueToSet: value);
 		}
 
 		/// <summary>
@@ -587,106 +587,98 @@ namespace Microsoft.UI.Xaml
 
 			var actualInstanceAlias = ActualInstance;
 
-			if (actualInstanceAlias != null)
+			var overrideDisposable = ApplyPrecedenceOverride(ref precedence);
+
+			try
 			{
-				var overrideDisposable = ApplyPrecedenceOverride(ref precedence);
-
-				try
+				if ((value == DependencyProperty.UnsetValue) && precedence == DependencyPropertyValuePrecedences.DefaultValue)
 				{
-					if ((value == DependencyProperty.UnsetValue) && precedence == DependencyPropertyValuePrecedences.DefaultValue)
-					{
-						throw new InvalidOperationException("The default value must be a valid value");
-					}
-
-					ValidatePropertyOwner(property);
-
-					// Resolve the stack once for the instance, for performance.
-					propertyDetails ??= _properties.GetPropertyDetails(property);
-
-					if (precedence <= DependencyPropertyValuePrecedences.Local)
-					{
-						TryClearBinding(value, propertyDetails);
-					}
-
-					if (!_inheritanceContextEnabled && precedence == DependencyPropertyValuePrecedences.Inheritance)
-					{
-						value = DependencyProperty.UnsetValue;
-					}
-
-					var previousValue = GetValue(propertyDetails);
-					var previousPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
-
-					// Coercion must be applied before we set the new value
-					// see https://github.com/unoplatform/uno/pull/12884
-					ApplyCoercion(actualInstanceAlias, propertyDetails, previousValue, value, precedence);
-
-					SetValueInternal(value, precedence, propertyDetails);
-
-					if (!isPersistentResourceBinding && !_isSettingPersistentResourceBinding)
-					{
-						// If a non-theme value is being set, clear any theme binding so it's not overwritten if the theme changes.
-						_resourceBindings?.ClearBinding(property, precedence);
-						_themeResources?.Clear(property, precedence);
-					}
-
-					// Value may or may not have changed based on the precedence
-					var newValue = GetValue(propertyDetails);
-					var newPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
-
-					if (property == _dataContextProperty)
-					{
-						OnDataContextChanged(value, newValue, precedence);
-					}
-
-					TryApplyDataContextOnPrecedenceChange(property, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence);
-
-					TryUpdateInheritedAttachedProperty(property, propertyDetails);
-
-					if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
-					{
-						var name = (this as IFrameworkElement)?.Name ?? GetType().Name;
-						var hashCode = GetHashCode();
-
-						this.Log().Debug(
-							$"SetValue on [{name}/{hashCode:X8}] for [{property.Name}] to [{newValue}] (req:{value} reqp:{precedence} p:{previousValue} pp:{previousPrecedence} np:{newPrecedence})"
-						);
-					}
-
-					RaiseCallbacks(actualInstanceAlias, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence);
-
-					// MUX Reference: CDependencyObject::UpdateEffectiveValue — PropertySystem.cpp:1893-1898,
-					// commit fc2f82117: after a direct SetValue is applied (and its theme reference cleared
-					// above), notify the new value of the theme that was applied to the property owner, so a
-					// DO value set on an already-themed owner carries the owner's theme.
-					//   // If this DP had an associated theme reference, clear it because a new value has been set.
-					//   ClearThemeResource(args.m_pDP);
-					//   if (m_theme != Theming::Theme::None)
-					//   {
-					//       IFC_RETURN(NotifyPropertyValueOfThemeChange(args.m_pDP, pEffectiveValue));
-					//   }
-					// The persistent-resource-binding flags are the ValueOperationFromSetValue analog (theme
-					// reference re-application is excluded, like WinUI's modified-value branch). The set-time
-					// Enter (UpdateAutoParent → EnterObjectProperty) covers logical-child properties; this
-					// covers the DO-valued properties WinUI notifies that carry no logical-child metadata
-					// (e.g. brushes). DataContext is excluded — Uno's core inherits user data through it,
-					// which WinUI's core property system never carries.
-					if (_theme != Theme.None
-						&& !isPersistentResourceBinding
-						&& !_isSettingPersistentResourceBinding
-						&& property != _dataContextProperty)
-					{
-						NotifyPropertyValueOfThemeChange(property, newValue);
-					}
+					throw new InvalidOperationException("The default value must be a valid value");
 				}
-				finally
+
+				ValidatePropertyOwner(property);
+
+				// Resolve the stack once for the instance, for performance.
+				propertyDetails ??= _properties.GetPropertyDetails(property);
+
+				if (precedence <= DependencyPropertyValuePrecedences.Local)
 				{
-					overrideDisposable?.Dispose();
+					TryClearBinding(value, propertyDetails);
+				}
+
+				if (!_inheritanceContextEnabled && precedence == DependencyPropertyValuePrecedences.Inheritance)
+				{
+					value = DependencyProperty.UnsetValue;
+				}
+
+				var previousValue = GetValue(propertyDetails);
+				var previousPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
+
+				// Coercion must be applied before we set the new value
+				// see https://github.com/unoplatform/uno/pull/12884
+				ApplyCoercion(actualInstanceAlias, propertyDetails, previousValue, value, precedence);
+
+				SetValueInternal(value, precedence, propertyDetails);
+
+				if (!isPersistentResourceBinding && !_isSettingPersistentResourceBinding)
+				{
+					// If a non-theme value is being set, clear any theme binding so it's not overwritten if the theme changes.
+					_resourceBindings?.ClearBinding(property, precedence);
+					_themeResources?.Clear(property, precedence);
+				}
+
+				// Value may or may not have changed based on the precedence
+				var newValue = GetValue(propertyDetails);
+				var newPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
+
+				if (property == _dataContextProperty)
+				{
+					OnDataContextChanged(value, newValue, precedence);
+				}
+
+				TryApplyDataContextOnPrecedenceChange(property, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence);
+
+				TryUpdateInheritedAttachedProperty(property, propertyDetails);
+
+				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+				{
+					var name = (this as IFrameworkElement)?.Name ?? GetType().Name;
+					var hashCode = GetHashCode();
+
+					this.Log().Debug(
+						$"SetValue on [{name}/{hashCode:X8}] for [{property.Name}] to [{newValue}] (req:{value} reqp:{precedence} p:{previousValue} pp:{previousPrecedence} np:{newPrecedence})"
+					);
+				}
+
+				RaiseCallbacks(actualInstanceAlias, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence);
+
+				// MUX Reference: CDependencyObject::UpdateEffectiveValue — PropertySystem.cpp:1893-1898,
+				// commit fc2f82117: after a direct SetValue is applied (and its theme reference cleared
+				// above), notify the new value of the theme that was applied to the property owner, so a
+				// DO value set on an already-themed owner carries the owner's theme.
+				//   // If this DP had an associated theme reference, clear it because a new value has been set.
+				//   ClearThemeResource(args.m_pDP);
+				//   if (m_theme != Theming::Theme::None)
+				//   {
+				//       IFC_RETURN(NotifyPropertyValueOfThemeChange(args.m_pDP, pEffectiveValue));
+				//   }
+				// The persistent-resource-binding flags are the ValueOperationFromSetValue analog (theme
+				// reference re-application is excluded, like WinUI's modified-value branch). The set-time
+				// Enter (UpdateAutoParent → EnterObjectProperty) covers logical-child properties; this
+				// covers the DO-valued properties WinUI notifies that carry no logical-child metadata
+				// (e.g. brushes). DataContext is excluded — Uno's core inherits user data through it,
+				// which WinUI's core property system never carries.
+				if (_theme != Theme.None
+					&& !isPersistentResourceBinding
+					&& !_isSettingPersistentResourceBinding
+					&& property != _dataContextProperty)
+				{
+					NotifyPropertyValueOfThemeChange(property, newValue);
 				}
 			}
-			else
+			finally
 			{
-				// The store has lost its current instance, renove it from its parent.
-				Parent = null;
+				overrideDisposable?.Dispose();
 			}
 		}
 
@@ -1320,7 +1312,7 @@ namespace Microsoft.UI.Xaml
 		internal object GetDefaultValue(DependencyProperty dp)
 		{
 			var actualInstance = ActualInstance;
-			var defaultValue = dp.GetDefaultValue(actualInstance, actualInstance?.GetType());
+			var defaultValue = dp.GetDefaultValue(actualInstance, actualInstance.GetType());
 			if (GetCurrentHighestValuePrecedence(dp) == DependencyPropertyValuePrecedences.DefaultValue &&
 				// This should be for OnDemand DPs in general which we don't yet support
 				dp == UIElement.KeyboardAcceleratorsProperty)
@@ -1499,21 +1491,17 @@ namespace Microsoft.UI.Xaml
 
 				_inheritedForwardedProperties.Clear();
 
-				if (ActualInstance != null)
+				if (_updatedProperties is not null)
 				{
-					if (_updatedProperties is not null)
+					foreach (var dp in _updatedProperties)
 					{
-						foreach (var dp in _updatedProperties)
-						{
-							SetValue(dp, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
-						}
+						SetValue(dp, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
 					}
+				}
 
-
-					if (_dataContextProperty is { } dataContextProperty)
-					{
-						SetValue(dataContextProperty, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
-					}
+				if (_dataContextProperty is { } dataContextProperty)
+				{
+					SetValue(dataContextProperty, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
 				}
 			}
 			finally
@@ -1807,7 +1795,7 @@ namespace Microsoft.UI.Xaml
 			return isAncestor;
 		}
 
-		internal DependencyObject? ActualInstance => this;
+		internal DependencyObject ActualInstance => this;
 
 		/// <summary>
 		/// Creates a weak delegate for the specified PropertyChangedCallback callback.
@@ -2231,17 +2219,13 @@ namespace Microsoft.UI.Xaml
 			if (_parentChangedCallbacks.Data.Length != 0)
 			{
 				var actualInstanceAlias = ActualInstance;
+				var args = new DependencyObjectParentChangedEventArgs(previousParent, value);
 
-				if (actualInstanceAlias != null)
+				var currentCallbacks = _parentChangedCallbacks.Data;
+				for (var parentCallbackIndex = 0; parentCallbackIndex < currentCallbacks.Length; parentCallbackIndex++)
 				{
-					var args = new DependencyObjectParentChangedEventArgs(previousParent, value);
-
-					var currentCallbacks = _parentChangedCallbacks.Data;
-					for (var parentCallbackIndex = 0; parentCallbackIndex < currentCallbacks.Length; parentCallbackIndex++)
-					{
-						var handler = currentCallbacks[parentCallbackIndex];
-						handler.Invoke(actualInstanceAlias, null, args);
-					}
+					var handler = currentCallbacks[parentCallbackIndex];
+					handler.Invoke(actualInstanceAlias, null, args);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObject.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Uno.UI;
 using Uno.UI.Controls;
 using Uno.UI.DataBinding;
@@ -60,7 +61,20 @@ namespace Microsoft.UI.Xaml
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetBinding(string dependencyProperty, BindingBase binding) => SetBindingInternal(dependencyProperty, binding);
 
-		internal ManagedWeakReference SelfWeakReference => _selfWeakReference ??= WeakReferencePool.RentSelfWeakReference(this);
+		internal ManagedWeakReference SelfWeakReference
+		{
+			get
+			{
+				if (_selfWeakReference is null)
+				{
+					// Published atomically: consumers compare handle identity, and a losing racer's
+					// handle cannot be pooled back (it is a self reference), so it must not escape.
+					Interlocked.CompareExchange(ref _selfWeakReference, WeakReferencePool.RentSelfWeakReference(this), null);
+				}
+
+				return _selfWeakReference;
+			}
+		}
 
 		ManagedWeakReference IWeakReferenceProvider.WeakReference => SelfWeakReference;
 

--- a/src/Uno.UI/UI/Xaml/DependencyObject.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.cs
@@ -65,14 +65,29 @@ namespace Microsoft.UI.Xaml
 		{
 			get
 			{
-				if (_selfWeakReference is null)
+				var current = _selfWeakReference;
+				if (current is not null)
 				{
-					// Published atomically: consumers compare handle identity, and a losing racer's
-					// handle cannot be pooled back (it is a self reference), so it must not escape.
-					Interlocked.CompareExchange(ref _selfWeakReference, WeakReferencePool.RentSelfWeakReference(this), null);
+					return current;
 				}
 
-				return _selfWeakReference;
+				// Published atomically: consumers compare handle identity, so exactly one handle
+				// may ever escape for a given object.
+				var minted = WeakReferencePool.RentSelfWeakReference(this);
+				var published = Interlocked.CompareExchange(ref _selfWeakReference, minted, null);
+
+				if (published is not null)
+				{
+					// Lost the race. The minted handle never escaped and a self reference cannot go
+					// back to the pool (ReturnWeakReference refuses them), so free its GC handle here
+					// rather than leaving it for ManagedGCHandle's finalizer.
+					minted.GetUnsafeTargetHandle()?.Dispose();
+					minted.Dispose();
+
+					return published;
+				}
+
+				return minted;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObject.mux.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.mux.cs
@@ -3,9 +3,9 @@
 // MUX Reference depends.cpp, commit fc2f82117
 //
 // CDependencyObject::Enter/EnterImpl/Leave/LeaveImpl. In WinUI these are methods on
-// CDependencyObject; in Uno, DependencyObject is an interface on every target, so the
-// CDependencyObject layer lives on the DependencyObject that every DependencyObject owns
-// (operating on ActualInstance). UIElement's visual Enter walk (UIElement.mux.cs, ported from
+// CDependencyObject; in Uno, DependencyObject is the concrete base class that directly carries the
+// property store, so the CDependencyObject layer lives on it (ActualInstance is an identity alias
+// returning `this`). UIElement's visual Enter walk (UIElement.mux.cs, ported from
 // uielement.cpp) calls into this layer exactly where CUIElement::EnterImpl calls
 // CDependencyObject::EnterImpl. The enter-property walks live in
 // DependencyObject.PropertySystem.mux.cs (ported from PropertySystem.cpp).

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -13,8 +13,10 @@ namespace Microsoft.UI.Xaml
 	/// </summary>
 	partial class DependencyPropertyDetailsCollection : IDisposable
 	{
-		private readonly ManagedWeakReference _ownerReference;
-		private object? _hardOwnerReference;
+		// The owning DependencyObject is held strongly: the collection is private to that DO, so the
+		// DO <-> collection cycle is collected together by the tracing GC. Holding it strongly avoids
+		// renting a pooled weak self-handle (ManagedGCHandle) per DependencyObject.
+		private readonly object _owner;
 		// Null when the owner is not a FrameworkElement (DataContext is FrameworkElement-only).
 		private readonly DependencyProperty? _dataContextProperty;
 		private DependencyPropertyDetails? _dataContextPropertyDetails;
@@ -29,14 +31,14 @@ namespace Microsoft.UI.Xaml
 
 		private const int BucketSize = 16;
 
-		private object? Owner => _hardOwnerReference ?? _ownerReference.Target;
+		private object? Owner => _owner;
 
 		/// <summary>
 		/// Creates an instance using the specified DependencyObject <see cref="Type"/>
 		/// </summary>
-		public DependencyPropertyDetailsCollection(ManagedWeakReference ownerReference, DependencyProperty? dataContextProperty)
+		public DependencyPropertyDetailsCollection(object owner, DependencyProperty? dataContextProperty)
 		{
-			_ownerReference = ownerReference;
+			_owner = owner;
 
 			_dataContextProperty = dataContextProperty;
 
@@ -231,14 +233,13 @@ namespace Microsoft.UI.Xaml
 			// If _entries is null, it means we were already disposed. Gracefully return empty so that the caller doesn't have anything to do.
 			=> _entries ?? _empty;
 
+		// The owner is always held strongly now, so there is nothing to toggle.
 		internal void TryEnableHardReferences()
 		{
-			_hardOwnerReference = _ownerReference.Target;
 		}
 
 		internal void DisableHardReferences()
 		{
-			_hardOwnerReference = null;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -236,13 +236,5 @@ namespace Microsoft.UI.Xaml
 			// If _entries is null, it means we were already disposed. Gracefully return empty so that the caller doesn't have anything to do.
 			=> _entries ?? _empty;
 
-		// The owner is always held strongly now, so there is nothing to toggle.
-		internal void TryEnableHardReferences()
-		{
-		}
-
-		internal void DisableHardReferences()
-		{
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -13,10 +13,13 @@ namespace Microsoft.UI.Xaml
 	/// </summary>
 	partial class DependencyPropertyDetailsCollection : IDisposable
 	{
-		// The owning DependencyObject is held strongly: the collection is private to that DO, so the
-		// DO <-> collection cycle is collected together by the tracing GC. Holding it strongly avoids
-		// renting a pooled weak self-handle (ManagedGCHandle) per DependencyObject.
-		private readonly object _owner;
+		// The owning DependencyObject is held strongly, which is safe only because this collection never
+		// escapes it: the DO <-> collection cycle is then unreachable as a unit and the tracing GC
+		// collects it whole. Holding it strongly avoids renting a pooled weak self-handle
+		// (ManagedGCHandle) per DependencyObject.
+		// INVARIANT: never store this collection, or a closure capturing it, outside the owning
+		// DependencyObject. Doing so would transitively pin the owner and every object it references.
+		private readonly DependencyObject _owner;
 		// Null when the owner is not a FrameworkElement (DataContext is FrameworkElement-only).
 		private readonly DependencyProperty? _dataContextProperty;
 		private DependencyPropertyDetails? _dataContextPropertyDetails;
@@ -31,12 +34,12 @@ namespace Microsoft.UI.Xaml
 
 		private const int BucketSize = 16;
 
-		private object? Owner => _owner;
+		private DependencyObject Owner => _owner;
 
 		/// <summary>
 		/// Creates an instance using the specified DependencyObject <see cref="Type"/>
 		/// </summary>
-		public DependencyPropertyDetailsCollection(object owner, DependencyProperty? dataContextProperty)
+		public DependencyPropertyDetailsCollection(DependencyObject owner, DependencyProperty? dataContextProperty)
 		{
 			_owner = owner;
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -152,8 +152,9 @@ namespace Microsoft.UI.Xaml
 				// Offsets have not been initialized or need to be resized
 				if (entryOffsets == null || bucketIndex >= entryOffsets.Length)
 				{
-					// Rent the next multiple of BucketSize available : 0 -> 16, 16 -> 32, 32 -> 64 ...
-					var newOffsets = _offsetsPool.Rent((bucketIndex * BucketSize) + 1);
+					// Indexed by bucketIndex alone, so bucketIndex + 1 slots are enough. The pool rounds the
+					// request up to a power-of-two bucket, which already provides amortized growth.
+					var newOffsets = _offsetsPool.Rent(bucketIndex + 1);
 
 					// Since newOffsets is an Int16 array we can memset it with 0xFFs, 0xFFFF is -1, regardless of endianness
 					// This avoids the slow path in Span<T>.Fill()

--- a/src/Uno.UI/UI/Xaml/Internal/EventManager.uno.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/EventManager.uno.cs
@@ -69,13 +69,6 @@ internal sealed partial class EventManager
 		// This is actually what we want and what WinUI does.
 		foreach (var item in _layoutUpdatedSubscribers)
 		{
-			// Guards against a disposed DependencyObject. Inert while the DO finalizer is removed —
-			// nothing sets IsDisposed (see the EXPERIMENT note in DependencyObject.Store.cs).
-			if (((DependencyObject)item.Key).IsDisposed)
-			{
-				continue;
-			}
-
 			item.Key.OnLayoutUpdated();
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Internal/EventManager.uno.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/EventManager.uno.cs
@@ -69,7 +69,8 @@ internal sealed partial class EventManager
 		// This is actually what we want and what WinUI does.
 		foreach (var item in _layoutUpdatedSubscribers)
 		{
-			// Sometimes, we are racing with GC and the DependencyObject is disposed (via finalizer)
+			// Guards against a disposed DependencyObject. Inert while the DO finalizer is removed —
+			// nothing sets IsDisposed (see the EXPERIMENT note in DependencyObject.Store.cs).
 			if (((DependencyObject)item.Key).IsDisposed)
 			{
 				continue;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -20,7 +20,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		private BindingPath _propertyInfo;
 		private List<ITimelineListener> _timelineListeners = new();
 		private List<EventHandler<object>> _completedHandlers;
-		private bool _disposed;
 
 		public event EventHandler<object> Completed
 		{
@@ -418,22 +417,16 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		internal void Dispose()
 		{
 			Dispose(true);
-			_disposed = true;
+			GC.SuppressFinalize(this);
 		}
 
 		void IThemeChangeAware.OnThemeChanged() => OnThemeChanged();
 
 		private protected virtual void OnThemeChanged() { }
 
-		// Finalization must not be suppressed here: it would also skip the inherited ~DependencyObject,
-		// leaving the binder state and its pooled references unreleased. The flag skips only the
-		// dispatcher round-trip, which is what an explicit Dispose() makes redundant.
 		~Timeline()
 		{
-			if (!_disposed)
-			{
-				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => Dispose(false));
-			}
+			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => Dispose(false));
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** Part of #8339 — also advances [unoplatform/uno-private#2055](https://github.com/unoplatform/uno-private/issues/2055) (_`DependencyObject` should be a class [7.0]_, BC26).

> ⚠️ **Stacked on #23702** (`dev/mazi/dostore`). Only the commits from `cfdc06e` onward are unique to this PR; everything before them belongs to #23702. Review that one first.

## PR Type:

🔄 Refactoring (no functional changes, no api changes) — internal lifetime/GC semantics only

## What changed? 🚀

#23702 left every `DependencyObject` finalizable and renting a pooled weak self-handle. This PR takes both off the table, so `DependencyObject` — the most-instantiated type in the framework — no longer participates in finalization at all.

**1. `~DependencyObject` is removed.** The finalizer was not load-bearing: it only called `BinderDispose`, whose entire payload was returning pooled weak references and arrays. It unrooted nothing. Native weak handles are freed by `ManagedGCHandle`'s own finalizer, which remains.

**2. The per-DO weak self-handle is dropped.** `DependencyPropertyDetailsCollection` now holds its owning `DependencyObject` **strongly** instead of through a rented `ManagedGCHandle`, and `SelfWeakReference` is minted lazily — only once an object actually has an inheriting child or a registered callback.

**3. The disposal path is removed rather than left inert.** With no finalizer, `BinderDispose` had no caller and `IsDisposed` was permanently `false`. Both are deleted, along with `_gate`, `_isDisposed` and the now-unreachable guard in `EventManager.RaiseLayoutUpdated`. An always-false guard reads as a live safety check, which is worse than no guard.

**4. The offsets array is no longer over-rented.** `DependencyPropertyDetailsCollection._entryOffsets` is indexed by `bucketIndex` alone, so it needs `bucketIndex + 1` slots — but it rented `(bucketIndex * BucketSize) + 1`, a **16× over-allocation**. Because `bucketIndex` derives from `DependencyProperty.UniqueId`, a process-wide counter, the waste scaled with the highest property id an object touched: with ~2000 properties registered in `Uno.UI` alone, a `DependencyObject` that set a late-registered property carried a **4 KB** `short[]` where 256 bytes suffice. The multiplier bought nothing — `ArrayPool` already rounds a request up to a power-of-two bucket, so growth stays geometric and resizes stay amortized O(1). This is independent of the finalizer work, but it is what turns item 1's lost pool returns into a net win rather than a trade (see the measurement below).

### Why the smaller rent is safe

The claim that `bucketIndex + 1` is sufficient rests on `_entryOffsets` never being indexed by anything else, which is exhaustive rather than a spot check — the array has exactly three index sites, all `bucketIndex`: `DependencyPropertyDetailsCollection.cs:174` (read), `:180` (write) and `:212` (read, already guarded by `bucketIndex < _entryOffsets.Length`). Nothing indexes it by `offset + bucketRemainder`; that is `_entries`, a different array.

The resize path stays safe for the same reason it did before. `Utilities.GetMaxSizeForBucket` is `16 << binIndex`, so a rent returns a power-of-two length of at least 16. The resize only runs when `bucketIndex >= entryOffsets.Length`, so the new request (`bucketIndex + 1`) is strictly greater than the old length, and the returned array is at least that — `entryOffsets.AsSpan().CopyTo(newOffsets)` therefore cannot overflow, and `Unsafe.InitBlockUnaligned` still has a non-empty array to fill. Growth remains geometric because the pool rounds up, so the `* BucketSize` multiplier was buying nothing that the rounding did not already provide.

### Why holding the owner strongly is safe

The collection and its owner now form a reference cycle. That is safe **only** because the collection never escapes its owner — the cycle is then unreachable as a unit and a tracing GC reclaims it whole. This was verified rather than assumed:

- The collection's only storage site is the private `DependencyObject._properties`; its single pass-by-argument (`CloneToForHotReload`) is a stack local.
- `DependencyPropertyDetails` — which *does* escape constantly — carries no back-pointer to the collection or the owner. A `BindingExpression` pinned by a long-lived ViewModel therefore pins details, **not** the element.
- The reference the removed hard-reference toggles governed was `_hardOwnerReference = _ownerReference.Target`, i.e. **the owner itself** — always a self-edge *inside* that same cycle. Clearing it on unload released nothing, which is why making it permanent is leak-neutral and why no leak test moved.

The owner is now typed `DependencyObject` rather than `object`, and the invariant is stated on the field, so a future caller cannot quietly pass a foreign object and turn this into an unbounded pin.

### Does dropping the pool returns leak?

No, and it cannot. Neither pool tracks what it hands out — `LinearArrayPool.Bucket.TryPop` nulls the slot on rent and `DefaultArrayPoolBucket` does the same — so an unreturned array is referenced only by the collection that rented it, and dies in the same collection as its owner. `WeakReferencePool` says so outright: *Returned `ManagedWeakReference` are not tracked by the pool and do not have to be returned.*

More fundamentally, a finalizer runs only on an object the GC has already proven unreachable, so it can never un-leak anything. Everything `BinderDispose` did was recycling — the callback manager's shadow array, `HashtableEx` buckets, pooled weak refs, the entries/offsets arrays. None of it broke a reference from a live root. The cost of dropping it is allocation churn, not retention — and that is measurable.

## Benchmark 📈

600k control-like DOs, 4 DPs each, Skia Desktop, across `dostore` → finalizer-drop → this branch:

| | `dostore` | −finalizer | −self-handle |
|---|---|---|---|
| peak finalization queue | 40002 | 20002 | 2 |
| finalize drain | 94 ms | 34 ms | 1 ms |
| throughput | 1235 ms | 864 ms | 741 ms |

**Read this carefully.** The `40002 → 20002` step (dropping the finalizer) is workload-independent. The `20002 → 2` step depends on objects never minting a self-handle, and the benchmark's DOs are parentless leaves — the best case. A real visual tree mints one for every element with an inheriting child (`DependencyObject.Store.cs:826, 1009, 1176, 1225`), so expect the real-world figure to land between the two columns. Worth re-measuring on a load/unload page before quoting the headline number.

## Allocation & GC measurement 📊

100,000 `DependencyObject`s created, properties set, dropped. 2048 properties are pre-registered first so the bucket index (127) lands where a real app's would rather than near zero. .NET 11 preview, x64, CoreCLR; `GC.GetTotalAllocatedBytes(precise: true)` and `GC.CollectionCount`.

**A — one high-id property per object**

| | allocated | per object | gen0 / gen1 / gen2 | elapsed |
|---|---|---|---|---|
| `dostore` (finalizer + pool returns) | 449.1 MB | 4709 B | 34 / 33 / 9 | 378 ms |
| − finalizer | 518.8 MB | 5440 B | 30 / 2 / 2 | 122 ms |
| − finalizer + right-sized rent | **152.6 MB** | **1600 B** | **10 / 2 / 2** | **100 ms** |

**B — five properties spread across the id range**

| | allocated | per object | gen0 / gen1 / gen2 | elapsed |
|---|---|---|---|---|
| `dostore` | 578.8 MB | 6069 B | 39 / 38 / 7 | 725 ms |
| − finalizer | 611.0 MB | 6407 B | 36 / 2 / 2 | 442 ms |
| − finalizer + right-sized rent | **440.1 MB** | **4615 B** | **26 / 2 / 2** | **438 ms** |

Three things fall out:

1. **Dropping the finalizer really does cost allocation** — +15% (A), +6% (B). The lost pool returns are not free, and the earlier "small amount of allocation churn" note understated them.
2. **It eliminates the promotion storm.** gen1 collections fall 33 → 2 and gen2 9 → 2. Every finalizable `DependencyObject` previously survived the collection that found it dead and was promoted a generation, taking whole discarded subtrees with it. That is why throughput improves ~3× *while allocating more*.
3. **Right-sizing the rent more than repays the churn.** Against the `dostore` baseline the net is **−66%** allocated bytes in A and **−24%** in B, with gen1/gen2 collections down ~16×/4× and wall clock down 3.8×/1.7×. Both axes improve; nothing is traded.

**How this was measured.** Three builds of `Uno.UI.UnitTests` at net11.0, each running the same throwaway harness (not committed — it is a measurement tool, not a test):

| row | build |
|---|---|
| `dostore` | `d083fba` in a separate worktree — finalizer present, pool returns live, original rent |
| − finalizer | `e65d97f` (this branch, before the rent fix) |
| − finalizer + right-sized rent | `fbfead4` (this branch, after) |

The harness registers 2048 padding properties, warms up 20k iterations to let each build's pool reach its own steady state, then brackets 100k iterations with `GC.GetTotalAllocatedBytes(precise: true)` and `GC.CollectionCount(0..2)`, forcing `Collect / WaitForPendingFinalizers / Collect` between scenarios so the finalizer build is not credited with work it deferred. Rebuilding the middle row rather than inferring it is what separates the finalizer's cost from the rent fix's benefit — the two changes pull in opposite directions and would otherwise be indistinguishable.

Caveats: this is synthetic — bare `DependencyObject`s in a tight loop, no visual tree or layout — so it isolates the property store rather than modelling a page, and real-world relative deltas will be smaller. Desktop CoreCLR only; WASM/Mono has a different collector and was **not** measured, though fewer finalizable objects and fewer bytes are strictly better there too. A "heap at end" column was collected and deliberately omitted: it is a snapshot taken at an arbitrary point relative to the last gen0 GC, and was too noisy to quote.

## Validation 🔍

- **Compile:** `Uno.UI`, `Uno.UI.UnitTests`, `Uno.UI.RuntimeTests.Skia`, `SamplesApp.Skia.Generic`, net10.0; `Uno.UI.UnitTests` at net11.0.
- **Unit tests:** 4021 total, 12 failed — the pre-existing `When_Gregorian_*` timezone failures. 0 regressions.
- **Unit tests, offsets fix:** re-run against a rebuilt baseline with the one-line change reverted — 13 failures before, 12 after, and the failure-*set* diff is exactly the new sizing test. The other 12 are the pre-existing `When_Gregorian_FixedDate*` Calendar/ICU failures.
- **Runtime (Skia Desktop)** — leak, collectible-ALC and ContextFlyout suites: **94/95**, byte-identical to the `dostore` baseline and to the merge base. The one failure (`When_Add_Remove(CommandBarFlyout_Leak, …)`) is pre-existing, confirmed by building and running `aff73c4c` separately.
- **New test:** `Given_DependencyProperty_Propagation.When_Store_Populated_Then_Owner_Collected` pins the collectibility invariant — a populated store with an inheriting child is still reclaimed. Proven meaningful by negative control: inverting the owner assertion makes it fail with a non-null target, so it neither vacuously passes nor silently skips.
- **New test:** `Given_DependencyPropertyDetailsCollection` pins the offsets sizing. It fails before the fix with *"512 slots for bucket index 17 (needs 18, tolerated 64)"*, and two companion tests grow the array from the top down and the bottom up, reading back every bucket it claims to cover, so a future resizing change cannot trade addressability for the smaller rental.

## Breaking changes ❗

No public API changes. Two behavioural notes, both Uno-only:

- **`DependencyObject` is no longer finalizable.** A derived type declaring its own finalizer previously chained into `~DependencyObject`; it no longer does. In-repo subclasses are unaffected (the base finalizer only recycled pooled objects). `Timeline` is updated accordingly — it can suppress its own finalization again, which it could not while a base finalizer existed.
- **Pooled arrays are no longer returned.** `DependencyPropertyDetailsCollection.Dispose` was reached only from the finalizer, so entries/offsets arrays now become gen0 garbage instead of being recycled. This cannot leak (see above); measured on its own it costs +15% allocation, and right-sizing the offsets rent more than repays it — the branch lands well below the `dostore` baseline on both allocated bytes and collection count.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
