### PR TITLE
fix(x11): Fix WebView2 native element embedding on WSLg (Weston/XWayland)

### DIFF
--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -207,7 +207,15 @@ public class X11NativeWebView : INativeWebView
 			var tcs = new TaskCompletionSource<T>();
 			GLib.Idle.Add(() =>
 			{
-				tcs.SetResult(func());
+				// an exception escaping the idle callback would leave the caller blocked forever
+				try
+				{
+					tcs.SetResult(func());
+				}
+				catch (Exception e)
+				{
+					tcs.SetException(e);
+				}
 				return false;
 			});
 			return tcs.Task.Result;
@@ -225,8 +233,16 @@ public class X11NativeWebView : INativeWebView
 			var tcs = new TaskCompletionSource();
 			GLib.Idle.Add(() =>
 			{
-				func();
-				tcs.SetResult();
+				// an exception escaping the idle callback would leave the caller blocked forever
+				try
+				{
+					func();
+					tcs.SetResult();
+				}
+				catch (Exception e)
+				{
+					tcs.SetException(e);
+				}
 				return false;
 			});
 			tcs.Task.Wait();

--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -171,6 +171,11 @@ public class X11NativeWebView : INativeWebView
 			_window.Add(_webview);
 			_webview.ShowAll();
 			_window.Realize(); // creates the Gdk window (and the X11 window) without showing it
+			// Set override-redirect before the window is first mapped, so that the WM never
+			// starts managing it as a toplevel. Some WMs (e.g. Weston's XWM on WSLg) would
+			// otherwise never let go of the window when we reparent it into the app's window,
+			// leaving the webview invisible.
+			_window.Window.OverrideRedirect = true;
 			return gdk_x11_window_get_xid(_window.Window.Handle);
 		});
 

--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -171,6 +171,7 @@ public class X11NativeWebView : INativeWebView
 			_window.Add(_webview);
 			_webview.ShowAll();
 			_window.Realize(); // creates the Gdk window (and the X11 window) without showing it
+
 			// Set override-redirect before the window is first mapped, so that the WM never
 			// starts managing it as a toplevel. Some WMs (e.g. Weston's XWM on WSLg) would
 			// otherwise never let go of the window when we reparent it into the app's window,

--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -218,7 +218,7 @@ public class X11NativeWebView : INativeWebView
 				}
 				return false;
 			});
-			return tcs.Task.Result;
+			return tcs.Task.GetAwaiter().GetResult();
 		}
 	}
 
@@ -245,7 +245,7 @@ public class X11NativeWebView : INativeWebView
 				}
 				return false;
 			});
-			tcs.Task.Wait();
+			tcs.Task.GetAwaiter().GetResult();
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -671,12 +671,15 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		_ = XLib.XFlush(RootX11Window.Display);
 		XLib.XSync(RootX11Window.Display, false); // XSync is necessary after XReparent for unknown reasons
 
