### PR TITLE
fix(hr): Probe runtime platform for hot-reload TFM on skia-mobile heads

### DIFF
--- a/src/Uno.HotReload.Tests/TestUtils/RecordingReporter.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/RecordingReporter.cs
@@ -14,6 +14,17 @@ internal sealed class RecordingReporter : IReporter
 	private readonly List<string> _errors = [];
 	private readonly Lock _gate = new();
 
+	public IReadOnlyList<string> Outputs
+	{
+		get
+		{
+			lock (_gate)
+			{
+				return [.. _output];
+			}
+		}
+	}
+
 	public IReadOnlyList<string> Warnings
 	{
 		get

--- a/src/Uno.HotReload.Tests/Utils/Given_FilterHeadProjectTargetFramework.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_FilterHeadProjectTargetFramework.cs
@@ -74,7 +74,7 @@ public sealed class Given_FilterHeadProjectTargetFramework
 	}
 
 	[TestMethod]
-	public void When_SingleFlavor_Then_SolutionIsUnchanged_And_TracesLoadedVsReported()
+	public void When_SingleFlavor_And_RuntimeMatches_Then_SolutionIsUnchanged_And_TracesLoadedVsReported()
 	{
 		using var workspace = new AdhocWorkspace();
 		AddProject(workspace, "app", filePath: _headPath, refPacks: [AndroidPack()]);
@@ -82,11 +82,7 @@ public sealed class Given_FilterHeadProjectTargetFramework
 		var reporter = new RecordingReporter();
 		var solution = workspace.CurrentSolution;
 
-		// Even a non-matching runtime TFM must not disturb a single-flavor solution: either the
-		// project is single-targeted or MSBuild already pinned the TargetFramework. The trace
-		// must still expose the loaded flavor against the reported TFM, so a workspace pinned
-		// to the wrong flavor is diagnosable from the logs.
-		var filtered = solution.FilterHeadProjectTargetFramework(_headPath, "net10.0-skia", reporter);
+		var filtered = solution.FilterHeadProjectTargetFramework(_headPath, "net10.0-android", reporter);
 
 		Assert.AreSame(solution, filtered);
 		Assert.AreEqual(0, reporter.Warnings.Count);
@@ -94,7 +90,49 @@ public sealed class Given_FilterHeadProjectTargetFramework
 
 		var trace = reporter.Outputs.Single();
 		StringAssert.Contains(trace, "'net10.0-android36.0'");
-		StringAssert.Contains(trace, "'net10.0-skia'");
+		StringAssert.Contains(trace, "'net10.0-android'");
+	}
+
+	[TestMethod]
+	public void When_SingleFlavor_And_RuntimeDoesNotMatch_Then_SolutionIsUnchanged_And_Warns()
+	{
+		using var workspace = new AdhocWorkspace();
+		AddProject(workspace, "app", filePath: _headPath, refPacks: [AndroidPack()]);
+
+		var reporter = new RecordingReporter();
+		var solution = workspace.CurrentSolution;
+
+		// A non-matching runtime TFM must not disturb a single-flavor solution (either the
+		// project is single-targeted or MSBuild already pinned the TargetFramework), but a
+		// workspace pinned to the wrong flavor must be called out: updates emitted from it
+		// will most likely not apply to the running application.
+		var filtered = solution.FilterHeadProjectTargetFramework(_headPath, "net10.0-skia", reporter);
+
+		Assert.AreSame(solution, filtered);
+		Assert.AreEqual(0, reporter.Errors.Count);
+
+		var warning = reporter.Warnings.Single();
+		StringAssert.Contains(warning, "'net10.0-android36.0'");
+		StringAssert.Contains(warning, "'net10.0-skia'");
+	}
+
+	[TestMethod]
+	public void When_SingleFlavor_And_TfmUnresolvable_Then_SolutionIsUnchanged_And_TracesWithoutWarning()
+	{
+		using var workspace = new AdhocWorkspace();
+		// A flavor whose design-time load failed carries no metadata references at all: its TFM
+		// cannot be compared to the reported one, so no mismatch warning must be speculated.
+		AddProject(workspace, "app", filePath: _headPath, refPacks: []);
+
+		var reporter = new RecordingReporter();
+		var solution = workspace.CurrentSolution;
+
+		var filtered = solution.FilterHeadProjectTargetFramework(_headPath, "net10.0-skia", reporter);
+
+		Assert.AreSame(solution, filtered);
+		Assert.AreEqual(0, reporter.Warnings.Count);
+		Assert.AreEqual(0, reporter.Errors.Count);
+		StringAssert.Contains(reporter.Outputs.Single(), "<unresolved");
 	}
 
 	[TestMethod]

