### PR TITLE
ci: Fix DevServer CLI tests — bump .NET SDK 10.0.105 → 10.0.302

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -31,7 +31,7 @@ variables:
   enable_dotnet_cache: true
   enable_emsdk_cache: true
   GlobalUnoCheckVersion: '1.33.0-dev.26'
-  DotNetSdkVersion: '10.0.105'
+  DotNetSdkVersion: '10.0.302'
 
 stages:
 - template: build/ci/.azure-devops-stages-docs.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -71,7 +71,7 @@ variables:
   enable_dotnet_cache: true
   enable_emsdk_cache: true
   GlobalUnoCheckVersion: '1.34.0-dev.23'
-  DotNetSdkVersion: '10.0.105'
+  DotNetSdkVersion: '10.0.302'
 
 stages:
 - template: build/ci/.azure-devops-stages.yml

--- a/build/ci/net10/_global.json
+++ b/build/ci/net10/_global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "10.0.105",
+		"version": "10.0.302",
 		"allowPrerelease": true,
 		"rollForward": "disable"
 	},
@@ -8,7 +8,7 @@
 		"runner": "Microsoft.Testing.Platform"
 	},
 	"tools": {
-		"dotnet": "10.0.105"
+		"dotnet": "10.0.302"
 	},
 	"msbuild-sdks": {
 		"Microsoft.Build.NoTargets": "3.7.56"

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -114,7 +114,7 @@ jobs:
     displayName: Install .NET 10 SDK
     inputs:
       packageType: 'sdk'
-      version: '10.0.105'
+      version: '10.0.302'
       installationPath: $(DOTNET_INSTALL_DIR)
 
   - task: CopyFiles@2
@@ -180,7 +180,7 @@ jobs:
     displayName: Install .NET 10 SDK
     inputs:
       packageType: 'sdk'
-      version: '10.0.105'
+      version: '10.0.302'
       installationPath: $(DOTNET_INSTALL_DIR)
 
   - task: CopyFiles@2

--- a/build/ci/tests/.azure-devops-tests-unit-tests.yml
+++ b/build/ci/tests/.azure-devops-tests-unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
     displayName: Install .NET 10 SDK
     inputs:
       packageType: 'sdk'
-      version: '10.0.105'
+      version: '10.0.302'
       installationPath: $(DOTNET_INSTALL_DIR)
 
   # This task is required to run in separately to avoid hitting targets file


### PR DESCRIPTION
**GitHub Issue:** closes #23823

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The **DevServer CLI Tests** CI job (`Run DevServer Tests`, Windows/macOS/Linux) was failing at
`dotnet tool install uno.devserver` with:

> Settings file 'DotnetToolSettings.xml' was not found in the package.

**Root cause:** CI was pinned to .NET SDK **10.0.105** (feature band `1xx`), which hits a known .NET
tool-packaging regression (dotnet/sdk#53101) when packing the DevServer CLI's `DotnetTool;McpServer`
tool package. Verified that a `10.0.3xx` SDK packs a valid, installable tool package. The pin dates back
to April; it only surfaced recently because the DevServer CLI test stage runs only when devserver/
template files change.

This bumps **every** CI .NET SDK pin `10.0.105 → 10.0.302`:

- `.vsts-ci.yml` / `.vsts-ci-docs.yml` (`DotNetSdkVersion` — the SDK the test job installs)
- `build/ci/net10/_global.json` (the SDK the packaging build uses)
- `build/ci/tests/.azure-devops-tests-templates.yml`
- `build/ci/tests/.azure-devops-tests-unit-tests.yml`

## PR Checklist ✅

- [ ] 🧪 Added tests — N/A (CI configuration change; validated by the DevServer CLI test stage itself)
- [ ] 📚 Docs — N/A
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes