### PR TITLE
feat(textbox): Native iOS/Android touch text selection on Skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/ClipboardHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ClipboardHelper.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Uno.UI.RuntimeTests.Helpers;
+
+public static class ClipboardHelper
+{
+	/// <summary>
+	/// Reads the clipboard, polling until it returns <paramref name="expected"/> (or attempts run out), and
+	/// returns the last-read value for the caller to assert on.
+	/// </summary>
+	/// <remarks>
+	/// On the Win32 backend the clipboard-content cache is invalidated asynchronously (via WM_CLIPBOARDUPDATE)
+	/// and OpenClipboard can transiently fail while another process holds the clipboard, so a single-shot read
+	/// right after a copy flakes. Each miss pumps the message loop via <see cref="UITestHelper.WaitForIdle"/>.
+	/// </remarks>
+	public static async Task<string?> WaitForTextAsync(string expected, int attempts = 30)
+	{
+		string? actual = null;
+		for (var i = 0; i < attempts && actual != expected; i++)
+		{
+			try
+			{
+				actual = await Clipboard.GetContent()!.GetTextAsync();
+			}
+			catch
+			{
+				// transient clipboard failure — retry after pumping the message loop
+			}
+
+			if (actual != expected)
+			{
+				await UITestHelper.WaitForIdle();
+			}
+		}
+
+		return actual;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_PasswordBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_PasswordBox.cs
@@ -189,11 +189,11 @@ public class Given_PasswordBox
 
 		passwordBox.CopySelectionToClipboard();
 		await TestServices.WindowHelper.WaitForIdle();
-		Assert.AreEqual(sentinel, await Clipboard.GetContent()!.GetTextAsync());
+		Assert.AreEqual(sentinel, await ClipboardHelper.WaitForTextAsync(sentinel));
 
 		passwordBox.CutSelectionToClipboard();
 		await TestServices.WindowHelper.WaitForIdle();
-		Assert.AreEqual(sentinel, await Clipboard.GetContent()!.GetTextAsync());
+		Assert.AreEqual(sentinel, await ClipboardHelper.WaitForTextAsync(sentinel));
 		Assert.AreEqual(secret, passwordBox.Password);
 	}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -12,7 +12,6 @@ using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI.Input.Preview.Injection;
 using System.Collections.Generic;
@@ -1669,7 +1668,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.CopySelectionToClipboard();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual("Hello ", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual("Hello ", await ClipboardHelper.WaitForTextAsync("Hello "));
 		}
 
 #if !HAS_INPUT_INJECTOR
@@ -1716,7 +1715,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.CopySelectionToClipboard();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual("FirstLine", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual("FirstLine", await ClipboardHelper.WaitForTextAsync("FirstLine"));
 
 			// move to the center of the second line
 			mouse.MoveTo(SUT.GetAbsoluteBounds().Location + new Point(SUT.ActualWidth / 2, 25));
@@ -1731,7 +1730,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.CopySelectionToClipboard();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual("Second", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual("Second", await ClipboardHelper.WaitForTextAsync("Second"));
 
 			// move to the start of the second line
 			mouse.MoveTo(SUT.GetAbsoluteBounds().Location + new Point(0, 25));
@@ -1746,7 +1745,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.CopySelectionToClipboard();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual(" ", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual(" ", await ClipboardHelper.WaitForTextAsync(" "));
 		}
 
 		[TestMethod]
@@ -1844,7 +1843,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.C, mod));
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(SUT.Text, await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual(SUT.Text, await ClipboardHelper.WaitForTextAsync(SUT.Text));
 		}
 
 		[TestMethod]
@@ -1946,7 +1945,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			mouse.Release();
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual("world", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual("world", await ClipboardHelper.WaitForTextAsync("world"));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5185,12 +5185,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var processor = VisualTree.GetContentRootForElement(SUT)?.InputManager?.ContextMenuProcessor;
 			Assert.IsNotNull(processor);
-			processor.SetIsContextMenuOnHolding(false);
+			var nonNullProcessor = processor ?? throw new InvalidOperationException("ContextMenuProcessor should be available for this test.");
+			nonNullProcessor.SetIsContextMenuOnHolding(false);
 
-			processor.RaiseContextRequestedEvent(SUT, SUT.GetAbsoluteBoundsRect().GetCenter(), isTouchInput: true);
+			nonNullProcessor.RaiseContextRequestedEvent(SUT, SUT.GetAbsoluteBoundsRect().GetCenter(), isTouchInput: true);
 			await WindowHelper.WaitForIdle();
 
-			Assert.IsFalse(processor.IsContextMenuOnHolding, "a mobile touch-and-hold is handled without a context menu, so it must not be flagged as menu-showing");
+			Assert.IsFalse(nonNullProcessor.IsContextMenuOnHolding, "a mobile touch-and-hold is handled without a context menu, so it must not be flagged as menu-showing");
 		}
 
 		// Native iOS: a touch long-press begins dragging the caret; the caret follows the finger and

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4857,6 +4857,58 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_Touch_Handle_Drag_Off_Text_Vertically_Still_Adjusts()
+		{
+			var SUT = new TextBox
+			{
+				Width = 300,
+				Text = "The quick brown fox jumps over",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			// Single Android tap mid-text -> collapsed caret + single insertion handle (EndOnly).
+			finger.Press(new Point(bounds.GetCenter().X, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "tap should place the single insertion handle");
+			await WindowHelper.WaitFor(
+				() => SUT.VisibleGrippersForTesting is { } vg && vg.end.GetAbsoluteBoundsRect().Width > 0,
+				timeoutMS: 3000,
+				message: "insertion handle should be positioned before dragging");
+
+			var caretBefore = SUT.SelectionStart;
+			Assert.IsTrue(caretBefore > 2 && caretBefore < SUT.Text.Length - 2, $"precondition: caret should be mid-text (now {caretBefore})");
+
+			// Grab the thumb and drag LEFT while far BELOW the text. The Y is off the text, but the caret should
+			// still follow the finger left (clamped Y) instead of snapping to the line's start.
+			var gripperBounds = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(gripperBounds.GetCenter().X, gripperBounds.Bottom - 2));
+			finger.MoveBy(-30, 300, stepOffsetInMilliseconds: 20);
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(SUT.SelectionStart < caretBefore, $"caret should move left while dragging below the text (before {caretBefore}, now {SUT.SelectionStart})");
+			Assert.IsTrue(SUT.SelectionStart > 0, $"caret should NOT snap to start of line (now {SUT.SelectionStart})");
+
+			var caretAfterLeft = SUT.SelectionStart;
+
+			// Grab the thumb again and drag RIGHT while far ABOVE the text: the caret follows the finger right.
+			gripperBounds = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(gripperBounds.GetCenter().X, gripperBounds.Bottom - 2));
+			finger.MoveBy(60, -300, stepOffsetInMilliseconds: 20);
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(SUT.SelectionStart > caretAfterLeft, $"caret should move right while dragging above the text (before {caretAfterLeft}, now {SUT.SelectionStart})");
+			Assert.IsTrue(SUT.SelectionStart < SUT.Text.Length, $"caret should NOT snap to end of line (now {SUT.SelectionStart})");
+		}
+
+		[TestMethod]
 		public Task When_Touch_SingleTap_Places_Caret_Android()
 			=> AssertTouchSingleTapPlacesCaret(TextBox.TouchTextSelectionConvention.Android, TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4809,6 +4809,75 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public Task When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs_Android()
+			=> AssertGripperDragReadjustsWordSelection(TextBox.TouchTextSelectionConvention.Android);
+
+		[TestMethod]
+		public Task When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs_iOS()
+			=> AssertGripperDragReadjustsWordSelection(TextBox.TouchTextSelectionConvention.iOS);
+
+		// Native iOS/Android sister of When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs: on mobile a
+		// single tap only places a caret, so the word selection comes from a double-tap. Dragging the end
+		// gripper then readjusts (extends) the selection, and spanning past the 800ms hold threshold must NOT
+		// be mistaken for a long-press (which word-selects on Android / caret-drags on iOS) and must keep both thumbs.
+		private static async Task AssertGripperDragReadjustsWordSelection(TextBox.TouchTextSelectionConvention convention)
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text long enough to drag",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Double-tap the first word (back-to-back, no idle between) to select it and show both thumbs.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var wordPoint = new Point(bounds.Left + 15, bounds.GetCenter().Y);
+			finger.Press(wordPoint);
+			finger.Release();
+			finger.Press(wordPoint);
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				message: "double-tap should select the word and show both thumbs");
+			var lengthBeforeDrag = SUT.SelectionLength;
+
+			// The gripper popups are (re)positioned asynchronously on a later frame, so GetAbsoluteBoundsRect
+			// is stale right after selecting. Wait until the end gripper is actually placed over the control
+			// before pressing it, otherwise the press can miss and the drag becomes a no-op (test flake).
+			await WindowHelper.WaitFor(
+				() =>
+				{
+					if (SUT.VisibleGrippersForTesting is not { } vg)
+					{
+						return false;
+					}
+					var g = vg.end.GetAbsoluteBoundsRect();
+					var s = SUT.GetAbsoluteBoundsRect();
+					return g.Width > 0 && g.Left < s.Right && s.Left < g.Right && g.Top < s.Bottom && s.Top < g.Bottom;
+				},
+				timeoutMS: 3000,
+				message: "end gripper should be positioned over the TextBox before dragging it");
+
+			// Grab the end THUMB near its bottom edge (what a real finger hits): the thumb hangs a full line
+			// below the caret, so sampling from the center can spill onto the next render line.
+			var gripperBounds = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(gripperBounds.GetCenter().X, gripperBounds.Bottom - 2));
+			finger.MoveBy(60, 0, stepOffsetInMilliseconds: 100); // spans >800ms, past the hold threshold, so a bug would trigger the long-press
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			// The drag readjusted (extended) the selection...
+			Assert.IsTrue(SUT.SelectionLength > lengthBeforeDrag, $"drag should extend the selection (was {lengthBeforeDrag}, now {SUT.SelectionLength})");
+			// ...and both thumbs must remain visible (the readjust must not be mistaken for a long-press that changes the selection and hides thumbs).
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
+		}
+
+		[TestMethod]
 		public async Task When_Touch_Single_Handle_Drag_From_Thumb_Keeps_Caret_In_Line()
 		{
 			var SUT = new TextBox

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4854,6 +4854,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public Task When_Touch_LongPress_Selects_Word_Android()
+			=> AssertTouchLongPress(TextBox.TouchTextSelectionConvention.Android, expectWordSelected: true);
+
+		[TestMethod]
+		public Task When_Touch_LongPress_Keeps_ContextMenu_Windows()
+			=> AssertTouchLongPress(TextBox.TouchTextSelectionConvention.Windows, expectWordSelected: false);
+
+		// Native Android: a touch long-press selects the word (and suppresses the context menu).
+		// The Windows convention keeps the default context-menu behavior (no auto word selection).
+		private static async Task AssertTouchLongPress(TextBox.TouchTextSelectionConvention convention, bool expectWordSelected)
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			// A touch long-press surfaces as a touch-originated ContextRequested (raised by the Holding
+			// gesture in the framework). Raise it directly to exercise the TextBox's handling
+			// deterministically, without depending on the 800ms hold timer.
+			var args = new ContextRequestedEventArgs { IsTouchInput = true };
+			args.SetGlobalPoint(SUT.GetAbsoluteBoundsRect().GetCenter());
+			SUT.SafeRaiseEvent(UIElement.ContextRequestedEvent, args);
+			await WindowHelper.WaitForIdle();
+
+			if (expectWordSelected)
+			{
+				Assert.AreEqual("Text", SUT.SelectedText);
+				Assert.IsTrue(args.Handled); // context menu suppressed
+			}
+			else
+			{
+				Assert.AreEqual("", SUT.SelectedText);
+			}
+		}
+
+		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
 		public async Task When_Touch_Focused_Then_Scrolled_Away()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4809,10 +4809,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
 		public Task When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs_Android()
 			=> AssertGripperDragReadjustsWordSelection(TextBox.TouchTextSelectionConvention.Android);
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaUIKit)] // iOS convention: run on Desktop (dev) + real iOS only
 		public Task When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs_iOS()
 			=> AssertGripperDragReadjustsWordSelection(TextBox.TouchTextSelectionConvention.iOS);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4769,16 +4769,31 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var bounds = SUT.GetAbsoluteBoundsRect();
 			finger.Press(new Point(bounds.Left + 15, bounds.GetCenter().Y));
 			finger.Release();
