### PR TITLE
fix(skia): Bound frame picture recording to frame size

### DIFF
--- a/src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs
+++ b/src/Uno.UI/Helpers/SkiaRenderHelper.skia.cs
@@ -35,7 +35,9 @@ internal static class SkiaRenderHelper
 
 	internal static (SKPicture picture, SKPath nativeClipPath, List<Visual> nativeVisualsInZOrder) RecordPictureAndReturnPath(float width, float height, ContainerVisual rootVisual, bool invertPath, SKPath? damage = null)
 	{
-		var canvas = _recorder.BeginRecording(Visual.InfiniteClipRect);
+		// Bounding the recording to the frame makes the picture's CullRect report the frame size
+		// (in logical pixels), which consumers of RenderingEventArgs.FrameData rely on.
+		var canvas = _recorder.BeginRecording(new SKRect(0, 0, width, height));
 		using var _ = new SKAutoCanvasRestore(canvas, true);
 		canvas.Clear(SKColors.Transparent);
 


### PR DESCRIPTION
**GitHub Issue:** https://github.com/unoplatform/kahua-private/issues/505

## PR Type:

🐞 Bugfix

## What changed? 🚀

Follow-up to #23762. The `SKPicture` exposed through `RenderingEventArgs.FrameData` had a near-infinite `CullRect`, so consumers couldn't size a surface from it. The root frame recording is now bounded to the frame (`BeginRecording(new SKRect(0, 0, width, height))` instead of `Visual.InfiniteClipRect`), making `CullRect` report the frame bounds in logical pixels.

This only affects the root frame picture, whose consumers are the window present (already clipped to the window) and `FrameData` readers; `RenderTargetBitmap` records its own picture, and the per-`Visual` picture caches keep the infinite cull rect they require. Draw ops entirely outside the frame are now culled at record time — they were never visible in the window.

Validated at runtime on Skia Desktop (Win32): `Given_CompositionTarget`, `Given_RenderTargetBitmap`, `Given_ItemCollectionTransitionProvider`, and `Given_AnimatedVisualPlayer` runtime tests all pass (11/11).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
