### PR TITLE
refactor(controls)!: Reparent RadioMenuFlyoutItem to MenuFlyoutItem (BC52)

### DIFF
--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -217,7 +217,7 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [ ] **BC36** — `ContentPresenter.ContentTemplateRoot` -> internal  `d3·S` · #16148
   - Make `internal` (not `private` — in-assembly callers read it cross-type).
   - Files: `src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs`, `src/Uno.UI/UI/Xaml/Controls/Button/HyperlinkButton.mux.cs`, `src/Uno.UI/UI/Xaml/FrameworkElement.cs`
-- [ ] **BC52** — Reparent `RadioMenuFlyoutItem` -> `MenuFlyoutItem`  `d3·M`
+- [x] **BC52** — Reparent `RadioMenuFlyoutItem` -> `MenuFlyoutItem`  `d3·M`
   - Reparent to `MenuFlyoutItem`; re-implement the toggle behavior currently inherited from `ToggleMenuFlyoutItem`.
   - Files: `src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cs`, `src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.Properties.cs`, `src/Uno.WinAppSDKSyncGenerator/Generator.cs`
 - [ ] **BC74** — Android drawable extension in retarget keys  `d3·S` · PR #15891

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioMenuFlyoutItem.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioMenuFlyoutItem.cs
@@ -16,6 +16,31 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 public class Given_RadioMenuFlyoutItem
 {
 	[TestMethod]
+	public void When_AutomationPeer_Reports_Toggle_State()
+	{
+		// RadioMenuFlyoutItem derives from MenuFlyoutItem (not ToggleMenuFlyoutItem), but must still
+		// expose the toggle automation surface, matching WinUI's secret ToggleMenuFlyoutItem base.
+		var item = new Microsoft.UI.Xaml.Controls.RadioMenuFlyoutItem();
+
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(item);
+		Assert.IsInstanceOfType(peer, typeof(ToggleMenuFlyoutItemAutomationPeer));
+
+		var toggleProvider = (Microsoft.UI.Xaml.Automation.Provider.IToggleProvider)peer.GetPattern(PatternInterface.Toggle);
+		Assert.IsNotNull(toggleProvider);
+		Assert.AreEqual(Microsoft.UI.Xaml.Automation.ToggleState.Off, toggleProvider.ToggleState);
+
+		item.IsChecked = true;
+		Assert.AreEqual(Microsoft.UI.Xaml.Automation.ToggleState.On, toggleProvider.ToggleState);
+
+		// Invoking a radio item checks it; invoking again keeps it checked (radio never toggles off).
+		item.IsChecked = false;
+		toggleProvider.Toggle();
+		Assert.IsTrue(item.IsChecked);
+		toggleProvider.Toggle();
+		Assert.IsTrue(item.IsChecked);
+	}
+
+	[TestMethod]
 	public async Task When_Check_Sequence()
 	{
 		var item1 = new Microsoft.UI.Xaml.Controls.RadioMenuFlyoutItem { GroupName = "group1", IsChecked = true };

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/RadioMenuFlyoutItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/RadioMenuFlyoutItem.cs
@@ -6,7 +6,7 @@ namespace Microsoft.UI.Xaml.Controls
 #if false || false
 	[global::Uno.NotImplemented]
 #endif
-	public partial class RadioMenuFlyoutItem
+	public partial class RadioMenuFlyoutItem : global::Microsoft.UI.Xaml.Controls.MenuFlyoutItem
 	{
 		// Skipping already declared property AreCheckStatesEnabledProperty
 		// Skipping already declared property GroupNameProperty

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleMenuFlyoutItemAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleMenuFlyoutItemAutomationPeer.cs
@@ -23,6 +23,12 @@ public partial class ToggleMenuFlyoutItemAutomationPeer : FrameworkElementAutoma
 	{
 	}
 
+	// RadioMenuFlyoutItem is not a ToggleMenuFlyoutItem in Uno (it derives from MenuFlyoutItem to match
+	// the public WinUI base), but exposes the same toggle automation surface, so it reuses this peer.
+	internal ToggleMenuFlyoutItemAutomationPeer(MenuFlyoutItem owner) : base(owner)
+	{
+	}
+
 	protected override object GetPatternCore(PatternInterface patternInterface)
 	{
 		if (patternInterface == PatternInterface.Toggle)
@@ -44,8 +50,8 @@ public partial class ToggleMenuFlyoutItemAutomationPeer : FrameworkElementAutoma
 		if (string.IsNullOrEmpty(returnValue))
 		{
 			// If AutomationProperties.AcceleratorKey hasn't been set, then return the value of our KeyboardAcceleratorTextOverride property.
-			var ownerAsToggleMenuFlyoutItem = (ToggleMenuFlyoutItem)Owner;
-			var keyboardAcceleratorTextOverride = ownerAsToggleMenuFlyoutItem.KeyboardAcceleratorTextOverride;
+			var ownerAsMenuFlyoutItem = (MenuFlyoutItem)Owner;
+			var keyboardAcceleratorTextOverride = ownerAsMenuFlyoutItem.KeyboardAcceleratorTextOverride;
 			returnValue = GetTrimmedKeyboardAcceleratorTextOverride(keyboardAcceleratorTextOverride);
 		}
 
@@ -91,7 +97,7 @@ public partial class ToggleMenuFlyoutItemAutomationPeer : FrameworkElementAutoma
 			throw new ElementNotEnabledException();
 		}
 
-		((ToggleMenuFlyoutItem)Owner).Invoke();
+		((MenuFlyoutItem)Owner).Invoke();
 	}
 
 	/// <summary>
@@ -101,7 +107,12 @@ public partial class ToggleMenuFlyoutItemAutomationPeer : FrameworkElementAutoma
 	{
 		get
 		{
-			var isChecked = ((ToggleMenuFlyoutItem)Owner).IsChecked;
+			var isChecked = Owner switch
+			{
+				ToggleMenuFlyoutItem toggleItem => toggleItem.IsChecked,
+				RadioMenuFlyoutItem radioItem => radioItem.IsChecked,
+				_ => false,
+			};
 			return isChecked ? Automation.ToggleState.On : Automation.ToggleState.Off;
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.Properties.cs
@@ -32,13 +32,13 @@ namespace Microsoft.UI.Xaml.Controls
 		public static DependencyProperty GroupNameProperty { get; } =
 			DependencyProperty.Register(nameof(GroupName), typeof(string), typeof(RadioMenuFlyoutItem), new FrameworkPropertyMetadata(string.Empty, (s, e) => (s as RadioMenuFlyoutItem)?.OnPropertyChanged(e)));
 
-		public new bool IsChecked
+		public bool IsChecked
 		{
 			get { return (bool)GetValue(IsCheckedProperty); }
 			set { SetValue(IsCheckedProperty, value); }
 		}
 
-		public static new DependencyProperty IsCheckedProperty { get; } =
+		public static DependencyProperty IsCheckedProperty { get; } =
 			DependencyProperty.Register(nameof(IsChecked), typeof(bool), typeof(RadioMenuFlyoutItem), new FrameworkPropertyMetadata(false, (s, e) => (s as RadioMenuFlyoutItem)?.OnPropertyChanged(e)));
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cs
@@ -1,18 +1,20 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference RadioMenuFlyoutItem.cpp, commit 69097129a853c65a16447aade4c82576d4724b1a
 using System;
 using System.Collections.Generic;
+using DirectUI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Uno.UI.Helpers.WinUI;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	// UNO Docs:
-	// In WinUI 2.6. RadioMenuFlyoutItem derives publically from MenuFlyoutItem, but secretly from ToggleMenuFlyoutItem.
-	// Since we can't do that in C#, the important functionality are in ToggleMenuFlyoutItem, we derive from it.
-	public partial class RadioMenuFlyoutItem : ToggleMenuFlyoutItem
+	// In WinUI, RadioMenuFlyoutItem derives publicly from MenuFlyoutItem but secretly from ToggleMenuFlyoutItem.
+	// C# has no such double inheritance, so we derive from MenuFlyoutItem (matching the public WinUI base) and
+	// duplicate the check/toggle rendering behaviour ToggleMenuFlyoutItem would otherwise provide.
+	public partial class RadioMenuFlyoutItem : MenuFlyoutItem
 	{
 		[ThreadStatic]
 		private static Dictionary<string, WeakReference<RadioMenuFlyoutItem>> s_selectionMap;
@@ -21,8 +23,6 @@ namespace Microsoft.UI.Xaml.Controls
 		// even if the dependency properties have since changed.
 		private bool m_isChecked;
 		private string m_groupName = "";
-
-		private bool m_isSafeUncheck;
 
 #if HAS_UNO
 		// Uno-specific: the GroupName under which we last registered ourselves in
@@ -36,9 +36,6 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public RadioMenuFlyoutItem()
 		{
-			this.RegisterPropertyChangedCallback(ToggleMenuFlyoutItem.IsCheckedProperty, OnInternalIsCheckedChanged);
-
-
 			if (s_selectionMap == null)
 			{
 				// Ensure that this object exists
@@ -49,7 +46,6 @@ namespace Microsoft.UI.Xaml.Controls
 			Unloaded += OnUnloaded;
 
 			this.SetDefaultStyleKey();
-
 		}
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
@@ -90,14 +86,22 @@ namespace Microsoft.UI.Xaml.Controls
 			DependencyProperty property = args.Property;
 			if (property == IsCheckedProperty)
 			{
-				if (base.IsChecked != IsChecked)
+				m_isChecked = IsChecked;
+
+				UpdateVisualState();
+
+				if (IsChecked)
 				{
-					m_isSafeUncheck = true;
-					base.IsChecked = IsChecked;
-					m_isSafeUncheck = false;
 					UpdateCheckedItemInGroup();
 				}
-				m_isChecked = IsChecked;
+
+				if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged))
+				{
+					if (GetOrCreateAutomationPeer() is ToggleMenuFlyoutItemAutomationPeer toggleAutomationPeer)
+					{
+						toggleAutomationPeer.RaiseToggleStatePropertyChangedEvent(args.OldValue, args.NewValue);
+					}
+				}
 			}
 			else if (property == GroupNameProperty)
 			{
@@ -105,26 +109,17 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		private void OnInternalIsCheckedChanged(DependencyObject sender, DependencyProperty args)
+		// Reserve the check/toggle column in the parent MenuFlyoutPresenter, as ToggleMenuFlyoutItem does.
+		// Otherwise a menu containing only RadioMenuFlyoutItems would not reserve space for the checkmark.
+		internal override bool HasToggle() => true;
+
+		// Performs appropriate actions upon a mouse/keyboard invocation of a RadioMenuFlyoutItem.
+		// A radio item is always checked on invocation; it is never toggled off by user interaction.
+		internal override void Invoke()
 		{
-			if (!base.IsChecked)
-			{
-				if (m_isSafeUncheck)
-				{
-					// The uncheck is due to another radio button being checked -- that's all right.
-					IsChecked = false;
-				}
-				else
-				{
-					// The uncheck is due to user interaction -- not allowed.
-					base.IsChecked = true;
-				}
-			}
-			else if (!IsChecked)
-			{
-				IsChecked = true;
-				UpdateCheckedItemInGroup();
-			}
+			IsChecked = true;
+
+			base.Invoke();
 		}
 
 		private void UpdateCheckedItemInGroup()
@@ -164,6 +159,117 @@ namespace Microsoft.UI.Xaml.Controls
 				s_selectionMap[groupName] = new WeakReference<RadioMenuFlyoutItem>(this);
 			}
 		}
+
+		// Change to the correct visual state for the RadioMenuFlyoutItem.
+		private protected override void ChangeVisualState(
+			// true to use transitions when updating the visual state, false
+			// to snap directly to the new visual state.
+			bool bUseTransitions)
+		{
+			bool hasIconMenuItem = false;
+			bool hasMenuItemWithKeyboardAcceleratorText = false;
+			bool isKeyboardPresent = false;
+
+			var isPressed = IsPointerPressed;
+			var isPointerOver = IsPointerOver;
+			var isEnabled = IsEnabled;
+			var isChecked = IsChecked;
+			var focusState = FocusState;
+			var shouldBeNarrow = GetShouldBeNarrow();
+			var spPresenter = GetParentMenuFlyoutPresenter();
+
+			if (spPresenter is not null)
+			{
+				hasIconMenuItem = spPresenter.GetContainsIconItems();
+				hasMenuItemWithKeyboardAcceleratorText = spPresenter.GetContainsItemsWithKeyboardAcceleratorText();
+			}
+
+			// We only care about finding if we have a keyboard if we also have a menu item with accelerator text,
+			// since if we don't have any menu items with accelerator text, we won't be showing any accelerator text anyway.
+			if (hasMenuItemWithKeyboardAcceleratorText)
+			{
+				isKeyboardPresent = DXamlCore.Current.IsKeyboardPresent;
+			}
+
+			// CommonStates
+			if (!isEnabled)
+			{
+				VisualStateManager.GoToState(this, "Disabled", bUseTransitions);
+			}
+			else if (isPressed)
+			{
+				VisualStateManager.GoToState(this, "Pressed", bUseTransitions);
+			}
+			else if (isPointerOver)
+			{
+				VisualStateManager.GoToState(this, "PointerOver", bUseTransitions);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, "Normal", bUseTransitions);
+			}
+
+			// FocusStates
+			if (FocusState.Unfocused != focusState && isEnabled)
+			{
+				if (FocusState.Pointer == focusState)
+				{
+					VisualStateManager.GoToState(this, "PointerFocused", bUseTransitions);
+				}
+				else
+				{
+					VisualStateManager.GoToState(this, "Focused", bUseTransitions);
+				}
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, "Unfocused", bUseTransitions);
+			}
+
+			// CheckStates
+			if (isChecked && hasIconMenuItem)
+			{
+				VisualStateManager.GoToState(this, "CheckedWithIcon", bUseTransitions);
+			}
+			else if (hasIconMenuItem)
+			{
+				VisualStateManager.GoToState(this, "UncheckedWithIcon", bUseTransitions);
+			}
+			else if (isChecked)
+			{
+				VisualStateManager.GoToState(this, "Checked", bUseTransitions);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, "Unchecked", bUseTransitions);
+			}
+
+			// PaddingSizeStates
+			if (shouldBeNarrow)
+			{
+				VisualStateManager.GoToState(this, "NarrowPadding", bUseTransitions);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, "DefaultPadding", bUseTransitions);
+			}
+
+			// We'll make the accelerator text visible if any item has accelerator text,
+			// as this causes the margin to be applied which reserves space, ensuring that accelerator text
+			// in one item won't be at the same horizontal position as label text in another item.
+			if (hasMenuItemWithKeyboardAcceleratorText && isKeyboardPresent)
+			{
+				VisualStateManager.GoToState(this, "KeyboardAcceleratorTextVisible", bUseTransitions);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, "KeyboardAcceleratorTextCollapsed", bUseTransitions);
+			}
+		}
+
+		// Radio menu items expose the same toggle automation surface as ToggleMenuFlyoutItem,
+		// matching WinUI where RadioMenuFlyoutItem secretly derives from ToggleMenuFlyoutItem.
+		protected override AutomationPeer OnCreateAutomationPeer() => new ToggleMenuFlyoutItemAutomationPeer(this);
 
 		private static void OnAreCheckStatesEnabledPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