-			await WindowHelper.WaitForIdle();
-			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				message: "first tap should select the word and show both thumbs");
 			var lengthBeforeDrag = SUT.SelectionLength;
 
-			var grippers = SUT.VisibleGrippersForTesting;
-			Assert.IsNotNull(grippers, "expected the selection grippers to be visible after selecting a word");
+			// The gripper popups are (re)positioned asynchronously on a later frame, so GetAbsoluteBoundsRect
+			// is stale right after selecting. Wait until the end gripper is actually placed over the control
+			// before pressing it, otherwise the press can miss and the drag becomes a no-op (test flake).
+			await WindowHelper.WaitFor(
+				() =>
+				{
+					if (SUT.VisibleGrippersForTesting is not { } vg)
+					{
+						return false;
+					}
+					var g = vg.end.GetAbsoluteBoundsRect();
+					var s = SUT.GetAbsoluteBoundsRect();
+					return g.Width > 0 && g.Left < s.Right && s.Left < g.Right && g.Top < s.Bottom && s.Top < g.Bottom;
+				},
+				timeoutMS: 3000,
+				message: "end gripper should be positioned over the TextBox before dragging it");
 
 			// Drag the end gripper to the right to extend the selection, spanning >800ms press-to-release
 			// (a deliberate readjust naturally exceeds the hold threshold).
-			var endGripperCenter = grippers.Value.end.GetAbsoluteBoundsRect().GetCenter();
+			var endGripperCenter = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect().GetCenter();
 			finger.Press(endGripperCenter);
 			finger.MoveBy(60, 0, stepOffsetInMilliseconds: 100); // spans >800ms, past the hold threshold, so a bug would open the context menu
 			finger.Release();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4896,7 +4896,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finger.Release();
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual("Some ", SUT.SelectedText); // word + trailing space, as with the mouse double-click path
+			Assert.AreEqual("Some", SUT.SelectedText); // native Android selects just the word, not the trailing space
 			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4695,6 +4695,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop)] // Desktop touch-selection convention; mobile conventions tested separately
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
 		public async Task When_TextBox_Touch_Tapped_At_End()
 		{
@@ -4717,6 +4718,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop)] // Desktop touch-selection convention; mobile conventions tested separately
 		public async Task When_First_Second_Tap_Caret_Thumb_Shows()
 		{
 			var SUT = new TextBox
@@ -4752,6 +4754,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop)] // Desktop touch-selection convention; mobile conventions tested separately
 		public async Task When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs()
 		{
 			var SUT = new TextBox
@@ -5353,6 +5356,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop)] // Desktop touch-selection convention; mobile conventions tested separately
 		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21961")]
 		public async Task When_Caret_Positioning_With_Complex_Transformations()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4806,6 +4806,57 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_Touch_Single_Handle_Drag_From_Thumb_Keeps_Caret_In_Line()
