### PR TITLE
fix: Reuse ListView containers on drag-drop reorder

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -5855,7 +5855,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		// Maps each data item to its realized container. Keyed by data item (not index) so identity can be
 		// compared across a reorder, where indices change. Asserts every item is realized at capture time.
-		// Typed on ItemsControl so it serves both ListView and GridView (containers derive from SelectorItem).
+		// Typed on ItemsControl (which defines ContainerFromItem); items comes in as IEnumerable<object>,
+		// which ObservableCollection<string> satisfies via IEnumerable<out T> covariance.
 		private static Dictionary<object, object> CaptureContainersByItem(ItemsControl list, IEnumerable<object> items)
 		{
 			var map = new Dictionary<object, object>();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -5335,6 +5335,153 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreSame(containersBefore[2], containersAfter[1], "Container at 2→1 must be the same instance (displaced item)");
 			Assert.AreSame(containersBefore[3], containersAfter[3], "Container at 3→3 must be the same instance");
 		}
+
+		// The four tests below reproduce the drag-drop reorder "whole-list flicker": on drop the managed
+		// layout used to call the heavy Refresh() (recycle every container) instead of a light re-measure,
+		// re-dealing containers to different data so every row re-templated. Identity is keyed by data item
+		// (indices change across a reorder). A/B are the collection-mutation paths (always reused); C is the
+		// real drag-drop drop path (the regression); D isolates that Refresh() itself churns containers.
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_Reorder_Move_ReusesContainers()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 8).Select(x => $"Item {x}"));
+			var SUT = new ListView
+			{
+				Height = 400, // tall enough to realize all 8 items at 29px (no scroll virtualization)
+				ItemsSource = source,
+				ItemTemplate = FixedSizeItemTemplate, // height=29
+			};
+
+			await UITestHelper.Load(SUT, x => x.IsLoaded && SUT.ContainerFromIndex(7) is { });
+			await UITestHelper.WaitForIdle();
+
+			var before = CaptureContainersByItem(SUT, source);
+
+			source.Move(2, 5); // the Move Up/Down button path — a single NCC 'Move'
+			await UITestHelper.WaitForIdle();
+
+			var after = CaptureContainersByItem(SUT, source);
+			AssertAllContainersReused(before, after, "Move(2→5)");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_Reorder_RemoveInsert_ReusesContainers()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 8).Select(x => $"Item {x}"));
+			var SUT = new ListView
+			{
+				Height = 400,
+				ItemsSource = source,
+				ItemTemplate = FixedSizeItemTemplate,
+			};
+
+			await UITestHelper.Load(SUT, x => x.IsLoaded && SUT.ContainerFromIndex(7) is { });
+			await UITestHelper.WaitForIdle();
+
+			var before = CaptureContainersByItem(SUT, source);
+
+			// The collection-mutation half of a drag-drop commit (UWP uses RemoveAt+Insert, not Move).
+			var item = source[2];
+			source.RemoveAt(2);
+			source.Insert(5, item);
+			await UITestHelper.WaitForIdle();
+
+			var after = CaptureContainersByItem(SUT, source);
+			AssertAllContainersReused(before, after, "RemoveAt(2)+Insert(5)");
+		}
+
+#if HAS_UNO
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_Reorder_DragDrop_ReusesContainers()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 8).Select(x => $"Item {x}"));
+			var SUT = new ListView
+			{
+				Height = 400,
+				AllowDrop = true,
+				CanDragItems = true,
+				CanReorderItems = true,
+				ItemsSource = source,
+				ItemTemplate = FixedSizeItemTemplate,
+			};
+
+			await UITestHelper.Load(SUT, x => x.IsLoaded && SUT.ContainerFromIndex(7) is { });
+			await UITestHelper.WaitForIdle();
+
+			var dragged = source[2];
+			var before = CaptureContainersByItem(SUT, source);
+
+			var fromRect = (SUT.ContainerFromIndex(2) as ListViewItem ?? throw new InvalidOperationException("no container at index 2")).GetAbsoluteBoundsRect();
+			var toRect = (SUT.ContainerFromIndex(5) as ListViewItem ?? throw new InvalidOperationException("no container at index 5")).GetAbsoluteBoundsRect();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			// pick up item#2, drag down over item#5's row, then drop
+			mouse.MoveTo(fromRect.GetCenter());
+			await WindowHelper.WaitForIdle();
+			mouse.Press();
+			await WindowHelper.WaitForIdle();
+			mouse.MoveTo(toRect.GetCenter(), 16);
+			await WindowHelper.WaitForIdle();
+			await UITestHelper.WaitForRender();
+			mouse.MoveTo(toRect.GetCenter(), 2);
+			await WindowHelper.WaitForIdle();
+			mouse.Release();
+			await WindowHelper.WaitForIdle();
+			await UITestHelper.WaitForIdle();
+
+			// Guard: the drop must actually have reordered, otherwise the reuse check would be vacuous.
+			Assert.AreNotEqual(2, source.IndexOf(dragged), "drag-drop did not reorder the dragged item");
+
+			var after = CaptureContainersByItem(SUT, source);
+
+			// The drop must keep every container's identity — the managed layout used to call the heavy
+			// Refresh() here, recycling and re-dealing every container (the whole-list flicker).
+			AssertAllContainersReused(before, after, "drag-drop reorder");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_Layouter_Refresh_RecreatesContainers()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 8).Select(x => $"Item {x}"));
+			var SUT = new ListView
+			{
+				Height = 400,
+				ItemsSource = source,
+				ItemTemplate = FixedSizeItemTemplate,
+			};
+
+			await UITestHelper.Load(SUT, x => x.IsLoaded && SUT.ContainerFromIndex(7) is { });
+			await UITestHelper.WaitForIdle();
+
+			var before = CaptureContainersByItem(SUT, source);
+
+			// Isolation: drive the heavy layout path a drop used to call, with NO collection change at all.
+			var layout = (SUT.ItemsPanelRoot as IVirtualizingPanel)?.GetLayouter()
+				?? throw new InvalidOperationException("ListView is not backed by a virtualizing panel layout");
+			layout.Refresh();
+			await UITestHelper.WaitForIdle();
+
+			var after = CaptureContainersByItem(SUT, source);
+
+			// Refresh() recycles every container and clears the id cache → containers are re-dealt.
+			var reused = CountReusedContainers(before, after);
+			Assert.IsTrue(reused < before.Count, $"Refresh() should recycle/re-deal containers, but all {before.Count} were reused");
+		}
+#endif
 	}
 
 	public partial class Given_ListViewBase // data class, data-context, view-model, template-selector
