### PR TITLE
fix(hot-reload): only request an explicit IDE hot reload inside Visual Studio

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -337,6 +337,18 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		private async ValueTask<bool> RequestHotReloadToIde()
 		{
+			// Only Visual Studio handles the explicit force-hot-reload request. Other IDEs (VS Code,
+			// Rider) register no callback for ForceHotReloadIdeMessage, so sending it there only logs a
+			// "no callback" error on the IDE side and blocks here until the IDE-result timeout — and they
+			// drive hot reload through the dev-server's own pipeline anyway. Outside VS this is a no-op:
+			// no request is sent and no ProcessingFiles is reported, and we return false so the
+			// no-changes auto-retry (HotReloadOperation) completes the operation instead of deferring
+			// while waiting for an IDE acknowledgement that will never come.
+			if (!_isRunningInsideVisualStudio)
+			{
+				return false;
+			}
+
 			var result = await SendAndWaitForResult(new ForceHotReloadIdeMessage(GetNextIdeCorrelationId()));
 
 			if (result.IsSuccess)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.hotdesign/issues/7130
related https://github.com/unoplatform/uno-private/issues/2211

second step of https://github.com/unoplatform/uno/pull/23692
NOT related to the already existing follow up PR https://github.com/unoplatform/uno/pull/23696

## PR Type:

🐞 Bugfix

## What changed? 🚀

Editing a file from a non-Visual-Studio IDE (VS Code, Rider) broke hot reload: after applying the
edit, the dev-server sent a `ForceHotReloadIdeMessage` to the IDE and **waited for a reply that never
came**. Those IDEs register no callback for that message — they drive hot reload through the
dev-server's own pipeline, not an explicit IDE force-reload — so the IDE side only logged
`No callback registered for method: …ForceHotReloadIdeMessage` and sent nothing back. The dev-server
then blocked the update path for the full 25s IDE-result timeout, and `ProcessingFiles` was never
reported.

`RequestHotReloadToIde` is now a no-op outside Visual Studio:

- no `ForceHotReloadIdeMessage` is sent (no more 25s stall, no more "no callback" error);
- no `ProcessingFiles` is reported (the IDE never acknowledges, and the dev-server's own pipeline
  reports hot-reload status independently);
- it returns `false`, so the no-changes auto-retry (`HotReloadOperation`) completes the operation
  instead of deferring while waiting for an IDE acknowledgement that never comes.

Behaviour inside Visual Studio is unchanged (VS registers the handler and replies).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — server-side IDE-channel timing behaviour; validated by running the hot-reload scenario from VS Code / Rider (no automated coverage for the IDE-channel round-trip).
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no UI change.
- [x] ❗ Contains **NO** breaking changes — internal behaviour only, no API change.
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)