+		{
+			var SUT = new TextBox
+			{
+				Width = 300,
+				Text = "The quick brown fox jumps over",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			// Single Android tap mid-text -> collapsed caret + single insertion handle (EndOnly).
+			finger.Press(new Point(bounds.Left + 90, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "tap should place the single insertion handle");
+
+			await WindowHelper.WaitFor(
+				() =>
+				{
+					if (SUT.VisibleGrippersForTesting is not { } vg)
+					{
+						return false;
+					}
+					var g = vg.end.GetAbsoluteBoundsRect();
+					var s = SUT.GetAbsoluteBoundsRect();
+					return g.Width > 0 && g.Left < s.Right && s.Left < g.Right && g.Top < s.Bottom && s.Top < g.Bottom;
+				},
+				timeoutMS: 3000,
+				message: "insertion handle should be positioned over the TextBox before dragging");
+
+			// Grab the THUMB near its bottom edge (what a real finger hits) rather than the gripper's center.
+			// The thumb hangs a full line below the caret; sampling the drag point without correcting for that
+			// spilled onto the next render line and snapped the caret to the end of the text (see the Y offset
+			// in TextSelectionGripperPresenter.OnGripperPointerMoved).
+			var gripperBounds = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(gripperBounds.GetCenter().X, gripperBounds.Bottom - 2));
+			finger.MoveBy(20, 0, stepOffsetInMilliseconds: 20);
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			// The caret should track the finger mid-text, NOT jump to the end of the text.
+			Assert.IsTrue(SUT.SelectionStart < SUT.Text.Length, $"caret should NOT jump to end of text (len {SUT.Text.Length}, now {SUT.SelectionStart})");
+		}
+
+		[TestMethod]
 		public Task When_Touch_SingleTap_Places_Caret_Android()
 			=> AssertTouchSingleTapPlacesCaret(TextBox.TouchTextSelectionConvention.Android, TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4864,6 +4864,42 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
 		}
 
+		[TestMethod]
+		public async Task When_Touch_DoubleTap_Android_After_Handle_Shown()
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Tap ON the first word (near the left) so the insertion handle lands over the tapped character.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var point = new Point(bounds.Left + 20, bounds.GetCenter().Y);
+
+			// First tap: Android places a caret with the single insertion handle.
+			finger.Press(point);
+			finger.Release();
+			await WindowHelper.WaitForIdle(); // let the insertion handle render + position (a real double-tap has this gap)
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing, SUT.CaretMode);
+			Assert.IsNotNull(SUT.VisibleGrippersForTesting, "insertion handle should be visible after the first Android tap");
+
+			// Second tap a few px away: still lands on the insertion handle (within its hit-rect) yet within the
+			// multi-tap window, so the double-tap must still select the word instead of being eaten by the handle.
+			finger.Press(new Point(point.X + 4, point.Y));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("Some ", SUT.SelectedText); // word + trailing space, as with the mouse double-click path
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
+		}
+
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
 		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4752,6 +4752,108 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public Task When_Touch_SingleTap_Places_Caret_Android()
+			=> AssertTouchSingleTapPlacesCaret(TextBox.TouchTextSelectionConvention.Android, TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing);
+
+		[TestMethod]
+		public Task When_Touch_SingleTap_Places_Caret_iOS()
+			=> AssertTouchSingleTapPlacesCaret(TextBox.TouchTextSelectionConvention.iOS, TextBox.CaretDisplayMode.ThumblessCaretShowing);
+
+		[TestMethod]
+		public Task When_Touch_DoubleTap_Selects_Word_Android()
+			=> AssertTouchDoubleTapSelectsWord(TextBox.TouchTextSelectionConvention.Android);
+
+		[TestMethod]
+		public Task When_Touch_DoubleTap_Selects_Word_iOS()
+			=> AssertTouchDoubleTapSelectsWord(TextBox.TouchTextSelectionConvention.iOS);
+
+		[TestMethod]
+		public Task When_Touch_Tap_Collapses_Selection_Android()
+			=> AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention.Android);
+
+		[TestMethod]
+		public Task When_Touch_Tap_Collapses_Selection_iOS()
+			=> AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention.iOS);
+
+		// Native iOS/Android: a single tap places a caret (it does NOT select a word like the Windows convention).
+		private static async Task AssertTouchSingleTapPlacesCaret(TextBox.TouchTextSelectionConvention convention, TextBox.CaretDisplayMode expectedCaret)
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.SelectedText);
+			Assert.AreEqual(expectedCaret, SUT.CaretMode);
+		}
+
+		// Native iOS/Android: a double-tap selects the word under the tap.
+		private static async Task AssertTouchDoubleTapSelectsWord(TextBox.TouchTextSelectionConvention convention)
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Two back-to-back taps (no idle between) fall inside the multi-tap window.
+			var center = SUT.GetAbsoluteBoundsRect().GetCenter();
+			finger.Press(center);
+			finger.Release();
+			finger.Press(center);
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("Text", SUT.SelectedText);
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
+		}
+
+		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
+		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			SUT.SelectAll();
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual("Some Text", SUT.SelectedText);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Tap near the left edge, inside the selected text.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			finger.Press(new Point(bounds.Left + 15, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.SelectedText);
+		}
+
+		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
 		public async Task When_Touch_Focused_Then_Scrolled_Away()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5051,11 +5051,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			=> AssertTouchLongPress(TextBox.TouchTextSelectionConvention.Android, expectWordSelected: true);
 
 		[TestMethod]
-		public Task When_Touch_LongPress_Keeps_ContextMenu_Windows()
-			=> AssertTouchLongPress(TextBox.TouchTextSelectionConvention.Windows, expectWordSelected: false);
+		public Task When_Touch_LongPress_Keeps_ContextMenu_Desktop()
+			=> AssertTouchLongPress(TextBox.TouchTextSelectionConvention.Desktop, expectWordSelected: false);
 
 		// Native Android: a touch long-press selects the word (and suppresses the context menu).
-		// The Windows convention keeps the default context-menu behavior (no auto word selection).
+		// The Desktop convention keeps the default context-menu behavior (no auto word selection).
 		private static async Task AssertTouchLongPress(TextBox.TouchTextSelectionConvention convention, bool expectWordSelected)
 		{
 			var SUT = new TextBox

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4893,6 +4893,50 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+		// Native iOS: a touch long-press begins dragging the caret; the caret follows the finger and
+		// no selection is created (no context menu).
+		[TestMethod]
+		public async Task When_Touch_LongPress_Drags_Caret_iOS()
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text long enough",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.iOS
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var startPoint = new Point(bounds.Left + 15, bounds.GetCenter().Y);
+
+			// Press, then simulate the 800ms hold as a touch ContextRequested (the iOS long-press
+			// entry) so the caret-drag starts and captures the pointer, without waiting on the timer.
+			finger.Press(startPoint);
+			var args = new ContextRequestedEventArgs { IsTouchInput = true };
+			args.SetGlobalPoint(startPoint);
+			SUT.SafeRaiseEvent(UIElement.ContextRequestedEvent, args);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(args.Handled); // context menu suppressed
+			Assert.AreEqual(0, SUT.SelectionLength); // a caret, not a selection
+			var caretAfterPress = SUT.SelectionStart;
+
+			// Dragging the finger to the right moves the caret with it (still no selection).
+			finger.MoveBy(150, 0, stepOffsetInMilliseconds: 20);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionLength);
+			Assert.IsTrue(SUT.SelectionStart > caretAfterPress, $"caret should advance with the drag (was {caretAfterPress}, now {SUT.SelectionStart})");
+
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
 		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
 		public async Task When_Touch_Focused_Then_Scrolled_Away()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5160,6 +5160,39 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+		[TestMethod]