--- a/src/Uno.HotReload.Tests/Utils/Given_FilterHeadProjectTargetFramework.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_FilterHeadProjectTargetFramework.cs
@@ -35,6 +35,12 @@ public sealed class Given_FilterHeadProjectTargetFramework
 		Assert.IsFalse(remainingIds.Contains(androidLib), "a library only reachable from the removed flavor must be removed");
 		Assert.AreEqual(0, reporter.Warnings.Count);
 		Assert.AreEqual(0, reporter.Errors.Count);
+
+		// The restriction trace must carry the loaded flavors, the reported TFM and the kept flavors.
+		var restriction = reporter.Outputs.Single(message => message.Contains("restricted"));
+		StringAssert.Contains(restriction, "restricted to 'net10.0-desktop'");
+		StringAssert.Contains(restriction, "'net10.0-skia'");
+		StringAssert.Contains(restriction, "net10.0-android");
 	}
 
 	[TestMethod]
@@ -68,7 +74,7 @@ public sealed class Given_FilterHeadProjectTargetFramework
 	}
 
 	[TestMethod]
-	public void When_SingleFlavor_Then_SolutionIsUnchanged_And_Silent()
+	public void When_SingleFlavor_Then_SolutionIsUnchanged_And_TracesLoadedVsReported()
 	{
 		using var workspace = new AdhocWorkspace();
 		AddProject(workspace, "app", filePath: _headPath, refPacks: [AndroidPack()]);
@@ -77,12 +83,18 @@ public sealed class Given_FilterHeadProjectTargetFramework
 		var solution = workspace.CurrentSolution;
 
 		// Even a non-matching runtime TFM must not disturb a single-flavor solution: either the
-		// project is single-targeted or MSBuild already pinned the TargetFramework.
+		// project is single-targeted or MSBuild already pinned the TargetFramework. The trace
+		// must still expose the loaded flavor against the reported TFM, so a workspace pinned
+		// to the wrong flavor is diagnosable from the logs.
 		var filtered = solution.FilterHeadProjectTargetFramework(_headPath, "net10.0-skia", reporter);
 
 		Assert.AreSame(solution, filtered);
 		Assert.AreEqual(0, reporter.Warnings.Count);
 		Assert.AreEqual(0, reporter.Errors.Count);
+
+		var trace = reporter.Outputs.Single();
+		StringAssert.Contains(trace, "'net10.0-android36.0'");
+		StringAssert.Contains(trace, "'net10.0-skia'");
 	}
 
 	[TestMethod]

--- a/src/Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs
@@ -100,7 +100,9 @@ public static partial class RoslynExtensions
 	/// The filter is conservative: when the head project cannot be found, when the runtime
 	/// target framework is unknown, or when no flavor matches it, the solution is returned
 	/// unchanged and the situation is reported — a degraded-but-functional workspace beats a
-	/// wrongly-emptied one.
+	/// wrongly-emptied one. Every path logs the loaded flavors, the target framework the
+	/// application reported and the flavors kept, so a mis-targeted workspace stays
+	/// diagnosable from the logs alone.
 	/// </remarks>
 	/// <param name="solution">The solution to filter (typically the freshly-opened workspace solution).</param>
 	/// <param name="headProjectPath">Full path of the head project (<c>.csproj</c>) the application runs.</param>
