### PR TITLE
fix(foundation): make ApiExtensibility.Register idempotent

### DIFF
--- a/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
+++ b/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
@@ -18,7 +18,18 @@ public static class ApiExtensibility
 	/// </summary>
 	/// <param name="type">The type to register</param>
 	/// <param name="builder">A builder that will be provided an optional owner, and returns an instance of the extension</param>
-	/// <remarks>This method is generally called automatically when the <see cref="ApiExtensionAttribute"/> has been defined in an assembly.</remarks>
+	/// <remarks>
+	/// This method is generally called automatically when the <see cref="ApiExtensionAttribute"/> has been defined in an assembly.
+	/// <para>
+	/// Registration is idempotent: if <paramref name="type"/> is already registered the first registration
+	/// is kept and this call is a no-op. This supports scenarios where multiple applications run in the same
+	/// process and share this registry — for example a host and a secondary application loaded into a
+	/// collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/> that shares Uno.Foundation with
+	/// the host. Each application's generated startup registers the same framework providers via
+	/// <see cref="ApiExtensionAttribute"/>; keeping the first avoids a fatal duplicate-key
+	/// <see cref="ArgumentException"/> when the second application initializes.
+	/// </para>
+	/// </remarks>
 	public static void Register(Type type, Func<object, object> builder)
 	{
 		type = type ?? throw new ArgumentNullException(nameof(type));
@@ -26,7 +37,10 @@ public static class ApiExtensibility
 
 		lock (_gate)
 		{
-			_registrations.Add(type, builder);
+			if (!_registrations.ContainsKey(type))
+			{
+				_registrations.Add(type, builder);
+			}
 		}
 	}
 
@@ -36,7 +50,10 @@ public static class ApiExtensibility
 	/// <typeparam name="TOwner">Type of owner.</typeparam>
 	/// <param name="type">The type to register</param>
 	/// <param name="builder">A builder that will be provided an optional owner, and returns an instance of the extension</param>
-	/// <remarks>This method is generally called automatically when the <see cref="ApiExtensionAttribute"/> has been defined in an assembly.</remarks>
+	/// <remarks>
+	/// This method is generally called automatically when the <see cref="ApiExtensionAttribute"/> has been defined in an assembly.
+	/// Registration is idempotent — see <see cref="Register(Type, Func{object, object})"/> for details.
+	/// </remarks>
 	public static void Register<TOwner>(Type type, Func<TOwner, object> builder)
 	{
 		type = type ?? throw new ArgumentNullException(nameof(type));
@@ -54,7 +71,10 @@ public static class ApiExtensibility
 
 		lock (_gate)
 		{
-			_registrations.Add(type, objectBuilder);
+			if (!_registrations.ContainsKey(type))
+			{
+				_registrations.Add(type, objectBuilder);
+			}
 		}
 	}
 

