### PR TITLE
refactor(controls)!: ContentPresenter.ContentTemplateRoot internal (BC36)

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2585,6 +2585,9 @@
 		  <!-- FrameworkElement.Background removed: declared per-type to match WinUI (BC38, breaking changes for 7.0). -->
 		  <Member fullName="Microsoft.UI.Xaml.Media.Brush Microsoft.UI.Xaml.FrameworkElement::Background()" reason="WinUI sync (BC38): Background declared per-type, not on FrameworkElement" />
 		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement::BackgroundProperty()" reason="WinUI sync (BC38): BackgroundProperty declared per-type, not on FrameworkElement" />
+
+		  <!-- Uno-only public ContentPresenter.ContentTemplateRoot reduced to internal (WinUI's ContentPresenter has no such member; the real WinUI ContentTemplateRoot lives on ContentControl). Accessors paired in <Methods> below. -->
+		  <Member fullName="Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Controls.ContentPresenter::ContentTemplateRoot()" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
@@ -3056,6 +3059,10 @@
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Page.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.CalendarViewBaseItem.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+
+		  <!-- ContentPresenter.ContentTemplateRoot accessors (paired with the <Properties> entry above); getter public->internal, setter protected->private. -->
+		  <Member fullName="Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Controls.ContentPresenter.get_ContentTemplateRoot()" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.set_ContentTemplateRoot(Microsoft.UI.Xaml.UIElement value)" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
 	  </Methods>
 	  <Events>
 		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -214,7 +214,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC34** — Remove `TextBox.OnVerticalContentAlignmentChanged` override  `d3·S`
   - Delete the `TextBox` override; make base `OnVerticalContentAlignmentChanged` `private protected`.
   - Files: `src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs`, `src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs`
-- [ ] **BC36** — `ContentPresenter.ContentTemplateRoot` -> internal  `d3·S` · #16148
+- [x] **BC36** — `ContentPresenter.ContentTemplateRoot` -> internal  `d3·S` · #16148
   - Make `internal` (not `private` — in-assembly callers read it cross-type).
   - Files: `src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs`, `src/Uno.UI/UI/Xaml/Controls/Button/HyperlinkButton.mux.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.cs`
 - [x] **BC52** — Reparent `RadioMenuFlyoutItem` -> `MenuFlyoutItem`  `d3·M`

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -826,14 +826,14 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 
 	partial void UnregisterContentTemplateRoot();
 
-	public View ContentTemplateRoot
+	internal View ContentTemplateRoot
 	{
 		get
 		{
 			return _contentTemplateRoot;
 		}
 
-		protected set
+		private set
 		{
 			var previousValue = _contentTemplateRoot;
 


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

Reduces the Uno-only public **`ContentPresenter.ContentTemplateRoot`** to `internal` (**BC36** of the Phase 5 breaking-changes wave):

- Getter `public` → `internal`; setter `protected` → `private`.
- WinUI's `ContentPresenter` exposes **no** `ContentTemplateRoot` member. The real WinUI `ContentTemplateRoot` lives on **`ContentControl`**, which is **unchanged** (it stays public — it is a genuine WinUI API, confirmed by the sync-generator stub).

All in-assembly readers keep working via the internal getter (e.g. `HyperlinkButton`, which reads `contentPresenter.ContentTemplateRoot`); `InternalsVisibleTo` covers the test assemblies. Every set-site is inside `ContentPresenter` itself, so the setter safely narrows to `private`.

## Validation

- **Compile:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean (0 warnings / 0 errors). The `private set` compiling proves there is no cross-type/subclass set-site.
- Native Android/iOS heads not built locally — CI validates them; grep confirmed no native/cross-assembly caller of the property.

`PackageDiffIgnore.xml` (6.5 baseline) gets three entries — the property form in `<Properties>` and the `get_`/`set_` accessors in `<Methods>` — since a public→internal reduction removes the member from the compared public surface.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests / UI tests / manual sample — **N/A**: visibility-only change, no behaviour change.
- [ ] 📚 Docs added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — **N/A** (no visual change).
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** external code that read `ContentPresenter.ContentTemplateRoot`, or subclasses that set it, no longer compile. (The property on `ContentControl` — the WinUI API — is unaffected.)
- **Migration:** access the template root via `ContentControl.ContentTemplateRoot` where a `ContentControl` is available, or via the visual tree (`VisualTreeHelper`). This matches WinUI, which never exposed `ContentTemplateRoot` on `ContentPresenter`.
