### PR TITLE
refactor(animation)!: Reparent theme animations to Timeline

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2679,6 +2679,10 @@
 
 		  <!-- PrimaryLanguageOverride no longer applies the culture in its setter (restart-to-apply, as on WinUI), so the opt-out flag is gone. Accessors paired in <Methods> below. -->
 		  <Member fullName="System.Boolean Uno.WinRTFeatureConfiguration/ApplicationLanguages::UseLegacyPrimaryLanguageOverride()" reason="Removed ApplicationLanguages.UseLegacyPrimaryLanguageOverride legacy flag; PrimaryLanguageOverride is always restart-to-apply (BC50, breaking changes for 7.0)" />
+
+		  <!-- FadeIn/FadeOutThemeAnimation reparented from DoubleAnimation to Timeline (WinUI parity); the DoubleAnimation-only From/To/By/EasingFunction/EnableDependentAnimation properties (and their DP fields) read as removed. Accessor methods paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.(FadeIn|FadeOut)ThemeAnimation(::|\.)(From|To|By|EasingFunction|EnableDependentAnimation|FromProperty|ToProperty|ByProperty|EasingFunctionProperty|EnableDependentAnimationProperty)\(\)" reason="Reparented *ThemeAnimation from DoubleAnimation to Timeline for WinUI parity; DoubleAnimation-only members removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
@@ -3252,6 +3256,10 @@
 
 		  <!-- WinRTFeatureConfiguration.ApplicationLanguages.UseLegacyPrimaryLanguageOverride accessors (paired with the <Properties> entry above). -->
 		  <Member fullName="System.Boolean Uno.WinRTFeatureConfiguration/ApplicationLanguages.get_UseLegacyPrimaryLanguageOverride()" reason="Removed ApplicationLanguages.UseLegacyPrimaryLanguageOverride legacy flag (BC50, breaking changes for 7.0)" />
+
+		  <!-- FadeIn/FadeOutThemeAnimation reparent accessors (paired with the <Properties> entry above): get_/set_ for the removed From/To/By/EasingFunction/EnableDependentAnimation and the get_ DP-field accessors. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.(FadeIn|FadeOut)ThemeAnimation(::|\.)(get_From|set_From|get_To|set_To|get_By|set_By|get_EasingFunction|set_EasingFunction|get_EnableDependentAnimation|set_EnableDependentAnimation|get_FromProperty|get_ToProperty|get_ByProperty|get_EasingFunctionProperty|get_EnableDependentAnimationProperty)\(.*\)" reason="Reparented *ThemeAnimation from DoubleAnimation to Timeline for WinUI parity; DoubleAnimation-only member accessors removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
 	  </Methods>
 	  <Events>
 		  <!-- ====================================================================== -->

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -227,6 +227,14 @@ change only breaks code that used the Uno-only members leaked by the wrong base.
   (`ImageBrush.StretchProperty`, `AlignmentXProperty`, `AlignmentYProperty`) still resolves
   via inheritance, and `is TileBrush` is now `true` for an `ImageBrush`. Instance usage
   (`imageBrush.Stretch`, XAML `Stretch="…"`) is unaffected.
+- **`FadeInThemeAnimation` / `FadeOutThemeAnimation`** now derive directly from `Timeline`
+  (matching WinUI) instead of Uno's `DoubleAnimation`. The `DoubleAnimation`-only members
+  they used to inherit — `From`, `To`, `By`, `EasingFunction`, and
+  `EnableDependentAnimation` — are gone; WinUI never exposed them on these theme
+  animations. `TargetName` and the `Timeline` members (`Duration`, `BeginTime`,
+  `RepeatBehavior`, `FillBehavior`) are unchanged. Set only `TargetName` (as the built-in
+  styles do); the fade always animates `Opacity` to its fixed target (1 for fade-in, 0 for
+  fade-out).
 
 ### XAML changes
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5112,7 +5112,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual("", SUT.SelectedText);
-			Assert.AreEqual(expectedCaret, SUT.CaretMode);
+			// The thumbless iOS caret blinks on a 500 ms timer, so sampling CaretMode once fails when the assert
+			// lands on the hidden half; the thumbed Android mode stops the timer and matches immediately.
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == expectedCaret,
+				timeoutMS: 3000,
+				message: $"tap should settle the caret in {expectedCaret}");
 		}
 
 		// Native iOS/Android: a double-tap selects the word under the tap.