+		public Task When_Touch_Hold_Does_Not_Flag_ContextMenu_Android()
+			=> AssertTouchHoldDoesNotFlagContextMenuOnHolding(TextBox.TouchTextSelectionConvention.Android);
+
+		[TestMethod]
+		public Task When_Touch_Hold_Does_Not_Flag_ContextMenu_iOS()
+			=> AssertTouchHoldDoesNotFlagContextMenuOnHolding(TextBox.TouchTextSelectionConvention.iOS);
+
+		// Native iOS/Android handle a touch-and-hold without opening a context menu. Routing it through the
+		// ContextMenuProcessor (the path the Holding gesture uses) must NOT flag the hold as menu-showing;
+		// otherwise a later HoldingState.Canceled (the finger moving during the caret-drag / after word-select)
+		// would spuriously raise ContextCanceled or close a light-dismiss popup the TextBox lives in.
+		private static async Task AssertTouchHoldDoesNotFlagContextMenuOnHolding(TextBox.TouchTextSelectionConvention convention)
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var processor = VisualTree.GetContentRootForElement(SUT)?.InputManager?.ContextMenuProcessor;
+			Assert.IsNotNull(processor);
+			processor.SetIsContextMenuOnHolding(false);
+
+			processor.RaiseContextRequestedEvent(SUT, SUT.GetAbsoluteBoundsRect().GetCenter(), isTouchInput: true);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(processor.IsContextMenuOnHolding, "a mobile touch-and-hold is handled without a context menu, so it must not be flagged as menu-showing");
+		}
+
 		// Native iOS: a touch long-press begins dragging the caret; the caret follows the finger and
 		// no selection is created (no context menu).
 		[TestMethod]
@@ -5202,6 +5235,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finger.Release();
 			await WindowHelper.WaitForIdle();
 			Assert.AreEqual(0, SUT.SelectionLength);
+			// The capture taken to drag the caret must be released on pointer up, not held past the gesture.
+			Assert.AreEqual(0, SUT.PointerCaptures?.Count ?? 0, "the caret-drag pointer capture must be released on release");
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -2111,7 +2111,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.IsFalse(handled);
-			Assert.AreEqual(SUT.Text.Substring(2, 4), await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual(SUT.Text.Substring(2, 4), await ClipboardHelper.WaitForTextAsync(SUT.Text.Substring(2, 4)));
 			Assert.AreEqual(2, SUT.SelectionStart);
 			Assert.AreEqual(4, SUT.SelectionLength);
 
@@ -2174,7 +2174,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.IsFalse(handled);
-			Assert.AreEqual("llo ", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual("llo ", await ClipboardHelper.WaitForTextAsync("llo "));
 			Assert.AreEqual("Heworld", SUT.Text);
 			Assert.AreEqual(2, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
@@ -3096,7 +3096,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.CopySelectionToClipboard();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual("Hello ", await Clipboard.GetContent()!.GetTextAsync());
+			Assert.AreEqual("Hello ", await ClipboardHelper.WaitForTextAsync("Hello "));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4752,6 +4752,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_Touch_Gripper_Drag_Readjusts_Selection_Keeps_Thumbs()
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text long enough to drag"
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// A single touch tap near the left selects the first word and shows both selection thumbs.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			finger.Press(new Point(bounds.Left + 15, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
+			var lengthBeforeDrag = SUT.SelectionLength;
+
+			var grippers = SUT.VisibleGrippersForTesting;
+			Assert.IsNotNull(grippers, "expected the selection grippers to be visible after selecting a word");
+
+			// Drag the end gripper to the right to extend the selection, spanning >800ms press-to-release
+			// (a deliberate readjust naturally exceeds the hold threshold).
+			var endGripperCenter = grippers.Value.end.GetAbsoluteBoundsRect().GetCenter();
+			finger.Press(endGripperCenter);
+			finger.MoveBy(60, 0, stepOffsetInMilliseconds: 100); // spans >800ms, past the hold threshold, so a bug would open the context menu
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			// The drag readjusted (extended) the selection...
+			Assert.IsTrue(SUT.SelectionLength > lengthBeforeDrag, $"drag should extend the selection (was {lengthBeforeDrag}, now {SUT.SelectionLength})");
+			// ...and both thumbs must remain visible (the readjust must not be mistaken for a long-press that opens the context menu and hides the thumbs).
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
+		}
+
+		[TestMethod]
 		public Task When_Touch_SingleTap_Places_Caret_Android()
 			=> AssertTouchSingleTapPlacesCaret(TextBox.TouchTextSelectionConvention.Android, TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
@@ -28,6 +28,13 @@ internal sealed class CaretWithStemAndThumb : Grid
 
 	public PointerPoint LastPointerDown { get; set; }
 
+	/// <summary>
+	/// Vertical distance (in the text surface's coordinates) from the finger to the caret line it points at,
+	/// captured when the gripper is pressed. The thumb hangs below the line, so the drag must subtract this to
+	/// sample the text on the caret's own line instead of the one below it. See TextSelectionGripperPresenter.
+	/// </summary>
+	public double GrabOffsetY { get; set; }
+
 	/// <param name="repositionCallback">
 	/// Invoked once per rendered frame while the gripper is showing, so the owner
 	/// can keep the gripper glued to its anchor character as the text moves.

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -67,8 +67,12 @@ internal interface ITextSelectionGripperHost
 	/// <summary>A gripper interaction ended: queue a selection-flyout visibility update.</summary>
 	void QueueGripperSelectionFlyout(PointerRoutedEventArgs args);
 
-	/// <summary>The gripper was tapped (not dragged or held): treat it like a tap on the text.</summary>
-	void OnGripperTapped(PointerRoutedEventArgs args);
+	/// <summary>
+	/// The gripper was tapped (not dragged or held): treat it like a tap on the text. <paramref name="press"/>
+	/// is the tap's <em>press</em> point, so the host can fold it into its multi-tap counter (a tap landing on
+	/// the insertion handle is still the second tap of a double-tap-to-select-word).
+	/// </summary>
+	void OnGripperTapped(PointerPoint press, PointerRoutedEventArgs args);
 }
 
 /// <summary>
@@ -263,7 +267,7 @@ internal sealed class TextSelectionGripperPresenter
 		else if (IsMultiTapGesture((previous.PointerId, previous.Timestamp, previous.Position), current))
 		{
 			args.Handled = true;
-			_host.OnGripperTapped(args);
+			_host.OnGripperTapped(previous, args);
 			_host.QueueGripperSelectionFlyout(args);
 		}
 		else

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -197,6 +197,16 @@ internal sealed class TextSelectionGripperPresenter
 		}
 
 		gripper.LastPointerDown = args.GetCurrentPoint(null);
+
+		// The finger grabs the thumb, which hangs below the caret line the gripper points at. Remember how far
+		// below that line's center the finger landed so the drag can sample the text on the caret's own line
+		// (see OnGripperPointerMoved). Without this the sample spills onto the line below and GetIndexAt jumps
+		// to the end of that line — on a single-line box, the end of the whole text.
+		var surface = _host.GripperTextSurface;
+		var gripperIndex = gripper == _startGripper ? _host.SelectionLowerIndex : _host.SelectionUpperIndex;
+		var lineRect = surface.ParsedText.GetRectForIndex(gripperIndex);
+		var lineCenterSurfaceY = surface.Padding.Top + lineRect.Y + lineRect.Height / 2;
+		gripper.GrabOffsetY = args.GetCurrentPoint(surface).Position.Y - lineCenterSurfaceY;
 	}
 
 	private void OnGripperPointerMoved(object sender, PointerRoutedEventArgs args)
@@ -209,9 +219,13 @@ internal sealed class TextSelectionGripperPresenter
 		args.Handled = true;
 
 		var surface = _host.GripperTextSurface;
-		var point = args.GetCurrentPoint(surface).Position
-			- new Point(surface.Padding.Left, surface.Padding.Top)
-			- new Point(0, (gripper.Height - 16) / 2);
+		// Subtract the grab offset captured on press so the drag samples the caret's own line (where the finger
+		// started relative to it), not the thumb's position a line below. Dragging vertically still moves across
+		// lines because the finger's own vertical movement is preserved in GetCurrentPoint.
+		var moveSurface = args.GetCurrentPoint(surface).Position;
+		var point = new Point(
+			moveSurface.X - surface.Padding.Left,
+			moveSurface.Y - gripper.GrabOffsetY - surface.Padding.Top);
 		var index = Math.Max(0, surface.ParsedText.GetIndexAt(point, false, true));
 
 		if (_host.GripperMode == GripperMode.EndOnly)

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -253,9 +253,10 @@ internal sealed class TextSelectionGripperPresenter
 		var current = args.GetCurrentPoint(null);
 
 		var holdDuration = current.Timestamp - previous.Timestamp;
