### PR TITLE
fix(ci): Exclude flaky Repeater ChangeView test on SkiaWasm

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -495,6 +495,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 
 		[TestMethod]
 		[RunsOnUIThread]
+		// SkiaWasm excluded: render-loop-driven ChangeView smooth-scroll stalls under the headless xvfb browser (flaky). #23524
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23524")]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
 #if !__SKIA__
 		[Ignore("Fails due to async native scrolling.")]
 #endif


### PR DESCRIPTION
**GitHub Issue:** related to #23524

<!-- #23524 tracks the SkiaWasm render-loop flake class. It is currently closed; this PR references it as the documentation anchor (consistent with the existing sibling exclusions) rather than reopening it. -->

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Given_ItemsRepeater.When_Repeater_ChangedView` is a smooth-scroll **animation** test: `ChangeView(null, 1000000, null, disableAnimation: false)` over a 300-item virtualized `ItemsRepeater`, then it polls for the last item to materialize. Under the **SkiaWasm** CI stage (headless `xvfb` Chromium), `requestAnimationFrame`/timers are throttled, so the render-loop-driven scroll **stalls** before reaching the end and the second `WaitFor` ("ChangeView should have scrolled to the last item") times out intermittently:

```
AssertFailedException: Timed out waiting for condition to be met. ChangeView should have scrolled to the last item
   at WindowHelper.WaitFor(...)
   at Given_ItemsRepeater.When_Repeater_ChangedView()
```

This is the same environment-flake class already documented in #23524 and mitigated for its sibling tests (`ListViewBase`, `TreeView`, `PipsPager`, `CalendarView`, `Theme_Materialization`). The earlier de-flake pass (`a2e7470b41`) hardened *this* test with `WaitFor` instead of excluding it — but a **stall** does not yield to a longer timeout.

This PR excludes the test on **SkiaWasm only**, matching the established sibling pattern:

```csharp
// SkiaWasm excluded: render-loop-driven ChangeView smooth-scroll stalls under the headless xvfb browser (flaky). #23524
[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23524")]
[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
```

Coverage is retained on all other Skia targets (Win32 / X11 / macOS) **by construction** — the same managed scroll-presenter logic runs there; only the WASM render path loses this one smooth-scroll check. Native targets remain `[Ignore]`d via the pre-existing `#if !__SKIA__`.

## PR Checklist ✅

- [x] 🧪 Test-infra only — de-flakes an existing runtime test on one CI target; no product code changes, no new test needed.
- [x] 📚 Docs — N/A (no public API or behavior change).
- [x] 🖼️ No visual change; `Screenshots Compare Test Run` N/A.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests (optional).
