### PR TITLE
refactor(xaml)!: Drop Uno-only IEnumerable on FE/CC (BC65)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3076,6 +3076,11 @@
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnHorizontalContentAlignmentChanged(Microsoft.UI.Xaml.HorizontalAlignment oldHorizontalContentAlignment, Microsoft.UI.Xaml.HorizontalAlignment newHorizontalContentAlignment)" reason="Removed ContentPresenter.OnHorizontalContentAlignmentChanged virtual (BC34, breaking changes for 7.0)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.TextBox.OnVerticalContentAlignmentChanged(Microsoft.UI.Xaml.VerticalAlignment oldVerticalContentAlignment, Microsoft.UI.Xaml.VerticalAlignment newVerticalContentAlignment)" reason="Removed empty TextBox.OnVerticalContentAlignmentChanged override (BC34, breaking changes for 7.0)" />
 
+		  <!-- Uno-only IEnumerable.GetEnumerator on FrameworkElement (enumerated the visual children); WinUI's FrameworkElement is not IEnumerable. ContentControl inherited it and re-declared the interface only. -->
+		  <Member fullName="System.Collections.IEnumerator Microsoft.UI.Xaml.FrameworkElement.GetEnumerator()" reason="Removed Uno-only IEnumerable/GetEnumerator (BC65, breaking changes for 7.0)" />
+
+		  <!-- Uno-only collection-initializer Add(UIElement) on Border/Panel/ScrollViewer, paired with the removed FrameworkElement IEnumerable to enable 'new Panel { child }' markup; WinUI has neither. -->
+		  <Member fullName="System\.Void Microsoft\.UI\.Xaml\.Controls\.(Border|Panel|ScrollViewer)(::|\.)Add\(.+\)" reason="Removed Uno-only collection-initializer Add(UIElement) (BC65, breaking changes for 7.0)" isRegex="true" />
 	  </Methods>
 	  <Events>
 		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -208,7 +208,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [x] **BC13** — Fix `WindowActivatedEventArgs.WindowActivationState` type  `d3·M`
   - See notes.
   - Files: `src/Uno.UI/UI/Xaml/Window/WindowActivatedEventArgs.cs`, `src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/WindowActivationState.cs`, `src/Uno.WinAppSDKSyncGenerator/Helpers/SymbolMatchingHelpers.cs`
-- [ ] **BC65** — `FrameworkElement`/`ContentControl`: drop `IEnumerable`  `d3·S`
+- [x] **BC65** — `FrameworkElement`/`ContentControl`: drop `IEnumerable`  `d3·S`
   - See notes.
   - Files: `src/Uno.UI/UI/Xaml/FrameworkElement.crossruntime.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs`
 - [x] **BC34** — Remove `TextBox.OnVerticalContentAlignmentChanged` override  `d3·S`

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
@@ -286,7 +286,7 @@ public class Given_InputManager
 		var button1 = stackPanel.Children[0] as Button;
 		var button2 = stackPanel.Children[1] as Button;
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 
@@ -332,7 +332,7 @@ public class Given_InputManager
 
 		button1.SetProtectedCursor(InputSystemCursor.Create(InputSystemCursorShape.IBeam));
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 
@@ -373,7 +373,7 @@ public class Given_InputManager
 
 		button1.SetProtectedCursor(InputSystemCursor.Create(InputSystemCursorShape.IBeam));
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 
@@ -420,7 +420,7 @@ public class Given_InputManager
 
 		button1.SetProtectedCursor(InputSystemCursor.Create(InputSystemCursorShape.IBeam));
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 
@@ -465,7 +465,7 @@ public class Given_InputManager
 
 		button1.SetProtectedCursor(InputSystemCursor.Create(InputSystemCursorShape.IBeam));
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 
@@ -518,7 +518,7 @@ public class Given_InputManager
 		var cursor = InputSystemCursor.Create(InputSystemCursorShape.IBeam);
 		button1.SetProtectedCursor(cursor);
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 
@@ -572,7 +572,7 @@ public class Given_InputManager
 
 		button1.SetProtectedCursor(InputSystemCursor.Create(InputSystemCursorShape.IBeam));
 
