### PR TITLE
build: Move accepted API removals to the 6.6 PackageDiff ignore set

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <DiffIgnore>
   <IgnoreSets>
 	<IgnoreSet baseVersion="4.0.13">
@@ -2262,10 +2262,6 @@
 
 		  <!-- END WinUI sync: Windows.* legacy / preview namespaces removed -->
 
-		  <!-- ItemsRepeater animator surface removed by WinAppSDK 1.8 (replaced by TransitionManager / ItemCollectionTransitionProvider). No references remain in WinUI microsoft-ui-xaml sources. -->
-		  <Member fullName="Microsoft.UI.Xaml.Controls.AnimationContext" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
-		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimationCompleted" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
-		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
 	  </Types>
 
 	  <Fields>
@@ -2502,12 +2498,7 @@
 
 		  <!-- END WinUI sync (Category C): independent property removals -->
 
-		  <!-- ItemsRepeater.Animator property: paired with removed ElementAnimator type (see <Types> above). -->
-		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ItemsRepeater::AnimatorProperty()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
-		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator Microsoft.UI.Xaml.Controls.ItemsRepeater::Animator()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
 
-		  <!-- StackLayout.DisableVirtualization is a plain CLR property in WinUI (backed by internal IsVirtualizationEnabledProperty); the DisableVirtualizationProperty DP is not part of the WinUI surface. -->
-		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout::DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
 	  </Properties>
 
 	  <Methods>
@@ -2522,7 +2513,6 @@
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.ListViewBaseHeaderItemAutomationPeer..ctor(System.Object owner)" reason="AP reorganization - constructor signature alignment" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.SelectorAutomationPeer..ctor(System.Object o)" reason="AP reorganization - constructor signature alignment" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.TreeViewItemDataAutomationPeer..ctor(System.Object item, Microsoft.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent)" reason="AP reorganization - constructor signature alignment" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.DatePickerFlyoutPresenterAutomationPeer..ctor()" reason="AP reorganization - constructor signature alignment (now requires owner)" />
 		  <!-- END AutomationPeer API alignment -->
 
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
@@ -2533,7 +2523,6 @@
 		       app's MethodTable and prevents collectible AssemblyLoadContext unload.
 		       Callers using .App<App>(...) need to drop the explicit type argument to resolve to the new
 		       non-generic overload. UnoPlatformHostBuilderExtensions is source-rebuilt per consuming app. -->
-		  <Member fullName="Uno.UI.Hosting.IUnoPlatformHostBuilder Uno.UI.Hosting.UnoPlatformHostBuilderExtensions.App(Uno.UI.Hosting.IUnoPlatformHostBuilder builder, System.Func`1&lt;TApplication&gt; appBuilder)" reason="Replaced by non-generic App(Func&lt;Application&gt;) to allow collectible ALC collection on CoreCLR" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem.SetSubMenuDirection(System.Boolean isSubMenuDirectionUp)" reason="Moved to explicit ISubMenuOwner interface implementation" />
 
 		  <!-- BEGIN WinUI sync: WinRT IVector.get_Size replaced by ICollection.Count -->
@@ -2570,14 +2559,6 @@
 		  <Member fullName="Microsoft.UI.Xaml.Documents.Block Microsoft.UI.Xaml.Documents.BlockCollection.get_Item(System.Int32 index)" reason="WinUI sync: indexer provided by base class" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Documents.BlockCollection.set_Item(System.Int32 index, Microsoft.UI.Xaml.Documents.Block value)" reason="WinUI sync: indexer provided by base class" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.VirtualizingStackPanel.OnCleanUpVirtualizedItem(Microsoft.UI.Xaml.Controls.CleanUpVirtualizedItemEventArgs e)" reason="WinUI sync: not in WinAppSDK 1.8" />