@@ -125,7 +127,13 @@ public static partial class RoslynExtensions
 		if (headFlavors.Count == 1)
 		{
 			// Single flavor: either the project is single-targeted or MSBuild already pinned
-			// the TargetFramework during evaluation. Nothing to filter.
+			// the TargetFramework during evaluation. Nothing to filter, but still trace what
+			// was loaded against what the application reported: a workspace pinned to the
+			// wrong flavor is otherwise invisible in the logs.
+			var singleFlavor = headFlavors[0].TryGetTargetFramework(out var tfm) ? tfm : $"<unresolved: {headFlavors[0].Name}>";
+			reporter.Output(
+				$"Hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}' " +
+				$"(application's '{(string.IsNullOrWhiteSpace(runtimeTargetFramework) ? "<not reported>" : runtimeTargetFramework)}'); nothing to filter.");
 			return solution;
 		}
 
@@ -195,7 +203,8 @@ public static partial class RoslynExtensions
 
 		reporter.Output(
 			$"Hot-reload workspace restricted to '{string.Join(", ", matchedFlavors.Select(f => f.TargetFramework))}' for the " +
-			$"application's '{runtimeTargetFramework}' ({remove.Count} project(s) from the other target frameworks removed).");
+			$"application's '{runtimeTargetFramework}' (loaded target frameworks: {flavorsDescription}; " +
+			$"{remove.Count} project(s) from the other target frameworks removed).");
 
 		return solution;
 	}

--- a/src/Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.TargetFrameworkFiltering.cs
@@ -130,10 +130,22 @@ public static partial class RoslynExtensions
 			// the TargetFramework during evaluation. Nothing to filter, but still trace what
 			// was loaded against what the application reported: a workspace pinned to the
 			// wrong flavor is otherwise invisible in the logs.
-			var singleFlavor = headFlavors[0].TryGetTargetFramework(out var tfm) ? tfm : $"<unresolved: {headFlavors[0].Name}>";
-			reporter.Output(
-				$"Hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}' " +
-				$"(application's '{(string.IsNullOrWhiteSpace(runtimeTargetFramework) ? "<not reported>" : runtimeTargetFramework)}'); nothing to filter.");
+			var resolved = headFlavors[0].TryGetTargetFramework(out var tfm);
+			var singleFlavor = resolved ? tfm! : $"<unresolved: {headFlavors[0].Name}>";
+			if (resolved && !string.IsNullOrWhiteSpace(runtimeTargetFramework) && !RuntimeTargetFrameworkMatches(runtimeTargetFramework, singleFlavor))
+			{
+				reporter.Warn(
+					$"The hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}', " +
+					$"which does not match the application's '{runtimeTargetFramework}'. Hot reload updates will most likely " +
+					"not apply to the running application.");
+			}
+			else
+			{
+				reporter.Output(
+					$"Hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}' " +
+					$"(application's '{(string.IsNullOrWhiteSpace(runtimeTargetFramework) ? "<not reported>" : runtimeTargetFramework)}'); nothing to filter.");
+			}
+
 			return solution;
 		}
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -144,9 +144,8 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 
 	/// <summary>
 	/// Composes the target framework the application is running on, from data available at
-	/// runtime only: the platform is compile-time knowledge of this (per-flavor) client
-	/// assembly (except for the skia flavor, which serves several runtimes and completes the
-	/// picture with a runtime check), the framework version comes from the application assembly's
+	/// runtime only: the platform is probed through <see cref="OperatingSystem"/> checks, the
+	/// framework version comes from the application assembly's
 	/// <see cref="System.Runtime.Versioning.TargetFrameworkAttribute"/> (falling back to the
 	/// runtime version). This intentionally does NOT rely on MSBuild property capture, so it
 	/// stays correct regardless of how the IDE orchestrated the build.
@@ -170,27 +169,20 @@ public partial class ClientHotReloadProcessor : IClientProcessor, IDisposable
 
 		frameworkVersion ??= Environment.Version;
 