-		if (holdDuration >= GestureRecognizer.HoldMinDelayMicroseconds)
+		var stayedInPlace = !GestureRecognizer.IsOutOfTapRange(previous.Position, current.Position);
+		if (stayedInPlace && holdDuration >= GestureRecognizer.HoldMinDelayMicroseconds)
 		{
-			// Gripper was held: open the context menu (mirrors WinUI OnGripperHeld).
+			// The gripper was held in place (not dragged): open the context menu (mirrors WinUI OnGripperHeld).
 			args.Handled = true;
 			_host.RequestGripperContextMenu(args);
 		}
@@ -267,6 +268,7 @@ internal sealed class TextSelectionGripperPresenter
 		}
 		else
 		{
+			// The gripper was dragged to adjust the selection: keep the thumbs and re-show the selection toolbar.
 			_host.QueueGripperSelectionFlyout(args);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -220,12 +220,19 @@ internal sealed class TextSelectionGripperPresenter
 
 		var surface = _host.GripperTextSurface;
 		// Subtract the grab offset captured on press so the drag samples the caret's own line (where the finger
-		// started relative to it), not the thumb's position a line below. Dragging vertically still moves across
-		// lines because the finger's own vertical movement is preserved in GetCurrentPoint.
+		// started relative to it), not the thumb's position a line below.
 		var moveSurface = args.GetCurrentPoint(surface).Position;
-		var point = new Point(
-			moveSurface.X - surface.Padding.Left,
-			moveSurface.Y - gripper.GrabOffsetY - surface.Padding.Top);
+		var sampleY = moveSurface.Y - gripper.GrabOffsetY - surface.Padding.Top;
+
+		// Clamp the sampled Y into the text's vertical span (first line's centre .. last line's centre) so a finger
+		// that drifts above or below the text still adjusts the caret horizontally, instead of GetIndexAt clamping
+		// the out-of-range Y and snapping the caret to a line's start/end. GetRectForIndex clamps its index, so
+		// int.MaxValue yields the last line's rect.
+		var firstLine = surface.ParsedText.GetRectForIndex(0);
+		var lastLine = surface.ParsedText.GetRectForIndex(int.MaxValue);
+		sampleY = Math.Clamp(sampleY, firstLine.GetMidY(), lastLine.GetMidY());
+
+		var point = new Point(moveSurface.X - surface.Padding.Left, sampleY);
 		var index = Math.Max(0, surface.ParsedText.GetIndexAt(point, false, true));
 
 		if (_host.GripperMode == GripperMode.EndOnly)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -752,7 +752,9 @@ namespace Microsoft.UI.Xaml.Controls
 		void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args)
 			=> QueueUpdateSelectionFlyoutVisibility(args.Pointer.PointerDeviceType, args.GetCurrentPoint(this).Position);
 
-		void ITextSelectionGripperHost.OnGripperTapped(PointerRoutedEventArgs args)
+		// A TextBlock only ever shows Both-mode grippers (at the selection edges), so there's no insertion
+		// handle to fold into a double-tap counter; the press point is unused here.
+		void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, PointerRoutedEventArgs args)
 			=> TouchTap(args.GetCurrentPoint(this).Position);
 		#endregion
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -268,6 +268,26 @@ public partial class TextBox
 		CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
 	}
 
+	// On iOS/Android a touch-and-hold does native text selection instead of opening a context menu:
+	// Android selects the word under the press (the selection toolbar then appears via the selection
+	// flyout). Mouse/pen right-click and the Windows convention keep the default context flyout.
+	private protected override void OnContextRequestedImpl(ContextRequestedEventArgs args)
+	{
+		if (_isSkiaTextBox
+			&& args.IsTouchInput
+			&& TouchSelectionConvention == TouchTextSelectionConvention.Android
+			&& args.TryGetPosition(TextBoxView.DisplayBlock, out var displayBlockPoint))
+		{
+			TouchSelectWord(displayBlockPoint);
+			args.TryGetPosition(this, out var textBoxPoint);
+			QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, textBoxPoint);
+			args.Handled = true; // suppress the default context flyout
+			return;
+		}
+
+		base.OnContextRequestedImpl(args);
+	}
+
 	partial void OnPointerCaptureLostPartial(PointerRoutedEventArgs e)
 	{
 		_isPressed = false;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -118,7 +118,9 @@ public partial class TextBox
 	// Touch taps can't reuse IsMultiTapGesture: successive touch presses get different pointer ids,
 	// so we compare only the timing and distance between the two taps.
 	private static bool IsTouchMultiTap(PointerPoint previous, PointerPoint current)
-		=> current.Timestamp - previous.Timestamp <= GestureRecognizer.MultiTapMaxDelayMicroseconds
+		=> previous.PointerDeviceType == PointerDeviceType.Touch
+			&& current.PointerDeviceType == PointerDeviceType.Touch
+			&& current.Timestamp - previous.Timestamp <= GestureRecognizer.MultiTapMaxDelayMicroseconds
 			&& !GestureRecognizer.IsOutOfTapRange(previous.Position, current.Position);
 
 	partial void OnPointerPressedPartial(PointerRoutedEventArgs args)
@@ -332,10 +334,13 @@ public partial class TextBox
 					break;
 			}
 
-			args.Handled = true; // suppress the default context flyout on iOS/Android
+			// suppress the default context flyout on iOS/Android
+			args.Handled = true;
+
 			// We handled the hold without opening a context menu, so don't let a later HoldingState.Canceled
 			// (finger moves during the caret-drag / after word-select) spuriously cancel a non-existent menu.
 			args.PreventContextMenuOnHolding = true;
+
 			return;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -217,6 +217,7 @@ public partial class TextBox
 		if (_touchCaretDrag)
 		{
 			// End the iOS caret-drag; OnPointerMoved has already positioned the caret at the finger.
+			// The framework releases the touch capture on pointer-up, so no explicit release is needed here.
 			_touchCaretDrag = false;
 			return;
 		}
@@ -332,6 +333,9 @@ public partial class TextBox
 			}
 
 			args.Handled = true; // suppress the default context flyout on iOS/Android
+			// We handled the hold without opening a context menu, so don't let a later HoldingState.Canceled
+			// (finger moves during the caret-drag / after word-select) spuriously cancel a non-existent menu.
+			args.PreventContextMenuOnHolding = true;
 			return;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -280,9 +280,24 @@ public partial class TextBox
 
 	private void TouchSelectWord(Point point)
 	{
-		var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point, true, true));
-		var chunk = TextBoxView.DisplayBlock.ParsedText.GetWordAt(index, true);
-		Select(chunk.start, chunk.length); // touch selection doesn't go backwards (no "negative length")
+		var displayBlock = TextBoxView.DisplayBlock;
+		var index = Math.Max(0, displayBlock.ParsedText.GetIndexAt(point, true, true));
+		var chunk = displayBlock.ParsedText.GetWordAt(index, true);
+
+		// GetWordAt bundles the trailing space into the word chunk; native iOS/Android select just the word,
+		// so trim it off (but keep a whitespace-only chunk intact).
+		var text = displayBlock.Text;
+		var length = chunk.length;
+		while (length > 0 && text[chunk.start + length - 1] == ' ')
+		{
+			length--;
+		}
+		if (length == 0)
+		{
+			length = chunk.length;
+		}
+
+		Select(chunk.start, length); // touch selection doesn't go backwards (no "negative length")
 		CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -24,6 +24,9 @@ public partial class TextBox
 	// this is necessary because we can receive a PointerReleased without a PointerPressed (e.g. clicking on the
 	// TextBox while the context menu is open to dismiss it). We want to ignore such PointerPressed's.
 	private bool _isPressed;
