### PR TITLE
feat(skia): Expose frame data on Rendering event

### DIFF
--- a/src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs
+++ b/src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs
@@ -33,7 +33,7 @@ internal static class SkiaRenderHelper
 	internal static bool CanRecordPicture([NotNullWhen(true)] UIElement? rootElement) =>
 		rootElement is { IsArrangeDirtyOrArrangeDirtyPath: false, IsMeasureDirtyOrMeasureDirtyPath: false };
 
-	internal static (IntPtr picture, SKPath nativeClipPath, List<Visual> nativeVisualsInZOrder) RecordPictureAndReturnPath(float width, float height, ContainerVisual rootVisual, bool invertPath, SKPath? damage = null)
+	internal static (SKPicture picture, SKPath nativeClipPath, List<Visual> nativeVisualsInZOrder) RecordPictureAndReturnPath(float width, float height, ContainerVisual rootVisual, bool invertPath, SKPath? damage = null)
 	{
 		var canvas = _recorder.BeginRecording(Visual.InfiniteClipRect);
 		using var _ = new SKAutoCanvasRestore(canvas, true);
@@ -45,23 +45,20 @@ internal static class SkiaRenderHelper
 			(!invertPath ? _emptyClipPath : GetOrUpdateInvertedClippingPath(width, height), _emptyList) :
 			CalculateClippingPath(width, height, rootVisual, invertPath);
 
-		var picture = UnoSkiaApi.sk_picture_recorder_end_recording(_recorder.Handle);
+		var picture = _recorder.EndRecording();
 
 		return (picture, path, nativeVisualsInZOrder);
 	}
 
-	internal static void RenderPicture(SKCanvas canvas, IntPtr picture, SKColor background, Action<SKCanvas>? postRenderAction)
+	internal static void RenderPicture(SKCanvas canvas, SKPicture? picture, SKColor background, Action<SKCanvas>? postRenderAction)
 	{
 		using (new SKAutoCanvasRestore(canvas, true))
 		{
 			canvas.Clear(background);
-			if (picture != IntPtr.Zero)
+			if (picture is not null)
 			{
 				// This might happen if we get render request before the first frame is painted
-				unsafe
-				{
-					UnoSkiaApi.sk_canvas_draw_picture(canvas.Handle, picture, null, IntPtr.Zero);
-				}
+				canvas.DrawPicture(picture);
 			}
 
 			postRenderAction?.Invoke(canvas);

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -32,10 +32,24 @@ public partial class CompositionTarget
 
 	static CompositionTarget()
 	{
-		// A closing window stops calling Draw; fail its pending render jobs so awaiters fall
-		// back to software rendering instead of hanging.
-		XamlRootMap.Unregistered += (_, xamlRoot) => xamlRoot.VisualTree.ContentRoot.CompositionTarget.FailPendingRenderJobs();
+		XamlRootMap.Unregistered += (_, xamlRoot) =>
+		{
+			var target = xamlRoot.VisualTree.ContentRoot.CompositionTarget;
+			// A closing window stops calling Draw; fail its pending render jobs so awaiters fall
+			// back to software rendering instead of hanging.
+			target.FailPendingRenderJobs();
+			OnTargetUnregistered(target);
+		};
 	}
+
+	// Latest recorded frame per live target. Only touched on the UI thread. Entries are retained
+	// until replaced by a newer frame or until the target unregisters, so a Rendering raise can
+	// resend the last picture of a target that hasn't re-rendered since (e.g. a window minimized
+	// on hosts that stop servicing invalidations, like macOS).
+	private static readonly Dictionary<CompositionTarget, FramePicture> _latestFrames = new();
+
+	// Only touched on the UI thread.
+	private static bool _renderingRaiseScheduled;
 
 	private readonly SkiaRenderHelper.FpsHelper _fpsHelper = new();
 	private readonly Lock _frameGate = new();
@@ -55,7 +69,7 @@ public partial class CompositionTarget
 	private readonly Stack<SKPath> _damageSnapshotPool = new();
 
 	// only set on the UI thread and under _frameGate, only read under _frameGate
-	private (IntPtr frame, SKPath nativeElementClipPath, SKPath damage)? _lastRenderedFrame;
+	private (FramePicture picture, SKPath nativeElementClipPath, SKPath damage)? _lastRenderedFrame;
 	// only set and read under _xamlRootBoundsGate
 	private Size _xamlRootBounds;
 	// only set and read under _xamlRootBoundsGate
@@ -114,8 +128,9 @@ public partial class CompositionTarget
 			_pendingDamage.UnionRect(fpsBounds);
 		}
 
+		var framePicture = new FramePicture(picture);
 		var frameRect = new SKRect(0, 0, (float)bounds.Width, (float)bounds.Height);
-		var previousFrame = default((IntPtr frame, SKPath path, SKPath damage)?);
+		var previousFrame = default((FramePicture picture, SKPath path, SKPath damage)?);
 		SKPath damageSnapshot;
 		lock (_frameGate)
 		{
@@ -133,7 +148,7 @@ public partial class CompositionTarget
 			damageSnapshot.AddPath(_pendingDamage);
 			_pendingDamage.Rewind();
 
-			_lastRenderedFrame = (picture, path, damageSnapshot);
+			_lastRenderedFrame = (framePicture, path, damageSnapshot);
 
 			// The previous frame is being superseded in place (it wasn't borrowed for present, since the
 			// slot was non-null); its snapshot is no longer referenced, so recycle it for the next frame.
@@ -147,7 +162,7 @@ public partial class CompositionTarget
 
 		if (previousFrame is { } prev)
 		{
-			UnoSkiaApi.sk_refcnt_safe_unref(prev.frame);
+			prev.picture.OnPipelineReleased();
 		}
 
 		if (_isRenderingActive)
@@ -180,6 +195,9 @@ public partial class CompositionTarget
 		}
 
 		FrameRendered?.Invoke();
+
+		OnFramePictureRecorded(this, framePicture);
+
 		this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(Render)} ends");
 	}
 
