### PR TITLE
fix(hr): Re-point hot-reload baselines to the RID-specific build outputs

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,6 +4,7 @@ exclude_paths:
   - 'src/SamplesApp/**'
   - '**/tsBindings/*.ts'
   - 'doc/**'
+  - 'specs/**'
   - 'src/Uno.UI/UI/Xaml/Controls/Repeater/**'
   - 'src/Uno.UI/UI/Xaml/Controls/CalendarView/**'
   - 'src/Uno.UI/DirectUI/**'

--- a/specs/051-hotreload-baseline-identity-handshake/spec.md
+++ b/specs/051-hotreload-baseline-identity-handshake/spec.md
@@ -1,0 +1,151 @@
+# Hot-Reload Baseline Identity Handshake: RID & Module MVIDs in `ConfigureServer`
+
+> **Status: DRAFT — hard requirement: needs reviews before implementation.**
+> Written 2026-07-16, following the uno-private#2256 investigation. Nothing below is
+> committed design; the protocol addition in particular must be reviewed (message
+> compatibility, module-list scope) before any code is written.
+
+## Overview & Objectives
+
+The RID-specific baseline alignment (follow-up of spec 047/049, shipped for
+uno-private#2256) re-points the kept head flavor's `CompilationOutputInfo` to the output the
+running application was *probably* built from: the trigger is declarative (the
+`RuntimeIdentifier` captured in the application's build properties), and a candidate path is
+accepted when its module is **readable** (a valid PE with an MVID — the same primitive
+Roslyn's EnC uses to decide a project is "built").
+
+Readability is however not **identity**. Roslyn's EnC contract is stricter: the baseline
+assembly on disk must be *the very module loaded in the application* (same MVID), otherwise:
+
+- the emitted deltas carry a `ModuleId` the application never loaded, and the client drops
+  them silently — server says `Found 1 metadata updates`, device shows nothing;
+- or (missing baseline) EnC treats the project as **not built** and emits nothing at all —
+  `Solution update status: None`, visible only in Roslyn's own EnC session log
+  (`EditSession.cs`: `mvid == Guid.Empty` → `project not built`).
+
+Debugger-based EnC does not have this gap: the debugger reports the debuggee's loaded-module
+MVIDs and Roslyn matches baselines against them. Watch-mode Roslyn cannot — it has no channel
+to the application. **The dev-server does have that channel.** This spec closes the gap the
+same way the debugger does: the client reports its module identities, and the server treats
+MVID equality as the source of truth for baseline selection and diagnostics.
+
+Remaining failure modes this addresses (all silent today, even after the alignment):
+
+1. **Stale RID-specific output** — the app was deployed, then rebuilt locally (other RID, or
+   RID-less `dotnet build`): a readable-but-wrong baseline wins; deltas are emitted and
+   silently dropped client-side.
+2. **Ambiguous probe** — custom output layouts resolved by "newest readable candidate", a
+   heuristic tie-break where identity would decide exactly.
+3. **Library staleness** — the alignment deliberately leaves project references untouched
+   (their RID-less evaluated paths are correct *by layout*), but nothing verifies their
+   on-disk baselines match the modules deployed in the app.
+4. **Configuration mismatch** — Release-deployed app against a Debug workspace baseline (and
+   vice versa): readable, wrong, silent.
+
+## Proposal
+
+### 1. Protocol — `ConfigureServer` additions
+
+```csharp
+public record ConfigureServer(
+	string ProjectPath,
+	string[] MetadataUpdateCapabilities,
+	string[] MSBuildPropertiesRaw,
+	string? HotReloadInfoPath,
+	bool EnableMetadataUpdates,
+	bool EnableHotReloadThruDebugger,
+	string? RuntimeTargetFramework = null,
+	string? RuntimeIdentifier = null,          // NEW — the RID the running build was produced with
+	AppModuleId[]? AppModules = null)          // NEW — loaded module identities
+	: IMessage;
+
+public record AppModuleId(string AssemblyName, Guid Mvid);
+```
+
+- `RuntimeIdentifier`: determined client-side the same declarative way as
+  `RuntimeTargetFramework` (from the build capture; unlike the TFM it cannot be probed at
+  runtime, but transporting it explicitly removes the server's dependency on the MSBuild
+  property bag shape). The captured-properties entry remains the fallback for older clients.
+- `AppModules`: the identities of the modules loaded in the application —
+  `Assembly.Modules[0].ModuleVersionId` over `AppDomain.CurrentDomain.GetAssemblies()`,
+  filtered to non-framework assemblies (heuristic to review: exclude `System.*`,
+  `Microsoft.*` except `Microsoft.UI/Uno.*`? — see Open questions). Collected once at
+  `ConfigureServer` time; cost is negligible (no metadata read, the MVID is already in
+  memory).
+
+Both fields default to `null`: an older client simply doesn't send them and the server keeps
+today's behavior end-to-end (captured RID + readability acceptance). An older *server*
+receiving the new fields must ignore them — to be covered by a serializer-tolerance test.
+
+### 2. Server — identity-based selection and diagnostics
+
+In the workspace initialization pipeline (after TFM filtering, replacing the acceptance rule
+of the current alignment):
+
+1. **Head flavor**: among the candidate output paths (evaluated path, RID-specific path,
+   subtree probe), accept the one whose MVID **equals** the app-reported MVID for the head
+   assembly. The "newest readable" tie-break disappears — identity decides.
+   - No candidate matches → `Warn` stating the app's MVID, every probed path with its MVID,
+     and that hot reload will not apply until the deployed build's outputs are present.
+     (Open question: degrade vs refuse init.)
+   - App didn't report modules (older client) → keep the current acceptance (readability,
+     RID-specific preferred).
+2. **Project references**: for each library of the filtered solution present in
+   `AppModules`, compare the baseline MVID with the reported one; mismatches produce a
+   single aggregated `Warn` (list of stale libraries). No re-pointing for libraries — their
+   correct location is unambiguous; staleness means *rebuild*, which the user must do anyway.
+3. **Emit-time anti-silence**: when EnC returns zero updates and zero rude-edit diagnostics
+   for a change that touched a project flagged unmatched/unbuilt in (1)/(2), surface a
+   `Warn` correlating the two (today the only trace is Roslyn's session log).
+
+### 3. Explicitly out of scope
+
+- **Evaluation-side RID injection** (global properties, or the
+  `UnoHotReloadRuntimeIdentifier`/`UnoHotReloadTargetFramework` props pipe): rejected during
+  the 2256 investigation — `MSBuildWorkspace` applies global properties to every project of
+  the graph without MSBuild's P2P negotiation (`SetTargetFramework` /
+  `GlobalPropertiesToRemove`), so a global RID relocates the expected outputs of every
+  RID-less-built library; and the props pipe is maintenance the team wants to remove, not
+  entrench.
+- **Per-root-project global properties** (evaluating only the head with pinned TFM/RID):
+  separate investigation, parked — requires a custom loader/BuildHost; would subsume part of
+  this spec if it ever lands, and the MVID handshake remains valuable regardless (it
+  validates *whatever* path selection produced).
+
+## Test plan (sketch)
+
+- **Unit (server)**: fixture emitting PE files with controlled distinct MVIDs (two `Emit`s of
+  the same compilation source differ; capture each MVID at emit time) — selection by
+  identity among decoys, no-match warning content, older-client fallback, library staleness
+  aggregation.
+- **Protocol**: round-trip serialization with/without the new fields; old-server tolerance
+  (unknown members ignored) and old-client tolerance (nulls).
+- **Runtime tests (client)**: `AppModules` contains the head assembly with its real MVID on
+  every target (extends the existing ungated `Given_ClientHotReloadProcessor` coverage).
+- **E2E (DevServer.Tests)**: workspace against a deployed-then-rebuilt app layout asserting
+  the mismatch warning fires and deltas stop being emitted against the wrong baseline.
+
+## References
+
+- uno-private#2256 (both episodes: `netX.0-skia` TFM misreport; RID-less baseline silently
+  "not built").
+- PRs: #23790 (client runtime TFM probe, master), #23791 (6.6 backport, merged), #23798
+  (RID-specific baseline alignment, 6.6), plus its master port.
+- Roslyn: `EditSession.cs` ("project not built" on `mvid == Guid.Empty`),
+  `DebuggingSession.GetProjectModuleIdAsync` (`ReadAssemblyModuleVersionId`,
+  `FileNotFoundException → Guid.Empty` without error) — the primitives this spec builds on.
+- Specs: 047 (property whitelist & runtime-reported TFM filtering), 049, 050.
+
+## Open questions (to settle in review)
+
+1. **Module list scope**: all loaded assemblies vs user-code filter — size vs completeness;
+   should dynamically-loaded (post-`ConfigureServer`) assemblies trigger an update message?
+2. **Refuse vs degrade** when the head MVID matches no candidate: refusing init makes the
+   failure loud but kills XAML-only `UpdateFile` scenarios that don't need EnC; degrading
+   keeps them alive behind a warning.
+3. **wasm**: `ModuleVersionId` availability and cost under Mono interpreter — expected fine,
+   to verify.
+4. **Serializer tolerance** of the message pipeline for unknown/extra members (old server ×
+   new client) — verify, don't assume.
+5. Should `RuntimeIdentifier` eventually feed a *validated* evaluation (the parked
+   root-project investigation) instead of path probing entirely?

--- a/specs/051-hotreload-baseline-identity-handshake/spec.md
+++ b/specs/051-hotreload-baseline-identity-handshake/spec.md
@@ -1,14 +1,15 @@
 # Hot-Reload Baseline Identity Handshake: RID & Module MVIDs in `ConfigureServer`
 
 > **Status: DRAFT — hard requirement: needs reviews before implementation.**
-> Written 2026-07-16, following the uno-private#2256 investigation. Nothing below is
+> Written 2026-07-16, following an internal investigation into hot-reload silence on
+> RID-specific Android deployments. Nothing below is
 > committed design; the protocol addition in particular must be reviewed (message
 > compatibility, module-list scope) before any code is written.
 
 ## Overview & Objectives
 
-The RID-specific baseline alignment (follow-up of spec 047/049, shipped for
-uno-private#2256) re-points the kept head flavor's `CompilationOutputInfo` to the output the
+The RID-specific baseline alignment (follow-up of spec 047/049, shipped as part of the same
+investigation) re-points the kept head flavor's `CompilationOutputInfo` to the output the
 running application was *probably* built from: the trigger is declarative (the
 `RuntimeIdentifier` captured in the application's build properties), and a candidate path is
 accepted when its module is **readable** (a valid PE with an MVID — the same primitive
@@ -102,7 +103,7 @@ of the current alignment):
 
 - **Evaluation-side RID injection** (global properties, or the
   `UnoHotReloadRuntimeIdentifier`/`UnoHotReloadTargetFramework` props pipe): rejected during
-  the 2256 investigation — `MSBuildWorkspace` applies global properties to every project of
+  the same investigation — `MSBuildWorkspace` applies global properties to every project of
   the graph without MSBuild's P2P negotiation (`SetTargetFramework` /
   `GlobalPropertiesToRemove`), so a global RID relocates the expected outputs of every
   RID-less-built library; and the props pipe is maintenance the team wants to remove, not
@@ -127,8 +128,8 @@ of the current alignment):
 
 ## References
 
-- uno-private#2256 (both episodes: `netX.0-skia` TFM misreport; RID-less baseline silently
-  "not built").
+- Internal issue tracking (both episodes: `netX.0-skia` TFM misreport; RID-less baseline
+  silently "not built").
 - PRs: #23790 (client runtime TFM probe, master), #23791 (6.6 backport, merged), #23798
   (RID-specific baseline alignment, 6.6), plus its master port.
 - Roslyn: `EditSession.cs` ("project not built" on `mvid == Guid.Empty`),