+	// True while an iOS-convention touch caret-drag is in progress (started by a long-press): the caret
+	// follows the finger until release. See BeginTouchCaretDrag / OnContextRequestedImpl.
+	private bool _touchCaretDrag;
 
 	protected override void OnPointerMoved(PointerRoutedEventArgs e)
 	{
@@ -37,8 +40,16 @@ public partial class TextBox
 
 		if (e.Pointer.PointerDeviceType == PointerDeviceType.Touch)
 		{
-			// do nothing whether the touch pointer is pressed on not.
-			// Moving while pressing the caret thumb or stem will move it. Anything else won't do anything.
+			if (_touchCaretDrag)
+			{
+				// iOS caret dragging (started by a long-press): the caret follows the finger.
+				var point = e.GetCurrentPoint(TextBoxView.DisplayBlock);
+				var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point.Position, true, true));
+				Select(index, 0);
+				CaretMode = CaretDisplayMode.ThumblessCaretShowing;
+			}
+			// Otherwise do nothing: moving while pressing the caret thumb or stem moves it (handled by the
+			// gripper presenter); any other plain touch move does nothing.
 		}
 		else
 		{
@@ -196,6 +207,13 @@ public partial class TextBox
 			return;
 		}
 
+		if (_touchCaretDrag)
+		{
+			// End the iOS caret-drag; OnPointerMoved has already positioned the caret at the finger.
+			_touchCaretDrag = false;
+			return;
+		}
+
 		var touchHoldTime = args.GetCurrentPoint(null).Timestamp - _lastPointerDown.point.Timestamp;
 
 		if (touchHoldTime >= GestureRecognizer.HoldMinDelayMicroseconds)
@@ -270,28 +288,53 @@ public partial class TextBox
 
 	// On iOS/Android a touch-and-hold does native text selection instead of opening a context menu:
 	// Android selects the word under the press (the selection toolbar then appears via the selection
-	// flyout). Mouse/pen right-click and the Windows convention keep the default context flyout.
+	// flyout); iOS starts dragging the caret. Mouse/pen right-click and the Windows convention keep
+	// the default context flyout.
 	private protected override void OnContextRequestedImpl(ContextRequestedEventArgs args)
 	{
 		if (_isSkiaTextBox
 			&& args.IsTouchInput
-			&& TouchSelectionConvention == TouchTextSelectionConvention.Android
+			&& TouchSelectionConvention != TouchTextSelectionConvention.Windows
 			&& args.TryGetPosition(TextBoxView.DisplayBlock, out var displayBlockPoint))
 		{
-			TouchSelectWord(displayBlockPoint);
-			args.TryGetPosition(this, out var textBoxPoint);
-			QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, textBoxPoint);
-			args.Handled = true; // suppress the default context flyout
+			switch (TouchSelectionConvention)
+			{
+				case TouchTextSelectionConvention.Android:
+					TouchSelectWord(displayBlockPoint);
+					args.TryGetPosition(this, out var textBoxPoint);
+					QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, textBoxPoint);
+					break;
+				case TouchTextSelectionConvention.iOS:
+					BeginTouchCaretDrag(displayBlockPoint);
+					break;
+			}
+
+			args.Handled = true; // suppress the default context flyout on iOS/Android
 			return;
 		}
 
 		base.OnContextRequestedImpl(args);
 	}
 
+	// iOS long-press: place the caret at the press point and capture the pointer so the caret follows
+	// the finger (see OnPointerMoved). Approximates the native magnifier without the zoomed loupe.
+	private void BeginTouchCaretDrag(Point displayBlockPoint)
+	{
+		var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(displayBlockPoint, true, true));
+		Select(index, 0);
+		CaretMode = CaretDisplayMode.ThumblessCaretShowing;
+		_touchCaretDrag = true;
+		if (PointerRoutedEventArgs.LastPointerEvent?.Pointer is { } pointer)
+		{
+			CapturePointer(pointer);
+		}
+	}
+
 	partial void OnPointerCaptureLostPartial(PointerRoutedEventArgs e)
 	{
 		_isPressed = false;
 		_mouseMultiTapChunk = null;
+		_touchCaretDrag = false;
 	}
 
 	protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -224,7 +224,7 @@ public partial class TextBox
 		else if (!Text.IsNullOrEmpty()) // Touch tap
 		{
 			var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
-			if (TouchSelectionConvention != TouchTextSelectionConvention.Windows && _lastPointerDown.repeatedPresses >= 1)
+			if (TouchSelectionConvention != TouchTextSelectionConvention.Desktop && _lastPointerDown.repeatedPresses >= 1)
 			{
 				// Native iOS/Android: a double-tap selects the word under the tap.
 				TouchSelectWord(displayBlockPoint);
@@ -257,7 +257,7 @@ public partial class TextBox
 				Select(index, 0);
 				CaretMode = CaretDisplayMode.ThumblessCaretShowing;
 				break;
-			default: // Windows
+			default: // Desktop
 				var tappedChunk = TextBoxView.DisplayBlock.ParsedText.GetWordAt(index, true);
 				var tappedInsideSelection = _selection.start <= index && index < _selection.start + _selection.length;
 				if (tappedInsideSelection)
@@ -303,13 +303,13 @@ public partial class TextBox
 
 	// On iOS/Android a touch-and-hold does native text selection instead of opening a context menu:
 	// Android selects the word under the press (the selection toolbar then appears via the selection
-	// flyout); iOS starts dragging the caret. Mouse/pen right-click and the Windows convention keep
+	// flyout); iOS starts dragging the caret. Mouse/pen right-click and the Desktop convention keep
 	// the default context flyout.
 	private protected override void OnContextRequestedImpl(ContextRequestedEventArgs args)
 	{
 		if (_isSkiaTextBox
 			&& args.IsTouchInput
-			&& TouchSelectionConvention != TouchTextSelectionConvention.Windows
+			&& TouchSelectionConvention != TouchTextSelectionConvention.Desktop
 			&& args.TryGetPosition(TextBoxView.DisplayBlock, out var displayBlockPoint))
 		{
 			switch (TouchSelectionConvention)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -16,8 +16,8 @@ namespace Microsoft.UI.Xaml.Controls;
 public partial class TextBox
 {
 	/// <summary>
-	/// point is null before first press. repeatedPresses is only valid if point.Pointer.PointerDeviceType
-	/// is Mouse.
+	/// point is null before first press. repeatedPresses counts consecutive multi-taps for both Mouse
+	/// (see OnPointerPressedPartial) and Touch (OnPointerPressedPartial / OnGripperTapped).
 	/// </summary>
 	private (PointerPoint point, int repeatedPresses) _lastPointerDown;
 	private (int start, int length, bool tripleTap)? _mouseMultiTapChunk;
@@ -104,6 +104,12 @@ public partial class TextBox
 			&& !GestureRecognizer.IsOutOfTapRange(previousTap.position, currentPosition);
 	}
 
+	// Touch taps can't reuse IsMultiTapGesture: successive touch presses get different pointer ids,
+	// so we compare only the timing and distance between the two taps.
+	private static bool IsTouchMultiTap(PointerPoint previous, PointerPoint current)
+		=> current.Timestamp - previous.Timestamp <= GestureRecognizer.MultiTapMaxDelayMicroseconds
+			&& !GestureRecognizer.IsOutOfTapRange(previous.Position, current.Position);
+
 	partial void OnPointerPressedPartial(PointerRoutedEventArgs args)
 	{
 		_isPressed = true;
@@ -117,8 +123,12 @@ public partial class TextBox
 		var currentPoint = args.GetCurrentPoint(null);
 		if (args.Pointer.PointerDeviceType == PointerDeviceType.Touch)
 		{
-			// we handle touch on the PointerReleased end
-			_lastPointerDown = (currentPoint, 0);
+			// We handle touch on the PointerReleased end, but count repeated taps here (mirroring the
+			// mouse multi-tap path) so a touch double-tap can select a word on release.
+			var repeatedPresses = _lastPointerDown.point is { } previous && IsTouchMultiTap(previous, currentPoint)
+				? _lastPointerDown.repeatedPresses + 1
+				: 0;
+			_lastPointerDown = (currentPoint, repeatedPresses);
 			// Dismiss the selection flyout on press; the gesture re-shows it (tap) or yields to the context menu (hold).
 			DismissSelectionFlyoutForPointerPress();
 		}
@@ -195,7 +205,16 @@ public partial class TextBox
 		}
 		else if (!Text.IsNullOrEmpty()) // Touch tap
 		{
-			TouchTap(args.GetCurrentPoint(TextBoxView.DisplayBlock).Position, wasFocused);
+			var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
+			if (TouchSelectionConvention != TouchTextSelectionConvention.Windows && _lastPointerDown.repeatedPresses >= 1)
+			{
+				// Native iOS/Android: a double-tap selects the word under the tap.
+				TouchSelectWord(displayBlockPoint);
+			}
+			else
+			{
+				TouchTap(displayBlockPoint, wasFocused);
+			}
 			// Ported from: microsoft-ui-xaml2/src/dxaml/xcp/core/native/text/Controls/TextBoxBase.cpp (line 2088)
 			// OnPointerReleased - queue SelectionFlyout visibility update after pointer release
 			QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, args.GetCurrentPoint(this).Position);
@@ -206,23 +225,47 @@ public partial class TextBox
 	{
 		var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point, true, true));
 
-		var tappedChunk = TextBoxView.DisplayBlock.ParsedText.GetWordAt(index, true);
+		switch (TouchSelectionConvention)
+		{
+			case TouchTextSelectionConvention.Android:
+				// A single tap places the caret with the single insertion handle; tapping inside an
+				// existing selection collapses it to a caret at the tap (native Android).
+				Select(index, 0);
+				CaretMode = CaretDisplayMode.CaretWithThumbsOnlyEndShowing;
+				break;
+			case TouchTextSelectionConvention.iOS:
+				// A single tap places a bare blinking caret (no handle); tapping inside a selection
+				// collapses it to a caret at the tap (native iOS).
+				Select(index, 0);
+				CaretMode = CaretDisplayMode.ThumblessCaretShowing;
+				break;
+			default: // Windows
+				var tappedChunk = TextBoxView.DisplayBlock.ParsedText.GetWordAt(index, true);
+				var tappedInsideSelection = _selection.start <= index && index < _selection.start + _selection.length;
+				if (tappedInsideSelection)
+				{
+					CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
+				}
+				else if (_selection.length == 0)
+				{
+					Select(tappedChunk.start, tappedChunk.length); // touch selection doesn't go backwards (no "negative length")
+					CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
+				}
+				else // outside a selection
+				{
+					Select(tappedChunk.start, 0);
+					CaretMode = CaretDisplayMode.CaretWithThumbsOnlyEndShowing;
+				}
+				break;
+		}
+	}
 
-		var tappedInsideSelection = _selection.start <= index && index < _selection.start + _selection.length;
-		if (tappedInsideSelection)
-		{
-			CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
-		}
-		else if (_selection.length == 0)
-		{
-			Select(tappedChunk.start, tappedChunk.length); // touch selection doesn't go backwards (no "negative length")
-			CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
-		}
-		else // outside a selection
-		{
-			Select(tappedChunk.start, 0);
-			CaretMode = CaretDisplayMode.CaretWithThumbsOnlyEndShowing;
-		}
+	private void TouchSelectWord(Point point)
+	{
+		var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point, true, true));
+		var chunk = TextBoxView.DisplayBlock.ParsedText.GetWordAt(index, true);
+		Select(chunk.start, chunk.length); // touch selection doesn't go backwards (no "negative length")
+		CaretMode = CaretDisplayMode.CaretWithThumbsBothEndsShowing;
 	}
 
 	partial void OnPointerCaptureLostPartial(PointerRoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -338,11 +338,10 @@ public partial class TextBox
 		var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(displayBlockPoint, true, true));
 		Select(index, 0);
 		CaretMode = CaretDisplayMode.ThumblessCaretShowing;
