### PR TITLE
fix(hot-reload): report browserwasm from the skia client flavor running in the browser

### DIFF
--- a/specs/047-hotreload-workspace-single-tfm/spec.md
+++ b/specs/047-hotreload-workspace-single-tfm/spec.md
@@ -74,7 +74,11 @@ captured from MSBuild at build time.
 - The `Uno.UI.RemoteControl` client ships per-flavor (`netcoremobile`, `Skia`, `Wasm`,
   `Reference`), so the **platform identifier** is compile-time knowledge of the client
   assembly (`android` / `ios` / `tvos` / `maccatalyst` / `browserwasm` / skia-desktop), and
-  the **framework version** comes from the runtime (`Environment.Version`).
+  the **framework version** comes from the runtime (`Environment.Version`). One exception:
+  the skia flavor serves every skia-rendering head — desktop **and** browser
+  (`netX.0-browserwasm` with the skia renderer) — so it completes the compile-time knowledge
+  with a runtime check (`OperatingSystem.IsBrowser()` → `browserwasm`, otherwise the
+  skia-desktop pseudo-platform).
 - The value is a *normalized runtime descriptor*, not a raw TFM string reconstruction —
   the skia client cannot (and must not) guess whether the head TFM was spelled
   `net10.0-desktop` or `net10.0`; the matching rules below treat those as equivalent.

--- a/src/Uno.HotReload.Tests/Utils/Given_RuntimeTargetFrameworkMatching.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_RuntimeTargetFrameworkMatching.cs
@@ -43,6 +43,9 @@ public sealed class Given_RuntimeTargetFrameworkMatching
 	[DataRow("net10.0-android", "net10.0-android36.0", true)]
 	[DataRow("net10.0-ios", "net10.0-ios26.0", true)]
 	[DataRow("net10.0-IOS", "net10.0-ios26.0", true)]
+	// A browser app reports browserwasm (runtime-detected in the skia client flavor) and must
+	// select the browserwasm head flavor — never the desktop one.
+	[DataRow("net10.0-browserwasm", "net10.0-browserwasm", true)]
 	// The skia pseudo-platform designates the desktop family — both spellings.
 	[DataRow("net10.0-skia", "net10.0-desktop", true)]
 	[DataRow("net10.0-skia", "net10.0", true)]

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -145,7 +145,8 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 	/// <summary>
 	/// Composes the target framework the application is running on, from data available at
 	/// runtime only: the platform is compile-time knowledge of this (per-flavor) client
-	/// assembly, the framework version comes from the application assembly's
+	/// assembly (except for the skia flavor, which serves several runtimes and completes the
+	/// picture with a runtime check), the framework version comes from the application assembly's
 	/// <see cref="System.Runtime.Versioning.TargetFrameworkAttribute"/> (falling back to the
 	/// runtime version). This intentionally does NOT rely on MSBuild property capture, so it
 	/// stays correct regardless of how the IDE orchestrated the build.
@@ -169,7 +170,7 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 
 		frameworkVersion ??= Environment.Version;
 
-		const string platform =
+		var platform =
 #if __ANDROID__ || ANDROID
 			"android";
 #elif __TVOS__ || TVOS
@@ -179,12 +180,16 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 #elif __IOS__ || IOS
 			"ios";
 #elif __WASM__
+			// The (legacy) native-rendering wasm flavor of this assembly only serves browser heads.
 			"browserwasm";
 #else
-			// The skia flavor of this assembly serves both `netX.0-desktop` and plain `netX.0`
-			// heads and cannot tell them apart; the server treats this pseudo-platform as
-			// matching either spelling.
-			"skia";
+			// The skia flavor of this assembly is compiled for the plain `netX.0` TFM and serves
+			// every skia-rendering head that resolves the `skia` uno-runtime folder — desktop AND
+			// browser (`netX.0-browserwasm` with the skia renderer, the modern default). The
+			// browser case is only distinguishable at runtime. For desktop, the flavor still
+			// cannot tell `netX.0-desktop` from a plain `netX.0` head, so it reports the `skia`
+			// pseudo-platform which the server treats as matching either spelling.
+			OperatingSystem.IsBrowser() ? "browserwasm" : "skia";
 #endif
 
 		return $"net{frameworkVersion.Major}.{frameworkVersion.Minor}-{platform}";


### PR DESCRIPTION
**GitHub Issue:** _Follow-up to #23692 — WebAssembly regression of the workspace target-framework scoping (no separate public issue)._

closes https://github.com/unoplatform/uno-private/issues/2211

## PR Type:

🐞 Bugfix

## What changed? 🚀

With #23692, the dev-server restricts the hot-reload workspace to the target framework the running
application reports. On **WebAssembly with the Skia renderer** (the modern default), that report was
wrong: the app loads the **skia flavor** of `Uno.UI.RemoteControl` (the `Skia.WebAssembly.Browser`
runtime sets `UnoUIRuntimeIdentifier=Skia`, so the `uno-runtime/<tfm>/skia` assemblies are used),
which is compiled for the plain `netX.0` TFM **without** `__WASM__`. Its compile-time platform
knowledge therefore reported `netX.0-skia` even when running in the browser — and the dev-server
mapped that to the skia-**desktop** family, restricting the workspace to the `netX.0-desktop` flavor
while the application was actually running `netX.0-browserwasm`. Observed as the hot-reload
processor initializing with `net10.0-desktop` for a WASM app.

The skia client flavor now completes its compile-time knowledge with a **runtime check**:
`OperatingSystem.IsBrowser()` → report `browserwasm`, otherwise keep reporting the skia-desktop
pseudo-platform (it still cannot — and must not — guess whether a desktop head is spelled
`netX.0-desktop` or plain `netX.0`).

- The mobile (`netcoremobile`) and legacy native-rendering wasm flavors are per-TFM builds with
  unambiguous defines — unchanged.
- The server side was already correct: browserwasm head flavors define `__WASM__`, so
  `TryGetTargetFramework` resolves them and the reported descriptor now matches exactly.
- Spec 047 amended (the platform identifier is compile-time knowledge *except* for the skia flavor).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — matcher case added (`net10.0-browserwasm` ↔ `net10.0-browserwasm`); the `OperatingSystem.IsBrowser()` branch itself requires an in-browser run and is validated manually on a WASM head.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — internal spec update only; no user-facing docs.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no UI change.
- [x] ❗ Contains **NO** breaking changes — client-side reporting fix, protocol unchanged.
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)