### PR TITLE
refactor(brush)!: Materialize TileBrush and reparent ImageBrush

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2588,6 +2588,10 @@
 
 		  <!-- Uno-only public ContentPresenter.ContentTemplateRoot reduced to internal (WinUI's ContentPresenter has no such member; the real WinUI ContentTemplateRoot lives on ContentControl). Accessors paired in <Methods> below. -->
 		  <Member fullName="Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Controls.ContentPresenter::ContentTemplateRoot()" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
+
+		  <!-- ImageBrush reparented to derive from a materialized TileBrush (Brush -> TileBrush -> ImageBrush, WinUI parity); AlignmentX/AlignmentY/Stretch and their DP fields are now declared on TileBrush and read as removed from ImageBrush (still resolve via inheritance at runtime). Accessor methods paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.ImageBrush(::|\.)(AlignmentX|AlignmentY|Stretch|AlignmentXProperty|AlignmentYProperty|StretchProperty)\(\)" reason="Moved AlignmentX/AlignmentY/Stretch owner from ImageBrush to TileBrush base for WinUI parity (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
@@ -3063,6 +3067,10 @@
 		  <!-- ContentPresenter.ContentTemplateRoot accessors (paired with the <Properties> entry above); getter public->internal, setter protected->private. -->
 		  <Member fullName="Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Controls.ContentPresenter.get_ContentTemplateRoot()" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.set_ContentTemplateRoot(Microsoft.UI.Xaml.UIElement value)" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
+
+		  <!-- ImageBrush->TileBrush reparent accessors (paired with the <Properties> entry above): get_/set_ for AlignmentX/AlignmentY/Stretch and the get_ DP-field accessors, now inherited from TileBrush. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.ImageBrush(::|\.)(get_AlignmentX|set_AlignmentX|get_AlignmentY|set_AlignmentY|get_Stretch|set_Stretch|get_AlignmentXProperty|get_AlignmentYProperty|get_StretchProperty)\(.*\)" reason="Moved AlignmentX/AlignmentY/Stretch owner from ImageBrush to TileBrush base for WinUI parity (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
 	  </Methods>
 	  <Events>
 		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -159,6 +159,13 @@ change only breaks code that used the Uno-only members leaked by the wrong base.
   a presenter. The video surface is hosted internally, so playback and `Stretch` are
   unchanged. `MediaPlayerElement` sets its own `Background` (black) on the template root, so
   letterbox bars stay black.
+- **`ImageBrush`** now derives from a real **`TileBrush`** (`Brush → TileBrush →
+  ImageBrush`, matching WinUI) instead of directly from `Brush`. `AlignmentX`,
+  `AlignmentY`, and `Stretch` behave the same for callers but are now **declared on
+  `TileBrush`** — code that referenced the static DPs by their declaring type
+  (`ImageBrush.StretchProperty`, `AlignmentXProperty`, `AlignmentYProperty`) still resolves
+  via inheritance, and `is TileBrush` is now `true` for an `ImageBrush`. Instance usage
+  (`imageBrush.Stretch`, XAML `Stretch="…"`) is unaffected.
 
 ### Templates and project heads
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrush.cs
@@ -17,6 +17,32 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 	[RunsOnUIThread]
 	public class Given_ImageBrush
 	{
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/8339")]
+		public void When_Reparented_To_TileBrush()
+		{
+			// Reparent (7.0 breaking change): the hierarchy is now Brush -> TileBrush -> ImageBrush, matching WinUI.
+			Assert.AreEqual(typeof(TileBrush), typeof(ImageBrush).BaseType);
+			Assert.IsInstanceOfType(new ImageBrush(), typeof(TileBrush));
+#if HAS_UNO
+			// AlignmentX/AlignmentY/Stretch are now owned by TileBrush, not ImageBrush.
+			Assert.AreEqual(typeof(TileBrush), ImageBrush.AlignmentXProperty.OwnerType);
+			Assert.AreEqual(typeof(TileBrush), ImageBrush.AlignmentYProperty.OwnerType);
+			Assert.AreEqual(typeof(TileBrush), ImageBrush.StretchProperty.OwnerType);
+#endif
+		}
+
+		[TestMethod]
+		public void When_TileBrush_Defaults_Preserved()
+		{
+			// Guards the reparent against adopting the generated stub's default(...) metadata,
+			// which would silently flip Stretch Fill->None and alignment Center->Left/Top.
+			var brush = new ImageBrush();
+			Assert.AreEqual(Stretch.Fill, brush.Stretch);
+			Assert.AreEqual(AlignmentX.Center, brush.AlignmentX);
+			Assert.AreEqual(AlignmentY.Center, brush.AlignmentY);
+		}
+
 		[DataRow(Stretch.Fill, false)]
 		[DataRow(Stretch.Fill, true)]
 #if !__APPLE_UIKIT__

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Media/TileBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Media/TileBrush.cs
@@ -3,84 +3,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Media
 {
-#if __SKIA__ || __NETSTD_REFERENCE__
+#if false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class TileBrush : global::Microsoft.UI.Xaml.Media.Brush
 	{
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty AlignmentXProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(AlignmentX), typeof(global::Microsoft.UI.Xaml.Media.AlignmentX),
-			typeof(global::Microsoft.UI.Xaml.Media.TileBrush),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.AlignmentX)));
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty AlignmentYProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(AlignmentY), typeof(global::Microsoft.UI.Xaml.Media.AlignmentY),
-			typeof(global::Microsoft.UI.Xaml.Media.TileBrush),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.AlignmentY)));
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.DependencyProperty StretchProperty { get; } =
-		Microsoft.UI.Xaml.DependencyProperty.Register(
-			nameof(Stretch), typeof(global::Microsoft.UI.Xaml.Media.Stretch),
-			typeof(global::Microsoft.UI.Xaml.Media.TileBrush),
-			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.Media.Stretch)));
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.AlignmentX AlignmentX
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.AlignmentX)this.GetValue(AlignmentXProperty);
-			}
-			set
-			{
-				this.SetValue(AlignmentXProperty, value);
-			}
-		}
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.AlignmentY AlignmentY
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.AlignmentY)this.GetValue(AlignmentYProperty);
-			}
-			set
-			{
-				this.SetValue(AlignmentYProperty, value);
-			}
-		}
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.UI.Xaml.Media.Stretch Stretch
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Media.Stretch)this.GetValue(StretchProperty);
-			}
-			set
-			{
-				this.SetValue(StretchProperty, value);
-			}
-		}
-#endif
-#if __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
-		protected TileBrush() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Media.TileBrush", "TileBrush()");
-		}
-#endif
+		// Skipping already declared property AlignmentXProperty
+		// Skipping already declared property AlignmentYProperty
+		// Skipping already declared property StretchProperty
+		// Skipping already declared property AlignmentX
+		// Skipping already declared property AlignmentY
+		// Skipping already declared property Stretch
+		// Skipping already declared method Microsoft.UI.Xaml.Media.TileBrush.TileBrush()
 		// Forced skipping of method Microsoft.UI.Xaml.Media.TileBrush.TileBrush()
 		// Forced skipping of method Microsoft.UI.Xaml.Media.TileBrush.AlignmentXProperty.get
 		// Forced skipping of method Microsoft.UI.Xaml.Media.TileBrush.AlignmentYProperty.get

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.cs
@@ -15,7 +15,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace Microsoft.UI.Xaml.Media
 {
-	public partial class ImageBrush : Brush
+	public partial class ImageBrush : TileBrush
 	{
 		private readonly SerialDisposable _sourceDisposable = new SerialDisposable();
 
@@ -23,39 +23,6 @@ namespace Microsoft.UI.Xaml.Media
 		public event RoutedEventHandler ImageOpened;
 		public event ExceptionRoutedEventHandler ImageFailed;
 #pragma warning restore CS0067 // The event 'ImageBrush.ImageFailed' is never used
-
-		#region AlignmentX DP
-		public static DependencyProperty AlignmentXProperty { get; } =
-			DependencyProperty.Register("AlignmentX", typeof(AlignmentX), typeof(ImageBrush), new FrameworkPropertyMetadata(AlignmentX.Center));
-
-		public AlignmentX AlignmentX
-		{
-			get => (AlignmentX)GetValue(AlignmentXProperty);
-			set => this.SetValue(AlignmentXProperty, value);
-		}
-		#endregion
-
-		#region AlignmentY DP
-		public static DependencyProperty AlignmentYProperty { get; } =
-			DependencyProperty.Register("AlignmentY", typeof(AlignmentY), typeof(ImageBrush), new FrameworkPropertyMetadata(AlignmentY.Center));
-
-		public AlignmentY AlignmentY
-		{
-			get => (AlignmentY)GetValue(AlignmentYProperty);
-			set => this.SetValue(AlignmentYProperty, value);
-		}
-		#endregion
-
-		#region Stretch DP
-		public static DependencyProperty StretchProperty { get; } =
-		  DependencyProperty.Register("Stretch", typeof(Stretch), typeof(ImageBrush), new FrameworkPropertyMetadata(defaultValue: Stretch.Fill, propertyChangedCallback: null));
-
-		public Stretch Stretch
-		{
-			get => (Stretch)this.GetValue(StretchProperty);
-			set => this.SetValue(StretchProperty, value);
-		}
-		#endregion
 
 		#region ImageSource DP
 		public static DependencyProperty ImageSourceProperty { get; } =

--- a/src/Uno.UI/UI/Xaml/Media/TileBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/TileBrush.cs
@@ -1,0 +1,35 @@
+namespace Microsoft.UI.Xaml.Media;
+
+public partial class TileBrush : Brush
+{
+	public static DependencyProperty AlignmentXProperty { get; } =
+		DependencyProperty.Register(nameof(AlignmentX), typeof(AlignmentX), typeof(TileBrush), new FrameworkPropertyMetadata(AlignmentX.Center));
+
+	public AlignmentX AlignmentX
+	{
+		get => (AlignmentX)GetValue(AlignmentXProperty);
+		set => SetValue(AlignmentXProperty, value);
+	}
+
+	public static DependencyProperty AlignmentYProperty { get; } =
+		DependencyProperty.Register(nameof(AlignmentY), typeof(AlignmentY), typeof(TileBrush), new FrameworkPropertyMetadata(AlignmentY.Center));
+
+	public AlignmentY AlignmentY
+	{
+		get => (AlignmentY)GetValue(AlignmentYProperty);
+		set => SetValue(AlignmentYProperty, value);
+	}
+
+	public static DependencyProperty StretchProperty { get; } =
+		DependencyProperty.Register(nameof(Stretch), typeof(Stretch), typeof(TileBrush), new FrameworkPropertyMetadata(Stretch.Fill));
+
+	public Stretch Stretch
+	{
+		get => (Stretch)GetValue(StretchProperty);
+		set => SetValue(StretchProperty, value);
+	}
+
+	protected TileBrush()
+	{
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** Part of #8339

## PR Type:

💬 Other — Breaking change (base-class realignment for WinUI parity; targets `feature/breakingchanges`)

## What changed? 🚀

Materialized a real `TileBrush : Brush` (previously a `[NotImplemented]` generated stub) and reparented `ImageBrush` to it, so the hierarchy is now `Brush → TileBrush → ImageBrush`, matching WinUI. `AlignmentX`, `AlignmentY`, and `Stretch` move ownership from `ImageBrush` to `TileBrush` (callers resolve them via inheritance; instance/XAML usage is unchanged). Defaults stay `Center`/`Center`/`Fill`.

**Validation (Skia Desktop):**
- Compile: `SamplesApp.Skia.Generic` (net10.0) — ✅ 0 errors
- Runtime: `Given_ImageBrush` 10/10 (hierarchy, DP-owner move, default-value guard, and all `When_Stretch` rendering DataRows — confirms the reparent didn't regress image-brush rendering)

> ⚠️ **Before merge — sync generator:** the generated `TileBrush.cs` stub was hand-collapsed to its skip-comment form so the branch builds. The `WinAppSDK Sync Generator Check` will flag drift because it won't match byte-for-byte. **Comment `/apply-sync-gen` on this PR** (or run `build\run-api-sync-tool.cmd` locally) to have the real generator output committed. Also drop `ImageBrush` from `_skipBaseTypes` in `Uno.WinAppSDKSyncGenerator` as part of that regen.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests (`Given_ImageBrush` — hierarchy, DP ownership, defaults)
- [x] 📚 Docs updated (`migrating-to-uno-7.md` → "Type-hierarchy changes")
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

**Breaking change / migration:** the `AlignmentX`/`AlignmentY`/`Stretch` DPs are now declared on `TileBrush`; code referencing them by declaring type still resolves via inheritance, and `is TileBrush` is now `true` for an `ImageBrush`. Migration note included in `migrating-to-uno-7.md`.
