### PR TITLE
feat(hr): recover the workspace when a targeting pack is missing at design time

### DIFF
--- a/specs/049-hotreload-workspace-missing-targeting-pack/spec.md
+++ b/specs/049-hotreload-workspace-missing-targeting-pack/spec.md
@@ -93,9 +93,12 @@ When D1 fires on any head flavor:
    - executable: `dotnet` resolved exactly as the BuildHost resolves it (PATH of the host
      process, environment inherited — F5);
    - working directory: the head project directory (`global.json` honored);
-   - no extra global properties (the restore must reproduce what the app's own build
-     restore would do; the workspace-only `UnoIsHotReloadHost` marker is deliberately not
-     passed);
+   - the workspace's allow-listed global properties (`Configuration`, `Platform`, `Solution*`)
+     forwarded as `-p:` arguments, so the restore evaluates the **same** project graph the
+     workspace opened; the workspace-only `UnoIsHotReloadHost` marker is deliberately *not*
+     passed. Forwarding is required: a property-conditioned targeting pack (e.g. a
+     `Release`-only `TargetingPackVersion`) would otherwise be restored for the default (Debug)
+     graph, leaving the reloaded workspace just as broken;
    - bounded by a timeout — the `DotnetRestoreRunner.TryRestoreAsync` `timeout` parameter,
      defaulting to 120 s and overridable by callers (integration tests pass a short value) —
      and the init `CancellationToken`;

--- a/specs/049-hotreload-workspace-missing-targeting-pack/spec.md
+++ b/specs/049-hotreload-workspace-missing-targeting-pack/spec.md
@@ -96,17 +96,24 @@ When D1 fires on any head flavor:
    - no extra global properties (the restore must reproduce what the app's own build
      restore would do; the workspace-only `UnoIsHotReloadHost` marker is deliberately not
      passed);
-   - bounded by a timeout (default 120 s) and the init `CancellationToken`;
+   - bounded by a timeout — the `DotnetRestoreRunner.TryRestoreAsync` `timeout` parameter,
+     defaulting to 120 s and overridable by callers (integration tests pass a short value) —
+     and the init `CancellationToken`;
    - stdout/stderr relayed at verbose level, one info line for start/outcome.
 3. Re-run `MSBuildWorkspace.Create` + `OpenProjectAsync` (fresh workspace — Roslyn caches
    the design-time build results per workspace instance).
-4. Re-evaluate D1. Recovery is attempted **at most once per init**; the flag lives in the
-   `CreateWorkspaceAsync` retry loop alongside the existing
-   "app build not yet completed" retry.
+4. Re-evaluate D1. Recovery is attempted **at most once per `CreateWorkspaceAsync` call**:
+   the `restoreAttempted` flag is declared *outside* the retry loop, so the separate
+   "app build not yet completed" open-retry path never resets it — once a restore has run,
+   no later loop iteration (an open-retry or the post-restore reopen) can trigger a second.
 
-If the restore process fails to start (no `dotnet`, non-zero exit), log the outcome and
-fall through to D3 with the first workspace re-opened (a failed restore does not abort HR
-init — degraded-but-functional beats dead, same policy as 047).
+Whatever the restore's outcome — clean exit, non-zero exit, timeout, or failure to start
+(no `dotnet` on `PATH`) — the workspace is reopened exactly once (step 3) and D1 is
+re-evaluated against that reopened workspace. A non-zero or aborted restore is treated the
+same as success (its result is not branched on) because a partial restore may still have
+materialized the missing packs; the outcome is only logged. If D1 still fires, init falls
+through to D3 (a failed restore does not abort HR init — degraded-but-functional beats
+dead, same policy as 047).
 
 ### D3 — Actionable diagnostic
 
@@ -130,7 +137,7 @@ failure mode "design-time build failed with MSBuild errors") are logged at Verbo
 `CompilationWorkspaceProvider` and never reach users. Buffer the diagnostics during
 `OpenProjectAsync`; when the loaded solution ends up with any unresolved head flavor
 (D1 signature *or* `TryGetTargetFramework == false`), re-emit the buffered
-`WorkspaceDiagnosticKind.Failure` entries at **Warn** (bounded, e.g. first 10). Nominal
+`WorkspaceDiagnosticKind.Failure` entries at **Warn** (first 10, then drop the rest). Nominal
 loads keep today's quiet behavior.
 
 ### Explicit non-goals
@@ -166,7 +173,7 @@ loads keep today's quiet behavior.
 | `Uno.HotReload/Utils/RoslynExtensions.TryGetTargetFramework.cs` | Expose `HasFrameworkReferences(Project)` (reusing `TryParseRefPackPath`); no behavior change to the resolver itself. |
 | `Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs` | D3 message enrichment: when flavors are `<unresolved:` **and** carry references without ref packs, the keep-all warning gains the missing-targeting-pack hint (kept coherent with the D3 warning emitted by the provider). |
 | `Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs` | D1 detection after `OpenProjectAsync`; D2 one-shot restore + reopen inside the existing retry loop; D4 diagnostic buffering/re-emission; D3 warning. |
-| `Uno.UI.RemoteControl.Server.Processors/…` (new) `DotnetRestoreRunner` (or equivalent helper) | Process invocation: muxer resolution mirroring the BuildHost (F5), cwd, timeout, cancellation, output relay. |
+| `Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs` (new) | Process invocation: muxer resolution mirroring the BuildHost (F5), cwd, timeout, cancellation, output relay. |
 | `Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs` | Unchanged flow; benefits from the recovered workspace. |
 
 ---