@@ -215,7 +233,7 @@ public partial class CompositionTarget
 			RunRenderJobs(canvas.Context as GRContext);
 		}
 
-		(IntPtr frame, SKPath nativeElementClipPath, SKPath damage)? lastRenderedFrameNullable;
+		(FramePicture picture, SKPath nativeElementClipPath, SKPath damage)? lastRenderedFrameNullable;
 		lock (_frameGate)
 		{
 			lastRenderedFrameNullable = _lastRenderedFrame;
@@ -280,7 +298,7 @@ public partial class CompositionTarget
 			using var fpsHelperDisposable = _fpsHelper.BeginFrame();
 			SkiaRenderHelper.RenderPicture(
 				canvas,
-				lastRenderedFrame.frame,
+				lastRenderedFrame.picture.Picture,
 				SKColors.Transparent,
 				_fpsHelper.DrawFps);
 
@@ -294,8 +312,6 @@ public partial class CompositionTarget
 			// This frame's damage is now presented; clear it so Render's carry-forward doesn't re-damage it next frame.
 			lastRenderedFrame.damage.Rewind();
 			ReturnFrame(lastRenderedFrame);
-
-			InvokeRendering();
 
 			if (FrameRenderingOptions.applyScalingToNativeElementClipPath && rasterizationScale != 1)
 			{
@@ -397,9 +413,9 @@ public partial class CompositionTarget
 		public void Fail() => _tcs.TrySetResult(false);
 	}
 
-	private void ReturnFrame((IntPtr picture, SKPath path, SKPath damage) frame)
+	private void ReturnFrame((FramePicture picture, SKPath path, SKPath damage) frame)
 	{
-		var pictureToDelete = IntPtr.Zero;
+		var releasedPicture = default(FramePicture);
 
 		lock (_frameGate)
 		{
@@ -410,7 +426,7 @@ public partial class CompositionTarget
 			}
 			else
 			{
-				pictureToDelete = frame.picture;
+				releasedPicture = frame.picture;
 				// This presented frame is superseded by a newer one; its snapshot (already rewound in Draw)
 				// is done — recycle it.
 				_damageSnapshotPool.Push(frame.damage);
@@ -418,24 +434,126 @@ public partial class CompositionTarget
 		}
 
 		// Delete it then
-		if (pictureToDelete != IntPtr.Zero)
+		releasedPicture?.OnPipelineReleased();
+	}
+
+	private static void OnFramePictureRecorded(CompositionTarget target, FramePicture picture)
+	{
+		picture.Retain();
+		if (_latestFrames.TryGetValue(target, out var replaced))
 		{
-			UnoSkiaApi.sk_refcnt_safe_unref(pictureToDelete);
+			replaced.Release(pictureAccessed: false);
+		}
+		_latestFrames[target] = picture;
+
+		if (_isRenderingActive && !_renderingRaiseScheduled)
+		{
+			_renderingRaiseScheduled = true;
+			NativeDispatcher.Main.Enqueue(RaiseRendering, NativeDispatcherPriority.High);
 		}
 	}
 
-	internal static void InvokeRendering()
+	// Raises Rendering once per batch of recorded frames, with the latest picture of every live
+	// target — including targets that haven't re-rendered since the last raise, whose previous
+	// picture is resent. Synchronous callout to app code.
+	private static void RaiseRendering()
 	{
-		if (NativeDispatcher.Main.HasThreadAccess)
+		_renderingRaiseScheduled = false;
+
+		var pictures = new FramePicture[_latestFrames.Count];
+		var frameData = new List<(Window Window, object Data)>(_latestFrames.Count);
+		var i = 0;
+		foreach (var (target, picture) in _latestFrames)
 		{
-			_rendering?.Invoke(null, new RenderingEventArgs(Stopwatch.GetElapsedTime(_start)));
-		}
-		else
-		{
-			NativeDispatcher.Main.Enqueue(() =>
+			picture.Retain();
+			pictures[i++] = picture;
+			if (target.ContentRoot.GetOwnerWindow() is { } window)
 			{
-				_rendering?.Invoke(null, new RenderingEventArgs(Stopwatch.GetElapsedTime(_start)));
-			}, NativeDispatcherPriority.High);
+				frameData.Add((window, picture.Picture));
+			}
 		}
+
+		var args = new RenderingEventArgs(Stopwatch.GetElapsedTime(_start), frameData);
+		try
+		{
+			_rendering?.Invoke(null, args);
+		}
+		finally
+		{
+			foreach (var picture in pictures)
+			{
+				picture.Release(args.FrameDataAccessed);
+			}
+		}
+	}
+
+	private static void OnTargetUnregistered(CompositionTarget target)
+	{
+		_targets.Remove(target);
+		if (_latestFrames.Remove(target, out var picture))
+		{
+			picture.Release(pictureAccessed: false);
+		}
+	}
+
+	/// <summary>
+	/// Owns a frame's recorded picture. The picture is disposed deterministically once the
+	/// pipeline released it and all retentions (the latest-frame cache, in-flight Rendering
+	/// raises) are gone — unless a Rendering subscriber actually read it from the event args,
+	/// in which case user code may still hold it and the GC reclaims it instead.
+	/// </summary>
+	internal sealed class FramePicture(SKPicture picture)
+	{
+		private readonly Lock _gate = new();
+		private int _retainCount;
+		private bool _publicized;
+		private bool _releasedByPipeline;
+		private bool _disposed;
+
+		public SKPicture Picture { get; } = picture;
+
+		public void Retain()
+		{
+			lock (_gate)
+			{
+				_retainCount++;
+			}
+		}
+
+		public void Release(bool pictureAccessed)
+		{
+			bool dispose;
+			lock (_gate)
+			{
+				_retainCount--;
+				_publicized |= pictureAccessed;
+				dispose = ShouldDispose();
+				_disposed |= dispose;
+			}
+
+			if (dispose)
+			{
+				Picture.Dispose();
+			}
+		}
+
+		public void OnPipelineReleased()
+		{
+			bool dispose;
+			lock (_gate)
+			{
+				_releasedByPipeline = true;
+				dispose = ShouldDispose();
+				_disposed |= dispose;
+			}
+
+			if (dispose)
+			{
+				Picture.Dispose();
+			}
+		}
+
+		// only call under _gate
+		private bool ShouldDispose() => !_disposed && !_publicized && _releasedByPipeline && _retainCount == 0;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RenderingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RenderingEventArgs.cs
@@ -1,16 +1,35 @@
-﻿using System;
+#nullable enable
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.UI.Xaml.Media
 {
 	public sealed partial class RenderingEventArgs
 	{
-		internal RenderingEventArgs(TimeSpan renderingTime)
+		private readonly IReadOnlyList<(Window Window, object Data)>? _frameData;
+
+		internal RenderingEventArgs(TimeSpan renderingTime, IReadOnlyList<(Window Window, object Data)>? frameData = null)
 		{
 			RenderingTime = renderingTime;
+			_frameData = frameData;
 		}
 
 		public TimeSpan RenderingTime { get; }
+
+		/// <summary>
+		/// The frames recorded for this rendering pass, as pairs of a window and its opaque
+		/// frame data, when available. Intended for internal and advanced scenarios.
+		/// </summary>
+		public IReadOnlyList<(Window Window, object Data)>? FrameData
+		{
+			get
+			{
+				FrameDataAccessed = true;
+				return _frameData;
+			}
+		}
+
+		internal bool FrameDataAccessed { get; private set; }
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/kahua-private/issues/505

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
