### PR TITLE
fix(devserver): forward host logs to console in direct mode

### DIFF
--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_StartCommandHandler.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_StartCommandHandler.cs
@@ -261,7 +261,7 @@ public class Given_StartCommandHandler
 	{
 		var spawns = new List<ProcessStartInfo>();
 		var results = new Queue<DirectSpawnResult>([
-			new DirectSpawnResult(1, DirectSpawnFailure.DiedBeforeReady, -532462766, "Unhandled exception. FileNotFoundException: System.Text.Encodings.Web"),
+			new DirectSpawnResult(1, DirectSpawnFailure.DiedBeforeReady, -532462766),
 			DirectSpawnResult.Ready,
 		]);
 
@@ -295,7 +295,7 @@ public class Given_StartCommandHandler
 			onSpawnProcess: _ =>
 			{
 				spawnCount++;
-				return Task.FromResult(new DirectSpawnResult(1, DirectSpawnFailure.DiedBeforeReady, -1, "boom"));
+				return Task.FromResult(new DirectSpawnResult(1, DirectSpawnFailure.DiedBeforeReady, -1));
 			});
 
 		var exitCode = await handler.RunAsync(
@@ -317,7 +317,7 @@ public class Given_StartCommandHandler
 			onSpawnProcess: _ =>
 			{
 				spawnCount++;
-				return Task.FromResult(new DirectSpawnResult(1, DirectSpawnFailure.DiedBeforeReady, -1, "boom"));
+				return Task.FromResult(new DirectSpawnResult(1, DirectSpawnFailure.DiedBeforeReady, -1));
 			});
 
 		var exitCode = await handler.RunAsync(
@@ -339,7 +339,7 @@ public class Given_StartCommandHandler
 			onSpawnProcess: _ =>
 			{
 				spawnCount++;
-				return Task.FromResult(new DirectSpawnResult(1, DirectSpawnFailure.ReadinessTimeout, null, ""));
+				return Task.FromResult(new DirectSpawnResult(1, DirectSpawnFailure.ReadinessTimeout, null));
 			});
 
 		var exitCode = await handler.RunAsync(
@@ -365,7 +365,7 @@ public class Given_StartCommandHandler
 	{
 		var failure = (DirectSpawnFailure)failureKind;
 		var result = new DirectSpawnResult(
-			failure == DirectSpawnFailure.None ? 0 : 1, failure, null, "");
+			failure == DirectSpawnFailure.None ? 0 : 1, failure, null);
 
 		StartCommandHandler.ShouldRetryInSafeMode(result, addins, solution)
 			.Should().Be(expected);

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -165,8 +165,10 @@ internal class CliManager
 
 			var startInfo = BuildHostArgs(hostPath, originalArgs, workingDirectory, redirectOutput: true, addins: null, enableMajorRollForward: hostLaunchPlan.RequiresMajorRollForward);
 
-			var (ExitCode, StdOut, StdErr) = await DevServerProcessHelper.RunConsoleProcessAsync(startInfo, _logger, forwardOutputToConsole: requiresHostOutputPassthrough);
-			return ExitCode;
+			// Passthrough commands (list/cleanup) print output the user asked for → surface it at
+			// Information (verbatim); everything else relays host output at Debug for diagnostics.
+			var stdLevel = requiresHostOutputPassthrough ? LogLevel.Information : LogLevel.Debug;
+			return await DevServerProcessHelper.RunConsoleProcessAsync(startInfo, _logger, stdLevel);
 		}
 		catch (Exception ex)
 		{

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -205,9 +205,9 @@ internal static class DevServerProcessHelper
 	/// <summary>
 	/// Relays the process's stdout/stderr to <paramref name="logger"/> line by line as they
 	/// arrive — stdout at <paramref name="stdLevel"/>, stderr at <paramref name="errLevel"/>.
-	/// When <paramref name="displayName"/> is set, lines are tagged <c>[name:stdout|stderr]</c>
-	/// to mark provenance; leave it <c>null</c> to relay verbatim (needed when the child's
-	/// stdout is itself a result the caller passes through, e.g. JSON). Where those lines
+	/// When <paramref name="displayName"/> is set, lines are tagged <c>[name]</c> to mark
+	/// provenance; leave it <c>null</c> to relay verbatim (needed when the child's stdout is
+	/// itself a result the caller passes through, e.g. JSON). Where those lines
 	/// surface (console, file, both) is the logger configuration's concern, not this method's:
 	/// attach a console sink to see them, and in MCP mode the logger already routes everything
 	/// to stderr so the JSON-RPC stdout stays clean. The stream events are multicast, so a
@@ -222,10 +222,11 @@ internal static class DevServerProcessHelper
 		LogLevel errLevel = _defaultErrLevel)
 	{
 		// e.Data is passed as a value, not folded into the template, so braces in the
-		// payload are safe; displayName (when set) is a known-safe constant tag.
-		void Relay(LogLevel level, string stream, string data)
+		// payload are safe; displayName (when set) is a known-safe constant tag. The
+		// stream is not tagged — the log level already distinguishes stdout from stderr.
+		void Relay(LogLevel level, string? data)
 		{
-			if (!logger.IsEnabled(level))
+			if (data is null || !logger.IsEnabled(level))
 			{
 				return;
 			}
@@ -236,30 +237,18 @@ internal static class DevServerProcessHelper
 			}
 			else
 			{
-				logger.Log(level, "[{Name}:{Stream}] {Data}", displayName, stream, data);
+				logger.Log(level, "[{Name}] {Data}", displayName, data);
 			}
 		}
 
 		if (startInfo.RedirectStandardOutput)
 		{
-			process.OutputDataReceived += (_, e) =>
-			{
-				if (e.Data is not null)
-				{
-					Relay(stdLevel, "stdout", e.Data);
-				}
-			};
+			process.OutputDataReceived += (_, e) => Relay(stdLevel, e.Data);
 		}
 
 		if (startInfo.RedirectStandardError)
 		{
-			process.ErrorDataReceived += (_, e) =>
-			{
-				if (e.Data is not null)
-				{
-					Relay(errLevel, "stderr", e.Data);
-				}
-			};
+			process.ErrorDataReceived += (_, e) => Relay(errLevel, e.Data);
 		}
 	}
 

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -342,7 +342,13 @@ internal static class DevServerProcessHelper
 			EnableRaisingEvents = true
 		};
 
