### PR TITLE
refactor(window)!: Retype WindowActivationState to WinUI (BC13)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2546,6 +2546,9 @@
 		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)TemplatedParentProperty\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
 		  <!-- ColorKeyFrameCollection carried a binary-compat 'new'-shadow block (Size/Count/IsReadOnly/indexer) that its zero-shadow siblings Double/ObjectKeyFrameCollection never had; the get-only base DependencyObjectCollection<T> members show through with identical behavior. Accessor methods are paired in <Methods> below. -->
 		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.ColorKeyFrameCollection(::|\.)(Size|Count|IsReadOnly|Item)\(.*\)" reason="Removed ColorKeyFrameCollection binary-compat shadow members; provided by base DependencyObjectCollection&lt;T&gt; (BC67, breaking changes for 7.0)" isRegex="true" />
+
+		  <!-- WindowActivatedEventArgs.WindowActivationState retyped from the Uno-only Windows.UI.Core.CoreWindowActivationState to the WinUI Microsoft.UI.Xaml.WindowActivationState; the old-typed property reads as removed (getter accessor paired in <Methods> below). -->
+		  <Member fullName="Windows.UI.Core.CoreWindowActivationState Microsoft.UI.Xaml.WindowActivatedEventArgs::WindowActivationState()" reason="Retyped WindowActivationState to Microsoft.UI.Xaml.WindowActivationState (BC13, breaking changes for 7.0)" />
 	  </Properties>
 
 	  <Methods>
@@ -2964,6 +2967,9 @@
 
 		  <!-- No-op AdjustArrange(Size) (always returned its input) declared on the internal IFrameworkElement; publicly surfaced only as this implicit implementation on FrameworkElement. The lone caller in the legacy Layouter path is inlined. -->
 		  <Member fullName="Windows.Foundation.Size Microsoft.UI.Xaml.FrameworkElement.AdjustArrange(Windows.Foundation.Size finalSize)" reason="Removed no-op AdjustArrange (BC70, breaking changes for 7.0)" />
+
+		  <!-- WindowActivatedEventArgs.WindowActivationState getter accessor retyped from the Uno-only Windows.UI.Core.CoreWindowActivationState to the WinUI Microsoft.UI.Xaml.WindowActivationState; the old-typed getter reads as removed (property paired in <Properties> above). -->
+		  <Member fullName="Windows.UI.Core.CoreWindowActivationState Microsoft.UI.Xaml.WindowActivatedEventArgs.get_WindowActivationState()" reason="Retyped WindowActivationState to Microsoft.UI.Xaml.WindowActivationState (BC13, breaking changes for 7.0)" />
 	  </Methods>
 
 	  <Events>

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -205,7 +205,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC73** — `TimePickerFlyoutPresenter` -> `Control` base  `d3·S`
   - Reparent to match WinUI.
   - Files: `src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.cs`, `src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.Properties.cs`, `src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyoutPresenter.partial.mux.cs`
