### PR TITLE
refactor(flyout)!: Remove FlyoutBase.Close() (BC19) and lock down Open()

### DIFF
--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -196,7 +196,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC17** — `XamlCompositionBrushBase.CompositionBrush` -> protected  `d3·S`
   - Reduce visibility to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.cs`, `src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.skia.cs`, `src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs`
-- [ ] **BC19** — Remove `FlyoutBase.Close()` (use `Hide()`)  `d3·S`
+- [x] **BC19** — Remove `FlyoutBase.Close()` (use `Hide()`)  `d3·S`
   - Reduce visibility to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs`, `src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs`, `src/Uno.UI/UI/Xaml/Controls/Button/Button.cs`
 - [ ] **BC27** — `DoubleCollection`: composition not `List<T>`  `d3·S`

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarDatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarDatePicker.cs
@@ -36,7 +36,7 @@ public class Given_CalendarDatePicker
 
 		Assert.IsGreaterThan(300, calendarView.ActualHeight);
 
-		flyout.Close();
+		flyout.Hide();
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -351,7 +351,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			bool flyoutClosed = false;
 			datePickerFlyout.Closed += (s, e) => flyoutClosed = true;
-			datePickerFlyout.Close();
+			datePickerFlyout.Hide();
 
 			await TestServices.WindowHelper.WaitFor(() => flyoutClosed, message: "Flyout did not close");
 
@@ -394,7 +394,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 			finally
 			{
-				datePickerFlyout.Close();
+				datePickerFlyout.Hide();
 			}
 		}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -755,7 +755,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finally
 			{
 #if HAS_UNO
-				SUT.contextFlyout.Close();
+				SUT.contextFlyout.Hide();
 #endif
 			}
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -409,7 +409,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finally
 			{
 				subItem.Close();
-				flyout.Close();
+				flyout.Hide();
 			}
 		}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -307,7 +307,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var timePickerFlyout = (TimePickerFlyout)associatedFlyout;
 			bool flyoutClosed = false;
 			timePickerFlyout.Closed += (s, e) => flyoutClosed = true;
-			timePickerFlyout.Close();
+			timePickerFlyout.Hide();
 
 			await TestServices.WindowHelper.WaitFor(() => flyoutClosed, message: "Flyout did not close");
 

--- a/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
@@ -42,7 +42,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (Flyout is { IsOpen: true } flyout)
 			{
-				flyout.Close();
+				flyout.Hide();
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
@@ -62,7 +62,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			_datePicked?.Invoke(this, new DatePickedEventArgs(newDateTime, oldDateTime));
 
-			Close();
+			Hide();
 		}
 
 		//// -----

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
@@ -47,7 +47,7 @@ public
 
 	internal DateTimeOffset NativeDialogDate => _dialog.DatePicker.DateTime;
 
-	protected internal override void Open()
+	internal override void Open()
 	{
 		var date = Date;
 		// If we're setting the date to the null sentinel value,

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -96,12 +96,6 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 		}
 
-		protected internal override void Close()
-		{
-			// This overload is required for binary compatibility
-			base.Close();
-		}
-
 		protected internal override void Open()
 		{
 			// This overload is required for binary compatibility

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -96,12 +96,6 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 		}
 
-		protected internal override void Open()
-		{
-			// This overload is required for binary compatibility
-			base.Open();
-		}
-
 		protected override Control CreatePresenter()
 		{
 			_presenter = new FlyoutPresenter();

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -876,11 +876,6 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			}
 		}
 
-		protected internal virtual void Close()
-		{
-			Hide(canCancel: true);
-		}
-
 		protected internal virtual void Open()
 		{
 			EnsurePopupCreated();

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -876,7 +876,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			}
 		}
 
-		protected internal virtual void Open()
+		internal virtual void Open()
 		{
 			EnsurePopupCreated();
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
@@ -21,7 +21,7 @@ partial class NativeTimePickerFlyout : TimePickerFlyout
 	internal UnoTimePickerDialog GetNativeDialog() => _dialog;
 
 
-	internal protected override void Open()
+	internal override void Open()
 	{
 		if (Time.Ticks == DEFAULT_TIME_TICKS)
 		{


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

Two related `FlyoutBase` API-surface changes that stop Uno exposing opening/closing internals that WinUI keeps non-public.

### 1. Remove Uno-only `FlyoutBase.Close()` (BC19)

`FlyoutBase.Close()` was a **Uno-only** `protected internal virtual` method — a byte-for-byte alias of the public `Hide()` (both bodies are `Hide(canCancel: true)`). WinUI has no `Close()` on `FlyoutBase`. This removes it (**BC19** of the Phase 5 breaking-changes wave), along with the `Flyout.Close()` binary-compat override, and redirects every caller to the public `Hide()`.

Callers redirected:
- **Production:** `Button` flyout dismissal (`OnUnloaded`), `DatePickerFlyout` confirmation path.
- **Tests:** `Given_CalendarDatePicker`, `Given_DatePicker`, `Given_TimePicker`, `Given_MenuFlyout` (the flyout call — `MenuFlyoutSubItem.Close()` is a different, unrelated method and is left as-is), `Given_Flyout`.

Behaviour is preserved exactly, since `Close()` and `Hide()` were identical.

### 2. Lock down `FlyoutBase.Open()` to `internal`

`FlyoutBase.Open()` — the internal popup-opening step invoked from `ShowAtCore` — was `protected internal virtual`. The `protected` half leaked this Uno-internal mechanism to external `FlyoutBase` subclasses, though WinUI keeps it non-public. This reduces it to `internal virtual` (kept `virtual` for the native Android `NativeDatePickerFlyout` / `NativeTimePickerFlyout` overrides, which replace it with native OS dialogs), and drops the now-redundant `Flyout.Open()` override — a no-op `base.Open()` passthrough whose only purpose was the `protected` binary-compat vtable slot. The two native Android overrides are realigned to `internal override`.

No `PackageDiffIgnore.xml` entry is required for either change — both members were `protected internal` (FamORAssem), which the package-diff gate excludes from its tracked surface (it counts only public and family members).

## Validation

- **BC19 (`Close()`):** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean (0 warnings / 0 errors), transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, and all consuming samples. The BC19 change is unchanged from its original review (identical `git patch-id` after rebase).
- **`Open()` lockdown:** `Uno.UI.Skia` and `Uno.UI.RuntimeTests.Skia` (net10.0) both build clean (0/0). The native Android overrides aren't part of the Skia buildable set here, but the `internal override` realignment is required for any native-Android build to stay valid against the `internal virtual` base.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — **N/A**: not a behaviour change; existing flyout tests still exercise the dismissal/open paths.
- [ ] 📚 Docs have been added/updated — **N/A**.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **`Close()` removal:** Custom `FlyoutBase` subclasses that overrode or called the Uno-only `Close()` will no longer compile. **Migration:** replace `Close()` with the public `Hide()` (identical behaviour — cancellable dismiss).
- **`Open()` lockdown:** Custom `FlyoutBase` / `Flyout` subclasses that overrode or called the Uno-only `protected internal Open()` will no longer compile. **Migration:** drive the flyout through the public `ShowAt(...)` entry point; `Open()` was never part of WinUI's surface and is now Uno-internal only.