@@ -5705,6 +5852,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				.ToArray();
 #endif
 		}
+
+		// Maps each data item to its realized container. Keyed by data item (not index) so identity can be
+		// compared across a reorder, where indices change. Asserts every item is realized at capture time.
+		// Typed on ItemsControl so it serves both ListView and GridView (containers derive from SelectorItem).
+		private static Dictionary<object, object> CaptureContainersByItem(ItemsControl list, IEnumerable<object> items)
+		{
+			var map = new Dictionary<object, object>();
+			foreach (var item in items)
+			{
+				var container = list.ContainerFromItem(item);
+				Assert.IsNotNull(container, $"Expected a realized container for '{item}'");
+				map[item] = container;
+			}
+
+			return map;
+		}
+
+		private static void AssertAllContainersReused(Dictionary<object, object> before, Dictionary<object, object> after, string context)
+		{
+			using var _ = new AssertionScope();
+			foreach (var (item, container) in before)
+			{
+				Assert.AreSame(container, after[item], $"{context}: container for '{item}' must be reused (would flicker if recreated)");
+			}
+		}
+
+		private static int CountReusedContainers(Dictionary<object, object> before, Dictionary<object, object> after)
+			=> before.Count(kvp => ReferenceEquals(kvp.Value, after[kvp.Key]));
 
 		private static double GetTop(FrameworkElement element, FrameworkElement container)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -1256,9 +1256,10 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			_pendingReorder = null;
 
-			// We need a full refresh to properly re-arrange all items at their right location,
-			// ignoring the temp location of the dragged / reordered item.
-			Refresh();
+			// A light re-measure re-arranges all items at their final location (the temp reorder offset was
+			// just cleared) while preserving container identity. A full Refresh() would recycle and re-deal
+			// every container, re-templating the whole list on drop (the reorder flicker).
+			LightRefresh();
 
 			return updatedIndex;
 		}


### PR DESCRIPTION
**GitHub Issue:** Tracked internally (client-reported ListView drag-drop reorder flicker). No public issue.

## PR Type:

🐞 Bugfix

## What changed? 🚀

Reordering a `ListView` by **drag-and-drop** visibly flickered the **whole** list — every row re-templated — whereas the Move Up / Move Down buttons did not.

On drop, `VirtualizingPanelLayout.CompleteReorderingItem` called `Refresh()` unconditionally. `Refresh()` recycles **every** materialized container (`clearContainer: true`) and clears the generator id cache, so on the next measure the containers are re-dealt to *different* data items — every visible row re-templates (the flicker). The lighter `LightRefresh()` (used by `UpdateReorderingItem` / `CleanupReordering`) just re-measures and preserves container identity.

This PR switches the managed drop path to `LightRefresh()`. The temp reorder offset is already cleared before the call, so a re-measure re-arranges all items to their final positions while keeping each container instance bound to its data item. This is the same light path the Android layout already takes by default (its heavy recycle is gated behind `ForceRecycleOnDrop`, which is off by default and documented as *"known to cause a flicker of the whole list"*).

Scope: managed layout (Skia). GridView on Skia uses a non-virtualizing `WrapPanel`, so `CompleteReorderingItem` is never invoked for it — the change affects `ListView` (and any real virtualizing `ItemsStackPanel`).

**Tests** — four runtime tests in `Given_ListViewBase` covering the reorder paths, container identity keyed by data item:
- `When_Reorder_Move_ReusesContainers` — `ObservableCollection.Move` (button path)
- `When_Reorder_RemoveInsert_ReusesContainers` — `RemoveAt`+`Insert` (drag-drop's collection commit)
- `When_Reorder_DragDrop_ReusesContainers` — **real pointer-driven drag-drop** (fails before this change, passes after)
- `When_Layouter_Refresh_RecreatesContainers` — isolates that `Refresh()` itself churns containers

Validated on Skia Desktop: the drag-drop test flips FAIL→PASS with the fix, and the existing reorder/drag tests (`When_UpdateLayout_In_DragDropping`, `When_Drop_Outside_Bounds`, `When_UpdateLayout_In_DragDropping_2`, `When_DragDrop_ItemsSource_Is_Subclass_Of_ObservableCollection`, `When_INCC_Move_MinimalUpdate`) still pass — confirming the dropped item still lands in the correct position via incremental collection-change handling.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
