### PR TITLE
fix: re-create unmaterialized Frame content on hr element update

### DIFF
--- a/doc/articles/uno-development/uno-internals-hotreload.md
+++ b/doc/articles/uno-development/uno-internals-hotreload.md
@@ -52,6 +52,12 @@ static void BeforeElementReplaced(FrameworkElement, FrameworkElement, Type[]?);
 static void AfterElementReplaced(FrameworkElement, FrameworkElement, Type[]?);
 ```
 
+### Content that is not in the visual tree
+
+The UI Update only walks materialized elements, so content assigned to a `ContentControl` whose subtree never had a layout pass is invisible to it — the template never applied, so the content is not a visual child. The `ContentControl` and `Frame` element-update handlers re-create such content themselves, from `ElementUpdate`.
+
+`BeforeElementReplaced` / `AfterElementReplaced` are **not** raised for those swaps, and they are not counted in the operation's replaced-element total — those notifications belong to the elements the walk owns. A handler that tracks a content instance should reconcile in `AfterVisualTreeUpdate`, which runs once after the whole phase. `CaptureState` / `RestoreState` do not run either: the content was never materialized, so there is no visual state to preserve.
+
 ## Pausing / Resuming UI Update
 
 Pausing and resuming UI Update is done by calling

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
@@ -12,12 +12,10 @@ public class Given_ContentControl_StrandedContent : BaseTestClass
 	public const string ControlChangedText = ControlOriginalText + " (changed)";
 
 	/// <summary>
-	/// Same scenario as <see cref="Given_Frame_StrandedContent"/> but for a plain
-	/// <see cref="ContentControl"/>: content assigned while the host's subtree never had
-	/// a layout pass exists only as <c>ContentControl.Content</c> — the template is never
-	/// applied, so the content is not a materialized visual child and the hot-reload
-	/// visual-tree walk cannot see it. The ContentControl element-update handler must
-	/// re-create it so the updated content is shown once the subtree lays out.
+	/// Same scenario as <see cref="Given_Frame_StrandedContent"/> for a plain
+	/// <see cref="ContentControl"/>: content assigned while the host's subtree never
+	/// had a layout pass exists only as <c>ContentControl.Content</c>, invisible to
+	/// the HR visual-tree walk; the ContentControl handler must re-create it.
 	/// </summary>
 	[TestMethod]
 	public async Task When_Content_Updated_While_Unmaterialized_Then_Content_Recreated()
@@ -36,9 +34,8 @@ public class Given_ContentControl_StrandedContent : BaseTestClass
 		var staleContent = contentControl.Content as FrameworkElement;
 		Assert.IsNotNull(staleContent);
 
-		// Precondition: the content must be live-but-unmaterialized. If it has a visual
-		// parent, this test would exercise the regular visual-tree walk replacement
-		// path instead of the stranded-content one.
+		// Precondition: live-but-unmaterialized, otherwise this test exercises the
+		// regular visual-tree walk path instead of the stranded-content one.
 		Assert.IsNull(VisualTreeHelper.GetParent(staleContent), "the content must not be a materialized visual child");
 
 		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_UC1>(
@@ -46,13 +43,42 @@ public class Given_ContentControl_StrandedContent : BaseTestClass
 			ControlChangedText,
 			async () =>
 			{
-				// The stranded content must have been re-created by the ContentControl's
-				// element-update handler (the visual-tree walk cannot reach it).
-				Assert.AreNotEqual(staleContent, contentControl.Content, "the stranded content must be re-created by the hot reload");
+				Assert.AreNotSame(staleContent, contentControl.Content, "the stranded content must be re-created by the hot reload");
 
-				// Reveal the subtree and verify the updated content is what gets displayed.
 				host.Visibility = Visibility.Visible;
 				await contentControl.ValidateTextOnChildTextBlock(ControlChangedText);
+			},
+			ct);
+	}
+
+	/// <summary>
+	/// The "do not replace" guards: stranded content of a non-updated type keeps its
+	/// identity, and data-item content is never re-created.
+	/// </summary>
+	[TestMethod]
+	public async Task When_Unrelated_Type_Updated_Then_Stranded_Content_Untouched()
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+		var ct = cts.Token;
+
+		var host = new Grid { Visibility = Visibility.Collapsed };
+		var viewHost = new ContentControl { Content = new HR_Frame_Pages_UC1() };
+		var dataHost = new ContentControl { Content = "data-item" };
+		host.Children.Add(viewHost);
+		host.Children.Add(dataHost);
+		UnitTestsUIContentHelper.Content = host;
+
+		var staleView = viewHost.Content;
+		var staleData = dataHost.Content;
+
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_Page1>(
+			Given_Frame.FirstPageTextBlockOriginalText,
+			Given_Frame.FirstPageTextBlockChangedText,
+			() =>
+			{
+				Assert.AreSame(staleView, viewHost.Content, "stranded content of a non-updated type must keep its identity");
+				Assert.AreSame(staleData, dataHost.Content, "data-item content must never be re-created");
+				return Task.CompletedTask;
 			},
 			ct);
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
@@ -1,7 +1,5 @@
-using System.Reflection.Metadata;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml.Media;
-using Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
 using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
 
 namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
@@ -24,7 +22,8 @@ public class Given_ContentControl_StrandedContent : BaseTestClass
 	[TestMethod]
 	public async Task When_Content_Updated_While_Unmaterialized_Then_Content_Recreated()
 	{
-		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+		var ct = cts.Token;
 
 		var host = new Grid { Visibility = Visibility.Collapsed };
 		var contentControl = new ContentControl

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
@@ -1,0 +1,60 @@
+using System.Reflection.Metadata;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_ContentControl_StrandedContent : BaseTestClass
+{
+	public const string ControlOriginalText = "Control 1";
+	public const string ControlChangedText = ControlOriginalText + " (changed)";
+
+	/// <summary>
+	/// Same scenario as <see cref="Given_Frame_StrandedContent"/> but for a plain
+	/// <see cref="ContentControl"/>: content assigned while the host's subtree never had
+	/// a layout pass exists only as <c>ContentControl.Content</c> — the template is never
+	/// applied, so the content is not a materialized visual child and the hot-reload
+	/// visual-tree walk cannot see it. The ContentControl element-update handler must
+	/// re-create it so the updated content is shown once the subtree lays out.
+	/// </summary>
+	[TestMethod]
+	public async Task When_Content_Updated_While_Unmaterialized_Then_Content_Recreated()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+
+		var host = new Grid { Visibility = Visibility.Collapsed };
+		var contentControl = new ContentControl
+		{
+			Content = new HR_Frame_Pages_UC1(),
+		};
+		host.Children.Add(contentControl);
+		UnitTestsUIContentHelper.Content = host;
+
+		var staleContent = contentControl.Content as FrameworkElement;
+		Assert.IsNotNull(staleContent);
+
+		// Precondition: the content must be live-but-unmaterialized. If it has a visual
+		// parent, this test would exercise the regular visual-tree walk replacement
+		// path instead of the stranded-content one.
+		Assert.IsNull(VisualTreeHelper.GetParent(staleContent), "the content must not be a materialized visual child");
+
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_UC1>(
+			ControlOriginalText,
+			ControlChangedText,
+			async () =>
+			{
+				// The stranded content must have been re-created by the ContentControl's
+				// element-update handler (the visual-tree walk cannot reach it).
+				Assert.AreNotEqual(staleContent, contentControl.Content, "the stranded content must be re-created by the hot reload");
+
+				// Reveal the subtree and verify the updated content is what gets displayed.
+				host.Visibility = Visibility.Visible;
+				await contentControl.ValidateTextOnChildTextBlock(ControlChangedText);
+			},
+			ct);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
 
@@ -47,6 +48,45 @@ public class Given_ContentControl_StrandedContent : BaseTestClass
 
 				host.Visibility = Visibility.Visible;
 				await contentControl.ValidateTextOnChildTextBlock(ControlChangedText);
+			},
+			ct);
+	}
+
+	/// <summary>
+	/// Local values move to the re-created instance the same way the visual-tree walk
+	/// transfers them — notably attached properties, which navigation frameworks set on
+	/// content right after creating it — while an inherited DataContext keeps flowing
+	/// from the host rather than being pinned on the new instance.
+	/// </summary>
+	[TestMethod]
+	public async Task When_Content_Updated_While_Unmaterialized_Then_Local_Values_Are_Transferred()
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+		var ct = cts.Token;
+
+		var host = new Grid { Visibility = Visibility.Collapsed, DataContext = "host-context" };
+		var contentControl = new ContentControl { Content = new HR_Frame_Pages_UC1() };
+		host.Children.Add(contentControl);
+		UnitTestsUIContentHelper.Content = host;
+
+		var staleContent = (FrameworkElement)contentControl.Content;
+		staleContent.Tag = "local-tag";
+		AutomationProperties.SetName(staleContent, "local-attached");
+
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_UC1>(
+			ControlOriginalText,
+			ControlChangedText,
+			() =>
+			{
+				var newContent = contentControl.Content as FrameworkElement;
+				Assert.AreNotSame(staleContent, newContent);
+
+				Assert.AreEqual("local-tag", newContent.Tag, "a locally-set value must be transferred");
+				Assert.AreEqual("local-attached", AutomationProperties.GetName(newContent), "a locally-set attached property must be transferred");
+				Assert.AreEqual(DependencyProperty.UnsetValue, newContent.ReadLocalValue(FrameworkElement.DataContextProperty),
+					"an inherited DataContext must not be pinned as a local value");
+
+				return Task.CompletedTask;
 			},
 			ct);
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_ContentControl_StrandedContent.cs
@@ -79,6 +79,7 @@ public class Given_ContentControl_StrandedContent : BaseTestClass
 			() =>
 			{
 				var newContent = contentControl.Content as FrameworkElement;
+				Assert.IsNotNull(newContent, "the stranded content must have been re-created");
 				Assert.AreNotSame(staleContent, newContent);
 
 				Assert.AreEqual("local-tag", newContent.Tag, "a locally-set value must be transferred");

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_StrandedContent.cs
@@ -1,7 +1,5 @@
-using System.Reflection.Metadata;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml.Media;
-using Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
 using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
 
 namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
@@ -21,7 +19,8 @@ public class Given_Frame_StrandedContent : BaseTestClass
 	[TestMethod]
 	public async Task When_Page_Updated_While_Unmaterialized_Then_Content_Recreated()
 	{
-		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+		var ct = cts.Token;
 
 		var host = new Grid { Visibility = Visibility.Collapsed };
 		var frame = new Microsoft.UI.Xaml.Controls.Frame();

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_StrandedContent.cs
@@ -1,0 +1,57 @@
+using System.Reflection.Metadata;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_Frame_StrandedContent : BaseTestClass
+{
+	/// <summary>
+	/// A page navigated into a frame whose subtree never had a layout pass (e.g. a
+	/// collapsed ancestor) exists only as <c>Frame.Content</c> — the frame's template is
+	/// never applied, so the page is not a materialized visual child and the hot-reload
+	/// visual-tree walk cannot see it. The frame's element-update handler must re-create
+	/// the stranded page so the updated content is shown once the subtree finally lays
+	/// out; without that, the stale pre-update page is displayed.
+	/// </summary>
+	[TestMethod]
+	public async Task When_Page_Updated_While_Unmaterialized_Then_Content_Recreated()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+
+		var host = new Grid { Visibility = Visibility.Collapsed };
+		var frame = new Microsoft.UI.Xaml.Controls.Frame();
+		host.Children.Add(frame);
+		UnitTestsUIContentHelper.Content = host;
+
+		frame.Navigate(typeof(HR_Frame_Pages_Page1));
+
+		var stalePage = frame.Content as Page;
+		Assert.IsNotNull(stalePage, "Frame.Navigate must set Frame.Content even without a layout pass");
+
+		// Precondition: the page must be live-but-unmaterialized. If it has a visual
+		// parent, this test would exercise the regular visual-tree walk replacement
+		// path instead of the stranded-content one.
+		Assert.IsNull(VisualTreeHelper.GetParent(stalePage), "the page must not be a materialized visual child");
+
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_Page1>(
+			Given_Frame.FirstPageTextBlockOriginalText,
+			Given_Frame.FirstPageTextBlockChangedText,
+			async () =>
+			{
+				// The stranded page must have been re-created by the frame's
+				// element-update handler (the visual-tree walk cannot reach it).
+				Assert.AreNotEqual(stalePage, frame.Content, "the stranded page must be re-created by the hot reload");
+
+				// Reveal the subtree — the moment a real app's host view becomes
+				// visible — and verify the updated content is what gets displayed.
+				host.Visibility = Visibility.Visible;
+				await frame.ValidateTextOnChildTextBlock(Given_Frame.FirstPageTextBlockChangedText);
+			},
+			ct);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_StrandedContent.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_StrandedContent.cs
@@ -9,12 +9,10 @@ namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
 public class Given_Frame_StrandedContent : BaseTestClass
 {
 	/// <summary>
-	/// A page navigated into a frame whose subtree never had a layout pass (e.g. a
-	/// collapsed ancestor) exists only as <c>Frame.Content</c> — the frame's template is
-	/// never applied, so the page is not a materialized visual child and the hot-reload
-	/// visual-tree walk cannot see it. The frame's element-update handler must re-create
-	/// the stranded page so the updated content is shown once the subtree finally lays
-	/// out; without that, the stale pre-update page is displayed.
+	/// A page navigated into a frame whose subtree never had a layout pass exists only
+	/// as <c>Frame.Content</c> — the HR visual-tree walk cannot see it. The frame's
+	/// element-update handler must re-create it (and keep the navigation history in
+	/// sync) so the updated content is shown once the subtree lays out.
 	/// </summary>
 	[TestMethod]
 	public async Task When_Page_Updated_While_Unmaterialized_Then_Content_Recreated()
@@ -32,9 +30,8 @@ public class Given_Frame_StrandedContent : BaseTestClass
 		var stalePage = frame.Content as Page;
 		Assert.IsNotNull(stalePage, "Frame.Navigate must set Frame.Content even without a layout pass");
 
-		// Precondition: the page must be live-but-unmaterialized. If it has a visual
-		// parent, this test would exercise the regular visual-tree walk replacement
-		// path instead of the stranded-content one.
+		// Precondition: live-but-unmaterialized, otherwise this test exercises the
+		// regular visual-tree walk path instead of the stranded-content one.
 		Assert.IsNull(VisualTreeHelper.GetParent(stalePage), "the page must not be a materialized visual child");
 
 		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_Page1>(
@@ -42,13 +39,15 @@ public class Given_Frame_StrandedContent : BaseTestClass
 			Given_Frame.FirstPageTextBlockChangedText,
 			async () =>
 			{
-				// The stranded page must have been re-created by the frame's
-				// element-update handler (the visual-tree walk cannot reach it).
-				Assert.AreNotEqual(stalePage, frame.Content, "the stranded page must be re-created by the hot reload");
+				Assert.AreNotSame(stalePage, frame.Content, "the stranded page must be re-created by the hot reload");
 
-				// Reveal the subtree — the moment a real app's host view becomes
-				// visible — and verify the updated content is what gets displayed.
 				host.Visibility = Visibility.Visible;
+				await frame.ValidateTextOnChildTextBlock(Given_Frame.FirstPageTextBlockChangedText);
+
+				// Back-navigation must land on the re-created instance, not the stale one.
+				frame.Navigate(typeof(HR_Frame_Pages_Page2));
+				await frame.ValidateTextOnChildTextBlock(Given_Frame.SecondPageTextBlockOriginalText);
+				frame.GoBack();
 				await frame.ValidateTextOnChildTextBlock(Given_Frame.FirstPageTextBlockChangedText);
 			},
 			ct);

--- a/src/Uno.UI/Helpers/TypeActivator.cs
+++ b/src/Uno.UI/Helpers/TypeActivator.cs
@@ -1,0 +1,30 @@
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.UI.Helpers;
+
+/// <summary>
+/// Creates view instances honoring the current hot-reload replacement type, preferring the
+/// bindable metadata provider's generated activator when one is registered.
+/// </summary>
+/// <remarks>
+/// Kept out of <see cref="TypeMappings"/> on purpose: that file is linked into
+/// <c>Uno.UI.Toolkit.Windows</c>, where <c>Uno.UI.DataBinding</c> does not exist.
+/// </remarks>
+internal static class TypeActivator
+{
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
+	internal static object CreateInstance([DynamicallyAccessedMembers(TypeMappings.TypeRequirements)] Type type)
+	{
+		var replacementType = type.GetReplacementType();
+
+		if (Uno.UI.DataBinding.BindingPropertyHelper.BindableMetadataProvider?.GetBindableTypeByType(replacementType)?.CreateInstance() is { } factory)
+		{
+			return factory();
+		}
+
+		return Activator.CreateInstance(replacementType)!;
+	}
+}

--- a/src/Uno.UI/Helpers/TypeMappings.cs
+++ b/src/Uno.UI/Helpers/TypeMappings.cs
@@ -71,6 +71,23 @@ public static class TypeMappings
 	public static object CreateInstance<[DynamicallyAccessedMembers(TypeRequirements)] TOriginalType>(params object[] args)
 		=> Activator.CreateInstance(typeof(TOriginalType).GetReplacementType(), args: args);
 
+	/// <summary>
+	/// Creates an instance of <paramref name="type"/>'s current replacement type, going through the
+	/// bindable metadata provider when one is registered so generated activators are used.
+	/// </summary>
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
+	internal static object CreateInstance([DynamicallyAccessedMembers(TypeRequirements)] Type type)
+	{
+		var replacementType = type.GetReplacementType();
+
+		if (Uno.UI.DataBinding.BindingPropertyHelper.BindableMetadataProvider?.GetBindableTypeByType(replacementType) is { } bindableType)
+		{
+			return bindableType.CreateInstance()();
+		}
+
+		return Activator.CreateInstance(replacementType);
+	}
+
 	[return: DynamicallyAccessedMembers(TypeRequirements)]
 	internal static Type GetMappedType(
 		[DynamicallyAccessedMembers(TypeRequirements)]

--- a/src/Uno.UI/Helpers/TypeMappings.cs
+++ b/src/Uno.UI/Helpers/TypeMappings.cs
@@ -71,23 +71,6 @@ public static class TypeMappings
 	public static object CreateInstance<[DynamicallyAccessedMembers(TypeRequirements)] TOriginalType>(params object[] args)
 		=> Activator.CreateInstance(typeof(TOriginalType).GetReplacementType(), args: args);
 
-	/// <summary>
-	/// Creates an instance of <paramref name="type"/>'s current replacement type, going through the
-	/// bindable metadata provider when one is registered so generated activators are used.
-	/// </summary>
-	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
-	internal static object CreateInstance([DynamicallyAccessedMembers(TypeRequirements)] Type type)
-	{
-		var replacementType = type.GetReplacementType();
-
-		if (Uno.UI.DataBinding.BindingPropertyHelper.BindableMetadataProvider?.GetBindableTypeByType(replacementType) is { } bindableType)
-		{
-			return bindableType.CreateInstance()();
-		}
-
-		return Activator.CreateInstance(replacementType);
-	}
-
 	[return: DynamicallyAccessedMembers(TypeRequirements)]
 	internal static Type GetMappedType(
 		[DynamicallyAccessedMembers(TypeRequirements)]

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -16,9 +16,8 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 {
 	public static void ElementUpdate(FrameworkElement element, Type[] updatedTypes)
 	{
-		// Frame has its own element-update handler which additionally keeps the navigation
-		// history in sync with the re-created page — let it own its content patching
-		// entirely so the two handlers never double-replace the same instance.
+		// Frame's own handler patches its content and syncs the navigation history;
+		// skipping it here prevents the two handlers from double-replacing.
 		if (element is not ContentControl contentControl || contentControl is Frame)
 		{
 			return;
@@ -31,30 +30,22 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 	}
 
 	/// <summary>
-	/// Creates a replacement for the host's current content when that content's type was
-	/// hot-reloaded but the content was never materialized in the visual tree — e.g. the
-	/// host lives under an ancestor that has not had a layout pass, so its template was
-	/// never applied and the content exists only as <see cref="ContentControl.Content"/>.
-	/// The hot-reload visual-tree walk enumerates materialized children only, so it cannot
-	/// replace such an instance itself; without this, the stale pre-update content is what
-	/// gets displayed once the subtree is finally materialized.
-	/// Returns <see langword="null"/> when there is nothing to patch (data-item content,
-	/// materialized content, type not updated, or no parameterless constructor).
+	/// Re-creates content whose type was hot-reloaded while the content was never
+	/// materialized in the visual tree (host not laid out, template never applied) —
+	/// the HR visual-tree walk only enumerates materialized children and cannot
+	/// replace such an instance itself. Returns null when there is nothing to patch.
 	/// </summary>
 	[UnconditionalSuppressMessage("Trimming", "IL2072")]
-	// Hot reload is only expected to work when trimming is disabled; TypeMappings
-	// preserves the replacement types' constructors.
+	// Hot reload requires trimming disabled; TypeMappings preserves replacement ctors.
 	internal static FrameworkElement? CreateReplacementForStrandedContent(ContentControl host, Type[] updatedTypes)
 	{
-		// Content can be a plain data item rendered through a ContentTemplate — only view
-		// instances can be re-created here.
+		// Data-item content rendered through a ContentTemplate is never re-created.
 		if (host.Content is not FrameworkElement currentContent)
 		{
 			return null;
 		}
 
-		// Materialized content is enumerated (and replaced) by the hot-reload visual-tree
-		// walk itself — patching it here as well would double-replace it.
+		// Materialized content is replaced by the visual-tree walk itself.
 		if (VisualTreeHelper.GetParent(currentContent) is not null)
 		{
 			return null;
@@ -63,8 +54,7 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 		var liveType = currentContent.GetType();
 		var expectedType = liveType.GetReplacementType();
 
-		// CNOMU update: the live type maps to a replacement type.
-		// In-place (EnC) update: same type identity, but present in the updated list.
+		// Same triggers as the walk: a CNOMU replacement type or an in-place (EnC) update.
 		var isUpdated = expectedType != liveType || Array.IndexOf(updatedTypes, liveType) >= 0;
 		if (!isUpdated)
 		{
@@ -80,22 +70,16 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 		FrameworkElement? newContent;
 		try
 		{
-			// Despite its name, Frame.CreatePageInstance is the centralized, type-agnostic
-			// hot-reload-aware creation path (replacement-type resolution + bindable metadata
-			// provider support) also used by NavigationCache and PagePool. No constructor
-			// pre-check here: a bindable metadata activator may construct types a reflection
-			// probe would reject, so creation failure is handled instead of predicted.
+			// Centralized HR-aware creation (replacement-type resolution + bindable
+			// metadata provider), also used by NavigationCache and PagePool.
 			newContent = Frame.CreatePageInstance(liveType) as FrameworkElement;
 		}
 		catch (Exception e)
 		{
-			// The replacement type cannot be constructed (e.g. no parameterless constructor
-			// and no bindable activator) — keep the stale content rather than failing the
-			// hot-reload pass; the visual-tree walk applies the same tolerance.
-			if (typeof(ContentControlElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Debug))
+			if (typeof(ContentControlElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Warning))
 			{
-				typeof(ContentControlElementMetadataUpdateHandler).Log().Debug(
-					$"Could not re-create stranded content {liveType.Name} as {expectedType.Name}: {e.Message}");
+				typeof(ContentControlElementMetadataUpdateHandler).Log().Warn(
+					$"Could not re-create stranded content {liveType.Name} as {expectedType.Name}; keeping the stale instance.", e);
 			}
 
 			return null;
@@ -103,13 +87,18 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 
 		if (newContent is null)
 		{
+			if (typeof(ContentControlElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Warning))
+			{
+				typeof(ContentControlElementMetadataUpdateHandler).Log().Warn(
+					$"Could not re-create stranded content {liveType.Name} as {expectedType.Name} (no instance produced); keeping the stale instance.");
+			}
+
 			return null;
 		}
 
-		// Carry the DataContext over only when the old content had its own value —
-		// an inherited DataContext must keep flowing from the host rather than being
-		// pinned onto the new instance.
-		if (!ReferenceEquals(currentContent.DataContext, host.DataContext))
+		// Copy the DataContext only when it was locally set; an inherited value must
+		// keep flowing from the host instead of being pinned on the new instance.
+		if (currentContent.ReadLocalValue(FrameworkElement.DataContextProperty) != DependencyProperty.UnsetValue)
 		{
 			newContent.DataContext = currentContent.DataContext;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -1,0 +1,96 @@
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection.Metadata;
+using Microsoft.UI.Xaml.Media;
+using Uno.Foundation.Logging;
+using Uno.UI.Helpers;
+
+[assembly: ElementMetadataUpdateHandlerAttribute(typeof(Microsoft.UI.Xaml.Controls.ContentControl), typeof(Microsoft.UI.Xaml.Controls.ContentControlElementMetadataUpdateHandler))]
+
+namespace Microsoft.UI.Xaml.Controls;
+
+internal static partial class ContentControlElementMetadataUpdateHandler
+{
+	public static void ElementUpdate(FrameworkElement element, Type[] updatedTypes)
+	{
+		// Frame has its own element-update handler which additionally keeps the navigation
+		// history in sync with the re-created page — let it own its content patching
+		// entirely so the two handlers never double-replace the same instance.
+		if (element is not ContentControl contentControl || contentControl is Frame)
+		{
+			return;
+		}
+
+		if (CreateReplacementForStrandedContent(contentControl, updatedTypes) is { } newContent)
+		{
+			contentControl.Content = newContent;
+		}
+	}
+
+	/// <summary>
+	/// Creates a replacement for the host's current content when that content's type was
+	/// hot-reloaded but the content was never materialized in the visual tree — e.g. the
+	/// host lives under an ancestor that has not had a layout pass, so its template was
+	/// never applied and the content exists only as <see cref="ContentControl.Content"/>.
+	/// The hot-reload visual-tree walk enumerates materialized children only, so it cannot
+	/// replace such an instance itself; without this, the stale pre-update content is what
+	/// gets displayed once the subtree is finally materialized.
+	/// Returns <see langword="null"/> when there is nothing to patch (data-item content,
+	/// materialized content, type not updated, or no parameterless constructor).
+	/// </summary>
+	[UnconditionalSuppressMessage("Trimming", "IL2072")]
+	// Hot reload is only expected to work when trimming is disabled; TypeMappings
+	// preserves the replacement types' constructors.
+	internal static FrameworkElement? CreateReplacementForStrandedContent(ContentControl host, Type[] updatedTypes)
+	{
+		// Content can be a plain data item rendered through a ContentTemplate — only view
+		// instances can be re-created here.
+		if (host.Content is not FrameworkElement currentContent)
+		{
+			return null;
+		}
+
+		// Materialized content is enumerated (and replaced) by the hot-reload visual-tree
+		// walk itself — patching it here as well would double-replace it.
+		if (VisualTreeHelper.GetParent(currentContent) is not null)
+		{
+			return null;
+		}
+
+		var liveType = currentContent.GetType();
+		var expectedType = liveType.GetReplacementType();
+
+		// CNOMU update: the live type maps to a replacement type.
+		// In-place (EnC) update: same type identity, but present in the updated list.
+		var isUpdated = expectedType != liveType || Array.IndexOf(updatedTypes, liveType) >= 0;
+		if (!isUpdated || expectedType.GetConstructor(Type.EmptyTypes) is null)
+		{
+			return null;
+		}
+
+		if (typeof(ContentControlElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Debug))
+		{
+			typeof(ContentControlElementMetadataUpdateHandler).Log().Debug(
+				$"Re-creating stranded (unmaterialized) content {liveType.Name} of {host.GetType().Name} as {expectedType.Name}");
+		}
+
+		if (Activator.CreateInstance(expectedType) is not FrameworkElement newContent)
+		{
+			return null;
+		}
+
+		// Carry the DataContext over only when the old content had its own value —
+		// an inherited DataContext must keep flowing from the host rather than being
+		// pinned onto the new instance.
+		if (!ReferenceEquals(currentContent.DataContext, host.DataContext))
+		{
+			newContent.DataContext = currentContent.DataContext;
+		}
+
+		return newContent;
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -66,7 +66,7 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 		// CNOMU update: the live type maps to a replacement type.
 		// In-place (EnC) update: same type identity, but present in the updated list.
 		var isUpdated = expectedType != liveType || Array.IndexOf(updatedTypes, liveType) >= 0;
-		if (!isUpdated || expectedType.GetConstructor(Type.EmptyTypes) is null)
+		if (!isUpdated)
 		{
 			return null;
 		}
@@ -77,10 +77,31 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 				$"Re-creating stranded (unmaterialized) content {liveType.Name} of {host.GetType().Name} as {expectedType.Name}");
 		}
 
-		// Despite its name, Frame.CreatePageInstance is the centralized, type-agnostic
-		// hot-reload-aware creation path (replacement-type resolution + bindable metadata
-		// provider support) also used by NavigationCache and PagePool.
-		if (Frame.CreatePageInstance(liveType) is not FrameworkElement newContent)
+		FrameworkElement? newContent;
+		try
+		{
+			// Despite its name, Frame.CreatePageInstance is the centralized, type-agnostic
+			// hot-reload-aware creation path (replacement-type resolution + bindable metadata
+			// provider support) also used by NavigationCache and PagePool. No constructor
+			// pre-check here: a bindable metadata activator may construct types a reflection
+			// probe would reject, so creation failure is handled instead of predicted.
+			newContent = Frame.CreatePageInstance(liveType) as FrameworkElement;
+		}
+		catch (Exception e)
+		{
+			// The replacement type cannot be constructed (e.g. no parameterless constructor
+			// and no bindable activator) — keep the stale content rather than failing the
+			// hot-reload pass; the visual-tree walk applies the same tolerance.
+			if (typeof(ContentControlElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(ContentControlElementMetadataUpdateHandler).Log().Debug(
+					$"Could not re-create stranded content {liveType.Name} as {expectedType.Name}: {e.Message}");
+			}
+
+			return null;
+		}
+
+		if (newContent is null)
 		{
 			return null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -77,7 +77,10 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 				$"Re-creating stranded (unmaterialized) content {liveType.Name} of {host.GetType().Name} as {expectedType.Name}");
 		}
 
-		if (Activator.CreateInstance(expectedType) is not FrameworkElement newContent)
+		// Despite its name, Frame.CreatePageInstance is the centralized, type-agnostic
+		// hot-reload-aware creation path (replacement-type resolution + bindable metadata
+		// provider support) also used by NavigationCache and PagePool.
+		if (Frame.CreatePageInstance(liveType) is not FrameworkElement newContent)
 		{
 			return null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -75,7 +75,7 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 		{
 			// Centralized HR-aware creation (replacement-type resolution + bindable
 			// metadata provider), also used by navigation through Frame.CreatePageInstance.
-			newContent = TypeMappings.CreateInstance(liveType) as FrameworkElement;
+			newContent = TypeActivator.CreateInstance(liveType) as FrameworkElement;
 		}
 		catch (Exception e)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using Microsoft.UI.Xaml.Media;
 using Uno.Foundation.Logging;
+using Uno.UI.DataBinding;
 using Uno.UI.Helpers;
 
 [assembly: ElementMetadataUpdateHandlerAttribute(typeof(Microsoft.UI.Xaml.Controls.ContentControl), typeof(Microsoft.UI.Xaml.Controls.ContentControlElementMetadataUpdateHandler))]
@@ -34,6 +35,8 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 	/// materialized in the visual tree (host not laid out, template never applied) —
 	/// the HR visual-tree walk only enumerates materialized children and cannot
 	/// replace such an instance itself. Returns null when there is nothing to patch.
+	/// Deliberately does not raise Before/AfterElementReplaced — those belong to the walk;
+	/// consumers reconcile in AfterVisualTreeUpdate (see uno-internals-hotreload.md).
 	/// </summary>
 	[UnconditionalSuppressMessage("Trimming", "IL2072")]
 	// Hot reload requires trimming disabled; TypeMappings preserves replacement ctors.
@@ -96,12 +99,11 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 			return null;
 		}
 
-		// Copy the DataContext only when it was locally set; an inherited value must
-		// keep flowing from the host instead of being pinned on the new instance.
-		if (currentContent.ReadLocalValue(FrameworkElement.DataContextProperty) != DependencyProperty.UnsetValue)
-		{
-			newContent.DataContext = currentContent.DataContext;
-		}
+		// Same transfer the walk's ReplaceViewInstance does. It moves local values only — including
+		// attached properties (region/route properties set by navigation frameworks) and bindings —
+		// so an inherited DataContext keeps flowing from the host instead of being pinned here.
+		((IDependencyObjectStoreProvider)currentContent).Store
+			.ClonePropertiesToAnotherStoreForHotReload(((IDependencyObjectStoreProvider)newContent).Store);
 
 		return newContent;
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.HotReload.cs
@@ -74,8 +74,8 @@ internal static partial class ContentControlElementMetadataUpdateHandler
 		try
 		{
 			// Centralized HR-aware creation (replacement-type resolution + bindable
-			// metadata provider), also used by NavigationCache and PagePool.
-			newContent = Frame.CreatePageInstance(liveType) as FrameworkElement;
+			// metadata provider), also used by navigation through Frame.CreatePageInstance.
+			newContent = TypeMappings.CreateInstance(liveType) as FrameworkElement;
 		}
 		catch (Exception e)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.HotReload.cs
@@ -77,12 +77,9 @@ partial class Frame
 		}
 
 		/// <summary>
-		/// Re-creates the frame's current page when its type was hot-reloaded but the page
-		/// was never materialized in the visual tree (see
-		/// <see cref="ContentControlElementMetadataUpdateHandler.CreateReplacementForStrandedContent"/>,
-		/// which implements the shared stranded-content detection), then keeps the
-		/// navigation history pointing at the new instance — the Frame-specific part a
-		/// plain <see cref="ContentControl"/> does not need.
+		/// Re-creates the frame's current page when it was hot-reloaded while never
+		/// materialized (see <see cref="ContentControlElementMetadataUpdateHandler.CreateReplacementForStrandedContent"/>),
+		/// then keeps the navigation history pointing at the new instance.
 		/// </summary>
 		private static void PatchStrandedContent(Frame frame, Type[] updatedTypes)
 		{
@@ -92,19 +89,18 @@ partial class Frame
 			}
 
 			newPage.Frame = frame;
+			frame.SetContent(newPage);
 
-			// In legacy mode OnContentChanged syncs CurrentEntry automatically when Content
-			// changes; the WinUI-behavior history entry must be patched explicitly.
+			// Legacy mode syncs CurrentEntry in OnContentChanged; the WinUI-behavior
+			// history entry must be patched explicitly.
 			if (frame._useWinUIBehavior && frame.GetCurrentPageStackEntry() is { } entry)
 			{
 				entry.Instance = newPage;
 				SetSourcePageType(entry, newPage.GetType());
 			}
 
-			frame.SetContent(newPage);
-
 			[UnconditionalSuppressMessage("Trimming", "IL2067")]
-			// The replacement type comes from TypeMappings which preserves constructors for hot reload.
+			// Replacement types come from TypeMappings, which preserves their constructors.
 			static void SetSourcePageType(Navigation.PageStackEntry entry, Type type)
 			{
 				entry.SourcePageType = type;

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.HotReload.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
-using Microsoft.UI.Xaml.Media;
 using Uno.Foundation.Logging;
 using Uno.UI.Helpers;
 
@@ -79,67 +78,33 @@ partial class Frame
 
 		/// <summary>
 		/// Re-creates the frame's current page when its type was hot-reloaded but the page
-		/// was never materialized in the visual tree — e.g. the frame lives under an ancestor
-		/// that has not had a layout pass, so the page exists only as <see cref="ContentControl.Content"/>.
-		/// The hot-reload visual-tree walk enumerates materialized children only, so it cannot
-		/// replace such an instance itself; without this patch the stale pre-update page is shown
-		/// once the subtree is finally materialized.
+		/// was never materialized in the visual tree (see
+		/// <see cref="ContentControlElementMetadataUpdateHandler.CreateReplacementForStrandedContent"/>,
+		/// which implements the shared stranded-content detection), then keeps the
+		/// navigation history pointing at the new instance — the Frame-specific part a
+		/// plain <see cref="ContentControl"/> does not need.
 		/// </summary>
-		[UnconditionalSuppressMessage("Trimming", "IL2072")]
-		// Hot reload is only expected to work when trimming is disabled; TypeMappings
-		// preserves the replacement types' constructors.
 		private static void PatchStrandedContent(Frame frame, Type[] updatedTypes)
 		{
-			if (frame.Content is not Page currentPage)
-			{
-				return;
-			}
-
-			// A materialized page is enumerated (and replaced) by the hot-reload visual-tree
-			// walk itself — patching it here as well would double-replace it.
-			if (VisualTreeHelper.GetParent(currentPage) is not null)
-			{
-				return;
-			}
-
-			var liveType = currentPage.GetType();
-			var expectedType = liveType.GetReplacementType();
-
-			// CNOMU update: the live type maps to a replacement type.
-			// In-place (EnC) update: same type identity, but present in the updated list.
-			var isUpdated = expectedType != liveType || Array.IndexOf(updatedTypes, liveType) >= 0;
-			if (!isUpdated || expectedType.GetConstructor(Type.EmptyTypes) is null)
-			{
-				return;
-			}
-
-			if (typeof(FrameElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Debug))
-			{
-				typeof(FrameElementMetadataUpdateHandler).Log().Debug(
-					$"Re-creating stranded (unmaterialized) frame content {liveType.Name} as {expectedType.Name}");
-			}
-
-			if (Activator.CreateInstance(expectedType) is not Page newPage)
+			if (ContentControlElementMetadataUpdateHandler.CreateReplacementForStrandedContent(frame, updatedTypes) is not Page newPage)
 			{
 				return;
 			}
 
 			newPage.Frame = frame;
-			newPage.DataContext = currentPage.DataContext;
 
-			// Keep the navigation history pointing at the new instance. In legacy mode
-			// OnContentChanged syncs CurrentEntry automatically when Content changes; the
-			// WinUI-behavior history entry must be patched explicitly.
+			// In legacy mode OnContentChanged syncs CurrentEntry automatically when Content
+			// changes; the WinUI-behavior history entry must be patched explicitly.
 			if (frame._useWinUIBehavior && frame.GetCurrentPageStackEntry() is { } entry)
 			{
 				entry.Instance = newPage;
-				SetSourcePageType(entry, expectedType);
+				SetSourcePageType(entry, newPage.GetType());
 			}
 
 			frame.SetContent(newPage);
 
 			[UnconditionalSuppressMessage("Trimming", "IL2067")]
-			// 'expectedType' comes from TypeMappings which preserves constructors for hot reload.
+			// The replacement type comes from TypeMappings which preserves constructors for hot reload.
 			static void SetSourcePageType(Navigation.PageStackEntry entry, Type type)
 			{
 				entry.SourcePageType = type;

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.HotReload.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.HotReload.cs
@@ -1,7 +1,9 @@
 ﻿#if HAS_UNO // We don't have access to the instance of the page entry in the backstack on Windows
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
+using Microsoft.UI.Xaml.Media;
 using Uno.Foundation.Logging;
 using Uno.UI.Helpers;
 
@@ -34,6 +36,8 @@ partial class Frame
 					frame.RemovePageFromCache(type.FullName);
 					frame.RemovePageFromCache(Navigation.PageStackEntry.BuildDescriptor(type));
 				}
+
+				PatchStrandedContent(frame, updatedTypes);
 			}
 			else // Uno's legacy implementation
 			{
@@ -68,6 +72,77 @@ partial class Frame
 						entry.SourcePageType = expectedType;
 					}
 				}
+
+				PatchStrandedContent(frame, updatedTypes);
+			}
+		}
+
+		/// <summary>
+		/// Re-creates the frame's current page when its type was hot-reloaded but the page
+		/// was never materialized in the visual tree — e.g. the frame lives under an ancestor
+		/// that has not had a layout pass, so the page exists only as <see cref="ContentControl.Content"/>.
+		/// The hot-reload visual-tree walk enumerates materialized children only, so it cannot
+		/// replace such an instance itself; without this patch the stale pre-update page is shown
+		/// once the subtree is finally materialized.
+		/// </summary>
+		[UnconditionalSuppressMessage("Trimming", "IL2072")]
+		// Hot reload is only expected to work when trimming is disabled; TypeMappings
+		// preserves the replacement types' constructors.
+		private static void PatchStrandedContent(Frame frame, Type[] updatedTypes)
+		{
+			if (frame.Content is not Page currentPage)
+			{
+				return;
+			}
+
+			// A materialized page is enumerated (and replaced) by the hot-reload visual-tree
+			// walk itself — patching it here as well would double-replace it.
+			if (VisualTreeHelper.GetParent(currentPage) is not null)
+			{
+				return;
+			}
+
+			var liveType = currentPage.GetType();
+			var expectedType = liveType.GetReplacementType();
+
+			// CNOMU update: the live type maps to a replacement type.
+			// In-place (EnC) update: same type identity, but present in the updated list.
+			var isUpdated = expectedType != liveType || Array.IndexOf(updatedTypes, liveType) >= 0;
+			if (!isUpdated || expectedType.GetConstructor(Type.EmptyTypes) is null)
+			{
+				return;
+			}
+
+			if (typeof(FrameElementMetadataUpdateHandler).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(FrameElementMetadataUpdateHandler).Log().Debug(
+					$"Re-creating stranded (unmaterialized) frame content {liveType.Name} as {expectedType.Name}");
+			}
+
+			if (Activator.CreateInstance(expectedType) is not Page newPage)
+			{
+				return;
+			}
+
+			newPage.Frame = frame;
+			newPage.DataContext = currentPage.DataContext;
+
+			// Keep the navigation history pointing at the new instance. In legacy mode
+			// OnContentChanged syncs CurrentEntry automatically when Content changes; the
+			// WinUI-behavior history entry must be patched explicitly.
+			if (frame._useWinUIBehavior && frame.GetCurrentPageStackEntry() is { } entry)
+			{
+				entry.Instance = newPage;
+				SetSourcePageType(entry, expectedType);
+			}
+
+			frame.SetContent(newPage);
+
+			[UnconditionalSuppressMessage("Trimming", "IL2067")]
+			// 'expectedType' comes from TypeMappings which preserves constructors for hot reload.
+			static void SetSourcePageType(Navigation.PageStackEntry entry, Type type)
+			{
+				entry.SourcePageType = type;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -166,7 +166,7 @@ public partial class Frame : ContentControl
 	internal static object CreatePageInstance(
 		[DynamicallyAccessedMembers(TypeMappings.TypeRequirements)]
 		Type sourcePageType)
-		=> TypeMappings.CreateInstance(sourcePageType);
+		=> TypeActivator.CreateInstance(sourcePageType);
 
 	internal PageStackEntry GetCurrentPageStackEntry() => _useWinUIBehavior ? m_tpNavigationHistory.GetCurrentPageStackEntry() : CurrentEntry;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -163,24 +163,10 @@ public partial class Frame : ContentControl
 		}
 	}
 
-	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
 	internal static object CreatePageInstance(
 		[DynamicallyAccessedMembers(TypeMappings.TypeRequirements)]
 		Type sourcePageType)
-	{
-		var replacementType = sourcePageType.GetReplacementType(); // Get latest replacement type to handle Hot Reload.
-		if (Uno.UI.DataBinding.BindingPropertyHelper.BindableMetadataProvider != null)
-		{
-			var bindableType = Uno.UI.DataBinding.BindingPropertyHelper.BindableMetadataProvider.GetBindableTypeByType(replacementType);
-
-			if (bindableType != null)
-			{
-				return bindableType.CreateInstance()();
-			}
-		}
-
-		return Activator.CreateInstance(replacementType);
-	}
+		=> TypeMappings.CreateInstance(sourcePageType);
 
 	internal PageStackEntry GetCurrentPageStackEntry() => _useWinUIBehavior ? m_tpNavigationHistory.GetCurrentPageStackEntry() : CurrentEntry;
 


### PR DESCRIPTION
**GitHub Issue:** related to https://github.com/unoplatform/uno.extensions/issues/3130

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior:** the hot-reload UI-update phase replaces live instances of updated types by walking the visual tree (`VisualTreeHelper` children only). Content assigned to a `ContentControl` whose subtree never got a layout pass — e.g. the host sits under a collapsed ancestor, or the hosting view is not composited yet — exists only as the `Content` property: the control's template never applied, so the content is never materialized as a visual child. The walk cannot see it, so the stale pre-update instance is what gets shown once the subtree finally lays out. The most common shape is a `Page` navigated into a `Frame` (`FrameElementMetadataUpdateHandler` already re-creates page instances for the back/forward stack, but not the current page), but any `ContentControl` hosting an updated view type has the same blind spot.

**New behavior:** stranded content is re-created by the element-update handlers, for all ContentControls:

- New `ContentControlElementMetadataUpdateHandler` (registered for `ContentControl`) owns the shared detection/re-creation (`CreateReplacementForStrandedContent`): only when the content is a `FrameworkElement` (data-item content rendered through a `ContentTemplate` is never touched), only when it is **not** materialized (`VisualTreeHelper.GetParent` is null — a materialized element is still handled by the visual-tree walk itself, so there is no double replacement), and only when its type was updated — either a CNOMU replacement type (`GetReplacementType()`) or an in-place EnC update where the type identity is unchanged but present in the updated list. Local values are transferred with the walk's own `ClonePropertiesToAnotherStoreForHotReload`, so an inherited DataContext keeps flowing from the host.
- `FrameElementMetadataUpdateHandler` reuses that shared helper and adds the Frame-specific part: `newPage.Frame` wiring and keeping the navigation history consistent (the current `PageStackEntry`'s `Instance`/`SourcePageType` — explicitly in WinUI-behavior mode; legacy mode syncs through `OnContentChanged`). The ContentControl handler skips Frames so the two handlers never double-patch the same instance.
- Known not-covered (follow-up material): standalone `ContentPresenter` (not a `ContentControl`) and unrealized `ItemsControl` containers have the same theoretical blind spot; no known repro for either.

**Review feedback addressed:**

- Content re-creation now goes through `Frame.CreatePageInstance` (the centralized creation path also used by `NavigationCache` and `PagePool`) instead of a raw `Activator.CreateInstance`, so hot-reload re-creation matches normal navigation — including `BindableMetadataProvider` support and the replacement-type indirection. Despite its name the helper is type-agnostic, which is what the shared ContentControl path needs.
- Consequently, the parameterless-constructor pre-check was removed: a bindable metadata activator may construct types a reflection probe would reject. Creation failure is handled instead of predicted.
- **State transfer now reuses the walk's `ClonePropertiesToAnotherStoreForHotReload`** instead of a hand-rolled DataContext copy. That helper moves **local** values only, and only where the new instance does not already have one, so page-XAML values win, an inherited DataContext keeps flowing from the host, and local bindings carry over as expressions rather than pinned resolved values. It also stops silently dropping attached properties — navigation frameworks set region/route properties on content right after creating it, so that loss was real rather than theoretical. The previous thin copy was inherited from the pre-existing back-stack re-creation loop rather than a deliberate decision for this path, so it is replaced rather than rationalized.
- **Creation failures are diagnosable**: both the exception path and a null result from `CreatePageInstance` log at Warning (with the exception) and keep the stale instance — "hot reload silently kept stale UI" should never require a debugger to notice.
- **`SetContent` runs before the history-entry sync** in the Frame handler, so a failed content assignment cannot leave the navigation history pointing at a page that was never displayed.
- Tests: back-navigation round-trip added (pins the history-entry sync — landing back on the stale instance would show pre-update text); negative test added asserting stranded content of a **non-updated** type keeps its identity and data-item content is never touched; unused usings removed; `CancellationTokenSource` disposed via `using var`; `Assert.AreNotSame` for identity assertions.

**Design notes (scope and semantics):**

- **Scope**: the handler intentionally covers every `ContentControl` subclass — the blind spot is structural (template-mediated content), not Frame-specific. The guards keep it inert for the common cases: data-item content (most Buttons/items) exits on the first check, materialized content on the second.
- **Eager re-creation** (rather than deferring the swap to materialization) deliberately mirrors the visual-tree walk's semantics for materialized instances of updated types: replace at update time. The discarded instance was never loaded, so no `Loaded`/`Unloaded` pairing is broken; references held by outer code go stale exactly as they already do when the walk replaces a materialized instance.
- **Trigger parity**: re-creating on `liveType ∈ updatedTypes` (in-place EnC) in addition to CNOMU mappings matches the walk's own replacement trigger for materialized elements.
- **Replacement notifications are intentionally not raised** for this swap, and it is not counted in the operation's replaced-element total. `Before`/`AfterElementReplaced` are the walk's contract for elements it owns; raising them from a handler would mean either exposing the agent's handler actions to `ElementUpdate` or moving this patch into the agent's dispatch, i.e. giving up the layer this fix deliberately sits at. Impact was checked rather than assumed: `Page.HotReload.cs` is the only in-box handler implementing either method, and its whole body (`newPage.Frame = oldPage.Frame` plus re-assigning `Frame.Content`) is already what `PatchStrandedContent` does — so notifying it here would be a no-op. The count feeds only `TotalElementCount` on the client-operation event; nothing branches on it, and HR success is not count-derived. What remains is third-party handlers registered for a replaced content type, which is why this is documented rather than left implicit. `AfterVisualTreeUpdate` already exists for exactly this — a once-per-phase reconciliation point — and is what a consumer tracking a content instance should use. Worth noting the downstream navigation fix needs that hook regardless of notifications: it also has to recover from `FrameNavigator` tracking a dead instance (no `Frame.Navigated` is raised on either replacement path), rebuild the view model (an in-place EnC update keeps type identity, so the "wrong VM type" check sees the stale VM as valid), and re-parent nested regions. Documented in `doc/articles/uno-development/uno-internals-hotreload.md`.
- **`CaptureState`/`RestoreState` is not run** for this content: it was never materialized, so there is no visual state to preserve, and the walk keys its capture on a visual-tree position this content does not have. Also documented.
- **Not covered (follow-ups)**: standalone `ContentPresenter` and unrealized `ItemsControl` containers (same theoretical blind spot, no repro); nested stranded content of a *non-updated* type containing an updated child (one-level scope, same as what the walk can reach today); page-cache eviction under CNOMU (pre-existing "does not support CNOMUA" note on the cache-removal path).

**Red/green coverage:**

- `Given_Frame_StrandedContent.When_Page_Updated_While_Unmaterialized_Then_Content_Recreated` — navigates a page into a frame under a collapsed ancestor (asserting the live-but-unmaterialized precondition), applies a server-side XAML update, and verifies the stranded page is re-created and shows the updated content once the subtree is revealed. Red without the fix, green with it.
- `Given_ContentControl_StrandedContent.When_Content_Updated_While_Unmaterialized_Then_Content_Recreated` — same scenario for a plain `ContentControl` hosting a `UserControl`.
- `Given_ContentControl_StrandedContent.When_Content_Updated_While_Unmaterialized_Then_Local_Values_Are_Transferred` — a locally-set value (`Tag`) and a locally-set attached property (`AutomationProperties.Name`) survive the re-creation, while an inherited DataContext is not pinned as a local value on the new instance.
- Also verified end-to-end by a deterministic runtime test in uno.extensions (`Given_HotReload.When_PageXamlUpdatedWhileUnmaterialized_Then_RevealShowsUpdatedContent`): red on current packages, green with this change, and no regressions across the navigation + TabBar hot-reload runtime suites there (29 tests).