--- a/src/Uno.HotReload.Tests/Utils/Given_AlignHeadProjectCompilationOutputs.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_AlignHeadProjectCompilationOutputs.cs
@@ -155,6 +155,21 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 		StringAssert.Contains(reporter.Warnings.Single(), "app(net10.0-android)");
 	}
 
+	[TestMethod]
+	public void When_Rid_And_OutputPathHasNoDirectory_Then_Warns()
+	{
+		// A bare-filename output path has no directory to probe: the alignment must warn and
+		// skip instead of failing the workspace initialization.
+		using var workspace = new AdhocWorkspace();
+		AddProject(workspace, "app(net10.0-android)", _headPath, assemblyPath: "app.dll");
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter, CancellationToken.None);
+
+		Assert.AreSame(workspace.CurrentSolution, aligned);
+		StringAssert.Contains(reporter.Warnings.Single(), "app.dll");
+	}
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Fixture
 	// ────────────────────────────────────────────────────────────────────────

--- a/src/Uno.HotReload.Tests/Utils/Given_AlignHeadProjectCompilationOutputs.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_AlignHeadProjectCompilationOutputs.cs
@@ -1,0 +1,194 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Uno.HotReload.Tests.TestUtils;
+using Uno.HotReload.Utils;
+
+namespace Uno.HotReload.Tests.Utils;
+
+/// <summary>
+/// Tests for <see cref="RoslynExtensions.AlignHeadProjectCompilationOutputs"/> — the pass
+/// re-pointing the kept head flavor's compilation outputs to the assembly the running
+/// application was actually built from (RID-specific build outputs).
+/// </summary>
+[TestClass]
+public sealed class Given_AlignHeadProjectCompilationOutputs
+{
+	private static readonly string _headPath = Given_TryGetTargetFramework.ToOsPath("/src/app/app.csproj");
+
+	public TestContext TestContext { get; set; } = null!;
+
+	private string _outputRoot = null!;
+
+	[TestInitialize]
+	public void Initialize()
+		=> _outputRoot = Directory.CreateTempSubdirectory("uno_hr_align_").FullName;
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			Directory.Delete(_outputRoot, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Never fail a test on temp cleanup.
+		}
+	}
+
+	[TestMethod]
+	public void When_NoRid_And_OutputReadable_Then_SolutionUnchanged()
+	{
+		var evaluatedPath = EmitAssembly(Path.Combine(_outputRoot, "app.dll"));
+		using var workspace = new AdhocWorkspace();
+		AddProject(workspace, "app(net10.0-desktop)", _headPath, evaluatedPath);
+
+		var reporter = new RecordingReporter();
+		var solution = workspace.CurrentSolution;
+		var aligned = solution.AlignHeadProjectCompilationOutputs(_headPath, runtimeIdentifier: null, reporter);
+
+		Assert.AreSame(solution, aligned);
+		Assert.AreEqual(0, reporter.Warnings.Count);
+	}
+
+	[TestMethod]
+	public void When_NoRid_And_OutputMissing_Then_Warns()
+	{
+		var evaluatedPath = Path.Combine(_outputRoot, "app.dll"); // never emitted
+		using var workspace = new AdhocWorkspace();
+		AddProject(workspace, "app(net10.0-desktop)", _headPath, evaluatedPath);
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, runtimeIdentifier: null, reporter);
+
+		Assert.AreSame(workspace.CurrentSolution, aligned);
+		StringAssert.Contains(reporter.Warnings.Single(), evaluatedPath);
+	}
+
+	[TestMethod]
+	public void When_Rid_Then_RidSpecificOutputPreferred()
+	{
+		// Both the RID-less twin and the RID-specific output exist: the RID-specific one is the
+		// binary that was deployed, the RID-less one can be stale — it must lose.
+		var evaluatedPath = EmitAssembly(Path.Combine(_outputRoot, "app.dll"));
+		var ridPath = EmitAssembly(Path.Combine(_outputRoot, "android-x64", "app.dll"));
+		using var workspace = new AdhocWorkspace();
+		var projectId = AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+
+		Assert.AreEqual(ridPath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
+		Assert.AreEqual(0, reporter.Warnings.Count);
+	}
+
+	[TestMethod]
+	public void When_Rid_And_OnlyProbedCandidate_Then_Remapped_IgnoringReferenceAssemblies()
+	{
+		// No RID-named folder (custom output layout); the real output sits deeper in the
+		// evaluated directory subtree. Reference-assembly folders must never be picked, even
+		// when their files are more recent.
+		var evaluatedPath = Path.Combine(_outputRoot, "app.dll"); // never emitted
+		var candidatePath = EmitAssembly(Path.Combine(_outputRoot, "custom", "app.dll"));
+		var refPath = EmitAssembly(Path.Combine(_outputRoot, "ref", "app.dll"));
+		var refintPath = EmitAssembly(Path.Combine(_outputRoot, "refint", "app.dll"));
+		File.SetLastWriteTimeUtc(refPath, DateTime.UtcNow.AddHours(1));
+		File.SetLastWriteTimeUtc(refintPath, DateTime.UtcNow.AddHours(1));
+
+		using var workspace = new AdhocWorkspace();
+		var projectId = AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+
+		Assert.AreEqual(candidatePath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
+	}
+
+	[TestMethod]
+	public void When_Rid_And_OnlyRidlessOutput_Then_EvaluatedKept()
+	{
+		var evaluatedPath = EmitAssembly(Path.Combine(_outputRoot, "app.dll"));
+		using var workspace = new AdhocWorkspace();
+		var projectId = AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+
+		Assert.AreEqual(evaluatedPath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
+		Assert.AreEqual(0, reporter.Warnings.Count);
+	}
+
+	[TestMethod]
+	public void When_Rid_And_NothingReadable_Then_Warns_And_OtherProjectsUntouched()
+	{
+		// The RID path exists but is not a PE — module readability is the acceptance gate, mere
+		// file existence is not enough. A non-head project with a dead output path must not
+		// produce any warning: only the head flavor is aligned.
+		var evaluatedPath = Path.Combine(_outputRoot, "app.dll"); // never emitted
+		Directory.CreateDirectory(Path.Combine(_outputRoot, "android-x64"));
+		File.WriteAllText(Path.Combine(_outputRoot, "android-x64", "app.dll"), "not a PE");
+
+		using var workspace = new AdhocWorkspace();
+		AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
+		AddProject(workspace, "lib", Given_TryGetTargetFramework.ToOsPath("/src/lib/lib.csproj"), Path.Combine(_outputRoot, "lib", "lib.dll"));
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+
+		Assert.AreSame(workspace.CurrentSolution, aligned);
+		StringAssert.Contains(reporter.Warnings.Single(), "app.dll");
+	}
+
+	[TestMethod]
+	public void When_OutputPathUnset_Then_Warns()
+	{
+		using var workspace = new AdhocWorkspace();
+		AddProject(workspace, "app(net10.0-android)", _headPath, assemblyPath: null);
+
+		var reporter = new RecordingReporter();
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+
+		Assert.AreSame(workspace.CurrentSolution, aligned);
+		Assert.AreEqual(1, reporter.Warnings.Count);
+	}
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Fixture
+	// ────────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Emits a minimal valid assembly at <paramref name="path"/> — the alignment accepts a
+	/// candidate only when its module (MVID) is readable, so the fixture needs real PE files.
+	/// </summary>
+	private static string EmitAssembly(string path)
+	{
+		Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+		var compilation = CSharpCompilation.Create(
+			Path.GetFileNameWithoutExtension(path),
+			references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+			options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		var emit = compilation.Emit(path);
+		Assert.IsTrue(emit.Success, $"Fixture assembly emit failed: {string.Join(", ", emit.Diagnostics)}");
+		return path;
+	}
+
+	private static ProjectId AddProject(AdhocWorkspace workspace, string name, string filePath, string? assemblyPath)
+	{
+		var projectId = ProjectId.CreateNewId(name);
+
+		var projectInfo = ProjectInfo.Create(
+			projectId,
+			VersionStamp.Default,
+			name: name,
+			assemblyName: name,
+			language: LanguageNames.CSharp,
+			filePath: filePath)
+			.WithCompilationOutputInfo(default(CompilationOutputInfo).WithAssemblyPath(assemblyPath));
+
+		workspace.AddProject(projectInfo);
+		return projectId;
+	}
+}

--- a/src/Uno.HotReload.Tests/Utils/Given_AlignHeadProjectCompilationOutputs.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_AlignHeadProjectCompilationOutputs.cs
@@ -40,13 +40,13 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 	[TestMethod]
 	public void When_NoRid_And_OutputReadable_Then_SolutionUnchanged()
 	{
-		var evaluatedPath = EmitAssembly(Path.Combine(_outputRoot, "app.dll"));
+		var evaluatedPath = EmitAssembly(Path.Join(_outputRoot, "app.dll"));
 		using var workspace = new AdhocWorkspace();
 		AddProject(workspace, "app(net10.0-desktop)", _headPath, evaluatedPath);
 
 		var reporter = new RecordingReporter();
 		var solution = workspace.CurrentSolution;
-		var aligned = solution.AlignHeadProjectCompilationOutputs(_headPath, runtimeIdentifier: null, reporter);
+		var aligned = solution.AlignHeadProjectCompilationOutputs(_headPath, runtimeIdentifier: null, reporter, CancellationToken.None);
 
 		Assert.AreSame(solution, aligned);
 		Assert.AreEqual(0, reporter.Warnings.Count);
@@ -55,12 +55,12 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 	[TestMethod]
 	public void When_NoRid_And_OutputMissing_Then_Warns()
 	{
-		var evaluatedPath = Path.Combine(_outputRoot, "app.dll"); // never emitted
+		var evaluatedPath = Path.Join(_outputRoot, "app.dll"); // never emitted
 		using var workspace = new AdhocWorkspace();
 		AddProject(workspace, "app(net10.0-desktop)", _headPath, evaluatedPath);
 
 		var reporter = new RecordingReporter();
-		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, runtimeIdentifier: null, reporter);
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, runtimeIdentifier: null, reporter, CancellationToken.None);
 
 		Assert.AreSame(workspace.CurrentSolution, aligned);
 		StringAssert.Contains(reporter.Warnings.Single(), evaluatedPath);
@@ -71,15 +71,16 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 	{
 		// Both the RID-less twin and the RID-specific output exist: the RID-specific one is the
 		// binary that was deployed, the RID-less one can be stale — it must lose.
-		var evaluatedPath = EmitAssembly(Path.Combine(_outputRoot, "app.dll"));
-		var ridPath = EmitAssembly(Path.Combine(_outputRoot, "android-x64", "app.dll"));
+		var evaluatedPath = EmitAssembly(Path.Join(_outputRoot, "app.dll"));
+		var ridPath = EmitAssembly(Path.Join(_outputRoot, "android-x64", "app.dll"));
 		using var workspace = new AdhocWorkspace();
 		var projectId = AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
 
 		var reporter = new RecordingReporter();
-		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter, CancellationToken.None);
 
 		Assert.AreEqual(ridPath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
+		Assert.AreNotEqual(evaluatedPath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
 		Assert.AreEqual(0, reporter.Warnings.Count);
 	}
 
@@ -89,10 +90,10 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 		// No RID-named folder (custom output layout); the real output sits deeper in the
 		// evaluated directory subtree. Reference-assembly folders must never be picked, even
 		// when their files are more recent.
-		var evaluatedPath = Path.Combine(_outputRoot, "app.dll"); // never emitted
-		var candidatePath = EmitAssembly(Path.Combine(_outputRoot, "custom", "app.dll"));
-		var refPath = EmitAssembly(Path.Combine(_outputRoot, "ref", "app.dll"));
-		var refintPath = EmitAssembly(Path.Combine(_outputRoot, "refint", "app.dll"));
+		var evaluatedPath = Path.Join(_outputRoot, "app.dll"); // never emitted
+		var candidatePath = EmitAssembly(Path.Join(_outputRoot, "custom", "app.dll"));
+		var refPath = EmitAssembly(Path.Join(_outputRoot, "ref", "app.dll"));
+		var refintPath = EmitAssembly(Path.Join(_outputRoot, "refint", "app.dll"));
 		File.SetLastWriteTimeUtc(refPath, DateTime.UtcNow.AddHours(1));
 		File.SetLastWriteTimeUtc(refintPath, DateTime.UtcNow.AddHours(1));
 
@@ -100,7 +101,7 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 		var projectId = AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
 
 		var reporter = new RecordingReporter();
-		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter, CancellationToken.None);
 
 		Assert.AreEqual(candidatePath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
 	}
@@ -108,13 +109,14 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 	[TestMethod]
 	public void When_Rid_And_OnlyRidlessOutput_Then_EvaluatedKept()
 	{
-		var evaluatedPath = EmitAssembly(Path.Combine(_outputRoot, "app.dll"));
+		var evaluatedPath = EmitAssembly(Path.Join(_outputRoot, "app.dll"));
 		using var workspace = new AdhocWorkspace();
 		var projectId = AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
 
 		var reporter = new RecordingReporter();
-		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter, CancellationToken.None);
 
+		Assert.AreSame(workspace.CurrentSolution, aligned);
 		Assert.AreEqual(evaluatedPath, aligned.GetProject(projectId)!.CompilationOutputInfo.AssemblyPath);
 		Assert.AreEqual(0, reporter.Warnings.Count);
 	}
@@ -125,16 +127,16 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 		// The RID path exists but is not a PE — module readability is the acceptance gate, mere
 		// file existence is not enough. A non-head project with a dead output path must not
 		// produce any warning: only the head flavor is aligned.
-		var evaluatedPath = Path.Combine(_outputRoot, "app.dll"); // never emitted
-		Directory.CreateDirectory(Path.Combine(_outputRoot, "android-x64"));
-		File.WriteAllText(Path.Combine(_outputRoot, "android-x64", "app.dll"), "not a PE");
+		var evaluatedPath = Path.Join(_outputRoot, "app.dll"); // never emitted
+		Directory.CreateDirectory(Path.Join(_outputRoot, "android-x64"));
+		File.WriteAllText(Path.Join(_outputRoot, "android-x64", "app.dll"), "not a PE");
 
 		using var workspace = new AdhocWorkspace();
 		AddProject(workspace, "app(net10.0-android)", _headPath, evaluatedPath);
-		AddProject(workspace, "lib", Given_TryGetTargetFramework.ToOsPath("/src/lib/lib.csproj"), Path.Combine(_outputRoot, "lib", "lib.dll"));
+		AddProject(workspace, "lib", Given_TryGetTargetFramework.ToOsPath("/src/lib/lib.csproj"), Path.Join(_outputRoot, "lib", "lib.dll"));
 
 		var reporter = new RecordingReporter();
-		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter, CancellationToken.None);
 
 		Assert.AreSame(workspace.CurrentSolution, aligned);
 		StringAssert.Contains(reporter.Warnings.Single(), "app.dll");
@@ -147,10 +149,10 @@ public sealed class Given_AlignHeadProjectCompilationOutputs
 		AddProject(workspace, "app(net10.0-android)", _headPath, assemblyPath: null);
 
 		var reporter = new RecordingReporter();
-		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter);
+		var aligned = workspace.CurrentSolution.AlignHeadProjectCompilationOutputs(_headPath, "android-x64", reporter, CancellationToken.None);
 
 		Assert.AreSame(workspace.CurrentSolution, aligned);
