### PR TITLE
test: backport native-target runtime-test gating from master

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
@@ -1315,7 +1315,7 @@ namespace Windows.UI.Tests.Enterprise
 		}
 
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.SkiaIOS)] // Flaky on iOS native and iOS Skia https://github.com/unoplatform/uno/issues/9080
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.SkiaIOS | RuntimeTestPlatforms.NativeWasm)] // Flaky on iOS native and iOS Skia https://github.com/unoplatform/uno/issues/9080
 		[Description("Validates that the overflow menu's scrollviewer does not scroll with arrow keys.")]
 		public async Task ValidateOverflowScrollViewerDoesNotScrollWithArrowKeys()
 		{

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
@@ -1315,7 +1315,7 @@ namespace Windows.UI.Tests.Enterprise
 		}
 
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.SkiaIOS | RuntimeTestPlatforms.NativeWasm)] // Flaky on iOS native and iOS Skia https://github.com/unoplatform/uno/issues/9080
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native | RuntimeTestPlatforms.SkiaIOS)] // Flaky on native targets and iOS Skia https://github.com/unoplatform/uno/issues/9080
 		[Description("Validates that the overflow menu's scrollviewer does not scroll with arrow keys.")]
 		public async Task ValidateOverflowScrollViewerDoesNotScrollWithArrowKeys()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_CheckBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_CheckBox.cs