-		var border = new Border { scrollViewer };
+		var border = new Border { Child = scrollViewer };
 
 		await UITestHelper.Load(border);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Input/Given_UnoFocusInputHandler.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Input/Given_UnoFocusInputHandler.cs
@@ -45,7 +45,7 @@ public class Given_UnoFocusInputHandler
 		var ts2 = new ToggleSwitch();
 		var SUT = new ScrollViewer
 		{
-			new StackPanel
+			Content = new StackPanel
 			{
 				Spacing = 1200,
 				Children =

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -1841,20 +1841,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			Rectangle source, target;
 			var sp = new StackPanel
 			{
-				(source = new Rectangle
+				Children =
 				{
-					Width = 100,
-					Height = 100,
-					Fill = new SolidColorBrush(Microsoft.UI.Colors.LightCoral),
-					CanDrag = true
-				}),
-				(target = new Rectangle
-				{
-					Width = 100,
-					Height = 100,
-					Fill = new SolidColorBrush(Microsoft.UI.Colors.LightCoral),
-					AllowDrop = true
-				})
+					(source = new Rectangle
+					{
+						Width = 100,
+						Height = 100,
+						Fill = new SolidColorBrush(Microsoft.UI.Colors.LightCoral),
+						CanDrag = true
+					}),
+					(target = new Rectangle
+					{
+						Width = 100,
+						Height = 100,
+						Fill = new SolidColorBrush(Microsoft.UI.Colors.LightCoral),
+						AllowDrop = true
+					})
+				}
 			};
 
 			target.Drop += (_, _) => dropCount++;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -4860,7 +4860,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Height = 100,
 				Background = new SolidColorBrush(Colors.Pink),
 			};
-			var setup = new StackPanel { border, SUT };
+			var setup = new StackPanel { Children = { border, SUT } };
 
 			await UITestHelper.Load(setup, x => x.IsLoaded && SUT.ContainerFromIndex(2) is { });
 			await WindowHelper.WaitForIdle();
@@ -5779,8 +5779,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 							ItemsSource = Enumerable.Range(0, 200).Select(x => $"asd {x}"),
 							HeaderTemplate = new DataTemplate(() => new StackPanel
 							{
-								new TextBlock() { Text = "header" },
-								new TextBlock().Apply(x => x.SetBinding(TextBlock.TextProperty, new Binding())),
+								Children =
+								{
+									new TextBlock() { Text = "header" },
+									new TextBlock().Apply(x => x.SetBinding(TextBlock.TextProperty, new Binding())),
+								}
 							}.Apply(x => x.DataContextChanged += (s, e) => LvHeaderDcChanged?.Invoke(s, e))),
 						}.Apply(x => Grid.SetRow(x, 1)),
 					},

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -255,8 +255,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await UITestHelper.Load(new StackPanel
 			{
-				expected,
-				SUT
+				Children =
+				{
+					expected,
+					SUT
+				}
 			});
 
 			Action OnFrameRendered = async () =>
@@ -1048,8 +1051,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await UITestHelper.Load(new StackPanel
 			{
-				textbox,
-				textblock
+				Children =
+				{
+					textbox,
+					textblock
+				}
 			});
 
 			for (int i = 0; i < 5; i++)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4130,8 +4130,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var sp = new StackPanel()
 			{
-				SUT,
-				new TextBox() { Text="focus dummy" }
+				Children =
+				{
+					SUT,
+					new TextBox() { Text="focus dummy" }
+				}
 			};
 
 			WindowHelper.WindowContent = sp;

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.cs
@@ -10,7 +10,6 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Markup;
 using Uno.UI.Xaml;
 using Color = System.Drawing.Color;
-using View = Microsoft.UI.Xaml.UIElement;
 using _Debug = System.Diagnostics.Debug;
 
 using RadialGradientBrush = Microsoft.UI.Xaml.Media.RadialGradientBrush;
@@ -42,21 +41,6 @@ public partial class Border : FrameworkElement
 #if UNO_HAS_BORDER_VISUAL
 	private protected override ContainerVisual CreateElementVisual() => Compositor.GetSharedCompositor().CreateBorderVisual();
 #endif