--- a/specs/049-hotreload-workspace-missing-targeting-pack/spec.md
+++ b/specs/049-hotreload-workspace-missing-targeting-pack/spec.md
@@ -1,0 +1,218 @@
+# Hot-Reload Workspace: Missing-Targeting-Pack Detection & Restore-Based Recovery
+
+Issue: [unoplatform/uno#23780](https://github.com/unoplatform/uno/issues/23780)
+Companion (environment detection/repair): [unoplatform/uno.check#542](https://github.com/unoplatform/uno.check/issues/542)
+Builds on: [spec 047](../047-hotreload-workspace-single-tfm/spec.md) (runtime-reported TFM filtering).
+
+## Overview & Objectives
+
+Field case (Linux + WASM, devserver 6.6.151, `TargetFrameworks=net10.0-browserwasm;net10.0-desktop`):
+hot reload is blocked at workspace init with the 047 keep-all fallback:
+
+```
+[Warn] None of the 2 target frameworks loaded for '…/testerrorfix1.csproj'
+(<unresolved: testerrorfix1(net10.0-browserwasm)>, net10.0-desktop) matches the
+application's 'net10.0-browserwasm'. Keeping all of them; …
+```
+
+The wasm flavor is in the solution (evaluation succeeded — Roslyn's `name(tfm)` naming),
+carries documents and 168 metadata references, **but not a single .NET ref-pack reference**
+(no `Microsoft.NETCore.App.Ref`). Its compilation has no BCL, `TryGetTargetFramework`
+returns `false` (`<unresolved:`), the 047 filter keeps all flavors, and the broken flavor
+blocks every update with compilation errors. **Zero `WorkspaceFailed` diagnostics** are
+emitted anywhere on this path — the failure is silent end to end.
+
+Root cause (established from the user's design-time binlogs): the dotnet root the Roslyn
+BuildHost resolves has a **stale mono-toolchain workload manifest** pinning the wasm chain
+to a `Microsoft.NETCore.App` version whose **targeting pack is not on disk**. The SDK falls
+back to `PackageDownload` (`_PackageToDownload: Microsoft.NETCore.App.Ref`) — a mechanism
+that only materializes during **restore**, which Roslyn's `MSBuildWorkspace` never runs.
+With `DesignTimeBuild=true` the SDK's `ResolveTargetingPackAssets` deliberately does *not*
+error on the missing pack; it silently yields no `Reference` items. The user's regular
+`dotnet build` works because restore materializes the download (and, in the field case, the
+terminal resolved a different, correctly-aligned dotnet root — `PATH` vs `DOTNET_ROOT`).
+
+### Key objective
+
+The workspace init must **detect** the "flavor without framework references" state,
+**recover** from it when a restore can fix it, and otherwise emit a **diagnostic that names
+the cause and the remediation** instead of the generic keep-all warning:
+
+1. Detect the signature after `OpenProjectAsync` (per head flavor).
+2. Recover: run `dotnet restore` on the head project in the *same SDK resolution context*
+   as the BuildHost, then reload the workspace — once.
+3. If still broken, warn with the SDK root in use and the `dotnet workload update`
+   remediation.
+
+---
+
+## Verified facts (investigation grounding)
+
+Established from the field binlogs (`MSBUILDDEBUGENGINE` capture of the BuildHost
+design-time builds), local reproduction (aligned SDK: both flavors resolve fine on Linux
+with Uno.Sdk 6.5 *and* 6.6 — the misalignment is the determining factor, not the OS nor the
+Uno version), and Roslyn/dotnet-sdk source review:
+
+| # | Fact | Consequence |
+|---|------|-------------|
+| F1 | Roslyn's `MSBuildWorkspace` never restores. Design-time builds run `Compile;CoreCompile` with `DesignTimeBuild=true`, `SkipCompilerExecution=true`, `ProvideCommandLineArgs=true`; project references come exclusively from the captured `CscCommandLineArgs` (fallback `ReferencePath`). | Any resolution mechanism that relies on restore-time materialization silently produces nothing at design time. |
+| F2 | When a `KnownFrameworkReference`-selected targeting pack version is absent from `<root>/packs/`, `ProcessFrameworkReferences` emits `PackageDownload: Microsoft.NETCore.App.Ref` and `ResolveTargetingPackAssets` yields **zero `Reference` items without any error** under `DesignTimeBuild=true` (by design in dotnet/sdk). | The flavor compiles a BCL-less command line; `Csc` "succeeds" (`SkipCompilerExecution`); no `WorkspaceFailed`, no MSBuild error, nothing in any log. |
+| F3 | After a successful restore, the downloaded ref pack lands in the NuGet cache and subsequent design-time builds resolve it from there (this is how regular builds compile in this configuration). | A one-shot `restore` + workspace reload is a *real* recovery, not a mitigation. |
+| F4 | The signature is precisely distinguishable workspace-side: the flavor has non-empty `MetadataReferences` but no reference classified as a .NET ref pack by `TryParseRefPackPath` — versus the *design-time-build-failed* state (empty or near-empty references, and Roslyn *does* report those through `WorkspaceFailed`). | Detection can be implemented as a pure `Solution`-snapshot predicate next to the existing 047 helpers; no Roslyn diagnostics needed. |
+| F5 | The BuildHost resolves its SDK via `dotnet` from the host process `PATH`/environment (`DOTNET_ROOT`-aware muxer resolution, `global.json` honored via the project directory). | Running `dotnet restore` from the devserver host process, with inherited environment and the project directory as cwd, restores against the **same SDK** the BuildHost uses. |
+| F6 | Environmental root cause class: multiple dotnet roots and/or workload manifests out of sync with installed packs (field case: `DOTNET_ROOT=~/.dotnet`, SDK 10.0.203, mono-toolchain manifest 10.0.105 pinning `Microsoft.NETCore.App@10.0.5`, packs containing only `10.0.7`). | The devserver cannot *fix* the environment (that is uno-check's job, uno.check#542); it can recover the workspace (F3) and name the cause. |
+
+---
+
+## Design
+
+### D1 — Missing-framework-references detection
+
+New helper next to the 047 resolver (`Uno.HotReload/Utils/`):
+
+- `Project.HasFrameworkReferences()` — true when at least one `PortableExecutableReference`
+  path classifies as a .NET ref pack (reuses `TryParseRefPackPath`, base *or* platform
+  packs).
+- Detection predicate for a loaded head: a head flavor with `MetadataReferences.Any()` and
+  `!HasFrameworkReferences()`. Non-head projects are not scanned (a class-library flavor
+  without ref packs would be flushed by 047 filtering anyway when its head goes).
+
+Placement: in `CompilationWorkspaceProvider.CreateWorkspaceAsync`, right after
+`OpenProjectAsync` succeeds — *before* the 047 filtering that runs in the caller — because
+recovery (D2) must reopen the workspace, which is this provider's responsibility. The check
+applies to **all** head flavors, including single-TFM heads: a single-flavor head in this
+state never reaches the 047 filter (count == 1 fast path) yet is just as broken (blocked by
+BCL-less compilation errors at first update).
+
+### D2 — Restore-based recovery (one shot)
+
+When D1 fires on any head flavor:
+
+1. Dispose the freshly-opened workspace.
+2. Run `dotnet restore "<headProjectPath>"`:
+   - executable: `dotnet` resolved exactly as the BuildHost resolves it (PATH of the host
+     process, environment inherited — F5);
+   - working directory: the head project directory (`global.json` honored);
+   - no extra global properties (the restore must reproduce what the app's own build
+     restore would do; the workspace-only `UnoIsHotReloadHost` marker is deliberately not
+     passed);
+   - bounded by a timeout (default 120 s) and the init `CancellationToken`;
+   - stdout/stderr relayed at verbose level, one info line for start/outcome.
+3. Re-run `MSBuildWorkspace.Create` + `OpenProjectAsync` (fresh workspace — Roslyn caches
+   the design-time build results per workspace instance).
+4. Re-evaluate D1. Recovery is attempted **at most once per init**; the flag lives in the
+   `CreateWorkspaceAsync` retry loop alongside the existing
+   "app build not yet completed" retry.
+
+If the restore process fails to start (no `dotnet`, non-zero exit), log the outcome and
+fall through to D3 with the first workspace re-opened (a failed restore does not abort HR
+init — degraded-but-functional beats dead, same policy as 047).
+
+### D3 — Actionable diagnostic
+
+When D1 still fires after D2 (or D2 could not run):
+
+- Warn (replacing nothing — this is *in addition to* the 047 keep-all warning, which stays
+  as-is for its own failure mode) with:
+  - the flavor(s) concerned (project name incl. Roslyn's `(tfm)` discriminator),
+  - the statement that the design-time build produced **no .NET framework references**
+    (missing targeting pack at design time),
+  - the SDK root in use when determinable — derived from the ref-pack paths of the sibling
+    flavors that *did* resolve (`<root>/packs/Microsoft.NETCore.App.Ref/…`); omitted
+    otherwise,
+  - the remediation: `dotnet workload update` against that SDK root, and a pointer to
+    uno-check (uno.check#542).
+
+### D4 — `WorkspaceFailed` visibility (small, related)
+
+The investigation showed `WorkspaceFailed` diagnostics (which *do* fire for the sibling
+failure mode "design-time build failed with MSBuild errors") are logged at Verbose in
+`CompilationWorkspaceProvider` and never reach users. Buffer the diagnostics during
+`OpenProjectAsync`; when the loaded solution ends up with any unresolved head flavor
+(D1 signature *or* `TryGetTargetFramework == false`), re-emit the buffered
+`WorkspaceDiagnosticKind.Failure` entries at **Warn** (bounded, e.g. first 10). Nominal
+loads keep today's quiet behavior.
+
+### Explicit non-goals
+
+- **No "restore always before open"**: rejected for now — adds seconds to every init to
+  cover a rare environmental state; D2 pays the cost only when the state is detected.
+  Revisit if field reports surface adjacent stale-assets classes (tracked in issue #23780
+  as option 3).
+- **No filtering "by elimination"**: keeping the unresolved flavor because the resolved
+  ones don't match would not help — its compilation has no BCL; without a successful
+  restore there is nothing to recover to.
+- **No environment mutation**: the devserver never runs `dotnet workload update` itself
+  (long, mutating, may require elevation; uno-check owns remediation).
+
+---
+
+## Compatibility
+
+- Server-side only; no protocol change, no client change, no `ConfigureServer` change.
+- Nominal init path: one extra pass over head-flavor `MetadataReferences` (negligible);
+  no restore, no behavior change.
+- Degraded path: one `dotnet restore` + one workspace reload at init (seconds). Strictly
+  better than the current outcome (permanently blocked HR).
+- Old-client/new-server and new-client/old-server matrices are unaffected (feature is
+  entirely inside workspace init).
+
+---
+
+## Implementation map
+
+| Area | Change |
+|---|---|
+| `Uno.HotReload/Utils/RoslynExtensions.TryGetTargetFramework.cs` | Expose `HasFrameworkReferences(Project)` (reusing `TryParseRefPackPath`); no behavior change to the resolver itself. |
+| `Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs` | D3 message enrichment: when flavors are `<unresolved:` **and** carry references without ref packs, the keep-all warning gains the missing-targeting-pack hint (kept coherent with the D3 warning emitted by the provider). |
+| `Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs` | D1 detection after `OpenProjectAsync`; D2 one-shot restore + reopen inside the existing retry loop; D4 diagnostic buffering/re-emission; D3 warning. |
+| `Uno.UI.RemoteControl.Server.Processors/…` (new) `DotnetRestoreRunner` (or equivalent helper) | Process invocation: muxer resolution mirroring the BuildHost (F5), cwd, timeout, cancellation, output relay. |
+| `Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs` | Unchanged flow; benefits from the recovered workspace. |
+
+---
+
+## Test plan
+
+**Unit (DevServer tests, linked sources):**
+
+- `HasFrameworkReferences`: ref-pack paths (SDK `packs/` layout and NuGet-cache layout) →
+  true; NuGet `lib/`-only reference sets → false; empty references → false.
+- Detection predicate: distinguishes *missing-pack* (refs without ref packs) from
+  *build-failed* (no refs) states.
+- D3 message composition: SDK root extraction from sibling ref-pack paths; message without
+  root when no sibling resolved.
+
+**Integration (DevServer tests):**
+
+- **Deterministic missing-pack fixture** (no workloads involved): a head project with
+  `<FrameworkReference Update="Microsoft.NETCore.App" TargetingPackVersion="X">` where `X`
+  is a valid-but-not-installed patch version, and `NUGET_PACKAGES` redirected to a clean
+  temp folder. Restore-less design-time load → D1 fires (reproduces the field state
+  CI-deterministically). Then: end-to-end recovery — the D2 restore materializes the
+  `PackageDownload` into the temp cache, reload resolves, `TryGetTargetFramework`
+  succeeds, 047 filtering restricts normally.
+- Restore-failure path: unreachable NuGet source → D2 fails → init completes degraded with
+  the D3 warning (assert message contains the remediation and the SDK root).
+- Single-TFM head with the same fixture: D1/D2 apply even though 047 filtering is a no-op.
+- Canary guarding F2: assert that a restore-less design-time build of the fixture yields a
+  project with references but no ref packs — if a future .NET SDK starts erroring (or
+  resolving) in this state, the canary flags the behavior change.
+
+**Manual QA:**
+
+- Field scenario replay: misaligned root (`dotnet workload` manifests pinning a
+  non-installed targeting pack), VS Code + wasm head on Linux → HR recovers at init
+  (restore visible in devserver log), edits apply.
+- Aligned environment: no restore triggered, no new log noise.
+
+---
+
+## Out of scope / follow-ups
+
+- Environment detection/repair (multiple dotnet roots, `DOTNET_ROOT`/`PATH` divergence,
+  manifest/packs alignment): uno-check, tracked in
+  [uno.check#542](https://github.com/unoplatform/uno.check/issues/542).
+- Restore-always-before-open option (issue #23780, option 3) — revisit on field feedback.
+- Stale `project.assets.json` recovery (different signature: design-time build *fails*
+  with NETSDK1004/1005 and surfaces through `WorkspaceFailed`/D4) — same D2 machinery
+  could be triggered from those diagnostics later; not wired in this spec.

--- a/src/Uno.HotReload.Tests/Utils/Given_MissingFrameworkReferences.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_MissingFrameworkReferences.cs
@@ -110,7 +110,7 @@ public sealed class Given_MissingFrameworkReferences
 		var headPath = ToOsPath("/src/app/app.csproj");
 		var libPath = ToOsPath("/src/lib/lib.csproj");
 
-		var workspace = new AdhocWorkspace();
+		using var workspace = new AdhocWorkspace();
 		var solution = workspace.CurrentSolution
 			// Healthy head flavor (desktop): SDK-installed ref pack.
 			.AddProject(CreateProjectInfo("app(net10.0-desktop)", headPath,

--- a/src/Uno.HotReload.Tests/Utils/Given_MissingFrameworkReferences.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_MissingFrameworkReferences.cs
@@ -1,0 +1,140 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Utils;
+using static Uno.HotReload.Tests.Utils.Given_TryGetTargetFramework;
+
+namespace Uno.HotReload.Tests.Utils;
+
+/// <summary>
+/// Tests for the missing-targeting-pack detection helpers (spec 049):
+/// <see cref="RoslynExtensions.HasFrameworkReferences"/>,
+/// <see cref="RoslynExtensions.IsMissingFrameworkReferences"/> and
+/// <see cref="RoslynExtensions.TryGetDotnetRootFromFrameworkReferences"/>.
+/// </summary>
+[TestClass]
+public sealed class Given_MissingFrameworkReferences
+{
+	[TestMethod]
+	public void HasFrameworkReferences_SdkInstalledRefPack_True()
+	{
+		var project = CreateProject(
+			refPaths: [ToOsPath("/usr/share/dotnet/packs/Microsoft.NETCore.App.Ref/10.0.7/ref/net10.0/System.Runtime.dll")],
+			preprocessorSymbols: []);
+
+		Assert.IsTrue(project.HasFrameworkReferences());
+		Assert.IsFalse(project.IsMissingFrameworkReferences());
+	}
+
+	[TestMethod]
+	public void HasFrameworkReferences_NugetCachedRefPack_True()
+	{
+		// A restored PackageDownload lands in the NuGet cache: still a framework reference.
+		var project = CreateProject(
+			refPaths: [ToOsPath("/home/user/.nuget/packages/microsoft.netcore.app.ref/10.0.5/ref/net10.0/System.Runtime.dll")],
+			preprocessorSymbols: []);
+
+		Assert.IsTrue(project.HasFrameworkReferences());
+		Assert.IsFalse(project.IsMissingFrameworkReferences());
+	}
+
+	[TestMethod]
+	public void IsMissingFrameworkReferences_NugetLibsOnly_True()
+	{
+		// The field signature: the design-time build resolved NuGet package references but no
+		// targeting pack (missing on disk, PackageDownload never materialized — no restore).
+		var project = CreateProject(
+			refPaths:
+			[
+				ToOsPath("/home/user/.nuget/packages/newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll"),
+				ToOsPath("/home/user/.nuget/packages/skiasharp/3.119.2/ref/net8.0/SkiaSharp.dll"),
+			],
+			preprocessorSymbols: []);
+
+		Assert.IsFalse(project.HasFrameworkReferences());
+		Assert.IsTrue(project.IsMissingFrameworkReferences());
+	}
+
+	[TestMethod]
+	public void IsMissingFrameworkReferences_NoReferencesAtAll_False()
+	{
+		// No references at all is the design-time-build-failed state, not the
+		// missing-targeting-pack one — Roslyn reports that through WorkspaceFailed already.
+		var project = CreateProject(refPaths: [], preprocessorSymbols: []);
+
+		Assert.IsFalse(project.HasFrameworkReferences());
+		Assert.IsFalse(project.IsMissingFrameworkReferences());
+	}
+
+	[TestMethod]
+	public void TryGetDotnetRoot_SdkInstalledRefPack_ReturnsRoot()
+	{
+		var project = CreateProject(
+			refPaths: [ToOsPath("/home/user/.dotnet/packs/Microsoft.NETCore.App.Ref/10.0.7/ref/net10.0/System.Runtime.dll")],
+			preprocessorSymbols: []);
+
+		Assert.IsTrue(project.TryGetDotnetRootFromFrameworkReferences(out var root));
+		Assert.AreEqual(ToOsPath("/home/user/.dotnet"), root);
+	}
+
+	[TestMethod]
+	public void TryGetDotnetRoot_NugetCachedRefPack_ReturnsFalse()
+	{
+		// The NuGet-cache layout carries no SDK root ("packages", not "packs").
+		var project = CreateProject(
+			refPaths: [ToOsPath("/home/user/.nuget/packages/microsoft.netcore.app.ref/10.0.5/ref/net10.0/System.Runtime.dll")],
+			preprocessorSymbols: []);
+
+		Assert.IsFalse(project.TryGetDotnetRootFromFrameworkReferences(out var root));
+		Assert.IsNull(root);
+	}
+
+	[TestMethod]
+	public void TryGetDotnetRoot_MixedReferences_SkipsToSdkInstalledPack()
+	{
+		var project = CreateProject(
+			refPaths:
+			[
+				ToOsPath("/home/user/.nuget/packages/newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll"),
+				ToOsPath("/home/user/.nuget/packages/microsoft.netcore.app.ref/10.0.5/ref/net10.0/System.Runtime.dll"),
+				ToOsPath("/usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/10.0.7/ref/net10.0/System.Linq.dll"),
+			],
+			preprocessorSymbols: []);
+
+		Assert.IsTrue(project.TryGetDotnetRootFromFrameworkReferences(out var root));
+		Assert.AreEqual(ToOsPath("/usr/lib/dotnet"), root);
+	}
+
+	[TestMethod]
+	public void GetHeadFlavorsMissingFrameworkReferences_MixedSolution_ReturnsOnlyBrokenHeadFlavors()
+	{
+		var headPath = ToOsPath("/src/app/app.csproj");
+		var libPath = ToOsPath("/src/lib/lib.csproj");
+
+		var workspace = new AdhocWorkspace();
+		var solution = workspace.CurrentSolution
+			// Healthy head flavor (desktop): SDK-installed ref pack.
+			.AddProject(CreateProjectInfo("app(net10.0-desktop)", headPath,
+				[ToOsPath("/home/user/.dotnet/packs/Microsoft.NETCore.App.Ref/10.0.7/ref/net10.0/System.Runtime.dll")]))
+			// Broken head flavor (wasm): NuGet libs only.
+			.AddProject(CreateProjectInfo("app(net10.0-browserwasm)", headPath,
+				[ToOsPath("/home/user/.nuget/packages/newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll")]))
+			// Broken-looking *library* flavor: must not be reported (head-only scan).
+			.AddProject(CreateProjectInfo("lib(net10.0-browserwasm)", libPath,
+				[ToOsPath("/home/user/.nuget/packages/newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll")]));
+
+		var broken = solution.GetHeadFlavorsMissingFrameworkReferences(headPath);
+
+		Assert.AreEqual(1, broken.Count);
+		Assert.AreEqual("app(net10.0-browserwasm)", broken[0].Name);
+	}
+
+	private static ProjectInfo CreateProjectInfo(string name, string filePath, IReadOnlyList<string> refPaths)
+		=> ProjectInfo.Create(
+			ProjectId.CreateNewId(),
+			VersionStamp.Default,
+			name: name,
+			assemblyName: name,
+			language: LanguageNames.CSharp,
+			filePath: filePath,
+			metadataReferences: refPaths.Select(StubMetadataReference.Create).ToImmutableArray<MetadataReference>());
+}

--- a/src/Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs
@@ -152,7 +152,10 @@ public static partial class RoslynExtensions
 		var resolvedFlavors = headFlavors
 			.Select(p => (Project: p, TargetFramework: p.TryGetTargetFramework(out var tfm) ? tfm : null))
 			.ToList();
-		var flavorsDescription = string.Join(", ", resolvedFlavors.Select(f => f.TargetFramework ?? $"<unresolved: {f.Project.Name}>"));
+		var flavorsDescription = string.Join(", ", resolvedFlavors.Select(f => f.TargetFramework
+			?? (f.Project.IsMissingFrameworkReferences()
+				? $"<unresolved, no framework references: {f.Project.Name}>"
+				: $"<unresolved: {f.Project.Name}>")));
 
 		if (string.IsNullOrWhiteSpace(runtimeTargetFramework))
 		{
@@ -169,10 +172,15 @@ public static partial class RoslynExtensions
 
 		if (matchedFlavors.Count == 0)
 		{
+			var missingPackHint = resolvedFlavors.Any(f => f.TargetFramework is null && f.Project.IsMissingFrameworkReferences())
+				? " At least one flavor loaded without .NET framework references (missing targeting pack at design time) — " +
+					"see the preceding workspace warning for the remediation."
+				: "";
+
 			reporter.Warn(
 				$"None of the {headFlavors.Count} target frameworks loaded for '{headProjectPath}' ({flavorsDescription}) matches " +
 				$"the application's '{runtimeTargetFramework}'. Keeping all of them; hot reload may be blocked by compilation " +
-				"errors coming from the other target frameworks.");
+				$"errors coming from the other target frameworks.{missingPackHint}");
 			return solution;
 		}
 

--- a/src/Uno.HotReload/Utils/RoslynExtensions.TryGetTargetFramework.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.TryGetTargetFramework.cs
@@ -112,16 +112,9 @@ public static partial class RoslynExtensions
 	{
 		ArgumentNullException.ThrowIfNull(project);
 
-		foreach (var reference in project.MetadataReferences)
-		{
-			if (reference is PortableExecutableReference { FilePath: { Length: > 0 } path }
-				&& TryParseRefPackPath(path, out _, out _, out _))
-			{
-				return true;
-			}
-		}
-
-		return false;
+		return project.MetadataReferences.Any(reference =>
+			reference is PortableExecutableReference { FilePath: { Length: > 0 } path }
+			&& TryParseRefPackPath(path, out _, out _, out _));
 	}
 
 	/// <summary>

--- a/src/Uno.HotReload/Utils/RoslynExtensions.TryGetTargetFramework.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.TryGetTargetFramework.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -100,6 +101,108 @@ public static partial class RoslynExtensions
 		// Plain net10.0 (no platform marker, no platform-specific ref pack).
 		targetFramework = frameworkVersion;
 		return true;
+	}
+
+	/// <summary>
+	/// Determines whether the project links at least one recognised .NET ref pack (see
+	/// <see cref="TryParseRefPackPath"/>), i.e. whether its design-time build resolved the
+	/// framework references at all.
+	/// </summary>
+	public static bool HasFrameworkReferences(this Project project)
+	{
+		ArgumentNullException.ThrowIfNull(project);
+
+		foreach (var reference in project.MetadataReferences)
+		{
+			if (reference is PortableExecutableReference { FilePath: { Length: > 0 } path }
+				&& TryParseRefPackPath(path, out _, out _, out _))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Detects the missing-targeting-pack signature (spec 049): the design-time build
+	/// resolved package references (the project is not empty) but produced no .NET framework
+	/// reference — typically because the targeting pack pinned by a workload manifest is not
+	/// installed and is only satisfied through a restore-time <c>PackageDownload</c>, which
+	/// Roslyn's <c>MSBuildWorkspace</c> never runs. The .NET SDK deliberately emits no error
+	/// for this under <c>DesignTimeBuild=true</c>, making this snapshot inspection the only
+	/// detection point.
+	/// </summary>
+	public static bool IsMissingFrameworkReferences(this Project project)
+	{
+		ArgumentNullException.ThrowIfNull(project);
+
+		return project.MetadataReferences
+				.OfType<PortableExecutableReference>()
+				.Any(r => r.FilePath is { Length: > 0 })
+			&& !project.HasFrameworkReferences();
+	}
+
+	/// <summary>
+	/// The flavors of <paramref name="headProjectPath"/> in <paramref name="solution"/>
+	/// exhibiting the missing-targeting-pack signature (see
+	/// <see cref="IsMissingFrameworkReferences"/>). Non-head projects are not scanned: a
+	/// library flavor without framework references follows its head's fate through the
+	/// reachability-based filtering.
+	/// </summary>
+	public static IReadOnlyList<Project> GetHeadFlavorsMissingFrameworkReferences(this Solution solution, string headProjectPath)
+	{
+		ArgumentNullException.ThrowIfNull(solution);
+
+		return solution.Projects
+			.Where(p => PathComparer.PathEquals(p.FilePath, headProjectPath))
+			.Where(IsMissingFrameworkReferences)
+			.ToList();
+	}
+
+	/// <summary>
+	/// Attempts to locate the dotnet root whose SDK-installed targeting packs the project
+	/// links, from the ref-pack layout <c>&lt;root&gt;/packs/&lt;Pack&gt;/&lt;ver&gt;/ref/&lt;tfm&gt;/&lt;asm&gt;.dll</c>.
+	/// Returns <see langword="false"/> when the project's ref packs come from the NuGet
+	/// cache (which carries no SDK root) or when it has none.
+	/// </summary>
+	public static bool TryGetDotnetRootFromFrameworkReferences(this Project project, [NotNullWhen(true)] out string? dotnetRoot)
+	{
+		ArgumentNullException.ThrowIfNull(project);
+
+		dotnetRoot = null;
+
+		foreach (var reference in project.MetadataReferences)
+		{
+			if (reference is not PortableExecutableReference { FilePath: { Length: > 0 } path }
+				|| !TryParseRefPackPath(path, out _, out _, out _))
+			{
+				continue;
+			}
+
+			// path = <root>/packs/<PackName>/<PackVersion>/ref/<tfm>/<asm>.dll
+			// Five parents up is the "packs" folder; its own parent is the dotnet root.
+			var packsDirectory = path;
+			for (var i = 0; i < 5 && packsDirectory is not null; i++)
+			{
+				packsDirectory = Path.GetDirectoryName(packsDirectory);
+			}
+
+			if (packsDirectory is null
+				|| !"packs".Equals(Path.GetFileName(packsDirectory), StringComparison.OrdinalIgnoreCase))
+			{
+				// NuGet-cache layout (…/.nuget/packages/…) or an unexpected shape — no SDK root.
+				continue;
+			}
+
+			if (Path.GetDirectoryName(packsDirectory) is { Length: > 0 } root)
+			{
+				dotnetRoot = root;
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -191,7 +191,7 @@ public static class CompilationWorkspaceProvider
 
 			var remediation = sdkRoot is null
 				? "Run 'dotnet workload update' with the SDK the dev-server uses (uno-check can locate and fix it), or restore the project with that SDK, then restart the application."
-				: $"Run '{Path.Join(sdkRoot, "dotnet")} workload update' (or a restore with that SDK), then restart the application.";
+				: $"Run '\"{Path.Join(sdkRoot, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet")}\" workload update' (or a restore with that SDK), then restart the application.";
 
 			reporter.Warn(
 				$"The hot-reload workspace loaded {Describe(brokenFlavors)} without any .NET framework references even after a restore attempt: " +

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -191,7 +191,7 @@ public static class CompilationWorkspaceProvider
 
 			var remediation = sdkRoot is null
 				? "Run 'dotnet workload update' with the SDK the dev-server uses (uno-check can locate and fix it), or restore the project with that SDK, then restart the application."
-				: $"Run '{Path.Combine(sdkRoot, "dotnet")} workload update' (or a restore with that SDK), then restart the application.";
+				: $"Run '{Path.Join(sdkRoot, "dotnet")} workload update' (or a restore with that SDK), then restart the application.";
 
 			reporter.Warn(
 				$"The hot-reload workspace loaded {Describe(brokenFlavors)} without any .NET framework references even after a restore attempt: " +

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -46,6 +46,13 @@ public static class CompilationWorkspaceProvider
 	];
 
 	/// <summary>
+	/// The workspace-only MSBuild property that flags a hot-reload host build. It shapes how the
+	/// workspace evaluates the projects, but is deliberately NOT forwarded to the recovery restore
+	/// (which must reproduce the application's own restore, not the hot-reload variant).
+	/// </summary>
+	private const string UnoIsHotReloadHostProperty = "UnoIsHotReloadHost";
+
+	/// <summary>
 	/// Opens the hot-reload <see cref="MSBuildWorkspace"/> for <paramref name="projectPath"/>: the
 	/// projects are evaluated with the whitelisted global properties only (see
 	/// <see cref="_globalPropertiesAllowList"/>). The workspace owns the MSBuild services and is
@@ -79,7 +86,7 @@ public static class CompilationWorkspaceProvider
 		{
 			// Flag the current build as created for hot reload, which allows for running targets
 			// or setting props/items in the context of the hot reload workspace.
-			["UnoIsHotReloadHost"] = "True",
+			[UnoIsHotReloadHostProperty] = "True",
 		};
 
 		foreach (var property in _globalPropertiesAllowList)
@@ -156,7 +163,14 @@ public static class CompilationWorkspaceProvider
 					$"The hot-reload workspace loaded {Describe(brokenFlavors)} without any .NET framework references " +
 					"(missing targeting pack at design time); attempting to recover with 'dotnet restore'.");
 				workspace.Dispose();
-				await DotnetRestoreRunner.TryRestoreAsync(projectPath, reporter, ct);
+
+				// Restore under the same allow-listed evaluation context the workspace used (minus the
+				// workspace-only hot-reload marker), so a property-conditioned targeting pack is
+				// restored for the graph that was actually opened.
+				var restoreProperties = globalProperties
+					.Where(entry => entry.Key != UnoIsHotReloadHostProperty)
+					.ToDictionary(entry => entry.Key, entry => entry.Value);
+				await DotnetRestoreRunner.TryRestoreAsync(projectPath, restoreProperties, reporter, ct);
 				continue;
 			}
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Uno.HotReload;
 using Uno.HotReload.Tracking;
+using Uno.HotReload.Utils;
 
 namespace Uno.Roslyn.MSBuild;
 
@@ -48,6 +52,13 @@ public static class CompilationWorkspaceProvider
 	/// application's flavor is left to the caller — this provider deliberately exposes the raw,
 	/// unfiltered <see cref="MSBuildWorkspace"/>.
 	/// </summary>
+	/// <remarks>
+	/// When a head flavor loads with package references but no .NET framework references — the
+	/// missing-targeting-pack signature (spec 049): a workload-manifest-pinned targeting pack
+	/// absent from the SDK, satisfied only by a restore-time <c>PackageDownload</c> that the
+	/// design-time build never runs — the provider recovers by running <c>dotnet restore</c> on
+	/// the head project once and reloading the workspace.
+	/// </remarks>
 	/// <param name="projectPath">Full path of the head project the application runs.</param>
 	/// <param name="reporter">Reporter used to surface workspace diagnostics.</param>
 	/// <param name="properties">The MSBuild properties captured by the application build (only whitelisted entries are re-applied globally).</param>
@@ -82,43 +93,122 @@ public static class CompilationWorkspaceProvider
 		}
 
 		MSBuildWorkspace workspace = null!;
-		for (var i = 3; i > 0; i--)
+		var workspaceDiagnostics = new List<WorkspaceDiagnostic>();
+		var openRetries = 3;
+		var restoreAttempted = false;
+
+		while (true)
 		{
+			workspaceDiagnostics.Clear();
+			workspace = MSBuildWorkspace.Create(globalProperties);
+
+			workspace.WorkspaceFailed += (_sender, diag) =>
+			{
+				// In some cases, load failures may be incorrectly reported such as this one:
+				// https://github.com/dotnet/roslyn/blob/fd45aeb5fbc97d09d4043cef9c9c5142f7638e5c/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs#L245-L259
+				// Since the text may be localized we cannot rely on it, so we never fail the project loading for now.
+				// The diagnostics are buffered: when the load leaves a head flavor unresolved they
+				// are the only trace of the root cause and get re-emitted as warnings (below).
+				workspaceDiagnostics.Add(diag.Diagnostic);
+				reporter.Verbose($"MSBuildWorkspace {diag.Diagnostic}");
+			};
+
 			try
 			{
-				workspace = MSBuildWorkspace.Create(globalProperties);
-
-				workspace.WorkspaceFailed += (_sender, diag) =>
-				{
-					// In some cases, load failures may be incorrectly reported such as this one:
-					// https://github.com/dotnet/roslyn/blob/fd45aeb5fbc97d09d4043cef9c9c5142f7638e5c/src/Workspaces/Core/MSBuild/MSBuild/MSBuildProjectLoader.Worker.cs#L245-L259
-					// Since the text may be localized we cannot rely on it, so we never fail the project loading for now.
-					reporter.Verbose($"MSBuildWorkspace {diag.Diagnostic}");
-				};
-
 				await workspace.OpenProjectAsync(projectPath, cancellationToken: ct);
-				break;
 			}
-			catch (InvalidOperationException) when (i > 1)
+			catch (InvalidOperationException) when (openRetries > 1)
 			{
 				// When we load the workspace right after the app was started, it happens that it "app build" is not yet completed, preventing us to open the project.
 				// We retry a few times to let the build complete. Dispose the failed workspace first:
 				// MSBuildWorkspace hosts MSBuild evaluation nodes (real OS resources), so a workspace
 				// left behind on a failed attempt would linger for the server's lifetime.
-				workspace?.Dispose();
-				workspace = null!;
+				openRetries--;
+				workspace.Dispose();
 				await Task.Delay(5_000, ct);
+				continue;
 			}
 			catch
 			{
 				// Non-retried failure (the final attempt, or any other exception type): dispose the
 				// partially-created workspace before surfacing the exception — same lingering MSBuild
 				// evaluation-node concern as the retry path above.
-				workspace?.Dispose();
+				workspace.Dispose();
 				throw;
 			}
+
+			if (!restoreAttempted
+				&& workspace.CurrentSolution.GetHeadFlavorsMissingFrameworkReferences(projectPath) is { Count: > 0 } brokenFlavors)
+			{
+				// Missing-targeting-pack recovery (spec 049), attempted at most once: restore
+				// materializes the PackageDownload-satisfied packs into the NuGet cache, from
+				// which the next design-time build resolves them. The workspace is reloaded even
+				// when the restore reports a failure — a partial restore may still have
+				// materialized what this project needs.
+				restoreAttempted = true;
+				reporter.Warn(
+					$"The hot-reload workspace loaded {Describe(brokenFlavors)} without any .NET framework references " +
+					"(missing targeting pack at design time); attempting to recover with 'dotnet restore'.");
+				workspace.Dispose();
+				await DotnetRestoreRunner.TryRestoreAsync(projectPath, reporter, ct);
+				continue;
+			}
+
+			break;
 		}
+
+		ReportUnresolvedHeadFlavors(workspace.CurrentSolution, projectPath, workspaceDiagnostics, reporter);
 
 		return workspace;
 	}
+
+	/// <summary>
+	/// Surfaces the degraded-load states the pipeline would otherwise hide: the
+	/// missing-targeting-pack signature with its remediation (spec 049 D3), and the buffered
+	/// <see cref="MSBuildWorkspace.Diagnostics"/> failures — verbose-only on nominal loads —
+	/// re-emitted as warnings when a head flavor could not be resolved (spec 049 D4).
+	/// </summary>
+	private static void ReportUnresolvedHeadFlavors(
+		Solution solution,
+		string projectPath,
+		List<WorkspaceDiagnostic> workspaceDiagnostics,
+		IReporter reporter)
+	{
+		var headFlavors = solution.Projects
+			.Where(p => PathComparer.PathEquals(p.FilePath, projectPath))
+			.ToList();
+
+		var brokenFlavors = headFlavors.Where(RoslynExtensions.IsMissingFrameworkReferences).ToList();
+
+		if (brokenFlavors.Count > 0)
+		{
+			// The SDK root is recoverable from the flavors that did resolve their ref packs
+			// from an SDK-installed targeting pack; broken and NuGet-cache-resolved flavors
+			// contribute nothing (the remediation stays generic then).
+			var sdkRoot = headFlavors
+				.Select(p => p.TryGetDotnetRootFromFrameworkReferences(out var root) ? root : null)
+				.FirstOrDefault(root => root is not null);
+
+			var remediation = sdkRoot is null
+				? "Run 'dotnet workload update' with the SDK the dev-server uses (uno-check can locate and fix it), or restore the project with that SDK, then restart the application."
+				: $"Run '{Path.Combine(sdkRoot, "dotnet")} workload update' (or a restore with that SDK), then restart the application.";
+
+			reporter.Warn(
+				$"The hot-reload workspace loaded {Describe(brokenFlavors)} without any .NET framework references even after a restore attempt: " +
+				"the design-time build could not resolve a targeting pack (typically pinned by a workload manifest but not installed). " +
+				$"Hot reload will most likely be blocked by compilation errors for this target framework. {remediation} " +
+				"See https://github.com/unoplatform/uno/issues/23780.");
+		}
+
+		if (headFlavors.Any(p => !p.TryGetTargetFramework(out _)))
+		{
+			foreach (var diagnostic in workspaceDiagnostics.Where(d => d.Kind == WorkspaceDiagnosticKind.Failure).Take(10))
+			{
+				reporter.Warn($"MSBuildWorkspace {diagnostic}");
+			}
+		}
+	}
+
+	private static string Describe(IReadOnlyList<Project> projects)
+		=> string.Join(", ", projects.Select(p => $"'{p.Name}'"));
 }

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/CompilationWorkspaceProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -93,14 +94,19 @@ public static class CompilationWorkspaceProvider
 		}
 
 		MSBuildWorkspace workspace = null!;
-		var workspaceDiagnostics = new List<WorkspaceDiagnostic>();
+		ConcurrentQueue<WorkspaceDiagnostic> workspaceDiagnostics = null!;
 		var openRetries = 3;
 		var restoreAttempted = false;
 
 		while (true)
 		{
-			workspaceDiagnostics.Clear();
 			workspace = MSBuildWorkspace.Create(globalProperties);
+
+			// Fresh per workspace instance and thread-safe: MSBuildWorkspace raises WorkspaceFailed
+			// from background threads (potentially concurrently), so the buffer is never shared or
+			// cleared across retries while a previous instance's handler might still be firing.
+			var diagnostics = new ConcurrentQueue<WorkspaceDiagnostic>();
+			workspaceDiagnostics = diagnostics;
 
 			workspace.WorkspaceFailed += (_sender, diag) =>
 			{
@@ -109,7 +115,7 @@ public static class CompilationWorkspaceProvider
 				// Since the text may be localized we cannot rely on it, so we never fail the project loading for now.
 				// The diagnostics are buffered: when the load leaves a head flavor unresolved they
 				// are the only trace of the root cause and get re-emitted as warnings (below).
-				workspaceDiagnostics.Add(diag.Diagnostic);
+				diagnostics.Enqueue(diag.Diagnostic);
 				reporter.Verbose($"MSBuildWorkspace {diag.Diagnostic}");
 			};
 
@@ -171,7 +177,7 @@ public static class CompilationWorkspaceProvider
 	private static void ReportUnresolvedHeadFlavors(
 		Solution solution,
 		string projectPath,
-		List<WorkspaceDiagnostic> workspaceDiagnostics,
+		IReadOnlyCollection<WorkspaceDiagnostic> workspaceDiagnostics,
 		IReporter reporter)
 	{
 		var headFlavors = solution.Projects

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
@@ -23,7 +23,7 @@ internal static class DotnetRestoreRunner
 	/// Restores <paramref name="projectPath"/>. Never throws: failures are reported and
 	/// surface as <see langword="false"/> — the caller decides how to degrade.
 	/// </summary>
-	public static async Task<bool> TryRestoreAsync(string projectPath, IReporter reporter, CancellationToken ct, TimeSpan? timeout = null)
+	internal static async Task<bool> TryRestoreAsync(string projectPath, IReporter reporter, CancellationToken ct, TimeSpan? timeout = null)
 	{
 		try
 		{
@@ -32,7 +32,7 @@ internal static class DotnetRestoreRunner
 				// "dotnet" from PATH, environment inherited: the same muxer resolution the
 				// BuildHost uses, so the restored state matches the SDK of the workspace.
 				FileName = "dotnet",
-				WorkingDirectory = Path.GetDirectoryName(projectPath),
+				WorkingDirectory = Path.GetDirectoryName(projectPath) ?? Environment.CurrentDirectory,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 				UseShellExecute = false,

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
@@ -20,8 +20,10 @@ internal static class DotnetRestoreRunner
 	private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(120);
 
 	/// <summary>
-	/// Restores <paramref name="projectPath"/>. Never throws: failures are reported and
-	/// surface as <see langword="false"/> — the caller decides how to degrade.
+	/// Restores <paramref name="projectPath"/>. Only throws <see cref="OperationCanceledException"/>
+	/// when <paramref name="ct"/> is cancelled — all other failures are reported via
+	/// <paramref name="reporter"/> and surface as <see langword="false"/>, so the caller decides
+	/// how to degrade.
 	/// </summary>
 	internal static async Task<bool> TryRestoreAsync(string projectPath, IReporter reporter, CancellationToken ct, TimeSpan? timeout = null)
 	{
@@ -75,18 +77,19 @@ internal static class DotnetRestoreRunner
 			{
 				await process.WaitForExitAsync(timeoutCts.Token);
 			}
-			catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+			catch (OperationCanceledException)
 			{
-				reporter.Warn($"'dotnet restore' timed out after {(timeout ?? _defaultTimeout).TotalSeconds:F0}s; killing it.");
-				try
+				// WaitForExitAsync observed either the caller's token or the timeout — the restore
+				// is still running in both cases. Kill the whole tree (and wait for it to exit) so a
+				// cancelled or timed-out init never orphans a long-running 'dotnet restore'.
+				await KillProcessTreeAsync(process);
+
+				if (ct.IsCancellationRequested)
 				{
-					process.Kill(entireProcessTree: true);
-				}
-				catch
-				{
-					// The process may have exited in the meantime; nothing else to do.
+					throw;
 				}
 
+				reporter.Warn($"'dotnet restore' timed out after {(timeout ?? _defaultTimeout).TotalSeconds:F0}s; killed it.");
 				return false;
 			}
 
@@ -107,6 +110,31 @@ internal static class DotnetRestoreRunner
 		{
 			reporter.Warn($"'dotnet restore' failed to run: {e.Message}");
 			return false;
+		}
+	}
+
+	/// <summary>
+	/// Best-effort kill of the process and its children, then a bounded, uncancellable wait for
+	/// the tree to exit. Swallows every failure (already exited, kill raced with a natural exit,
+	/// or the wait elapsed) — cleanup must never mask the cancellation/timeout being handled.
+	/// </summary>
+	private static async Task KillProcessTreeAsync(Process process)
+	{
+		try
+		{
+			if (process.HasExited)
+			{
+				return;
+			}
+
+			process.Kill(entireProcessTree: true);
+
+			using var reapTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+			await process.WaitForExitAsync(reapTimeout.Token);
+		}
+		catch
+		{
+			// Best effort; nothing actionable if the kill or the bounded wait did not complete.
 		}
 	}
 }

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -20,12 +21,14 @@ internal static class DotnetRestoreRunner
 	private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(120);
 
 	/// <summary>
-	/// Restores <paramref name="projectPath"/>. Only throws <see cref="OperationCanceledException"/>
-	/// when <paramref name="ct"/> is cancelled — all other failures are reported via
-	/// <paramref name="reporter"/> and surface as <see langword="false"/>, so the caller decides
-	/// how to degrade.
+	/// Restores <paramref name="projectPath"/> under <paramref name="globalProperties"/> (the
+	/// workspace's allow-listed evaluation context, forwarded as <c>-p:</c> arguments so the
+	/// restore evaluates the same project graph the workspace opened). Only throws
+	/// <see cref="OperationCanceledException"/> when <paramref name="ct"/> is cancelled — all other
+	/// failures are reported via <paramref name="reporter"/> and surface as <see langword="false"/>,
+	/// so the caller decides how to degrade.
 	/// </summary>
-	internal static async Task<bool> TryRestoreAsync(string projectPath, IReporter reporter, CancellationToken ct, TimeSpan? timeout = null)
+	internal static async Task<bool> TryRestoreAsync(string projectPath, IReadOnlyDictionary<string, string> globalProperties, IReporter reporter, CancellationToken ct, TimeSpan? timeout = null)
 	{
 		try
 		{
@@ -41,6 +44,15 @@ internal static class DotnetRestoreRunner
 			};
 			startInfo.ArgumentList.Add("restore");
 			startInfo.ArgumentList.Add(projectPath);
+
+			// Forward the workspace's evaluation context so the restore resolves the SAME project
+			// graph the workspace opened. Without Configuration/Platform/Solution*, a restore of a
+			// property-conditioned targeting pack (e.g. a Release-only TargetingPackVersion) would
+			// evaluate the default (Debug) graph and leave the reloaded workspace just as broken.
+			foreach (var (key, value) in globalProperties)
+			{
+				startInfo.ArgumentList.Add($"-p:{key}={value}");
+			}
 
 			using var process = new Process { StartInfo = startInfo };
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.Roslyn/MsBuild/DotnetRestoreRunner.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.HotReload.Tracking;
+
+namespace Uno.Roslyn.MSBuild;
+
+/// <summary>
+/// Runs <c>dotnet restore</c> on a project in the same SDK-resolution context as Roslyn's
+/// out-of-process BuildHost: the <c>dotnet</c> muxer from the host process <c>PATH</c>, the
+/// environment inherited, and the project directory as working directory (so
+/// <c>global.json</c> applies). Used by the missing-targeting-pack recovery (spec 049): the
+/// restore materializes the <c>PackageDownload</c>-satisfied targeting packs into the NuGet
+/// cache, from which the next design-time build resolves them.
+/// </summary>
+internal static class DotnetRestoreRunner
+{
+	private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(120);
+
+	/// <summary>
+	/// Restores <paramref name="projectPath"/>. Never throws: failures are reported and
+	/// surface as <see langword="false"/> — the caller decides how to degrade.
+	/// </summary>
+	public static async Task<bool> TryRestoreAsync(string projectPath, IReporter reporter, CancellationToken ct, TimeSpan? timeout = null)
+	{
+		try
+		{
+			var startInfo = new ProcessStartInfo
+			{
+				// "dotnet" from PATH, environment inherited: the same muxer resolution the
+				// BuildHost uses, so the restored state matches the SDK of the workspace.
+				FileName = "dotnet",
+				WorkingDirectory = Path.GetDirectoryName(projectPath),
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				UseShellExecute = false,
+			};
+			startInfo.ArgumentList.Add("restore");
+			startInfo.ArgumentList.Add(projectPath);
+
+			using var process = new Process { StartInfo = startInfo };
+
+			process.OutputDataReceived += (_, e) =>
+			{
+				if (e.Data is { Length: > 0 } line)
+				{
+					reporter.Verbose($"dotnet restore: {line}");
+				}
+			};
+			process.ErrorDataReceived += (_, e) =>
+			{
+				if (e.Data is { Length: > 0 } line)
+				{
+					reporter.Verbose($"dotnet restore (stderr): {line}");
+				}
+			};
+
+			reporter.Output($"Running 'dotnet restore \"{projectPath}\"' to recover the hot-reload workspace.");
+
+			if (!process.Start())
+			{
+				reporter.Warn("Failed to start 'dotnet restore' (process did not start).");
+				return false;
+			}
+
+			process.BeginOutputReadLine();
+			process.BeginErrorReadLine();
+
+			using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+			timeoutCts.CancelAfter(timeout ?? _defaultTimeout);
+
+			try
+			{
+				await process.WaitForExitAsync(timeoutCts.Token);
+			}
+			catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+			{
+				reporter.Warn($"'dotnet restore' timed out after {(timeout ?? _defaultTimeout).TotalSeconds:F0}s; killing it.");
+				try
+				{
+					process.Kill(entireProcessTree: true);
+				}
+				catch
+				{
+					// The process may have exited in the meantime; nothing else to do.
+				}
+
+				return false;
+			}
+
+			if (process.ExitCode == 0)
+			{
+				reporter.Output("'dotnet restore' completed successfully.");
+				return true;
+			}
+
+			reporter.Warn($"'dotnet restore' exited with code {process.ExitCode}; the workspace will be reloaded anyway (a partial restore may still have materialized the missing packs).");
+			return false;
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
+		{
+			throw;
+		}
+		catch (Exception e)
+		{
+			reporter.Warn($"'dotnet restore' failed to run: {e.Message}");
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** closes #23780

## PR Type:

✨ Feature

## What changed? 🚀

When a workload-manifest-pinned targeting pack is missing from the SDK, Roslyn's restore-less design-time build silently produces a head flavor with package references but **zero .NET framework references** (the SDK deliberately emits no error under `DesignTimeBuild=true`). The flavor enters the workspace as a BCL-less husk, `TryGetTargetFramework` cannot resolve it (`<unresolved:`), and hot reload is blocked with no actionable diagnostic anywhere (field case: Linux + `net10.0-browserwasm`, stale mono-toolchain manifest pinning `Microsoft.NETCore.App@10.0.5` while only `10.0.7` is installed).

This PR implements spec `049-hotreload-workspace-missing-targeting-pack` (included):

- **Detection** — new `RoslynExtensions` helpers (`HasFrameworkReferences`, `IsMissingFrameworkReferences`, `GetHeadFlavorsMissingFrameworkReferences`, `TryGetDotnetRootFromFrameworkReferences`) identify the signature on every head flavor right after `OpenProjectAsync`, including single-TFM heads.
- **Recovery** — `CompilationWorkspaceProvider` runs `dotnet restore` on the head project once (same muxer resolution as the Roslyn BuildHost, project dir as cwd, 120 s timeout, new `DotnetRestoreRunner`) and reloads the workspace: the restore materializes the `PackageDownload`-satisfied targeting pack into the NuGet cache, from which the next design-time build resolves.
- **Actionable diagnostics** — when the signature survives the restore attempt, a warning names the flavors, the SDK root in use (derived from the sibling flavors' ref-pack paths) and the `dotnet workload update` remediation; the buffered `WorkspaceFailed` diagnostics (previously verbose-only) are re-emitted as warnings whenever a head flavor stays unresolved; the TFM-filtering keep-all warning now distinguishes `<unresolved, no framework references: …>` and points at the remediation.

Environment-side detection/repair (multiple dotnet roots, manifest/packs alignment) is the uno-check companion: unoplatform/uno.check#542.

Unit tests cover the new helpers (ref-pack layouts, NuGet-cache layout, head-only scan, SDK-root extraction); the full `Uno.HotReload.Tests` suite passes (82/82). The spec's CI integration fixture (pinned `TargetingPackVersion` + redirected `NUGET_PACKAGES`) is listed as follow-up.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)