### PR TITLE
refactor(brush)!: Reduce CompositionBrush to protected (BC17)

### DIFF
--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -193,7 +193,7 @@ _Danger 2. Tighten Uno-only public surface to match WinUI (internal/protected/se
 
 _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type base-class realignments, enum/type-shape changes, and behaviour-changing defaults. Several silently change runtime behaviour even on defaults — gate each on a migration note + runtime/visual validation, not compile-only._
 
-- [ ] **BC17** — `XamlCompositionBrushBase.CompositionBrush` -> protected  `d3·S`
+- [x] **BC17** — `XamlCompositionBrushBase.CompositionBrush` -> protected  `d3·S`
   - Reduce visibility to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.cs`, `src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.skia.cs`, `src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs`
 - [ ] **BC19** — Remove `FlyoutBase.Close()` (use `Hide()`)  `d3·S`

--- a/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.cs
@@ -26,7 +26,7 @@ public partial class XamlCompositionBrushBase : Brush
 	/// </summary>
 	internal Color FallbackColorWithOpacity => FallbackColor.WithOpacity(Opacity);
 
-	public CompositionBrush CompositionBrush
+	protected CompositionBrush CompositionBrush
 	{
 		get => (CompositionBrush)GetValue(CompositionBrushProperty);
 		set => SetValue(CompositionBrushProperty, value);


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

`XamlCompositionBrushBase.CompositionBrush` was exposed as `public` in Uno — an unintended Uno-only widening. WinUI declares it as `protected`. This PR reduces it to `protected` to match the WinUI contract (**BC17** of the Phase 5 breaking-changes wave).

All in-repo consumers already set the property from *within* `XamlCompositionBrushBase` subclasses (`AcrylicBrush`, `RadialGradientBrush`, `RevealBrush`, and the sample/test custom brushes), so `protected` access is sufficient — no callers needed widening. The backing `internal CompositionBrushProperty` is unchanged.

**Validation:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean (0 warnings / 0 errors), transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, and all consuming samples. No `PackageDiffIgnore.xml` entry is required — the package-diff gate treats `public` and `protected` as equally "visible" (matched by name/return/params), so a public→protected reduction is not flagged.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — **N/A**: pure compile-time visibility reduction, no runtime behavior change.
- [ ] 📚 Docs have been added/updated — **N/A**.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact:** Code outside an `XamlCompositionBrushBase` subclass that reads or writes `brush.CompositionBrush` will no longer compile.
- **Migration:** `CompositionBrush` is only meaningful to assign from a custom brush's `OnConnected`/`OnDisconnected`. Move such access into a subclass (the WinUI-supported pattern). This aligns with WinUI, where the member has always been `protected`.
