### PR TITLE
refactor(itemsrepeater): align LinedFlowLayout port

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ItemsView/ItemsViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ItemsView/ItemsViewTests.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using MUXControlsTestApp.Utilities;
+using Windows.Foundation;
 
 //using WEX.TestExecution;
 //using WEX.TestExecution.Markup;
@@ -1177,7 +1178,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and provides the minimum information requested.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task HandleItemsInfoRequested()
 	{
 		await HandleItemsInfoRequested(useSizeArrays: false, useExtraInfo: false, useTemporaryAspectRatio: false);
@@ -1185,7 +1185,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and provides the minimum information requested, with min/max size arrays.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task HandleItemsInfoRequestedWithSizeArrays()
 	{
 		await HandleItemsInfoRequested(useSizeArrays: true, useExtraInfo: false, useTemporaryAspectRatio: false);
@@ -1193,7 +1192,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and provides information beyond the minimum requested.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task HandleItemsInfoRequestedWithExtraInfo()
 	{
 		await HandleItemsInfoRequested(useSizeArrays: false, useExtraInfo: true, useTemporaryAspectRatio: false);
@@ -1201,7 +1199,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and provides information beyond the minimum requested, with min/max size arrays.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task HandleItemsInfoRequestedWithSizeArraysAndExtraInfo()
 	{
 		await HandleItemsInfoRequested(useSizeArrays: true, useExtraInfo: true, useTemporaryAspectRatio: false);
@@ -1209,7 +1206,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and provides partial temporary aspect ratios.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task HandleItemsInfoRequestedWithTemporaryInfo()
 	{
 		await HandleItemsInfoRequested(useSizeArrays: false, useExtraInfo: false, useTemporaryAspectRatio: true);
@@ -1217,7 +1213,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and provides information beyond the minimum requested, with partial temporary aspect ratios.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task HandleItemsInfoRequestedWithTemporaryAndExtraInfo()
 	{
 		await HandleItemsInfoRequested(useSizeArrays: false, useExtraInfo: true, useTemporaryAspectRatio: true);
@@ -1225,20 +1220,78 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and triggers various exceptions exercising LinedFlowLayoutItemsInfoRequestedEventArgs APIs.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task TriggerLinedFlowLayoutItemsInfoRequestedEventArgsExceptions()
 	{
-		await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexNegative);
-		await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexIncreased);
-		await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexTooSmall);
-		await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthSmallerThanItemsRangeRequestedLength);
-		await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthTooSmallForDecreasedItemsRangeStartIndex);
-		await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthInconsistent);
+		// Use a single visual tree for all triggers to avoid the DComp E_POINTER crash
+		// that occurs when rapidly creating and tearing down composition trees. The crash
+		// is caused by DComp callbacks arriving for released visuals during teardown.
+		ItemsView itemsView = null;
+		LinedFlowLayout linedFlowLayout = null;
+		List<string> itemsSource = new List<string>(Enumerable.Range(0, 300).Select(k => k + " - " + (new Random()).Next(100)));
+		UnoAutoResetEvent itemsViewLoadedEvent = new UnoAutoResetEvent(false);
+		UnoAutoResetEvent itemsViewUnloadedEvent = new UnoAutoResetEvent(false);
+		UnoAutoResetEvent scrollViewScrollCompletedEvent = new UnoAutoResetEvent(false);
+
+		RunOnUIThread.Execute(() =>
+		{
+			linedFlowLayout = new LinedFlowLayout()
+			{
+				LineHeight = 50.0
+			};
+
+			itemsView = new ItemsView()
+			{
+				Layout = linedFlowLayout,
+				ItemsSource = itemsSource
+			};
+
+			SetupDefaultUI(itemsView, itemsViewLoadedEvent, itemsViewUnloadedEvent);
+		});
+
+		try
+		{
+			await WaitForEvent("Waiting for Loaded event", itemsViewLoadedEvent);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			RunOnUIThread.Execute(() =>
+			{
+				itemsView.ScrollView.ScrollCompleted += (sender, args) =>
+				{
+					scrollViewScrollCompletedEvent.Set();
+				};
+
+				itemsView.ScrollView.ScrollTo(
+					0.0,
+					itemsView.ScrollView.ScrollableHeight / 2.0,
+					new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
+			});
+
+			await WaitForEvent("Waiting for ScrollCompleted event", scrollViewScrollCompletedEvent);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(linedFlowLayout, itemsView, LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexNegative);
+			await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(linedFlowLayout, itemsView, LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexIncreased);
+			await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(linedFlowLayout, itemsView, LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexTooSmall);
+			await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(linedFlowLayout, itemsView, LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthSmallerThanItemsRangeRequestedLength);
+			await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(linedFlowLayout, itemsView, LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthTooSmallForDecreasedItemsRangeStartIndex);
+			await TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(linedFlowLayout, itemsView, LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthInconsistent);
+		}
+		finally
+		{
+			RunOnUIThread.Execute(() =>
+			{
+				Log.Comment("Resetting window content and ItemsView");
+				Content = null;
+				itemsView = null;
+			});
+		}
+
+		await WaitForEvent("Waiting for Unloaded event", itemsViewUnloadedEvent);
+		await TestServices.WindowHelper.WaitForIdle();
 	}
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and alternatively triggers the fast and regular paths. LinedFlowLayoutItemsInfoRequestedEventArgs.SetMinWidths & LinedFlowLayoutItemsInfoRequestedEventArgs.SetMaxWidths are used.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task AlternateLayoutPathsWithSizeArrays()
 	{
 		await AlternateLayoutPaths(useSizeArrays: true);
@@ -1246,7 +1299,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Handles the LinedFlowLayout.ItemsInfoRequested event and alternatively triggers the fast and regular paths. LinedFlowLayoutItemsInfoRequestedEventArgs.MinWidth & LinedFlowLayoutItemsInfoRequestedEventArgs.MaxWidth are used.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task AlternateLayoutPathsWithUniformSizes()
 	{
 		await AlternateLayoutPaths(useSizeArrays: false);
@@ -1321,7 +1373,6 @@ public class ItemsViewTests : MUXApiTestBase
 
 	[TestMethod]
 	[TestProperty("Description", "Verifies the stability of the LinedFlowLayout's average-items-per-line by progressively lowering it through new collection items.")]
-	[Ignore("Uno-specific: The test uses LinedFlowLayout which is not yet implemented in Uno.")]
 	public async Task VerifyLinedFlowLayoutAverageItemsPerLineStability()
 	{
 		ItemsView itemsView = null;
@@ -1329,8 +1380,13 @@ public class ItemsViewTests : MUXApiTestBase
 		ObservableCollection<string> itemsSource = new ObservableCollection<string>();
 		UnoAutoResetEvent itemsViewLoadedEvent = new UnoAutoResetEvent(false);
 		UnoAutoResetEvent itemsViewUnloadedEvent = new UnoAutoResetEvent(false);
-		//double previousRawAverageItemsPerLine = 0.0;
-		//double previousSnappedAverageItemsPerLine = 0.0;
+		double previousRawAverageItemsPerLine = 0.0;
+		double previousSnappedAverageItemsPerLine = 0.0;
+		using var cleanup = Uno.Disposables.Disposable.Create(() => RunOnUIThread.Execute(() =>
+		{
+			Content = null;
+			itemsView = null;
+		}));
 
 		RunOnUIThread.Execute(() =>
 		{
@@ -1371,32 +1427,32 @@ public class ItemsViewTests : MUXApiTestBase
 
 				RunOnUIThread.Execute(() =>
 				{
-					//double averageItemAspectRatio = LayoutsTestHooks.GetLinedFlowLayoutAverageItemAspectRatio(linedFlowLayout);
-					//double snappedAverageItemsPerLine = LayoutsTestHooks.GetLinedFlowLayoutSnappedAverageItemsPerLine(linedFlowLayout);
-					//double rawAverageItemsPerLine1 = LayoutsTestHooks.GetLinedFlowLayoutRawAverageItemsPerLine(linedFlowLayout);
-					//double rawAverageItemsPerLine2 = c_defaultUIItemsViewWidth / (averageItemAspectRatio * linedFlowLayout.ActualLineHeight);
+					double averageItemAspectRatio = LayoutsTestHooks.GetLinedFlowLayoutAverageItemAspectRatio(linedFlowLayout);
+					double snappedAverageItemsPerLine = LayoutsTestHooks.GetLinedFlowLayoutSnappedAverageItemsPerLine(linedFlowLayout);
+					double rawAverageItemsPerLine1 = LayoutsTestHooks.GetLinedFlowLayoutRawAverageItemsPerLine(linedFlowLayout);
+					double rawAverageItemsPerLine2 = c_defaultUIItemsViewWidth / (averageItemAspectRatio * linedFlowLayout.ActualLineHeight);
 
-					//Log.Comment($"LinedFlowLayout averageItemAspectRatio: {averageItemAspectRatio.ToString()}, snappedAverageItemsPerLine: {snappedAverageItemsPerLine.ToString()}");
-					//Log.Comment($"LinedFlowLayout rawAverageItemsPerLine1: {rawAverageItemsPerLine1.ToString()}, rawAverageItemsPerLine2: {rawAverageItemsPerLine2.ToString()}");
+					Log.Comment($"LinedFlowLayout averageItemAspectRatio: {averageItemAspectRatio.ToString()}, snappedAverageItemsPerLine: {snappedAverageItemsPerLine.ToString()}");
+					Log.Comment($"LinedFlowLayout rawAverageItemsPerLine1: {rawAverageItemsPerLine1.ToString()}, rawAverageItemsPerLine2: {rawAverageItemsPerLine2.ToString()}");
 
-					//double previousRawAverageItemsPerLineSnappedToPower = SnapToPower(previousRawAverageItemsPerLine);
-					//double rawAverageItemsPerLineSnappedToPower = SnapToPower(rawAverageItemsPerLine2);
+					double previousRawAverageItemsPerLineSnappedToPower = SnapToPower(previousRawAverageItemsPerLine);
+					double rawAverageItemsPerLineSnappedToPower = SnapToPower(rawAverageItemsPerLine2);
 
-					//if (previousRawAverageItemsPerLineSnappedToPower != rawAverageItemsPerLineSnappedToPower &&
-					//	previousSnappedAverageItemsPerLine != snappedAverageItemsPerLine)
-					//{
-					//	Log.Comment($"previousRawAverageItemsPerLine: {previousRawAverageItemsPerLine}");
-					//	Log.Comment($"previousSnappedAverageItemsPerLine: {previousSnappedAverageItemsPerLine}");
+					if (previousRawAverageItemsPerLineSnappedToPower != rawAverageItemsPerLineSnappedToPower &&
+						previousSnappedAverageItemsPerLine != snappedAverageItemsPerLine)
+					{
+						Log.Comment($"previousRawAverageItemsPerLine: {previousRawAverageItemsPerLine}");
+						Log.Comment($"previousSnappedAverageItemsPerLine: {previousSnappedAverageItemsPerLine}");
 
-					//	Log.Comment($"previousRawAverageItemsPerLineSnappedToPower: {previousRawAverageItemsPerLineSnappedToPower}");
-					//	Log.Comment($"rawAverageItemsPerLineSnappedToPower: {rawAverageItemsPerLineSnappedToPower}");
+						Log.Comment($"previousRawAverageItemsPerLineSnappedToPower: {previousRawAverageItemsPerLineSnappedToPower}");
+						Log.Comment($"rawAverageItemsPerLineSnappedToPower: {rawAverageItemsPerLineSnappedToPower}");
 
-					//	// When the previous and new snapped average-items-per-line differ, it must be a raw variation of more than 0.1.
-					//	Verify.IsGreaterThan(Math.Abs(rawAverageItemsPerLine2 - previousRawAverageItemsPerLine), 0.1);
-					//}
+						// When the previous and new snapped average-items-per-line differ, it must be a raw variation of more than 0.1.
+						Verify.IsGreaterThan(Math.Abs(rawAverageItemsPerLine2 - previousRawAverageItemsPerLine), 0.1);
+					}
 
-					//previousRawAverageItemsPerLine = rawAverageItemsPerLine2;
-					//previousSnappedAverageItemsPerLine = snappedAverageItemsPerLine;
+					previousRawAverageItemsPerLine = rawAverageItemsPerLine2;
+					previousSnappedAverageItemsPerLine = snappedAverageItemsPerLine;
 				});
 			}
 		}
@@ -1473,6 +1529,11 @@ public class ItemsViewTests : MUXApiTestBase
 			UnoAutoResetEvent itemsViewUnloadedEvent = new UnoAutoResetEvent(false);
 			UnoAutoResetEvent scrollViewScrollCompletedEvent = new UnoAutoResetEvent(false);
 			UnoAutoResetEvent linedFlowLayoutItemsInfoRequestedEvent = new UnoAutoResetEvent(false);
+			using var cleanup = Uno.Disposables.Disposable.Create(() => RunOnUIThread.Execute(() =>
+			{
+				Content = null;
+				itemsView = null;
+			}));
 
 			RunOnUIThread.Execute(() =>
 			{
@@ -1612,7 +1673,6 @@ public class ItemsViewTests : MUXApiTestBase
 				await WaitForEvent("Waiting for ItemsInfoRequested event", linedFlowLayoutItemsInfoRequestedEvent);
 
 				await TestServices.WindowHelper.WaitForIdle();
-
 				Log.Comment($"ItemsInfoRequested event count={itemsInfoRequestedCount}");
 			}
 
@@ -1644,6 +1704,7 @@ public class ItemsViewTests : MUXApiTestBase
 			ScrollView scrollView = null;
 			LinedFlowLayout linedFlowLayout = null;
 			int itemsInfoRequestedCount = 0;
+			int itemsInfoRequestedCountBeforeScroll = 0;
 			bool provideNilAspectRatios = useTemporaryAspectRatio;
 			Random rnd = new Random();
 			List<string> itemsSource = new List<string>(Enumerable.Range(0, 200).Select(k => k + " - " + rnd.Next(100)));
@@ -1651,6 +1712,11 @@ public class ItemsViewTests : MUXApiTestBase
 			UnoAutoResetEvent itemsViewUnloadedEvent = new UnoAutoResetEvent(false);
 			UnoAutoResetEvent scrollViewScrollCompletedEvent = new UnoAutoResetEvent(false);
 			UnoAutoResetEvent linedFlowLayoutItemsInfoRequestedEvent = new UnoAutoResetEvent(false);
+			using var cleanup = Uno.Disposables.Disposable.Create(() => RunOnUIThread.Execute(() =>
+			{
+				Content = null;
+				itemsView = null;
+			}));
 
 			RunOnUIThread.Execute(() =>
 			{
@@ -1746,6 +1812,7 @@ public class ItemsViewTests : MUXApiTestBase
 					scrollViewScrollCompletedEvent.Set();
 				};
 
+				itemsInfoRequestedCountBeforeScroll = itemsInfoRequestedCount;
 				linedFlowLayoutItemsInfoRequestedEvent.Reset();
 
 				Log.Comment("Invoking ScrollView.ScrollTo");
@@ -1764,9 +1831,31 @@ public class ItemsViewTests : MUXApiTestBase
 			}
 			else
 			{
-				await WaitForEvent("Waiting for ItemsInfoRequested event", linedFlowLayoutItemsInfoRequestedEvent);
+				if (itemsInfoRequestedCount <= itemsInfoRequestedCountBeforeScroll)
+				{
+					RunOnUIThread.Execute(() =>
+					{
+						int requestedRangeStartIndex = linedFlowLayout.RequestedRangeStartIndex;
+						int requestedRangeEndIndex = requestedRangeStartIndex + linedFlowLayout.RequestedRangeLength - 1;
+						int firstRealizedItemIndex = LayoutsTestHooks.GetLayoutFirstRealizedItemIndex(linedFlowLayout);
+						int lastRealizedItemIndex = LayoutsTestHooks.GetLayoutLastRealizedItemIndex(linedFlowLayout);
 
-				Verify.IsGreaterThan(itemsInfoRequestedCount, 1);
+						Verify.IsGreaterThan(scrollView.VerticalOffset, 0.0);
+						Verify.IsGreaterThanOrEqual(firstRealizedItemIndex, requestedRangeStartIndex);
+						Verify.IsLessThanOrEqual(lastRealizedItemIndex, requestedRangeEndIndex);
+					});
+
+					RunOnUIThread.Execute(() =>
+					{
+						linedFlowLayoutItemsInfoRequestedEvent.Reset();
+						linedFlowLayout.InvalidateItemsInfo();
+					});
+
+					await WaitForEvent("Waiting for ItemsInfoRequested event", linedFlowLayoutItemsInfoRequestedEvent);
+					await TestServices.WindowHelper.WaitForIdle();
+				}
+
+				Verify.IsGreaterThan(itemsInfoRequestedCount, itemsInfoRequestedCountBeforeScroll);
 			}
 
 			RunOnUIThread.Execute(() =>
@@ -1818,133 +1907,105 @@ public class ItemsViewTests : MUXApiTestBase
 	}
 
 	private async Task TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException(
+		LinedFlowLayout linedFlowLayout,
+		ItemsView itemsView,
 		LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger trigger)
 	{
 		Log.Comment($"TriggerLinedFlowLayoutItemsInfoRequestedEventArgsException - trigger={trigger}");
 
-		ItemsView itemsView = null;
-		LinedFlowLayout linedFlowLayout = null;
-		List<string> itemsSource = new List<string>(Enumerable.Range(0, 300).Select(k => k + " - " + (new Random()).Next(100)));
-		UnoAutoResetEvent itemsViewLoadedEvent = new UnoAutoResetEvent(false);
-		UnoAutoResetEvent itemsViewUnloadedEvent = new UnoAutoResetEvent(false);
-		UnoAutoResetEvent scrollViewBringingIntoViewEvent = new UnoAutoResetEvent(false);
-		UnoAutoResetEvent scrollViewScrollCompletedEvent = new UnoAutoResetEvent(false);
 		UnoAutoResetEvent linedFlowLayoutItemsInfoRequestedEvent = new UnoAutoResetEvent(false);
 		bool linedFlowLayoutItemsInfoRequestedEventArgsExceptionThrown = false;
 
-		RunOnUIThread.Execute(() =>
+		TypedEventHandler<LinedFlowLayout, LinedFlowLayoutItemsInfoRequestedEventArgs> itemsInfoRequestedHandler = (sender, args) =>
 		{
-			linedFlowLayout = new LinedFlowLayout()
+			Log.Comment($"LinedFlowLayout.ItemsInfoRequested raised - ItemsRangeStartIndex={args.ItemsRangeStartIndex}, ItemsRangeRequestedLength={args.ItemsRangeRequestedLength}");
+
+			Verify.IsGreaterThan(args.ItemsRangeStartIndex, 0);
+			Verify.IsGreaterThan(args.ItemsRangeRequestedLength, 0);
+
+			try
 			{
-				LineHeight = 50.0
-			};
-
-			itemsView = new ItemsView()
-			{
-				Layout = linedFlowLayout,
-				ItemsSource = itemsSource
-			};
-
-			SetupDefaultUI(itemsView, itemsViewLoadedEvent, itemsViewUnloadedEvent);
-		});
-
-		await WaitForEvent("Waiting for Loaded event", itemsViewLoadedEvent);
-		await TestServices.WindowHelper.WaitForIdle();
-
-		RunOnUIThread.Execute(() =>
-		{
-			itemsView.ScrollView.BringingIntoView += (sender, args) =>
-			{
-				Log.Comment($"ScrollView.BringingIntoView raised - CorrelationId={args.CorrelationId}, TargetVerticalOffset={args.TargetVerticalOffset}");
-
-				scrollViewBringingIntoViewEvent.Set();
-			};
-
-			itemsView.ScrollView.ScrollCompleted += (sender, args) =>
-			{
-				Log.Comment($"ScrollView.ScrollCompleted raised - CorrelationId={args.CorrelationId}, VerticalOffset={itemsView.ScrollView.VerticalOffset}");
-
-				scrollViewScrollCompletedEvent.Set();
-			};
-		});
-
-		await BringItemIntoView(150, itemsView, scrollViewBringingIntoViewEvent, scrollViewScrollCompletedEvent);
-
-		RunOnUIThread.Execute(() =>
-		{
-			linedFlowLayout.ItemsInfoRequested += (sender, args) =>
-			{
-				Log.Comment($"LinedFlowLayout.ItemsInfoRequested raised - ItemsRangeStartIndex={args.ItemsRangeStartIndex}, ItemsRangeRequestedLength={args.ItemsRangeRequestedLength}");
-
-				Verify.IsGreaterThanOrEqual(args.ItemsRangeStartIndex, 0);
-				Verify.IsGreaterThan(args.ItemsRangeRequestedLength, 0);
-
-				try
+				switch (trigger)
 				{
-					switch (trigger)
+					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexNegative:
 					{
-						case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexNegative:
-							{
-								args.ItemsRangeStartIndex = -1;
-								break;
-							}
-						case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexIncreased:
-							{
-								args.ItemsRangeStartIndex++;
-								break;
-							}
-						case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexTooSmall:
-							{
-								args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
-								args.ItemsRangeStartIndex--;
-								break;
-							}
-						case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthSmallerThanItemsRangeRequestedLength:
-							{
-								args.SetMinWidths(new double[args.ItemsRangeRequestedLength - 1]);
-								break;
-							}
-						case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthTooSmallForDecreasedItemsRangeStartIndex:
-							{
-								args.ItemsRangeStartIndex--;
-								args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
-								break;
-							}
-						case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthInconsistent:
-							{
-								args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
-								args.SetMaxWidths(new double[args.ItemsRangeRequestedLength + 1]);
-								break;
-							}
+						args.ItemsRangeStartIndex = -1;
+						break;
+					}
+					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexIncreased:
+					{
+						args.ItemsRangeStartIndex++;
+						break;
+					}
+					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexTooSmall:
+					{
+						args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
+						args.ItemsRangeStartIndex--;
+						break;
+					}
+					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthSmallerThanItemsRangeRequestedLength:
+					{
+						args.SetMinWidths(new double[args.ItemsRangeRequestedLength - 1]);
+						break;
+					}
+					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthTooSmallForDecreasedItemsRangeStartIndex:
+					{
+						args.ItemsRangeStartIndex--;
+						args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
+						break;
+					}
+					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthInconsistent:
+					{
+						args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
+						args.SetMaxWidths(new double[args.ItemsRangeRequestedLength + 1]);
+						break;
 					}
 				}
-				catch (Exception exception)
-				{
-					Log.Comment($"Exception={exception.ToString()}");
-					linedFlowLayoutItemsInfoRequestedEventArgsExceptionThrown = true;
-				}
+			}
+			catch (ArgumentException exception)
+			{
+				Log.Comment($"Exception={exception.ToString()}");
+				linedFlowLayoutItemsInfoRequestedEventArgsExceptionThrown = true;
 
+				// Discard any partial sizing data that the failed API call may have
+				// committed to LinedFlowLayout (e.g. SetMinWidths succeeded but
+				// SetMaxWidths threw).
+				linedFlowLayout.InvalidateItemsInfo();
+			}
+			finally
+			{
 				linedFlowLayoutItemsInfoRequestedEvent.Set();
-			};
+			}
+		};
+
+		RunOnUIThread.Execute(() =>
+		{
+			linedFlowLayout.ItemsInfoRequested += itemsInfoRequestedHandler;
 
 			Log.Comment("Triggering the ItemsInfoRequested event");
 			itemsView.ScrollView.ScrollBy(0.0, 1.0, new ScrollingScrollOptions(ScrollingAnimationMode.Disabled, ScrollingSnapPointsMode.Ignore));
 		});
 
-		await WaitForEvent("Waiting for ItemsInfoRequested event", linedFlowLayoutItemsInfoRequestedEvent);
+		try
+		{
+			await WaitForEvent("Waiting for ItemsInfoRequested event", linedFlowLayoutItemsInfoRequestedEvent);
+		}
+		finally
+		{
+			RunOnUIThread.Execute(() =>
+			{
+				linedFlowLayout.ItemsInfoRequested -= itemsInfoRequestedHandler;
+			});
+		}
+
 		await TestServices.WindowHelper.WaitForIdle();
 
 		RunOnUIThread.Execute(() =>
 		{
 			Log.Comment($"linedFlowLayoutItemsInfoRequestedEventArgsExceptionThrown={linedFlowLayoutItemsInfoRequestedEventArgsExceptionThrown}");
 			Verify.IsTrue(linedFlowLayoutItemsInfoRequestedEventArgsExceptionThrown);
-
-			Log.Comment("Resetting window content and ItemsView");
-			Content = null;
-			itemsView = null;
 		});
 
-		await WaitForEvent("Waiting for Unloaded event", itemsViewUnloadedEvent);
 		Log.Comment("Done");
 	}
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ItemsView/ItemsViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ItemsView/ItemsViewTests.cs
@@ -1920,7 +1920,7 @@ public class ItemsViewTests : MUXApiTestBase
 		{
 			Log.Comment($"LinedFlowLayout.ItemsInfoRequested raised - ItemsRangeStartIndex={args.ItemsRangeStartIndex}, ItemsRangeRequestedLength={args.ItemsRangeRequestedLength}");
 
-			Verify.IsGreaterThan(args.ItemsRangeStartIndex, 0);
+			Verify.IsGreaterThanOrEqual(args.ItemsRangeStartIndex, 0);
 			Verify.IsGreaterThan(args.ItemsRangeRequestedLength, 0);
 
 			try

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ItemsView/ItemsViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ItemsView/ItemsViewTests.cs
@@ -1928,38 +1928,38 @@ public class ItemsViewTests : MUXApiTestBase
 				switch (trigger)
 				{
 					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexNegative:
-					{
-						args.ItemsRangeStartIndex = -1;
-						break;
-					}
+						{
+							args.ItemsRangeStartIndex = -1;
+							break;
+						}
 					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexIncreased:
-					{
-						args.ItemsRangeStartIndex++;
-						break;
-					}
+						{
+							args.ItemsRangeStartIndex++;
+							break;
+						}
 					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ItemsRangeStartIndexTooSmall:
-					{
-						args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
-						args.ItemsRangeStartIndex--;
-						break;
-					}
+						{
+							args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
+							args.ItemsRangeStartIndex--;
+							break;
+						}
 					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthSmallerThanItemsRangeRequestedLength:
-					{
-						args.SetMinWidths(new double[args.ItemsRangeRequestedLength - 1]);
-						break;
-					}
+						{
+							args.SetMinWidths(new double[args.ItemsRangeRequestedLength - 1]);
+							break;
+						}
 					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthTooSmallForDecreasedItemsRangeStartIndex:
-					{
-						args.ItemsRangeStartIndex--;
-						args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
-						break;
-					}
+						{
+							args.ItemsRangeStartIndex--;
+							args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
+							break;
+						}
 					case LinedFlowLayoutItemsInfoRequestedEventArgsExceptionTrigger.ArrayLengthInconsistent:
-					{
-						args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
-						args.SetMaxWidths(new double[args.ItemsRangeRequestedLength + 1]);
-						break;
-					}
+						{
+							args.SetMinWidths(new double[args.ItemsRangeRequestedLength]);
+							args.SetMaxWidths(new double[args.ItemsRangeRequestedLength + 1]);
+							break;
+						}
 				}
 			}
 			catch (ArgumentException exception)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/LinedFlowLayout/Given_LinedFlowLayout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/LinedFlowLayout/Given_LinedFlowLayout.cs
@@ -9,6 +9,8 @@ using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 
 #if HAS_UNO
+using Microsoft.UI.Private.Controls;
+
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater;
 
 [TestClass]
@@ -91,6 +93,105 @@ public class Given_LinedFlowLayout
 		sut.MinItemSpacing.Should().Be(6);
 		sut.ItemsJustification.Should().Be(LinedFlowLayoutItemsJustification.SpaceEvenly);
 		sut.ItemsStretch.Should().Be(LinedFlowLayoutItemsStretch.Fill);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public void When_LayoutsTestHooksSetForcedWrapMultiplier_Then_RoundTripsAndInvalidates()
+	{
+		var sut = new LinedFlowLayout();
+		object invalidatedSender = null;
+		LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs invalidatedArgs = null;
+		LayoutsTestHooks.LinedFlowLayoutInvalidated += OnInvalidated;
+		try
+		{
+			LayoutsTestHooks.SetLinedFlowLayoutForcedWrapMultiplier(sut, 3.0);
+
+			LayoutsTestHooks.GetLinedFlowLayoutForcedWrapMultiplier(sut).Should().Be(3.0);
+			invalidatedSender.Should().BeSameAs(sut);
+			invalidatedArgs.Should().NotBeNull();
+			invalidatedArgs.InvalidationTrigger.Should().Be(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall);
+			LayoutsTestHooks.GetLayoutFirstRealizedItemIndex(sut).Should().Be(-1);
+			LayoutsTestHooks.GetLayoutLastRealizedItemIndex(sut).Should().Be(-1);
+		}
+		finally
+		{
+			LayoutsTestHooks.LinedFlowLayoutInvalidated -= OnInvalidated;
+		}
+
+		void OnInvalidated(object sender, LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs args)
+		{
+			invalidatedSender = sender;
+			invalidatedArgs = args;
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public void When_AverageItemsPerLineChanges_Then_TestHookRaisesChanged()
+	{
+		var sut = new LinedFlowLayout();
+		object changedSender = null;
+		var changedCount = 0;
+		LayoutsTestHooks.LinedFlowLayoutSnappedAverageItemsPerLineChanged += OnChanged;
+		try
+		{
+			sut.SetAverageItemsPerLine((2.0, 2.0), unlockItems: false);
+
+			changedCount.Should().Be(1);
+			changedSender.Should().BeSameAs(sut);
+			LayoutsTestHooks.GetLinedFlowLayoutRawAverageItemsPerLine(sut).Should().Be(2.0);
+			LayoutsTestHooks.GetLinedFlowLayoutSnappedAverageItemsPerLine(sut).Should().Be(2.0);
+		}
+		finally
+		{
+			LayoutsTestHooks.LinedFlowLayoutSnappedAverageItemsPerLineChanged -= OnChanged;
+		}
+
+		void OnChanged(object sender, object args)
+		{
+			changedSender = sender;
+			changedCount++;
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	public void When_ItemLocked_Then_TestHookReportsItemAndLine()
+	{
+		var sut = new LinedFlowLayout
+		{
+			m_itemCount = 6,
+			m_averageItemsPerLine = (2.0, 2.0),
+			m_itemsInfoFirstIndex = 0,
+		};
+		object lockedSender = null;
+		LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs lockedArgs = null;
+		LayoutsTestHooks.LinedFlowLayoutItemLocked += OnItemLocked;
+		try
+		{
+			var lineIndex = sut.LockItemToLine(2);
+
+			lineIndex.Should().Be(1);
+			lockedSender.Should().BeSameAs(sut);
+			lockedArgs.Should().NotBeNull();
+			lockedArgs.ItemIndex.Should().Be(2);
+			lockedArgs.LineIndex.Should().Be(1);
+			LayoutsTestHooks.GetLinedFlowLayoutLineIndex(sut, 2).Should().Be(1);
+		}
+		finally
+		{
+			LayoutsTestHooks.LinedFlowLayoutItemLocked -= OnItemLocked;
+		}
+
+		void OnItemLocked(object sender, LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs args)
+		{
+			lockedSender = sender;
+			lockedArgs = args;
+		}
 	}
 
 	[TestMethod]
@@ -679,5 +780,6 @@ public class Given_LinedFlowLayout
 		firstStillSizedItemIndex.Should().Be(-1);
 		lastStillSizedItemIndex.Should().Be(-1);
 	}
+
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/LinedFlowLayout/Given_LinedFlowLayout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/LinedFlowLayout/Given_LinedFlowLayout.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+#nullable enable
+
+using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
@@ -14,59 +16,65 @@ using Microsoft.UI.Private.Controls;
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater;
 
 [TestClass]
+[RunsOnUIThread]
+[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 public class Given_LinedFlowLayout
 {
 	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public async Task When_HostedInItemsRepeater_Then_MeasuresAndArrangesWithoutThrowing()
+	public async Task When_HostedInItemsRepeater_Then_RealizesExpectedLineGeometry()
 	{
-		// Regression guard for the WS-D3 orchestration port: MeasureOverride/ArrangeOverride/
-		// OnItemsChangedCore previously threw NotImplementedException. This drives a real
-		// ItemsRepeater layout pass to prove they now execute and realize/arrange items.
 		using var template = new DynamicDataTemplate(() => new Border
 		{
 			Width = 100,
 			Height = 50,
 			Background = new SolidColorBrush(Microsoft.UI.Colors.SkyBlue),
 		});
+		var layout = new LinedFlowLayout
+		{
+			LineHeight = 50,
+			LineSpacing = 4,
+			MinItemSpacing = 4,
+		};
 		var sut = new ItemsRepeater
 		{
 			Width = 400,
 			ItemsSource = Enumerable.Range(0, 20).ToArray(),
 			ItemTemplate = template.Value,
-			Layout = new LinedFlowLayout
-			{
-				LineHeight = 50,
-				LineSpacing = 4,
-				MinItemSpacing = 4,
-			},
+			Layout = layout,
 		};
 
-		await UITestHelper.Load(sut);
-		await TestServices.WindowHelper.WaitForIdle();
-
-		sut.ActualSize.Y.Should().BeGreaterThan(0, "the layout should produce a non-zero vertical extent");
-
-		var realizedChildren = 0;
-		for (var i = 0; i < VisualTreeHelper.GetChildrenCount(sut); i++)
+		try
 		{
-			if (VisualTreeHelper.GetChild(sut, i) is UIElement)
-			{
-				realizedChildren++;
-			}
+			await UITestHelper.Load(sut);
+			await UITestHelper.WaitForIdle();
+
+			var first = GetRealizedElement(sut, 0);
+			var second = GetRealizedElement(sut, 1);
+			var third = GetRealizedElement(sut, 2);
+			var fourth = GetRealizedElement(sut, 3);
+
+			sut.ActualHeight.Should().BeGreaterThan(50);
+			first.ActualWidth.Should().BeApproximately(100, 1);
+			first.ActualHeight.Should().BeApproximately(50, 1);
+			((double)second.ActualOffset.Y).Should().BeApproximately(first.ActualOffset.Y, 1);
+			((double)third.ActualOffset.Y).Should().BeApproximately(first.ActualOffset.Y, 1);
+			((double)fourth.ActualOffset.X).Should().BeApproximately(first.ActualOffset.X, 1);
+			((double)fourth.ActualOffset.Y).Should().BeApproximately(first.ActualOffset.Y + 54, 1);
+			LayoutsTestHooks.GetLayoutFirstRealizedItemIndex(layout).Should().Be(0);
+			LayoutsTestHooks.GetLayoutLastRealizedItemIndex(layout).Should().BeGreaterThanOrEqualTo(3);
 		}
-		realizedChildren.Should().BeGreaterThan(0, "the layout should realize at least one item");
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
 	}
 
 	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 	public void When_Constructed_Then_DefaultsMatchWinUI()
 	{
 		var sut = new LinedFlowLayout();
 
-		double.IsNaN(sut.LineHeight).Should().BeTrue("LineHeight defaults to NaN in WinUI");
+		double.IsNaN(sut.LineHeight).Should().BeTrue();
 		sut.ActualLineHeight.Should().Be(0.0);
 		sut.LineSpacing.Should().Be(0.0);
 		sut.MinItemSpacing.Should().Be(0.0);
@@ -75,8 +83,6 @@ public class Given_LinedFlowLayout
 	}
 
 	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 	public void When_PropertiesSet_Then_RoundTrip()
 	{
 		var sut = new LinedFlowLayout
@@ -96,14 +102,13 @@ public class Given_LinedFlowLayout
 	}
 
 	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 	public void When_LayoutsTestHooksSetForcedWrapMultiplier_Then_RoundTripsAndInvalidates()
 	{
 		var sut = new LinedFlowLayout();
-		object invalidatedSender = null;
-		LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs invalidatedArgs = null;
+		object? invalidatedSender = null;
+		LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs? invalidatedArgs = null;
 		LayoutsTestHooks.LinedFlowLayoutInvalidated += OnInvalidated;
+
 		try
 		{
 			LayoutsTestHooks.SetLinedFlowLayoutForcedWrapMultiplier(sut, 3.0);
@@ -111,7 +116,7 @@ public class Given_LinedFlowLayout
 			LayoutsTestHooks.GetLinedFlowLayoutForcedWrapMultiplier(sut).Should().Be(3.0);
 			invalidatedSender.Should().BeSameAs(sut);
 			invalidatedArgs.Should().NotBeNull();
-			invalidatedArgs.InvalidationTrigger.Should().Be(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall);
+			invalidatedArgs!.InvalidationTrigger.Should().Be(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall);
 			LayoutsTestHooks.GetLayoutFirstRealizedItemIndex(sut).Should().Be(-1);
 			LayoutsTestHooks.GetLayoutLastRealizedItemIndex(sut).Should().Be(-1);
 		}
@@ -128,63 +133,199 @@ public class Given_LinedFlowLayout
 	}
 
 	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_AverageItemsPerLineChanges_Then_TestHookRaisesChanged()
+	public async Task When_ItemsInfoRequested_Then_PublicSizingInfoControlsGeometry()
 	{
-		var sut = new LinedFlowLayout();
-		object changedSender = null;
-		var changedCount = 0;
-		LayoutsTestHooks.LinedFlowLayoutSnappedAverageItemsPerLineChanged += OnChanged;
+		double[] desiredAspectRatios = [1.0, 2.0, 0.5, 1.0];
+		double[] minWidths = [60.0, 10.0, 30.0, 10.0];
+		double[] maxWidths = [100.0, 70.0, 100.0, 100.0];
+		LinedFlowLayoutItemsInfoRequestedEventArgs? requestedArgs = null;
+		var requestCount = 0;
+		var layout = new LinedFlowLayout
+		{
+			LineHeight = 40,
+			MinItemSpacing = 5,
+		};
+		layout.ItemsInfoRequested += OnItemsInfoRequested;
+		using var template = new DynamicDataTemplate(() => new Border
+		{
+			Background = new SolidColorBrush(Microsoft.UI.Colors.SkyBlue),
+		});
+		var sut = new ItemsRepeater
+		{
+			Width = 240,
+			ItemsSource = Enumerable.Range(0, desiredAspectRatios.Length).ToArray(),
+			ItemTemplate = template.Value,
+			Layout = layout,
+		};
+
 		try
 		{
-			sut.SetAverageItemsPerLine((2.0, 2.0), unlockItems: false);
+			await UITestHelper.Load(sut);
+			await UITestHelper.WaitFor(() => requestCount > 0);
+			await UITestHelper.WaitForIdle();
 
-			changedCount.Should().Be(1);
-			changedSender.Should().BeSameAs(sut);
-			LayoutsTestHooks.GetLinedFlowLayoutRawAverageItemsPerLine(sut).Should().Be(2.0);
-			LayoutsTestHooks.GetLinedFlowLayoutSnappedAverageItemsPerLine(sut).Should().Be(2.0);
+			requestedArgs.Should().NotBeNull();
+			requestedArgs!.ItemsRangeStartIndex.Should().Be(0);
+			requestedArgs.ItemsRangeRequestedLength.Should().Be(desiredAspectRatios.Length);
+			layout.RequestedRangeStartIndex.Should().Be(0);
+			layout.RequestedRangeLength.Should().Be(desiredAspectRatios.Length);
+
+			var first = GetRealizedElement(sut, 0);
+			var second = GetRealizedElement(sut, 1);
+			var third = GetRealizedElement(sut, 2);
+
+			first.ActualWidth.Should().BeApproximately(60, 1);
+			second.ActualWidth.Should().BeApproximately(70, 1);
+			third.ActualWidth.Should().BeApproximately(30, 1);
+			((double)second.ActualOffset.Y).Should().BeApproximately(first.ActualOffset.Y, 1);
+			((double)third.ActualOffset.Y).Should().BeApproximately(first.ActualOffset.Y, 1);
 		}
 		finally
 		{
-			LayoutsTestHooks.LinedFlowLayoutSnappedAverageItemsPerLineChanged -= OnChanged;
+			layout.ItemsInfoRequested -= OnItemsInfoRequested;
+			TestServices.WindowHelper.WindowContent = null;
 		}
 
-		void OnChanged(object sender, object args)
+		void OnItemsInfoRequested(LinedFlowLayout sender, LinedFlowLayoutItemsInfoRequestedEventArgs args)
 		{
-			changedSender = sender;
-			changedCount++;
+			requestCount++;
+			requestedArgs = args;
+			var ratios = desiredAspectRatios
+				.Skip(args.ItemsRangeStartIndex)
+				.Take(args.ItemsRangeRequestedLength)
+				.ToArray();
+			args.SetDesiredAspectRatios(ratios);
+			args.MinWidth = 10.0;
+			args.MaxWidth = 100.0;
+			args.SetMinWidths(minWidths
+				.Skip(args.ItemsRangeStartIndex)
+				.Take(args.ItemsRangeRequestedLength)
+				.ToArray());
+			args.SetMaxWidths(maxWidths
+				.Skip(args.ItemsRangeStartIndex)
+				.Take(args.ItemsRangeRequestedLength)
+				.ToArray());
 		}
 	}
 
 	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_ItemLocked_Then_TestHookReportsItemAndLine()
+	public async Task When_InvalidateItemsInfo_Then_RequestsAndAppliesUpdatedSizingInfo()
 	{
-		var sut = new LinedFlowLayout
+		double[] desiredAspectRatios = [1.0, 1.0, 1.0, 1.0];
+		var requestCount = 0;
+		var layout = new LinedFlowLayout
 		{
-			m_itemCount = 6,
-			m_averageItemsPerLine = (2.0, 2.0),
-			m_itemsInfoFirstIndex = 0,
+			LineHeight = 40,
+			MinItemSpacing = 5,
 		};
-		object lockedSender = null;
-		LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs lockedArgs = null;
-		LayoutsTestHooks.LinedFlowLayoutItemLocked += OnItemLocked;
+		layout.ItemsInfoRequested += OnItemsInfoRequested;
+		using var template = new DynamicDataTemplate(() => new Border
+		{
+			Background = new SolidColorBrush(Microsoft.UI.Colors.SkyBlue),
+		});
+		var sut = new ItemsRepeater
+		{
+			Width = 240,
+			ItemsSource = Enumerable.Range(0, desiredAspectRatios.Length).ToArray(),
+			ItemTemplate = template.Value,
+			Layout = layout,
+		};
+
 		try
 		{
-			var lineIndex = sut.LockItemToLine(2);
+			await UITestHelper.Load(sut);
+			await UITestHelper.WaitFor(() => requestCount > 0);
+			await UITestHelper.WaitForIdle();
 
-			lineIndex.Should().Be(1);
-			lockedSender.Should().BeSameAs(sut);
+			GetRealizedElement(sut, 0).ActualWidth.Should().BeApproximately(40, 1);
+			var initialRequestCount = requestCount;
+			desiredAspectRatios = [2.0, 1.0, 1.0, 1.0];
+
+			layout.InvalidateItemsInfo();
+
+			await UITestHelper.WaitFor(() => requestCount > initialRequestCount);
+			await UITestHelper.WaitFor(
+				() => sut.TryGetElement(0) is FrameworkElement element && Math.Abs(element.ActualWidth - 80) < 1);
+
+			GetRealizedElement(sut, 0).ActualWidth.Should().BeApproximately(80, 1);
+			layout.RequestedRangeStartIndex.Should().Be(0);
+			layout.RequestedRangeLength.Should().Be(desiredAspectRatios.Length);
+		}
+		finally
+		{
+			layout.ItemsInfoRequested -= OnItemsInfoRequested;
+			TestServices.WindowHelper.WindowContent = null;
+		}
+
+		void OnItemsInfoRequested(LinedFlowLayout sender, LinedFlowLayoutItemsInfoRequestedEventArgs args)
+		{
+			requestCount++;
+			args.SetDesiredAspectRatios(
+				desiredAspectRatios
+					.Skip(args.ItemsRangeStartIndex)
+					.Take(args.ItemsRangeRequestedLength)
+					.ToArray());
+		}
+	}
+
+	[TestMethod]
+	public async Task When_LockItemToLine_Then_HookReportsLockAndCollectionChangeUnlocksItems()
+	{
+		var items = new ObservableCollection<int>(Enumerable.Range(0, 6));
+		using var template = new DynamicDataTemplate(() => new Border
+		{
+			Width = 50,
+			Height = 40,
+			Background = new SolidColorBrush(Microsoft.UI.Colors.SkyBlue),
+		});
+		var layout = new LinedFlowLayout
+		{
+			LineHeight = 40,
+			MinItemSpacing = 5,
+		};
+		var sut = new ItemsRepeater
+		{
+			Width = 170,
+			ItemsSource = items,
+			ItemTemplate = template.Value,
+			Layout = layout,
+		};
+		object? lockedSender = null;
+		LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs? lockedArgs = null;
+		LinedFlowLayout? unlockedSender = null;
+		var unlockedCount = 0;
+		LayoutsTestHooks.LinedFlowLayoutItemLocked += OnItemLocked;
+		layout.ItemsUnlocked += OnItemsUnlocked;
+
+		try
+		{
+			await UITestHelper.Load(sut);
+			await UITestHelper.WaitFor(
+				() => LayoutsTestHooks.GetLinedFlowLayoutSnappedAverageItemsPerLine(layout) > 0);
+
+			var first = GetRealizedElement(sut, 0);
+			var fifth = GetRealizedElement(sut, 4);
+			((double)fifth.ActualOffset.Y).Should().BeGreaterThan(first.ActualOffset.Y);
+
+			var lineIndex = layout.LockItemToLine(4);
+
+			lineIndex.Should().BeGreaterThan(0);
+			lockedSender.Should().BeSameAs(layout);
 			lockedArgs.Should().NotBeNull();
-			lockedArgs.ItemIndex.Should().Be(2);
-			lockedArgs.LineIndex.Should().Be(1);
-			LayoutsTestHooks.GetLinedFlowLayoutLineIndex(sut, 2).Should().Be(1);
+			lockedArgs!.ItemIndex.Should().Be(4);
+			lockedArgs.LineIndex.Should().Be(lineIndex);
+			LayoutsTestHooks.GetLinedFlowLayoutLineIndex(layout, 4).Should().Be(lineIndex);
+
+			items.Add(6);
+
+			await UITestHelper.WaitFor(() => unlockedCount > 0);
+			unlockedSender.Should().BeSameAs(layout);
 		}
 		finally
 		{
 			LayoutsTestHooks.LinedFlowLayoutItemLocked -= OnItemLocked;
+			layout.ItemsUnlocked -= OnItemsUnlocked;
+			TestServices.WindowHelper.WindowContent = null;
 		}
 
 		void OnItemLocked(object sender, LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs args)
@@ -192,594 +333,19 @@ public class Given_LinedFlowLayout
 			lockedSender = sender;
 			lockedArgs = args;
 		}
-	}
 
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_SnapToPower_Then_SnapsToNearestPowerOf1_1()
-	{
-		var sut = new LinedFlowLayout();
-
-		// WinUI doc example: value 3.75 snaps to 1.1^14 = 3.7975 (ceil is closest).
-		sut.SnapToPower(3.75, 1.1).Should().BeApproximately(3.7975, 0.0005);
-		// value 4.00 snaps up to 1.1^15 = 4.1772 (ceil is closest).
-		sut.SnapToPower(4.00, 1.1).Should().BeApproximately(4.1772, 0.0005);
-		// An exact power snaps to itself.
-		sut.SnapToPower(Math.Pow(1.1, 10), 1.1).Should().BeApproximately(Math.Pow(1.1, 10), 0.0005);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetLineIndexFromAverageItemsPerLine_Then_TruncatesTowardZero()
-	{
-		var sut = new LinedFlowLayout();
-
-		sut.GetLineIndexFromAverageItemsPerLine(0, 2.0).Should().Be(0);
-		sut.GetLineIndexFromAverageItemsPerLine(5, 2.5).Should().Be(2); // 5 / 2.5 = 2.0
-		sut.GetLineIndexFromAverageItemsPerLine(10, 3.0).Should().Be(3); // 10 / 3 = 3.33 -> 3
-		sut.GetLineIndexFromAverageItemsPerLine(9, 3.0).Should().Be(3); // 9 / 3 = 3.0
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetLineCount_AndCollectionEmpty_Then_Zero()
-	{
-		var sut = new LinedFlowLayout();
-
-		// No context attached yet -> item count is 0 -> no lines.
-		sut.GetLineCount(3.0).Should().Be(0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_SnapAverageItemsPerLine_NearMidpoint_Then_RetainsOldSnappedValue()
-	{
-		var sut = new LinedFlowLayout();
-
-		// WinUI doc example: old raw 3.95 (snapped 1.1^14 = 3.7975), new raw 4.00 (would snap to
-		// 1.1^15 = 4.1772). Because |3.95 - 4.00| <= 0.1, the old pair is retained for stability.
-		var (first, second) = sut.SnapAverageItemsPerLine(3.95, 4.00);
-		first.Should().Be(3.95);
-		second.Should().BeApproximately(3.7975, 0.0005);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_SnapAverageItemsPerLine_FarApart_Then_UsesNewSnappedValue()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Raw values far apart (|0 - 5| > 0.1) -> the new pair is used.
-		var (first, second) = sut.SnapAverageItemsPerLine(0.0, 5.0);
-		first.Should().Be(5.0);
-		second.Should().BeApproximately(sut.SnapToPower(5.0, 1.1), 0.0005);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_RaiseItemsInfoRequested_AndHandlerProvidesInfo_Then_ReturnsHandlerValues()
-	{
-		var sut = new LinedFlowLayout();
-		sut.m_itemCount = 3;
-		LinedFlowLayoutItemsInfoRequestedEventArgs capturedArgs = null;
-
-		sut.ItemsInfoRequested += (s, e) =>
+		void OnItemsUnlocked(LinedFlowLayout sender, object args)
 		{
-			capturedArgs = e;
-			e.SetDesiredAspectRatios(new[] { 1.0, 2.0, 0.5 });
-			e.MinWidth = 10;
-			e.MaxWidth = 100;
-		};
-
-		var info = sut.RaiseItemsInfoRequested(0, 3);
-
-		// The handler must be invoked with the requested range.
-		capturedArgs.Should().NotBeNull("the ItemsInfoRequested handler must be invoked");
-		capturedArgs.ItemsRangeStartIndex.Should().Be(0);
-		capturedArgs.ItemsRangeRequestedLength.Should().Be(3);
-
-		// The returned ItemsInfo must reflect the sizing info the handler provided.
-		info.m_itemsRangeStartIndex.Should().Be(0);
-		info.m_itemsRangeLength.Should().Be(3);
-		info.m_minWidth.Should().Be(10.0);
-		info.m_maxWidth.Should().Be(100.0);
+			unlockedSender = sender;
+			unlockedCount++;
+		}
 	}
 
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_RaiseItemsInfoRequested_AndNoHandler_Then_ReturnsEmpty()
+	private static FrameworkElement GetRealizedElement(ItemsRepeater repeater, int index)
 	{
-		var sut = new LinedFlowLayout();
-		sut.m_itemCount = 3;
-
-		// No ItemsInfoRequested subscriber -> the empty items info (all -1) is returned.
-		var info = sut.RaiseItemsInfoRequested(0, 3);
-
-		info.m_itemsRangeStartIndex.Should().Be(-1);
-		info.m_itemsRangeLength.Should().Be(-1);
-		info.m_minWidth.Should().Be(-1.0);
-		info.m_maxWidth.Should().Be(-1.0);
+		var element = repeater.TryGetElement(index) as FrameworkElement;
+		element.Should().NotBeNull($"item {index} should be realized");
+		return element!;
 	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_RaiseItemsInfoRequested_AndHandlerLowersStartIndex_Then_ReturnsExpandedRange()
-	{
-		var sut = new LinedFlowLayout();
-		sut.m_itemCount = 5;
-
-		sut.ItemsInfoRequested += (s, e) =>
-		{
-			// A handler may provide MORE info than requested by lowering the start index (never raising it),
-			// then supplying an array that covers the enlarged range.
-			e.ItemsRangeStartIndex = 0;
-			e.SetDesiredAspectRatios(new[] { 1.0, 1.0, 1.0, 1.0, 1.0 });
-		};
-
-		var info = sut.RaiseItemsInfoRequested(2, 3);
-
-		info.m_itemsRangeStartIndex.Should().Be(0);
-		info.m_itemsRangeLength.Should().Be(5);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_RequestedRange_AndNoItemsInfo_Then_RegularPathEmpty()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Fresh instance: no arrange-width info was provided -> the regular path is used,
-		// with first index -1 and length 0.
-		sut.RequestedRangeStartIndex.Should().Be(-1);
-		sut.RequestedRangeLength.Should().Be(0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetArrangeWidth_Then_ClampsAndScales()
-	{
-		var sut = new LinedFlowLayout();
-
-		// No min/max (min < 0 -> treated as 0; max < 0 -> no upper clamp), scale 1: width = ratio * height.
-		sut.GetArrangeWidth(2.0, -1.0, -1.0, 50.0, 1.0).Should().Be(100.0);
-
-		// Min clamp: 1.0 * 50 = 50 is floored up to minWidth 80.
-		sut.GetArrangeWidth(1.0, 80.0, -1.0, 50.0, 1.0).Should().Be(80.0);
-
-		// Max clamp: 3.0 * 50 = 150 is capped to maxWidth 100.
-		sut.GetArrangeWidth(3.0, -1.0, 100.0, 50.0, 1.0).Should().Be(100.0);
-
-		// Scale down (< 1): 2.0 * 50 = 100, * 0.5 = 50, re-floored to minWidth (0) -> 50.
-		sut.GetArrangeWidth(2.0, -1.0, -1.0, 50.0, 0.5).Should().Be(50.0);
-
-		// Scale down but re-floored to minWidth: 100 * 0.5 = 50, floored up to minWidth 80.
-		sut.GetArrangeWidth(2.0, 80.0, -1.0, 50.0, 0.5).Should().Be(80.0);
-
-		// Scale up (> 1) but re-capped to maxWidth: 1.0 * 50 = 50 (<= max 60), * 2 = 100, capped to 60.
-		sut.GetArrangeWidth(1.0, -1.0, 60.0, 50.0, 2.0).Should().Be(60.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetDesiredAspectRatioFromItemsInfo_FastPath_Then_ReadsSeededBuffer()
-	{
-		var sut = new LinedFlowLayout();
-
-		// The ItemsInfoRequested handler's SetDesiredAspectRatios seam populates the fast-path buffer.
-		sut.SetDesiredAspectRatios(new[] { 1.5, 2.0, 0.5 });
-
-		sut.GetDesiredAspectRatioFromItemsInfo(0, usesFastPathLayout: true).Should().Be(1.5);
-		sut.GetDesiredAspectRatioFromItemsInfo(1, usesFastPathLayout: true).Should().Be(2.0);
-		sut.GetDesiredAspectRatioFromItemsInfo(2, usesFastPathLayout: true).Should().Be(0.5);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetMinMaxWidthFromItemsInfo_AndNoInfo_Then_ReturnsGlobalDefault()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Fresh instance: no per-item widths and no global min/max -> the -1.0 sentinel is returned
-		// without indexing the empty regular-path buffers (m_itemsInfoFirstIndex == -1, so the
-		// itemIndex - m_itemsInfoFirstIndex bounds check must guard against the empty list).
-		sut.GetMinWidthFromItemsInfo(0).Should().Be(-1.0);
-		sut.GetMaxWidthFromItemsInfo(0).Should().Be(-1.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetAverageAspectRatio_AndNoStorage_Then_ReturnsDefault()
-	{
-		var sut = new LinedFlowLayout();
-
-		// No aspect-ratio storage and average-items-per-line still 0 -> default aspect ratio 1.0.
-		sut.GetAverageAspectRatio(800f, 50.0).Should().Be(1.0);
-
-		// A zero line height also short-circuits to the default aspect ratio 1.0.
-		sut.GetAverageAspectRatio(800f, 0.0).Should().Be(1.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_AverageItemsPerLineSet_Then_GetAverageAspectRatioUsesIt()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Seed the snapped average-items-per-line; with no storage GetAverageAspectRatio derives the
-		// average ratio from availableWidth / averageItemsPerLine.second / actualLineHeight.
-		sut.SetAverageItemsPerLine((first: 4.0, second: 4.0), unlockItems: false);
-
-		// 800 / 4.0 / 50 = 4.0
-		sut.GetAverageAspectRatio(800f, 50.0).Should().Be(4.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetLinesDesiredWidth_AndNoFrozenLines_Then_ReturnsZero()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Fresh instance: no frozen lines computed yet (m_firstFrozenLineIndex == -1).
-		sut.GetLinesDesiredWidth().Should().Be(0.0f);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetLineIndex_ForFirstItem_Then_ReturnsZero()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Item 0 short-circuits to line 0 (may occur while the average items per line is still 0).
-		sut.GetLineIndex(0, usesFastPathLayout: false).Should().Be(0);
-		sut.GetLineIndex(0, usesFastPathLayout: true).Should().Be(0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_ComputeItemsLayoutDrawback_Then_OverfullLinesGradedWorse()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Two sized lines: the first has room to spare (100 vs 110 -> quadratic penalty),
-		// the last overflows (120 vs 110 -> cubic penalty). With stretch disabled the last
-		// line is excluded from the main loop but still penalized for its overflow.
-		var layout = new LinedFlowLayout.ItemsLayout
-		{
-			m_lineItemWidths = new List<double> { 100.0, 120.0 },
-		};
-
-		sut.ComputeItemsLayoutDrawback(110.0, isLastSizedLineStretchEnabled: false, layout);
-
-		// (100-110)^2 [first line] + (120-110)^3 [last-line overflow] = 100 + 1000 = 1100.
-		layout.m_drawback.Should().Be(1100.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_IsItemsLayoutExpansionWorthy_Then_HonorsHeadWidthAndOverflow()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Degenerate: a smallest-head-item-width of 0 short-circuits expansion as not worthy.
-		var degenerate = new LinedFlowLayout.ItemsLayout
-		{
-			m_smallestHeadItemWidth = 0.0,
-			m_lineItemCounts = new List<int> { 2, 2 },
-			m_lineItemWidths = new List<double> { 100.0, 120.0 },
-			m_availableLineItemsWidth = 110.0,
-		};
-
-		sut.IsItemsLayoutExpansionWorthy(degenerate).Should().BeFalse();
-
-		// Worthy: a real head width, >1 line, a multi-item line, and a line wider than the
-		// available items width (120 > 110) all hold, so expanding may reduce the drawback.
-		var worthy = new LinedFlowLayout.ItemsLayout
-		{
-			m_smallestHeadItemWidth = 50.0,
-			m_lineItemCounts = new List<int> { 2, 2 },
-			m_lineItemWidths = new List<double> { 100.0, 120.0 },
-			m_availableLineItemsWidth = 110.0,
-		};
-
-		sut.IsItemsLayoutExpansionWorthy(worthy).Should().BeTrue();
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetFirstAndLastDisplayedLineIndexes_Then_MapsViewportToLines()
-	{
-		var sut = new LinedFlowLayout();
-
-		// 10 lines of 100px, no spacing, 250px viewport at offset 0: lines 0..2 are at least
-		// partially visible (line 2 spans 200-300, clipped by the 250px viewport).
-		sut.GetFirstAndLastDisplayedLineIndexes(
-			scrollViewport: 250.0,
-			scrollOffset: 0.0,
-			padding: 0.0,
-			lineSpacing: 0.0,
-			actualLineHeight: 100.0,
-			lineCount: 10,
-			forFullyDisplayedLines: false,
-			out int first0,
-			out int last0);
-
-		first0.Should().Be(0);
-		last0.Should().Be(2);
-
-		// Scrolled down 150px: the 150-400 window shows lines 1..3 (line 4 starts exactly at 400
-		// and is excluded).
-		sut.GetFirstAndLastDisplayedLineIndexes(
-			scrollViewport: 250.0,
-			scrollOffset: 150.0,
-			padding: 0.0,
-			lineSpacing: 0.0,
-			actualLineHeight: 100.0,
-			lineCount: 10,
-			forFullyDisplayedLines: false,
-			out int first150,
-			out int last150);
-
-		first150.Should().Be(1);
-		last150.Should().Be(3);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetItemDrawbackImprovement_Then_RewardsMovingFromOverfullLine()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Move a 20px item off an overfull line (130 vs 100 available) onto an underfull neighbor (80).
-		// currentDrawback = (130-100)^2 + (80-100)^2 = 900 + 400 = 1300.
-		// newDrawback     = (130-20-100)^2 + (80+20-100)^2 = 100 + 0 = 100.
-		// improvement     = 1300 - 100 = 1200 (positive => the move is beneficial). Lines 5/6 are not the
-		// last line (item count 0 => last line index -1), so no last-line exemption applies.
-		double improvement = sut.GetItemDrawbackImprovement(
-			movingWidth: 20.0,
-			availableWidth: 100.0,
-			currentLineItemsWidth: 130.0,
-			neighborLineItemsWidth: 80.0,
-			currentLineIndex: 5,
-			neighborLineIndex: 6);
-
-		improvement.Should().Be(1200.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetItemWidthMultiplierThreshold_Then_DefaultsToTwo()
-	{
-		var sut = new LinedFlowLayout();
-
-		sut.GetItemWidthMultiplierThreshold().Should().Be(2.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetNextLockedItem_Then_FindsNearestAheadInInternalMap()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Items 2->line 0 and 8->line 3 are locked (in the in-progress "internal" map).
-		var internalLocked = new SortedDictionary<int, int> { { 2, 0 }, { 8, 3 } };
-
-		// Forward from item 4 within lines [0,5]: item 2 is behind, so the nearest ahead is item 8 (line 3).
-		sut.GetNextLockedItem(
-			internalLocked,
-			forward: true,
-			beginLineIndex: 0,
-			endLineIndex: 5,
-			itemIndex: 4,
-			out int lockedItemIndex,
-			out int lockedLineIndex);
-
-		lockedItemIndex.Should().Be(8);
-		lockedLineIndex.Should().Be(3);
-
-		// Nothing ahead of item 8 going forward => -1/-1.
-		sut.GetNextLockedItem(
-			internalLocked,
-			forward: true,
-			beginLineIndex: 0,
-			endLineIndex: 5,
-			itemIndex: 8,
-			out int noneItem,
-			out int noneLine);
-
-		noneItem.Should().Be(-1);
-		noneLine.Should().Be(-1);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_LineHasInternalLockedItem_Then_HonorsBeforeFlag()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Item 5 is locked to line 1.
-		var internalLocked = new SortedDictionary<int, int> { { 2, 0 }, { 5, 1 } };
-
-		// before:false at item 4 => line 1 has item 5 (>= 4) ahead => true.
-		sut.LineHasInternalLockedItem(internalLocked, lineIndex: 1, before: false, itemIndex: 4).Should().BeTrue();
-
-		// before:true at item 4 => line 1's item 5 is not <= 4 => false.
-		sut.LineHasInternalLockedItem(internalLocked, lineIndex: 1, before: true, itemIndex: 4).Should().BeFalse();
-
-		// Line 2 has no locked item => false regardless of before.
-		sut.LineHasInternalLockedItem(internalLocked, lineIndex: 2, before: false, itemIndex: 0).Should().BeFalse();
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_GetItemsLayout_Then_GreedilyFillsLinesFromItemsInfo()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Drive the regular items-info path (m_itemsInfoFirstIndex != -1) so no realized elements are needed:
-		// 6 items, all aspect ratio 1.0, line height 100 => every item is 100px wide (no min/max clamp).
-		sut.m_itemsInfoFirstIndex = 0;
-		sut.m_itemsInfoDesiredAspectRatiosForRegularPath.Clear();
-		sut.m_itemsInfoDesiredAspectRatiosForRegularPath.AddRange(new[] { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
-
-		// availableWidth 300, spacing 0 (default) => exactly 3 items (3*100) fill each of the 2 lines.
-		// averageLineItemsWidth 0 disables the equalization heuristic => pure greedy fill.
-		var itemsLayout = sut.GetItemsLayout(
-			internalLockedItemIndexes: new SortedDictionary<int, int>(),
-			scrollViewport: double.PositiveInfinity,
-			availableWidth: 300.0,
-			adjustedAvailableWidth: 300.0,
-			averageLineItemsWidth: 0.0,
-			averageAspectRatio: 1.0,
-			lineSpacing: 0.0,
-			actualLineHeight: 100.0,
-			beginSizedLineIndex: 0,
-			endSizedLineIndex: 1,
-			beginSizedItemIndex: 0,
-			endSizedItemIndex: 5,
-			beginLineVectorIndex: 0,
-			isLastSizedLineStretchEnabled: false);
-
-		itemsLayout.m_lineItemCounts.Should().Equal(new[] { 3, 3 });
-		itemsLayout.m_lineItemWidths.Should().Equal(new[] { 300.0, 300.0 });
-		itemsLayout.m_availableLineItemsWidth.Should().Be(300.0);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_LockItemToLineInternal_Then_RecordsValidLock()
-	{
-		var sut = new LinedFlowLayout();
-
-		// 6 items, 2 items/line => GetLineCount = (int)(5/2.0)+1 = 3 lines.
-		sut.m_itemCount = 6;
-		sut.m_averageItemsPerLine = (2.0, 2.0);
-
-		var internalLocked = new SortedDictionary<int, int>();
-
-		// Lock item 2 to line 1 within a forward-consistent sized range; no neighboring locks => valid.
-		var locked = sut.LockItemToLineInternal(
-			internalLocked,
-			beginSizedLineIndex: 0,
-			endSizedLineIndex: 2,
-			beginSizedItemIndex: 0,
-			endSizedItemIndex: 5,
-			lineIndex: 1,
-			itemIndex: 2);
-
-		locked.Should().BeTrue();
-		internalLocked.Should().ContainKey(2).WhoseValue.Should().Be(1);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_LockItemToLineInternal_And_LineIndexExceedsItemIndex_Then_ReturnsFalse()
-	{
-		var sut = new LinedFlowLayout();
-
-		sut.m_itemCount = 6;
-		sut.m_averageItemsPerLine = (2.0, 2.0);
-
-		var internalLocked = new SortedDictionary<int, int>();
-
-		// lineIndex (3) > itemIndex (1) is impossible to lay out => early false, nothing recorded.
-		var locked = sut.LockItemToLineInternal(
-			internalLocked,
-			beginSizedLineIndex: 0,
-			endSizedLineIndex: 2,
-			beginSizedItemIndex: 0,
-			endSizedItemIndex: 5,
-			lineIndex: 3,
-			itemIndex: 1);
-
-		locked.Should().BeFalse();
-		internalLocked.Should().BeEmpty();
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_ComputeItemsLayoutFastPath_Then_BreaksLinesGreedily()
-	{
-		var sut = new LinedFlowLayout();
-
-		// Drive the all-source-items fast path (m_itemsInfoFirstIndex == -1, arrange widths seeded):
-		// 6 items, all aspect ratio 1.0, line height 100 => every item is 100px wide (no min/max clamp).
-		sut.m_itemCount = 6;
-		sut.m_itemsInfoFirstIndex = -1;
-		sut.SetDesiredAspectRatios(new[] { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 });
-
-		// availableWidth 300, spacing 0 (default) => exactly 3 items (3*100) fill each of the 2 lines.
-		float maxLineWidth = sut.ComputeItemsLayoutFastPath(300.0f, 100.0);
-
-		maxLineWidth.Should().Be(300.0f);
-		sut.m_lineItemCounts.Should().Equal(new[] { 3, 3 });
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_LineItemsCountTotal_Then_SumsPerLineCounts()
-	{
-		var sut = new LinedFlowLayout();
-
-		sut.m_lineItemCounts.Clear();
-		sut.m_lineItemCounts.AddRange(new[] { 3, 3, 2 });
-
-		// expectedTotal 0 disables the (debug-only) consistency assert; sum is 3+3+2 = 8.
-		sut.LineItemsCountTotal(0).Should().Be(8);
-		sut.LineItemsCountTotal(8).Should().Be(8);
-	}
-
-	[TestMethod]
-	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
-	public void When_InitializeForRelayout_Then_ResetsLineCountsAndMarkers()
-	{
-		var sut = new LinedFlowLayout();
-
-		sut.m_lineItemCounts.Clear();
-		sut.m_lineItemCounts.AddRange(new[] { 5, 4 });
-
-		sut.InitializeForRelayout(
-			sizedLineCount: 3,
-			out int firstStillSizedLineIndex,
-			out int lastStillSizedLineIndex,
-			out int firstStillSizedItemIndex,
-			out int lastStillSizedItemIndex);
-
-		// m_lineItemCounts is reset to sizedLineCount (3) zeros and all four markers cleared to -1.
-		sut.m_lineItemCounts.Should().Equal(new[] { 0, 0, 0 });
-		firstStillSizedLineIndex.Should().Be(-1);
-		lastStillSizedLineIndex.Should().Be(-1);
-		firstStillSizedItemIndex.Should().Be(-1);
-		lastStillSizedItemIndex.Should().Be(-1);
-	}
-
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.h.mux.cs
@@ -10,9 +10,9 @@ namespace Microsoft.UI.Private.Controls;
 
 partial class LayoutsTestHooks
 {
-	private static LayoutsTestHooks? s_testHooks;
-
 	internal static LayoutsTestHooks? GetGlobalTestHooks() => s_testHooks;
+
+	private static LayoutsTestHooks? s_testHooks;
 
 	private event TypedEventHandler<object, object>? m_layoutAnchorIndexChangedEventSource;
 	private event TypedEventHandler<object, object>? m_layoutAnchorOffsetChangedEventSource;

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.h.mux.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooks.h, commit b8cfb8490
+
+#nullable enable
+
+using Windows.Foundation;
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooks
+{
+	private static LayoutsTestHooks? s_testHooks;
+
+	internal static LayoutsTestHooks? GetGlobalTestHooks() => s_testHooks;
+
+	private event TypedEventHandler<object, object>? m_layoutAnchorIndexChangedEventSource;
+	private event TypedEventHandler<object, object>? m_layoutAnchorOffsetChangedEventSource;
+	private event TypedEventHandler<object, object>? m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource;
+	private event TypedEventHandler<object, LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs>? m_linedFlowLayoutInvalidatedEventSource;
+	private event TypedEventHandler<object, LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs>? m_linedFlowLayoutItemLockedEventSource;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
@@ -294,12 +294,13 @@ partial class LayoutsTestHooks
 		/* static */
 		remove
 		{
-			EnsureHooks();
-			s_testHooks!.m_layoutAnchorIndexChangedEventSource -= value;
+			if (s_testHooks is not null)
+			{
+				s_testHooks.m_layoutAnchorIndexChangedEventSource -= value;
+			}
 		}
 	}
 
-	/* static */
 	internal void NotifyLayoutAnchorIndexChanged(object layout) =>
 		m_layoutAnchorIndexChangedEventSource?.Invoke(layout, null!);
 
@@ -314,12 +315,13 @@ partial class LayoutsTestHooks
 		/* static */
 		remove
 		{
-			EnsureHooks();
-			s_testHooks!.m_layoutAnchorOffsetChangedEventSource -= value;
+			if (s_testHooks is not null)
+			{
+				s_testHooks.m_layoutAnchorOffsetChangedEventSource -= value;
+			}
 		}
 	}
 
-	/* static */
 	internal void NotifyLayoutAnchorOffsetChanged(object layout) =>
 		m_layoutAnchorOffsetChangedEventSource?.Invoke(layout, null!);
 
@@ -334,12 +336,13 @@ partial class LayoutsTestHooks
 		/* static */
 		remove
 		{
-			EnsureHooks();
-			s_testHooks!.m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource -= value;
+			if (s_testHooks is not null)
+			{
+				s_testHooks.m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource -= value;
+			}
 		}
 	}
 
-	/* static */
 	internal void NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(object linedFlowLayout) =>
 		m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource?.Invoke(linedFlowLayout, null!);
 
@@ -354,12 +357,13 @@ partial class LayoutsTestHooks
 		/* static */
 		remove
 		{
-			EnsureHooks();
-			s_testHooks!.m_linedFlowLayoutInvalidatedEventSource -= value;
+			if (s_testHooks is not null)
+			{
+				s_testHooks.m_linedFlowLayoutInvalidatedEventSource -= value;
+			}
 		}
 	}
 
-	/* static */
 	internal void NotifyLinedFlowLayoutInvalidated(object linedFlowLayout, LinedFlowLayoutInvalidationTrigger invalidationTrigger) =>
 		m_linedFlowLayoutInvalidatedEventSource?.Invoke(
 			linedFlowLayout,
@@ -376,12 +380,13 @@ partial class LayoutsTestHooks
 		/* static */
 		remove
 		{
-			EnsureHooks();
-			s_testHooks!.m_linedFlowLayoutItemLockedEventSource -= value;
+			if (s_testHooks is not null)
+			{
+				s_testHooks.m_linedFlowLayoutItemLockedEventSource -= value;
+			}
 		}
 	}
 
-	/* static */
 	internal void NotifyLinedFlowLayoutItemLocked(object linedFlowLayout, int itemIndex, int lineIndex) =>
 		m_linedFlowLayoutItemLockedEventSource?.Invoke(
 			linedFlowLayout,

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
@@ -11,11 +11,7 @@ namespace Microsoft.UI.Private.Controls;
 
 partial class LayoutsTestHooks
 {
-	private static void EnsureHooks()
-	{
-		s_testHooks ??= new LayoutsTestHooks();
-	}
-
+	/* static */
 	internal static IndexBasedLayoutOrientation GetLayoutForcedIndexBasedLayoutOrientation(object layout)
 	{
 		if (layout is Layout instance)
@@ -26,6 +22,7 @@ partial class LayoutsTestHooks
 		return IndexBasedLayoutOrientation.None;
 	}
 
+	/* static */
 	internal static void SetLayoutForcedIndexBasedLayoutOrientation(object layout, IndexBasedLayoutOrientation forcedIndexBasedLayoutOrientation)
 	{
 		if (layout is Layout instance)
@@ -34,6 +31,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static void ResetLayoutForcedIndexBasedLayoutOrientation(object layout)
 	{
 		if (layout is Layout instance)
@@ -42,6 +40,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static void LayoutInvalidateMeasure(object layout, bool relayout)
 	{
 		if (relayout && layout is LinedFlowLayout linedFlowLayout)
@@ -56,6 +55,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static int GetLayoutLogItemIndex(object layout)
 	{
 		if (layout is Layout instance)
@@ -66,6 +66,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static void SetLayoutLogItemIndex(object layout, int logItemIndex)
 	{
 		if (layout is Layout instance)
@@ -74,6 +75,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static int GetLayoutAnchorIndex(object layout)
 	{
 		if (layout is Layout instance)
@@ -84,6 +86,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static double GetLayoutAnchorOffset(object layout)
 	{
 		if (layout is Layout instance)
@@ -94,6 +97,7 @@ partial class LayoutsTestHooks
 		return -1.0;
 	}
 
+	/* static */
 	internal static int GetLayoutFirstRealizedItemIndex(object layout)
 	{
 		if (layout is LinedFlowLayout instance)
@@ -104,6 +108,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static int GetLayoutLastRealizedItemIndex(object layout)
 	{
 		if (layout is LinedFlowLayout instance)
@@ -114,6 +119,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static int GetLinedFlowLayoutFirstFrozenItemIndex(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -124,6 +130,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static int GetLinedFlowLayoutLastFrozenItemIndex(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -134,6 +141,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static double GetLinedFlowLayoutAverageItemAspectRatio(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -144,6 +152,7 @@ partial class LayoutsTestHooks
 		return 0.0;
 	}
 
+	/* static */
 	internal static double GetLinedFlowLayoutRawAverageItemsPerLine(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -154,6 +163,7 @@ partial class LayoutsTestHooks
 		return 0.0;
 	}
 
+	/* static */
 	internal static double GetLinedFlowLayoutSnappedAverageItemsPerLine(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -164,6 +174,7 @@ partial class LayoutsTestHooks
 		return 0.0;
 	}
 
+	/* static */
 	internal static double GetLinedFlowLayoutForcedAverageItemAspectRatio(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -174,6 +185,7 @@ partial class LayoutsTestHooks
 		return 0.0;
 	}
 
+	/* static */
 	internal static void SetLinedFlowLayoutForcedAverageItemAspectRatio(object linedFlowLayout, double forcedAverageItemAspectRatio)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -182,6 +194,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static double GetLinedFlowLayoutForcedAverageItemsPerLineDivider(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -192,6 +205,7 @@ partial class LayoutsTestHooks
 		return 0.0;
 	}
 
+	/* static */
 	internal static void SetLinedFlowLayoutForcedAverageItemsPerLineDivider(object linedFlowLayout, double forcedAverageItemsPerLineDivider)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -200,6 +214,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static double GetLinedFlowLayoutForcedWrapMultiplier(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -210,6 +225,7 @@ partial class LayoutsTestHooks
 		return 0.0;
 	}
 
+	/* static */
 	internal static void SetLinedFlowLayoutForcedWrapMultiplier(object linedFlowLayout, double forcedWrapMultiplier)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -218,6 +234,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static bool GetLinedFlowLayoutIsFastPathSupported(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -228,6 +245,7 @@ partial class LayoutsTestHooks
 		return false;
 	}
 
+	/* static */
 	internal static void SetLinedFlowLayoutIsFastPathSupported(object linedFlowLayout, bool isFastPathSupported)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -236,6 +254,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static int GetLinedFlowLayoutLineIndex(object linedFlowLayout, int itemIndex)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -246,6 +265,7 @@ partial class LayoutsTestHooks
 		return -1;
 	}
 
+	/* static */
 	internal static void ClearLinedFlowLayoutItemAspectRatios(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -254,6 +274,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static void UnlockLinedFlowLayoutItems(object linedFlowLayout)
 	{
 		if (linedFlowLayout is LinedFlowLayout instance)
@@ -262,6 +283,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal static event TypedEventHandler<object, object> LayoutAnchorIndexChanged
 	{
 		add
@@ -269,6 +291,7 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_layoutAnchorIndexChangedEventSource += value;
 		}
+		/* static */
 		remove
 		{
 			EnsureHooks();
@@ -276,9 +299,11 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal void NotifyLayoutAnchorIndexChanged(object layout) =>
 		m_layoutAnchorIndexChangedEventSource?.Invoke(layout, null!);
 
+	/* static */
 	internal static event TypedEventHandler<object, object> LayoutAnchorOffsetChanged
 	{
 		add
@@ -286,6 +311,7 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_layoutAnchorOffsetChangedEventSource += value;
 		}
+		/* static */
 		remove
 		{
 			EnsureHooks();
@@ -293,9 +319,11 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal void NotifyLayoutAnchorOffsetChanged(object layout) =>
 		m_layoutAnchorOffsetChangedEventSource?.Invoke(layout, null!);
 
+	/* static */
 	internal static event TypedEventHandler<object, object> LinedFlowLayoutSnappedAverageItemsPerLineChanged
 	{
 		add
@@ -303,6 +331,7 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource += value;
 		}
+		/* static */
 		remove
 		{
 			EnsureHooks();
@@ -310,9 +339,11 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal void NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(object linedFlowLayout) =>
 		m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource?.Invoke(linedFlowLayout, null!);
 
+	/* static */
 	internal static event TypedEventHandler<object, LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs> LinedFlowLayoutInvalidated
 	{
 		add
@@ -320,6 +351,7 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_linedFlowLayoutInvalidatedEventSource += value;
 		}
+		/* static */
 		remove
 		{
 			EnsureHooks();
@@ -327,11 +359,13 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal void NotifyLinedFlowLayoutInvalidated(object linedFlowLayout, LinedFlowLayoutInvalidationTrigger invalidationTrigger) =>
 		m_linedFlowLayoutInvalidatedEventSource?.Invoke(
 			linedFlowLayout,
 			new LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs(invalidationTrigger));
 
+	/* static */
 	internal static event TypedEventHandler<object, LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs> LinedFlowLayoutItemLocked
 	{
 		add
@@ -339,6 +373,7 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_linedFlowLayoutItemLockedEventSource += value;
 		}
+		/* static */
 		remove
 		{
 			EnsureHooks();
@@ -346,6 +381,7 @@ partial class LayoutsTestHooks
 		}
 	}
 
+	/* static */
 	internal void NotifyLinedFlowLayoutItemLocked(object linedFlowLayout, int itemIndex, int lineIndex) =>
 		m_linedFlowLayoutItemLockedEventSource?.Invoke(
 			linedFlowLayout,

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
@@ -291,7 +291,6 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_layoutAnchorIndexChangedEventSource += value;
 		}
-		/* static */
 		remove
 		{
 			if (s_testHooks is not null)
@@ -312,7 +311,6 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_layoutAnchorOffsetChangedEventSource += value;
 		}
-		/* static */
 		remove
 		{
 			if (s_testHooks is not null)
@@ -333,7 +331,6 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource += value;
 		}
-		/* static */
 		remove
 		{
 			if (s_testHooks is not null)
@@ -354,7 +351,6 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_linedFlowLayoutInvalidatedEventSource += value;
 		}
-		/* static */
 		remove
 		{
 			if (s_testHooks is not null)
@@ -377,7 +373,6 @@ partial class LayoutsTestHooks
 			EnsureHooks();
 			s_testHooks!.m_linedFlowLayoutItemLockedEventSource += value;
 		}
-		/* static */
 		remove
 		{
 			if (s_testHooks is not null)

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooks.mux.cs
@@ -1,0 +1,353 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooks.cpp, commit b8cfb8490
+
+#nullable enable
+
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooks
+{
+	private static void EnsureHooks()
+	{
+		s_testHooks ??= new LayoutsTestHooks();
+	}
+
+	internal static IndexBasedLayoutOrientation GetLayoutForcedIndexBasedLayoutOrientation(object layout)
+	{
+		if (layout is Layout instance)
+		{
+			return instance.GetForcedIndexBasedLayoutOrientationDbg();
+		}
+
+		return IndexBasedLayoutOrientation.None;
+	}
+
+	internal static void SetLayoutForcedIndexBasedLayoutOrientation(object layout, IndexBasedLayoutOrientation forcedIndexBasedLayoutOrientation)
+	{
+		if (layout is Layout instance)
+		{
+			instance.SetForcedIndexBasedLayoutOrientationDbg(forcedIndexBasedLayoutOrientation);
+		}
+	}
+
+	internal static void ResetLayoutForcedIndexBasedLayoutOrientation(object layout)
+	{
+		if (layout is Layout instance)
+		{
+			instance.ResetForcedIndexBasedLayoutOrientationDbg();
+		}
+	}
+
+	internal static void LayoutInvalidateMeasure(object layout, bool relayout)
+	{
+		if (relayout && layout is LinedFlowLayout linedFlowLayout)
+		{
+			linedFlowLayout.InvalidateLayout();
+			return;
+		}
+
+		if (layout is Layout instance)
+		{
+			instance.InvalidateMeasure();
+		}
+	}
+
+	internal static int GetLayoutLogItemIndex(object layout)
+	{
+		if (layout is Layout instance)
+		{
+			return instance.LogItemIndexDbg();
+		}
+
+		return -1;
+	}
+
+	internal static void SetLayoutLogItemIndex(object layout, int logItemIndex)
+	{
+		if (layout is Layout instance)
+		{
+			instance.LogItemIndexDbg(logItemIndex);
+		}
+	}
+
+	internal static int GetLayoutAnchorIndex(object layout)
+	{
+		if (layout is Layout instance)
+		{
+			return instance.LayoutAnchorIndexDbg();
+		}
+
+		return -1;
+	}
+
+	internal static double GetLayoutAnchorOffset(object layout)
+	{
+		if (layout is Layout instance)
+		{
+			return instance.LayoutAnchorOffsetDbg();
+		}
+
+		return -1.0;
+	}
+
+	internal static int GetLayoutFirstRealizedItemIndex(object layout)
+	{
+		if (layout is LinedFlowLayout instance)
+		{
+			return instance.FirstRealizedItemIndexDbg();
+		}
+
+		return -1;
+	}
+
+	internal static int GetLayoutLastRealizedItemIndex(object layout)
+	{
+		if (layout is LinedFlowLayout instance)
+		{
+			return instance.LastRealizedItemIndexDbg();
+		}
+
+		return -1;
+	}
+
+	internal static int GetLinedFlowLayoutFirstFrozenItemIndex(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.FirstFrozenItemIndexDbg();
+		}
+
+		return -1;
+	}
+
+	internal static int GetLinedFlowLayoutLastFrozenItemIndex(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.LastFrozenItemIndexDbg();
+		}
+
+		return -1;
+	}
+
+	internal static double GetLinedFlowLayoutAverageItemAspectRatio(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.AverageItemAspectRatioDbg();
+		}
+
+		return 0.0;
+	}
+
+	internal static double GetLinedFlowLayoutRawAverageItemsPerLine(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.RawAverageItemsPerLineDbg();
+		}
+
+		return 0.0;
+	}
+
+	internal static double GetLinedFlowLayoutSnappedAverageItemsPerLine(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.SnappedAverageItemsPerLineDbg();
+		}
+
+		return 0.0;
+	}
+
+	internal static double GetLinedFlowLayoutForcedAverageItemAspectRatio(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.ForcedAverageItemAspectRatioDbg();
+		}
+
+		return 0.0;
+	}
+
+	internal static void SetLinedFlowLayoutForcedAverageItemAspectRatio(object linedFlowLayout, double forcedAverageItemAspectRatio)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			instance.ForcedAverageItemAspectRatioDbg(forcedAverageItemAspectRatio);
+		}
+	}
+
+	internal static double GetLinedFlowLayoutForcedAverageItemsPerLineDivider(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.ForcedAverageItemsPerLineDividerDbg();
+		}
+
+		return 0.0;
+	}
+
+	internal static void SetLinedFlowLayoutForcedAverageItemsPerLineDivider(object linedFlowLayout, double forcedAverageItemsPerLineDivider)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			instance.ForcedAverageItemsPerLineDividerDbg(forcedAverageItemsPerLineDivider);
+		}
+	}
+
+	internal static double GetLinedFlowLayoutForcedWrapMultiplier(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.ForcedWrapMultiplierDbg();
+		}
+
+		return 0.0;
+	}
+
+	internal static void SetLinedFlowLayoutForcedWrapMultiplier(object linedFlowLayout, double forcedWrapMultiplier)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			instance.ForcedWrapMultiplierDbg(forcedWrapMultiplier);
+		}
+	}
+
+	internal static bool GetLinedFlowLayoutIsFastPathSupported(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.IsFastPathSupportedDbg();
+		}
+
+		return false;
+	}
+
+	internal static void SetLinedFlowLayoutIsFastPathSupported(object linedFlowLayout, bool isFastPathSupported)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			instance.IsFastPathSupportedDbg(isFastPathSupported);
+		}
+	}
+
+	internal static int GetLinedFlowLayoutLineIndex(object linedFlowLayout, int itemIndex)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			return instance.GetLineIndexDbg(itemIndex);
+		}
+
+		return -1;
+	}
+
+	internal static void ClearLinedFlowLayoutItemAspectRatios(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			instance.ClearItemAspectRatios();
+		}
+	}
+
+	internal static void UnlockLinedFlowLayoutItems(object linedFlowLayout)
+	{
+		if (linedFlowLayout is LinedFlowLayout instance)
+		{
+			instance.UnlockItems();
+		}
+	}
+
+	internal static event TypedEventHandler<object, object> LayoutAnchorIndexChanged
+	{
+		add
+		{
+			EnsureHooks();
+			s_testHooks!.m_layoutAnchorIndexChangedEventSource += value;
+		}
+		remove
+		{
+			EnsureHooks();
+			s_testHooks!.m_layoutAnchorIndexChangedEventSource -= value;
+		}
+	}
+
+	internal void NotifyLayoutAnchorIndexChanged(object layout) =>
+		m_layoutAnchorIndexChangedEventSource?.Invoke(layout, null!);
+
+	internal static event TypedEventHandler<object, object> LayoutAnchorOffsetChanged
+	{
+		add
+		{
+			EnsureHooks();
+			s_testHooks!.m_layoutAnchorOffsetChangedEventSource += value;
+		}
+		remove
+		{
+			EnsureHooks();
+			s_testHooks!.m_layoutAnchorOffsetChangedEventSource -= value;
+		}
+	}
+
+	internal void NotifyLayoutAnchorOffsetChanged(object layout) =>
+		m_layoutAnchorOffsetChangedEventSource?.Invoke(layout, null!);
+
+	internal static event TypedEventHandler<object, object> LinedFlowLayoutSnappedAverageItemsPerLineChanged
+	{
+		add
+		{
+			EnsureHooks();
+			s_testHooks!.m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource += value;
+		}
+		remove
+		{
+			EnsureHooks();
+			s_testHooks!.m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource -= value;
+		}
+	}
+
+	internal void NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(object linedFlowLayout) =>
+		m_linedFlowLayoutSnappedAverageItemsPerLineChangedEventSource?.Invoke(linedFlowLayout, null!);
+
+	internal static event TypedEventHandler<object, LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs> LinedFlowLayoutInvalidated
+	{
+		add
+		{
+			EnsureHooks();
+			s_testHooks!.m_linedFlowLayoutInvalidatedEventSource += value;
+		}
+		remove
+		{
+			EnsureHooks();
+			s_testHooks!.m_linedFlowLayoutInvalidatedEventSource -= value;
+		}
+	}
+
+	internal void NotifyLinedFlowLayoutInvalidated(object linedFlowLayout, LinedFlowLayoutInvalidationTrigger invalidationTrigger) =>
+		m_linedFlowLayoutInvalidatedEventSource?.Invoke(
+			linedFlowLayout,
+			new LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs(invalidationTrigger));
+
+	internal static event TypedEventHandler<object, LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs> LinedFlowLayoutItemLocked
+	{
+		add
+		{
+			EnsureHooks();
+			s_testHooks!.m_linedFlowLayoutItemLockedEventSource += value;
+		}
+		remove
+		{
+			EnsureHooks();
+			s_testHooks!.m_linedFlowLayoutItemLockedEventSource -= value;
+		}
+	}
+
+	internal void NotifyLinedFlowLayoutItemLocked(object linedFlowLayout, int itemIndex, int lineIndex) =>
+		m_linedFlowLayoutItemLockedEventSource?.Invoke(
+			linedFlowLayout,
+			new LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs(itemIndex, lineIndex));
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksFactory.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksFactory.mux.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooksFactory.cpp, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooks
+{
+	private static void EnsureHooks()
+	{
+		s_testHooks ??= new LayoutsTestHooks();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooks.idl, commit b8cfb8490
 
-#nullable enable
-
 namespace Microsoft.UI.Private.Controls;
 
-internal partial class LayoutsTestHooks
+internal partial class LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs
 {
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooks.idl, commit b8cfb8490
 
+#nullable enable
+
 namespace Microsoft.UI.Private.Controls;
 
 internal partial class LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.h.mux.cs
@@ -6,5 +6,7 @@ namespace Microsoft.UI.Private.Controls;
 
 partial class LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs
 {
+	// ILayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs overrides
+
 	private readonly LinedFlowLayoutInvalidationTrigger m_invalidationTrigger;
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.h.mux.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.h, commit b8cfb8490
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs
+{
+	private readonly LinedFlowLayoutInvalidationTrigger m_invalidationTrigger;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.mux.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.cpp, commit b8cfb8490
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs
+{
+	internal LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs(LinedFlowLayoutInvalidationTrigger invalidationTrigger)
+	{
+		m_invalidationTrigger = invalidationTrigger;
+	}
+
+	// #pragma region ILayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs
+
+	internal LinedFlowLayoutInvalidationTrigger InvalidationTrigger => m_invalidationTrigger;
+
+	// #pragma endregion
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.mux.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs.cpp, commit b8cfb8490
 
+#nullable enable
+
 namespace Microsoft.UI.Private.Controls;
 
 partial class LayoutsTestHooksLinedFlowLayoutInvalidatedEventArgs

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooks.idl, commit b8cfb8490
 
-#nullable enable
-
 namespace Microsoft.UI.Private.Controls;
 
-internal partial class LayoutsTestHooks
+internal partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs
 {
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooks.idl, commit b8cfb8490
 
+#nullable enable
+
 namespace Microsoft.UI.Private.Controls;
 
 internal partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.h.mux.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.h, commit b8cfb8490
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs
+{
+	private readonly int m_itemIndex;
+	private readonly int m_lineIndex;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.h.mux.cs
@@ -6,6 +6,8 @@ namespace Microsoft.UI.Private.Controls;
 
 partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs
 {
+	// ILayoutsTestHooksLinedFlowLayoutItemLockedEventArgs overrides
+
 	private readonly int m_itemIndex;
 	private readonly int m_lineIndex;
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.mux.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.cpp, commit b8cfb8490
 
+#nullable enable
+
 namespace Microsoft.UI.Private.Controls;
 
 partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.mux.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.cpp, commit b8cfb8490
+
+namespace Microsoft.UI.Private.Controls;
+
+partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs
+{
+	internal LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs(int itemIndex, int lineIndex)
+	{
+		m_itemIndex = itemIndex;
+		m_lineIndex = lineIndex;
+	}
+
+	// ILayoutsTestHooksLinedFlowLayoutItemLockedEventArgs overrides
+	internal int ItemIndex => m_itemIndex;
+	internal int LineIndex => m_lineIndex;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs.mux.cs
@@ -12,7 +12,10 @@ partial class LayoutsTestHooksLinedFlowLayoutItemLockedEventArgs
 		m_lineIndex = lineIndex;
 	}
 
-	// ILayoutsTestHooksLinedFlowLayoutItemLockedEventArgs overrides
+	// #pragma region ILayoutsTestHooksLinedFlowLayoutItemLockedEventArgs
+
 	internal int ItemIndex => m_itemIndex;
 	internal int LineIndex => m_lineIndex;
+
+	// #pragma endregion
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.Properties.cs
@@ -6,73 +6,115 @@
 
 using Windows.Foundation;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public partial class LinedFlowLayout
+	partial class LinedFlowLayout
 	{
+		/// <summary>
+		/// Identifies the <see cref="ActualLineHeight"/> dependency property.
+		/// </summary>
 		public static DependencyProperty ActualLineHeightProperty { get; } = DependencyProperty.Register(
 			nameof(ActualLineHeight), typeof(double), typeof(LinedFlowLayout),
 			new FrameworkPropertyMetadata(s_defaultActualLineHeight, propertyChangedCallback: (sender, args) => ((LinedFlowLayout)sender).OnPropertyChanged(args)));
 
+		/// <summary>
+		/// Gets the actual height used to arrange each line.
+		/// </summary>
 		public double ActualLineHeight
 		{
 			get => (double)GetValue(ActualLineHeightProperty);
 			internal set => SetValue(ActualLineHeightProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the <see cref="ItemsJustification"/> dependency property.
+		/// </summary>
 		public static DependencyProperty ItemsJustificationProperty { get; } = DependencyProperty.Register(
 			nameof(ItemsJustification), typeof(LinedFlowLayoutItemsJustification), typeof(LinedFlowLayout),
 			new FrameworkPropertyMetadata(s_defaultItemsJustification, propertyChangedCallback: (sender, args) => ((LinedFlowLayout)sender).OnPropertyChanged(args)));
 
+		/// <summary>
+		/// Gets or sets how items are aligned along each line.
+		/// </summary>
 		public LinedFlowLayoutItemsJustification ItemsJustification
 		{
 			get => (LinedFlowLayoutItemsJustification)GetValue(ItemsJustificationProperty);
 			set => SetValue(ItemsJustificationProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the <see cref="ItemsStretch"/> dependency property.
+		/// </summary>
 		public static DependencyProperty ItemsStretchProperty { get; } = DependencyProperty.Register(
 			nameof(ItemsStretch), typeof(LinedFlowLayoutItemsStretch), typeof(LinedFlowLayout),
 			new FrameworkPropertyMetadata(s_defaultItemsStretch, propertyChangedCallback: (sender, args) => ((LinedFlowLayout)sender).OnPropertyChanged(args)));
 
+		/// <summary>
+		/// Gets or sets how items are stretched to fill each line.
+		/// </summary>
 		public LinedFlowLayoutItemsStretch ItemsStretch
 		{
 			get => (LinedFlowLayoutItemsStretch)GetValue(ItemsStretchProperty);
 			set => SetValue(ItemsStretchProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the <see cref="LineHeight"/> dependency property.
+		/// </summary>
 		public static DependencyProperty LineHeightProperty { get; } = DependencyProperty.Register(
 			nameof(LineHeight), typeof(double), typeof(LinedFlowLayout),
 			new FrameworkPropertyMetadata(s_defaultLineHeight, propertyChangedCallback: (sender, args) => ((LinedFlowLayout)sender).OnPropertyChanged(args)));
 
+		/// <summary>
+		/// Gets or sets the requested height of each line.
+		/// </summary>
 		public double LineHeight
 		{
 			get => (double)GetValue(LineHeightProperty);
 			set => SetValue(LineHeightProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the <see cref="LineSpacing"/> dependency property.
+		/// </summary>
 		public static DependencyProperty LineSpacingProperty { get; } = DependencyProperty.Register(
 			nameof(LineSpacing), typeof(double), typeof(LinedFlowLayout),
 			new FrameworkPropertyMetadata(s_defaultLineSpacing, propertyChangedCallback: (sender, args) => ((LinedFlowLayout)sender).OnPropertyChanged(args)));
 
+		/// <summary>
+		/// Gets or sets the spacing between lines.
+		/// </summary>
 		public double LineSpacing
 		{
 			get => (double)GetValue(LineSpacingProperty);
 			set => SetValue(LineSpacingProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the <see cref="MinItemSpacing"/> dependency property.
+		/// </summary>
 		public static DependencyProperty MinItemSpacingProperty { get; } = DependencyProperty.Register(
 			nameof(MinItemSpacing), typeof(double), typeof(LinedFlowLayout),
 			new FrameworkPropertyMetadata(s_defaultMinItemSpacing, propertyChangedCallback: (sender, args) => ((LinedFlowLayout)sender).OnPropertyChanged(args)));
 
+		/// <summary>
+		/// Gets or sets the minimum spacing between items in a line.
+		/// </summary>
 		public double MinItemSpacing
 		{
 			get => (double)GetValue(MinItemSpacingProperty);
 			set => SetValue(MinItemSpacingProperty, value);
 		}
 
+		/// <summary>
+		/// Occurs when the layout requests sizing information for a range of items.
+		/// </summary>
 		public event TypedEventHandler<LinedFlowLayout, LinedFlowLayoutItemsInfoRequestedEventArgs>? ItemsInfoRequested;
+
+		/// <summary>
+		/// Occurs when items previously locked to lines are unlocked.
+		/// </summary>
 		public event TypedEventHandler<LinedFlowLayout, object>? ItemsUnlocked;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ItemsRepeater.idl, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Xaml.Controls
+{
+	/// <summary>
+	/// A layout that arranges items into justified lines of equal height, sizing each item according to its aspect ratio.
+	/// </summary>
+	public partial class LinedFlowLayout : VirtualizingLayout
+	{
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.h.mux.cs
@@ -24,6 +24,97 @@ namespace Microsoft.UI.Xaml.Controls
 		private const string s_cannotShareLinedFlowLayout = "LinedFlowLayout cannot be shared.";
 		private const int s_measureCountdownStart = 5;
 
+		#region LayoutsTestHooks
+
+		internal int FirstRealizedItemIndexDbg()
+		{
+			if (!m_wasInitializedForContext)
+			{
+				return -1;
+			}
+
+			return m_elementManager.GetFirstRealizedDataIndex();
+		}
+
+		internal int LastRealizedItemIndexDbg()
+		{
+			if (!m_wasInitializedForContext)
+			{
+				return -1;
+			}
+
+			int realizedElementCount = m_elementManager.GetRealizedElementCount;
+			return realizedElementCount == 0 ? -1 : m_elementManager.GetFirstRealizedDataIndex() + realizedElementCount - 1;
+		}
+
+		internal int FirstFrozenItemIndexDbg() => m_firstFrozenItemIndex;
+
+		internal int LastFrozenItemIndexDbg() => m_lastFrozenItemIndex;
+
+		internal double AverageItemAspectRatioDbg() => m_averageItemAspectRatioDbg;
+
+		internal double ForcedAverageItemAspectRatioDbg() => m_forcedAverageItemAspectRatioDbg;
+
+		internal void ForcedAverageItemAspectRatioDbg(double forcedAverageItemAspectRatio)
+		{
+			if (m_forcedAverageItemAspectRatioDbg != forcedAverageItemAspectRatio)
+			{
+				m_forcedAverageItemAspectRatioDbg = forcedAverageItemAspectRatio;
+				InvalidateLayout();
+			}
+		}
+
+		internal double ForcedAverageItemsPerLineDividerDbg() => m_forcedAverageItemsPerLineDividerDbg;
+
+		internal void ForcedAverageItemsPerLineDividerDbg(double forcedAverageItemsPerLineDivider)
+		{
+			if (m_forcedAverageItemsPerLineDividerDbg != forcedAverageItemsPerLineDivider)
+			{
+				m_forcedAverageItemsPerLineDividerDbg = forcedAverageItemsPerLineDivider;
+				InvalidateLayout();
+			}
+		}
+
+		internal double ForcedWrapMultiplierDbg() => m_forcedWrapMultiplierDbg;
+
+		// Allows to change LinedFlowLayout::GetItemWidthMultiplierThreshold()'s return value for testing purposes.
+		internal void ForcedWrapMultiplierDbg(double forcedWrapMultiplier)
+		{
+			if (m_forcedWrapMultiplierDbg != forcedWrapMultiplier)
+			{
+				m_forcedWrapMultiplierDbg = forcedWrapMultiplier;
+				InvalidateLayout();
+			}
+		}
+
+		internal bool IsFastPathSupportedDbg() => m_isFastPathSupportedDbg;
+
+		// Allows the fall path layout to be turned off for testing purposes.
+		// This allows for instance to provide sizing information for an entire
+		// small source collection and still exercise the regular path.
+		internal void IsFastPathSupportedDbg(bool isFastPathSupported)
+		{
+			if (m_isFastPathSupportedDbg != isFastPathSupported)
+			{
+				m_isFastPathSupportedDbg = isFastPathSupported;
+
+				if (UsesFastPathLayout())
+				{
+					ResetItemsInfo();
+				}
+
+				InvalidateLayout();
+			}
+		}
+
+		internal double RawAverageItemsPerLineDbg() => m_averageItemsPerLine.first;
+
+		internal double SnappedAverageItemsPerLineDbg() => m_averageItemsPerLine.second;
+
+		internal int GetLineIndexDbg(int itemIndex) => GetLineIndex(itemIndex, UsesFastPathLayout());
+
+		#endregion
+
 		// The desired aspect ratio associated with an item has a weight between 1 and 16. Each time an item's
 		// aspect ratio is evaluated, its weight is incremented up to 16. The average aspect ratio is computed
 		// using those weights to stabilize m_averageItemsPerLine and reduce total re-layouts (LinedFlowLayout.cpp).

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.h.mux.cs
@@ -6,13 +6,12 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public partial class LinedFlowLayout
+	partial class LinedFlowLayout
 	{
-		// Default property values (LinedFlowLayout.h).
+		// Properties' default values.
 		private const LinedFlowLayoutItemsJustification s_defaultItemsJustification = LinedFlowLayoutItemsJustification.Start;
 		private const LinedFlowLayoutItemsStretch s_defaultItemsStretch = LinedFlowLayoutItemsStretch.None;
 		private const double s_defaultActualLineHeight = 0.0;
@@ -20,11 +19,19 @@ namespace Microsoft.UI.Xaml.Controls
 		private const double s_defaultLineHeight = double.NaN;
 		private const double s_defaultMinItemSpacing = 0.0;
 
-		// Constants (LinedFlowLayout.h).
-		private const string s_cannotShareLinedFlowLayout = "LinedFlowLayout cannot be shared.";
-		private const int s_measureCountdownStart = 5;
+		// #pragma region ILayoutOverrides
+		// #pragma endregion
 
-		#region LayoutsTestHooks
+		// #pragma region IVirtualizingLayoutOverrides
+		// #pragma endregion
+
+		internal void SetDesiredAspectRatios(double[] values) => m_itemsInfoDesiredAspectRatiosForFastPath = (double[])values.Clone();
+
+		internal void SetMinWidths(double[] values) => m_itemsInfoMinWidthsForFastPath = (double[])values.Clone();
+
+		internal void SetMaxWidths(double[] values) => m_itemsInfoMaxWidthsForFastPath = (double[])values.Clone();
+
+		// #pragma region LayoutsTestHooks
 
 		internal int FirstRealizedItemIndexDbg()
 		{
@@ -113,28 +120,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal int GetLineIndexDbg(int itemIndex) => GetLineIndex(itemIndex, UsesFastPathLayout());
 
-		#endregion
+		// #pragma endregion
 
-		// The desired aspect ratio associated with an item has a weight between 1 and 16. Each time an item's
-		// aspect ratio is evaluated, its weight is incremented up to 16. The average aspect ratio is computed
-		// using those weights to stabilize m_averageItemsPerLine and reduce total re-layouts (LinedFlowLayout.cpp).
-		private const int c_maxAspectRatioWeight = 16;
-
-		// Frozen lines before/after the displayed lines use 80% of a scroll viewport (or 40% of the
-		// sized area, whichever is largest) so small scroll deltas don't force a re-layout.
-		private const double c_frozenLinesRatio = 0.8;
-
-		// Scroll offsets within this epsilon of 0 are snapped to 0 to avoid sub-pixel line-index jitter.
-		private const double c_offsetEqualityEpsilon = 0.01;
-
-		// Number of layout passes m_anchorIndex is retained after RecommendedAnchorIndex momentarily
-		// switches to -1 during a bring-into-view operation (purely experimental value).
-		private const int c_maxAnchorIndexRetentionCount = 10;
-
-		// Sizing info returned by the ItemsInfoRequested event handler for a range of items.
-		// WinUI declares ItemsInfo private; it is internal here so RaiseItemsInfoRequested's return
-		// value can be validated by tests before the measure path that consumes it (WS-D3c) is ported.
-		internal struct ItemsInfo
+		// Structs
+		private struct ItemsInfo
 		{
 			public int m_itemsRangeStartIndex = -1;
 			public int m_itemsRangeLength = -1;
@@ -146,22 +135,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		private static readonly ItemsInfo s_emptyItemsInfo = new()
-		{
-			m_itemsRangeStartIndex = -1,
-			m_itemsRangeLength = -1,
-			m_minWidth = -1.0,
-			m_maxWidth = -1.0,
-		};
-
-		// WinUI declares ItemsLayout as a private value struct that is always either mutated through an
-		// ItemsLayout& reference or copied by value (stored in a std::vector<ItemsLayout>, reassigned as
-		// bestItemsLayout = itemsLayout, etc.). Those value copies deep-copy the inner std::vector members.
-		// It is modelled here as a reference type (avoids C# ref-parameter churn on the many mutating helpers)
-		// with an explicit Clone() that deep-copies the two lists; GetItemsLayout inserts Clone() at exactly
-		// the points where WinUI relies on value-copy semantics. It is internal so GetItemsLayout can be
-		// white-box tested via hand-built aspect-ratio arrays.
-		internal sealed class ItemsLayout
+		private sealed class ItemsLayout
 		{
 			public List<int> m_lineItemCounts = new();
 			public List<double> m_lineItemWidths = new();
@@ -179,96 +153,94 @@ namespace Microsoft.UI.Xaml.Controls
 			public int m_bestEqualizingTailItemIndex;
 			public int m_bestEqualizingHeadLineIndex;
 			public int m_bestEqualizingTailLineIndex;
-
-			public ItemsLayout Clone()
-			{
-				return new ItemsLayout
-				{
-					m_lineItemCounts = new List<int>(m_lineItemCounts),
-					m_lineItemWidths = new List<double>(m_lineItemWidths),
-					m_availableLineItemsWidth = m_availableLineItemsWidth,
-					m_drawback = m_drawback,
-					m_smallestHeadItemWidth = m_smallestHeadItemWidth,
-					m_smallestTailItemWidth = m_smallestTailItemWidth,
-					m_bestEqualizingHeadItemDrawbackImprovement = m_bestEqualizingHeadItemDrawbackImprovement,
-					m_bestEqualizingTailItemDrawbackImprovement = m_bestEqualizingTailItemDrawbackImprovement,
-					m_smallestHeadItemIndex = m_smallestHeadItemIndex,
-					m_smallestTailItemIndex = m_smallestTailItemIndex,
-					m_smallestHeadLineIndex = m_smallestHeadLineIndex,
-					m_smallestTailLineIndex = m_smallestTailLineIndex,
-					m_bestEqualizingHeadItemIndex = m_bestEqualizingHeadItemIndex,
-					m_bestEqualizingTailItemIndex = m_bestEqualizingTailItemIndex,
-					m_bestEqualizingHeadLineIndex = m_bestEqualizingHeadLineIndex,
-					m_bestEqualizingTailLineIndex = m_bestEqualizingTailLineIndex,
-				};
-			}
 		}
 
-		// Items info collected through the ItemsInfoRequested event for the regular (non-fast) path.
-		// WinUI declares this private; it is internal here so GetItemsLayout can be white-box tested with
-		// a hand-built aspect-ratio list before the measure path (WS-D3c sub-slice 5) that fills it is ported.
-		internal readonly List<double> m_itemsInfoDesiredAspectRatiosForRegularPath = new();
-		private readonly List<double> m_itemsInfoMinWidthsForRegularPath = new();
-		private readonly List<double> m_itemsInfoMaxWidthsForRegularPath = new();
-		// WinUI: std::vector<float>. Holds the per-item arrange widths (fast or regular path).
-		private readonly List<float> m_itemsInfoArrangeWidths = new();
+		// Constants
+		private const string s_cannotShareLinedFlowLayout = "LinedFlowLayout cannot be shared.";
+		private const int s_measureCountdownStart = 5;
 
-		// First index of the regular-path items info (-1 when the fast path is used or no info is available).
-		// Read by UsesFastPathLayout()/RequestedRangeStartIndex (WS-D3b); written by ResetItemsInfo (WS-D3c: ExitRegularPath).
-		// WinUI declares this private; it is internal here so GetItemsLayout can be white-box tested (see above).
-		internal int m_itemsInfoFirstIndex = -1;
+		private static readonly ItemsInfo s_emptyItemsInfo = new()
+		{
+			m_itemsRangeStartIndex = -1 /*itemsRangeStartIndex*/,
+			m_itemsRangeLength = -1 /*itemsRangeLength*/,
+			m_minWidth = -1.0 /*minWidth*/,
+			m_maxWidth = -1.0 /*maxWidth*/,
+		};
 
-		// Items info collected through the ItemsInfoRequested event for the fast path.
-		// WinUI: winrt::com_array<double>. Written by the Set*Widths seams; read by Get*FromItemsInfo (WS-D3c).
-		private double[] m_itemsInfoDesiredAspectRatiosForFastPath = Array.Empty<double>();
-		private double[] m_itemsInfoMinWidthsForFastPath = Array.Empty<double>();
-		private double[] m_itemsInfoMaxWidthsForFastPath = Array.Empty<double>();
+		// Methods
 
-		// Global min/max widths provided by the ItemsInfoRequested handler; read by Get{Min,Max}WidthFromItemsInfo (WS-D3c).
-		private double m_itemsInfoMinWidth = -1.0;
-		private double m_itemsInfoMaxWidth = -1.0;
+		// #ifdef DBG
+		// static winrt::hstring DependencyPropertyToStringDbg(
+		//     winrt::IDependencyProperty const& dependencyProperty);
+		// void LogElementManagerDbg();
+		// void LogItemsInfoDbg(
+		//     int itemsRangeStartIndex,
+		//     int itemsRangeRequestedLength,
+		//     ItemsInfo const& itemsInfo);
+		// void LogItemsLayoutDbg(
+		//     ItemsLayout const& itemsLayout,
+		//     double averageLineItemsWidth) const;
+		// void LogLayoutDbg();
+		// void LogVirtualizingLayoutContextDbg(
+		//     winrt::VirtualizingLayoutContext const& context) const;
+		// void VerifyInternalLockedItemsDbg(
+		//     std::map<int, int> const& internalLockedItemIndexes,
+		//     int beginSizedLineIndex,
+		//     int endSizedLineIndex,
+		//     int beginSizedItemIndex,
+		//     int endSizedItemIndex);
+		// void VerifyLockedItemsDbg();
+		// #endif
 
-#pragma warning disable 414 // Assigned but not yet read: consumed by later WS-D3c measure slices, kept to mirror WinUI.
-		private bool m_forceRelayout;
-#pragma warning restore 414
-
-		// Core state (LinedFlowLayout.h). Owns the realized-element bookkeeping and the
-		// weighted aspect-ratio cache. LinedFlowLayout stores its state on the instance
-		// (it cannot be shared across ItemsRepeaters, unlike the other layouts).
+		// Fields
 		private readonly ElementManager m_elementManager = new();
 
-		// Item count as reported by the context; refreshed on each Initialize/OnItemsChanged.
-		// internal for white-box testability of the line-breaking helpers.
-		internal int m_itemCount;
-
-		// Map keeping track of the locked items. Key: locked item index; Value: line index holding it.
-		private readonly SortedDictionary<int, int> m_lockedItemIndexes = new();
-
-		private bool m_isVirtualizingContext;
-		private bool m_wasInitializedForContext;
-		private bool m_isFirstOrLastItemLocked;
-
-		// Fields consumed by later WS-D3b..D3f measure/arrange slices. Declared now so the state
-		// shape mirrors LinedFlowLayout.h; some are only read (or only written) until those slices land.
-#pragma warning disable 169, 414, 649
-		// Data structure for storing item desired aspect ratios (allocated during measure).
+		// Data structure for storing item desired aspect ratios.
 		private LinedFlowLayoutItemAspectRatios? m_aspectRatios;
+
+		// Map keeping track of the locked items.
+		// Key:   index of locked item
+		// Value: index of line holding the locked item
+		private readonly SortedDictionary<int, int> m_lockedItemIndexes = new();
 
 		// Element index used in bring-into-view operations to disconnected items.
 		private int m_anchorIndex = -1;
 		private int m_anchorIndexRetentionCountdown;
 
-		// Measured item widths (heights are always equal to ActualLineHeight).
+		// Keep track of the measured items width. The heights are always equal to LineHeight.
 		private Dictionary<UIElement, float>? m_elementAvailableWidths;
 		private Dictionary<UIElement, float>? m_elementDesiredWidths;
 
-		// Instance line-item-counts written by the measure paths (fast/regular). Internal for white-box testability.
-		internal readonly List<int> m_lineItemCounts = new();
+		private readonly List<int> m_lineItemCounts = new();
+		private readonly List<float> m_itemsInfoArrangeWidths = new();
 
-		// Clamps the average aspect ratio during initial loading; also progressively expands the
-		// effective CacheLength to a minimum of 4.
+		// Items info collected through the ItemsInfoRequested event:
+		// - Used only by the regular path layout:
+		private readonly List<double> m_itemsInfoDesiredAspectRatiosForRegularPath = new();
+		private readonly List<double> m_itemsInfoMinWidthsForRegularPath = new();
+		private readonly List<double> m_itemsInfoMaxWidthsForRegularPath = new();
+		private int m_itemsInfoFirstIndex = -1; // Indicates the index of the first element represented in the 4 vectors above.
+
+		// - Used only by the fast path layout
+		private double[] m_itemsInfoDesiredAspectRatiosForFastPath = Array.Empty<double>();
+		private double[] m_itemsInfoMinWidthsForFastPath = Array.Empty<double>();
+		private double[] m_itemsInfoMaxWidthsForFastPath = Array.Empty<double>();
+		// - Used by both layout paths:
+		private double m_itemsInfoMinWidth = -1.0;
+		private double m_itemsInfoMaxWidth = -1.0;
+		// Note that the List<double> instances are used in the regular path because information gathered by successive ItemsInfoRequested occurrences
+		// is stitched together in those lists. This allows to only request information for a fraction of the sized items belonging to 5 viewports
+		// in each ItemsInfoRequested event.
+		// The fast path is only using cheaper temporary arrays because no such stitching is performed. Information is gathered for
+		// the entire source collection and the arrays are discarded at the end of the measure path.
+
+		// This countdown is used during initial loading in order to clamp the average aspect ratio between
+		// 2/3 and 3/2 to avoid extranuous item realizations while the first items are still unpopulated.
+		// It also allows a progressive expansion of the effective CacheLength to the minimum of 4 when
+		// the ItemsRepeater's value is smaller than that.
 		private int m_measureCountdown = s_measureCountdownStart;
 
+		private int m_itemCount;
 		private int m_unsizedNearLineCount = -1;
 		private int m_unrealizedNearLineCount = -1;
 		private int m_firstSizedLineIndex = -1;
@@ -280,25 +252,37 @@ namespace Microsoft.UI.Xaml.Controls
 		private int m_firstFrozenItemIndex = -1;
 		private int m_lastFrozenItemIndex = -1;
 		private int m_invalidateMeasureTimerTickCount;
+		private bool m_isVirtualizingContext;
+		private bool m_wasInitializedForContext;
+		private bool m_forceRelayout;
+		private bool m_isFirstOrLastItemLocked;
 		private float m_previousAvailableWidth;
 		private float m_maxLineWidth;
 		private double m_roundingScaleFactor = 1.0;
 
-		// First value is the 'raw' average-items-per-line; second is that value snapped to a power of 1.1.
-		// internal for white-box testability of the line-breaking helpers.
-		internal (double first, double second) m_averageItemsPerLine;
+		// First double is the 'raw' average-items-per-line value that was snapped to the second double.
+		// Second double is the 'snapped' average-items-per-line value starting from the raw first double.
+		// The snapping is to a power of 1.1.
+		private (double first, double second) m_averageItemsPerLine;
 
-		// Timer used to trigger an asynchronous measure pass when no items info was provided by the
-		// ItemsInfoRequested event (started from the measure path in WS-D3f).
+		// Timer used to trigger an asynchronous measure pass when no items info was provided by the ItemsInfoRequested event.
+		// It is started after an item was realized or when the timer expires and m_invalidateMeasureTimerTickCount is still
+		// smaller than 7. The interval begins at 100ms and is then increased by 50% each time it is re-started, until
+		// m_invalidateMeasureTimerTickCount reaches 7. By then the interval is 1.7s and the total time elapsed is about 5s
+		// when the timer is no longer re-started.
 		private DispatcherTimer? m_invalidateMeasureTimer;
 
-		// Fields backing the LayoutsTestHooks (WS-D5). Always compiled (not DBG-only); consumed by the
-		// measure algorithm (e.g. m_forcedAverageItemsPerLineDividerDbg tunes SnapAverageItemsPerLine).
+		// Fields used to support the LayoutsTestHooks
 		private double m_averageItemAspectRatioDbg;
 		private double m_forcedAverageItemAspectRatioDbg;
 		private double m_forcedAverageItemsPerLineDividerDbg;
 		private double m_forcedWrapMultiplierDbg;
 		private bool m_isFastPathSupportedDbg = true;
-#pragma warning restore 169, 414, 649
+
+		// #ifdef DBG
+		// Other debug fields
+		// int m_previousFirstDisplayedArrangedLineIndexDbg{ -1 };
+		// int m_previousLastDisplayedArrangedLineIndexDbg{ -1 };
+		// #endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.mux.cs
@@ -10,6 +10,7 @@ using System.Collections.Specialized;
 using Windows.Foundation;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Private.Controls;
 using static Microsoft.UI.Xaml.Controls._Tracing;
 
 namespace Microsoft.UI.Xaml.Controls
@@ -23,8 +24,7 @@ namespace Microsoft.UI.Xaml.Controls
 	/// line-breaking orchestration (<see cref="MeasureOverride"/>/<see cref="ArrangeOverride"/>/
 	/// <see cref="OnItemsChangedCore"/>), the <see cref="LockItemToLine"/> API and their helpers
 	/// are ported. Default item transitions (<see cref="CreateDefaultItemTransitionProvider"/>)
-	/// are deferred to WS-D4 (see that method), and the ETW/test-hook notifications are stubbed
-	/// as WS-D5 TODOs.
+	/// are deferred to WS-D4 (see that method).
 	/// </remarks>
 	public partial class LinedFlowLayout : VirtualizingLayout
 	{
@@ -132,7 +132,7 @@ namespace Microsoft.UI.Xaml.Controls
 								{
 									m_lockedItemIndexes.Add(lockedItemIndexTmp, lockedLineIndex);
 
-									// TODO (WS-D5): NotifyLinedFlowLayoutItemLockedDbg(lockedItemIndexTmp, lockedLineIndex);
+									NotifyLinedFlowLayoutItemLockedDbg(lockedItemIndexTmp, lockedLineIndex);
 								}
 							}
 
@@ -150,7 +150,7 @@ namespace Microsoft.UI.Xaml.Controls
 								{
 									m_lockedItemIndexes.Add(lockedItemIndexTmp, lockedLineIndex);
 
-									// TODO (WS-D5): NotifyLinedFlowLayoutItemLockedDbg(lockedItemIndexTmp, lockedLineIndex);
+									NotifyLinedFlowLayoutItemLockedDbg(lockedItemIndexTmp, lockedLineIndex);
 								}
 							}
 
@@ -169,7 +169,7 @@ namespace Microsoft.UI.Xaml.Controls
 				m_lockedItemIndexes.Add(itemIndex, lockedLineIndex);
 			}
 
-			// TODO (WS-D5): NotifyLinedFlowLayoutItemLockedDbg(itemIndex, lockedLineIndex);
+			NotifyLinedFlowLayoutItemLockedDbg(itemIndex, lockedLineIndex);
 
 			return lockedLineIndex;
 		}
@@ -228,7 +228,7 @@ namespace Microsoft.UI.Xaml.Controls
 			if (forceRelayout)
 			{
 				// Perform a complete re-layout during the next layout pass.
-				// TODO (WS-D5): NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall).
+				NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall);
 				m_forceRelayout = true;
 			}
 
@@ -714,7 +714,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		// Raises the ItemsUnlocked event when there are locked items. Raised when previously locked
 		// items are cleared because the source collection or the average items per line changed.
-		private void UnlockItems()
+		internal void UnlockItems()
 		{
 			if (m_lockedItemIndexes.Count > 0 || m_isFirstOrLastItemLocked)
 			{
@@ -1256,7 +1256,12 @@ namespace Microsoft.UI.Xaml.Controls
 					UnlockItems();
 				}
 
-				// TODO (WS-D5): globalTestHooks.NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(this).
+				var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
+
+				if (globalTestHooks is not null)
+				{
+					globalTestHooks.NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(this);
+				}
 			}
 		}
 
@@ -3709,7 +3714,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 							if (desiredWidthChanged || !hasOldDesiredWidth)
 							{
-								// TODO (WS-D5): NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.ItemDesiredWidthChange).
+								NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.ItemDesiredWidthChange);
 
 								if (itemIndex < m_firstFrozenItemIndex)
 								{
@@ -5691,7 +5696,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 						SetAverageItemsPerLine(newAverageItemsPerLine, true /*unlockItems*/);
 
-						// TODO (WS-D5): NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.SnappedAverageItemsPerLineChange).
+						NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.SnappedAverageItemsPerLineChange);
 
 						if (m_isVirtualizingContext)
 						{
@@ -6479,11 +6484,33 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void ClearItemAspectRatios()
+		internal void ClearItemAspectRatios()
 		{
 			if (m_aspectRatios != null)
 			{
 				m_aspectRatios.Clear();
+			}
+		}
+
+		// Raises the LayoutsTestHooks LinedFlowLayoutInvalidated event for testing purposes.
+		private void NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger invalidationTrigger)
+		{
+			var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
+
+			if (globalTestHooks is not null)
+			{
+				globalTestHooks.NotifyLinedFlowLayoutInvalidated(this, invalidationTrigger);
+			}
+		}
+
+		// Raises the LayoutsTestHooks LinedFlowLayoutItemLocked event for testing purposes.
+		private void NotifyLinedFlowLayoutItemLockedDbg(int itemIndex, int lineIndex)
+		{
+			var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
+
+			if (globalTestHooks is not null)
+			{
+				globalTestHooks.NotifyLinedFlowLayoutItemLocked(this, itemIndex, lineIndex);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.mux.cs
@@ -15,42 +15,70 @@ using static Microsoft.UI.Xaml.Controls._Tracing;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	/// <summary>
-	/// A layout that arranges items into justified lines of equal height, sizing each item
-	/// according to its aspect ratio (WinUI 1.8 LinedFlowLayout).
-	/// </summary>
-	/// <remarks>
-	/// Ported incrementally (workstream D) from LinedFlowLayout.cpp. The measure/arrange
-	/// line-breaking orchestration (<see cref="MeasureOverride"/>/<see cref="ArrangeOverride"/>/
-	/// <see cref="OnItemsChangedCore"/>), the <see cref="LockItemToLine"/> API and their helpers
-	/// are ported. Default item transitions (<see cref="CreateDefaultItemTransitionProvider"/>)
-	/// are deferred to WS-D4 (see that method).
-	/// </remarks>
-	public partial class LinedFlowLayout : VirtualizingLayout
+	partial class LinedFlowLayout
 	{
+		// Change to 'true' to turn on debugging outputs in Output window
+		// TODO Uno: Uno does not provide the TraceLogging and MUXControlsTestHooks backends used by LinedFlowLayoutTrace.
+		// Original C++:
+		// bool LinedFlowLayoutTrace::s_IsDebugOutputEnabled{ false };
+		// bool LinedFlowLayoutTrace::s_IsVerboseDebugOutputEnabled{ false };
+
+		// Maximum difference for scroll offsets to be considered equal. Used in GetFirstAndLastDisplayedLineIndexes for the moment.
+		private const double c_offsetEqualityEpsilon = 0.01;
+
+		// The desired aspect ratio associated with an item has a weight between 1 and 16. Each time an item's aspect ratio is evaluated, its weight is incremented up to 16.
+		// The average aspect ratio is computed using those weights. This is to avoid giving too much importance to newly realized items which are still loading their content
+		// and temporarily provide an aspect ratio that would throw off the average. This stabilizes the m_averageItemsPerLine field which leads to fewer total re-layouts.
+		private const int c_maxAspectRatioWeight = 16;
+
+		// See m_anchorIndexRetentionCountdown usage below. Represents the measure pass count after which a RecommendedAnchorIndex reset to -1 takes effect.
+		private const int c_maxAnchorIndexRetentionCount = 10;
+
+		// An area sized 80% of a scroll viewport made of frozen lines is placed before the displayed lines. An identically sized area is also placed after the displayed lines.
+		private const double c_frozenLinesRatio = 0.8;
+
+		// #pragma region ILinedFlowLayout
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LinedFlowLayout"/> class.
+		/// </summary>
 		public LinedFlowLayout()
 		{
-			//__RP_Marker_ClassById(RuntimeProfiler.ProfId_LinedFlowLayout);
+			// LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
+			// TODO Uno: RuntimeProfiler is unavailable.
+			// __RP_Marker_ClassById(RuntimeProfiler::ProfId_LinedFlowLayout);
 			LayoutId = "LinedFlowLayout";
 
-			// DPs are registered via the static initializers in LinedFlowLayout.Properties.cs
-			// (WinUI's EnsureProperties()).
+			// TODO Uno: Dependency properties are registered by static initializers in LinedFlowLayout.Properties.cs.
 
 			SetIndexBasedLayoutOrientation(IndexBasedLayoutOrientation.LeftToRight);
 		}
 
-		#region ILinedFlowLayout
+#if HAS_UNO
+		// TODO Uno: Original C++ destructor cleanup. Uno does not support cleanup via finalizers.
+		// Move this logic into Loaded/Unloaded event handlers or other lifecycle methods to avoid leaks.
 
+		// Original destructor logic (not executed):
+		// LinedFlowLayout::~LinedFlowLayout()
+		// {
+		//     LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
+		//
+		//     InvalidateMeasureTimerStop(true /*isForDestructor*/);
+		// }
+#endif
+
+		// Locks the 'itemIndex' into its line until the m_averageItemsPerLine or collection changes,
+		// at which point the ItemsUnlocked event is raised.
 		/// <summary>
 		/// Locks the provided item to its line until the average-items-per-line or the collection
 		/// changes, at which point the <see cref="ItemsUnlocked"/> event is raised.
 		/// </summary>
 		public int LockItemToLine(int itemIndex)
 		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT, METH_NAME, this, itemIndex);
 			if (itemIndex < 0 || itemIndex >= m_itemCount)
 			{
-				// WinUI throws winrt::hresult_out_of_bounds(); ArgumentOutOfRangeException is the
-				// repo-standard mapping for out-of-range item indexes in the Repeater code.
+				// TODO Uno: ArgumentOutOfRangeException maps WinUI's hresult_out_of_bounds.
 				throw new ArgumentOutOfRangeException(nameof(itemIndex));
 			}
 
@@ -114,8 +142,7 @@ namespace Microsoft.UI.Xaml.Controls
 			if (m_lockedItemIndexes.Count > 0)
 			{
 				// Check if that line already has locked items. Any unlocked item squeezed between two locked items is declared locked.
-				// Iterate over a snapshot because the loop inserts into m_lockedItemIndexes; WinUI relies on std::map
-				// iterator stability plus the immediate break below, which the snapshot reproduces exactly.
+				// TODO Uno: Iterate a snapshot to preserve std::map iterator stability while inserting.
 				foreach (var lockedItemIterator in new List<KeyValuePair<int, int>>(m_lockedItemIndexes))
 				{
 					if (lockedItemIterator.Value == lockedLineIndex)
@@ -174,40 +201,10 @@ namespace Microsoft.UI.Xaml.Controls
 			return lockedLineIndex;
 		}
 
-		/// <summary>
-		/// Discards the item sizing info previously gathered through the <see cref="ItemsInfoRequested"/>
-		/// event and forces a re-layout in the next measure pass.
-		/// </summary>
-		public void InvalidateItemsInfo()
-		{
-			InvalidateLayout(forceRelayout: true, resetItemsInfo: true, invalidateMeasure: true);
-		}
-
-		/// <summary>
-		/// Index of the first item for which sizing info is requested through the
-		/// <see cref="ItemsInfoRequested"/> event.
-		/// </summary>
-		public int RequestedRangeStartIndex => UsesFastPathLayout() ? 0 : m_itemsInfoFirstIndex;
-
-		/// <summary>
-		/// Number of items for which sizing info is requested through the
-		/// <see cref="ItemsInfoRequested"/> event.
-		/// </summary>
-		public int RequestedRangeLength => UsesFastPathLayout() ? m_itemCount : m_itemsInfoDesiredAspectRatiosForRegularPath.Count;
-
-		#endregion
-
-		// Seams invoked by LinedFlowLayoutItemsInfoRequestedEventArgs to store the fast-path sizing
-		// info provided by an ItemsInfoRequested event handler (LinedFlowLayout.h).
-		internal void SetDesiredAspectRatios(double[] values) => m_itemsInfoDesiredAspectRatiosForFastPath = (double[])values.Clone();
-
-		internal void SetMinWidths(double[] values) => m_itemsInfoMinWidthsForFastPath = (double[])values.Clone();
-
-		internal void SetMaxWidths(double[] values) => m_itemsInfoMaxWidthsForFastPath = (double[])values.Clone();
-
 		private void OnPropertyChanged(DependencyPropertyChangedEventArgs args)
 		{
 			var dependencyProperty = args.Property;
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(nullptr, L"%s(property: %s)\n", METH_NAME, DependencyPropertyToStringDbg(dependencyProperty).c_str());
 
 			if (dependencyProperty != ActualLineHeightProperty)
 			{
@@ -215,116 +212,25 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		// - forceRelayout == true:     forces a re-layout in the next measure pass.
-		// - resetItemsInfo == true:    resets the items info gathered so far.
-		// - invalidateMeasure == true: triggers a new measure pass.
-		internal void InvalidateLayout(
-			bool forceRelayout = true,
-			bool resetItemsInfo = false,
-			bool invalidateMeasure = true)
-		{
-			MUX_ASSERT(forceRelayout || resetItemsInfo || invalidateMeasure);
+		// #pragma endregion
 
-			if (forceRelayout)
-			{
-				// Perform a complete re-layout during the next layout pass.
-				NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall);
-				m_forceRelayout = true;
-			}
+		// #pragma region ILayoutOverrides
 
-			if (resetItemsInfo)
-			{
-				// Discard any potential item sizing info previously collected through the ItemsInfoRequested event.
-				ResetItemsInfo();
-			}
-
-			if (invalidateMeasure)
-			{
-				// Trigger a new layout pass.
-				InvalidateMeasure();
-			}
-		}
-
-		private void ResetItemsInfo()
-		{
-			m_itemsInfoDesiredAspectRatiosForRegularPath.Clear();
-			m_itemsInfoMinWidthsForRegularPath.Clear();
-			m_itemsInfoMaxWidthsForRegularPath.Clear();
-			m_itemsInfoArrangeWidths.Clear();
-			m_itemsInfoFirstIndex = -1;
-			m_itemsInfoMinWidth = -1.0;
-			m_itemsInfoMaxWidth = -1.0;
-		}
-
-		#region Items info (ItemsInfoRequested plumbing)
-
-		// Returns True when an ItemsInfoRequested handler provided arrange widths (fast or regular path).
-		private bool UsesArrangeWidthInfo() => m_itemsInfoArrangeWidths.Count > 0;
-
-		// Returns True when an ItemsInfoRequested handler provided sizing information for the entire source
-		// collection. In that case the fast path can be performed; it is characterized by a populated
-		// m_itemsInfoArrangeWidths and m_itemsInfoFirstIndex remaining at -1.
-		private bool UsesFastPathLayout() => UsesArrangeWidthInfo() && m_itemsInfoFirstIndex == -1;
-
-		// Raises the ItemsInfoRequested event for the [itemsRangeStartIndex, +itemsRangeRequestedLength) range
-		// and returns the sizing info the handler provided (or s_emptyItemsInfo when there is no handler).
-		// WinUI declares this private; it is internal here so the public ItemsInfoRequested round-trip is
-		// testable before the measure path that calls it (WS-D3c) is ported.
-		internal ItemsInfo RaiseItemsInfoRequested(
-			int itemsRangeStartIndex,
-			int itemsRangeRequestedLength)
-		{
-			MUX_ASSERT(itemsRangeStartIndex >= 0);
-			MUX_ASSERT(itemsRangeRequestedLength > 0);
-			MUX_ASSERT(itemsRangeStartIndex + itemsRangeRequestedLength - 1 < m_itemCount);
-
-			if (ItemsInfoRequested is { } itemsInfoRequested)
-			{
-				var itemsInfoRequestedEventArgs = new LinedFlowLayoutItemsInfoRequestedEventArgs(this, itemsRangeStartIndex, itemsRangeRequestedLength);
-
-				itemsInfoRequested(this, itemsInfoRequestedEventArgs);
-
-				// Disconnect the LinedFlowLayout from the LinedFlowLayoutItemsInfoRequestedEventArgs so that any
-				// subsequent calls to SetDesiredAspectRatios/SetMinWidths/SetMaxWidths have no effect.
-				itemsInfoRequestedEventArgs.ResetLinedFlowLayout();
-
-				// The original ItemsRangeStartIndex value may have been overwritten by the handler to a smaller
-				// value. This allows a handler to provide more information than requested, because it's available
-				// and performant to do so. It reduces subsequent needs to raise the event again.
-				return new ItemsInfo
-				{
-					m_itemsRangeStartIndex = itemsInfoRequestedEventArgs.ItemsRangeStartIndex,
-					m_itemsRangeLength = itemsInfoRequestedEventArgs.ItemsRangeLength,
-					m_minWidth = itemsInfoRequestedEventArgs.MinWidth,
-					m_maxWidth = itemsInfoRequestedEventArgs.MaxWidth,
-				};
-			}
-
-			return s_emptyItemsInfo;
-		}
-
-		#endregion
-
-		#region ILayoutOverrides
-
+		/// <inheritdoc />
 		protected internal override ItemCollectionTransitionProvider CreateDefaultItemTransitionProvider()
 		{
-			// WinUI returns make<LinedFlowLayoutItemCollectionTransitionProvider>() here. That provider drives
-			// its animations through CompositionAnimationGroup / Visual.StartAnimationGroup(/StopAnimationGroup)
-			// and KeyFrameAnimation DelayTime|DelayBehavior, all of which are still [Uno.NotImplemented] on Uno's
-			// Composition targets - so porting the provider now (tracked as WS-D4) would either not animate or
-			// throw at runtime. Until then, return null, which the base Layout contract explicitly allows
-			// ("... or null"): ItemsRepeater simply runs without LinedFlowLayout's default item transitions
-			// instead of instantiating the throwing stub.
+			// TODO Uno: Port the default transition provider when its composition animation APIs are supported.
 			return null!;
 		}
 
-		#endregion
+		// #pragma endregion
 
-		#region IVirtualizingLayoutOverrides
+		// #pragma region IVirtualizingLayoutOverrides
 
+		/// <inheritdoc />
 		protected internal override void InitializeForContextCore(VirtualizingLayoutContext context)
 		{
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
 			if (m_wasInitializedForContext)
 			{
 				throw new InvalidOperationException(s_cannotShareLinedFlowLayout);
@@ -338,8 +244,10 @@ namespace Microsoft.UI.Xaml.Controls
 			m_elementManager.SetContext(context);
 		}
 
+		/// <inheritdoc />
 		protected internal override void UninitializeForContextCore(VirtualizingLayoutContext context)
 		{
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
 			MUX_ASSERT(m_wasInitializedForContext);
 			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
 
@@ -357,10 +265,17 @@ namespace Microsoft.UI.Xaml.Controls
 			UnlockItems();
 		}
 
+		/// <inheritdoc />
 		protected internal override Size MeasureOverride(VirtualizingLayoutContext context, Size availableSize)
 		{
 			float availableWidth = (float)availableSize.Width;
 
+#if DEBUG
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"availableSize", availableWidth, availableSize.Height);
+			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
+			// LogVirtualizingLayoutContextDbg(context);
+			// LogElementManagerDbg();
+#endif
 			if (!m_isVirtualizingContext)
 			{
 				// LinedFlowLayout is expected to be hosted by a panel like LayoutPanel. Always perform a complete re-layout in non-virtualizing scenarios.
@@ -451,7 +366,7 @@ namespace Microsoft.UI.Xaml.Controls
 							// new ItemsInfoRequested event to be raised.
 							lineCount = MeasureConstrainedLinesRegularPath(
 								context,
-								fastPathLayoutResults.itemsInfo,
+								fastPathLayoutResults.itemsInfo /*itemsInfo*/,
 								availableWidth,
 								actualLineHeight);
 
@@ -461,6 +376,7 @@ namespace Microsoft.UI.Xaml.Controls
 								// (m_forceRelayout || m_previousAvailableWidth != availableWidth) evaluated to False in the
 								// MeasureConstrainedLinesFastPath call above, and a transition out of the regular path is
 								// enabled in MeasureConstrainedLinesRegularPath.
+								// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"MeasureConstrainedLinesRegularPath enabled fast path");
 								fastPathLayoutResults = MeasureConstrainedLinesFastPath(
 									context,
 									availableWidth,
@@ -477,6 +393,17 @@ namespace Microsoft.UI.Xaml.Controls
 							{
 								m_maxLineWidth = GetLinesDesiredWidth();
 							}
+
+							// #ifdef DBG
+							// if (m_aspectRatios != nullptr && !m_aspectRatios->IsEmpty())
+							// {
+							//     // Uncomment for verbose tracing off all stored aspect ratios & weights.
+							//     //m_aspectRatios->LogItemAspectRatiosDbg();
+							//     const int firstRealizedItemIndexDbg = m_isVirtualizingContext ? m_elementManager.GetFirstRealizedDataIndex() : 0;
+							//     const int lastRealizedItemIndexDbg = firstRealizedItemIndexDbg + m_elementManager.GetRealizedElementCount() - 1;
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"averageAspectRatio (1)", m_aspectRatios->GetAverageAspectRatio(firstRealizedItemIndexDbg, lastRealizedItemIndexDbg, c_maxAspectRatioWeight));
+							// }
+							// #endif
 						}
 						else
 						{
@@ -501,16 +428,37 @@ namespace Microsoft.UI.Xaml.Controls
 							actualLineHeight);
 
 						m_maxLineWidth = GetLinesDesiredWidth();
+
+						// #ifdef DBG
+						// if (m_aspectRatios != nullptr && !m_aspectRatios->IsEmpty())
+						// {
+						//     // Uncomment for verbose tracing off all stored aspect ratios & weights.
+						//     //m_aspectRatios->LogItemAspectRatiosDbg();
+						//     const int firstRealizedItemIndexDbg = m_isVirtualizingContext ? m_elementManager.GetFirstRealizedDataIndex() : 0;
+						//     const int lastRealizedItemIndexDbg = firstRealizedItemIndexDbg + m_elementManager.GetRealizedElementCount() - 1;
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"averageAspectRatio (2)", m_aspectRatios->GetAverageAspectRatio(firstRealizedItemIndexDbg, lastRealizedItemIndexDbg, c_maxAspectRatioWeight));
+						// }
+						// #endif
 					}
 
 					desiredWidth = availableWidth;
 					desiredExtraWidth = m_maxLineWidth - availableWidth;
 
+					// #ifdef DBG
+					// if (desiredExtraWidth != 0.0f)
+					// {
+					//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"desiredExtraWidth used", desiredExtraWidth);
+					// }
+					// #endif
 					// Only account for the extra desired width if it goes beyond pixel snapping rounding.
 					if (desiredExtraWidth > 0.5f / (float)m_roundingScaleFactor * m_averageItemsPerLine.second)
 					{
 						desiredWidth += desiredExtraWidth;
 					}
+
+					// #ifdef DBG_VERBOSE
+					// LogLayoutDbg();
+					// #endif
 				}
 
 				linesSpacing = ((double)lineCount - 1) * LineSpacing;
@@ -525,6 +473,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 					if (m_aspectRatios.HasLowerWeight(firstRealizedItemIndex, lastRealizedItemIndex, c_maxAspectRatioWeight))
 					{
+						// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"Forcing layout pass for low aspect ratio weight");
 						// No items info was provided in the ItemsInfoRequest handler and there is at least an aspect ratio with a growing weight.
 						// Making sure there is another layout coming so that weights below c_maxAspectRatioWeight can be increased and ultimately
 						// reach c_maxAspectRatioWeight. Otherwise scrolling could trigger weight increases, an average-items-per-line change and re-layout.
@@ -555,11 +504,22 @@ namespace Microsoft.UI.Xaml.Controls
 
 			Size desiredSize = new Size(desiredWidth, (float)(lineCount * actualLineHeight + linesSpacing));
 
+			// #ifdef DBG
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"desiredSize", desiredSize.Width, desiredSize.Height);
+			// LogElementManagerDbg();
+			// #endif
 			return desiredSize;
 		}
 
+		/// <inheritdoc />
 		protected internal override Size ArrangeOverride(VirtualizingLayoutContext context, Size finalSize)
 		{
+#if DEBUG
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"finalSize", finalSize.Width, finalSize.Height);
+			MUX_ASSERT(m_itemCount == context.ItemCount);
+			// LogVirtualizingLayoutContextDbg(context);
+			// LogElementManagerDbg();
+#endif
 			if (float.IsInfinity(m_previousAvailableWidth))
 			{
 				ArrangeUnconstrainedLine(context);
@@ -572,8 +532,10 @@ namespace Microsoft.UI.Xaml.Controls
 			return finalSize;
 		}
 
+		/// <inheritdoc />
 		protected internal override void OnItemsChangedCore(VirtualizingLayoutContext context, object source, NotifyCollectionChangedEventArgs args)
 		{
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
 			m_elementManager.DataSourceChanged(source, args);
 
 			m_itemCount = context.ItemCount;
@@ -606,3588 +568,355 @@ namespace Microsoft.UI.Xaml.Controls
 			UnlockItems();
 		}
 
-		#endregion
+		// #pragma endregion
 
-		#region State helpers
+		// #pragma region private helpers
 
-		private bool IsVirtualizingContext(VirtualizingLayoutContext context)
+		// Items arrangement when the non-scrolling dimension is constrained.
+		private void ArrangeConstrainedLines(
+			VirtualizingLayoutContext context)
 		{
-			if (context != null)
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
+			double actualLineHeight = ActualLineHeight;
+
+			if (m_lineItemCounts.Count == 0 || actualLineHeight <= 0.0)
 			{
-				var rect = context.RealizationRect;
-				bool hasInfiniteSize = double.IsInfinity(rect.Height) || double.IsInfinity(rect.Width);
-				return !hasInfiniteSize;
-			}
-			return false;
-		}
-
-		// Enqueues an asynchronous measure pass on the dispatcher. Used to check whether the ItemsRepeater's children
-		// have a new desired size (see InvalidateMeasureTimerStart for the rationale).
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void InvalidateMeasureAsync()
-		{
-			// WinUI captures a weak reference to avoid an extra Release during dispatch, and skips the callback
-			// once the Xaml core has shut down. Here the weak reference guards against a collected layout; Uno has
-			// no direct WindowsXamlManager shutdown probe, so that early-exit is omitted.
-			var weakThis = new WeakReference<LinedFlowLayout>(this);
-
-			DispatcherQueue.TryEnqueue(() =>
-			{
-				if (weakThis.TryGetTarget(out var strongThis))
-				{
-					strongThis.InvalidateLayout(false /*forceRelayout*/, false /*resetItemsInfo*/, true /*invalidateMeasure*/);
-				}
-			});
-		}
-
-		// Starts the timer used to trigger an asynchronous measure pass when no items info was provided by the ItemsInfoRequested
-		// event. Invoked after an item was realized or when the timer expires and the tickCount is still smaller than 7.
-		// The timer interval begins at 100ms and is then increased by 50% each time it is re-started, until tickCount reaches 7.
-		// By then the interval is 1.7s and the total time elapsed is about 5s when the timer is no longer re-started.
-		// Asynchronous measure passes are triggered to check if the ItemsRepeater's children have a new desired size.
-		// This is done because when a child is re-measured because its content changed, the Xaml layout engine uses its previous
-		// available size, preventing the ItemsRepeater from being re-measured. The use of LinedFlowLayout.ItemRangesHaveNewDesiredWidths
-		// in the asynchronous measure pass will ensure that new desired widths for the frozen items will trigger a full re-layout.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void InvalidateMeasureTimerStart(int tickCount)
-		{
-			MUX_ASSERT(!UsesArrangeWidthInfo());
-
-			if (m_invalidateMeasureTimer is not null)
-			{
-				if (m_invalidateMeasureTimer.IsEnabled)
-				{
-					m_invalidateMeasureTimer.Stop();
-				}
-			}
-			else
-			{
-				m_invalidateMeasureTimer = new DispatcherTimer();
-
-				m_invalidateMeasureTimer.Tick += InvalidateMeasureTimerTick;
+				return;
 			}
 
-			m_invalidateMeasureTimerTickCount = tickCount;
-
-			const double timerFactor = 1.5;
-			double timerMultiplier = Math.Pow(timerFactor, tickCount);
-
-			const long timerBase = 1000000; // 100ms
-			long timerInterval = (long)(timerBase * timerMultiplier);
-
-			m_invalidateMeasureTimer.Interval = TimeSpan.FromTicks(timerInterval);
-			m_invalidateMeasureTimer.Start();
-		}
-
-		// Stops the timer used to trigger an asynchronous measure pass when no items info was provided by the ItemsInfoRequested event.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void InvalidateMeasureTimerStop()
-		{
-			if (m_invalidateMeasureTimer is not null && m_invalidateMeasureTimer.IsEnabled)
-			{
-				m_invalidateMeasureTimer.Stop();
-			}
-		}
-
-		// Invoked when the timer used to trigger asynchronous measure passes expires.
-		// Re-starts it with a longer interval until m_invalidateMeasureTimerTickCount
-		// reaches the value 7, for a total of 8 invalidations.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void InvalidateMeasureTimerTick(object? sender, object args)
-		{
-			InvalidateMeasureAsync();
-
-			// The asynchronous measure pass is triggered 8 times to check if the ItemsRepeater's children
-			// have a new desired size. This is done because when a child is re-measured because its content changed,
-			// the Xaml layout engine uses its previous available size, preventing the ItemsRepeater from being re-measured.
-			const int maxInvalidateMeasureTimerTickCount = 7;
-
-			if (!UsesArrangeWidthInfo() && m_invalidateMeasureTimerTickCount < maxInvalidateMeasureTimerTickCount)
-			{
-				InvalidateMeasureTimerStart(m_invalidateMeasureTimerTickCount + 1);
-			}
-			else
-			{
-				InvalidateMeasureTimerStop();
-			}
-		}
-
-		// Raises the ItemsUnlocked event when there are locked items. Raised when previously locked
-		// items are cleared because the source collection or the average items per line changed.
-		internal void UnlockItems()
-		{
-			if (m_lockedItemIndexes.Count > 0 || m_isFirstOrLastItemLocked)
-			{
-				m_lockedItemIndexes.Clear();
-				m_isFirstOrLastItemLocked = false;
-				ItemsUnlocked?.Invoke(this, null!);
-			}
-		}
-
-		#endregion
-
-		#region Line geometry & snapping (pure helpers)
-
-		// internal (rather than WinUI's private) so the pure-math slices can be unit/runtime-tested
-		// in isolation before the measure algorithm that consumes them is ported.
-		internal int GetLineCount(double averageItemsPerLine)
-		{
-			if (m_itemCount == 0)
-			{
-				return 0;
-			}
-
-			MUX_ASSERT(m_itemCount > 0);
-
-			int lineCount = GetLineIndexFromAverageItemsPerLine(m_itemCount - 1, averageItemsPerLine) + 1;
-
-			return lineCount;
-		}
-
-		internal int GetLineIndexFromAverageItemsPerLine(int itemIndex, double averageItemsPerLine)
-		{
-			MUX_ASSERT(averageItemsPerLine >= 1.0);
-
-			int lineIndex = (int)(itemIndex / averageItemsPerLine);
-
-			return lineIndex;
-		}
-
-		internal (double first, double second) SnapAverageItemsPerLine(
-			double oldAverageItemsPerLineRaw,
-			double newAverageItemsPerLineRaw)
-		{
-			MUX_ASSERT(oldAverageItemsPerLineRaw == 0.0 || oldAverageItemsPerLineRaw >= 1.0);
-			MUX_ASSERT(newAverageItemsPerLineRaw == 0.0 || newAverageItemsPerLineRaw >= 1.0);
-
-			// A snapped average-items-per-line value must be a power of 1.1.
-			const double valuePower = 1.1;
-			// When the raw value crosses the median between two successive powers of 1.1, the old snapped
-			// value is retained unless the raw delta is greater than 0.1.
-			const double distanceThreshold = 0.1;
-			double appliedValuePower = m_forcedAverageItemsPerLineDividerDbg == 0.0 ? valuePower : m_forcedAverageItemsPerLineDividerDbg;
-			double oldAverageItemsPerLineSnapped = (oldAverageItemsPerLineRaw == 0.0) ? 0.0 : SnapToPower(oldAverageItemsPerLineRaw, appliedValuePower);
-			double newAverageItemsPerLineSnapped = (newAverageItemsPerLineRaw == 0.0) ? 0.0 : SnapToPower(newAverageItemsPerLineRaw, appliedValuePower);
-
-			if (oldAverageItemsPerLineSnapped != newAverageItemsPerLineSnapped &&
-				Math.Abs(oldAverageItemsPerLineRaw - newAverageItemsPerLineRaw) <= distanceThreshold)
-			{
-				// The snapped values differ but the raw values are close: keep the old pair so the applied
-				// average items per line is stable when the raw values hover around the 1.1^N midpoint.
-				return (oldAverageItemsPerLineRaw, oldAverageItemsPerLineSnapped);
-			}
-
-			return (newAverageItemsPerLineRaw, newAverageItemsPerLineSnapped);
-		}
-
-		// Snaps the provided value to a power of valuePower. Example: value=3.75 snaps to 1.1^14 = 3.7975.
-		internal double SnapToPower(double value, double valuePower)
-		{
-			double dividerLog = Math.Log(valuePower);
-			double valueLog = Math.Log(value);
-			double valueExp = Math.Ceiling(valueLog / dividerLog);
-			double valueRndCeil = Math.Pow(valuePower, valueExp);
-			double valueRndFloor = valueRndCeil / valuePower;
-
-			// Return valuePower^valueExp or valuePower^(valueExp - 1), whichever is closest to value.
-			if (Math.Abs(valueRndCeil - value) <= Math.Abs(valueRndFloor - value))
-			{
-				return valueRndCeil;
-			}
-			else
-			{
-				return valueRndFloor;
-			}
-		}
-
-		#endregion
-
-		#region Arrange width (pure)
-
-		// Clamps desiredAspectRatio * actualLineHeight to [minWidth, maxWidth] and then applies scaleFactor,
-		// re-clamping to the relevant bound. WinUI declares this private; it is internal here so it can be
-		// unit-tested before the measure path that consumes it is fully ported (WS-D3c).
-		internal double GetArrangeWidth(
-			double desiredAspectRatio,
-			double minWidth,
-			double maxWidth,
-			double actualLineHeight,
-			double scaleFactor)
-		{
-			MUX_ASSERT(desiredAspectRatio > 0.0);
-
-			double arrangeWidth = desiredAspectRatio * actualLineHeight;
-
-			minWidth = Math.Max(0.0, minWidth);
-
-			arrangeWidth = Math.Max(minWidth, arrangeWidth);
-
-			if (maxWidth >= 0.0)
-			{
-				arrangeWidth = Math.Min(maxWidth, arrangeWidth);
-			}
-
-			if (scaleFactor != 1.0)
-			{
-				arrangeWidth *= scaleFactor;
-
-				if (scaleFactor < 1.0)
-				{
-					arrangeWidth = Math.Max(minWidth, arrangeWidth);
-				}
-
-				if (maxWidth >= 0.0 && scaleFactor > 1.0)
-				{
-					arrangeWidth = Math.Min(maxWidth, arrangeWidth);
-				}
-			}
-
-			return arrangeWidth;
-		}
-
-		#endregion
-
-		#region Items info accessors & buffers (WS-D3c)
-
-		// std::vector::resize(count, value) equivalent for a List<T> (clear + fill).
-		private static void ClearAndFill<T>(List<T> list, int count, T value)
-		{
-			list.Clear();
-
-			for (int i = 0; i < count; i++)
-			{
-				list.Add(value);
-			}
-		}
-
-		// std::vector::resize(count, value) equivalent that preserves existing elements: grows by appending
-		// `value` or truncates from the end. Used by the fast path which progressively grows m_lineItemCounts.
-		private static void ResizeList<T>(List<T> list, int count, T value)
-		{
-			if (count < list.Count)
-			{
-				list.RemoveRange(count, list.Count - count);
-			}
-			else
-			{
-				while (list.Count < count)
-				{
-					list.Add(value);
-				}
-			}
-		}
-
-		private void EnsureItemsInfoDesiredAspectRatios(int itemCount) => ClearAndFill(m_itemsInfoDesiredAspectRatiosForRegularPath, itemCount, -1.0);
-
-		private void EnsureItemsInfoMinWidths(int itemCount) => ClearAndFill(m_itemsInfoMinWidthsForRegularPath, itemCount, -1.0);
-
-		private void EnsureItemsInfoMaxWidths(int itemCount) => ClearAndFill(m_itemsInfoMaxWidthsForRegularPath, itemCount, -1.0);
-
-		private void EnsureItemsInfoArrangeWidths(int itemCount) => ClearAndFill(m_itemsInfoArrangeWidths, itemCount, -1.0f);
-
-		private void EnsureLineItemCounts(int lineCount) => ClearAndFill(m_lineItemCounts, lineCount, 0);
-
-		private void ResetLinesInfo()
-		{
-			m_lineItemCounts.Clear();
-		}
-
-		private void ResetSizedLines()
-		{
-			m_firstSizedLineIndex = -1;
-			m_lastSizedLineIndex = -1;
-			m_firstSizedItemIndex = -1;
-			m_lastSizedItemIndex = -1;
-			m_firstFrozenLineIndex = -1;
-			m_lastFrozenLineIndex = -1;
-			m_firstFrozenItemIndex = -1;
-			m_lastFrozenItemIndex = -1;
-		}
-
-		private void ExitRegularPath()
-		{
-			m_itemsInfoFirstIndex = -1;
-			m_unsizedNearLineCount = -1;
-			m_unrealizedNearLineCount = -1;
-			m_elementAvailableWidths = null;
-			m_elementDesiredWidths = null;
-			ResetSizedLines();
-		}
-
-		// Fast path layout:
-		//   Returns the arrange width computed from the m_itemsInfoDesiredAspectRatiosForFastPath, m_itemsInfoMinWidthsForFastPath, m_itemsInfoMaxWidthsForFastPath,
-		//   m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
-		// Regular path layout:
-		//   Returns the arrange width computed from the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath,
-		//   m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
-		// The desired aspect ratio is combined with the provided scaleFactor.
-		// internal (rather than WinUI's private) so it can be white-box tested before the measure path that consumes it lands.
-		internal float GetArrangeWidthFromItemsInfo(
-			int sizedItemIndex,
-			double actualLineHeight,
-			double averageAspectRatio,
-			double scaleFactor = 1.0)
-		{
-			double desiredAspectRatio = GetDesiredAspectRatioFromItemsInfo(sizedItemIndex, UsesFastPathLayout());
-
-			if (desiredAspectRatio <= 0)
-			{
-				// The average aspect ratio is used as a fallback value for items that were given a negative ratio
-				// by the ItemsInfoRequested handler.
-				desiredAspectRatio = averageAspectRatio;
-			}
-
-			return (float)GetArrangeWidth(
-				desiredAspectRatio,
-				GetMinWidthFromItemsInfo(sizedItemIndex),
-				GetMaxWidthFromItemsInfo(sizedItemIndex),
-				actualLineHeight,
-				scaleFactor);
-		}
-
-		internal double GetDesiredAspectRatioFromItemsInfo(
-			int itemIndex,
-			bool usesFastPathLayout)
-		{
-			MUX_ASSERT(itemIndex >= 0);
-			MUX_ASSERT(itemIndex < m_itemCount);
-
-			double desiredAspectRatio;
-
-			if (usesFastPathLayout)
-			{
-				MUX_ASSERT(m_itemsInfoFirstIndex == -1);
-				MUX_ASSERT(itemIndex < m_itemsInfoDesiredAspectRatiosForFastPath.Length);
-
-				desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForFastPath[itemIndex];
-			}
-			else
-			{
-				MUX_ASSERT(m_itemsInfoFirstIndex >= 0);
-				MUX_ASSERT(itemIndex - m_itemsInfoFirstIndex < m_itemsInfoDesiredAspectRatiosForRegularPath.Count);
-
-				desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForRegularPath[itemIndex - m_itemsInfoFirstIndex];
-			}
-
-			return desiredAspectRatio;
-		}
-
-		internal double GetMaxWidthFromItemsInfo(int itemIndex)
-		{
-			MUX_ASSERT(itemIndex >= 0);
-			MUX_ASSERT(itemIndex < m_itemCount);
-			MUX_ASSERT(m_itemsInfoMaxWidth >= 0.0 || m_itemsInfoMaxWidth == -1.0);
-
-			// Preserve WinUI's sentinel behavior: an unset global max (-1) disables per-item max caps.
-			if (UsesFastPathLayout())
-			{
-				// Fast path layout
-				if (itemIndex < m_itemsInfoMaxWidthsForFastPath.Length)
-				{
-					return Math.Min(m_itemsInfoMaxWidth, m_itemsInfoMaxWidthsForFastPath[itemIndex]);
-				}
-			}
-			else
-			{
-				// Regular path layout
-				if (itemIndex - m_itemsInfoFirstIndex >= 0 &&
-					itemIndex - m_itemsInfoFirstIndex < m_itemsInfoMaxWidthsForRegularPath.Count)
-				{
-					return Math.Min(m_itemsInfoMaxWidth, m_itemsInfoMaxWidthsForRegularPath[itemIndex - m_itemsInfoFirstIndex]);
-				}
-			}
-
-			return m_itemsInfoMaxWidth;
-		}
-
-		internal double GetMinWidthFromItemsInfo(int itemIndex)
-		{
-			MUX_ASSERT(itemIndex >= 0);
-			MUX_ASSERT(itemIndex < m_itemCount);
-			MUX_ASSERT(m_itemsInfoMinWidth >= 0.0 || m_itemsInfoMinWidth == -1.0);
-
-			if (UsesFastPathLayout())
-			{
-				// Fast path layout
-				if (itemIndex < m_itemsInfoMinWidthsForFastPath.Length)
-				{
-					return Math.Max(m_itemsInfoMinWidth, m_itemsInfoMinWidthsForFastPath[itemIndex]);
-				}
-			}
-			else
-			{
-				// Regular path layout
-				if (itemIndex - m_itemsInfoFirstIndex >= 0 &&
-					itemIndex - m_itemsInfoFirstIndex < m_itemsInfoMinWidthsForRegularPath.Count)
-				{
-					return Math.Max(m_itemsInfoMinWidth, m_itemsInfoMinWidthsForRegularPath[itemIndex - m_itemsInfoFirstIndex]);
-				}
-			}
-
-			return m_itemsInfoMinWidth;
-		}
-
-		#endregion
-
-		#region Line geometry & averages (WS-D3c)
-
-		internal int GetFirstItemIndexInLineIndex(int lineVectorIndex)
-		{
-			MUX_ASSERT(lineVectorIndex >= 0);
-			MUX_ASSERT(lineVectorIndex < m_lineItemCounts.Count);
-
-			int itemIndex = 0;
-
-			for (int lineVectorIndexTmp = 0; lineVectorIndexTmp < lineVectorIndex; lineVectorIndexTmp++)
-			{
-				itemIndex += m_lineItemCounts[lineVectorIndexTmp];
-			}
-
-			return itemIndex;
-		}
-
-		internal int GetLastItemIndexInLineIndex(int lineVectorIndex)
-		{
-			MUX_ASSERT(lineVectorIndex >= 0);
-			MUX_ASSERT(lineVectorIndex < m_lineItemCounts.Count);
-
-			int firstItemIndexInLineIndex = GetFirstItemIndexInLineIndex(lineVectorIndex);
-
-			return firstItemIndexInLineIndex + m_lineItemCounts[lineVectorIndex] - 1;
-		}
-
-		// Returns the line index for the provided item index.
-		internal int GetLineIndex(int itemIndex, bool usesFastPathLayout)
-		{
-			MUX_ASSERT(m_isVirtualizingContext);
-			MUX_ASSERT(itemIndex >= 0);
-			MUX_ASSERT(itemIndex < m_itemCount);
-
-			if (itemIndex == 0)
-			{
-				// May occur while m_averageItemsPerLine.second is still 0.
-				return 0;
-			}
-
-			int lineIndex = 0;
-
-			if (usesFastPathLayout)
-			{
-				int lineItemCounts = 0;
-
-				while (lineItemCounts + m_lineItemCounts[lineIndex] <= itemIndex)
-				{
-					lineItemCounts += m_lineItemCounts[lineIndex];
-					lineIndex++;
-				}
-			}
-			else
-			{
-				MUX_ASSERT(m_averageItemsPerLine.second >= 1.0);
-
-				// Determine the element's line index depending on its locked status.
-				if (m_lockedItemIndexes.TryGetValue(itemIndex, out int lockedLineIndex))
-				{
-					// Since the item is locked, use the line index it's locked on.
-					lineIndex = lockedLineIndex;
-				}
-				else
-				{
-					int sizedItemIndex = m_firstSizedItemIndex;
-					int sizedItemCount = m_lastSizedItemIndex - m_firstSizedItemIndex + 1;
-					int sizedLineVectorCount = m_lineItemCounts.Count;
-
-					// If the item is sized, use its sized line index.
-					if (sizedItemIndex != -1 &&
-						itemIndex >= sizedItemIndex &&
-						itemIndex < sizedItemIndex + sizedItemCount &&
-						m_lastSizedLineIndex - m_firstSizedLineIndex + 1 == sizedLineVectorCount)
-					{
-						MUX_ASSERT(m_firstSizedLineIndex >= 0);
-
-						int sizedLineVectorIndex = 0;
-
-						while (sizedItemIndex + m_lineItemCounts[sizedLineVectorIndex] - 1 < itemIndex)
-						{
-							sizedItemIndex += m_lineItemCounts[sizedLineVectorIndex];
-							sizedLineVectorIndex++;
-
-							MUX_ASSERT(sizedLineVectorIndex < sizedLineVectorCount);
-						}
-
-						lineIndex = m_firstSizedLineIndex + sizedLineVectorIndex;
-					}
-					else
-					{
-						// As a last resort, use the estimated line index based on the average items per line.
-						lineIndex = GetLineIndexFromAverageItemsPerLine(itemIndex, m_averageItemsPerLine.second);
-					}
-				}
-			}
-
-			return lineIndex;
-		}
-
-		// Returns the largest line width for a range of lines.
-		// When item sizing info is used, that range is the sized lines.
-		// Otherwise it's the frozen lines only.
-		internal float GetLinesDesiredWidth()
-		{
-			if (m_firstFrozenLineIndex == -1)
-			{
-				// This occurs when GetFirstAndLastDisplayedLineIndexes returns firstDisplayedLineIndex==-1
-				// because the scrollViewport is still 0.0 for example.
-				return 0.0f;
-			}
-
-			MUX_ASSERT(m_firstSizedLineIndex >= 0);
-			MUX_ASSERT(m_lastSizedLineIndex >= m_firstSizedLineIndex);
-			MUX_ASSERT(m_firstSizedItemIndex >= 0);
-			MUX_ASSERT(m_lastSizedItemIndex >= m_firstSizedItemIndex);
-			MUX_ASSERT(m_firstFrozenLineIndex >= 0);
-			MUX_ASSERT(m_lastFrozenLineIndex >= m_firstFrozenLineIndex);
-			MUX_ASSERT(m_firstFrozenItemIndex >= 0);
-			MUX_ASSERT(m_lastFrozenItemIndex >= m_firstFrozenItemIndex);
+			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
 
 			bool usesArrangeWidthInfo = UsesArrangeWidthInfo();
 			float minItemSpacing = (float)MinItemSpacing;
-			int firstLineIndex = usesArrangeWidthInfo ? m_firstSizedLineIndex : m_firstFrozenLineIndex;
-			int lastLineIndex = usesArrangeWidthInfo ? m_lastSizedLineIndex : m_lastFrozenLineIndex;
-			int itemIndex = usesArrangeWidthInfo ? m_firstSizedItemIndex : m_firstFrozenItemIndex;
-			float maxLineWidth = 0.0f;
+			double lineSpacing = LineSpacing;
+			int firstSizedLineIndex = m_firstSizedLineIndex == -1 ? 0 : m_firstSizedLineIndex;
+			int lineCount = m_firstSizedLineIndex == -1 ? m_lineItemCounts.Count : GetLineCount(m_averageItemsPerLine.second);
+			var itemsStretch = ItemsStretch;
+			var itemsJustification = ItemsJustification;
 
-			MUX_ASSERT(!usesArrangeWidthInfo || m_itemsInfoFirstIndex >= 0);
+#if DEBUG
+			// const int sizedItemCountDbg = LineItemsCountTotal(m_firstSizedItemIndex == -1 ? 0 : m_lastSizedItemIndex - m_firstSizedItemIndex + 1);
 
-			for (int lineIndex = firstLineIndex; lineIndex <= lastLineIndex; lineIndex++)
+			if (UsesFastPathLayout())
 			{
-				int lineItemsCount = m_lineItemCounts[lineIndex - m_firstSizedLineIndex];
-				float lineWidth = 0.0f;
-
-				for (int lineItemIndex = 0; lineItemIndex < lineItemsCount; lineItemIndex++)
-				{
-					float itemWidth = 0.0f;
-
-					if (usesArrangeWidthInfo)
-					{
-						itemWidth = m_itemsInfoArrangeWidths[itemIndex - m_itemsInfoFirstIndex];
-					}
-					else
-					{
-						MUX_ASSERT(m_elementManager.IsDataIndexRealized(itemIndex));
-
-						if (m_elementManager.GetRealizedElement(itemIndex) is { } element)
-						{
-							itemWidth = (float)element.DesiredSize.Width;
-						}
-					}
-
-					if (lineItemIndex > 0)
-					{
-						lineWidth += minItemSpacing;
-					}
-
-					lineWidth += itemWidth;
-
-					itemIndex++;
-				}
-
-				maxLineWidth = Math.Max(lineWidth, maxLineWidth);
-			}
-
-			return maxLineWidth;
-		}
-
-		// Returns the current average aspect ratio, either based on the m_aspectRatios storage when it's
-		// populated, or m_averageItemsPerLine when set, or finally the default defaultAspectRatio == 1.0.
-		internal double GetAverageAspectRatio(float availableWidth, double actualLineHeight)
-		{
-			if (m_aspectRatios == null || m_aspectRatios.IsEmpty())
-			{
-				if (m_averageItemsPerLine.second == 0.0 || actualLineHeight == 0.0)
-				{
-					const double defaultAspectRatio = 1.0;
-
-					return defaultAspectRatio;
-				}
-				else
-				{
-					return availableWidth / m_averageItemsPerLine.second / actualLineHeight;
-				}
-			}
-
-			return GetAverageAspectRatioFromStorage();
-		}
-
-		// Returns the average aspect ratio from m_aspectRatios or 1.0 when it is empty.
-		internal double GetAverageAspectRatioFromStorage()
-		{
-			const double defaultAspectRatio = 1.0;
-
-			if (m_aspectRatios == null || m_aspectRatios.IsEmpty())
-			{
-				return defaultAspectRatio;
-			}
-
-			int firstRealizedItemIndex = m_isVirtualizingContext ? m_elementManager.GetDataIndexFromRealizedRangeIndex(0) : 0;
-			int lastRealizedItemIndex = firstRealizedItemIndex + m_elementManager.GetRealizedElementCount - 1;
-			// Items outside the current realized range must have a weight equal to c_maxAspectRatioWeight to be taken into account.
-			// Smaller weights may not reflect the real aspect ratio and negatively influence the average.
-			float averageItemAspectRatio = m_aspectRatios.GetAverageAspectRatio(firstRealizedItemIndex, lastRealizedItemIndex, c_maxAspectRatioWeight);
-
-			return averageItemAspectRatio == 0.0f ? defaultAspectRatio : averageItemAspectRatio;
-		}
-
-		internal void SetAverageItemsPerLine(
-			(double first, double second) averageItemsPerLine,
-			bool unlockItems)
-		{
-			if (averageItemsPerLine.second == m_averageItemsPerLine.second)
-			{
-				// When the old and new snapped average-items-per-line are identical,
-				// just retain the raw value change.
-				m_averageItemsPerLine.first = averageItemsPerLine.first;
+				MUX_ASSERT(m_unsizedNearLineCount == -1);
 			}
 			else
 			{
-				m_averageItemsPerLine = averageItemsPerLine;
-
-				if (unlockItems)
-				{
-					UnlockItems();
-				}
-
-				var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
-
-				if (globalTestHooks is not null)
-				{
-					globalTestHooks.NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(this);
-				}
-			}
-		}
-
-		#endregion
-
-		#region Measure engine: realization leaf + scale factors (WS-D3c)
-
-		// Measures 'element' with 'availableSize' and returns its resulting DesiredSize, then re-measures it
-		// with the width that must be restored (its recorded arrange/available/desired width) so the temporary
-		// measure has no lasting effect. Returns (-1, -1) when no width is available to undo the measure.
-		internal Size GetDesiredSizeForAvailableSize(
-			int itemIndex,
-			UIElement element,
-			Size availableSize,
-			double actualLineHeightToRestore)
-		{
-			// WinUI asserts element != null here; the non-nullable UIElement parameter already enforces that
-			// in C# (and MUX_ASSERT, being [Conditional("DEBUG")], would otherwise demote element to maybe-null).
-			MUX_ASSERT(itemIndex >= 0);
-
-			// When m_itemsInfoArrangeWidths is populated,
-			// - m_itemsInfoFirstIndex != -1: Regular path layout case, with items info available.
-			// - m_itemsInfoFirstIndex == -1: Fast path layout case, without items info available.
-			int itemsInfoArrangeWidthsIndex = itemIndex - (m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex);
-			float measureWidthToRestore = 0.0f;
-
-			if (itemsInfoArrangeWidthsIndex < m_itemsInfoArrangeWidths.Count)
-			{
-				float arrangeWidth = m_itemsInfoArrangeWidths[itemsInfoArrangeWidthsIndex];
-
-				if (arrangeWidth < 0.0f)
-				{
-					// The m_itemsInfoArrangeWidths vector has not been set for the provided 'itemIndex' yet.
-					// The effects of measuring 'element' with 'availableSize' below could not be undone.
-					// Returning -1, -1 to indicate no desired size could be measured.
-					return new Size(-1.0f, -1.0f);
-				}
-				else
-				{
-					measureWidthToRestore = arrangeWidth;
-				}
-			}
-			else if (m_elementAvailableWidths != null && m_elementDesiredWidths != null)
-			{
-				// Check if the element has a recorded desired or available width
-				// to restore after measurement with the provided 'availableSize'.
-				if (m_elementAvailableWidths.TryGetValue(element, out float recordedAvailableWidth))
-				{
-					// Use the previous available width to undo the effects of the measure with 'availableSize'.
-					measureWidthToRestore = recordedAvailableWidth;
-				}
-				else if (m_elementDesiredWidths.TryGetValue(element, out float recordedDesiredWidth))
-				{
-					// Use the previous desired width to undo the effects of the measure with 'availableSize'.
-					measureWidthToRestore = recordedDesiredWidth;
-				}
-				else
-				{
-					// No recorded width to use to undo effects of a measure with 'availableSize'.
-					return new Size(-1.0f, -1.0f);
-				}
+				MUX_ASSERT(m_firstSizedItemIndex < m_itemCount);
 			}
 
-			element.Measure(availableSize);
+			// TODO Uno: The displayed-line tracking below depends on debug-only fields that are not compiled.
+			// if (m_isVirtualizingContext)
+			// {
+			//     const double scrollViewport = context.VisibleRect().Height;
+			//     const double scrollOffset = context.VisibleRect().Y;
+			//
+			//     GetFirstAndLastDisplayedLineIndexes(
+			//         scrollViewport,
+			//         scrollOffset,
+			//         0 /*padding*/,
+			//         lineSpacing,
+			//         actualLineHeight,
+			//         lineCount,
+			//         false /*forFullyDisplayedLines*/,
+			//         &m_previousFirstDisplayedArrangedLineIndexDbg,
+			//         &m_previousLastDisplayedArrangedLineIndexDbg);
+			// }
+#endif
 
-			Size desiredSize = element.DesiredSize;
+			GetFirstFullyRealizedLineIndex(
+				out int firstFullyRealizedLineIndex,
+				out int firstItemInFullyRealizedLine);
 
-			element.Measure(new Size(measureWidthToRestore, (float)actualLineHeightToRestore));
-
-			return desiredSize;
-		}
-
-		// Computes the expansion factor for a line with a desired width smaller than the available width.
-		internal double ComputeLineExpandFactor(
-			bool forward,
-			int sizedItemIndex,
-			int lineItemsCount,
-			double lineItemsWidth,
-			double availableWidth,
-			double minItemSpacings,
-			double actualLineHeight,
-			double averageAspectRatio)
-		{
-			bool usesFastPathLayout = UsesFastPathLayout();
-			double scaleFactor;
-			bool largerScaleFactorNeeded;
-			HashSet<int> ignoredItemIndexes = new();
-
-			MUX_ASSERT(lineItemsWidth < availableWidth);
-
-			availableWidth -= minItemSpacings;
-			lineItemsWidth -= minItemSpacings;
-
-			MUX_ASSERT(availableWidth > 0.0);
-			MUX_ASSERT(lineItemsWidth > 0.0);
-
-			do
+			if (firstFullyRealizedLineIndex == -1)
 			{
-				int sizedItemIndexTmp = sizedItemIndex;
+				// This situation can occur when context.VisibleRect().Height is 0.
+				MUX_ASSERT(firstItemInFullyRealizedLine == -1);
 
-				largerScaleFactorNeeded = false;
-				scaleFactor = availableWidth / lineItemsWidth;
-
-				for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
-				{
-					if (!ignoredItemIndexes.Contains(itemIndex))
-					{
-						double minWidth = 0.0, maxWidth = double.PositiveInfinity, desiredWidth = 0.0;
-						UIElement? element = null;
-
-						if (!usesFastPathLayout && m_itemsInfoFirstIndex == -1)
-						{
-							MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndexTmp));
-
-							if ((element = m_elementManager.GetRealizedElement(sizedItemIndexTmp /*dataIndex*/)) != null)
-							{
-								if (element is FrameworkElement frameworkElement)
-								{
-									minWidth = frameworkElement.MinWidth;
-									maxWidth = frameworkElement.MaxWidth;
-									desiredWidth = element.DesiredSize.Width;
-								}
-							}
-						}
-						else
-						{
-							double desiredAspectRatio = GetDesiredAspectRatioFromItemsInfo(sizedItemIndexTmp, usesFastPathLayout);
-
-							if (desiredAspectRatio <= 0)
-							{
-								// The average aspect ratio is used as a fallback value for items that were given a negative ratio
-								// by the ItemsInfoRequested handler.
-								desiredAspectRatio = averageAspectRatio;
-							}
-
-							desiredWidth = desiredAspectRatio * actualLineHeight;
-
-							double desiredMinWidth = GetMinWidthFromItemsInfo(sizedItemIndexTmp);
-
-							if (desiredMinWidth >= 0.0)
-							{
-								minWidth = desiredMinWidth;
-								desiredWidth = Math.Max(minWidth, desiredWidth);
-							}
-
-							double desiredMaxWidth = GetMaxWidthFromItemsInfo(sizedItemIndexTmp);
-
-							if (desiredMaxWidth >= 0.0)
-							{
-								maxWidth = desiredMaxWidth;
-								desiredWidth = Math.Min(maxWidth, desiredWidth);
-							}
-						}
-
-						if (maxWidth < desiredWidth * scaleFactor)
-						{
-							availableWidth = Math.Max(0.0, availableWidth - maxWidth);
-							lineItemsWidth = Math.Max(0.0, lineItemsWidth - desiredWidth);
-
-							ignoredItemIndexes.Add(itemIndex);
-							largerScaleFactorNeeded = true;
-							break;
-						}
-
-						if (element != null &&                                                  // ItemsInfoRequested event did not provide sizing information.
-							(scaleFactor - 1.0) * minWidth > 1.0 / m_roundingScaleFactor &&     // scaleFactor is large enough that the rounded scaled desired width is expected to be larger than the rounded min width.
-							Math.Abs(minWidth - desiredWidth) <= 1.0 / m_roundingScaleFactor)    // element's DesiredSize.Width and element.MinWidth have the same rounded value.
-						{
-							Size scaledAvailableSize = new Size((float)(desiredWidth * scaleFactor), (float)actualLineHeight);
-							Size scaledDesiredSize = GetDesiredSizeForAvailableSize(sizedItemIndexTmp, element, scaledAvailableSize, actualLineHeight);
-
-							if (scaledDesiredSize.Width != -1.0f && Math.Abs(minWidth - scaledDesiredSize.Width) <= 1.0 / m_roundingScaleFactor)
-							{
-								// These are cases where the desired width matches the minimum width even though the element is given a larger available width.
-								availableWidth = Math.Max(0.0, availableWidth - minWidth);
-								lineItemsWidth = Math.Max(0.0, lineItemsWidth - minWidth);
-
-								ignoredItemIndexes.Add(itemIndex);
-								largerScaleFactorNeeded = true;
-								break;
-							}
-						}
-					}
-
-					sizedItemIndexTmp = forward ? sizedItemIndexTmp + 1 : sizedItemIndexTmp - 1;
-				}
-			}
-			while (availableWidth > 0.0 && lineItemsWidth > 0.0 && largerScaleFactorNeeded);
-
-			MUX_ASSERT(scaleFactor > 1.0);
-
-			return scaleFactor;
-		}
-
-		// Computes the shrinking factor for a line with a desired width larger than the available width.
-		// Returns 0 when the items' minimum width prevent enough shrinking to accommodate the available width.
-		internal double ComputeLineShrinkFactor(
-			bool forward,
-			int sizedItemIndex,
-			int lineItemsCount,
-			double lineItemsWidth,
-			double availableWidth,
-			double minItemSpacings,
-			double actualLineHeight,
-			double averageAspectRatio)
-		{
-			bool usesFastPathLayout = UsesFastPathLayout();
-			double scaleFactor;
-			bool smallerScaleFactorNeeded;
-			HashSet<int> ignoredItemIndexes = new();
-
-			MUX_ASSERT(lineItemsWidth > availableWidth);
-
-			availableWidth -= minItemSpacings;
-			lineItemsWidth -= minItemSpacings;
-
-			MUX_ASSERT(availableWidth > 0.0);
-			MUX_ASSERT(lineItemsWidth > 0.0);
-
-			do
-			{
-				int sizedItemIndexTmp = sizedItemIndex;
-
-				smallerScaleFactorNeeded = false;
-				scaleFactor = availableWidth / lineItemsWidth;
-
-				for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
-				{
-					if (!ignoredItemIndexes.Contains(itemIndex))
-					{
-						double minWidth = 0.0, desiredWidth = 0.0;
-
-						if (!usesFastPathLayout && m_itemsInfoFirstIndex == -1)
-						{
-							MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndexTmp));
-
-							if (m_elementManager.GetRealizedElement(sizedItemIndexTmp /*dataIndex*/) is { } element)
-							{
-								if (element is FrameworkElement frameworkElement)
-								{
-									minWidth = frameworkElement.MinWidth;
-								}
-
-								desiredWidth = element.DesiredSize.Width;
-							}
-						}
-						else
-						{
-							double desiredAspectRatio = GetDesiredAspectRatioFromItemsInfo(sizedItemIndexTmp, usesFastPathLayout);
-
-							if (desiredAspectRatio <= 0)
-							{
-								// The average aspect ratio is used as a fallback value for items that were given a negative ratio
-								// by the ItemsInfoRequested handler.
-								desiredAspectRatio = averageAspectRatio;
-							}
-
-							desiredWidth = desiredAspectRatio * actualLineHeight;
-
-							double desiredMaxWidth = GetMaxWidthFromItemsInfo(sizedItemIndexTmp);
-
-							if (desiredMaxWidth >= 0.0)
-							{
-								desiredWidth = Math.Min(desiredMaxWidth, desiredWidth);
-							}
-
-							double desiredMinWidth = GetMinWidthFromItemsInfo(sizedItemIndexTmp);
-
-							if (desiredMinWidth >= 0.0)
-							{
-								minWidth = desiredMinWidth;
-								desiredWidth = Math.Max(minWidth, desiredWidth);
-							}
-						}
-
-						if (minWidth > desiredWidth * scaleFactor)
-						{
-							availableWidth = Math.Max(0.0, availableWidth - minWidth);
-							lineItemsWidth = Math.Max(0.0, lineItemsWidth - desiredWidth);
-
-							ignoredItemIndexes.Add(itemIndex);
-							smallerScaleFactorNeeded = true;
-							break;
-						}
-					}
-
-					sizedItemIndexTmp = forward ? sizedItemIndexTmp + 1 : sizedItemIndexTmp - 1;
-				}
-			}
-			while (availableWidth > 0.0 && lineItemsWidth > 0.0 && smallerScaleFactorNeeded);
-
-			MUX_ASSERT(scaleFactor > 0.0);
-			MUX_ASSERT(scaleFactor < 1.0);
-
-			return smallerScaleFactorNeeded ? 0.0 : scaleFactor;
-		}
-
-		#endregion
-
-		#region Measure engine: drawback + layout-worthiness + items-info setters (WS-D3c)
-
-		// Grades an ItemsLayout: lines that exceed the available width are penalized more (cubic) than lines
-		// with room to spare (quadratic). A lower drawback is a better layout.
-		internal void ComputeItemsLayoutDrawback(
-			double availableWidth,
-			bool isLastSizedLineStretchEnabled,
-			ItemsLayout itemsLayout)
-		{
-			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
-			int lineVectorCount = isLastSizedLineStretchEnabled ? sizedLineCount : sizedLineCount - 1;
-
-			if (lineVectorCount == 0)
-			{
-				itemsLayout.m_drawback = 0;
 				return;
 			}
-
-			const double c_lineTooSmallExponent = 2.0;
-			// Be careful when using Math.Pow(..., 3) as a negative input results in a negative output.
-			// For the moment, c_lineTooLargeExponent is only applied to positive numbers, so its use is safe.
-			const double c_lineTooLargeExponent = 3.0;
-			double drawback = 0.0;
-
-			for (int lineVectorIndex = 0; lineVectorIndex < lineVectorCount; lineVectorIndex++)
-			{
-				double lineWidthDelta = itemsLayout.m_lineItemWidths[lineVectorIndex] - availableWidth;
-
-				if (lineWidthDelta != 0.0)
-				{
-					// To minimize the occurrences of lines that exceed the available width, they are graded worse than lines that have room to spare.
-					drawback += Math.Pow(lineWidthDelta, lineWidthDelta > 0.0 ? c_lineTooLargeExponent : c_lineTooSmallExponent);
-				}
-			}
-
-			// The last line does not participate in the grading if it's smaller than the available width, whether ItemsStretch is Fill or not.
-			if (!isLastSizedLineStretchEnabled)
-			{
-				double lineWidthDelta = itemsLayout.m_lineItemWidths[sizedLineCount - 1] - availableWidth;
-
-				if (lineWidthDelta > 0.0)
-				{
-					// The last line exceeds the available width, grade it as such.
-					drawback += Math.Pow(lineWidthDelta, c_lineTooLargeExponent);
-				}
-			}
-
-			itemsLayout.m_drawback = drawback;
-		}
-
-		internal bool IsItemsLayoutContractionWorthy(ItemsLayout itemsLayout)
-		{
-			if (itemsLayout.m_smallestTailItemWidth == double.MaxValue || itemsLayout.m_smallestTailItemWidth == 0.0)
-			{
-				return false;
-			}
-
-			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
-
-			if (sizedLineCount > 1)
-			{
-				for (int lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-				{
-					if (itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
-					{
-						return true;
-					}
-				}
-			}
-
-			return false;
-		}
-
-		internal bool IsItemsLayoutEqualizationWorthy(
-			ItemsLayout itemsLayout,
-			bool withHeadItem)
-		{
-			if ((withHeadItem && itemsLayout.m_bestEqualizingHeadItemIndex == int.MaxValue) ||
-				(!withHeadItem && itemsLayout.m_bestEqualizingTailItemIndex == int.MaxValue))
-			{
-				return false;
-			}
-
-			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
-
-			if (sizedLineCount > 1)
-			{
-				for (int lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-				{
-					if (itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
-					{
-						return true;
-					}
-				}
-			}
-
-			return false;
-		}
-
-		// Determines whether using a larger adjustedAvailableWidth may lead to an ItemsLayout with a smaller drawback.
-		internal bool IsItemsLayoutExpansionWorthy(ItemsLayout itemsLayout)
-		{
-			if (itemsLayout.m_smallestHeadItemWidth == double.MaxValue || itemsLayout.m_smallestHeadItemWidth == 0.0)
-			{
-				return false;
-			}
-
-			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
-			bool isExpansionWorthy = false;
-
-			if (sizedLineCount > 1)
-			{
-				for (int lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-				{
-					if (itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
-					{
-						isExpansionWorthy = true;
-						break;
-					}
-				}
-			}
-
-			if (isExpansionWorthy)
-			{
-				int lineVectorIndex;
-
-				for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-				{
-					if (itemsLayout.m_lineItemWidths[lineVectorIndex] > itemsLayout.m_availableLineItemsWidth)
-					{
-						break;
-					}
-				}
-
-				isExpansionWorthy = lineVectorIndex < sizedLineCount;
-			}
-
-			MUX_ASSERT(!isExpansionWorthy || itemsLayout.m_smallestHeadItemWidth > 0);
-
-			return isExpansionWorthy;
-		}
-
-		// Returns True when 'itemIndex' is locked in a line within the [beginLineIndex, endLineIndex] range.
-		internal bool IsLockedItem(
-			bool forward,
-			int beginLineIndex,
-			int endLineIndex,
-			int itemIndex)
-		{
-			if (m_lockedItemIndexes.TryGetValue(itemIndex, out int lineIndex))
-			{
-				if (forward)
-				{
-					if (lineIndex >= beginLineIndex && lineIndex <= endLineIndex)
-					{
-						return true;
-					}
-				}
-				else
-				{
-					if (lineIndex <= beginLineIndex && lineIndex >= endLineIndex)
-					{
-						return true;
-					}
-				}
-			}
-
-			return false;
-		}
-
-		internal void SetArrangeWidthFromItemsInfo(
-			int itemIndex,
-			float arrangeWidth)
-		{
-			MUX_ASSERT(m_itemsInfoFirstIndex >= -1);
-
-			// m_itemsInfoFirstIndex >=  0: Regular path layout case, with items info available.
-			// m_itemsInfoFirstIndex == -1: Fast path layout case, without items info available.
-			int itemsInfoArrangeWidthsIndex = itemIndex - (m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex);
-
-			MUX_ASSERT(itemsInfoArrangeWidthsIndex >= 0);
-			MUX_ASSERT(itemsInfoArrangeWidthsIndex < m_itemsInfoArrangeWidths.Count);
-
-			m_itemsInfoArrangeWidths[itemsInfoArrangeWidthsIndex] = arrangeWidth;
-		}
-
-		internal void SetDesiredAspectRatioFromItemsInfo(
-			int itemIndex,
-			double desiredAspectRatio)
-		{
-			MUX_ASSERT(itemIndex < m_itemCount);
-			MUX_ASSERT(m_itemsInfoFirstIndex >= 0);
-			MUX_ASSERT(itemIndex - m_itemsInfoFirstIndex >= 0);
-			MUX_ASSERT(itemIndex - m_itemsInfoFirstIndex < m_itemsInfoDesiredAspectRatiosForRegularPath.Count);
-
-			m_itemsInfoDesiredAspectRatiosForRegularPath[itemIndex - m_itemsInfoFirstIndex] = desiredAspectRatio;
-		}
-
-		#endregion
-
-		#region Measure engine: apply per-line item widths (WS-D3c)
-
-		// Computes the final item widths based on the best ItemsLayout, available width and stretching mode.
-		// Items are potentially shrunk to accommodate a smaller available line width, or stretched to accommodate a larger available line width.
-		internal void ComputeItemsLayoutWithLockedItems(
-			ItemsLayout itemsLayout,
-			double availableWidth,
-			double minItemSpacing,
-			double actualLineHeight,
-			double averageAspectRatio,
-			int beginSizedLineIndex,
-			int endSizedLineIndex,
-			int beginSizedItemIndex,
-			int endSizedItemIndex,
-			int beginLineVectorIndex,
-			bool isLastSizedLineStretchEnabled)
-		{
-			MUX_ASSERT(!UsesFastPathLayout());
-			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
-			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
-			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
-
-			bool forward = beginSizedItemIndex <= endSizedItemIndex;
-			int sizedLineCount = itemsLayout.m_lineItemCounts.Count;
-
-			int lineVectorIndex;
-
-			for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-			{
-				MUX_ASSERT(itemsLayout.m_lineItemCounts[lineVectorIndex] > 0);
-
-				m_lineItemCounts[beginLineVectorIndex + lineVectorIndex] = itemsLayout.m_lineItemCounts[lineVectorIndex];
-			}
-
-			bool itemsAreStretched = ItemsStretch == LinedFlowLayoutItemsStretch.Fill;
-			int sizedItemIndex = beginSizedItemIndex;
-
-			for (lineVectorIndex = forward ? 0 : sizedLineCount - 1; ; lineVectorIndex = forward ? lineVectorIndex + 1 : lineVectorIndex - 1)
-			{
-				int lineItemsCount = itemsLayout.m_lineItemCounts[lineVectorIndex];
-				double lineItemsWidth = itemsLayout.m_lineItemWidths[lineVectorIndex];
-				double minItemSpacings = lineItemsCount > 1 ? (lineItemsCount - 1) * minItemSpacing : 0.0;
-				double scaleFactor = 1.0;
-
-				if (lineItemsWidth - minItemSpacings > 0.0)
-				{
-					if (lineItemsWidth > availableWidth)
-					{
-						scaleFactor = ComputeLineShrinkFactor(
-							forward,
-							sizedItemIndex,
-							lineItemsCount,
-							lineItemsWidth,
-							availableWidth,
-							minItemSpacings,
-							actualLineHeight,
-							averageAspectRatio);
-						MUX_ASSERT(scaleFactor >= 0.0);
-						MUX_ASSERT(scaleFactor < 1.0);
-					}
-					else if ((!forward || lineVectorIndex < (isLastSizedLineStretchEnabled ? sizedLineCount : sizedLineCount - 1)) &&
-						lineItemsWidth < availableWidth &&
-						itemsAreStretched)
-					{
-						scaleFactor = ComputeLineExpandFactor(
-							forward,
-							sizedItemIndex,
-							lineItemsCount,
-							lineItemsWidth,
-							availableWidth,
-							minItemSpacings,
-							actualLineHeight,
-							averageAspectRatio);
-						MUX_ASSERT(scaleFactor > 1.0);
-					}
-				}
-
-				if (scaleFactor != 1.0)
-				{
-					for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
-					{
-						MUX_ASSERT((forward && sizedItemIndex <= endSizedItemIndex) || (!forward && sizedItemIndex >= endSizedItemIndex));
-
-						double minWidth = 0.0;
-
-						if (m_itemsInfoFirstIndex == -1)
-						{
-							MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndex));
-
-							if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
-							{
-								if (scaleFactor < 1.0)
-								{
-									if (element is FrameworkElement frameworkElement)
-									{
-										minWidth = frameworkElement.MinWidth;
-									}
-								}
-
-								var elementAvailableSize = new Size(
-									Math.Max((float)minWidth, (float)(element.DesiredSize.Width * scaleFactor)),
-									(float)actualLineHeight);
-
-								element.Measure(elementAvailableSize);
-
-								float itemWidth = (float)element.DesiredSize.Width;
-
-								elementAvailableSize.Width = itemWidth;
-
-								MUX_ASSERT(m_elementAvailableWidths != null);
-
-								// WinUI's find-then-insert/emplace keeps the value already stored for an existing
-								// key (std::map::emplace does not overwrite), i.e. TryAdd semantics.
-								m_elementAvailableWidths!.TryAdd(element, itemWidth);
-							}
-						}
-						else
-						{
-							MUX_ASSERT(sizedItemIndex - m_itemsInfoFirstIndex < m_itemsInfoArrangeWidths.Count);
-
-							float arrangeWidth = GetArrangeWidthFromItemsInfo(sizedItemIndex, actualLineHeight, averageAspectRatio, scaleFactor);
-
-							SetArrangeWidthFromItemsInfo(sizedItemIndex, arrangeWidth);
-
-							if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
-							{
-								if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
-								{
-									var elementAvailableSize = new Size(
-										arrangeWidth,
-										(float)actualLineHeight);
-
-									element.Measure(elementAvailableSize);
-								}
-							}
-						}
-
-						sizedItemIndex = forward ? sizedItemIndex + 1 : sizedItemIndex - 1;
-					}
-				}
-				else
-				{
-					// Measuring items even when no scale factor is applied so that they fill their available width (otherwise background-colored bands appear on the items' left/right edges).
-					for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
-					{
-						MUX_ASSERT((forward && sizedItemIndex <= endSizedItemIndex) || (!forward && sizedItemIndex >= endSizedItemIndex));
-						MUX_ASSERT(m_itemsInfoFirstIndex == -1 || sizedItemIndex - m_itemsInfoFirstIndex < m_itemsInfoArrangeWidths.Count);
-
-						float arrangeWidth = 0.0f;
-
-						if (m_itemsInfoFirstIndex != -1)
-						{
-							// Case where LinedFlowLayout.ItemsInfoRequested returned partial sizing information.
-							// Retrieve the item's arrange width computed from the regular-path items-info fields.
-							arrangeWidth = GetArrangeWidthFromItemsInfo(sizedItemIndex, actualLineHeight, averageAspectRatio);
-
-							// Store that arrange width in the m_itemsInfoArrangeWidths vector.
-							SetArrangeWidthFromItemsInfo(sizedItemIndex, arrangeWidth);
-						}
-
-						if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
-						{
-							if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
-							{
-								if (m_itemsInfoFirstIndex == -1)
-								{
-									// Case where LinedFlowLayout.ItemsInfoRequested returned no sizing information.
-									// Retrieve the item's arrange width as its desired width.
-									arrangeWidth = (float)element.DesiredSize.Width;
-								}
-
-								var elementAvailableSize = new Size(
-									arrangeWidth,
-									(float)actualLineHeight);
-
-								element.Measure(elementAvailableSize);
-							}
-						}
-
-						sizedItemIndex = forward ? sizedItemIndex + 1 : sizedItemIndex - 1;
-					}
-
-					// Making sure the items fill the line when ItemsStretch is Fill.
-					MUX_ASSERT(!(itemsAreStretched && availableWidth - lineItemsWidth > lineItemsCount && lineItemsWidth > minItemSpacings && lineVectorIndex != sizedLineCount - 1));
-				}
-
-				if (forward && lineVectorIndex == sizedLineCount - 1)
-				{
-					break;
-				}
-				if (!forward && lineVectorIndex == 0)
-				{
-					break;
-				}
-			}
-		}
-
-		#endregion
-
-		#region Measure engine: displayed & frozen lines (WS-D3c)
-
-		// Computes the first and last line indexes at least partially (or, for forFullyDisplayedLines, fully)
-		// displayed within the scroll viewport. Returns -1/-1 when nothing is displayable.
-		internal void GetFirstAndLastDisplayedLineIndexes(
-			double scrollViewport,
-			double scrollOffset,
-			double padding,
-			double lineSpacing,
-			double actualLineHeight,
-			int lineCount,
-			bool forFullyDisplayedLines,
-			out int firstDisplayedLineIndex,
-			out int lastDisplayedLineIndex)
-		{
-			MUX_ASSERT(m_isVirtualizingContext);
-			MUX_ASSERT(scrollViewport != double.PositiveInfinity);
-			MUX_ASSERT(lineCount > 0);
-
-			firstDisplayedLineIndex = lastDisplayedLineIndex = -1;
-
-			double lineHeight = actualLineHeight + lineSpacing;
-
-			if (lineHeight == 0.0 || scrollViewport == 0.0)
-			{
-				return;
-			}
-
-			double linesSpacing = lineCount == 0 ? 0.0 : (lineCount - 1) * lineSpacing;
-			double scrollExtent = lineCount * actualLineHeight + linesSpacing;
-			double maxScrollOffset = Math.Max(0.0, scrollExtent - scrollViewport);
-			double lineSpacingPortion = lineSpacing / lineHeight;
-
-			scrollOffset = Math.Min(maxScrollOffset, scrollOffset);
-
-			if (Math.Abs(scrollOffset) < c_offsetEqualityEpsilon)
-			{
-				scrollOffset = 0.0;
-			}
-
-			padding = Math.Min(padding, scrollViewport / 2.0);
-
-			double nearPadding = Math.Min(scrollOffset, padding);
-			double farPadding = Math.Min(maxScrollOffset - scrollOffset, padding);
-
-			if (!(forFullyDisplayedLines && actualLineHeight + nearPadding + farPadding > scrollViewport))
-			{
-				double nearDisplayed = scrollOffset + nearPadding;
-				double farDisplayed = scrollOffset + scrollViewport - farPadding;
-
-				if (farDisplayed > 0.0 && nearDisplayed < scrollExtent)
-				{
-					nearDisplayed = Math.Max(0.0, nearDisplayed);
-					farDisplayed = Math.Min(scrollExtent, farDisplayed);
-
-					double fractionalFirstDisplayedLineIndex = nearDisplayed / lineHeight;
-					int roundedFirstDisplayedLineIndex = (int)fractionalFirstDisplayedLineIndex;
-
-					if ((double)roundedFirstDisplayedLineIndex + 1 - fractionalFirstDisplayedLineIndex <= lineSpacingPortion &&
-						roundedFirstDisplayedLineIndex + 1 < lineCount)
-					{
-						// The portion displayed before the first displayed item is smaller than the line spacing - it can be ignored.
-						firstDisplayedLineIndex = roundedFirstDisplayedLineIndex + 1;
-					}
-					else
-					{
-						firstDisplayedLineIndex = roundedFirstDisplayedLineIndex;
-					}
-
-					if (forFullyDisplayedLines &&
-						fractionalFirstDisplayedLineIndex > roundedFirstDisplayedLineIndex &&
-						roundedFirstDisplayedLineIndex + 1 < lineCount)
-					{
-						firstDisplayedLineIndex = roundedFirstDisplayedLineIndex + 1;
-					}
-
-					MUX_ASSERT(firstDisplayedLineIndex >= 0);
-					MUX_ASSERT(firstDisplayedLineIndex < lineCount);
-
-					double fractionalLastDisplayedLineIndex = (farDisplayed + lineSpacing) / lineHeight;
-					int roundedLastDisplayedLineIndex = (int)fractionalLastDisplayedLineIndex;
-
-					lastDisplayedLineIndex = roundedLastDisplayedLineIndex;
-
-					if (forFullyDisplayedLines)
-					{
-						if (fractionalLastDisplayedLineIndex >= 1.0)
-						{
-							lastDisplayedLineIndex = Math.Min(roundedLastDisplayedLineIndex, lineCount) - 1;
-						}
-					}
-					else
-					{
-						if (fractionalLastDisplayedLineIndex - roundedLastDisplayedLineIndex <= lineSpacingPortion)
-						{
-							lastDisplayedLineIndex = Math.Max(roundedLastDisplayedLineIndex - 1, 0);
-						}
-					}
-
-					MUX_ASSERT(lastDisplayedLineIndex >= 0);
-					MUX_ASSERT(lastDisplayedLineIndex < lineCount);
-
-					if (firstDisplayedLineIndex > lastDisplayedLineIndex)
-					{
-						firstDisplayedLineIndex = lastDisplayedLineIndex = -1;
-					}
-				}
-			}
-			// else actualLineHeight is large enough that no line can be fully displayed in the scroll viewport.
-		}
-
-		// Computes the range of frozen lines/items around the displayed lines. Returns True when the scroll
-		// offset jumped far enough that a full re-layout is required.
-		internal bool ComputeFrozenItemsRange(
-			double scrollViewport,
-			double scrollOffset,
-			double lineSpacing,
-			double actualLineHeight,
-			int lineCount,
-			int beginSizedLineIndex,
-			int endSizedLineIndex,
-			int beginSizedItemIndex,
-			int endSizedItemIndex,
-			out int adjustedBeginSizedItemIndex,
-			out int adjustedEndSizedItemIndex)
-		{
-			MUX_ASSERT(!UsesFastPathLayout());
-			MUX_ASSERT(m_isVirtualizingContext == (scrollViewport != double.PositiveInfinity));
-			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
-			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
-			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
-
-			adjustedBeginSizedItemIndex = -1;
-			adjustedEndSizedItemIndex = -1;
-
-			if (!m_isVirtualizingContext)
-			{
-				// Layout operating in non-virtualizing mode. All lines and items are frozen.
-				MUX_ASSERT(m_firstSizedLineIndex == 0);
-				MUX_ASSERT(m_itemCount > 0);
-
-				m_firstFrozenLineIndex = 0;
-				m_lastFrozenLineIndex = m_lastSizedLineIndex;
-				m_firstFrozenItemIndex = 0;
-				m_lastFrozenItemIndex = m_itemCount - 1;
-				return false;
-			}
-
-			GetFirstAndLastDisplayedLineIndexes(
-				scrollViewport,
-				scrollOffset,
-				0 /*padding*/,
-				lineSpacing,
-				actualLineHeight,
-				lineCount,
-				false /*forFullyDisplayedLines*/,
-				out int firstDisplayedLineIndex,
-				out int lastDisplayedLineIndex);
-
-			if (firstDisplayedLineIndex == -1)
-			{
-				// This situation occurs when actualLineHeight + lineSpacing or context.VisibleRect().Height is 0.
-				m_firstFrozenLineIndex = -1;
-				m_lastFrozenLineIndex = -1;
-				m_firstFrozenItemIndex = -1;
-				m_lastFrozenItemIndex = -1;
-				return false;
-			}
-
-			MUX_ASSERT(lastDisplayedLineIndex != -1);
-			MUX_ASSERT(firstDisplayedLineIndex >= m_firstSizedLineIndex);
-			MUX_ASSERT(lastDisplayedLineIndex <= m_lastSizedLineIndex);
-
-			int linesPerScrollViewport = (int)(scrollViewport / (actualLineHeight + lineSpacing));
-
-			// Frozen lines before the first displayed line use 80% of a scroll viewport or 40% of the sized area whichever is largest.
-			int nearFrozenLinesCount = Math.Min((int)(c_frozenLinesRatio * linesPerScrollViewport) + 1, firstDisplayedLineIndex - m_firstSizedLineIndex);
-			nearFrozenLinesCount = Math.Max(nearFrozenLinesCount, (int)(c_frozenLinesRatio / 2.0 * ((double)firstDisplayedLineIndex - m_firstSizedLineIndex)));
-
-			// Frozen lines after the last displayed line use 80% of a scroll viewport or 40% of the sized area whichever is largest.
-			int farFrozenLinesCount = Math.Min((int)(c_frozenLinesRatio * linesPerScrollViewport) + 1, m_lastSizedLineIndex - lastDisplayedLineIndex);
-			farFrozenLinesCount = Math.Max(farFrozenLinesCount, (int)(c_frozenLinesRatio / 2.0 * ((double)m_lastSizedLineIndex - lastDisplayedLineIndex)));
-
-			m_firstFrozenLineIndex = firstDisplayedLineIndex - nearFrozenLinesCount;
-			m_lastFrozenLineIndex = lastDisplayedLineIndex + farFrozenLinesCount;
-
-			MUX_ASSERT(m_firstFrozenLineIndex >= m_firstSizedLineIndex);
-			MUX_ASSERT(m_lastFrozenLineIndex <= m_lastSizedLineIndex);
-
-			int nearUnfrozenLinesCount = m_firstFrozenLineIndex - beginSizedLineIndex;
-			int farUnfrozenLinesCount = endSizedLineIndex - m_lastFrozenLineIndex;
-
-			if (nearUnfrozenLinesCount < 0 || farUnfrozenLinesCount < 0)
-			{
-				// nearUnfrozenLinesCount < 0 occurs when the scrolling offset has decreased too fast and the first frozen line has caught up and crossed the previous first sized line.
-				// farUnfrozenLinesCount < 0 occurs when the scrolling offset has increased too fast and the last frozen line has caught up and crossed the previous last sized line.
-				// These conditions can also occur when performing a large programmatic offset jump via ScrollView.ScrollTo/ScrollBy. Trigger a full re-layout.
-				return true;
-			}
-
-			int firstFrozenItemIndex = beginSizedItemIndex;
-			int lastFrozenItemIndex = endSizedItemIndex;
-
-			adjustedBeginSizedItemIndex = beginSizedItemIndex;
-			adjustedEndSizedItemIndex = endSizedItemIndex;
-
-			if (m_firstSizedLineIndex < beginSizedLineIndex)
-			{
-				MUX_ASSERT(beginSizedItemIndex > 0);
-				MUX_ASSERT(m_firstSizedItemIndex <= beginSizedItemIndex);
-
-				if (nearUnfrozenLinesCount > 0)
-				{
-					MUX_ASSERT(beginSizedLineIndex - m_firstSizedLineIndex + nearUnfrozenLinesCount <= m_lineItemCounts.Count);
-
-					for (int frozenLineVectorIndex = beginSizedLineIndex - m_firstSizedLineIndex;
-						frozenLineVectorIndex < beginSizedLineIndex - m_firstSizedLineIndex + nearUnfrozenLinesCount;
-						frozenLineVectorIndex++)
-					{
-						MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
-
-						adjustedBeginSizedItemIndex += m_lineItemCounts[frozenLineVectorIndex];
-						m_lineItemCounts[frozenLineVectorIndex] = 0;
-					}
-
-					firstFrozenItemIndex = adjustedBeginSizedItemIndex;
-				}
-			}
-			else if (nearUnfrozenLinesCount > 0)
-			{
-				MUX_ASSERT(m_firstSizedLineIndex == beginSizedLineIndex);
-				MUX_ASSERT(nearUnfrozenLinesCount <= m_lineItemCounts.Count);
-
-				for (int frozenLineVectorIndex = 0; frozenLineVectorIndex < nearUnfrozenLinesCount; frozenLineVectorIndex++)
-				{
-					MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
-
-					firstFrozenItemIndex += m_lineItemCounts[frozenLineVectorIndex];
-				}
-			}
-
-			if (endSizedLineIndex < m_lastSizedLineIndex)
-			{
-				if (farUnfrozenLinesCount > 0)
-				{
-					for (int frozenLineVectorIndex = m_lineItemCounts.Count - farUnfrozenLinesCount - m_lastSizedLineIndex + endSizedLineIndex;
-						frozenLineVectorIndex < m_lineItemCounts.Count - m_lastSizedLineIndex + endSizedLineIndex;
-						frozenLineVectorIndex++)
-					{
-						MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
-
-						adjustedEndSizedItemIndex -= m_lineItemCounts[frozenLineVectorIndex];
-						m_lineItemCounts[frozenLineVectorIndex] = 0;
-					}
-
-					lastFrozenItemIndex = adjustedEndSizedItemIndex;
-				}
-			}
-			else if (farUnfrozenLinesCount > 0)
-			{
-				MUX_ASSERT(endSizedLineIndex == m_lastSizedLineIndex);
-				MUX_ASSERT(farUnfrozenLinesCount <= m_lineItemCounts.Count);
-
-				for (int frozenLineVectorIndex = m_lineItemCounts.Count - farUnfrozenLinesCount;
-					frozenLineVectorIndex < m_lineItemCounts.Count;
-					frozenLineVectorIndex++)
-				{
-					MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
-
-					lastFrozenItemIndex -= m_lineItemCounts[frozenLineVectorIndex];
-				}
-			}
-
-			m_firstFrozenItemIndex = firstFrozenItemIndex;
-			m_lastFrozenItemIndex = lastFrozenItemIndex;
-
-			return false;
-		}
-
-		#endregion
-
-		#region Measure engine: locked-item lookups + drawback improvement (WS-D3c)
-
-		// Returns how much the total drawback improves (positive is better) when an item of movingWidth is
-		// moved from currentLine to the adjacent neighborLine. The last line is exempt from the underfull
-		// penalty (it is allowed to be short) unless it actually overflows availableWidth.
-		internal double GetItemDrawbackImprovement(
-			double movingWidth,
-			double availableWidth,
-			double currentLineItemsWidth,
-			double neighborLineItemsWidth,
-			int currentLineIndex,
-			int neighborLineIndex)
-		{
-			MUX_ASSERT(movingWidth - MinItemSpacing <= currentLineItemsWidth);
-			MUX_ASSERT(Math.Abs(currentLineIndex - neighborLineIndex) == 1);
-
-			int lastLineIndex = GetLineCount(m_averageItemsPerLine.second) - 1;
-			double currentDrawback = 0.0;
-
-			if (currentLineIndex != lastLineIndex || currentLineItemsWidth > availableWidth)
-			{
-				currentDrawback = Math.Pow(currentLineItemsWidth - availableWidth, 2.0);
-			}
-
-			if (neighborLineIndex != lastLineIndex || neighborLineItemsWidth > availableWidth)
-			{
-				currentDrawback += Math.Pow(neighborLineItemsWidth - availableWidth, 2.0);
-			}
-
-			double newDrawback = 0.0;
-
-			if (currentLineIndex != lastLineIndex || currentLineItemsWidth - movingWidth > availableWidth)
-			{
-				newDrawback = Math.Pow(currentLineItemsWidth - movingWidth - availableWidth, 2.0);
-			}
-
-			if (neighborLineIndex != lastLineIndex || neighborLineItemsWidth + movingWidth > availableWidth)
-			{
-				newDrawback += Math.Pow(neighborLineItemsWidth + movingWidth - availableWidth, 2.0);
-			}
-
-			return currentDrawback - newDrawback;
-		}
-
-		// The item-width multiplier GetItemsLayout uses to decide wrap-vs-append: when the discrepancy between
-		// the actual and expected cumulated line widths exceeds this multiple of the processed item width, the
-		// default wrapping behavior is reversed. m_forcedWrapMultiplierDbg (a test hook, default 0) overrides it.
-		internal double GetItemWidthMultiplierThreshold()
-		{
-			const double c_itemWidthMultiplierThreshold = 2.0;
-
-			double forcedWrapMultiplierDbg = m_forcedWrapMultiplierDbg;
-
-			return forcedWrapMultiplierDbg != 0.0 ? forcedWrapMultiplierDbg : c_itemWidthMultiplierThreshold;
-		}
-
-		// Finds the nearest locked item strictly ahead of itemIndex (in the forward/backward direction) whose
-		// locked line falls within [beginLineIndex, endLineIndex], searching both the internal (in-progress) and
-		// public locked-item maps. Returns -1/-1 when none is found.
-		internal void GetNextLockedItem(
-			SortedDictionary<int, int>? internalLockedItemIndexes,
-			bool forward,
-			int beginLineIndex,
-			int endLineIndex,
-			int itemIndex,
-			out int lockedItemIndex,
-			out int lockedLineIndex)
-		{
-			lockedItemIndex = lockedLineIndex = -1;
-
-			int distance = int.MaxValue;
-
-			if (internalLockedItemIndexes != null)
-			{
-				foreach (var lockedItemIterator in internalLockedItemIndexes)
-				{
-					if (forward &&
-						lockedItemIterator.Key > itemIndex &&
-						lockedItemIterator.Key - itemIndex < distance &&
-						lockedItemIterator.Value >= beginLineIndex &&
-						lockedItemIterator.Value <= endLineIndex)
-					{
-						distance = lockedItemIterator.Key - itemIndex;
-						lockedItemIndex = lockedItemIterator.Key;
-						lockedLineIndex = lockedItemIterator.Value;
-					}
-					else if (!forward &&
-						lockedItemIterator.Key < itemIndex &&
-						itemIndex - lockedItemIterator.Key < distance &&
-						lockedItemIterator.Value <= beginLineIndex &&
-						lockedItemIterator.Value >= endLineIndex)
-					{
-						distance = itemIndex - lockedItemIterator.Key;
-						lockedItemIndex = lockedItemIterator.Key;
-						lockedLineIndex = lockedItemIterator.Value;
-					}
-				}
-			}
-
-			foreach (var lockedItemIterator in m_lockedItemIndexes)
-			{
-				if (forward &&
-					lockedItemIterator.Key > itemIndex &&
-					lockedItemIterator.Key - itemIndex < distance &&
-					lockedItemIterator.Value >= beginLineIndex &&
-					lockedItemIterator.Value <= endLineIndex)
-				{
-					distance = lockedItemIterator.Key - itemIndex;
-					lockedItemIndex = lockedItemIterator.Key;
-					lockedLineIndex = lockedItemIterator.Value;
-				}
-				else if (!forward &&
-					lockedItemIterator.Key < itemIndex &&
-					itemIndex - lockedItemIterator.Key < distance &&
-					lockedItemIterator.Value <= beginLineIndex &&
-					lockedItemIterator.Value >= endLineIndex)
-				{
-					distance = itemIndex - lockedItemIterator.Key;
-					lockedItemIndex = lockedItemIterator.Key;
-					lockedLineIndex = lockedItemIterator.Value;
-				}
-			}
-		}
-
-		// Returns true when the given internal (in-progress) locked-item map has an item locked to lineIndex
-		// that is at or before itemIndex (before) / at or after itemIndex (!before).
-		internal bool LineHasInternalLockedItem(
-			SortedDictionary<int, int> internalLockedItemIndexes,
-			int lineIndex,
-			bool before,
-			int itemIndex)
-		{
-			foreach (var lockedItemIterator in internalLockedItemIndexes)
-			{
-				if (lockedItemIterator.Value == lineIndex)
-				{
-					int lockedItemIndex = lockedItemIterator.Key;
-
-					if ((before && lockedItemIndex <= itemIndex) || (!before && lockedItemIndex >= itemIndex))
-					{
-						return true;
-					}
-				}
-			}
-
-			return false;
-		}
-
-		// Returns true when the public locked-item map has an item locked to lineIndex that is at or before
-		// itemIndex (before) / at or after itemIndex (!before).
-		internal bool LineHasLockedItem(
-			int lineIndex,
-			bool before,
-			int itemIndex)
-		{
-			foreach (var lockedItemIterator in m_lockedItemIndexes)
-			{
-				if (lockedItemIterator.Value == lineIndex)
-				{
-					int lockedItemIndex = lockedItemIterator.Key;
-
-					if ((before && lockedItemIndex <= itemIndex) || (!before && lockedItemIndex >= itemIndex))
-					{
-						return true;
-					}
-				}
-			}
-
-			return false;
-		}
-
-		// Attempts to record a lock of itemIndex to lineIndex in the in-progress internal locked-item map,
-		// honoring the sized line/item ranges and neighboring already-locked items. Returns true when the
-		// lock is valid and was recorded. MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal bool LockItemToLineInternal(
-			SortedDictionary<int, int> internalLockedItemIndexes,
-			int beginSizedLineIndex,
-			int endSizedLineIndex,
-			int beginSizedItemIndex,
-			int endSizedItemIndex,
-			int lineIndex,
-			int itemIndex)
-		{
-			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
-			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
-			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
-
-			if (lineIndex > itemIndex)
-			{
-				return false;
-			}
-
-			MUX_ASSERT(lineIndex <= itemIndex);
-
-			int lineCount = GetLineCount(m_averageItemsPerLine.second);
-
-			MUX_ASSERT(lineCount > 0);
-			MUX_ASSERT(lineIndex < lineCount);
-
-			if (lineCount - lineIndex > m_itemCount - itemIndex)
-			{
-				return false;
-			}
-
-			if (Math.Abs(beginSizedLineIndex - lineIndex) > Math.Abs(beginSizedItemIndex - itemIndex))
-			{
-				return false;
-			}
-
-			if (Math.Abs(endSizedLineIndex - lineIndex) > Math.Abs(endSizedItemIndex - itemIndex))
-			{
-				return false;
-			}
-
-			GetNextLockedItem(
-				internalLockedItemIndexes,
-				false /*forward*/,
-				lineCount - 1 /*beginLineIndex*/,
-				0 /*endLineIndex*/,
-				itemIndex,
-				out int beforeLockedItemIndex,
-				out int beforeLockedLineIndex);
-
-			GetNextLockedItem(
-				internalLockedItemIndexes,
-				true /*forward*/,
-				0 /*beginLineIndex*/,
-				lineCount - 1 /*endLineIndex*/,
-				itemIndex,
-				out int afterLockedItemIndex,
-				out int afterLockedLineIndex);
-
-			if ((beforeLockedItemIndex == -1 || (itemIndex - beforeLockedItemIndex >= lineIndex - beforeLockedLineIndex)) &&
-				(afterLockedItemIndex == -1 || (afterLockedItemIndex - itemIndex >= afterLockedLineIndex - lineIndex)))
-			{
-				// std::map::insert does not overwrite an existing key; TryAdd matches that (result ignored).
-				internalLockedItemIndexes.TryAdd(itemIndex, lineIndex);
-
-				return true;
-			}
-
-			return false;
-		}
-
-		#endregion
-
-		#region Measure engine: line-breaking (GetItemsLayout) (WS-D3c)
-
-		// Computes an ItemsLayout for the provided available width.
-		// availableWidth: available width as provided by MeasureOverride.
-		// adjustedAvailableWidth: variation of availableWidth to equalize the items' layout on the lines.
-		// Walks the sized item range forward or backward, assigning each item to a line by cumulating widths
-		// (honoring locked items and the line-equalization heuristics), records per-line head/tail move
-		// candidates used later to shuffle items between lines, then grades the layout via ComputeItemsLayoutDrawback.
-		// The single ItemsLayout is built locally and returned; callers that snapshot it must deep-copy via Clone().
-		internal ItemsLayout GetItemsLayout(
-			SortedDictionary<int, int> internalLockedItemIndexes,
-			double scrollViewport,
-			double availableWidth,
-			double adjustedAvailableWidth,
-			double averageLineItemsWidth,
-			double averageAspectRatio,
-			double lineSpacing,
-			double actualLineHeight,
-			int beginSizedLineIndex,
-			int endSizedLineIndex,
-			int beginSizedItemIndex,
-			int endSizedItemIndex,
-			int beginLineVectorIndex,
-			bool isLastSizedLineStretchEnabled)
-		{
-			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
-			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
-			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
-
-			bool forward = beginSizedItemIndex <= endSizedItemIndex;
-			int sizedLineCount = forward ? endSizedLineIndex - beginSizedLineIndex + 1 : beginSizedLineIndex - endSizedLineIndex + 1;
-			double minItemSpacing = MinItemSpacing;
-			int lineVectorIndex;
-			int lineItemsCount = 0;
-			int lastItemIndex = int.MaxValue;
-			double cumulatedLinesWidth = 0.0;
-			double cumulatedWidth = 0.0;
-			double lastItemWidth = double.MaxValue;
-			double[] headItemWidths = new double[sizedLineCount];
-			double[] tailItemWidths = new double[sizedLineCount];
-			double[] headItemDrawbackImprovements = new double[sizedLineCount];
-			double[] tailItemDrawbackImprovements = new double[sizedLineCount];
-			int[] headItemIndexes = new int[sizedLineCount];
-			int[] tailItemIndexes = new int[sizedLineCount];
-
-			Array.Fill(headItemIndexes, int.MaxValue);
-			Array.Fill(tailItemIndexes, int.MaxValue);
-
-			ItemsLayout itemsLayout = new();
-
-			itemsLayout.m_availableLineItemsWidth = adjustedAvailableWidth;
-			ClearAndFill(itemsLayout.m_lineItemCounts, sizedLineCount, 0);
-			ClearAndFill(itemsLayout.m_lineItemWidths, sizedLineCount, 0.0);
-
-			lineVectorIndex = forward ? 0 : sizedLineCount - 1;
-
-			for (int sizedItemIndex = beginSizedItemIndex; ; sizedItemIndex = forward ? sizedItemIndex + 1 : sizedItemIndex - 1)
-			{
-				double itemWidth = 0.0;
-
-				if (m_itemsInfoFirstIndex == -1)
-				{
-					MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndex));
-
-					if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
-					{
-						itemWidth = element.DesiredSize.Width;
-					}
-				}
-				else
-				{
-					MUX_ASSERT(sizedItemIndex - m_itemsInfoFirstIndex < m_itemsInfoDesiredAspectRatiosForRegularPath.Count);
-
-					double desiredMinWidth = GetMinWidthFromItemsInfo(sizedItemIndex);
-					double desiredMaxWidth = GetMaxWidthFromItemsInfo(sizedItemIndex);
-					double desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForRegularPath[sizedItemIndex - m_itemsInfoFirstIndex];
-
-					if (desiredAspectRatio <= 0.0)
-					{
-						// The average aspect ratio is used as a fallback value for items that were given a negative ratio
-						// by the ItemsInfoRequested handler.
-						desiredAspectRatio = averageAspectRatio;
-					}
-
-					itemWidth = desiredAspectRatio * actualLineHeight;
-
-					if (desiredMinWidth >= 0.0)
-					{
-						itemWidth = Math.Max(desiredMinWidth, itemWidth);
-					}
-
-					if (desiredMaxWidth >= 0.0)
-					{
-						itemWidth = Math.Min(desiredMaxWidth, itemWidth);
-					}
-				}
-
-				bool isInternalLockedItem = internalLockedItemIndexes.TryGetValue(sizedItemIndex, out int internalLockedLineIndexValue);
-				int internalLockedLineIndex = isInternalLockedItem ? internalLockedLineIndexValue : -1;
-
-				bool isLockedItem = IsLockedItem(
-					forward,
-					beginSizedLineIndex,
-					endSizedLineIndex,
-					sizedItemIndex);
-
-				int lockedLineIndex = isLockedItem ? m_lockedItemIndexes[sizedItemIndex] : -1;
-
-				GetNextLockedItem(
-					internalLockedItemIndexes,
-					forward,
-					beginSizedLineIndex,
-					endSizedLineIndex,
-					sizedItemIndex,
-					out int nextLockedItemIndex,
-					out int nextLockedLineIndex);
-
-				MUX_ASSERT(!(nextLockedItemIndex == -1 && nextLockedLineIndex != -1));
-				MUX_ASSERT(!(nextLockedItemIndex != -1 && nextLockedLineIndex == -1));
-
-				// mustCumulate is set to True when 'element' must be appended to the current line.
-				bool mustCumulate =
-					lineItemsCount == 0 ||                                                                                                                       // No item is present on the current line - it must at least contain one item
-					(forward && LineHasLockedItem(beginSizedLineIndex + lineVectorIndex, false /*before*/, sizedItemIndex)) ||                                     // A publicly locked item is ahead going forward, and must be on the current line
-					(!forward && LineHasLockedItem(endSizedLineIndex + lineVectorIndex, true /*before*/, sizedItemIndex)) ||                                       // A publicly locked item is ahead going backward, and must be on the current line
-					(forward && LineHasInternalLockedItem(internalLockedItemIndexes, beginSizedLineIndex + lineVectorIndex, false /*before*/, sizedItemIndex)) || // An internally locked item is ahead going forward, and must be on the current line
-					(!forward && LineHasInternalLockedItem(internalLockedItemIndexes, endSizedLineIndex + lineVectorIndex, true /*before*/, sizedItemIndex)) ||   // An internally locked item is ahead going backward, and must be on the current line
-					(forward && lineVectorIndex == sizedLineCount - 1) ||                                                                                         // The current line is the last one processed, going forward
-					(!forward && lineVectorIndex == 0);                                                                                                           // The current line is the last one processed, going backward
-
-				// canCumulate is set to True when 'element' has enough room to fit in the current line.
-				bool canCumulate = cumulatedWidth + (lineItemsCount == 0 ? 0.0 : minItemSpacing) + itemWidth <= adjustedAvailableWidth;
-				// mustNotCumulate is set to True when 'element' must wrap to the next line.
-				bool mustNotCumulate = false;
-				// shouldNotCumulate is set to True when there is still room for 'element' on the current line but, to equalize lines, wrapping is preferred.
-				bool shouldNotCumulate = false;
-				// shouldCumulate is set to True when there is no room for 'element' on the current line but, to equalize lines, wrapping is skipped.
-				bool shouldCumulate = false;
-
-				if (!mustCumulate)
-				{
-					mustNotCumulate =
-						(forward && endSizedItemIndex - sizedItemIndex < sizedLineCount - 1 - lineVectorIndex) ||                                                         // There are as many items left as there are lines, going forward
-						(!forward && sizedItemIndex - endSizedItemIndex < lineVectorIndex) ||                                                                             // There are as many items left as there are lines, going backward
-						(forward && isLockedItem && lockedLineIndex != beginSizedLineIndex + lineVectorIndex) ||                                                          // 'element' is a publicly locked item for the next line, going forward
-						(!forward && isLockedItem && lockedLineIndex != endSizedLineIndex + lineVectorIndex) ||                                                           // 'element' is a publicly locked item for the next line, going backward
-						(forward && isInternalLockedItem && internalLockedLineIndex != beginSizedLineIndex + lineVectorIndex) ||                                          // 'element' is an internally locked item for the next line, going forward
-						(!forward && isInternalLockedItem && internalLockedLineIndex != endSizedLineIndex + lineVectorIndex) ||                                           // 'element' is an internally locked item for the next line, going backward
-						(forward && nextLockedItemIndex != -1 && nextLockedItemIndex - sizedItemIndex < nextLockedLineIndex - (beginSizedLineIndex + lineVectorIndex)) || // A locked item is ahead, going forward, just far enough to impose the minimum of one item per line
-						(!forward && nextLockedItemIndex != -1 && sizedItemIndex - nextLockedItemIndex < endSizedLineIndex + lineVectorIndex - nextLockedLineIndex);      // A locked item is ahead, going backward, just far enough to impose the minimum of one item per line
-
-					if (!mustNotCumulate)
-					{
-						if (canCumulate)
-						{
-							if (nextLockedItemIndex != -1)
-							{
-								// Avoiding under-filled lines around publicly locked items.
-								GetNextLockedItem(
-									null,
-									forward,
-									beginSizedLineIndex,
-									endSizedLineIndex,
-									sizedItemIndex,
-									out int nextPublicLockedItemIndex,
-									out int nextPublicLockedLineIndex);
-
-								if (nextPublicLockedItemIndex != -1)
-								{
-									MUX_ASSERT(nextPublicLockedLineIndex != -1);
-
-									int linesToFill = forward ? nextPublicLockedLineIndex - beginSizedLineIndex - lineVectorIndex : endSizedLineIndex + lineVectorIndex - nextPublicLockedLineIndex;
-									int linesPerScrollViewport = (int)(scrollViewport / (actualLineHeight + lineSpacing));
-
-									if (linesToFill <= linesPerScrollViewport)
-									{
-										MUX_ASSERT(lineItemsCount > 0);
-
-										int itemsAvailable = forward ? nextPublicLockedItemIndex - sizedItemIndex + lineItemsCount : sizedItemIndex - nextPublicLockedItemIndex + lineItemsCount;
-										int averageItemsToFill = (int)(m_averageItemsPerLine.second * linesToFill);
-
-										// shouldNotCumulate is set to true to wrap earlier than necessary to avoid under-filled lines around the publicly locked item.
-										shouldNotCumulate = itemsAvailable < averageItemsToFill;
-									}
-								}
-							}
-						}
-
-						if (averageLineItemsWidth > 0.0 && ((canCumulate && !shouldNotCumulate) || !canCumulate))
-						{
-							MUX_ASSERT(!mustCumulate);
-							MUX_ASSERT(!mustNotCumulate);
-
-							// Check if cumulated total line widths is much larger or smaller than expected total based on average line width.
-							int lineCount = forward ? (lineVectorIndex + 1) : (sizedLineCount - lineVectorIndex);
-							MUX_ASSERT(lineCount > 0);
-							double itemWidthMultiplierThreshold = GetItemWidthMultiplierThreshold();
-							double expectedCumulatedLinesWidth = averageLineItemsWidth * lineCount;
-							double actualCumulatedLinesWidth = cumulatedLinesWidth + cumulatedWidth + itemWidth;
-
-							if (canCumulate && !shouldNotCumulate)
-							{
-								if (actualCumulatedLinesWidth - expectedCumulatedLinesWidth > itemWidthMultiplierThreshold * itemWidth)
-								{
-									// In order to equalize lines, wrapping is preferred over not wrapping because the cumulated item widths significantly exceeds the expected one given the line index.
-									shouldNotCumulate = true;
-								}
-							}
-							else
-							{
-								MUX_ASSERT(!canCumulate);
-								MUX_ASSERT(!shouldNotCumulate);
-
-								if (expectedCumulatedLinesWidth - actualCumulatedLinesWidth > itemWidthMultiplierThreshold * itemWidth)
-								{
-									// In order to equalize lines, not wrapping is preferred over wrapping because the cumulated item widths is significantly lower than the expected one given the line index.
-									shouldCumulate = true;
-								}
-							}
-						}
-					}
-				}
-
-				MUX_ASSERT(!shouldNotCumulate || !shouldCumulate);
-
-				if (mustCumulate || ((canCumulate || shouldCumulate) && !mustNotCumulate && !shouldNotCumulate))
-				{
-					// The current item sizedItemIndex is appended on the current line.
-					if (isLockedItem ||
-						isInternalLockedItem ||
-						sizedItemIndex == beginSizedItemIndex ||
-						sizedItemIndex == endSizedItemIndex)
-					{
-						lastItemWidth = double.MaxValue;
-						lastItemIndex = int.MaxValue;
-					}
-					else
-					{
-						lastItemWidth = itemWidth;
-						lastItemIndex = sizedItemIndex;
-					}
-
-					if (lineItemsCount != 0)
-					{
-						cumulatedWidth += minItemSpacing;
-					}
-
-					cumulatedWidth += itemWidth;
-					lineItemsCount++;
-				}
-				else
-				{
-					// The current item sizedItemIndex creates a brand new line.
-					MUX_ASSERT(lineItemsCount > 0);
-
-					if (lastItemWidth != double.MaxValue)
-					{
-						tailItemWidths[lineVectorIndex] = lastItemWidth;
-						tailItemIndexes[lineVectorIndex] = lastItemIndex;
-
-						lastItemWidth = double.MaxValue;
-						lastItemIndex = int.MaxValue;
-					}
-
-					cumulatedLinesWidth += cumulatedWidth;
-					cumulatedWidth = itemWidth;
-					lineItemsCount = 1;
-
-					if (isLockedItem)
-					{
-						lineVectorIndex = lockedLineIndex - (forward ? beginSizedLineIndex : endSizedLineIndex);
-						MUX_ASSERT(lineVectorIndex >= 0);
-						MUX_ASSERT(lineVectorIndex <= sizedLineCount - 1);
-					}
-					else if (isInternalLockedItem)
-					{
-						lineVectorIndex = internalLockedLineIndex - (forward ? beginSizedLineIndex : endSizedLineIndex);
-						MUX_ASSERT(lineVectorIndex >= 0);
-						MUX_ASSERT(lineVectorIndex <= sizedLineCount - 1);
-					}
-					else if (sizedItemIndex == endSizedItemIndex)
-					{
-						lineVectorIndex = forward ? sizedLineCount - 1 : 0;
-					}
-					else
-					{
-						MUX_ASSERT(itemsLayout.m_lineItemCounts[lineVectorIndex] > 0);
-						lineVectorIndex = forward ? lineVectorIndex + 1 : lineVectorIndex - 1;
-						MUX_ASSERT(lineVectorIndex >= 0);
-						MUX_ASSERT(lineVectorIndex <= sizedLineCount - 1);
-					}
-
-					if (!isLockedItem &&
-						!isInternalLockedItem &&
-						sizedItemIndex != beginSizedItemIndex &&
-						sizedItemIndex != endSizedItemIndex &&
-						((forward && endSizedItemIndex - sizedItemIndex >= sizedLineCount - lineVectorIndex) ||
-							(!forward && sizedItemIndex - endSizedItemIndex > lineVectorIndex)))
-					{
-						headItemWidths[lineVectorIndex] = itemWidth;
-						headItemIndexes[lineVectorIndex] = sizedItemIndex;
-					}
-				}
-
-				itemsLayout.m_lineItemCounts[lineVectorIndex] = lineItemsCount;
-				itemsLayout.m_lineItemWidths[lineVectorIndex] = cumulatedWidth;
-
-				if (sizedItemIndex == endSizedItemIndex)
-				{
-					break;
-				}
-			}
-
-			for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-			{
-				if (headItemWidths[lineVectorIndex] != 0.0 && itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
-				{
-					MUX_ASSERT(!forward || lineVectorIndex - 1 >= 0);
-					MUX_ASSERT(forward || lineVectorIndex + 1 < sizedLineCount);
-
-					headItemDrawbackImprovements[lineVectorIndex] = GetItemDrawbackImprovement(
-						headItemWidths[lineVectorIndex] + minItemSpacing,
-						adjustedAvailableWidth,
-						itemsLayout.m_lineItemWidths[lineVectorIndex],
-						itemsLayout.m_lineItemWidths[forward ? lineVectorIndex - 1 : lineVectorIndex + 1],
-						beginLineVectorIndex + lineVectorIndex,
-						beginLineVectorIndex + (forward ? lineVectorIndex - 1 : lineVectorIndex + 1));
-				}
-
-				if (tailItemWidths[lineVectorIndex] != 0.0 && itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
-				{
-					MUX_ASSERT(!forward || lineVectorIndex + 1 < sizedLineCount);
-					MUX_ASSERT(forward || lineVectorIndex - 1 >= 0);
-
-					tailItemDrawbackImprovements[lineVectorIndex] = GetItemDrawbackImprovement(
-						tailItemWidths[lineVectorIndex] + minItemSpacing,
-						adjustedAvailableWidth,
-						itemsLayout.m_lineItemWidths[lineVectorIndex],
-						itemsLayout.m_lineItemWidths[forward ? lineVectorIndex + 1 : lineVectorIndex - 1],
-						beginLineVectorIndex + lineVectorIndex,
-						beginLineVectorIndex + (forward ? lineVectorIndex + 1 : lineVectorIndex - 1));
-				}
-			}
-
-			double smallestHeadItemWidth = double.MaxValue;
-			double smallestTailItemWidth = double.MaxValue;
-			double bestEqualizingHeadItemDrawbackImprovement = 0.0;
-			double bestEqualizingTailItemDrawbackImprovement = 0.0;
-			int smallestHeadItemIndex = int.MaxValue;
-			int smallestTailItemIndex = int.MaxValue;
-			int smallestHeadLineIndex = int.MaxValue;
-			int smallestTailLineIndex = int.MaxValue;
-			int bestEqualizingHeadItemIndex = int.MaxValue;
-			int bestEqualizingTailItemIndex = int.MaxValue;
-			int bestEqualizingHeadLineIndex = int.MaxValue;
-			int bestEqualizingTailLineIndex = int.MaxValue;
-
-			for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
-			{
-				if (smallestHeadItemWidth > headItemWidths[lineVectorIndex] &&
-					headItemWidths[lineVectorIndex] > 0.0)
-				{
-					smallestHeadItemWidth = headItemWidths[lineVectorIndex];
-					smallestHeadItemIndex = headItemIndexes[lineVectorIndex];
-					smallestHeadLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
-				}
-
-				if (bestEqualizingHeadItemDrawbackImprovement < headItemDrawbackImprovements[lineVectorIndex])
-				{
-					bestEqualizingHeadItemDrawbackImprovement = headItemDrawbackImprovements[lineVectorIndex];
-					bestEqualizingHeadItemIndex = headItemIndexes[lineVectorIndex];
-					bestEqualizingHeadLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
-				}
-
-				if (itemsLayout.m_lineItemWidths[lineVectorIndex] <= adjustedAvailableWidth &&
-					tailItemWidths[lineVectorIndex] > 0.0 &&
-					smallestTailItemWidth > tailItemWidths[lineVectorIndex] + adjustedAvailableWidth - itemsLayout.m_lineItemWidths[lineVectorIndex])
-				{
-					smallestTailItemWidth = tailItemWidths[lineVectorIndex] + adjustedAvailableWidth - itemsLayout.m_lineItemWidths[lineVectorIndex];
-					smallestTailItemIndex = tailItemIndexes[lineVectorIndex];
-					smallestTailLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
-				}
-
-				if (bestEqualizingTailItemDrawbackImprovement < tailItemDrawbackImprovements[lineVectorIndex])
-				{
-					bestEqualizingTailItemDrawbackImprovement = tailItemDrawbackImprovements[lineVectorIndex];
-					bestEqualizingTailItemIndex = tailItemIndexes[lineVectorIndex];
-					bestEqualizingTailLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
-				}
-			}
-
-			itemsLayout.m_smallestHeadItemWidth = smallestHeadItemWidth;
-			itemsLayout.m_smallestTailItemWidth = smallestTailItemWidth;
-			itemsLayout.m_smallestHeadItemIndex = smallestHeadItemIndex;
-			itemsLayout.m_smallestTailItemIndex = smallestTailItemIndex;
-			itemsLayout.m_smallestHeadLineIndex = smallestHeadLineIndex;
-			itemsLayout.m_smallestTailLineIndex = smallestTailLineIndex;
-
-			itemsLayout.m_bestEqualizingHeadItemDrawbackImprovement = bestEqualizingHeadItemDrawbackImprovement;
-			itemsLayout.m_bestEqualizingTailItemDrawbackImprovement = bestEqualizingTailItemDrawbackImprovement;
-			itemsLayout.m_bestEqualizingHeadItemIndex = bestEqualizingHeadItemIndex;
-			itemsLayout.m_bestEqualizingTailItemIndex = bestEqualizingTailItemIndex;
-			itemsLayout.m_bestEqualizingHeadLineIndex = bestEqualizingHeadLineIndex;
-			itemsLayout.m_bestEqualizingTailLineIndex = bestEqualizingTailLineIndex;
-
-			// When itemsLayout.m_smallestTailItemWidth == double.MaxValue, i.e. when all itemsLayout.m_lineItemWidths[lineVectorIndex] are greater
-			// than adjustedAvailableWidth, it's not worth collapsing the adjustedAvailableWidth.
-			// When all itemsLayout.m_lineItemWidths[lineVectorIndex] are smaller than adjustedAvailableWidth, it's not worth expanding the adjustedAvailableWidth.
-
-			ComputeItemsLayoutDrawback(availableWidth, isLastSizedLineStretchEnabled, itemsLayout);
-
-			return itemsLayout;
-		}
-
-		#endregion
-
-		#region Measure engine: regular-path layout search (ComputeItemsLayoutRegularPath) (WS-D3c)
-
-		// Computes the regular-path items layout: evaluates several candidate layouts (via GetItemsLayout) at
-		// different adjusted available widths, picks the lowest-drawback candidate, then fine-tunes it by moving
-		// equalizing head/tail items into neighboring lines via internal locks. The winning layout's per-item
-		// widths are applied by ComputeItemsLayoutWithLockedItems, writing the per-line state onto the instance.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		//
-		// ItemsLayout is a reference type here (WinUI uses a value struct), so every WinUI value-copy of an
-		// ItemsLayout is reproduced with an explicit .Clone() to preserve value semantics: the candidate list and
-		// every 'best'/'to-improve' snapshot must stay independent from the reused fresh GetItemsLayout local.
-		internal void ComputeItemsLayoutRegularPath(
-			float availableWidth,
-			double scrollViewport,
-			double lineSpacing,
-			double actualLineHeight,
-			int beginSizedLineIndex,
-			int endSizedLineIndex,
-			int beginSizedItemIndex,
-			int endSizedItemIndex,
-			int beginLineVectorIndex,
-			bool isLastSizedLineStretchEnabled)
-		{
-			double minItemSpacing = MinItemSpacing;
-			double averageAspectRatio = GetAverageAspectRatio(availableWidth, actualLineHeight);
-			double averageLineItemsWidth = double.MaxValue;
-			List<ItemsLayout> itemsLayouts = new();
-
-			// Internal locks are used to force an item to belong to a particular line.
-			SortedDictionary<int, int> internalLockedItemIndexes = new();
-
-			// Phase 1: evaluate layout for an available width equal to the MeasureOverride's available width.
-			ItemsLayout itemsLayout = GetItemsLayout(
-				internalLockedItemIndexes,
-				scrollViewport,
-				availableWidth,
-				availableWidth /*adjustedAvailableWidth*/,
-				-1.0 /*averageLineItemsWidth*/,
-				averageAspectRatio,
-				lineSpacing,
-				actualLineHeight,
-				beginSizedLineIndex,
-				endSizedLineIndex,
-				beginSizedItemIndex,
-				endSizedItemIndex,
-				beginLineVectorIndex,
-				isLastSizedLineStretchEnabled);
-
-			MUX_ASSERT(itemsLayout.m_availableLineItemsWidth > 0.0);
-			MUX_ASSERT(itemsLayout.m_lineItemCounts.Count > 0);
-			MUX_ASSERT(itemsLayout.m_lineItemWidths.Count > 0);
-
-			itemsLayouts.Add(itemsLayout.Clone());
-
-			SortedSet<double> availableWidthsProcessed = new();
-
-			if (beginSizedLineIndex != endSizedLineIndex)
-			{
-				availableWidthsProcessed.Add(availableWidth);
-
-				// Phase 2: evaluate layout for an available width equal to the resulting average desired line items width of Phase 1.
-				SortedSet<double> availableWidthsToProcess = new();
-
-				double totalLineItemWidths = 0.0;
-
-				foreach (double lineItemWidthsIterator in itemsLayout.m_lineItemWidths)
-				{
-					totalLineItemWidths += lineItemWidthsIterator;
-				}
-
-				averageLineItemsWidth = totalLineItemWidths / itemsLayout.m_lineItemWidths.Count;
-
-				availableWidthsToProcess.Add(averageLineItemsWidth);
-
-				double availableWidthLowerbound = averageLineItemsWidth;
-				double availableWidthUpperbound = averageLineItemsWidth;
-
-				while (availableWidthsToProcess.Count > 0)
-				{
-					// std::set is ordered ascending; *begin() is the smallest element.
-					double adjustedAvailableWidth = availableWidthsToProcess.Min;
-
-					MUX_ASSERT(adjustedAvailableWidth >= 0.0);
-
-					itemsLayout = GetItemsLayout(
-						internalLockedItemIndexes,
-						scrollViewport,
-						availableWidth,
-						adjustedAvailableWidth,
-						averageLineItemsWidth,
-						averageAspectRatio,
-						lineSpacing,
-						actualLineHeight,
-						beginSizedLineIndex,
-						endSizedLineIndex,
-						beginSizedItemIndex,
-						endSizedItemIndex,
-						beginLineVectorIndex,
-						isLastSizedLineStretchEnabled);
-
-					itemsLayouts.Add(itemsLayout.Clone());
-					availableWidthsProcessed.Add(adjustedAvailableWidth);
-
-					// Phase 3: evaluate layouts with an available width within 30% of the average desired line items width using the smallest head and smallest tail items of prior layouts.
-					// Any layouts with an available width further away is not likely to produce the best layout. Pick the layout with the lowest drawback.
-					const double availableWidthClampingPercent = 0.3;
-					bool isExpansionWorthy = IsItemsLayoutExpansionWorthy(itemsLayout);
-					bool isContractionWorthy = IsItemsLayoutContractionWorthy(itemsLayout);
-
-					if (isExpansionWorthy)
-					{
-						MUX_ASSERT(itemsLayout.m_smallestHeadItemWidth > 0);
-
-						double availableWidthToProcess = adjustedAvailableWidth + minItemSpacing + itemsLayout.m_smallestHeadItemWidth;
-
-						if (Math.Abs(availableWidthToProcess - averageLineItemsWidth) < availableWidthClampingPercent * averageLineItemsWidth &&
-							availableWidthToProcess > availableWidthUpperbound &&
-							availableWidthToProcess != availableWidth &&
-							!availableWidthsProcessed.Contains(availableWidthToProcess) &&
-							!availableWidthsToProcess.Contains(availableWidthToProcess))
-						{
-							availableWidthUpperbound = availableWidthToProcess;
-							availableWidthsToProcess.Add(availableWidthToProcess);
-						}
-					}
-
-					if (isContractionWorthy)
-					{
-						MUX_ASSERT(itemsLayout.m_smallestTailItemWidth > 0);
-
-						double availableWidthToProcess = adjustedAvailableWidth - minItemSpacing - itemsLayout.m_smallestTailItemWidth;
-
-						if (availableWidthToProcess > 0.0 &&
-							Math.Abs(availableWidthToProcess - averageLineItemsWidth) < availableWidthClampingPercent * averageLineItemsWidth &&
-							availableWidthToProcess < availableWidthLowerbound &&
-							availableWidthToProcess != availableWidth &&
-							!availableWidthsProcessed.Contains(availableWidthToProcess) &&
-							!availableWidthsToProcess.Contains(availableWidthToProcess))
-						{
-							availableWidthLowerbound = availableWidthToProcess;
-							availableWidthsToProcess.Add(availableWidthToProcess);
-						}
-					}
-
-					availableWidthsToProcess.Remove(adjustedAvailableWidth);
-				}
-			}
-
-			ItemsLayout bestItemsLayout = itemsLayouts[0].Clone();
-
-			if (itemsLayouts.Count > 1)
-			{
-				// Figure out the layout with the lowest drawback so far.
-				double bestDrawback = double.MaxValue;
-
-				// Find the layout with the smallest drawback so far.
-				foreach (ItemsLayout itemsLayoutIterator in itemsLayouts)
-				{
-					ItemsLayout itemsLayoutTmp = itemsLayoutIterator;
-
-					if (itemsLayoutTmp.m_drawback < bestDrawback)
-					{
-						bestDrawback = itemsLayoutTmp.m_drawback;
-						bestItemsLayout = itemsLayoutTmp.Clone();
-					}
-				}
-
-				// Phase 4: try a layout with adjustedAvailableWidth = (bestItemsLayout.m_availableLineItemsWidth + averageLineItemsWidth) / 2.0,
-				// i.e. the average of the best available width so far and the average line width, as it sometimes results in a lower drawback.
-				// A layout for averageLineItemsWidth was performed in Phase 2, a layout for bestItemsLayout.m_availableLineItemsWidth was performed
-				// in Phase 3 - the optimum available width is likely to be in the neighborhood of those two numbers and trying a layout with their
-				// average has proven worthy through experimentations.
-				double adjustedAvailableWidth = (bestItemsLayout.m_availableLineItemsWidth + averageLineItemsWidth) / 2.0;
-
-				// Make sure adjustedAvailableWidth has not been processed already in Phase 3.
-				if (!availableWidthsProcessed.Contains(adjustedAvailableWidth))
-				{
-					itemsLayout = GetItemsLayout(
-						internalLockedItemIndexes,
-						scrollViewport,
-						availableWidth,
-						adjustedAvailableWidth,
-						averageLineItemsWidth,
-						averageAspectRatio,
-						lineSpacing,
-						actualLineHeight,
-						beginSizedLineIndex,
-						endSizedLineIndex,
-						beginSizedItemIndex,
-						endSizedItemIndex,
-						beginLineVectorIndex,
-						isLastSizedLineStretchEnabled);
-
-					if (itemsLayout.m_drawback < bestItemsLayout.m_drawback)
-					{
-						bestItemsLayout = itemsLayout.Clone();
-					}
-				}
-
-				ItemsLayout itemsLayoutToImprove = bestItemsLayout.Clone();
-				// noDrawbackDecreaseCount indicates how many successive attempts at decreasing the drawback have failed.
-				int noDrawbackDecreaseCount = 0;
-				bool forward = beginSizedLineIndex < endSizedLineIndex;
-
-				// Phase 5: keeping the available width from Phase 4, fine tune that layout by moving best equalizing head and best equalizing tail items into their neighboring lines using internal locks.
-				// Whichever item among the best equalizing head and best equalizing tail is present and provides the largest drawback improvement is moved.
-				// The move with the best anticipated outcome is performed until several attempts produce no drawback improvements.
-				do
-				{
-					if (itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement != 0.0 &&
-						(itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement == 0.0 ||
-						 itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement > itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement))
-					{
-						if (IsItemsLayoutEqualizationWorthy(itemsLayoutToImprove, true /*withHeadItem*/))
-						{
-							if (LockItemToLineInternal(
-									internalLockedItemIndexes,
-									beginSizedLineIndex,
-									endSizedLineIndex,
-									beginSizedItemIndex,
-									endSizedItemIndex,
-									forward ? itemsLayoutToImprove.m_bestEqualizingHeadLineIndex - 1 : itemsLayoutToImprove.m_bestEqualizingHeadLineIndex + 1,
-									itemsLayoutToImprove.m_bestEqualizingHeadItemIndex))
-							{
-								itemsLayout = GetItemsLayout(
-									internalLockedItemIndexes,
-									scrollViewport,
-									availableWidth,
-									itemsLayoutToImprove.m_availableLineItemsWidth,
-									averageLineItemsWidth,
-									averageAspectRatio,
-									lineSpacing,
-									actualLineHeight,
-									beginSizedLineIndex,
-									endSizedLineIndex,
-									beginSizedItemIndex,
-									endSizedItemIndex,
-									beginLineVectorIndex,
-									isLastSizedLineStretchEnabled);
-
-								if (itemsLayout.m_drawback < bestItemsLayout.m_drawback)
-								{
-									bestItemsLayout = itemsLayout.Clone();
-									noDrawbackDecreaseCount = 0;
-								}
-								else
-								{
-									noDrawbackDecreaseCount++;
-								}
-
-								itemsLayoutToImprove = itemsLayout.Clone();
-
-								continue;
-							}
-						}
-					}
-
-					if (itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement != 0.0 &&
-						(itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement == 0.0 ||
-						 itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement > itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement))
-					{
-						if (IsItemsLayoutEqualizationWorthy(itemsLayoutToImprove, false /*withHeadItem*/))
-						{
-							if (LockItemToLineInternal(
-									internalLockedItemIndexes,
-									beginSizedLineIndex,
-									endSizedLineIndex,
-									beginSizedItemIndex,
-									endSizedItemIndex,
-									forward ? itemsLayoutToImprove.m_bestEqualizingTailLineIndex + 1 : itemsLayoutToImprove.m_bestEqualizingTailLineIndex - 1,
-									itemsLayoutToImprove.m_bestEqualizingTailItemIndex))
-							{
-								itemsLayout = GetItemsLayout(
-									internalLockedItemIndexes,
-									scrollViewport,
-									availableWidth,
-									itemsLayoutToImprove.m_availableLineItemsWidth,
-									averageLineItemsWidth,
-									averageAspectRatio,
-									lineSpacing,
-									actualLineHeight,
-									beginSizedLineIndex,
-									endSizedLineIndex,
-									beginSizedItemIndex,
-									endSizedItemIndex,
-									beginLineVectorIndex,
-									isLastSizedLineStretchEnabled);
-
-								if (itemsLayout.m_drawback < bestItemsLayout.m_drawback)
-								{
-									bestItemsLayout = itemsLayout.Clone();
-									noDrawbackDecreaseCount = 0;
-								}
-								else
-								{
-									noDrawbackDecreaseCount++;
-								}
-
-								itemsLayoutToImprove = itemsLayout.Clone();
-							}
-							else
-							{
-								break;
-							}
-						}
-						else
-						{
-							break;
-						}
-					}
-					else
-					{
-						break;
-					}
-				}
-				while (noDrawbackDecreaseCount < bestItemsLayout.m_lineItemCounts.Count / 2);
-				// TODO: Task 38031375 - Performance optimizations.
-				// Given a line count, investigate what the typical number of iterations without drawback improvement
-				// leads to no improvements no matter the number of subsequent tries.
-			}
-
-			// Phase 6: Final item measurements.
-			ComputeItemsLayoutWithLockedItems(
-				bestItemsLayout,
-				availableWidth,
-				minItemSpacing,
-				actualLineHeight,
-				averageAspectRatio,
-				beginSizedLineIndex,
-				endSizedLineIndex,
-				beginSizedItemIndex,
-				endSizedItemIndex,
-				beginLineVectorIndex,
-				isLastSizedLineStretchEnabled);
-		}
-
-		#endregion
-
-		#region Measure engine: fast-path layout (ComputeItemsLayoutFastPath) (WS-D3c)
-
-		// Applies the given scale factor to items [beginItemIndex, endItemIndex]'s items-info arrange widths,
-		// returning their total (unscaled by spacing) arrange width. MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal float SetItemRangeArrangeWidth(
-			int beginItemIndex,
-			int endItemIndex,
-			double actualLineHeight,
-			double averageAspectRatio,
-			double scaleFactor = 1.0)
-		{
-			MUX_ASSERT(beginItemIndex <= endItemIndex);
-			MUX_ASSERT(beginItemIndex >= 0);
-			MUX_ASSERT(endItemIndex < m_itemsInfoArrangeWidths.Count);
-
-			float totalArrangeWidth = 0.0f;
-
-			for (int itemIndex = beginItemIndex; itemIndex <= endItemIndex; itemIndex++)
-			{
-				float arrangeWidth = GetArrangeWidthFromItemsInfo(itemIndex, actualLineHeight, averageAspectRatio, scaleFactor);
-
-				SetArrangeWidthFromItemsInfo(itemIndex, arrangeWidth);
-
-				totalArrangeWidth += arrangeWidth;
-			}
-
-			return totalArrangeWidth;
-		}
-
-		// Fast-path layout used when the ItemsInfoRequested handler supplied aspect ratios for the entire source
-		// collection: performs a single greedy forward pass over m_itemsInfoArrangeWidths, deciding for each item
-		// whether to cumulate it on the current line or start a new one by comparing the shrink vs expand scale
-		// factors, growing m_lineItemCounts as needed. Returns the largest resulting line width.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal float ComputeItemsLayoutFastPath(
-			float availableWidth,
-			double actualLineHeight)
-		{
-			MUX_ASSERT(m_itemCount > 0);
-
-			EnsureItemsInfoArrangeWidths(m_itemCount);
-
-			MUX_ASSERT(UsesFastPathLayout());
-
-			// The existing average aspect ratio is used as a fallback aspect ratio for items
-			// given an aspect ratio <= 0 by the ItemsInfoRequested handler.
-			double averageAspectRatio = GetAverageAspectRatio(availableWidth, actualLineHeight);
-
-			for (int itemIndex = 0; itemIndex < m_itemCount; itemIndex++)
-			{
-				float arrangeWidth = GetArrangeWidthFromItemsInfo(itemIndex, actualLineHeight, averageAspectRatio);
-
-				SetArrangeWidthFromItemsInfo(itemIndex, arrangeWidth);
-			}
-
-			// Final line count is originally unknown. m_lineItemCounts is originally allocated to accommodate 5 items per line.
-			// The vector is progressively grown as needed when that assumption is too optimistic.
-			const int c_itemsPerLineAllocation = 5;
-			// The vector capacity is increased by 25% each time its size becomes too small.
-			const double c_lineCountGrowthFactor = 1.25;
-			int allocatedLineCount = m_itemCount / c_itemsPerLineAllocation + 1;
-
-			EnsureLineItemCounts(allocatedLineCount);
-
-			float minItemSpacing = (float)MinItemSpacing;
-			bool itemsAreStretched = ItemsStretch == LinedFlowLayoutItemsStretch.Fill;
-			int lineIndex = -1;
-			int lineItemCount = 0;
-			float lineWidth = 0.0f;
-			float maxLineWidth = 0.0f;
-
-			for (int itemIndex = 0; itemIndex < m_itemCount; itemIndex++)
-			{
-				float arrangeWidth = m_itemsInfoArrangeWidths[itemIndex];
-				double scaleFactor = 1.0;
-
-				if (lineWidth == 0.0f || lineWidth + minItemSpacing + arrangeWidth > availableWidth)
-				{
-					bool cumulate = lineWidth != 0.0f;
-
-					if (cumulate)
-					{
-						// Additional item goes beyond the available width.
-						MUX_ASSERT(lineWidth > 0.0);
-						MUX_ASSERT(lineWidth + minItemSpacing + arrangeWidth > availableWidth);
-						MUX_ASSERT(lineItemCount > 0);
-
-						// Determine whether it is better to create a new line or not.
-						double shrinkScaleFactor = ComputeLineShrinkFactor(
-							true /*forward*/,
-							itemIndex - lineItemCount /*sizedItemIndex*/,
-							lineItemCount + 1,
-							(double)lineWidth + minItemSpacing + arrangeWidth /*lineItemsWidth*/,
-							availableWidth,
-							(double)lineItemCount * minItemSpacing /*minItemSpacings*/,
-							actualLineHeight,
-							averageAspectRatio);
-
-						MUX_ASSERT(shrinkScaleFactor >= 0.0);
-						MUX_ASSERT(shrinkScaleFactor < 1.0);
-
-						double expandScaleFactor = ComputeLineExpandFactor(
-							true /*forward*/,
-							itemIndex - lineItemCount /*sizedItemIndex*/,
-							lineItemCount,
-							lineWidth /*lineItemsWidth*/,
-							availableWidth,
-							((double)lineItemCount - 1) * minItemSpacing /*minItemSpacings*/,
-							actualLineHeight,
-							averageAspectRatio);
-
-						MUX_ASSERT(expandScaleFactor > 1.0);
-
-						if (expandScaleFactor - 1.0 < 1.0 - shrinkScaleFactor || shrinkScaleFactor == 0.0)
-						{
-							// Creating a new line and leaving a gap in the current one requires a smaller
-							// expansion than the shrinkage required to add this item.
-							// Or the items' min widths prevent the shrinkage required to fit them in the line.
-							cumulate = false;
-
-							if (itemsAreStretched)
-							{
-								// Only expand the items when ItemsStretch is LinedFlowLayoutItemsStretch::Fill.
-								scaleFactor = expandScaleFactor;
-							}
-						}
-						else
-						{
-							// The line items need to shrink less to accommodate this additional item than expand to fill the gap,
-							// let it belong to the current line (cumulate == true).
-							scaleFactor = shrinkScaleFactor;
-						}
-					}
-
-					if (cumulate)
-					{
-						lineWidth += minItemSpacing + arrangeWidth;
-						lineItemCount++;
-					}
-					else
-					{
-						if (lineIndex >= 0 && m_lineItemCounts[lineIndex] == 0)
-						{
-							MUX_ASSERT(lineIndex < allocatedLineCount);
-							MUX_ASSERT(lineItemCount > 0);
-							MUX_ASSERT(lineWidth > 0);
-
-							m_lineItemCounts[lineIndex] = lineItemCount;
-
-							if (lineIndex + 1 == allocatedLineCount)
-							{
-								allocatedLineCount = Math.Max(allocatedLineCount + 1, (int)(c_lineCountGrowthFactor * allocatedLineCount));
-								ResizeList(m_lineItemCounts, allocatedLineCount, 0);
-							}
-
-							if (scaleFactor == 1.0)
-							{
-								maxLineWidth = Math.Max(lineWidth, maxLineWidth);
-							}
-							else
-							{
-								// Apply shrinking or expanding scale factor to line's m_itemsInfoArrangeWidths.
-								float totalArrangeWidth = SetItemRangeArrangeWidth(
-									itemIndex - lineItemCount /*beginItemIndex*/,
-									itemIndex - 1 /*endItemIndex*/,
-									actualLineHeight,
-									averageAspectRatio,
-									scaleFactor);
-
-								maxLineWidth = Math.Max(totalArrangeWidth + (lineItemCount - 1) * minItemSpacing, maxLineWidth);
-							}
-						}
-
-						lineWidth = arrangeWidth;
-						lineItemCount = 1;
-						lineIndex++;
-					}
-				}
-				else
-				{
-					lineWidth += minItemSpacing + arrangeWidth;
-					lineItemCount++;
-				}
-
-				if (lineWidth >= availableWidth)
-				{
-					MUX_ASSERT(lineIndex >= 0);
-					MUX_ASSERT(lineIndex < allocatedLineCount);
-					MUX_ASSERT(lineItemCount > 0);
-					MUX_ASSERT(lineWidth > 0);
-
-					m_lineItemCounts[lineIndex] = lineItemCount;
-
-					if (lineIndex + 1 == allocatedLineCount)
-					{
-						allocatedLineCount = Math.Max(allocatedLineCount + 1, (int)(c_lineCountGrowthFactor * allocatedLineCount));
-						ResizeList(m_lineItemCounts, allocatedLineCount, 0);
-					}
-
-					if (lineItemCount == 1 && lineWidth != availableWidth)
-					{
-						// The single item on the line is bigger than the available width.
-						scaleFactor = ComputeLineShrinkFactor(
-							true /*forward*/,
-							itemIndex /*sizedItemIndex*/,
-							1 /*lineItemCount*/,
-							lineWidth /*lineItemsWidth*/,
-							availableWidth,
-							0.0 /*minItemSpacings*/,
-							actualLineHeight,
-							averageAspectRatio);
-
-						MUX_ASSERT(scaleFactor >= 0.0);
-						MUX_ASSERT(scaleFactor < 1.0);
-					}
-
-					if (scaleFactor != 0.0 && scaleFactor != 1.0)
-					{
-						// Apply shrinking scale factor to line's m_itemsInfoArrangeWidths.
-						float totalArrangeWidth = SetItemRangeArrangeWidth(
-							itemIndex - lineItemCount + 1 /*beginItemIndex*/,
-							itemIndex /*endItemIndex*/,
-							actualLineHeight,
-							averageAspectRatio,
-							scaleFactor);
-
-						maxLineWidth = Math.Max(totalArrangeWidth + (lineItemCount - 1) * minItemSpacing, maxLineWidth);
-					}
-					else
-					{
-						maxLineWidth = Math.Max(lineWidth, maxLineWidth);
-					}
-
-					lineWidth = 0.0f;
-					lineItemCount = 0;
-				}
-			}
-
-			MUX_ASSERT(lineIndex >= 0);
-			MUX_ASSERT(lineIndex < allocatedLineCount);
-
-			if (lineItemCount > 0)
-			{
-				MUX_ASSERT(lineWidth > 0);
-				MUX_ASSERT(availableWidth >= lineWidth);
-
-				maxLineWidth = Math.Max(lineWidth, maxLineWidth);
-				m_lineItemCounts[lineIndex] = lineItemCount;
-			}
-
-			ResizeList(m_lineItemCounts, lineIndex + 1, 0);
-
-			return maxLineWidth;
-		}
-
-		#endregion
-
-		#region Element realization: measurement leaves (WS-D3c sub-slice 4)
-
-		// Sums the per-line item counts. When expectedTotal is non-zero, asserts the sum matches it (debug only).
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal int LineItemsCountTotal(int expectedTotal)
-		{
-			int sizedItemCount = 0;
-
-			foreach (int lineItemsCount in m_lineItemCounts)
-			{
-				sizedItemCount += lineItemsCount;
-			}
-
-			MUX_ASSERT(expectedTotal == 0 || sizedItemCount == expectedTotal);
-
-			return sizedItemCount;
-		}
-
-		// Resets the per-line item counts to sizedLineCount zeros and clears the four still-sized range markers,
-		// readying the layout for a full re-layout of the sized lines. MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal void InitializeForRelayout(
-			int sizedLineCount,
-			out int firstStillSizedLineIndex,
-			out int lastStillSizedLineIndex,
-			out int firstStillSizedItemIndex,
-			out int lastStillSizedItemIndex)
-		{
-			EnsureLineItemCounts(sizedLineCount);
-
-			firstStillSizedLineIndex = -1;
-			lastStillSizedLineIndex = -1;
-			firstStillSizedItemIndex = -1;
-			lastStillSizedItemIndex = -1;
-		}
-
-		// Measures the realized items in [beginRealizedItemIndex, endRealizedItemIndex] with their computed
-		// items-info arrange width (fast path or items-info regular path). MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal void MeasureItemRange(
-			double actualLineHeight,
-			int beginRealizedItemIndex,
-			int endRealizedItemIndex)
-		{
-			MUX_ASSERT(beginRealizedItemIndex >= 0);
-			MUX_ASSERT(beginRealizedItemIndex <= endRealizedItemIndex);
-			MUX_ASSERT(m_itemsInfoArrangeWidths.Count > 0);
 
 			int itemsInfoArrangeWidthsOffset = m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex;
+			int lastSizedLineVectorIndex = m_lineItemCounts.Count - 1;
+			int sizedItemIndex = firstItemInFullyRealizedLine;
 
-			for (int realizedItemIndex = beginRealizedItemIndex; realizedItemIndex <= endRealizedItemIndex; realizedItemIndex++)
+			for (int sizedLineVectorIndex = firstFullyRealizedLineIndex - firstSizedLineIndex; sizedLineVectorIndex <= lastSizedLineVectorIndex; sizedLineVectorIndex++)
 			{
-				MUX_ASSERT(m_elementManager.IsDataIndexRealized(realizedItemIndex));
+				float cumulatedOffset = 0.0f;
+				float itemSpacing = minItemSpacing;
+				int lineItemsCount = m_lineItemCounts[sizedLineVectorIndex];
+				float lineArrangeWidth = GetItemsRangeArrangeWidth(sizedItemIndex /*beginSizedItemIndex*/, sizedItemIndex + lineItemsCount - 1 /*endSizedItemIndex*/, usesArrangeWidthInfo);
+				double lineExtraAvailableWidth = (double)m_previousAvailableWidth - lineArrangeWidth - itemSpacing * ((double)lineItemsCount - 1);
 
-				var element = m_elementManager.GetRealizedElement(realizedItemIndex /*dataIndex*/);
+				// #ifdef DBG
+				// float cumulatedWidthDbg = 0.0;
+				// #endif
 
-				// Making sure the element is not null for safety.
+				if (itemsStretch == LinedFlowLayoutItemsStretch.None)
+				{
+					if (lineExtraAvailableWidth > 0.0)
+					{
+						switch (itemsJustification)
+						{
+							case LinedFlowLayoutItemsJustification.Start:
+								// #ifdef DBG
+								// cumulatedWidthDbg = static_cast<float>(lineExtraAvailableWidth);
+								// #endif
+								break;
+							case LinedFlowLayoutItemsJustification.Center:
+								cumulatedOffset = (float)(lineExtraAvailableWidth / 2.0);
+								// #ifdef DBG
+								// cumulatedWidthDbg = 2.0f * cumulatedOffset;
+								// #endif
+								break;
+							case LinedFlowLayoutItemsJustification.End:
+								cumulatedOffset = (float)lineExtraAvailableWidth;
+								// #ifdef DBG
+								// cumulatedWidthDbg = cumulatedOffset;
+								// #endif
+								break;
+							case LinedFlowLayoutItemsJustification.SpaceEvenly:
+								cumulatedOffset = (float)(lineExtraAvailableWidth / ((double)lineItemsCount + 1));
+								itemSpacing += cumulatedOffset;
+								// #ifdef DBG
+								// cumulatedWidthDbg = 2.0f * cumulatedOffset;
+								// #endif
+								break;
+							case LinedFlowLayoutItemsJustification.SpaceAround:
+								cumulatedOffset = (float)(lineExtraAvailableWidth / lineItemsCount / 2.0);
+								itemSpacing += cumulatedOffset * 2.0f;
+								// #ifdef DBG
+								// cumulatedWidthDbg = 2.0f * cumulatedOffset;
+								// #endif
+								break;
+							case LinedFlowLayoutItemsJustification.SpaceBetween:
+								if (lineItemsCount > 1)
+								{
+									itemSpacing += (float)(lineExtraAvailableWidth / ((double)lineItemsCount - 1));
+								}
+								break;
+						}
+					}
+					else if (lineExtraAvailableWidth < 0.0)
+					{
+						if (lineExtraAvailableWidth >= -0.5 / m_roundingScaleFactor * lineItemsCount)
+						{
+							// Because of pixel snapping based on m_roundingScaleFactor, lineExtraAvailableWidth can be slightly different from 0.0.
+							// In that case we adjust the minItemSpacing by distributing the small delta equally.
+							itemSpacing += (float)(lineExtraAvailableWidth / ((double)lineItemsCount - 1));
+						}
+
+						// #ifdef DBG
+						// else
+						// {
+						//     // Because of items MinWidth, items could not be scaled down to make them fit in the line.
+						//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"lineExtraAvailableWidth", lineExtraAvailableWidth);
+						// }
+						// #endif
+					}
+				}
+				else if (lineExtraAvailableWidth != 0.0)
+				{
+					// Condition #1. Because of pixel snapping based on m_roundingScaleFactor, lineExtraAvailableWidth can be slightly different from 0.0.
+					// Condition #2. Because of MaxWidth constraining the expansion of line items, lineExtraAvailableWidth can be much larger than 0.0.
+					// Condition #2. Because Image elements do not expand beyond MinWidth when their natural width is smaller than MinWidth, lineExtraAvailableWidth can be much larger than 0.0.
+					// In those cases we adjust the minItemSpacing by distributing the small delta equally.
+					bool itemSpacingAdjustedForRounding = Math.Abs(lineExtraAvailableWidth) <= 0.5 / m_roundingScaleFactor * lineItemsCount;
+					bool itemSpacingAdjustedForMinMaxWidth = !itemSpacingAdjustedForRounding && lineExtraAvailableWidth > 0.0 && lineCount != firstSizedLineIndex + sizedLineVectorIndex + 1;
+
+					if (itemSpacingAdjustedForRounding || itemSpacingAdjustedForMinMaxWidth)
+					{
+						// #ifdef DBG
+						// if (itemSpacingAdjustedForMinMaxWidth)
+						// {
+						//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"lineExtraAvailableWidth", lineExtraAvailableWidth);
+						// }
+						// #endif
+						itemSpacing += (float)(lineExtraAvailableWidth / ((double)lineItemsCount - 1));
+					}
+
+					// #ifdef DBG
+					// else
+					// {
+					//     // In addition to those three cases above, the line items' MinWidth may prevent them from being shrunk sufficiently to fit in the available width. In those cases nothing is done.
+					//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"lineExtraAvailableWidth", lineExtraAvailableWidth);
+					// }
+					// #endif
+				}
+
+				int lineIndex = sizedLineVectorIndex + (m_unsizedNearLineCount == -1 ? 0 : m_unsizedNearLineCount);
+
+				MUX_ASSERT(lineIndex < lineCount);
+
+				for (int sizedLineItemIndex = 0; sizedLineItemIndex < lineItemsCount; sizedLineItemIndex++)
+				{
+					if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
+					{
+						if (m_elementManager.GetRealizedElement(sizedItemIndex /*dataIndex*/) is { } element)
+						{
+							float arrangeWidth;
+
+							if (usesArrangeWidthInfo)
+							{
+								// Use the item info provided by the ItemsInfoRequested handler since the DesiredSize
+								// may be different from the computed arrange width when the item content failed to load properly.
+								arrangeWidth = m_itemsInfoArrangeWidths[sizedItemIndex - itemsInfoArrangeWidthsOffset];
+							}
+							else
+							{
+								arrangeWidth = (float)element.DesiredSize.Width;
+							}
+							// #ifdef DBG
+							// if (arrangeWidth == 0.0f)
+							// {
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, usesArrangeWidthInfo ? L"Unexpected nil arrange width" : L"Unexpected nil desired width", sizedItemIndex);
+							// }
+							// #endif
+
+							Rect elementRect = new(cumulatedOffset, (float)(lineIndex * (actualLineHeight + lineSpacing)), arrangeWidth, (float)actualLineHeight);
+
+							element.Arrange(elementRect);
+
+							// #ifdef DBG
+							// if (sizedItemIndex == LogItemIndexDbg())
+							// {
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_PTR_STR, METH_NAME, this, element, L"Arrange element");
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"Arrange line", lineIndex);
+							// }
+							//
+							MUX_ASSERT(m_elementAvailableWidths is null || m_elementDesiredWidths is null || !UsesFastPathLayout());
+							// if (m_elementAvailableWidths && m_elementDesiredWidths)
+							// {
+							//     const auto elementTracker = tracker_ref<winrt::UIElement>(this, element);
+							//     auto recordedSizeIterator = m_elementAvailableWidths->find(elementTracker);
+							//
+							//     if (recordedSizeIterator == m_elementAvailableWidths->end())
+							//     {
+							//         recordedSizeIterator = m_elementDesiredWidths->find(elementTracker);
+							//
+							//         if (recordedSizeIterator != m_elementDesiredWidths->end())
+							//         {
+							//             const float desiredWidth = recordedSizeIterator->second;
+							//
+							//             if ((std::abs(desiredWidth - element.DesiredSize().Width) >= 1.0f || std::abs(actualLineHeight - element.DesiredSize().Height) >= 1.0f) ||
+							//                 sizedItemIndex == LogItemIndexDbg())
+							//             {
+							//                 if (sizedItemIndex != LogItemIndexDbg())
+							//                 {
+							//                     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"sizedItemIndex", sizedItemIndex);
+							//                 }
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"desiredWidth", desiredWidth);
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"element.DesiredSize.Width", element.DesiredSize().Width);
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"desiredHeight", actualLineHeight);
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"element.DesiredSize.Height", element.DesiredSize().Height);
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"arrangeWidth", arrangeWidth);
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"renderWidth", element.RenderSize().Width);
+							//             }
+							//         }
+							//     }
+							//     else
+							//     {
+							//         const float arrangeWidthDbg = recordedSizeIterator->second;
+							//
+							//         if (std::abs(arrangeWidthDbg - element.DesiredSize().Width) >= 1.0f ||
+							//             sizedItemIndex == LogItemIndexDbg())
+							//         {
+							//             if (sizedItemIndex != LogItemIndexDbg())
+							//             {
+							//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"sizedItemIndex", sizedItemIndex);
+							//             }
+							//             LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"element.DesiredSize.Width", element.DesiredSize().Width);
+							//             LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"arrangeWidthDbg", arrangeWidthDbg);
+							//             LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"arrangeWidth", arrangeWidth);
+							//             LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"renderWidth", element.RenderSize().Width);
+							//         }
+							//     }
+							// }
+							// else if (sizedItemIndex == LogItemIndexDbg())
+							// {
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"desiredWidth", element.DesiredSize().Width);
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"arrangeWidth", arrangeWidth);
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"renderWidth", element.RenderSize().Width);
+							// }
+							//
+							// if (sizedLineItemIndex > 0)
+							// {
+							//     cumulatedWidthDbg += itemSpacing;
+							// }
+							//
+							// cumulatedWidthDbg += elementRect.Width;
+							// #endif
+							cumulatedOffset += (float)elementRect.Width + itemSpacing;
+						}
+					}
+					else
+					{
+						// The unrealized area was reached.
+						return;
+					}
+
+					sizedItemIndex++;
+				}
+				// #ifdef DBG
+				// if (std::abs(context.VisibleRect().Width - cumulatedWidthDbg) > 1.0f)
+				// {
+				//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"cumulatedWidth", cumulatedWidthDbg);
+				// }
+				// #endif
+			}
+		}
+
+		// Items arrangement when the non-scrolling dimension is unconstrained.
+		private void ArrangeUnconstrainedLine(
+			VirtualizingLayoutContext context)
+		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
+			if (ActualLineHeight <= 0.0)
+			{
+				return;
+			}
+
+			float minItemSpacing = (float)MinItemSpacing;
+			float cumulatedOffset = 0.0f;
+
+			if (ItemsStretch == LinedFlowLayoutItemsStretch.None)
+			{
+				switch (ItemsJustification)
+				{
+					case LinedFlowLayoutItemsJustification.SpaceEvenly:
+						cumulatedOffset = minItemSpacing;
+						break;
+					case LinedFlowLayoutItemsJustification.SpaceAround:
+						cumulatedOffset = minItemSpacing / 2.0f;
+						break;
+				}
+			}
+
+			for (int itemIndex = 0; itemIndex < context.ItemCount; itemIndex++)
+			{
+				var element = m_elementManager.GetAt(itemIndex);
+
 				if (element != null)
 				{
-					MUX_ASSERT(realizedItemIndex - itemsInfoArrangeWidthsOffset < m_itemsInfoArrangeWidths.Count);
+					var desiredSize = element.DesiredSize;
+					float itemWidth = (float)desiredSize.Width;
+					Rect arrangeRect = new(cumulatedOffset, 0.0f, itemWidth, (float)desiredSize.Height);
 
-					float arrangeWidth = m_itemsInfoArrangeWidths[realizedItemIndex - itemsInfoArrangeWidthsOffset];
-
-					if (arrangeWidth >= 0.0f)
-					{
-						element.Measure(new Size(arrangeWidth, (float)actualLineHeight));
-					}
+					element.Arrange(arrangeRect);
+					cumulatedOffset += itemWidth + minItemSpacing;
 				}
 			}
 		}
 
-		// Measures a range of realized items based on previously computed available widths 'elementAvailableWidths'.
-		// Re-populates m_elementAvailableWidths with the old & re-applied available widths.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal void MeasureItemRangeRegularPath(
-			Dictionary<UIElement, float> elementAvailableWidths,
-			double actualLineHeight,
-			int beginRealizedItemIndex,
-			int endRealizedItemIndex)
+		internal void ClearItemAspectRatios()
 		{
-			MUX_ASSERT(m_itemsInfoFirstIndex == -1);
-			MUX_ASSERT(beginRealizedItemIndex <= endRealizedItemIndex);
-
-			for (int realizedItemIndex = beginRealizedItemIndex; realizedItemIndex <= endRealizedItemIndex; realizedItemIndex++)
+			if (m_aspectRatios != null)
 			{
-				MUX_ASSERT(m_elementManager.IsDataIndexRealized(realizedItemIndex));
-
-				var element = m_elementManager.GetRealizedElement(realizedItemIndex /*dataIndex*/);
-
-				// Making sure the element is not null for safety.
-				if (element != null)
-				{
-					float elementAvailableWidth = -1.0f;
-
-					if (elementAvailableWidths.TryGetValue(element, out float recordedAvailableWidth))
-					{
-						// The element has an existing recorded available width because it needs to be scaled up or down, to fill or fit the available line width respectively.
-						elementAvailableWidth = recordedAvailableWidth;
-
-						MUX_ASSERT(m_elementAvailableWidths != null);
-						MUX_ASSERT(!m_elementAvailableWidths!.ContainsKey(element));
-
-						// Maintain that recording and measure the element again with it.
-						m_elementAvailableWidths!.TryAdd(element, elementAvailableWidth);
-					}
-					else if (element is FrameworkElement frameworkElement)
-					{
-						// The element has no recorded available width because it is not scaled down or up, so only its desired width is recorded.
-						float minWidth = (float)frameworkElement.MinWidth;
-
-						if (element.DesiredSize.Width == minWidth)
-						{
-							// Making sure the item is measured and stretched according to the MinWidth value (otherwise background-colored bands appear on the items' left/right edges).
-							elementAvailableWidth = minWidth;
-						}
-					}
-
-					if (elementAvailableWidth != -1.0f)
-					{
-						element.Measure(new Size(elementAvailableWidth, (float)actualLineHeight));
-					}
-				}
+				m_aspectRatios.Clear();
 			}
 		}
-
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureItemAspectRatios()
-		{
-			if (m_aspectRatios == null)
-			{
-				m_aspectRatios = new LinedFlowLayoutItemAspectRatios();
-			}
-		}
-
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureElementRealized(
-			bool forward,
-			int itemIndex)
-		{
-			MUX_ASSERT(m_isVirtualizingContext);
-			MUX_ASSERT(!m_elementManager.IsDataIndexRealized(itemIndex));
-
-			m_elementManager.EnsureElementRealized(forward, itemIndex, LayoutId);
-		}
-
-		// Ensures the items in the provided range are realized.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureItemRange(
-			bool forward,
-			int beginRealizedItemIndex,
-			int endRealizedItemIndex)
-		{
-			bool realizedNewElement = false;
-
-			for (int realizedItemIndex = beginRealizedItemIndex; ; realizedItemIndex = forward ? realizedItemIndex + 1 : realizedItemIndex - 1)
-			{
-				if (!m_elementManager.IsDataIndexRealized(realizedItemIndex))
-				{
-					EnsureElementRealized(forward, realizedItemIndex);
-
-					realizedNewElement = true;
-				}
-
-				if (realizedItemIndex == endRealizedItemIndex)
-				{
-					break;
-				}
-			}
-
-			if (realizedNewElement && !UsesArrangeWidthInfo())
-			{
-				InvalidateMeasureTimerStart(0 /*tickCount*/);
-			}
-		}
-
-		// Returns a 3-tuple indicating whether any pre-frozen, frozen or post-frozen realized item has a new desired
-		// width compared to the provided oldElementDesiredWidths snapshot. Used by the asynchronous measure pass to
-		// decide whether a re-measure must trigger a full re-layout.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal (bool preFrozenItemHasNewDesiredWidth, bool frozenItemHasNewDesiredWidth, bool postFrozenItemHasNewDesiredWidth) ItemRangesHaveNewDesiredWidths(
-			Dictionary<UIElement, float> oldElementDesiredWidths,
-			int beginRealizedItemIndex,
-			int endRealizedItemIndex)
-		{
-			MUX_ASSERT(m_itemsInfoFirstIndex == -1);
-			MUX_ASSERT(m_elementDesiredWidths != null);
-			MUX_ASSERT(beginRealizedItemIndex <= endRealizedItemIndex);
-			MUX_ASSERT(beginRealizedItemIndex <= m_firstFrozenItemIndex);
-			MUX_ASSERT(endRealizedItemIndex >= m_lastFrozenItemIndex);
-
-			bool preFrozenItemHasNewDesiredWidth = false;
-			bool frozenItemHasNewDesiredWidth = false;
-
-			for (int itemIndex = beginRealizedItemIndex; itemIndex <= endRealizedItemIndex; itemIndex++)
-			{
-				if (m_elementManager.IsDataIndexRealized(itemIndex))
-				{
-					if (m_elementManager.GetRealizedElement(itemIndex /*dataIndex*/) is { } element)
-					{
-						bool hasNewDesiredWidth = m_elementDesiredWidths!.ContainsKey(element);
-
-						if (hasNewDesiredWidth)
-						{
-							bool hasOldDesiredWidth = oldElementDesiredWidths.ContainsKey(element);
-							float newDesiredWidth = m_elementDesiredWidths![element];
-							bool desiredWidthChanged = false;
-
-							MUX_ASSERT(element.DesiredSize.Width == newDesiredWidth);
-
-							if (hasOldDesiredWidth)
-							{
-								float oldDesiredWidth = oldElementDesiredWidths[element];
-
-								desiredWidthChanged = oldDesiredWidth != newDesiredWidth;
-							}
-
-							if (desiredWidthChanged || !hasOldDesiredWidth)
-							{
-								NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.ItemDesiredWidthChange);
-
-								if (itemIndex < m_firstFrozenItemIndex)
-								{
-									MUX_ASSERT(!preFrozenItemHasNewDesiredWidth);
-
-									preFrozenItemHasNewDesiredWidth = true;
-
-									// Now that preFrozenItemHasNewDesiredWidth was set for the initial unfrozen items range, skip the remaining initial unfrozen items after itemIndex.
-									itemIndex = m_firstFrozenItemIndex - 1;
-								}
-								else if (itemIndex <= m_lastFrozenItemIndex)
-								{
-									MUX_ASSERT(!frozenItemHasNewDesiredWidth);
-
-									frozenItemHasNewDesiredWidth = true;
-
-									// Now that frozenItemHasNewDesiredWidth was set for the frozen items range, skip the remaining frozen items after itemIndex.
-									itemIndex = m_lastFrozenItemIndex;
-								}
-								else
-								{
-									return (preFrozenItemHasNewDesiredWidth, frozenItemHasNewDesiredWidth, true /*postFrozenItemHasNewDesiredWidth*/);
-								}
-							}
-						}
-					}
-				}
-			}
-
-			return (preFrozenItemHasNewDesiredWidth, frozenItemHasNewDesiredWidth, false /*postFrozenItemHasNewDesiredWidth*/);
-		}
-
-		#endregion
-
-		#region Element realization: measure + resize orchestrators (WS-D3c sub-slice 4)
-
-		// Ensures items are realized and measured to determine their desired width. WinUI's original comment describes a
-		// bool return (used to request an extra UI-thread tick while a stored aspect ratio still has a weight below
-		// c_maxAspectRatioWeight), but the shipped signature is void; the async re-tick is driven via InvalidateMeasureTimerStart.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureAndMeasureItemRange(
-			VirtualizingLayoutContext context,
-			float availableWidth,
-			double actualLineHeight,
-			bool forward,
-			int beginRealizedItemIndex,
-			int endRealizedItemIndex)
-		{
-			bool realizedNewElement = false;
-
-			for (int realizedItemIndex = beginRealizedItemIndex; ; realizedItemIndex = forward ? realizedItemIndex + 1 : realizedItemIndex - 1)
-			{
-				bool isElementNewlyRealized = false;
-
-				if (!m_elementManager.IsDataIndexRealized(realizedItemIndex))
-				{
-					EnsureElementRealized(forward, realizedItemIndex);
-
-					realizedNewElement = isElementNewlyRealized = true;
-				}
-
-				if (m_itemsInfoFirstIndex == -1)
-				{
-					if (m_elementManager.GetRealizedElement(realizedItemIndex /*dataIndex*/) is { } element)
-					{
-						if (!m_elementDesiredWidths!.ContainsKey(element))
-						{
-							var elementAvailableSize = new Size(float.PositiveInfinity, actualLineHeight);
-
-							element.Measure(elementAvailableSize);
-
-							var desiredSize = element.DesiredSize;
-
-							bool desiredWidthGreaterThanMinWidth = false;
-
-							if (element is FrameworkElement frameworkElement)
-							{
-								float minWidth = (float)frameworkElement.MinWidth;
-
-								if (desiredSize.Width > minWidth)
-								{
-									// Items for which the desired width is greater than the min width are immediately
-									// assigned the c_maxAspectRatioWeight weight. For the other items, the weight is
-									// incremented from 1 to c_maxAspectRatioWeight as the min width may be due to the
-									// item content not being loaded yet.
-									desiredWidthGreaterThanMinWidth = true;
-								}
-							}
-
-							m_elementDesiredWidths![element] = (float)desiredSize.Width;
-
-							if (desiredSize.Height != 0.0 && m_aspectRatios != null)
-							{
-								var itemAspectRatio = m_aspectRatios.GetAt(realizedItemIndex);
-								float aspectRatio = (float)(desiredSize.Width / desiredSize.Height);
-
-								// The Uno LinedFlowLayoutItemAspectRatios.ItemAspectRatio is a readonly struct, so WinUI's
-								// in-place mutation of the copied value is reproduced by tracking the new aspect ratio/weight
-								// in locals and writing back a fresh struct via SetAt.
-								float newAspectRatio = itemAspectRatio.AspectRatio;
-								int newWeight = itemAspectRatio.Weight;
-
-								if (itemAspectRatio.Weight == 0)
-								{
-									newAspectRatio = aspectRatio;
-									newWeight = desiredWidthGreaterThanMinWidth ? c_maxAspectRatioWeight : 1;
-								}
-								else
-								{
-									if (isElementNewlyRealized)
-									{
-										newWeight = desiredWidthGreaterThanMinWidth ? c_maxAspectRatioWeight : 1;
-									}
-									else
-									{
-										int aspectRatioWeight = itemAspectRatio.Weight;
-
-										MUX_ASSERT(itemAspectRatio.AspectRatio >= 0.0f);
-										MUX_ASSERT(aspectRatioWeight >= 1);
-										MUX_ASSERT(aspectRatioWeight <= c_maxAspectRatioWeight);
-
-										if (aspectRatioWeight < c_maxAspectRatioWeight)
-										{
-											if (desiredWidthGreaterThanMinWidth)
-											{
-												newWeight = c_maxAspectRatioWeight;
-											}
-											else
-											{
-												newWeight++;
-											}
-										}
-									}
-
-									if (itemAspectRatio.AspectRatio != aspectRatio)
-									{
-										newAspectRatio = aspectRatio;
-									}
-								}
-
-								m_aspectRatios.SetAt(realizedItemIndex, new LinedFlowLayoutItemAspectRatios.ItemAspectRatio(newAspectRatio, newWeight));
-							}
-						}
-					}
-				}
-
-				if (realizedItemIndex == endRealizedItemIndex)
-				{
-					break;
-				}
-			}
-
-			if (realizedNewElement && !UsesArrangeWidthInfo())
-			{
-				InvalidateMeasureTimerStart(0 /*tickCount*/);
-			}
-		}
-
-		// Allocates the storage for tracking weighted aspect ratios. Sizes that storage to track about 10 viewports worth of items at the most.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureAndResizeItemAspectRatios(
-			double scrollViewport,
-			double actualLineHeight,
-			double lineSpacing)
-		{
-			MUX_ASSERT(m_averageItemsPerLine.second > 0.0);
-			MUX_ASSERT(m_firstSizedItemIndex >= 0);
-			MUX_ASSERT(m_firstSizedItemIndex <= m_lastSizedItemIndex);
-
-			EnsureItemAspectRatios();
-
-			const int c_scrollViewportCount = 10; // m_aspectRatios is sized large enough to hold aspect ratio information for 10 viewport worth of items.
-			int referenceItemIndex = (m_lastSizedItemIndex - m_firstSizedItemIndex) / 2;
-			const double c_minItemsPerScrollViewport = 20.0; // Avoid small aspect ratio sampling that is not statistically significant by forcing at least 20 items per viewport.
-			double linesPerScrollViewport = scrollViewport / (actualLineHeight + lineSpacing);
-			double averageItemsPerScrollViewport = Math.Max(c_minItemsPerScrollViewport, linesPerScrollViewport * m_averageItemsPerLine.second);
-			int itemAspectRatiosStorageSize = Math.Max((int)(averageItemsPerScrollViewport * c_scrollViewportCount), m_lastSizedItemIndex - m_firstSizedItemIndex + 1);
-
-			itemAspectRatiosStorageSize = Math.Min(itemAspectRatiosStorageSize, m_itemCount);
-
-			m_aspectRatios!.Resize(itemAspectRatiosStorageSize, referenceItemIndex);
-		}
-
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureElementAvailableWidths()
-		{
-			if (m_elementAvailableWidths == null)
-			{
-				m_elementAvailableWidths = new Dictionary<UIElement, float>();
-			}
-		}
-
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureElementDesiredWidths()
-		{
-			if (m_elementDesiredWidths == null)
-			{
-				m_elementDesiredWidths = new Dictionary<UIElement, float>();
-			}
-		}
-
-		// Rounds the provided value to the nearest physical pixel based on m_roundingScaleFactor.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private float GetRoundedFloat(
-			float value)
-		{
-			return (float)(Math.Round(value * m_roundingScaleFactor, MidpointRounding.AwayFromZero) / m_roundingScaleFactor);
-		}
-
-		// Ensures items are realized exactly for the context's realization window - for the fast path layout.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void EnsureItemRangeFastPath(
-			VirtualizingLayoutContext context,
-			double actualLineHeight)
-		{
-			int newRecommendedAnchorIndex = context.RecommendedAnchorIndex;
-
-			MUX_ASSERT(actualLineHeight > 0.0);
-			MUX_ASSERT(m_itemCount > 0);
-
-			int newFirstRealizedItemIndex = 0;
-			int newLastRealizedItemIndex = 0;
-
-			MUX_ASSERT(m_isVirtualizingContext == (context.VisibleRect.Height != double.PositiveInfinity));
-
-			if (m_isVirtualizingContext)
-			{
-				float realizationRectHeight = (float)context.RealizationRect.Height;
-
-				if (realizationRectHeight == 0.0)
-				{
-					return;
-				}
-
-				int lineCount = m_lineItemCounts.Count;
-
-				MUX_ASSERT(lineCount >= 0);
-
-				double lineSpacing = LineSpacing;
-				float nearRealizationRect = GetRoundedFloat((float)context.RealizationRect.Y);
-				int firstRealizedLineIndex = -1;
-				int lastRealizedLineIndex = -1;
-
-				GetFirstAndLastDisplayedLineIndexes(
-					realizationRectHeight /*scrollViewport*/,
-					nearRealizationRect,
-					0 /*padding*/,
-					lineSpacing,
-					actualLineHeight,
-					lineCount,
-					false /*forFullyDisplayedLines*/,
-					out firstRealizedLineIndex,
-					out lastRealizedLineIndex);
-
-				MUX_ASSERT(firstRealizedLineIndex >= 0);
-				MUX_ASSERT(lastRealizedLineIndex >= 0);
-				MUX_ASSERT(firstRealizedLineIndex < lineCount);
-				MUX_ASSERT(lastRealizedLineIndex < lineCount);
-
-				newFirstRealizedItemIndex = GetFirstItemIndexInLineIndex(firstRealizedLineIndex);
-				newLastRealizedItemIndex = GetLastItemIndexInLineIndex(lastRealizedLineIndex);
-
-				MUX_ASSERT(newFirstRealizedItemIndex >= 0);
-				MUX_ASSERT(newLastRealizedItemIndex >= 0);
-				MUX_ASSERT(newFirstRealizedItemIndex < m_itemCount);
-				MUX_ASSERT(newLastRealizedItemIndex < m_itemCount);
-
-				bool realizationRectCenteredAroundAnchor = false;
-
-				if (m_anchorIndex != -1 || newRecommendedAnchorIndex != -1)
-				{
-					int anchorLineIndex = GetLineIndex(newRecommendedAnchorIndex == -1 ? m_anchorIndex : newRecommendedAnchorIndex, true /*usesFastPathLayout*/);
-
-					MUX_ASSERT(anchorLineIndex >= 0);
-					MUX_ASSERT(anchorLineIndex < lineCount);
-
-					if (anchorLineIndex < firstRealizedLineIndex || anchorLineIndex > lastRealizedLineIndex)
-					{
-						// The anchor line is disconnected. Centering the realization window around its center.
-						float anchorLineNearEdge = (float)(anchorLineIndex * (actualLineHeight + lineSpacing));
-						float anchorLineMiddle = (float)(anchorLineNearEdge + actualLineHeight / 2.0);
-
-						nearRealizationRect = GetRoundedFloat(anchorLineMiddle - realizationRectHeight / 2.0f);
-						realizationRectCenteredAroundAnchor = true;
-
-						// Same comments and treatment as in MeasureConstrainedLinesRegularPath. Sometimes during a bring-into-view
-						// operation the RecommendedAnchorIndex momentarily switches from the target index N to -1 and then back to N.
-						// To avoid momentarily setting m_anchorIndex to -1, its value is preserved c_maxAnchorIndexRetentionCount
-						// times, based purely on experimentations.
-						if (newRecommendedAnchorIndex == -1)
-						{
-							MUX_ASSERT(m_anchorIndexRetentionCountdown >= 1 && m_anchorIndexRetentionCountdown <= c_maxAnchorIndexRetentionCount);
-
-							m_anchorIndexRetentionCountdown--;
-
-							if (m_anchorIndexRetentionCountdown == 0)
-							{
-								m_anchorIndex = -1;
-							}
-						}
-						else
-						{
-							m_anchorIndexRetentionCountdown = c_maxAnchorIndexRetentionCount;
-							m_anchorIndex = newRecommendedAnchorIndex;
-						}
-
-						// Layout is invalidated to ensure that m_anchorIndexRetentionCountdown is decremented from
-						// c_maxAnchorIndexRetentionCount all the way to 0 (a few lines above). Otherwise m_anchorIndex could be
-						// stuck to a value that prevents the realization window from moving to the actual scroller's offset.
-						InvalidateMeasureAsync();
-					}
-				}
-
-				if (realizationRectCenteredAroundAnchor)
-				{
-					// Re-evaluate realization range after centering around the anchor line.
-					GetFirstAndLastDisplayedLineIndexes(
-						realizationRectHeight /*scrollViewport*/,
-						nearRealizationRect,
-						0 /*padding*/,
-						lineSpacing,
-						actualLineHeight,
-						lineCount,
-						false /*forFullyDisplayedLines*/,
-						out firstRealizedLineIndex,
-						out lastRealizedLineIndex);
-
-					MUX_ASSERT(firstRealizedLineIndex >= 0);
-					MUX_ASSERT(lastRealizedLineIndex >= 0);
-					MUX_ASSERT(firstRealizedLineIndex < lineCount);
-					MUX_ASSERT(lastRealizedLineIndex < lineCount);
-
-					newFirstRealizedItemIndex = GetFirstItemIndexInLineIndex(firstRealizedLineIndex);
-					newLastRealizedItemIndex = GetLastItemIndexInLineIndex(lastRealizedLineIndex);
-
-					MUX_ASSERT(newFirstRealizedItemIndex >= 0);
-					MUX_ASSERT(newLastRealizedItemIndex >= 0);
-					MUX_ASSERT(newFirstRealizedItemIndex < m_itemCount);
-					MUX_ASSERT(newLastRealizedItemIndex < m_itemCount);
-				}
-				else if (m_anchorIndex != -1)
-				{
-					m_anchorIndex = -1;
-				}
-			}
-			else
-			{
-				// All items are realized in non-virtualizing mode.
-				MUX_ASSERT(context.VisibleRect.Y == 0.0);
-
-				newLastRealizedItemIndex = m_itemCount - 1;
-			}
-
-			int newRealizedItemCount = newLastRealizedItemIndex - newFirstRealizedItemIndex + 1;
-
-			int oldFirstRealizedItemIndex = m_elementManager.GetFirstRealizedDataIndex(); // -1 and unused in non-virtualizing mode.
-			int oldLastRealizedItemIndex = oldFirstRealizedItemIndex == -1 ? -1 : oldFirstRealizedItemIndex + m_elementManager.GetRealizedElementCount - 1;
-
-			// Discard the first realized items fallen off the realization window.
-			if (oldFirstRealizedItemIndex != -1 && oldFirstRealizedItemIndex < newFirstRealizedItemIndex)
-			{
-				MUX_ASSERT(m_isVirtualizingContext);
-
-				m_elementManager.DiscardElementsOutsideWindow(
-					false /*forward*/,
-					Math.Min(newFirstRealizedItemIndex, oldFirstRealizedItemIndex + m_elementManager.GetRealizedElementCount) - 1 /*startIndex*/);
-			}
-
-			MUX_ASSERT(newFirstRealizedItemIndex <= m_elementManager.GetFirstRealizedDataIndex() || -1 == m_elementManager.GetFirstRealizedDataIndex());
-
-			int firstStillRealizedItemIndex = -1;
-			int lastStillRealizedItemIndex = -1;
-
-			if (oldFirstRealizedItemIndex != -1 && oldLastRealizedItemIndex != -1)
-			{
-				if (newFirstRealizedItemIndex >= oldFirstRealizedItemIndex && newFirstRealizedItemIndex <= oldLastRealizedItemIndex)
-				{
-					firstStillRealizedItemIndex = newFirstRealizedItemIndex;
-					lastStillRealizedItemIndex = Math.Min(oldLastRealizedItemIndex, newLastRealizedItemIndex);
-				}
-				else if (newLastRealizedItemIndex >= oldFirstRealizedItemIndex && newLastRealizedItemIndex <= oldLastRealizedItemIndex)
-				{
-					lastStillRealizedItemIndex = newLastRealizedItemIndex;
-					firstStillRealizedItemIndex = Math.Max(oldFirstRealizedItemIndex, newFirstRealizedItemIndex);
-				}
-			}
-
-			if (m_elementManager.GetFirstRealizedDataIndex() != -1 && newFirstRealizedItemIndex < m_elementManager.GetFirstRealizedDataIndex())
-			{
-				MUX_ASSERT(oldFirstRealizedItemIndex > 0);
-
-				// Ensure and measure the realized items before the old first realized item.
-				EnsureItemRange(
-					false /*forward*/,
-					Math.Min(oldFirstRealizedItemIndex - 1, newFirstRealizedItemIndex + newRealizedItemCount - 1) /*beginRealizedItemIndex*/,
-					newFirstRealizedItemIndex /*endRealizedItemIndex*/);
-
-				// Ensure and measure the realized items after the old first realized item.
-				MUX_ASSERT(newFirstRealizedItemIndex == m_elementManager.GetFirstRealizedDataIndex());
-
-				if (firstStillRealizedItemIndex != -1)
-				{
-					if (firstStillRealizedItemIndex > 0 && oldFirstRealizedItemIndex <= firstStillRealizedItemIndex - 1)
-					{
-						EnsureItemRange(
-							true /*forward*/,
-							oldFirstRealizedItemIndex /*beginRealizedItemIndex*/,
-							firstStillRealizedItemIndex - 1 /*endRealizedItemIndex*/);
-					}
-
-					if (lastStillRealizedItemIndex + 1 <= newFirstRealizedItemIndex + newRealizedItemCount - 1)
-					{
-						EnsureItemRange(
-							true /*forward*/,
-							lastStillRealizedItemIndex + 1 /*beginRealizedItemIndex*/,
-							newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
-					}
-				}
-				else if (newFirstRealizedItemIndex + newRealizedItemCount - 1 >= oldFirstRealizedItemIndex)
-				{
-					EnsureItemRange(
-						true /*forward*/,
-						oldFirstRealizedItemIndex /*beginRealizedItemIndex*/,
-						newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
-				}
-			}
-			else
-			{
-				// Ensure and measure the realized items.
-				MUX_ASSERT(newFirstRealizedItemIndex == m_elementManager.GetFirstRealizedDataIndex() || m_elementManager.GetFirstRealizedDataIndex() == -1);
-
-				if (firstStillRealizedItemIndex != -1)
-				{
-					if (firstStillRealizedItemIndex > 0 && newFirstRealizedItemIndex <= firstStillRealizedItemIndex - 1)
-					{
-						EnsureItemRange(
-							true /*forward*/,
-							newFirstRealizedItemIndex /*beginRealizedItemIndex*/,
-							firstStillRealizedItemIndex - 1 /*endRealizedItemIndex*/);
-					}
-
-					if (lastStillRealizedItemIndex + 1 <= newFirstRealizedItemIndex + newRealizedItemCount - 1)
-					{
-						EnsureItemRange(
-							true /*forward*/,
-							lastStillRealizedItemIndex + 1 /*beginRealizedItemIndex*/,
-							newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
-					}
-				}
-				else
-				{
-					EnsureItemRange(
-						true /*forward*/,
-						newFirstRealizedItemIndex /*beginRealizedItemIndex*/,
-						newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
-				}
-			}
-
-			// Discard the last realized items fallen off the realization window.
-			if (oldLastRealizedItemIndex != -1 && oldLastRealizedItemIndex > newLastRealizedItemIndex)
-			{
-				MUX_ASSERT(m_isVirtualizingContext);
-				MUX_ASSERT(m_elementManager.GetRealizedElementCount > newRealizedItemCount);
-
-				m_elementManager.DiscardElementsOutsideWindow(
-					true /*forward*/,
-					newLastRealizedItemIndex + 1 /*startIndex*/);
-			}
-		}
-
-		#endregion
-
-		#region Measure engine: frozen-window layout assembly (WS-D3c sub-slice 4)
 
 		// Last major phase of a measure pass:
 		// - updates the range of frozen lines and items (ComputeFrozenItemsRange calls).
@@ -4196,7 +925,6 @@ namespace Microsoft.UI.Xaml.Controls
 		//   * otherwise two unfrozen blocks before and after the frozen lines can produce up to two items distributions.
 		//     These two distributions are getting lines at the edges of the unfrozen blocks ready to become frozen due to a scroll viewport size or scroll offset change.
 		// Returns True when a still sized item has a new desired width.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
 		private bool ComputeFrozenItemsAndLayout(
 			VirtualizingLayoutContext context,
 			List<int> oldLineItemCounts,
@@ -4220,11 +948,36 @@ namespace Microsoft.UI.Xaml.Controls
 			int firstStillSizedItemIndex,
 			int lastStillSizedItemIndex)
 		{
+#if DEBUG
+			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
+			MUX_ASSERT(nearSizedItemsRect <= nearRealizationRect);
+			MUX_ASSERT(farSizedItemsRect >= farRealizationRect);
+			MUX_ASSERT(sizedLineCount <= lineCount);
+			MUX_ASSERT(sizedItemCount >= m_elementManager.GetRealizedElementCount);
+#endif
+
 			bool itemHasNewDesiredWidth = false;
 
 			if (firstStillSizedLineIndex != -1)
 			{
 				// Some line indexes are present in the previous measure pass and this new one.
+#if DEBUG
+				MUX_ASSERT(m_isVirtualizingContext);
+				MUX_ASSERT(lastStillSizedLineIndex != -1);
+				MUX_ASSERT(m_firstSizedLineIndex <= firstStillSizedLineIndex);
+				MUX_ASSERT(m_lastSizedLineIndex >= lastStillSizedLineIndex);
+				MUX_ASSERT(m_firstSizedItemIndex <= firstStillSizedItemIndex);
+				MUX_ASSERT(m_lastSizedItemIndex >= lastStillSizedItemIndex);
+				MUX_ASSERT(m_lastSizedItemIndex - m_firstSizedItemIndex + 1 == sizedItemCount);
+				MUX_ASSERT(lastStillSizedItemIndex - firstStillSizedItemIndex + 1 <= sizedItemCount);
+
+				int stillSizedItemCountDbg = LineItemsCountTotal(0);
+				int preStillSizedItemCountDbg = firstStillSizedItemIndex - m_firstSizedItemIndex;
+				int postStillSizedItemCountDbg = m_firstSizedItemIndex + sizedItemCount - lastStillSizedItemIndex - 1;
+
+				MUX_ASSERT(preStillSizedItemCountDbg + stillSizedItemCountDbg + postStillSizedItemCountDbg == sizedItemCount);
+#endif
+
 				int firstRealizedItemIndex = m_elementManager.GetFirstRealizedDataIndex();
 				int lastRealizedItemIndex = firstRealizedItemIndex + m_elementManager.GetRealizedElementCount - 1;
 
@@ -4272,7 +1025,7 @@ namespace Microsoft.UI.Xaml.Controls
 							// In that case, a full re-layout is required.
 							// When a sized item before the frozen ones has a modified DesiredSize, it does not cause a full re-layout, but
 							// the pre-frozen-range is laid out in isolation. The same is applicable to the post-frozen-range.
-							var itemRangesHaveNewDesiredWidths =
+							(bool preFrozenItemHasNewDesiredWidth /*preFrozenItemHasNewDesiredWidth*/, bool frozenItemHasNewDesiredWidth /*frozenItemHasNewDesiredWidth*/, bool postFrozenItemHasNewDesiredWidth /*postFrozenItemHasNewDesiredWidth*/) itemRangesHaveNewDesiredWidths =
 								ItemRangesHaveNewDesiredWidths(
 									oldElementDesiredWidths,
 									Math.Min(firstStillSizedItemIndex, m_firstFrozenItemIndex),
@@ -4531,176 +1284,1398 @@ namespace Microsoft.UI.Xaml.Controls
 					out adjustedLastSizedItemIndex);
 			}
 
+			// #ifdef DBG
+			// if (itemHasNewDesiredWidth)
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns True");
+			// }
+			// #endif
 			return itemHasNewDesiredWidth;
 		}
 
-		#endregion
-
-		#region Measure engine: items-info + line-height leaves (WS-D3c sub-slice 5)
-
-		private float GetSizedItemsRectHeight(
-			VirtualizingLayoutContext context,
+		// Updates the m_firstFrozenLineIndex, m_lastFrozenLineIndex, m_firstFrozenItemIndex and m_lastFrozenItemIndex fields.
+		// Returns 'True' when still sized lines must be ignored & a full re-layout must be performed.
+		// beginSizedLineIndex:
+		//  - m_firstSizedLineIndex when no scrolling occurred since the last measure pass, or when doing a full re-layout.
+		//  - or first sized line index common among the previous and current measure passes. Slightly different from m_firstSizedLineIndex because of scrolling.
+		// endSizedLineIndex:
+		//  - m_lastSizedLineIndex when no scrolling occurred since the last measure pass, or when doing a full re-layout.
+		//  - or last sized line index common among the previous and current measure passes. Slightly different from m_lastSizedLineIndex because of scrolling.
+		// beginSizedItemIndex:
+		//  - first sized item index when no scrolling occurred since the last measure pass, or when doing a full re-layout.
+		//  - or first sized item index common among the previous and current measure passes. Slightly different from previously first sized item index because of scrolling.
+		// endSizedItemIndex:
+		//  - last sized item index when no scrolling occurred since the last measure pass, or when doing a full re-layout.
+		//  - or last sized item index common among the previous and current measure passes. Slightly different from previously last sized item index because of scrolling.
+		// adjustedBeginSizedItemIndex:
+		//  returned as a variation of beginSizedItemIndex. For example, when the scroll offset decreased, the m_firstFrozenLineIndex and m_firstFrozenItemIndex can decrease
+		//  and adjustedBeginSizedItemIndex becomes beginSizedItemIndex minus the number of items that have become frozen.
+		// adjustedEndSizedItemIndex:
+		//  returned as a variation of endSizedItemIndex. For example, when the scroll offset increased, the m_lastFrozenLineIndex and m_lastFrozenItemIndex can increase
+		//  and adjustedEndSizedItemIndex becomes endSizedItemIndex plus the number of items that have become frozen.
+		private bool ComputeFrozenItemsRange(
+			double scrollViewport,
+			double scrollOffset,
+			double lineSpacing,
 			double actualLineHeight,
-			double lineSpacing)
+			int lineCount,
+			int beginSizedLineIndex,
+			int endSizedLineIndex,
+			int beginSizedItemIndex,
+			int endSizedItemIndex,
+			out int adjustedBeginSizedItemIndex,
+			out int adjustedEndSizedItemIndex)
 		{
-			// This layout performs poorly when there are less than 20 lines to operate with in 5 scroll viewports.
-			// The target rect height for the realized + unrealized sized items is at least 5 viewports and 20 lines.
-			const float minimumCacheLength = 4.0f;
-			const float minimumCacheLineCount = 4.0f;
+			MUX_ASSERT(!UsesFastPathLayout());
+			MUX_ASSERT(m_isVirtualizingContext == (scrollViewport != double.PositiveInfinity));
+			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
+			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
+			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
 
-			// Ensure there are 4 buffer viewports before and after the visible viewport.
-			float sizedItemsRectHeight = (minimumCacheLength + 1.0f) * (float)context.VisibleRect.Height;
+			adjustedBeginSizedItemIndex = -1;
+			adjustedEndSizedItemIndex = -1;
 
-			// Ensure there are 20 lines in the resulting 5 viewports.
-			return Math.Max(sizedItemsRectHeight, (minimumCacheLength + 1.0f) * minimumCacheLineCount * (float)(actualLineHeight + lineSpacing));
-		}
-
-		private bool UpdateActualLineHeight(
-			VirtualizingLayoutContext context,
-			Size availableSize)
-		{
-			double lineHeight = LineHeight;
-			double oldActualLineHeight = ActualLineHeight;
-			double newActualLineHeight = 0.0;
-
-			if (double.IsNaN(lineHeight))
+			if (!m_isVirtualizingContext)
 			{
-				if (context.ItemCount > 0)
-				{
-					UIElement? element = null;
-					Size desiredSize = new Size(-1.0, -1.0);
+				// Layout operating in non-virtualizing mode. All lines and items are frozen.
+				MUX_ASSERT(m_firstSizedLineIndex == 0);
+				MUX_ASSERT(m_itemCount > 0);
 
-					// Element for first data item determines ActualLineHeight value.
-					if (oldActualLineHeight != 0.0 &&
-						m_elementManager.IsDataIndexRealized(0) &&
-						(element = m_elementManager.GetRealizedElement(0)) != null)
-					{
-						// Check if the realized element at index 0 has a recorded desired or available size
-						// to restore after measurement with the provided 'availableSize'.
-						desiredSize = GetDesiredSizeForAvailableSize(0, element, availableSize, oldActualLineHeight);
-
-						if (desiredSize.Height != -1.0)
-						{
-							newActualLineHeight = desiredSize.Height;
-						}
-						// Else use context.GetOrCreateElementAt instead.
-					}
-
-					if (desiredSize.Height == -1.0)
-					{
-						// The element for the first item is not realized or has no recorded measurement size, so generate a new element and let it be recycled.
-						// Since LineHeight is NaN, this element is not meant to have a height based on content asynchronously loaded.
-						// That would lead to a temporary incorrect ActualLineHeight and potentially numerous item realizations.
-						if ((element = context.GetOrCreateElementAt(0 /*dataIndex*/, ElementRealizationOptions.ForceCreate)) != null)
-						{
-							element.Measure(availableSize);
-							newActualLineHeight = element.DesiredSize.Height;
-							//TODO: Bug 41896454.
-							//      Why is this RecycleElement call triggering endless measure passes?
-							//      This element needs to be discarded or else bring-into-view operations to index 0 will be animated (because index 0 is considered realized).
-							//context.RecycleElement(element);
-						}
-					}
-				}
-			}
-			else
-			{
-				newActualLineHeight = lineHeight;
+				m_firstFrozenLineIndex = 0;
+				m_lastFrozenLineIndex = m_lastSizedLineIndex;
+				m_firstFrozenItemIndex = 0;
+				m_lastFrozenItemIndex = m_itemCount - 1;
+				return false;
 			}
 
-			if (oldActualLineHeight != newActualLineHeight)
-			{
-				ActualLineHeight = newActualLineHeight;
+			GetFirstAndLastDisplayedLineIndexes(
+				scrollViewport,
+				scrollOffset,
+				0 /*padding*/,
+				lineSpacing,
+				actualLineHeight,
+				lineCount,
+				false /*forFullyDisplayedLines*/,
+				out int firstDisplayedLineIndex,
+				out int lastDisplayedLineIndex);
 
+			if (firstDisplayedLineIndex == -1)
+			{
+				// This situation occurs when actualLineHeight + lineSpacing or context.VisibleRect().Height is 0.
+				m_firstFrozenLineIndex = -1;
+				m_lastFrozenLineIndex = -1;
+				m_firstFrozenItemIndex = -1;
+				m_lastFrozenItemIndex = -1;
+				return false;
+			}
+
+			MUX_ASSERT(lastDisplayedLineIndex != -1);
+			MUX_ASSERT(firstDisplayedLineIndex >= m_firstSizedLineIndex);
+			MUX_ASSERT(lastDisplayedLineIndex <= m_lastSizedLineIndex);
+
+			int linesPerScrollViewport = (int)(scrollViewport / (actualLineHeight + lineSpacing));
+
+			// Frozen lines before the first displayed line use 80% of a scroll viewport or 40% of the sized area whichever is largest.
+			int nearFrozenLinesCount = Math.Min((int)(c_frozenLinesRatio * linesPerScrollViewport) + 1, firstDisplayedLineIndex - m_firstSizedLineIndex);
+			nearFrozenLinesCount = Math.Max(nearFrozenLinesCount, (int)(c_frozenLinesRatio / 2.0 * ((double)firstDisplayedLineIndex - m_firstSizedLineIndex)));
+
+			// Frozen lines after the last displayed line use 80% of a scroll viewport or 40% of the sized area whichever is largest.
+			int farFrozenLinesCount = Math.Min((int)(c_frozenLinesRatio * linesPerScrollViewport) + 1, m_lastSizedLineIndex - lastDisplayedLineIndex);
+			farFrozenLinesCount = Math.Max(farFrozenLinesCount, (int)(c_frozenLinesRatio / 2.0 * ((double)m_lastSizedLineIndex - lastDisplayedLineIndex)));
+
+			m_firstFrozenLineIndex = firstDisplayedLineIndex - nearFrozenLinesCount;
+			m_lastFrozenLineIndex = lastDisplayedLineIndex + farFrozenLinesCount;
+
+			MUX_ASSERT(m_firstFrozenLineIndex >= m_firstSizedLineIndex);
+			MUX_ASSERT(m_lastFrozenLineIndex <= m_lastSizedLineIndex);
+
+			// #ifdef DBG
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_firstFrozenLineIndex", m_firstFrozenLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_lastFrozenLineIndex", m_lastFrozenLineIndex);
+			//
+			// // Check if the previously first displayed & arranged line is still frozen
+			// if (m_previousFirstDisplayedArrangedLineIndexDbg != -1 && (m_previousFirstDisplayedArrangedLineIndexDbg < m_firstFrozenLineIndex || m_previousFirstDisplayedArrangedLineIndexDbg > m_lastFrozenLineIndex))
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_previousFirstDisplayedArrangedLineIndexDbg", m_previousFirstDisplayedArrangedLineIndexDbg);
+			// }
+			//
+			// // Check if the previously last displayed & arranged line is still frozen
+			// if (m_previousLastDisplayedArrangedLineIndexDbg != -1 && (m_previousLastDisplayedArrangedLineIndexDbg < m_firstFrozenLineIndex || m_previousLastDisplayedArrangedLineIndexDbg > m_lastFrozenLineIndex))
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_previousLastDisplayedArrangedLineIndexDbg", m_previousLastDisplayedArrangedLineIndexDbg);
+			// }
+			// #endif
+
+			int nearUnfrozenLinesCount = m_firstFrozenLineIndex - beginSizedLineIndex;
+			int farUnfrozenLinesCount = endSizedLineIndex - m_lastFrozenLineIndex;
+
+			if (nearUnfrozenLinesCount < 0 || farUnfrozenLinesCount < 0)
+			{
+				// nearUnfrozenLinesCount < 0 occurs when the scrolling offset has decreased too fast and the first frozen line has caught up and crossed the previous first sized line.
+				// farUnfrozenLinesCount < 0 occurs when the scrolling offset has increased too fast and the last frozen line has caught up and crossed the previous last sized line.
+				// These conditions can also occur when performing a large programmatic offset jump via ScrollView.ScrollTo/ScrollBy. Trigger a full re-layout.
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"nearUnfrozenLinesCount", nearUnfrozenLinesCount);
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"farUnfrozenLinesCount", farUnfrozenLinesCount);
 				return true;
 			}
 
+			int firstFrozenItemIndex = beginSizedItemIndex;
+			int lastFrozenItemIndex = endSizedItemIndex;
+
+			adjustedBeginSizedItemIndex = beginSizedItemIndex;
+			adjustedEndSizedItemIndex = endSizedItemIndex;
+
+			if (m_firstSizedLineIndex < beginSizedLineIndex)
+			{
+				MUX_ASSERT(beginSizedItemIndex > 0);
+				MUX_ASSERT(m_firstSizedItemIndex <= beginSizedItemIndex);
+
+				if (nearUnfrozenLinesCount > 0)
+				{
+					MUX_ASSERT(beginSizedLineIndex - m_firstSizedLineIndex + nearUnfrozenLinesCount <= m_lineItemCounts.Count);
+
+					for (int frozenLineVectorIndex = beginSizedLineIndex - m_firstSizedLineIndex;
+						frozenLineVectorIndex < beginSizedLineIndex - m_firstSizedLineIndex + nearUnfrozenLinesCount;
+						frozenLineVectorIndex++)
+					{
+						MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
+
+						adjustedBeginSizedItemIndex += m_lineItemCounts[frozenLineVectorIndex];
+						m_lineItemCounts[frozenLineVectorIndex] = 0;
+					}
+
+					firstFrozenItemIndex = adjustedBeginSizedItemIndex;
+				}
+			}
+			else if (nearUnfrozenLinesCount > 0)
+			{
+				MUX_ASSERT(m_firstSizedLineIndex == beginSizedLineIndex);
+				MUX_ASSERT(nearUnfrozenLinesCount <= m_lineItemCounts.Count);
+
+				for (int frozenLineVectorIndex = 0; frozenLineVectorIndex < nearUnfrozenLinesCount; frozenLineVectorIndex++)
+				{
+					MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
+
+					firstFrozenItemIndex += m_lineItemCounts[frozenLineVectorIndex];
+				}
+			}
+
+			if (endSizedLineIndex < m_lastSizedLineIndex)
+			{
+				if (farUnfrozenLinesCount > 0)
+				{
+					for (int frozenLineVectorIndex = m_lineItemCounts.Count - farUnfrozenLinesCount - m_lastSizedLineIndex + endSizedLineIndex;
+						frozenLineVectorIndex < m_lineItemCounts.Count - m_lastSizedLineIndex + endSizedLineIndex;
+						frozenLineVectorIndex++)
+					{
+						MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
+
+						adjustedEndSizedItemIndex -= m_lineItemCounts[frozenLineVectorIndex];
+						m_lineItemCounts[frozenLineVectorIndex] = 0;
+					}
+
+					lastFrozenItemIndex = adjustedEndSizedItemIndex;
+				}
+			}
+			else if (farUnfrozenLinesCount > 0)
+			{
+				MUX_ASSERT(endSizedLineIndex == m_lastSizedLineIndex);
+				MUX_ASSERT(farUnfrozenLinesCount <= m_lineItemCounts.Count);
+
+				for (int frozenLineVectorIndex = m_lineItemCounts.Count - farUnfrozenLinesCount;
+					frozenLineVectorIndex < m_lineItemCounts.Count;
+					frozenLineVectorIndex++)
+				{
+					MUX_ASSERT(m_lineItemCounts[frozenLineVectorIndex] > 0);
+
+					lastFrozenItemIndex -= m_lineItemCounts[frozenLineVectorIndex];
+				}
+			}
+
+			m_firstFrozenItemIndex = firstFrozenItemIndex;
+			m_lastFrozenItemIndex = lastFrozenItemIndex;
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_firstFrozenItemIndex", firstFrozenItemIndex);
+
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_lastFrozenItemIndex", lastFrozenItemIndex);
 			return false;
 		}
 
-		// Updates the m_aspectRatios storage based on the items info collected from the ItemsInfoRequested event handler.
-		// The aspect ratios put in the storage immediately get the maximum weight c_maxAspectRatioWeight as the application-provided
-		// information is fully trusted.
-		// The application may not provide accurate aspect ratios though. It may temporarily provide placeholder ratios until the
-		// accurate values are evaluated, at which point it calls LinedFlowLayout.InvalidateItemsInfo. m_aspectRatios then gets updated
-		// with new aspect ratios with the maximum weight c_maxAspectRatioWeight again.
-		// The application may also provide aspect ratios <= 0 instead of valid placeholder values. Those temporary values, unlike
-		// the positive placeholder values, are not stored in m_aspectRatios. The average aspect ratio is a replacement for negative values.
-		private void UpdateAspectRatiosWithItemsInfo()
+		// Computes an drawback for the provided ItemsLayout. That drawback is stored in ItemsLayout.m_drawback, the smaller the better.
+		// The drawback is the sum of distances between the available width and the line widths.
+		private void ComputeItemsLayoutDrawback(
+			double availableWidth,
+			bool isLastSizedLineStretchEnabled,
+			ItemsLayout itemsLayout)
 		{
-			LinedFlowLayoutItemAspectRatios aspectRatios = m_aspectRatios!;
+			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
+			int lineVectorCount = isLastSizedLineStretchEnabled ? sizedLineCount : sizedLineCount - 1;
 
-			int itemsInfoCount = m_itemsInfoDesiredAspectRatiosForRegularPath.Count;
-			double actualLineHeight = ActualLineHeight;
-
-			for (int index = 0; index < itemsInfoCount; index++)
+			if (lineVectorCount == 0)
 			{
-				double desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForRegularPath[index];
+				itemsLayout.m_drawback = 0;
+				return;
+			}
 
-				if (desiredAspectRatio <= 0.0)
+			const double c_lineTooSmallExponent = 2.0;
+			// Be careful when using Math.Pow(..., 3) as a negative input results in a negative output.
+			// For the moment, c_lineTooLargeExponent is only applied to positive numbers, so its use is safe.
+			const double c_lineTooLargeExponent = 3.0;
+			double drawback = 0.0;
+
+			for (int lineVectorIndex = 0; lineVectorIndex < lineVectorCount; lineVectorIndex++)
+			{
+				double lineWidthDelta = itemsLayout.m_lineItemWidths[lineVectorIndex] - availableWidth;
+
+				if (lineWidthDelta != 0.0)
 				{
-					continue;
+					// To minimize the occurrences of lines that exceed the available width, they are graded worse than lines that have room to spare.
+					drawback += Math.Pow(lineWidthDelta, lineWidthDelta > 0.0 ? c_lineTooLargeExponent : c_lineTooSmallExponent);
+				}
+			}
+
+			// The last line does not participate in the grading if it's smaller than the available width, whether ItemsStretch is Fill or not.
+			if (!isLastSizedLineStretchEnabled)
+			{
+				double lineWidthDelta = itemsLayout.m_lineItemWidths[sizedLineCount - 1] - availableWidth;
+
+				if (lineWidthDelta > 0.0)
+				{
+					// The last line exceeds the available width, grade it as such.
+					drawback += Math.Pow(lineWidthDelta, c_lineTooLargeExponent);
+				}
+			}
+
+			itemsLayout.m_drawback = drawback;
+		}
+
+		// Computes the final item widths based on the best ItemsLayout, available width and stretching mode.
+		// Items are potentially shrunk to accommodate a smaller available line width, or stretched to accommodate a larger available line width.
+		private void ComputeItemsLayoutWithLockedItems(
+			ItemsLayout itemsLayout,
+			double availableWidth,
+			double minItemSpacing,
+			double actualLineHeight,
+			double averageAspectRatio,
+			int beginSizedLineIndex,
+			int endSizedLineIndex,
+			int beginSizedItemIndex,
+			int endSizedItemIndex,
+			int beginLineVectorIndex,
+			bool isLastSizedLineStretchEnabled)
+		{
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginSizedLineIndex", beginSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endSizedLineIndex", endSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginSizedItemIndex", beginSizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endSizedItemIndex", endSizedItemIndex);
+			MUX_ASSERT(!UsesFastPathLayout());
+			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
+			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
+			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
+
+			bool forward = beginSizedItemIndex <= endSizedItemIndex;
+			int sizedLineCount = itemsLayout.m_lineItemCounts.Count;
+
+#if DEBUG
+			MUX_ASSERT(sizedLineCount == (forward ? endSizedLineIndex - beginSizedLineIndex + 1 : beginSizedLineIndex - endSizedLineIndex + 1));
+
+			int sizedLineCountDbg = forward ? endSizedItemIndex - beginSizedItemIndex + 1 : beginSizedItemIndex - endSizedItemIndex + 1;
+
+			MUX_ASSERT(sizedLineCountDbg >= sizedLineCount);
+#endif
+
+			int lineVectorIndex;
+
+			for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+			{
+				MUX_ASSERT(itemsLayout.m_lineItemCounts[lineVectorIndex] > 0);
+
+				m_lineItemCounts[beginLineVectorIndex + lineVectorIndex] = itemsLayout.m_lineItemCounts[lineVectorIndex];
+			}
+
+			bool itemsAreStretched = ItemsStretch == LinedFlowLayoutItemsStretch.Fill;
+			int sizedItemIndex = beginSizedItemIndex;
+
+			for (lineVectorIndex = forward ? 0 : sizedLineCount - 1; ; lineVectorIndex = forward ? lineVectorIndex + 1 : lineVectorIndex - 1)
+			{
+				int lineItemsCount = itemsLayout.m_lineItemCounts[lineVectorIndex];
+				double lineItemsWidth = itemsLayout.m_lineItemWidths[lineVectorIndex];
+				double minItemSpacings = lineItemsCount > 1 ? (lineItemsCount - 1) * minItemSpacing : 0.0;
+				double scaleFactor = 1.0;
+
+				if (lineItemsWidth - minItemSpacings > 0.0)
+				{
+					if (lineItemsWidth > availableWidth)
+					{
+						scaleFactor = ComputeLineShrinkFactor(
+							forward,
+							sizedItemIndex,
+							lineItemsCount,
+							lineItemsWidth,
+							availableWidth,
+							minItemSpacings,
+							actualLineHeight,
+							averageAspectRatio);
+						MUX_ASSERT(scaleFactor >= 0.0);
+						MUX_ASSERT(scaleFactor < 1.0);
+					}
+					else if ((!forward || lineVectorIndex < (isLastSizedLineStretchEnabled ? sizedLineCount : sizedLineCount - 1)) &&
+						lineItemsWidth < availableWidth &&
+						itemsAreStretched)
+					{
+						scaleFactor = ComputeLineExpandFactor(
+							forward,
+							sizedItemIndex,
+							lineItemsCount,
+							lineItemsWidth,
+							availableWidth,
+							minItemSpacings,
+							actualLineHeight,
+							averageAspectRatio);
+						MUX_ASSERT(scaleFactor > 1.0);
+					}
 				}
 
-				double minWidth = GetMinWidthFromItemsInfo(m_itemsInfoFirstIndex + index);
-				double maxWidth = GetMaxWidthFromItemsInfo(m_itemsInfoFirstIndex + index);
-
-				if (minWidth > 0.0 || maxWidth >= 0.0)
+				if (scaleFactor != 1.0)
 				{
-					double desiredWidth = desiredAspectRatio * actualLineHeight;
-
-					if (minWidth > 0.0 && minWidth > desiredWidth)
+					for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
 					{
-						desiredWidth = minWidth;
+						MUX_ASSERT((forward && sizedItemIndex <= endSizedItemIndex) || (!forward && sizedItemIndex >= endSizedItemIndex));
+
+						double minWidth = 0.0;
+
+						if (m_itemsInfoFirstIndex == -1)
+						{
+							MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndex));
+
+							if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
+							{
+								if (scaleFactor < 1.0)
+								{
+									if (element is FrameworkElement frameworkElement)
+									{
+										minWidth = frameworkElement.MinWidth;
+									}
+								}
+
+								var elementAvailableSize = new Size(
+									Math.Max((float)minWidth, (float)(element.DesiredSize.Width * scaleFactor)),
+									(float)actualLineHeight);
+
+								element.Measure(elementAvailableSize);
+
+								float itemWidth = (float)element.DesiredSize.Width;
+
+								elementAvailableSize.Width = itemWidth;
+
+								MUX_ASSERT(m_elementAvailableWidths != null);
+
+								// WinUI's find-then-insert/emplace keeps the value already stored for an existing
+								// key (std::map::emplace does not overwrite), i.e. TryAdd semantics.
+								m_elementAvailableWidths!.TryAdd(element, itemWidth);
+								// #ifdef DBG
+								// if (sizedItemIndex == LogItemIndexDbg())
+								// {
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"measured with elementAvailableSize (1)",
+								//         elementAvailableSize.Width,
+								//         elementAvailableSize.Height);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"element.DesiredSize",
+								//         element.DesiredSize().Width,
+								//         element.DesiredSize().Height);
+								// }
+								// #endif
+							}
+						}
+						else
+						{
+							MUX_ASSERT(sizedItemIndex - m_itemsInfoFirstIndex < m_itemsInfoArrangeWidths.Count);
+
+							float arrangeWidth = GetArrangeWidthFromItemsInfo(sizedItemIndex, actualLineHeight, averageAspectRatio, scaleFactor);
+
+							SetArrangeWidthFromItemsInfo(sizedItemIndex, arrangeWidth);
+
+							if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
+							{
+								if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
+								{
+									var elementAvailableSize = new Size(
+										arrangeWidth,
+										(float)actualLineHeight);
+
+									element.Measure(elementAvailableSize);
+									// #ifdef DBG
+									// if (sizedItemIndex == LogItemIndexDbg())
+									// {
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"measured with elementAvailableSize (2)",
+									//         elementAvailableSize.Width,
+									//         elementAvailableSize.Height);
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"element.DesiredSize",
+									//         element.DesiredSize().Width,
+									//         element.DesiredSize().Height);
+									// }
+									// #endif
+								}
+							}
+						}
+
+						sizedItemIndex = forward ? sizedItemIndex + 1 : sizedItemIndex - 1;
 					}
-
-					if (maxWidth >= 0.0 && maxWidth < desiredWidth)
-					{
-						desiredWidth = maxWidth;
-					}
-
-					desiredAspectRatio = desiredWidth / actualLineHeight;
-				}
-
-				LinedFlowLayoutItemAspectRatios.ItemAspectRatio itemAspectRatio = aspectRatios.GetAt(m_itemsInfoFirstIndex + index);
-				float aspectRatio = (float)desiredAspectRatio;
-				float newAspectRatio = itemAspectRatio.AspectRatio;
-				int newWeight = itemAspectRatio.Weight;
-				bool updateItemAspectRatio = false;
-
-				if (newWeight == 0)
-				{
-					newAspectRatio = aspectRatio;
-					newWeight = c_maxAspectRatioWeight;
-					updateItemAspectRatio = true;
 				}
 				else
 				{
-					MUX_ASSERT(itemAspectRatio.AspectRatio >= 0.0f);
-					MUX_ASSERT(itemAspectRatio.Weight >= 1);
-					MUX_ASSERT(itemAspectRatio.Weight <= c_maxAspectRatioWeight);
-
-					if (newWeight != c_maxAspectRatioWeight)
+					// Measuring items even when no scale factor is applied so that they fill their available width (otherwise background-colored bands appear on the items' left/right edges).
+					for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
 					{
-						newWeight = c_maxAspectRatioWeight;
-						updateItemAspectRatio = true;
+						MUX_ASSERT((forward && sizedItemIndex <= endSizedItemIndex) || (!forward && sizedItemIndex >= endSizedItemIndex));
+						MUX_ASSERT(m_itemsInfoFirstIndex == -1 || sizedItemIndex - m_itemsInfoFirstIndex < m_itemsInfoArrangeWidths.Count);
+
+						float arrangeWidth = 0.0f;
+
+						if (m_itemsInfoFirstIndex != -1)
+						{
+							// Case where LinedFlowLayout.ItemsInfoRequested returned partial sizing information.
+							// Retrieve the item's arrange width computed from the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath,
+							// m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
+							arrangeWidth = GetArrangeWidthFromItemsInfo(sizedItemIndex, actualLineHeight, averageAspectRatio);
+
+							// Store that arrange width in the m_itemsInfoArrangeWidths vector.
+							SetArrangeWidthFromItemsInfo(sizedItemIndex, arrangeWidth);
+						}
+
+						if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
+						{
+							if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
+							{
+								if (m_itemsInfoFirstIndex == -1)
+								{
+									// Case where LinedFlowLayout.ItemsInfoRequested returned no sizing information.
+									// Retrieve the item's arrange width as its desired width.
+									arrangeWidth = (float)element.DesiredSize.Width;
+								}
+
+								var elementAvailableSize = new Size(
+									arrangeWidth,
+									(float)actualLineHeight);
+
+								element.Measure(elementAvailableSize);
+								// #ifdef DBG
+								// if (sizedItemIndex == LogItemIndexDbg())
+								// {
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"measured with elementAvailableSize (3)",
+								//         elementAvailableSize.Width,
+								//         elementAvailableSize.Height);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"element.DesiredSize",
+								//         element.DesiredSize().Width,
+								//         element.DesiredSize().Height);
+								// }
+								// #endif
+							}
+						}
+
+						sizedItemIndex = forward ? sizedItemIndex + 1 : sizedItemIndex - 1;
 					}
 
-					// Ignore aspect ratio deltas coming from pixel snapping rounding. The aspect ratios coming from UIElement.Measure are preserved.
-					if (Math.Abs(itemAspectRatio.AspectRatio - aspectRatio) > 0.5 / (m_roundingScaleFactor * actualLineHeight))
-					{
-						newAspectRatio = aspectRatio;
-						updateItemAspectRatio = true;
-					}
+					// Making sure the items fill the line when ItemsStretch is Fill.
+					MUX_ASSERT(!(itemsAreStretched && availableWidth - lineItemsWidth > lineItemsCount && lineItemsWidth > minItemSpacings && lineVectorIndex != sizedLineCount - 1));
 				}
 
-				if (updateItemAspectRatio)
+				if (forward && lineVectorIndex == sizedLineCount - 1)
 				{
-					aspectRatios.SetAt(m_itemsInfoFirstIndex + index, new LinedFlowLayoutItemAspectRatios.ItemAspectRatio(newAspectRatio, newWeight));
+					break;
+				}
+				if (!forward && lineVectorIndex == 0)
+				{
+					break;
 				}
 			}
 		}
 
+		// Computes the best layout by assigning items to lines - for the fast path.
+		// This method populates the m_itemsInfoArrangeWidths and m_lineItemCounts vectors successively, using the
+		// m_itemsInfoDesiredAspectRatiosForFastPath, m_itemsInfoMinWidthsForFastPath, m_itemsInfoMaxWidthsForFastPath,
+		// m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
+		// Returns the largest line width among all the lines.
+		private float ComputeItemsLayoutFastPath(
+			float availableWidth,
+			double actualLineHeight)
+		{
+			MUX_ASSERT(m_itemCount > 0);
+
+			EnsureItemsInfoArrangeWidths(m_itemCount);
+
+			MUX_ASSERT(UsesFastPathLayout());
+
+			// The existing average aspect ratio is used as a fallback aspect ratio for items
+			// given an aspect ratio <= 0 by the ItemsInfoRequested handler.
+			double averageAspectRatio = GetAverageAspectRatio(availableWidth, actualLineHeight);
+
+			for (int itemIndex = 0; itemIndex < m_itemCount; itemIndex++)
+			{
+				float arrangeWidth = GetArrangeWidthFromItemsInfo(itemIndex, actualLineHeight, averageAspectRatio);
+
+				SetArrangeWidthFromItemsInfo(itemIndex, arrangeWidth);
+			}
+
+			// Final line count is originally unknown. m_lineItemCounts is originally allocated to accommodate 5 items per line.
+			// The vector is progressively grown as needed when that assumption is too optimistic.
+			const int c_itemsPerLineAllocation = 5;
+			// The vector capacity is increased by 25% each time its size becomes too small.
+			const double c_lineCountGrowthFactor = 1.25;
+			int allocatedLineCount = m_itemCount / c_itemsPerLineAllocation + 1;
+
+			EnsureLineItemCounts(allocatedLineCount);
+
+			float minItemSpacing = (float)MinItemSpacing;
+			bool itemsAreStretched = ItemsStretch == LinedFlowLayoutItemsStretch.Fill;
+			int lineIndex = -1;
+			int lineItemCount = 0;
+			float lineWidth = 0.0f;
+			float maxLineWidth = 0.0f;
+
+			for (int itemIndex = 0; itemIndex < m_itemCount; itemIndex++)
+			{
+				float arrangeWidth = m_itemsInfoArrangeWidths[itemIndex];
+				double scaleFactor = 1.0;
+
+				if (lineWidth == 0.0f || lineWidth + minItemSpacing + arrangeWidth > availableWidth)
+				{
+					bool cumulate = lineWidth != 0.0f;
+
+					if (cumulate)
+					{
+						// Additional item goes beyond the available width.
+						MUX_ASSERT(lineWidth > 0.0);
+						MUX_ASSERT(lineWidth + minItemSpacing + arrangeWidth > availableWidth);
+						MUX_ASSERT(lineItemCount > 0);
+
+						// Determine whether it is better to create a new line or not.
+						double shrinkScaleFactor = ComputeLineShrinkFactor(
+							true /*forward*/,
+							itemIndex - lineItemCount /*sizedItemIndex*/,
+							lineItemCount + 1,
+							(double)lineWidth + minItemSpacing + arrangeWidth /*lineItemsWidth*/,
+							availableWidth,
+							(double)lineItemCount * minItemSpacing /*minItemSpacings*/,
+							actualLineHeight,
+							averageAspectRatio);
+
+						MUX_ASSERT(shrinkScaleFactor >= 0.0);
+						MUX_ASSERT(shrinkScaleFactor < 1.0);
+
+						double expandScaleFactor = ComputeLineExpandFactor(
+							true /*forward*/,
+							itemIndex - lineItemCount /*sizedItemIndex*/,
+							lineItemCount,
+							lineWidth /*lineItemsWidth*/,
+							availableWidth,
+							((double)lineItemCount - 1) * minItemSpacing /*minItemSpacings*/,
+							actualLineHeight,
+							averageAspectRatio);
+
+						MUX_ASSERT(expandScaleFactor > 1.0);
+
+						if (expandScaleFactor - 1.0 < 1.0 - shrinkScaleFactor || shrinkScaleFactor == 0.0)
+						{
+							// Creating a new line and leaving a gap in the current one requires a smaller
+							// expansion than the shrinkage required to add this item.
+							// Or the items' min widths prevent the shrinkage required to fit them in the line.
+							cumulate = false;
+
+							if (itemsAreStretched)
+							{
+								// Only expand the items when ItemsStretch is LinedFlowLayoutItemsStretch::Fill.
+								scaleFactor = expandScaleFactor;
+							}
+						}
+						else
+						{
+							// The line items need to shrink less to accommodate this additional item than expand to fill the gap,
+							// let it belong to the current line (cumulate == true).
+							scaleFactor = shrinkScaleFactor;
+						}
+					}
+
+					if (cumulate)
+					{
+						lineWidth += minItemSpacing + arrangeWidth;
+						lineItemCount++;
+					}
+					else
+					{
+						if (lineIndex >= 0 && m_lineItemCounts[lineIndex] == 0)
+						{
+							MUX_ASSERT(lineIndex < allocatedLineCount);
+							MUX_ASSERT(lineItemCount > 0);
+							MUX_ASSERT(lineWidth > 0);
+
+							m_lineItemCounts[lineIndex] = lineItemCount;
+
+							if (lineIndex + 1 == allocatedLineCount)
+							{
+								allocatedLineCount = Math.Max(allocatedLineCount + 1, (int)(c_lineCountGrowthFactor * allocatedLineCount));
+								ResizeList(m_lineItemCounts, allocatedLineCount, 0);
+							}
+
+							if (scaleFactor == 1.0)
+							{
+								maxLineWidth = Math.Max(lineWidth, maxLineWidth);
+							}
+							else
+							{
+								// Apply shrinking or expanding scale factor to line's m_itemsInfoArrangeWidths.
+								float totalArrangeWidth = SetItemRangeArrangeWidth(
+									itemIndex - lineItemCount /*beginItemIndex*/,
+									itemIndex - 1 /*endItemIndex*/,
+									actualLineHeight,
+									averageAspectRatio,
+									scaleFactor);
+
+								maxLineWidth = Math.Max(totalArrangeWidth + (lineItemCount - 1) * minItemSpacing, maxLineWidth);
+							}
+						}
+
+						lineWidth = arrangeWidth;
+						lineItemCount = 1;
+						lineIndex++;
+					}
+				}
+				else
+				{
+					lineWidth += minItemSpacing + arrangeWidth;
+					lineItemCount++;
+				}
+
+				if (lineWidth >= availableWidth)
+				{
+					MUX_ASSERT(lineIndex >= 0);
+					MUX_ASSERT(lineIndex < allocatedLineCount);
+					MUX_ASSERT(lineItemCount > 0);
+					MUX_ASSERT(lineWidth > 0);
+
+					m_lineItemCounts[lineIndex] = lineItemCount;
+
+					if (lineIndex + 1 == allocatedLineCount)
+					{
+						allocatedLineCount = Math.Max(allocatedLineCount + 1, (int)(c_lineCountGrowthFactor * allocatedLineCount));
+						ResizeList(m_lineItemCounts, allocatedLineCount, 0);
+					}
+
+					if (lineItemCount == 1 && lineWidth != availableWidth)
+					{
+						// The single item on the line is bigger than the available width.
+						scaleFactor = ComputeLineShrinkFactor(
+							true /*forward*/,
+							itemIndex /*sizedItemIndex*/,
+							1 /*lineItemCount*/,
+							lineWidth /*lineItemsWidth*/,
+							availableWidth,
+							0.0 /*minItemSpacings*/,
+							actualLineHeight,
+							averageAspectRatio);
+
+						MUX_ASSERT(scaleFactor >= 0.0);
+						MUX_ASSERT(scaleFactor < 1.0);
+					}
+
+					if (scaleFactor != 0.0 && scaleFactor != 1.0)
+					{
+						// Apply shrinking scale factor to line's m_itemsInfoArrangeWidths.
+						float totalArrangeWidth = SetItemRangeArrangeWidth(
+							itemIndex - lineItemCount + 1 /*beginItemIndex*/,
+							itemIndex /*endItemIndex*/,
+							actualLineHeight,
+							averageAspectRatio,
+							scaleFactor);
+
+						maxLineWidth = Math.Max(totalArrangeWidth + (lineItemCount - 1) * minItemSpacing, maxLineWidth);
+					}
+					else
+					{
+						maxLineWidth = Math.Max(lineWidth, maxLineWidth);
+					}
+
+					lineWidth = 0.0f;
+					lineItemCount = 0;
+				}
+			}
+
+			MUX_ASSERT(lineIndex >= 0);
+			MUX_ASSERT(lineIndex < allocatedLineCount);
+
+			if (lineItemCount > 0)
+			{
+				MUX_ASSERT(lineWidth > 0);
+				MUX_ASSERT(availableWidth >= lineWidth);
+
+				maxLineWidth = Math.Max(lineWidth, maxLineWidth);
+				m_lineItemCounts[lineIndex] = lineItemCount;
+			}
+
+#if DEBUG
+			for (int lineIndexTmp = 0; lineIndexTmp <= lineIndex; lineIndexTmp++)
+			{
+				MUX_ASSERT(m_lineItemCounts[lineIndexTmp] > 0);
+			}
+#endif
+
+			ResizeList(m_lineItemCounts, lineIndex + 1, 0);
+
+#if DEBUG
+			for (int lineIndexTmp = 0; lineIndexTmp <= lineIndex; lineIndexTmp++)
+			{
+				MUX_ASSERT(m_lineItemCounts[lineIndexTmp] > 0);
+			}
+#endif
+
+			return maxLineWidth;
+		}
+
+		// Computes the ItemsLayout with the best drawback by assigning items to lines - for the regular path.
+		// This method populates the m_itemsInfoArrangeWidths / m_lineItemCounts vectors and the m_elementAvailableWidths map,
+		// using the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath,
+		// m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
+		// The work is broken down into 6 successive phases:
+		// Phase 1: Compute an initial layout and its drawback using an available width coming from LinedFlowLayout::MeasureOverride.
+		//          This phase provides an average line width ALW for the following phases which successively try to compute layouts with a lower drawback.
+		// Phase 2: Compute another layout and drawback using the resulting average line width ALW from Phase 1 as the available width.
+		// Phase 3: Compute layouts and drawbacks with an available width within 30% of the average line width ALW from Phase 1 using the smallest head and smallest tail items of prior layouts.
+		//          The layout with the lowest drawback is kept - it corresponds to a best available width BAW.
+		// Phase 4: Compute a layout using the average of ALW and BAW for the available width, which may result in an even better drawback.
+		// Phase 5: Keeping the available width from Phase 4, fine tune that layout by moving best equalizing head and best equalizing tail items into their neighboring lines using internal locks.
+		//          Whichever item among the best equalizing head and best equalizing tail is present and provides the largest drawback improvement is moved.
+		// Phase 6: Items are finally measured based on the best outcome of Phase 5.
+		private void ComputeItemsLayoutRegularPath(
+			float availableWidth,
+			double scrollViewport,
+			double lineSpacing,
+			double actualLineHeight,
+			int beginSizedLineIndex,
+			int endSizedLineIndex,
+			int beginSizedItemIndex,
+			int endSizedItemIndex,
+			int beginLineVectorIndex,
+			bool isLastSizedLineStretchEnabled)
+		{
+#if DEBUG
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginSizedLineIndex", beginSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endSizedLineIndex", endSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginSizedItemIndex", beginSizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endSizedItemIndex", endSizedItemIndex);
+			MUX_ASSERT(m_isVirtualizingContext == (scrollViewport != double.PositiveInfinity));
+
+			int sizedItemCountDbg = m_lastSizedItemIndex - m_firstSizedItemIndex + 1;
+			// const int realizedItemCountDbg = m_elementManager.GetRealizedElementCount();
+			// const int unrealizedNearItemCountDbg = m_isVirtualizingContext ? m_elementManager.GetFirstRealizedDataIndex() : 0;
+
+			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
+			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
+			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
+			MUX_ASSERT(beginSizedItemIndex > endSizedItemIndex || beginSizedItemIndex >= m_firstSizedItemIndex);
+			MUX_ASSERT(beginSizedItemIndex > endSizedItemIndex || endSizedItemIndex <= m_firstSizedItemIndex + sizedItemCountDbg - 1);
+			MUX_ASSERT(beginSizedItemIndex <= endSizedItemIndex || endSizedItemIndex >= m_firstSizedItemIndex);
+			MUX_ASSERT(beginSizedItemIndex <= endSizedItemIndex || beginSizedItemIndex <= m_firstSizedItemIndex + sizedItemCountDbg - 1);
+#endif
+			double minItemSpacing = MinItemSpacing;
+			double averageAspectRatio = GetAverageAspectRatio(availableWidth, actualLineHeight);
+			double averageLineItemsWidth = double.MaxValue;
+			List<ItemsLayout> itemsLayouts = new();
+
+			// Internal locks are used to force an item to belong to a particular line.
+			SortedDictionary<int /*itemIndex*/, int /*lineIndex*/> internalLockedItemIndexes = new();
+
+			// Phase 1: evaluate layout for an available width equal to the MeasureOverride's available width.
+			ItemsLayout itemsLayout = GetItemsLayout(
+				internalLockedItemIndexes,
+				scrollViewport,
+				availableWidth,
+				availableWidth /*adjustedAvailableWidth*/,
+				-1.0 /*averageLineItemsWidth*/,
+				averageAspectRatio,
+				lineSpacing,
+				actualLineHeight,
+				beginSizedLineIndex,
+				endSizedLineIndex,
+				beginSizedItemIndex,
+				endSizedItemIndex,
+				beginLineVectorIndex,
+				isLastSizedLineStretchEnabled);
+
+			MUX_ASSERT(itemsLayout.m_availableLineItemsWidth > 0.0);
+			MUX_ASSERT(itemsLayout.m_lineItemCounts.Count > 0);
+			MUX_ASSERT(itemsLayout.m_lineItemWidths.Count > 0);
+
+			itemsLayouts.Add(CloneItemsLayout(itemsLayout));
+
+			// #ifdef DBG
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"End-of-Phase-1 layout for MeasureOverride's availableWidth", availableWidth);
+			// LogItemsLayoutDbg(itemsLayout, 0);
+			// #endif
+
+			SortedSet<double> availableWidthsProcessed = new();
+
+			if (beginSizedLineIndex != endSizedLineIndex)
+			{
+				availableWidthsProcessed.Add(availableWidth);
+
+				// Phase 2: evaluate layout for an available width equal to the resulting average desired line items width of Phase 1.
+				SortedSet<double> availableWidthsToProcess = new();
+
+				double totalLineItemWidths = 0.0;
+
+				foreach (double lineItemWidthsIterator in itemsLayout.m_lineItemWidths)
+				{
+					totalLineItemWidths += lineItemWidthsIterator;
+				}
+
+				averageLineItemsWidth = totalLineItemWidths / itemsLayout.m_lineItemWidths.Count;
+
+				availableWidthsToProcess.Add(averageLineItemsWidth);
+
+				double availableWidthLowerbound = averageLineItemsWidth;
+				double availableWidthUpperbound = averageLineItemsWidth;
+
+				while (availableWidthsToProcess.Count > 0)
+				{
+					// std::set is ordered ascending; *begin() is the smallest element.
+					double adjustedAvailableWidth = availableWidthsToProcess.Min;
+
+					MUX_ASSERT(adjustedAvailableWidth >= 0.0);
+
+					itemsLayout = GetItemsLayout(
+						internalLockedItemIndexes,
+						scrollViewport,
+						availableWidth,
+						adjustedAvailableWidth,
+						averageLineItemsWidth,
+						averageAspectRatio,
+						lineSpacing,
+						actualLineHeight,
+						beginSizedLineIndex,
+						endSizedLineIndex,
+						beginSizedItemIndex,
+						endSizedItemIndex,
+						beginLineVectorIndex,
+						isLastSizedLineStretchEnabled);
+					// #ifdef DBG
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"Phases-2&3 layout for adjustedAvailableWidth", adjustedAvailableWidth);
+					// LogItemsLayoutDbg(itemsLayout, averageLineItemsWidth);
+					// #endif
+
+					itemsLayouts.Add(CloneItemsLayout(itemsLayout));
+					availableWidthsProcessed.Add(adjustedAvailableWidth);
+
+					// Phase 3: evaluate layouts with an available width within 30% of the average desired line items width using the smallest head and smallest tail items of prior layouts.
+					// Any layouts with an available width further away is not likely to produce the best layout. Pick the layout with the lowest drawback.
+					const double availableWidthClampingPercent = 0.3;
+					bool isExpansionWorthy = IsItemsLayoutExpansionWorthy(itemsLayout);
+					bool isContractionWorthy = IsItemsLayoutContractionWorthy(itemsLayout);
+
+					if (isExpansionWorthy)
+					{
+						MUX_ASSERT(itemsLayout.m_smallestHeadItemWidth > 0);
+
+						double availableWidthToProcess = adjustedAvailableWidth + minItemSpacing + itemsLayout.m_smallestHeadItemWidth;
+
+						if (Math.Abs(availableWidthToProcess - averageLineItemsWidth) < availableWidthClampingPercent * averageLineItemsWidth &&
+							availableWidthToProcess > availableWidthUpperbound &&
+							availableWidthToProcess != availableWidth &&
+							!availableWidthsProcessed.Contains(availableWidthToProcess) &&
+							!availableWidthsToProcess.Contains(availableWidthToProcess))
+						{
+							availableWidthUpperbound = availableWidthToProcess;
+							availableWidthsToProcess.Add(availableWidthToProcess);
+						}
+					}
+
+					if (isContractionWorthy)
+					{
+						MUX_ASSERT(itemsLayout.m_smallestTailItemWidth > 0);
+
+						double availableWidthToProcess = adjustedAvailableWidth - minItemSpacing - itemsLayout.m_smallestTailItemWidth;
+
+						if (availableWidthToProcess > 0.0 &&
+							Math.Abs(availableWidthToProcess - averageLineItemsWidth) < availableWidthClampingPercent * averageLineItemsWidth &&
+							availableWidthToProcess < availableWidthLowerbound &&
+							availableWidthToProcess != availableWidth &&
+							!availableWidthsProcessed.Contains(availableWidthToProcess) &&
+							!availableWidthsToProcess.Contains(availableWidthToProcess))
+						{
+							availableWidthLowerbound = availableWidthToProcess;
+							availableWidthsToProcess.Add(availableWidthToProcess);
+						}
+					}
+
+					availableWidthsToProcess.Remove(adjustedAvailableWidth);
+				}
+			}
+
+			ItemsLayout bestItemsLayout = CloneItemsLayout(itemsLayouts[0]);
+
+			if (itemsLayouts.Count > 1)
+			{
+				// Figure out the layout with the lowest drawback so far.
+				double bestDrawback = double.MaxValue;
+
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemsLayouts.size", itemsLayouts.size());
+				// Find the layout with the smallest drawback so far.
+				foreach (ItemsLayout itemsLayoutIterator in itemsLayouts)
+				{
+					ItemsLayout itemsLayoutTmp = itemsLayoutIterator;
+
+					if (itemsLayoutTmp.m_drawback < bestDrawback)
+					{
+						bestDrawback = itemsLayoutTmp.m_drawback;
+						bestItemsLayout = CloneItemsLayout(itemsLayoutTmp);
+					}
+				}
+
+#if DEBUG
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"End-of-Phase-4 best layout");
+				// LogItemsLayoutDbg(bestItemsLayout, averageLineItemsWidth);
+				MUX_ASSERT(beginSizedLineIndex != endSizedLineIndex);
+#endif
+				// Phase 4: try a layout with adjustedAvailableWidth = (bestItemsLayout.m_availableLineItemsWidth + averageLineItemsWidth) / 2.0,
+				// i.e. the average of the best available width so far and the average line width, as it sometimes results in a lower drawback.
+				// A layout for averageLineItemsWidth was performed in Phase 2, a layout for bestItemsLayout.m_availableLineItemsWidth was performed
+				// in Phase 3 - the optimum available width is likely to be in the neighborhood of those two numbers and trying a layout with their
+				// average has proven worthy through experimentations.
+				double adjustedAvailableWidth = (bestItemsLayout.m_availableLineItemsWidth + averageLineItemsWidth) / 2.0;
+
+				// Make sure adjustedAvailableWidth has not been processed already in Phase 3.
+				if (!availableWidthsProcessed.Contains(adjustedAvailableWidth))
+				{
+					itemsLayout = GetItemsLayout(
+						internalLockedItemIndexes,
+						scrollViewport,
+						availableWidth,
+						adjustedAvailableWidth,
+						averageLineItemsWidth,
+						averageAspectRatio,
+						lineSpacing,
+						actualLineHeight,
+						beginSizedLineIndex,
+						endSizedLineIndex,
+						beginSizedItemIndex,
+						endSizedItemIndex,
+						beginLineVectorIndex,
+						isLastSizedLineStretchEnabled);
+
+					// #ifdef DBG
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"Phase-5 layout for adjustedAvailableWidth", adjustedAvailableWidth);
+					// LogItemsLayoutDbg(itemsLayout, averageLineItemsWidth);
+					// #endif
+					if (itemsLayout.m_drawback < bestItemsLayout.m_drawback)
+					{
+						bestItemsLayout = CloneItemsLayout(itemsLayout);
+
+						// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"End-of-Phase-5 picking phase 5's layout");
+					}
+				}
+
+				ItemsLayout itemsLayoutToImprove = CloneItemsLayout(bestItemsLayout);
+				// noDrawbackDecreaseCount indicates how many successive attempts at decreasing the drawback have failed.
+				int noDrawbackDecreaseCount = 0;
+				bool forward = beginSizedLineIndex < endSizedLineIndex;
+
+				// Phase 5: keeping the available width from Phase 4, fine tune that layout by moving best equalizing head and best equalizing tail items into their neighboring lines using internal locks.
+				// Whichever item among the best equalizing head and best equalizing tail is present and provides the largest drawback improvement is moved.
+				// The move with the best anticipated outcome is performed until several attempts produce no drawback improvements.
+				// Incrementally improve the drawback by moving the best equalizing head to its previous line, or the best equalizing tail to its next line.
+				do
+				{
+					if (itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement != 0.0 &&
+						(itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement == 0.0 ||
+						 itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement > itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement))
+					{
+						if (IsItemsLayoutEqualizationWorthy(itemsLayoutToImprove, true /*withHeadItem*/))
+						{
+							if (LockItemToLineInternal(
+									internalLockedItemIndexes,
+									beginSizedLineIndex,
+									endSizedLineIndex,
+									beginSizedItemIndex,
+									endSizedItemIndex,
+									forward ? itemsLayoutToImprove.m_bestEqualizingHeadLineIndex - 1 : itemsLayoutToImprove.m_bestEqualizingHeadLineIndex + 1,
+									itemsLayoutToImprove.m_bestEqualizingHeadItemIndex))
+							{
+								itemsLayout = GetItemsLayout(
+									internalLockedItemIndexes,
+									scrollViewport,
+									availableWidth,
+									itemsLayoutToImprove.m_availableLineItemsWidth,
+									averageLineItemsWidth,
+									averageAspectRatio,
+									lineSpacing,
+									actualLineHeight,
+									beginSizedLineIndex,
+									endSizedLineIndex,
+									beginSizedItemIndex,
+									endSizedItemIndex,
+									beginLineVectorIndex,
+									isLastSizedLineStretchEnabled);
+
+								// #ifdef DBG
+								// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_STR, METH_NAME, this, L"Phase-6 layout after equalization attempt with head item", itemsLayout.m_drawback < bestItemsLayout.m_drawback ? L"improvement" : L"no improvement");
+								// LogItemsLayoutDbg(itemsLayout, averageLineItemsWidth);
+								// #endif
+								if (itemsLayout.m_drawback < bestItemsLayout.m_drawback)
+								{
+									bestItemsLayout = CloneItemsLayout(itemsLayout);
+									noDrawbackDecreaseCount = 0;
+								}
+								else
+								{
+									noDrawbackDecreaseCount++;
+								}
+
+								itemsLayoutToImprove = CloneItemsLayout(itemsLayout);
+
+								continue;
+							}
+						}
+					}
+
+					if (itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement != 0.0 &&
+						(itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement == 0.0 ||
+						 itemsLayoutToImprove.m_bestEqualizingTailItemDrawbackImprovement > itemsLayoutToImprove.m_bestEqualizingHeadItemDrawbackImprovement))
+					{
+						if (IsItemsLayoutEqualizationWorthy(itemsLayoutToImprove, false /*withHeadItem*/))
+						{
+							if (LockItemToLineInternal(
+									internalLockedItemIndexes,
+									beginSizedLineIndex,
+									endSizedLineIndex,
+									beginSizedItemIndex,
+									endSizedItemIndex,
+									forward ? itemsLayoutToImprove.m_bestEqualizingTailLineIndex + 1 : itemsLayoutToImprove.m_bestEqualizingTailLineIndex - 1,
+									itemsLayoutToImprove.m_bestEqualizingTailItemIndex))
+							{
+								itemsLayout = GetItemsLayout(
+									internalLockedItemIndexes,
+									scrollViewport,
+									availableWidth,
+									itemsLayoutToImprove.m_availableLineItemsWidth,
+									averageLineItemsWidth,
+									averageAspectRatio,
+									lineSpacing,
+									actualLineHeight,
+									beginSizedLineIndex,
+									endSizedLineIndex,
+									beginSizedItemIndex,
+									endSizedItemIndex,
+									beginLineVectorIndex,
+									isLastSizedLineStretchEnabled);
+
+								// #ifdef DBG
+								// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_STR, METH_NAME, this, L"Phase-6 layout after equalization attempt with tail item", itemsLayout.m_drawback < bestItemsLayout.m_drawback ? L"improvement" : L"no improvement");
+								// LogItemsLayoutDbg(itemsLayout, averageLineItemsWidth);
+								// #endif
+								if (itemsLayout.m_drawback < bestItemsLayout.m_drawback)
+								{
+									bestItemsLayout = CloneItemsLayout(itemsLayout);
+									noDrawbackDecreaseCount = 0;
+								}
+								else
+								{
+									noDrawbackDecreaseCount++;
+								}
+
+								itemsLayoutToImprove = CloneItemsLayout(itemsLayout);
+							}
+							else
+							{
+								break;
+							}
+						}
+						else
+						{
+							break;
+						}
+					}
+					else
+					{
+						break;
+					}
+				}
+				while (noDrawbackDecreaseCount < bestItemsLayout.m_lineItemCounts.Count / 2);
+				// TODO: Task 38031375 - Performance optimizations.
+				// Given a line count, investigate what the typical number of iterations without drawback improvement
+				// leads to no improvements no matter the number of subsequent tries.
+			}
+
+			// #ifdef DBG
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"End-of-Phase-6 best layout");
+			// LogItemsLayoutDbg(bestItemsLayout, averageLineItemsWidth);
+			// #endif
+			// Phase 6: Final item measurements.
+			ComputeItemsLayoutWithLockedItems(
+				bestItemsLayout,
+				availableWidth,
+				minItemSpacing,
+				actualLineHeight,
+				averageAspectRatio,
+				beginSizedLineIndex,
+				endSizedLineIndex,
+				beginSizedItemIndex,
+				endSizedItemIndex,
+				beginLineVectorIndex,
+				isLastSizedLineStretchEnabled);
+
+#if DEBUG
+			bool forwardDbg = beginSizedItemIndex <= endSizedItemIndex;
+
+			MUX_ASSERT(!(!forwardDbg && beginSizedLineIndex < endSizedLineIndex));
+
+			int sizedLineCountDbg = forwardDbg ? endSizedLineIndex - beginSizedLineIndex + 1 :
+				beginSizedLineIndex - endSizedLineIndex + 1;
+			int sizedItemCountExpectedDbg = forwardDbg ? endSizedItemIndex - beginSizedItemIndex + 1 :
+				beginSizedItemIndex - endSizedItemIndex + 1;
+
+			MUX_ASSERT(sizedItemCountExpectedDbg >= sizedLineCountDbg);
+
+			int sizedItemCountActualDbg = 0;
+
+			for (int sizedLineVectorIndexDbg = 0; sizedLineVectorIndexDbg < sizedLineCountDbg; sizedLineVectorIndexDbg++)
+			{
+				int lineItemsCountDbg = m_lineItemCounts[beginLineVectorIndex + sizedLineVectorIndexDbg /*lineVectorIndex*/];
+
+				MUX_ASSERT(lineItemsCountDbg > 0);
+
+				sizedItemCountActualDbg += lineItemsCountDbg;
+			}
+
+			MUX_ASSERT(sizedItemCountActualDbg == sizedItemCountExpectedDbg);
+#endif
+		}
+
+		// Computes the expanding factor for a line with a desired width smaller than the available width.
+		private double ComputeLineExpandFactor(
+			bool forward,
+			int sizedItemIndex,
+			int lineItemsCount,
+			double lineItemsWidth,
+			double availableWidth,
+			double minItemSpacings,
+			double actualLineHeight,
+			double averageAspectRatio)
+		{
+			bool usesFastPathLayout = UsesFastPathLayout();
+			double scaleFactor;
+			bool largerScaleFactorNeeded;
+			HashSet<int> ignoredItemIndexes = new();
+
+			MUX_ASSERT(lineItemsWidth < availableWidth);
+
+			availableWidth -= minItemSpacings;
+			lineItemsWidth -= minItemSpacings;
+
+			MUX_ASSERT(availableWidth > 0.0);
+			MUX_ASSERT(lineItemsWidth > 0.0);
+
+			do
+			{
+				int sizedItemIndexTmp = sizedItemIndex;
+
+				largerScaleFactorNeeded = false;
+				scaleFactor = availableWidth / lineItemsWidth;
+
+				for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
+				{
+					if (!ignoredItemIndexes.Contains(itemIndex))
+					{
+						double minWidth = 0.0, maxWidth = double.PositiveInfinity, desiredWidth = 0.0;
+						UIElement? element = null;
+
+						if (!usesFastPathLayout && m_itemsInfoFirstIndex == -1)
+						{
+							MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndexTmp));
+
+							if ((element = m_elementManager.GetRealizedElement(sizedItemIndexTmp /*dataIndex*/)) != null)
+							{
+								if (element is FrameworkElement frameworkElement)
+								{
+									minWidth = frameworkElement.MinWidth;
+									maxWidth = frameworkElement.MaxWidth;
+									desiredWidth = element.DesiredSize.Width;
+								}
+							}
+						}
+						else
+						{
+							double desiredAspectRatio = GetDesiredAspectRatioFromItemsInfo(sizedItemIndexTmp, usesFastPathLayout);
+
+							if (desiredAspectRatio <= 0)
+							{
+								// The average aspect ratio is used as a fallback value for items that were given a negative ratio
+								// by the ItemsInfoRequested handler.
+								desiredAspectRatio = averageAspectRatio;
+							}
+
+							desiredWidth = desiredAspectRatio * actualLineHeight;
+
+							double desiredMinWidth = GetMinWidthFromItemsInfo(sizedItemIndexTmp);
+
+							if (desiredMinWidth >= 0.0)
+							{
+								minWidth = desiredMinWidth;
+								desiredWidth = Math.Max(minWidth, desiredWidth);
+							}
+
+							double desiredMaxWidth = GetMaxWidthFromItemsInfo(sizedItemIndexTmp);
+
+							if (desiredMaxWidth >= 0.0)
+							{
+								maxWidth = desiredMaxWidth;
+								desiredWidth = Math.Min(maxWidth, desiredWidth);
+							}
+						}
+
+						if (maxWidth < desiredWidth * scaleFactor)
+						{
+							availableWidth = Math.Max(0.0, availableWidth - maxWidth);
+							lineItemsWidth = Math.Max(0.0, lineItemsWidth - desiredWidth);
+
+							ignoredItemIndexes.Add(itemIndex);
+							largerScaleFactorNeeded = true;
+							break;
+						}
+
+						if (element != null &&                                                  // ItemsInfoRequested event did not provide sizing information.
+							(scaleFactor - 1.0) * minWidth > 1.0 / m_roundingScaleFactor &&     // scaleFactor is large enough that the rounded scaled desired width is expected to be larger than the rounded min width.
+							Math.Abs(minWidth - desiredWidth) <= 1.0 / m_roundingScaleFactor)    // element's DesiredSize.Width and element.MinWidth have the same rounded value.
+						{
+							Size scaledAvailableSize = new Size((float)(desiredWidth * scaleFactor), (float)actualLineHeight);
+							Size scaledDesiredSize = GetDesiredSizeForAvailableSize(sizedItemIndexTmp, element, scaledAvailableSize, actualLineHeight);
+
+							if (scaledDesiredSize.Width != -1.0f && Math.Abs(minWidth - scaledDesiredSize.Width) <= 1.0 / m_roundingScaleFactor)
+							{
+								// These are cases where the desired width matches the minimum width even though the element is given a larger available width.
+								availableWidth = Math.Max(0.0, availableWidth - minWidth);
+								lineItemsWidth = Math.Max(0.0, lineItemsWidth - minWidth);
+
+								ignoredItemIndexes.Add(itemIndex);
+								largerScaleFactorNeeded = true;
+								break;
+							}
+						}
+					}
+
+					sizedItemIndexTmp = forward ? sizedItemIndexTmp + 1 : sizedItemIndexTmp - 1;
+				}
+			}
+			while (availableWidth > 0.0 && lineItemsWidth > 0.0 && largerScaleFactorNeeded);
+
+			MUX_ASSERT(scaleFactor > 1.0);
+
+			return scaleFactor;
+		}
+
+		// Computes the shrinking factor for a line with a desired width larger than the available width.
+		// Returns 0 when the items' minimum width prevent enough shrinking to accommodate the available width.
+		private double ComputeLineShrinkFactor(
+			bool forward,
+			int sizedItemIndex,
+			int lineItemsCount,
+			double lineItemsWidth,
+			double availableWidth,
+			double minItemSpacings,
+			double actualLineHeight,
+			double averageAspectRatio)
+		{
+			bool usesFastPathLayout = UsesFastPathLayout();
+			double scaleFactor;
+			bool smallerScaleFactorNeeded;
+			HashSet<int> ignoredItemIndexes = new();
+
+			MUX_ASSERT(lineItemsWidth > availableWidth);
+
+			availableWidth -= minItemSpacings;
+			lineItemsWidth -= minItemSpacings;
+
+			MUX_ASSERT(availableWidth > 0.0);
+			MUX_ASSERT(lineItemsWidth > 0.0);
+
+			do
+			{
+				int sizedItemIndexTmp = sizedItemIndex;
+
+				smallerScaleFactorNeeded = false;
+				scaleFactor = availableWidth / lineItemsWidth;
+
+				for (int itemIndex = 0; itemIndex < lineItemsCount; itemIndex++)
+				{
+					if (!ignoredItemIndexes.Contains(itemIndex))
+					{
+						double minWidth = 0.0, desiredWidth = 0.0;
+
+						if (!usesFastPathLayout && m_itemsInfoFirstIndex == -1)
+						{
+							MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndexTmp));
+
+							if (m_elementManager.GetRealizedElement(sizedItemIndexTmp /*dataIndex*/) is { } element)
+							{
+								if (element is FrameworkElement frameworkElement)
+								{
+									minWidth = frameworkElement.MinWidth;
+								}
+
+								desiredWidth = element.DesiredSize.Width;
+							}
+						}
+						else
+						{
+							double desiredAspectRatio = GetDesiredAspectRatioFromItemsInfo(sizedItemIndexTmp, usesFastPathLayout);
+
+							if (desiredAspectRatio <= 0)
+							{
+								// The average aspect ratio is used as a fallback value for items that were given a negative ratio
+								// by the ItemsInfoRequested handler.
+								desiredAspectRatio = averageAspectRatio;
+							}
+
+							desiredWidth = desiredAspectRatio * actualLineHeight;
+
+							double desiredMaxWidth = GetMaxWidthFromItemsInfo(sizedItemIndexTmp);
+
+							if (desiredMaxWidth >= 0.0)
+							{
+								desiredWidth = Math.Min(desiredMaxWidth, desiredWidth);
+							}
+
+							double desiredMinWidth = GetMinWidthFromItemsInfo(sizedItemIndexTmp);
+
+							if (desiredMinWidth >= 0.0)
+							{
+								minWidth = desiredMinWidth;
+								desiredWidth = Math.Max(minWidth, desiredWidth);
+							}
+						}
+
+						if (minWidth > desiredWidth * scaleFactor)
+						{
+							availableWidth = Math.Max(0.0, availableWidth - minWidth);
+							lineItemsWidth = Math.Max(0.0, lineItemsWidth - desiredWidth);
+
+							ignoredItemIndexes.Add(itemIndex);
+							smallerScaleFactorNeeded = true;
+							break;
+						}
+					}
+
+					sizedItemIndexTmp = forward ? sizedItemIndexTmp + 1 : sizedItemIndexTmp - 1;
+				}
+			}
+			while (availableWidth > 0.0 && lineItemsWidth > 0.0 && smallerScaleFactorNeeded);
+
+			MUX_ASSERT(scaleFactor > 0.0);
+			MUX_ASSERT(scaleFactor < 1.0);
+
+			return smallerScaleFactorNeeded ? 0.0 : scaleFactor;
+		}
+
+		// Copies a section of the provided oldItemsInfo vector into m_itemsInfoDesiredAspectRatiosForRegularPath.
 		private void CopyItemsInfo(
 			List<double> oldItemsInfoDesiredAspectRatios,
 			List<double> oldItemsInfoMinWidths,
@@ -4710,6 +2685,11 @@ namespace Microsoft.UI.Xaml.Controls
 			int newStart,
 			int copyCount)
 		{
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"oldStart", oldStart);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"newStart", newStart);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"copyCount", copyCount);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, oldStart + copyCount, oldItemsInfoDesiredAspectRatios.size());
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, newStart + copyCount, m_itemsInfoDesiredAspectRatiosForRegularPath.size());
 			MUX_ASSERT(oldStart >= 0);
 			MUX_ASSERT(newStart >= 0);
 			MUX_ASSERT(copyCount > 0);
@@ -4738,6 +2718,1129 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		// Ensures items are realized and measured to determine their desired width.
+		// Returns True when there is at least one stored aspect ratio with a weight
+		// lower than c_maxAspectRatioWeight. In those cases the caller must trigger
+		// an additional UI thread tick so that those low weights can be increased
+		// and ultimately hit the c_maxAspectRatioWeight value.
+		private void EnsureAndMeasureItemRange(
+			VirtualizingLayoutContext context,
+			float availableWidth,
+			double actualLineHeight,
+			bool forward,
+			int beginRealizedItemIndex,
+			int endRealizedItemIndex)
+		{
+#if DEBUG
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginRealizedItemIndex", beginRealizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endRealizedItemIndex", endRealizedItemIndex);
+			MUX_ASSERT(!(forward && beginRealizedItemIndex > endRealizedItemIndex));
+			MUX_ASSERT(!(!forward && beginRealizedItemIndex < endRealizedItemIndex));
+			MUX_ASSERT(beginRealizedItemIndex < context.ItemCount);
+			MUX_ASSERT(endRealizedItemIndex < context.ItemCount);
+			MUX_ASSERT(m_elementDesiredWidths is not null);
+
+			// int beginNewRealizedItemIndexDbg = -1, endNewRealizedItemIndexDbg = -1;
+#endif
+			bool realizedNewElement = false;
+
+			for (int realizedItemIndex = beginRealizedItemIndex; ; realizedItemIndex = forward ? realizedItemIndex + 1 : realizedItemIndex - 1)
+			{
+				bool isElementNewlyRealized = false;
+
+				if (!m_elementManager.IsDataIndexRealized(realizedItemIndex))
+				{
+					EnsureElementRealized(forward, realizedItemIndex);
+
+					realizedNewElement = isElementNewlyRealized = true;
+
+					// #ifdef DBG
+					// if (beginNewRealizedItemIndexDbg == -1)
+					// {
+					//     beginNewRealizedItemIndexDbg = realizedItemIndex;
+					// }
+					// else
+					// {
+					//     endNewRealizedItemIndexDbg = realizedItemIndex;
+					// }
+					// #endif
+				}
+
+				if (m_itemsInfoFirstIndex == -1)
+				{
+					if (m_elementManager.GetRealizedElement(realizedItemIndex /*dataIndex*/) is { } element)
+					{
+						if (!m_elementDesiredWidths!.ContainsKey(element))
+						{
+							var elementAvailableSize = new Size(float.PositiveInfinity, actualLineHeight);
+
+							element.Measure(elementAvailableSize);
+
+							var desiredSize = element.DesiredSize;
+
+							bool desiredWidthGreaterThanMinWidth = false;
+
+							if (element is FrameworkElement frameworkElement)
+							{
+								float minWidth = (float)frameworkElement.MinWidth;
+
+								if (desiredSize.Width > minWidth)
+								{
+									// Items for which the desired width is greater than the min width are immediately
+									// assigned the c_maxAspectRatioWeight weight. For the other items, the weight is
+									// incremented from 1 to c_maxAspectRatioWeight as the min width may be due to the
+									// item content not being loaded yet.
+									desiredWidthGreaterThanMinWidth = true;
+								}
+							}
+
+							m_elementDesiredWidths![element] = (float)desiredSize.Width;
+
+							if (desiredSize.Height != 0.0 && m_aspectRatios != null)
+							{
+								var itemAspectRatio = m_aspectRatios.GetAt(realizedItemIndex);
+								float aspectRatio = (float)(desiredSize.Width / desiredSize.Height);
+
+								// The Uno LinedFlowLayoutItemAspectRatios.ItemAspectRatio is a readonly struct, so WinUI's
+								// in-place mutation of the copied value is reproduced by tracking the new aspect ratio/weight
+								// in locals and writing back a fresh struct via SetAt.
+								float newAspectRatio = itemAspectRatio.AspectRatio;
+								int newWeight = itemAspectRatio.Weight;
+
+								if (itemAspectRatio.Weight == 0)
+								{
+									newAspectRatio = aspectRatio;
+									newWeight = desiredWidthGreaterThanMinWidth ? c_maxAspectRatioWeight : 1;
+									// #ifdef DBG
+									// if (realizedItemIndex == LogItemIndexDbg())
+									// {
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"initial aspect ratio", aspectRatio);
+									// }
+									// #endif
+								}
+								else
+								{
+									if (isElementNewlyRealized)
+									{
+										newWeight = desiredWidthGreaterThanMinWidth ? c_maxAspectRatioWeight : 1;
+									}
+									else
+									{
+										int aspectRatioWeight = itemAspectRatio.Weight;
+
+										MUX_ASSERT(itemAspectRatio.AspectRatio >= 0.0f);
+										MUX_ASSERT(aspectRatioWeight >= 1);
+										MUX_ASSERT(aspectRatioWeight <= c_maxAspectRatioWeight);
+
+										if (aspectRatioWeight < c_maxAspectRatioWeight)
+										{
+											if (desiredWidthGreaterThanMinWidth)
+											{
+												newWeight = c_maxAspectRatioWeight;
+											}
+											else
+											{
+												newWeight++;
+											}
+										}
+									}
+
+									// #ifdef DBG
+									// if (realizedItemIndex == LogItemIndexDbg())
+									// {
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this,
+									//         itemAspectRatio.m_aspectRatio == aspectRatio ? L"same aspect ratio" : L"new aspect ratio", aspectRatio);
+									//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"weight", itemAspectRatio.m_weight);
+									// }
+									// #endif
+									if (itemAspectRatio.AspectRatio != aspectRatio)
+									{
+										newAspectRatio = aspectRatio;
+									}
+								}
+
+								m_aspectRatios.SetAt(realizedItemIndex, new LinedFlowLayoutItemAspectRatios.ItemAspectRatio(newAspectRatio, newWeight));
+								// #ifdef DBG
+								// if (realizedItemIndex == LogItemIndexDbg())
+								// {
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"measured with elementAvailableSize",
+								//         elementAvailableSize.Width,
+								//         elementAvailableSize.Height);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"element.DesiredSize",
+								//         desiredSize.Width,
+								//         desiredSize.Height);
+								// }
+								// #endif
+							}
+						}
+					}
+				}
+
+				if (realizedItemIndex == endRealizedItemIndex)
+				{
+					break;
+				}
+			}
+
+			// #ifdef DBG
+			// if (beginNewRealizedItemIndexDbg != -1)
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"newly realized item index range", beginNewRealizedItemIndexDbg, endNewRealizedItemIndexDbg);
+			// }
+			// #endif
+			if (realizedNewElement && !UsesArrangeWidthInfo())
+			{
+				InvalidateMeasureTimerStart(0 /*tickCount*/);
+			}
+		}
+
+		// Allocates the storage for tracking weighted aspect ratios. Widths that storage to track about 10 viewports worth of items at the most.
+		private void EnsureAndResizeItemAspectRatios(
+			double scrollViewport,
+			double actualLineHeight,
+			double lineSpacing)
+		{
+			MUX_ASSERT(m_averageItemsPerLine.second > 0.0);
+			MUX_ASSERT(m_firstSizedItemIndex >= 0);
+			MUX_ASSERT(m_firstSizedItemIndex <= m_lastSizedItemIndex);
+
+			EnsureItemAspectRatios();
+
+			const int c_scrollViewportCount = 10; // m_aspectRatios is sized large enough to hold aspect ratio information for 10 viewport worth of items.
+			int referenceItemIndex = (m_lastSizedItemIndex - m_firstSizedItemIndex) / 2;
+			const double c_minItemsPerScrollViewport = 20.0; // Avoid small aspect ratio sampling that is not statistically significant by forcing at least 20 items per viewport.
+			double linesPerScrollViewport = scrollViewport / (actualLineHeight + lineSpacing);
+			double averageItemsPerScrollViewport = Math.Max(c_minItemsPerScrollViewport, linesPerScrollViewport * m_averageItemsPerLine.second);
+			int itemAspectRatiosStorageSize = Math.Max((int)(averageItemsPerScrollViewport * c_scrollViewportCount), m_lastSizedItemIndex - m_firstSizedItemIndex + 1);
+
+			itemAspectRatiosStorageSize = Math.Min(itemAspectRatiosStorageSize, m_itemCount);
+
+			m_aspectRatios!.Resize(itemAspectRatiosStorageSize, referenceItemIndex);
+		}
+
+		private void EnsureElementAvailableWidths()
+		{
+			if (m_elementAvailableWidths == null)
+			{
+				m_elementAvailableWidths = new Dictionary<UIElement, float>();
+			}
+		}
+
+		private void EnsureElementDesiredWidths()
+		{
+			if (m_elementDesiredWidths == null)
+			{
+				m_elementDesiredWidths = new Dictionary<UIElement, float>();
+			}
+		}
+
+		private void EnsureElementRealized(
+			bool forward,
+			int itemIndex)
+		{
+			MUX_ASSERT(m_isVirtualizingContext);
+			MUX_ASSERT(!m_elementManager.IsDataIndexRealized(itemIndex));
+
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemIndex", itemIndex);
+			m_elementManager.EnsureElementRealized(forward, itemIndex, LayoutId);
+		}
+
+		private void EnsureItemAspectRatios()
+		{
+			if (m_aspectRatios == null)
+			{
+				m_aspectRatios = new LinedFlowLayoutItemAspectRatios();
+			}
+		}
+
+		// Ensures the items in the provided range are realized.
+		private void EnsureItemRange(
+			bool forward,
+			int beginRealizedItemIndex,
+			int endRealizedItemIndex)
+		{
+#if DEBUG
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginRealizedItemIndex", beginRealizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endRealizedItemIndex", endRealizedItemIndex);
+			MUX_ASSERT(!(forward && beginRealizedItemIndex > endRealizedItemIndex));
+			MUX_ASSERT(!(!forward && beginRealizedItemIndex < endRealizedItemIndex));
+			MUX_ASSERT(beginRealizedItemIndex < m_itemCount);
+			MUX_ASSERT(endRealizedItemIndex < m_itemCount);
+
+			// int beginNewRealizedItemIndexDbg = -1, endNewRealizedItemIndexDbg = -1;
+#endif
+			bool realizedNewElement = false;
+
+			for (int realizedItemIndex = beginRealizedItemIndex; ; realizedItemIndex = forward ? realizedItemIndex + 1 : realizedItemIndex - 1)
+			{
+				if (!m_elementManager.IsDataIndexRealized(realizedItemIndex))
+				{
+					EnsureElementRealized(forward, realizedItemIndex);
+
+					realizedNewElement = true;
+
+					// #ifdef DBG
+					// if (beginNewRealizedItemIndexDbg == -1)
+					// {
+					//     beginNewRealizedItemIndexDbg = realizedItemIndex;
+					// }
+					// else
+					// {
+					//     endNewRealizedItemIndexDbg = realizedItemIndex;
+					// }
+					// #endif
+				}
+
+				if (realizedItemIndex == endRealizedItemIndex)
+				{
+					break;
+				}
+			}
+
+			// #ifdef DBG
+			// if (beginNewRealizedItemIndexDbg != -1)
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"newly realized item index range", beginNewRealizedItemIndexDbg, endNewRealizedItemIndexDbg);
+			// }
+			// #endif
+			if (realizedNewElement && !UsesArrangeWidthInfo())
+			{
+				InvalidateMeasureTimerStart(0 /*tickCount*/);
+			}
+		}
+
+		// Ensures items are realized exactly for the context's realization window - for the fast path layout.
+		private void EnsureItemRangeFastPath(
+			VirtualizingLayoutContext context,
+			double actualLineHeight)
+		{
+			int newRecommendedAnchorIndex = context.RecommendedAnchorIndex;
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"entry", actualLineHeight);
+
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_anchorIndex", m_anchorIndex);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"newRecommendedAnchorIndex", newRecommendedAnchorIndex);
+			MUX_ASSERT(actualLineHeight > 0.0);
+			MUX_ASSERT(m_itemCount > 0);
+
+			int newFirstRealizedItemIndex = 0;
+			int newLastRealizedItemIndex = 0;
+
+			MUX_ASSERT(m_isVirtualizingContext == (context.VisibleRect.Height != double.PositiveInfinity));
+
+			if (m_isVirtualizingContext)
+			{
+				float realizationRectHeight = (float)context.RealizationRect.Height;
+
+				if (realizationRectHeight == 0.0)
+				{
+					return;
+				}
+
+				int lineCount = m_lineItemCounts.Count;
+
+				MUX_ASSERT(lineCount >= 0);
+
+				double lineSpacing = LineSpacing;
+				float nearRealizationRect = GetRoundedFloat((float)context.RealizationRect.Y);
+				int firstRealizedLineIndex = -1;
+				int lastRealizedLineIndex = -1;
+
+				GetFirstAndLastDisplayedLineIndexes(
+					realizationRectHeight /*scrollViewport*/,
+					nearRealizationRect,
+					0 /*padding*/,
+					lineSpacing,
+					actualLineHeight,
+					lineCount,
+					false /*forFullyDisplayedLines*/,
+					out firstRealizedLineIndex,
+					out lastRealizedLineIndex);
+
+				MUX_ASSERT(firstRealizedLineIndex >= 0);
+				MUX_ASSERT(lastRealizedLineIndex >= 0);
+				MUX_ASSERT(firstRealizedLineIndex < lineCount);
+				MUX_ASSERT(lastRealizedLineIndex < lineCount);
+
+				newFirstRealizedItemIndex = GetFirstItemIndexInLineIndex(firstRealizedLineIndex);
+				newLastRealizedItemIndex = GetLastItemIndexInLineIndex(lastRealizedLineIndex);
+
+				MUX_ASSERT(newFirstRealizedItemIndex >= 0);
+				MUX_ASSERT(newLastRealizedItemIndex >= 0);
+				MUX_ASSERT(newFirstRealizedItemIndex < m_itemCount);
+				MUX_ASSERT(newLastRealizedItemIndex < m_itemCount);
+
+				bool realizationRectCenteredAroundAnchor = false;
+
+				if (m_anchorIndex != -1 || newRecommendedAnchorIndex != -1)
+				{
+					int anchorLineIndex = GetLineIndex(newRecommendedAnchorIndex == -1 ? m_anchorIndex : newRecommendedAnchorIndex, true /*usesFastPathLayout*/);
+
+					MUX_ASSERT(anchorLineIndex >= 0);
+					MUX_ASSERT(anchorLineIndex < lineCount);
+
+					if (anchorLineIndex < firstRealizedLineIndex || anchorLineIndex > lastRealizedLineIndex)
+					{
+						// The anchor line is disconnected. Centering the realization window around its center.
+						float anchorLineNearEdge = (float)(anchorLineIndex * (actualLineHeight + lineSpacing));
+						float anchorLineMiddle = (float)(anchorLineNearEdge + actualLineHeight / 2.0);
+
+						nearRealizationRect = GetRoundedFloat(anchorLineMiddle - realizationRectHeight / 2.0f);
+						realizationRectCenteredAroundAnchor = true;
+
+						// Same comments and treatment as in LinedFlowLayout::MeasureConstrainedLinesRegularPath.
+						// Sometimes during a bring-into-view operation the RecommendedAnchorIndex momentarily switches from the target index N to -1 and then back to the target index N.
+						// To avoid momentarily setting m_anchorIndex to -1, its value is preserved c_maxAnchorIndexRetentionCount times, based purely on experimentations.
+						// Without this momentary retention the bring-into-view operation lands on incorrect offsets. If m_anchorIndex were to be preserved without a countdown, large offset changes
+						// through ScrollView.ScrollTo calls would not complete.
+						// TODO: Bug 41896418 - Investigate why the occurrences of -1 sometimes come up - even when the ScrollView anchoring is turned on.
+						//                      Does such a countdown need to be used? What is a reliable countdown starting value?
+						if (newRecommendedAnchorIndex == -1)
+						{
+							MUX_ASSERT(m_anchorIndexRetentionCountdown >= 1 && m_anchorIndexRetentionCountdown <= c_maxAnchorIndexRetentionCount);
+
+							m_anchorIndexRetentionCountdown--;
+
+							if (m_anchorIndexRetentionCountdown == 0)
+							{
+								m_anchorIndex = -1;
+							}
+						}
+						else
+						{
+							m_anchorIndexRetentionCountdown = c_maxAnchorIndexRetentionCount;
+							m_anchorIndex = newRecommendedAnchorIndex;
+						}
+						// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"Forcing layout pass to decrement m_anchorIndexRetentionCountdown");
+
+						// Layout is invalidated to ensure that m_anchorIndexRetentionCountdown is decremented from
+						// c_maxAnchorIndexRetentionCount all the way to 0 (a few lines above). Otherwise m_anchorIndex could be
+						// stuck to a value that prevents the realization window from moving to the actual scroller's offset.
+						InvalidateMeasureAsync();
+					}
+				}
+
+				if (realizationRectCenteredAroundAnchor)
+				{
+					// Re-evaluate realization range after centering around the anchor line.
+					GetFirstAndLastDisplayedLineIndexes(
+						realizationRectHeight /*scrollViewport*/,
+						nearRealizationRect,
+						0 /*padding*/,
+						lineSpacing,
+						actualLineHeight,
+						lineCount,
+						false /*forFullyDisplayedLines*/,
+						out firstRealizedLineIndex,
+						out lastRealizedLineIndex);
+
+					MUX_ASSERT(firstRealizedLineIndex >= 0);
+					MUX_ASSERT(lastRealizedLineIndex >= 0);
+					MUX_ASSERT(firstRealizedLineIndex < lineCount);
+					MUX_ASSERT(lastRealizedLineIndex < lineCount);
+
+					newFirstRealizedItemIndex = GetFirstItemIndexInLineIndex(firstRealizedLineIndex);
+					newLastRealizedItemIndex = GetLastItemIndexInLineIndex(lastRealizedLineIndex);
+
+					MUX_ASSERT(newFirstRealizedItemIndex >= 0);
+					MUX_ASSERT(newLastRealizedItemIndex >= 0);
+					MUX_ASSERT(newFirstRealizedItemIndex < m_itemCount);
+					MUX_ASSERT(newLastRealizedItemIndex < m_itemCount);
+				}
+				else if (m_anchorIndex != -1)
+				{
+					m_anchorIndex = -1;
+				}
+			}
+			else
+			{
+				// All items are realized in non-virtualizing mode.
+				MUX_ASSERT(context.VisibleRect.Y == 0.0);
+
+				newLastRealizedItemIndex = m_itemCount - 1;
+			}
+
+			int newRealizedItemCount = newLastRealizedItemIndex - newFirstRealizedItemIndex + 1;
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"newFirstRealizedItemIndex", newFirstRealizedItemIndex);
+
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"newLastRealizedItemIndex", newLastRealizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"newRealizedItemCount", newRealizedItemCount);
+			int oldFirstRealizedItemIndex = m_elementManager.GetFirstRealizedDataIndex(); // -1 and unused in non-virtualizing mode.
+			int oldLastRealizedItemIndex = oldFirstRealizedItemIndex == -1 ? -1 : oldFirstRealizedItemIndex + m_elementManager.GetRealizedElementCount - 1;
+
+			// Discard the first realized items fallen off the realization window.
+			if (oldFirstRealizedItemIndex != -1 && oldFirstRealizedItemIndex < newFirstRealizedItemIndex)
+			{
+				MUX_ASSERT(m_isVirtualizingContext);
+
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"discarded realized head range",
+				//     oldFirstRealizedItemIndex, newFirstRealizedItemIndex - 1);
+				m_elementManager.DiscardElementsOutsideWindow(
+					false /*forward*/,
+					Math.Min(newFirstRealizedItemIndex, oldFirstRealizedItemIndex + m_elementManager.GetRealizedElementCount) - 1 /*startIndex*/);
+			}
+
+			MUX_ASSERT(newFirstRealizedItemIndex <= m_elementManager.GetFirstRealizedDataIndex() || -1 == m_elementManager.GetFirstRealizedDataIndex());
+
+			int firstStillRealizedItemIndex = -1;
+			int lastStillRealizedItemIndex = -1;
+
+			if (oldFirstRealizedItemIndex != -1 && oldLastRealizedItemIndex != -1)
+			{
+				if (newFirstRealizedItemIndex >= oldFirstRealizedItemIndex && newFirstRealizedItemIndex <= oldLastRealizedItemIndex)
+				{
+					firstStillRealizedItemIndex = newFirstRealizedItemIndex;
+					lastStillRealizedItemIndex = Math.Min(oldLastRealizedItemIndex, newLastRealizedItemIndex);
+				}
+				else if (newLastRealizedItemIndex >= oldFirstRealizedItemIndex && newLastRealizedItemIndex <= oldLastRealizedItemIndex)
+				{
+					lastStillRealizedItemIndex = newLastRealizedItemIndex;
+					firstStillRealizedItemIndex = Math.Max(oldFirstRealizedItemIndex, newFirstRealizedItemIndex);
+				}
+			}
+
+			if (m_elementManager.GetFirstRealizedDataIndex() != -1 && newFirstRealizedItemIndex < m_elementManager.GetFirstRealizedDataIndex())
+			{
+				MUX_ASSERT(oldFirstRealizedItemIndex > 0);
+
+				// Ensure and measure the realized items before the old first realized item.
+				EnsureItemRange(
+					false /*forward*/,
+					Math.Min(oldFirstRealizedItemIndex - 1, newFirstRealizedItemIndex + newRealizedItemCount - 1) /*beginRealizedItemIndex*/,
+					newFirstRealizedItemIndex /*endRealizedItemIndex*/);
+
+				// Ensure and measure the realized items after the old first realized item.
+				MUX_ASSERT(newFirstRealizedItemIndex == m_elementManager.GetFirstRealizedDataIndex());
+
+				if (firstStillRealizedItemIndex != -1)
+				{
+					if (firstStillRealizedItemIndex > 0 && oldFirstRealizedItemIndex <= firstStillRealizedItemIndex - 1)
+					{
+						EnsureItemRange(
+							true /*forward*/,
+							oldFirstRealizedItemIndex /*beginRealizedItemIndex*/,
+							firstStillRealizedItemIndex - 1 /*endRealizedItemIndex*/);
+					}
+
+					if (lastStillRealizedItemIndex + 1 <= newFirstRealizedItemIndex + newRealizedItemCount - 1)
+					{
+						EnsureItemRange(
+							true /*forward*/,
+							lastStillRealizedItemIndex + 1 /*beginRealizedItemIndex*/,
+							newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
+					}
+				}
+				else if (newFirstRealizedItemIndex + newRealizedItemCount - 1 >= oldFirstRealizedItemIndex)
+				{
+					EnsureItemRange(
+						true /*forward*/,
+						oldFirstRealizedItemIndex /*beginRealizedItemIndex*/,
+						newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
+				}
+			}
+			else
+			{
+				// Ensure and measure the realized items.
+				MUX_ASSERT(newFirstRealizedItemIndex == m_elementManager.GetFirstRealizedDataIndex() || m_elementManager.GetFirstRealizedDataIndex() == -1);
+
+				if (firstStillRealizedItemIndex != -1)
+				{
+					if (firstStillRealizedItemIndex > 0 && newFirstRealizedItemIndex <= firstStillRealizedItemIndex - 1)
+					{
+						EnsureItemRange(
+							true /*forward*/,
+							newFirstRealizedItemIndex /*beginRealizedItemIndex*/,
+							firstStillRealizedItemIndex - 1 /*endRealizedItemIndex*/);
+					}
+
+					if (lastStillRealizedItemIndex + 1 <= newFirstRealizedItemIndex + newRealizedItemCount - 1)
+					{
+						EnsureItemRange(
+							true /*forward*/,
+							lastStillRealizedItemIndex + 1 /*beginRealizedItemIndex*/,
+							newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
+					}
+				}
+				else
+				{
+					EnsureItemRange(
+						true /*forward*/,
+						newFirstRealizedItemIndex /*beginRealizedItemIndex*/,
+						newFirstRealizedItemIndex + newRealizedItemCount - 1 /*endRealizedItemIndex*/);
+				}
+			}
+
+			// Discard the last realized items fallen off the realization window.
+			if (oldLastRealizedItemIndex != -1 && oldLastRealizedItemIndex > newLastRealizedItemIndex)
+			{
+				MUX_ASSERT(m_isVirtualizingContext);
+				MUX_ASSERT(m_elementManager.GetRealizedElementCount > newRealizedItemCount);
+
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"discarded realized tail range",
+				//     newFirstRealizedItemIndex + newRealizedItemCount, m_elementManager.GetFirstRealizedDataIndex() + m_elementManager.GetRealizedElementCount() - 1);
+				m_elementManager.DiscardElementsOutsideWindow(
+					true /*forward*/,
+					newLastRealizedItemIndex + 1 /*startIndex*/);
+			}
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"exit");
+		}
+
+		private void EnsureItemsInfoDesiredAspectRatios(int itemCount) => ClearAndFill(m_itemsInfoDesiredAspectRatiosForRegularPath, itemCount, -1.0);
+
+		private void EnsureItemsInfoMinWidths(int itemCount) => ClearAndFill(m_itemsInfoMinWidthsForRegularPath, itemCount, -1.0);
+
+		private void EnsureItemsInfoMaxWidths(int itemCount) => ClearAndFill(m_itemsInfoMaxWidthsForRegularPath, itemCount, -1.0);
+
+		private void EnsureItemsInfoArrangeWidths(int itemCount) => ClearAndFill(m_itemsInfoArrangeWidths, itemCount, -1.0f);
+
+		private void EnsureLineItemCounts(int lineCount) => ClearAndFill(m_lineItemCounts, lineCount, 0);
+
+		private void ExitRegularPath()
+		{
+			m_itemsInfoFirstIndex = -1;
+			m_unsizedNearLineCount = -1;
+			m_unrealizedNearLineCount = -1;
+			m_elementAvailableWidths = null;
+			m_elementDesiredWidths = null;
+			ResetSizedLines();
+		}
+
+		private double GetArrangeWidth(
+			double desiredAspectRatio,
+			double minWidth,
+			double maxWidth,
+			double actualLineHeight,
+			double scaleFactor)
+		{
+			MUX_ASSERT(desiredAspectRatio > 0.0);
+
+			double arrangeWidth = desiredAspectRatio * actualLineHeight;
+
+			minWidth = Math.Max(0.0, minWidth);
+
+			arrangeWidth = Math.Max(minWidth, arrangeWidth);
+
+			if (maxWidth >= 0.0)
+			{
+				arrangeWidth = Math.Min(maxWidth, arrangeWidth);
+			}
+
+			if (scaleFactor != 1.0)
+			{
+				arrangeWidth *= scaleFactor;
+
+				if (scaleFactor < 1.0)
+				{
+					arrangeWidth = Math.Max(minWidth, arrangeWidth);
+				}
+
+				if (maxWidth >= 0.0 && scaleFactor > 1.0)
+				{
+					arrangeWidth = Math.Min(maxWidth, arrangeWidth);
+				}
+			}
+
+			return arrangeWidth;
+		}
+
+		// Fast path layout:
+		//   Returns the arrange width computed from the m_itemsInfoDesiredAspectRatiosForFastPath, m_itemsInfoMinWidthsForFastPath, m_itemsInfoMaxWidthsForFastPath,
+		//   m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
+		// Regular path layout:
+		//   Returns the arrange width computed from the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath,
+		//   m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields.
+		// The desired aspect ratio is combined with the provided scaleFactor.
+		private float GetArrangeWidthFromItemsInfo(
+			int sizedItemIndex,
+			double actualLineHeight,
+			double averageAspectRatio,
+			double scaleFactor = 1.0)
+		{
+			double desiredAspectRatio = GetDesiredAspectRatioFromItemsInfo(sizedItemIndex, UsesFastPathLayout());
+
+			if (desiredAspectRatio <= 0)
+			{
+				// The average aspect ratio is used as a fallback value for items that were given a negative ratio
+				// by the ItemsInfoRequested handler.
+				desiredAspectRatio = averageAspectRatio;
+			}
+
+			return (float)GetArrangeWidth(
+				desiredAspectRatio,
+				GetMinWidthFromItemsInfo(sizedItemIndex),
+				GetMaxWidthFromItemsInfo(sizedItemIndex),
+				actualLineHeight,
+				scaleFactor);
+		}
+
+		// Returns the current average aspect ratio, either
+		// based on the m_aspectRatios storage when it's
+		// populated, or m_averageItemsPerLine when set, or
+		// finally the default defaultAspectRatio == 1.0.
+		private double GetAverageAspectRatio(float availableWidth, double actualLineHeight)
+		{
+			if (m_aspectRatios == null || m_aspectRatios.IsEmpty())
+			{
+				if (m_averageItemsPerLine.second == 0.0 || actualLineHeight == 0.0)
+				{
+					const double defaultAspectRatio = 1.0;
+
+					return defaultAspectRatio;
+				}
+				else
+				{
+					return availableWidth / m_averageItemsPerLine.second / actualLineHeight;
+				}
+			}
+
+			return GetAverageAspectRatioFromStorage();
+		}
+
+		// Returns the average aspect ratio from m_aspectRatios or 1.0 when it is empty.
+		private double GetAverageAspectRatioFromStorage()
+		{
+			const double defaultAspectRatio = 1.0;
+
+			if (m_aspectRatios == null || m_aspectRatios.IsEmpty())
+			{
+				return defaultAspectRatio;
+			}
+
+			int firstRealizedItemIndex = m_isVirtualizingContext ? m_elementManager.GetDataIndexFromRealizedRangeIndex(0) : 0;
+			int lastRealizedItemIndex = firstRealizedItemIndex + m_elementManager.GetRealizedElementCount - 1;
+			// Items outside the current realized range must have a weight equal to c_maxAspectRatioWeight to be taken into account.
+			// Smaller weights may not reflect the real aspect ratio and negatively influence the average.
+			float averageItemAspectRatio = m_aspectRatios.GetAverageAspectRatio(firstRealizedItemIndex, lastRealizedItemIndex, c_maxAspectRatioWeight);
+
+			return averageItemAspectRatio == 0.0f ? defaultAspectRatio : averageItemAspectRatio;
+		}
+
+		private (double first, double second) GetAverageItemsPerLine(
+			float availableWidth)
+		{
+			double averageWidth;
+			double minItemSpacing = MinItemSpacing;
+			double actualLineHeight = ActualLineHeight;
+
+			// During initial loading, in cases no sizing information is provided by an ItemsInfoRequested event handler,
+			// the average item aspect ratio is set no lower than 1.5, 1.25 & 1.0 in the first 3 measure passes.
+			// This is to avoid the unpopulated items' small MinWidth to artificially result in a small average aspect ratio
+			// causing a momentary item realization that gets thrown away as soon as the real average aspect ratio is set.
+			double minAverageItemAspectRatio = m_measureCountdown * 0.25 + 0.5;
+
+			if (m_aspectRatios != null && !m_aspectRatios.IsEmpty())
+			{
+				double averageItemAspectRatio = GetAverageAspectRatioFromStorage();
+
+				// During initial load, avoid small aspect ratios while the first items are still loading
+				// to avoid unnecessary item realizations. This is only done when the ItemsInfoRequested event handler did not provide sizing information.
+				if (m_itemsInfoFirstIndex == -1 && m_measureCountdown > 1 && averageItemAspectRatio < minAverageItemAspectRatio)
+				{
+					// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"Forcing layout pass for low initial aspect ratio average");
+					// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"minAverageItemAspectRatio", minAverageItemAspectRatio);
+					// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"averageItemAspectRatio", averageItemAspectRatio);
+					averageItemAspectRatio = minAverageItemAspectRatio;
+
+					// Making sure there is another layout coming with a decreased m_measureCountdown value to stop using an adjusted averageItemAspectRatio.
+					// Layout invalidation is done asynchronously to have an effect since this method, GetAverageItemsPerLine, is called during measure passes.
+					InvalidateMeasureAsync();
+				}
+
+				m_averageItemAspectRatioDbg = averageItemAspectRatio;
+
+				averageWidth = averageItemAspectRatio * actualLineHeight;
+			}
+			else
+			{
+				m_averageItemAspectRatioDbg = minAverageItemAspectRatio;
+
+				// When no item is realized, minAverageItemAspectRatio which starts at 1.5 is used.
+				averageWidth = minAverageItemAspectRatio * actualLineHeight;
+			}
+
+			if (m_forcedAverageItemAspectRatioDbg != 0.0)
+			{
+				averageWidth = m_forcedAverageItemAspectRatioDbg * actualLineHeight;
+			}
+
+			// Account for the minimum spacing between items by adding minItemSpacing
+			// minItemSpacing is over-counted once for the last item.
+			averageWidth = Math.Max(1.0, averageWidth + minItemSpacing);
+
+			// minItemSpacing is added to the availableWidth to account for the over-counting above.
+			double averageItemsPerLineRaw = (availableWidth + minItemSpacing) / averageWidth;
+
+			averageItemsPerLineRaw = Math.Max(1.0, averageItemsPerLineRaw);
+
+			(double first, double second) averageItemsPerLine = SnapAverageItemsPerLine(
+				m_averageItemsPerLine.first /*oldAverageItemsPerLineRaw*/,
+				averageItemsPerLineRaw /*newAverageItemsPerLineRaw*/);
+
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_DBL, METH_NAME, this, averageItemsPerLine.second);
+			MUX_ASSERT(averageItemsPerLine.second >= 1.0);
+
+			return averageItemsPerLine;
+		}
+
+		private double GetDesiredAspectRatioFromItemsInfo(
+			int itemIndex,
+			bool usesFastPathLayout)
+		{
+			MUX_ASSERT(itemIndex >= 0);
+			MUX_ASSERT(itemIndex < m_itemCount);
+
+			double desiredAspectRatio;
+
+			if (usesFastPathLayout)
+			{
+				MUX_ASSERT(m_itemsInfoFirstIndex == -1);
+				MUX_ASSERT(itemIndex < m_itemsInfoDesiredAspectRatiosForFastPath.Length);
+
+				desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForFastPath[itemIndex];
+			}
+			else
+			{
+				MUX_ASSERT(m_itemsInfoFirstIndex >= 0);
+				MUX_ASSERT(itemIndex - m_itemsInfoFirstIndex < m_itemsInfoDesiredAspectRatiosForRegularPath.Count);
+
+				desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForRegularPath[itemIndex - m_itemsInfoFirstIndex];
+			}
+
+			return desiredAspectRatio;
+		}
+
+		// Measures the element with the provided availableSize if there is a recorded width from a prior measure call.
+		// Returns the resulting desired size, or -1,-1 otherwise.
+		private Size GetDesiredSizeForAvailableSize(
+			int itemIndex,
+			UIElement element,
+			Size availableSize,
+			double actualLineHeightToRestore)
+		{
+			// MUX_ASSERT(element != nullptr);
+			MUX_ASSERT(itemIndex >= 0);
+
+			// When m_itemsInfoArrangeWidths is populated,
+			// - m_itemsInfoFirstIndex != -1: Regular path layout case, with items info available (m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath).
+			// - m_itemsInfoFirstIndex == -1: Fast path layout case, without items info available.
+			int itemsInfoArrangeWidthsIndex = itemIndex - (m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex);
+			float measureWidthToRestore = 0.0f;
+
+			if (itemsInfoArrangeWidthsIndex < m_itemsInfoArrangeWidths.Count)
+			{
+				float arrangeWidth = m_itemsInfoArrangeWidths[itemsInfoArrangeWidthsIndex];
+
+				if (arrangeWidth < 0.0f)
+				{
+					// The m_itemsInfoArrangeWidths vector has not been set for the provided 'itemIndex' yet.
+					// The effects of measuring 'element' with 'availableSize' below could not be undone.
+					// Returning -1, -1 to indicate no desired size could be measured.
+					return new Size(-1.0f, -1.0f);
+				}
+				else
+				{
+					measureWidthToRestore = arrangeWidth;
+				}
+			}
+			else if (m_elementAvailableWidths != null && m_elementDesiredWidths != null)
+			{
+				// Check if the element has a recorded desired or available width
+				// to restore after measurement with the provided 'availableSize'.
+				if (m_elementAvailableWidths.TryGetValue(element, out float recordedAvailableWidth))
+				{
+					// Use the previous available width to undo the effects of the measure with 'availableSize'.
+					measureWidthToRestore = recordedAvailableWidth;
+				}
+				else if (m_elementDesiredWidths.TryGetValue(element, out float recordedDesiredWidth))
+				{
+					// Use the previous desired width to undo the effects of the measure with 'availableSize'.
+					measureWidthToRestore = recordedDesiredWidth;
+				}
+				else
+				{
+					// No recorded width to use to undo effects of a measure with 'availableSize'.
+					return new Size(-1.0f, -1.0f);
+				}
+			}
+
+			element.Measure(availableSize);
+
+			Size desiredSize = element.DesiredSize;
+
+			element.Measure(new Size(measureWidthToRestore, (float)actualLineHeightToRestore));
+
+			return desiredSize;
+		}
+
+		private void GetFirstAndLastDisplayedLineIndexes(
+			double scrollViewport,
+			double scrollOffset,
+			double padding,
+			double lineSpacing,
+			double actualLineHeight,
+			int lineCount,
+			bool forFullyDisplayedLines,
+			out int firstDisplayedLineIndex,
+			out int lastDisplayedLineIndex)
+		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"scrollViewport", scrollViewport);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"scrollOffset", scrollOffset);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"padding", padding);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"lineSpacing", lineSpacing);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"actualLineHeight", actualLineHeight);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lineCount", lineCount);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"forFullyDisplayedLines", forFullyDisplayedLines);
+			MUX_ASSERT(m_isVirtualizingContext);
+			MUX_ASSERT(scrollViewport != double.PositiveInfinity);
+			MUX_ASSERT(lineCount > 0);
+
+			firstDisplayedLineIndex = lastDisplayedLineIndex = -1;
+
+			double lineHeight = actualLineHeight + lineSpacing;
+
+			if (lineHeight == 0.0 || scrollViewport == 0.0)
+			{
+				return;
+			}
+
+			double linesSpacing = lineCount == 0 ? 0.0 : (lineCount - 1) * lineSpacing;
+			double scrollExtent = lineCount * actualLineHeight + linesSpacing;
+			double maxScrollOffset = Math.Max(0.0, scrollExtent - scrollViewport);
+			double lineSpacingPortion = lineSpacing / lineHeight;
+
+			scrollOffset = Math.Min(maxScrollOffset, scrollOffset);
+
+			if (Math.Abs(scrollOffset) < c_offsetEqualityEpsilon)
+			{
+				scrollOffset = 0.0;
+			}
+
+			padding = Math.Min(padding, scrollViewport / 2.0);
+
+			double nearPadding = Math.Min(scrollOffset, padding);
+			double farPadding = Math.Min(maxScrollOffset - scrollOffset, padding);
+
+			if (!(forFullyDisplayedLines && actualLineHeight + nearPadding + farPadding > scrollViewport))
+			{
+				double nearDisplayed = scrollOffset + nearPadding;
+				double farDisplayed = scrollOffset + scrollViewport - farPadding;
+
+				if (farDisplayed > 0.0 && nearDisplayed < scrollExtent)
+				{
+					nearDisplayed = Math.Max(0.0, nearDisplayed);
+					farDisplayed = Math.Min(scrollExtent, farDisplayed);
+
+					double fractionalFirstDisplayedLineIndex = nearDisplayed / lineHeight;
+					int roundedFirstDisplayedLineIndex = (int)fractionalFirstDisplayedLineIndex;
+
+					if ((double)roundedFirstDisplayedLineIndex + 1 - fractionalFirstDisplayedLineIndex <= lineSpacingPortion &&
+						roundedFirstDisplayedLineIndex + 1 < lineCount)
+					{
+						// The portion displayed before the first displayed item is smaller than the line spacing - it can be ignored.
+						firstDisplayedLineIndex = roundedFirstDisplayedLineIndex + 1;
+					}
+					else
+					{
+						firstDisplayedLineIndex = roundedFirstDisplayedLineIndex;
+					}
+
+					if (forFullyDisplayedLines &&
+						fractionalFirstDisplayedLineIndex > roundedFirstDisplayedLineIndex &&
+						roundedFirstDisplayedLineIndex + 1 < lineCount)
+					{
+						firstDisplayedLineIndex = roundedFirstDisplayedLineIndex + 1;
+					}
+
+					MUX_ASSERT(firstDisplayedLineIndex >= 0);
+					MUX_ASSERT(firstDisplayedLineIndex < lineCount);
+
+					double fractionalLastDisplayedLineIndex = (farDisplayed + lineSpacing) / lineHeight;
+					int roundedLastDisplayedLineIndex = (int)fractionalLastDisplayedLineIndex;
+
+					lastDisplayedLineIndex = roundedLastDisplayedLineIndex;
+
+					if (forFullyDisplayedLines)
+					{
+						if (fractionalLastDisplayedLineIndex >= 1.0)
+						{
+							lastDisplayedLineIndex = Math.Min(roundedLastDisplayedLineIndex, lineCount) - 1;
+						}
+					}
+					else
+					{
+						if (fractionalLastDisplayedLineIndex - roundedLastDisplayedLineIndex <= lineSpacingPortion)
+						{
+							lastDisplayedLineIndex = Math.Max(roundedLastDisplayedLineIndex - 1, 0);
+						}
+					}
+
+					MUX_ASSERT(lastDisplayedLineIndex >= 0);
+					MUX_ASSERT(lastDisplayedLineIndex < lineCount);
+
+					if (firstDisplayedLineIndex > lastDisplayedLineIndex)
+					{
+						firstDisplayedLineIndex = lastDisplayedLineIndex = -1;
+					}
+				}
+			}
+			// else actualLineHeight is large enough that no line can be fully displayed in the scroll viewport.
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, forFullyDisplayedLines ? L"fullyDisplayedLines" : L"displayedLines", *firstDisplayedLineIndex, *lastDisplayedLineIndex);
+		}
+
+		// Returns the index of the first fully realized line, as well as the first item index in that line.
+		private void GetFirstFullyRealizedLineIndex(
+			out int firstFullyRealizedLineIndex,
+			out int firstItemInFullyRealizedLine)
+		{
+			int firstRealizedItemIndex = m_isVirtualizingContext ? m_elementManager.GetFirstRealizedDataIndex() : 0;
+
+			if (firstRealizedItemIndex == -1)
+			{
+				firstFullyRealizedLineIndex = -1;
+				firstItemInFullyRealizedLine = -1;
+				return;
+			}
+
+			int sizedItemIndex = m_firstSizedItemIndex == -1 ? 0 : m_firstSizedItemIndex;
+			int sizedLineIndex = m_firstSizedLineIndex == -1 ? 0 : m_firstSizedLineIndex;
+			int sizedLineVectorIndex = 0;
+
+			MUX_ASSERT(firstRealizedItemIndex >= 0);
+			MUX_ASSERT(sizedItemIndex >= 0);
+			MUX_ASSERT(sizedLineIndex >= 0);
+
+			while (sizedItemIndex < firstRealizedItemIndex)
+			{
+				sizedItemIndex += m_lineItemCounts[sizedLineVectorIndex];
+				sizedLineIndex++;
+				sizedLineVectorIndex++;
+			}
+
+			MUX_ASSERT(m_lastSizedLineIndex == -1 || sizedLineIndex <= m_lastSizedLineIndex);
+			MUX_ASSERT(m_lastSizedItemIndex == -1 || sizedItemIndex <= m_lastSizedItemIndex);
+
+			firstFullyRealizedLineIndex = sizedLineIndex;
+			firstItemInFullyRealizedLine = sizedItemIndex;
+		}
+
+		// Uses the m_lineItemCounts vector to return the index of the first item in the provided line index.
+		private int GetFirstItemIndexInLineIndex(int lineVectorIndex)
+		{
+			MUX_ASSERT(lineVectorIndex >= 0);
+			MUX_ASSERT(lineVectorIndex < m_lineItemCounts.Count);
+
+			int itemIndex = 0;
+
+			for (int lineVectorIndexTmp = 0; lineVectorIndexTmp < lineVectorIndex; lineVectorIndexTmp++)
+			{
+				itemIndex += m_lineItemCounts[lineVectorIndexTmp];
+			}
+
+			return itemIndex;
+		}
+
+		private int GetFrozenLineIndexFromFrozenItemIndex(
+			int frozenItemIndex)
+		{
+			MUX_ASSERT(m_firstSizedLineIndex != -1);
+			MUX_ASSERT(m_lastSizedLineIndex != -1);
+			MUX_ASSERT(frozenItemIndex >= m_firstFrozenItemIndex);
+			MUX_ASSERT(frozenItemIndex <= m_lastFrozenItemIndex);
+			MUX_ASSERT(m_firstFrozenLineIndex != -1);
+			MUX_ASSERT(m_lastFrozenLineIndex != -1);
+
+			int frozenItemVectorIndex = frozenItemIndex - m_firstFrozenItemIndex;
+
+			for (int frozenLineVectorIndex = m_firstFrozenLineIndex - m_firstSizedLineIndex;
+				frozenLineVectorIndex <= m_lastFrozenLineIndex - m_firstSizedLineIndex;
+				frozenLineVectorIndex++)
+			{
+				MUX_ASSERT(frozenLineVectorIndex >= 0);
+				MUX_ASSERT(frozenLineVectorIndex < m_lineItemCounts.Count);
+
+				if (frozenItemVectorIndex < m_lineItemCounts[frozenLineVectorIndex])
+				{
+					return frozenLineVectorIndex + m_firstSizedLineIndex;
+				}
+				frozenItemVectorIndex -= m_lineItemCounts[frozenLineVectorIndex];
+			}
+
+			MUX_ASSERT(false);
+			return -1;
+		}
+
+		// Returns the drawback improvement when an item moves from a line to a neighboring one.
+		// The drawback is nil for the last line when it is smaller than the available width.
+		private double GetItemDrawbackImprovement(
+			double movingWidth,
+			double availableWidth,
+			double currentLineItemsWidth,
+			double neighborLineItemsWidth,
+			int currentLineIndex,
+			int neighborLineIndex)
+		{
+			MUX_ASSERT(movingWidth - MinItemSpacing <= currentLineItemsWidth);
+			MUX_ASSERT(Math.Abs(currentLineIndex - neighborLineIndex) == 1);
+
+			int lastLineIndex = GetLineCount(m_averageItemsPerLine.second) - 1;
+			double currentDrawback = 0.0;
+
+			if (currentLineIndex != lastLineIndex || currentLineItemsWidth > availableWidth)
+			{
+				currentDrawback = Math.Pow(currentLineItemsWidth - availableWidth, 2.0);
+			}
+
+			if (neighborLineIndex != lastLineIndex || neighborLineItemsWidth > availableWidth)
+			{
+				currentDrawback += Math.Pow(neighborLineItemsWidth - availableWidth, 2.0);
+			}
+
+			double newDrawback = 0.0;
+
+			if (currentLineIndex != lastLineIndex || currentLineItemsWidth - movingWidth > availableWidth)
+			{
+				newDrawback = Math.Pow(currentLineItemsWidth - movingWidth - availableWidth, 2.0);
+			}
+
+			if (neighborLineIndex != lastLineIndex || neighborLineItemsWidth + movingWidth > availableWidth)
+			{
+				newDrawback += Math.Pow(neighborLineItemsWidth + movingWidth - availableWidth, 2.0);
+			}
+
+			return currentDrawback - newDrawback;
+		}
+
+		// Returns the line index the provided element belongs to, or -1 if not found.
+#pragma warning disable IDE0051 // Unused upstream as well, kept for 1:1 parity with LinedFlowLayout.cpp.
+		private int GetItemLineIndex(
+			UIElement element)
+		{
+			int sizedLineVectorCount = m_lineItemCounts.Count;
+			int sizedItemIndex = m_firstSizedItemIndex;
+
+			for (int sizedLineVectorIndex = 0; sizedLineVectorIndex < sizedLineVectorCount; sizedLineVectorIndex++)
+			{
+				int lineItemsCount = m_lineItemCounts[sizedLineVectorIndex];
+
+				for (int itemVectorIndex = 0; itemVectorIndex < lineItemsCount; itemVectorIndex++)
+				{
+					if (m_elementManager.IsDataIndexRealized(sizedItemIndex) &&
+						m_elementManager.GetRealizedElement(sizedItemIndex /*dataIndex*/) == element)
+					{
+						return sizedLineVectorIndex + m_firstSizedLineIndex;
+					}
+
+					sizedItemIndex++;
+				}
+			}
+
+			return -1;
+		}
+#pragma warning restore IDE0051
+
+		// Returns the item range for the ItemsInfoRequested event based on the average items per line, the realization rect size and offset.
 		private void GetItemsInfoRequestedRange(
 			VirtualizingLayoutContext context,
 			float availableWidth,
@@ -4756,7 +3859,13 @@ namespace Microsoft.UI.Xaml.Controls
 				float realizationRectHeightDeficit = Math.Max(0.0f, sizedItemsRectHeight - farRealizationRect + nearRealizationRect);
 				float nearSizedItemsRect = nearRealizationRect - realizationRectHeightDeficit / 2.0f;
 				float farSizedItemsRect = farRealizationRect + realizationRectHeightDeficit / 2.0f;
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"sizedItemsRectHeight", sizedItemsRectHeight);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"nearRealizationRect", nearRealizationRect);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"farRealizationRect", farRealizationRect);
 
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"realizationRectHeightDeficit", realizationRectHeightDeficit);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"nearSizedItemsRect", nearSizedItemsRect);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"farSizedItemsRect", farSizedItemsRect);
 				double minItemSpacing = MinItemSpacing;
 				// Either an average was recorded in a prior measure pass, or the items are considered square for an initial rough estimation.
 				double averageItemsPerLine = m_averageItemsPerLine.second == 0.0 ? ((availableWidth + minItemSpacing) / (actualLineHeight + minItemSpacing)) : m_averageItemsPerLine.second;
@@ -4789,6 +3898,8 @@ namespace Microsoft.UI.Xaml.Controls
 						sizedItemsRectHeight = farRealizationRect - nearRealizationRect;
 						nearSizedItemsRect = GetRoundedFloat(anchorLineMiddle - sizedItemsRectHeight / 2.0f);
 						farSizedItemsRect = nearSizedItemsRect + sizedItemsRectHeight;
+						// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"nearSizedItemsRect", nearSizedItemsRect);
+						// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"farSizedItemsRect", farSizedItemsRect);
 					}
 				}
 
@@ -4797,6 +3908,10 @@ namespace Microsoft.UI.Xaml.Controls
 				double scrollViewport = context.VisibleRect.Height;
 				double scrollableSize = Math.Max(0.0, linesHeight - scrollViewport);
 
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"linesHeight", linesHeight);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"scrollViewport", scrollViewport);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"scrollableSize", scrollableSize);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"sizedItemsRectHeight", sizedItemsRectHeight);
 				// nearSizedItemsRect must not be negative.
 				if (nearSizedItemsRect < 0.0)
 				{
@@ -4825,6 +3940,8 @@ namespace Microsoft.UI.Xaml.Controls
 				clampedNearSizedItemsRect = Math.Min(clampedFarSizedItemsRect - sizedItemsRectHeight, clampedNearSizedItemsRect);
 				clampedNearSizedItemsRect = Math.Max(0.0, clampedNearSizedItemsRect);
 
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"clampedNearSizedItemsRect", clampedNearSizedItemsRect);
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"clampedFarSizedItemsRect", clampedFarSizedItemsRect);
 				MUX_ASSERT(clampedFarSizedItemsRect - clampedNearSizedItemsRect <= sizedItemsRectHeight + 0.001);
 				MUX_ASSERT(clampedNearSizedItemsRect >= 0.0);
 				MUX_ASSERT(clampedNearSizedItemsRect <= scrollableSize);
@@ -4871,349 +3988,929 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		#endregion
+		// Used by LinedFlowLayout::GetItemsLayout to determine whether an item is wrapping to a new line or appended
+		// to the current line. The current item's width is multiplied by this 'item-size-multiplier-threshold' and then
+		// compared to the expected cumulated line widths and actual cumulated line widths.
+		private double GetItemWidthMultiplierThreshold()
+		{
+			// If the discrepancy between the actual and expected total line width is greater than twice the processed item width,
+			// the default wrapping behavior is reversed.
+			const double c_itemWidthMultiplierThreshold = 2.0;
 
-		#region Measure engine: items-info request/update (WS-D3c sub-slice 5)
+			double forcedWrapMultiplierDbg = m_forcedWrapMultiplierDbg;
 
-		// Based on info provided by a potential ItemsInfoRequested event handler, returns True when the info covers the entire data source and the fast path must be engaged, and False to stay in the regular path.
-		// Before returning False, this method updates the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath, m_itemsInfoArrangeWidths and
-		// m_itemsInfoFirstIndex fields. The m_itemsInfoMinWidth and m_itemsInfoMaxWidth fields are updated irrespective of the return value.
-		private bool RequestItemsInfo(
-			ItemsInfo itemsInfo,
+			return forcedWrapMultiplierDbg != 0.0 ? forcedWrapMultiplierDbg : c_itemWidthMultiplierThreshold;
+		}
+
+		// Computes an ItemsLayout for the provided available width.
+		// availableWidth: available width as provided by MeasureOverride.
+		// adjustedAvailableWidth: variation of availableWidth to equalize the items' layout on the lines.
+		private ItemsLayout GetItemsLayout(
+			SortedDictionary<int, int> internalLockedItemIndexes,
+			double scrollViewport,
+			double availableWidth,
+			double adjustedAvailableWidth,
+			double averageLineItemsWidth,
+			double averageAspectRatio,
+			double lineSpacing,
+			double actualLineHeight,
+			int beginSizedLineIndex,
+			int endSizedLineIndex,
 			int beginSizedItemIndex,
-			int endSizedItemIndex)
+			int endSizedItemIndex,
+			int beginLineVectorIndex,
+			bool isLastSizedLineStretchEnabled)
 		{
-			MUX_ASSERT(beginSizedItemIndex <= endSizedItemIndex);
-			MUX_ASSERT(beginSizedItemIndex >= m_firstSizedItemIndex);
-			MUX_ASSERT(endSizedItemIndex <= m_lastSizedItemIndex);
+			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
+			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
+			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
 
-			ItemsInfo newItemsInfo = new();
-			int desiredAspectRatiosCount = 0;
+			bool forward = beginSizedItemIndex <= endSizedItemIndex;
+			int sizedLineCount = forward ? endSizedLineIndex - beginSizedLineIndex + 1 : beginSizedLineIndex - endSizedLineIndex + 1;
+			double minItemSpacing = MinItemSpacing;
+			int lineVectorIndex;
+			int lineItemsCount = 0;
+			int lastItemIndex = int.MaxValue;
+			double cumulatedLinesWidth = 0.0;
+			double cumulatedWidth = 0.0;
+			double lastItemWidth = double.MaxValue;
+			double[] headItemWidths = new double[sizedLineCount];
+			double[] tailItemWidths = new double[sizedLineCount];
+			double[] headItemDrawbackImprovements = new double[sizedLineCount];
+			double[] tailItemDrawbackImprovements = new double[sizedLineCount];
+			int[] headItemIndexes = new int[sizedLineCount];
+			int[] tailItemIndexes = new int[sizedLineCount];
 
-			if (itemsInfo.m_itemsRangeStartIndex != -1 &&
-				beginSizedItemIndex >= itemsInfo.m_itemsRangeStartIndex &&
-				endSizedItemIndex <= itemsInfo.m_itemsRangeStartIndex + itemsInfo.m_itemsRangeLength - 1)
+			Array.Fill(headItemIndexes, int.MaxValue);
+			Array.Fill(tailItemIndexes, int.MaxValue);
+
+#if DEBUG
+			MUX_ASSERT(m_isVirtualizingContext == (scrollViewport != double.PositiveInfinity));
+			// MUX_ASSERT(internalLockedItemIndexes != nullptr);
+			MUX_ASSERT(!forward || beginSizedItemIndex >= m_firstSizedItemIndex);
+			MUX_ASSERT(!forward || endSizedItemIndex <= m_lastSizedItemIndex);
+			MUX_ASSERT(forward || endSizedItemIndex >= m_firstSizedItemIndex);
+			MUX_ASSERT(forward || beginSizedItemIndex <= m_lastSizedItemIndex);
+
+			// VerifyInternalLockedItemsDbg(
+			//     *internalLockedItemIndexes,
+			//     beginSizedLineIndex,
+			//     endSizedLineIndex,
+			//     beginSizedItemIndex,
+			//     endSizedItemIndex);
+#endif
+
+			ItemsLayout itemsLayout = new();
+
+			itemsLayout.m_availableLineItemsWidth = adjustedAvailableWidth;
+			ClearAndFill(itemsLayout.m_lineItemCounts, sizedLineCount, 0);
+			ClearAndFill(itemsLayout.m_lineItemWidths, sizedLineCount, 0.0);
+
+			lineVectorIndex = forward ? 0 : sizedLineCount - 1;
+
+#if DEBUG
+			// const int lineCountDbg = GetLineCount(m_averageItemsPerLine.second);
+			int sizedItemCountDbg = forward ? endSizedItemIndex - beginSizedItemIndex + 1 : beginSizedItemIndex - endSizedItemIndex + 1;
+
+			MUX_ASSERT(sizedItemCountDbg >= sizedLineCount);
+#endif
+
+			for (int sizedItemIndex = beginSizedItemIndex; ; sizedItemIndex = forward ? sizedItemIndex + 1 : sizedItemIndex - 1)
 			{
-				// The items info gathered during the fast path attempt covers the current request.
-				// Use it instead of launching a new request.
-				newItemsInfo = itemsInfo;
+				double itemWidth = 0.0;
 
-				desiredAspectRatiosCount = newItemsInfo.m_itemsRangeLength;
-
-				MUX_ASSERT(desiredAspectRatiosCount == m_itemsInfoDesiredAspectRatiosForFastPath.Length);
-				MUX_ASSERT(desiredAspectRatiosCount >= endSizedItemIndex - beginSizedItemIndex + 1);
-			}
-			else
-			{
-				int itemsRangeStartIndex = beginSizedItemIndex;
-				int itemsRangeRequestedLength = endSizedItemIndex - beginSizedItemIndex + 1;
-
-				MUX_ASSERT(itemsRangeStartIndex + itemsRangeRequestedLength - 1 < m_itemCount);
-
-				newItemsInfo = RaiseItemsInfoRequested(itemsRangeStartIndex, itemsRangeRequestedLength);
-
-				desiredAspectRatiosCount = newItemsInfo.m_itemsRangeLength;
-
-				if (desiredAspectRatiosCount <= 0)
+				if (m_itemsInfoFirstIndex == -1)
 				{
-					// No aspect ratios were provided. Discard all info and use the fallback pass with larger realization rect.
-					ResetItemsInfo();
-					return false;
-				}
+					MUX_ASSERT(m_elementManager.IsDataIndexRealized(sizedItemIndex));
 
-				MUX_ASSERT(newItemsInfo.m_itemsRangeStartIndex >= 0);
-				MUX_ASSERT(newItemsInfo.m_itemsRangeStartIndex <= beginSizedItemIndex);
-				MUX_ASSERT(newItemsInfo.m_itemsRangeStartIndex + desiredAspectRatiosCount - 1 >= endSizedItemIndex);
-			}
-
-			m_itemsInfoMinWidth = newItemsInfo.m_minWidth < 0.0 ? -1.0 : newItemsInfo.m_minWidth;
-			m_itemsInfoMaxWidth = newItemsInfo.m_maxWidth < 0.0 ? -1.0 : newItemsInfo.m_maxWidth;
-
-			int minWidthsCount = m_itemsInfoMinWidthsForFastPath.Length;
-			int maxWidthsCount = m_itemsInfoMaxWidthsForFastPath.Length;
-			int itemsRangeLength = Math.Min(desiredAspectRatiosCount, m_itemCount - newItemsInfo.m_itemsRangeStartIndex);
-
-			MUX_ASSERT(itemsRangeLength > 0);
-
-			if (itemsRangeLength == m_itemCount)
-			{
-				// The ItemsInfoRequested event handler provided ratios for the entire data source. This situation can occur when a measure path
-				// is performed and (m_forceRelayout || m_previousAvailableWidth != availableWidth) evaluated to False in the initial fast path attempt,
-				// in LinedFlowLayout::MeasureConstrainedLinesFastPath. The ItemsInfoRequested event was thus skipped. Here a transition from regular path
-				// to fast path is enabled. One of two unfortunate behaviors needs to be picked:
-				// a. Remain in the regular path until a future measure path with m_forceRelayout==True or a different availableWidth is triggered.
-				//    The m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath
-				//    vectors could grow very large hindering performance.
-				// b. Stop the regular path and backtrack to the fast path since aspect ratios were provided for the entire collection.
-				//    This can result in a re-arrangement of the visible items.
-				// Option b. is picked for its perf benefits.
-				return true;
-			}
-
-			if (m_itemsInfoFirstIndex == -1)
-			{
-				m_itemsInfoFirstIndex = newItemsInfo.m_itemsRangeStartIndex;
-			}
-			else
-			{
-				m_itemsInfoFirstIndex = Math.Min(newItemsInfo.m_itemsRangeStartIndex, m_itemsInfoFirstIndex);
-			}
-
-			int minItemsInfoRequiredSize = Math.Min(newItemsInfo.m_itemsRangeStartIndex + itemsRangeLength - m_itemsInfoFirstIndex, m_itemCount);
-
-			if (m_itemsInfoDesiredAspectRatiosForRegularPath.Count < minItemsInfoRequiredSize)
-			{
-				ResizeList(m_itemsInfoDesiredAspectRatiosForRegularPath, minItemsInfoRequiredSize, -1.0);
-			}
-
-			if (minWidthsCount > 0 && m_itemsInfoMinWidthsForRegularPath.Count < minItemsInfoRequiredSize)
-			{
-				ResizeList(m_itemsInfoMinWidthsForRegularPath, minItemsInfoRequiredSize, -1.0);
-			}
-
-			if (maxWidthsCount > 0 && m_itemsInfoMaxWidthsForRegularPath.Count < minItemsInfoRequiredSize)
-			{
-				ResizeList(m_itemsInfoMaxWidthsForRegularPath, minItemsInfoRequiredSize, -1.0);
-			}
-
-			if (m_itemsInfoArrangeWidths.Count < minItemsInfoRequiredSize)
-			{
-				ResizeList(m_itemsInfoArrangeWidths, minItemsInfoRequiredSize, -1.0f);
-			}
-
-			int itemsInfoIndexStart = newItemsInfo.m_itemsRangeStartIndex - m_itemsInfoFirstIndex;
-
-			for (int index = 0; index < itemsRangeLength; index++)
-			{
-				double desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForFastPath[index];
-
-				SetDesiredAspectRatioFromItemsInfo(
-					m_itemsInfoFirstIndex + itemsInfoIndexStart + index,
-					desiredAspectRatio);
-
-				MUX_ASSERT(m_itemsInfoDesiredAspectRatiosForRegularPath[itemsInfoIndexStart + index] == desiredAspectRatio);
-
-				if (minWidthsCount > 0 && index < minWidthsCount)
-				{
-					m_itemsInfoMinWidthsForRegularPath[itemsInfoIndexStart + index] = m_itemsInfoMinWidthsForFastPath[index];
-				}
-
-				if (maxWidthsCount > 0 && index < maxWidthsCount)
-				{
-					m_itemsInfoMaxWidthsForRegularPath[itemsInfoIndexStart + index] = m_itemsInfoMaxWidthsForFastPath[index];
-				}
-			}
-
-			return false;
-		}
-
-		private bool UpdateItemsInfo(
-			ItemsInfo itemsInfo,
-			int oldFirstItemsInfoIndex,
-			int oldLastItemsInfoIndex)
-		{
-			// Raise ItemsInfoRequested events.
-			if (oldFirstItemsInfoIndex == -1 || m_lastSizedItemIndex < oldFirstItemsInfoIndex || m_firstSizedItemIndex > oldLastItemsInfoIndex)
-			{
-				// No overlapping of old items info and new sized items. Build the items info from scratch.
-				ResetItemsInfo();
-
-				// Raise event for [m_firstSizedItemIndex, m_lastSizedItemIndex] range.
-				if (RequestItemsInfo(itemsInfo, m_firstSizedItemIndex /*beginSizedItemIndex*/, m_lastSizedItemIndex /*endSizedItemIndex*/))
-				{
-					return true;
-				}
-
-				UpdateAspectRatiosWithItemsInfo();
-			}
-			else if (m_firstSizedItemIndex < oldFirstItemsInfoIndex || m_lastSizedItemIndex > oldLastItemsInfoIndex)
-			{
-				// Partial overlapping.
-				MUX_ASSERT(oldLastItemsInfoIndex != -1);
-
-				// TODO as part of perf Task 42298247 - see if these copies can be avoided by copying vector elements 'in place'.
-				List<double> oldItemsInfoDesiredAspectRatios = new List<double>(m_itemsInfoDesiredAspectRatiosForRegularPath);
-				List<double> oldItemsInfoMinWidths = new List<double>(m_itemsInfoMinWidthsForRegularPath);
-				List<double> oldItemsInfoMaxWidths = new List<double>(m_itemsInfoMaxWidthsForRegularPath);
-				List<float> oldItemsInfoArrangeWidths = new List<float>(m_itemsInfoArrangeWidths);
-
-				int newItemsInfoCount = m_lastSizedItemIndex - m_firstSizedItemIndex + 1;
-
-				EnsureItemsInfoDesiredAspectRatios(newItemsInfoCount /*itemCount*/);
-
-				if (m_itemsInfoMinWidthsForRegularPath.Count > 0)
-				{
-					EnsureItemsInfoMinWidths(newItemsInfoCount /*itemCount*/);
-				}
-
-				if (m_itemsInfoMaxWidthsForRegularPath.Count > 0)
-				{
-					EnsureItemsInfoMaxWidths(newItemsInfoCount /*itemCount*/);
-				}
-
-				EnsureItemsInfoArrangeWidths(newItemsInfoCount /*itemCount*/);
-
-				m_itemsInfoFirstIndex = m_firstSizedItemIndex;
-
-				bool oldFirstOverlaps = oldFirstItemsInfoIndex >= m_firstSizedItemIndex && oldFirstItemsInfoIndex <= m_lastSizedItemIndex;
-				bool oldLastOverlaps = oldLastItemsInfoIndex >= m_firstSizedItemIndex && oldLastItemsInfoIndex <= m_lastSizedItemIndex;
-				bool newFirstOverlaps = m_firstSizedItemIndex >= oldFirstItemsInfoIndex && m_firstSizedItemIndex <= oldLastItemsInfoIndex;
-				bool newLastOverlaps = m_lastSizedItemIndex >= oldFirstItemsInfoIndex && m_lastSizedItemIndex <= oldLastItemsInfoIndex;
-
-				if (oldFirstOverlaps || oldLastOverlaps || newFirstOverlaps || newLastOverlaps)
-				{
-					MUX_ASSERT(!newFirstOverlaps || !newLastOverlaps);
-
-					// Fill m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath, m_itemsInfoArrangeWidths vectors with overlapping
-					// oldItemsInfoDesiredAspectRatios, oldItemsInfoMinWidths, oldItemsInfoMaxWidths, oldItemsInfoArrangeWidths ones.
-					if (oldFirstOverlaps && oldLastOverlaps)
+					if (m_elementManager.GetRealizedElement(sizedItemIndex) is { } element)
 					{
-						CopyItemsInfo(
-							oldItemsInfoDesiredAspectRatios,
-							oldItemsInfoMinWidths,
-							oldItemsInfoMaxWidths,
-							oldItemsInfoArrangeWidths,
-							0 /*oldStart*/,
-							oldFirstItemsInfoIndex - m_firstSizedItemIndex /*newStart*/,
-							oldLastItemsInfoIndex - oldFirstItemsInfoIndex + 1 /*copyCount*/);
-					}
-					else if (newFirstOverlaps && oldLastOverlaps)
-					{
-						CopyItemsInfo(
-							oldItemsInfoDesiredAspectRatios,
-							oldItemsInfoMinWidths,
-							oldItemsInfoMaxWidths,
-							oldItemsInfoArrangeWidths,
-							m_firstSizedItemIndex - oldFirstItemsInfoIndex /*oldStart*/,
-							0 /*newStart*/,
-							oldLastItemsInfoIndex - m_firstSizedItemIndex + 1 /*copyCount*/);
-					}
-					else if (oldFirstOverlaps && newLastOverlaps)
-					{
-						CopyItemsInfo(
-							oldItemsInfoDesiredAspectRatios,
-							oldItemsInfoMinWidths,
-							oldItemsInfoMaxWidths,
-							oldItemsInfoArrangeWidths,
-							0 /*oldStart*/,
-							oldFirstItemsInfoIndex - m_firstSizedItemIndex /*newStart*/,
-							m_lastSizedItemIndex - oldFirstItemsInfoIndex + 1 /*copyCount*/);
-					}
-				}
-
-				if (m_firstSizedItemIndex < oldFirstItemsInfoIndex)
-				{
-					// Raise event for [m_firstSizedItemIndex, oldFirstItemsInfoIndex - 1] range.
-					if (RequestItemsInfo(itemsInfo, m_firstSizedItemIndex /*beginSizedItemIndex*/, oldFirstItemsInfoIndex - 1 /*endSizedItemIndex*/))
-					{
-						return true;
-					}
-				}
-
-				if (m_lastSizedItemIndex > oldLastItemsInfoIndex)
-				{
-					// Raise event for [oldLastItemsInfoIndex + 1, m_lastSizedItemIndex] range.
-					if (RequestItemsInfo(itemsInfo, oldLastItemsInfoIndex + 1 /*beginSizedItemIndex*/, m_lastSizedItemIndex /*endSizedItemIndex*/))
-					{
-						return true;
-					}
-				}
-
-				UpdateAspectRatiosWithItemsInfo();
-			}
-			else
-			{
-				// Full overlapping. [m_firstSizedItemIndex, m_lastSizedItemIndex] is a subset of [oldFirstItemsInfoIndex, oldLastItemsInfoIndex].
-				// m_itemsInfoDesiredAspectRatiosForRegularPath left unchanged.
-				MUX_ASSERT(m_itemsInfoFirstIndex != -1);
-				MUX_ASSERT(m_firstSizedItemIndex >= oldFirstItemsInfoIndex);
-				MUX_ASSERT(m_firstSizedItemIndex <= oldLastItemsInfoIndex);
-				MUX_ASSERT(m_lastSizedItemIndex >= oldFirstItemsInfoIndex);
-				MUX_ASSERT(m_lastSizedItemIndex <= oldLastItemsInfoIndex);
-			}
-
-			return false;
-		}
-
-		#endregion
-
-		#region Measure engine: unconstrained-line measure (WS-D3c sub-slice 5)
-
-		// Measures all items in a single unconstrained (infinite-width) line, returning the total desired width.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private float MeasureUnconstrainedLine(
-			VirtualizingLayoutContext context)
-		{
-			MUX_ASSERT(m_itemCount == context.ItemCount);
-			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
-			MUX_ASSERT(!UsesArrangeWidthInfo());
-
-			float actualLineHeight = (float)ActualLineHeight;
-			Size measureAvailableSize = new Size(float.PositiveInfinity, actualLineHeight);
-			float desiredWidth = 0.0f;
-			bool isNewlyRealizedElementMeasuredWithMinWidth = false;
-
-			for (int itemIndex = 0; itemIndex < m_itemCount; itemIndex++)
-			{
-				bool isElementNewlyRealized = false;
-
-				if (m_isVirtualizingContext && !m_elementManager.IsDataIndexRealized(itemIndex))
-				{
-					EnsureElementRealized(true /*forward*/, itemIndex);
-
-					isElementNewlyRealized = true;
-				}
-
-				if (m_elementManager.GetAt(itemIndex) is { } element)
-				{
-					element.Measure(measureAvailableSize);
-
-					if (element is FrameworkElement frameworkElement)
-					{
-						float minWidth = (float)frameworkElement.MinWidth;
-
-						if ((float)element.DesiredSize.Width == minWidth)
+						itemWidth = element.DesiredSize.Width;
+#if DEBUG
+						if (element is FrameworkElement frameworkElementDbg)
 						{
-							// Making sure the item is stretched according to the MinWidth value.
-							element.Measure(new Size(minWidth, actualLineHeight));
-
-							if (isElementNewlyRealized)
+							if (itemWidth < frameworkElementDbg.MinWidth - 1.0 / m_roundingScaleFactor)
 							{
-								isNewlyRealizedElementMeasuredWithMinWidth = true;
+								// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, itemWidth, frameworkElementDbg.MinWidth());
+							}
+							if (itemWidth > frameworkElementDbg.MaxWidth + 1.0 / m_roundingScaleFactor)
+							{
+								// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, itemWidth, frameworkElementDbg.MaxWidth());
+							}
+							MUX_ASSERT(itemWidth >= frameworkElementDbg.MinWidth - 1.0 / m_roundingScaleFactor);
+							MUX_ASSERT(itemWidth <= frameworkElementDbg.MaxWidth + 1.0 / m_roundingScaleFactor);
+						}
+#endif
+					}
+				}
+				else
+				{
+					MUX_ASSERT(sizedItemIndex - m_itemsInfoFirstIndex < m_itemsInfoDesiredAspectRatiosForRegularPath.Count);
+
+					double desiredMinWidth = GetMinWidthFromItemsInfo(sizedItemIndex);
+					double desiredMaxWidth = GetMaxWidthFromItemsInfo(sizedItemIndex);
+					double desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForRegularPath[sizedItemIndex - m_itemsInfoFirstIndex];
+
+					if (desiredAspectRatio <= 0.0)
+					{
+						// The average aspect ratio is used as a fallback value for items that were given a negative ratio
+						// by the ItemsInfoRequested handler.
+						desiredAspectRatio = averageAspectRatio;
+					}
+
+					itemWidth = desiredAspectRatio * actualLineHeight;
+
+					if (desiredMinWidth >= 0.0)
+					{
+						itemWidth = Math.Max(desiredMinWidth, itemWidth);
+					}
+
+					if (desiredMaxWidth >= 0.0)
+					{
+						itemWidth = Math.Min(desiredMaxWidth, itemWidth);
+					}
+				}
+
+				bool isInternalLockedItem = internalLockedItemIndexes.TryGetValue(sizedItemIndex, out int internalLockedLineIndexValue);
+				int internalLockedLineIndex = isInternalLockedItem ? internalLockedLineIndexValue : -1;
+
+				MUX_ASSERT(!forward || beginSizedLineIndex + lineVectorIndex < GetLineCount(m_averageItemsPerLine.second));
+				MUX_ASSERT(forward || endSizedLineIndex + lineVectorIndex < GetLineCount(m_averageItemsPerLine.second));
+
+				bool isLockedItem = IsLockedItem(
+					forward,
+					beginSizedLineIndex,
+					endSizedLineIndex,
+					sizedItemIndex);
+
+				int lockedLineIndex = isLockedItem ? m_lockedItemIndexes[sizedItemIndex] : -1;
+
+				GetNextLockedItem(
+					internalLockedItemIndexes,
+					forward,
+					beginSizedLineIndex,
+					endSizedLineIndex,
+					sizedItemIndex,
+					out int nextLockedItemIndex,
+					out int nextLockedLineIndex);
+
+				MUX_ASSERT(!(nextLockedItemIndex == -1 && nextLockedLineIndex != -1));
+				MUX_ASSERT(!(nextLockedItemIndex != -1 && nextLockedLineIndex == -1));
+
+				// mustCumulate is set to True when 'element' must be appended to the current line.
+				bool mustCumulate =
+					lineItemsCount == 0 ||                                                                                                                       // No item is present on the current line - it must at least contain one item
+					(forward && LineHasLockedItem(beginSizedLineIndex + lineVectorIndex, false /*before*/, sizedItemIndex)) ||                                     // A publicly locked item is ahead going forward, and must be on the current line
+					(!forward && LineHasLockedItem(endSizedLineIndex + lineVectorIndex, true /*before*/, sizedItemIndex)) ||                                       // A publicly locked item is ahead going backward, and must be on the current line
+					(forward && LineHasInternalLockedItem(internalLockedItemIndexes, beginSizedLineIndex + lineVectorIndex, false /*before*/, sizedItemIndex)) || // An internally locked item is ahead going forward, and must be on the current line
+					(!forward && LineHasInternalLockedItem(internalLockedItemIndexes, endSizedLineIndex + lineVectorIndex, true /*before*/, sizedItemIndex)) ||   // An internally locked item is ahead going backward, and must be on the current line
+					(forward && lineVectorIndex == sizedLineCount - 1) ||                                                                                         // The current line is the last one processed, going forward
+					(!forward && lineVectorIndex == 0);                                                                                                           // The current line is the last one processed, going backward
+
+				// canCumulate is set to True when 'element' has enough room to fit in the current line.
+				bool canCumulate = cumulatedWidth + (lineItemsCount == 0 ? 0.0 : minItemSpacing) + itemWidth <= adjustedAvailableWidth;
+				// mustNotCumulate is set to True when 'element' must wrap to the next line.
+				bool mustNotCumulate = false;
+				// shouldNotCumulate is set to True when there is no mandatory assignment for 'element', there is still room for it on the current line,
+				// but in order to equalize lines, wrapping is preferred over not wrapping,
+				//   - because of an upcoming publicly locked item,
+				//   - because the cumulated item widths significantly exceeds the expected one given the line index.
+				bool shouldNotCumulate = false;
+				// shouldCumulate is set to True when there is no mandatory assignment for 'element', there is no room for it on the current line,
+				// but in order to equalize lines, wrapping is skipped because the cumulated item widths is significantly lower than the expected one given the line index.
+				bool shouldCumulate = false;
+
+#if DEBUG
+				// mustNotCumulateDbg is a replica of mustNotCumulate below. It is only evaluated in debug mode for the purpose of the assertion
+				// in order to detect an expected situation where the current item must and must not belong to the current line at the same time.
+				// This avoids the evaluation of mustNotCumulate when not needed in retail mode.
+				bool mustNotCumulateDbg =
+					(forward && endSizedItemIndex - sizedItemIndex < sizedLineCount - 1 - lineVectorIndex) ||
+					(!forward && sizedItemIndex - endSizedItemIndex < lineVectorIndex) ||
+					(forward && isLockedItem && lockedLineIndex != beginSizedLineIndex + lineVectorIndex) ||
+					(!forward && isLockedItem && lockedLineIndex != endSizedLineIndex + lineVectorIndex) ||
+					(forward && isInternalLockedItem && internalLockedLineIndex != beginSizedLineIndex + lineVectorIndex) ||
+					(!forward && isInternalLockedItem && internalLockedLineIndex != endSizedLineIndex + lineVectorIndex) ||
+					(forward && nextLockedItemIndex != -1 && nextLockedItemIndex - sizedItemIndex < nextLockedLineIndex - (beginSizedLineIndex + lineVectorIndex)) ||
+					(!forward && nextLockedItemIndex != -1 && sizedItemIndex - nextLockedItemIndex < endSizedLineIndex + lineVectorIndex - nextLockedLineIndex);
+
+				MUX_ASSERT(!(mustCumulate && mustNotCumulateDbg));
+#endif
+
+				if (!mustCumulate)
+				{
+					mustNotCumulate =
+						(forward && endSizedItemIndex - sizedItemIndex < sizedLineCount - 1 - lineVectorIndex) ||                                                         // There are as many items left as there are lines, going forward
+						(!forward && sizedItemIndex - endSizedItemIndex < lineVectorIndex) ||                                                                             // There are as many items left as there are lines, going backward
+						(forward && isLockedItem && lockedLineIndex != beginSizedLineIndex + lineVectorIndex) ||                                                          // 'element' is a publicly locked item for the next line, going forward
+						(!forward && isLockedItem && lockedLineIndex != endSizedLineIndex + lineVectorIndex) ||                                                           // 'element' is a publicly locked item for the next line, going backward
+						(forward && isInternalLockedItem && internalLockedLineIndex != beginSizedLineIndex + lineVectorIndex) ||                                          // 'element' is an internally locked item for the next line, going forward
+						(!forward && isInternalLockedItem && internalLockedLineIndex != endSizedLineIndex + lineVectorIndex) ||                                           // 'element' is an internally locked item for the next line, going backward
+						(forward && nextLockedItemIndex != -1 && nextLockedItemIndex - sizedItemIndex < nextLockedLineIndex - (beginSizedLineIndex + lineVectorIndex)) || // A locked item is ahead, going forward, just far enough to impose the minimum of one item per line
+						(!forward && nextLockedItemIndex != -1 && sizedItemIndex - nextLockedItemIndex < endSizedLineIndex + lineVectorIndex - nextLockedLineIndex);      // A locked item is ahead, going backward, just far enough to impose the minimum of one item per line
+
+					if (!mustNotCumulate)
+					{
+						if (canCumulate)
+						{
+							if (nextLockedItemIndex != -1)
+							{
+								// Avoiding under-filled lines around publicly locked items.
+								GetNextLockedItem(
+									null,
+									forward,
+									beginSizedLineIndex,
+									endSizedLineIndex,
+									sizedItemIndex,
+									out int nextPublicLockedItemIndex,
+									out int nextPublicLockedLineIndex);
+
+								if (nextPublicLockedItemIndex != -1)
+								{
+									MUX_ASSERT(nextPublicLockedLineIndex != -1);
+
+									int linesToFill = forward ? nextPublicLockedLineIndex - beginSizedLineIndex - lineVectorIndex : endSizedLineIndex + lineVectorIndex - nextPublicLockedLineIndex;
+									int linesPerScrollViewport = (int)(scrollViewport / (actualLineHeight + lineSpacing));
+
+									if (linesToFill <= linesPerScrollViewport)
+									{
+										MUX_ASSERT(lineItemsCount > 0);
+
+										int itemsAvailable = forward ? nextPublicLockedItemIndex - sizedItemIndex + lineItemsCount : sizedItemIndex - nextPublicLockedItemIndex + lineItemsCount;
+										int averageItemsToFill = (int)(m_averageItemsPerLine.second * linesToFill);
+
+										// shouldNotCumulate is set to true to wrap earlier than necessary to avoid under-filled lines around the publicly locked item.
+										shouldNotCumulate = itemsAvailable < averageItemsToFill;
+									}
+								}
+							}
+						}
+
+						if (averageLineItemsWidth > 0.0 && ((canCumulate && !shouldNotCumulate) || !canCumulate))
+						{
+							MUX_ASSERT(!mustCumulate);
+							MUX_ASSERT(!mustNotCumulate);
+
+							// Check if cumulated total line widths is much larger or smaller than expected total based on average line width.
+							int lineCount = forward ? (lineVectorIndex + 1) : (sizedLineCount - lineVectorIndex);
+							MUX_ASSERT(lineCount > 0);
+							double itemWidthMultiplierThreshold = GetItemWidthMultiplierThreshold();
+							double expectedCumulatedLinesWidth = averageLineItemsWidth * lineCount;
+							double actualCumulatedLinesWidth = cumulatedLinesWidth + cumulatedWidth + itemWidth;
+
+							if (canCumulate && !shouldNotCumulate)
+							{
+								if (actualCumulatedLinesWidth - expectedCumulatedLinesWidth > itemWidthMultiplierThreshold * itemWidth)
+								{
+									// In order to equalize lines, wrapping is preferred over not wrapping because the cumulated item widths significantly exceeds the expected one given the line index.
+									shouldNotCumulate = true;
+								}
+							}
+							else
+							{
+								MUX_ASSERT(!canCumulate);
+								MUX_ASSERT(!shouldNotCumulate);
+
+								if (expectedCumulatedLinesWidth - actualCumulatedLinesWidth > itemWidthMultiplierThreshold * itemWidth)
+								{
+									// In order to equalize lines, not wrapping is preferred over wrapping because the cumulated item widths is significantly lower than the expected one given the line index.
+									shouldCumulate = true;
+								}
 							}
 						}
 					}
+				}
 
-					desiredWidth += (float)element.DesiredSize.Width;
+				MUX_ASSERT(!shouldNotCumulate || !shouldCumulate);
+
+				if (mustCumulate || ((canCumulate || shouldCumulate) && !mustNotCumulate && !shouldNotCumulate))
+				{
+					// The current item sizedItemIndex is appended on the current line.
+					if (isLockedItem ||
+						isInternalLockedItem ||
+						sizedItemIndex == beginSizedItemIndex ||
+						sizedItemIndex == endSizedItemIndex)
+					{
+						lastItemWidth = double.MaxValue;
+						lastItemIndex = int.MaxValue;
+					}
+					else
+					{
+						lastItemWidth = itemWidth;
+						lastItemIndex = sizedItemIndex;
+					}
+
+					if (lineItemsCount != 0)
+					{
+						cumulatedWidth += minItemSpacing;
+					}
+
+					cumulatedWidth += itemWidth;
+					lineItemsCount++;
+				}
+				else
+				{
+					// The current item sizedItemIndex creates a brand new line.
+					MUX_ASSERT(lineItemsCount > 0);
+
+					if (lastItemWidth != double.MaxValue)
+					{
+						tailItemWidths[lineVectorIndex] = lastItemWidth;
+						tailItemIndexes[lineVectorIndex] = lastItemIndex;
+
+						lastItemWidth = double.MaxValue;
+						lastItemIndex = int.MaxValue;
+					}
+
+					cumulatedLinesWidth += cumulatedWidth;
+					cumulatedWidth = itemWidth;
+					lineItemsCount = 1;
+
+					if (isLockedItem)
+					{
+						lineVectorIndex = lockedLineIndex - (forward ? beginSizedLineIndex : endSizedLineIndex);
+						MUX_ASSERT(lineVectorIndex >= 0);
+						MUX_ASSERT(lineVectorIndex <= sizedLineCount - 1);
+					}
+					else if (isInternalLockedItem)
+					{
+						lineVectorIndex = internalLockedLineIndex - (forward ? beginSizedLineIndex : endSizedLineIndex);
+						MUX_ASSERT(lineVectorIndex >= 0);
+						MUX_ASSERT(lineVectorIndex <= sizedLineCount - 1);
+					}
+					else if (sizedItemIndex == endSizedItemIndex)
+					{
+						lineVectorIndex = forward ? sizedLineCount - 1 : 0;
+#if DEBUG
+						if (forward)
+						{
+							MUX_ASSERT(lineVectorIndex == 0 || itemsLayout.m_lineItemCounts[lineVectorIndex - 1] > 0);
+						}
+						else
+						{
+							MUX_ASSERT(lineVectorIndex == sizedLineCount - 1 || itemsLayout.m_lineItemCounts[lineVectorIndex + 1] > 0);
+						}
+#endif
+					}
+					else
+					{
+						MUX_ASSERT(itemsLayout.m_lineItemCounts[lineVectorIndex] > 0);
+						lineVectorIndex = forward ? lineVectorIndex + 1 : lineVectorIndex - 1;
+						MUX_ASSERT(lineVectorIndex >= 0);
+						MUX_ASSERT(lineVectorIndex <= sizedLineCount - 1);
+					}
+
+					if (!isLockedItem &&
+						!isInternalLockedItem &&
+						sizedItemIndex != beginSizedItemIndex &&
+						sizedItemIndex != endSizedItemIndex &&
+						((forward && endSizedItemIndex - sizedItemIndex >= sizedLineCount - lineVectorIndex) ||
+							(!forward && sizedItemIndex - endSizedItemIndex > lineVectorIndex)))
+					{
+						headItemWidths[lineVectorIndex] = itemWidth;
+						headItemIndexes[lineVectorIndex] = sizedItemIndex;
+					}
+				}
+
+				itemsLayout.m_lineItemCounts[lineVectorIndex] = lineItemsCount;
+				itemsLayout.m_lineItemWidths[lineVectorIndex] = cumulatedWidth;
+
+				if (sizedItemIndex == endSizedItemIndex)
+				{
+					break;
 				}
 			}
 
-			if (isNewlyRealizedElementMeasuredWithMinWidth)
+#if DEBUG
+			if (forward)
 			{
-				InvalidateMeasureTimerStart(0 /*tickCount*/);
+				MUX_ASSERT(headItemWidths[0] == 0.0);
+				MUX_ASSERT(headItemIndexes[0] == int.MaxValue);
+				MUX_ASSERT(tailItemWidths[sizedLineCount - 1] == 0.0);
+				MUX_ASSERT(tailItemIndexes[sizedLineCount - 1] == int.MaxValue);
+			}
+			else
+			{
+				MUX_ASSERT(tailItemWidths[0] == 0.0);
+				MUX_ASSERT(tailItemIndexes[0] == int.MaxValue);
+				MUX_ASSERT(headItemWidths[sizedLineCount - 1] == 0.0);
+				MUX_ASSERT(headItemIndexes[sizedLineCount - 1] == int.MaxValue);
 			}
 
-			SetAverageItemsPerLine(
-				SnapAverageItemsPerLine(
-					m_averageItemsPerLine.first /*oldAverageItemsPerLineRaw*/,
-					m_itemCount /*newAverageItemsPerLineRaw*/),
-				true /*unlockItems*/);
-
-			if (m_itemCount > 0)
+			for (lineVectorIndex = 1; lineVectorIndex < sizedLineCount; lineVectorIndex++)
 			{
-				desiredWidth += (float)((m_itemCount - 1) * MinItemSpacing);
+				MUX_ASSERT(headItemIndexes[lineVectorIndex - 1] == int.MaxValue ||
+					headItemIndexes[lineVectorIndex] == int.MaxValue ||
+					headItemIndexes[lineVectorIndex - 1] < headItemIndexes[lineVectorIndex]);
+				MUX_ASSERT(tailItemIndexes[lineVectorIndex - 1] == int.MaxValue ||
+					tailItemIndexes[lineVectorIndex] == int.MaxValue ||
+					tailItemIndexes[lineVectorIndex - 1] < tailItemIndexes[lineVectorIndex]);
+			}
+#endif
+
+			for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+			{
+				if (headItemWidths[lineVectorIndex] != 0.0 && itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
+				{
+					MUX_ASSERT(!forward || lineVectorIndex - 1 >= 0);
+					MUX_ASSERT(forward || lineVectorIndex + 1 < sizedLineCount);
+
+					headItemDrawbackImprovements[lineVectorIndex] = GetItemDrawbackImprovement(
+						headItemWidths[lineVectorIndex] + minItemSpacing,
+						adjustedAvailableWidth,
+						itemsLayout.m_lineItemWidths[lineVectorIndex],
+						itemsLayout.m_lineItemWidths[forward ? lineVectorIndex - 1 : lineVectorIndex + 1],
+						beginLineVectorIndex + lineVectorIndex,
+						beginLineVectorIndex + (forward ? lineVectorIndex - 1 : lineVectorIndex + 1));
+				}
+
+				if (tailItemWidths[lineVectorIndex] != 0.0 && itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
+				{
+					MUX_ASSERT(!forward || lineVectorIndex + 1 < sizedLineCount);
+					MUX_ASSERT(forward || lineVectorIndex - 1 >= 0);
+
+					tailItemDrawbackImprovements[lineVectorIndex] = GetItemDrawbackImprovement(
+						tailItemWidths[lineVectorIndex] + minItemSpacing,
+						adjustedAvailableWidth,
+						itemsLayout.m_lineItemWidths[lineVectorIndex],
+						itemsLayout.m_lineItemWidths[forward ? lineVectorIndex + 1 : lineVectorIndex - 1],
+						beginLineVectorIndex + lineVectorIndex,
+						beginLineVectorIndex + (forward ? lineVectorIndex + 1 : lineVectorIndex - 1));
+				}
 			}
 
-			return desiredWidth;
+#if DEBUG
+			if (forward)
+			{
+				MUX_ASSERT(headItemDrawbackImprovements[0] == 0.0);
+				MUX_ASSERT(tailItemDrawbackImprovements[sizedLineCount - 1] == 0.0);
+			}
+			else
+			{
+				MUX_ASSERT(tailItemDrawbackImprovements[0] == 0.0);
+				MUX_ASSERT(headItemDrawbackImprovements[sizedLineCount - 1] == 0.0);
+			}
+#endif
+
+			double smallestHeadItemWidth = double.MaxValue;
+			double smallestTailItemWidth = double.MaxValue;
+			double bestEqualizingHeadItemDrawbackImprovement = 0.0;
+			double bestEqualizingTailItemDrawbackImprovement = 0.0;
+			int smallestHeadItemIndex = int.MaxValue;
+			int smallestTailItemIndex = int.MaxValue;
+			int smallestHeadLineIndex = int.MaxValue;
+			int smallestTailLineIndex = int.MaxValue;
+			int bestEqualizingHeadItemIndex = int.MaxValue;
+			int bestEqualizingTailItemIndex = int.MaxValue;
+			int bestEqualizingHeadLineIndex = int.MaxValue;
+			int bestEqualizingTailLineIndex = int.MaxValue;
+
+			for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+			{
+				if (smallestHeadItemWidth > headItemWidths[lineVectorIndex] &&
+					headItemWidths[lineVectorIndex] > 0.0)
+				{
+					smallestHeadItemWidth = headItemWidths[lineVectorIndex];
+					smallestHeadItemIndex = headItemIndexes[lineVectorIndex];
+					smallestHeadLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
+				}
+
+				if (bestEqualizingHeadItemDrawbackImprovement < headItemDrawbackImprovements[lineVectorIndex])
+				{
+					bestEqualizingHeadItemDrawbackImprovement = headItemDrawbackImprovements[lineVectorIndex];
+					bestEqualizingHeadItemIndex = headItemIndexes[lineVectorIndex];
+					bestEqualizingHeadLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
+				}
+
+				if (itemsLayout.m_lineItemWidths[lineVectorIndex] <= adjustedAvailableWidth &&
+					tailItemWidths[lineVectorIndex] > 0.0 &&
+					smallestTailItemWidth > tailItemWidths[lineVectorIndex] + adjustedAvailableWidth - itemsLayout.m_lineItemWidths[lineVectorIndex])
+				{
+					smallestTailItemWidth = tailItemWidths[lineVectorIndex] + adjustedAvailableWidth - itemsLayout.m_lineItemWidths[lineVectorIndex];
+					smallestTailItemIndex = tailItemIndexes[lineVectorIndex];
+					smallestTailLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
+				}
+
+				if (bestEqualizingTailItemDrawbackImprovement < tailItemDrawbackImprovements[lineVectorIndex])
+				{
+					bestEqualizingTailItemDrawbackImprovement = tailItemDrawbackImprovements[lineVectorIndex];
+					bestEqualizingTailItemIndex = tailItemIndexes[lineVectorIndex];
+					bestEqualizingTailLineIndex = forward ? beginSizedLineIndex + lineVectorIndex : endSizedLineIndex + lineVectorIndex;
+				}
+			}
+
+#if DEBUG
+			if (forward)
+			{
+				MUX_ASSERT(smallestHeadLineIndex == int.MaxValue || smallestHeadLineIndex > beginSizedLineIndex);
+				MUX_ASSERT(smallestHeadLineIndex == int.MaxValue || smallestHeadLineIndex <= endSizedLineIndex);
+				MUX_ASSERT(smallestTailLineIndex == int.MaxValue || smallestTailLineIndex >= beginSizedLineIndex);
+				MUX_ASSERT(smallestTailLineIndex == int.MaxValue || smallestTailLineIndex < endSizedLineIndex);
+
+				MUX_ASSERT(bestEqualizingHeadLineIndex == int.MaxValue || bestEqualizingHeadLineIndex > beginSizedLineIndex);
+				MUX_ASSERT(bestEqualizingHeadLineIndex == int.MaxValue || bestEqualizingHeadLineIndex <= endSizedLineIndex);
+				MUX_ASSERT(bestEqualizingTailLineIndex == int.MaxValue || bestEqualizingTailLineIndex >= beginSizedLineIndex);
+				MUX_ASSERT(bestEqualizingTailLineIndex == int.MaxValue || bestEqualizingTailLineIndex < endSizedLineIndex);
+			}
+			else
+			{
+				MUX_ASSERT(smallestHeadLineIndex == int.MaxValue || smallestHeadLineIndex >= endSizedLineIndex);
+				MUX_ASSERT(smallestHeadLineIndex == int.MaxValue || smallestHeadLineIndex < beginSizedLineIndex);
+				MUX_ASSERT(smallestTailLineIndex == int.MaxValue || smallestTailLineIndex > endSizedLineIndex);
+				MUX_ASSERT(smallestTailLineIndex == int.MaxValue || smallestTailLineIndex <= beginSizedLineIndex);
+
+				MUX_ASSERT(bestEqualizingHeadLineIndex == int.MaxValue || bestEqualizingHeadLineIndex >= endSizedLineIndex);
+				MUX_ASSERT(bestEqualizingHeadLineIndex == int.MaxValue || bestEqualizingHeadLineIndex < beginSizedLineIndex);
+				MUX_ASSERT(bestEqualizingTailLineIndex == int.MaxValue || bestEqualizingTailLineIndex > endSizedLineIndex);
+				MUX_ASSERT(bestEqualizingTailLineIndex == int.MaxValue || bestEqualizingTailLineIndex <= beginSizedLineIndex);
+			}
+
+			MUX_ASSERT(smallestHeadItemIndex != beginSizedItemIndex);
+			MUX_ASSERT(smallestHeadItemIndex != endSizedItemIndex);
+			MUX_ASSERT(smallestTailItemIndex != beginSizedItemIndex);
+			MUX_ASSERT(smallestTailItemIndex != endSizedItemIndex);
+
+			MUX_ASSERT(bestEqualizingHeadItemIndex != beginSizedItemIndex);
+			MUX_ASSERT(bestEqualizingHeadItemIndex != endSizedItemIndex);
+			MUX_ASSERT(bestEqualizingTailItemIndex != beginSizedItemIndex);
+			MUX_ASSERT(bestEqualizingTailItemIndex != endSizedItemIndex);
+#endif
+
+			itemsLayout.m_smallestHeadItemWidth = smallestHeadItemWidth;
+			itemsLayout.m_smallestTailItemWidth = smallestTailItemWidth;
+			itemsLayout.m_smallestHeadItemIndex = smallestHeadItemIndex;
+			itemsLayout.m_smallestTailItemIndex = smallestTailItemIndex;
+			itemsLayout.m_smallestHeadLineIndex = smallestHeadLineIndex;
+			itemsLayout.m_smallestTailLineIndex = smallestTailLineIndex;
+
+			itemsLayout.m_bestEqualizingHeadItemDrawbackImprovement = bestEqualizingHeadItemDrawbackImprovement;
+			itemsLayout.m_bestEqualizingTailItemDrawbackImprovement = bestEqualizingTailItemDrawbackImprovement;
+			itemsLayout.m_bestEqualizingHeadItemIndex = bestEqualizingHeadItemIndex;
+			itemsLayout.m_bestEqualizingTailItemIndex = bestEqualizingTailItemIndex;
+			itemsLayout.m_bestEqualizingHeadLineIndex = bestEqualizingHeadLineIndex;
+			itemsLayout.m_bestEqualizingTailLineIndex = bestEqualizingTailLineIndex;
+
+			// When itemsLayout.m_smallestTailItemWidth == double.MaxValue, i.e. when all itemsLayout.m_lineItemWidths[lineVectorIndex] are greater
+			// than adjustedAvailableWidth, it's not worth collapsing the adjustedAvailableWidth.
+			// When all itemsLayout.m_lineItemWidths[lineVectorIndex] are smaller than adjustedAvailableWidth, it's not worth expanding the adjustedAvailableWidth.
+
+			ComputeItemsLayoutDrawback(availableWidth, isLastSizedLineStretchEnabled, itemsLayout);
+
+#if DEBUG
+			MUX_ASSERT(itemsLayout.m_lineItemCounts[0] > 0);
+			MUX_ASSERT(itemsLayout.m_lineItemCounts[sizedLineCount - 1] > 0);
+
+			int lineItemCountsDbg = 0;
+
+			for (lineVectorIndex = 0; lineVectorIndex < itemsLayout.m_lineItemCounts.Count; lineVectorIndex++)
+			{
+				MUX_ASSERT(itemsLayout.m_lineItemCounts[lineVectorIndex] > 0);
+
+				lineItemCountsDbg += itemsLayout.m_lineItemCounts[lineVectorIndex];
+			}
+
+			MUX_ASSERT(sizedItemCountDbg == lineItemCountsDbg);
+#endif
+
+			return itemsLayout;
 		}
 
-		#endregion
+		// Returns the total arrange width of the items within the provided range.
+		private float GetItemsRangeArrangeWidth(
+			int beginSizedItemIndex,
+			int endSizedItemIndex,
+			bool usesArrangeWidthInfo)
+		{
+			MUX_ASSERT(beginSizedItemIndex >= 0);
+			MUX_ASSERT(endSizedItemIndex < m_itemCount);
+			MUX_ASSERT(beginSizedItemIndex <= endSizedItemIndex);
+			MUX_ASSERT(!UsesFastPathLayout() || usesArrangeWidthInfo);
+			MUX_ASSERT(!UsesFastPathLayout() || m_itemsInfoArrangeWidths.Count > endSizedItemIndex);
 
-		#region Measure engine: constrained-lines leaves (WS-D3c sub-slice 5)
+			int itemsInfoArrangeWidthsOffset = m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex;
+			float cumulatedArrangeWidth = 0.0f;
 
-		// Returns the additional realization rect height needed so that the realization window spans at least
-		// 3 viewports and 12 lines. Used to inflate the realization rect in the regular path.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
+			for (int sizedItemIndex = beginSizedItemIndex; sizedItemIndex <= endSizedItemIndex; sizedItemIndex++)
+			{
+				if (usesArrangeWidthInfo)
+				{
+					// Use the item info provided by the ItemsInfoRequested handler since the DesiredSize.Width
+					// may still be the MinWidth because the content is loading.
+					// The use of m_itemsInfoArrangeWidths must be consistent with the one in LinedFlowLayout::ArrangeConstrainedLines.
+					cumulatedArrangeWidth += m_itemsInfoArrangeWidths[sizedItemIndex - itemsInfoArrangeWidthsOffset];
+				}
+				else if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
+				{
+					if (m_elementManager.GetRealizedElement(sizedItemIndex /*dataIndex*/) is { } element)
+					{
+						cumulatedArrangeWidth += (float)element.DesiredSize.Width;
+					}
+				}
+			}
+
+			return cumulatedArrangeWidth;
+		}
+
+		// Uses the m_lineItemCounts vector to return the index of the last item in the provided line index.
+		private int GetLastItemIndexInLineIndex(int lineVectorIndex)
+		{
+			MUX_ASSERT(lineVectorIndex >= 0);
+			MUX_ASSERT(lineVectorIndex < m_lineItemCounts.Count);
+
+			int firstItemIndexInLineIndex = GetFirstItemIndexInLineIndex(lineVectorIndex);
+
+			return firstItemIndexInLineIndex + m_lineItemCounts[lineVectorIndex] - 1;
+		}
+
+		private int GetLineCount(double averageItemsPerLine)
+		{
+			if (m_itemCount == 0)
+			{
+				return 0;
+			}
+
+			MUX_ASSERT(m_itemCount > 0);
+
+			int lineCount = GetLineIndexFromAverageItemsPerLine(m_itemCount - 1, averageItemsPerLine) + 1;
+
+			// #ifdef DBG_VERBOSE
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT, METH_NAME, this, lineCount);
+			// #endif
+			return lineCount;
+		}
+
+		// Returns the line index for the provided item index.
+		private int GetLineIndex(int itemIndex, bool usesFastPathLayout)
+		{
+			MUX_ASSERT(m_isVirtualizingContext);
+			MUX_ASSERT(itemIndex >= 0);
+			MUX_ASSERT(itemIndex < m_itemCount);
+
+			if (itemIndex == 0)
+			{
+				// May occur while m_averageItemsPerLine.second is still 0.
+				return 0;
+			}
+
+			int lineIndex = 0;
+
+			if (usesFastPathLayout)
+			{
+				int lineItemCounts = 0;
+
+				while (lineItemCounts + m_lineItemCounts[lineIndex] <= itemIndex)
+				{
+					lineItemCounts += m_lineItemCounts[lineIndex];
+					lineIndex++;
+				}
+			}
+			else
+			{
+				MUX_ASSERT(m_averageItemsPerLine.second >= 1.0);
+
+				// Determine the element's line index depending on its locked status.
+				if (m_lockedItemIndexes.TryGetValue(itemIndex, out int lockedLineIndex))
+				{
+					// Since the item is locked, use the line index it's locked on.
+					lineIndex = lockedLineIndex;
+				}
+				else
+				{
+					int sizedItemIndex = m_firstSizedItemIndex;
+					int sizedItemCount = m_lastSizedItemIndex - m_firstSizedItemIndex + 1;
+					int sizedLineVectorCount = m_lineItemCounts.Count;
+
+					// If the item is sized, use its sized line index.
+					if (sizedItemIndex != -1 &&
+						itemIndex >= sizedItemIndex &&
+						itemIndex < sizedItemIndex + sizedItemCount &&
+						m_lastSizedLineIndex - m_firstSizedLineIndex + 1 == sizedLineVectorCount)
+					{
+						MUX_ASSERT(m_firstSizedLineIndex >= 0);
+
+						int sizedLineVectorIndex = 0;
+
+						while (sizedItemIndex + m_lineItemCounts[sizedLineVectorIndex] - 1 < itemIndex)
+						{
+							sizedItemIndex += m_lineItemCounts[sizedLineVectorIndex];
+							sizedLineVectorIndex++;
+
+							MUX_ASSERT(sizedLineVectorIndex < sizedLineVectorCount);
+						}
+
+						lineIndex = m_firstSizedLineIndex + sizedLineVectorIndex;
+					}
+					else
+					{
+						// As a last resort, use the estimated line index based on the average items per line.
+						lineIndex = GetLineIndexFromAverageItemsPerLine(itemIndex, m_averageItemsPerLine.second);
+					}
+				}
+			}
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, L"lineIndex", lineIndex);
+
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, L"itemIndex", itemIndex);
+			return lineIndex;
+		}
+
+		private int GetLineIndexFromAverageItemsPerLine(int itemIndex, double averageItemsPerLine)
+		{
+			MUX_ASSERT(averageItemsPerLine >= 1.0);
+
+			int lineIndex = (int)(itemIndex / averageItemsPerLine);
+
+			return lineIndex;
+		}
+
+		// Returns the largest line width for a range of lines.
+		// When item sizing info is used, that range is the sized lines.
+		// Otherwise it's the frozen lines only.
+		private float GetLinesDesiredWidth()
+		{
+			if (m_firstFrozenLineIndex == -1)
+			{
+				// This occurs when GetFirstAndLastDisplayedLineIndexes returns firstDisplayedLineIndex==-1
+				// because the scrollViewport is still 0.0 for example.
+				return 0.0f;
+			}
+
+			MUX_ASSERT(m_firstSizedLineIndex >= 0);
+			MUX_ASSERT(m_lastSizedLineIndex >= m_firstSizedLineIndex);
+			MUX_ASSERT(m_firstSizedItemIndex >= 0);
+			MUX_ASSERT(m_lastSizedItemIndex >= m_firstSizedItemIndex);
+			MUX_ASSERT(m_firstFrozenLineIndex >= 0);
+			MUX_ASSERT(m_lastFrozenLineIndex >= m_firstFrozenLineIndex);
+			MUX_ASSERT(m_firstFrozenItemIndex >= 0);
+			MUX_ASSERT(m_lastFrozenItemIndex >= m_firstFrozenItemIndex);
+
+			bool usesArrangeWidthInfo = UsesArrangeWidthInfo();
+			float minItemSpacing = (float)MinItemSpacing;
+			int firstLineIndex = usesArrangeWidthInfo ? m_firstSizedLineIndex : m_firstFrozenLineIndex;
+			int lastLineIndex = usesArrangeWidthInfo ? m_lastSizedLineIndex : m_lastFrozenLineIndex;
+			int itemIndex = usesArrangeWidthInfo ? m_firstSizedItemIndex : m_firstFrozenItemIndex;
+			float maxLineWidth = 0.0f;
+
+			MUX_ASSERT(!usesArrangeWidthInfo || m_itemsInfoFirstIndex >= 0);
+
+			for (int lineIndex = firstLineIndex; lineIndex <= lastLineIndex; lineIndex++)
+			{
+				int lineItemsCount = m_lineItemCounts[lineIndex - m_firstSizedLineIndex];
+				float lineWidth = 0.0f;
+
+				for (int lineItemIndex = 0; lineItemIndex < lineItemsCount; lineItemIndex++)
+				{
+					float itemWidth = 0.0f;
+
+					if (usesArrangeWidthInfo)
+					{
+						itemWidth = m_itemsInfoArrangeWidths[itemIndex - m_itemsInfoFirstIndex];
+					}
+					else
+					{
+						MUX_ASSERT(m_elementManager.IsDataIndexRealized(itemIndex));
+
+						if (m_elementManager.GetRealizedElement(itemIndex) is { } element)
+						{
+							itemWidth = (float)element.DesiredSize.Width;
+						}
+					}
+
+					if (lineItemIndex > 0)
+					{
+						lineWidth += minItemSpacing;
+					}
+
+					lineWidth += itemWidth;
+
+					itemIndex++;
+				}
+
+				maxLineWidth = Math.Max(lineWidth, maxLineWidth);
+			}
+
+			return maxLineWidth;
+		}
+
+		private double GetMaxWidthFromItemsInfo(int itemIndex)
+		{
+			MUX_ASSERT(itemIndex >= 0);
+			MUX_ASSERT(itemIndex < m_itemCount);
+			MUX_ASSERT(m_itemsInfoMaxWidth >= 0.0 || m_itemsInfoMaxWidth == -1.0);
+
+			// Preserve WinUI's sentinel behavior: an unset global max (-1) disables per-item max caps.
+			if (UsesFastPathLayout())
+			{
+				// Fast path layout
+				if (itemIndex < m_itemsInfoMaxWidthsForFastPath.Length)
+				{
+					return Math.Min(m_itemsInfoMaxWidth, m_itemsInfoMaxWidthsForFastPath[itemIndex]);
+				}
+			}
+			else
+			{
+				// Regular path layout
+				if (itemIndex - m_itemsInfoFirstIndex >= 0 &&
+					itemIndex - m_itemsInfoFirstIndex < m_itemsInfoMaxWidthsForRegularPath.Count)
+				{
+					return Math.Min(m_itemsInfoMaxWidth, m_itemsInfoMaxWidthsForRegularPath[itemIndex - m_itemsInfoFirstIndex]);
+				}
+			}
+
+			return m_itemsInfoMaxWidth;
+		}
+
+		private double GetMinWidthFromItemsInfo(int itemIndex)
+		{
+			MUX_ASSERT(itemIndex >= 0);
+			MUX_ASSERT(itemIndex < m_itemCount);
+			MUX_ASSERT(m_itemsInfoMinWidth >= 0.0 || m_itemsInfoMinWidth == -1.0);
+
+			if (UsesFastPathLayout())
+			{
+				// Fast path layout
+				if (itemIndex < m_itemsInfoMinWidthsForFastPath.Length)
+				{
+					return Math.Max(m_itemsInfoMinWidth, m_itemsInfoMinWidthsForFastPath[itemIndex]);
+				}
+			}
+			else
+			{
+				// Regular path layout
+				if (itemIndex - m_itemsInfoFirstIndex >= 0 &&
+					itemIndex - m_itemsInfoFirstIndex < m_itemsInfoMinWidthsForRegularPath.Count)
+				{
+					return Math.Max(m_itemsInfoMinWidth, m_itemsInfoMinWidthsForRegularPath[itemIndex - m_itemsInfoFirstIndex]);
+				}
+			}
+
+			return m_itemsInfoMinWidth;
+		}
+
+		private void GetNextLockedItem(
+			SortedDictionary<int, int>? internalLockedItemIndexes,
+			bool forward,
+			int beginLineIndex,
+			int endLineIndex,
+			int itemIndex,
+			out int lockedItemIndex,
+			out int lockedLineIndex)
+		{
+			lockedItemIndex = lockedLineIndex = -1;
+
+			int distance = int.MaxValue;
+
+			if (internalLockedItemIndexes != null)
+			{
+				foreach (var lockedItemIterator in internalLockedItemIndexes)
+				{
+					if (forward &&
+						lockedItemIterator.Key > itemIndex &&
+						lockedItemIterator.Key - itemIndex < distance &&
+						lockedItemIterator.Value >= beginLineIndex &&
+						lockedItemIterator.Value <= endLineIndex)
+					{
+						distance = lockedItemIterator.Key - itemIndex;
+						lockedItemIndex = lockedItemIterator.Key;
+						lockedLineIndex = lockedItemIterator.Value;
+					}
+					else if (!forward &&
+						lockedItemIterator.Key < itemIndex &&
+						itemIndex - lockedItemIterator.Key < distance &&
+						lockedItemIterator.Value <= beginLineIndex &&
+						lockedItemIterator.Value >= endLineIndex)
+					{
+						distance = itemIndex - lockedItemIterator.Key;
+						lockedItemIndex = lockedItemIterator.Key;
+						lockedLineIndex = lockedItemIterator.Value;
+					}
+				}
+			}
+
+			foreach (var lockedItemIterator in m_lockedItemIndexes)
+			{
+				if (forward &&
+					lockedItemIterator.Key > itemIndex &&
+					lockedItemIterator.Key - itemIndex < distance &&
+					lockedItemIterator.Value >= beginLineIndex &&
+					lockedItemIterator.Value <= endLineIndex)
+				{
+					distance = lockedItemIterator.Key - itemIndex;
+					lockedItemIndex = lockedItemIterator.Key;
+					lockedLineIndex = lockedItemIterator.Value;
+				}
+				else if (!forward &&
+					lockedItemIterator.Key < itemIndex &&
+					itemIndex - lockedItemIterator.Key < distance &&
+					lockedItemIterator.Value <= beginLineIndex &&
+					lockedItemIterator.Value >= endLineIndex)
+				{
+					distance = itemIndex - lockedItemIterator.Key;
+					lockedItemIndex = lockedItemIterator.Key;
+					lockedLineIndex = lockedItemIterator.Value;
+				}
+			}
+		}
+
 		private float GetRealizationRectHeightDeficit(
 			VirtualizingLayoutContext context,
 			double actualLineHeight,
@@ -5237,11 +4934,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 			MUX_ASSERT(realizationRectHeightDeficit >= 0.0);
 
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_FLT, METH_NAME, this, realizationRectHeightDeficit);
 			return realizationRectHeightDeficit;
 		}
 
 		// Returns the range of realized items given a larger range of sized items.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
 		private void GetRealizedItemsFromSizedItems(
 			int realizedLineCount,
 			int lineCount,
@@ -5269,6 +4966,9 @@ namespace Microsoft.UI.Xaml.Controls
 			realizedItemCountTmp = Math.Max(realizedLineCount, realizedItemCountTmp);
 			realizedItemCountTmp = Math.Min(m_lastSizedItemIndex - unrealizedNearItemCountTmp + 1, realizedItemCountTmp);
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"unrealizedNearItemCount", unrealizedNearItemCountTmp);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"realizedItemCount", realizedItemCountTmp);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"realized item index range", unrealizedNearItemCountTmp, unrealizedNearItemCountTmp + realizedItemCountTmp - 1);
 			MUX_ASSERT(unrealizedNearItemCountTmp < m_itemCount);
 			MUX_ASSERT(unrealizedNearItemCountTmp >= m_unrealizedNearLineCount);
 			MUX_ASSERT((m_unrealizedNearLineCount == 0 && unrealizedNearItemCountTmp == 0) || (m_unrealizedNearLineCount > 0 && unrealizedNearItemCountTmp > 0));
@@ -5280,121 +4980,652 @@ namespace Microsoft.UI.Xaml.Controls
 			realizedItemCount = realizedItemCountTmp;
 		}
 
-		// Rounds 'value' to the current rasterization scale factor.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
+		private float GetSizedItemsRectHeight(
+			VirtualizingLayoutContext context,
+			double actualLineHeight,
+			double lineSpacing)
+		{
+			// This layout performs poorly when there are less than 20 lines to operate with in 5 scroll viewports.
+			// The target rect height for the realized + unrealized sized items is at least 5 viewports and 20 lines.
+			const float minimumCacheLength = 4.0f;
+			const float minimumCacheLineCount = 4.0f;
+
+			// Ensure there are 4 buffer viewports before and after the visible viewport.
+			float sizedItemsRectHeight = (minimumCacheLength + 1.0f) * (float)context.VisibleRect.Height;
+
+			// Ensure there are 20 lines in the resulting 5 viewports.
+			return Math.Max(sizedItemsRectHeight, (minimumCacheLength + 1.0f) * minimumCacheLineCount * (float)(actualLineHeight + lineSpacing));
+		}
+
 		private double GetRoundedDouble(
 			double value)
 		{
 			return Math.Round(value * m_roundingScaleFactor, MidpointRounding.AwayFromZero) / m_roundingScaleFactor;
 		}
 
-		// Computes the raw and snapped average items per line based on the average item aspect ratio and available width.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private (double first, double second) GetAverageItemsPerLine(
-			float availableWidth)
+		private float GetRoundedFloat(
+			float value)
 		{
-			double averageWidth;
-			double minItemSpacing = MinItemSpacing;
-			double actualLineHeight = ActualLineHeight;
+			return (float)(Math.Round(value * m_roundingScaleFactor, MidpointRounding.AwayFromZero) / m_roundingScaleFactor);
+		}
 
-			// During initial loading, in cases no sizing information is provided by an ItemsInfoRequested event handler,
-			// the average item aspect ratio is set no lower than 1.5, 1.25 & 1.0 in the first 3 measure passes.
-			// This is to avoid the unpopulated items' small MinWidth to artificially result in a small average aspect ratio
-			// causing a momentary item realization that gets thrown away as soon as the real average aspect ratio is set.
-			double minAverageItemAspectRatio = m_measureCountdown * 0.25 + 0.5;
+		private void InitializeForRelayout(
+			int sizedLineCount,
+			out int firstStillSizedLineIndex,
+			out int lastStillSizedLineIndex,
+			out int firstStillSizedItemIndex,
+			out int lastStillSizedItemIndex)
+		{
+			EnsureLineItemCounts(sizedLineCount);
 
-			if (m_aspectRatios != null && !m_aspectRatios.IsEmpty())
+			firstStillSizedLineIndex = -1;
+			lastStillSizedLineIndex = -1;
+			firstStillSizedItemIndex = -1;
+			lastStillSizedItemIndex = -1;
+		}
+
+		// Causes potential items info to be discarded and triggers a complete re-layout so that
+		// the ItemsInfoRequested event gets raised again to retrieve updated sizing information.
+		/// <summary>
+		/// Discards the item sizing info previously gathered through the <see cref="ItemsInfoRequested"/>
+		/// event and forces a re-layout in the next measure pass.
+		/// </summary>
+		public void InvalidateItemsInfo()
+		{
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+			InvalidateLayout(forceRelayout: true, resetItemsInfo: true, invalidateMeasure: true);
+		}
+
+		// - forceRelayout == True:     forces a re-layout in the next measure pass.
+		// - resetItemsInfo == True:    resets the items info gathered so far.
+		// - invalidateMeasure == True: triggers a new measure pass.
+		internal void InvalidateLayout(
+			bool forceRelayout = true,
+			bool resetItemsInfo = false,
+			bool invalidateMeasure = true)
+		{
+			MUX_ASSERT(forceRelayout || resetItemsInfo || invalidateMeasure);
+
+			if (forceRelayout)
 			{
-				double averageItemAspectRatio = GetAverageAspectRatioFromStorage();
+				// Perform a complete re-layout during the next layout pass.
+				NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.InvalidateLayoutCall);
+				m_forceRelayout = true;
+			}
 
-				// During initial load, avoid small aspect ratios while the first items are still loading
-				// to avoid unnecessary item realizations. This is only done when the ItemsInfoRequested event handler did not provide sizing information.
-				if (m_itemsInfoFirstIndex == -1 && m_measureCountdown > 1 && averageItemAspectRatio < minAverageItemAspectRatio)
+			if (resetItemsInfo)
+			{
+				// Discard any potential item sizing info previously collected through the ItemsInfoRequested event.
+				ResetItemsInfo();
+			}
+
+			if (invalidateMeasure)
+			{
+				// Trigger a new layout pass.
+				InvalidateMeasure();
+			}
+		}
+
+		// Invokes InvalidateLayout asynchronously with only invalidateMeasure == True to trigger a new measure pass.
+		private void InvalidateMeasureAsync()
+		{
+			// Previously we used get_weak() here, but we found the potential to hit a
+			// refcounting problem where in some scenarios the outer object gets
+			// an extra Release() in this process.
+			// Exit early if Xaml core has already shut down.
+			// TODO Uno: The weak reference guards against a collected layout. Uno has no direct
+			// WindowsXamlManager shutdown probe, so the Xaml-core early exit is omitted.
+			var weakThis = new WeakReference<LinedFlowLayout>(this);
+
+			DispatcherQueue.TryEnqueue(() =>
+			{
+				if (weakThis.TryGetTarget(out var strongThis))
 				{
-					averageItemAspectRatio = minAverageItemAspectRatio;
+					strongThis.InvalidateLayout(false /*forceRelayout*/, false /*resetItemsInfo*/, true /*invalidateMeasure*/);
+				}
+			});
+		}
 
-					// Making sure there is another layout coming with a decreased m_measureCountdown value to stop using an adjusted averageItemAspectRatio.
-					// Layout invalidation is done asynchronously to have an effect since this method, GetAverageItemsPerLine, is called during measure passes.
-					InvalidateMeasureAsync();
+		// Starts the timer used to trigger an asynchronous measure pass when no items info was provided by the ItemsInfoRequested
+		// event. Invoked after an item was realized or when the timer expires and the tickCount is still smaller than 7.
+		// The timer interval begins at 100ms and is then increased by 50% each time it is re-started, until tickCount reaches 7.
+		// By then the interval is 1.7s and the total time elapsed is about 5s when the timer is no longer re-started.
+		// Asynchronous measure passes are triggered to check if the ItemsRepeater's children have a new desired size.
+		// This is done because when a child is re-measured because its content changed, the Xaml layout engine uses its previous
+		// available size, preventing the ItemsRepeater from being re-measured. The use of LinedFlowLayout::ItemRangesHaveNewDesiredWidths
+		// in the asynchronous measure pass will ensure that new desired widths for the frozen items will trigger a full re-layout.
+		private void InvalidateMeasureTimerStart(int tickCount)
+		{
+			MUX_ASSERT(!UsesArrangeWidthInfo());
+
+			if (m_invalidateMeasureTimer is not null)
+			{
+				if (m_invalidateMeasureTimer.IsEnabled)
+				{
+					m_invalidateMeasureTimer.Stop();
+				}
+			}
+			else
+			{
+				m_invalidateMeasureTimer = new DispatcherTimer();
+
+				m_invalidateMeasureTimer.Tick += InvalidateMeasureTimerTick;
+			}
+
+			m_invalidateMeasureTimerTickCount = tickCount;
+
+			const double timerFactor = 1.5;
+			double timerMultiplier = Math.Pow(timerFactor, tickCount);
+
+			const long timerBase = 1000000; // 100ms
+			long timerInterval = (long)(timerBase * timerMultiplier);
+
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"tickCount", tickCount);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"timerInterval", timerInterval);
+
+			m_invalidateMeasureTimer.Interval = TimeSpan.FromTicks(timerInterval);
+			m_invalidateMeasureTimer.Start();
+		}
+
+		// Stops the timer used to trigger an asynchronous measure pass when no items info was provided by the ItemsInfoRequested event.
+		private void InvalidateMeasureTimerStop()
+		{
+			// TODO Uno: The C++ isForDestructor branch is unsupported because Uno does not use finalizers.
+			// Original C++:
+			// if (isForDestructor)
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
+			// }
+			// else
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+			// }
+			//
+			if (m_invalidateMeasureTimer is not null && m_invalidateMeasureTimer.IsEnabled)
+			{
+				m_invalidateMeasureTimer.Stop();
+			}
+		}
+
+		// Invoked when the timer used to trigger asynchronous measure passes expires.
+		// Re-starts it with a longer interval until m_invalidateMeasureTimerTickCount
+		// reaches the value 7, for a total of 8 invalidations.
+		private void InvalidateMeasureTimerTick(object? sender /*sender*/, object args /*args*/)
+		{
+			// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+			InvalidateMeasureAsync();
+
+			// The asynchronous measure pass is triggered 8 times to check if the ItemsRepeater's children
+			// have a new desired size. This is done because when a child is re-measured because its content changed,
+			// the Xaml layout engine uses its previous available size, preventing the ItemsRepeater from being re-measured.
+			const int maxInvalidateMeasureTimerTickCount = 7;
+
+			if (!UsesArrangeWidthInfo() && m_invalidateMeasureTimerTickCount < maxInvalidateMeasureTimerTickCount)
+			{
+				InvalidateMeasureTimerStart(m_invalidateMeasureTimerTickCount + 1);
+			}
+			else
+			{
+				InvalidateMeasureTimerStop();
+			}
+		}
+
+		// Determines whether using a smaller adjustedAvailableWidth may lead to an ItemsLayout with a smaller drawback.
+		private bool IsItemsLayoutContractionWorthy(ItemsLayout itemsLayout)
+		{
+			if (itemsLayout.m_smallestTailItemWidth == double.MaxValue || itemsLayout.m_smallestTailItemWidth == 0.0)
+			{
+				return false;
+			}
+
+			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
+
+			if (sizedLineCount > 1)
+			{
+				for (int lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+				{
+					if (itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		private bool IsItemsLayoutEqualizationWorthy(
+			ItemsLayout itemsLayout,
+			bool withHeadItem)
+		{
+			if ((withHeadItem && itemsLayout.m_bestEqualizingHeadItemIndex == int.MaxValue) ||
+				(!withHeadItem && itemsLayout.m_bestEqualizingTailItemIndex == int.MaxValue))
+			{
+				return false;
+			}
+
+			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
+
+			if (sizedLineCount > 1)
+			{
+				for (int lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+				{
+					if (itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		// Determines whether using a larger adjustedAvailableWidth may lead to an ItemsLayout with a smaller drawback.
+		private bool IsItemsLayoutExpansionWorthy(ItemsLayout itemsLayout)
+		{
+			if (itemsLayout.m_smallestHeadItemWidth == double.MaxValue || itemsLayout.m_smallestHeadItemWidth == 0.0)
+			{
+				return false;
+			}
+
+			int sizedLineCount = itemsLayout.m_lineItemWidths.Count;
+			bool isExpansionWorthy = false;
+
+			if (sizedLineCount > 1)
+			{
+				for (int lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+				{
+					if (itemsLayout.m_lineItemCounts[lineVectorIndex] > 1)
+					{
+						isExpansionWorthy = true;
+						break;
+					}
+				}
+			}
+
+			if (isExpansionWorthy)
+			{
+				int lineVectorIndex;
+
+				for (lineVectorIndex = 0; lineVectorIndex < sizedLineCount; lineVectorIndex++)
+				{
+					if (itemsLayout.m_lineItemWidths[lineVectorIndex] > itemsLayout.m_availableLineItemsWidth)
+					{
+						break;
+					}
 				}
 
-				m_averageItemAspectRatioDbg = averageItemAspectRatio;
-
-				averageWidth = averageItemAspectRatio * actualLineHeight;
-			}
-			else
-			{
-				m_averageItemAspectRatioDbg = minAverageItemAspectRatio;
-
-				// When no item is realized, minAverageItemAspectRatio which starts at 1.5 is used.
-				averageWidth = minAverageItemAspectRatio * actualLineHeight;
+				isExpansionWorthy = lineVectorIndex < sizedLineCount;
 			}
 
-			if (m_forcedAverageItemAspectRatioDbg != 0.0)
-			{
-				averageWidth = m_forcedAverageItemAspectRatioDbg * actualLineHeight;
-			}
+			MUX_ASSERT(!isExpansionWorthy || itemsLayout.m_smallestHeadItemWidth > 0);
 
-			// Account for the minimum spacing between items by adding minItemSpacing
-			// minItemSpacing is over-counted once for the last item.
-			averageWidth = Math.Max(1.0, averageWidth + minItemSpacing);
-
-			// minItemSpacing is added to the availableWidth to account for the over-counting above.
-			double averageItemsPerLineRaw = (availableWidth + minItemSpacing) / averageWidth;
-
-			averageItemsPerLineRaw = Math.Max(1.0, averageItemsPerLineRaw);
-
-			(double first, double second) averageItemsPerLine = SnapAverageItemsPerLine(
-				m_averageItemsPerLine.first /*oldAverageItemsPerLineRaw*/,
-				averageItemsPerLineRaw /*newAverageItemsPerLineRaw*/);
-
-			MUX_ASSERT(averageItemsPerLine.second >= 1.0);
-
-			return averageItemsPerLine;
+			return isExpansionWorthy;
 		}
 
-		// Clears the fast-path items-info buffers gathered from the ItemsInfoRequested event handler.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void ResetItemsInfoForFastPath()
+		// Returns True when 'itemIndex' is locked in a line within the [beginLineIndex, endLineIndex] range.
+		private bool IsLockedItem(
+			bool forward,
+			int beginLineIndex,
+			int endLineIndex,
+			int itemIndex)
 		{
-			m_itemsInfoDesiredAspectRatiosForFastPath = Array.Empty<double>();
-			m_itemsInfoMinWidthsForFastPath = Array.Empty<double>();
-			m_itemsInfoMaxWidthsForFastPath = Array.Empty<double>();
+			if (m_lockedItemIndexes.TryGetValue(itemIndex, out int lineIndex))
+			{
+				if (forward)
+				{
+					if (lineIndex >= beginLineIndex && lineIndex <= endLineIndex)
+					{
+						return true;
+					}
+				}
+				else
+				{
+					if (lineIndex <= beginLineIndex && lineIndex >= endLineIndex)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
 		}
 
-		// Updates m_roundingScaleFactor from the XamlRoot's rasterization scale, falling back to 1.0.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void UpdateRoundingScaleFactor(
-			UIElement xamlRootReference)
+		private bool IsVirtualizingContext(VirtualizingLayoutContext context)
 		{
-			// WinUI calls xamlRootReference.XamlRoot().RasterizationScale() inside a try/catch because
-			// GetForCurrentView on threads without a CoreWindow throws. In Uno, XamlRoot is a nullable
-			// property returning null instead of throwing, so a null check provides the equivalent fallback.
-			if (xamlRootReference.XamlRoot is { } xamlRoot)
+			if (context != null)
 			{
-				m_roundingScaleFactor = xamlRoot.RasterizationScale;
+				var rect = context.RealizationRect;
+				bool hasInfiniteSize = double.IsInfinity(rect.Height) || double.IsInfinity(rect.Width);
+				return !hasInfiniteSize;
 			}
-			else
-			{
-				// Calling GetForCurrentView on threads without a CoreWindow throws in WinUI.
-				// In this circumstance, we'll just always round to the closest integer.
-				m_roundingScaleFactor = 1.0;
-			}
+			return false;
 		}
 
-		#endregion
+		private bool LineHasInternalLockedItem(
+			SortedDictionary<int, int> internalLockedItemIndexes,
+			int lineIndex,
+			bool before,
+			int itemIndex)
+		{
+			foreach (var lockedItemIterator in internalLockedItemIndexes)
+			{
+				if (lockedItemIterator.Value == lineIndex)
+				{
+					int lockedItemIndex = lockedItemIterator.Key;
 
-		#region Measure engine: constrained-lines fast path (WS-D3c sub-slice 5)
+					if ((before && lockedItemIndex <= itemIndex) || (!before && lockedItemIndex >= itemIndex))
+					{
+						return true;
+					}
+				}
+			}
 
-		// Items measurement fast path, used when an ItemsInfoRequested handler provided sizing information for the entire data source.
-		// Returns (lineCount, maxLineWidth, itemsInfo). A lineCount of -1 signals that the regular path must be engaged instead.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
+			return false;
+		}
+
+		private bool LineHasLockedItem(
+			int lineIndex,
+			bool before,
+			int itemIndex)
+		{
+			foreach (var lockedItemIterator in m_lockedItemIndexes)
+			{
+				if (lockedItemIterator.Value == lineIndex)
+				{
+					int lockedItemIndex = lockedItemIterator.Key;
+
+					if ((before && lockedItemIndex <= itemIndex) || (!before && lockedItemIndex >= itemIndex))
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		// Returns a boolean triplet covering 3 adjacent item ranges: items preceding the frozen ones, the frozen items, and finally the items following the frozen ones.
+		// A True value is returned either when an item is recorded in m_elementDesiredWidths and not in oldElementDesiredWidths because of fast scrolling, or
+		// m_elementDesiredWidths & oldElementDesiredWidths have an item with different widths.
+		private (bool preFrozenItemHasNewDesiredWidth, bool frozenItemHasNewDesiredWidth, bool postFrozenItemHasNewDesiredWidth) ItemRangesHaveNewDesiredWidths(
+			Dictionary<UIElement, float> oldElementDesiredWidths,
+			int beginRealizedItemIndex,
+			int endRealizedItemIndex)
+		{
+			MUX_ASSERT(m_itemsInfoFirstIndex == -1);
+			MUX_ASSERT(m_elementDesiredWidths != null);
+			// MUX_ASSERT(oldElementDesiredWidths);
+			MUX_ASSERT(beginRealizedItemIndex <= endRealizedItemIndex);
+			MUX_ASSERT(beginRealizedItemIndex <= m_firstFrozenItemIndex);
+			MUX_ASSERT(endRealizedItemIndex >= m_lastFrozenItemIndex);
+
+			bool preFrozenItemHasNewDesiredWidth = false;
+			bool frozenItemHasNewDesiredWidth = false;
+
+			for (int itemIndex = beginRealizedItemIndex; itemIndex <= endRealizedItemIndex; itemIndex++)
+			{
+				if (m_elementManager.IsDataIndexRealized(itemIndex))
+				{
+					if (m_elementManager.GetRealizedElement(itemIndex /*dataIndex*/) is { } element)
+					{
+						bool hasNewDesiredWidth = m_elementDesiredWidths!.ContainsKey(element);
+
+						if (hasNewDesiredWidth)
+						{
+							bool hasOldDesiredWidth = oldElementDesiredWidths.ContainsKey(element);
+							float newDesiredWidth = m_elementDesiredWidths![element];
+							bool desiredWidthChanged = false;
+
+							MUX_ASSERT(element.DesiredSize.Width == newDesiredWidth);
+
+							if (hasOldDesiredWidth)
+							{
+								float oldDesiredWidth = oldElementDesiredWidths[element];
+
+								desiredWidthChanged = oldDesiredWidth != newDesiredWidth;
+								// #ifdef DBG
+								// if (desiredWidthChanged)
+								// {
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginRealizedItemIndex", beginRealizedItemIndex);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endRealizedItemIndex", endRealizedItemIndex);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"index causing relayout for changed desired size", itemIndex);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"oldDesiredWidth", oldDesiredWidth);
+								// }
+								// else if (itemIndex == LogItemIndexDbg())
+								// {
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginRealizedItemIndex", beginRealizedItemIndex);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endRealizedItemIndex", endRealizedItemIndex);
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+								//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"oldDesiredWidth", oldDesiredWidth);
+								// }
+								// #endif
+							}
+
+							// #ifdef DBG
+							// else
+							// {
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"index causing relayout for new desired size", itemIndex);
+							// }
+							// #endif
+							if (desiredWidthChanged || !hasOldDesiredWidth)
+							{
+								// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"newDesiredWidth", newDesiredWidth);
+								NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger.ItemDesiredWidthChange);
+
+								if (itemIndex < m_firstFrozenItemIndex)
+								{
+									MUX_ASSERT(!preFrozenItemHasNewDesiredWidth);
+
+									preFrozenItemHasNewDesiredWidth = true;
+
+									// Now that preFrozenItemHasNewDesiredWidth was set for the initial unfrozen items range, skip the remaining initial unfrozen items after itemIndex.
+									itemIndex = m_firstFrozenItemIndex - 1;
+								}
+								else if (itemIndex <= m_lastFrozenItemIndex)
+								{
+									MUX_ASSERT(!frozenItemHasNewDesiredWidth);
+
+									frozenItemHasNewDesiredWidth = true;
+
+									// Now that frozenItemHasNewDesiredWidth was set for the frozen items range, skip the remaining frozen items after itemIndex.
+									itemIndex = m_lastFrozenItemIndex;
+								}
+								else
+								{
+									// #ifdef DBG
+									// if (preFrozenItemHasNewDesiredWidth)
+									// {
+									//     if (frozenItemHasNewDesiredWidth)
+									//     {
+									//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <true, true, true>");
+									//     }
+									//     else
+									//     {
+									//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <true, false, true>");
+									//     }
+									// }
+									// else
+									// {
+									//     if (frozenItemHasNewDesiredWidth)
+									//     {
+									//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <false, true, true>");
+									//     }
+									//     else
+									//     {
+									//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <false, false, true>");
+									//     }
+									// }
+									// #endif
+									return (preFrozenItemHasNewDesiredWidth, frozenItemHasNewDesiredWidth, true /*postFrozenItemHasNewDesiredWidth*/);
+								}
+							}
+							// #ifdef DBG
+							// else if (itemIndex == LogItemIndexDbg())
+							// {
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+							//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"newDesiredWidth", newDesiredWidth);
+							// }
+							// #endif
+						}
+					}
+				}
+			}
+
+			// #ifdef DBG
+			// if (preFrozenItemHasNewDesiredWidth)
+			// {
+			//     if (frozenItemHasNewDesiredWidth)
+			//     {
+			//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <true, true, false>");
+			//     }
+			//     else
+			//     {
+			//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <true, false, false>");
+			//     }
+			// }
+			// else
+			// {
+			//     if (frozenItemHasNewDesiredWidth)
+			//     {
+			//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <false, true, false>");
+			//     }
+			//     else
+			//     {
+			//         LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"returns <false, false, false>");
+			//     }
+			// }
+			// #endif
+			return (preFrozenItemHasNewDesiredWidth, frozenItemHasNewDesiredWidth, false /*postFrozenItemHasNewDesiredWidth*/);
+		}
+
+		private int LineItemsCountTotal(int expectedTotal)
+		{
+			int sizedItemCount = 0;
+
+			foreach (int lineItemsCount in m_lineItemCounts)
+			{
+				sizedItemCount += lineItemsCount;
+			}
+
+			MUX_ASSERT(expectedTotal == 0 || sizedItemCount == expectedTotal);
+
+			return sizedItemCount;
+		}
+
+		private bool LockItemToLineInternal(
+			SortedDictionary<int, int> internalLockedItemIndexes,
+			int beginSizedLineIndex,
+			int endSizedLineIndex,
+			int beginSizedItemIndex,
+			int endSizedItemIndex,
+			int lineIndex,
+			int itemIndex)
+		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, lineIndex, itemIndex);
+			MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
+			MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
+			MUX_ASSERT(Math.Abs(beginSizedLineIndex - endSizedLineIndex) <= Math.Abs(beginSizedItemIndex - endSizedItemIndex));
+
+			if (lineIndex > itemIndex)
+			{
+				return false;
+			}
+
+			MUX_ASSERT(lineIndex <= itemIndex);
+
+			int lineCount = GetLineCount(m_averageItemsPerLine.second);
+
+			MUX_ASSERT(lineCount > 0);
+			MUX_ASSERT(lineIndex < lineCount);
+
+			if (lineCount - lineIndex > m_itemCount - itemIndex)
+			{
+				return false;
+			}
+
+			if (Math.Abs(beginSizedLineIndex - lineIndex) > Math.Abs(beginSizedItemIndex - itemIndex))
+			{
+				return false;
+			}
+
+			if (Math.Abs(endSizedLineIndex - lineIndex) > Math.Abs(endSizedItemIndex - itemIndex))
+			{
+				return false;
+			}
+
+			GetNextLockedItem(
+				internalLockedItemIndexes,
+				false /*forward*/,
+				lineCount - 1 /*beginLineIndex*/,
+				0 /*endLineIndex*/,
+				itemIndex,
+				out int beforeLockedItemIndex,
+				out int beforeLockedLineIndex);
+
+			GetNextLockedItem(
+				internalLockedItemIndexes,
+				true /*forward*/,
+				0 /*beginLineIndex*/,
+				lineCount - 1 /*endLineIndex*/,
+				itemIndex,
+				out int afterLockedItemIndex,
+				out int afterLockedLineIndex);
+
+			if ((beforeLockedItemIndex == -1 || (itemIndex - beforeLockedItemIndex >= lineIndex - beforeLockedLineIndex)) &&
+				(afterLockedItemIndex == -1 || (afterLockedItemIndex - itemIndex >= afterLockedLineIndex - lineIndex)))
+			{
+				// std::map::insert does not overwrite an existing key; TryAdd matches that (result ignored).
+				internalLockedItemIndexes.TryAdd(itemIndex, lineIndex);
+
+				// #ifdef DBG
+				// VerifyInternalLockedItemsDbg(
+				//     internalLockedItemIndexes,
+				//     beginSizedLineIndex,
+				//     endSizedLineIndex,
+				//     beginSizedItemIndex,
+				//     endSizedItemIndex);
+				// #endif
+				return true;
+			}
+
+			return false;
+		}
+
+		// The ItemsInfo struct returned as the third tuple element is only filled when the first element, lineCount, is -1.
+		// This indicates that the regular path layout must take over because the ItemsInfoRequested event did not provide sufficient info for the fast path.
+		// The returned lineCount is > 0 when the fast path was successfully taken. In that case, the second element returned is the largest line width.
+		// When is the fast path taken?
+		//   When an ItemsInfoRequested event handler provided aspect ratios for all items in the source collection.
+		// When is the regular path taken as a fallback after this method returns?
+		//   - No ItemsInfoRequested event handler,
+		//   - Or ItemsInfoRequested event handler provided incomplete information (it does not cover the entire source collection).
+		// Fast path algorithm overview:
+		//   - aspect ratios, min and max widths gathered for the entire source collection are used to do a layout of all items.
+		//   - when a negative or nil aspect ratio is provided for an item, the average aspect ratio is used for it instead.
+		//   - items are cumulated on the current line as long as their desired width does not exceed the available width.
+		//   - once the next item goes beyond the available width, a key decision needs to be made: should that item be added to the current line or should it create a new line?
+		//   - two scale factors are then computed:
+		//     * the scale factor < 1 required to shrink the items in the current line to fit the available width, were the next item appended.
+		//     * the scale factor > 1 required to grow the items in the current line to fill the available width, were the next item create a new line.
+		//   - whichever resulting scale factor is closest to 1 wins. The next item is appended or creates a new line accordingly.
+		// Fast path characteristics versus regular path:
+		//   - the fast path lays out the entire collection at once. Scrolling does not raise the ItemsInfoRequested event, and does not trigger a layout.
+		//     It just causes realized items to be recycled, and new item realizations.
+		//   - the m_lineItemCounts and m_itemsInfoArrangeWidths vectors grow indefinitely as the source collection grows.
+		//   - after a certain collection size threshold, the time required to do the full collection layout and the memory requirements negate the efficiency of the algorithm.
+		//   - it is qualified as 'fast' because it employs a single pass of all items with simple decisions as to whether each item should be the beginning of a new line or not.
+		//     The regular path involves iterative passes for assigning items to increasingly equalized lines.
+		//   - a new available width always triggers a full re-layout of the entire collection. In the regular path case, no re-layout is required as long as the average-items-per-line
+		//     does not change.
+		//   - the fast path does not have to stick to a line count based on the average item aspect ratio. It has thus more freedom to lay out items with less clipping.
 		private (int lineCount, float maxLineWidth, ItemsInfo itemsInfo) MeasureConstrainedLinesFastPath(
 			VirtualizingLayoutContext context,
 			float availableWidth,
 			double actualLineHeight,
 			bool forceLayoutWithoutItemsInfoRequest)
 		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, availableWidth, actualLineHeight);
 			MUX_ASSERT(m_itemCount > 0);
 
 			float maxLineWidth = 0.0f;
@@ -5430,6 +5661,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 						ItemsInfo itemsInfo = RaiseItemsInfoRequested(itemsRangeStartIndex, itemsRangeRequestedLength);
 
+						// #ifdef DBG
+						// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"ItemsInfo for fast path");
+						// LogItemsInfoDbg(itemsRangeStartIndex, itemsRangeRequestedLength, itemsInfo);
+						// #endif
 						// Fall back to regular layout path when ItemsInfo::m_itemsRangeStartIndex is not 0.
 						if (itemsInfo.m_itemsRangeStartIndex != 0)
 						{
@@ -5524,14 +5759,147 @@ namespace Microsoft.UI.Xaml.Controls
 			return (lineCount, maxLineWidth, s_emptyItemsInfo);
 		}
 
-		#endregion
-
-		#region Measure/Arrange orchestration (WS-D3)
-
-		// Returns the final line count when the regular path is kept to the end,
-		// or -1 when the ItemsInfoRequested provided ratios for the entire data source,
-		// indicating that the fast path must be engaged.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
+		// Items measurement when the non-scrolling dimension is constrained.
+		// Algorithm details:
+		// The layout deals with up to 9 stacks of lines:
+		// ******************************************
+		// * E: Unrealized lines                    *
+		// ******************************************
+		// * D: Unrealized sized lines              *
+		// ******************************************
+		// * C: Realized unfrozen lines             *
+		// ******************************************
+		// * B: Realized frozen lines               *
+		// ******************************************
+		// * A: Realized frozen displayed lines     *
+		// ******************************************
+		// * B: Realized frozen lines               *
+		// ******************************************
+		// * C: Realized unfrozen lines             *
+		// ******************************************
+		// * D: Unrealized sized lines              *
+		// ******************************************
+		// * E: Unrealized lines                    *
+		// ******************************************
+		// A, B, C, D, E is the decreasing order for the likelihood of such lines being present.
+		// Frozen lines contain items that keep their assigned line between successive layouts.
+		// Because the layout performs poorly with fewer than 5 viewports worth of sizing information,
+		// the ItemsInfoRequested event is used to gather sizing information for 5 scroll viewports (i.e. 5 x VirtualizingLayoutContext.VisibleRect).
+		// The resulting information covers the zones D C B A B C D, i.e. any line within zones A B C & D is called 'sized'.
+		// Likewise, any line within zones A B & C is called 'realized'.
+		// A zone grows to 1.0 scroll viewport.
+		// B zone grows to 0.8 scroll viewport.
+		// C zone grows to 0.2 scroll viewport.
+		// D zone grows to 1.0 scroll viewport.
+		// D + C + B + A + B + C + D = 1.0 + 0.2 + 0.8 + 1.0 + 0.8 + 0.2 + 1.0 = 5.0 scroll viewports.
+		// When the ItemsInfoRequested handler does not provide the minimum information requested, the D zones shrink to nothing while the C zones grow to 1.2 viewports.
+		// The more lines in a zone the better the ability to optimize its items distribution.
+		// A better items distribution means:
+		// - smaller items shrinking to accommodate the available width in the non-scrolling direction,
+		// - smaller items expansion when ItemsStretch is Fill,
+		// - smaller items spacing when ItemsStretch is None.
+		// Displayed lines A and their surrounding lines B are frozen so that items are not re-shuffled while on screen.
+		// B zone exists for two reasons:
+		// - the off-UI-thread aspect of scrolling (independent scrolling), so that items freshly brought into view are not reshuffled,
+		// - have enough lines to perform an acceptable distribution.
+		// Average items per line:
+		//   The average items per line is computed based on realized items desired size aspect ratios. The effective average items per line is
+		//   always a power of 1.1 (i.e. 1.0, 1.1, 1.21, 1.331, 1.4641 etc...), and thus only changes when a new actual value differs by at least 10%.
+		//   This keeps the effective average number stable, since a change causes a complete re-layout.
+		// Aspect ratio:
+		//   The desired size of an item provides a desired aspect ratio (width / height). A weight is given to that aspect ratio: the first aspect ratio computed
+		//   for a newly realized item gets a weight of 1. Each time that item is re-measured the weight is incremented by 1 until it reaches 16.
+		//   This is to give more credibility to items that had the time to be properly populated (with an Image for example).
+		//   Using a weighted average aspect ratio contributes to the stability of the effective average items per line.
+		// Total line count:
+		//   The effective average items per line and datasource item count are used to compute the total line count E + D + C + B + A + B + C + D + E.
+		//   Example: 1000 datasource items / 4.1772 effective average items per line = 240 total lines.
+		// Realized item count:
+		//   The effective average items per line and realized line count are used to compute the realized item count.
+		//   Example: 50 realized lines x 4.1772 effective average items per line = 209 realized items.
+		// Item locking capability:
+		//   An item can be locked into a line by calling 'int lineIndex = LinedFlowLayout.LockItemToLine(itemIndex)'.
+		//   If the item in question belongs to a current A or B zone, its current line assignment is returned.
+		//   Otherwise it belongs to a C, D or E zone and the returned line index is based on the itemIndex and effective average items per line.
+		//   When the datasource or effective average items per line changes, the locks are invalidated and the ItemsUnlocked event is raised.
+		// Line height:
+		//   When LinedFlowLayout.LineHeight is NaN, the item for the first datasource entry is used to compute LinedFlowLayout.ActualLineHeight.
+		//   Otherwise ActualLineHeight just reflects the LineHeight value.
+		// Items distribution:
+		//   A valid items distributions verifies:
+		//   - each line has at least one item,
+		//   - locked items belong to their locked line.
+		//   Given I items to distribute among L lines, there are (I - L)^L combinations. Which one to pick?
+		//   A distribution is associated with a drawback number. The smaller that drawback, the better. The LinedFlowLayout computes a few distributions
+		//   and picks the one with the lowest drawback.
+		//   Distribution example:
+		//   ---- ------ --- ------------    *
+		//   |  | |    | | | |          |    *
+		//   ---- ------ --- ------------    *
+		//   -------- --------- --- ----- ---*--
+		//   |      | |       | | | |   | |  * |
+		//   -------- --------- --- ----- ---*--
+		//   ----- ------- ------ -----      *
+		//   |   | |     | |    | |   |      *
+		//   ----- ------- ------ -----      *
+		//   The available width, marked by the * vertical line is 1000px. The desired item widths and LinedFlowLayout.ItemsSpacing provide a desired width for each line.
+		//   That desired width can be smaller or greater than the available width, as shown in the example above.
+		//   The calculated drawback is the sum of the squared (desired width - available width).
+		//   For example (800 - 1000)^2 + (1100 - 1000)^2 + (700 - 1000)^2.
+		//   When LinedFlowLayout.ItemsStretch is None, the very last line does not participate in the drawback evaluation if its desired width is smaller than the available width.
+		//   Potentially four items in a distribution are special:
+		//   ---- ------ --- ------------            *
+		//   |  | |    | | | |          |            *
+		//   ---- ------ --- ------------            *
+		//   ------------ --------- --- ----- -----  *
+		//   |          | |       | | | |   | |ST |  *
+		//   ------------ --------- --- ----- -----  *
+		//   ----- ------- ------ ----- ---------    *
+		//   |SH | |     | |    | |   | |       |    *
+		//   ----- ------- ------ ----- ---------    *
+		//   -------- ----- ------- ------           *
+		//   |      | |   | |     | |    |           *
+		//   -------- ----- ------- ------           *
+		//   - the Smallest Head (SH) item
+		//   - the Smallest Tail (ST) item
+		//   The SH item is the smallest item such that by increasing the available width, it will be assigned the prior line (the increase is SH width + ItemsSpacing).
+		//   The ST item is the smallest item such that by decreasing the available width, it will be assigned the next line (the decrease is SH width + ItemsSpacing).
+		//   ---- ------ --- ----------              *
+		//   |  | |    | | | |        |              *
+		//   ---- ------ --- ----------              *
+		//   -------------- ------- --- ----- ----- -*-------
+		//   |BEH         | |     | | | |   | |   | |*      |
+		//   -------------- ------- --- ----- ----- -*-------
+		//   ----- ------- ------ ----- ------- -----*--
+		//   |   | |     | |    | |   | |     | |BET * |
+		//   ----- ------- ------ ----- ------- -----*--
+		//   -------- ----- ------- ------           *
+		//   |      | |   | |     | |    |           *
+		//   -------- ----- ------- ------           *
+		//   - the Best Equalizing Head (BEH) item
+		//   - the Best Equalizing Tail (BET) item
+		//   The BEH item provides the most drawback improvement if it moves to the prior line.
+		//   The BET item provides the most drawback improvement if it moves to the next line.
+		//   Best distribution evaluation:
+		//     Phase 1: evaluate distribution for an available width equal to the MeasureOverride's availableWidth.
+		//     Phase 2: evaluate distribution for an available width equal to the resulting average desired line width of Phase 1.
+		//     Phase 3: evaluate distributions with an available width within 30% of the average desired line width using the SH and ST items of prior distributions. Pick the distribution with the lowest drawback.
+		//     Phase 4: keeping the available width from Phase 3, fine tune that distribution by moving BEH / BET items into their neighboring lines using internal locks.
+		//              Whichever item among BEH & BET is present and provides the largest drawback improvement is moved.
+		// Items scaling:
+		//   Once the best items distribution is picked, each item is scaled up or down (or unscaled) in order to accommodate the final available width and LinedFlowLayout.ItemsStretch setting.
+		//   When a desired line width is smaller than the available width and ItemsStretch is Fill, the items are uniformly scaled up and cropped to completly fill the line.
+		//   When a desired line width is greater than the available width, the items are uniformly scaled down and cropped to just fill the line.
+		//   All items are measured based on the scaled available widths.
+		// Complete layouts:
+		//   A complete re-layout is performed when:
+		//   - the datasource changed,
+		//   - LineHeight, ItemsSpacing or LineSpacing changed,
+		//   - the effective average items per line changed,
+		//   - a frozen item gets a new desired width.
+		//   For a re-layout, an items distribution is performed for all realized lines, all at once.
+		// Partial layouts:
+		//   When scrolling, items distributions are performed for lines in the updated C & D zones.
 		private int MeasureConstrainedLinesRegularPath(
 			VirtualizingLayoutContext context,
 			ItemsInfo itemsInfo,
@@ -5586,9 +5954,13 @@ namespace Microsoft.UI.Xaml.Controls
 							scrollOffset = Math.Max(0.0, anchorLineMiddle - scrollViewport / 2.0);
 							realizationRectCenteredAroundAnchor = true;
 
-							// Same comments and treatment as in EnsureItemRangeFastPath.
+							// Same comments and treatment as in LinedFlowLayout::EnsureItemRangeFastPath.
 							// Sometimes during a bring-into-view operation the RecommendedAnchorIndex momentarily switches from the target index N to -1 and then back to the target index N.
 							// To avoid momentarily setting m_anchorIndex to -1, its value is preserved c_maxAnchorIndexRetentionCount times, based purely on experimentations.
+							// Without this momentary retention the bring-into-view operation lands on incorrect offsets. If m_anchorIndex were to be preserved without a countdown, large offset changes
+							// through ScrollView.ScrollTo calls would not complete.
+							// TODO: Bug 41896418 - Investigate why the occurrences of -1 sometimes come up - even when the ScrollView anchoring is turned on.
+							//                      Does such a countdown need to be used? What is a reliable countdown starting value?
 							if (newRecommendedAnchorIndex == -1)
 							{
 								MUX_ASSERT(m_anchorIndexRetentionCountdown >= 1 && m_anchorIndexRetentionCountdown <= c_maxAnchorIndexRetentionCount);
@@ -5609,6 +5981,7 @@ namespace Microsoft.UI.Xaml.Controls
 							// Layout is invalidated to ensure that m_anchorIndexRetentionCountdown is decremented from c_maxAnchorIndexRetentionCount all the way to 0 (a few lines above).
 							// Otherwise m_anchorIndex could be stuck to a value that prevents the realization window from moving to the actual scroller's offset.
 							InvalidateMeasureAsync();
+							// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_DBL_INT, METH_NAME, this, scrollOffset, m_anchorIndex);
 						}
 					}
 
@@ -5738,13 +6111,24 @@ namespace Microsoft.UI.Xaml.Controls
 			// Clear the arrays collected from the ItemsInfoRequested event handler.
 			ResetItemsInfoForFastPath();
 
+#if DEBUG
+			if (m_isVirtualizingContext)
+			{
+				int newRecommendedAnchorIndexDbg = context.RecommendedAnchorIndex;
+
+				MUX_ASSERT(newRecommendedAnchorIndexDbg == -1 || m_elementManager.IsDataIndexRealized(newRecommendedAnchorIndexDbg));
+
+				// const int anchorLineIndexDbg = newRecommendedAnchorIndexDbg == -1 ? -1 : GetLineIndex(newRecommendedAnchorIndexDbg, false /*usesFastPathLayout*/);
+
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"realized anchor", anchorLineIndexDbg, newRecommendedAnchorIndexDbg);
+			}
+#endif
 			return lineCount;
 		}
 
 		// Returns the final line count when the regular path is kept to the end,
 		// or -1 when the ItemsInfoRequested provided ratios for the entire data source,
 		// indicating that the fast path must be engaged.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
 		private int MeasureConstrainedLines(
 			VirtualizingLayoutContext context,
 			HashSet<double> averageItemsPerLineProcessed,
@@ -5758,6 +6142,8 @@ namespace Microsoft.UI.Xaml.Controls
 			double actualLineHeight,
 			ref (double first, double second) newAverageItemsPerLine)
 		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT, METH_NAME, this, forceRelayout);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_unrealizedNearLineCount", m_unrealizedNearLineCount);
 			MUX_ASSERT(!UsesFastPathLayout());
 			MUX_ASSERT(actualLineHeight > 0.0);
 
@@ -5782,6 +6168,7 @@ namespace Microsoft.UI.Xaml.Controls
 			int unrealizedFarLineCount = (int)((linesHeight - clampedFarRealizationRect) / (actualLineHeight + lineSpacing));
 			int realizedLineCount = lineCount - m_unrealizedNearLineCount - unrealizedFarLineCount;
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"realizedLineCount", realizedLineCount);
 			MUX_ASSERT(realizedLineCount <= lineCount);
 
 			if (realizedLineCount == 0)
@@ -5802,12 +6189,14 @@ namespace Microsoft.UI.Xaml.Controls
 
 			m_unsizedNearLineCount = (int)(clampedNearSizedItemsRect / (actualLineHeight + lineSpacing));
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_unsizedNearLineCount", m_unsizedNearLineCount);
 			MUX_ASSERT(m_unsizedNearLineCount <= m_unrealizedNearLineCount);
 
 			double clampedFarSizedItemsRect = Math.Max(0.0, Math.Min(linesHeight, (double)farSizedItemsRect));
 			int unsizedFarLineCount = (int)((linesHeight - clampedFarSizedItemsRect) / (actualLineHeight + lineSpacing));
 			int sizedLineCount = lineCount - m_unsizedNearLineCount - unsizedFarLineCount;
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"sizedLineCount", sizedLineCount);
 			MUX_ASSERT(sizedLineCount <= lineCount);
 			MUX_ASSERT(sizedLineCount >= realizedLineCount);
 
@@ -5820,6 +6209,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 			m_firstSizedLineIndex = m_unsizedNearLineCount;
 			m_lastSizedLineIndex = m_unsizedNearLineCount + sizedLineCount - 1;
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_firstSizedLineIndex", m_firstSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_lastSizedLineIndex", m_lastSizedLineIndex);
 
 			List<int> oldLineItemCounts = new();
 			int oldFirstItemsInfoIndex = m_itemsInfoFirstIndex;
@@ -6037,14 +6428,18 @@ namespace Microsoft.UI.Xaml.Controls
 			MUX_ASSERT(sizedItemCount > 0);
 			MUX_ASSERT(sizedItemCount >= sizedLineCount);
 			MUX_ASSERT(unsizedNearItemCount + sizedItemCount <= m_itemCount);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"sizedItemCount", sizedItemCount);
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"unsizedNearItemCount", unsizedNearItemCount);
 			m_firstSizedItemIndex = unsizedNearItemCount;
 			m_lastSizedItemIndex = m_firstSizedItemIndex + sizedItemCount - 1;
 
 			MUX_ASSERT((firstStillSizedItemIndex == -1) == (lastStillSizedItemIndex == -1));
 			MUX_ASSERT(m_firstSizedItemIndex <= firstStillSizedItemIndex || firstStillSizedItemIndex == -1);
 			MUX_ASSERT(m_lastSizedItemIndex >= lastStillSizedItemIndex || lastStillSizedItemIndex == -1);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_firstSizedItemIndex", m_firstSizedItemIndex);
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_lastSizedItemIndex", m_lastSizedItemIndex);
 			EnsureAndResizeItemAspectRatios(
 				scrollViewport,
 				actualLineHeight,
@@ -6067,6 +6462,9 @@ namespace Microsoft.UI.Xaml.Controls
 				// Fall back to realizing all sized items instead.
 				unrealizedNearItemCount = unsizedNearItemCount;
 				realizedItemCount = sizedItemCount;
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"unrealizedNearItemCount fallback", unrealizedNearItemCount);
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"realizedItemCount fallback", realizedItemCount);
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"realized item index range fallback", unrealizedNearItemCount, unrealizedNearItemCount + realizedItemCount - 1);
 			}
 			else
 			{
@@ -6105,11 +6503,19 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 			}
 
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstStillSizedLineIndex", firstStillSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastStillSizedLineIndex", lastStillSizedLineIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstStillSizedItemIndex", firstStillSizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastStillSizedItemIndex", lastStillSizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstStillRealizedItemIndex", firstStillRealizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastStillRealizedItemIndex", lastStillRealizedItemIndex);
 			// Discard the first realized items fallen off the realization window.
 			if (m_elementManager.GetFirstRealizedDataIndex() != -1 && unrealizedNearItemCount > m_elementManager.GetFirstRealizedDataIndex())
 			{
 				MUX_ASSERT(m_isVirtualizingContext);
 
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"discarded realized head range",
+				//     m_elementManager.GetFirstRealizedDataIndex(), unrealizedNearItemCount - 1);
 				m_elementManager.DiscardElementsOutsideWindow(
 					false /*forward*/,
 					Math.Min(unrealizedNearItemCount, m_elementManager.GetFirstRealizedDataIndex() + m_elementManager.GetRealizedElementCount) - 1 /*startIndex*/);
@@ -6212,6 +6618,8 @@ namespace Microsoft.UI.Xaml.Controls
 			// Discard the last realized items fallen off the realization window.
 			if (m_isVirtualizingContext && unrealizedFarLineCount > 0 && m_elementManager.GetRealizedElementCount > realizedItemCount)
 			{
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"discarded realized tail range",
+				//     unrealizedNearItemCount + realizedItemCount, m_elementManager.GetFirstRealizedDataIndex() + m_elementManager.GetRealizedElementCount() - 1);
 				m_elementManager.DiscardElementsOutsideWindow(
 					true /*forward*/,
 					unrealizedNearItemCount + realizedItemCount /*startIndex*/);
@@ -6279,6 +6687,12 @@ namespace Microsoft.UI.Xaml.Controls
 				firstStillSizedItemIndex,
 				lastStillSizedItemIndex);
 
+			// #ifdef DBG
+			// const int sizedItemCountDbg = LineItemsCountTotal(m_lastSizedItemIndex - m_firstSizedItemIndex + 1);
+			//
+			// VerifyLockedItemsDbg();
+			// #endif
+
 			if (itemHasNewDesiredWidth)
 			{
 				// When at least one item has a new desired width, the average items-per-line evaluation may change.
@@ -6299,202 +6713,192 @@ namespace Microsoft.UI.Xaml.Controls
 			return lineCount;
 		}
 
-		// Items arrangement when the non-scrolling dimension is constrained.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void ArrangeConstrainedLines(
-			VirtualizingLayoutContext context)
+		// Measures a range of realized items based on the final arrange widths stored in m_itemsInfoArrangeWidths.
+		private void MeasureItemRange(
+			double actualLineHeight,
+			int beginRealizedItemIndex,
+			int endRealizedItemIndex)
 		{
-			double actualLineHeight = ActualLineHeight;
-
-			if (m_lineItemCounts.Count == 0 || actualLineHeight <= 0.0)
-			{
-				return;
-			}
-
-			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
-
-			bool usesArrangeWidthInfo = UsesArrangeWidthInfo();
-			float minItemSpacing = (float)MinItemSpacing;
-			double lineSpacing = LineSpacing;
-			int firstSizedLineIndex = m_firstSizedLineIndex == -1 ? 0 : m_firstSizedLineIndex;
-			int lineCount = m_firstSizedLineIndex == -1 ? m_lineItemCounts.Count : GetLineCount(m_averageItemsPerLine.second);
-			var itemsStretch = ItemsStretch;
-			var itemsJustification = ItemsJustification;
-
-			GetFirstFullyRealizedLineIndex(
-				out int firstFullyRealizedLineIndex,
-				out int firstItemInFullyRealizedLine);
-
-			if (firstFullyRealizedLineIndex == -1)
-			{
-				// This situation can occur when context.VisibleRect().Height is 0.
-				MUX_ASSERT(firstItemInFullyRealizedLine == -1);
-
-				return;
-			}
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginRealizedItemIndex", beginRealizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endRealizedItemIndex", endRealizedItemIndex);
+			MUX_ASSERT(beginRealizedItemIndex >= 0);
+			MUX_ASSERT(beginRealizedItemIndex <= endRealizedItemIndex);
+			MUX_ASSERT(m_itemsInfoArrangeWidths.Count > 0);
 
 			int itemsInfoArrangeWidthsOffset = m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex;
-			int lastSizedLineVectorIndex = m_lineItemCounts.Count - 1;
-			int sizedItemIndex = firstItemInFullyRealizedLine;
 
-			for (int sizedLineVectorIndex = firstFullyRealizedLineIndex - firstSizedLineIndex; sizedLineVectorIndex <= lastSizedLineVectorIndex; sizedLineVectorIndex++)
+			for (int realizedItemIndex = beginRealizedItemIndex; realizedItemIndex <= endRealizedItemIndex; realizedItemIndex++)
 			{
-				float cumulatedOffset = 0.0f;
-				float itemSpacing = minItemSpacing;
-				int lineItemsCount = m_lineItemCounts[sizedLineVectorIndex];
-				float lineArrangeWidth = GetItemsRangeArrangeWidth(sizedItemIndex /*beginSizedItemIndex*/, sizedItemIndex + lineItemsCount - 1 /*endSizedItemIndex*/, usesArrangeWidthInfo);
-				double lineExtraAvailableWidth = (double)m_previousAvailableWidth - lineArrangeWidth - itemSpacing * ((double)lineItemsCount - 1);
+				MUX_ASSERT(m_elementManager.IsDataIndexRealized(realizedItemIndex));
 
-				if (itemsStretch == LinedFlowLayoutItemsStretch.None)
-				{
-					if (lineExtraAvailableWidth > 0.0)
-					{
-						switch (itemsJustification)
-						{
-							case LinedFlowLayoutItemsJustification.Start:
-								break;
-							case LinedFlowLayoutItemsJustification.Center:
-								cumulatedOffset = (float)(lineExtraAvailableWidth / 2.0);
-								break;
-							case LinedFlowLayoutItemsJustification.End:
-								cumulatedOffset = (float)lineExtraAvailableWidth;
-								break;
-							case LinedFlowLayoutItemsJustification.SpaceEvenly:
-								cumulatedOffset = (float)(lineExtraAvailableWidth / ((double)lineItemsCount + 1));
-								itemSpacing += cumulatedOffset;
-								break;
-							case LinedFlowLayoutItemsJustification.SpaceAround:
-								cumulatedOffset = (float)(lineExtraAvailableWidth / lineItemsCount / 2.0);
-								itemSpacing += cumulatedOffset * 2.0f;
-								break;
-							case LinedFlowLayoutItemsJustification.SpaceBetween:
-								if (lineItemsCount > 1)
-								{
-									itemSpacing += (float)(lineExtraAvailableWidth / ((double)lineItemsCount - 1));
-								}
-								break;
-						}
-					}
-					else if (lineExtraAvailableWidth < 0.0)
-					{
-						if (lineExtraAvailableWidth >= -0.5 / m_roundingScaleFactor * lineItemsCount)
-						{
-							// Because of pixel snapping based on m_roundingScaleFactor, lineExtraAvailableWidth can be slightly different from 0.0.
-							// In that case we adjust the minItemSpacing by distributing the small delta equally.
-							itemSpacing += (float)(lineExtraAvailableWidth / ((double)lineItemsCount - 1));
-						}
-					}
-				}
-				else if (lineExtraAvailableWidth != 0.0)
-				{
-					// Condition #1. Because of pixel snapping based on m_roundingScaleFactor, lineExtraAvailableWidth can be slightly different from 0.0.
-					// Condition #2. Because of MaxWidth constraining the expansion of line items, lineExtraAvailableWidth can be much larger than 0.0.
-					// Condition #2. Because Image elements do not expand beyond MinWidth when their natural width is smaller than MinWidth, lineExtraAvailableWidth can be much larger than 0.0.
-					// In those cases we adjust the minItemSpacing by distributing the small delta equally.
-					bool itemSpacingAdjustedForRounding = Math.Abs(lineExtraAvailableWidth) <= 0.5 / m_roundingScaleFactor * lineItemsCount;
-					bool itemSpacingAdjustedForMinMaxWidth = !itemSpacingAdjustedForRounding && lineExtraAvailableWidth > 0.0 && lineCount != firstSizedLineIndex + sizedLineVectorIndex + 1;
+				var element = m_elementManager.GetRealizedElement(realizedItemIndex /*dataIndex*/);
 
-					if (itemSpacingAdjustedForRounding || itemSpacingAdjustedForMinMaxWidth)
-					{
-						itemSpacing += (float)(lineExtraAvailableWidth / ((double)lineItemsCount - 1));
-					}
-				}
-
-				int lineIndex = sizedLineVectorIndex + (m_unsizedNearLineCount == -1 ? 0 : m_unsizedNearLineCount);
-
-				MUX_ASSERT(lineIndex < lineCount);
-
-				for (int sizedLineItemIndex = 0; sizedLineItemIndex < lineItemsCount; sizedLineItemIndex++)
-				{
-					if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
-					{
-						if (m_elementManager.GetRealizedElement(sizedItemIndex /*dataIndex*/) is { } element)
-						{
-							float arrangeWidth;
-
-							if (usesArrangeWidthInfo)
-							{
-								// Use the item info provided by the ItemsInfoRequested handler since the DesiredSize
-								// may be different from the computed arrange width when the item content failed to load properly.
-								arrangeWidth = m_itemsInfoArrangeWidths[sizedItemIndex - itemsInfoArrangeWidthsOffset];
-							}
-							else
-							{
-								arrangeWidth = (float)element.DesiredSize.Width;
-							}
-
-							Rect elementRect = new(cumulatedOffset, (float)(lineIndex * (actualLineHeight + lineSpacing)), arrangeWidth, (float)actualLineHeight);
-
-							element.Arrange(elementRect);
-
-							cumulatedOffset += (float)elementRect.Width + itemSpacing;
-						}
-					}
-					else
-					{
-						// The unrealized area was reached.
-						return;
-					}
-
-					sizedItemIndex++;
-				}
-			}
-		}
-
-		// Items arrangement when the non-scrolling dimension is unconstrained.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void ArrangeUnconstrainedLine(
-			VirtualizingLayoutContext context)
-		{
-			if (ActualLineHeight <= 0.0)
-			{
-				return;
-			}
-
-			float minItemSpacing = (float)MinItemSpacing;
-			float cumulatedOffset = 0.0f;
-
-			if (ItemsStretch == LinedFlowLayoutItemsStretch.None)
-			{
-				switch (ItemsJustification)
-				{
-					case LinedFlowLayoutItemsJustification.SpaceEvenly:
-						cumulatedOffset = minItemSpacing;
-						break;
-					case LinedFlowLayoutItemsJustification.SpaceAround:
-						cumulatedOffset = minItemSpacing / 2.0f;
-						break;
-				}
-			}
-
-			for (int itemIndex = 0; itemIndex < context.ItemCount; itemIndex++)
-			{
-				var element = m_elementManager.GetAt(itemIndex);
-
+				// Making sure the element is not null for safety.
 				if (element != null)
 				{
-					var desiredSize = element.DesiredSize;
-					float itemWidth = (float)desiredSize.Width;
-					Rect arrangeRect = new(cumulatedOffset, 0.0f, itemWidth, (float)desiredSize.Height);
+					MUX_ASSERT(realizedItemIndex - itemsInfoArrangeWidthsOffset < m_itemsInfoArrangeWidths.Count);
 
-					element.Arrange(arrangeRect);
-					cumulatedOffset += itemWidth + minItemSpacing;
+					float arrangeWidth = m_itemsInfoArrangeWidths[realizedItemIndex - itemsInfoArrangeWidthsOffset];
+
+					if (arrangeWidth >= 0.0f)
+					{
+						// #ifdef DBG
+						// if (realizedItemIndex == LogItemIndexDbg())
+						// {
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"measured with elementAvailableSize",
+						//         arrangeWidth,
+						//         actualLineHeight);
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"element.DesiredSize",
+						//         element.DesiredSize().Width,
+						//         element.DesiredSize().Height);
+						// }
+						// #endif
+						element.Measure(new Size(arrangeWidth, (float)actualLineHeight));
+					}
 				}
 			}
 		}
 
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		internal void ClearItemAspectRatios()
+		// Measures a range of realized items based on previously computed available widths elementAvailableWidths.
+		// Re-populates m_elementAvailableWidths with the old & re-applied available widths.
+		private void MeasureItemRangeRegularPath(
+			Dictionary<UIElement, float> elementAvailableWidths,
+			double actualLineHeight,
+			int beginRealizedItemIndex,
+			int endRealizedItemIndex)
 		{
-			if (m_aspectRatios != null)
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"with ElementAvailableSize", beginRealizedItemIndex, endRealizedItemIndex);
+			MUX_ASSERT(m_itemsInfoFirstIndex == -1);
+			MUX_ASSERT(beginRealizedItemIndex <= endRealizedItemIndex);
+			// MUX_ASSERT(elementAvailableWidths);
+
+			for (int realizedItemIndex = beginRealizedItemIndex; realizedItemIndex <= endRealizedItemIndex; realizedItemIndex++)
 			{
-				m_aspectRatios.Clear();
+				MUX_ASSERT(m_elementManager.IsDataIndexRealized(realizedItemIndex));
+
+				var element = m_elementManager.GetRealizedElement(realizedItemIndex /*dataIndex*/);
+
+				// Making sure the element is not null for safety.
+				if (element != null)
+				{
+					float elementAvailableWidth = -1.0f;
+
+					if (elementAvailableWidths.TryGetValue(element, out float recordedAvailableWidth))
+					{
+						// The element has an existing recorded available width because it needs to be scaled up or down, to fill or fit the available line width respectively.
+						elementAvailableWidth = recordedAvailableWidth;
+
+						MUX_ASSERT(m_elementAvailableWidths != null);
+						MUX_ASSERT(!m_elementAvailableWidths!.ContainsKey(element));
+
+						// Maintain that recording and measure the element again with it.
+						m_elementAvailableWidths!.TryAdd(element, elementAvailableWidth);
+					}
+					else if (element is FrameworkElement frameworkElement)
+					{
+						// The element has no recorded available width because it is not scaled down or up, so only its desired width is recorded.
+						float minWidth = (float)frameworkElement.MinWidth;
+
+						if (element.DesiredSize.Width == minWidth)
+						{
+							// Making sure the item is measured and stretched according to the MinWidth value (otherwise background-colored bands appear on the items' left/right edges).
+							elementAvailableWidth = minWidth;
+						}
+					}
+
+					if (elementAvailableWidth != -1.0f)
+					{
+						// #ifdef DBG
+						// if (realizedItemIndex == LogItemIndexDbg())
+						// {
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"measured with elementAvailableSize",
+						//         elementAvailableWidth,
+						//         actualLineHeight);
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"element.DesiredSize",
+						//         element.DesiredSize().Width,
+						//         element.DesiredSize().Height);
+						// }
+						// #endif
+						element.Measure(new Size(elementAvailableWidth, (float)actualLineHeight));
+					}
+				}
 			}
+		}
+
+		// Items measurement when the non-scrolling dimension is unconstrained.
+		private float MeasureUnconstrainedLine(
+			VirtualizingLayoutContext context)
+		{
+			MUX_ASSERT(m_itemCount == context.ItemCount);
+			MUX_ASSERT(m_isVirtualizingContext == IsVirtualizingContext(context));
+			MUX_ASSERT(!UsesArrangeWidthInfo());
+
+			float actualLineHeight = (float)ActualLineHeight;
+			Size measureAvailableSize = new Size(float.PositiveInfinity, actualLineHeight);
+			float desiredWidth = 0.0f;
+			bool isNewlyRealizedElementMeasuredWithMinWidth = false;
+
+			for (int itemIndex = 0; itemIndex < m_itemCount; itemIndex++)
+			{
+				bool isElementNewlyRealized = false;
+
+				if (m_isVirtualizingContext && !m_elementManager.IsDataIndexRealized(itemIndex))
+				{
+					EnsureElementRealized(true /*forward*/, itemIndex);
+
+					isElementNewlyRealized = true;
+				}
+
+				if (m_elementManager.GetAt(itemIndex) is { } element)
+				{
+					element.Measure(measureAvailableSize);
+
+					if (element is FrameworkElement frameworkElement)
+					{
+						float minWidth = (float)frameworkElement.MinWidth;
+
+						if ((float)element.DesiredSize.Width == minWidth)
+						{
+							// Making sure the item is stretched according to the MinWidth value.
+							element.Measure(new Size(minWidth, actualLineHeight));
+
+							if (isElementNewlyRealized)
+							{
+								isNewlyRealizedElementMeasuredWithMinWidth = true;
+							}
+						}
+					}
+
+					desiredWidth += (float)element.DesiredSize.Width;
+				}
+			}
+
+			if (isNewlyRealizedElementMeasuredWithMinWidth)
+			{
+				InvalidateMeasureTimerStart(0 /*tickCount*/);
+			}
+
+			SetAverageItemsPerLine(
+				SnapAverageItemsPerLine(
+					m_averageItemsPerLine.first /*oldAverageItemsPerLineRaw*/,
+					m_itemCount /*newAverageItemsPerLineRaw*/),
+				true /*unlockItems*/);
+
+			if (m_itemCount > 0)
+			{
+				desiredWidth += (float)((m_itemCount - 1) * MinItemSpacing);
+			}
+
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_DBL, METH_NAME, this, desiredWidth);
+			return desiredWidth;
 		}
 
 		// Raises the LayoutsTestHooks LinedFlowLayoutInvalidated event for testing purposes.
 		private void NotifyLinedFlowLayoutInvalidatedDbg(LinedFlowLayoutInvalidationTrigger invalidationTrigger)
 		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT, METH_NAME, this, static_cast<int>(invalidationTrigger));
 			var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
 
 			if (globalTestHooks is not null)
@@ -6506,6 +6910,7 @@ namespace Microsoft.UI.Xaml.Controls
 		// Raises the LayoutsTestHooks LinedFlowLayoutItemLocked event for testing purposes.
 		private void NotifyLinedFlowLayoutItemLockedDbg(int itemIndex, int lineIndex)
 		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, itemIndex, lineIndex);
 			var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
 
 			if (globalTestHooks is not null)
@@ -6514,110 +6919,1032 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private void GetFirstFullyRealizedLineIndex(
-			out int firstFullyRealizedLineIndex,
-			out int firstItemInFullyRealizedLine)
+		private ItemsInfo RaiseItemsInfoRequested(
+			int itemsRangeStartIndex,
+			int itemsRangeRequestedLength)
 		{
-			int firstRealizedItemIndex = m_isVirtualizingContext ? m_elementManager.GetFirstRealizedDataIndex() : 0;
+			MUX_ASSERT(itemsRangeStartIndex >= 0);
+			MUX_ASSERT(itemsRangeRequestedLength > 0);
+			MUX_ASSERT(itemsRangeStartIndex + itemsRangeRequestedLength - 1 < m_itemCount);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemsRangeStartIndex", itemsRangeStartIndex);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemsRangeRequestedLength", itemsRangeRequestedLength);
 
-			if (firstRealizedItemIndex == -1)
+			if (ItemsInfoRequested is { } itemsInfoRequested)
 			{
-				firstFullyRealizedLineIndex = -1;
-				firstItemInFullyRealizedLine = -1;
-				return;
-			}
+				var itemsInfoRequestedEventArgs = new LinedFlowLayoutItemsInfoRequestedEventArgs(this, itemsRangeStartIndex, itemsRangeRequestedLength);
 
-			int sizedItemIndex = m_firstSizedItemIndex == -1 ? 0 : m_firstSizedItemIndex;
-			int sizedLineIndex = m_firstSizedLineIndex == -1 ? 0 : m_firstSizedLineIndex;
-			int sizedLineVectorIndex = 0;
+				itemsInfoRequested(this, itemsInfoRequestedEventArgs);
 
-			MUX_ASSERT(firstRealizedItemIndex >= 0);
-			MUX_ASSERT(sizedItemIndex >= 0);
-			MUX_ASSERT(sizedLineIndex >= 0);
+				// Disconnect the LinedFlowLayout from the LinedFlowLayoutItemsInfoRequestedEventArgs so that any subsequent calls to
+				// SetDesiredAspectRatios/SetMinWiths/SetMaxWiths have no effect.
+				itemsInfoRequestedEventArgs.ResetLinedFlowLayout();
 
-			while (sizedItemIndex < firstRealizedItemIndex)
-			{
-				sizedItemIndex += m_lineItemCounts[sizedLineVectorIndex];
-				sizedLineIndex++;
-				sizedLineVectorIndex++;
-			}
-
-			MUX_ASSERT(m_lastSizedLineIndex == -1 || sizedLineIndex <= m_lastSizedLineIndex);
-			MUX_ASSERT(m_lastSizedItemIndex == -1 || sizedItemIndex <= m_lastSizedItemIndex);
-
-			firstFullyRealizedLineIndex = sizedLineIndex;
-			firstItemInFullyRealizedLine = sizedItemIndex;
-		}
-
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private int GetFrozenLineIndexFromFrozenItemIndex(
-			int frozenItemIndex)
-		{
-			MUX_ASSERT(m_firstSizedLineIndex != -1);
-			MUX_ASSERT(m_lastSizedLineIndex != -1);
-			MUX_ASSERT(frozenItemIndex >= m_firstFrozenItemIndex);
-			MUX_ASSERT(frozenItemIndex <= m_lastFrozenItemIndex);
-			MUX_ASSERT(m_firstFrozenLineIndex != -1);
-			MUX_ASSERT(m_lastFrozenLineIndex != -1);
-
-			int frozenItemVectorIndex = frozenItemIndex - m_firstFrozenItemIndex;
-
-			for (int frozenLineVectorIndex = m_firstFrozenLineIndex - m_firstSizedLineIndex;
-				frozenLineVectorIndex <= m_lastFrozenLineIndex - m_firstSizedLineIndex;
-				frozenLineVectorIndex++)
-			{
-				MUX_ASSERT(frozenLineVectorIndex >= 0);
-				MUX_ASSERT(frozenLineVectorIndex < m_lineItemCounts.Count);
-
-				if (frozenItemVectorIndex < m_lineItemCounts[frozenLineVectorIndex])
+				// The original LinedFlowLayoutItemsInfoRequestedEventArgs.ItemsRangeStartIndex value may have been overwritten by the handler to a smaller value.
+				// This allows a handler to provide more information than requested, because it's available and performant to do so. It reduces subsequent needs to
+				// raise the ItemsRangeStartIndex event again.
+				return new ItemsInfo
 				{
-					return frozenLineVectorIndex + m_firstSizedLineIndex;
-				}
-				frozenItemVectorIndex -= m_lineItemCounts[frozenLineVectorIndex];
+					m_itemsRangeStartIndex = itemsInfoRequestedEventArgs.ItemsRangeStartIndex,
+					m_itemsRangeLength = itemsInfoRequestedEventArgs.ItemsRangeLength,
+					m_minWidth = itemsInfoRequestedEventArgs.MinWidth,
+					m_maxWidth = itemsInfoRequestedEventArgs.MaxWidth,
+				};
 			}
 
-			MUX_ASSERT(false);
-			return -1;
+			return s_emptyItemsInfo;
 		}
 
-		// Returns the total arrange width of the items within the provided range.
-		// MUX Reference LinedFlowLayout.cpp, commit b8cfb8490.
-		private float GetItemsRangeArrangeWidth(
+		// Returns the index of the first sized item, or -1 if there is none.
+		// This property is meant to be accessed by LinedFlowLayout consumers
+		// when a sizing information changed and LinedFlowLayout.InvalidateItemsInfo
+		// may need to be called. If the sizing information changed for an item outside
+		// the [RequestedRangeStartIndex, RequestedRangeStartIndex + RequestedRangeLength - 1]
+		// range, there is no need to call InvalidateItemsInfo. It would trigger a wasteful
+		// layout pass.
+		/// <summary>
+		/// Index of the first item for which sizing info is requested through the
+		/// <see cref="ItemsInfoRequested"/> event.
+		/// </summary>
+		public int RequestedRangeStartIndex => UsesFastPathLayout() ? 0 : m_itemsInfoFirstIndex;
+
+		// Returns the number of sized items. Like RequestedRangeStartIndex, this property
+		// is meant to be used to determine whether LinedFlowLayout.InvalidateItemsInfo must be
+		// called after a sizing information change (i.e. a temporary aspect ratio needs to
+		// be replaced with its final value for example).
+		/// <summary>
+		/// Number of items for which sizing info is requested through the
+		/// <see cref="ItemsInfoRequested"/> event.
+		/// </summary>
+		public int RequestedRangeLength => UsesFastPathLayout() ? m_itemCount : m_itemsInfoDesiredAspectRatiosForRegularPath.Count;
+
+		// Based on info provided by a potential ItemsInfoRequested event handler, returns True when the info covers the entire data source and the fast path must be engaged, and False to stay in the regular path.
+		// Before returning False, this method updates the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath, m_itemsInfoArrangeWidths and
+		// m_itemsInfoFirstIndex fields. The m_itemsInfoMinWidth and m_itemsInfoMaxWidth fields are updated irrespective of the return value.
+		private bool RequestItemsInfo(
+			ItemsInfo itemsInfo,
 			int beginSizedItemIndex,
-			int endSizedItemIndex,
-			bool usesArrangeWidthInfo)
+			int endSizedItemIndex)
 		{
-			MUX_ASSERT(beginSizedItemIndex >= 0);
-			MUX_ASSERT(endSizedItemIndex < m_itemCount);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"beginSizedItemIndex", beginSizedItemIndex);
+			// LINEDFLOWLAYOUT_TRACE_INFO_DBG(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"endSizedItemIndex", endSizedItemIndex);
 			MUX_ASSERT(beginSizedItemIndex <= endSizedItemIndex);
-			MUX_ASSERT(!UsesFastPathLayout() || usesArrangeWidthInfo);
-			MUX_ASSERT(!UsesFastPathLayout() || m_itemsInfoArrangeWidths.Count > endSizedItemIndex);
+			MUX_ASSERT(beginSizedItemIndex >= m_firstSizedItemIndex);
+			MUX_ASSERT(endSizedItemIndex <= m_lastSizedItemIndex);
 
-			int itemsInfoArrangeWidthsOffset = m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex;
-			float cumulatedArrangeWidth = 0.0f;
+			ItemsInfo newItemsInfo = new();
+			int desiredAspectRatiosCount = 0;
 
-			for (int sizedItemIndex = beginSizedItemIndex; sizedItemIndex <= endSizedItemIndex; sizedItemIndex++)
+			if (itemsInfo.m_itemsRangeStartIndex != -1 &&
+				beginSizedItemIndex >= itemsInfo.m_itemsRangeStartIndex &&
+				endSizedItemIndex <= itemsInfo.m_itemsRangeStartIndex + itemsInfo.m_itemsRangeLength - 1)
 			{
-				if (usesArrangeWidthInfo)
+				// The items info gathered during the fast path attempt covers the current request.
+				// Use it instead of launching a new request.
+				newItemsInfo = itemsInfo;
+
+				desiredAspectRatiosCount = newItemsInfo.m_itemsRangeLength;
+
+				MUX_ASSERT(desiredAspectRatiosCount == m_itemsInfoDesiredAspectRatiosForFastPath.Length);
+				MUX_ASSERT(desiredAspectRatiosCount >= endSizedItemIndex - beginSizedItemIndex + 1);
+			}
+			else
+			{
+				int itemsRangeStartIndex = beginSizedItemIndex;
+				int itemsRangeRequestedLength = endSizedItemIndex - beginSizedItemIndex + 1;
+
+				MUX_ASSERT(itemsRangeStartIndex + itemsRangeRequestedLength - 1 < m_itemCount);
+
+				newItemsInfo = RaiseItemsInfoRequested(itemsRangeStartIndex, itemsRangeRequestedLength);
+
+				// #ifdef DBG
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR, METH_NAME, this, L"ItemsInfo for regular path");
+				// LogItemsInfoDbg(itemsRangeStartIndex, itemsRangeRequestedLength, newItemsInfo);
+				// #endif
+				desiredAspectRatiosCount = newItemsInfo.m_itemsRangeLength;
+
+				if (desiredAspectRatiosCount <= 0)
 				{
-					// Use the item info provided by the ItemsInfoRequested handler since the DesiredSize.Width
-					// may still be the MinWidth because the content is loading.
-					// The use of m_itemsInfoArrangeWidths must be consistent with the one in ArrangeConstrainedLines.
-					cumulatedArrangeWidth += m_itemsInfoArrangeWidths[sizedItemIndex - itemsInfoArrangeWidthsOffset];
+					// No aspect ratios were provided. Discard all info and use the fallback pass with larger realization rect.
+					ResetItemsInfo();
+					return false;
 				}
-				else if (m_elementManager.IsDataIndexRealized(sizedItemIndex))
+
+				MUX_ASSERT(newItemsInfo.m_itemsRangeStartIndex >= 0);
+				MUX_ASSERT(newItemsInfo.m_itemsRangeStartIndex <= beginSizedItemIndex);
+				MUX_ASSERT(newItemsInfo.m_itemsRangeStartIndex + desiredAspectRatiosCount - 1 >= endSizedItemIndex);
+			}
+
+			m_itemsInfoMinWidth = newItemsInfo.m_minWidth < 0.0 ? -1.0 : newItemsInfo.m_minWidth;
+			m_itemsInfoMaxWidth = newItemsInfo.m_maxWidth < 0.0 ? -1.0 : newItemsInfo.m_maxWidth;
+
+			int minWidthsCount = m_itemsInfoMinWidthsForFastPath.Length;
+			int maxWidthsCount = m_itemsInfoMaxWidthsForFastPath.Length;
+			int itemsRangeLength = Math.Min(desiredAspectRatiosCount, m_itemCount - newItemsInfo.m_itemsRangeStartIndex);
+
+			MUX_ASSERT(itemsRangeLength > 0);
+
+			if (itemsRangeLength == m_itemCount)
+			{
+				// The ItemsInfoRequested event handler provided ratios for the entire data source. This situation can occur when a measure path
+				// is performed and (m_forceRelayout || m_previousAvailableWidth != availableWidth) evaluated to False in the initial fast path attempt,
+				// in LinedFlowLayout::MeasureConstrainedLinesFastPath. The ItemsInfoRequested event was thus skipped. Here a transition from regular path
+				// to fast path is enabled. One of two unfortunate behaviors needs to be picked:
+				// a. Remain in the regular path until a future measure path with m_forceRelayout==True or a different availableWidth is triggered.
+				//    The m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath
+				//    vectors could grow very large hindering performance.
+				// b. Stop the regular path and backtrack to the fast path since aspect ratios were provided for the entire collection.
+				//    This can result in a re-arrangement of the visible items.
+				// Option b. is picked for its perf benefits.
+				return true;
+			}
+
+			if (m_itemsInfoFirstIndex == -1)
+			{
+				m_itemsInfoFirstIndex = newItemsInfo.m_itemsRangeStartIndex;
+			}
+			else
+			{
+				m_itemsInfoFirstIndex = Math.Min(newItemsInfo.m_itemsRangeStartIndex, m_itemsInfoFirstIndex);
+			}
+
+			int minItemsInfoRequiredSize = Math.Min(newItemsInfo.m_itemsRangeStartIndex + itemsRangeLength - m_itemsInfoFirstIndex, m_itemCount);
+
+			if (m_itemsInfoDesiredAspectRatiosForRegularPath.Count < minItemsInfoRequiredSize)
+			{
+				ResizeList(m_itemsInfoDesiredAspectRatiosForRegularPath, minItemsInfoRequiredSize, -1.0);
+			}
+
+			if (minWidthsCount > 0 && m_itemsInfoMinWidthsForRegularPath.Count < minItemsInfoRequiredSize)
+			{
+				ResizeList(m_itemsInfoMinWidthsForRegularPath, minItemsInfoRequiredSize, -1.0);
+			}
+
+			if (maxWidthsCount > 0 && m_itemsInfoMaxWidthsForRegularPath.Count < minItemsInfoRequiredSize)
+			{
+				ResizeList(m_itemsInfoMaxWidthsForRegularPath, minItemsInfoRequiredSize, -1.0);
+			}
+
+			if (m_itemsInfoArrangeWidths.Count < minItemsInfoRequiredSize)
+			{
+				ResizeList(m_itemsInfoArrangeWidths, minItemsInfoRequiredSize, -1.0f);
+			}
+
+			int itemsInfoIndexStart = newItemsInfo.m_itemsRangeStartIndex - m_itemsInfoFirstIndex;
+
+			for (int index = 0; index < itemsRangeLength; index++)
+			{
+				double desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForFastPath[index];
+
+				// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"desiredAspectRatio", desiredAspectRatio);
+				SetDesiredAspectRatioFromItemsInfo(
+					m_itemsInfoFirstIndex + itemsInfoIndexStart + index,
+					desiredAspectRatio);
+
+				MUX_ASSERT(m_itemsInfoDesiredAspectRatiosForRegularPath[itemsInfoIndexStart + index] == desiredAspectRatio);
+
+				if (minWidthsCount > 0 && index < minWidthsCount)
 				{
-					if (m_elementManager.GetRealizedElement(sizedItemIndex /*dataIndex*/) is { } element)
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"minWidth", m_itemsInfoMinWidthsForFastPath[index]);
+					m_itemsInfoMinWidthsForRegularPath[itemsInfoIndexStart + index] = m_itemsInfoMinWidthsForFastPath[index];
+				}
+
+				if (maxWidthsCount > 0 && index < maxWidthsCount)
+				{
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"maxWidth", m_itemsInfoMaxWidthsForFastPath[index]);
+					m_itemsInfoMaxWidthsForRegularPath[itemsInfoIndexStart + index] = m_itemsInfoMaxWidthsForFastPath[index];
+				}
+			}
+
+			return false;
+		}
+
+		private void ResetItemsInfo()
+		{
+			m_itemsInfoDesiredAspectRatiosForRegularPath.Clear();
+			m_itemsInfoMinWidthsForRegularPath.Clear();
+			m_itemsInfoMaxWidthsForRegularPath.Clear();
+			m_itemsInfoArrangeWidths.Clear();
+			m_itemsInfoFirstIndex = -1;
+			m_itemsInfoMinWidth = -1.0;
+			m_itemsInfoMaxWidth = -1.0;
+		}
+
+		private void ResetItemsInfoForFastPath()
+		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
+			m_itemsInfoDesiredAspectRatiosForFastPath = Array.Empty<double>();
+			m_itemsInfoMinWidthsForFastPath = Array.Empty<double>();
+			m_itemsInfoMaxWidthsForFastPath = Array.Empty<double>();
+		}
+
+		private void ResetLinesInfo()
+		{
+			m_lineItemCounts.Clear();
+		}
+
+		private void ResetSizedLines()
+		{
+			m_firstSizedLineIndex = -1;
+			m_lastSizedLineIndex = -1;
+			m_firstSizedItemIndex = -1;
+			m_lastSizedItemIndex = -1;
+			m_firstFrozenLineIndex = -1;
+			m_lastFrozenLineIndex = -1;
+			m_firstFrozenItemIndex = -1;
+			m_lastFrozenItemIndex = -1;
+		}
+
+		// Stores the item's arrange width in the m_itemsInfoArrangeWidths vector.
+		private void SetArrangeWidthFromItemsInfo(
+			int itemIndex,
+			float arrangeWidth)
+		{
+			// #ifdef DBG
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemIndex", itemIndex);
+			//
+			// if (itemIndex == LogItemIndexDbg())
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"arrangeWidth", arrangeWidth);
+			// }
+			// else
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"arrangeWidth", arrangeWidth);
+			// }
+			// #endif
+			MUX_ASSERT(m_itemsInfoFirstIndex >= -1);
+
+			// m_itemsInfoFirstIndex >=  0: Regular path layout case, with items info available (m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath).
+			// m_itemsInfoFirstIndex == -1: Fast path layout case, without items info available.
+			int itemsInfoArrangeWidthsIndex = itemIndex - (m_itemsInfoFirstIndex == -1 ? 0 : m_itemsInfoFirstIndex);
+
+			MUX_ASSERT(itemsInfoArrangeWidthsIndex >= 0);
+			MUX_ASSERT(itemsInfoArrangeWidthsIndex < m_itemsInfoArrangeWidths.Count);
+
+			m_itemsInfoArrangeWidths[itemsInfoArrangeWidthsIndex] = arrangeWidth;
+		}
+
+		private void SetAverageItemsPerLine(
+			(double first, double second) averageItemsPerLine,
+			bool unlockItems)
+		{
+			if (averageItemsPerLine.second == m_averageItemsPerLine.second)
+			{
+				// When the old and new snapped average-items-per-line are identical,
+				// just retain the raw value change.
+				m_averageItemsPerLine.first = averageItemsPerLine.first;
+			}
+			else
+			{
+				// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_DBL_DBL, METH_NAME, this, m_averageItemsPerLine.second, averageItemsPerLine.second);
+				m_averageItemsPerLine = averageItemsPerLine;
+
+				if (unlockItems)
+				{
+					UnlockItems();
+				}
+
+				var globalTestHooks = LayoutsTestHooks.GetGlobalTestHooks();
+
+				if (globalTestHooks is not null)
+				{
+					globalTestHooks.NotifyLinedFlowLayoutSnappedAverageItemsPerLineChanged(this);
+				}
+			}
+		}
+
+		private void SetDesiredAspectRatioFromItemsInfo(
+			int itemIndex,
+			double desiredAspectRatio)
+		{
+#if DEBUG
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemIndex", itemIndex);
+			// if (itemIndex == LogItemIndexDbg())
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+			//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"desiredAspectRatio", desiredAspectRatio);
+			// }
+			// else
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"desiredAspectRatio", desiredAspectRatio);
+			// }
+			MUX_ASSERT(itemIndex < m_itemCount);
+			MUX_ASSERT(m_itemsInfoFirstIndex >= 0);
+			MUX_ASSERT(itemIndex - m_itemsInfoFirstIndex >= 0);
+			MUX_ASSERT(itemIndex - m_itemsInfoFirstIndex < m_itemsInfoDesiredAspectRatiosForRegularPath.Count);
+#endif
+
+			m_itemsInfoDesiredAspectRatiosForRegularPath[itemIndex - m_itemsInfoFirstIndex] = desiredAspectRatio;
+		}
+
+		// Returns the total arrange width for the provided index range.
+		private float SetItemRangeArrangeWidth(
+			int beginItemIndex,
+			int endItemIndex,
+			double actualLineHeight,
+			double averageAspectRatio,
+			double scaleFactor = 1.0)
+		{
+			MUX_ASSERT(beginItemIndex <= endItemIndex);
+			MUX_ASSERT(beginItemIndex >= 0);
+			MUX_ASSERT(endItemIndex < m_itemsInfoArrangeWidths.Count);
+
+			float totalArrangeWidth = 0.0f;
+
+			for (int itemIndex = beginItemIndex; itemIndex <= endItemIndex; itemIndex++)
+			{
+				float arrangeWidth = GetArrangeWidthFromItemsInfo(itemIndex, actualLineHeight, averageAspectRatio, scaleFactor);
+
+				SetArrangeWidthFromItemsInfo(itemIndex, arrangeWidth);
+
+				totalArrangeWidth += arrangeWidth;
+			}
+
+			return totalArrangeWidth;
+		}
+
+		// Snaps the provided average items per line to a power of 1.1, taking into account the old averageItemsPerLine raw (i.e. unsnapped) value.
+		private (double first, double second) SnapAverageItemsPerLine(
+			double oldAverageItemsPerLineRaw,
+			double newAverageItemsPerLineRaw)
+		{
+			MUX_ASSERT(oldAverageItemsPerLineRaw == 0.0 || oldAverageItemsPerLineRaw >= 1.0);
+			MUX_ASSERT(newAverageItemsPerLineRaw == 0.0 || newAverageItemsPerLineRaw >= 1.0);
+
+			// A snapped average-items-per-line value must be a power of 1.1.
+			const double valuePower = 1.1;
+			// When the raw value crosses the median line betweeen two successive powers of 1.1, the old snapped value is retained unless the raw delta is greater than 0.1.
+			const double distanceThreshold = 0.1;
+			double appliedValuePower = m_forcedAverageItemsPerLineDividerDbg == 0.0 ? valuePower : m_forcedAverageItemsPerLineDividerDbg;
+			double oldAverageItemsPerLineSnapped = (oldAverageItemsPerLineRaw == 0.0) ? 0.0 : SnapToPower(oldAverageItemsPerLineRaw, appliedValuePower);
+			double newAverageItemsPerLineSnapped = (newAverageItemsPerLineRaw == 0.0) ? 0.0 : SnapToPower(newAverageItemsPerLineRaw, appliedValuePower);
+
+			if (oldAverageItemsPerLineSnapped != newAverageItemsPerLineSnapped &&
+				Math.Abs(oldAverageItemsPerLineRaw - newAverageItemsPerLineRaw) <= distanceThreshold)
+			{
+				// The old and new snapped values are different, but their respective raw values are close (i.e. within a distanceThreshold delta).
+				// Instead of returning newAverageItemsPerLineSnapped, return oldAverageItemsPerLineSnapped so the applied average items per line
+				// is more stable when the raw values hover around the middle point between 1.1^N and 1.1^(N+1).
+				// Example:
+				// 1.1^14 = 3.7975, 1.1^15 = 4.1772. Their middle point is about 3.9874.
+				// oldAverageItemsPerLineRaw = 3.95 snapped to oldAverageItemsPerLineSnapped = 1.1^14 = 3.7975.
+				// newAverageItemsPerLineRaw = 4.00 would normally snap to 1.1^15 = 4.1772, but because |3.95 - 4.00| <= 0.1, the old pair is returned.
+				return (oldAverageItemsPerLineRaw, oldAverageItemsPerLineSnapped);
+			}
+
+			return (newAverageItemsPerLineRaw, newAverageItemsPerLineSnapped);
+		}
+
+		// Snaps the provided value to a power of valuePower.
+		// Example: value=3.75 snaps to 1.1^14 = 3.7975, valuePower being 1.1.
+		private double SnapToPower(double value, double valuePower)
+		{
+#if DEBUG
+			// constexpr double defaultValuePowerDbg = 1.1;
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"value", value);
+			// if (valuePower != defaultValuePowerDbg)
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"valuePower", valuePower);
+			// }
+			MUX_ASSERT(value >= 1.0);
+#endif
+			double dividerLog = Math.Log(valuePower);
+			double valueLog = Math.Log(value);
+			double valueExp = Math.Ceiling(valueLog / dividerLog);
+			double valueRndCeil = Math.Pow(valuePower, valueExp);
+			double valueRndFloor = valueRndCeil / valuePower;
+
+			// #ifdef DBG
+			// if (valuePower != defaultValuePowerDbg)
+			// {
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"dividerLog", dividerLog);
+			//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"valueLog", valueLog);
+			// }
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"valueExp", valueExp);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"valueRndCeil", valueRndCeil);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"valueRndFloor", valueRndFloor);
+			// #endif
+			// Return valuePower^valueExp or valuePower^(valueExp - 1), whichever is closest to value.
+			if (Math.Abs(valueRndCeil - value) <= Math.Abs(valueRndFloor - value))
+			{
+				return valueRndCeil;
+			}
+			else
+			{
+				return valueRndFloor;
+			}
+		}
+
+		// Raises the ItemsUnlocked event when there are locked items.
+		// This event is raised when previously locked items are cleared and declared unlocked because the source collection
+		// or the average items per line changed.
+		internal void UnlockItems()
+		{
+			if (m_lockedItemIndexes.Count > 0 || m_isFirstOrLastItemLocked)
+			{
+				// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, m_lockedItemIndexes.size(), m_isFirstOrLastItemLocked);
+				m_lockedItemIndexes.Clear();
+				m_isFirstOrLastItemLocked = false;
+				ItemsUnlocked?.Invoke(this, null!);
+			}
+		}
+
+		// Computes the ActualLineHeight property value. Returns True when it changed.
+		private bool UpdateActualLineHeight(
+			VirtualizingLayoutContext context,
+			Size availableSize)
+		{
+			double lineHeight = LineHeight;
+			double oldActualLineHeight = ActualLineHeight;
+			double newActualLineHeight = 0.0;
+
+			if (double.IsNaN(lineHeight))
+			{
+				if (context.ItemCount > 0)
+				{
+					UIElement? element = null;
+					Size desiredSize = new Size(-1.0, -1.0);
+
+					// Element for first data item determines ActualLineHeight value.
+					if (oldActualLineHeight != 0.0 &&
+						m_elementManager.IsDataIndexRealized(0) &&
+						(element = m_elementManager.GetRealizedElement(0)) != null)
 					{
-						cumulatedArrangeWidth += (float)element.DesiredSize.Width;
+						// Check if the realized element at index 0 has a recorded desired or available size
+						// to restore after measurement with the provided 'availableSize'.
+						desiredSize = GetDesiredSizeForAvailableSize(0, element, availableSize, oldActualLineHeight);
+
+						if (desiredSize.Height != -1.0)
+						{
+							newActualLineHeight = desiredSize.Height;
+						}
+						// Else use context.GetOrCreateElementAt instead.
+					}
+
+					if (desiredSize.Height == -1.0)
+					{
+						// The element for the first item is not realized or has no recorded measurement size, so generate a new element and let it be recycled.
+						// Since LineHeight is NaN, this element is not meant to have a height based on content asynchronously loaded.
+						// That would lead to a temporary incorrect ActualLineHeight and potentially numerous item realizations.
+						if ((element = context.GetOrCreateElementAt(0 /*dataIndex*/, ElementRealizationOptions.ForceCreate)) != null)
+						{
+							element.Measure(availableSize);
+							newActualLineHeight = element.DesiredSize.Height;
+							//TODO: Bug 41896454.
+							//      Why is this RecycleElement call triggering endless measure passes?
+							//      This element needs to be discarded or else bring-into-view operations to index 0 will be animated (because index 0 is considered realized).
+							//context.RecycleElement(element);
+						}
 					}
 				}
 			}
+			else
+			{
+				newActualLineHeight = lineHeight;
+			}
 
-			return cumulatedArrangeWidth;
+			if (oldActualLineHeight != newActualLineHeight)
+			{
+				// LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_DBL, METH_NAME, this, newActualLineHeight);
+				ActualLineHeight = newActualLineHeight;
+
+				return true;
+			}
+
+			return false;
 		}
 
-		#endregion
+		// Updates the m_aspectRatios storage based on the items info collected from the ItemsInfoRequested event handler.
+		// The aspect ratios put in the storage immediately get the maximum weight c_maxAspectRatioWeight as the application-provided
+		// information is fully trusted.
+		// The application may not provide accurate aspect ratios though. It may temporarily provide placeholder ratios until the
+		// accurate values are evaluated, at which point it calls LinedFlowLayout.InvalidateItemsInfo. m_aspectRatios then gets updated
+		// with new aspect ratios with the maximum weight c_maxAspectRatioWeight again.
+		// The application may also provide aspect ratios <= 0 instead of valid placeholder values. Those temporary values, unlike
+		// the positive placeholder values, are not stored in m_aspectRatios. The average aspect ratio is a replacement for negative values.
+		private void UpdateAspectRatiosWithItemsInfo()
+		{
+			MUX_ASSERT(m_aspectRatios is not null);
+
+			LinedFlowLayoutItemAspectRatios aspectRatios = m_aspectRatios!;
+
+			int itemsInfoCount = m_itemsInfoDesiredAspectRatiosForRegularPath.Count;
+			double actualLineHeight = ActualLineHeight;
+
+			for (int index = 0; index < itemsInfoCount; index++)
+			{
+				double desiredAspectRatio = m_itemsInfoDesiredAspectRatiosForRegularPath[index];
+
+				if (desiredAspectRatio <= 0.0)
+				{
+					continue;
+				}
+
+				double minWidth = GetMinWidthFromItemsInfo(m_itemsInfoFirstIndex + index);
+				double maxWidth = GetMaxWidthFromItemsInfo(m_itemsInfoFirstIndex + index);
+
+				if (minWidth > 0.0 || maxWidth >= 0.0)
+				{
+					double desiredWidth = desiredAspectRatio * actualLineHeight;
+
+					if (minWidth > 0.0 && minWidth > desiredWidth)
+					{
+						desiredWidth = minWidth;
+					}
+
+					if (maxWidth >= 0.0 && maxWidth < desiredWidth)
+					{
+						desiredWidth = maxWidth;
+					}
+
+					desiredAspectRatio = desiredWidth / actualLineHeight;
+				}
+
+				LinedFlowLayoutItemAspectRatios.ItemAspectRatio itemAspectRatio = aspectRatios.GetAt(m_itemsInfoFirstIndex + index);
+				float aspectRatio = (float)desiredAspectRatio;
+				float newAspectRatio = itemAspectRatio.AspectRatio;
+				int newWeight = itemAspectRatio.Weight;
+				bool updateItemAspectRatio = false;
+
+				if (newWeight == 0)
+				{
+					newAspectRatio = aspectRatio;
+					newWeight = c_maxAspectRatioWeight;
+					updateItemAspectRatio = true;
+					// #ifdef DBG
+					// if (m_itemsInfoFirstIndex + index == LogItemIndexDbg())
+					// {
+					//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+					//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"ItemsInfo aspect ratio", aspectRatio);
+					// }
+					// #endif
+				}
+				else
+				{
+					MUX_ASSERT(itemAspectRatio.AspectRatio >= 0.0f);
+					MUX_ASSERT(itemAspectRatio.Weight >= 1);
+					MUX_ASSERT(itemAspectRatio.Weight <= c_maxAspectRatioWeight);
+
+					if (newWeight != c_maxAspectRatioWeight)
+					{
+						newWeight = c_maxAspectRatioWeight;
+						updateItemAspectRatio = true;
+					}
+
+					// Ignore aspect ratio deltas coming from pixel snapping rounding. The aspect ratios coming from UIElement.Measure are preserved.
+					if (Math.Abs(itemAspectRatio.AspectRatio - aspectRatio) > 0.5 / (m_roundingScaleFactor * actualLineHeight))
+					{
+						// #ifdef DBG
+						// if (m_itemsInfoFirstIndex + index == LogItemIndexDbg())
+						// {
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"logItemIndexDbg", LogItemIndexDbg());
+						//     LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"ItemsInfo aspect ratio overwriting", itemAspectRatio.m_aspectRatio, aspectRatio);
+						// }
+						// #endif
+						newAspectRatio = aspectRatio;
+						updateItemAspectRatio = true;
+					}
+				}
+
+				if (updateItemAspectRatio)
+				{
+					aspectRatios.SetAt(m_itemsInfoFirstIndex + index, new LinedFlowLayoutItemAspectRatios.ItemAspectRatio(newAspectRatio, newWeight));
+				}
+			}
+		}
+
+		// Raises the ItemsInfoRequested event to potentially fill the m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath,
+		// m_itemsInfoFirstIndex, m_itemsInfoMinWidth, m_itemsInfoMaxWidth fields with item sizing information.
+		// Returns True when the provided info covers the entire data source and the fast path must be engaged, and False to stay in the regular path.
+		private bool UpdateItemsInfo(
+			ItemsInfo itemsInfo,
+			int oldFirstItemsInfoIndex,
+			int oldLastItemsInfoIndex)
+		{
+			// #ifdef DBG
+			// LogItemsInfoDbg(-1, -1, itemsInfo);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"oldFirstItemsInfoIndex", oldFirstItemsInfoIndex);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"oldLastItemsInfoIndex", oldLastItemsInfoIndex);
+			// #endif
+			// Raise ItemsInfoRequested events.
+			if (oldFirstItemsInfoIndex == -1 || m_lastSizedItemIndex < oldFirstItemsInfoIndex || m_firstSizedItemIndex > oldLastItemsInfoIndex)
+			{
+				// No overlapping of old items info and new sized items. Build the items info from scratch.
+				ResetItemsInfo();
+
+				// Raise event for [m_firstSizedItemIndex, m_lastSizedItemIndex] range.
+				if (RequestItemsInfo(itemsInfo, m_firstSizedItemIndex /*beginSizedItemIndex*/, m_lastSizedItemIndex /*endSizedItemIndex*/))
+				{
+					return true;
+				}
+
+				UpdateAspectRatiosWithItemsInfo();
+			}
+			else if (m_firstSizedItemIndex < oldFirstItemsInfoIndex || m_lastSizedItemIndex > oldLastItemsInfoIndex)
+			{
+				// Partial overlapping.
+				MUX_ASSERT(oldLastItemsInfoIndex != -1);
+
+				// TODO as part of perf Task 42298247 - see if these copies can be avoided by copying vector elements 'in place'.
+				List<double> oldItemsInfoDesiredAspectRatios = new List<double>(m_itemsInfoDesiredAspectRatiosForRegularPath);
+				List<double> oldItemsInfoMinWidths = new List<double>(m_itemsInfoMinWidthsForRegularPath);
+				List<double> oldItemsInfoMaxWidths = new List<double>(m_itemsInfoMaxWidthsForRegularPath);
+				List<float> oldItemsInfoArrangeWidths = new List<float>(m_itemsInfoArrangeWidths);
+
+				int newItemsInfoCount = m_lastSizedItemIndex - m_firstSizedItemIndex + 1;
+
+				EnsureItemsInfoDesiredAspectRatios(newItemsInfoCount /*itemCount*/);
+
+				if (m_itemsInfoMinWidthsForRegularPath.Count > 0)
+				{
+					EnsureItemsInfoMinWidths(newItemsInfoCount /*itemCount*/);
+				}
+
+				if (m_itemsInfoMaxWidthsForRegularPath.Count > 0)
+				{
+					EnsureItemsInfoMaxWidths(newItemsInfoCount /*itemCount*/);
+				}
+
+				EnsureItemsInfoArrangeWidths(newItemsInfoCount /*itemCount*/);
+
+				m_itemsInfoFirstIndex = m_firstSizedItemIndex;
+
+				bool oldFirstOverlaps = oldFirstItemsInfoIndex >= m_firstSizedItemIndex && oldFirstItemsInfoIndex <= m_lastSizedItemIndex;
+				bool oldLastOverlaps = oldLastItemsInfoIndex >= m_firstSizedItemIndex && oldLastItemsInfoIndex <= m_lastSizedItemIndex;
+				bool newFirstOverlaps = m_firstSizedItemIndex >= oldFirstItemsInfoIndex && m_firstSizedItemIndex <= oldLastItemsInfoIndex;
+				bool newLastOverlaps = m_lastSizedItemIndex >= oldFirstItemsInfoIndex && m_lastSizedItemIndex <= oldLastItemsInfoIndex;
+
+				if (oldFirstOverlaps || oldLastOverlaps || newFirstOverlaps || newLastOverlaps)
+				{
+					MUX_ASSERT(!newFirstOverlaps || !newLastOverlaps);
+
+					// Fill m_itemsInfoDesiredAspectRatiosForRegularPath, m_itemsInfoMinWidthsForRegularPath, m_itemsInfoMaxWidthsForRegularPath, m_itemsInfoArrangeWidths vectors with overlapping
+					// oldItemsInfoDesiredAspectRatios, oldItemsInfoMinWidths, oldItemsInfoMaxWidths, oldItemsInfoArrangeWidths ones.
+					if (oldFirstOverlaps && oldLastOverlaps)
+					{
+						CopyItemsInfo(
+							oldItemsInfoDesiredAspectRatios,
+							oldItemsInfoMinWidths,
+							oldItemsInfoMaxWidths,
+							oldItemsInfoArrangeWidths,
+							0 /*oldStart*/,
+							oldFirstItemsInfoIndex - m_firstSizedItemIndex /*newStart*/,
+							oldLastItemsInfoIndex - oldFirstItemsInfoIndex + 1 /*copyCount*/);
+					}
+					else if (newFirstOverlaps && oldLastOverlaps)
+					{
+						CopyItemsInfo(
+							oldItemsInfoDesiredAspectRatios,
+							oldItemsInfoMinWidths,
+							oldItemsInfoMaxWidths,
+							oldItemsInfoArrangeWidths,
+							m_firstSizedItemIndex - oldFirstItemsInfoIndex /*oldStart*/,
+							0 /*newStart*/,
+							oldLastItemsInfoIndex - m_firstSizedItemIndex + 1 /*copyCount*/);
+					}
+					else if (oldFirstOverlaps && newLastOverlaps)
+					{
+						CopyItemsInfo(
+							oldItemsInfoDesiredAspectRatios,
+							oldItemsInfoMinWidths,
+							oldItemsInfoMaxWidths,
+							oldItemsInfoArrangeWidths,
+							0 /*oldStart*/,
+							oldFirstItemsInfoIndex - m_firstSizedItemIndex /*newStart*/,
+							m_lastSizedItemIndex - oldFirstItemsInfoIndex + 1 /*copyCount*/);
+					}
+				}
+
+				if (m_firstSizedItemIndex < oldFirstItemsInfoIndex)
+				{
+					// Raise event for [m_firstSizedItemIndex, oldFirstItemsInfoIndex - 1] range.
+					if (RequestItemsInfo(itemsInfo, m_firstSizedItemIndex /*beginSizedItemIndex*/, oldFirstItemsInfoIndex - 1 /*endSizedItemIndex*/))
+					{
+						return true;
+					}
+				}
+
+				if (m_lastSizedItemIndex > oldLastItemsInfoIndex)
+				{
+					// Raise event for [oldLastItemsInfoIndex + 1, m_lastSizedItemIndex] range.
+					if (RequestItemsInfo(itemsInfo, oldLastItemsInfoIndex + 1 /*beginSizedItemIndex*/, m_lastSizedItemIndex /*endSizedItemIndex*/))
+					{
+						return true;
+					}
+				}
+
+				UpdateAspectRatiosWithItemsInfo();
+			}
+			else
+			{
+				// Full overlapping. [m_firstSizedItemIndex, m_lastSizedItemIndex] is a subset of [oldFirstItemsInfoIndex, oldLastItemsInfoIndex].
+				// m_itemsInfoDesiredAspectRatiosForRegularPath left unchanged.
+				MUX_ASSERT(m_itemsInfoFirstIndex != -1);
+				MUX_ASSERT(m_firstSizedItemIndex >= oldFirstItemsInfoIndex);
+				MUX_ASSERT(m_firstSizedItemIndex <= oldLastItemsInfoIndex);
+				MUX_ASSERT(m_lastSizedItemIndex >= oldFirstItemsInfoIndex);
+				MUX_ASSERT(m_lastSizedItemIndex <= oldLastItemsInfoIndex);
+			}
+
+			return false;
+		}
+
+		private void UpdateRoundingScaleFactor(
+			UIElement xamlRootReference)
+		{
+			// WinUI calls xamlRootReference.XamlRoot().RasterizationScale() inside a try/catch because
+			// GetForCurrentView on threads without a CoreWindow throws. In Uno, XamlRoot is a nullable
+			// property returning null instead of throwing, so a null check provides the equivalent fallback.
+			if (xamlRootReference.XamlRoot is { } xamlRoot)
+			{
+				m_roundingScaleFactor = xamlRoot.RasterizationScale;
+			}
+			else
+			{
+				// Calling GetForCurrentView on threads without a CoreWindow throws an error.
+				// In this circumstance, we'll just always round to the closest integer.
+				m_roundingScaleFactor = 1.0;
+			}
+		}
+
+		// Returns True when an ItemsInfoRequested handler provided sizing information for
+		// the request item range or more.  In either cases, m_itemsInfoArrangeWidths is populated
+		// with arrange widths resulting from the provided information.
+		// When returning True,
+		//  - when the handler provided information for less than the entire source collection, m_itemsInfoFirstIndex is >= 0.
+		//  - when the handler provided information the entire source collection, m_itemsInfoFirstIndex is -1.
+		private bool UsesArrangeWidthInfo() => m_itemsInfoArrangeWidths.Count > 0;
+
+		// Returns True when an ItemsInfoRequested handler provided sizing information for
+		// the entire source collection.  In that case, the fast path can be performed, and
+		// it is characterized by having a populated m_itemsInfoArrangeWidths vector and m_itemsInfoFirstIndex remaining at -1.
+		private bool UsesFastPathLayout() => UsesArrangeWidthInfo() && m_itemsInfoFirstIndex == -1;
+		// #ifdef DBG
+		//
+		// winrt::hstring LinedFlowLayout::DependencyPropertyToStringDbg(
+		//     winrt::IDependencyProperty const& dependencyProperty)
+		// {
+		//     if (dependencyProperty == s_ItemsJustificationProperty)
+		//     {
+		//         return L"ItemsJustification";
+		//     }
+		//     else if (dependencyProperty == s_ItemsStretchProperty)
+		//     {
+		//         return L"ItemsStretch";
+		//     }
+		//     else if (dependencyProperty == s_MinItemSpacingProperty)
+		//     {
+		//         return L"MinItemSpacing";
+		//     }
+		//     else if (dependencyProperty == s_LineSpacingProperty)
+		//     {
+		//         return L"LineSpacing";
+		//     }
+		//     else if (dependencyProperty == s_LineHeightProperty)
+		//     {
+		//         return L"LineHeight";
+		//     }
+		//     else if (dependencyProperty == s_ActualLineHeightProperty)
+		//     {
+		//         return L"ActualLineHeight";
+		//     }
+		//     else
+		//     {
+		//         return L"UNKNOWN";
+		//     }
+		// }
+		//
+		// void LinedFlowLayout::LogElementManagerDbg()
+		// {
+		//     const int firstRealizedDataIndex = m_elementManager.GetFirstRealizedDataIndex();
+		//
+		//     if (firstRealizedDataIndex != - 1)
+		//     {
+		//         const int realizedElementCount = m_elementManager.GetRealizedElementCount();
+		//
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstRealizedDataIndex", firstRealizedDataIndex);
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastRealizedDataIndex", firstRealizedDataIndex + realizedElementCount - 1);
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"realizedElementCount", realizedElementCount);
+		//     }
+		// }
+		//
+		// void LinedFlowLayout::LogItemsInfoDbg(
+		//     int itemsRangeStartIndex,
+		//     int itemsRangeRequestedLength,
+		//     ItemsInfo const& itemsInfo)
+		// {
+		//     if (itemsRangeStartIndex != -1 && itemsRangeRequestedLength != -1)
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemsRangeStartIndex", itemsRangeStartIndex);
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemsRangeRequestedLength", itemsRangeRequestedLength);
+		//     }
+		//
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"ii.m_itemsRangeStartIndex", itemsInfo.m_itemsRangeStartIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"ii.m_itemsRangeLength", itemsInfo.m_itemsRangeLength);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"ii.m_minWidth", itemsInfo.m_minWidth);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"ii.m_maxWidth", itemsInfo.m_maxWidth);
+		//
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_itemsInfoDesiredAspectRatiosForFastPath.size", m_itemsInfoDesiredAspectRatiosForFastPath.size());
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_itemsInfoMinWidthsForFastPath.size", m_itemsInfoMinWidthsForFastPath.size());
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_itemsInfoMaxWidthsForFastPath.size", m_itemsInfoMaxWidthsForFastPath.size());
+		// }
+		//
+		// void LinedFlowLayout::LogItemsLayoutDbg(
+		//     ItemsLayout const& itemsLayout,
+		//     double averageLineItemsWidth) const
+		// {
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"drawback", itemsLayout.m_drawback);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"availableLineItemsWidth", itemsLayout.m_availableLineItemsWidth);
+		//     if (averageLineItemsWidth > 0)
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"averageLineItemsWidth",
+		//             averageLineItemsWidth);
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"delta (%)",
+		//             std::abs(itemsLayout.m_availableLineItemsWidth - averageLineItemsWidth) / averageLineItemsWidth * 100.0);
+		//     }
+		//
+		//     if (itemsLayout.m_smallestHeadLineIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"smallestHeadLineIndex", itemsLayout.m_smallestHeadLineIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_smallestHeadItemIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"smallestHeadItemIndex", itemsLayout.m_smallestHeadItemIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_smallestHeadItemWidth != std::numeric_limits<double>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"smallestHeadItemWidth", itemsLayout.m_smallestHeadItemWidth);
+		//     }
+		//
+		//     if (itemsLayout.m_smallestTailLineIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"smallestTailLineIndex", itemsLayout.m_smallestTailLineIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_smallestTailItemIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"smallestTailItemIndex", itemsLayout.m_smallestTailItemIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_smallestTailItemWidth != std::numeric_limits<double>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"smallestTailItemWidth", itemsLayout.m_smallestTailItemWidth);
+		//     }
+		//
+		//     if (itemsLayout.m_bestEqualizingHeadLineIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"bestEqualizingHeadLineIndex", itemsLayout.m_bestEqualizingHeadLineIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_bestEqualizingHeadItemIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"bestEqualizingHeadItemIndex", itemsLayout.m_bestEqualizingHeadItemIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_bestEqualizingHeadItemDrawbackImprovement != 0.0)
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"bestEqualizingHeadItemDrawbackImprovement", itemsLayout.m_bestEqualizingHeadItemDrawbackImprovement);
+		//     }
+		//
+		//     if (itemsLayout.m_bestEqualizingTailLineIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"bestEqualizingTailLineIndex", itemsLayout.m_bestEqualizingTailLineIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_bestEqualizingTailItemIndex != std::numeric_limits<int>::max())
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"bestEqualizingTailItemIndex", itemsLayout.m_bestEqualizingTailItemIndex);
+		//     }
+		//
+		//     if (itemsLayout.m_bestEqualizingTailItemDrawbackImprovement != 0.0)
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"bestEqualizingTailItemDrawbackImprovement", itemsLayout.m_bestEqualizingTailItemDrawbackImprovement);
+		//     }
+		//
+		//     // Uncomment for verbose tracing of line item counts and widths:
+		//     //for (int index = 0; index < static_cast<int>(itemsLayout.m_lineItemWidths.size()); index++)
+		//     //{
+		//     //    LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT_INT, METH_NAME, this, L"line item count", index, itemsLayout.m_lineItemCounts[index]);
+		//     //    LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"line size", itemsLayout.m_lineItemWidths[index]);
+		//     //}
+		// }
+		//
+		// void LinedFlowLayout::LogLayoutDbg()
+		// {
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"averageItemAspectRatioDbg", m_averageItemAspectRatioDbg);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"averageItemsPerLine raw", m_averageItemsPerLine.first);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_DBL, METH_NAME, this, L"averageItemsPerLine snapped", m_averageItemsPerLine.second);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"measureCountdown", m_measureCountdown);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemCount", m_itemCount);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"unsizedNearLineCount", m_unsizedNearLineCount);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstSizedLineIndex", m_firstSizedLineIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastSizedLineIndex", m_lastSizedLineIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstSizedItemIndex", m_firstSizedItemIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastSizedItemIndex", m_lastSizedItemIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"unrealizedNearLineCount", m_unrealizedNearLineCount);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstRealizedItemIndex", FirstRealizedItemIndexDbg());
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastRealizedItemIndex", LastRealizedItemIndexDbg());
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstFrozenLineIndex", m_firstFrozenLineIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastFrozenLineIndex", m_lastFrozenLineIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstFrozenItemIndex", m_firstFrozenItemIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastFrozenItemIndex", m_lastFrozenItemIndex);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"m_previousAvailableWidth", m_previousAvailableWidth);
+		//
+		//     for (const auto& lockedItemIterator : m_lockedItemIndexes)
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"lockedItem", lockedItemIterator.first, lockedItemIterator.second);
+		//     }
+		//
+		//     for (const int lineItemsCount : m_lineItemCounts)
+		//     {
+		//         LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lineItemsCount", lineItemsCount);
+		//     }
+		// }
+		//
+		// void LinedFlowLayout::LogVirtualizingLayoutContextDbg(
+		//     winrt::VirtualizingLayoutContext const& context) const
+		// {
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"ItemCount", context.ItemCount());
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"RecommendedAnchorIndex", context.RecommendedAnchorIndex());
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"RealizationRect", context.RealizationRect().Y, context.RealizationRect().Height);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT_FLT, METH_NAME, this, L"VisibleRect", context.VisibleRect().Y, context.VisibleRect().Height);
+		//     LINEDFLOWLAYOUT_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"LayoutOrigin", context.LayoutOrigin().Y);
+		// }
+		//
+		// void LinedFlowLayout::VerifyInternalLockedItemsDbg(
+		//     std::map<int, int> const& internalLockedItemIndexes,
+		//     int beginSizedLineIndex,
+		//     int endSizedLineIndex,
+		//     int beginSizedItemIndex,
+		//     int endSizedItemIndex)
+		// {
+		//     MUX_ASSERT(!(beginSizedLineIndex < endSizedLineIndex && beginSizedItemIndex >= endSizedItemIndex));
+		//     MUX_ASSERT(!(beginSizedLineIndex > endSizedLineIndex && beginSizedItemIndex <= endSizedItemIndex));
+		//     MUX_ASSERT(std::abs(beginSizedLineIndex - endSizedLineIndex) <= std::abs(beginSizedItemIndex - endSizedItemIndex));
+		//
+		//     if (internalLockedItemIndexes.size() == 0)
+		//     {
+		//         return;
+		//     }
+		//
+		//     int previousLockedItemIndex = endSizedItemIndex >= beginSizedItemIndex ? beginSizedItemIndex : endSizedItemIndex;
+		//     int previousLockedLineIndex = endSizedItemIndex >= beginSizedItemIndex ? beginSizedLineIndex : endSizedLineIndex;
+		//
+		//     for (const auto& lockedItemIterator : internalLockedItemIndexes)
+		//     {
+		//         const int lockedItemIndex = lockedItemIterator.first;
+		//         const int lockedLineIndex = lockedItemIterator.second;
+		//
+		//         MUX_ASSERT(lockedLineIndex >= previousLockedLineIndex);
+		//         MUX_ASSERT(lockedItemIndex > previousLockedItemIndex);
+		//         MUX_ASSERT(lockedItemIndex - previousLockedItemIndex >= lockedLineIndex - previousLockedLineIndex);
+		//
+		//         previousLockedItemIndex = lockedItemIndex;
+		//         previousLockedLineIndex = lockedLineIndex;
+		//     }
+		//
+		//     const int lockedItemIndex = endSizedItemIndex >= beginSizedItemIndex ? endSizedItemIndex : beginSizedItemIndex;
+		//     const int lockedLineIndex = endSizedItemIndex >= beginSizedItemIndex ? endSizedLineIndex : beginSizedLineIndex;
+		//
+		//     MUX_ASSERT(lockedLineIndex >= previousLockedLineIndex);
+		//     MUX_ASSERT(lockedItemIndex > previousLockedItemIndex);
+		//     MUX_ASSERT(lockedItemIndex - previousLockedItemIndex >= lockedLineIndex - previousLockedLineIndex);
+		// }
+		//
+		// void LinedFlowLayout::VerifyLockedItemsDbg()
+		// {
+		//     if (m_lockedItemIndexes.size() == 0)
+		//     {
+		//         return;
+		//     }
+		//
+		//     int sizedItemIndex = m_firstSizedItemIndex;
+		//
+		//     for (int sizedLineVectorIndex = 0; sizedLineVectorIndex < static_cast<int>(m_lineItemCounts.size()); sizedLineVectorIndex++)
+		//     {
+		//         const int lineItemsCount = m_lineItemCounts[sizedLineVectorIndex];
+		//         const int lineIndex = sizedLineVectorIndex + m_firstSizedLineIndex;
+		//
+		//         for (int itemVectorIndex = 0; itemVectorIndex < lineItemsCount; itemVectorIndex++)
+		//         {
+		//             if (sizedItemIndex >= m_firstFrozenItemIndex &&
+		//                 sizedItemIndex <= m_lastFrozenItemIndex &&
+		//                 m_lockedItemIndexes.find(sizedItemIndex) != m_lockedItemIndexes.end() &&
+		//                 m_lockedItemIndexes[sizedItemIndex] != lineIndex)
+		//             {
+		//                 LINEDFLOWLAYOUT_TRACE_INFO(*this, TRACE_MSG_METH_INT_INT, METH_NAME, this, m_lockedItemIndexes[sizedItemIndex], lineIndex);
+		//                 MUX_ASSERT(false);
+		//             }
+		//
+		//             sizedItemIndex++;
+		//         }
+		//     }
+		// }
+		//
+		// #endif
+
+		// #pragma endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayout.uno.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+#if HAS_UNO
+using System.Collections.Generic;
+
+namespace Microsoft.UI.Xaml.Controls
+{
+	partial class LinedFlowLayout
+	{
+		// Uno maps std::vector to List<T> and the C++ ItemsLayout value type to a class.
+		// Keep these managed adaptations out of the source-ordered MUX files.
+		private static void ClearAndFill<T>(List<T> list, int count, T value)
+		{
+			list.Clear();
+
+			for (int i = 0; i < count; i++)
+			{
+				list.Add(value);
+			}
+		}
+
+		private static ItemsLayout CloneItemsLayout(ItemsLayout source) =>
+			new()
+			{
+				m_lineItemCounts = new List<int>(source.m_lineItemCounts),
+				m_lineItemWidths = new List<double>(source.m_lineItemWidths),
+				m_availableLineItemsWidth = source.m_availableLineItemsWidth,
+				m_drawback = source.m_drawback,
+				m_smallestHeadItemWidth = source.m_smallestHeadItemWidth,
+				m_smallestTailItemWidth = source.m_smallestTailItemWidth,
+				m_bestEqualizingHeadItemDrawbackImprovement = source.m_bestEqualizingHeadItemDrawbackImprovement,
+				m_bestEqualizingTailItemDrawbackImprovement = source.m_bestEqualizingTailItemDrawbackImprovement,
+				m_smallestHeadItemIndex = source.m_smallestHeadItemIndex,
+				m_smallestTailItemIndex = source.m_smallestTailItemIndex,
+				m_smallestHeadLineIndex = source.m_smallestHeadLineIndex,
+				m_smallestTailLineIndex = source.m_smallestTailLineIndex,
+				m_bestEqualizingHeadItemIndex = source.m_bestEqualizingHeadItemIndex,
+				m_bestEqualizingTailItemIndex = source.m_bestEqualizingTailItemIndex,
+				m_bestEqualizingHeadLineIndex = source.m_bestEqualizingHeadLineIndex,
+				m_bestEqualizingTailLineIndex = source.m_bestEqualizingTailLineIndex,
+			};
+
+		private static void ResizeList<T>(List<T> list, int count, T value)
+		{
+			if (count < list.Count)
+			{
+				list.RemoveRange(count, list.Count - count);
+			}
+			else
+			{
+				while (list.Count < count)
+				{
+					list.Add(value);
+				}
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemAspectRatios.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemAspectRatios.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LinedFlowLayoutItemAspectRatios.h, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Xaml.Controls;
+
+internal partial class LinedFlowLayoutItemAspectRatios
+{
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemAspectRatios.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemAspectRatios.h.mux.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LinedFlowLayoutItemAspectRatios.h, commit b8cfb8490
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+// This class is used to track weighted aspect ratios of some LinedFlowLayout items. Blocks tracking 64 contiguous items
+// are allocated. To minimize allocations, those blocks are re-used when a different area of the items collection needs
+// to be tracked.
+//
+// Example:
+// Initially blocks [0,63][64,127] track the first items of 5700 items i the collection.  The user uses the PageDown key a
+// few times and the tracking blocks are extended to [0,63][64,127][128,191][192,255].  Then the user hits the End key
+// causing the blocks to track [0,63][64,127][128,191][192,255][5632,5695][5696,5759].  Finally the user keeps hitting the
+// PageUp key to the middle of the collection and the blocks become:
+// [2624,2687][2688,2751][2752,2815][2816,2879][2880,2943][2944,3007][3008,3071].
+//
+// The consumer of this class is in charge of setting a limit to the number of items being tracked. In this case the LinedFlowLayout
+// sets the limit to 10 scrolling viewports worth of items. If on average a scrolling viewport can hold 40 items, no more than
+// 7 blocks (i.e. 400 / 64) will be allocated to store aspect ratios of 400 items at a time.
+//
+// As the user jumps from area to area in the items collection, the closest existing blocks from the new area are preserved,
+// while the furthest away are recycled.
+partial class LinedFlowLayoutItemAspectRatios
+{
+	internal LinedFlowLayoutItemAspectRatios()
+	{
+	}
+
+	internal readonly struct ItemAspectRatio
+	{
+		internal ItemAspectRatio(float aspectRatio, int weight)
+		{
+			AspectRatio = aspectRatio;
+			Weight = weight;
+		}
+
+		internal float AspectRatio { get; }
+
+		internal int Weight { get; }
+	}
+
+	private static readonly ItemAspectRatio s_emptyItemAspectRatio = new(
+		0.0f /*aspectRatio*/,
+		0 /*weight*/);
+
+	// #ifdef DBG
+	// void LogItemAspectRatiosDbg();
+	// #endif
+
+	private partial class ItemAspectRatioBlock
+	{
+		internal ItemAspectRatioBlock()
+		{
+		}
+
+		internal int StartIndex
+		{
+			get => m_startIndex;
+			set => m_startIndex = value;
+		}
+
+		internal int EndIndex => m_startIndex == -1 ? -1 : m_startIndex + c_blockSize - 1;
+
+		internal static int BlockSize() => c_blockSize;
+
+		// #ifdef DBG
+		// void LogItemAspectRatioBlockDbg();
+		// #endif
+
+		private const int c_blockSize = 64;
+
+		private readonly ItemAspectRatio[] m_aspectRatios = new ItemAspectRatio[c_blockSize];
+		private int m_startIndex = -1;
+	}
+
+	// WinUI stores the blocks in a std::set<std::shared_ptr<ItemAspectRatioBlock>>. Every consumer iterates
+	// all blocks (the aggregations are order-independent sums) and block reuse/removal is always chosen
+	// explicitly by GetEmptyOrFurthestBlock, so a List reproduces WinUI's behavior without relying on the
+	// set's pointer-ordering.
+	private readonly List<ItemAspectRatioBlock> m_itemAspectRatioBlocks = new();
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemAspectRatios.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemAspectRatios.mux.cs
@@ -1,53 +1,242 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LinedFlowLayoutItemAspectRatios.cpp, commit b8cfb8490
 
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using static Microsoft.UI.Xaml.Controls._Tracing;
 
-namespace Microsoft.UI.Xaml.Controls
-{
-	/// <summary>
-	/// Tracks weighted aspect ratios of some LinedFlowLayout items. Blocks tracking 64 contiguous items
-	/// are allocated and re-used when a different area of the items collection needs to be tracked, so as
-	/// the user jumps around the collection the closest existing blocks to the new area are preserved while
-	/// the furthest away are recycled. The consumer (LinedFlowLayout) caps how many items are tracked.
-	/// </summary>
-	internal class LinedFlowLayoutItemAspectRatios
-	{
-		internal readonly struct ItemAspectRatio
-		{
-			public ItemAspectRatio(float aspectRatio, int weight)
-			{
-				AspectRatio = aspectRatio;
-				Weight = weight;
-			}
+namespace Microsoft.UI.Xaml.Controls;
 
-			public float AspectRatio { get; }
-			public int Weight { get; }
+partial class LinedFlowLayoutItemAspectRatios
+{
+	// Returns True when there is at least one stored ratio in the provided index range,
+	// with a strictly positive weight lower than the provided number.
+	internal bool HasLowerWeight(
+		int firstItemIndex,
+		int lastItemIndex,
+		int weight)
+	{
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			if (itemAspectRatioBlock.HasLowerWeight(firstItemIndex, lastItemIndex, weight))
+			{
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstItemIndex", firstItemIndex);
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastItemIndex", lastItemIndex);
+				// LINEDFLOWLAYOUT_TRACE_INFO_DBG(nullptr, TRACE_MSG_METH_STR, METH_NAME, this, L"returns True");
+				return true;
+			}
 		}
 
-		internal static readonly ItemAspectRatio s_emptyItemAspectRatio = new(0.0f /*aspectRatio*/, 0 /*weight*/);
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstItemIndex", firstItemIndex);
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastItemIndex", lastItemIndex);
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR, METH_NAME, this, L"returns False");
+		return false;
+	}
 
-		// WinUI stores the blocks in a std::set<std::shared_ptr<ItemAspectRatioBlock>>. Every consumer iterates
-		// all blocks (the aggregations are order-independent sums) and block reuse/removal is always chosen
-		// explicitly by GetEmptyOrFurthestBlock, so a List reproduces WinUI's behavior without relying on the
-		// set's pointer-ordering.
-		private readonly List<ItemAspectRatioBlock> m_itemAspectRatioBlocks = new();
+	// Returns False when at least one aspect ratio is being tracked.
+	internal bool IsEmpty()
+	{
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			if (itemAspectRatioBlock.StartIndex != -1)
+			{
+				// StartIndex() != -1 indicates that this block tracks at least one aspect ratio.
+				return false;
+			}
+		}
 
-		// Returns True when there is at least one stored ratio in the provided index range,
-		// with a strictly positive weight lower than the provided number.
-		public bool HasLowerWeight(
+		return true;
+	}
+
+	// Returns the average of the weighted aspect ratios. Items outside the provided index range must
+	// have a weight equal to the provided number to be included.
+	internal float GetAverageAspectRatio(
+		int firstItemIndex,
+		int lastItemIndex,
+		int weight)
+	{
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"firstItemIndex", firstItemIndex);
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"lastItemIndex", lastItemIndex);
+		MUX_ASSERT(!IsEmpty());
+
+		var totalAspectRatios = 0.0f;
+		var totalWeights = 0;
+
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			var itemAspectRatioBlockTotals = itemAspectRatioBlock.GetTotals(firstItemIndex, lastItemIndex, weight);
+
+			totalAspectRatios += itemAspectRatioBlockTotals.AspectRatio;
+			totalWeights += itemAspectRatioBlockTotals.Weight;
+		}
+
+		if (totalAspectRatios > 0.0f && totalWeights > 0)
+		{
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"totalAspectRatios", totalAspectRatios);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"totalWeights", totalWeights);
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"returned value", totalAspectRatios / totalWeights);
+			return totalAspectRatios / totalWeights;
+		}
+
+		return 0.0f;
+	}
+
+	// Returns the ItemAspectRatio stored for the provided item index, or s_emptyItemAspectRatio
+	// when no storage was done for that index.
+	internal ItemAspectRatio GetAt(
+		int itemIndex)
+	{
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			if (itemAspectRatioBlock.IncludesItemIndex(itemIndex))
+			{
+				return itemAspectRatioBlock.GetAt(itemIndex);
+			}
+		}
+
+		return s_emptyItemAspectRatio;
+	}
+
+	// Stores the ItemAspectRatio for the specified index.
+	internal void SetAt(int itemIndex, ItemAspectRatio itemAspectRatio)
+	{
+		// Look through the existing blocks to see if one already covers the provided index.
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			if (itemAspectRatioBlock.IncludesItemIndex(itemIndex))
+			{
+				// Found a match for the provided index. Use that existing block to store the ItemAspectRatio.
+				itemAspectRatioBlock.SetAt(itemIndex, itemAspectRatio);
+				return;
+			}
+		}
+
+		// Get a block to store the ItemAspectRatio. GetEmptyOrFurthestBlock either returns a still empty block or the furthest away block from itemIndex.
+		var itemAspectRatioBlockToReuse = GetEmptyOrFurthestBlock(itemIndex);
+
+		MUX_ASSERT(itemAspectRatioBlockToReuse != null);
+
+		if (itemAspectRatioBlockToReuse!.StartIndex != -1)
+		{
+			// Clear the furthest block from itemIndex.
+			itemAspectRatioBlockToReuse.Clear();
+		}
+
+		// Use it to store the provided ItemAspectRatio.
+		// Blocks are such that m_startIndex has to be a multiple of c_blockSize: 0, 64, 128, etc... to avoid having two blocks covering the same item index.
+		itemAspectRatioBlockToReuse.StartIndex = (itemIndex / ItemAspectRatioBlock.BlockSize()) * ItemAspectRatioBlock.BlockSize();
+		itemAspectRatioBlockToReuse.SetAt(itemIndex, itemAspectRatio);
+	}
+
+	// Keeps 4 cleared blocks at most for future use and deletes all the others.
+	internal void Clear()
+	{
+		const int c_minBlockCount = 4;
+
+		// Keep at most c_minBlockCount ItemAspectRatioBlock instances allocated for future use, to avoid reallocations.
+		while (m_itemAspectRatioBlocks.Count > c_minBlockCount)
+		{
+			m_itemAspectRatioBlocks.RemoveAt(0);
+		}
+
+		// Each remaining ItemAspectRatioBlock is cleared for future reuse.
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			itemAspectRatioBlock.Clear();
+		}
+
+		MUX_ASSERT(IsEmpty());
+	}
+
+	// Allocates enough blocks to store 'size' ItemAspectRatio instances. When the required number of blocks
+	// is smaller than the already existing ones, the furthest away block(s) from 'referenceItemIndex' are deleted.
+	internal void Resize(
+		int size,
+		int referenceItemIndex)
+	{
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_INT_INT, METH_NAME, this, size, referenceItemIndex);
+		MUX_ASSERT(size >= 1);
+		MUX_ASSERT(referenceItemIndex >= 0);
+
+		var requiredBlocks = (int)Math.Ceiling((double)size / ItemAspectRatioBlock.BlockSize());
+		var existingBlocks = m_itemAspectRatioBlocks.Count;
+
+		if (requiredBlocks == existingBlocks)
+		{
+			return;
+		}
+
+		// LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"size", size);
+		// LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"referenceItemIndex", referenceItemIndex);
+		// LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"requiredBlocks", requiredBlocks);
+		// LINEDFLOWLAYOUT_TRACE_INFO(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"existingBlocks", existingBlocks);
+		if (requiredBlocks > existingBlocks)
+		{
+			for (var block = existingBlocks + 1; block <= requiredBlocks; block++)
+			{
+				m_itemAspectRatioBlocks.Add(new ItemAspectRatioBlock());
+			}
+		}
+		else
+		{
+			for (var block = requiredBlocks; block < existingBlocks; block++)
+			{
+				var itemAspectRatioBlockToRemove = GetEmptyOrFurthestBlock(referenceItemIndex);
+
+				MUX_ASSERT(itemAspectRatioBlockToRemove != null);
+
+				m_itemAspectRatioBlocks.Remove(itemAspectRatioBlockToRemove!);
+			}
+		}
+
+		MUX_ASSERT(requiredBlocks == m_itemAspectRatioBlocks.Count);
+	}
+
+	// Returns an empty block if one still exists, or else the furthest block away from 'fromItemIndex'.
+	private ItemAspectRatioBlock? GetEmptyOrFurthestBlock(
+		int fromItemIndex)
+	{
+		ItemAspectRatioBlock? furthestItemAspectRatioBlock = null;
+
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+		{
+			if (itemAspectRatioBlock.StartIndex == -1)
+			{
+				return itemAspectRatioBlock;
+			}
+			else if (furthestItemAspectRatioBlock == null ||
+				Math.Abs((furthestItemAspectRatioBlock.StartIndex + furthestItemAspectRatioBlock.EndIndex) / 2 - fromItemIndex) < Math.Abs((itemAspectRatioBlock.StartIndex + itemAspectRatioBlock.EndIndex) / 2 - fromItemIndex))
+			{
+				furthestItemAspectRatioBlock = itemAspectRatioBlock;
+			}
+		}
+
+		return furthestItemAspectRatioBlock;
+	}
+
+	private partial class ItemAspectRatioBlock
+	{
+		// Returns True when there is at least one stored ratio in the block, within the provided
+		// index range, with a strictly positive weight lower than the provided number.
+		internal bool HasLowerWeight(
 			int firstItemIndex,
 			int lastItemIndex,
 			int weight)
 		{
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+			if (m_startIndex == -1)
 			{
-				if (itemAspectRatioBlock.HasLowerWeight(firstItemIndex, lastItemIndex, weight))
+				return false;
+			}
+
+			for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
+			{
+				var currentWeight = m_aspectRatios[itemAspectRatioIndex].Weight;
+				var currentIndex = m_startIndex + itemAspectRatioIndex;
+
+				if (currentWeight > 0 && currentWeight < weight &&
+					currentIndex >= firstItemIndex && currentIndex <= lastItemIndex)
 				{
 					return true;
 				}
@@ -56,288 +245,114 @@ namespace Microsoft.UI.Xaml.Controls
 			return false;
 		}
 
-		// Returns False when at least one aspect ratio is being tracked.
-		public bool IsEmpty()
-		{
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
-			{
-				if (itemAspectRatioBlock.StartIndex != -1)
-				{
-					// StartIndex != -1 indicates that this block tracks at least one aspect ratio.
-					return false;
-				}
-			}
+		internal bool IncludesItemIndex(
+			int itemIndex) => StartIndex <= itemIndex && EndIndex >= itemIndex;
 
-			return true;
-		}
-
-		// Returns the average of the weighted aspect ratios. Items outside the provided index range must
-		// have a weight equal to the provided number to be included.
-		public float GetAverageAspectRatio(
+		// Returns an ItemAspectRatio for which the ratio is the total of the block's weighted ratios, and the weight is the total of
+		// the block's weights. Items outside the provided index range must have a weight equal to the provided number to be included.
+		internal ItemAspectRatio GetTotals(
 			int firstItemIndex,
 			int lastItemIndex,
 			int weight)
 		{
-			MUX_ASSERT(!IsEmpty());
+			if (m_startIndex == -1)
+			{
+				return s_emptyItemAspectRatio;
+			}
 
 			var totalAspectRatios = 0.0f;
 			var totalWeights = 0;
 
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+			for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
 			{
-				var itemAspectRatioBlockTotals = itemAspectRatioBlock.GetTotals(firstItemIndex, lastItemIndex, weight);
+				var currentWeight = m_aspectRatios[itemAspectRatioIndex].Weight;
+				var currentIndex = m_startIndex + itemAspectRatioIndex;
 
-				totalAspectRatios += itemAspectRatioBlockTotals.AspectRatio;
-				totalWeights += itemAspectRatioBlockTotals.Weight;
+				if (currentWeight == weight || (currentIndex >= firstItemIndex && currentIndex <= lastItemIndex))
+				{
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemIndex included", currentIndex);
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"weight included", currentWeight);
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(nullptr, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"aspect ratio included", m_aspectRatios[itemAspectRatioIndex].m_aspectRatio);
+					totalAspectRatios += m_aspectRatios[itemAspectRatioIndex].AspectRatio * currentWeight;
+					totalWeights += currentWeight;
+				}
+#if DEBUG
+				else if (currentWeight != 0)
+				{
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemIndex excluded", currentIndex);
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"weight excluded", currentWeight);
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"aspect ratio excluded", m_aspectRatios[itemAspectRatioIndex].m_aspectRatio);
+				}
+#endif
 			}
 
-			if (totalAspectRatios > 0.0f && totalWeights > 0)
-			{
-				return totalAspectRatios / totalWeights;
-			}
-
-			return 0.0f;
+			return new ItemAspectRatio(totalAspectRatios, totalWeights);
 		}
 
-		// Returns the ItemAspectRatio stored for the provided item index, or s_emptyItemAspectRatio
-		// when no storage was done for that index.
-		public ItemAspectRatio GetAt(
+		// Returns the ItemAspectRatio stored in this block for the provided item index.
+		internal ItemAspectRatio GetAt(
 			int itemIndex)
 		{
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
-			{
-				if (itemAspectRatioBlock.IncludesItemIndex(itemIndex))
-				{
-					return itemAspectRatioBlock.GetAt(itemIndex);
-				}
-			}
+			MUX_ASSERT(m_startIndex >= 0);
+			MUX_ASSERT(itemIndex >= m_startIndex);
+			MUX_ASSERT(itemIndex <= m_startIndex + c_blockSize - 1);
 
-			return s_emptyItemAspectRatio;
+			return m_aspectRatios[itemIndex - m_startIndex];
 		}
 
-		// Stores the ItemAspectRatio for the specified index.
-		public void SetAt(int itemIndex, ItemAspectRatio itemAspectRatio)
+		// Sets the ItemAspectRatio in this block for the provided item index.
+		internal void SetAt(int itemIndex, ItemAspectRatio itemAspectRatio)
 		{
-			// Look through the existing blocks to see if one already covers the provided index.
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
-			{
-				if (itemAspectRatioBlock.IncludesItemIndex(itemIndex))
-				{
-					// Found a match for the provided index. Use that existing block to store the ItemAspectRatio.
-					itemAspectRatioBlock.SetAt(itemIndex, itemAspectRatio);
-					return;
-				}
-			}
+			MUX_ASSERT(m_startIndex >= 0);
+			MUX_ASSERT(itemIndex >= m_startIndex);
+			MUX_ASSERT(itemIndex <= m_startIndex + c_blockSize - 1);
 
-			// Get a block to store the ItemAspectRatio. GetEmptyOrFurthestBlock either returns a still empty block
-			// or the furthest away block from itemIndex.
-			var itemAspectRatioBlockToReuse = GetEmptyOrFurthestBlock(itemIndex);
-
-			MUX_ASSERT(itemAspectRatioBlockToReuse != null);
-
-			if (itemAspectRatioBlockToReuse!.StartIndex != -1)
-			{
-				// Clear the furthest block from itemIndex.
-				itemAspectRatioBlockToReuse.Clear();
-			}
-
-			// Use it to store the provided ItemAspectRatio.
-			// Blocks are such that StartIndex has to be a multiple of c_blockSize: 0, 64, 128, etc... to avoid
-			// having two blocks covering the same item index.
-			itemAspectRatioBlockToReuse.StartIndex = (itemIndex / ItemAspectRatioBlock.BlockSize()) * ItemAspectRatioBlock.BlockSize();
-			itemAspectRatioBlockToReuse.SetAt(itemIndex, itemAspectRatio);
+			m_aspectRatios[itemIndex - m_startIndex] = itemAspectRatio;
 		}
 
-		// Keeps 4 cleared blocks at most for future use and deletes all the others.
-		public void Clear()
+		// Clears the block for future reuse.
+		internal void Clear()
 		{
-			const int c_minBlockCount = 4;
+			m_startIndex = -1;
 
-			// Keep at most c_minBlockCount ItemAspectRatioBlock instances allocated for future use, to avoid reallocations.
-			while (m_itemAspectRatioBlocks.Count > c_minBlockCount)
+			for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
 			{
-				m_itemAspectRatioBlocks.RemoveAt(0);
+				m_aspectRatios[itemAspectRatioIndex] = s_emptyItemAspectRatio;
 			}
-
-			// Each remaining ItemAspectRatioBlock is cleared for future reuse.
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
-			{
-				itemAspectRatioBlock.Clear();
-			}
-
-			MUX_ASSERT(IsEmpty());
 		}
+	}
 
-		// Allocates enough blocks to store 'size' ItemAspectRatio instances. When the required number of blocks
-		// is smaller than the already existing ones, the furthest away block(s) from 'referenceItemIndex' are deleted.
-		public void Resize(
-			int size,
-			int referenceItemIndex)
+#if DEBUG
+	internal void LogItemAspectRatiosDbg()
+	{
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"Block count", m_itemAspectRatioBlocks.size());
+		foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
 		{
-			MUX_ASSERT(size >= 1);
-			MUX_ASSERT(referenceItemIndex >= 0);
-
-			var requiredBlocks = (int)Math.Ceiling((double)size / ItemAspectRatioBlock.BlockSize());
-			var existingBlocks = m_itemAspectRatioBlocks.Count;
-
-			if (requiredBlocks == existingBlocks)
-			{
-				return;
-			}
-
-			if (requiredBlocks > existingBlocks)
-			{
-				for (var block = existingBlocks + 1; block <= requiredBlocks; block++)
-				{
-					m_itemAspectRatioBlocks.Add(new ItemAspectRatioBlock());
-				}
-			}
-			else
-			{
-				for (var block = requiredBlocks; block < existingBlocks; block++)
-				{
-					var itemAspectRatioBlockToRemove = GetEmptyOrFurthestBlock(referenceItemIndex);
-
-					MUX_ASSERT(itemAspectRatioBlockToRemove != null);
-
-					m_itemAspectRatioBlocks.Remove(itemAspectRatioBlockToRemove!);
-				}
-			}
-
-			MUX_ASSERT(requiredBlocks == m_itemAspectRatioBlocks.Count);
+			itemAspectRatioBlock.LogItemAspectRatioBlockDbg();
 		}
+	}
 
-		// Returns an empty block if one still exists, or else the furthest block away from 'fromItemIndex'.
-		private ItemAspectRatioBlock? GetEmptyOrFurthestBlock(
-			int fromItemIndex)
+	private partial class ItemAspectRatioBlock
+	{
+		internal void LogItemAspectRatioBlockDbg()
 		{
-			ItemAspectRatioBlock? furthestItemAspectRatioBlock = null;
-
-			foreach (var itemAspectRatioBlock in m_itemAspectRatioBlocks)
+			// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"m_startIndex", m_startIndex);
+			for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
 			{
-				if (itemAspectRatioBlock.StartIndex == -1)
+				var aspectRatio = m_aspectRatios[itemAspectRatioIndex].AspectRatio;
+				var weight = m_aspectRatios[itemAspectRatioIndex].Weight;
+
+				MUX_ASSERT(!(m_startIndex == -1 && aspectRatio != 0.0f));
+				MUX_ASSERT(!(m_startIndex == -1 && weight != 0));
+
+				if (weight != 0)
 				{
-					return itemAspectRatioBlock;
-				}
-				else if (furthestItemAspectRatioBlock == null ||
-					Math.Abs((furthestItemAspectRatioBlock.StartIndex + furthestItemAspectRatioBlock.EndIndex) / 2 - fromItemIndex) < Math.Abs((itemAspectRatioBlock.StartIndex + itemAspectRatioBlock.EndIndex) / 2 - fromItemIndex))
-				{
-					furthestItemAspectRatioBlock = itemAspectRatioBlock;
-				}
-			}
-
-			return furthestItemAspectRatioBlock;
-		}
-
-		private class ItemAspectRatioBlock
-		{
-			private const int c_blockSize = 64;
-
-			private readonly ItemAspectRatio[] m_aspectRatios = new ItemAspectRatio[c_blockSize];
-			private int m_startIndex = -1;
-
-			public int StartIndex
-			{
-				get => m_startIndex;
-				set => m_startIndex = value;
-			}
-
-			public int EndIndex => m_startIndex == -1 ? -1 : m_startIndex + c_blockSize - 1;
-
-			public static int BlockSize() => c_blockSize;
-
-			// Returns True when there is at least one stored ratio in the block, within the provided
-			// index range, with a strictly positive weight lower than the provided number.
-			public bool HasLowerWeight(
-				int firstItemIndex,
-				int lastItemIndex,
-				int weight)
-			{
-				if (m_startIndex == -1)
-				{
-					return false;
-				}
-
-				for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
-				{
-					var currentWeight = m_aspectRatios[itemAspectRatioIndex].Weight;
-					var currentIndex = m_startIndex + itemAspectRatioIndex;
-
-					if (currentWeight > 0 && currentWeight < weight &&
-						currentIndex >= firstItemIndex && currentIndex <= lastItemIndex)
-					{
-						return true;
-					}
-				}
-
-				return false;
-			}
-
-			public bool IncludesItemIndex(
-				int itemIndex) => StartIndex <= itemIndex && EndIndex >= itemIndex;
-
-			// Returns an ItemAspectRatio for which the ratio is the total of the block's weighted ratios, and the
-			// weight is the total of the block's weights. Items outside the provided index range must have a weight
-			// equal to the provided number to be included.
-			public ItemAspectRatio GetTotals(
-				int firstItemIndex,
-				int lastItemIndex,
-				int weight)
-			{
-				if (m_startIndex == -1)
-				{
-					return s_emptyItemAspectRatio;
-				}
-
-				var totalAspectRatios = 0.0f;
-				var totalWeights = 0;
-
-				for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
-				{
-					var currentWeight = m_aspectRatios[itemAspectRatioIndex].Weight;
-					var currentIndex = m_startIndex + itemAspectRatioIndex;
-
-					if (currentWeight == weight || (currentIndex >= firstItemIndex && currentIndex <= lastItemIndex))
-					{
-						totalAspectRatios += m_aspectRatios[itemAspectRatioIndex].AspectRatio * currentWeight;
-						totalWeights += currentWeight;
-					}
-				}
-
-				return new ItemAspectRatio(totalAspectRatios, totalWeights);
-			}
-
-			// Returns the ItemAspectRatio stored in this block for the provided item index.
-			public ItemAspectRatio GetAt(
-				int itemIndex)
-			{
-				MUX_ASSERT(m_startIndex >= 0);
-				MUX_ASSERT(itemIndex >= m_startIndex);
-				MUX_ASSERT(itemIndex <= m_startIndex + c_blockSize - 1);
-
-				return m_aspectRatios[itemIndex - m_startIndex];
-			}
-
-			// Sets the ItemAspectRatio in this block for the provided item index.
-			public void SetAt(int itemIndex, ItemAspectRatio itemAspectRatio)
-			{
-				MUX_ASSERT(m_startIndex >= 0);
-				MUX_ASSERT(itemIndex >= m_startIndex);
-				MUX_ASSERT(itemIndex <= m_startIndex + c_blockSize - 1);
-
-				m_aspectRatios[itemIndex - m_startIndex] = itemAspectRatio;
-			}
-
-			// Clears the block for future reuse.
-			public void Clear()
-			{
-				m_startIndex = -1;
-
-				for (var itemAspectRatioIndex = 0; itemAspectRatioIndex < c_blockSize; itemAspectRatioIndex++)
-				{
-					m_aspectRatios[itemAspectRatioIndex] = s_emptyItemAspectRatio;
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"itemIndex", m_startIndex + itemAspectRatioIndex);
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_FLT, METH_NAME, this, L"aspectRatio", aspectRatio);
+					// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_STR_INT, METH_NAME, this, L"weight", weight);
 				}
 			}
 		}
 	}
+#endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemsInfoRequestedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemsInfoRequestedEventArgs.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference ItemsRepeater.idl, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Xaml.Controls;
+
+/// <summary>
+/// Provides data for the <see cref="LinedFlowLayout.ItemsInfoRequested"/> event, allowing a
+/// handler to supply the desired aspect ratios and width bounds for a range of items.
+/// </summary>
+public partial class LinedFlowLayoutItemsInfoRequestedEventArgs
+{
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemsInfoRequestedEventArgs.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemsInfoRequestedEventArgs.h.mux.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LinedFlowLayoutItemsInfoRequestedEventArgs.h, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class LinedFlowLayoutItemsInfoRequestedEventArgs
+{
+	// ~LinedFlowLayoutItemsInfoRequestedEventArgs();
+
+	// #pragma region ILinedFlowLayoutItemsInfoRequestedEventArgs
+
+	/// <summary>
+	/// Gets or sets the start index of the item range for which information is provided.
+	/// </summary>
+	public int ItemsRangeStartIndex
+	{
+		get => m_itemsRangeStartIndex;
+		set => SetItemsRangeStartIndex(value);
+	}
+
+	/// <summary>
+	/// Gets the requested number of items in the range.
+	/// </summary>
+	public int ItemsRangeRequestedLength => m_itemsRangeRequestedLength;
+
+	/// <summary>
+	/// Gets or sets the minimum item width for the requested range.
+	/// </summary>
+	public double MinWidth
+	{
+		get => m_minWidth;
+		set => SetMinWidth(value);
+	}
+
+	/// <summary>
+	/// Gets or sets the maximum item width for the requested range.
+	/// </summary>
+	public double MaxWidth
+	{
+		get => m_maxWidth;
+		set => SetMaxWidth(value);
+	}
+
+	// #pragma endregion
+
+	internal int ItemsRangeLength => m_itemsRangeLength;
+
+	internal void ResetLinedFlowLayout() => m_linedFlowLayout = null;
+
+	private int m_itemsRangeStartIndex;
+	private int m_itemsRangeRequestedStartIndex;
+	private int m_itemsRangeEstablishedLength;
+	private int m_itemsRangeLength;
+	private int m_itemsRangeRequestedLength;
+	private double m_minWidth = -1.0;
+	private double m_maxWidth = -1.0;
+	private LinedFlowLayout? m_linedFlowLayout;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemsInfoRequestedEventArgs.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutItemsInfoRequestedEventArgs.mux.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LinedFlowLayoutItemsInfoRequestedEventArgs.cpp, commit b8cfb8490
 
@@ -7,137 +7,144 @@
 using System;
 using static Microsoft.UI.Xaml.Controls._Tracing;
 
-namespace Microsoft.UI.Xaml.Controls
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class LinedFlowLayoutItemsInfoRequestedEventArgs
 {
-	/// <summary>
-	/// Provides data for the <see cref="LinedFlowLayout.ItemsInfoRequested"/> event, allowing a
-	/// handler to supply the desired aspect ratios and width bounds for a range of items.
-	/// </summary>
-	public partial class LinedFlowLayoutItemsInfoRequestedEventArgs
+	internal LinedFlowLayoutItemsInfoRequestedEventArgs(
+		LinedFlowLayout linedFlowLayout,
+		int itemsRangeStartIndex,
+		int itemsRangeRequestedLength)
 	{
-		private int m_itemsRangeStartIndex;
-		private int m_itemsRangeRequestedStartIndex;
-		private int m_itemsRangeEstablishedLength;
-		private int m_itemsRangeLength;
-		private int m_itemsRangeRequestedLength;
-		private double m_minWidth = -1.0;
-		private double m_maxWidth = -1.0;
-		private LinedFlowLayout? m_linedFlowLayout;
+		m_itemsRangeStartIndex = itemsRangeStartIndex;
+		m_itemsRangeRequestedStartIndex = itemsRangeStartIndex;
+		m_itemsRangeRequestedLength = itemsRangeRequestedLength;
 
-		internal LinedFlowLayoutItemsInfoRequestedEventArgs(
-			LinedFlowLayout linedFlowLayout,
-			int itemsRangeStartIndex,
-			int itemsRangeRequestedLength)
+		MUX_ASSERT(itemsRangeStartIndex >= 0);
+		MUX_ASSERT(itemsRangeRequestedLength > 0);
+
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_INT_INT, METH_NAME, this, itemsRangeStartIndex, itemsRangeRequestedLength);
+		m_linedFlowLayout = linedFlowLayout;
+	}
+
+	// LinedFlowLayoutItemsInfoRequestedEventArgs::~LinedFlowLayoutItemsInfoRequestedEventArgs()
+	// {
+	//     LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+	// }
+
+	// #pragma region ILinedFlowLayoutItemsInfoRequestedEventArgs
+
+	private void SetItemsRangeStartIndex(int value)
+	{
+		// LINEDFLOWLAYOUT_TRACE_VERBOSE(nullptr, TRACE_MSG_METH_INT, METH_NAME, this, value);
+		if (value < 0)
 		{
-			MUX_ASSERT(itemsRangeStartIndex >= 0);
-			MUX_ASSERT(itemsRangeRequestedLength > 0);
-
-			m_itemsRangeStartIndex = itemsRangeStartIndex;
-			m_itemsRangeRequestedStartIndex = itemsRangeStartIndex;
-			m_itemsRangeRequestedLength = itemsRangeRequestedLength;
-
-			m_linedFlowLayout = linedFlowLayout;
+			throw new ArgumentException("'ItemsRangeStartIndex' must be positive.");
 		}
 
-		#region ILinedFlowLayoutItemsInfoRequestedEventArgs
-
-		public int ItemsRangeStartIndex
+		if (value > m_itemsRangeStartIndex)
 		{
-			get => m_itemsRangeStartIndex;
-			set
-			{
-				if (value < 0)
-				{
-					throw new ArgumentException("'ItemsRangeStartIndex' must be positive.");
-				}
-
-				if (value > m_itemsRangeStartIndex)
-				{
-					throw new ArgumentException("'ItemsRangeStartIndex' cannot be increased.");
-				}
-
-				if (m_itemsRangeEstablishedLength != 0 && value + m_itemsRangeEstablishedLength < m_itemsRangeRequestedStartIndex + m_itemsRangeRequestedLength)
-				{
-					throw new ArgumentException("Value is too small given the array length already provided.");
-				}
-
-				m_itemsRangeStartIndex = value;
-			}
+			throw new ArgumentException("'ItemsRangeStartIndex' cannot be increased.");
 		}
 
-		public int ItemsRangeRequestedLength => m_itemsRangeRequestedLength;
-
-		public double MinWidth
+		if (m_itemsRangeEstablishedLength != 0 && value + m_itemsRangeEstablishedLength < m_itemsRangeRequestedStartIndex + m_itemsRangeRequestedLength)
 		{
-			get => m_minWidth;
-			set => m_minWidth = value < 0.0 ? -1.0 : value;
+			throw new ArgumentException("Value is too small given the array length already provided.");
 		}
 
-		public double MaxWidth
+		m_itemsRangeStartIndex = value;
+	}
+
+	private void SetMinWidth(double value)
+	{
+		if (value < 0.0)
 		{
-			get => m_maxWidth;
-			set => m_maxWidth = value < 0.0 ? -1.0 : value;
+			m_minWidth = -1.0;
 		}
-
-		public void SetDesiredAspectRatios(double[] values)
+		else
 		{
-			if (m_linedFlowLayout is { } linedFlowLayout)
-			{
-				SetItemsRangeEstablishedLength(values.Length);
-
-				m_itemsRangeLength = m_itemsRangeEstablishedLength;
-
-				linedFlowLayout.SetDesiredAspectRatios(values);
-			}
-		}
-
-		public void SetMinWidths(double[] values)
-		{
-			if (m_linedFlowLayout is { } linedFlowLayout)
-			{
-				SetItemsRangeEstablishedLength(values.Length);
-
-				linedFlowLayout.SetMinWidths(values);
-			}
-		}
-
-		public void SetMaxWidths(double[] values)
-		{
-			if (m_linedFlowLayout is { } linedFlowLayout)
-			{
-				SetItemsRangeEstablishedLength(values.Length);
-
-				linedFlowLayout.SetMaxWidths(values);
-			}
-		}
-
-		#endregion
-
-		internal int ItemsRangeLength => m_itemsRangeLength;
-
-		internal void ResetLinedFlowLayout() => m_linedFlowLayout = null;
-
-		private void SetItemsRangeEstablishedLength(int value)
-		{
-			if (value != m_itemsRangeEstablishedLength)
-			{
-				if (value < m_itemsRangeRequestedLength && m_itemsRangeStartIndex == m_itemsRangeRequestedStartIndex)
-				{
-					throw new ArgumentException("The provided array length must be greater than or equal to 'ItemsRangeRequestedLength'.");
-				}
-
-				if (m_itemsRangeStartIndex + value < m_itemsRangeRequestedStartIndex + m_itemsRangeRequestedLength && m_itemsRangeStartIndex < m_itemsRangeRequestedStartIndex)
-				{
-					throw new ArgumentException("The provided array length is too small given the decreased 'ItemsRangeStartIndex' and the 'ItemsRangeRequestedLength' values.");
-				}
-
-				if (m_itemsRangeEstablishedLength > 0)
-				{
-					throw new ArgumentException("All provided arrays must have the same length.");
-				}
-
-				m_itemsRangeEstablishedLength = value;
-			}
+			m_minWidth = value;
 		}
 	}
+
+	private void SetMaxWidth(double value)
+	{
+		if (value < 0.0)
+		{
+			m_maxWidth = -1.0;
+		}
+		else
+		{
+			m_maxWidth = value;
+		}
+	}
+
+	/// <summary>
+	/// Sets the desired aspect ratios for the item range.
+	/// </summary>
+	/// <param name="values">The desired aspect ratios.</param>
+	public void SetDesiredAspectRatios(double[] values)
+	{
+		if (m_linedFlowLayout is { } linedFlowLayout)
+		{
+			SetItemsRangeEstablishedLength(values.Length);
+
+			m_itemsRangeLength = m_itemsRangeEstablishedLength;
+
+			linedFlowLayout.SetDesiredAspectRatios(values);
+		}
+	}
+
+	/// <summary>
+	/// Sets the minimum widths for the item range.
+	/// </summary>
+	/// <param name="values">The minimum widths.</param>
+	public void SetMinWidths(double[] values)
+	{
+		if (m_linedFlowLayout is { } linedFlowLayout)
+		{
+			SetItemsRangeEstablishedLength(values.Length);
+
+			linedFlowLayout.SetMinWidths(values);
+		}
+	}
+
+	/// <summary>
+	/// Sets the maximum widths for the item range.
+	/// </summary>
+	/// <param name="values">The maximum widths.</param>
+	public void SetMaxWidths(double[] values)
+	{
+		if (m_linedFlowLayout is { } linedFlowLayout)
+		{
+			SetItemsRangeEstablishedLength(values.Length);
+
+			linedFlowLayout.SetMaxWidths(values);
+		}
+	}
+
+	private void SetItemsRangeEstablishedLength(int value)
+	{
+		if (value != m_itemsRangeEstablishedLength)
+		{
+			if (value < m_itemsRangeRequestedLength && m_itemsRangeStartIndex == m_itemsRangeRequestedStartIndex)
+			{
+				throw new ArgumentException("The provided array length must be greater than or equal to 'ItemsRangeRequestedLength'.");
+			}
+
+			if (m_itemsRangeStartIndex + value < m_itemsRangeRequestedStartIndex + m_itemsRangeRequestedLength && m_itemsRangeStartIndex < m_itemsRangeRequestedStartIndex)
+			{
+				throw new ArgumentException("The provided array length is too small given the decreased 'ItemsRangeStartIndex' and the 'ItemsRangeRequestedLength' values.");
+			}
+
+			if (m_itemsRangeEstablishedLength > 0)
+			{
+				throw new ArgumentException("All provided arrays must have the same length.");
+			}
+
+			m_itemsRangeEstablishedLength = value;
+		}
+	}
+
+	// #pragma endregion
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutTrace.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutTrace.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LinedFlowLayoutTrace.h, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Xaml.Controls;
+
+internal static partial class LinedFlowLayoutTrace
+{
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutTrace.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayout/LinedFlowLayoutTrace.h.mux.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference LinedFlowLayoutTrace.h, commit b8cfb8490
+
+#nullable enable
+
+namespace Microsoft.UI.Xaml.Controls;
+
+static partial class LinedFlowLayoutTrace
+{
+	// TODO Uno: Uno has no TraceLogging providers, OutputDebugStringW backend, or
+	// MUXControlsTestHooks logging bridge. The complete header implementation remains
+	// commented original source so its switches, formatting, and backend behavior are not lost.
+	// Original C++:
+	// #pragma once
+	//
+	// #include "common.h"
+	// #include "MuxcTraceLogging.h"
+	// #include "Utils.h"
+	// #include "MUXControlsTestHooks.h"
+	//
+	// inline bool IsLinedFlowLayoutTracingEnabled()
+	// {
+	//     return g_IsLoggingProviderEnabled &&
+	//         g_LoggingProviderLevel >= WINEVENT_LEVEL_INFO &&
+	//         (g_LoggingProviderMatchAnyKeyword & KEYWORD_LINEDFLOWLAYOUT || g_LoggingProviderMatchAnyKeyword == 0);
+	// }
+	//
+	// inline bool IsLinedFlowLayoutVerboseTracingEnabled()
+	// {
+	//     return g_IsLoggingProviderEnabled &&
+	//         g_LoggingProviderLevel >= WINEVENT_LEVEL_VERBOSE &&
+	//         (g_LoggingProviderMatchAnyKeyword & KEYWORD_LINEDFLOWLAYOUT || g_LoggingProviderMatchAnyKeyword == 0);
+	// }
+	//
+	// inline bool IsLinedFlowLayoutPerfTracingEnabled()
+	// {
+	//     return g_IsPerfProviderEnabled &&
+	//         g_PerfProviderLevel >= WINEVENT_LEVEL_INFO &&
+	//         (g_PerfProviderMatchAnyKeyword & KEYWORD_LINEDFLOWLAYOUT || g_PerfProviderMatchAnyKeyword == 0);
+	// }
+	//
+	// #define LINEDFLOWLAYOUT_TRACE_INFO_ENABLED(includeTraceLogging, sender, message, ...) \
+	// LinedFlowLayoutTrace::TraceInfo(includeTraceLogging, sender, message, __VA_ARGS__); \
+	//
+	// #define LINEDFLOWLAYOUT_TRACE_INFO(sender, message, ...) \
+	// if (IsLinedFlowLayoutTracingEnabled()) \
+	// { \
+	//     LINEDFLOWLAYOUT_TRACE_INFO_ENABLED(true /*includeTraceLogging*/, sender, message, __VA_ARGS__); \
+	// } \
+	// else if (LinedFlowLayoutTrace::s_IsDebugOutputEnabled || LinedFlowLayoutTrace::s_IsVerboseDebugOutputEnabled) \
+	// { \
+	//     LINEDFLOWLAYOUT_TRACE_INFO_ENABLED(false /*includeTraceLogging*/, sender, message, __VA_ARGS__); \
+	// } \
+	//
+	// #define LINEDFLOWLAYOUT_TRACE_VERBOSE_ENABLED(includeTraceLogging, sender, message, ...) \
+	// LinedFlowLayoutTrace::TraceVerbose(includeTraceLogging, sender, message, __VA_ARGS__); \
+	//
+	// #define LINEDFLOWLAYOUT_TRACE_VERBOSE(sender, message, ...) \
+	// if (IsLinedFlowLayoutVerboseTracingEnabled()) \
+	// { \
+	//     LINEDFLOWLAYOUT_TRACE_VERBOSE_ENABLED(true /*includeTraceLogging*/, sender, message, __VA_ARGS__); \
+	// } \
+	// else if (LinedFlowLayoutTrace::s_IsVerboseDebugOutputEnabled) \
+	// { \
+	//     LINEDFLOWLAYOUT_TRACE_VERBOSE_ENABLED(false /*includeTraceLogging*/, sender, message, __VA_ARGS__); \
+	// } \
+	//
+	// #define LINEDFLOWLAYOUT_TRACE_PERF(info) \
+	// if (IsLinedFlowLayoutPerfTracingEnabled()) \
+	// { \
+	//     LINEDFLOWLAYOUTTrace::TracePerfInfo(info); \
+	// } \
+	//
+	// #ifdef DBG
+	// #define LINEDFLOWLAYOUT_TRACE_INFO_DBG(sender, message, ...)    LINEDFLOWLAYOUT_TRACE_INFO(sender, message, __VA_ARGS__)
+	// #define LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(sender, message, ...) LINEDFLOWLAYOUT_TRACE_VERBOSE(sender, message, __VA_ARGS__)
+	// #define LINEDFLOWLAYOUT_TRACE_PERF_DBG(info)                    LINEDFLOWLAYOUT_TRACE_PERF(info)
+	// #else
+	// #define LINEDFLOWLAYOUT_TRACE_INFO_DBG(sender, message, ...)
+	// #define LINEDFLOWLAYOUT_TRACE_VERBOSE_DBG(sender, message, ...)
+	// #define LINEDFLOWLAYOUT_TRACE_PERF_DBG(info)
+	// #endif // DBG
+	//
+	// class LinedFlowLayoutTrace
+	// {
+	// public:
+	//     static bool s_IsDebugOutputEnabled;
+	//     static bool s_IsVerboseDebugOutputEnabled;
+	//
+	//     static void TraceInfo(bool includeTraceLogging, const winrt::IInspectable& sender, PCWSTR message, ...) noexcept
+	//     {
+	//         va_list args;
+	//         va_start(args, message);
+	//         WCHAR buffer[384]{};
+	//         if (SUCCEEDED(StringCchVPrintfW(buffer, ARRAYSIZE(buffer), message, args)))
+	//         {
+	//             if (includeTraceLogging)
+	//             {
+	//                 // TraceViewers
+	//                 // http://toolbox/pef
+	//                 // http://fastetw/index.aspx
+	//                 TraceLoggingWrite(
+	//                     g_hLoggingProvider,
+	//                     "LinedFlowLayoutInfo" /* eventName */,
+	//                     TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+	//                     TraceLoggingKeyword(KEYWORD_LINEDFLOWLAYOUT),
+	//                     TraceLoggingWideString(buffer, "Message"));
+	//             }
+	//
+	//             if (s_IsDebugOutputEnabled)
+	//             {
+	//                 OutputDebugStringW(buffer);
+	//             }
+	//
+	//             com_ptr<MUXControlsTestHooks> globalTestHooks = MUXControlsTestHooks::GetGlobalTestHooks();
+	//
+	//             if (globalTestHooks &&
+	//                 (globalTestHooks->GetLoggingLevelForType(L"LinedFlowLayout") >= WINEVENT_LEVEL_INFO || globalTestHooks->GetLoggingLevelForInstance(sender) >= WINEVENT_LEVEL_INFO))
+	//             {
+	//                 globalTestHooks->LogMessage(sender, buffer, false /*isVerboseLevel*/);
+	//             }
+	//         }
+	//         va_end(args);
+	//     }
+	//
+	//     static void TraceVerbose(bool includeTraceLogging, const winrt::IInspectable& sender, PCWSTR message, ...) noexcept
+	//     {
+	//         va_list args;
+	//         va_start(args, message);
+	//         WCHAR buffer[1024]{};
+	//         const HRESULT hr = StringCchVPrintfW(buffer, ARRAYSIZE(buffer), message, args);
+	//         if (SUCCEEDED(hr) || hr == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER))
+	//         {
+	//             if (includeTraceLogging)
+	//             {
+	//                 // TraceViewers
+	//                 // http://toolbox/pef
+	//                 // http://fastetw/index.aspx
+	//                 TraceLoggingWrite(
+	//                     g_hLoggingProvider,
+	//                     "LinedFlowLayoutVerbose" /* eventName */,
+	//                     TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),
+	//                     TraceLoggingKeyword(KEYWORD_LINEDFLOWLAYOUT),
+	//                     TraceLoggingWideString(buffer, "Message"));
+	//             }
+	//
+	//             if (s_IsDebugOutputEnabled || s_IsVerboseDebugOutputEnabled)
+	//             {
+	//                 OutputDebugStringW(buffer);
+	//             }
+	//
+	//             com_ptr<MUXControlsTestHooks> globalTestHooks = MUXControlsTestHooks::GetGlobalTestHooks();
+	//
+	//             if (globalTestHooks &&
+	//                 (globalTestHooks->GetLoggingLevelForType(L"LinedFlowLayout") >= WINEVENT_LEVEL_VERBOSE || globalTestHooks->GetLoggingLevelForInstance(sender) >= WINEVENT_LEVEL_VERBOSE))
+	//             {
+	//                 globalTestHooks->LogMessage(sender, buffer, true /*isVerboseLevel*/);
+	//             }
+	//         }
+	//         va_end(args);
+	//     }
+	//
+	//     static void TracePerfInfo(PCWSTR info) noexcept
+	//     {
+	//         // TraceViewers
+	//         // http://toolbox/pef
+	//         // http://fastetw/index.aspx
+	//         TraceLoggingWrite(
+	//             g_hPerfProvider,
+	//             "LinedFlowLayoutPerf" /* eventName */,
+	//             TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+	//             TraceLoggingKeyword(KEYWORD_LINEDFLOWLAYOUT),
+	//             TraceLoggingWideString(info, "Info"));
+	//     }
+	// };
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayoutInvalidationTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayoutInvalidationTrigger.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooks.idl, commit b8cfb8490
 
+#nullable enable
+
 namespace Microsoft.UI.Private.Controls;
 
 internal enum LinedFlowLayoutInvalidationTrigger

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayoutInvalidationTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/LinedFlowLayoutInvalidationTrigger.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference LayoutsTestHooks.idl, commit b8cfb8490
 
-#nullable enable
-
 namespace Microsoft.UI.Private.Controls;
 
-internal partial class LayoutsTestHooks
+internal enum LinedFlowLayoutInvalidationTrigger
 {
+	InvalidateLayoutCall = 0,
+	SnappedAverageItemsPerLineChange = 1,
+	ItemDesiredWidthChange = 2,
 }


### PR DESCRIPTION
**GitHub Issue:** closes #22909

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

Aligns the `LinedFlowLayout` port with the WinUI 3 source at `microsoft-ui-xaml` commit `b8cfb8490`.

This follow-up ports the layout test hooks, restores the WinUI source structure and diagnostic mappings, and enables the 10 existing ItemsView/LinedFlowLayout runtime tests. It is stacked on #23691 so the diff contains only the relevant follow-up files.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
