### PR TITLE
refactor(mediaplayer)!: Reparent MediaPlayerPresenter to FrameworkElement

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2579,6 +2579,9 @@
 
 		  <!-- WindowActivatedEventArgs.WindowActivationState retyped from the Uno-only Windows.UI.Core.CoreWindowActivationState to the WinUI Microsoft.UI.Xaml.WindowActivationState; the old-typed property reads as removed (getter accessor paired in <Methods> below). -->
 		  <Member fullName="Windows.UI.Core.CoreWindowActivationState Microsoft.UI.Xaml.WindowActivatedEventArgs::WindowActivationState()" reason="Retyped WindowActivationState to Microsoft.UI.Xaml.WindowActivationState (BC13, breaking changes for 7.0)" />
+
+		  <!-- MediaPlayerPresenter reparented from Border to FrameworkElement (WinUI parity); the Border-only Child/BorderBrush/BorderThickness/CornerRadius/Padding/BackgroundSizing/ChildTransitions surface (and DP fields) reads as removed. Background stays (Uno declares it on FrameworkElement). Accessor methods paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.MediaPlayerPresenter(::|\.)(Child|ChildProperty|BorderBrush|BorderBrushProperty|BorderThickness|BorderThicknessProperty|CornerRadius|CornerRadiusProperty|Padding|PaddingProperty|BackgroundSizing|BackgroundSizingProperty|ChildTransitions|ChildTransitionsProperty|BackgroundTransition|BackgroundTransitionProperty)\(\)" reason="Reparented MediaPlayerPresenter from Border to FrameworkElement for WinUI parity; Border-only members removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
@@ -3035,6 +3038,9 @@
 
 		  <!-- WindowActivatedEventArgs.WindowActivationState getter accessor retyped from the Uno-only Windows.UI.Core.CoreWindowActivationState to the WinUI Microsoft.UI.Xaml.WindowActivationState; the old-typed getter reads as removed (property paired in <Properties> above). -->
 		  <Member fullName="Windows.UI.Core.CoreWindowActivationState Microsoft.UI.Xaml.WindowActivatedEventArgs.get_WindowActivationState()" reason="Retyped WindowActivationState to Microsoft.UI.Xaml.WindowActivationState (BC13, breaking changes for 7.0)" />
+
+		  <!-- MediaPlayerPresenter->FrameworkElement reparent accessors (paired with the <Properties> entry above): get_/set_ and DP-field get_ accessors for the removed Border-only members. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.MediaPlayerPresenter(::|\.)(get_Child|set_Child|get_ChildProperty|get_BorderBrush|set_BorderBrush|get_BorderBrushProperty|get_BorderThickness|set_BorderThickness|get_BorderThicknessProperty|get_CornerRadius|set_CornerRadius|get_CornerRadiusProperty|get_Padding|set_Padding|get_PaddingProperty|get_BackgroundSizing|set_BackgroundSizing|get_BackgroundSizingProperty|get_ChildTransitions|set_ChildTransitions|get_ChildTransitionsProperty|get_BackgroundTransition|set_BackgroundTransition|Add)\(.*\)" reason="Reparented MediaPlayerPresenter from Border to FrameworkElement for WinUI parity; Border-only member accessors removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
 	  </Methods>
 	  <Events>
 		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -147,6 +147,19 @@ re-baseline visual tests:
 - **Animation timing:** Skia interpolation replaces `CABasicAnimation` — standard easing
   matches; exotic timing may not.
 
