### PR TITLE
test(a11y): Cover icon button names

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AccessibleButton.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AccessibleButton.cs
@@ -6,8 +6,11 @@ using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using static Private.Infrastructure.TestServices;
 
 #if HAS_UNO
 using Uno.UI.Runtime.Skia;
@@ -293,10 +296,76 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 			Assert.AreEqual("Submit Form", GetSemanticAttribute(button, "aria-label"), "A Button's AutomationProperties.Name must surface as aria-label on the DOM node.");
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWasm)]
+		public async Task When_Button_With_PathIcon_And_AutomationName_Then_Dom_AriaLabel_Is_Set()
+		{
+			var button = new Button
+			{
+				Width = 48,
+				Height = 48,
+				Content = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } },
+			};
+			AutomationProperties.SetName(button, "Refresh");
 
+			try
+			{
+				await UITestHelper.Load(button);
+				button.GetOrCreateAutomationPeer();
 
+				EnableAccessibilityThroughDom();
+				await UITestHelper.WaitFor(() => SemanticElementExists(button), timeoutMS: 5000, message: "Timed out waiting for the icon button semantic element to be created.");
+				await UITestHelper.WaitFor(
+					() => SemanticElementHasNonEmptyBounds(button),
+					timeoutMS: 5000,
+					message: "Timed out waiting for the icon button semantic element to receive non-zero bounds.");
 
+				Assert.AreEqual("button", GetSemanticElementTagName(button), "An icon-only Button must emit a native <button> semantic element.");
+				Assert.AreEqual("Refresh", GetSemanticAttribute(button, "aria-label"), "An icon-only Button's AutomationProperties.Name must surface as aria-label on the DOM node.");
+				Assert.IsTrue(SemanticElementHasNonEmptyBounds(button), "The semantic Button must have non-zero bounds so assistive technology can locate it.");
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWasm)]
+		public async Task When_Button_With_PathIcon_Gets_AutomationName_Then_Dom_AriaLabel_Is_Updated()
+		{
+			var button = new Button
+			{
+				Width = 48,
+				Height = 48,
+				Content = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } },
+			};
+
+			try
+			{
+				await UITestHelper.Load(button);
+				button.GetOrCreateAutomationPeer();
+
+				EnableAccessibilityThroughDom();
+				await UITestHelper.WaitFor(() => SemanticElementExists(button), timeoutMS: 5000, message: "Timed out waiting for the unnamed icon button semantic element to be created.");
+
+				Assert.IsFalse(SemanticElementHasAttribute(button, "aria-label"), "An unnamed icon-only Button must not emit aria-label.");
+
+				AutomationProperties.SetName(button, "Refresh");
+				await UITestHelper.WaitFor(
+					() => GetSemanticAttribute(button, "aria-label") == "Refresh",
+					timeoutMS: 5000,
+					message: "Timed out waiting for the icon button aria-label to update.");
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
 
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -1,9 +1,13 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
@@ -553,6 +557,113 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 			var automationPeer = new TestAutomationPeer();
 			var result = automationPeer.GetFullDescription();
 			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+		public async Task When_Button_With_PathIcon_Content_And_AutomationName()
+		{
+			var button = new Button
+			{
+				Width = 48,
+				Height = 48,
+				Content = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } },
+			};
+			AutomationProperties.SetName(button, "Refresh");
+
+			try
+			{
+				await UITestHelper.Load(button);
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(peer);
+				Assert.AreEqual("Refresh", peer.GetName());
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+		public async Task When_Button_With_PathIcon_Content_Without_AutomationName()
+		{
+			var button = new Button
+			{
+				Width = 48,
+				Height = 48,
+				Content = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } },
+			};
+
+			try
+			{
+				await UITestHelper.Load(button);
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(peer);
+
+				// Icon content contributes no text — an icon-only button without AutomationProperties.Name is unnamed.
+				Assert.AreEqual(string.Empty, peer.GetName());
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+		public async Task When_Button_With_String_Content_Then_GetName_Returns_Content()
+		{
+			var button = new Button { Content = "Help Center" };
+
+			try
+			{
+				await UITestHelper.Load(button);
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(peer);
+				Assert.AreEqual("Help Center", peer.GetName());
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+		public async Task When_PathIcon_Has_No_AutomationPeer()
+		{
+			var pathIcon = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } };
+			var button = new Button
+			{
+				Width = 48,
+				Height = 48,
+				Content = pathIcon,
+			};
+			AutomationProperties.SetName(button, "Refresh");
+
+			try
+			{
+				await UITestHelper.Load(button);
+
+				Assert.IsNull(FrameworkElementAutomationPeer.CreatePeerForElement(pathIcon));
+
+				var buttonPeer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(buttonPeer);
+				var children = buttonPeer.GetChildren();
+				Assert.IsTrue(children == null || children.Count == 0, "An icon-only Button should be a leaf in the automation tree.");
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
 		}
 
 		private class TestAutomationPeer : AutomationPeer

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
@@ -4,10 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation;
 
@@ -16,6 +22,62 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation;
 [PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
 public class Given_Win32Accessibility
 {
+	// UIA_NamePropertyId; Win32UIAutomationInterop is internal to the runtime assembly.
+	private const int UiaNamePropertyId = 30005;
+
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23802")]
+	public async Task When_PathIcon_Button_Name_Is_Exposed_Through_Uia_Provider()
+	{
+		var namedIcon = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } };
+		var namedButton = new Button
+		{
+			Width = 48,
+			Height = 48,
+			Content = namedIcon,
+		};
+		AutomationProperties.SetName(namedButton, "Refresh");
+
+		var unnamedIcon = new PathIcon { Data = new RectangleGeometry { Rect = new Rect(0, 0, 12, 12) } };
+		var unnamedButton = new Button
+		{
+			Width = 48,
+			Height = 48,
+			Content = unnamedIcon,
+		};
+		var panel = new StackPanel
+		{
+			Children =
+			{
+				namedButton,
+				unnamedButton,
+			},
+		};
+
+		try
+		{
+			await UITestHelper.Load(panel);
+
+			var accessibility = ResolveAccessibility(namedButton)
+				?? throw new InvalidOperationException("Win32Accessibility instance not found.");
+			var namedProvider = GetOrCreateProvider(accessibility, namedButton)
+				?? throw new InvalidOperationException("Named Button provider not found.");
+			var unnamedProvider = GetOrCreateProvider(accessibility, unnamedButton)
+				?? throw new InvalidOperationException("Unnamed Button provider not found.");
+
+			Assert.AreEqual("Refresh", GetPropertyValue(namedProvider, UiaNamePropertyId));
+			Assert.IsNull(GetPropertyValue(unnamedProvider, UiaNamePropertyId));
+			Assert.IsNull(GetOrCreateProvider(accessibility, namedIcon), "PathIcon must not create its own UIA provider.");
+
+			AutomationProperties.SetName(unnamedButton, "Settings");
+			Assert.AreEqual("Settings", GetPropertyValue(unnamedProvider, UiaNamePropertyId));
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
 	[TestMethod]
 	public void When_Traversing_Deep_Cyclic_Descendants()
 	{
@@ -66,6 +128,44 @@ public class Given_Win32Accessibility
 
 		Assert.IsTrue(visited.Contains(target), "Deep descendants after a cycle must still be reached.");
 		Assert.AreEqual(descendants.Length + 1, visited.Count);
+	}
+
+	private static object? ResolveAccessibility(UIElement element)
+	{
+		var router = FindType("Uno.UI.Runtime.Skia.AccessibilityRouter")
+			?? throw new InvalidOperationException("AccessibilityRouter type not found.");
+		var resolve = router.GetMethod(
+			"Resolve",
+			BindingFlags.Static | BindingFlags.Public,
+			binder: null,
+			types: new[] { typeof(UIElement) },
+			modifiers: null)
+			?? throw new InvalidOperationException("AccessibilityRouter.Resolve(UIElement) not found.");
+		return resolve.Invoke(null, new object[] { element });
+	}
+
+	private static object? GetOrCreateProvider(object accessibility, UIElement element)
+	{
+		var getOrCreateProvider = accessibility.GetType().GetMethod(
+			"GetOrCreateProvider",
+			BindingFlags.Instance | BindingFlags.NonPublic,
+			binder: null,
+			types: new[] { typeof(UIElement) },
+			modifiers: null)
+			?? throw new InvalidOperationException("Win32Accessibility.GetOrCreateProvider(UIElement) not found.");
+		return getOrCreateProvider.Invoke(accessibility, new object[] { element });
+	}
+
+	private static object? GetPropertyValue(object provider, int propertyId)
+	{
+		var getPropertyValue = provider.GetType().GetMethod(
+			"GetPropertyValue",
+			BindingFlags.Instance | BindingFlags.Public,
+			binder: null,
+			types: new[] { typeof(int) },
+			modifiers: null)
+			?? throw new InvalidOperationException("Win32RawElementProvider.GetPropertyValue(int) not found.");
+		return getPropertyValue.Invoke(provider, new object[] { propertyId });
 	}
 
 	private static Type? FindType(string fullName)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/WasmSemanticDomHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/WasmSemanticDomHelper.cs
@@ -39,6 +39,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 		public static bool SemanticElementExists(UIElement element)
 			=> InvokeBrowserJs($"(function(){{return document.getElementById('{GetSemanticElementId(element)}') ? '1' : '0';}})()") == "1";
 
+		/// <summary>Returns true when the semantic node has non-zero browser bounds.</summary>
+		public static bool SemanticElementHasNonEmptyBounds(UIElement element)
+			=> InvokeBrowserJs($"(function(){{const e = document.getElementById('{GetSemanticElementId(element)}'); if (!e) {{ return '0'; }} const r = e.getBoundingClientRect(); return r.width > 0 && r.height > 0 ? '1' : '0'; }})()") == "1";
+
 		/// <summary>
 		/// Returns the value of an attribute on the element's semantic node, or empty string when the
 		/// node or attribute is absent. Use <see cref="SemanticElementHasAttribute"/> to distinguish


### PR DESCRIPTION
**GitHub Issue:** closes #23802

## PR Type:

💬 Other... (Test coverage)

## What changed? 🚀

Adds focused icon-only `Button` accessible-name regression coverage for WinUI parity, Skia WASM, and Skia Win32.

The shared automation-peer tests verify named and unnamed `PathIcon` content against WinUI behavior. The WASM tests verify native semantic `<button>` creation, `aria-label`, non-zero browser bounds, and live name updates. The Win32 test verifies the exposed UIA Name and confirms that `PathIcon` does not create a separate provider.

Current `master` already contains the production behavior, so this PR changes tests only.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