+		// The platform MUST be probed at runtime, not from compile-time symbols: the skia flavor
+		// of this assembly is compiled for the plain `netX.0` TFM yet serves every skia-rendering
+		// head — the uno-runtime asset selection swaps it in for `netX.0-android`, `netX.0-ios`,
+		// etc. heads too, where `__ANDROID__`-style symbols were never defined. Mac Catalyst is
+		// tested before iOS as it also reports IsIOS(). On desktop no check matches, and the
+		// flavor cannot tell a `netX.0-desktop` head from a plain `netX.0` one, so it reports the
+		// `skia` pseudo-platform which the server treats as matching either spelling.
 		var platform =
-#if __ANDROID__ || ANDROID
-			"android";
-#elif __TVOS__ || TVOS
-			"tvos";
-#elif __MACCATALYST__ || MACCATALYST
-			"maccatalyst";
-#elif __IOS__ || IOS
-			"ios";
-#elif __WASM__
-			// The (legacy) native-rendering wasm flavor of this assembly only serves browser heads.
-			"browserwasm";
-#else
-			// The skia flavor of this assembly is compiled for the plain `netX.0` TFM and serves
-			// every skia-rendering head that resolves the `skia` uno-runtime folder — desktop AND
-			// browser (`netX.0-browserwasm` with the skia renderer, the modern default). The
-			// browser case is only distinguishable at runtime. For desktop, the flavor still
-			// cannot tell `netX.0-desktop` from a plain `netX.0` head, so it reports the `skia`
-			// pseudo-platform which the server treats as matching either spelling.
-			OperatingSystem.IsBrowser() ? "browserwasm" : "skia";
-#endif
+			OperatingSystem.IsAndroid() ? "android"
+			: OperatingSystem.IsTvOS() ? "tvos"
+			: OperatingSystem.IsMacCatalyst() ? "maccatalyst"
+			: OperatingSystem.IsIOS() ? "ios"
+			: OperatingSystem.IsBrowser() ? "browserwasm"
+			: "skia";
 
 		return $"net{frameworkVersion.Major}.{frameworkVersion.Minor}-{platform}";
 	}


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno-private#2256

## PR Type:

🐞 Bugfix

## What changed? 🚀

On skia-rendering Android/iOS (and Mac Catalyst/tvOS) heads, hot reload detects XAML/C# changes but never applies them on the device.

The client computed the platform part of its `RuntimeTargetFramework` from compile-time symbols (`__ANDROID__` & co.). Those symbols are meaningless on skia-rendering mobile heads: the uno-runtime asset selection swaps the plain-`netX.0` skia flavor of `Uno.UI.RemoteControl.dll` in for the per-platform one, so no platform symbol is defined and the client reports the `netX.0-skia` pseudo-TFM. The server then restricts the hot-reload workspace to the desktop flavor of the head (`Hot-reload workspace restricted to 'net10.0-desktop' for the application's 'net10.0-skia'`), and the metadata updates are computed for a target framework the device never runs.

This PR probes the platform at runtime through `OperatingSystem` checks instead (`IsAndroid()`, `IsTvOS()`, `IsMacCatalyst()` — tested before `IsIOS()` since Catalyst also reports it — `IsIOS()`, `IsBrowser()`), which stays correct in every flavor of the assembly. Desktop heads still report the `skia` pseudo-TFM, which the server already treats as the `netX.0-desktop`/`netX.0` family; the server-side matching is unchanged.

On the server side, the workspace target-framework filtering now systematically logs the loaded flavors, the target framework the application reported and the flavors kept — including the previously-silent single-flavor path (project single-targeted, or `TargetFramework` already pinned by the IDE at evaluation). When that single loaded flavor does not match the reported target framework — a workspace pinned to the wrong flavor, from which updates will most likely not apply — it is surfaced as a warning.

Validated with the `Uno.HotReload.Tests` suite (76 passing, now also asserting the filtering traces and the mismatch warning); the platform probe itself is runtime-OS dependent and covered by the existing server-side matching tests consuming the reported values.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)