### PR TITLE
chore: Bump Uno.ICU to 77.3.0-dev.4

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -76,7 +76,7 @@
 		<MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
 		<SkiaSharpVersion>3.119.0</SkiaSharpVersion>
 		<HarfbuzzSharpVersion>8.3.1.1</HarfbuzzSharpVersion>
-		<UnoICUVersion>77.2.1</UnoICUVersion>
+		<UnoICUVersion>77.3.0-dev.4</UnoICUVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.7.1" />
-		<PackageReference Include="Uno.icu-win" Version="77.3.0-dev.4" />
+		<PackageReference Include="Uno.icu-win" />
 
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.7.1" />
-		<PackageReference Include="Uno.icu-win" Version="77.1.2" />
+		<PackageReference Include="Uno.icu-win" Version="77.3.0-dev.4" />
 
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />


### PR DESCRIPTION
**GitHub Issue:** N/A (dependency bump)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Bumps the Uno.ICU dependency (`Uno.icu-macos` / `Uno.icu-wasm` / `Uno.icu-ios` / `Uno.icu-win`) from 77.2.1 to 77.3.0-dev.4, the latest version available on nuget.org:

- `UnoICUVersion` in `src/Directory.Build.targets`: 77.2.1 → 77.3.0-dev.4
- Hardcoded `Uno.icu-win` reference in `Uno.UI.RuntimeTests.HRApp.Skia.csproj`: 77.1.2 → 77.3.0-dev.4

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