@@ -5558,12 +5563,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual("", SUT.SelectedText, "there is nothing to select in an empty box");
-			Assert.AreEqual(
-				convention == TextBox.TouchTextSelectionConvention.Android
-					? TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing
-					: TextBox.CaretDisplayMode.ThumblessCaretShowing,
-				SUT.CaretMode,
-				"the gesture should leave the convention's collapsed caret");
+			// The thumbless iOS caret blinks on a 500 ms timer, so it can be mid-blink by the time the flyout opens.
+			var expectedCaret = convention == TextBox.TouchTextSelectionConvention.Android
+				? TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing
+				: TextBox.CaretDisplayMode.ThumblessCaretShowing;
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == expectedCaret,
+				timeoutMS: 3000,
+				message: $"the gesture should leave the convention's collapsed caret ({expectedCaret})");
 
 			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ThemeAnimation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ThemeAnimation.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_ThemeAnimation
+	{
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/8339")]
+		public void When_FadeInThemeAnimation_Reparented_To_Timeline()
+		{
+			// Reparent (7.0 breaking change): the *ThemeAnimation family derives directly
+			// from Timeline, matching WinUI, instead of Uno's legacy DoubleAnimation base.
+			Assert.AreEqual(typeof(Timeline), typeof(FadeInThemeAnimation).BaseType);
+			Assert.AreNotEqual(typeof(DoubleAnimation), typeof(FadeInThemeAnimation).BaseType);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/8339")]
+		public void When_FadeOutThemeAnimation_Reparented_To_Timeline()
+		{
+			Assert.AreEqual(typeof(Timeline), typeof(FadeOutThemeAnimation).BaseType);
+			Assert.AreNotEqual(typeof(DoubleAnimation), typeof(FadeOutThemeAnimation).BaseType);
+		}
+
+		[TestMethod]
+		public async Task When_FadeInThemeAnimation_Animates_Opacity()
+		{
+			var target = new Border { Width = 100, Height = 100, Opacity = 0 };
+			await UITestHelper.Load(target);
+
+			var animation = new FadeInThemeAnimation().BindTo(target, nameof(UIElement.Opacity));
+			await animation.ToStoryboard().RunAsync(TimeSpan.FromSeconds(5), throwsException: true);
+
+			Assert.AreEqual(1.0, target.Opacity, 0.05);
+		}
+
+		[TestMethod]
+		public async Task When_FadeOutThemeAnimation_Animates_Opacity()
+		{
+			var target = new Border { Width = 100, Height = 100, Opacity = 1 };
+			await UITestHelper.Load(target);
+
+			var animation = new FadeOutThemeAnimation().BindTo(target, nameof(UIElement.Opacity));
+			await animation.ToStoryboard().RunAsync(TimeSpan.FromSeconds(5), throwsException: true);
+
+			Assert.AreEqual(0.0, target.Opacity, 0.05);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ThemeAnimation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ThemeAnimation.cs
@@ -32,6 +32,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 		}
 
 		[TestMethod]
+		// Driving a theme animation through Storyboard.Target/TargetProperty is Uno-only: WinUI
+		// resolves the target from TargetName and animates Opacity implicitly, so the storyboard
+		// completes without touching Opacity there.
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public async Task When_FadeInThemeAnimation_Animates_Opacity()
 		{
 			var target = new Border { Width = 100, Height = 100, Opacity = 0 };
@@ -44,6 +48,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public async Task When_FadeOutThemeAnimation_Animates_Opacity()
 		{
 			var target = new Border { Width = 100, Height = 100, Opacity = 1 };

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -610,18 +610,6 @@ namespace Microsoft.UI.Xaml
 				}
 			}
 
-			if (this == DoubleAnimation.ToProperty)
-			{
-				if (referenceObject is FadeInThemeAnimation)
-				{
-					return Uno.UI.Helpers.Boxes.NullableDoubleBoxes.One;
-				}
-				else if (referenceObject is FadeOutThemeAnimation)
-				{
-					return Uno.UI.Helpers.Boxes.NullableDoubleBoxes.Zero;
-				}
-			}
-
 			if (_ownerTypeMetadata.CreateDefaultValueCallback != null)
 			{
 				return _ownerTypeMetadata.CreateDefaultValueCallback();

--- a/src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs
@@ -1,12 +1,18 @@
-﻿using System;
-using Microsoft.UI.Xaml.Data;
+using System;
+using System.Globalization;
 using Microsoft.UI.Xaml.Markup;
-using Uno.UI;
 
 namespace Microsoft.UI.Xaml.Media.Animation
 {
-	public partial class FadeInThemeAnimation : DoubleAnimation, ITimeline
+	public partial class FadeInThemeAnimation : Timeline, ITimeline, IAnimation<float>
 	{
+		private readonly AnimationImplementation<float> _animationImplementation;
+
+		public FadeInThemeAnimation()
+		{
+			_animationImplementation = new AnimationImplementation<float>(this);
+		}
+
 		public static DependencyProperty TargetNameProperty { get; } = DependencyProperty.Register(
 			"TargetName", typeof(string), typeof(FadeInThemeAnimation), new FrameworkPropertyMetadata(string.Empty));
 
@@ -23,6 +29,50 @@ namespace Microsoft.UI.Xaml.Media.Animation
 			{
 				Storyboard.SetTarget(this, depObj);
 			}
+		}
+
+		float? IAnimation<float>.To => 1f;
+
+		float? IAnimation<float>.From => null;
+
+		float? IAnimation<float>.By => null;
+
+		bool IAnimation<float>.EnableDependentAnimation => false;
+
+		IEasingFunction IAnimation<float>.EasingFunction => null;
+
+		float IAnimation<float>.Subtract(float minuend, float subtrahend) => minuend - subtrahend;
+
+		float IAnimation<float>.Add(float first, float second) => first + second;
+
+		float IAnimation<float>.Convert(object value) => Convert.ToSingle(value, CultureInfo.InvariantCulture);
+
+		float IAnimation<float>.Multiply(float multiplier, float t) => multiplier * t;
+
+		void ITimeline.Begin() => _animationImplementation.Begin();
+
+		void ITimeline.Stop() => _animationImplementation.Stop();
+
+		void ITimeline.Resume() => _animationImplementation.Resume();
+
+		void ITimeline.Pause() => _animationImplementation.Pause();
+
+		void ITimeline.Seek(TimeSpan offset) => _animationImplementation.Seek(offset);
+
+		void ITimeline.SeekAlignedToLastTick(TimeSpan offset) => _animationImplementation.SeekAlignedToLastTick(offset);
+
+		void ITimeline.SkipToFill() => _animationImplementation.SkipToFill();
+
+		void ITimeline.Deactivate() => _animationImplementation.Deactivate();
+
+		private protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				_animationImplementation.Dispose();
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs
@@ -1,12 +1,18 @@
-﻿using System;
-using System.Threading;
+using System;
+using System.Globalization;
 using Microsoft.UI.Xaml.Markup;
-using Uno.UI;
 
 namespace Microsoft.UI.Xaml.Media.Animation
 {
-	public partial class FadeOutThemeAnimation : DoubleAnimation
+	public partial class FadeOutThemeAnimation : Timeline, ITimeline, IAnimation<float>
 	{
+		private readonly AnimationImplementation<float> _animationImplementation;
+
+		public FadeOutThemeAnimation()
+		{
+			_animationImplementation = new AnimationImplementation<float>(this);
+		}
+
 		public static DependencyProperty TargetNameProperty { get; } = DependencyProperty.Register(
 			"TargetName", typeof(string), typeof(FadeOutThemeAnimation), new FrameworkPropertyMetadata(string.Empty));
 
@@ -23,6 +29,50 @@ namespace Microsoft.UI.Xaml.Media.Animation
 			{
 				Storyboard.SetTarget(this, depObj);
 			}
+		}
+
+		float? IAnimation<float>.To => 0f;
+
+		float? IAnimation<float>.From => null;
+
+		float? IAnimation<float>.By => null;
+
+		bool IAnimation<float>.EnableDependentAnimation => false;
+
+		IEasingFunction IAnimation<float>.EasingFunction => null;
+
+		float IAnimation<float>.Subtract(float minuend, float subtrahend) => minuend - subtrahend;
+
+		float IAnimation<float>.Add(float first, float second) => first + second;
+
+		float IAnimation<float>.Convert(object value) => Convert.ToSingle(value, CultureInfo.InvariantCulture);
+
+		float IAnimation<float>.Multiply(float multiplier, float t) => multiplier * t;
+
+		void ITimeline.Begin() => _animationImplementation.Begin();
+
+		void ITimeline.Stop() => _animationImplementation.Stop();
+
+		void ITimeline.Resume() => _animationImplementation.Resume();
+
+		void ITimeline.Pause() => _animationImplementation.Pause();
+
+		void ITimeline.Seek(TimeSpan offset) => _animationImplementation.Seek(offset);
+
+		void ITimeline.SeekAlignedToLastTick(TimeSpan offset) => _animationImplementation.SeekAlignedToLastTick(offset);
+
+		void ITimeline.SkipToFill() => _animationImplementation.SkipToFill();
+
+		void ITimeline.Deactivate() => _animationImplementation.Deactivate();
+
+		private protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				_animationImplementation.Dispose();
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** Part of #8339

## PR Type:

💬 Other — Breaking change (base-class realignment for WinUI parity; targets `feature/breakingchanges`)

## What changed? 🚀

`FadeInThemeAnimation` and `FadeOutThemeAnimation` now derive directly from `Timeline` (matching WinUI's sealed theme animations) instead of Uno's `DoubleAnimation`. The `DoubleAnimation`-only surface they leaked — `From`, `To`, `By`, `EasingFunction`, `EnableDependentAnimation` (and their DP fields) — is removed. Each type now hosts the `Timeline` animation engine (`AnimationImplementation<float>` via `ITimeline`/`IAnimation<float>`) directly; the fixed fade target moved to an `IAnimation<float>.To` override, and the now-dead type-keyed `To` default was removed from `DependencyProperty`.

The other 14 `*ThemeAnimation` types already derived from `Timeline` — unchanged.

**Validation (Skia Desktop):**
- Compile: `SamplesApp.Skia.Generic` (net10.0) — ✅ 0 errors
- Runtime: `Given_ThemeAnimation` 4/4 (hierarchy + opacity animates 0→1 / 1→0)
- Adjacent regression: `Given_DoubleAnimation` 8/8 (guards the shared `DependencyProperty` edit)

## PR Checklist ✅

- [x] 🧪 Added Runtime tests (`Given_ThemeAnimation`)
- [x] 📚 Docs updated (`migrating-to-uno-7.md` → "Type-hierarchy changes")
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

**Breaking change / migration:** the `DoubleAnimation`-only members are gone from the fade theme animations (WinUI never exposed them). Set only `TargetName` (the built-in styles already do); the fade always animates `Opacity` to its fixed target. Migration note included in `migrating-to-uno-7.md`.
