### PR TITLE
chore: Update to .NET 11 Preview 6

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -30,8 +30,8 @@ variables:
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.35.0-dev.28'
-  DotNetSdkVersion: '11.0.100-preview.5.26302.115'
+  GlobalUnoCheckVersion: '1.35.0-dev.33'
+  DotNetSdkVersion: '11.0.100-preview.6.26359.118'
 
   netCurrentTargetFramework: 'net11.0'
   netPreviousTargetFramework: 'net10.0'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -58,7 +58,7 @@ variables:
   linuxScaledPool: 'Ubuntu2404-20251016'
   macOSVMImage: 'macOS-26'
   macOSVMImage_UITests: 'macOS-14'
-  xCodeRoot: '/Applications/Xcode_26.5.app'
+  xCodeRoot: '/Applications/Xcode_26.6.app'
   xCodeRoot_iOS_UITests: '/Applications/Xcode_15.3.app'
 
   # Offline validation to improve build performance
@@ -70,8 +70,8 @@ variables:
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.35.0-dev.28'
-  DotNetSdkVersion: '11.0.100-preview.5.26302.115'
+  GlobalUnoCheckVersion: '1.35.0-dev.33'
+  DotNetSdkVersion: '11.0.100-preview.6.26359.118'
 
   netCurrentTargetFramework: 'net11.0'
   netPreviousTargetFramework: 'net10.0'

--- a/build/ci/net11/_global.json
+++ b/build/ci/net11/_global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "11.0.100-preview.5.26302.115",
+		"version": "11.0.100-preview.6.26359.118",
 		"allowPrerelease": true,
 		"rollForward": "disable"
 	},
