### PR TITLE
fix(tests): exclude Skia semantic-DOM a11y tests from the native WASM head

### DIFF
--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Wasm.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Wasm.csproj
@@ -85,6 +85,15 @@
 		<PRIResource Include="Resources\**\*.resw" />
 	</ItemGroup>
 
+	<!-- The Skia/WASM accessibility semantic-DOM tests use composition APIs (UIElement.Visual) that
+	     don't exist on the native WASM head, so they don't compile there and aren't applicable (native
+	     WASM surfaces accessibility through the regular DOM elements). Exclude them, like the
+	     netcoremobile head does. -->
+	<ItemGroup>
+		<Compile Remove="Tests\Windows_UI_Xaml_Automation\Given_Accessible*.cs" />
+		<Compile Remove="Tests\Windows_UI_Xaml_Automation\WasmSemanticDomHelper.cs" />
+	</ItemGroup>
+
 	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" />
 	<Import Project="..\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks.targets" Condition="'$(SkipUnoResourceGeneration)' == '' " />
 </Project>


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- CI-only compilation fix: the `Tests - WebAssembly Native` stage fails to build on master. -->

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The `Tests - WebAssembly Native` stage has been failing on master since 2026-07-10 (first seen in build 221706, still failing in 222040 and 222344): the native-WASM runtime-tests head no longer compiles.

```
src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/WasmSemanticDomHelper.cs(36,41):
error CS1061: 'UIElement' does not contain a definition for 'Visual'
[src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Wasm.csproj::TargetFramework=net10.0]
```

`WasmSemanticDomHelper` (and the `Given_Accessible*` semantic-DOM assertions that use it) exercise the Skia-WASM accessibility semantic DOM through `UIElement.Visual.Handle`, a composition API that only exists on the Skia heads (`UIElement.skia.cs`). On the native WASM head accessibility is surfaced through the regular DOM elements, so these tests neither compile nor apply there — same situation as the native mobile head, which already excludes them (`Uno.UI.RuntimeTests.netcoremobile.csproj`).

This PR mirrors that existing exclusion in `Uno.UI.RuntimeTests.Wasm.csproj`. The semantic-DOM tests keep compiling and running where they are meant to (Skia heads, gated by `[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWasm)]`), and the native WASM head compiles again.

Verified locally with the same build the CI stage runs into:

- before: `dotnet build src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Wasm.csproj -c Release -p:UnoTargetFrameworkOverride=net10.0` → `CS1061`
- after: same command → 0 errors, 0 warnings

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, restores compilation of the existing test suite
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)