### PR TITLE
fix(hr): gate UpdateFile requests on workspace initialization (spec 050)

### DIFF
--- a/specs/050-hotreload-updatefile-workspace-gate/spec.md
+++ b/specs/050-hotreload-updatefile-workspace-gate/spec.md
@@ -3,6 +3,11 @@
 Issue: [unoplatform/uno#23787](https://github.com/unoplatform/uno/issues/23787)
 Related: [spec 049](../049-hotreload-workspace-missing-targeting-pack/spec.md) (workspace init failures), [spec 047](../047-hotreload-workspace-single-tfm/spec.md) (baseline TFM filtering).
 
+**Status: IMPLEMENTED** — `WorkspaceGatedFileUpdater` + `IFileUpdater` in
+`src/Uno.HotReload/IO/`, wired in `ServerHotReloadProcessor`; unit tests in
+`src/Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs`. See
+*Implementation notes* at the end for the deltas vs. this design.
+
 ## Overview & Objectives
 
 The dev-server processes hot-reload file-update requests (`UpdateFileRequest` /
@@ -264,3 +269,55 @@ transport):
 3. **`Failed` state: no proactive push.** The existing `Disabled` broadcast
    through `HotReloadStatusMessage` is sufficient; revisit only if tooling
    demonstrates a need.
+
+## Implementation notes (deltas & concretizations vs. the design above)
+
+Implemented as designed; the following points are where the implementation
+concretized or slightly adjusted the text:
+
+- **Rejection result code:** rejections (terminal states, TTL expiry,
+  cancellation) use `FileUpdateResult.NotAvailable` (503) on every edit, with
+  the same message duplicated as `GlobalError`. Per-edit results are always
+  populated because `ClientHotReloadProcessor.TryUpdateFilesAsync` treats an
+  empty `Results` array as a "no changes" **success**
+  (`Results.All(NoChanges)` is vacuously true) — a global-error-only response
+  would be silently swallowed.
+- **Winner-takes-the-entry semantics:** each queued entry is claimed
+  atomically (`TryTake`) by exactly one of flush / TTL expiry / cancellation /
+  terminal rejection. Expired or cancelled entries stay in the queue but are
+  skipped by the flush — this is what guarantees R5's "never applied
+  afterwards" without cross-cancelling timers.
+- **Strict FIFO across the flush boundary:** in `Ready`/`NoWorkspace`, a
+  request arriving while the queue is non-empty (or a drain is in progress)
+  is queued behind it rather than passed through, so a flush can never be
+  overtaken by a newer request. Pass-through only happens on an empty, idle
+  queue.
+- **Cancellation (R9):** a queued entry watches its own `CancellationToken`
+  (the processor passes its connection-level token); cancellation completes
+  the request with an explicit "cancelled while waiting" error response
+  rather than a fault, and the entry is never applied.
+- **Inner swap:** `WorkspaceGatedFileUpdater.Inner` is a settable property;
+  `InitializeProcessor` replaces only the decorated `FileUpdater` (editor
+  refinement on `ConfigureServer`) while the gate — lifecycle state and queued
+  requests — survives, per R6. A flush that races the swap uses the inner
+  present at entry-execution time.
+- **Diagnostics surface (R8):** the decorator raises a `WorkspaceGateEvent`
+  (`queued` / `flushed` / `expired` / `rejected`, queue length, wait duration)
+  through an optional callback; the processor relays them as telemetry events
+  `update-<kind>` with `QueueLength` / `WaitDurationMs` measurements, and logs
+  through the existing `IReporter`.
+- **Config key:** `update-file-queue-timeout` (integer, seconds), read once at
+  processor construction via `GetServerConfiguration` — same mechanism as
+  `metadata-updates`.
+- **`Ready` placement:** reported from `InitializeAsync` **after** the
+  `FileSystemObserver` is constructed (not at the `HotReloadEvent.Ready`
+  notification a few lines earlier), closing Window B as required by R2.
+- **Test coverage:** the decorator unit tests (13 tests, MSTest +
+  AwesomeAssertions) cover test-plan items 1–8 at the state-machine level,
+  including two cases the plan didn't list explicitly: an expired entry must
+  not block later live entries from flushing, and an `Inner` swap while
+  queued must flush through the new inner. The **end-to-end DevServer
+  integration tests** (real `ConfigureServer` → `UpdateFile` race against an
+  in-process server) are NOT included in the initial implementation and
+  remain as follow-up; the full existing DevServer suite passes unchanged
+  (481 ✔).

--- a/specs/050-hotreload-updatefile-workspace-gate/spec.md
+++ b/specs/050-hotreload-updatefile-workspace-gate/spec.md
@@ -1,0 +1,266 @@
+# Hot-Reload: Gate `UpdateFile` Requests on Workspace Initialization
+
+Issue: [unoplatform/uno#23787](https://github.com/unoplatform/uno/issues/23787)
+Related: [spec 049](../049-hotreload-workspace-missing-targeting-pack/spec.md) (workspace init failures), [spec 047](../047-hotreload-workspace-single-tfm/spec.md) (baseline TFM filtering).
+
+## Overview & Objectives
+
+The dev-server processes hot-reload file-update requests (`UpdateFileRequest` /
+legacy `UpdateSingleFileRequest`) the moment they arrive, with **no dependency on
+the Roslyn workspace initialization**. The workspace captures its baseline by
+reading the solution **from disk**, asynchronously, after `ConfigureServer`.
+Any update request that lands before that read completes writes its edit to disk
+*first* — and the baseline is then loaded from the already-mutated file.
+
+Two distinct failure windows exist, both producing *"request acknowledged,
+change never applied"*:
+
+- **Window A — edit lands before the baseline disk read.** The baseline
+  silently absorbs the edit. Roslyn diffs every subsequent change against a
+  solution that already contains it → the edit is **never emitted as a delta**,
+  and the running application permanently diverges from the delta engine's
+  baseline (until full rebuild).
+- **Window B — edit lands after the baseline read but before the
+  `FileSystemObserver` exists.** The observer is only constructed once the
+  workspace has fully loaded, so the change is **never observed** and no
+  hot-reload is triggered for it (it self-heals only if the same file is edited
+  again later — but the original request was already reported successful).
+
+This is most easily hit by design-time tooling that starts issuing update
+requests at application startup, before the server has notified
+`HotReloadEvent.Ready` — a scenario that has moved from theoretical/QA to
+real with tooling that connects immediately at app launch.
+
+### Key objective
+
+`UpdateFile` requests received while the workspace **will exist but is not
+ready yet** must be **queued** and applied only once the baseline has been
+captured. Requests must **never be written to disk ahead of the initial
+baseline read**. When the workspace will never be available (failed init,
+disposed connection), or a queued request outlives a hard time limit, the
+server must **fail the request with an explicit error** instead of applying it
+late or silently.
+
+The Visual Studio path (no dev-server workspace at all — VS's own hot-reload
+engine owns delta generation) must remain strictly pass-through: no gate, no
+queue, no behavior change.
+
+---
+
+## Verified facts (investigation grounding)
+
+Established from source review of `Uno.UI.RemoteControl.Server.Processors`,
+`Uno.UI.RemoteControl` (client), `Uno.UI.RemoteControl.ServerCore` and
+`Uno.HotReload`:
+
+| # | Fact | Consequence |
+|---|------|-------------|
+| F1 | `ServerHotReloadProcessor.ProcessUpdateFile` (both overloads) calls `_fileUpdater.UpdateAsync(request, _ct.Token)` immediately; nothing awaits or checks `_workspace` (`ServerHotReloadProcessor.cs:314`, `:328`). `_workspace.GetAsync` is in fact **never consumed** outside `InitializeAsync` itself. | Any request racing the init writes to disk unguarded. |
+| F2 | The workspace is created asynchronously: `InitializeInner` stores `(InitializeAsync(ct), ct)` into `_workspace` and returns; the baseline is read **from disk** inside `LoadSolutionFromDisk` → `CompilationWorkspaceProvider.CreateWorkspaceAsync` (`ServerHotReloadProcessor.MetadataUpdate.cs:70`, `:88-97`). | Window A. |
+| F3 | The `FileSystemObserver` is constructed only **after** the manager is fully created and `Ready` notified (`ServerHotReloadProcessor.MetadataUpdate.cs:105`). | Window B. |
+| F4 | `_fileUpdater` is initialized **in the constructor** with the on-disk editor (`ServerHotReloadProcessor.cs:56`), before any `ConfigureServer`. | A request arriving before *any* configuration still writes to disk — the gate must also cover the not-yet-configured state. |
+| F5 | Visual Studio mode: the client computes `devServerEnabled = false` when `BuildingInsideVisualStudio` (`ClientHotReloadProcessor.Agent.cs:102-124`) → `ConfigureServer.EnableMetadataUpdates = false` → server-side `InitializeMetadataUpdater` returns `false` → `Notify(Ready)` immediately, **no workspace is ever created** (`ServerHotReloadProcessor.cs:261-270`). File edits are routed to the `IDEFileEditor` (VS applies them, VS's HR pipeline emits deltas). | HR is active as soon as the app starts; the gate must NOT apply — pass-through preserved. |
+| F6 | `ConfigureServer` can be received **multiple times** on one connection (explicit warning in `InitializeProcessor`, `ServerHotReloadProcessor.cs:66-77` — e.g. once by the app, once by design-time tooling). `InitializeInner` guards with `_workspace is not null` → warn + return: the workspace is initialized **once per connection**. `_useRoslynHotReload` is a sticky OR across calls (`MetadataUpdate.cs:40`), so a *later* `ConfigureServer` can be the one that enables and triggers the init. | The gate must key on the workspace lifecycle, not on "first ConfigureServer processed"; mode can transition no-workspace → workspace-initializing on a subsequent `ConfigureServer`. |
+| F7 | `RemoteControlServer` is a **per-connection instance** ("Creates a per-connection server instance", `RemoteControlServer.cs:45`); processors are registered per connection. A client reconnection (e.g. an app/worker restart against a long-lived dev-server) gets a **fresh `ServerHotReloadProcessor`** with `_workspace == null`. | Workspace "re-init" happens naturally via a new connection — no in-place re-init path exists (a commented-out `ProcessPackWorkspaceAsync` reload sketch exists at `ServerHotReloadProcessor.cs:364-405` but is dead code). |
+| F8 | Within one connection there is no recovery: if `InitializeAsync` faults, `_workspace` stays non-null holding a **faulted task** forever; `Dispose()` cancels `_workspace.Ct` (kills manager + observer) with no reset (`ServerHotReloadProcessor.cs:415-419`). | "Workspace unloaded / failed and will never come back" is a real terminal state on a live connection — queued and future requests must fail fast with an explicit error. |
+| F9 | There is **no server-side time bound** on update processing: the transport is WebSocket frames (not HTTP request/response). The client's `UpdateRequest.ServerUpdateTimeout` (default 10 s, extendable ×10/×30 via `WithExtendedTimeouts`) is purely client-side — the client stops *waiting*, but the server would still apply the edit later, mutating disk with nobody listening. | A hard server-side limit is required; applying an edit after the requester gave up is strictly worse than failing it. |
+
+---
+
+## Design
+
+### Workspace lifecycle states (server-side, per connection)
+
+The gate is driven by an explicit lifecycle around `_workspace`:
+
+```
+                 ┌──────────────────────────────┐
+                 │  NotConfigured               │  (no ConfigureServer yet — F4)
+                 └──────┬───────────────────────┘
+        ConfigureServer │
+            ┌───────────┴─────────────┐
+            ▼                         ▼
+   ┌────────────────┐        ┌──────────────────┐
+   │ NoWorkspace    │        │ Initializing     │  (metadata updates enabled — F2)
+   │ (VS/IDE-driven)│        └───┬──────────┬───┘
+   └────────────────┘   success  │          │ failure
+     pass-through               ▼          ▼
+                        ┌───────────┐  ┌───────────┐
+                        │  Ready    │  │  Failed   │  (terminal — F8)
+                        └───────────┘  └───────────┘
+                              any state ──Dispose──▶ Disposed (terminal)
+```
+
+- `NoWorkspace → Initializing` remains possible on a **subsequent**
+  `ConfigureServer` that enables metadata updates (F6).
+- `Failed` and `Disposed` are terminal for the connection; recovery is a new
+  connection with a fresh processor (F7).
+
+### Request handling per state
+
+| State | Behavior for `UpdateFileRequest` / `UpdateSingleFileRequest` |
+|---|---|
+| `NotConfigured` | **Queue.** Mode is not yet known; do not touch the disk. |
+| `NoWorkspace` (VS/IDE-driven) | **Pass-through immediately** — current behavior, unchanged (F5). Requests queued while `NotConfigured` are flushed through the same path. |
+| `Initializing` | **Queue.** Flush in arrival order on transition to `Ready`. |
+| `Ready` | Process immediately (current behavior). |
+| `Failed` / `Disposed` | **Fail fast**: respond with an explicit error (see below), **no disk write**, including any still-queued requests at the moment of the transition. |
+
+### Gate placement — a decorator over the file updater
+
+The state handling must **not** live as inline conditionals in the processor's
+message paths. The gate is a **decorator** over an updater abstraction:
+
+- Extract the updater contract consumed by the processor into an interface
+  (e.g. `IFileUpdater` with `Task<IUpdateFileResponse> UpdateAsync(IUpdateFileRequest, CancellationToken)` —
+  the exact shape `FileUpdater` already exposes).
+- Implement the whole state machine (queue, FIFO flush, TTL, terminal-state
+  rejection) in a `WorkspaceGatedFileUpdater` decorator wrapping the real
+  `FileUpdater`. Terminal-state and TTL rejections are just
+  `IUpdateFileResponse` instances carrying the global error — the processor
+  sends the response frame exactly as it does today.
+- The decorator is fed workspace lifecycle transitions
+  (`NotConfigured / NoWorkspace / Initializing / Ready / Failed / Disposed`)
+  by the processor, which remains the only party that *knows* the lifecycle —
+  but contains no gating logic: `ProcessUpdateFile` keeps its current
+  one-liner shape, only the construction/composition changes.
+- Consumers that have no Roslyn workspace (ad-hoc processors) keep composing
+  the bare `FileUpdater` — behavior unchanged.
+
+This keeps the state machine unit-testable in isolation (no processor, no
+transport) and the processor free of state spaghetti.
+
+Both message shapes funnel through the same updater call (a single-file
+request is a multi-edit with one edit — the legacy response is likewise
+reconstructed from the multi result), so the gate covers them uniformly by
+construction.
+
+### Requirements
+
+- **R1 — Queue before ready.** While `NotConfigured` or `Initializing`, incoming
+  update requests (both message shapes) are enqueued; the disk is not touched
+  and the IDE is not solicited. FIFO order is preserved on flush.
+- **R2 — Flush on Ready, after baseline.** The queue is flushed only once the
+  baseline solution has been captured **and** the `FileSystemObserver` is
+  active (i.e. at the point `HotReloadEvent.Ready` is notified today — closing
+  both Window A and Window B). Flushed requests follow the normal
+  `FileUpdater.UpdateAsync` path (including the existing `BufferGate` batching).
+- **R3 — VS pass-through.** In `NoWorkspace` mode nothing is gated. Requests
+  received while `NotConfigured` and resolved to `NoWorkspace` by the first
+  `ConfigureServer` are flushed immediately at that point.
+- **R4 — Fail terminal states.** In `Failed`/`Disposed`, respond
+  `UpdateFileResponse` / `UpdateSingleFileResponse` with a global error clearly
+  stating the workspace is unavailable and will not recover on this connection
+  (e.g. `"Hot-reload workspace failed to initialize; reconnect to retry"`).
+  Existing `FileUpdateResult` codes are reused (≥ `Failed`); no wire-format
+  change.
+- **R5 — Hard queue TTL.** Every queued request carries a deadline. On expiry
+  the server responds with an explicit timeout error and **never applies the
+  edit afterwards** (F9). Default: **30 s** (decided — covers typical workspace
+  loads while staying within the same order of magnitude as the client's
+  default patience; the client's debugger-extended timeouts go far beyond, so
+  the server limit is the effective bound). Configurable via a server
+  configuration key (same mechanism as `metadata-updates`, e.g.
+  `update-file-queue-timeout`). A request whose deadline expires is removed
+  without touching the disk.
+- **R6 — Re-entrant `ConfigureServer`.** The gate keys on the workspace
+  lifecycle, not on configuration calls: repeated `ConfigureServer` messages
+  must not re-create, reset, or double-flush the queue; a later call enabling
+  metadata updates transitions `NoWorkspace → Initializing` and gating resumes
+  (F6). Requests already passed through in `NoWorkspace` mode are not replayed.
+- **R7 — Scope of the gate.** The gate is the `WorkspaceGatedFileUpdater`
+  decorator (see *Gate placement* above): all state handling lives there, the
+  processor only composes it and reports lifecycle transitions. Out-of-tree
+  ad-hoc consumers of the bare `FileUpdater` (no Roslyn workspace) keep
+  current semantics untouched.
+- **R8 — Diagnosability.** Queue transitions are observable: log on enqueue
+  (with current state), on flush (count + max wait), on TTL expiry and on
+  terminal-state rejection; telemetry events mirroring the existing
+  `notify-*` pattern (`update-queued`, `update-flushed`, `update-expired`,
+  `update-rejected`) with queue length / wait-duration measurements.
+- **R9 — Cancellation.** Queued requests are dropped (with error responses
+  where the transport still allows it) when the processor is disposed;
+  no orphaned `TaskCompletionSource`, no unobserved task exceptions.
+
+### Client-side impact
+
+None required: the client already surfaces `UpdateFileResponse.GlobalError` as
+an `InvalidOperationException` through `TryUpdateFilesAsync`, and already
+handles server timeouts. Callers automatically benefit: an early request now
+either succeeds (after the workspace is ready) or fails with an actionable
+error instead of silently corrupting the baseline.
+
+Callers issuing startup-time updates should account for queueing latency in
+`ServerUpdateTimeout` (the existing `WithExtendedTimeouts` covers this).
+
+### Validation task — reconnection lifecycle (Studio Live-style hosts)
+
+The per-connection assumption (F7) is established from `RemoteControlServer`
+source, but must be validated end-to-end for hosts that keep the dev-server
+alive across app sessions:
+
+1. Confirm that an app/worker restart produces a **new transport connection**
+   → new scoped `RemoteControlServer` → new `ServerHotReloadProcessor` (fresh
+   `_workspace`), and that the previous processor is disposed.
+2. Confirm no host reuses a single connection across a workspace unload; if
+   such a flow exists, it lands in the `Failed`/`Disposed` terminal handling
+   (R4) by design — the error message must make the "reconnect to retry"
+   remediation explicit.
+
+---
+
+## Non-goals
+
+- **In-place workspace re-initialization / reload** on a live connection (the
+  dead `ProcessPackWorkspaceAsync` sketch). Recovery remains connection-scoped.
+- Changing `FileUpdater`'s own behavior or the ad-hoc processor path — the
+  interface extraction (R7) is contract-neutral; the bare updater keeps
+  current semantics.
+- Wire-format changes to the update messages or responses.
+- Gating of the file-system-watcher pipeline itself (the `BufferGate` batching
+  behavior is unchanged; the observer keeps starting with the workspace).
+- Proactive push of the `Failed` state to late-joining tooling beyond the
+  existing `Disabled` broadcast (`HotReloadStatusMessage`), which is deemed
+  sufficient for now.
+
+## Test plan
+
+DevServer integration tests (`Uno.UI.RemoteControl.DevServer.Tests`) plus
+focused unit tests on the `WorkspaceGatedFileUpdater` decorator in isolation
+(fake inner updater + scripted lifecycle transitions — no processor, no
+transport):
+
+1. **Race regression (Window A):** send `UpdateFileRequest` immediately after
+   `ConfigureServer` (before `HotReloadWorkspaceLoadResult`); assert the edit
+   is applied only after `Ready`, a delta is produced for it, and the response
+   is successful.
+2. **Pre-configuration request (F4):** send an update before any
+   `ConfigureServer`; assert it is queued, not written to disk, then flushed
+   per the resolved mode.
+3. **VS mode pass-through (R3):** `EnableMetadataUpdates=false` +
+   `BuildingInsideVisualStudio=true`; assert no queueing/delay and the
+   IDE-editor path is used.
+4. **Init failure (R4):** force workspace init failure (e.g. invalid project
+   path); assert queued and subsequent requests get the explicit terminal
+   error, and nothing touches the disk.
+5. **TTL expiry (R5):** stall init beyond the (test-shortened) TTL; assert the
+   timeout error response and that a late `Ready` does **not** apply the
+   expired edit.
+6. **Double `ConfigureServer` (R6):** app + tooling configuration sequence;
+   assert single init, single flush, no duplicate application of queued edits.
+7. **Order preservation (R1):** multiple queued edits on distinct files flush
+   FIFO and batch through the `BufferGate`.
+8. **Dispose during queue (R9):** close the connection with a non-empty queue;
+   assert clean teardown (no unobserved exceptions).
+
+## Resolved decisions
+
+1. **TTL default (R5): 30 s.** Fixed default, server-side configuration key
+   for overrides; no derivation from a client-declared timeout (not on the
+   wire today).
+2. **Legacy single-file message: gated identically.** A single-file request is
+   converted to a multi-edit with one edit and flows through the same updater
+   call, so the gate covers it by construction — no special-casing.
+3. **`Failed` state: no proactive push.** The existing `Disabled` broadcast
+   through `HotReloadStatusMessage` is sufficient; revisit only if tooling
+   demonstrates a need.

--- a/specs/050-hotreload-updatefile-workspace-gate/spec.md
+++ b/specs/050-hotreload-updatefile-workspace-gate/spec.md
@@ -1,9 +1,12 @@
 # Hot-Reload: Gate `UpdateFile` Requests on Workspace Initialization
 
-Issue: [unoplatform/uno#23787](https://github.com/unoplatform/uno/issues/23787)
-Related: [spec 049](../049-hotreload-workspace-missing-targeting-pack/spec.md) (workspace init failures), [spec 047](../047-hotreload-workspace-single-tfm/spec.md) (baseline TFM filtering).
+**Repo**: `uno` (Uno.HotReload)
+**Created**: 2026-07-16
+**Status**: Implemented
+**Issue**: [unoplatform/uno#23787](https://github.com/unoplatform/uno/issues/23787)
+**Related**: [spec 047](../047-hotreload-workspace-single-tfm/spec.md) (baseline TFM filtering)
 
-**Status: IMPLEMENTED** — `WorkspaceGatedFileUpdater` + `IFileUpdater` in
+**Implementation** — `WorkspaceGatedFileUpdater` + `IFileUpdater` in
 `src/Uno.HotReload/IO/`, wired in `ServerHotReloadProcessor`; unit tests in
 `src/Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs`. See
 *Implementation notes* at the end for the deltas vs. this design.
@@ -60,14 +63,14 @@ Established from source review of `Uno.UI.RemoteControl.Server.Processors`,
 
 | # | Fact | Consequence |
 |---|------|-------------|
-| F1 | `ServerHotReloadProcessor.ProcessUpdateFile` (both overloads) calls `_fileUpdater.UpdateAsync(request, _ct.Token)` immediately; nothing awaits or checks `_workspace` (`ServerHotReloadProcessor.cs:314`, `:328`). `_workspace.GetAsync` is in fact **never consumed** outside `InitializeAsync` itself. | Any request racing the init writes to disk unguarded. |
-| F2 | The workspace is created asynchronously: `InitializeInner` stores `(InitializeAsync(ct), ct)` into `_workspace` and returns; the baseline is read **from disk** inside `LoadSolutionFromDisk` → `CompilationWorkspaceProvider.CreateWorkspaceAsync` (`ServerHotReloadProcessor.MetadataUpdate.cs:70`, `:88-97`). | Window A. |
-| F3 | The `FileSystemObserver` is constructed only **after** the manager is fully created and `Ready` notified (`ServerHotReloadProcessor.MetadataUpdate.cs:105`). | Window B. |
-| F4 | `_fileUpdater` is initialized **in the constructor** with the on-disk editor (`ServerHotReloadProcessor.cs:56`), before any `ConfigureServer`. | A request arriving before *any* configuration still writes to disk — the gate must also cover the not-yet-configured state. |
-| F5 | Visual Studio mode: the client computes `devServerEnabled = false` when `BuildingInsideVisualStudio` (`ClientHotReloadProcessor.Agent.cs:102-124`) → `ConfigureServer.EnableMetadataUpdates = false` → server-side `InitializeMetadataUpdater` returns `false` → `Notify(Ready)` immediately, **no workspace is ever created** (`ServerHotReloadProcessor.cs:261-270`). File edits are routed to the `IDEFileEditor` (VS applies them, VS's HR pipeline emits deltas). | HR is active as soon as the app starts; the gate must NOT apply — pass-through preserved. |
-| F6 | `ConfigureServer` can be received **multiple times** on one connection (explicit warning in `InitializeProcessor`, `ServerHotReloadProcessor.cs:66-77` — e.g. once by the app, once by design-time tooling). `InitializeInner` guards with `_workspace is not null` → warn + return: the workspace is initialized **once per connection**. `_useRoslynHotReload` is a sticky OR across calls (`MetadataUpdate.cs:40`), so a *later* `ConfigureServer` can be the one that enables and triggers the init. | The gate must key on the workspace lifecycle, not on "first ConfigureServer processed"; mode can transition no-workspace → workspace-initializing on a subsequent `ConfigureServer`. |
-| F7 | `RemoteControlServer` is a **per-connection instance** ("Creates a per-connection server instance", `RemoteControlServer.cs:45`); processors are registered per connection. A client reconnection (e.g. an app/worker restart against a long-lived dev-server) gets a **fresh `ServerHotReloadProcessor`** with `_workspace == null`. | Workspace "re-init" happens naturally via a new connection — no in-place re-init path exists (a commented-out `ProcessPackWorkspaceAsync` reload sketch exists at `ServerHotReloadProcessor.cs:364-405` but is dead code). |
-| F8 | Within one connection there is no recovery: if `InitializeAsync` faults, `_workspace` stays non-null holding a **faulted task** forever; `Dispose()` cancels `_workspace.Ct` (kills manager + observer) with no reset (`ServerHotReloadProcessor.cs:415-419`). | "Workspace unloaded / failed and will never come back" is a real terminal state on a live connection — queued and future requests must fail fast with an explicit error. |
+| F1 | `ServerHotReloadProcessor.ProcessUpdateFile` (both overloads) calls `_fileUpdater.UpdateAsync(request, _ct.Token)` immediately; nothing awaits or checks `_workspace`. `_workspace.GetAsync` is in fact **never consumed** outside `InitializeAsync` itself. | Any request racing the init writes to disk unguarded. |
+| F2 | The workspace is created asynchronously: `ServerHotReloadProcessor.InitializeInner` stores `(InitializeAsync(ct), ct)` into `_workspace` and returns; the baseline is read **from disk** inside `LoadSolutionFromDisk` → `CompilationWorkspaceProvider.CreateWorkspaceAsync` (`ServerHotReloadProcessor.MetadataUpdate.cs`). | Window A. |
+| F3 | The `FileSystemObserver` is constructed only **after** the manager is fully created and `Ready` notified (`ServerHotReloadProcessor.InitializeAsync`, `ServerHotReloadProcessor.MetadataUpdate.cs`). | Window B. |
+| F4 | `_fileUpdater` is initialized **in the `ServerHotReloadProcessor` constructor** with the on-disk editor, before any `ConfigureServer`. | A request arriving before *any* configuration still writes to disk — the gate must also cover the not-yet-configured state. |
+| F5 | Visual Studio mode: the client computes `devServerEnabled = false` when `BuildingInsideVisualStudio` (`ClientHotReloadProcessor.Agent.cs`) → `ConfigureServer.EnableMetadataUpdates = false` → server-side `InitializeMetadataUpdater` returns `false` → `Notify(Ready)` immediately, **no workspace is ever created** (`ServerHotReloadProcessor.InitializeMetadataUpdater`). File edits are routed to the `IDEFileEditor` (VS applies them, VS's HR pipeline emits deltas). | HR is active as soon as the app starts; the gate must NOT apply — pass-through preserved. |
+| F6 | `ConfigureServer` can be received **multiple times** on one connection (explicit warning in `ServerHotReloadProcessor.InitializeProcessor` — e.g. once by the app, once by design-time tooling). `InitializeInner` guards with `_workspace is not null` → warn + return: the workspace is initialized **once per connection**. `_useRoslynHotReload` is a sticky OR across calls (`ServerHotReloadProcessor.MetadataUpdate.cs`), so a *later* `ConfigureServer` can be the one that enables and triggers the init. | The gate must key on the workspace lifecycle, not on "first ConfigureServer processed"; mode can transition no-workspace → workspace-initializing on a subsequent `ConfigureServer`. |
+| F7 | `RemoteControlServer` is a **per-connection instance** ("Creates a per-connection server instance", `RemoteControlServer`); processors are registered per connection. A client reconnection (e.g. an app/worker restart against a long-lived dev-server) gets a **fresh `ServerHotReloadProcessor`** with `_workspace == null`. | Workspace "re-init" happens naturally via a new connection — no in-place re-init path exists (a commented-out `ServerHotReloadProcessor.ProcessPackWorkspaceAsync` reload sketch exists but is dead code). |
+| F8 | Within one connection there is no recovery: if `InitializeAsync` faults, `_workspace` stays non-null holding a **faulted task** forever; `ServerHotReloadProcessor.Dispose` cancels `_workspace.Ct` (kills manager + observer) with no reset. | "Workspace unloaded / failed and will never come back" is a real terminal state on a live connection — queued and future requests must fail fast with an explicit error. |
 | F9 | There is **no server-side time bound** on update processing: the transport is WebSocket frames (not HTTP request/response). The client's `UpdateRequest.ServerUpdateTimeout` (default 10 s, extendable ×10/×30 via `WithExtendedTimeouts`) is purely client-side — the client stops *waiting*, but the server would still apply the edit later, mutating disk with nobody listening. | A hard server-side limit is required; applying an edit after the requester gave up is strictly worse than failing it. |
 
 ---
@@ -88,11 +91,12 @@ The gate is driven by an explicit lifecycle around `_workspace`:
    ┌────────────────┐        ┌──────────────────┐
    │ NoWorkspace    │        │ Initializing     │  (metadata updates enabled — F2)
    │ (VS/IDE-driven)│        └───┬──────────┬───┘
-   └────────────────┘   success  │          │ failure
-     pass-through               ▼          ▼
-                        ┌───────────┐  ┌───────────┐
-                        │  Ready    │  │  Failed   │  (terminal — F8)
-                        └───────────┘  └───────────┘
+   └───────┬────────┘   success  │          │ failure
+     pass-through│               ▼          ▼
+                 │        ┌───────────┐  ┌───────────┐
+                 │        │  Ready    │  │  Failed   │  (terminal — F8)
+                 │        └───────────┘  └───────────┘
+                 └─ subsequent ConfigureServer (enables metadata updates — F6) ─▶ Initializing
                               any state ──Dispose──▶ Disposed (terminal)
 ```
 
@@ -147,8 +151,12 @@ construction.
   and the IDE is not solicited. FIFO order is preserved on flush.
 - **R2 — Flush on Ready, after baseline.** The queue is flushed only once the
   baseline solution has been captured **and** the `FileSystemObserver` is
-  active (i.e. at the point `HotReloadEvent.Ready` is notified today — closing
-  both Window A and Window B). Flushed requests follow the normal
+  active — i.e. after *both* Window A and Window B have closed. Note this is
+  **not** where `HotReloadEvent.Ready` is notified today: today's `Notify(Ready)`
+  fires *before* the `FileSystemObserver` is constructed, so the implementation
+  reports the gate's `Ready` transition from a later point (after the observer
+  exists) rather than reusing the existing notification (see *Implementation
+  notes → `Ready` placement*). Flushed requests follow the normal
   `FileUpdater.UpdateAsync` path (including the existing `BufferGate` batching).
 - **R3 — VS pass-through.** In `NoWorkspace` mode nothing is gated. Requests
   received while `NotConfigured` and resolved to `NoWorkspace` by the first
@@ -159,12 +167,16 @@ construction.
   (e.g. `"Hot-reload workspace failed to initialize; reconnect to retry"`).
   Existing `FileUpdateResult` codes are reused (≥ `Failed`); no wire-format
   change.
-- **R5 — Hard queue TTL.** Every queued request carries a deadline. On expiry
-  the server responds with an explicit timeout error and **never applies the
-  edit afterwards** (F9). Default: **30 s** (decided — covers typical workspace
-  loads while staying within the same order of magnitude as the client's
-  default patience; the client's debugger-extended timeouts go far beyond, so
-  the server limit is the effective bound). Configurable via a server
+- **R5 — Hard queue TTL.** Every queued request carries a deadline. TTL is
+  enforced **proactively (timer-based)**: each queued request arms its own timer
+  (`WatchTimeoutAsync` awaiting `Task.Delay(QueueTimeout, ct)`), so on expiry the
+  server responds with the explicit timeout error **within ~TTL regardless of
+  how long initialization takes** — the error is *not* deferred until the queue
+  next flushes or reaches a terminal state. The expired request is **never
+  applied afterwards** (F9). Default: **30 s** (decided — covers typical
+  workspace loads while staying within the same order of magnitude as the
+  client's default patience; the client's debugger-extended timeouts go far
+  beyond, so the server limit is the effective bound). Configurable via a server
   configuration key (same mechanism as `metadata-updates`, e.g.
   `update-file-queue-timeout`). A request whose deadline expires is removed
   without touching the disk.
@@ -257,6 +269,12 @@ transport):
    FIFO and batch through the `BufferGate`.
 8. **Dispose during queue (R9):** close the connection with a non-empty queue;
    assert clean teardown (no unobserved exceptions).
+9. **`NoWorkspace → Initializing` mode change (F6/R6):** first `ConfigureServer`
+   resolves to `NoWorkspace` (`EnableMetadataUpdates=false`) and two update
+   requests pass through (no queuing); a second `ConfigureServer` with
+   `EnableMetadataUpdates=true` transitions to `Initializing`; a third request
+   is now queued. Assert the third request is applied **exactly once** after
+   `Ready`, and the first two are **not** replayed (R6).
 
 ## Resolved decisions
 
@@ -284,9 +302,14 @@ concretized or slightly adjusted the text:
   would be silently swallowed.
 - **Winner-takes-the-entry semantics:** each queued entry is claimed
   atomically (`TryTake`) by exactly one of flush / TTL expiry / cancellation /
-  terminal rejection. Expired or cancelled entries stay in the queue but are
-  skipped by the flush — this is what guarantees R5's "never applied
-  afterwards" without cross-cancelling timers.
+  terminal rejection. A claimed entry is guaranteed to be skipped by the flush
+  (which re-checks `TryTake` before applying) — this is what guarantees R5's
+  "never applied afterwards" without cross-cancelling timers. To avoid the queue
+  retaining already-claimed entries when the workspace never reaches a flushing
+  or terminal state (stuck `Initializing`), the timeout/cancellation path
+  compacts them out of the queue (`CompactQueue`), preserving FIFO order of the
+  survivors, so a stalled workspace cannot accumulate dead entries (nor inflate
+  the queue-length telemetry).
 - **Strict FIFO across the flush boundary:** in `Ready`/`NoWorkspace`, a
   request arriving while the queue is non-empty (or a drain is in progress)
   is queued behind it rather than passed through, so a flush can never be

--- a/src/Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs
@@ -286,6 +286,61 @@ public class Given_WorkspaceGatedFileUpdater
 		events.Select(evt => evt.Kind).Should().ContainInOrder("queued", "flushed");
 	}
 
+	[TestMethod]
+	[Description(
+		"A throwing diagnostic callback (reporter/onEvent) during the flush must never orphan the " +
+		"request's awaiter nor wedge the drain loop: the request still completes and a subsequent " +
+		"request must still flow through (the gate must not stay permanently 'draining').")]
+	public async Task When_OnEventThrowsDuringFlush_Then_RequestCompletesAndGateNotWedged()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner, onEvent: evt =>
+		{
+			if (evt.Kind == "flushed")
+			{
+				throw new InvalidOperationException("telemetry sink blew up");
+			}
+		});
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var first = sut.UpdateAsync(Request("first.xaml"), CancellationToken.None);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
+		// Despite the callback throwing, the awaiter is resolved (completed before the callback runs).
+		(await first.WaitAsync(_flushTimeout)).GlobalError.Should().BeNull();
+
+		// The drain loop must have reset its state: a later request still gets applied.
+		var second = sut.UpdateAsync(Request("second.xaml"), CancellationToken.None);
+		(await second.WaitAsync(_flushTimeout)).GlobalError.Should().BeNull();
+		inner.Requests.Should().HaveCount(2);
+	}
+
+	[TestMethod]
+	[Description(
+		"Expired/cancelled entries must be compacted out of the queue rather than lingering: a " +
+		"workspace stuck initializing must not accumulate dead entries. Observed via the queue " +
+		"length reported on the next enqueue.")]
+	public async Task When_EntryExpires_Then_ItIsRemovedFromTheQueue()
+	{
+		var inner = new RecordingUpdater();
+		var events = new ConcurrentQueue<WorkspaceGateEvent>();
+		var sut = new WorkspaceGatedFileUpdater(inner, queueTimeout: TimeSpan.FromMilliseconds(100), onEvent: events.Enqueue);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		// First request expires while the workspace stays 'Initializing'.
+		var expired = sut.UpdateAsync(Request("expired.xaml"), CancellationToken.None);
+		(await expired.WaitAsync(_flushTimeout)).GlobalError.Should().NotBeNull();
+
+		// Let the timeout path's compaction (which runs after the awaiter is resolved) settle.
+		await Task.Delay(50);
+
+		// Second enqueue must see a queue of 1 (the expired entry was compacted out, not still present).
+		_ = sut.UpdateAsync(Request("next.xaml"), CancellationToken.None);
+
+		var queuedLengths = events.Where(evt => evt.Kind == "queued").Select(evt => evt.QueueLength).ToArray();
+		queuedLengths.Should().Equal([1, 1], "the expired entry must not inflate the queue length");
+	}
+
 	private static TestUpdateRequest Request(string filePath)
 		=> new([new FileEdit(filePath, OldText: null, NewText: "<new content />")]);
 

--- a/src/Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs
@@ -1,0 +1,322 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Uno.HotReload.IO;
+
+namespace Uno.HotReload.Tests.IO;
+
+[TestClass]
+public class Given_WorkspaceGatedFileUpdater
+{
+	private static readonly TimeSpan _flushTimeout = TimeSpan.FromSeconds(5);
+
+	[TestMethod]
+	[Description(
+		"An update request received while the workspace is initializing must not reach the " +
+		"inner updater (i.e. must not touch the disk) before the workspace is ready — an early " +
+		"edit would be folded into the baseline and never emitted as a delta.")]
+	public async Task When_RequestWhileInitializing_Then_QueuedAndAppliedOnReady()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var pending = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+
+		await Task.Delay(50);
+		pending.IsCompleted.Should().BeFalse("the request must wait for the workspace");
+		inner.Requests.Should().BeEmpty("nothing may be applied before the baseline is captured");
+
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
+		var response = await pending.WaitAsync(_flushTimeout);
+		response.GlobalError.Should().BeNull();
+		inner.Requests.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description(
+		"A request received before any configuration (mode not known yet) must be queued too: " +
+		"the bare updater writes to disk from the constructor otherwise.")]
+	public async Task When_RequestBeforeConfiguration_Then_QueuedUntilModeIsKnown()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+
+		sut.State.Should().Be(HotReloadWorkspaceState.NotConfigured);
+		var pending = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+		inner.Requests.Should().BeEmpty();
+
+		// First configuration resolves to IDE-driven hot reload (e.g. Visual Studio): flush as-is.
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.NoWorkspace);
+
+		(await pending.WaitAsync(_flushTimeout)).GlobalError.Should().BeNull();
+		inner.Requests.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description(
+		"IDE-driven mode (no workspace, e.g. Visual Studio) must remain strictly pass-through: " +
+		"hot reload is active as soon as the app starts there.")]
+	public async Task When_NoWorkspaceMode_Then_PassThrough()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.NoWorkspace);
+
+		var response = await sut.UpdateAsync(Request("a.xaml"), CancellationToken.None).WaitAsync(_flushTimeout);
+
+		response.GlobalError.Should().BeNull();
+		inner.Requests.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description("Queued requests must be flushed in arrival order (FIFO).")]
+	public async Task When_MultipleRequestsQueued_Then_FlushedInArrivalOrder()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var pending = new[]
+		{
+			sut.UpdateAsync(Request("first.xaml"), CancellationToken.None),
+			sut.UpdateAsync(Request("second.xaml"), CancellationToken.None),
+			sut.UpdateAsync(Request("third.xaml"), CancellationToken.None),
+		};
+
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+		await Task.WhenAll(pending).WaitAsync(_flushTimeout);
+
+		inner.Requests.Select(req => req.Edits.Single().FilePath)
+			.Should().ContainInOrder("first.xaml", "second.xaml", "third.xaml");
+	}
+
+	[TestMethod]
+	[Description(
+		"When the workspace failed to initialize, queued and subsequent requests must fail fast " +
+		"with an explicit error — never be applied, never wait forever.")]
+	public async Task When_WorkspaceFails_Then_QueuedAndSubsequentRequestsAreRejected()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var queued = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Failed);
+
+		var queuedResponse = await queued.WaitAsync(_flushTimeout);
+		queuedResponse.GlobalError.Should().Contain("failed to initialize");
+		queuedResponse.Results.Should().OnlyContain(result => result.Result == FileUpdateResult.NotAvailable);
+
+		var lateResponse = await sut.UpdateAsync(Request("b.xaml"), CancellationToken.None).WaitAsync(_flushTimeout);
+		lateResponse.GlobalError.Should().Contain("failed to initialize");
+
+		inner.Requests.Should().BeEmpty("a failed workspace must never let an edit through");
+	}
+
+	[TestMethod]
+	[Description(
+		"Terminal states are sticky: a Ready reported after a failure must not resurrect the " +
+		"gate on this connection (recovery is a new connection with a fresh processor).")]
+	public async Task When_ReadyAfterFailed_Then_StillRejected()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Failed);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
+		sut.State.Should().Be(HotReloadWorkspaceState.Failed);
+		var response = await sut.UpdateAsync(Request("a.xaml"), CancellationToken.None).WaitAsync(_flushTimeout);
+		response.GlobalError.Should().NotBeNull();
+		inner.Requests.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description(
+		"A queued request must expire after the hard queue timeout with an explicit error, and a " +
+		"late workspace Ready must NOT apply the expired edit: the requester gave up long ago and " +
+		"a late disk write would mutate sources with nobody listening.")]
+	public async Task When_QueueTimeoutExpires_Then_RequestFailsAndIsNeverAppliedLate()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner, queueTimeout: TimeSpan.FromMilliseconds(100));
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var pending = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+
+		var response = await pending.WaitAsync(_flushTimeout);
+		response.GlobalError.Should().Contain("was not ready within");
+		response.Results.Should().OnlyContain(result => result.Result == FileUpdateResult.NotAvailable);
+
+		// The workspace becoming ready afterwards must not resurrect the expired request.
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+		await Task.Delay(100);
+		inner.Requests.Should().BeEmpty("an expired request must never be applied late");
+	}
+
+	[TestMethod]
+	[Description(
+		"An expired request sitting in the queue must not block later, still-live requests from " +
+		"being flushed when the workspace becomes ready.")]
+	public async Task When_SomeRequestsExpired_Then_RemainingOnesStillFlush()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner, queueTimeout: TimeSpan.FromMilliseconds(100));
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var expired = sut.UpdateAsync(Request("expired.xaml"), CancellationToken.None);
+		(await expired.WaitAsync(_flushTimeout)).GlobalError.Should().NotBeNull();
+
+		// This one is enqueued after the first expired; its own TTL has not elapsed yet.
+		var live = sut.UpdateAsync(Request("live.xaml"), CancellationToken.None);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
+		(await live.WaitAsync(_flushTimeout)).GlobalError.Should().BeNull();
+		inner.Requests.Should().ContainSingle(because: "only the live request may be applied")
+			.Which.Edits.Single().FilePath.Should().Be("live.xaml");
+	}
+
+	[TestMethod]
+	[Description(
+		"Disposing the connection with a non-empty queue must fail all pending requests cleanly " +
+		"(no orphaned awaiter), and reject any subsequent request.")]
+	public async Task When_DisposedWithQueuedRequests_Then_AllPendingAreRejected()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var pending = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Disposed);
+
+		var response = await pending.WaitAsync(_flushTimeout);
+		response.GlobalError.Should().Contain("closed");
+
+		var late = await sut.UpdateAsync(Request("b.xaml"), CancellationToken.None).WaitAsync(_flushTimeout);
+		late.GlobalError.Should().Contain("closed");
+		inner.Requests.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description(
+		"Re-entrant configuration: hot reload first resolved as IDE-driven, then a later " +
+		"configuration enables the workspace — the gate must resume queueing during the " +
+		"initialization without replaying requests already passed through.")]
+	public async Task When_NoWorkspaceThenInitializing_Then_GatingResumes()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.NoWorkspace);
+		await sut.UpdateAsync(Request("direct.xaml"), CancellationToken.None).WaitAsync(_flushTimeout);
+		inner.Requests.Should().ContainSingle();
+
+		// A later ConfigureServer enables metadata updates: workspace init starts.
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var gated = sut.UpdateAsync(Request("gated.xaml"), CancellationToken.None);
+		await Task.Delay(50);
+		gated.IsCompleted.Should().BeFalse("gating must resume while the workspace initializes");
+
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+		(await gated.WaitAsync(_flushTimeout)).GlobalError.Should().BeNull();
+		inner.Requests.Should().HaveCount(2, "the direct request must not be replayed");
+	}
+
+	[TestMethod]
+	[Description(
+		"Replacing the inner updater (the processor refines the editor on configuration) must " +
+		"preserve the gate: lifecycle state and queued requests survive, and the flush goes " +
+		"through the NEW inner.")]
+	public async Task When_InnerReplacedWhileQueued_Then_FlushUsesNewInner()
+	{
+		var initialInner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(initialInner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var pending = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+
+		var replacementInner = new RecordingUpdater();
+		sut.Inner = replacementInner;
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
+		await pending.WaitAsync(_flushTimeout);
+		initialInner.Requests.Should().BeEmpty();
+		replacementInner.Requests.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description(
+		"A request cancelled (e.g. connection tear-down) while queued must complete with an " +
+		"error and never be applied by a later flush.")]
+	public async Task When_RequestCancelledWhileQueued_Then_RejectedAndNeverApplied()
+	{
+		var inner = new RecordingUpdater();
+		var sut = new WorkspaceGatedFileUpdater(inner);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		using var cts = new CancellationTokenSource();
+		var pending = sut.UpdateAsync(Request("a.xaml"), cts.Token);
+		cts.Cancel();
+
+		var response = await pending.WaitAsync(_flushTimeout);
+		response.GlobalError.Should().Contain("cancelled");
+
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+		await Task.Delay(100);
+		inner.Requests.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description(
+		"Diagnostic events must be raised for queueing and flushing so the processor can relay " +
+		"them as telemetry.")]
+	public async Task When_QueuedAndFlushed_Then_GateEventsAreRaised()
+	{
+		var inner = new RecordingUpdater();
+		var events = new ConcurrentQueue<WorkspaceGateEvent>();
+		var sut = new WorkspaceGatedFileUpdater(inner, onEvent: events.Enqueue);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
+		var pending = sut.UpdateAsync(Request("a.xaml"), CancellationToken.None);
+		sut.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+		await pending.WaitAsync(_flushTimeout);
+
+		events.Select(evt => evt.Kind).Should().ContainInOrder("queued", "flushed");
+	}
+
+	private static TestUpdateRequest Request(string filePath)
+		=> new([new FileEdit(filePath, OldText: null, NewText: "<new content />")]);
+
+	private sealed record TestUpdateRequest(ImmutableArray<FileEdit> Edits) : IUpdateFileRequest
+	{
+		public string RequestId { get; } = Guid.NewGuid().ToString();
+		public bool? ForceSaveOnDisk => null;
+		public bool IsForceHotReloadDisabled => false;
+		public TimeSpan? ForceHotReloadDelay => null;
+		public int? ForceHotReloadAttempts => null;
+	}
+
+	private sealed class RecordingUpdater : IFileUpdater
+	{
+		private readonly ConcurrentQueue<IUpdateFileRequest> _requests = new();
+
+		public IReadOnlyCollection<IUpdateFileRequest> Requests => _requests;
+
+		public Task<IUpdateFileResponse> UpdateAsync(IUpdateFileRequest request, CancellationToken ct)
+		{
+			_requests.Enqueue(request);
+			return Task.FromResult<IUpdateFileResponse>(new SuccessResponse(
+				request.RequestId,
+				null,
+				[.. request.Edits.Select(edit => new FileEditResult(edit.FilePath, FileUpdateResult.Success, null))]));
+		}
+
+		private sealed record SuccessResponse(
+			string RequestId,
+			string? GlobalError,
+			ImmutableArray<FileEditResult> Results,
+			long? HotReloadCorrelationId = null) : IUpdateFileResponse;
+	}
+}

--- a/src/Uno.HotReload/IO/FileUpdater.cs
+++ b/src/Uno.HotReload/IO/FileUpdater.cs
@@ -18,7 +18,7 @@ public class FileUpdater(
 	BufferGate gate,
 	HotReloadTracker tracker,
 	HotReloadInfoFile hotReloadInfoFile,
-	Func<ValueTask> requestHotReload)
+	Func<ValueTask> requestHotReload) : IFileUpdater
 {
 	public async Task<IUpdateFileResponse> UpdateAsync(IUpdateFileRequest request, CancellationToken ct)
 	{

--- a/src/Uno.HotReload/IO/HotReloadWorkspaceState.cs
+++ b/src/Uno.HotReload/IO/HotReloadWorkspaceState.cs
@@ -1,0 +1,39 @@
+namespace Uno.HotReload.IO;
+
+/// <summary>
+/// Lifecycle of the hot-reload compilation workspace, as reported to the
+/// <see cref="WorkspaceGatedFileUpdater"/> by the hot-reload server processor.
+/// </summary>
+public enum HotReloadWorkspaceState
+{
+	/// <summary>
+	/// No configuration received yet: it is not known whether a workspace will be created.
+	/// </summary>
+	NotConfigured,
+
+	/// <summary>
+	/// Hot reload is IDE-driven (e.g. Visual Studio): no workspace will be created and
+	/// file updates flow directly to the editor.
+	/// </summary>
+	NoWorkspace,
+
+	/// <summary>
+	/// The workspace is initializing: the baseline solution is being captured from disk.
+	/// </summary>
+	Initializing,
+
+	/// <summary>
+	/// The workspace is ready: the baseline has been captured and the file-system observer is active.
+	/// </summary>
+	Ready,
+
+	/// <summary>
+	/// The workspace failed to initialize and will not recover on this connection.
+	/// </summary>
+	Failed,
+
+	/// <summary>
+	/// The processor (i.e. the connection) has been disposed.
+	/// </summary>
+	Disposed,
+}

--- a/src/Uno.HotReload/IO/IFileUpdater.cs
+++ b/src/Uno.HotReload/IO/IFileUpdater.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.HotReload.IO;
+
+/// <summary>
+/// Contract of the file-update orchestrator consumed by hot-reload server processors.
+/// </summary>
+/// <remarks>
+/// Extracted from <see cref="FileUpdater"/> so behavior can be composed by decoration
+/// (e.g. <see cref="WorkspaceGatedFileUpdater"/> queueing requests until the hot-reload
+/// workspace has captured its baseline).
+/// </remarks>
+public interface IFileUpdater
+{
+	/// <summary>
+	/// Applies the given file-update request and reports the per-edit results.
+	/// </summary>
+	Task<IUpdateFileResponse> UpdateAsync(IUpdateFileRequest request, CancellationToken ct);
+}

--- a/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.IO;
+
+/// <summary>
+/// Decorates an <see cref="IFileUpdater"/> with a gate driven by the hot-reload workspace lifecycle
+/// (see <see cref="HotReloadWorkspaceState"/>): update requests received while the workspace is
+/// expected but not ready yet are queued and applied — in arrival order — only once the baseline
+/// solution has been captured, so an early edit can never be folded into the baseline (nor written
+/// to disk before the file-system observer exists).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Requests are failed with an explicit <see cref="IUpdateFileResponse.GlobalError"/> (and never
+/// applied) when the workspace will not become available on this connection
+/// (<see cref="HotReloadWorkspaceState.Failed"/> / <see cref="HotReloadWorkspaceState.Disposed"/>),
+/// or when a queued request out-lives <see cref="QueueTimeout"/>.
+/// </para>
+/// <para>
+/// When hot reload is IDE-driven (<see cref="HotReloadWorkspaceState.NoWorkspace"/>, e.g. Visual
+/// Studio), requests pass through untouched.
+/// </para>
+/// </remarks>
+public sealed class WorkspaceGatedFileUpdater(
+	IFileUpdater inner,
+	TimeSpan? queueTimeout = null,
+	IReporter? reporter = null,
+	Action<WorkspaceGateEvent>? onEvent = null) : IFileUpdater
+{
+	/// <summary>
+	/// Default max delay a request is kept queued while waiting for the workspace to become ready.
+	/// </summary>
+	public static readonly TimeSpan DefaultQueueTimeout = TimeSpan.FromSeconds(30);
+
+	private readonly object _gate = new();
+	private readonly Queue<PendingUpdate> _queue = new();
+	private IFileUpdater _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+	private HotReloadWorkspaceState _state = HotReloadWorkspaceState.NotConfigured;
+	private bool _draining;
+
+	/// <summary>
+	/// Max delay a request is kept queued while waiting for the workspace to become ready.
+	/// On expiry the request is failed and is never applied afterwards.
+	/// </summary>
+	public TimeSpan QueueTimeout { get; } = queueTimeout ?? DefaultQueueTimeout;
+
+	/// <summary>
+	/// The decorated updater. Replaceable: the processor refines the editor as configuration
+	/// arrives (e.g. switching to the IDE editor once Visual Studio is detected) without
+	/// resetting the gate (queued requests and lifecycle state are preserved).
+	/// </summary>
+	public IFileUpdater Inner
+	{
+		get => _inner;
+		set => _inner = value ?? throw new ArgumentNullException(nameof(value));
+	}
+
+	/// <summary>
+	/// Current workspace lifecycle state driving the gate.
+	/// </summary>
+	public HotReloadWorkspaceState State
+	{
+		get
+		{
+			lock (_gate)
+			{
+				return _state;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Reports a workspace lifecycle transition. Terminal states
+	/// (<see cref="HotReloadWorkspaceState.Failed"/>, <see cref="HotReloadWorkspaceState.Disposed"/>)
+	/// fail all queued requests; pass-through states (<see cref="HotReloadWorkspaceState.Ready"/>,
+	/// <see cref="HotReloadWorkspaceState.NoWorkspace"/>) flush them in arrival order.
+	/// </summary>
+	public void ReportWorkspaceState(HotReloadWorkspaceState state)
+	{
+		List<PendingUpdate>? toFail = null;
+		var drain = false;
+
+		lock (_gate)
+		{
+			if (_state == state
+				|| _state is HotReloadWorkspaceState.Disposed
+				|| (_state is HotReloadWorkspaceState.Failed && state is not HotReloadWorkspaceState.Disposed))
+			{
+				return; // Terminal states are sticky for the lifetime of the connection.
+			}
+
+			_state = state;
+
+			switch (state)
+			{
+				case HotReloadWorkspaceState.Ready:
+				case HotReloadWorkspaceState.NoWorkspace:
+					if (!_draining && _queue.Count > 0)
+					{
+						_draining = drain = true;
+					}
+					break;
+
+				case HotReloadWorkspaceState.Failed:
+				case HotReloadWorkspaceState.Disposed:
+					if (_queue.Count > 0)
+					{
+						toFail = [.. _queue];
+						_queue.Clear();
+					}
+					break;
+			}
+		}
+
+		if (toFail is not null)
+		{
+			var error = GetTerminalError(state);
+			foreach (var entry in toFail)
+			{
+				if (entry.TryTake())
+				{
+					reporter?.Warn($"Hot-reload update request '{entry.Request.RequestId}' rejected after {entry.Age.Elapsed.TotalSeconds:F1}s in queue: {error}");
+					onEvent?.Invoke(new WorkspaceGateEvent("rejected", 0, entry.Age.Elapsed));
+					entry.Complete(Reject(entry.Request, error));
+				}
+			}
+		}
+
+		if (drain)
+		{
+			_ = DrainAsync();
+		}
+	}
+
+	/// <inheritdoc />
+	public Task<IUpdateFileResponse> UpdateAsync(IUpdateFileRequest request, CancellationToken ct)
+	{
+		PendingUpdate entry;
+		int queueLength;
+
+		lock (_gate)
+		{
+			switch (_state)
+			{
+				case HotReloadWorkspaceState.Failed:
+				case HotReloadWorkspaceState.Disposed:
+					return Task.FromResult(Reject(request, GetTerminalError(_state)));
+
+				case HotReloadWorkspaceState.Ready:
+				case HotReloadWorkspaceState.NoWorkspace:
+					if (!_draining && _queue.Count is 0)
+					{
+						break; // Pass-through, invoked below outside the lock.
+					}
+					goto default; // A flush is in progress: queue behind it to preserve ordering.
+
+				default:
+					entry = new PendingUpdate(request, ct);
+					_queue.Enqueue(entry);
+					queueLength = _queue.Count;
+
+					// Schedule the TTL outside the state machine: whichever of flush /
+					// terminal-rejection / timeout / cancellation takes the entry first wins.
+					_ = WatchTimeoutAsync(entry);
+
+					reporter?.Verbose($"Hot-reload workspace not ready ({_state}), queuing update request '{request.RequestId}' ({queueLength} pending).");
+					onEvent?.Invoke(new WorkspaceGateEvent("queued", queueLength));
+
+					return entry.Task;
+			}
+		}
+
+		return _inner.UpdateAsync(request, ct);
+	}
+
+	private async Task DrainAsync()
+	{
+		while (true)
+		{
+			PendingUpdate entry;
+			lock (_gate)
+			{
+				// Terminal transitions clear the queue themselves; only stop on empty.
+				if (_queue.Count is 0)
+				{
+					_draining = false;
+					return;
+				}
+
+				entry = _queue.Dequeue();
+			}
+
+			if (!entry.TryTake())
+			{
+				continue; // Already expired or cancelled while queued.
+			}
+
+			reporter?.Verbose($"Hot-reload workspace ready, applying queued update request '{entry.Request.RequestId}' (waited {entry.Age.Elapsed.TotalSeconds:F1}s).");
+			onEvent?.Invoke(new WorkspaceGateEvent("flushed", GetQueueLength(), entry.Age.Elapsed));
+
+			try
+			{
+				entry.Complete(await _inner.UpdateAsync(entry.Request, entry.Ct).ConfigureAwait(false));
+			}
+			catch (Exception ex)
+			{
+				entry.Complete(Reject(entry.Request, ex.Message));
+			}
+		}
+	}
+
+	private async Task WatchTimeoutAsync(PendingUpdate entry)
+	{
+		try
+		{
+			await Task.Delay(QueueTimeout, entry.Ct).ConfigureAwait(false);
+		}
+		catch (OperationCanceledException)
+		{
+			if (entry.TryTake())
+			{
+				entry.Complete(Reject(entry.Request, "The update request has been cancelled while waiting for the hot-reload workspace to initialize."));
+			}
+			return;
+		}
+
+		if (entry.TryTake())
+		{
+			var error = $"The hot-reload workspace was not ready within {QueueTimeout.TotalSeconds:F0}s; the request was not applied.";
+			reporter?.Warn($"Hot-reload update request '{entry.Request.RequestId}' expired: {error}");
+			onEvent?.Invoke(new WorkspaceGateEvent("expired", GetQueueLength(), entry.Age.Elapsed));
+			entry.Complete(Reject(entry.Request, error));
+		}
+	}
+
+	private int GetQueueLength()
+	{
+		lock (_gate)
+		{
+			return _queue.Count;
+		}
+	}
+
+	private static string GetTerminalError(HotReloadWorkspaceState state)
+		=> state is HotReloadWorkspaceState.Disposed
+			? "The hot-reload connection has been closed; the request was not applied."
+			: "The hot-reload workspace failed to initialize and will not recover on this connection; the request was not applied. Reconnect to retry.";
+
+	private static IUpdateFileResponse Reject(IUpdateFileRequest request, string error)
+		// Per-edit results are populated (not just the global error) so clients that scan
+		// Results do not mistake the rejection for an empty "no changes" success.
+		=> new GatedUpdateResponse(
+			request.RequestId,
+			error,
+			[.. request.Edits.Select(edit => new FileEditResult(edit.FilePath, FileUpdateResult.NotAvailable, error))]);
+
+	private sealed class PendingUpdate(IUpdateFileRequest request, CancellationToken ct)
+	{
+		private readonly TaskCompletionSource<IUpdateFileResponse> _result = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private int _taken;
+
+		public IUpdateFileRequest Request => request;
+
+		public CancellationToken Ct => ct;
+
+		public Stopwatch Age { get; } = Stopwatch.StartNew();
+
+		public Task<IUpdateFileResponse> Task => _result.Task;
+
+		/// <summary>
+		/// Claims the entry for completion. Exactly one of flush / timeout / cancellation /
+		/// terminal-rejection wins; an expired entry left in the queue is skipped by the flush.
+		/// </summary>
+		public bool TryTake()
+			=> Interlocked.CompareExchange(ref _taken, 1, 0) is 0;
+
+		public void Complete(IUpdateFileResponse response)
+			=> _result.TrySetResult(response);
+	}
+
+	private sealed record GatedUpdateResponse(
+		string RequestId,
+		string? GlobalError,
+		ImmutableArray<FileEditResult> Results,
+		long? HotReloadCorrelationId = null) : IUpdateFileResponse;
+}
+
+/// <summary>
+/// Diagnostic event raised by <see cref="WorkspaceGatedFileUpdater"/> when a request is
+/// queued, flushed, expired or rejected — intended for telemetry relaying.
+/// </summary>
+/// <param name="Kind">One of <c>queued</c>, <c>flushed</c>, <c>expired</c>, <c>rejected</c>.</param>
+/// <param name="QueueLength">Number of requests still pending after this event.</param>
+/// <param name="WaitDuration">Time the request spent in the queue, when applicable.</param>
+public sealed record WorkspaceGateEvent(string Kind, int QueueLength, TimeSpan? WaitDuration = null);

--- a/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
@@ -147,8 +147,7 @@ public sealed class WorkspaceGatedFileUpdater(
 	/// <inheritdoc />
 	public Task<IUpdateFileResponse> UpdateAsync(IUpdateFileRequest request, CancellationToken ct)
 	{
-		PendingUpdate entry;
-		int queueLength;
+		PendingUpdate? queued = null;
 
 		lock (_gate)
 		{
@@ -167,21 +166,27 @@ public sealed class WorkspaceGatedFileUpdater(
 					goto default; // A flush is in progress: queue behind it to preserve ordering.
 
 				default:
-					entry = new PendingUpdate(request, ct);
-					_queue.Enqueue(entry);
-					queueLength = _queue.Count;
-
-					// Schedule the TTL outside the state machine: whichever of flush /
-					// terminal-rejection / timeout / cancellation takes the entry first wins.
-					_ = WatchTimeoutAsync(entry);
+					queued = new PendingUpdate(request, ct);
+					_queue.Enqueue(queued);
+					var queueLength = _queue.Count;
 
 					// Guard the diagnostics: a throwing reporter/onEvent must not leave the just-enqueued
 					// entry orphaned (the caller would see the exception instead of the awaiter).
 					try { reporter?.Verbose($"Hot-reload workspace not ready ({_state}), queuing update request '{request.RequestId}' ({queueLength} pending)."); } catch { /* diagnostics are best-effort */ }
 					try { onEvent?.Invoke(new WorkspaceGateEvent("queued", queueLength)); } catch { /* diagnostics are best-effort */ }
-
-					return entry.Task;
+					break;
 			}
+		}
+
+		if (queued is not null)
+		{
+			// Arm the TTL OUTSIDE the lock: if ct is already cancelled (or the timeout is zero) the
+			// watcher runs synchronously through its finally -> CompactQueue, which re-enters _gate;
+			// starting it under the held lock would run that re-entrant queue mutation mid-enqueue on
+			// this thread. Whichever of flush / terminal-rejection / timeout / cancellation takes the
+			// entry first wins.
+			_ = WatchTimeoutAsync(queued);
+			return queued.Task;
 		}
 
 		return _inner.UpdateAsync(request, ct);

--- a/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
@@ -189,6 +189,18 @@ public sealed class WorkspaceGatedFileUpdater(
 			return queued.Task;
 		}
 
+		// Pass-through: re-check the lifecycle as late as possible — a terminal transition
+		// (ReportWorkspaceState from the init task / Dispose) may have raced the pass-through decision
+		// made under the lock above. Terminal states must reject without applying (mirrors the same
+		// re-check on the drain path).
+		lock (_gate)
+		{
+			if (_state is HotReloadWorkspaceState.Failed or HotReloadWorkspaceState.Disposed)
+			{
+				return Task.FromResult(Reject(request, GetTerminalError(_state)));
+			}
+		}
+
 		return _inner.UpdateAsync(request, ct);
 	}
 

--- a/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
@@ -41,7 +41,10 @@ public sealed class WorkspaceGatedFileUpdater(
 
 	private readonly object _gate = new();
 	private readonly Queue<PendingUpdate> _queue = new();
-	private IFileUpdater _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+	// Read on the drain task's thread, written from the message-processing thread via the Inner setter
+	// (called on each ConfigureServer). volatile guarantees the drain loop sees the updated reference
+	// promptly on weakly-ordered targets (ARM Skia: iOS, Android, M-series Mac).
+	private volatile IFileUpdater _inner = inner ?? throw new ArgumentNullException(nameof(inner));
 	private HotReloadWorkspaceState _state = HotReloadWorkspaceState.NotConfigured;
 	private bool _draining;
 
@@ -126,9 +129,11 @@ public sealed class WorkspaceGatedFileUpdater(
 			{
 				if (entry.TryTake())
 				{
-					reporter?.Warn($"Hot-reload update request '{entry.Request.RequestId}' rejected after {entry.Age.Elapsed.TotalSeconds:F1}s in queue: {error}");
-					onEvent?.Invoke(new WorkspaceGateEvent("rejected", 0, entry.Age.Elapsed));
+					// Resolve the awaiter before any external callback: a throwing reporter/onEvent must
+					// neither orphan this entry's TaskCompletionSource nor abort the loop over the rest.
 					entry.Complete(Reject(entry.Request, error));
+					try { reporter?.Warn($"Hot-reload update request '{entry.Request.RequestId}' rejected after {entry.Age.Elapsed.TotalSeconds:F1}s in queue: {error}"); } catch { /* diagnostics are best-effort */ }
+					try { onEvent?.Invoke(new WorkspaceGateEvent("rejected", 0, entry.Age.Elapsed)); } catch { /* diagnostics are best-effort */ }
 				}
 			}
 		}
@@ -170,8 +175,10 @@ public sealed class WorkspaceGatedFileUpdater(
 					// terminal-rejection / timeout / cancellation takes the entry first wins.
 					_ = WatchTimeoutAsync(entry);
 
-					reporter?.Verbose($"Hot-reload workspace not ready ({_state}), queuing update request '{request.RequestId}' ({queueLength} pending).");
-					onEvent?.Invoke(new WorkspaceGateEvent("queued", queueLength));
+					// Guard the diagnostics: a throwing reporter/onEvent must not leave the just-enqueued
+					// entry orphaned (the caller would see the exception instead of the awaiter).
+					try { reporter?.Verbose($"Hot-reload workspace not ready ({_state}), queuing update request '{request.RequestId}' ({queueLength} pending)."); } catch { /* diagnostics are best-effort */ }
+					try { onEvent?.Invoke(new WorkspaceGateEvent("queued", queueLength)); } catch { /* diagnostics are best-effort */ }
 
 					return entry.Task;
 			}
@@ -182,61 +189,136 @@ public sealed class WorkspaceGatedFileUpdater(
 
 	private async Task DrainAsync()
 	{
-		while (true)
+		// Launched fire-and-forget: an unexpected escape must never leave _draining stuck true (which
+		// would permanently divert every future Ready request into the queue with no drain to flush it),
+		// and the error must be logged rather than silently dropped into TaskScheduler.
+		try
 		{
-			PendingUpdate entry;
-			lock (_gate)
+			while (true)
 			{
-				// Terminal transitions clear the queue themselves; only stop on empty.
-				if (_queue.Count is 0)
+				PendingUpdate entry;
+				lock (_gate)
 				{
-					_draining = false;
-					return;
+					// Terminal transitions clear the queue themselves; only stop on empty.
+					if (_queue.Count is 0)
+					{
+						return; // _draining is reset in the finally below.
+					}
+
+					entry = _queue.Dequeue();
 				}
 
-				entry = _queue.Dequeue();
-			}
+				if (!entry.TryTake())
+				{
+					continue; // Already expired or cancelled while queued.
+				}
 
-			if (!entry.TryTake())
-			{
-				continue; // Already expired or cancelled while queued.
-			}
+				IUpdateFileResponse response;
+				try
+				{
+					response = await _inner.UpdateAsync(entry.Request, entry.Ct).ConfigureAwait(false);
+				}
+				catch (Exception ex)
+				{
+					response = Reject(entry.Request, ex.Message);
+				}
 
-			reporter?.Verbose($"Hot-reload workspace ready, applying queued update request '{entry.Request.RequestId}' (waited {entry.Age.Elapsed.TotalSeconds:F1}s).");
-			onEvent?.Invoke(new WorkspaceGateEvent("flushed", GetQueueLength(), entry.Age.Elapsed));
-
-			try
-			{
-				entry.Complete(await _inner.UpdateAsync(entry.Request, entry.Ct).ConfigureAwait(false));
+				// Resolve the awaiter before any external callback: a throwing reporter/onEvent must
+				// neither orphan this entry's TaskCompletionSource nor escape the loop.
+				entry.Complete(response);
+				try { reporter?.Verbose($"Hot-reload workspace ready, applied queued update request '{entry.Request.RequestId}' (waited {entry.Age.Elapsed.TotalSeconds:F1}s)."); } catch { /* diagnostics are best-effort */ }
+				try { onEvent?.Invoke(new WorkspaceGateEvent("flushed", GetQueueLength(), entry.Age.Elapsed)); } catch { /* diagnostics are best-effort */ }
 			}
-			catch (Exception ex)
+		}
+		catch (Exception ex)
+		{
+			try { reporter?.Error($"Hot-reload queue drain faulted unexpectedly and was aborted: {ex}"); } catch { /* diagnostics are best-effort */ }
+		}
+		finally
+		{
+			lock (_gate)
 			{
-				entry.Complete(Reject(entry.Request, ex.Message));
+				_draining = false;
 			}
 		}
 	}
 
 	private async Task WatchTimeoutAsync(PendingUpdate entry)
 	{
+		// Fire-and-forget: any escape here would silently orphan the caller's awaiter, so every path
+		// must resolve the entry. A claimed entry is then physically dropped from the queue (see finally).
+		var taken = false;
 		try
 		{
-			await Task.Delay(QueueTimeout, entry.Ct).ConfigureAwait(false);
-		}
-		catch (OperationCanceledException)
-		{
-			if (entry.TryTake())
+			try
 			{
-				entry.Complete(Reject(entry.Request, "The update request has been cancelled while waiting for the hot-reload workspace to initialize."));
+				await Task.Delay(QueueTimeout, entry.Ct).ConfigureAwait(false);
 			}
-			return;
-		}
+			catch (OperationCanceledException)
+			{
+				taken = entry.TryTake();
+				if (taken)
+				{
+					entry.Complete(Reject(entry.Request, "The update request has been cancelled while waiting for the hot-reload workspace to initialize."));
+				}
+				return;
+			}
 
-		if (entry.TryTake())
+			taken = entry.TryTake();
+			if (taken)
+			{
+				var error = $"The hot-reload workspace was not ready within {QueueTimeout.TotalSeconds:F0}s; the request was not applied.";
+				// Resolve the awaiter before any external callback so a throwing reporter/onEvent can't
+				// orphan the request.
+				entry.Complete(Reject(entry.Request, error));
+				try { reporter?.Warn($"Hot-reload update request '{entry.Request.RequestId}' expired: {error}"); } catch { /* diagnostics are best-effort */ }
+				try { onEvent?.Invoke(new WorkspaceGateEvent("expired", GetQueueLength(), entry.Age.Elapsed)); } catch { /* diagnostics are best-effort */ }
+			}
+		}
+		catch (Exception ex)
 		{
-			var error = $"The hot-reload workspace was not ready within {QueueTimeout.TotalSeconds:F0}s; the request was not applied.";
-			reporter?.Warn($"Hot-reload update request '{entry.Request.RequestId}' expired: {error}");
-			onEvent?.Invoke(new WorkspaceGateEvent("expired", GetQueueLength(), entry.Age.Elapsed));
-			entry.Complete(Reject(entry.Request, error));
+			// Unexpected fault (e.g. a throwing dependency): still guarantee the awaiter is resolved.
+			taken = entry.TryTake();
+			if (taken)
+			{
+				entry.Complete(Reject(entry.Request, ex.Message));
+			}
+		}
+		finally
+		{
+			if (taken)
+			{
+				CompactQueue();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Removes entries already claimed (by timeout / cancellation) from the queue, preserving FIFO order
+	/// of the survivors. Claimed entries are otherwise only discarded lazily on the next flush; without
+	/// this a workspace that never reaches a flushing or terminal state (stuck <c>Initializing</c>) would
+	/// let dead entries — and the queue-length telemetry — grow unbounded.
+	/// </summary>
+	private void CompactQueue()
+	{
+		lock (_gate)
+		{
+			if (_queue.Count is 0)
+			{
+				return;
+			}
+
+			var live = _queue.Where(static entry => !entry.IsTaken).ToArray();
+			if (live.Length == _queue.Count)
+			{
+				return; // Nothing claimed — avoid the rebuild.
+			}
+
+			_queue.Clear();
+			foreach (var entry in live)
+			{
+				_queue.Enqueue(entry);
+			}
 		}
 	}
 
@@ -280,6 +362,12 @@ public sealed class WorkspaceGatedFileUpdater(
 		/// </summary>
 		public bool TryTake()
 			=> Interlocked.CompareExchange(ref _taken, 1, 0) is 0;
+
+		/// <summary>
+		/// Whether the entry has already been claimed (by flush / timeout / cancellation / terminal
+		/// rejection). Used to compact claimed-but-still-queued entries out of the queue.
+		/// </summary>
+		public bool IsTaken => Volatile.Read(ref _taken) is 1;
 
 		public void Complete(IUpdateFileResponse response)
 			=> _result.TrySetResult(response);

--- a/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
+++ b/src/Uno.HotReload/IO/WorkspaceGatedFileUpdater.cs
@@ -199,10 +199,14 @@ public sealed class WorkspaceGatedFileUpdater(
 				PendingUpdate entry;
 				lock (_gate)
 				{
-					// Terminal transitions clear the queue themselves; only stop on empty.
+					// Terminal transitions clear the queue themselves; only stop on empty. Reset
+					// _draining here — atomically with the empty check, under the same lock — so a
+					// request arriving in Ready state can never observe (empty queue + draining still
+					// latched) and get enqueued with no drain left to flush it.
 					if (_queue.Count is 0)
 					{
-						return; // _draining is reset in the finally below.
+						_draining = false;
+						return;
 					}
 
 					entry = _queue.Dequeue();
@@ -213,33 +217,51 @@ public sealed class WorkspaceGatedFileUpdater(
 					continue; // Already expired or cancelled while queued.
 				}
 
-				IUpdateFileResponse response;
-				try
+				// Re-check the lifecycle immediately before applying: a terminal transition may have
+				// raced the dequeue (the terminal sweep in ReportWorkspaceState only sees still-queued
+				// entries, not one already dequeued here). Terminal states must reject without applying.
+				HotReloadWorkspaceState state;
+				lock (_gate)
 				{
-					response = await _inner.UpdateAsync(entry.Request, entry.Ct).ConfigureAwait(false);
+					state = _state;
 				}
-				catch (Exception ex)
+
+				IUpdateFileResponse response;
+				string kind;
+				if (state is HotReloadWorkspaceState.Failed or HotReloadWorkspaceState.Disposed)
 				{
-					response = Reject(entry.Request, ex.Message);
+					response = Reject(entry.Request, GetTerminalError(state));
+					kind = "rejected";
+				}
+				else
+				{
+					try
+					{
+						response = await _inner.UpdateAsync(entry.Request, entry.Ct).ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						response = Reject(entry.Request, ex.Message);
+					}
+					kind = "flushed";
 				}
 
 				// Resolve the awaiter before any external callback: a throwing reporter/onEvent must
 				// neither orphan this entry's TaskCompletionSource nor escape the loop.
 				entry.Complete(response);
-				try { reporter?.Verbose($"Hot-reload workspace ready, applied queued update request '{entry.Request.RequestId}' (waited {entry.Age.Elapsed.TotalSeconds:F1}s)."); } catch { /* diagnostics are best-effort */ }
-				try { onEvent?.Invoke(new WorkspaceGateEvent("flushed", GetQueueLength(), entry.Age.Elapsed)); } catch { /* diagnostics are best-effort */ }
+				try { reporter?.Verbose($"Hot-reload queued update request '{entry.Request.RequestId}' {kind} (waited {entry.Age.Elapsed.TotalSeconds:F1}s)."); } catch { /* diagnostics are best-effort */ }
+				try { onEvent?.Invoke(new WorkspaceGateEvent(kind, GetQueueLength(), entry.Age.Elapsed)); } catch { /* diagnostics are best-effort */ }
 			}
 		}
 		catch (Exception ex)
 		{
-			try { reporter?.Error($"Hot-reload queue drain faulted unexpectedly and was aborted: {ex}"); } catch { /* diagnostics are best-effort */ }
-		}
-		finally
-		{
+			// Unexpected escape despite the guards above: release the gate under the lock so future work
+			// can still be drained, and log rather than dropping the fault into TaskScheduler.
 			lock (_gate)
 			{
 				_draining = false;
 			}
+			try { reporter?.Error($"Hot-reload queue drain faulted unexpectedly and was aborted: {ex}"); } catch { /* diagnostics are best-effort */ }
 		}
 	}
 
@@ -338,10 +360,14 @@ public sealed class WorkspaceGatedFileUpdater(
 	private static IUpdateFileResponse Reject(IUpdateFileRequest request, string error)
 		// Per-edit results are populated (not just the global error) so clients that scan
 		// Results do not mistake the rejection for an empty "no changes" success.
+		// Guard against a default (uninitialized) ImmutableArray — Select would throw NRE — matching
+		// FileUpdater.UpdateAsync's own IsDefaultOrEmpty entry guard.
 		=> new GatedUpdateResponse(
 			request.RequestId,
 			error,
-			[.. request.Edits.Select(edit => new FileEditResult(edit.FilePath, FileUpdateResult.NotAvailable, error))]);
+			request.Edits.IsDefaultOrEmpty
+				? []
+				: [.. request.Edits.Select(edit => new FileEditResult(edit.FilePath, FileUpdateResult.NotAvailable, error))]);
 
 	private sealed class PendingUpdate(IUpdateFileRequest request, CancellationToken ct)
 	{

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -66,12 +66,17 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				// This includes assembly resolution handlers required by Roslyn msbuild workspace
 				CompilationEnvironment.Initialize(Path.GetDirectoryName(configureServer.ProjectPath));
 
+				// From this point (and until the baseline solution has been captured from disk),
+				// update requests are queued by the gate instead of being written to disk.
+				_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Initializing);
+
 				var ct = new CancellationTokenSource();
 				_workspace = (InitializeAsync(ct.Token), ct);
 			}
 			catch (Exception e)
 			{
 				_reporter.Error($"Failed to initialize compilation workspace, hot-reload is disabled:\r\n{e}");
+				_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Failed);
 				_ = _remoteControlServer.SendFrame(new HotReloadWorkspaceLoadResult { WorkspaceInitialized = false });
 				_ = Notify(HotReloadEvent.Disabled);
 
@@ -105,11 +110,17 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					var fileSystemWatch = new FileSystemObserver(manager, _reporter, _solutionWatchersGate);
 					ct.Register(() => fileSystemWatch.Dispose());
 
+					// Release queued update requests only once the baseline has been captured AND the
+					// file-system observer is active, so a flushed edit can neither be folded into the
+					// baseline nor go unobserved.
+					_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
 					return manager;
 				}
 				catch (Exception e)
 				{
 					_reporter.Error($"Failed to initialize compilation workspace, hot-reload is disabled:\r\n{e}");
+					_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Failed);
 					await _remoteControlServer.SendFrame(new HotReloadWorkspaceLoadResult { WorkspaceInitialized = false });
 					await Notify(HotReloadEvent.Disabled);
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -309,7 +309,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		private async Task SafeNotifyMetadataInitializationFailed(Exception? ex = null)
 		{
-			var errorMessage = ex?.Message ?? ex?.ToString();
+			var errorMessage = ex?.Message;
 
 			// Terminal for this connection: fail queued and future update requests instead of queuing forever.
 			_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Failed);

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -290,8 +290,10 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				else
 				{
 					// We are relying on IDE, we won't have any other hot-reload initialization steps.
-					await Notify(HotReloadEvent.Ready);
+					// Report NoWorkspace *before* awaiting Notify so an UpdateFile racing this window
+					// passes through immediately (strict IDE-driven pass-through) instead of being queued.
 					_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.NoWorkspace);
+					await Notify(HotReloadEvent.Ready);
 					this.Log().LogDebug("Metadata updater **NOT** initialized.");
 				}
 			}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -46,14 +46,38 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 		private readonly IRemoteControlServer _remoteControlServer;
 		private readonly ITelemetry _telemetry;
 		private readonly HotReloadTracker _tracker;
-		private FileUpdater _fileUpdater;
+		private readonly WorkspaceGatedFileUpdater _fileUpdater;
 
 		public ServerHotReloadProcessor(IRemoteControlServer remoteControlServer, ITelemetry<ServerHotReloadProcessor> telemetry)
 		{
 			_remoteControlServer = remoteControlServer;
 			_telemetry = telemetry;
 			_tracker = new(async (status, ct) => await _remoteControlServer.SendFrame(new HotReloadStatusMessage(status)), ct => RequestHotReloadToIde(), _reporter);
-			_fileUpdater = CreateFileUpdater(isRunningInsideVisualStudio: false, hotReloadInfoPath: null);
+
+			// Update requests are gated on the workspace lifecycle: queued while the baseline is being
+			// captured, pass-through when hot reload is IDE-driven (no workspace), failed with an explicit
+			// error when the workspace will not become available. See spec 050.
+			_fileUpdater = new WorkspaceGatedFileUpdater(
+				CreateFileUpdater(isRunningInsideVisualStudio: false, hotReloadInfoPath: null),
+				GetUpdateFileQueueTimeout(),
+				_reporter,
+				OnUpdateGateEvent);
+		}
+
+		private TimeSpan? GetUpdateFileQueueTimeout()
+			=> int.TryParse(_remoteControlServer.GetServerConfiguration("update-file-queue-timeout"), out var seconds) && seconds > 0
+				? TimeSpan.FromSeconds(seconds)
+				: null; // WorkspaceGatedFileUpdater.DefaultQueueTimeout
+
+		private void OnUpdateGateEvent(WorkspaceGateEvent evt)
+		{
+			var measurements = new Dictionary<string, double> { ["QueueLength"] = evt.QueueLength };
+			if (evt.WaitDuration is { } wait)
+			{
+				measurements["WaitDurationMs"] = wait.TotalMilliseconds;
+			}
+
+			_telemetry.TrackEvent($"update-{evt.Kind}", properties: null, measurements);
 		}
 
 		public string Scope => WellKnownScopes.HotReload;
@@ -73,7 +97,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			_isRunningInsideVisualStudio = config.MSBuildProperties.TryGetValue("BuildingInsideVisualStudio", out var isVsRaw)
 				&& isVsRaw.Equals("true", StringComparison.OrdinalIgnoreCase);
 
-			_fileUpdater = CreateFileUpdater(_isRunningInsideVisualStudio, config.HotReloadInfoPath);
+			// Only the decorated updater is replaced: the gate (queued requests, lifecycle state) survives re-configuration.
+			_fileUpdater.Inner = CreateFileUpdater(_isRunningInsideVisualStudio, config.HotReloadInfoPath);
 		}
 
 		private FileUpdater CreateFileUpdater(bool isRunningInsideVisualStudio, string? hotReloadInfoPath)
@@ -266,6 +291,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				{
 					// We are relying on IDE, we won't have any other hot-reload initialization steps.
 					await Notify(HotReloadEvent.Ready);
+					_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.NoWorkspace);
 					this.Log().LogDebug("Metadata updater **NOT** initialized.");
 				}
 			}
@@ -284,6 +310,9 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 		private async Task SafeNotifyMetadataInitializationFailed(Exception? ex = null)
 		{
 			var errorMessage = ex?.Message ?? ex?.ToString();
+
+			// Terminal for this connection: fail queued and future update requests instead of queuing forever.
+			_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Failed);
 
 			try
 			{
@@ -414,6 +443,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		public void Dispose()
 		{
+			_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Disposed);
 			_ct.Cancel();
 			_workspace?.Ct.Cancel();
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #23787

## PR Type:

🐞 Bugfix

## What changed? 🚀

The dev-server processed hot-reload `UpdateFile` requests the moment they arrived, with no dependency on the Roslyn workspace initialization. Since the workspace captures its baseline by reading the solution from disk asynchronously, an update request racing that read was written to disk first — the baseline silently absorbed the edit and it was **never emitted as a delta** (the running app permanently diverges from the delta engine's baseline until rebuild). A second window existed where the edit landed after the baseline read but before the `FileSystemObserver` was created, so it was never observed at all. Both windows produce "request acknowledged, change never applied" — most easily hit by design-time tooling issuing updates at application startup.

This PR contains the design spec (`specs/050-hotreload-updatefile-workspace-gate/spec.md`, marked implemented with implementation notes) and its implementation:

- **`IFileUpdater`** (new, `Uno.HotReload/IO`): contract extracted from `FileUpdater` so behavior composes by decoration; the bare `FileUpdater` keeps its exact semantics for consumers without a Roslyn workspace.
- **`WorkspaceGatedFileUpdater`** (new): decorator holding the whole state machine, driven by `HotReloadWorkspaceState` (`NotConfigured / NoWorkspace / Initializing / Ready / Failed / Disposed`):
  - requests received while the workspace is expected but not ready are **queued** and flushed **FIFO** once the baseline is captured *and* the file-system observer is active;
  - **strict pass-through** when hot reload is IDE-driven (Visual Studio — no workspace, HR active at app start): no gate, no delay;
  - **fail-fast with an explicit error** when the workspace failed to initialize or the connection is disposed (recovery is a new connection), and after a hard **30 s queue timeout** (configurable via the `update-file-queue-timeout` server configuration) — an expired request is *never* applied late;
  - rejections populate per-edit `Results` (`FileUpdateResult.NotAvailable`) so clients don't mistake them for an empty "no changes" success;
  - diagnostic events (`queued`/`flushed`/`expired`/`rejected`) relayed as `update-*` telemetry.
- **`ServerHotReloadProcessor`**: stays a thin message router — it only composes the decorator and reports lifecycle transitions (`Initializing` before the workspace load, `Ready` after the `FileSystemObserver` is constructed, `Failed` on init failure, `Disposed` on dispose, `NoWorkspace` in IDE-driven mode). `ProcessUpdateFile` is unchanged; repeated `ConfigureServer` messages only swap the decorated editor, the gate (state + queued requests) survives.

Both message shapes (`UpdateFileRequest` and the legacy `UpdateSingleFileRequest`) funnel through the same updater call, so the gate covers them uniformly.

### Testing

- 13 new unit tests (`Uno.HotReload.Tests/IO/Given_WorkspaceGatedFileUpdater.cs`) covering the state machine in isolation: queue-then-flush ordering, pre-configuration queueing, VS pass-through, workspace failure, sticky terminal states, TTL expiry (incl. no late application), expired entries not blocking live ones, dispose with a non-empty queue, `NoWorkspace → Initializing` reconfiguration without replay, inner swap while queued, cancellation, gate events. All 87 tests of the project pass.
- Full DevServer suite (`Uno.UI.RemoteControl.DevServer.Tests`): 481 passed / 0 failed (2 pre-existing skips).
- End-to-end integration tests of the race against an in-process dev-server (spec test plan) are follow-up work.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)