-		_ = XLib.XQueryTree(RootX11Window.Display, window, out _, out var parent, out var children, out _);
-		_ = XLib.XFree(children);
-		if (parent != RootX11Window.Window && this.Log().IsEnabled(LogLevel.Warning))
+		// Best-effort diagnostic only: a WM that already manages `window` as a toplevel can also
+		// steal it back asynchronously after this check (observed with Weston's XWM on WSLg).
+		if (XLib.XQueryTree(RootX11Window.Display, window, out _, out var parent, out var children, out _) != 0)
 		{
-			// e.g. a WM that already manages `window` as a toplevel can steal it back (observed with Weston's XWM on WSLg)
-			this.Log().Warn($"Failed to reparent window 0x{window.ToString("X")} into the application window. The native element will likely not be visible.");
+			_ = XLib.XFree(children);
+			if (parent != RootX11Window.Window && this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn($"Failed to reparent window 0x{window.ToString("X")} into the application window; it is parented by 0x{parent.ToString("X")} instead, likely a window manager managing it as a toplevel. The native element will likely not be visible.");
+			}
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -665,7 +665,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		// Note that XSetWindowAttributes is a different struct from XWindowAttributes, and only
 		// the former is valid here.
 		var attributes = new XSetWindowAttributes { override_redirect = /* True */ 1 };
-		_ = X11Helper.XChangeWindowAttributes(RootX11Window.Display, window, (IntPtr)XCreateWindowFlags.CWOverrideRedirect, &attributes);
+		_ = X11Helper.XChangeWindowAttributes(RootX11Window.Display, window, (IntPtr)SetWindowValuemask.OverrideRedirect, &attributes);
 
 		_ = X11Helper.XReparentWindow(RootX11Window.Display, window, RootX11Window.Window, 0, 0);
 		_ = XLib.XFlush(RootX11Window.Display);

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -678,7 +679,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 			_ = XLib.XFree(children);
 			if (parent != RootX11Window.Window && this.Log().IsEnabled(LogLevel.Warning))
 			{
-				this.Log().Warn($"Failed to reparent window 0x{window.ToString("X")} into the application window; it is parented by 0x{parent.ToString("X")} instead, likely a window manager managing it as a toplevel. The native element will likely not be visible.");
+				this.Log().Warn($"Failed to reparent window 0x{window.ToString("X", CultureInfo.InvariantCulture)} into the application window; it is parented by 0x{parent.ToString("X", CultureInfo.InvariantCulture)} instead, likely a window manager managing it as a toplevel. The native element will likely not be visible.");
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -661,19 +661,23 @@ internal partial class X11XamlRootHost : IXamlRootHost
 	public unsafe void AttachSubWindow(IntPtr window)
 	{
 		using var lockDisposable = X11Helper.XLock(RootX11Window.Display);
-		// this seems to be necessary or else the WM will keep detaching the subwindow
-		XWindowAttributes attributes = default;
-		_ = XLib.XGetWindowAttributes(RootX11Window.Display, window, ref attributes);
-		attributes.override_direct = /* True */ 1;
-
-		IntPtr attr = Marshal.AllocHGlobal(Marshal.SizeOf(attributes));
-		Marshal.StructureToPtr(attributes, attr, false);
-		_ = X11Helper.XChangeWindowAttributes(RootX11Window.Display, window, (IntPtr)XCreateWindowFlags.CWOverrideRedirect, (XSetWindowAttributes*)attr.ToPointer());
-		Marshal.FreeHGlobal(attr);
+		// Setting override-redirect is necessary or else the WM will keep detaching the subwindow.
+		// Note that XSetWindowAttributes is a different struct from XWindowAttributes, and only
+		// the former is valid here.
+		var attributes = new XSetWindowAttributes { override_redirect = /* True */ 1 };
+		_ = X11Helper.XChangeWindowAttributes(RootX11Window.Display, window, (IntPtr)XCreateWindowFlags.CWOverrideRedirect, &attributes);
 
 		_ = X11Helper.XReparentWindow(RootX11Window.Display, window, RootX11Window.Window, 0, 0);
 		_ = XLib.XFlush(RootX11Window.Display);
 		XLib.XSync(RootX11Window.Display, false); // XSync is necessary after XReparent for unknown reasons
+
+		_ = XLib.XQueryTree(RootX11Window.Display, window, out _, out var parent, out var children, out _);
+		_ = XLib.XFree(children);
+		if (parent != RootX11Window.Window && this.Log().IsEnabled(LogLevel.Warning))
+		{
+			// e.g. a WM that already manages `window` as a toplevel can steal it back (observed with Weston's XWM on WSLg)
+			this.Log().Warn($"Failed to reparent window 0x{window.ToString("X")} into the application window. The native element will likely not be visible.");
+		}
 	}
 
 	private void SynchronizedShutDown(X11Window x11Window)


### PR DESCRIPTION
**GitHub Issue:** closes #23735, closes unoplatform/quadient-private#2

## PR Type:

🐞 Bugfix

## What changed? 🚀

On the X11 Skia target under WSLg (Weston/XWayland), a `WebView2` was never displayed: the WebKitGTK window ended up held under Weston's XWM frame window instead of being embedded in the app's window.

Two layered fixes:

- **`X11XamlRootHost.AttachSubWindow`**: the code passed an `XWindowAttributes` buffer to `XChangeWindowAttributes`, which expects the differently-laid-out `XSetWindowAttributes`. The `override_redirect` value actually applied came from whatever bytes sat at offset 88 (`map_installed`) — `1` for plain default-colormap windows, `0` for GTK windows — so the intended override-redirect was never reliably set. Now a properly-constructed `XSetWindowAttributes` is passed (this also drops a `Marshal.AllocHGlobal` and an `XGetWindowAttributes` round-trip). A best-effort post-reparent check now logs a warning naming the window that kept the native element, instead of failing silently.
- **`X11NativeWebView`**: sets override-redirect on the GTK window right after realization, **before it is first mapped**, so the WM never starts managing it. This matters because once Weston's XWM manages a toplevel, reparenting it away is not reliably possible (it re-reparents the client under its own window even after `XWithdrawWindow`); mainstream WMs (mutter/KWin) release the window, which is why this only broke under Weston/WSLg. Additionally, `RunOnGtkThread` now propagates exceptions from the GTK thread through the `TaskCompletionSource` instead of leaving the calling thread blocked forever.

The MediaPlayer add-in needs no equivalent change: its X window stays unmapped until `AttachNativeElement` reparents it (with the now-correct override-redirect) before mapping, so the WM never gets a chance to manage it.

**Validation (runtime, WSLg Ubuntu 24.04):**
- Before: `xwininfo -root -tree` shows the `Uno WebView` window under the `"Weston WM"` window (10x10 at origin) → invisible.
- After: the window is a child of the app window at the arranged size/position; `WebView2_Static` renders web content, and keyboard input into an HTML `<input>` inside an embedded override-redirect WebKitGTK window was verified (typed text round-tripped via JavaScript).
- No behavior change expected on desktop WMs where embedding already worked; not runtime-verified on mutter/KWin in this PR (X11 WM interaction isn't coverable by CI runtime tests — CI runs under Xvfb with no WM).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: the bug is X11 window-manager interaction, which cannot be exercised in CI (Xvfb has no WM); validated manually on WSLg with existing WebView samples
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — no user-facing behavior/API change
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