-
-	/// <summary>
-	/// Support for the C# collection initializer style.
-	/// Allows items to be added like this
-	/// new Border
-	/// {
-	///    new Border()
-	/// }
-	/// </summary>
-	/// <param name="view"></param>
-	public
-		void Add(View view)
-	{
-		Child = VisualTreeHelper.TryAdaptNative(view);
-	}
 
 	protected override bool IsSimpleLayout => true;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -8,7 +8,6 @@ using Uno.Foundation.Logging;
 using Uno.UI;
 using Uno.UI.DataBinding;
 using Microsoft.UI.Xaml.Media.Animation;
-using System.Collections;
 using System.Linq;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Markup;
@@ -19,7 +18,7 @@ using View = Microsoft.UI.Xaml.UIElement;
 namespace Microsoft.UI.Xaml.Controls
 {
 	[ContentProperty(Name = nameof(Content))]
-	public partial class ContentControl : Control, IEnumerable
+	public partial class ContentControl : Control
 	{
 		private View? _contentTemplateRoot;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
@@ -265,17 +265,4 @@ public partial class Panel : FrameworkElement, IPanel
 	private void UpdateBorder() => _borderRenderer.Update();
 #endif
 
-	/// <summary>        
-	/// Support for the C# collection initializer style.
-	/// Allows items to be added like this 
-	/// new Panel 
-	/// {
-	///    new Border()
-	/// }
-	/// </summary>
-	/// <param name="view"></param>
-	public
-	void Add(
-		UIElement view
-		) => Children.Add(view);
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -929,20 +929,6 @@ namespace Microsoft.UI.Xaml.Controls
 			};
 #endif
 
-		/// <summary>
-		/// Sets the content of the ScrollViewer
-		/// </summary>
-		/// <param name="view"></param>
-		/// <remarks>Used in the context of member initialization</remarks>
-		public
-#if !UNO_REFERENCE_API && !IS_UNIT_TESTS
-			new
-#endif
-			void Add(View view)
-		{
-			Content = view;
-		}
-
 		protected override void OnApplyTemplate()
 		{
 			// Cleanup previous template

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.crossruntime.cs
@@ -14,7 +14,6 @@ using Uno.Foundation.Logging;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
 using View = Microsoft.UI.Xaml.UIElement;
-using System.Collections;
 using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI;
@@ -24,7 +23,7 @@ using System.Dynamic;
 
 namespace Microsoft.UI.Xaml
 {
-	public partial class FrameworkElement : IEnumerable
+	public partial class FrameworkElement
 	{
 #pragma warning disable CS0067 // Unused only in reference API.
 		public event SizeChangedEventHandler SizeChanged;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.reference.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.reference.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Uno.Collections;
@@ -10,7 +9,7 @@ using View = Microsoft.UI.Xaml.UIElement;
 
 namespace Microsoft.UI.Xaml
 {
-	public partial class FrameworkElement : IEnumerable
+	public partial class FrameworkElement
 	{
 
 		public string Name { get; set; }
@@ -34,7 +33,6 @@ namespace Microsoft.UI.Xaml
 		internal void SuspendRendering() => throw new NotSupportedException("Reference assembly");
 
 		internal void ResumeRendering() => throw new NotSupportedException();
-		public IEnumerator GetEnumerator() => _children.GetEnumerator();
 
 #pragma warning disable 67
 #pragma warning disable IDE0051

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
@@ -3,7 +3,6 @@
 #endif
 
 using System;
-using System.Collections;
 using Uno.UI;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml;
@@ -11,7 +10,7 @@ using Windows.Foundation;
 
 namespace Microsoft.UI.Xaml
 {
-	public partial class FrameworkElement : IEnumerable
+	public partial class FrameworkElement
 	{
 		protected FrameworkElement()
 		{
@@ -27,7 +26,6 @@ namespace Microsoft.UI.Xaml
 		internal void SuspendRendering() => throw new NotSupportedException();
 
 		internal void ResumeRendering() => throw new NotSupportedException();
-		public IEnumerator GetEnumerator() => _children.GetEnumerator();
 
 		#region Name Dependency Property
 


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

`FrameworkElement` and `ContentControl` implemented **`System.Collections.IEnumerable`** in Uno — a Uno-only divergence WinUI does not have. On `FrameworkElement` it was paired with public `Add(...)` methods on `Border`, `Panel`, and `ScrollViewer` to enable C#-markup collection-initializer syntax (`new StackPanel { child1, child2 }`, `new Border { child }`). WinUI has **neither** the interface nor those `Add` methods.

This PR (**BC65** of the Phase 5 breaking-changes wave) removes the whole Uno-only surface for WinUI parity (ground rule #2 — remove divergences, don't preserve intermediate Uno-only shapes):

- **`FrameworkElement`** — dropped `: IEnumerable` (`FrameworkElement.crossruntime.cs`, `.skia.cs`, `.reference.cs`) and the public `IEnumerator GetEnumerator()` (`.skia.cs`, `.reference.cs`).
- **`ContentControl`** — dropped the redundant `: IEnumerable` re-declaration (it had no own `GetEnumerator`; it inherited FrameworkElement's).
- **`Border` / `Panel` / `ScrollViewer`** — removed the now-orphaned public `Add(UIElement)` collection-initializer helpers (they only had meaning together with the `IEnumerable`).

### Migration

Collection-initializer child syntax moves to the explicit content/children property:

| Before | After |
|---|---|
| `new StackPanel { a, b }` | `new StackPanel { Children = { a, b } }` |
| `new Border { child }` | `new Border { Child = child }` |
| `new ScrollViewer { content }` | `new ScrollViewer { Content = content }` |

All 14 in-repo call sites (in `Uno.UI.RuntimeTests`) were migrated accordingly. `foreach`/LINQ over a `FrameworkElement`'s visual children (which the `IEnumerable` also allowed) should use `VisualTreeHelper` or the control's own children collection instead.

**Validation:**
- **Compile (Skia RID = desktop + Skia-on-WASM):** `SamplesApp.Skia.Generic` (net10.0) builds clean, transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, and all samples — 0 warnings / 0 errors. SamplesApp had **no** bare-collection-init usages. Framework build surfaced **no** direct `.Add()` callers.
- **Native/WASM:** the native-WASM-DOM sample app no longer exists (the live WASM head is Skia-on-WASM, covered above); a sweep of all `.Android.cs` / `.iOS.cs` / `.UIKit.cs` / `.wasm.cs` / `.reference.cs` files found no element `.Add()` callers or bare-collection-init, so native heads keep compiling.
- **Runtime (Skia Desktop):** 33/33 pass across `Given_ThemeResource` (15), `Given_FrameworkElement_ThemeResources`, `Given_ContentControl`, plus the migrated `Given_UIElement`/`Given_UnoFocusInputHandler` cases. This specifically guards the `EnterProperties`/`LeaveProperties` namescope/theme walk: a detached `FrameworkElement` set as a property value used to *also* match `is IEnumerable` there and have its visual children iterated — an accidental divergence from the WinUI code being ported (WinUI's `FrameworkElement` isn't `IEnumerable`, so that branch only ever handled genuine DO-collections). Removal aligns Uno with WinUI; theme/namescope propagation is unchanged (children still enter via the visual walk on activation).

`PackageDiffIgnore.xml` (6.5 baseline) gets two entries for the removed declared members: `FrameworkElement.GetEnumerator()` and the `Border`/`Panel`/`ScrollViewer` `Add(UIElement)` methods. The interface-list change itself isn't tracked by the gate.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — **N/A**: not a behaviour change; existing theme/content/namescope tests exercise the affected Enter/Leave path and were run as regression guards, and the 14 migrated tests confirm the markup change is behaviour-preserving.
- [ ] 📚 Docs have been added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** `FrameworkElement`/`ContentControl` no longer implement `IEnumerable`. C#-markup collection-initializer child syntax (`new Panel { child }`, `new Border { child }`, `new ScrollViewer { content }`) no longer compiles, and the public `Add(UIElement)` helpers on `Border`/`Panel`/`ScrollViewer` are gone. `foreach`/LINQ directly over a `FrameworkElement` no longer compiles.
- **Migration:** Use the explicit content property in initializers — `Children = { … }` for panels, `Child = …` for `Border`, `Content = …` for `ScrollViewer` (see the table above). For enumerating children, use `VisualTreeHelper` or the panel's `Children`. This matches WinUI, whose `FrameworkElement`/`ContentControl` were never `IEnumerable`.
