### PR TITLE
fix(deps): Bump System.Security.Cryptography.Xml to 10.0.10

### DIFF
--- a/src/Uno.HotReload/Uno.HotReload.csproj
+++ b/src/Uno.HotReload/Uno.HotReload.csproj
@@ -31,7 +31,7 @@
 
 		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on a vulnerable version.
 		     Pinned to 8.0.3 to address GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf (affects <= 8.0.2). -->
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 
 		<PackageReference Include="Microsoft.CodeAnalysis"/>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -34,7 +34,7 @@
 
 		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on a vulnerable version.
 		     Pinned to 8.0.3 to address GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf (affects <= 8.0.2). -->
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 
 		<PackageReference Include="Microsoft.CodeAnalysis" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" />

--- a/src/Uno.WinAppSDKSyncGenerator/Uno.WinAppSDKSyncGenerator.csproj
+++ b/src/Uno.WinAppSDKSyncGenerator/Uno.WinAppSDKSyncGenerator.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(SyncGeneratorCodeAnalysisVersion)" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(SyncGeneratorCodeAnalysisVersion)" />
 		<PackageReference Include="Basic.Reference.Assemblies.Net100" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 		<PackageReference Include="Uno.Core.Extensions" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" />
 	</ItemGroup>


### PR DESCRIPTION
**GitHub Issue:** Security advisory (NU1903) on `System.Security.Cryptography.Xml` 10.0.9 — no public tracking issue; dependency/security fix per the template's "GitHub issue or internal" allowance.

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

A newly-published high-severity advisory on `System.Security.Cryptography.Xml` **10.0.9** (GHSA-23rf-6693-g89p, -8q5v-6pqq-x66h, -cvvh-rhrc-wg4q, -g8r8-53c2-pm3f) makes **NU1903** fail under `TreatWarningsAsErrors`, breaking **every build on `feature/breakingchanges`** that compiles the three projects referencing it:

- `Uno.HotReload`
- `Uno.UI.RemoteControl.Server.Processors`
- `Uno.WinAppSDKSyncGenerator`

That cascades into failures across the samples-app builds (WASM/iOS/Android/Skia), the WinAppSDK sync-generator check, the documentation build, CodeQL analyze, and the managed-binaries/package-diff build — i.e. it blocks the whole branch. It is advisory-driven: builds that were green yesterday fail today once the advisory dropped.

This PR bumps the three direct references from `10.0.9` to the patched **`10.0.10`**.

Branch-specific: `master` is still on the `8.0.x` line of this package and is unaffected; the `10.0.x` line was introduced on `feature/breakingchanges` as part of the .NET 11 work, so the fix belongs here.

## PR Checklist ✅

- [x] 🧪 N/A — dependency version bump; validated by the branch build going green (NU1903 cleared)
- [x] 📚 N/A — no API/behavior change
- [x] 🖼️ N/A — no visual change
- [x] ❗ Contains **NO** breaking changes (patch-level servicing bump)
- [ ] 👀 Reviewed 2 other open pull requests
