### PR TITLE
chore: bump windowsScaledPool='Windows2025-20260622-1'

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -25,13 +25,16 @@ pr:
       - '**/*.md'
 
 variables:
-  windowsScaledPool: 'Windows2025-20260406-1'
+  windowsScaledPool: 'Windows2025-20260622-1'
   linuxVMImage: 'ubuntu-22.04'
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.33.0-dev.26'
-  DotNetSdkVersion: '10.0.105'
+  GlobalUnoCheckVersion: '1.35.0-dev.28'
+  DotNetSdkVersion: '11.0.100-preview.5.26302.115'
+
+  netCurrentTargetFramework: 'net11.0'
+  netPreviousTargetFramework: 'net10.0'
 
 stages:
 - template: build/ci/.azure-devops-stages-docs.yml

--- a/build/ci/docs/.azure-devops-docs.yml
+++ b/build/ci/docs/.azure-devops-docs.yml
@@ -22,6 +22,8 @@ jobs:
       nugetPackages: $(NUGET_PACKAGES)
 
   - template: ../templates/dotnet-mobile-install-windows.yml
+    parameters:
+      UnoCheckParameters: '--preview-major --tfm $(netCurrentTargetFramework)-ios --tfm $(netCurrentTargetFramework)-maccatalyst --tfm $(netCurrentTargetFramework)-android --tfm $(netCurrentTargetFramework)-tvos'
 
   - template: ../templates/gitversion.yml
   - template: ../templates/jdk-setup.yml


### PR DESCRIPTION
Context: 926e421425492b5c4125ea4fa81211f0cad7d4b9

Some of the docs builds are failing, in a similar manner as described in commit 926e4214:

	##[error]Build\Uno.UI.Build.csproj(0,0): Error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
	  Version 11.0.100-preview.5.26302.115 of the .NET SDK requires at least version 18.6.0 of MSBuild. The current available version of MSBuild is 18.4.0.7901. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
	  The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
	  MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
	     0>C:\a\1\s\Build\Uno.UI.Build.csproj : error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
	C:\a\1\s\Build\Uno.UI.Build.csproj : error :   Version 11.0.100-preview.5.26302.115 of the .NET SDK requires at least version 18.6.0 of MSBuild. The current available version of MSBuild is 18.4.0.7901. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
	C:\a\1\s\Build\Uno.UI.Build.csproj : error :   The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
	C:\a\1\s\Build\Uno.UI.Build.csproj : error :   MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
	##[error]Build\Uno.UI.Build.csproj(0,0): Error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
	     1>Project "C:\a\1\s\Build\Uno.UI.Build.csproj" on node 1 (Restore target(s)).
	     1>C:\a\1\s\Build\Uno.UI.Build.csproj : error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
	     1>Done Building Project "C:\a\1\s\Build\Uno.UI.Build.csproj" (Restore target(s)) -- FAILED.

Update `.vsts-ci-docs.yml` so that
`$(windowsScaledPool)`='Windows2025-20260622-1', which should resolve the above error.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
🐞 Bugfix
🏗️ Build or CI related changes

<!--
Copy the label that applies to this PR and paste it above:

✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
