### PR TITLE
fix(x11): Disable GDK frame sync on embedded webview window

### DIFF
--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -180,7 +180,17 @@ public class X11NativeWebView : INativeWebView
 			// painting the next one. Our window gets reparented into the app's window and
 			// is never managed by the WM, so no acknowledgement ever comes and GTK (and
 			// therefore WebKit) stops painting entirely, leaving the webview blank.
-			gdk_x11_window_set_frame_sync_enabled(_window.Window.Handle, false);
+			try
+			{
+				gdk_x11_window_set_frame_sync_enabled(_window.Window.Handle, false);
+			}
+			catch (EntryPointNotFoundException e) // GTK < 3.8
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn("Couldn't disable GDK frame sync. The webview might not render under Mutter-based window managers (e.g. GNOME).", e);
+				}
+			}
 
 			// Set override-redirect before the window is first mapped, so that the WM never
 			// starts managing it as a toplevel. Some WMs (e.g. Weston's XWM on WSLg) would

--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -66,7 +66,7 @@ public class X11NativeWebView : INativeWebView
 	private static extern IntPtr gdk_x11_window_get_xid(IntPtr window);
 
 	[DllImport("libgdk-3.so", CallingConvention = CallingConvention.Cdecl)]
-	private static extern void gdk_x11_window_set_frame_sync_enabled(IntPtr window, bool frameSyncEnabled);
+	private static extern void gdk_x11_window_set_frame_sync_enabled(IntPtr window, int frameSyncEnabled);
 
 	static X11NativeWebView()
 	{
@@ -182,7 +182,7 @@ public class X11NativeWebView : INativeWebView
 			// therefore WebKit) stops painting entirely, leaving the webview blank.
 			try
 			{
-				gdk_x11_window_set_frame_sync_enabled(_window.Window.Handle, false);
+				gdk_x11_window_set_frame_sync_enabled(_window.Window.Handle, /* False */ 0);
 			}
 			catch (EntryPointNotFoundException e) // GTK < 3.8
 			{

--- a/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/X11NativeWebView.cs
@@ -65,6 +65,9 @@ public class X11NativeWebView : INativeWebView
 	[DllImport("libgdk-3.so", CallingConvention = CallingConvention.Cdecl)]
 	private static extern IntPtr gdk_x11_window_get_xid(IntPtr window);
 
+	[DllImport("libgdk-3.so", CallingConvention = CallingConvention.Cdecl)]
+	private static extern void gdk_x11_window_set_frame_sync_enabled(IntPtr window, bool frameSyncEnabled);
+
 	static X11NativeWebView()
 	{
 		try
@@ -171,6 +174,13 @@ public class X11NativeWebView : INativeWebView
 			_window.Add(_webview);
 			_webview.ShowAll();
 			_window.Realize(); // creates the Gdk window (and the X11 window) without showing it
+
+			// WMs that support _NET_WM_FRAME_DRAWN (e.g. Mutter/GNOME, on both X11 and
+			// XWayland) make GDK wait for the WM's acknowledgement of each frame before
+			// painting the next one. Our window gets reparented into the app's window and
+			// is never managed by the WM, so no acknowledgement ever comes and GTK (and
+			// therefore WebKit) stops painting entirely, leaving the webview blank.
+			gdk_x11_window_set_frame_sync_enabled(_window.Window.Handle, false);
 
 			// Set override-redirect before the window is first mapped, so that the WM never
 			// starts managing it as a toplevel. Some WMs (e.g. Weston's XWM on WSLg) would


### PR DESCRIPTION
**GitHub Issue:** closes #23159

## PR Type:

🐞 Bugfix

## What changed? 🚀

On GNOME (Mutter — both Xorg and XWayland sessions), `WebView2` on Skia X11 renders a permanently blank panel. Historically it was flaky (blank until scrolling forced a repaint); since 6.7.0-dev.123 (#23736) it stopped rendering entirely.

### Root cause

Mutter advertises `_NET_WM_FRAME_DRAWN` (compositor frame synchronization), so GDK paints a frame only after the WM acknowledges the previous one. The WebKitGTK window hosting the webview is reparented into the application's X11 window and is therefore never managed by the WM — no acknowledgement ever arrives, GDK's frame clock stalls, and WebKit stops painting. The X11 side is entirely healthy (correct parent, mapped, viewable, correct geometry); the window is just never drawn into.

Weston (WSLg) and wlroots-based compositors (sway, etc.) don't support frame sync, so GTK falls back to a timer-driven frame clock there — which is why the issue only reproduces on GNOME.

#23736 didn't regress this at the X11 level: before it, the marshaling bug in `AttachSubWindow` meant override-redirect was effectively never applied, so the window sometimes got *briefly* managed by Mutter during the map/attach race, letting a few frames through — the "blank until you scroll" flakiness reported in #23159. Making "never managed" deterministic made the stall permanent.

### Fix

Call `gdk_x11_window_set_frame_sync_enabled(window, FALSE)` on the GDK window right after `Realize()` — GDK's opt-out for exactly this scenario. The override-redirect handling from #23736 is unchanged (still required for Weston's XWM).

### Validation

- **Runtime, Mutter 46.2 (Ubuntu 24.04) headless XWayland**: `SamplesApp` → `WebView2_Basic` renders the page with the fix; a negative control build (same everything minus the one call) reproduces the permanently blank webview. Fails-before / passes-after, screenshot-verified.
- **Runtime, WSLg (Weston XWM)**: page renders with the fix — no regression of the #23736 scenario.
- **GTK-level repro matrix** replicating the exact embedding flow (realize → override-redirect → reparent → map → layout), across four XWMs (Weston, sway/wlroots, Mutter-on-XWayland, Mutter-on-Xorg) × both map/attach orderings × old/new attach variants: only frame-sync-disabled variants render everywhere; the current code fails only under Mutter, matching the field reports.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — covered by the existing `WebView2_Basic` manual-test sample; the failure depends on the window manager (GNOME/Mutter), which CI test environments don't exercise.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