-		var (_, errorSb) = ObserveOutputs(startInfo, "devserver", logger, process, forwardOutputToConsole: false);
+		// Forward the host's stdout/stderr to our own console so IDE launchers
+		// (e.g. the VS Code extension) that capture this CLI's output can surface
+		// the running DevServer host logs — not just the CLI launcher banner.
+		// Safe here: direct mode only runs for the `start` command, whose stdout is
+		// a plain output stream. The MCP stdio bridge never reaches this path (it
+		// spawns the host via DevServerMonitor), so the JSON-RPC channel is untouched.
+		var (_, errorSb) = ObserveOutputs(startInfo, "devserver", logger, process, forwardOutputToConsole: true);
 
 		process.Start();
 		logger.LogDebug("Started host process: {Pid}", process.Id);

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -199,7 +199,8 @@ internal static class DevServerProcessHelper
 		string displayName,
 		ILogger logger,
 		Process process,
-		bool forwardOutputToConsole)
+		bool forwardOutputToConsole,
+		bool bufferStdout = true)
 	{
 		var outputSb = new StringBuilder();
 		var errorSb = new StringBuilder();
@@ -210,7 +211,13 @@ internal static class DevServerProcessHelper
 			{
 				if (e.Data != null)
 				{
-					outputSb.AppendLine(e.Data);
+					// Skip buffering when the caller discards stdout (e.g. direct mode, where
+					// the CLI can stay alive as ppid guardian for the whole session) — otherwise
+					// the StringBuilder grows unbounded. stderr is always buffered for diagnostics.
+					if (bufferStdout)
+					{
+						outputSb.AppendLine(e.Data);
+					}
 					if (forwardOutputToConsole)
 					{
 						Console.Out.WriteLine(e.Data);
@@ -342,13 +349,13 @@ internal static class DevServerProcessHelper
 			EnableRaisingEvents = true
 		};
 
-		// Forward the host's stdout/stderr to our own console so IDE launchers
-		// (e.g. the VS Code extension) that capture this CLI's output can surface
-		// the running DevServer host logs — not just the CLI launcher banner.
-		// Safe here: direct mode only runs for the `start` command, whose stdout is
-		// a plain output stream. The MCP stdio bridge never reaches this path (it
-		// spawns the host via DevServerMonitor), so the JSON-RPC channel is untouched.
-		var (_, errorSb) = ObserveOutputs(startInfo, "devserver", logger, process, forwardOutputToConsole: true);
+		// Forward host stdout/stderr to the CLI console so IDE launchers surface the
+		// running host logs (incl. hot reload), not just the startup banner. Safe:
+		// direct mode is only reachable from `start` (plain stdout); the MCP bridge
+		// spawns via DevServerMonitor, never this path. stdout isn't buffered — it's
+		// discarded here and the session can be long-lived; stderr stays buffered for
+		// the failure diagnostics below.
+		var (_, errorSb) = ObserveOutputs(startInfo, "devserver", logger, process, forwardOutputToConsole: true, bufferStdout: false);
 
 		process.Start();
 		logger.LogDebug("Started host process: {Pid}", process.Id);
@@ -409,11 +416,10 @@ internal static class DevServerProcessHelper
 				catch { }
 			}
 
+			// stderr was already forwarded live to the console; don't re-dump the whole
+			// buffer here (it only duplicates the output). Still return it so the caller
+			// can decide on a safe-mode retry from the captured error text.
 			var stdErr = errorSb.ToString();
-			if (!string.IsNullOrWhiteSpace(stdErr))
-			{
-				logger.LogError("Host stderr:\n{ErrorOutput}", stdErr);
-			}
 
 			return new DirectSpawnResult(
 				1,

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -25,12 +25,12 @@ internal enum DirectSpawnFailure
 
 /// <summary>
 /// Outcome of <see cref="DevServerProcessHelper.RunDirectProcessAsync"/>:
-/// the CLI exit code plus enough failure context (kind, host exit code, captured
-/// stderr) for the caller to decide on a retry and to surface an actionable error.
+/// the CLI exit code plus enough failure context (kind, host exit code) for the caller
+/// to decide on a retry. Host output is relayed live through the logger, not captured here.
 /// </summary>
-internal sealed record DirectSpawnResult(int ExitCode, DirectSpawnFailure Failure, int? HostExitCode, string StdErr)
+internal sealed record DirectSpawnResult(int ExitCode, DirectSpawnFailure Failure, int? HostExitCode)
 {
-	public static DirectSpawnResult Ready { get; } = new(0, DirectSpawnFailure.None, null, "");
+	public static DirectSpawnResult Ready { get; } = new(0, DirectSpawnFailure.None, null);
 }
 
 internal static class DevServerProcessHelper
@@ -152,7 +152,7 @@ internal static class DevServerProcessHelper
 			EnableRaisingEvents = true
 		};
 
-		var (outputSb, errorSb) = ObserveOutputs(startInfo, "studio", logger, process, forwardOutputToConsole: false);
+		var (outputSb, errorSb) = CaptureOutputs(process, startInfo);
 
 		var processExited = new TaskCompletionSource();
 		process.Exited += (_, __) =>
@@ -194,57 +194,105 @@ internal static class DevServerProcessHelper
 		return (gracePeriodTask == resultTask || !process.HasExited ? null : process.ExitCode, stdOut, stdErr);
 	}
 
-	private static (StringBuilder output, StringBuilder error) ObserveOutputs(
-		ProcessStartInfo startInfo,
-		string displayName,
-		ILogger logger,
+	/// <summary>
+	/// Default levels for relaying a child process's streams through the logger. Shared by
+	/// <see cref="LogOutputs"/> and <see cref="RunConsoleProcessAsync"/> so their defaults
+	/// can never drift apart.
+	/// </summary>
+	private const LogLevel _defaultStdLevel = LogLevel.Debug;
+	private const LogLevel _defaultErrLevel = LogLevel.Error;
+
+	/// <summary>
+	/// Relays the process's stdout/stderr to <paramref name="logger"/> line by line as they
+	/// arrive — stdout at <paramref name="stdLevel"/>, stderr at <paramref name="errLevel"/>.
+	/// When <paramref name="displayName"/> is set, lines are tagged <c>[name:stdout|stderr]</c>
+	/// to mark provenance; leave it <c>null</c> to relay verbatim (needed when the child's
+	/// stdout is itself a result the caller passes through, e.g. JSON). Where those lines
+	/// surface (console, file, both) is the logger configuration's concern, not this method's:
+	/// attach a console sink to see them, and in MCP mode the logger already routes everything
+	/// to stderr so the JSON-RPC stdout stays clean. The stream events are multicast, so a
+	/// caller can also subscribe <see cref="CaptureOutputs"/> on the same process.
+	/// </summary>
+	private static void LogOutputs(
 		Process process,
-		bool forwardOutputToConsole,
-		bool bufferStdout = true)
+		ProcessStartInfo startInfo,
+		ILogger logger,
+		string? displayName = null,
+		LogLevel stdLevel = _defaultStdLevel,
+		LogLevel errLevel = _defaultErrLevel)
 	{
-		var outputSb = new StringBuilder();
-		var errorSb = new StringBuilder();
+		// e.Data is passed as a value, not folded into the template, so braces in the
+		// payload are safe; displayName (when set) is a known-safe constant tag.
+		void Relay(LogLevel level, string stream, string data)
+		{
+			if (!logger.IsEnabled(level))
+			{
+				return;
+			}
+
+			if (displayName is null)
+			{
+				logger.Log(level, "{Data}", data);
+			}
+			else
+			{
+				logger.Log(level, "[{Name}:{Stream}] {Data}", displayName, stream, data);
+			}
+		}
 
 		if (startInfo.RedirectStandardOutput)
 		{
-			process.OutputDataReceived += (s, e) =>
+			process.OutputDataReceived += (_, e) =>
 			{
-				if (e.Data != null)
+				if (e.Data is not null)
 				{
-					// Skip buffering when the caller discards stdout (e.g. direct mode, where
-					// the CLI can stay alive as ppid guardian for the whole session) — otherwise
-					// the StringBuilder grows unbounded. stderr is always buffered for diagnostics.
-					if (bufferStdout)
-					{
-						outputSb.AppendLine(e.Data);
-					}
-					if (forwardOutputToConsole)
-					{
-						Console.Out.WriteLine(e.Data);
-					}
-					else if (logger.IsEnabled(LogLevel.Debug))
-					{
-						logger.LogDebug("[{DisplayName}:stdout] {Data}", displayName, e.Data);
-					}
+					Relay(stdLevel, "stdout", e.Data);
 				}
 			};
 		}
 
 		if (startInfo.RedirectStandardError)
 		{
-			process.ErrorDataReceived += (s, e) =>
+			process.ErrorDataReceived += (_, e) =>
 			{
-				if (e.Data != null)
+				if (e.Data is not null)
+				{
+					Relay(errLevel, "stderr", e.Data);
+				}
+			};
+		}
+	}
+
+	/// <summary>
+	/// Subscribes buffers to the process's stdout/stderr and returns them, for callers that
+	/// need the captured text after exit (e.g. to log a failure summary). Multicast events,
+	/// so this composes with <see cref="LogOutputs"/> on the same process.
+	/// </summary>
+	private static (StringBuilder output, StringBuilder error) CaptureOutputs(
+		Process process,
+		ProcessStartInfo startInfo)
+	{
+		var outputSb = new StringBuilder();
+		var errorSb = new StringBuilder();
+
+		if (startInfo.RedirectStandardOutput)
+		{
+			process.OutputDataReceived += (_, e) =>
+			{
+				if (e.Data is not null)
+				{
+					outputSb.AppendLine(e.Data);
+				}
+			};
+		}
+
+		if (startInfo.RedirectStandardError)
+		{
+			process.ErrorDataReceived += (_, e) =>
+			{
+				if (e.Data is not null)
 				{
 					errorSb.AppendLine(e.Data);
-					if (forwardOutputToConsole)
-					{
-						Console.Error.WriteLine(e.Data);
-					}
-					else if (logger.IsEnabled(LogLevel.Debug))
-					{
-						logger.LogDebug("[{DisplayName}:stderr] {Data}", displayName, e.Data);
-					}
 				}
 			};
 		}
@@ -252,10 +300,11 @@ internal static class DevServerProcessHelper
 		return (outputSb, errorSb);
 	}
 
-	public static async Task<(int ExitCode, string StdOut, string StdErr)> RunConsoleProcessAsync(
+	public static async Task<int> RunConsoleProcessAsync(
 		ProcessStartInfo startInfo,
 		ILogger logger,
-		bool forwardOutputToConsole = false)
+		LogLevel stdLevel = _defaultStdLevel,
+		LogLevel errLevel = _defaultErrLevel)
 	{
 		logger.LogDebug("Starting host process: {File} {Args}", startInfo.FileName, startInfo.Arguments);
 
@@ -265,7 +314,9 @@ internal static class DevServerProcessHelper
 			EnableRaisingEvents = true
 		};
 
-		var (outputSb, errorSb) = ObserveOutputs(startInfo, "devserver", logger, process, forwardOutputToConsole);
+		// stdout at the caller's level (Information for the passthrough commands whose output
+		// the user asked for, Debug otherwise); stderr at Error. The logger owns where it lands.
+		LogOutputs(process, startInfo, logger, stdLevel: stdLevel, errLevel: errLevel);
 
 		var processExited = new TaskCompletionSource();
 		process.Exited += (_, __) =>
@@ -299,35 +350,16 @@ internal static class DevServerProcessHelper
 		// case some std is blocking the process exit.
 		await Task.WhenAny(process.WaitForExitAsync(), processExited.Task);
 
-		var stdOut = outputSb.ToString();
-		var stdErr = errorSb.ToString();
-
 		if (process.ExitCode != 0)
 		{
 			logger.LogError("Host exited with code {ExitCode}", process.ExitCode);
-			if (!string.IsNullOrWhiteSpace(stdOut))
-			{
-				logger.LogError("Host standard output for troubleshooting:\n{Output}", stdOut);
-			}
-			if (!string.IsNullOrWhiteSpace(stdErr))
-			{
-				logger.LogError("Host error output for troubleshooting:\n{ErrorOutput}", stdErr);
-			}
 		}
 		else
 		{
 			logger.LogInformation("Command completed successfully.");
-			if (!string.IsNullOrWhiteSpace(stdOut))
-			{
-				logger.LogDebug("Host stdout:\n{Output}", stdOut);
-			}
-			if (!string.IsNullOrWhiteSpace(stdErr))
-			{
-				logger.LogDebug("Host stderr:\n{ErrorOutput}", stdErr);
-			}
 		}
 
-		return (process.ExitCode, stdOut, stdErr);
+		return process.ExitCode;
 	}
 
 	/// <summary>