+### Type-hierarchy changes (WinUI parity)
+
+7.0 realigns several types to their WinUI base classes. Most code is unaffected — the
+change only breaks code that used the Uno-only members leaked by the wrong base.
+
+- **`MediaPlayerPresenter`** now derives directly from **`FrameworkElement`** (matching
+  WinUI) instead of `Border`, removing the extra `Border` level. The `Border`-only surface
+  it used to expose — `Child`, `BorderBrush`, `BorderThickness`, `CornerRadius`, `Padding`,
+  `BackgroundSizing`, `ChildTransitions` — is gone, and `is Border` is no longer `true` for
+  a presenter. The video surface is hosted internally, so playback and `Stretch` are
+  unchanged. `MediaPlayerElement` sets its own `Background` (black) on the template root, so
+  letterbox bars stay black.
+
 ### Templates and project heads
 
 New apps get Skia heads only. Existing apps should drop native `*.Mobile` / native

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerPresenter.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+public class Given_MediaPlayerPresenter
+{
+	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/8339")]
+	public void When_Reparented_To_FrameworkElement()
+	{
+		// Reparent (7.0 breaking change): MediaPlayerPresenter derives directly from
+		// FrameworkElement (matching WinUI), dropping the extra Border level and its
+		// leaked Child/BorderBrush/BorderThickness/CornerRadius/Padding surface.
+		// (Reflection only — instantiating the presenter would spin up the platform
+		// media extension; video-hosting behaviour is validated by the MediaPlayerElement
+		// suite on heads where the media extension is available.)
+		Assert.AreEqual(typeof(FrameworkElement), typeof(MediaPlayerPresenter).BaseType);
+		Assert.AreNotEqual(typeof(Border), typeof(MediaPlayerPresenter).BaseType);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.Others.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.Others.cs
@@ -10,7 +10,7 @@ using Uno.Foundation.Logging;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public partial class MediaPlayerPresenter : Border
+	public partial class MediaPlayerPresenter : FrameworkElement
 	{
 		private IMediaPlayerPresenterExtension? _extension;
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
@@ -9,14 +9,46 @@ using Uno.Foundation.Logging;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public partial class MediaPlayerPresenter : Border
+	public partial class MediaPlayerPresenter : FrameworkElement
 	{
 		private WeakReference<MediaPlayerElement>? _wrOwner;
 		private CompositeDisposable? _mediaPlayerDisposable;
+		private UIElement? _child;
 
 		internal void SetOwner(MediaPlayerElement owner)
 		{
 			_wrOwner = new WeakReference<MediaPlayerElement>(owner);
+		}
+
+		/// <summary>
+		/// Hosts the video surface. Replaces the <see cref="Border.Child"/> slot the presenter
+		/// relied on before it was reparented from <see cref="Border"/> to <see cref="FrameworkElement"/>
+		/// (WinUI parity); the platform <c>IMediaPlayerPresenterExtension</c>s set it.
+		/// </summary>
+		internal UIElement Child
+		{
+			get => _child!;
+			set
+			{
+				if (_child == value)
+				{
+					return;
+				}
+
+				if (_child is not null)
+				{
+					RemoveChild(_child);
+				}
+
+				_child = value;
+
+				if (value is not null)
+				{
+					AddChild(value);
+				}
+
+				InvalidateMeasure();
+			}
 		}
 
 		private float GetScaledOtherDimension(
@@ -202,6 +234,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			if (_child is { } child)
+			{
+				MeasureElement(child, availableSize);
+			}
+
 			var layoutOwner = GetLayoutOwner();
 			var explicitWidth = layoutOwner.Width;
 			var explicitHeight = layoutOwner.Height;
@@ -274,6 +311,16 @@ namespace Microsoft.UI.Xaml.Controls
 					return new Size(NaturalVideoWidth, NaturalVideoHeight);
 				}
 			}
+		}
+
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			if (_child is { } child)
+			{
+				ArrangeElement(child, new Rect(0, 0, finalSize.Width, finalSize.Height));
+			}
+
+			return finalSize;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -6281,7 +6281,10 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="MediaPlayerElement">
-					<Grid x:Name="LayoutRoot">
+					<!-- LayoutRoot paints the (black) background so letterbox bars stay black now that
+					     MediaPlayerPresenter derives from FrameworkElement (which does not paint Background)
+					     instead of Border. -->
+					<Grid x:Name="LayoutRoot" Background="{TemplateBinding Background}">
 						<Border Background="Transparent" />
 						<Image x:Name="PosterImage"
 							   Visibility="Collapsed"


### PR DESCRIPTION
**GitHub Issue:** Part of #8339

## PR Type:

💬 Other — Breaking change (base-class realignment for WinUI parity; targets `feature/breakingchanges`)

## What changed? 🚀

`MediaPlayerPresenter` now derives directly from `FrameworkElement` (matching WinUI) instead of `Border`, removing the extra `Border` level and its leaked `Child`/`BorderBrush`/`BorderThickness`/`CornerRadius`/`Padding`/`BackgroundSizing`/`ChildTransitions` surface. The video surface is hosted via an internal `Child` slot (`AddChild`/`RemoveChild` + `ArrangeOverride`); the 6 platform media extensions reach it **unchanged** through `InternalsVisibleTo`. `MediaPlayerElement` now paints its black background on the template `LayoutRoot` (a `Panel`) so letterbox bars stay black.

**Validation (Skia Desktop):**
- Compile: `SamplesApp.Skia.Generic` (net10.0) — ✅ 0 errors, including the Win32 **and** X11 media extensions building against the internal `Child` via IVT.
- Runtime: `Given_MediaPlayerPresenter` 1/1 (structural — base is `FrameworkElement`, not `Border`).

> ⚠️ **Needs per-head validation before relying on this:** the load-bearing assumption is that `AddChild` on a bare `FrameworkElement` (not a `Panel`/`Border`) composites and renders the child on a **media-capable head** — media playback runtime tests are extension/codec-gated and largely `[Ignore]`d, so this and the black-letterbox visual weren't exercised here. The 4 non-desktop extensions (MacOS/Android/AppleUIKit/Browser) are **unchanged** but weren't compiled on this machine.

## PR Checklist ✅

- [x] 🧪 Added Runtime test (`Given_MediaPlayerPresenter`, structural)
- [x] 📚 Docs updated (`migrating-to-uno-7.md` → "Type-hierarchy changes")
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

**Breaking change / migration:** the `Border`-only surface is gone from `MediaPlayerPresenter` and `is Border` is no longer `true` for a presenter; playback and `Stretch` are unchanged. Migration note included in `migrating-to-uno-7.md`.
