### PR TITLE
fix(skia): Load WebView2Loader under dotnet host

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,6 +37,27 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 	private Dictionary<ulong, string> _navigationIdToUriMap = new();
 	private string _documentTitle = string.Empty;
 
+	private static bool _webView2LoaderLoaded;
+
+	private static void InitializeWebView2Loader()
+	{
+		if (_webView2LoaderLoaded)
+		{
+			return;
+		}
+
+		// WebView2Utilities.Initialize probes only next to Environment.ProcessPath, which is the
+		// dotnet host's directory when launched as `dotnet app.dll`. Resolve through the runtime
+		// first (honors deps.json and AppContext.BaseDirectory), then fall back to the library's
+		// own probing (embedded resource, process directory).
+		if (!NativeLibrary.TryLoad("WebView2Loader.dll", typeof(WebView2.Functions).Assembly, null, out _))
+		{
+			WebView2Utilities.Initialize(Assembly.GetEntryAssembly());
+		}
+
+		_webView2LoaderLoaded = true;
+	}
+
 	public Win32NativeAotWebView(CoreWebView2 owner, ContentPresenter presenter)
 	: base(presenter)
 	{
@@ -48,7 +70,7 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 		{
 			try
 			{
-				WebView2Utilities.Initialize(Assembly.GetEntryAssembly());
+				InitializeWebView2Loader();
 				var userDataFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "WebView2");
 
 				// These options must be applied at environment creation time; CoreWebView2EnvironmentOptions cannot be

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
@@ -40,12 +40,12 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 	static Win32NativeAotWebView()
 	{
 		// WebView2Utilities.Initialize probes only next to Environment.ProcessPath, which is the
-		// dotnet host's directory when launched as `dotnet app.dll`. Resolve through the runtime
-		// first (honors deps.json and AppContext.BaseDirectory), then fall back to the library's
-		// own probing (embedded resource, process directory).
-		if (!NativeLibrary.TryLoad("WebView2Loader.dll", typeof(WebView2.Functions).Assembly, null, out _))
+		// dotnet host's directory when launched as `dotnet app.dll`. In that case, fall back to
+		// resolving through the runtime, which honors deps.json and AppContext.BaseDirectory.
+		if (WebView2Utilities.Initialize(Assembly.GetEntryAssembly(), throwOnError: false).IsError
+			&& !NativeLibrary.TryLoad("WebView2Loader.dll", typeof(WebView2.Functions).Assembly, null, out _))
 		{
-			WebView2Utilities.Initialize(Assembly.GetEntryAssembly());
+			throw new DllNotFoundException("Cannot load WebView2Loader.dll. Make sure it's deployed next to the application or resolvable through its deps.json.");
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
@@ -37,15 +37,8 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 	private Dictionary<ulong, string> _navigationIdToUriMap = new();
 	private string _documentTitle = string.Empty;
 
-	private static bool _webView2LoaderLoaded;
-
-	private static void InitializeWebView2Loader()
+	static Win32NativeAotWebView()
 	{
-		if (_webView2LoaderLoaded)
-		{
-			return;
-		}
-
 		// WebView2Utilities.Initialize probes only next to Environment.ProcessPath, which is the
 		// dotnet host's directory when launched as `dotnet app.dll`. Resolve through the runtime
 		// first (honors deps.json and AppContext.BaseDirectory), then fall back to the library's
@@ -54,8 +47,6 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 		{
 			WebView2Utilities.Initialize(Assembly.GetEntryAssembly());
 		}
-
-		_webView2LoaderLoaded = true;
 	}
 
 	public Win32NativeAotWebView(CoreWebView2 owner, ContentPresenter presenter)
@@ -70,7 +61,6 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 		{
 			try
 			{
-				InitializeWebView2Loader();
 				var userDataFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "WebView2");
 
 				// These options must be applied at environment creation time; CoreWebView2EnvironmentOptions cannot be


### PR DESCRIPTION
**GitHub Issue:** closes #23794

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Windows (Skia/Win32) with the default `webview2aot` backend (net10.0+), creating a `WebView2` threw `Cannot load WebView2Loader.dll` when the app was launched through the .NET host (`dotnet App.dll`) instead of the apphost exe. The webview2aot package's `WebView2Utilities.Initialize` probes for the loader only next to `Environment.ProcessPath`, which is `dotnet.exe`'s directory in that launch mode — never the application directory.

`Win32NativeAotWebView` now initializes the loader in its static constructor (runs exactly once, thread-safe): it first calls `WebView2Utilities.Initialize(throwOnError: false)` so the library's own probing (embedded resource, process directory) keeps precedence, and when that fails — the `dotnet App.dll` case — falls back to `NativeLibrary.TryLoad`, which uses the runtime's native-library resolution (`AppContext.BaseDirectory` plus the `deps.json` native search directories, covering RID-less builds where the loader sits under `runtimes\win-x64\native\`). Once the module named `WebView2Loader` is loaded, webview2aot's P/Invokes bind to it exactly as they do after the library's own `LoadLibraryW`. If both strategies fail, a descriptive `DllNotFoundException` is thrown.

Validation: a standalone harness referencing the same WebView2Aot 1.5.0 + Microsoft.Web.WebView2 packages, exercising the old and new resolution logic in all four combinations:

| Launch mode | Old path | New path |
|---|---|---|
| `dotnet App.dll` | ❌ throws (reproduces the issue) | ✅ `Initialize` fails non-throwing, `NativeLibrary.TryLoad` resolves; P/Invoke returns WebView2 runtime `150.0.4078.65` |
| Apphost exe | ✅ | ✅ `Initialize` succeeds directly (no regression) |

`Uno.UI.Runtime.Skia.Win32` builds for net10.0 with 0 warnings / 0 errors.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: the failure depends on how the host process is launched (`dotnet App.dll` vs apphost exe), which the runtime-test host cannot vary; validated with a standalone harness as described above.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — no behavior change for documented scenarios.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
