### PR TITLE
refactor(controls)!: Remove no-op OnVerticalContentAlignmentChanged (BC34)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3071,6 +3071,11 @@
 		  <!-- ImageBrush->TileBrush reparent accessors (paired with the <Properties> entry above): get_/set_ for AlignmentX/AlignmentY/Stretch and the get_ DP-field accessors, now inherited from TileBrush. -->
 		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.ImageBrush(::|\.)(get_AlignmentX|set_AlignmentX|get_AlignmentY|set_AlignmentY|get_Stretch|set_Stretch|get_AlignmentXProperty|get_AlignmentYProperty|get_StretchProperty)\(.*\)" reason="Moved AlignmentX/AlignmentY/Stretch owner from ImageBrush to TileBrush base for WinUI parity (breaking changes for 7.0, uno#8339)" isRegex="true" />
 
+		  <!-- On[Vertical|Horizontal]ContentAlignmentChanged removed: the empty TextBox override and the ContentPresenter base virtuals. All no-ops (the ...Partial hooks were never implemented); layout is still driven by the AffectsArrange metadata option. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnVerticalContentAlignmentChanged(Microsoft.UI.Xaml.VerticalAlignment oldVerticalContentAlignment, Microsoft.UI.Xaml.VerticalAlignment newVerticalContentAlignment)" reason="Removed ContentPresenter.OnVerticalContentAlignmentChanged virtual (BC34, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnHorizontalContentAlignmentChanged(Microsoft.UI.Xaml.HorizontalAlignment oldHorizontalContentAlignment, Microsoft.UI.Xaml.HorizontalAlignment newHorizontalContentAlignment)" reason="Removed ContentPresenter.OnHorizontalContentAlignmentChanged virtual (BC34, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.TextBox.OnVerticalContentAlignmentChanged(Microsoft.UI.Xaml.VerticalAlignment oldVerticalContentAlignment, Microsoft.UI.Xaml.VerticalAlignment newVerticalContentAlignment)" reason="Removed empty TextBox.OnVerticalContentAlignmentChanged override (BC34, breaking changes for 7.0)" />
+
 	  </Methods>
 	  <Events>
 		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -211,8 +211,8 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC65** — `FrameworkElement`/`ContentControl`: drop `IEnumerable`  `d3·S`
   - See notes.
   - Files: `src/Uno.UI/UI/Xaml/FrameworkElement.crossruntime.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs`
-- [ ] **BC34** — Remove `TextBox.OnVerticalContentAlignmentChanged` override  `d3·S`
-  - Delete the `TextBox` override; make base `OnVerticalContentAlignmentChanged` `private protected`.
+- [x] **BC34** — Remove `TextBox.OnVerticalContentAlignmentChanged` override  `d3·S`
+  - Delete the empty `TextBox` override and the `ContentPresenter` base virtual (both no-ops; layout stays driven by `AffectsArrange`).
   - Files: `src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs`, `src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs`
 - [x] **BC36** — `ContentPresenter.ContentTemplateRoot` -> internal  `d3·S` · #16148
   - Make `internal` (not `private` — in-assembly callers read it cross-type).

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -481,17 +481,9 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 			typeof(ContentPresenter),
 			new FrameworkPropertyMetadata(
 				HorizontalAlignment.Stretch,
-				FrameworkPropertyMetadataOptions.AffectsArrange,
-				(s, e) => ((ContentPresenter)s)?.OnHorizontalContentAlignmentChanged((HorizontalAlignment)e.OldValue, (HorizontalAlignment)e.NewValue)
+				FrameworkPropertyMetadataOptions.AffectsArrange
 			)
 		);
-
-	protected virtual void OnHorizontalContentAlignmentChanged(HorizontalAlignment oldHorizontalContentAlignment, HorizontalAlignment newHorizontalContentAlignment)
-	{
-		OnHorizontalContentAlignmentChangedPartial(oldHorizontalContentAlignment, newHorizontalContentAlignment);
-	}
-
-	partial void OnHorizontalContentAlignmentChangedPartial(HorizontalAlignment oldHorizontalContentAlignment, HorizontalAlignment newHorizontalContentAlignment);
 
 	#endregion
 
@@ -510,17 +502,9 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 			typeof(ContentPresenter),
 			new FrameworkPropertyMetadata(
 				VerticalAlignment.Stretch,
-				FrameworkPropertyMetadataOptions.AffectsArrange,
-				(s, e) => ((ContentPresenter)s)?.OnVerticalContentAlignmentChanged((VerticalAlignment)e.OldValue, (VerticalAlignment)e.NewValue)
+				FrameworkPropertyMetadataOptions.AffectsArrange
 			)
 		);
-
-	protected virtual void OnVerticalContentAlignmentChanged(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment)
-	{
-		OnVerticalContentAlignmentChangedPartial(oldVerticalContentAlignment, newVerticalContentAlignment);
-	}
-
-	partial void OnVerticalContentAlignmentChangedPartial(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment);
 
 	#endregion
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -1353,10 +1353,6 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public override string GetAccessibilityInnerText() => Text;
 
-		// TODO: Remove as a breaking change for Uno 6
-		// Also, make OnVerticalContentAlignmentChanged private protected.
-		protected override void OnVerticalContentAlignmentChanged(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment) { }
-
 		public void Select(int start, int length)
 		{
 			if (start < 0)


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

Removes a Uno-only no-op API surface around content-alignment change notifications (**BC34** of the Phase 5 breaking-changes wave):

- **`TextBox.OnVerticalContentAlignmentChanged`** — deleted the empty `protected override`. It overrode `Control`'s (mixin-generated) virtual with an empty body to suppress it, but that base is itself a no-op (its `…Partial` hooks are never implemented), so the override suppressed nothing.
- **`ContentPresenter.OnVerticalContentAlignmentChanged` / `OnHorizontalContentAlignmentChanged`** — deleted both `protected virtual` methods and their unused `partial void …Partial` hooks. WinUI's `ContentPresenter` exposes neither. Layout invalidation is unchanged: it is driven by the `FrameworkPropertyMetadataOptions.AffectsArrange` option already on both `DependencyProperty` registrations. The change-callback lambdas (which only forwarded to the removed methods) are dropped, leaving a `FrameworkPropertyMetadata(defaultValue, AffectsArrange)` metadata.

The Horizontal twin is removed alongside Vertical so `ContentPresenter` stays symmetric and closer to the WinUI surface.

**⚠️ Generator check (resolved):** the `DependencyPropertyMixinGenerator` emits `On…ContentAlignmentChanged` **only for `Control`** (not `TextBox`, not `ContentPresenter`). Both removed members are hand-written and re-emitted by nothing, so no generator change was needed. `Control`'s base virtual is untouched, so `TextBox` still inherits an (inherited, no-op) `OnVerticalContentAlignmentChanged`.

## Validation

- **Compile:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean (0 warnings / 0 errors), transitively compiling `Uno.UI`, `Uno.UI.RuntimeTests`, and the samples.
- **Non-behavioural:** all removed members are provable no-ops (the `…Partial` hooks were never implemented on any platform; `AffectsArrange` retained), so compile + PackageDiff coverage is sufficient — no runtime test added.
- Native Android/iOS heads not built locally — CI validates them; grep confirmed no native partial implementation of the removed hooks.

`PackageDiffIgnore.xml` (6.5 baseline) gets three `<Methods>` entries for the removed `TextBox` / `ContentPresenter` methods.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests / UI tests / manual sample — **N/A**: not a behaviour change (removed members were no-ops; `AffectsArrange` unchanged).
- [ ] 📚 Docs added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** subclasses that `override` `ContentPresenter.OnVerticalContentAlignmentChanged` / `OnHorizontalContentAlignmentChanged`, or `TextBox.OnVerticalContentAlignmentChanged`, no longer compile.
- **Migration:** these overrides can be deleted — they were no-ops. To react to a content-alignment change, use a `DependencyPropertyChangedCallback` on `VerticalContentAlignmentProperty` / `HorizontalContentAlignmentProperty` instead. This matches WinUI, which never exposed these virtuals.
