### PR TITLE
fix(hr): Probe runtime platform for hot-reload TFM on skia-mobile heads (backport #23790)

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/RoslynTargetFrameworkExtensions.TargetFrameworkFiltering.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/RoslynTargetFrameworkExtensions.TargetFrameworkFiltering.cs
@@ -136,10 +136,22 @@ public static partial class RoslynTargetFrameworkExtensions
 			// the TargetFramework during evaluation. Nothing to filter, but still trace what
 			// was loaded against what the application reported: a workspace pinned to the
 			// wrong flavor is otherwise invisible in the logs.
-			var singleFlavor = headFlavors[0].TryGetTargetFramework(out var tfm) ? tfm : $"<unresolved: {headFlavors[0].Name}>";
-			reporter.Output(
-				$"Hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}' " +
-				$"(application's '{(string.IsNullOrWhiteSpace(runtimeTargetFramework) ? "<not reported>" : runtimeTargetFramework)}'); nothing to filter.");
+			var resolved = headFlavors[0].TryGetTargetFramework(out var tfm);
+			var singleFlavor = resolved ? tfm! : $"<unresolved: {headFlavors[0].Name}>";
+			if (resolved && !string.IsNullOrWhiteSpace(runtimeTargetFramework) && !RuntimeTargetFrameworkMatches(runtimeTargetFramework, singleFlavor))
+			{
+				reporter.Warn(
+					$"The hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}', " +
+					$"which does not match the application's '{runtimeTargetFramework}'. Hot reload updates will most likely " +
+					"not apply to the running application.");
+			}
+			else
+			{
+				reporter.Output(
+					$"Hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}' " +
+					$"(application's '{(string.IsNullOrWhiteSpace(runtimeTargetFramework) ? "<not reported>" : runtimeTargetFramework)}'); nothing to filter.");
+			}
+
 			return solution;
 		}
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/RoslynTargetFrameworkExtensions.TargetFrameworkFiltering.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/RoslynTargetFrameworkExtensions.TargetFrameworkFiltering.cs
@@ -106,7 +106,9 @@ public static partial class RoslynTargetFrameworkExtensions
 	/// The filter is conservative: when the head project cannot be found, when the runtime
 	/// target framework is unknown, or when no flavor matches it, the solution is returned
 	/// unchanged and the situation is reported — a degraded-but-functional workspace beats a
-	/// wrongly-emptied one.
+	/// wrongly-emptied one. Every path logs the loaded flavors, the target framework the
+	/// application reported and the flavors kept, so a mis-targeted workspace stays
+	/// diagnosable from the logs alone.
 	/// </remarks>
 	/// <param name="solution">The solution to filter (typically the freshly-opened workspace solution).</param>
 	/// <param name="headProjectPath">Full path of the head project (<c>.csproj</c>) the application runs.</param>
@@ -131,7 +133,13 @@ public static partial class RoslynTargetFrameworkExtensions
 		if (headFlavors.Count == 1)
 		{
 			// Single flavor: either the project is single-targeted or MSBuild already pinned
-			// the TargetFramework during evaluation. Nothing to filter.
+			// the TargetFramework during evaluation. Nothing to filter, but still trace what
+			// was loaded against what the application reported: a workspace pinned to the
+			// wrong flavor is otherwise invisible in the logs.
+			var singleFlavor = headFlavors[0].TryGetTargetFramework(out var tfm) ? tfm : $"<unresolved: {headFlavors[0].Name}>";
+			reporter.Output(
+				$"Hot-reload workspace loaded '{headProjectPath}' for the single target framework '{singleFlavor}' " +
+				$"(application's '{(string.IsNullOrWhiteSpace(runtimeTargetFramework) ? "<not reported>" : runtimeTargetFramework)}'); nothing to filter.");
 			return solution;
 		}
 
@@ -201,7 +209,8 @@ public static partial class RoslynTargetFrameworkExtensions
 
 		reporter.Output(
 			$"Hot-reload workspace restricted to '{string.Join(", ", matchedFlavors.Select(f => f.TargetFramework))}' for the " +
-			$"application's '{runtimeTargetFramework}' ({remove.Count} project(s) from the other target frameworks removed).");
+			$"application's '{runtimeTargetFramework}' (loaded target frameworks: {flavorsDescription}; " +
+			$"{remove.Count} project(s) from the other target frameworks removed).");
 
 		return solution;
 	}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -134,9 +134,8 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 
 	/// <summary>
 	/// Composes the target framework the application is running on, from data available at