@@ -32,6 +32,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		/// </summary>
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_Disabled_In_Disabled_ListView_Matches_Standalone()
 		{
 			var standalone = new CheckBox { Content = "Standalone", IsChecked = true, IsEnabled = false };
@@ -71,6 +72,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		/// </summary>
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_ListViewItem_Locally_Disabled_Matches_Enabled()
 		{
 			var checkBoxInEnabledItem = new CheckBox { Content = "Enabled item", IsChecked = true, IsEnabled = false };

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
@@ -311,6 +311,7 @@ public class Given_WebView2
 	[Ignore("Crashes")]
 #endif
 	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit)] // Flaky on UIKit - #9080
 	public async Task When_LocalFolder_File()
 	{
 		async Task Do()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_ThemeResources.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_ThemeResources.cs
@@ -26,7 +26,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 	public class Given_FrameworkElement_ThemeResources
 	{
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
+		// Not [RequiresFullWindow]/UseApplicationLightTheme: this test sets WindowContent=null mid-run,
+		// which nulls XamlRoot.Content in full-window mode (breaking UseDarkTheme). It runs embedded and
+		// relies on the host staying Light (IsAppThemeLight + the UseDarkTheme restore fix) for determinism.
 		public async Task When_Detached_From_Window_While_Theme_Changed()
 		{
 			var SUT = new Button { Content = "Ye button" };

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -77,7 +77,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_AppLevel_Resource_CheckBox_Override()
 		{
 			// Use fluent styles to rely on known Theme Resources
@@ -200,6 +200,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 #if HAS_UNO
 		[TestMethod]
+		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_ActualThemeChanged_Throws()
 		{
 			using (StyleHelper.UseAppLevelResources(new App_Level_Resources()))

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -306,6 +306,7 @@ public class Given_CalendarView
 	}
 
 	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit)] // Flaky on UIKit - #9080
 	public async Task When_Spanish_Language()
 	{
 		var calendarView = new CalendarView()
@@ -319,6 +320,7 @@ public class Given_CalendarView
 	}
 
 	[TestMethod]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit)] // Flaky on UIKit - #9080
 	public async Task When_English_Language()
 	{
 		var calendarView = new CalendarView()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
@@ -29,6 +29,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// must be re-pinned there; otherwise a checked CheckBox reverts to the stock brush on a visual-state re-entry.
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_App_Override_Checked_Survives_IsChecked_Reentry_Under_Dark_App()
 		{
 			using var _ = ThemeHelper.UseApplicationDarkTheme();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
@@ -121,6 +121,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// through Frame navigation and re-entering PointerOver must keep the Light (Blue) value.
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_VisualStateSetter_PointerOver_Keeps_Light_After_Frame_Navigation_Under_Dark_App()
 		{
 			using var _ = ThemeHelper.UseApplicationDarkTheme();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CheckBox_ThemeResource_Regression.cs
@@ -74,6 +74,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// CheckedNormal); asserts in the enabled CheckedNormal state after the round-trip.
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_App_Override_Checked_Survives_IsEnabled_Toggle_Under_Dark_App()
 		{
 			using var _ = ThemeHelper.UseApplicationDarkTheme();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -1309,6 +1309,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)] // Flaky on Skia WASM #9080
 		public async Task When_ComboPopup_Rearrange_ScrollShouldNotReset()
 		{
 			var SUT = new ComboBox()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CommandBarFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CommandBarFlyout.cs
@@ -106,6 +106,7 @@ public class Given_CommandBarFlyout
 	[TestMethod]
 	[RequiresFullWindow]
 	[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/480")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 	public async Task When_CommandBarFlyout_Opens_First_Time_Foreground_Should_Not_Flash_Wrong_Theme()
 	{
 #if HAS_UNO
@@ -217,6 +218,7 @@ public class Given_CommandBarFlyout
 	[TestMethod]
 	[RequiresFullWindow]
 	[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/480")]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 	public async Task When_CommandBarFlyout_Compiled_Opens_First_Time_Label_Should_Not_Flash_Wrong_Theme()
 	{
 #if HAS_UNO

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -2231,6 +2231,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		/// </summary>
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/475")]
 		public async Task When_Flyout_Opened_From_Inner_Light_Boundary_Resolves_Light_ThemeResource()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -5175,6 +5175,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/482")]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_Grid_Row_Presented_After_Tab_Navigation_Light_Under_Dark_App()
 		{
 #if HAS_UNO

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -725,6 +725,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// ------------------------------------------------------------------
 		[TestMethod]
 		[RequiresFullWindow]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/480")]
 		public async Task When_MenuFlyout_Opens_First_Time_Foreground_Should_Not_Flash_Wrong_Theme()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -548,6 +548,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/480")]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_Flyout_Menu_Uses_Owner_Subtree_Theme_Light_Under_Dark_App()
 		{
 #if HAS_UNO
@@ -630,6 +631,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/480")]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_MenuFlyout_Item_Uses_Owner_Subtree_Theme_Light_Under_Dark_App()
 		{
 #if HAS_UNO

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -602,6 +602,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/484")]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_ToolTip_Label_Uses_Owner_Subtree_Theme_Light_Under_Dark_App()
 		{
 #if HAS_UNO

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrush.cs
@@ -36,6 +36,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 #endif
 		[DataRow(Stretch.Uniform, true)]
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit)] // Flaky on UIKit - #9080
 		public async Task When_Stretch(Stretch stretch, bool useRectangle)
 		{
 			const string Redish = "#FFEB1C24";

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ColorAnimationUsingKeyFrames.cs
@@ -38,7 +38,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 		}
 
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]
 		public async Task When_ThemeChanged_WithBrushBinding_AndColorPath()
 		{
 			var page = new TestPages.ColorAnimationPage();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_DoubleAnimation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_DoubleAnimation.cs
@@ -121,7 +121,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 		}
 
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Skia)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeUIKit)]
 		public async Task When_RepeatForever_ShouldLoop() // Flaky - #9080
 		{
 			async Task Do()


### PR DESCRIPTION
**GitHub Issue:** related to #9080

## PR Type:

- 🏗️ Build or CI related changes

## What is the current behavior? 🤔

The `Tests - WebAssembly Native`, `Tests - Android Native` and `Tests - iOS Native` stages fail deterministically on `release/stable/6.6`: a set of theming / screenshot-dependent runtime tests reached 6.6 (via the June-30 sync batch, #23580) **without** the gating commits that `master` received for them. On native targets these tests either throw `System.NotSupportedException: Cannot take screenshot on this platform` (`UITestHelper.ScreenShot` requires `HAS_RENDER_TARGET_BITMAP`) or assert Skia-only owner-subtree theming behavior.

Any 6.6 PR touching client runtime code triggers those stages and goes red across all retry attempts (the failures are deterministic, so the failed-tests-only rerun fails identically). This currently blocks e.g. #23698. Affected tests include `Given_CheckBox_ThemeResource_Regression.*`, `Given_CheckBox` (ListView disabled-render), `Given_MenuFlyout` / `Given_CommandBarFlyout` / `Given_Flyout` / `Given_ToolTip` / `Given_ListViewBase` theme tests, `CommandBarIntegrationTests.ValidateOverflowScrollViewerDoesNotScrollWithArrowKeys`, `Given_WebView2` (UIKit) and `Given_ComboBox.When_ComboPopup_Rearrange_ScrollShouldNotReset` (Skia WASM).

## What is the new behavior? 🚀

Backports the six `master` gating commits, as plain cherry-picks (`-x`, provenance recorded):

| master commit | change |
|---|---|
| `6ffa1e583f` | test: Disable flaky UIKit native tests (WebView2, CalendarView, ImageBrush, DoubleAnimation) |
| `278870ecfe` | test: disable `When_ComboPopup_Rearrange_ScrollShouldNotReset` on Skia WASM (#9080) |
| `fe869c96da` | test: Disable native theming tests |
| `3c0a623721` | test: Disable theming tests on native targets |
| `9d4edae1ef` | test: Disable PointerOver theming test on native |
| `3356760bb4` | chore: Disable tests on native (incl. widening the CommandBar exclusion `NativeIOS` → `Native`) |

The affected tests are now excluded on native targets via `[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)]` (or the specific platform flags), exactly as on `master`. 16 files changed, +28/−5, test attributes only — no product code.

Cherry-pick deltas vs `master` (hunks dropped because the target files/tests were never backported to 6.6): `Given_ElementRefHandle_Threading.cs`, `Given_ElementTheme_Resolution_Regression.cs`, and the `When_App_Override_Checked_Survives_Application_Theme_Change` test of `Given_CheckBox_ThemeResource_Regression.cs`.

Verified locally by replicating the CI `WebAssembly Native Runtime Tests 0` job (published `SamplesApp.Wasm` net10.0 + dotnet-serve + chromedriver, group 0/3): before this change the run reproduces exactly the two CI failures (`Given_CheckBox.When_Disabled_In_Disabled_ListView_Matches_Standalone`, `Given_CheckBox_ThemeResource_Regression.When_App_Override_Checked_Survives_IsChecked_Reentry_Under_Dark_App`, both `Cannot take screenshot on this platform`); with it, those tests are excluded and no longer fail the run.

## PR Checklist ✅

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — n/a, test-infrastructure change (gating attributes only).
- [ ] 📚 Docs have been added/updated — n/a.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a, no UI change.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️

Unblocks the native-test stages for 6.6 backport PRs (first target: #23698, whose `Tests - WebAssembly/Android/iOS Native` stages fail solely on these pre-existing tests).