### PR TITLE
fix(skia): Native elements in Win32 never receive focus (WS_EX_LAYERED)

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ContentDialogFocus.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ContentDialogFocus.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl
+    x:Class="SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests.WebView2_ContentDialogFocus"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel
+            MaxWidth="640"
+            Padding="24"
+            HorizontalAlignment="Left"
+            Spacing="16">
+            <TextBlock
+                FontSize="20"
+                FontWeight="Bold"
+                Text="WebView2 focus/clicks in a ContentDialog (Win32 Skia Desktop)"
+                TextWrapping="Wrap" />
+
+            <TextBlock Text="Click 'Open SSO Modal' below — a ContentDialog opens hosting a WebView2 with a text &lt;input&gt; (mirrors the SSO WebView2 repro). Click into the input and try typing." TextWrapping="Wrap" />
+
+            <TextBlock
+                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                Text="Bug (pre-fix): keystrokes go nowhere, the input never focuses, and the cursor is stuck. Fixed: the input turns green and updates on every keystroke, showing the I-beam cursor."
+                TextWrapping="Wrap" />
+
+            <Button
+                x:Name="OpenDialogButton"
+                AutomationProperties.AutomationId="WebView2_ContentDialogFocus_OpenDialog"
+                Click="OpenDialogButton_Click"
+                Content="Open SSO Modal (ContentDialog)" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ContentDialogFocus.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ContentDialogFocus.xaml.cs
@@ -1,0 +1,63 @@
+using System;
+using Uno.UI.Samples.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests
+{
+	[Sample("WebView", Name = "WebView2_ContentDialogFocus",
+		Description = "WebView2 hosted in a ContentDialog on Win32 Skia Desktop; the text input should focus, type, and show the I-beam cursor.")]
+	public sealed partial class WebView2_ContentDialogFocus : UserControl
+	{
+		private const string ReproHtml = """
+			<html>
+			<body style="font-family:sans-serif;background:#f5f5f5;margin:0;padding:24px;">
+			  <h2>Simulated SSO WebView2</h2>
+			  <p>Click into the field below and start typing.</p>
+			  <input id="inp" autofocus style="font-size:24px;width:90%;padding:8px;" placeholder="Type here..." />
+			  <p id="status" style="font-size:20px;color:#555;">status: (waiting for focus/keydown)</p>
+			  <script>
+			    const inp = document.getElementById('inp');
+			    const status = document.getElementById('status');
+			    inp.addEventListener('focus', () => { status.textContent = 'status: FOCUSED'; document.body.style.background = '#d4f7d4'; });
+			    inp.addEventListener('blur', () => { status.textContent = 'status: blurred'; document.body.style.background = '#f5f5f5'; });
+			    inp.addEventListener('keydown', (e) => { status.textContent = 'status: key received -> ' + e.key; });
+			  </script>
+			</body>
+			</html>
+			""";
+
+		public WebView2_ContentDialogFocus()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void OpenDialogButton_Click(object sender, RoutedEventArgs e)
+		{
+			var webView = new WebView2 { MinWidth = 500, MinHeight = 300 };
+
+			var webViewHost = new Border
+			{
+				BorderThickness = new Thickness(2),
+				BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Red),
+				MinWidth = 500,
+				MinHeight = 300,
+				Child = webView
+			};
+
+			var dialog = new ContentDialog
+			{
+				Title = "Sign in (simulated SSO modal)",
+				PrimaryButtonText = "Close",
+				DefaultButton = ContentDialogButton.Primary,
+				XamlRoot = this.XamlRoot,
+				Content = webViewHost
+			};
+
+			var dataUri = "data:text/html," + Uri.EscapeDataString(ReproHtml);
+			webView.Source = new Uri(dataUri);
+
+			await dialog.ShowAsync();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Native/Win32NativeElementHostingExtension.cs
@@ -90,7 +90,13 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 		var oldExStyleVal = PInvoke.GetWindowLong((HWND)window.Hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
 		var oldStyleVal = PInvoke.GetWindowLong((HWND)window.Hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
-		PInvoke.SetWindowLong((HWND)window.Hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, oldExStyleVal | (int)WINDOW_EX_STYLE.WS_EX_LAYERED);
+		// WS_EX_LAYERED is intentionally never set — and actively cleared — on the hosted child window. It is
+		// the only way to give a classic Win32 child window per-window alpha, but a layered child is excluded
+		// from the OS's normal hit-testing and input routing (WindowFromPoint, mouse buttons, WM_SETCURSOR all
+		// resolve to the parent), which prevents hosted content such as WebView2 from receiving focus/clicks.
+		// Clearing it also covers a window that arrives already layered (e.g. re-attached after a prior attach
+		// set it). Native element opacity is therefore unsupported here (as on X11); see ChangeNativeElementOpacity.
+		PInvoke.SetWindowLong((HWND)window.Hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE, oldExStyleVal & ~(int)WINDOW_EX_STYLE.WS_EX_LAYERED);
 		PInvoke.SetWindowLong((HWND)window.Hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, (oldStyleVal | (int)WINDOW_STYLE.WS_CLIPSIBLINGS) & ~(int)WINDOW_STYLE.WS_CAPTION); // removes the title bar and borders
 
 		_ = PInvoke.ShowWindow((HWND)window.Hwnd, SHOW_WINDOW_CMD.SW_HIDE);
@@ -458,13 +464,10 @@ internal class Win32NativeElementHostingExtension : ContentPresenter.INativeElem
 
 	public void ChangeNativeElementOpacity(object content, double opacity)
 	{
-		if (content is not Win32NativeWindow window)
-		{
-			throw new ArgumentException($"content is not a {nameof(Win32NativeWindow)} instance.", nameof(content));
-		}
-
-		var success = PInvoke.SetLayeredWindowAttributes((HWND)window.Hwnd, new COLORREF(0), (byte)Math.Round(opacity * 255), LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_ALPHA);
-		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SetLayeredWindowAttributes)} failed: {Win32Helper.GetErrorMessage()}"); }
+		// Native element opacity is not supported on Win32. Per-window alpha for a classic Win32 child
+		// window requires WS_EX_LAYERED, which excludes the child from the OS's normal hit-testing and
+		// input routing and thus breaks focus/clicks for hosted content such as WebView2 (see
+		// AttachNativeElement). X11 likewise does not support opacity for hosted child windows.
 	}
 
 	public bool SupportsZIndex() => true;


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/518

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia Desktop (Win32), a hosted native element such as a `WebView2` never accepted keyboard/pointer focus, did not register clicks, and showed the wrong (stuck) cursor instead of its own (e.g. the I-beam over a text field). This was most reliably reproduced with a `WebView2` inside a `ContentDialog`.

`Win32NativeElementHostingExtension.AttachNativeElement` applied `WS_EX_LAYERED` unconditionally to every hosted native child window (to support opacity via `SetLayeredWindowAttributes`). A layered *child* window is excluded from the OS's normal hit-testing and message routing — `WindowFromPoint`, mouse buttons, `WM_SETCURSOR`, etc. all resolve to the parent instead — so the hosted content never received input.

This PR:
- Stops setting `WS_EX_LAYERED` on hosted native windows in `AttachNativeElement`, and **actively clears it** (covering a window re-attached after a prior attach set it).
- Makes `ChangeNativeElementOpacity` a no-op: per-window alpha for a classic Win32 child window is only possible via `WS_EX_LAYERED`, which is exactly what breaks input. Native-element fractional opacity is therefore unsupported on Win32 — the same stance the X11 head already takes.
- Adds a manual repro sample (`WebView → WebView2_ContentDialogFocus`).

> A runtime test was prototyped but removed: reliably asserting the hosted child's ex-style requires spawning an external native window (`CreateSampleComponent` → powershell/Windows Terminal), which carries its *own* `WS_EX_LAYERED` and produces false positives on CI. The manual sample covers the scenario instead.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the documentation template (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
