### PR TITLE
fix(Uno.Sdk): wire tvOS single-project + guard RetargetAssets against a missing app manifest

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.Fonts.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.Fonts.cs
@@ -72,14 +72,23 @@ public partial class RetargetAssets_v0
 
 	private string[] EnumerateFontsFromPList(string iosAppManifest)
 	{
+		// IosAppManifest is optional (not [Required]); some heads (e.g. a tvOS single-project that has no
+		// Info.plist wired) provide no manifest. With nothing to read there are no pre-existing fonts to
+		// preserve, so return an empty set rather than throwing from XmlDocument.Load(null).
+		if (string.IsNullOrEmpty(iosAppManifest) || !File.Exists(iosAppManifest))
+		{
+			return Array.Empty<string>();
+		}
+
 		XmlDocument doc = new();
 		doc.Load(iosAppManifest);
 
 		// Get the list of registered fonts in the info.plist
 		return doc
 			.SelectNodes("//key[text()='UIAppFonts']/following-sibling::array[1]/string")
-			.OfType<XmlNode>()
+			?.OfType<XmlNode>()
 			.Select(n => n.InnerText)
-			.ToArray();
+			.ToArray()
+			?? Array.Empty<string>();
 	}
 }

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -79,6 +79,8 @@
 		Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' " />
 	<Import Project="Uno.Common.MacCatalyst.targets"
 		Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' " />
+	<Import Project="Uno.Common.tvOS.targets"
+		Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tvos' " />
 	<Import Project="Uno.Common.Desktop.targets"
 		Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'desktop' " />
 	<Import Project="Uno.Common.Wasm.targets"