@@ -349,13 +381,13 @@ internal static class DevServerProcessHelper
 			EnableRaisingEvents = true
 		};
 
-		// Forward host stdout/stderr to the CLI console so IDE launchers surface the
-		// running host logs (incl. hot reload), not just the startup banner. Safe:
-		// direct mode is only reachable from `start` (plain stdout); the MCP bridge
-		// spawns via DevServerMonitor, never this path. stdout isn't buffered — it's
-		// discarded here and the session can be long-lived; stderr stays buffered for
-		// the failure diagnostics below.
-		var (_, errorSb) = ObserveOutputs(startInfo, "devserver", logger, process, forwardOutputToConsole: true, bufferStdout: false);
+		// Relay host output through the logger so IDE launchers surface the running host
+		// logs (incl. hot reload), not just the startup banner: stdout at Information (kept
+		// visible — that is the point of direct mode), stderr at Error. Nothing is buffered,
+		// so the long-lived (ppid-guardian) session cannot accumulate memory. The logger owns
+		// the destination — in MCP mode it already routes to stderr, keeping stdout clean for
+		// JSON-RPC (and this path is start-only anyway; the MCP bridge spawns via DevServerMonitor).
+		LogOutputs(process, startInfo, logger, displayName: "devserver", stdLevel: LogLevel.Information);
 
 		process.Start();
 		logger.LogDebug("Started host process: {Pid}", process.Id);
