### PR TITLE
fix(textbox): Drop iOS autocorrect autospace on caret move

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
@@ -15,12 +15,17 @@ internal static class InvisibleTextBoxAutocorrect
 	/// </summary>
 	internal static bool IsNoOpReplacement(string? currentText, NSRange range, string replacementString)
 	{
-		if (range.Length <= 0 || currentText is null)
+		// Bound-check in nint space before the int casts, so a pathological or NSNotFound
+		// range can't overflow into a negative offset/length and make AsSpan throw.
+		if (currentText is null
+			|| range.Location < 0
+			|| range.Length <= 0
+			|| range.Location > currentText.Length
+			|| range.Length > currentText.Length - range.Location)
 		{
 			return false;
 		}
 
-		return (int)(range.Location + range.Length) <= currentText.Length
-			&& currentText.AsSpan((int)range.Location, (int)range.Length).SequenceEqual(replacementString);
+		return currentText.AsSpan((int)range.Location, (int)range.Length).SequenceEqual(replacementString);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
@@ -1,3 +1,4 @@
+using System;
 using Foundation;
 
 namespace Uno.WinUI.Runtime.Skia.AppleUIKit.Controls;
@@ -20,6 +21,6 @@ internal static class InvisibleTextBoxAutocorrect
 		}
 
 		return (int)(range.Location + range.Length) <= currentText.Length
-			&& currentText.Substring((int)range.Location, (int)range.Length) == replacementString;
+			&& currentText.AsSpan((int)range.Location, (int)range.Length).SequenceEqual(replacementString);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
@@ -1,0 +1,25 @@
+using Foundation;
+
+namespace Uno.WinUI.Runtime.Skia.AppleUIKit.Controls;
+
+internal static class InvisibleTextBoxAutocorrect
+{
+	/// <summary>
+	/// Detects the no-op text replacement iOS autocorrection fires when the caret leaves the middle
+	/// of a word — it proposes replacing a range with its own current content and then appends a
+	/// stray separator space. On Skia the caret is driven programmatically on the off-screen input
+	/// proxy, so iOS misfires this on every tap-to-reposition. The delegates reject the no-op to
+	/// suppress that autospace; genuine edits and real corrections change the text, so they are not
+	/// matched here and pass through untouched.
+	/// </summary>
+	internal static bool IsNoOpReplacement(string? currentText, NSRange range, string replacementString)
+	{
+		if (range.Length <= 0 || currentText is null)
+		{
+			return false;
+		}
+
+		return (int)(range.Location + range.Length) <= currentText.Length
+			&& currentText.Substring((int)range.Location, (int)range.Length) == replacementString;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxAutocorrect.cs
@@ -13,7 +13,7 @@ internal static class InvisibleTextBoxAutocorrect
 	/// suppress that autospace; genuine edits and real corrections change the text, so they are not
 	/// matched here and pass through untouched.
 	/// </summary>
-	internal static bool IsNoOpReplacement(string? currentText, NSRange range, string replacementString)
+	internal static bool IsNoOpAutocorrectReplacement(string? currentText, NSRange range, string replacementString)
 	{
 		// Bound-check in nint space before the int casts, so a pathological or NSNotFound
 		// range can't overflow into a negative offset/length and make AsSpan throw.

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxDelegate.cs
@@ -58,6 +58,12 @@ internal partial class MultilineInvisibleTextBoxDelegate : UITextViewDelegate
 				return true;
 			}
 
+			// Suppress the iOS autocorrect autospace fired when the caret leaves a word (see IsNoOpReplacement).
+			if (InvisibleTextBoxAutocorrect.IsNoOpReplacement(textView.Text, range, replacementString))
+			{
+				return false;
+			}
+
 			// TODO:MZ:
 			//if (textBox.OnKey(text.FirstOrDefault()))
 			//{

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxDelegate.cs
@@ -58,8 +58,8 @@ internal partial class MultilineInvisibleTextBoxDelegate : UITextViewDelegate
 				return true;
 			}
 
-			// Suppress the iOS autocorrect autospace fired when the caret leaves a word (see IsNoOpReplacement).
-			if (InvisibleTextBoxAutocorrect.IsNoOpReplacement(textView.Text, range, replacementString))
+			// Suppress the iOS autocorrect autospace fired when the caret leaves a word (see IsNoOpAutocorrectReplacement).
+			if (InvisibleTextBoxAutocorrect.IsNoOpAutocorrectReplacement(textView.Text, range, replacementString))
 			{
 				return false;
 			}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxDelegate.cs
@@ -50,8 +50,8 @@ internal partial class SinglelineInvisibleTextBoxDelegate : UITextFieldDelegate
 				return true;
 			}
 
-			// Suppress the iOS autocorrect autospace fired when the caret leaves a word (see IsNoOpReplacement).
-			if (InvisibleTextBoxAutocorrect.IsNoOpReplacement(textField.Text, range, replacementString))
+			// Suppress the iOS autocorrect autospace fired when the caret leaves a word (see IsNoOpAutocorrectReplacement).
+			if (InvisibleTextBoxAutocorrect.IsNoOpAutocorrectReplacement(textField.Text, range, replacementString))
 			{
 				return false;
 			}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxDelegate.cs
@@ -50,6 +50,12 @@ internal partial class SinglelineInvisibleTextBoxDelegate : UITextFieldDelegate
 				return true;
 			}
 
+			// Suppress the iOS autocorrect autospace fired when the caret leaves a word (see IsNoOpReplacement).
+			if (InvisibleTextBoxAutocorrect.IsNoOpReplacement(textField.Text, range, replacementString))
+			{
+				return false;
+			}
+
 			// TODO:MZ:
 			//if (textBox.OnKey(replacementString.FirstOrDefault()))
 			//{


### PR DESCRIPTION
**GitHub Issue:** closes #23818

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia iOS, tapping to reposition the caret inside a word could inject a stray space into the text (e.g. `Modern` → `Mode rn`); the extra spaces accumulated at each tapped position and became visible when the field lost focus.

**Root cause:** the caret is managed by Uno and pushed programmatically to an off-screen native `UITextField`/`UITextView` that drives the soft keyboard. When the caret leaves the middle of a word, iOS autocorrection proposes a **no-op replacement** (a range replaced with its own current content) and then appends a separator space that bypasses the delegate. Because the caret is driven programmatically here, iOS misfires this on every tap-to-reposition — a real native field coordinates the move and never does.

**Fix:** both invisible-proxy delegates now reject that no-op replacement in `ShouldChangeText` / `ShouldChangeCharacters` via a small shared helper (`InvisibleTextBoxAutocorrect.IsNoOpReplacement`). Genuine edits and real autocorrections change the text, so they are unaffected; rejecting the no-op is also harmless while typing (the word is already correct and the real keystroke still passes through).

**Validation:** verified on the iOS simulator — no extra spaces on repeated tap-to-reposition, and typing/autocorrect still work. This path is not reproducible in Skia Desktop runtime tests (no real native text view), so no automated test is added.

> **Draft:** targets `master` but currently also carries unrelated in-flight mobile TextBox touch-selection commits. Blocked on that related change merging to `master` first; will rebase onto `master` and mark ready for review once it lands.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable; validated manually on iOS simulator (see above)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
