### PR TITLE
refactor(media)!: DoubleCollection as composition (BC27)

### DIFF
--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -199,7 +199,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC19** — Remove `FlyoutBase.Close()` (use `Hide()`)  `d3·S`
   - Reduce visibility to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs`, `src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs`, `src/Uno.UI/UI/Xaml/Controls/Button/Button.cs`
-- [ ] **BC27** — `DoubleCollection`: composition not `List<T>`  `d3·S`
+- [x] **BC27** — `DoubleCollection`: composition not `List<T>`  `d3·S`
   - Reparent to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Media/DoubleCollection.cs`, `src/Uno.UI/UI/Xaml/Media/PointCollection.cs`, `src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Media/DoubleCollection.cs`
 - [ ] **BC73** — `TimePickerFlyoutPresenter` -> `Control` base  `d3·S`

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Media/DoubleCollection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Media/DoubleCollection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.UI.Xaml.Media
 		// Skipping already declared method Microsoft.UI.Xaml.Media.DoubleCollection.Contains(double)
 		// Skipping already declared method Microsoft.UI.Xaml.Media.DoubleCollection.CopyTo(double[], int)
 		// Skipping already declared method Microsoft.UI.Xaml.Media.DoubleCollection.Remove(double)
-		// Skipping collection method provided by base class: Microsoft.UI.Xaml.Media.DoubleCollection.GetEnumerator()
+		// Skipping already declared method Microsoft.UI.Xaml.Media.DoubleCollection.GetEnumerator()
 		// Forced skipping of method Microsoft.UI.Xaml.Media.DoubleCollection.System.Collections.IEnumerable.GetEnumerator()
 		// Forced skipping of method Microsoft.UI.Xaml.Media.DoubleCollection.System.Collections.Generic.IList<double>.get_Item(int)
 		// Forced skipping of method Microsoft.UI.Xaml.Media.DoubleCollection.System.Collections.Generic.IList<double>.set_Item(int, double)

--- a/src/Uno.UI/UI/Xaml/Media/DoubleCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Media/DoubleCollection.cs
@@ -1,22 +1,63 @@
-﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 
 namespace Microsoft.UI.Xaml.Media
 {
-	public partial class DoubleCollection : List<double>, IList<double>, IEnumerable<double>
+	public partial class DoubleCollection : IList<double>, IEnumerable<double>
 	{
+		private readonly List<double> _values;
+
 		public DoubleCollection()
 		{
+			_values = new List<double>();
+		}
 
-		}
-		public DoubleCollection(IEnumerable<double> collection) : base(collection)
+		public DoubleCollection(IEnumerable<double> collection)
 		{
+			_values = collection.ToList();
 		}
+
+		public int Count => _values.Count;
 
 		public bool IsReadOnly => false;
+
+		public double this[int index]
+		{
+			get => _values[index];
+			set => _values[index] = value;
+		}
+
+		public IEnumerator<double> GetEnumerator()
+			=> _values.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator()
+			=> _values.GetEnumerator();
+
+		public int IndexOf(double item)
+			=> _values.IndexOf(item);
+
+		public bool Contains(double item)
+			=> _values.Contains(item);
+
+		public void CopyTo(double[] array, int arrayIndex)
+			=> _values.CopyTo(array, arrayIndex);
+
+		public void Insert(int index, double item)
+			=> _values.Insert(index, item);
+
+		public void RemoveAt(int index)
+			=> _values.RemoveAt(index);
+
+		public void Add(double item)
+			=> _values.Add(item);
+
+		public void Clear()
+			=> _values.Clear();
+
+		public bool Remove(double item)
+			=> _values.Remove(item);
 
 		static public implicit operator DoubleCollection(string value)
 		{
@@ -25,7 +66,6 @@ namespace Microsoft.UI.Xaml.Media
 
 		static public implicit operator DoubleCollection(double[] value)
 		{
-
 			return new DoubleCollection(value);
 		}
 	}


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

`DoubleCollection` was a **Uno-only** subclass of `List<double>`. WinUI's `DoubleCollection` is a sealed collection that implements `IList<double>` (and its bases) but is **not** a `List<T>` — it exposes none of `List<double>`'s extra surface (`AddRange`, `Sort`, `Capacity`, `Reverse`, `BinarySearch`, the non-generic `IList`/`ICollection`, `IReadOnlyList<double>`, …).

This PR (**BC27** of the Phase 5 breaking-changes wave) reshapes `DoubleCollection` to **composition over inheritance**: it now wraps a private `List<double>` and implements `IList<double>` directly, matching WinUI's surface and mirroring the existing `PointCollection` pattern (minus change-notification, which `DoubleCollection` never had).

Preserved verbatim:
- Both constructors — `DoubleCollection()` and `DoubleCollection(IEnumerable<double>)`.
- Both implicit conversion operators — from `string` (`"1,2"` / space-separated) and from `double[]`.
- The full `IList<double>` surface used by consumers: `Count`, indexer, `Add`, `Insert`, `Remove`, `RemoveAt`, `Clear`, `Contains`, `IndexOf`, `CopyTo`, `IsReadOnly`, and both `GetEnumerator()` overloads.

The only in-repo consumer that reads the collection contents is the Skia shape renderer (`Shape.skia.cs`, via `Count` + indexer); it and all `StrokeDashArray` usages continue to compile and run unchanged.

**Validation:**
- **Compile:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean, transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, and all consuming samples.
- **Runtime:** `Given_XamlReader.When_DoubleCollection` (exercises `StrokeDashArray="1,2"` string→collection population via `XamlReader` **and** `XamlBindingHelper.ConvertValue`) plus `When_Shape` `StrokeDashArray` rendering tests pass (Skia Desktop). Because behaviour is unchanged, these are pass-after regression guards, not fails-before repros.

No `PackageDiffIgnore.xml` entry is required — the package-diff gate tracks declared members only and does not track base-type changes; the declared-member set here only grows (the `IList<double>` members are now declared on the type instead of inherited from `List<double>`).

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — **N/A**: not a behaviour change; existing `Given_XamlReader` / `When_Shape` tests exercise the population and render paths and were run as regression guards.
- [ ] 📚 Docs have been added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** Code that relied on `DoubleCollection` being a `List<double>` no longer compiles — specifically calls to `List<double>`-only members (`AddRange`, `Sort`, `Reverse`, `Capacity`, `BinarySearch`, `InsertRange`, `RemoveAll`, …), or code that assigned/passed a `DoubleCollection` where a `List<double>`, non-generic `IList`/`ICollection`, or `IReadOnlyList<double>` was expected.
- **Migration:** Work against the `IList<double>` surface. Replace `AddRange(items)` with a loop or `new DoubleCollection(items)`; sort/reverse by materializing (`col.ToList().Sort()`) and rebuilding the collection. This aligns with WinUI, where `DoubleCollection` was never a `List<T>`.
