### PR TITLE
fix(security): Bump System.Security.Cryptography.Xml to 10.0.10

### DIFF
--- a/src/Uno.HotReload/Uno.HotReload.csproj
+++ b/src/Uno.HotReload/Uno.HotReload.csproj
@@ -29,9 +29,12 @@
 		<PackageReference Include="Uno.Core.Extensions.Threading" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" />
 
-		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on a vulnerable version.
-		     Pinned to 8.0.3 to address GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf (affects <= 8.0.2). -->
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<!-- Override the vulnerable System.Security.Cryptography.Xml that Microsoft.Build.Tasks.Core
+		     pulls in transitively. 10.0.10 is the first release clear of the July 2026 .NET
+		     XML-encryption advisories (CVE-2026-47304 / GHSA-g8r8-53c2-pm3f plus GHSA-cvvh-rhrc-wg4q,
+		     GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h; all affect <= 10.0.9). The 8.0.x line has no
+		     fixed release (8.0.4 is the highest published and still in range). -->
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -31,9 +31,12 @@
 		<PackageReference Include="Uno.Core.Extensions.Threading" Version="4.0.1" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" />
 
-		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on a vulnerable version.
-		     Pinned to 8.0.3 to address GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf (affects <= 8.0.2). -->
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<!-- Override the vulnerable System.Security.Cryptography.Xml that Microsoft.Build.Tasks.Core
+		     pulls in transitively. 10.0.10 is the first release clear of the July 2026 .NET
+		     XML-encryption advisories (CVE-2026-47304 / GHSA-g8r8-53c2-pm3f plus GHSA-cvvh-rhrc-wg4q,
+		     GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h; all affect <= 10.0.9). The 8.0.x line has no
+		     fixed release (8.0.4 is the highest published and still in range). -->
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">


### PR DESCRIPTION
**GitHub Issue:** closes #23829

## PR Type:

🐞 Bugfix

## What changed? 🚀

Bumps the `System.Security.Cryptography.Xml` transitive-override pin from `8.0.3` to `10.0.10` in the two build-tooling projects that carry it:

- `src/Uno.HotReload/Uno.HotReload.csproj`
- `src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj`

The pin exists to override the vulnerable version `Microsoft.Build.Tasks.Core` pulls in transitively. `8.0.3` is now flagged by **NU1903**: the July 2026 .NET XML-encryption advisories (`CVE-2026-47304` / `GHSA-g8r8-53c2-pm3f`, plus `GHSA-cvvh-rhrc-wg4q`, `GHSA-23rf-6693-g89p`, `GHSA-8q5v-6pqq-x66h`) cover the whole 8.0.x line, and the highest published 8.0.x package (`8.0.4`) is still in range — so there is no fixed 8.0.x release. `10.0.10` is the first release above the affected `<= 10.0.9` range on the 10.x line.

Verified against NuGet's raw vulnerability index and flat-container listing. `10.0.10` ships explicit `lib/net9.0/` and `lib/net10.0/` assets, matching the `NetPrevious`/`NetCurrent` TFMs of both projects, so it restores on both legs. The explanatory comment above each `PackageReference` was updated to reflect the current advisories and the reason for jumping to the 10.x major.

No source/API changes; tooling dependency hygiene only.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, dependency-version bump with no code change
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A, no UI change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