@@ -416,16 +448,12 @@ internal static class DevServerProcessHelper
 				catch { }
 			}
 
-			// stderr was already forwarded live to the console; don't re-dump the whole
-			// buffer here (it only duplicates the output). Still return it so the caller
-			// can decide on a safe-mode retry from the captured error text.
-			var stdErr = errorSb.ToString();
-
+			// Host stderr was already relayed live through the logger; the caller decides on a
+			// safe-mode retry from the failure kind + exit code, not from captured error text.
 			return new DirectSpawnResult(
 				1,
 				died ? DirectSpawnFailure.DiedBeforeReady : DirectSpawnFailure.ReadinessTimeout,
-				died ? process.ExitCode : null,
-				stdErr);
+				died ? process.ExitCode : null);
 		}
 
 		logger.LogInformation("DevServer is ready on port {Port}.", port);
@@ -443,7 +471,7 @@ internal static class DevServerProcessHelper
 				process.Id);
 			await process.WaitForExitAsync();
 			logger.LogDebug("Host process exited with code {ExitCode}.", process.ExitCode);
-			return new DirectSpawnResult(process.ExitCode, DirectSpawnFailure.None, process.ExitCode, errorSb.ToString());
+			return new DirectSpawnResult(process.ExitCode, DirectSpawnFailure.None, process.ExitCode);
 		}
 
 		return DirectSpawnResult.Ready;