-		Assert.AreEqual(1, reporter.Warnings.Count);
+		StringAssert.Contains(reporter.Warnings.Single(), "app(net10.0-android)");
 	}
 
 	// ────────────────────────────────────────────────────────────────────────

--- a/src/Uno.HotReload/Utils/RoslynExtensions.CompilationOutputAlignment.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.CompilationOutputAlignment.cs
@@ -75,7 +75,15 @@ public static partial class RoslynExtensions
 			// output — it is the binary that was actually deployed. Even when the RID-less file
 			// exists it can be a stale twin (an earlier RID-less build) with a mismatching MVID.
 			var fileName = Path.GetFileName(evaluatedPath);
-			var directory = Path.GetDirectoryName(evaluatedPath)!;
+			var directory = Path.GetDirectoryName(evaluatedPath);
+			if (string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(fileName))
+			{
+				reporter.Warn(
+					$"The output assembly path '{evaluatedPath}' of '{project.Name}' has no directory component — " +
+					"the RID-specific alignment cannot probe for the deployed output and is skipped.");
+				continue;
+			}
+
 			var ridSpecificPath = Path.Join(directory, runtimeIdentifier, fileName);
 
 			if (TryReadMvid(ridSpecificPath, out _))
@@ -174,7 +182,7 @@ public static partial class RoslynExtensions
 			mvid = metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
 			return mvid != Guid.Empty;
 		}