@@ -8,7 +8,7 @@
 		"runner": "Microsoft.Testing.Platform"
 	},
 	"tools": {
-		"dotnet": "11.0.100-preview.5.26302.115"
+		"dotnet": "11.0.100-preview.6.26359.118"
 	},
 	"msbuild-sdks": {
 		"Microsoft.Build.NoTargets": "3.7.56"

--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
@@ -27,7 +27,7 @@ jobs:
     parameters:
       UnoCheckParameters: '--preview-major --tfm $(netCurrentTargetFramework)-android'
 
-  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f $(netCurrentTargetFramework)-android -p:UnoTargetFrameworkOverride=$(netCurrentTargetFramework)-android -p:ApplicationId=uno.platform.samplesapp.skia.coreclr -p:UseMonoRuntime=false -p:SkiaSharpVersion=4.148.0 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-coreclr.binlog
+  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f $(netCurrentTargetFramework)-android -p:UnoTargetFrameworkOverride=$(netCurrentTargetFramework)-android -p:ApplicationId=uno.platform.samplesapp.skia.coreclr -p:UseMonoRuntime=false -p:SkiaSharpVersion=4.151.0-rc.1.1 -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-coreclr.binlog
     displayName: Build Android+CoreCLR Skia Head
 
   - script: >

--- a/build/ci/tests/.azure-devops-tests-android-nativeaot-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-nativeaot-skia-build.yml
@@ -25,7 +25,7 @@ jobs:
     parameters:
       UnoCheckParameters: '--preview-major --tfm $(netCurrentTargetFramework)-android'
 
-  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f $(netCurrentTargetFramework)-android -p:UnoTargetFrameworkOverride=$(netCurrentTargetFramework)-android -p:ApplicationId=uno.platform.samplesapp.skia.nativeaot -p:SkiaPublishAot=true -p:SkiaSharpVersion=4.148.0 /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-nativeaot.binlog
+  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f $(netCurrentTargetFramework)-android -p:UnoTargetFrameworkOverride=$(netCurrentTargetFramework)-android -p:ApplicationId=uno.platform.samplesapp.skia.nativeaot -p:SkiaPublishAot=true -p:SkiaSharpVersion=4.151.0-rc.1.1 /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-nativeaot.binlog
     displayName: Build Android+NativeAOT Skia Head
 
   - script: >

--- a/build/nuget/Uno.WinUI.Graphics2DSK.nuspec
+++ b/build/nuget/Uno.WinUI.Graphics2DSK.nuspec
@@ -13,33 +13,33 @@
 		<dependencies>
 			<group targetFramework="net10.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 
 			<group targetFramework="net10.0-windows10.0.19041.0">
 				<dependency id="Microsoft.WindowsAppSDK" version="1.5.240227000" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 
 			<group targetFramework="net10.0-android36.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 			<group targetFramework="net11.0-android37.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 			<group targetFramework="net10.0-ios26.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 			<group targetFramework="net11.0-ios26.5">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 			<group targetFramework="net10.0-tvos26.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="SkiaSharp" version="4.148.0" />
+				<dependency id="SkiaSharp" version="4.151.0-rc.1.1" />
 			</group>
 			<group targetFramework="net11.0-tvos26.5">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />

--- a/build/nuget/Uno.WinUI.Lottie.nuspec
+++ b/build/nuget/Uno.WinUI.Lottie.nuspec
@@ -32,25 +32,25 @@
 			</group>
 
 			<group targetFramework="net10.0-android">
-				<dependency id="SkiaSharp.Skottie" version="4.148.0" />
-				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.148.0" />
-				<dependency id="SkiaSharp.NativeAssets.android" version="4.148.0" />
+				<dependency id="SkiaSharp.Skottie" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.NativeAssets.android" version="4.151.0-rc.1.1" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
 			</group>
 			<group targetFramework="net10.0-ios26.0">
-				<dependency id="SkiaSharp.Skottie" version="4.148.0" />
-				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.148.0" />
-				<dependency id="SkiaSharp.NativeAssets.ios" version="4.148.0" />
+				<dependency id="SkiaSharp.Skottie" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.NativeAssets.ios" version="4.151.0-rc.1.1" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="System.Json" version="4.7.1" />
 			</group>
 			<group targetFramework="net10.0-tvos26.0">
-				<dependency id="SkiaSharp.Skottie" version="4.148.0" />
-				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.148.0" />
-				<dependency id="SkiaSharp.NativeAssets.tvos" version="4.148.0" />
+				<dependency id="SkiaSharp.Skottie" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.NativeAssets.tvos" version="4.151.0-rc.1.1" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="System.Json" version="4.7.1" />

--- a/build/nuget/Uno.WinUI.Svg.nuspec
+++ b/build/nuget/Uno.WinUI.Svg.nuspec
@@ -29,22 +29,22 @@
 
 			<group targetFramework="net10.0-android">
 				<dependency id="Svg.Skia" version="3.0.6" />
-				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.148.0" />
-				<dependency id="SkiaSharp.NativeAssets.android" version="4.148.0" />
+				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.NativeAssets.android" version="4.151.0-rc.1.1" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 			<group targetFramework="net10.0-ios26.0">
 				<dependency id="Svg.Skia" version="3.0.6" />
-				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.148.0" />
-				<dependency id="SkiaSharp.NativeAssets.ios" version="4.148.0" />
+				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.NativeAssets.ios" version="4.151.0-rc.1.1" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 			<group targetFramework="net10.0-tvos26.0">
 				<dependency id="Svg.Skia" version="3.0.6" />
-				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.148.0" />
-				<dependency id="SkiaSharp.NativeAssets.tvos" version="4.148.0" />
+				<dependency id="SkiaSharp.Views.Uno.WinUI" version="4.151.0-rc.1.1" />
+				<dependency id="SkiaSharp.NativeAssets.tvos" version="4.151.0-rc.1.1" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -28,7 +28,7 @@ $projects =
 @(
     # 5.3 Blank with net9
     @(0, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @(), @()),
-    @(0, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-browserwasm", "-p:UseArtifactsOutput=true", "-p:UnoXamlResourcesTrimming=true"), @()),
+    @(0, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-browserwasm", "-p:UseArtifactsOutput=true", "-p:UnoXamlResourcesTrimming=true"), @()),
 
     # 5.3 lib
     @(1, "5.3/uno53net9Lib/uno53net9Lib.csproj", @(), @()),
@@ -37,10 +37,10 @@ $projects =
     @(1, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @(), @()),
     
     # 5.6 net-current with XAML trimming validation - desktop
-    @(1, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net10.0-desktop", "-p:UnoXamlResourcesTrimming=true", "-p:PublishTrimmed=true", "-r", "linux-x64"), @("Publish")),
+    @(1, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net11.0-desktop", "-p:UnoXamlResourcesTrimming=true", "-p:PublishTrimmed=true", "-r", "linux-x64"), @("Publish")),
     
     # 5.6 net-current with XAML trimming validation - wasm
-    @(1, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net10.0-browserwasm", "-p:UnoXamlResourcesTrimming=true", "-p:WasmShellILLinkerEnabled=true"), @("Publish")),
+    @(1, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net11.0-browserwasm", "-p:UnoXamlResourcesTrimming=true", "-p:WasmShellILLinkerEnabled=true"), @("Publish")),
 
     # 5.3 Uno App with Library reference
     @(2, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @(), @()),
@@ -133,7 +133,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
 if ($TestGroup -eq '1')
 {
     $skiaAlignProject = "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj"
-    $skiaAlignVersion = "4.148.0"
+    $skiaAlignVersion = "4.151.0-rc.1.1"
     $skiaAlignAssets = "5.6/uno56netcurrent/uno56netcurrent/obj/project.assets.json"
 
     Write-Host "Validating SkiaSharp.NativeAssets.Linux aligns with an overridden SkiaSharpVersion ($skiaAlignVersion) - issue #23658"

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -157,7 +157,7 @@ $release = $default + '-p:Configuration=Release'
 
 & $env:BUILD_SOURCESDIRECTORY/build/test-scripts/update-uno-sdk-globaljson.ps1
 
-$sdkFeatures = $(If ($IsWindows) {"-p:UnoFeatures=Material%3BExtensions%3BToolkit%3BCSharpMarkup%3BSvg%3BMVUX"} Else { "-p:UnoFeatures=Material%3BToolkit" });
+$sdkFeatures = $(If ($IsWindows) {"-p:UnoFeaturesOverride=Material%3BExtensions%3BToolkit%3BCSharpMarkup%3BSvg%3BMVUX"} Else { "-p:UnoFeaturesOverride=Material%3BToolkit" });
 
 $projects =
 @(

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -61,7 +61,7 @@ if ( ($TestGroup -eq 0) -and ($env:UWPBuildEnabled -eq 'True') )
 
         # Build with msbuild because of https://github.com/microsoft/WindowsAppSDK/issues/1652
         # force targetframeworks until we can get WinAppSDK to build with `dotnet build`
-        & $msbuild $debug "/p:Platform=x86" "UnoAppWinUI.Windows\UnoAppWinUI.Windows.csproj" "/p:TargetFrameworks=net10.0-windows10.0.19041;TargetFramework=net10.0-windows10.0.19041" "/bl:../binlogs/UnoAppWinUI.Windows/debug/$i/msbuild.binlog"
+        & $msbuild $debug "/p:Platform=x86" "UnoAppWinUI.Windows\UnoAppWinUI.Windows.csproj" "/p:TargetFrameworks=net11.0-windows10.0.19041;TargetFramework=net11.0-windows10.0.19041" "/bl:../binlogs/UnoAppWinUI.Windows/debug/$i/msbuild.binlog"
         Assert-ExitCodeIsZero
     }
 
@@ -94,7 +94,7 @@ if ( ($TestGroup -eq 0) -and ($env:UWPBuildEnabled -eq 'True') )
             "$debug",
             "/t:pack",
             "MyUnoLib\MyUnoLib.csproj",
-            "/p:TargetFrameworks=""net10.0-windows10.0.19041;net10.0"""
+            "/p:TargetFrameworks=""net11.0-windows10.0.19041;net11.0"""
         )
         $responseFile | Out-File -FilePath "build.rsp" -Encoding ASCII
 
@@ -120,7 +120,7 @@ if ( ($TestGroup -eq 0) -and ($env:UWPBuildEnabled -eq 'True') )
             "/p:IncludeContentInPack=false",
             "MyUnoLib2\MyUnoLib2.csproj",
             "-bl",
-            "/p:TargetFrameworks=""net10.0-windows10.0.19041;net10.0"""
+            "/p:TargetFrameworks=""net11.0-windows10.0.19041;net11.0"""
         )
         $responseFile | Out-File -FilePath "build.rsp" -Encoding ASCII
 
@@ -161,44 +161,44 @@ $sdkFeatures = $(If ($IsWindows) {"-p:UnoFeatures=Material%3BExtensions%3BToolki
 
 $projects =
 @(
-    # 5.3 Uno App with net10
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0"), @("macOS", "NetCore")),
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0", $sdkFeatures), @("macOS", "NetCore")),
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-browserwasm"), @("macOS", "NetCore")),
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-browserwasm", $sdkFeatures), @("macOS", "NetCore")),
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-browserwasm", "-p:UseArtifactsOutput=true", "-p:UnoXamlResourcesTrimming=true"), @("macOS", "NetCore")),
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-desktop"), @("macOS", "NetCore")),
-    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-desktop", $sdkFeatures), @("macOS", "NetCore")),
+    # 5.3 Uno App with net11
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0"), @("macOS", "NetCore")),
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0", $sdkFeatures), @("macOS", "NetCore")),
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-browserwasm"), @("macOS", "NetCore")),
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-browserwasm", $sdkFeatures), @("macOS", "NetCore")),
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-browserwasm", "-p:UseArtifactsOutput=true", "-p:UnoXamlResourcesTrimming=true"), @("macOS", "NetCore")),
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-desktop"), @("macOS", "NetCore")),
+    @(1, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-desktop", $sdkFeatures), @("macOS", "NetCore")),
 
     # Default mode for the template is WindowsAppSDKSelfContained=true, which requires specifying a target platform.
-    @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-p:Platform=x86" , "-p:TargetFramework=net10.0-windows10.0.19041"), @()),
+    @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-p:Platform=x86" , "-p:TargetFramework=net11.0-windows10.0.19041"), @()),
 
     # 5.3 Library
     @(2, "5.3/uno53net9Lib/uno53net9Lib.csproj", @(), @("macOS", "NetCore")),
 
     # Publishing validation
-    @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-desktop", "-p:TargetFrameworks=net10.0-desktop", "-p:PackageFormat=app", "-r", "osx-x64", "-p:RuntimeIdentifiers=osx-x64"), @("OnlyMacOS", "NetCore", "Publish")),
+    @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-desktop", "-p:TargetFrameworks=net11.0-desktop", "-p:PackageFormat=app", "-r", "osx-x64", "-p:RuntimeIdentifiers=osx-x64"), @("OnlyMacOS", "NetCore", "Publish")),
 
     # Publish with no debug symbols validation
-    @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net10.0-desktop", "-p:TargetFrameworks=net10.0-desktop", "-r", "win-x64", "-p:DebugSymbols=false", "-p:DebugType=None"), @("NetCore", "Publish")),
+    @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net11.0-desktop", "-p:TargetFrameworks=net11.0-desktop", "-r", "win-x64", "-p:DebugSymbols=false", "-p:DebugType=None"), @("NetCore", "Publish")),
 
     # Publish with NativeAOT and *run*
-    @(2, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net10.0-desktop", "-r", "osx-x64", "-p:PublishAot=true"), @("OnlyMacOS", "NetCore", "Publish"),
-        @("5.6/uno56netcurrent/uno56netcurrent/bin/Release/net10.0-desktop/osx-x64/publish/uno56netcurrent"), @("--exit")),
+    @(2, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net11.0-desktop", "-r", "osx-x64", "-p:PublishAot=true"), @("OnlyMacOS", "NetCore", "Publish"),
+        @("5.6/uno56netcurrent/uno56netcurrent/bin/Release/net11.0-desktop/osx-x64/publish/uno56netcurrent"), @("--exit")),
 
     # 5.6 net-current runtime folder validation
     @(3, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @(), @("macOS", "NetCore")),
     
     # 5.6 net-current with XAML trimming validation - desktop
-    @(3, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net10.0-desktop", "-p:UnoXamlResourcesTrimming=true", "-p:PublishTrimmed=true", "-r", "win-x64"), @("NetCore", "Publish")),
+    @(3, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net11.0-desktop", "-p:UnoXamlResourcesTrimming=true", "-p:PublishTrimmed=true", "-r", "win-x64"), @("NetCore", "Publish")),
     
     # 5.6 net-current with XAML trimming validation - wasm
-    @(3, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net10.0-browserwasm", "-p:UnoXamlResourcesTrimming=true", "-p:WasmShellILLinkerEnabled=true"), @("macOS", "NetCore", "Publish")),
+    @(3, "5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj", @("-f", "net11.0-browserwasm", "-p:UnoXamlResourcesTrimming=true", "-p:WasmShellILLinkerEnabled=true"), @("macOS", "NetCore", "Publish")),
 
     # Ensure that build can happen even if a RID is specified
-    @(4, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @("-f", "net10.0"), @("macOS", "NetCore")),
-    @(4, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @("-f", "net10.0-browserwasm"), @("macOS", "NetCore")),
-    @(4, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @("-f", "net10.0-desktop"), @("macOS", "NetCore")),
+    @(4, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @("-f", "net11.0"), @("macOS", "NetCore")),
+    @(4, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @("-f", "net11.0-browserwasm"), @("macOS", "NetCore")),
+    @(4, "5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj", @("-f", "net11.0-desktop"), @("macOS", "NetCore")),
 
     ## Note for contributors
     ##

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -270,7 +270,7 @@ By default, the Uno.Sdk specifies a set of OS Platform versions, as follows:
 
 | Target | `SupportedOSPlatformVersion` |
 |--------|----------------------------|
-| Android | 21 |
+| Android | 24 |
 | iOS | 14.2 |
 | macOS | 10.14 |
 | tvOS  | 14.2 |
@@ -282,7 +282,7 @@ You can set this property in a `Choose` MSBuild block in order to alter its valu
  <Choose>
     <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
       <PropertyGroup>
-        <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>24.0</SupportedOSPlatformVersion>
       </PropertyGroup>
     </When>
     <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">

--- a/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.WinUI.Lottie.targets
+++ b/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.WinUI.Lottie.targets
@@ -25,7 +25,7 @@
 			<_SkottieRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'SkiaSharp.Skottie'" />
 		</ItemGroup>
 
-		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Lottie support, the '$(_SkiaSharpPackageName)' NuGet Package (4.148.0 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;4.148.0&quot; /> to your project." />
-		<Error Condition="'@(_SkottieRefs)'==''" Text="The 'SkiaSharp.Skottie' NuGet Package (4.148.0 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;SkiaSharp.Skottie&quot; Version=&quot;4.148.0&quot; /> to your project." />
+		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Lottie support, the '$(_SkiaSharpPackageName)' NuGet Package (4.151.0-rc.1.1 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;4.151.0-rc.1.1&quot; /> to your project." />
+		<Error Condition="'@(_SkottieRefs)'==''" Text="The 'SkiaSharp.Skottie' NuGet Package (4.151.0-rc.1.1 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;SkiaSharp.Skottie&quot; Version=&quot;4.151.0-rc.1.1&quot; /> to your project." />
 	</Target>
 </Project>

--- a/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.WinUI.Svg.targets
+++ b/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.WinUI.Svg.targets
@@ -25,7 +25,7 @@
 			<_SvgSkiaRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'Svg.Skia' AND '%(ReferencePath.NuGetPackageVersion)' >= '1.0.0.1'" />
 		</ItemGroup>
 
-		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Svg support, the '$(_SkiaSharpPackageName)' NuGet Package (4.148.0 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;4.148.0&quot; /> to your project." />
+		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Svg support, the '$(_SkiaSharpPackageName)' NuGet Package (4.151.0-rc.1.1 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;4.151.0-rc.1.1&quot; /> to your project." />
 		<Error Condition="'@(_SvgSkiaRefs)'==''" Text="In order to use Uno Svg support, the 'Svg.Skia' NuGet Package (1.0.0.1 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;Svg.Skia&quot; Version=&quot;1.0.0.1&quot; /> to your project." />
 	</Target>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -172,7 +172,7 @@
 		<PackageReference Update="harfbuzzsharp.nativeassets.tvos" Version="$(HarfbuzzSharpVersion)" />
 
 		<PackageReference Condition=" '$(TargetFramework)' == '$(NetPrevious)' "  Update="Microsoft.Win32.SystemEvents" Version="10.0.9" />
-		<PackageReference Condition=" '$(TargetFramework)' == '$(NetCurrent)' "   Update="Microsoft.Win32.SystemEvents" Version="11.0.0-preview.5.26302.115" />
+		<PackageReference Condition=" '$(TargetFramework)' == '$(NetCurrent)' "   Update="Microsoft.Win32.SystemEvents" Version="11.0.0-preview.6.26359.118" />
 
 		<PackageReference Update="Svg.Skia" Version="3.0.6" />
 		<PackageReference Update="GtkSharp" Version="3.24.24.38" />
@@ -205,11 +205,11 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net11.0-android'">
-		<PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.7.1.3" />
-		<PackageReference Update="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
-		<PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.4.0.5" />
-		<PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.10.0.2" />
-		<PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.2.0.2" />
+		<PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.7.1.4" />
+		<PackageReference Update="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.3" />
+		<PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.4.0.6" />
+		<PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.11.0.1" />
+		<PackageReference Update="Xamarin.AndroidX.SwipeRefreshLayout" Version="1.2.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -74,8 +74,8 @@
 	<PropertyGroup>
 		<MSTestVersion>4.2.1</MSTestVersion>
 		<MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
-		<SkiaSharpVersion>4.148.0</SkiaSharpVersion>
-		<HarfbuzzSharpVersion>14.2.0</HarfbuzzSharpVersion>
+		<SkiaSharpVersion>4.151.0-rc.1.1</SkiaSharpVersion>
+		<HarfbuzzSharpVersion>14.2.1.1</HarfbuzzSharpVersion>
 		<UnoICUVersion>77.3.0-dev.4</UnoICUVersion>
 	</PropertyGroup>
 

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -237,9 +237,9 @@
 			</ItemGroup>
 
 			<ItemGroup Condition=" '$(TargetFramework)' == 'net11.0-android'">
-				<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.9.0.2" />
-				<PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
-				<PackageReference Include="Xamarin.Google.Android.Material" Version="1.14.0.1" />
+				<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.10.0.1" />
+				<PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.3" />
+				<PackageReference Include="Xamarin.Google.Android.Material" Version="1.14.0.5" />
 			</ItemGroup>
 
 			<ItemGroup>

--- a/src/SolutionTemplate/5.3/uno53AppWithLib/uno53AppWithLib/Properties/launchSettings.json
+++ b/src/SolutionTemplate/5.3/uno53AppWithLib/uno53AppWithLib/Properties/launchSettings.json
@@ -42,7 +42,7 @@
     },
     "uno53AppWithLib (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/uno53AppWithLib.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net11.0-desktop/uno53AppWithLib.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/src/SolutionTemplate/5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj
+++ b/src/SolutionTemplate/5.3/uno53AppWithLib/uno53AppWithLib/uno53AppWithLib.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-desktop</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net11.0-browserwasm;net11.0-desktop;net11.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net11.0-android;net11.0-ios;net11.0-maccatalyst;net11.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
 
     <!-- Disable android on msbuild .NET Framework until android 35 is supported -->
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-android',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-ios',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-maccatalyst',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-android',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-ios',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-maccatalyst',''))</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -54,7 +54,7 @@
           BeforeTargets="AfterBuild" Condition=" $(_IsPublishing) != 'true' ">
 
       <ItemGroup
-          Condition=" '$(TargetFramework)' == 'net10.0-windows10.0.19041' OR '$(TargetFramework)' == 'net10.0-desktop' ">
+          Condition=" '$(TargetFramework)' == 'net11.0-windows10.0.19041' OR '$(TargetFramework)' == 'net11.0-desktop' ">
         <!-- Validates that assets are properly propagated to the output folder, regardless of their "copy to output" value -->
         <_AssetsToValidate Include="$(OutputPath)Assets\SharedAssets.md" />
         <_AssetsToValidate Include="$(OutputPath)Assets\Icons\icon_foreground.png" />
@@ -76,7 +76,7 @@
       </ItemGroup>
 
       <ItemGroup
-          Condition="'$(TargetFramework)'=='net10.0-browserwasm'">
+          Condition="'$(TargetFramework)'=='net11.0-browserwasm'">
         <_AssetsToValidate Include="$(OutputPath)wwwroot\$(WasmShellOutputPackagePath)\Assets\SharedAssets.md" />
         <_AssetsToValidate Include="$(OutputPath)wwwroot\$(WasmShellOutputPackagePath)\Assets\json_file_asset.json" />
         <_AssetsToValidate Include="$(OutputPath)wwwroot\$(WasmShellOutputPackagePath)\Assets\Icons\icon_foreground.png" />
@@ -112,7 +112,7 @@
 
     <!-- Validate assets file -->
 
-    <ItemGroup Condition="'$(TargetFramework)'=='net10.0-browserwasm'">
+    <ItemGroup Condition="'$(TargetFramework)'=='net11.0-browserwasm'">
       <_StaticAssetsToValidate Include="uno53lib-test.xml" />
       <_StaticAssetsToValidate Include="uno53lib_icon_lib.png" />
     </ItemGroup>
@@ -137,7 +137,7 @@
           BeforeTargets="AfterPublish" Condition=" $(_IsPublishing) == 'true' ">
 
       <ItemGroup
-          Condition="'$(TargetFramework)'=='net10.0-browserwasm'">
+          Condition="'$(TargetFramework)'=='net11.0-browserwasm'">
         <_AssetsToValidate Include="$(PublishDir)wwwroot\$(WasmShellOutputPackagePath)\Assets\SharedAssets.md" />
         <_AssetsToValidate Include="$(PublishDir)wwwroot\$(WasmShellOutputPackagePath)\Assets\json_file_asset.json" />
         <_AssetsToValidate Include="$(PublishDir)wwwroot\$(WasmShellOutputPackagePath)\Assets\Icons\icon_foreground.png" />

--- a/src/SolutionTemplate/5.3/uno53AppWithLib/uno53emptylib/uno53emptylib.csproj
+++ b/src/SolutionTemplate/5.3/uno53AppWithLib/uno53emptylib/uno53emptylib.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-desktop</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net11.0-browserwasm;net11.0-desktop;net11.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net11.0-android;net11.0-ios;net11.0-maccatalyst;net11.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
     
     <!-- Disable android on msbuild .NET Framework until android 35 is supported -->
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-android',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-ios',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-maccatalyst',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-android',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-ios',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-maccatalyst',''))</TargetFrameworks>
 
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/src/SolutionTemplate/5.3/uno53AppWithLib/uno53lib/uno53lib.csproj
+++ b/src/SolutionTemplate/5.3/uno53AppWithLib/uno53lib/uno53lib.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-desktop</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net11.0-browserwasm;net11.0-desktop;net11.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net11.0-android;net11.0-ios;net11.0-maccatalyst;net11.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
 
     <!-- Disable android on msbuild .NET Framework until android 35 is supported -->
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-android',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-ios',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-maccatalyst',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-android',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-ios',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-maccatalyst',''))</TargetFrameworks>
 
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>

--- a/src/SolutionTemplate/5.3/uno53net9Lib/uno53net9Lib.csproj
+++ b/src/SolutionTemplate/5.3/uno53net9Lib/uno53net9Lib.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Uno.Sdk.Private">
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
+		<TargetFrameworks>net11.0;net11.0-ios;net11.0-maccatalyst;net11.0-windows10.0.19041;net11.0-browserwasm;net11.0-desktop</TargetFrameworks>
 
 		<!-- Disabled for https://github.com/unoplatform/uno.check/issues/241 -->
-		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net11.0-android</TargetFrameworks>
 
 		<!-- Disable android on msbuild .NET Framework until android 35 is supported -->
-		<TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-android',''))</TargetFrameworks>
-		<TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-ios',''))</TargetFrameworks>
-		<TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-maccatalyst',''))</TargetFrameworks>
+		<TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-android',''))</TargetFrameworks>
+		<TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-ios',''))</TargetFrameworks>
+		<TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-maccatalyst',''))</TargetFrameworks>
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/SolutionTemplate/5.3/uno53net9blank/uno53net9blank/Properties/launchSettings.json
+++ b/src/SolutionTemplate/5.3/uno53net9blank/uno53net9blank/Properties/launchSettings.json
@@ -42,7 +42,7 @@
     },
     "uno53net9blank (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/uno53net9blank.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net11.0-desktop/uno53net9blank.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/src/SolutionTemplate/5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj
+++ b/src/SolutionTemplate/5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj
@@ -39,8 +39,7 @@
       UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
       https://aka.platform.uno/singleproject-features
     -->
-    <UnoFeatures>
-    </UnoFeatures>
+    <UnoFeatures Condition=" '$(UnoFeaturesOverride)' != '' ">$(UnoFeaturesOverride)</UnoFeatures>
   </PropertyGroup>
 
 	<Target Name="_ValidateNetSdkWasm" BeforeTargets="BeforeBuild" Condition=" '$(TargetFramework)' == 'net11.0-browserwasm' ">

--- a/src/SolutionTemplate/5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj
+++ b/src/SolutionTemplate/5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-desktop</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net11.0-browserwasm;net11.0-desktop;net11.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net11.0-android;net11.0-ios;net11.0-maccatalyst;net11.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
 
     <!-- Disable android on msbuild .NET Framework until android 35 is supported -->
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-android',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-ios',''))</TargetFrameworks>
-    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net10.0-maccatalyst',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-android',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-ios',''))</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks.Replace('net11.0-maccatalyst',''))</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -43,7 +43,7 @@
     </UnoFeatures>
   </PropertyGroup>
 
-	<Target Name="_ValidateNetSdkWasm" BeforeTargets="BeforeBuild" Condition=" '$(TargetFramework)' == 'net10.0-browserwasm' ">
+	<Target Name="_ValidateNetSdkWasm" BeforeTargets="BeforeBuild" Condition=" '$(TargetFramework)' == 'net11.0-browserwasm' ">
 		<Error Text="The Wasm SDK is not enabled" Condition=" '$(_UnoUseMicrosoftNETSdkWebAssembly)' != 'true' OR '$(UsingMicrosoftNETSdkWebAssembly)' != 'true' " />
 	</Target>
 
@@ -51,7 +51,7 @@
         AfterTargets="_UnoPublishAppBundle">
 
     <ItemGroup
-        Condition=" '$(TargetFramework)' == 'net10.0-desktop' and '$(PackageFormat)' == 'app' ">
+        Condition=" '$(TargetFramework)' == 'net11.0-desktop' and '$(PackageFormat)' == 'app' ">
       <!-- Validates that assets are properly propagated to the output folder, regardless of their "copy to output" value -->
       <_AssetsToValidate Include="$(PublishDir)$(AssemblyName).app" />
     </ItemGroup>
@@ -65,7 +65,7 @@
         BeforeTargets="AfterBuild">
 
     <ItemGroup
-        Condition=" '$(TargetFramework)' == 'net10.0-windows10.0.19041' OR '$(TargetFramework)' == 'net10.0-desktop' ">
+        Condition=" '$(TargetFramework)' == 'net11.0-windows10.0.19041' OR '$(TargetFramework)' == 'net11.0-desktop' ">
       <!-- Validates that assets are properly propagated to the output folder, regardless of their "copy to output" value -->
       <_AssetsToValidate Include="$(OutputPath)Assets\SharedAssets.md" />
       <_AssetsToValidate Include="$(OutputPath)Assets\Icons\icon_foreground.png" />
@@ -78,7 +78,7 @@
     </ItemGroup>
 
     <ItemGroup
-        Condition="'$(TargetFramework)'=='net10.0-browserwasm'">
+        Condition="'$(TargetFramework)'=='net11.0-browserwasm'">
 
       <_AssetsToValidate Include="$(OutputPath)wwwroot\$(WasmShellOutputPackagePath)\Assets\SharedAssets.md" />
       <_AssetsToValidate Include="$(OutputPath)wwwroot\$(WasmShellOutputPackagePath)\Assets\Icons\icon_foreground.png" />

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios;net10.0-maccatalyst;net10.0-android;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net11.0;net11.0-ios;net11.0-maccatalyst;net11.0-android;net11.0-windows10.0.26100;net11.0-browserwasm;net11.0-desktop</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/UnoLibrary1/UnoLibrary1.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/UnoLibrary1/UnoLibrary1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios;net10.0-maccatalyst;net10.0-android;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net11.0;net11.0-ios;net11.0-maccatalyst;net11.0-android;net11.0-windows10.0.26100;net11.0-browserwasm;net11.0-desktop</TargetFrameworks>
     <UnoSingleProject>true</UnoSingleProject>
     <OutputType>Library</OutputType>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-browserwasm;net10.0-ios;net10.0-android;net10.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net11.0-browserwasm;net11.0-ios;net11.0-android;net11.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/src/SolutionTemplate/5.6/uno56net9win32/uno56net9win32/Properties/launchSettings.json
+++ b/src/SolutionTemplate/5.6/uno56net9win32/uno56net9win32/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "uno56net9win32 (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/uno56net9win32.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net11.0-desktop/uno56net9win32.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/src/SolutionTemplate/5.6/uno56net9win32/uno56net9win32/uno56net9win32.csproj
+++ b/src/SolutionTemplate/5.6/uno56net9win32/uno56net9win32/uno56net9win32.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net11.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/src/SolutionTemplate/5.6/uno56netcurrent/uno56netcurrent/Properties/launchSettings.json
+++ b/src/SolutionTemplate/5.6/uno56netcurrent/uno56netcurrent/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "uno56netcurrent (Desktop WSL2)": {
       "commandName": "WSL2",
-      "commandLineArgs": "{ProjectDir}/bin/Debug/net10.0-desktop/uno56netcurrent.dll",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net11.0-desktop/uno56netcurrent.dll",
       "distributionName": "",
       "compatibleTargetFramework": "desktop"
     }

--- a/src/SolutionTemplate/5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj
+++ b/src/SolutionTemplate/5.6/uno56netcurrent/uno56netcurrent/uno56netcurrent.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk.Private">
     <PropertyGroup>
-        <TargetFrameworks>net10.0-desktop;net10.0-browserwasm</TargetFrameworks>
+        <TargetFrameworks>net11.0-desktop;net11.0-browserwasm</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <UnoSingleProject>true</UnoSingleProject>

--- a/src/SolutionTemplate/MyAppXamlTrim/MyAppXamlTrim.Mobile/MyAppXamlTrim.Mobile.csproj
+++ b/src/SolutionTemplate/MyAppXamlTrim/MyAppXamlTrim.Mobile/MyAppXamlTrim.Mobile.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>net11.0-android;net11.0-ios;net11.0-maccatalyst</TargetFrameworks>
     <!-- Disabled because of https://github.com/xamarin/xamarin-macios/issues/16401-->
     <SingleProject>true</SingleProject>
     <OutputType>Exe</OutputType>
@@ -20,7 +20,7 @@
     <IsUnoHead>true</IsUnoHead>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">10.14</SupportedOSPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)'==''">

--- a/src/SolutionTemplate/MyAppXamlTrim/MyAppXamlTrim.Skia.Linux.FrameBuffer/MyAppXamlTrim.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/MyAppXamlTrim/MyAppXamlTrim.Skia.Linux.FrameBuffer/MyAppXamlTrim.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\MyAppXamlTrim.UWP')">
     <EmbeddedResource Include="..\MyAppXamlTrim.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />

--- a/src/SolutionTemplate/MyAppXamlTrim/MyAppXamlTrim.Wasm/MyAppXamlTrim.Wasm.csproj
+++ b/src/SolutionTemplate/MyAppXamlTrim/MyAppXamlTrim.Wasm/MyAppXamlTrim.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFramework>net11.0</TargetFramework>
 		<NoWarn>NU1701</NoWarn>
 		<_RequiresILLinkPack>true</_RequiresILLinkPack>
 	</PropertyGroup>

--- a/src/SolutionTemplate/MyCrossRuntimeLib/MyCrossRuntimeLib/MyCrossRuntimeLib.Skia.csproj
+++ b/src/SolutionTemplate/MyCrossRuntimeLib/MyCrossRuntimeLib/MyCrossRuntimeLib.Skia.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>MyCrossRuntimeLib</RootNamespace>
     <AssemblyName>MyCrossRuntimeLib</AssemblyName>

--- a/src/SolutionTemplate/MyCrossRuntimeLib/MyCrossRuntimeLib/MyCrossRuntimeLib.Wasm.csproj
+++ b/src/SolutionTemplate/MyCrossRuntimeLib/MyCrossRuntimeLib/MyCrossRuntimeLib.Wasm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>MyCrossRuntimeLib</RootNamespace>
     <AssemblyName>MyCrossRuntimeLib</AssemblyName>

--- a/src/SolutionTemplate/MyCrossRuntimeLib/MyCrossRuntimeLib/MyCrossRuntimeLib.csproj
+++ b/src/SolutionTemplate/MyCrossRuntimeLib/MyCrossRuntimeLib/MyCrossRuntimeLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net11.0;net11.0-android;net11.0-ios;net11.0-maccatalyst</TargetFrameworks>
     <AssemblyName>MyCrossRuntimeLib</AssemblyName>
 
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86;win-x64;win-arm64</RuntimeIdentifiers>

--- a/src/SolutionTemplate/MyUnoLib/MyUnoLib.csproj
+++ b/src/SolutionTemplate/MyUnoLib/MyUnoLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net10.0;net10.0-ios;net10.0-maccatalyst;net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net11.0;net11.0-ios;net11.0-maccatalyst;net11.0-android</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
 

--- a/src/SolutionTemplate/MyUnoLib2/MyUnoLib2.csproj
+++ b/src/SolutionTemplate/MyUnoLib2/MyUnoLib2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net10.0;net10.0-ios;net10.0-maccatalyst;net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net11.0;net11.0-ios;net11.0-maccatalyst;net11.0-android</TargetFrameworks>
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">win-x86;win-x64;win-arm64</RuntimeIdentifiers>

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Mobile/UnoAppWinUI.Mobile.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Mobile/UnoAppWinUI.Mobile.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-		<TargetFrameworks>net10.0-android</TargetFrameworks>
-		<TargetFrameworks>$(TargetFrameworks);net10.0-ios</TargetFrameworks>
-		<TargetFrameworks>$(TargetFrameworks);net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net11.0-android</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks);net11.0-ios</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks);net11.0-maccatalyst</TargetFrameworks>
 
   	</PropertyGroup>
   <PropertyGroup>
@@ -18,16 +18,16 @@
     <ApplicationVersion>1</ApplicationVersion>
     <AndroidManifest>Android\AndroidManifest.xml</AndroidManifest>
     <IsUnoHead>true</IsUnoHead>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-ios'">26.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net10.0-android'">24.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net10.0-macos'">26.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net11.0-ios'">26.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net11.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net11.0-android'">24.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net11.0-macos'">26.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)'==''">
     <!-- Default values for command line builds -->
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net10.0-ios'">iossimulator-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net10.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net10.0-macos'">osx-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net11.0-ios'">iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net11.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net11.0-macos'">osx-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Uno.WinUI" Version="$(NBGV_SemVer2)" />
@@ -37,7 +37,7 @@
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(NBGV_SemVer2)" />
   </ItemGroup>
   <Choose>
-    <When Condition="'$(TargetFramework)'=='net10.0-android'">
+    <When Condition="'$(TargetFramework)'=='net11.0-android'">
       <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <!-- Workaround for .NET Android issue https://github.com/xamarin/xamarin-android/issues/7736 -->
         <RuntimeIdentifier>android-arm64</RuntimeIdentifier>
@@ -50,8 +50,8 @@
         <AndroidEnvironment Include="Android/environment.conf" />
       </ItemGroup>
     </When>
-    <When Condition="'$(TargetFramework)'=='net10.0-ios'">
-      <PropertyGroup Condition="'$(TargetFramework)'=='net10.0-ios'">
+    <When Condition="'$(TargetFramework)'=='net11.0-ios'">
+      <PropertyGroup Condition="'$(TargetFramework)'=='net11.0-ios'">
         <MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
         <!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
         <MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.Linux.FrameBuffer/UnoAppWinUI.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.Linux.FrameBuffer/UnoAppWinUI.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoAppWinUI.Windows')">
     <EmbeddedResource Include="..\UnoAppWinUI.Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
@@ -13,8 +13,8 @@
     <PackageReference Include="Uno.WinUI.DevServer" Version="$(NBGV_SemVer2)" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(NBGV_SemVer2)" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(NBGV_SemVer2)" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="4.148.0" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="4.148.0" />
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="4.151.0-rc.1.1" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="4.151.0-rc.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UnoAppWinUI\UnoAppWinUI.csproj" />

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Windows/UnoAppWinUI.Windows.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Windows/UnoAppWinUI.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net11.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>UnoAppWinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI/UnoAppWinUI.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI/UnoAppWinUI.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
-		<TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks><!--
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks);net11.0</TargetFrameworks><!--
 			This condition is used when building under Linux. If you're not building under
 			 Linux, you can remove this line and the conditions below.
 		--><_CanUseMobileTargets Condition="!$([MSBuild]::IsOSPlatform('Linux'))">true</_CanUseMobileTargets>
 
-		<TargetFrameworks Condition="'$(_CanUseMobileTargets)'=='true'">$(TargetFrameworks);net10.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="'$(_CanUseMobileTargets)'=='true'">$(TargetFrameworks);net10.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="'$(_CanUseMobileTargets)'=='true'">$(TargetFrameworks);net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="'$(_CanUseMobileTargets)'=='true'">$(TargetFrameworks);net11.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="'$(_CanUseMobileTargets)'=='true'">$(TargetFrameworks);net11.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="'$(_CanUseMobileTargets)'=='true'">$(TargetFrameworks);net11.0-maccatalyst</TargetFrameworks>
 
 		<DefaultLanguage>en</DefaultLanguage>
 
@@ -16,7 +16,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 	</PropertyGroup>
@@ -29,12 +29,12 @@
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageReference Include="Uno.WinUI" Version="$(NBGV_SemVer2)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net10.0-windows10.0.19041'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net11.0-windows10.0.19041'">
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.26100.84" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.26100.84" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net10.0-windows10.0.19041'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net11.0-windows10.0.19041'">
     <Content Include="Assets\**" />
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
     <ApplicationDefinition Include="App.xaml" Condition="exists('App.xaml')" />

--- a/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="exists('..\UnoAppWinUILinuxValidation.Windows')">
     <EmbeddedResource Include="..\UnoAppWinUILinuxValidation.Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />

--- a/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Windows/UnoAppWinUILinuxValidation.Windows.csproj
+++ b/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Windows/UnoAppWinUILinuxValidation.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net11.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>UnoAppWinUILinuxValidation</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.csproj
+++ b/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net10.0-windows10.0.19041</TargetFrameworks>
-		<TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks><!--
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net11.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks);net11.0</TargetFrameworks><!--
 			This condition is used when building under Linux. If you're not building under
 			 Linux, you can remove this line and the conditions below.
 		--><_CanUseMobileTargets Condition="!$([MSBuild]::IsOSPlatform('Linux'))">true</_CanUseMobileTargets>
@@ -21,12 +21,12 @@
     <PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageReference Include="Uno.WinUI" Version="$(NBGV_SemVer2)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net10.0-windows10.0.19041'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net11.0-windows10.0.19041'">
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.26100.84" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.26100.84" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net10.0-windows10.0.19041'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net11.0-windows10.0.19041'">
     <Content Include="Assets\**" />
     <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
     <ApplicationDefinition Include="App.xaml" Condition="exists('App.xaml')" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/_Dotnet.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/_Dotnet.cs
@@ -12,7 +12,7 @@ internal record class _Dotnet(string Moniker, ReferenceAssemblies ReferenceAssem
 		"net11.0",
 		new PackageIdentity(
 			"Microsoft.NETCore.App.Ref",
-			"11.0.0-preview.5.26302.115"),
+			"11.0.0-preview.6.26359.118"),
 		Path.Combine("ref", "net11.0")
 	);
 
@@ -21,7 +21,7 @@ internal record class _Dotnet(string Moniker, ReferenceAssemblies ReferenceAssem
 	private static ReferenceAssemblies Net110Android = Net110
 		.AddPackages(
 			ImmutableArray.Create(
-				new PackageIdentity("Microsoft.Android.Ref.37", "36.99.0-preview.5.308")));
+				new PackageIdentity("Microsoft.Android.Ref.37", "37.0.0-preview.6.59")));
 
 	public ReferenceAssemblies WithUnoPackage(string version = "5.0.118")
 		=> ReferenceAssemblies.AddPackages([new PackageIdentity("Uno.WinUI", version)]);

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -158,7 +158,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				$"--trim-mode link",
 				$"--action link",
 				$"-b true",
-				$"-a {AssemblyPath} entrypoint",
+				$"-a {Path.GetFileNameWithoutExtension(AssemblyPath)} entrypoint",
 				$"-out {outputPath}",
 				rootDescriptors,
 				referencedAssemblies,
@@ -170,12 +170,23 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			File.WriteAllText(file, paramString);
 
 			Directory.CreateDirectory(OutputPath);
-
 			var res = StartProcess("dotnet", $"\"{linkerPath}\" @{file}", CurrentProjectPath);
 
-			if (!string.IsNullOrEmpty(res.error))
+			if (res.error.Count > 0)
 			{
-				Log.LogError(res.error);
+				foreach (var error in res.error)
+				{
+					Log.LogError(error);
+				}
+			}
+
+			if (res.exitCode != 0)
+			{
+				// in https://github.com/dotnet/runtime/issues/126268, the `error IL1032` messages were written to stdout!
+				foreach (var error in res.output.Where(e => e.Contains(" error ")))
+				{
+					Log.LogError(error);
+				}
 			}
 		}
 
