### PR TITLE
ci(docs): Bump Windows scaled pool to unblock docs CI

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -25,7 +25,7 @@ pr:
       - '**/*.md'
 
 variables:
-  windowsScaledPool: 'Windows2025-20260406-1'
+  windowsScaledPool: 'Windows2025-20260622-1'
   linuxVMImage: 'ubuntu-22.04'
 
   enable_dotnet_cache: true


### PR DESCRIPTION
**GitHub Issue:** N/A — CI infrastructure maintenance

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The docs CI pipeline (`.vsts-ci-docs.yml`) referenced the `Windows2025-20260406-1` scaled pool image, which was causing the pipeline to fail. This bumps the reference to the current `Windows2025-20260622-1` image to unblock docs CI.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, CI config only
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
