### PR TITLE
fix(hr): Re-point hot-reload baselines to the RID-specific build outputs

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -45,6 +45,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 			string[] metadataUpdateCapabilities,
 			Dictionary<string, string> properties,
 			string? runtimeTargetFramework,
+			string? runtimeIdentifier,
 			CancellationToken ct)
 		{
 			if (properties.TryGetValue("UnoHotReloadDiagnosticsLogPath", out var logPath) && logPath is { Length: > 0 })
@@ -110,8 +111,13 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 			// Restrict a multi-targeted head to the flavor the running application reported: the
 			// workspace loads one project per TargetFrameworks entry when the evaluated TargetFramework
 			// is empty, and the non-running flavors would otherwise block hot reload with their
-			// compilation errors or fail the initial emit (they were never built).
-			var currentSolution = workspace.CurrentSolution.FilterHeadProjectTargetFramework(projectPath, runtimeTargetFramework, reporter);
+			// compilation errors or fail the initial emit (they were never built). Then re-point the
+			// kept flavor's compilation outputs to the assembly the running application was actually
+			// built from (RID-specific paths) — this must happen before the watch session starts, as
+			// EnC captures its baselines from those paths.
+			var currentSolution = workspace.CurrentSolution
+				.FilterHeadProjectTargetFramework(projectPath, runtimeTargetFramework, reporter)
+				.AlignHeadProjectCompilationOutputs(projectPath, runtimeIdentifier, reporter);
 			var hotReloadService = new WatchHotReloadService(workspace.Services, metadataUpdateCapabilities);
 			await hotReloadService.StartSessionAsync(currentSolution, ct);
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/RoslynTargetFrameworkExtensions.CompilationOutputAlignment.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/RoslynTargetFrameworkExtensions.CompilationOutputAlignment.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+
+namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates;
+
+public static partial class RoslynTargetFrameworkExtensions
+{
+	/// <summary>
+	/// Re-points the compilation outputs of the head-project flavor(s) kept in the solution to
+	/// the output assembly the running application was actually built from.
+	/// </summary>
+	/// <remarks>
+	/// The workspace evaluates the head without a <c>RuntimeIdentifier</c>, so
+	/// <see cref="Project.CompilationOutputInfo"/>.AssemblyPath is the RID-less intermediate
+	/// path (<c>obj/Debug/netX.0-android/App.dll</c>). A device deployment however builds
+	/// RID-specific (<c>obj/Debug/netX.0-android/android-arm64/App.dll</c>): the RID-less file
+	/// either does not exist — Roslyn's EnC then treats the project as "not built" and silently
+	/// emits no update — or is a stale twin from an earlier RID-less build whose MVID does not
+	/// match the deployed module, so emitted deltas would be dropped by the application. Only
+	/// the head flavor needs re-pointing: project references are built RID-less by MSBuild's
+	/// project-to-project protocol, their evaluated paths are correct.
+	///
+	/// The trigger is declarative — the <c>RuntimeIdentifier</c> captured from the running
+	/// application's build — and a candidate path is only accepted when its module is readable
+	/// (a valid PE with an MVID), the same primitive Roslyn's EnC uses to decide a project is
+	/// "built". When nothing readable is found the situation is reported as a warning: without
+	/// it, the EnC "project not built" outcome is invisible outside Roslyn's own session log.
+	/// </remarks>
+	/// <param name="solution">The (already flavor-filtered) solution.</param>
+	/// <param name="headProjectPath">Full path of the head project (<c>.csproj</c>) the application runs.</param>
+	/// <param name="runtimeIdentifier">The runtime identifier captured from the running application's build, when any.</param>
+	/// <param name="reporter">Reporter used to surface the alignment decisions.</param>
+	public static Solution AlignHeadProjectCompilationOutputs(
+		this Solution solution,
+		string headProjectPath,
+		string? runtimeIdentifier,
+		IReporter reporter)
+	{
+		foreach (var projectId in solution.Projects
+			.Where(p => string.Equals(p.FilePath, headProjectPath, _pathComparison))
+			.Select(p => p.Id)
+			.ToList())
+		{
+			var project = solution.GetProject(projectId)!;
+			var evaluatedPath = project.CompilationOutputInfo.AssemblyPath;
+			if (string.IsNullOrEmpty(evaluatedPath))
+			{
+				reporter.Warn(
+					$"The hot-reload workspace has no output assembly path for '{project.Name}' — Roslyn will consider the " +
+					"project not built and hot reload will silently produce no updates.");
+				continue;
+			}
+
+			if (string.IsNullOrEmpty(runtimeIdentifier))
+			{
+				// No RID captured from the running build: the evaluated (RID-less) path is the built
+				// one. Only surface the anti-silence warning when it isn't readable.
+				if (!TryReadMvid(evaluatedPath, out _))
+				{
+					reporter.Warn(
+						$"The output assembly of '{project.Name}' was not found at '{evaluatedPath}' — Roslyn will consider " +
+						"the project not built and hot reload will silently produce no updates. Build this target framework first.");
+				}
+
+				continue;
+			}
+
+			// The running application was built WITH a runtime identifier: prefer the RID-specific
+			// output — it is the binary that was actually deployed. Even when the RID-less file
+			// exists it can be a stale twin (an earlier RID-less build) with a mismatching MVID.
+			var fileName = Path.GetFileName(evaluatedPath);
+			var directory = Path.GetDirectoryName(evaluatedPath)!;
+			var ridSpecificPath = Path.Combine(directory, runtimeIdentifier, fileName);
+
+			if (TryReadMvid(ridSpecificPath, out _))
+			{
+				solution = Remap(project, ridSpecificPath);
+			}
+			else if (FindNewestReadableCandidate(directory, fileName, evaluatedPath) is { } candidate)
+			{
+				// Custom output layouts (artifacts output path, intermediate-path overrides, …):
+				// probe the evaluated directory subtree for the assembly instead.
+				solution = Remap(project, candidate);
+			}
+			else if (TryReadMvid(evaluatedPath, out _))
+			{
+				reporter.Output(
+					$"The application was built with runtime identifier '{runtimeIdentifier}' but no RID-specific output was " +
+					$"found for '{project.Name}'; keeping the evaluated '{evaluatedPath}'.");
+			}
+			else
+			{
+				reporter.Warn(
+					$"The output assembly of '{project.Name}' was not found (probed '{ridSpecificPath}' and '{evaluatedPath}') — " +
+					"Roslyn will consider the project not built and hot reload will silently produce no updates. " +
+					"Deploy this target framework first.");
+			}
+		}
+
+		return solution;
+
+		Solution Remap(Project project, string path)
+		{
+			reporter.Output($"Hot-reload baseline of '{project.Name}' re-pointed to '{path}' (runtime identifier '{runtimeIdentifier}').");
+			return solution.WithProjectCompilationOutputInfo(project.Id, project.CompilationOutputInfo.WithAssemblyPath(path));
+		}
+	}
+
+	/// <summary>
+	/// Probes the evaluated output directory subtree for a readable build of the assembly,
+	/// excluding reference-assembly folders (<c>ref</c>/<c>refint</c> — readable PEs, but not an
+	/// EnC baseline) and preferring the most recently written candidate.
+	/// </summary>
+	private static string? FindNewestReadableCandidate(string directory, string fileName, string evaluatedPath)
+	{
+		try
+		{
+			if (!Directory.Exists(directory))
+			{
+				return null;
+			}
+
+			return Directory
+				.EnumerateFiles(directory, fileName, SearchOption.AllDirectories)
+				.Where(path => !string.Equals(path, evaluatedPath, _pathComparison))
+				.Where(path => Path.GetDirectoryName(path) is { } dir
+					&& Path.GetFileName(dir) is { } dirName
+					&& !dirName.Equals("ref", StringComparison.OrdinalIgnoreCase)
+					&& !dirName.Equals("refint", StringComparison.OrdinalIgnoreCase))
+				.OrderByDescending(File.GetLastWriteTimeUtc)
+				.FirstOrDefault(path => TryReadMvid(path, out _));
+		}
+		catch (Exception)
+		{
+			// IO race with a build in progress — treat as "no candidate" rather than failing the
+			// workspace initialization.
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Reads the module version id the way Roslyn's EnC decides a project is "built" (see
+	/// Roslyn's <c>DebuggingSession.GetProjectModuleIdAsync</c>): a readable PE with metadata.
+	/// </summary>
+	private static bool TryReadMvid(string path, out Guid mvid)
+	{
+		mvid = default;
+		try
+		{
+			using var stream = File.OpenRead(path);
+			using var peReader = new PEReader(stream);
+			var metadataReader = peReader.GetMetadataReader();
+			mvid = metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
+			return mvid != Guid.Empty;
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -177,6 +177,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				configureServer.MetadataUpdateCapabilities,
 				properties,
 				runtimeTargetFramework,
+				runtimeIdentifier,
 				ct);
 
 			return new HotReloadWorkspace(workspace, watch, solution, [Trim(outputPath), Trim(intermediateOutputPath)]);


### PR DESCRIPTION
**GitHub Issue:** unoplatform/uno-private#2256

Follow-up of #23791 on `release/stable/6.6` (a master port follows separately): with the correct target framework now reported and the workspace correctly restricted, hot reload on Android still produced `Found 0 metadata updates` — silently.

## PR Type:

🐞 Bugfix

## What changed? 🚀

The hot-reload workspace evaluates the head project without a `RuntimeIdentifier`, so EnC captures its baseline from the RID-less intermediate assembly path (`obj/Debug/net10.0-android/App.dll`). A device deployment however builds RID-specific (`obj/Debug/net10.0-android/android-x64/App.dll`): the RID-less assembly either does not exist — Roslyn's EnC then treats the project as **"not built"** (`EditSession`: `mvid == Guid.Empty`) and silently emits zero updates for every change, C# and XAML alike — or is a stale twin from an earlier RID-less build whose MVID does not match the deployed module, so emitted deltas would be dropped by the application.

After the target-framework filtering, the kept head flavor's `CompilationOutputInfo` is now re-pointed to the assembly the running application was actually built from:

- **Trigger is declarative** — the `RuntimeIdentifier` captured from the running application's build (already present in the `ConfigureServer` MSBuild properties); no filesystem guessing in the decision, and no global property pushed to the workspace (a global RID would relocate the expected outputs of every project reference, which MSBuild's project-to-project protocol builds RID-less).
- **Candidates are accepted by module readability** (a valid PE with an MVID — the same primitive Roslyn's EnC uses to decide a project is "built"), preferring the RID-specific path over a potentially stale RID-less twin, with a recursive probe of the evaluated output directory as fallback for custom layouts (reference-assembly `ref`/`refint` folders excluded).
- **No more silence**: when nothing readable is found, an explicit warning states the probed paths and that hot reload will produce no updates — previously the only trace was `project not built` inside Roslyn's own EnC session log.

Project references are left untouched: their RID-less evaluated paths are correct.

Validated on an Android app (skia renderer, SDK 6.6 line) by patching the DevServer processors: the baseline is re-pointed to the `android-x64` output and C#/XAML edits produce and apply metadata updates; desktop/wasm heads (no RID split) are unaffected.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)