@@ -425,7 +436,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 		private string AlignPath(string outputPath)
 			=> outputPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Replace(new string(Path.DirectorySeparatorChar, 2), Path.DirectorySeparatorChar.ToString());
 
-		private (int exitCode, string output, string error) StartProcess(string executable, string parameters, string workingDirectory)
+		private (int exitCode, List<string> output, List<string> error) StartProcess(string executable, string parameters, string workingDirectory)
 		{
 			Log.LogMessage(
 				DefaultLogMessageLevel,
@@ -448,12 +459,12 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				p.StartInfo.WorkingDirectory = workingDirectory;
 			}
 
-			var output = new StringBuilder();
-			var error = new StringBuilder();
+			var output = new List<string>();
+			var error = new List<string>();
 			var elapsed = Stopwatch.StartNew();
 
-			p.OutputDataReceived += (s, e) => { if (e.Data != null) { Log.LogMessage(DefaultLogMessageLevel, $"[{elapsed.Elapsed}] {e.Data}"); output.Append(e.Data); } };
-			p.ErrorDataReceived += (s, e) => { if (e.Data != null) { Log.LogError($"[{elapsed.Elapsed}] {e.Data}"); error.Append(e.Data); } };
+			p.OutputDataReceived += (s, e) => { if (e.Data != null) { Log.LogMessage(DefaultLogMessageLevel, $"[{elapsed.Elapsed}] {e.Data}"); output.Add(e.Data); } };
+			p.ErrorDataReceived += (s, e) => { if (e.Data != null) { Log.LogError($"[{elapsed.Elapsed}] {e.Data}"); error.Add(e.Data); } };
 
 			if (p.Start())
 			{
@@ -465,7 +476,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				p.CancelOutputRead();
 				p.Close();
 
-				return (exitCore, output.ToString(), error.ToString());
+				return (exitCore, output, error);
 			}
 			else
 			{

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -98,7 +98,7 @@
 	},
 	{
 		"group": "SkiaSharp",
-		"version": "4.148.0",
+		"version": "4.151.0-rc.1.1",
 		"packages": [
 			"SkiaSharp.Skottie",
 			"SkiaSharp.Views.Uno.WinUI",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -29,7 +29,7 @@
 	},
 	{
 		"group": "WasmBootstrap",
-		"version": "9.0.23",
+		"version": "10.0.96",
 		"packages": [
 			"Uno.Wasm.Bootstrap",
 			"Uno.Wasm.Bootstrap.DevServer",
@@ -70,7 +70,7 @@
 	},
 	{
 		"group": "Resizetizer",
-		"version": "1.13.0-dev.11",
+		"version": "1.12.1",
 		"packages": [
 			"Uno.Resizetizer"
 		]
@@ -84,7 +84,7 @@
 	},
 	{
 		"group": "settings",
-		"version": "1.8.0-dev.42",
+		"version": "1.7.6",
 		"packages": [
 			"Uno.Settings.DevServer"
 		]
@@ -139,22 +139,22 @@
 	},
 	{
 		"group": "MicrosoftLoggingConsole",
-		"version": "9.0.18",
+		"version": "10.0.10",
 		"packages": [
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net11.0": "10.0.10"
+			"net11.0": "11.0.0-preview.6.26359.118"
 		}
 	},
 	{
 		"group": "WindowsCompatibility",
-		"version": "9.0.18",
+		"version": "10.0.10",
 		"packages": [
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net11.0": "10.0.10"
+			"net11.0": "11.0.0-preview.6.26359.118"
 		}
 	},
 	{
@@ -192,22 +192,22 @@
 	},
 	{
 		"group": "AndroidMaterial",
-		"version": "1.12.0.4",
+		"version": "1.12.0.5",
 		"packages": [
 			"Xamarin.Google.Android.Material"
 		],
 		"versionOverride": {
-			"net11.0": "1.12.0.5"
+			"net11.0": "1.14.0.5"
 		}
 	},
 	{
 		"group": "AndroidXLegacySupportV4",
-		"version": "1.0.0.23",
+		"version": "1.0.0.33",
 		"packages": [
 			"Xamarin.AndroidX.Legacy.Support.V4"
 		],
 		"versionOverride": {
-			"net11.0": "1.0.0.33"
+			"net11.0": "1.0.0.37"
 		}
 	},
 	{
@@ -217,102 +217,102 @@
 			"Xamarin.AndroidX.Core.SplashScreen"
 		],
 		"versionOverride": {
-			"net11.0": "1.0.1.14"
+			"net11.0": "1.2.0.3"
 		}
 	},
 	{
 		"group": "AndroidXAppCompat",
-		"version": "1.7.0.7",
+		"version": "1.7.1.1",
 		"packages": [
 			"Xamarin.AndroidX.AppCompat"
 		],
 		"versionOverride": {
-			"net11.0": "1.7.1.1"
+			"net11.0": "1.7.1.4"
 		}
 	},
 	{
 		"group": "AndroidXRecyclerView",
-		"version": "1.4.0.2",
+		"version": "1.4.0.3",
 		"packages": [
 			"Xamarin.AndroidX.RecyclerView"
 		],
 		"versionOverride": {
-			"net11.0": "1.4.0.3"
+			"net11.0": "1.4.0.6"
 		}
 	},
 	{
 		"group": "AndroidXActivity",
-		"version": "1.10.1.2",
+		"version": "1.10.1.3",
 		"packages": [
 			"Xamarin.AndroidX.Activity"
 		],
 		"versionOverride": {
-			"net11.0": "1.10.1.3"
+			"net11.0": "1.13.0.1"
 		}
 	},
 	{
 		"group": "AndroidXBrowser",
-		"version": "1.8.0.10",
+		"version": "1.8.0.11",
 		"packages": [
 			"Xamarin.AndroidX.Browser"
 		],
 		"versionOverride": {
-			"net11.0": "1.8.0.11"
+			"net11.0": "1.10.0.1"
 		}
 	},
 	{
 		"group": "AndroidXSwipeRefreshLayout",
-		"version": "1.1.0.28",
+		"version": "1.1.0.29",
 		"packages": [
 			"Xamarin.AndroidX.SwipeRefreshLayout"
 		],
 		"versionOverride": {
-			"net11.0": "1.1.0.29"
+			"net11.0": "1.2.0.3"
 		}
 	},
 	{
 		"group": "AndroidXLeanback",
-		"version": "1.0.0.30",
+		"version": "1.0.0.31",
 		"packages": [
 			"Xamarin.AndroidX.Leanback"
 		],
 		"versionOverride": {
-			"net10.0": "1.0.0.31"
+			"net11.0": "1.2.0.4"
 		}
 	},
 	{
 		"group": "AndroidXCarApp",
-		"version": "1.4.0.2",
+		"version": "1.4.0.3",
 		"packages": [
 			"Xamarin.AndroidX.Car.App.App"
 		],
 		"versionOverride": {
-			"net10.0": "1.4.0.3"
+			"net11.0": "1.7.0.4"
 		}
 	},
 	{
 		"group": "AndroidXWear",
-		"version": "1.3.0.16",
+		"version": "1.4.0.1",
 		"packages": [
 			"Xamarin.AndroidX.Wear"
 		],
 		"versionOverride": {
-			"net10.0": "1.4.0.1"
+			"net11.0": "1.4.0.2"
 		}
 	},
 	{
 		"group": "AndroidXWearTiles",
-		"version": "1.4.0.1",
+		"version": "1.4.1",
 		"packages": [
 			"Xamarin.AndroidX.Wear.Tiles"
 		],
 		"versionOverride": {
-			"net10.0": "1.4.1"
+			"net11.0": "1.6.1"
 		}
 	},
 	{
 		"group": "AndroidXNavigation",
-		"version": "2.8.9.2",
+		"version": "2.9.2.1",
 		"packages": [
 			"Xamarin.AndroidX.Navigation.UI",
 			"Xamarin.AndroidX.Navigation.Fragment",
@@ -320,30 +320,30 @@
 			"Xamarin.AndroidX.Navigation.Common"
 		],
 		"versionOverride": {
-			"net11.0": "2.9.2.1"
+			"net11.0": "2.9.8.1"
 		}
 	},
 	{
 		"group": "AndroidXCollection",
-		"version": "1.5.0.2",
+		"version": "1.5.0.3",
 		"packages": [
 			"Xamarin.AndroidX.Collection",
 			"Xamarin.AndroidX.Collection.Ktx"
 		],
 		"versionOverride": {
-			"net11.0": "1.5.0.3"
+			"net11.0": "1.6.0.1"
 		}
 	},
 	{
 		"group": "Maui",
-		"version": "9.0.120",
+		"version": "10.0.60",
 		"packages": [
 			"Microsoft.Maui.Controls",
 			"Microsoft.Maui.Controls.Compatibility",
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net11.0": "10.0.60"
+			"net11.0": "11.0.0-preview.6.26360.8"
 		}
 	},
 	{

--- a/src/Uno.Sdk/targets/Uno.Common.Android.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Android.targets
@@ -1,6 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<IsAndroid>true</IsAndroid>
+		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' And $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')) ">24.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">21.0</SupportedOSPlatformVersion>
 		<EnableDefaultAndroidItems Condition="$(EnableDefaultAndroidItems) == ''">false</EnableDefaultAndroidItems>
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxView.cs
@@ -132,14 +132,14 @@ internal partial class MultilineInvisibleTextBoxView : UITextView, IInvisibleTex
 	[Export("selectedTextRange")]
 	public new IntPtr SelectedTextRange
 	{
-		get => NativeTextSelection.GetSelectedTextRange(SuperHandle);
+		get => NativeTextSelection.GetSelectedTextRange(this);
 		set
 		{
 			var textBoxView = TextBoxViewExtension;
 
 			if (textBoxView != null && SelectedTextRange != value)
 			{
-				NativeTextSelection.SetSelectedTextRange(SuperHandle, value);
+				NativeTextSelection.SetSelectedTextRange(this, value);
 				if (!_settingSelectionFromManaged)
 				{
 					textBoxView.SyncSelectionToTextBox();

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/NativeTextSelection.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/NativeTextSelection.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using ObjCRuntime;
+using UIKit;
 
 namespace Uno.WinUI.Runtime.Skia.AppleUIKit.Controls;
 
@@ -14,18 +15,39 @@ internal static class NativeTextSelection
 	/// Workaround for https://github.com/unoplatform/uno/issues/9430
 	/// </summary>
 	[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
-	static internal extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
+#if NET11_0_OR_GREATER
+	private static extern unsafe IntPtr IntPtr_objc_msgSendSuper(ObjCSuper* super, IntPtr selector);
+#else // NET11_0_OR_GREATER
+	private static extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
+#endif // NET11_0_OR_GREATER
+
 
 	[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
-	static internal extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector, IntPtr arg);
+#if NET11_0_OR_GREATER
+	private static extern unsafe void void_objc_msgSendSuper(ObjCSuper* super, IntPtr selector, IntPtr arg);
+#else // NET11_0_OR_GREATER
+	private static extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector, IntPtr arg);
+#endif // NET11_0_OR_GREATER
 
-	internal static IntPtr GetSelectedTextRange(IntPtr superHandle)
+	internal static unsafe IntPtr GetSelectedTextRange(UIView view)
 	{
-		return IntPtr_objc_msgSendSuper(superHandle, Selector.GetHandle("selectedTextRange"));
+		var selector = Selector.GetHandle("selectedTextRange");
+#if NET11_0_OR_GREATER
+		var super = new ObjCSuper(view);
+		return IntPtr_objc_msgSendSuper(&super, selector);
+#else // NET11_0_OR_GREATER
+		return IntPtr_objc_msgSendSuper(view.SuperHandle, selector);
+#endif // NET11_0_OR_GREATER
 	}
 
-	internal static void SetSelectedTextRange(IntPtr superHandle, IntPtr value)
+	internal static unsafe void SetSelectedTextRange(UIView view, IntPtr value)
 	{
-		void_objc_msgSendSuper(superHandle, Selector.GetHandle("setSelectedTextRange:"), value);
+		var selector = Selector.GetHandle("setSelectedTextRange:");
+#if NET11_0_OR_GREATER
+		var super = new ObjCSuper(view);
+		void_objc_msgSendSuper(&super, selector, value);
+#else // NET11_0_OR_GREATER
+		void_objc_msgSendSuper(view.SuperHandle, selector, value);
+#endif // NET11_0_OR_GREATER
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -214,14 +214,14 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 	[Export("selectedTextRange")]
 	public new IntPtr SelectedTextRange
 	{
-		get => NativeTextSelection.GetSelectedTextRange(SuperHandle);
+		get => NativeTextSelection.GetSelectedTextRange(this);
 		set
 		{
 			var textBoxView = TextBoxViewExtension;
 
 			if (textBoxView != null && SelectedTextRange != value)
 			{
-				NativeTextSelection.SetSelectedTextRange(SuperHandle, value);
+				NativeTextSelection.SetSelectedTextRange(this, value);
 				if (!_settingSelectionFromManaged)
 				{
 					textBoxView.SyncSelectionToTextBox();

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/README.md
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/README.md
@@ -15,7 +15,7 @@ Run the following script to download and copy `libSkiaSharp.dylib` inside the Xc
 Set `VERSION` to the specific version you want then call `./getSkiaSharpDylib.sh`. E.g.
 
 ```bash
-VERSION=4.148.0 ./getSkiaSharpDylib.sh
+VERSION=4.151.0-rc.1.1 ./getSkiaSharpDylib.sh
 ```
 
 ### Updating `libSkiaSharp.dylib`

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/getSkiaSharpDylib.sh
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/getSkiaSharpDylib.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VERSION=${VERSION:-4.148.0}
+VERSION=${VERSION:-4.151.0-rc.1.1}
 
 filename="skiasharp_"${VERSION}"_nativeassets"
 build_dir="${filename}-tmp-build"

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/Uno.UI.RuntimeTests.AlcApp.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/Uno.UI.RuntimeTests.AlcApp.csproj
@@ -40,7 +40,7 @@
 		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
-		<PackageReference Include="SkiaSharp" Version="4.148.0" />
+		<PackageReference Include="SkiaSharp" Version="4.151.0-rc.1.1" />
 		<PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
@@ -49,8 +49,8 @@
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="4.148.0" />
-		<PackageReference Include="SkiaSharp.Skottie" Version="4.148.0" />
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="4.151.0-rc.1.1" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="4.151.0-rc.1.1" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="4.8.33" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.33" />
 		-->

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -40,7 +40,7 @@
 		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
-		<PackageReference Include="SkiaSharp" Version="4.148.0" />
+		<PackageReference Include="SkiaSharp" Version="4.151.0-rc.1.1" />
 		<PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
@@ -50,8 +50,8 @@
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="4.148.0" />
-		<PackageReference Include="SkiaSharp.Skottie" Version="4.148.0" />
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="4.151.0-rc.1.1" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="4.151.0-rc.1.1" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="4.8.33" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.33" />
 		-->

--- a/src/Uno.UWP/Uno.netcoremobile.csproj
+++ b/src/Uno.UWP/Uno.netcoremobile.csproj
@@ -42,7 +42,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net11.0-android'">
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.10.0" />
-		<PackageReference Include="Xamarin.AndroidX.DocumentFile" Version="1.1.0.3" />
+		<PackageReference Include="Xamarin.AndroidX.DocumentFile" Version="1.1.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/issues/22745 
Context: https://github.com/unoplatform/uno.check/pull/540

Update version numbers accordingly.

dotnet/macios on .NET 11 Preview 6 requires Xcode 26.6!

TODO: we'll need to bump `$(GlobalUnoCheckVersion)` once we have a new `uno-check`, once unoplatform/uno.check#540 is merged.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

✨ Feature
🏗️ Build or CI related changes

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
