### PR TITLE
Add Pure.DI to supported libraries

### DIFF
--- a/doc/articles/supported-libraries.md
+++ b/doc/articles/supported-libraries.md
@@ -22,6 +22,10 @@ This article lists some of the 3rd-party libraries supported by Uno Platform.
 * [ReactiveUI](https://www.reactiveui.net/)
 * [MVVMCross](https://www.mvvmcross.com/)
 
+## Dependency injection
+
+* [Pure.DI](https://github.com/DevTeam/Pure.DI/blob/master/readme/UnoApp.md) - Compile-time dependency injection with generated object graphs and no runtime container required
+
 ## Design and theming
 
 * [Uno.Material](external/uno.themes/doc/material-getting-started.md)


### PR DESCRIPTION
**GitHub Issue:** N/A — documentation-only change

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Added a Dependency injection section to the supported third-party libraries
documentation.

The section lists Pure.DI as a compile-time dependency injection option for
Uno Platform applications and links to its Uno Platform integration guide and
sample.

Pure.DI generates object graphs at compile time and does not require a runtime
DI container.

Validation:

- Verified that the Pure.DI documentation link returns HTTP 200.
- Verified that DocFX renders the new section and link correctly.
- Verified the changed Markdown with markdownlint.
- Confirmed that the change introduces no new DocFX diagnostics.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — N/A, documentation-only change.
- [x] 📚 Docs have been added/updated.
- [ ] 🖼️ Validated PR Screenshots Compare Test Run results — N/A, no UI changes.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests — optional.