-	/// runtime only: the platform is compile-time knowledge of this (per-flavor) client
-	/// assembly (except for the skia flavor, which serves several runtimes and completes the
-	/// picture with a runtime check), the framework version comes from the application assembly's
+	/// runtime only: the platform is probed through <see cref="OperatingSystem"/> checks, the
+	/// framework version comes from the application assembly's
 	/// <see cref="System.Runtime.Versioning.TargetFrameworkAttribute"/> (falling back to the
 	/// runtime version). This intentionally does NOT rely on MSBuild property capture, so it
 	/// stays correct regardless of how the IDE orchestrated the build.
@@ -160,27 +159,20 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 
 		frameworkVersion ??= Environment.Version;
 
+		// The platform MUST be probed at runtime, not from compile-time symbols: the skia flavor
+		// of this assembly is compiled for the plain `netX.0` TFM yet serves every skia-rendering
+		// head — the uno-runtime asset selection swaps it in for `netX.0-android`, `netX.0-ios`,
+		// etc. heads too, where `__ANDROID__`-style symbols were never defined. Mac Catalyst is
+		// tested before iOS as it also reports IsIOS(). On desktop no check matches, and the
+		// flavor cannot tell a `netX.0-desktop` head from a plain `netX.0` one, so it reports the
+		// `skia` pseudo-platform which the server treats as matching either spelling.
 		var platform =
-#if __ANDROID__ || ANDROID
-			"android";
-#elif __TVOS__ || TVOS
-			"tvos";
-#elif __MACCATALYST__ || MACCATALYST
-			"maccatalyst";
-#elif __IOS__ || IOS
-			"ios";
-#elif __WASM__
-			// The (legacy) native-rendering wasm flavor of this assembly only serves browser heads.
-			"browserwasm";
-#else
-			// The skia flavor of this assembly is compiled for the plain `netX.0` TFM and serves
-			// every skia-rendering head that resolves the `skia` uno-runtime folder — desktop AND
-			// browser (`netX.0-browserwasm` with the skia renderer, the modern default). The
-			// browser case is only distinguishable at runtime. For desktop, the flavor still
-			// cannot tell `netX.0-desktop` from a plain `netX.0` head, so it reports the `skia`
-			// pseudo-platform which the server treats as matching either spelling.
-			OperatingSystem.IsBrowser() ? "browserwasm" : "skia";
-#endif
+			OperatingSystem.IsAndroid() ? "android"
+			: OperatingSystem.IsTvOS() ? "tvos"
+			: OperatingSystem.IsMacCatalyst() ? "maccatalyst"
+			: OperatingSystem.IsIOS() ? "ios"
+			: OperatingSystem.IsBrowser() ? "browserwasm"
+			: "skia";
 
 		return $"net{frameworkVersion.Major}.{frameworkVersion.Minor}-{platform}";
 	}


### PR DESCRIPTION
**GitHub Issue:** unoplatform/uno-private#2256

Backport of #23790 to `release/stable/6.6` (cherry-picks of the three commits).

## PR Type:

🐞 Bugfix

## What changed? 🚀

On skia-rendering Android/iOS (and Mac Catalyst/tvOS) heads, hot reload detects XAML/C# changes but never applies them on the device.

The client computed the platform part of its `RuntimeTargetFramework` from compile-time symbols (`__ANDROID__` & co.). Those symbols are meaningless on skia-rendering mobile heads: the uno-runtime asset selection swaps the plain-`netX.0` skia flavor of `Uno.UI.RemoteControl.dll` in for the per-platform one, so no platform symbol is defined and the client reports the `netX.0-skia` pseudo-TFM. The server then restricts the hot-reload workspace to the desktop flavor of the head, and the metadata updates are computed for a target framework the device never runs. The client now probes the platform at runtime through `OperatingSystem` checks, which stays correct in every flavor of the assembly.

The server-side workspace target-framework filtering (living in `RoslynTargetFrameworkExtensions` on this branch — git followed the rename from the `Uno.HotReload` split on master) also systematically logs the loaded flavors, the reported target framework and the flavors kept, and warns when the single loaded flavor does not match the reported one.

Compared to #23790, the unit-test changes are not carried over: the `Uno.HotReload.Tests` project is not part of this branch (the folder only holds an orphaned file not referenced by any project here). The touched projects (`Uno.UI.RemoteControl.Server.Processors`, `Uno.UI.RemoteControl.Skia`) build; the behavior is covered by the test suite on master.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)