-		_touchCaretDrag = true;
-		if (PointerRoutedEventArgs.LastPointerEvent?.Pointer is { } pointer)
-		{
-			CapturePointer(pointer);
-		}
+		// Only enter caret-drag mode if we actually hold the pointer; without capture OnPointerMoved can't track
+		// the finger, so leaving the flag set would make OnPointerReleasedPartial skip normal touch-release handling.
+		_touchCaretDrag = PointerRoutedEventArgs.LastPointerEvent?.Pointer is { } pointer
+			&& (CapturePointer(pointer) || HasPointerCapture);
 	}
 
 	partial void OnPointerCaptureLostPartial(PointerRoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -201,6 +201,13 @@ public partial class TextBox
 		}
 		_isPressed = false;
 
+		if (!_isSkiaTextBox)
+		{
+			// Touch selection is handled by the native control for the overlay TextBox; the press side
+			// never runs for it, so _lastPointerDown is left uninitialized here.
+			return;
+		}
+
 		if (args.Pointer.PointerDeviceType is not PointerDeviceType.Touch)
 		{
 			// Mouse is handled on the PointerPressed side

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -115,6 +115,15 @@ public partial class TextBox : ITextSelectionGripperHost
 		}
 	}
 
+	// Settable so runtime tests can force a mobile convention on Skia Desktop, where
+	// OperatingSystem.IsAndroid()/IsIOS() are both false and the OS-derived default is Windows.
+	internal TouchTextSelectionConvention TouchSelectionConvention { get; set; } = GetDefaultTouchTextSelectionConvention();
+
+	private static TouchTextSelectionConvention GetDefaultTouchTextSelectionConvention()
+		=> OperatingSystem.IsAndroid() ? TouchTextSelectionConvention.Android
+			: Uno.UI.Helpers.DeviceTargetHelper.IsUIKit() ? TouchTextSelectionConvention.iOS
+			: TouchTextSelectionConvention.Windows;
+
 	public static DependencyProperty CanUndoProperty { get; } = DependencyProperty.Register(
 		nameof(CanUndo),
 		typeof(bool),
@@ -1800,6 +1809,16 @@ public partial class TextBox : ITextSelectionGripperHost
 		ThumblessCaretShowing,
 		CaretWithThumbsOnlyEndShowing,
 		CaretWithThumbsBothEndsShowing
+	}
+
+	// Which platform's native touch text-selection conventions the Skia TextBox follows.
+	// Defaults to the running OS; runtime tests override it to exercise the mobile behavior on
+	// Skia Desktop, where OperatingSystem.IsAndroid()/IsIOS() are both false.
+	internal enum TouchTextSelectionConvention
+	{
+		Windows,
+		Android,
+		iOS
 	}
 
 	private record struct HistoryRecord(TextBoxAction Action, int SelectionStart, int SelectionLength, bool SelectionEndsAtTheStart);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -120,13 +120,13 @@ public partial class TextBox : ITextSelectionGripperHost
 	}
 
 	// Settable so runtime tests can force a mobile convention on Skia Desktop, where
-	// OperatingSystem.IsAndroid()/IsIOS() are both false and the OS-derived default is Windows.
+	// OperatingSystem.IsAndroid()/IsIOS() are both false and the OS-derived default is Desktop.
 	internal TouchTextSelectionConvention TouchSelectionConvention { get; set; } = GetDefaultTouchTextSelectionConvention();
 
 	private static TouchTextSelectionConvention GetDefaultTouchTextSelectionConvention()
 		=> OperatingSystem.IsAndroid() ? TouchTextSelectionConvention.Android
 			: Uno.UI.Helpers.DeviceTargetHelper.IsUIKit() ? TouchTextSelectionConvention.iOS
