### PR TITLE
refactor(timepicker)!: Reparent presenter to Control (BC73)

### DIFF
--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -202,7 +202,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC27** — `DoubleCollection`: composition not `List<T>`  `d3·S`
   - Reparent to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Media/DoubleCollection.cs`, `src/Uno.UI/UI/Xaml/Media/PointCollection.cs`, `src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Media/DoubleCollection.cs`
-- [ ] **BC73** — `TimePickerFlyoutPresenter` -> `Control` base  `d3·S`
+- [x] **BC73** — `TimePickerFlyoutPresenter` -> `Control` base  `d3·S`
   - Reparent to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.cs`, `src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.Properties.cs`, `src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.partial.mux.cs`
 - [ ] **BC13** — Fix `WindowActivatedEventArgs.WindowActivationState` type  `d3·M`

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.Properties.cs
@@ -7,7 +7,7 @@ partial class TimePickerFlyoutPresenter
 	/// <summary>
 	/// Gets or sets a value that indicates whether the default shadow effect is shown.
 	/// </summary>
-	public new bool IsDefaultShadowEnabled
+	public bool IsDefaultShadowEnabled
 	{
 		get => (bool)GetValue(IsDefaultShadowEnabledProperty);
 		set => SetValue(IsDefaultShadowEnabledProperty, value);
@@ -16,7 +16,7 @@ partial class TimePickerFlyoutPresenter
 	/// <summary>
 	/// Identifies the IsDefaultShadowEnabled dependency property.
 	/// </summary>
-	public static new DependencyProperty IsDefaultShadowEnabledProperty { get; } =
+	public static DependencyProperty IsDefaultShadowEnabledProperty { get; } =
 		DependencyProperty.Register(
 			nameof(IsDefaultShadowEnabled),
 			typeof(bool),

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.cs
@@ -5,6 +5,6 @@ namespace Microsoft.UI.Xaml.Controls;
 /// <summary>
 /// Represents the visual container for the TimePickerFlyout.
 /// </summary>
-public partial class TimePickerFlyoutPresenter : FlyoutPresenter
+public partial class TimePickerFlyoutPresenter : Control
 {
 }


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

`TimePickerFlyoutPresenter` derived from **`FlyoutPresenter`** in Uno, but in WinUI it derives directly from **`Control`** — exactly like its sibling `DatePickerFlyoutPresenter` (which already ships as `: Control` in Uno). This PR (**BC73** of the Phase 5 breaking-changes wave) reparents `TimePickerFlyoutPresenter` to `Control` to match WinUI and bring the two picker presenters into line.

Changes:
- `TimePickerFlyoutPresenter : FlyoutPresenter` → `: Control`.
- Dropped the `new` modifier from `IsDefaultShadowEnabled` and `IsDefaultShadowEnabledProperty`. Those members were only marked `new` because they shadowed `FlyoutPresenter.IsDefaultShadowEnabled`; once the base is `Control` (which has no such member) they are ordinary declarations — matching WinUI, where `TimePickerFlyoutPresenter` declares its own `IsDefaultShadowEnabled`.

Nothing else was touched: the presenter already builds its visual tree from named template parts (it never used `ContentControl.Content` or any `FlyoutPresenter`-specific member), its default styles (Fluent v2/v1, Compact density, Generic) set only `Control`/`FrameworkElement` properties and carry no `BasedOn` on a `FlyoutPresenter` style, and it is created internally by `TimePickerFlyout` (typed as `TimePickerFlyoutPresenter`, not `FlyoutPresenter`).

**Validation:**
- **Compile:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean, transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, and all consuming samples.
- **Runtime (Skia Desktop):** 5/5 `Given_TimePicker` flyout tests pass — `When_12HourClock_Should_Display_12_Instead_Of_0`, `When_MinuteIncrement_In_Range_Should_Be_Set_Properly`, `When_MonochromaticOverlayPresenter_Workaround`, `When_PM_Opened_And_Closed`, `When_TimePickerFlyout_Placed_Outside_Window` — each opens the flyout, instantiates and templates the presenter, and reads its state (the run log shows the `TimePickerFlyoutPresenter` and its automation peer being created). `When_Time_Uninitialized_Should_Display_Current_Time` is `#if __IOS__ || __ANDROID__` and correctly did not run on Skia. Behaviour is unchanged (the shadow still applies via the presenter's own `IsDefaultShadowEnabled`), so these are pass-after regression guards.
- **Style sweep:** every style file naming the type (Fluent v2/v1, Compact density, `Generic.xaml`, `Generic.Native.xaml`, `SystemResources.xaml`, `mergedstyles.xaml`) was checked — none carry a `BasedOn` on a `FlyoutPresenter`-targeted style, so no native style-apply regression from the base-class change.

No `PackageDiffIgnore.xml` entry is required — the package-diff gate tracks declared members only and does not track base-type changes; no declared member is removed here (dropping the `new` keyword does not change the emitted metadata, and `IsDefaultShadowEnabled`/`IsDefaultShadowEnabledProperty` remain declared on the type).

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — **N/A**: not a behaviour change; existing `Given_TimePicker` tests exercise the flyout open/template/display path and were run as regression guards.
- [ ] 📚 Docs have been added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — no intended visual change (the TimePicker flyout renders identically).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** Code that treated `TimePickerFlyoutPresenter` as a `FlyoutPresenter`/`ContentControl` — assigning an instance to a `FlyoutPresenter`/`ContentControl` variable, or accessing inherited members such as `Content`/`ContentTemplate` or `FlyoutPresenter`-specific API through it — no longer compiles. This is the same shape `DatePickerFlyoutPresenter` already has.
- **Migration:** Work against `TimePickerFlyoutPresenter` (or `Control`) directly. Style it via `TimePickerFlyout.TimePickerFlyoutPresenterStyle` as before; the default templates are unchanged.