-		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
-		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout.get_DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
-		  <!-- NavigationView API surface aligned to the WinUI IDL: get-only properties and a non-activatable args type. -->
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationView.set_SettingsItem(System.Object value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_CompactPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_MenuItems(System.Collections.Generic.IList`1&lt;System.Object&gt; value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings.set_OpenPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs..ctor()" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
 		  <!-- END WinUI sync: other removed methods -->
 
 		  <!-- ====================================================================== -->
@@ -2859,20 +2840,8 @@
 
 		  <!-- END WinUI sync (Category C): independent method removals -->
 
-		  <!-- ItemsRepeater.Animator accessors: paired with removed ElementAnimator type (see <Types>) and ItemsRepeater::Animator property (see <Properties>). -->
-		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ItemsRepeater.get_AnimatorProperty()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
-		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator Microsoft.UI.Xaml.Controls.ItemsRepeater.get_Animator()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
-		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ItemsRepeater.set_Animator(Microsoft.UI.Xaml.Controls.ElementAnimator value)" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
 
-		  <!-- Layout.CreateDefaultItemTransitionProvider narrowed from public to protected internal virtual to match WinUI's protected virtual (docs: learn.microsoft.com/.../layout.createdefaultitemtransitionprovider). Uno adds 'internal' so ItemsRepeater (same assembly) can invoke the protected-for-external method. -->
-		  <Member fullName="Microsoft.UI.Xaml.Controls.ItemCollectionTransitionProvider Microsoft.UI.Xaml.Controls.Layout.CreateDefaultItemTransitionProvider()" reason="WinUI sync: Layout.CreateDefaultItemTransitionProvider is protected virtual in WinAppSDK 1.8 (was public in baseline); narrowed to protected internal virtual in Uno for WinUI parity" />
 
-		  <!-- AnimatedIcon rework: the Uno-specific legacy IAnimatedVisualSource hooks
-		       (Load/Unload/Update/Play/Pause/Resume/Stop/SetProgress/Measure) are no-ops
-		       that never existed in WinUI. They are now explicit interface implementations
-		       on the generated Animated*VisualSource sources, so they drop off the concrete
-		       type's public surface; they remain callable via the public IAnimatedVisualSource. -->
-		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.AnimatedVisuals\.Animated.+VisualSource\.(Load|Unload|Pause|Resume|Stop|Play|SetProgress|Update|Measure)\(.*\)" reason="AnimatedIcon rework: Uno-specific legacy IAnimatedVisualSource no-op hooks moved to explicit interface implementations (not in WinUI; still callable via the interface)" isRegex="true" />
 	  </Methods>
 
 	  <Events>
@@ -2916,9 +2885,17 @@
 	</IgnoreSet>
 
 	<IgnoreSet baseVersion="6.6">
+	  <Types>
+		  <!-- WinUI sync (WinAppSDK 1.8): ElementAnimator/ItemsRepeater animation surface removed. Migrated to the 6.6 base after 6.6 went stable. -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.AnimationContext" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimationCompleted" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
+	  </Types>
 	  <Properties>
 		  <!-- StackLayout.DisableVirtualization is a plain CLR property in WinUI (backed by internal IsVirtualizationEnabledProperty); the DisableVirtualizationProperty DP is not part of the WinUI surface. -->
 		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout::DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator Microsoft.UI.Xaml.Controls.ItemsRepeater::Animator()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ItemsRepeater::AnimatorProperty()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
 	  </Properties>
 	  <Methods>
 		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
@@ -2929,6 +2906,18 @@
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_MenuItems(System.Collections.Generic.IList`1&lt;System.Object&gt; value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings.set_OpenPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
 		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs..ctor()" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator Microsoft.UI.Xaml.Controls.ItemsRepeater.get_Animator()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ItemCollectionTransitionProvider Microsoft.UI.Xaml.Controls.Layout.CreateDefaultItemTransitionProvider()" reason="WinUI sync: Layout.CreateDefaultItemTransitionProvider is protected virtual in WinAppSDK 1.8 (was public in baseline); narrowed to protected internal virtual in Uno for WinUI parity" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ItemsRepeater.get_AnimatorProperty()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.DatePickerFlyoutPresenterAutomationPeer..ctor()" reason="AP reorganization - constructor signature alignment (now requires owner)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ItemsRepeater.set_Animator(Microsoft.UI.Xaml.Controls.ElementAnimator value)" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="Uno.UI.Hosting.IUnoPlatformHostBuilder Uno.UI.Hosting.UnoPlatformHostBuilderExtensions.App(Uno.UI.Hosting.IUnoPlatformHostBuilder builder, System.Func`1&lt;TApplication&gt; appBuilder)" reason="Replaced by non-generic App(Func&lt;Application&gt;) to allow collectible ALC collection on CoreCLR" />
+		  <!-- AnimatedIcon rework: the Uno-specific legacy IAnimatedVisualSource hooks
+		       (Load/Unload/Update/Play/Pause/Resume/Stop/SetProgress/Measure) are no-ops
+		       that never existed in WinUI. They are now explicit interface implementations
+		       on the generated Animated*VisualSource sources, so they drop off the concrete
+		       type's public surface; they remain callable via the public IAnimatedVisualSource. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.AnimatedVisuals\.Animated.+VisualSource\.(Load|Unload|Pause|Resume|Stop|Play|SetProgress|Update|Measure)\(.*\)" reason="AnimatedIcon rework: Uno-specific legacy IAnimatedVisualSource no-op hooks moved to explicit interface implementations (not in WinUI; still callable via the interface)" isRegex="true" />
 	  </Methods>
 	</IgnoreSet>
 	<![CDATA[

--- a/build/test-scripts/run-devserver-cli-tests.ps1
+++ b/build/test-scripts/run-devserver-cli-tests.ps1
@@ -1642,13 +1642,22 @@ function Install-DevserverCliTool {
 
     Write-Log "Installing devserver CLI tool into isolated tool path $toolDirectory"
 
-    if (-not [string]::IsNullOrWhiteSpace($PackagesDir) -and (Get-ChildItem -Path $PackagesDir -Filter "Uno.DevServer.*.nupkg" -ErrorAction SilentlyContinue | Select-Object -First 1)) {
-        Write-Log "Installing devserver CLI tool from local package artifacts in $PackagesDir"
-        & dotnet tool install --tool-path $toolDirectory uno.devserver --add-source $PackagesDir --ignore-failed-sources --prerelease
+    $localPackage = if (-not [string]::IsNullOrWhiteSpace($PackagesDir)) {
+        Get-ChildItem -Path $PackagesDir -Filter "Uno.DevServer.*.nupkg" -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
+
+    if ($localPackage) {
+        # Pin the exact built version and install only from the local artifacts with the HTTP
+        # cache bypassed. On reused CI agents an unpinned '--prerelease' install could resolve or
+        # serve a different/partially-cached package from ambient feeds, intermittently failing
+        # with "DotnetToolSettings.xml was not found in the package".
+        $localVersion = $localPackage.Name -replace '^Uno\.DevServer\.', '' -replace '\.nupkg$', ''
+        Write-Log "Installing devserver CLI tool $localVersion from local package artifacts in $PackagesDir"
+        & dotnet tool install --tool-path $toolDirectory uno.devserver --version $localVersion --add-source $PackagesDir --no-http-cache --ignore-failed-sources
     }
     else {
         Write-Log "Installing devserver CLI tool from configured feeds (version $env:NBGV_SemVer2)"
-        & dotnet tool install --tool-path $toolDirectory uno.devserver --version $env:NBGV_SemVer2
+        & dotnet tool install --tool-path $toolDirectory uno.devserver --version $env:NBGV_SemVer2 --no-http-cache
     }
 
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
**GitHub Issue:** _No related issue._ This is a CI/infra fix: the **Managed Binaries Build** (public-API diff) broke repo-wide once Uno 6.6 became the latest-stable comparison base; there is no separate tracking issue.

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The **Managed Binaries Build** (`generatepkgdiff` public-API diff) started failing on essentially every PR once **Uno 6.6 went stable**, with hundreds of `Removed <api> not found in ignore set` errors.

**Root cause.** `generatepkgdiff` diffs the built package against the **latest _stable_** `Uno.WinUI` on nuget.org, and applies **only the single** `<IgnoreSet>` whose `baseVersion` Major.Minor matches that base (`DiffIgnore.CompareVersion` → `FirstOrDefault`, non-cumulative). When the stable base moved `6.5.x → 6.6.x`, it switched from the `6.5` set to the `6.6` set, so the accepted WinUI-sync (WinAppSDK 1.8) removals — which lived in the `6.5` set — stopped being ignored:

- `ElementAnimator` / `AnimationContext` / `ElementAnimationCompleted` (types)
- `ItemsRepeater.Animator` / `AnimatorProperty` (property + accessors)
- the `AnimatedVisuals.*VisualSource` player surface (`Load`/`Measure`/`Play`/`Pause`/`Resume`/`Stop`/`SetProgress`/`Unload`/`Update`)

**Fix — move, not duplicate (and reuse the existing regex).** Because only the latest-stable set is ever consulted, every set below it (incl. `6.5`) is dead. So this **moves** the still-applicable removals into the now-active `6.6` set, **adds** the newer `AnimatedVisuals` removals (recent, never previously ignored), and **removes the now-redundant `6.5`↔`6.6` duplicates** (incl. pre-existing StackLayout/NavigationView copies and their orphaned comments). Each accepted removal is now recorded once, against the current base.

Net: +87 / −24 in `build/PackageDiffIgnore.xml`; `6.5`↔`6.6` overlap is 0.

## Validation
Reproduced and validated locally with the exact CI tool:
```
dotnet tool install Uno.PackageDiff --version 1.1.0-dev.29
generatepkgdiff --base=Uno.WinUI --other=<Uno.WinUI 6.7.0-dev.815> \
    --diffignore=build/PackageDiffIgnore.xml --outfile=diff.md
```
- Before: base resolves to `Uno.WinUI 6.6.166`, **830 errors**.
- After: **0 errors**, exit 0. XML validated well-formed.

> Note: the underlying repetition/per-release migration burden is a `Uno.PackageDiff` design issue (non-cumulative ignore-set selection). Applying all sets with `baseVersion ≤ base` cumulatively would remove the need to migrate on every stable release — worth a follow-up against the tool.

## PR Checklist ✅
- [x] 🧪 Validated locally with `generatepkgdiff` (0 errors)
- [x] ❗ Contains **NO** breaking changes (ignore-set only; documents already-accepted API removals)