-			: TouchTextSelectionConvention.Windows;
+			: TouchTextSelectionConvention.Desktop;
 
 	public static DependencyProperty CanUndoProperty { get; } = DependencyProperty.Register(
 		nameof(CanUndo),
@@ -1820,7 +1820,8 @@ public partial class TextBox : ITextSelectionGripperHost
 	// Skia Desktop, where OperatingSystem.IsAndroid()/IsIOS() are both false.
 	internal enum TouchTextSelectionConvention
 	{
-		Windows,
+		// Desktop convention (Windows, macOS and Linux): the OS-derived default for every non-mobile target.
+		Desktop,
 		Android,
 		iOS
 	}
@@ -1917,7 +1918,7 @@ public partial class TextBox : ITextSelectionGripperHost
 		_lastPointerDown = (press, repeatedPresses);
 
 		var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
-		if (TouchSelectionConvention != TouchTextSelectionConvention.Windows && repeatedPresses >= 1)
+		if (TouchSelectionConvention != TouchTextSelectionConvention.Desktop && repeatedPresses >= 1)
 		{
 			TouchSelectWord(displayBlockPoint);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1906,8 +1906,26 @@ public partial class TextBox : ITextSelectionGripperHost
 	void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args)
 		=> QueueUpdateSelectionFlyoutVisibility(args.Pointer.PointerDeviceType, args.GetCurrentPoint(this).Position);
 
-	void ITextSelectionGripperHost.OnGripperTapped(PointerRoutedEventArgs args)
-		=> TouchTap(args.GetCurrentPoint(TextBoxView.DisplayBlock).Position, true);
+	void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, PointerRoutedEventArgs args)
+	{
+		// The insertion handle (EndOnly gripper) sits over the character it points at, so the second tap of
+		// a double-tap lands on the handle instead of the text. Fold it into the same multi-tap counter as
+		// OnPointerReleasedPartial (press-to-press) so the double-tap still selects the word.
+		var repeatedPresses = _lastPointerDown.point is { } previous && IsTouchMultiTap(previous, press)
+			? _lastPointerDown.repeatedPresses + 1
+			: 0;
+		_lastPointerDown = (press, repeatedPresses);
+
+		var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
+		if (TouchSelectionConvention != TouchTextSelectionConvention.Windows && repeatedPresses >= 1)
+		{
+			TouchSelectWord(displayBlockPoint);
+		}
+		else
+		{
+			TouchTap(displayBlockPoint, true);
+		}
+	}
 	#endregion
 
 	/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -42,6 +42,10 @@ public partial class TextBox : ITextSelectionGripperHost
 	private readonly bool _isSkiaTextBox = !FeatureConfiguration.TextBox.UseOverlayOnSkia;
 
 	private TextSelectionGripperPresenter _gripperPresenter;
+
+	// Test hook: the pair of touch-selection grippers when they are currently showing, otherwise null.
+	internal (CaretWithStemAndThumb start, CaretWithStemAndThumb end)? VisibleGrippersForTesting => _gripperPresenter?.VisibleGrippersForTesting;
+
 	private TextBoxView _textBoxView;
 	private static ITextBoxNotificationsProviderSingleton _textBoxNotificationsSingleton;
 	private SerialDisposable _clipboardChangeSubscription = new SerialDisposable();

--- a/src/Uno.UI/UI/Xaml/Input/ContextRequestedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ContextRequestedEventArgs.cs
@@ -81,6 +81,12 @@ public partial class ContextRequestedEventArgs : RoutedEventArgs, IHandleableRou
 	}
 
 	/// <summary>
+	/// Whether this context request originated from touch input (a touch-and-hold gesture)
+	/// as opposed to mouse/pen right-click or keyboard. Set internally by ContextMenuProcessor.
+	/// </summary>
+	internal bool IsTouchInput { get; set; }
+
+	/// <summary>
 	/// Sets the global point position. Used internally by ContextMenuProcessor.
 	/// </summary>
 	/// <param name="point">The global point, or (-1, -1) for keyboard invocation.</param>

--- a/src/Uno.UI/UI/Xaml/Input/ContextRequestedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ContextRequestedEventArgs.cs
@@ -87,6 +87,14 @@ public partial class ContextRequestedEventArgs : RoutedEventArgs, IHandleableRou
 	internal bool IsTouchInput { get; set; }
 
 	/// <summary>
+	/// Set by a handler that marks the event Handled for a touch-and-hold but does NOT open a context
+	/// menu (e.g. the Skia TextBox iOS caret-drag / Android word-select). It tells ContextMenuProcessor
+	/// not to flag the hold as showing a menu, so a later HoldingState.Canceled won't spuriously raise
+	/// ContextCanceled or close a light-dismiss popup.
+	/// </summary>
+	internal bool PreventContextMenuOnHolding { get; set; }
+
+	/// <summary>
 	/// Sets the global point position. Used internally by ContextMenuProcessor.
 	/// </summary>
 	/// <param name="point">The global point, or (-1, -1) for keyboard invocation.</param>

--- a/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
@@ -93,7 +93,9 @@ internal partial class ContextMenuProcessor
 			uiElement.RaiseEvent(UIElement.ContextRequestedEvent, args);
 		}
 
-		if (args.Handled && isTouchInput)
+		// PreventContextMenuOnHolding: a handler marked the event Handled without showing a menu (e.g. the Skia
+		// TextBox mobile touch conventions), so don't treat the hold as menu-showing.
+		if (args.Handled && isTouchInput && !args.PreventContextMenuOnHolding)
 		{
 			_isContextMenuOnHolding = true;
 		}

--- a/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContextMenuProcessor.cs
@@ -77,6 +77,7 @@ internal partial class ContextMenuProcessor
 	{
 		var args = new ContextRequestedEventArgs();
 		args.SetGlobalPoint(point);
+		args.IsTouchInput = isTouchInput;
 
 		if (source is UIElement uiElement)
 		{


### PR DESCRIPTION
**GitHub Issue:** Tracked internally; No public issue.

## PR Type:

✨ Feature

## What changed? 🚀

Aligns the **Skia** `TextBox` touch text-selection to native **iOS / Android** conventions. Previously the Skia touch path behaved identically on every target and matched neither platform (a single tap selected the whole word, long-press opened the context menu, touch double-tap was discarded). Desktop / WASM Skia keep today's behavior via a default `Windows` convention, so this is a deliberate, contained divergence only on Skia-mobile.

Behavior is selected per-instance through an internal, test-settable `TouchTextSelectionConvention { Windows, Android, iOS }` (default derived from the OS). This makes every mobile path exercisable in the Skia-Desktop runtime-test harness, where `OperatingSystem.IsAndroid()/IsIOS()` are both false.

| Gesture | Windows (unchanged) | Android | iOS |
|---|---|---|---|
| Single tap | select word | caret + insertion handle | bare blinking caret |
| Tap inside selection | keep | collapse to caret | collapse to caret |
| Double tap | (n/a) | select word (no trailing space) | select word (no trailing space) |
| Long press | context menu | select word + selection toolbar | begin caret drag (live-move) |
| Drag a handle | existing | existing | existing |

Included fixes on top of the feature:
- Gripper drag no longer hides the selection thumbs, and a held gripper no longer bounces focus.
- Touch double-tap that lands on the insertion handle still selects the word.
- Word selection excludes the trailing space (native iOS/Android).
- **Insertion-handle drag no longer jumps the caret to the end of the text.** Root cause: the handle's thumb hangs a full line below the caret, and the drag sampled the text at a fixed offset that assumed a grid-center grab; a real finger grabs the thumb (lower), so the sample spilled onto the next render line and `GetIndexAt` returned end-of-line. Fixed by capturing the finger's vertical offset from the caret's line at press time and preserving it during the drag (validated on a physical Android device), plus clamping the sampled Y into the text's line span. The fix lives in the shared `TextSelectionGripperPresenter`, so it applies to both the `TextBox` insertion handle and the selectable `TextBlock` selection handles.

Scope is the Skia UI layer only; native (`.Android.cs` / `.iOS.cs`) `TextBox` uses the platform `EditText` / `UITextField` and is untouched. No public API changes (new members are `internal`).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