--- a/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
+++ b/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
@@ -33,7 +33,7 @@ public static class ApiExtensibility
 	public static void Register(Type type, Func<object, object> builder)
 	{
 		type = type ?? throw new ArgumentNullException(nameof(type));
-		builder = builder ?? throw new ArgumentNullException(nameof(type));
+		builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
 		lock (_gate)
 		{
@@ -57,24 +57,28 @@ public static class ApiExtensibility
 	public static void Register<TOwner>(Type type, Func<TOwner, object> builder)
 	{
 		type = type ?? throw new ArgumentNullException(nameof(type));
-		builder = builder ?? throw new ArgumentNullException(nameof(type));
-
-		Func<object, object> objectBuilder = o =>
-		{
-			if (!(o is TOwner owner))
-			{
-				throw new InvalidOperationException($"Expected owner of type {typeof(TOwner).Name} to resolve instance of {type.Name}.");
-			}
-
-			return builder(owner);
-		};
+		builder = builder ?? throw new ArgumentNullException(nameof(builder));
 
 		lock (_gate)
 		{
-			if (!_registrations.ContainsKey(type))
+			// Check for an existing registration before building the wrapper lambda so a duplicate
+			// (idempotent) registration does not allocate the closure needlessly.
+			if (_registrations.ContainsKey(type))
 			{
-				_registrations.Add(type, objectBuilder);
+				return;
 			}
+
+			Func<object, object> objectBuilder = o =>
+			{
+				if (!(o is TOwner owner))
+				{
+					throw new InvalidOperationException($"Expected owner of type {typeof(TOwner).Name} to resolve instance of {type.Name}.");
+				}
+
+				return builder(owner);
+			};
+
+			_registrations.Add(type, objectBuilder);
 		}
 	}
 

--- a/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
+++ b/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
@@ -37,10 +37,8 @@ public static class ApiExtensibility
 
 		lock (_gate)
 		{
-			if (!_registrations.ContainsKey(type))
-			{
-				_registrations.Add(type, builder);
-			}
+			// TryAdd is a single lookup and idempotent (no-op when already present) — CA1864.
+			_registrations.TryAdd(type, builder);
 		}
 	}
 

--- a/src/Uno.UI.UnitTests/Foundation/Given_ApiExtensibility.cs
+++ b/src/Uno.UI.UnitTests/Foundation/Given_ApiExtensibility.cs
@@ -1,0 +1,69 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Foundation.Extensibility;
+
+namespace Uno.UI.Tests.Foundation
+{
+	[TestClass]
+	public class Given_ApiExtensibility
+	{
+		// ApiExtensibility._registrations is a process-wide static with no unregister, so each test
+		// uses its OWN contract type — otherwise one test's registration would leak into another.
+		// Registering the same contract twice is idempotent (first wins) and is robust to the test
+		// runner re-executing a method in the same process (a retry sees the first run's registration).
+		public interface IContractA
+		{
+			int Value { get; }
+		}
+
+		public interface IContractB
+		{
+			int Value { get; }
+		}
+
+		private sealed class ExtensionA : IContractA
+		{
+			public ExtensionA(int value) => Value = value;
+
+			public int Value { get; }
+		}
+
+		private sealed class ExtensionB : IContractB
+		{
+			public ExtensionB(int value) => Value = value;
+
+			public int Value { get; }
+		}
+
+		private sealed class Owner
+		{
+		}
+
+		[TestMethod]
+		public void When_Register_Called_Twice_Then_No_Throw_And_First_Registration_Wins()
+		{
+			ApiExtensibility.Register(typeof(IContractA), _ => new ExtensionA(1));
+
+			// A duplicate registration must be an idempotent no-op. Before this fix it threw a
+			// duplicate-key ArgumentException — the regression that broke multi-app hosting where a
+			// host and a secondary app (in a collectible ALC sharing Uno.Foundation) each register
+			// the same framework providers.
+			ApiExtensibility.Register(typeof(IContractA), _ => new ExtensionA(2));
+
+			Assert.IsTrue(ApiExtensibility.CreateInstance<IContractA>(new object(), out var instance));
+			Assert.IsNotNull(instance);
+			Assert.AreEqual(1, instance!.Value, "The first registration must win.");
+		}
+
+		[TestMethod]
+		public void When_RegisterOfTOwner_Called_Twice_Then_No_Throw_And_First_Registration_Wins()
+		{
+			ApiExtensibility.Register<Owner>(typeof(IContractB), _ => new ExtensionB(1));
+			ApiExtensibility.Register<Owner>(typeof(IContractB), _ => new ExtensionB(2));
+
+			Assert.IsTrue(ApiExtensibility.CreateInstance<IContractB>(new Owner(), out var instance));
+			Assert.IsNotNull(instance);
+			Assert.AreEqual(1, instance!.Value, "The first registration must win.");
+		}
+	}
+}


### PR DESCRIPTION
### GitHub Issue
Fixes #23819

### What is the current behavior?
`ApiExtensibility.Register` registers via `Dictionary.Add`, throwing `ArgumentException` on a duplicate contract type. When two applications share the registry in one process — e.g. a host that loads a secondary application into a collectible `AssemblyLoadContext` sharing `Uno.Foundation` — each app's generated `App.InitializeComponent()` registers the same framework providers (via `[ApiExtension]`). The second app's initialization then throws a fatal duplicate-key exception (observed key: `Microsoft.UI.Xaml.Controls.ILottieVisualSourceProvider`).

### What is the new behavior?
`Register` (both overloads) now skips re-registration when the contract type is already registered — first registration wins, making it idempotent and safe for shared-registry multi-app hosting. No public API change; `Add`-throws-on-duplicate is replaced by a `ContainsKey` guard under the existing lock.

### Suggested test
A unit test along these lines (placement per maintainer preference):
```csharp
[TestMethod]
public void When_Register_Twice_Then_Idempotent_And_First_Wins()
{
    var contract = typeof(SomeContract);
    ApiExtensibility.Register(contract, _ => new First());
    ApiExtensibility.Register(contract, _ => new Second()); // must not throw
    Assert.IsTrue(ApiExtensibility.CreateInstance<SomeContract>(null, out var instance));
    Assert.IsInstanceOfType(instance, typeof(First));
}
```

### Checklist
- [x] Self-contained change in `Uno.Foundation`; `Uno.Foundation` builds clean.
- [x] No public API surface change.
- [ ] Unit test placement to confirm with maintainers.