### PR TITLE
fix(docs): External-docs updater honors per-repo tracking policy

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -7,18 +7,28 @@ param(
 Set-PSDebug -Trace 1
 
 # --- CONFIGURATION ----------------------------------------------------------
-# Each entry: repo name -> @{ ref = '<commit|branch>'; dest = '<sub-folder>'? }
+# Each entry: repo name -> @{ ref = '<commit|branch>'; dest = '<sub-folder>'?; track = 'release'? }
+#
+#   track = 'release' : this repo is versioned in lockstep with Uno releases. When the updater runs
+#                       against a release/stable/* branch, pin it to the repo's HIGHEST
+#                       release/stable/* branch (falling back to the default branch if none exist).
+#   track omitted     : the repo's docs are not versioned per Uno release; ALWAYS pin to its default
+#                       branch (main/master), in both default (master) and release modes.
+#
+# Only annotate 'release' repos here. Everything else must keep tracking its default branch — a repo
+# like uno.uitest / uno.resizetizer has release/stable/* branches of its own that are unrelated to
+# the Uno release line, so following them would pin stale/wrong (even years-old) docs.
 $external_docs = @{
     # use either commit, or branch name to use its latest commit
-    "uno.wasm.bootstrap" = @{ ref="1e094106842f6e7f43075f06d2a0354077da3a0f" }  #latest main commit
-    "uno.themes"         = @{ ref="09187371ab8a3c3c90739b3ac4c336b49e5edff4" }  #latest master commit
-    "uno.toolkit.ui"     = @{ ref="030026c023aa8ea3e82ec9f4dab264bd50086440" }  #latest main commit
-    "uno.check"          = @{ ref="da57de1d9dd4d3ef47623a80999d5df1b5ffcb10" }  #latest main commit
-    "uno.xamlmerge.task" = @{ ref="081dcfa44b5ce24ac0948675e5ee6b781e2107bc" }  #latest main commit
+    "uno.wasm.bootstrap" = @{ ref="1e094106842f6e7f43075f06d2a0354077da3a0f"; track="release" }  #latest main commit
+    "uno.themes"         = @{ ref="09187371ab8a3c3c90739b3ac4c336b49e5edff4"; track="release" }  #latest master commit
+    "uno.toolkit.ui"     = @{ ref="030026c023aa8ea3e82ec9f4dab264bd50086440"; track="release" }  #latest main commit
+    "uno.check"          = @{ ref="da57de1d9dd4d3ef47623a80999d5df1b5ffcb10"; track="release" }  #latest main commit
+    "uno.xamlmerge.task" = @{ ref="081dcfa44b5ce24ac0948675e5ee6b781e2107bc"; track="release" }  #latest main commit
     "figma-docs"         = @{ ref="842a2792282b88586a337381b2b3786e779973b4" }  #latest main commit
     "uno.resizetizer"    = @{ ref="e422ad9f26cf21ed02c339e717e0dd0189bb566e" }  #latest main commit
     "uno.uitest"         = @{ ref="94d027295b779e28064aebf99aeaee2b393ad558" }  #latest master commit
-    "uno.extensions"     = @{ ref="f3a5f9de7a2a5dccbf20a295270940dcca154ad8" }  #latest main commit
+    "uno.extensions"     = @{ ref="f3a5f9de7a2a5dccbf20a295270940dcca154ad8"; track="release" }  #latest main commit
     "workshops"          = @{ ref="3515c29e03dea36cf2206d797d1bf9f8620370e3" }  #latest master commit
     "uno.samples"        = @{ ref="dcb9604c49430a0e23a65050c6e70f94a30b4391" }  #latest master commit
     "uno.chefs"          = @{ ref="4bbc0569dc7ac0ddefe8b0de4be31beb3706a90b" }  #latest main commit
@@ -30,10 +40,16 @@ $uno_git_url = "https://github.com/unoplatform/"
 
 # --- END OF CONFIGURATION --------------------------------------------------
 
-# If -ListRepos flag is set, output the repository names and exit
+# If -ListRepos flag is set, output the repositories (name + tracking policy) and exit.
+# Emits one object per repo so consumers (the updater) know whether a repo follows release
+# branches or always its default branch. Track defaults to 'default' when not annotated.
 if ($ListRepos) {
     Set-PSDebug -Off
-    $external_docs.Keys | ForEach-Object { Write-Output $_ }
+    $external_docs.Keys | ForEach-Object {
+        $cfg = $external_docs[$_]
+        $track = if ($cfg.ContainsKey('track') -and $cfg.track) { $cfg.track } else { 'default' }
+        [pscustomobject]@{ Name = $_; Track = $track }
+    }
     exit 0
 }
 

--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -23,14 +23,14 @@ $external_docs = @{
     "uno.wasm.bootstrap" = @{ ref="1e094106842f6e7f43075f06d2a0354077da3a0f"; track="release" }  #latest main commit
     "uno.themes"         = @{ ref="09187371ab8a3c3c90739b3ac4c336b49e5edff4"; track="release" }  #latest master commit
     "uno.toolkit.ui"     = @{ ref="030026c023aa8ea3e82ec9f4dab264bd50086440"; track="release" }  #latest main commit
-    "uno.check"          = @{ ref="da57de1d9dd4d3ef47623a80999d5df1b5ffcb10"; track="release" }  #latest main commit
+    "uno.check"          = @{ ref="1eb2b63f57511ba78b40a82f7f1c245bc9c9aaf1"; track="release" }  #latest main commit
     "uno.xamlmerge.task" = @{ ref="081dcfa44b5ce24ac0948675e5ee6b781e2107bc"; track="release" }  #latest main commit
     "figma-docs"         = @{ ref="842a2792282b88586a337381b2b3786e779973b4" }  #latest main commit
     "uno.resizetizer"    = @{ ref="e422ad9f26cf21ed02c339e717e0dd0189bb566e" }  #latest main commit
     "uno.uitest"         = @{ ref="94d027295b779e28064aebf99aeaee2b393ad558" }  #latest master commit
     "uno.extensions"     = @{ ref="f3a5f9de7a2a5dccbf20a295270940dcca154ad8"; track="release" }  #latest main commit
     "workshops"          = @{ ref="3515c29e03dea36cf2206d797d1bf9f8620370e3" }  #latest master commit
-    "uno.samples"        = @{ ref="dcb9604c49430a0e23a65050c6e70f94a30b4391" }  #latest master commit
+    "uno.samples"        = @{ ref="2c8e58853a3795fe4250d39787225e55db18499d" }  #latest master commit
     "uno.chefs"          = @{ ref="4bbc0569dc7ac0ddefe8b0de4be31beb3706a90b" }  #latest main commit
     "hd-docs"            = @{ ref="c4c2f891544ae17b846b8fd24a90edd974ae6938"; dest="studio/Hot Design" } #latest main commit
     "studio-docs"        = @{ ref="3b86af4dac3e7a21c41b619960d14848ce95e2fd" }  #latest main commit

--- a/doc/update_external_docs_hashes.ps1
+++ b/doc/update_external_docs_hashes.ps1
@@ -80,7 +80,7 @@ if (-not $repos -or $repos.Count -eq 0) {
 }
 
 Write-Host "Found $($repos.Count) repositories to update:" -ForegroundColor Green
-$repos | ForEach-Object { Write-Host "  - $_" -ForegroundColor Gray }
+$repos | ForEach-Object { Write-Host "  - $($_.Name) [track=$($_.Track)]" -ForegroundColor Gray }
 
 # Determine behavior based on the provided branch
 $branchInput = $Branch
@@ -91,7 +91,7 @@ if (-not $branchInput) {
 $useReleaseBranches = $branchInput -like 'release/stable/*'
 
 if ($useReleaseBranches) {
-    Write-Host "Running in release mode for '$branchInput' - will use each repo's latest 'release/stable/*' branch if available, otherwise its default branch." -ForegroundColor Cyan
+    Write-Host "Running in release mode for '$branchInput' - repos marked track='release' use their highest 'release/stable/*' branch (fallback to default); all other repos always use their default branch." -ForegroundColor Cyan
 } else {
     Write-Host "Running in default mode for '$branchInput' - will use each repo's default branch." -ForegroundColor Cyan
 }
@@ -100,8 +100,10 @@ if ($useReleaseBranches) {
 $content = Get-Content $scriptPath -Raw
 $updatedCount = 0
 
-foreach ($repo in $repos) {
-    Write-Host "Processing $repo..." -ForegroundColor Cyan
+foreach ($repoObj in $repos) {
+    $repo  = $repoObj.Name
+    $track = $repoObj.Track
+    Write-Host "Processing $repo (track=$track)..." -ForegroundColor Cyan
 
     try {
         # First, get the repository info to find the default branch
@@ -112,9 +114,11 @@ foreach ($repo in $repos) {
         Write-Host "  Default branch: $defaultBranch" -ForegroundColor Gray
 
         $targetBranch = $defaultBranch
-        $branchDescription = $defaultBranch
 
-        if ($useReleaseBranches) {
+        # Only repos explicitly marked track='release' follow release/stable/* branches. Others
+        # always track their default branch, even in release mode - their own release branches are
+        # unrelated to the Uno release line and would pin stale/wrong docs.
+        if ($useReleaseBranches -and $track -eq 'release') {
             # Try to locate the latest release/stable/* branch for this repo
             $branchesUrl = "https://api.github.com/repos/unoplatform/$repo/branches?per_page=100"
 
@@ -158,7 +162,6 @@ foreach ($repo in $repos) {
             if ($releaseBranches.Count -gt 0) {
                 $latestRelease = $releaseBranches | Sort-Object Version -Descending | Select-Object -First 1
                 $targetBranch = $latestRelease.Name
-                $branchDescription = $latestRelease.Name
                 Write-Host "  Using latest release branch: $targetBranch" -ForegroundColor Gray
             } else {
                 Write-Host "  No 'release/stable/*' branches found - falling back to default branch '$defaultBranch'." -ForegroundColor DarkYellow
@@ -184,6 +187,15 @@ foreach ($repo in $repos) {
         $newContent = [regex]::Replace($content, $pattern, {
                 param($match)
                 $match.Groups[1].Value + $latestHash + $match.Groups[2].Value
+            })
+
+        # Regenerate the trailing comment so it always reflects the branch actually used. Previously
+        # the comment was left untouched, so a release-branch pin could still read "latest main commit".
+        $commentText = if ($targetBranch -like 'release/stable/*') { "latest $targetBranch branch commit" } else { "latest $targetBranch commit" }
+        $commentPattern = "(`"$escapedRepo`"\s*=\s*@\{[^}]*\}[^\S\r\n]*)#.*"
+        $newContent = [regex]::Replace($newContent, $commentPattern, {
+                param($match)
+                $match.Groups[1].Value + "#" + $commentText
             })
 
         if ($newContent -ne $content) {


### PR DESCRIPTION
## Problem

The external-docs updater (`doc/update_external_docs_hashes.ps1`) mis-resolved pins on the 6.6 run (unoplatform/uno#23808), breaking the docs build. In **release mode** it forced **every** repo that has *any* `release/stable/*` branch onto it — even repos whose docs aren't versioned with Uno:

- `uno.uitest` → `release/stable/1.0` = a **2020** commit predating `doc/toc.yml` → docfx `InvalidTocInclude`, **build broken**.
- `uno.resizetizer` → `release/stable/1.12` instead of `main`.

It also **preserved the old comment**, so a release-branch pin still read "latest main commit".

## Fix (root cause)

Make the tracking policy **explicit per repo** and have the updater honor it:

- **`import_external_docs.ps1`**: new optional `track='release'` per entry. Only the six Uno-versioned libraries are marked release-tracked: `uno.wasm.bootstrap`, `uno.themes`, `uno.toolkit.ui`, `uno.check`, `uno.xamlmerge.task`, `uno.extensions`. `-ListRepos` now emits `{Name, Track}`.
- **`update_external_docs_hashes.ps1`**: in release mode, only `track='release'` repos follow their highest `release/stable/*` branch; **all others always use their default branch**. The trailing comment is **regenerated** to match the branch actually pinned, so comments can't drift again.

The second commit is the output of running the fixed updater in default (master) mode — refreshing the two genuinely-stale pins. **This replaces the manual patch in #23809** (which will be closed).

## Local validation (both modes, no regression)

Ran the fixed updater locally against live GitHub:

**master mode** → only `uno.check` (`da57de1d`→`1eb2b63f`) and `uno.samples` (`dcb9604c`→`2c8e5885`) changed; `uno.uitest`/`uno.resizetizer` untouched. ✅ no regression.

**release/stable/6.6 mode** → produced exactly the correct set:
| Repo | Resolved to |
|------|-------------|
| wasm.bootstrap / themes / toolkit.ui / check / xamlmerge.task / extensions | highest `release/stable/*` (10.0 / 6.1 / 8.4 / 1.34 / 1.33 / 7.2) |
| **uno.uitest** | **master HEAD `94d0272`** (not the 2020 `release/stable/1.0`) |
| **uno.resizetizer** | **main HEAD `e422ad9f`** (not `release/stable/1.12`) |
| figma-docs / workshops / uno.samples / uno.chefs / hd-docs / studio-docs | default branch |

This matches the hand-fix already applied to #23808, confirming the updater now reproduces the correct 6.6 pins on its own.

## Follow-up

Tooling fix will be **backported to `release/stable/6.6`** so scheduled/dispatched 6.6 updater runs are correct too. (6.6's current pins are already fixed in #23808.)

Related to https://github.com/unoplatform/private/issues/1076