--- a/src/Uno.Sdk/targets/Uno.Common.tvOS.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.tvOS.targets
@@ -1,0 +1,10 @@
+<Project>
+	<PropertyGroup>
+		<IsTvOS>true</IsTvOS>
+		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">12.2</SupportedOSPlatformVersion>
+
+		<EnableDefaulttvOSItems Condition="$(EnableDefaulttvOSItems) == ''">false</EnableDefaulttvOSItems>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)Uno.SingleProject.tvOS.targets" Condition=" $(_IsUnoSingleProjectAndLegacy) == 'true' " />
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.tvOS.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.tvOS.targets
@@ -1,0 +1,36 @@
+<Project>
+	<PropertyGroup>
+		<!-- Required for C# Hot Reload -->
+		<UseInterpreter Condition="'$(Optimize)' != 'true'">True</UseInterpreter>
+
+		<IPhoneResourcePrefix Condition="$(IPhoneResourcePrefix) == ''">$(tvOSProjectFolder)Resources</IPhoneResourcePrefix>
+
+		<_SingleProjecttvOSExcludes>$(tvOSProjectFolder)/**/.*/**</_SingleProjecttvOSExcludes>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(CodesignEntitlements) == ''">
+		<CodesignEntitlements Condition=" Exists('$(tvOSProjectFolder)Entitlements.plist') ">$(tvOSProjectFolder)Entitlements.plist</CodesignEntitlements>
+		<CodesignEntitlements Condition=" Exists('$(tvOSProjectFolder)Entitlements-$(Configuration).plist') ">$(tvOSProjectFolder)Entitlements-$(Configuration).plist</CodesignEntitlements>
+	</PropertyGroup>
+
+	<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' ">
+		<None Include="$(tvOSProjectFolder)Info.plist" LogicalName="Info.plist" />
+
+		<ImageAsset Include="$(tvOSProjectFolder)**/*.xcassets/**/*.png;$(tvOSProjectFolder)**/*.xcassets/*/*.jpg;$(tvOSProjectFolder)**/*.xcassets/**/*.pdf;$(tvOSProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjecttvOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
+		<SceneKitAsset Include="$(tvOSProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjecttvOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+		<InterfaceDefinition Include="$(tvOSProjectFolder)**/*.storyboard;$(tvOSProjectFolder)**/*.xib" Exclude="$(_SingleProjecttvOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+		<BundleResource Include="$(tvOSProjectFolder)Resources\**" Exclude="$(_SingleProjecttvOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+
+		<!-- Apple privacy manifest support https://learn.microsoft.com/en-us/dotnet/maui/ios/privacy-manifest -->
+		<None
+			Include="$(tvOSProjectFolder)PrivacyInfo.xcprivacy"
+			LogicalName="PrivacyInfo.xcprivacy"
+			Condition="exists('$(tvOSProjectFolder)PrivacyInfo.xcprivacy')" />
+		<BundleResource
+			Include="$(tvOSProjectFolder)PrivacyInfo.xcprivacy"
+			LogicalName="PrivacyInfo.xcprivacy"
+			Condition="exists('$(tvOSProjectFolder)PrivacyInfo.xcprivacy')" />
+	</ItemGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)xamarin-ios-maccatalyst-workarounds.targets" />
+</Project>


### PR DESCRIPTION
## Problem

Building a **tvOS single-project** head fails in the asset pipeline with an opaque:

```
error MSB4018: The "RetargetAssets" task failed unexpectedly.
System.ArgumentNullException: Value cannot be null. (Parameter 'url')
   at System.Xml.XmlDocument.Load(String filename)
   at Uno.UI.Tasks.Assets.RetargetAssets.EnumerateFontsFromPList(String iosAppManifest)
```

## Root cause

There are two related issues:

1. **`RetargetAssets.EnumerateFontsFromPList` loads an optional input unconditionally.**
   `IosAppManifest` is declared without `[Required]`, so callers may legitimately pass nothing — but the method does `new XmlDocument().Load(iosAppManifest)` with no guard, throwing on `null`/empty. It's invoked for every `uikit` `TargetPlatform` (iOS, tvOS, macCatalyst).

2. **tvOS single-project has no target wiring an `Info.plist`.**
   `Uno.Sdk` ships `Uno.SingleProject.iOS.targets`, `.MacCatalyst.targets`, `.MacOS.targets` (each wires `Platforms/<head>/Info.plist` + entitlements/assets/privacy), and imports the matching `Uno.Common.<head>.targets` per `TargetPlatformIdentifier`. **There is no tvOS pair**, even though `$(tvOSProjectFolder)` (= `Platforms/tvOS/`) and `$(IsTvOS)` are already defined. So a tvOS head never gets an app manifest — which is exactly what makes (1) throw.

## Fix

- **`RetargetAssets.Fonts.cs`** — return an empty set when there is no manifest to read (no manifest ⇒ no pre-existing fonts to preserve), and null-guard `SelectNodes`. This respects the property's optional contract and turns the crash into a no-op for heads without a manifest.
- **`Uno.SingleProject.tvOS.targets`** (new) — mirrors the iOS/macCatalyst target: wires `$(tvOSProjectFolder)Info.plist` (+ entitlements, `.xcassets`, `PrivacyInfo.xcprivacy`).
- **`Uno.Common.tvOS.targets`** (new) — mirrors `Uno.Common.iOS.targets` (sets `IsTvOS`, a default `SupportedOSPlatformVersion`, imports the SingleProject target).
- **`Uno.Common.targets`** — import `Uno.Common.tvOS.targets` for `TargetPlatformIdentifier == 'tvos'`, alongside the existing per-head imports.

Either change alone stops the crash; together they make tvOS single-project a first-class head like the other Apple targets. The new `.targets` are picked up by the existing `targets\**\*.targets` pack glob.

## Testing

Reproduced and validated downstream on a real single-project app (Uno.Sdk 6.5.x, .NET 10, macOS 26 / Xcode 26.5): before, the tvOS head crashed in `RetargetAssets`; after supplying `Platforms/tvOS/Info.plist` (now wired by the new target), the tvOS head builds past the task and **compiles + native-links for `tvos-arm64`**. iOS and macCatalyst heads are unaffected.

One deliberate omission vs. `Uno.SingleProject.iOS.targets`: the `TrimmerRootAssembly` workaround for `Microsoft.Extensions.DependencyInjection` is not carried over, since I could not verify the underlying issue reproduces on tvOS - easy to add if you know it does.

Happy to adjust the `SupportedOSPlatformVersion` default or split this into two PRs (the task guard vs. the tvOS wiring) if preferred — they're independent but causally linked.