-		catch (Exception)
+		catch (Exception e) when (e is IOException or UnauthorizedAccessException or BadImageFormatException or InvalidOperationException)
 		{
 			return false;
 		}

--- a/src/Uno.HotReload/Utils/RoslynExtensions.CompilationOutputAlignment.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.CompilationOutputAlignment.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Uno.HotReload.Tracking;
 
@@ -35,18 +36,18 @@ public static partial class RoslynExtensions
 	/// <param name="headProjectPath">Full path of the head project (<c>.csproj</c>) the application runs.</param>
 	/// <param name="runtimeIdentifier">The runtime identifier captured from the running application's build, when any.</param>
 	/// <param name="reporter">Reporter used to surface the alignment decisions.</param>
+	/// <param name="cancellationToken">Cancellation of the filesystem probing.</param>
 	public static Solution AlignHeadProjectCompilationOutputs(
 		this Solution solution,
 		string headProjectPath,
 		string? runtimeIdentifier,
-		IReporter reporter)
+		IReporter reporter,
+		CancellationToken cancellationToken)
 	{
-		foreach (var projectId in solution.Projects
+		foreach (var project in solution.Projects
 			.Where(p => PathComparer.PathEquals(p.FilePath, headProjectPath))
-			.Select(p => p.Id)
 			.ToList())
 		{
-			var project = solution.GetProject(projectId)!;
 			var evaluatedPath = project.CompilationOutputInfo.AssemblyPath;
 			if (string.IsNullOrEmpty(evaluatedPath))
 			{
@@ -75,13 +76,13 @@ public static partial class RoslynExtensions
 			// exists it can be a stale twin (an earlier RID-less build) with a mismatching MVID.
 			var fileName = Path.GetFileName(evaluatedPath);
 			var directory = Path.GetDirectoryName(evaluatedPath)!;
-			var ridSpecificPath = Path.Combine(directory, runtimeIdentifier, fileName);
+			var ridSpecificPath = Path.Join(directory, runtimeIdentifier, fileName);
 
 			if (TryReadMvid(ridSpecificPath, out _))
 			{
 				solution = Remap(project, ridSpecificPath);
 			}
-			else if (FindNewestReadableCandidate(directory, fileName, evaluatedPath) is { } candidate)
+			else if (FindNewestReadableCandidate(directory, fileName, evaluatedPath, cancellationToken) is { } candidate)
 			{
 				// Custom output layouts (artifacts output path, intermediate-path overrides, …):
 				// probe the evaluated directory subtree for the assembly instead.
@@ -116,7 +117,7 @@ public static partial class RoslynExtensions
 	/// excluding reference-assembly folders (<c>ref</c>/<c>refint</c> — readable PEs, but not an
 	/// EnC baseline) and preferring the most recently written candidate.
 	/// </summary>
-	private static string? FindNewestReadableCandidate(string directory, string fileName, string evaluatedPath)
+	private static string? FindNewestReadableCandidate(string directory, string fileName, string evaluatedPath, CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -127,15 +128,30 @@ public static partial class RoslynExtensions
 
 			return Directory
 				.EnumerateFiles(directory, fileName, SearchOption.AllDirectories)
-				.Where(path => !PathComparer.PathEquals(path, evaluatedPath))
-				.Where(path => Path.GetDirectoryName(path) is { } dir
-					&& Path.GetFileName(dir) is { } dirName
-					&& !dirName.Equals("ref", StringComparison.OrdinalIgnoreCase)
-					&& !dirName.Equals("refint", StringComparison.OrdinalIgnoreCase))
+				.Where(path =>
+				{
+					cancellationToken.ThrowIfCancellationRequested();
+					if (PathComparer.PathEquals(path, evaluatedPath))
+					{
+						return false;
+					}
+
+					for (var dir = Path.GetDirectoryName(path); dir is not null && !PathComparer.PathEquals(dir, directory); dir = Path.GetDirectoryName(dir))
+					{
+						var segment = Path.GetFileName(dir);
+						if (segment.Equals("ref", StringComparison.OrdinalIgnoreCase)
+							|| segment.Equals("refint", StringComparison.OrdinalIgnoreCase))
+						{
+							return false;
+						}
+					}
+
+					return true;
+				})
 				.OrderByDescending(File.GetLastWriteTimeUtc)
 				.FirstOrDefault(path => TryReadMvid(path, out _));
 		}
-		catch (Exception)
+		catch (Exception e) when (e is not OperationCanceledException)
 		{
 			// IO race with a build in progress — treat as "no candidate" rather than failing the
 			// workspace initialization.

--- a/src/Uno.HotReload/Utils/RoslynExtensions.CompilationOutputAlignment.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.CompilationOutputAlignment.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.Utils;
+
+public static partial class RoslynExtensions
+{
+	/// <summary>
+	/// Re-points the compilation outputs of the head-project flavor(s) kept in the solution to
+	/// the output assembly the running application was actually built from.
+	/// </summary>
+	/// <remarks>
+	/// The workspace evaluates the head without a <c>RuntimeIdentifier</c>, so
+	/// <see cref="Project.CompilationOutputInfo"/>.AssemblyPath is the RID-less intermediate
+	/// path (<c>obj/Debug/netX.0-android/App.dll</c>). A device deployment however builds
+	/// RID-specific (<c>obj/Debug/netX.0-android/android-arm64/App.dll</c>): the RID-less file
+	/// either does not exist — Roslyn's EnC then treats the project as "not built" and silently
+	/// emits no update — or is a stale twin from an earlier RID-less build whose MVID does not
+	/// match the deployed module, so emitted deltas would be dropped by the application. Only
+	/// the head flavor needs re-pointing: project references are built RID-less by MSBuild's
+	/// project-to-project protocol, their evaluated paths are correct.
+	///
+	/// The trigger is declarative — the <c>RuntimeIdentifier</c> captured from the running
+	/// application's build — and a candidate path is only accepted when its module is readable
+	/// (a valid PE with an MVID), the same primitive Roslyn's EnC uses to decide a project is
+	/// "built". When nothing readable is found the situation is reported as a warning: without
+	/// it, the EnC "project not built" outcome is invisible outside Roslyn's own session log.
+	/// </remarks>
+	/// <param name="solution">The (already flavor-filtered) solution.</param>
+	/// <param name="headProjectPath">Full path of the head project (<c>.csproj</c>) the application runs.</param>
+	/// <param name="runtimeIdentifier">The runtime identifier captured from the running application's build, when any.</param>
+	/// <param name="reporter">Reporter used to surface the alignment decisions.</param>
+	public static Solution AlignHeadProjectCompilationOutputs(
+		this Solution solution,
+		string headProjectPath,
+		string? runtimeIdentifier,
+		IReporter reporter)
+	{
+		foreach (var projectId in solution.Projects
+			.Where(p => PathComparer.PathEquals(p.FilePath, headProjectPath))
+			.Select(p => p.Id)
+			.ToList())
+		{
+			var project = solution.GetProject(projectId)!;
+			var evaluatedPath = project.CompilationOutputInfo.AssemblyPath;
+			if (string.IsNullOrEmpty(evaluatedPath))
+			{
+				reporter.Warn(
+					$"The hot-reload workspace has no output assembly path for '{project.Name}' — Roslyn will consider the " +
+					"project not built and hot reload will silently produce no updates.");
+				continue;
+			}
+
+			if (string.IsNullOrEmpty(runtimeIdentifier))
+			{
+				// No RID captured from the running build: the evaluated (RID-less) path is the built
+				// one. Only surface the anti-silence warning when it isn't readable.
+				if (!TryReadMvid(evaluatedPath, out _))
+				{
+					reporter.Warn(
+						$"The output assembly of '{project.Name}' was not found at '{evaluatedPath}' — Roslyn will consider " +
+						"the project not built and hot reload will silently produce no updates. Build this target framework first.");
+				}
+
+				continue;
+			}
+
+			// The running application was built WITH a runtime identifier: prefer the RID-specific
+			// output — it is the binary that was actually deployed. Even when the RID-less file
+			// exists it can be a stale twin (an earlier RID-less build) with a mismatching MVID.
+			var fileName = Path.GetFileName(evaluatedPath);
+			var directory = Path.GetDirectoryName(evaluatedPath)!;
+			var ridSpecificPath = Path.Combine(directory, runtimeIdentifier, fileName);
+
+			if (TryReadMvid(ridSpecificPath, out _))
+			{
+				solution = Remap(project, ridSpecificPath);
+			}
+			else if (FindNewestReadableCandidate(directory, fileName, evaluatedPath) is { } candidate)
+			{
+				// Custom output layouts (artifacts output path, intermediate-path overrides, …):
+				// probe the evaluated directory subtree for the assembly instead.
+				solution = Remap(project, candidate);
+			}
+			else if (TryReadMvid(evaluatedPath, out _))
+			{
+				reporter.Output(
+					$"The application was built with runtime identifier '{runtimeIdentifier}' but no RID-specific output was " +
+					$"found for '{project.Name}'; keeping the evaluated '{evaluatedPath}'.");
+			}
+			else
+			{
+				reporter.Warn(
+					$"The output assembly of '{project.Name}' was not found (probed '{ridSpecificPath}' and '{evaluatedPath}') — " +
+					"Roslyn will consider the project not built and hot reload will silently produce no updates. " +
+					"Deploy this target framework first.");
+			}
+		}
+
+		return solution;
+
+		Solution Remap(Project project, string path)
+		{
+			reporter.Output($"Hot-reload baseline of '{project.Name}' re-pointed to '{path}' (runtime identifier '{runtimeIdentifier}').");
+			return solution.WithProjectCompilationOutputInfo(project.Id, project.CompilationOutputInfo.WithAssemblyPath(path));
+		}
+	}
+
+	/// <summary>
+	/// Probes the evaluated output directory subtree for a readable build of the assembly,
+	/// excluding reference-assembly folders (<c>ref</c>/<c>refint</c> — readable PEs, but not an
+	/// EnC baseline) and preferring the most recently written candidate.
+	/// </summary>
+	private static string? FindNewestReadableCandidate(string directory, string fileName, string evaluatedPath)
+	{
+		try
+		{
+			if (!Directory.Exists(directory))
+			{
+				return null;
+			}
+
+			return Directory
+				.EnumerateFiles(directory, fileName, SearchOption.AllDirectories)
+				.Where(path => !PathComparer.PathEquals(path, evaluatedPath))
+				.Where(path => Path.GetDirectoryName(path) is { } dir
+					&& Path.GetFileName(dir) is { } dirName
+					&& !dirName.Equals("ref", StringComparison.OrdinalIgnoreCase)
+					&& !dirName.Equals("refint", StringComparison.OrdinalIgnoreCase))
+				.OrderByDescending(File.GetLastWriteTimeUtc)
+				.FirstOrDefault(path => TryReadMvid(path, out _));
+		}
+		catch (Exception)
+		{
+			// IO race with a build in progress — treat as "no candidate" rather than failing the
+			// workspace initialization.
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Reads the module version id the way Roslyn's EnC decides a project is "built" (see
+	/// Roslyn's <c>DebuggingSession.GetProjectModuleIdAsync</c>): a readable PE with metadata.
+	/// </summary>
+	private static bool TryReadMvid(string path, out Guid mvid)
+	{
+		mvid = default;
+		try
+		{
+			using var stream = File.OpenRead(path);
+			using var peReader = new PEReader(stream);
+			var metadataReader = peReader.GetMetadataReader();
+			mvid = metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
+			return mvid != Guid.Empty;
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -85,6 +85,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 					var properties = configureServer.MSBuildProperties.ToDictionary();
 					var runtimeTargetFramework = GetRuntimeTargetFramework(configureServer);
+					var runtimeIdentifier = properties.GetValueOrDefault("RuntimeIdentifier");
 					async ValueTask<Solution> LoadSolutionFromDisk(CancellationToken ct2)
 					{
 						var workspace = await CompilationWorkspaceProvider.CreateWorkspaceAsync(configureServer.ProjectPath, _reporter, properties, ct2);
@@ -92,8 +93,13 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						// Restrict a multi-targeted head to the flavor the running application reported: the
 						// workspace loaded one project per TargetFrameworks entry (the evaluated TargetFramework
 						// is empty), and the non-running flavors would otherwise block hot reload with their
-						// compilation errors or fail the initial emit (they were never built).
-						return workspace.CurrentSolution.FilterHeadProjectTargetFramework(configureServer.ProjectPath, runtimeTargetFramework, _reporter);
+						// compilation errors or fail the initial emit (they were never built). Then re-point the
+						// kept flavor's compilation outputs to the assembly the running application was actually
+						// built from (RID-specific paths) — before the watch session starts, as EnC captures its
+						// baselines from those paths.
+						return workspace.CurrentSolution
+							.FilterHeadProjectTargetFramework(configureServer.ProjectPath, runtimeTargetFramework, _reporter)
+							.AlignHeadProjectCompilationOutputs(configureServer.ProjectPath, runtimeIdentifier, _reporter);
 					}
 
 					var manager = await HotReloadManager.CreateAsync(LoadSolutionFromDisk, configureServer.MetadataUpdateCapabilities, new DelegateHotReloadHandler(SendUpdates), _tracker, ct);

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -99,7 +99,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						// baselines from those paths.
 						return workspace.CurrentSolution
 							.FilterHeadProjectTargetFramework(configureServer.ProjectPath, runtimeTargetFramework, _reporter)
-							.AlignHeadProjectCompilationOutputs(configureServer.ProjectPath, runtimeIdentifier, _reporter);
+							.AlignHeadProjectCompilationOutputs(configureServer.ProjectPath, runtimeIdentifier, _reporter, ct2);
 					}
 
 					var manager = await HotReloadManager.CreateAsync(LoadSolutionFromDisk, configureServer.MetadataUpdateCapabilities, new DelegateHotReloadHandler(SendUpdates), _tracker, ct);


### PR DESCRIPTION
**GitHub Issue:** unoplatform/uno-private#2256

Master port of #23798 (`release/stable/6.6`-first fix), with unit-test coverage and a draft follow-up spec. Second half of the uno-private#2256 investigation — the first half (`netX.0-skia` TFM misreport) is #23790.

## PR Type:

🐞 Bugfix

## What changed? 🚀

With the correct target framework reported and the workspace correctly restricted, hot reload on Android still produced `Found 0 metadata updates` — silently, for C# and XAML edits alike.

The hot-reload workspace evaluates the head project without a `RuntimeIdentifier`, so EnC captures its baseline from the RID-less intermediate assembly path (`obj/Debug/net10.0-android/App.dll`). A device deployment however builds RID-specific (`obj/Debug/net10.0-android/android-x64/App.dll`): the RID-less assembly either does not exist — Roslyn's EnC then treats the project as **"not built"** (`EditSession`: `mvid == Guid.Empty`) and silently emits zero updates — or is a stale twin from an earlier RID-less build whose MVID does not match the deployed module, so emitted deltas would be dropped by the application.

- **`RoslynExtensions.AlignHeadProjectCompilationOutputs`** (new, `Uno.HotReload/Utils`, chained after `FilterHeadProjectTargetFramework` in the solution load): re-points the kept head flavor's `CompilationOutputInfo` to the assembly the running application was actually built from. Trigger is declarative — the `RuntimeIdentifier` captured from the application's build; no filesystem guessing in the decision, and no global property pushed to the workspace (a global RID would relocate the expected outputs of every project reference, which MSBuild's project-to-project protocol builds RID-less). Candidates are accepted by module readability (a valid PE with an MVID — the primitive Roslyn's EnC uses to decide a project is "built"), preferring the RID-specific path over a potentially stale RID-less twin, with a recursive probe of the evaluated output directory as fallback for custom layouts (reference-assembly `ref`/`refint` folders excluded). Project references are left untouched.
- **No more silence**: when nothing readable is found, an explicit warning states the probed paths and that hot reload will produce no updates — previously the only trace was `project not built` inside Roslyn's own EnC session log.
- **7 unit tests** (`Uno.HotReload.Tests`) covering the no-RID pass-through and warning, RID-specific preference over the stale twin, subtree probing with `ref`/`refint` exclusion, module-readability as the acceptance gate, untouched non-head projects, and the null-`AssemblyPath` warning — the fixture emits real minimal PE files since the alignment reads module metadata.
- **Draft spec 051** (`specs/051-hotreload-baseline-identity-handshake`, marked *draft — hard requirement: needs reviews before implementation*): the follow-up design transporting the `RuntimeIdentifier` and the loaded modules' MVIDs in `ConfigureServer`, so baseline selection and diagnostics rely on module **identity** (the invariant debugger-based EnC gets from the debuggee) instead of readability heuristics. Not implemented here.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)