-- [ ] **BC13** — Fix `WindowActivatedEventArgs.WindowActivationState` type  `d3·M`
+- [x] **BC13** — Fix `WindowActivatedEventArgs.WindowActivationState` type  `d3·M`
   - See notes.
   - Files: `src/Uno.UI/UI/Xaml/Window/WindowActivatedEventArgs.cs`, `src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/WindowActivationState.cs`, `src/Uno.WinAppSDKSyncGenerator/Helpers/SymbolMatchingHelpers.cs`
 - [ ] **BC65** — `FrameworkElement`/`ContentControl`: drop `IEnumerable`  `d3·S`

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -155,7 +155,7 @@ namespace UITests.Windows_UI_Core
 			)
 		{
 #if !WINAPPSDK
-			CoreWindowActivationState = e.WindowActivationState;
+			CoreWindowActivationState = (Windows.UI.Core.CoreWindowActivationState)e.WindowActivationState;
 #endif
 			AddHistory("Window.Activated");
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -235,7 +235,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		// Sticky active-owner tracking (FR-007, research Decision 3): update on
 		// Activated (WA_ACTIVE / NSWindowDidBecomeMainNotification analog), never
 		// clear on Deactivated.
-		if (args.WindowActivationState != Windows.UI.Core.CoreWindowActivationState.Deactivated &&
+		if (args.WindowActivationState != Microsoft.UI.Xaml.WindowActivationState.Deactivated &&
 			_accessibility is not null)
 		{
 			AccessibilityRouter.SetActive(this);

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -763,7 +763,7 @@ public class Given_AlcContentHost
 		alcWindow.Activated += (sender, args) =>
 		{
 			activatedFired = true;
-			activationState = args.WindowActivationState;
+			activationState = (Windows.UI.Core.CoreWindowActivationState)args.WindowActivationState;
 		};
 
 		alcWindow.Activate();
@@ -785,7 +785,7 @@ public class Given_AlcContentHost
 		alcWindow.Activated += (sender, args) =>
 		{
 			activatedFired = true;
-			activationState = args.WindowActivationState;
+			activationState = (Windows.UI.Core.CoreWindowActivationState)args.WindowActivationState;
 		};
 
 		alcWindow.Activate();
@@ -807,7 +807,7 @@ public class Given_AlcContentHost
 		alcWindow.Activated += (sender, args) =>
 		{
 			activatedFired = true;
-			activationState = args.WindowActivationState;
+			activationState = (Windows.UI.Core.CoreWindowActivationState)args.WindowActivationState;
 		};
 
 		ApplyDeferredContentFromSecondaryApp();
@@ -832,7 +832,7 @@ public class Given_AlcContentHost
 		alcWindow.Activated += (sender, args) =>
 		{
 			activatedFired = true;
-			activationState = args.WindowActivationState;
+			activationState = (Windows.UI.Core.CoreWindowActivationState)args.WindowActivationState;
 		};
 
 		ApplyDeferredContentFromSecondaryApp();

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/WindowActivationState.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/WindowActivationState.cs
@@ -3,18 +3,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml
 {
-#if __SKIA__ || __NETSTD_REFERENCE__
+#if false || false
 	public enum WindowActivationState
 	{
-#if __SKIA__ || __NETSTD_REFERENCE__
-		CodeActivated = 0,
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		Deactivated = 1,
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		PointerActivated = 2,
-#endif
+		// Skipping already declared field Microsoft.UI.Xaml.WindowActivationState.CodeActivated
+		// Skipping already declared field Microsoft.UI.Xaml.WindowActivationState.Deactivated
+		// Skipping already declared field Microsoft.UI.Xaml.WindowActivationState.PointerActivated
 	}
 #endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -231,7 +231,7 @@ namespace Microsoft.UI.Xaml.Controls
 					{
 						CoreWindowActivationState state =
 							CoreWindowActivationState.CodeActivated;
-						state = (args.WindowActivationState);
+						state = (CoreWindowActivationState)args.WindowActivationState;
 
 						if (state == CoreWindowActivationState.CodeActivated
 							|| state == CoreWindowActivationState.PointerActivated)

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -244,7 +244,7 @@ internal abstract partial class BaseWindowImplementation : IWindowImplementation
 		}
 
 		_lastActivationState = state;
-		var activatedEventArgs = new WindowActivatedEventArgs(state);
+		var activatedEventArgs = new WindowActivatedEventArgs((WindowActivationState)state);
 		// There are two "versions" of WindowActivatedEventArgs in Uno currently
 		// when using WinUI, we need to use "legacy" version to work with CoreWindow
 		// (which will eventually be removed as a legacy API as well.

--- a/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.alc.cs
@@ -275,7 +275,7 @@ partial class Window
 			throw new InvalidOperationException("Cannot activate a closed window.");
 		}
 
-		_windowImplementation.RaiseActivated(new WindowActivatedEventArgs(CoreWindowActivationState.CodeActivated));
+		_windowImplementation.RaiseActivated(new WindowActivatedEventArgs(WindowActivationState.CodeActivated));
 	}
 
 	/// <summary>

--- a/src/Uno.UI/UI/Xaml/Window/WindowActivatedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Window/WindowActivatedEventArgs.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
-using Windows.UI.Core;
 
 namespace Microsoft.UI.Xaml;
 
@@ -10,7 +9,7 @@ namespace Microsoft.UI.Xaml;
 /// </summary>
 public sealed partial class WindowActivatedEventArgs
 {
-	internal WindowActivatedEventArgs(CoreWindowActivationState windowActivationState)
+	internal WindowActivatedEventArgs(WindowActivationState windowActivationState)
 	{
 		WindowActivationState = windowActivationState;
 	}
@@ -23,5 +22,5 @@ public sealed partial class WindowActivatedEventArgs
 	/// <summary>
 	/// Gets the activation state of the window at the time the Activated event was raised.
 	/// </summary>
-	public CoreWindowActivationState WindowActivationState { get; }
+	public WindowActivationState WindowActivationState { get; }
 }

--- a/src/Uno.UI/UI/Xaml/Window/WindowActivationState.cs
+++ b/src/Uno.UI/UI/Xaml/Window/WindowActivationState.cs
@@ -1,0 +1,23 @@
+namespace Microsoft.UI.Xaml
+{
+	/// <summary>
+	/// Specifies the set of reasons that a window's Activated event was raised.
+	/// </summary>
+	public enum WindowActivationState
+	{
+		/// <summary>
+		/// The window was activated by a call to Activate.
+		/// </summary>
+		CodeActivated,
+
+		/// <summary>
+		/// The window was deactivated.
+		/// </summary>
+		Deactivated,
+
+		/// <summary>
+		/// The window was activated by pointer interaction.
+		/// </summary>
+		PointerActivated,
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Window/WindowChrome.cs
+++ b/src/Uno.UI/UI/Xaml/Window/WindowChrome.cs
@@ -92,7 +92,7 @@ internal sealed partial class WindowChrome : ContentControl
 		// See: https://github.com/unoplatform/uno/issues/21688
 		DefaultBrushes.ResetDefaultThemeBrushes();
 		this.SetValue(ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
-		if (e.WindowActivationState is Windows.UI.Core.CoreWindowActivationState.CodeActivated or Windows.UI.Core.CoreWindowActivationState.PointerActivated)
+		if (e.WindowActivationState is WindowActivationState.CodeActivated or WindowActivationState.PointerActivated)
 		{
 			VisualStateManager.GoToState(this, "Normal", true);
 		}

--- a/src/Uno.WinAppSDKSyncGenerator/Helpers/SymbolMatchingHelpers.cs
+++ b/src/Uno.WinAppSDKSyncGenerator/Helpers/SymbolMatchingHelpers.cs
@@ -187,12 +187,6 @@ internal static class SymbolMatchingHelpers
 
 	private static bool ArePropertiesMatching(IPropertySymbol uapProperty, IPropertySymbol unoProperty)
 	{
-		if (uapProperty.Name == "WindowActivationState" && uapProperty.ContainingType.Name == "WindowActivatedEventArgs")
-		{
-			// TODO: Match API with WinUI.
-			return true;
-		}
-
 		if (uapProperty.Name == "Name" && uapProperty.ContainingType.Name == "FrameworkElement")
 		{
 			// TODO: Name shouldn't be virtual.


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

`Microsoft.UI.Xaml.WindowActivatedEventArgs.WindowActivationState` was typed as the Uno-only **`Windows.UI.Core.CoreWindowActivationState`**. WinUI types it as **`Microsoft.UI.Xaml.WindowActivationState`**. This PR (**BC13** of the Phase 5 breaking-changes wave) retypes the property (and the internal constructor) to the WinUI enum.

The two enums are value-identical (`CodeActivated=0`, `Deactivated=1`, `PointerActivated=2`), so no runtime behaviour changes — only the public type.

Details:
- **New hand-written enum** `Microsoft.UI.Xaml.WindowActivationState` (`src/Uno.UI/UI/Xaml/Window/WindowActivationState.cs`), available on **all** platforms. The previous definition was a generated stub gated to `__SKIA__ || __NETSTD_REFERENCE__` only, so it couldn't back a cross-platform property. Following the "move out of `Generated/`" convention, the enum is now hand-written; the generated stub is set to the disabled `#if false` form the sync generator emits for hand-written enums (mirrors `ElementTheme`/`FocusState`).
- **`WindowActivatedEventArgs`** — property + internal ctor retyped.
- **Producers** (`BaseWindowImplementation`, `Window.alc.cs`) — the internal/native plumbing stays on `CoreWindowActivationState`; the value is cast to `WindowActivationState` at the public-args boundary (value-preserving).
- **Consumers** — `WindowChrome`, `DatePicker` (Uno-specific activation hook), `MacOSWindowHost`, the `Given_AlcContentHost` ALC tests, and the `WindowActivationTests` sample updated to the new type / value-preserving cast.
- **Parity shim removed** — the `SymbolMatchingHelpers` special-case that forced the WinUI-parity check to pass for this property (`// TODO: Match API with WinUI`) is deleted; the check now validates the real (matching) shape.

**Validation:**
- **Compile:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean, transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, samples, and the Skia runtimes (incl. `Uno.UI.Runtime.Skia.MacOS`). Reference build validated separately (the API-contract compilation). Native heads are safe **by construction** — the enum is now defined unconditionally, so no native head loses the type. (Native Android/iOS not built locally; stated, not implied.)
- **Runtime (Skia Desktop):** `Given_AlcContentHost` activation tests pass — they raise `Window.Activated`, read `args.WindowActivationState`, and assert `CodeActivated`, exercising the producer cast end-to-end. Value-identical retype ⇒ pass-after regression guards.
- The `Uno.WinAppSDKSyncGenerator` project targets .NET 11 (SDK not available locally); the shim removal is a mechanical block deletion — CI's parity gate validates it.

`PackageDiffIgnore.xml` (6.5 baseline) gets one entry for the retyped getter (`get_WindowActivationState()` return type changed ⇒ old signature reads as removed).

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — **N/A**: not a behaviour change; existing `Given_AlcContentHost` activation tests exercise the path and were run as regression guards.
- [ ] 📚 Docs have been added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** `WindowActivatedEventArgs.WindowActivationState` now returns `Microsoft.UI.Xaml.WindowActivationState` instead of `Windows.UI.Core.CoreWindowActivationState`. Code that assigned it to a `CoreWindowActivationState` variable or compared against `CoreWindowActivationState.*` members no longer compiles.
- **Migration:** Use `Microsoft.UI.Xaml.WindowActivationState` and its `CodeActivated`/`Deactivated`/`PointerActivated` members. The enum values are unchanged, so a value-preserving cast (`(CoreWindowActivationState)args.WindowActivationState`) bridges any code that must stay on the legacy type. This matches WinUI.