--- a/src/Uno.UI.DevServer.Cli/StartCommandHandler.cs
+++ b/src/Uno.UI.DevServer.Cli/StartCommandHandler.cs
@@ -339,8 +339,8 @@ internal sealed class StartCommandHandler
 			_logger.LogWarning(
 				"The DevServer host crashed during startup (exit code {HostExitCode}) before becoming ready — most often a " +
 				"broken add-in dependency. Retrying once in safe mode with add-ins disabled: Hot Reload stays available, " +
-				"but IDE add-ins (Hot Design, Uno Settings) are unavailable for this session. Host error output:\n{StdErr}",
-				result.HostExitCode, result.StdErr);
+				"but IDE add-ins (Hot Design, Uno Settings) are unavailable for this session. See the host output above for details.",
+				result.HostExitCode);
 
 			var safeModeStartInfo = BuildDirectLaunchArgs(
 				hostPath, effectiveParsed, SafeModeAddInsValue, workingDirectory, enableMajorRollForward: enableMajorRollForward);
@@ -355,8 +355,7 @@ internal sealed class StartCommandHandler
 			else
 			{
 				_logger.LogError(
-					"DevServer failed to start even in safe mode, so the crash is not add-in related. Host error output:\n{StdErr}",
-					safeModeResult.StdErr);
+					"DevServer failed to start even in safe mode, so the crash is not add-in related. See the host output above for details.");
 			}
 
 			return safeModeResult.ExitCode;


### PR DESCRIPTION
**GitHub Issue:** closes #23742

## PR Type:

🐞 Bugfix

## What changed? 🚀

The `uno.devserver start` CLI launches the RemoteControl host as a child process
through `RunDirectProcessAsync`. The host's `stdout`/`stderr` was captured into a
buffer but only echoed at `Debug` log level — never written to the CLI's own
console. IDE launchers that capture the CLI's `stdout` (such as the VS Code
extension's output channel) therefore only saw the CLI launcher banner up to
`DevServer is ready on port …`, and none of the running host logs (including Hot
Reload activity).

This change forwards the host's `stdout`/`stderr` to the console in direct mode
(`forwardOutputToConsole: true`), so the full DevServer host output surfaces in
the IDE again.

Why this is safe for the MCP stdio bridge:

- Direct mode only runs for the `start` command, whose `stdout` is a plain output
  stream — not a protocol channel.
- The MCP stdio bridge never reaches this path: it spawns the host via
  `DevServerMonitor`, which keeps `stdout` reserved for the JSON-RPC channel.
- The CLI logger already routes all diagnostics to `stderr` when running in MCP
  mode, keeping `stdout` clean for JSON-RPC.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)