@@ -13,7 +13,7 @@
     <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="ToggleMenuFlyoutItem">
+        <ControlTemplate TargetType="controls:RadioMenuFlyoutItem">
           <Grid x:Name="LayoutRoot" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" Margin="{StaticResource MenuFlyoutItemMargin}" CornerRadius="{TemplateBinding CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">

--- a/src/Uno.WinAppSDKSyncGenerator/Generator.cs
+++ b/src/Uno.WinAppSDKSyncGenerator/Generator.cs
@@ -108,9 +108,6 @@ namespace Uno.WinAppSDKSyncGenerator
 			BaseXamlNamespace + ".Controls.MediaPlayerPresenter",
 			BaseXamlNamespace + ".Controls.NavigationViewItemBase",
 			"Microsoft.UI.Xaml.Controls.WebView2",
-			// Mismatching public inheritance hierarchy because RadioMenuFlyoutItem has a double inheritance in WinUI.
-			// Remove this and update RadioMenuFlyoutItem if WinUI 3 removed the double inheritance.
-			"Microsoft.UI.Xaml.Controls.RadioMenuFlyoutItem",
 			// In Uno DependencyObjectCollection derives from DependencyObjectCollection<DependencyObject>, which
 			// carries the DependencyObject base and the IList implementation; emitting the metadata
 			// DependencyObject base here would clash with that hand-written hierarchy.


### PR DESCRIPTION
**GitHub Issue:** #8339

<!-- Part of the 7.0 breaking-changes rollup epic (#8339). -->

## PR Type:

💬 Other... Breaking change (API alignment with WinUI)

## What changed? 🚀

Reparents **`RadioMenuFlyoutItem`** from `ToggleMenuFlyoutItem` to **`MenuFlyoutItem`** (**BC52** of the Phase 5 breaking-changes wave).

WinUI derives `RadioMenuFlyoutItem` *publicly* from `MenuFlyoutItem` while *secretly* reusing `ToggleMenuFlyoutItem`. C# has no such double inheritance, so Uno derived from `ToggleMenuFlyoutItem` and shadowed its `IsChecked` with `new`. This PR matches the WinUI public base and duplicates the toggle behaviour that was previously inherited:

- **Base:** `RadioMenuFlyoutItem : MenuFlyoutItem` (was `: ToggleMenuFlyoutItem`). The twin-`IsChecked` sync dance (`base.IsChecked` ↔ own `IsChecked`, `m_isSafeUncheck`) is gone — there is now a single `IsChecked`.
- **`ChangeVisualState`** — duplicated from `ToggleMenuFlyoutItem`, driving the `CheckStates` (Checked/Unchecked, +WithIcon) off the control's own `IsChecked`.
- **`Invoke`** — a radio item is always checked on invocation and never toggled off by user interaction.
- **`HasToggle() => true`** — so the parent `MenuFlyoutPresenter` still reserves the check column for radio-only menus (this was previously inherited from `ToggleMenuFlyoutItem`; the presenter decides column reservation via the polymorphic `HasToggle()`, not a type check).
- **Automation** — `OnCreateAutomationPeer` returns `ToggleMenuFlyoutItemAutomationPeer` (matching WinUI's toggle automation surface). That peer gains an `internal` `MenuFlyoutItem` constructor and reads `IsChecked` polymorphically, so a `RadioMenuFlyoutItem` owner works.
- **`new` removed** from `IsChecked`/`IsCheckedProperty` (nothing to hide anymore).
- **Default template** — the `ControlTemplate` retargets from `ToggleMenuFlyoutItem` to `RadioMenuFlyoutItem`.
- **Sync generator** — the `RadioMenuFlyoutItem` entry is removed from `_skipBaseTypes` (the double-inheritance workaround); the generated stub now carries the `MenuFlyoutItem` base.

## Validation

- **Compile:** `SamplesApp.Skia.Generic` (net10.0 Skia) builds clean (0 warnings / 0 errors), regenerating the merged theme XAML with the retargeted template.
- **Runtime (Skia Desktop):** `Given_RadioMenuFlyoutItem` — **4/4 pass**. The 3 existing group-semantics tests stay green (behaviour-preserving), plus a new `When_AutomationPeer_Reports_Toggle_State` that asserts the peer type, `IToggleProvider.ToggleState`, and that invoking via `Toggle()` checks the item and never toggles it off.
- Native Android/iOS heads and the `Uno.WinAppSDKSyncGenerator` (net11) are not built locally — CI validates them. A repo-wide grep confirmed no `is/as ToggleMenuFlyoutItem` site actually receives a `RadioMenuFlyoutItem`.

No `PackageDiffIgnore.xml` entries needed: base-type changes are untracked by the diff, and the declared `IsChecked`/`IsCheckedProperty` signatures are unchanged (dropping `new` does not alter them).

**Note on `winappsdk-sync-check`:** the generated stub was hand-edited to add the `MenuFlyoutItem` base (matching the `SplitMenuFlyoutItem` format), so the check should pass. If it reports drift, applying `/apply-sync-gen` will reconcile it.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests — **done** (`Given_RadioMenuFlyoutItem.When_AutomationPeer_Reports_Toggle_State`, plus the existing suite as regression guards).
- [ ] 📚 Docs added/updated — **N/A** (migration note below).
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — recommended, given the visual-state/template changes.
- [ ] ❗ Contains **NO** breaking changes — intentionally left unchecked; this **is** a breaking change (see below).
- [ ] 👀 Reviewed 2 other open pull requests

### Breaking change — impact & migration path

- **Impact (source-breaking):** `RadioMenuFlyoutItem` no longer derives from `ToggleMenuFlyoutItem`. Code that treated a `RadioMenuFlyoutItem` as a `ToggleMenuFlyoutItem` (assignment, `is`/`as`, casts) no longer compiles.
- **Migration:** use `RadioMenuFlyoutItem` (or its now-direct base `MenuFlyoutItem`) directly. Its `IsChecked`, `GroupName`, and `AreCheckStatesEnabled` members are unchanged. This matches WinUI, where `RadioMenuFlyoutItem`'s public base is `MenuFlyoutItem`.
