### PR TITLE
feat(devserver): detect available Uno.Sdk update in uno_health (MCP)

### DIFF
--- a/specs/052-mcp-sdk-update-detection/spec.md
+++ b/specs/052-mcp-sdk-update-detection/spec.md
@@ -1,0 +1,56 @@
+# MCP / DevServer — Uno.Sdk update detection
+
+## Problem
+
+The IDE extensions notify a developer when a newer **recommended** `Uno.Sdk` is available and offer to update `global.json`. Agent/CLI users driving an app through the Uno DevServer MCP get **no equivalent signal** — an agent has no way to know the project is on an outdated SDK, or to tell the user to update.
+
+This closes that gap by surfacing the same "update available" signal through the DevServer's `uno_health` MCP tool (and the `uno.devserver health` command), using the **same source of truth** the extensions use so recommendations stay consistent.
+
+Related work is tracked in private issues: the original request to surface SDK-update state, and a broader agent sign-in effort whose next tier covers surfacing actionable state in `uno_health`.
+
+## Source of truth
+
+The recommended version is the curated manifest the IDE extensions already read:
+
+- URL: `https://aka.platform.uno/uno-sdk-manifest` → `https://uno-assets.platform.uno/manifests/uno-sdk.json`
+- Repo: `unoplatform/uno-assets` → `manifests/uno-sdk.json`
+- Shape: `{ "version": "<semver>" }`
+
+This is deliberately the **recommended** stable version, which may trail the newest NuGet release. We must **not** substitute raw NuGet "latest", or the DevServer would recommend a version the team has not blessed (and disagree with the IDE extensions).
+
+## Design
+
+1. **`SdkManifest` helper** (`Uno.UI.DevServer.Cli/Helpers`):
+   - `GetLatestUnoSdkVersionAsync()` — best-effort GET of the manifest (5s timeout); returns `null` (never throws) when offline/unreachable.
+   - `IsNewer(candidate, current)` — numeric component-by-component comparison, ignoring any `-prerelease` suffix. Mirrors the extension's comparison.
+
+2. **Health report fields** (`HealthReport`): `UnoSdkPackage`, `LatestUnoSdkVersion`, `UnoSdkUpdateAvailable`.
+
+3. **`HealthReportFactory.Create`** takes the fetched `latestUnoSdkVersion`, computes `updateAvailable` against the discovered `UnoSdkVersion`, and — when an update exists — adds an actionable **Warning** `ValidationIssue` (`IssueCode.UnoSdkUpdateAvailable`) whose remediation tells the agent to update the `Uno.Sdk` version in `global.json`.
+
+4. **Public `Uno.Sdk` only:** the manifest is the recommended version for the public `Uno.Sdk`. Detection is gated to `Uno.Sdk` workspaces — an `Uno.Sdk.Private` project is never compared or advised (its `LatestUnoSdkVersion` stays `null`). The plain-text/health label uses the discovered package id (`UnoSdkPackage`) rather than a hardcoded "Uno.Sdk".
+
+5. **Advisory is non-degrading:** an available update must not, on its own, move a working DevServer from `Healthy` to `Degraded`. The status computation excludes `UnoSdkUpdateAvailable` from the Degraded trigger (but a genuine `Warning`/`Fatal` alongside it still degrades/fails as usual).
+
+6. **Fetch placement:**
+   - MCP `uno_health` (`HealthService`) — background, cached fetch (`Lazy<Task>`, `ExecutionAndPublication`) so health calls stay non-blocking; the injected `ILogger` is threaded through so fetch failures are traceable. The version provider is injectable (`Func<CancellationToken, Task<string?>>`) so tests supply a value without real network I/O.
+   - `uno.devserver health` command — the fetch is started up front so it **overlaps** discovery/host checks, and is awaited only when building the report.
+   - Timeouts/cancellations are logged as a plain message (no stack trace); other failures log at Debug with the exception.
+
+## Surfaces
+
+- `uno_health` MCP tool → JSON now carries `unoSdkVersion`, `latestUnoSdkVersion`, `unoSdkUpdateAvailable`, and the advisory issue.
+- `uno.devserver health` (plain text) → a `Recommended Uno.Sdk: <v> (update available)` line.
+
+## Out of scope (follow-ups)
+
+- **Action tool** `uno_update_sdk` that rewrites `global.json` (the extension's "Update" button) — proposed follow-up.
+- **Uno Studio app** banner (reuses the same manifest) — tracked separately for the Studio app.
+- Server-side or per-version "ignore" preferences (the extension persists these per project).
+
+## Testing
+
+- `Given_SdkManifest` — `IsNewer` across newer/older/equal, differing segment counts, numeric-not-lexical ordering, pre-release suffixes, and missing inputs.
+- `Given_HealthReportFactory_SdkUpdate` — update-available advisory + fields; advisory-only status stays `Healthy`; up-to-date/ahead → no advisory; `Uno.Sdk.Private` → no advisory; manifest unavailable (`null`) → no advisory; a `Fatal` alongside the advisory → `Unhealthy`; a real `Warning` alongside it → `Degraded`.
+- `Given_HealthReportFormatter` — update-available suffix present, up-to-date suffix absent, `Uno.Sdk.Private` label uses the actual package id, and JSON carries the new fields.
+- Manual (runtime): `uno.devserver health` from a project pinned below vs. at/above the recommended version.

--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_HealthService.cs
@@ -65,7 +65,7 @@ public class Given_HealthService
 		var monitor = new DevServerMonitor(services, NullLogger<DevServerMonitor>.Instance);
 		var upstreamClient = new McpUpstreamClient(NullLogger<McpUpstreamClient>.Instance, monitor);
 		var toolListManager = new ToolListManager(NullLogger<ToolListManager>.Instance, upstreamClient);
-		var healthService = new HealthService(upstreamClient, monitor, toolListManager);
+		var healthService = new HealthService(upstreamClient, monitor, toolListManager, NullLogger<HealthService>.Instance, _ => System.Threading.Tasks.Task.FromResult<string?>(null));
 		var stdioServer = new McpStdioServer(NullLogger<McpStdioServer>.Instance, toolListManager, healthService, upstreamClient);
 		var workspaceResolver = new WorkspaceResolver(NullLogger<WorkspaceResolver>.Instance);
 

--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_McpStdioServer.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_McpStdioServer.cs
@@ -394,7 +394,7 @@ public class Given_McpStdioServer
 		var monitor = new DevServerMonitor(services, Microsoft.Extensions.Logging.Abstractions.NullLogger<DevServerMonitor>.Instance);
 		var upstreamClient = new McpUpstreamClient(Microsoft.Extensions.Logging.Abstractions.NullLogger<McpUpstreamClient>.Instance, monitor);
 		var toolListManager = new ToolListManager(Microsoft.Extensions.Logging.Abstractions.NullLogger<ToolListManager>.Instance, upstreamClient);
-		var healthService = new HealthService(upstreamClient, monitor, toolListManager);
+		var healthService = new HealthService(upstreamClient, monitor, toolListManager, Microsoft.Extensions.Logging.Abstractions.NullLogger<HealthService>.Instance, _ => System.Threading.Tasks.Task.FromResult<string?>(null));
 		return new McpStdioServer(Microsoft.Extensions.Logging.Abstractions.NullLogger<McpStdioServer>.Instance, toolListManager, healthService, upstreamClient);
 	}
 }

--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_ProxyLifecycleManager.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Given_ProxyLifecycleManager.cs
@@ -1607,7 +1607,7 @@ public class Given_ProxyLifecycleManager
 		var monitor = new DevServerMonitor(services, NullLogger<DevServerMonitor>.Instance);
 		var upstreamClient = new McpUpstreamClient(NullLogger<McpUpstreamClient>.Instance, monitor);
 		var toolListManager = new ToolListManager(NullLogger<ToolListManager>.Instance, upstreamClient);
-		var healthService = new HealthService(upstreamClient, monitor, toolListManager);
+		var healthService = new HealthService(upstreamClient, monitor, toolListManager, NullLogger<HealthService>.Instance, _ => System.Threading.Tasks.Task.FromResult<string?>(null));
 		var stdioServer = new McpStdioServer(NullLogger<McpStdioServer>.Instance, toolListManager, healthService, upstreamClient);
 		var finder = solutionFileFinder ?? new FileSystemSolutionFileFinder();
 		var workspaceResolver = new WorkspaceResolver(NullLogger<WorkspaceResolver>.Instance, finder);

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -294,6 +294,11 @@ internal class CliManager
 	private async Task<int> RunHealthAsync(string requestedWorkingDirectory, WorkspaceResolution workspaceResolution, bool outputJson)
 	{
 		var workingDirectory = workspaceResolution.EffectiveWorkspaceDirectory ?? requestedWorkingDirectory;
+
+		// Start the manifest fetch up front so it overlaps discovery + host checks rather than
+		// adding its latency serially at the end.
+		var latestUnoSdkVersionTask = SdkManifest.GetLatestUnoSdkVersionAsync(_logger);
+
 		var info = await _unoToolsLocator.DiscoverAsync(workingDirectory, workspaceResolution);
 
 		// In standalone CLI mode, check if any active workspace-matching server
@@ -316,7 +321,8 @@ internal class CliManager
 			connectionState: null,
 			discoveredSolutions: null,
 			hostProcessId: activeWorkspaceServer?.ProcessId,
-			hostEndpoint: activeWorkspaceServer?.McpEndpoint);
+			hostEndpoint: activeWorkspaceServer?.McpEndpoint,
+			latestUnoSdkVersion: await latestUnoSdkVersionTask);
 
 		if (outputJson)
 		{

--- a/src/Uno.UI.DevServer.Cli/Helpers/HealthReportFormatter.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/HealthReportFormatter.cs
@@ -20,6 +20,11 @@ internal static class HealthReportFormatter
 		builder.AppendLine($"Resolution: {report.ResolutionKind?.ToString() ?? "<unknown>"}");
 		builder.AppendLine($"Selection: {report.SelectionSource?.ToString() ?? "<unknown>"}");
 		builder.AppendLine($"Tools: {report.ToolCount}");
+		builder.AppendLine($"{report.UnoSdkPackage ?? "Uno.Sdk"}: {report.UnoSdkVersion ?? "<unknown>"}");
+		if (report.LatestUnoSdkVersion is not null)
+		{
+			builder.AppendLine($"Recommended {report.UnoSdkPackage ?? "Uno.Sdk"}: {report.LatestUnoSdkVersion}{(report.UnoSdkUpdateAvailable ? " (update available)" : "")}");
+		}
 
 		if (report.CandidateSolutions is { Count: > 0 })
 		{

--- a/src/Uno.UI.DevServer.Cli/Helpers/SdkManifest.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/SdkManifest.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Uno.UI.DevServer.Cli.Helpers;
+
+/// <summary>
+/// Reads the curated "recommended Uno.Sdk version" manifest — the same source the IDE
+/// extensions use (<c>https://aka.platform.uno/uno-sdk-manifest</c>, served from the
+/// <c>unoplatform/uno-assets</c> repo). Used to tell whether a project's pinned Uno.Sdk
+/// is behind the recommended version, so the DevServer/MCP can surface an update the same
+/// way the extensions do.
+/// </summary>
+internal static class SdkManifest
+{
+	private const string ManifestUrl = "https://aka.platform.uno/uno-sdk-manifest";
+	private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+	// No global Timeout on the shared client: each request bounds itself with a linked
+	// CancellationTokenSource so one caller's timeout can never affect another's request.
+	private static readonly HttpClient _httpClient = new();
+
+	/// <summary>
+	/// Fetches the recommended Uno.Sdk version from the manifest. Best-effort: returns
+	/// <c>null</c> (never throws) when the manifest is unreachable, times out, or is
+	/// malformed, so an offline environment simply reports "no update info". The request is
+	/// bounded by <paramref name="timeout"/> (default 5s) via a token linked to
+	/// <paramref name="ct"/>, so callers/tests can shorten the wait against a slow endpoint.
+	/// </summary>
+	public static async Task<string?> GetLatestUnoSdkVersionAsync(
+		ILogger? logger = null,
+		CancellationToken ct = default,
+		TimeSpan? timeout = null)
+	{
+		try
+		{
+			using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+			cts.CancelAfter(timeout ?? DefaultTimeout);
+
+			using var response = await _httpClient.GetAsync(ManifestUrl, cts.Token);
+			if (!response.IsSuccessStatusCode)
+			{
+				logger?.LogDebug("Uno.Sdk manifest fetch returned {StatusCode}", (int)response.StatusCode);
+				return null;
+			}
+
+			await using var stream = await response.Content.ReadAsStreamAsync(cts.Token);
+			var payload = await JsonSerializer.DeserializeAsync(stream, SdkManifestJsonContext.Default.SdkManifestPayload, cts.Token);
+			return payload?.Version;
+		}
+		catch (OperationCanceledException)
+		{
+			// Expected when the request times out (CancelAfter) or the caller cancels — log a
+			// plain message without the exception/stack trace to avoid noisy Debug output.
+			logger?.LogDebug("Uno.Sdk version manifest fetch timed out or was cancelled.");
+			return null;
+		}
+		catch (Exception ex)
+		{
+			logger?.LogDebug(ex, "Failed to fetch the Uno.Sdk version manifest.");
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// True when <paramref name="candidate"/> is strictly higher than <paramref name="current"/>,
+	/// compared numerically component-by-component (mirrors the IDE extension's comparison so
+	/// recommendations stay consistent). Any pre-release suffix is ignored.
+	/// </summary>
+	public static bool IsNewer(string? candidate, string? current)
+	{
+		if (string.IsNullOrWhiteSpace(candidate) || string.IsNullOrWhiteSpace(current))
+		{
+			return false;
+		}
+
+		var c = ParseParts(candidate);
+		var i = ParseParts(current);
+		var length = Math.Max(c.Length, i.Length);
+		for (var n = 0; n < length; n++)
+		{
+			var cp = n < c.Length ? c[n] : 0;
+			var ip = n < i.Length ? i[n] : 0;
+			if (cp > ip)
+			{
+				return true;
+			}
+			if (cp < ip)
+			{
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	private static int[] ParseParts(string version)
+	{
+		// Compare only the numeric dotted core (drop any "-prerelease" suffix).
+		var core = version.Split('-', 2)[0];
+		var segments = core.Split('.');
+		var parts = new int[segments.Length];
+		for (var i = 0; i < segments.Length; i++)
+		{
+			parts[i] = int.TryParse(segments[i], out var value) ? value : 0;
+		}
+
+		return parts;
+	}
+}
+
+/// <summary>Shape of the recommended-version manifest: <c>{ "version": "&lt;semver&gt;" }</c>.</summary>
+internal sealed record SdkManifestPayload(
+	[property: JsonPropertyName("version")] string? Version);
+
+[JsonSerializable(typeof(SdkManifestPayload))]
+internal partial class SdkManifestJsonContext : JsonSerializerContext;

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReport.cs
@@ -13,7 +13,10 @@ internal sealed record HealthReport
 	public string? HostEndpoint { get; init; }
 	public bool UpstreamConnected { get; init; }
 	public int ToolCount { get; init; }
+	public string? UnoSdkPackage { get; init; }
 	public string? UnoSdkVersion { get; init; }
+	public string? LatestUnoSdkVersion { get; init; }
+	public bool UnoSdkUpdateAvailable { get; init; }
 	public long DiscoveryDurationMs { get; init; }
 	public ConnectionState? ConnectionState { get; init; }
 	public IReadOnlyList<string>? DiscoveredSolutions { get; init; }
@@ -121,4 +124,5 @@ internal enum IssueCode
 	WorkspaceAmbiguous,
 	WorkspaceNotResolved,
 	HostMcpEndpointNotAvailable,
+	UnoSdkUpdateAvailable,
 }

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthReportFactory.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthReportFactory.cs
@@ -18,7 +18,8 @@ internal static class HealthReportFactory
 		string? upstreamError = null,
 		bool forceRootsFallback = false,
 		bool rootsProvided = false,
-		bool hostRespondedNoMcp = false)
+		bool hostRespondedNoMcp = false,
+		string? latestUnoSdkVersion = null)
 	{
 		var issues = new List<ValidationIssue>();
 
@@ -103,9 +104,29 @@ internal static class HealthReportFactory
 
 		issues.AddRange(DiscoveryIssueMapper.MapDiscoveryIssues(discovery));
 
+		var currentUnoSdkVersion = discovery?.UnoSdkVersion;
+		// The recommended-version manifest is for the public Uno.Sdk. Only compare/advise for
+		// Uno.Sdk workspaces — an Uno.Sdk.Private project must not be told to "update" to a
+		// public version it does not track.
+		var isPublicUnoSdk = string.Equals(discovery?.UnoSdkPackage, "Uno.Sdk", StringComparison.OrdinalIgnoreCase);
+		var recommendedUnoSdkVersion = isPublicUnoSdk ? latestUnoSdkVersion : null;
+		var unoSdkUpdateAvailable = SdkManifest.IsNewer(recommendedUnoSdkVersion, currentUnoSdkVersion);
+		if (unoSdkUpdateAvailable)
+		{
+			issues.Add(new ValidationIssue
+			{
+				Code = IssueCode.UnoSdkUpdateAvailable,
+				Severity = ValidationSeverity.Warning,
+				Message = $"A newer recommended Uno.Sdk is available: {recommendedUnoSdkVersion} (current {currentUnoSdkVersion}).",
+				Remediation = $"Update the \"Uno.Sdk\" version in global.json to {recommendedUnoSdkVersion}, then restart the DevServer.",
+			});
+		}
+
+		// An available SDK update is advisory: it must not, on its own, degrade the health
+		// status of an otherwise-working DevServer, so it is excluded from the Degraded trigger.
 		var status = issues.Any(i => i.Severity == ValidationSeverity.Fatal)
 			? HealthStatus.Unhealthy
-			: issues.Count > 0
+			: issues.Any(i => i.Severity == ValidationSeverity.Warning && i.Code != IssueCode.UnoSdkUpdateAvailable)
 				? HealthStatus.Degraded
 				: HealthStatus.Healthy;
 
@@ -125,7 +146,10 @@ internal static class HealthReportFactory
 			HostEndpoint = hostEndpoint,
 			UpstreamConnected = upstreamConnected,
 			ToolCount = toolCount,
-			UnoSdkVersion = discovery?.UnoSdkVersion,
+			UnoSdkPackage = discovery?.UnoSdkPackage,
+			UnoSdkVersion = currentUnoSdkVersion,
+			LatestUnoSdkVersion = recommendedUnoSdkVersion,
+			UnoSdkUpdateAvailable = unoSdkUpdateAvailable,
 			DiscoveryDurationMs = discovery?.DiscoveryDurationMs ?? 0,
 			ConnectionState = connectionState,
 			DiscoveredSolutions = discoveredSolutions,

--- a/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
+++ b/src/Uno.UI.DevServer.Cli/Mcp/HealthService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using Uno.UI.DevServer.Cli.Helpers;
 
@@ -14,7 +15,9 @@ namespace Uno.UI.DevServer.Cli.Mcp;
 internal class HealthService(
 	McpUpstreamClient mcpUpstreamClient,
 	DevServerMonitor devServerMonitor,
-	ToolListManager toolListManager)
+	ToolListManager toolListManager,
+	ILogger<HealthService> logger,
+	Func<CancellationToken, Task<string?>>? latestUnoSdkVersionProvider = null)
 {
 	internal bool ForceRootsFallback { get; set; }
 	internal bool RootsProvided { get; set; }
@@ -36,6 +39,15 @@ internal class HealthService(
 
 	public WorkspaceSelectionSnapshot? CurrentSelection { get; set; }
 
+	// Recommended Uno.Sdk version fetch, kicked off exactly once (Lazy + ExecutionAndPublication)
+	// so concurrent health calls never start duplicate fetches and never block. Best-effort: the
+	// fetch has its own short internal timeout, so no lifecycle token is plumbed here — it is a
+	// one-shot, self-bounding HTTP call. Health calls read the result only once it has completed.
+	// The provider is injectable so tests can supply a version without real network I/O.
+	private readonly Lazy<Task<string?>> _latestUnoSdkVersion = new(
+		() => (latestUnoSdkVersionProvider ?? (ct => SdkManifest.GetLatestUnoSdkVersionAsync(logger, ct)))(CancellationToken.None),
+		LazyThreadSafetyMode.ExecutionAndPublication);
+
 	public CallToolResult BuildHealthToolResponse()
 	{
 		var report = BuildHealthReport();
@@ -48,6 +60,9 @@ internal class HealthService(
 
 	public HealthReport BuildHealthReport()
 	{
+		var latestFetch = _latestUnoSdkVersion.Value;
+		var latestUnoSdkVersion = latestFetch.IsCompletedSuccessfully ? latestFetch.Result : null;
+
 		var upstreamTask = mcpUpstreamClient.UpstreamClient;
 		var upstreamConnected = upstreamTask.IsCompletedSuccessfully;
 
@@ -75,6 +90,7 @@ internal class HealthService(
 				: null,
 			forceRootsFallback: ForceRootsFallback,
 			rootsProvided: RootsProvided,
-			hostRespondedNoMcp: devServerMonitor.HostRespondedNoMcp);
+			hostRespondedNoMcp: devServerMonitor.HostRespondedNoMcp,
+			latestUnoSdkVersion: latestUnoSdkVersion);
 	}
 }

--- a/src/Uno.UI.DevServer.Cli/health-diagnostics.md
+++ b/src/Uno.UI.DevServer.Cli/health-diagnostics.md
@@ -71,6 +71,9 @@ These are added directly by `HealthService.BuildHealthReport()`:
 | `HostUnreachable` | Warning | Started but not yet connected |
 | `HostMcpEndpointNotAvailable` | Fatal | Host responds to HTTP but `/mcp` returns 404/400 — the host version predates MCP support (requires 6.6 or later). The MCP bridge cannot function without this endpoint. Remediation: upgrade the Uno.WinUI.DevServer package. |
 | `UpstreamError` | Fatal | Upstream task faulted |
+| `UnoSdkUpdateAvailable` | Warning | Pinned `Uno.Sdk` is behind the recommended version from the manifest (public `Uno.Sdk` only; skipped for `Uno.Sdk.Private`). **Non-degrading** (advisory only). |
+
+> Note: `UnoSdkUpdateAvailable` is produced by `HealthReportFactory.Create(...)` — shared by both the MCP `uno_health` tool and the one-shot `uno.devserver health` command — rather than by `HealthService.BuildHealthReport()` directly.
 
 ## Non-Mapped `IssueCode` Values
 
@@ -120,13 +123,13 @@ The CLI also forwards the Host subprocess stdout/stderr at Debug level on succes
 ## Health Status
 
 ```
-Fatal issue present --> Unhealthy
-Warning(s) only     --> Degraded
-No issues           --> Healthy
+Fatal issue present                                  --> Unhealthy
+Warning(s) present (excluding UnoSdkUpdateAvailable) --> Degraded
+Advisory-only (UnoSdkUpdateAvailable) or no issues   --> Healthy
 ```
 
 ## Adding New IssueCode Values
 
 1. Add the new value to the `IssueCode` enum in `Mcp/HealthReport.cs`
-2. Add mapping logic in `DiscoveryIssueMapper.cs` (if discovery-related) or `HealthService.BuildHealthReport()` (if runtime-related)
-3. Add test in `Given_DiscoveryIssueMapper.cs` verifying the trigger condition and severity
+2. Add mapping logic in `DiscoveryIssueMapper.cs` (if discovery-related), `HealthService.BuildHealthReport()` (if MCP-path-only runtime), or `HealthReportFactory.Create()` (if it must appear on both the MCP and CLI one-shot paths, e.g. `UnoSdkUpdateAvailable`)
+3. Add a test verifying the trigger condition and severity — in `Given_DiscoveryIssueMapper.cs` (discovery-related) or `Given_HealthReportFactory_SdkUpdate.cs` (runtime-related)

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/Given_SdkManifest.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Helpers/Given_SdkManifest.cs
@@ -1,0 +1,37 @@
+using AwesomeAssertions;
+using Uno.UI.DevServer.Cli.Helpers;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Helpers;
+
+[TestClass]
+public class Given_SdkManifest
+{
+	[TestMethod]
+	[DataRow("6.6.29", "6.5.31", true)]   // higher patch line
+	[DataRow("6.5.31", "6.4.12", true)]   // higher minor
+	[DataRow("7.0.0", "6.9.9", true)]     // higher major
+	[DataRow("6.5.31", "6.5.31", false)]  // equal
+	[DataRow("6.5.31", "6.6.29", false)]  // candidate older
+	[DataRow("6.5.3", "6.5.31", false)]   // 3 < 31 numerically, not lexically
+	[DataRow("6.6", "6.6.0", false)]      // missing trailing segment treated as zero
+	[DataRow("6.6.0.1", "6.6.0", true)]   // extra trailing segment is newer
+	[DataRow("6.10.0", "6.9.99", true)]   // numeric compare per segment (10 > 9)
+	public void WhenComparingVersions_IsNewerFollowsNumericOrder(string candidate, string current, bool expected)
+		=> SdkManifest.IsNewer(candidate, current).Should().Be(expected);
+
+	[TestMethod]
+	public void WhenPrereleaseSuffixPresent_ComparesNumericCoreOnly()
+	{
+		// The "-dev.N" suffix is ignored: same numeric core is not "newer".
+		SdkManifest.IsNewer("6.6.29-dev.5", "6.6.29").Should().BeFalse();
+		SdkManifest.IsNewer("6.7.0-dev.1", "6.6.29").Should().BeTrue();
+	}
+
+	[TestMethod]
+	[DataRow(null, "6.5.31")]
+	[DataRow("6.5.31", null)]
+	[DataRow("", "6.5.31")]
+	[DataRow("   ", "6.5.31")]
+	public void WhenEitherVersionMissing_ReturnsFalse(string? candidate, string? current)
+		=> SdkManifest.IsNewer(candidate, current).Should().BeFalse();
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_HealthReportFactory_SdkUpdate.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_HealthReportFactory_SdkUpdate.cs
@@ -1,0 +1,147 @@
+using System.Linq;
+using AwesomeAssertions;
+using Uno.UI.DevServer.Cli.Helpers;
+using Uno.UI.DevServer.Cli.Mcp;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.Mcp;
+
+[TestClass]
+public class Given_HealthReportFactory_SdkUpdate
+{
+	// A discovery that maps to zero issues, so the only issue in the resulting report
+	// can be the SDK-update advisory — used to prove the advisory alone does not
+	// degrade the health status.
+	private static DiscoveryInfo CleanDiscovery(string unoSdkVersion, string unoSdkPackage = "Uno.Sdk") => new()
+	{
+		ResolutionKind = WorkspaceResolutionKind.CurrentDirectory,
+		GlobalJsonPath = "global.json",
+		UnoSdkPackage = unoSdkPackage,
+		UnoSdkVersion = unoSdkVersion,
+		UnoSdkPath = @"C:\cache\uno.sdk\" + unoSdkVersion,
+		PackagesJsonPath = @"C:\cache\uno.sdk\packages.json",
+		DotNetVersion = "9.0.100",
+	};
+
+	private static HealthReport CreateWithLatest(string currentSdk, string? latestSdk)
+		=> HealthReportFactory.Create(
+			CleanDiscovery(currentSdk),
+			devServerStarted: true,
+			upstreamConnected: true,
+			toolCount: 5,
+			connectionState: ConnectionState.Connected,
+			discoveredSolutions: null,
+			latestUnoSdkVersion: latestSdk);
+
+	[TestMethod]
+	public void WhenLatestIsNewer_ReportsUpdateAvailableWithAdvisory()
+	{
+		var report = CreateWithLatest("6.4.12", "6.5.31");
+
+		report.UnoSdkUpdateAvailable.Should().BeTrue();
+		report.LatestUnoSdkVersion.Should().Be("6.5.31");
+		report.UnoSdkVersion.Should().Be("6.4.12");
+
+		var advisory = report.Issues.Single(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+		advisory.Severity.Should().Be(ValidationSeverity.Warning);
+		advisory.Message.Should().Contain("6.5.31");
+		advisory.Remediation.Should().Contain("global.json");
+	}
+
+	[TestMethod]
+	public void WhenUpdateIsTheOnlyIssue_StatusStaysHealthy()
+	{
+		var report = CreateWithLatest("6.4.12", "6.5.31");
+
+		report.Issues.Should().ContainSingle(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+		report.Status.Should().Be(HealthStatus.Healthy);
+	}
+
+	[TestMethod]
+	[DataRow("6.5.31")]  // equal to recommended
+	[DataRow("6.6.29")]  // ahead of recommended
+	public void WhenCurrentIsUpToDateOrAhead_NoUpdateAdvisory(string current)
+	{
+		var report = CreateWithLatest(current, "6.5.31");
+
+		report.UnoSdkUpdateAvailable.Should().BeFalse();
+		report.Issues.Should().NotContain(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+	}
+
+	[TestMethod]
+	public void WhenPackageIsUnoSdkPrivate_NoUpdateAdvisory()
+	{
+		// The recommended-version manifest is for the public Uno.Sdk; a Uno.Sdk.Private
+		// workspace behind that version must not be told to "update" to it.
+		var report = HealthReportFactory.Create(
+			CleanDiscovery("6.4.12", unoSdkPackage: "Uno.Sdk.Private"),
+			devServerStarted: true,
+			upstreamConnected: true,
+			toolCount: 5,
+			connectionState: ConnectionState.Connected,
+			discoveredSolutions: null,
+			latestUnoSdkVersion: "6.5.31");
+
+		report.UnoSdkUpdateAvailable.Should().BeFalse();
+		report.LatestUnoSdkVersion.Should().BeNull();
+		report.Issues.Should().NotContain(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+	}
+
+	[TestMethod]
+	public void WhenFatalIssueAndUpdateAvailable_StatusUnhealthyAndAdvisoryStillPresent()
+	{
+		// devServerStarted:false → HostNotStarted (Fatal). The advisory is still reported,
+		// but Fatal dominates the overall status.
+		var report = HealthReportFactory.Create(
+			CleanDiscovery("6.4.12"),
+			devServerStarted: false,
+			upstreamConnected: false,
+			toolCount: 0,
+			connectionState: null,
+			discoveredSolutions: null,
+			latestUnoSdkVersion: "6.5.31");
+
+		report.Status.Should().Be(HealthStatus.Unhealthy);
+		report.Issues.Should().Contain(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+	}
+
+	[TestMethod]
+	public void WhenRealWarningAndUpdateAvailable_StatusDegraded()
+	{
+		// A genuine (non-advisory) Warning must still degrade status even when the advisory
+		// is also present — the exclusion is surgical to UnoSdkUpdateAvailable only. Null
+		// PackagesJsonPath yields a PackagesJsonNotFound Warning.
+		var discovery = new DiscoveryInfo
+		{
+			ResolutionKind = WorkspaceResolutionKind.CurrentDirectory,
+			GlobalJsonPath = "global.json",
+			UnoSdkPackage = "Uno.Sdk",
+			UnoSdkVersion = "6.4.12",
+			UnoSdkPath = @"C:\cache\uno.sdk\6.4.12",
+			PackagesJsonPath = null,
+			DotNetVersion = "9.0.100",
+		};
+
+		var report = HealthReportFactory.Create(
+			discovery,
+			devServerStarted: true,
+			upstreamConnected: true,
+			toolCount: 5,
+			connectionState: ConnectionState.Connected,
+			discoveredSolutions: null,
+			latestUnoSdkVersion: "6.5.31");
+
+		report.Status.Should().Be(HealthStatus.Degraded);
+		report.Issues.Should().Contain(i => i.Code == IssueCode.PackagesJsonNotFound);
+		report.Issues.Should().Contain(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+	}
+
+	[TestMethod]
+	public void WhenManifestUnavailable_NoUpdateAdvisory()
+	{
+		var report = CreateWithLatest("6.4.12", latestSdk: null);
+
+		report.UnoSdkUpdateAvailable.Should().BeFalse();
+		report.LatestUnoSdkVersion.Should().BeNull();
+		report.Issues.Should().NotContain(i => i.Code == IssueCode.UnoSdkUpdateAvailable);
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_HealthReportFormatter.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Mcp/Given_HealthReportFormatter.cs
@@ -58,6 +58,81 @@ public class Given_HealthReportFormatter
 	}
 
 	[TestMethod]
+	public void WhenJsonRequested_IncludesSdkUpdateFields()
+	{
+		var report = new HealthReport
+		{
+			Status = HealthStatus.Healthy,
+			UnoSdkPackage = "Uno.Sdk",
+			UnoSdkVersion = "6.4.12",
+			LatestUnoSdkVersion = "6.5.31",
+			UnoSdkUpdateAvailable = true,
+			Issues = [],
+		};
+
+		var json = HealthReportFormatter.FormatJson(report);
+
+		json.Should().Contain("\"unoSdkPackage\":\"Uno.Sdk\"");
+		json.Should().Contain("\"unoSdkVersion\":\"6.4.12\"");
+		json.Should().Contain("\"latestUnoSdkVersion\":\"6.5.31\"");
+		json.Should().Contain("\"unoSdkUpdateAvailable\":true");
+	}
+
+	[TestMethod]
+	public void WhenUpdateAvailable_IncludesRecommendedVersionWithSuffix()
+	{
+		var report = new HealthReport
+		{
+			Status = HealthStatus.Healthy,
+			UnoSdkPackage = "Uno.Sdk",
+			UnoSdkVersion = "6.4.12",
+			LatestUnoSdkVersion = "6.5.31",
+			UnoSdkUpdateAvailable = true,
+			Issues = [],
+		};
+
+		var text = HealthReportFormatter.FormatPlainText(report);
+
+		text.Should().Contain("Uno.Sdk: 6.4.12");
+		text.Should().Contain("Recommended Uno.Sdk: 6.5.31 (update available)");
+	}
+
+	[TestMethod]
+	public void WhenUpToDate_OmitsUpdateSuffix()
+	{
+		var report = new HealthReport
+		{
+			Status = HealthStatus.Healthy,
+			UnoSdkPackage = "Uno.Sdk",
+			UnoSdkVersion = "6.5.31",
+			LatestUnoSdkVersion = "6.5.31",
+			UnoSdkUpdateAvailable = false,
+			Issues = [],
+		};
+
+		var text = HealthReportFormatter.FormatPlainText(report);
+
+		text.Should().Contain("Recommended Uno.Sdk: 6.5.31");
+		text.Should().NotContain("(update available)");
+	}
+
+	[TestMethod]
+	public void WhenPackageIsUnoSdkPrivate_LabelUsesActualPackageId()
+	{
+		var report = new HealthReport
+		{
+			Status = HealthStatus.Healthy,
+			UnoSdkPackage = "Uno.Sdk.Private",
+			UnoSdkVersion = "6.4.12",
+			Issues = [],
+		};
+
+		var text = HealthReportFormatter.FormatPlainText(report);
+
+		text.Should().Contain("Uno.Sdk.Private: 6.4.12");
+	}
+
+	[TestMethod]
 	public void WhenPlainTextRequested_IncludesActiveServerOwnershipDetails()
 	{
 		var report = new HealthReport

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -74,6 +74,7 @@
 		<Compile Include="..\Uno.UI.DevServer.Cli\Mcp\DiscoveryIssueMapper.cs" Link="Mcp\DiscoveryIssueMapper.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Mcp\HealthReport.cs" Link="Mcp\HealthReport.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Mcp\HealthReportFactory.cs" Link="Mcp\HealthReportFactory.cs" />
+		<Compile Include="..\Uno.UI.DevServer.Cli\Helpers\SdkManifest.cs" Link="Helpers\SdkManifest.cs" />
 		<Compile Include="..\Uno.UI.DevServer.Cli\Mcp\McpJsonUtilities.cs" Link="Mcp\McpJsonUtilities.cs" />
 
 		<!-- Link host-side assembly resolution helper for unit testing -->


### PR DESCRIPTION
**GitHub Issue:** Related to internal trackers [unoplatform/studio.live#3074](https://github.com/unoplatform/studio.live/issues/3074) and [unoplatform/uno-private#2263](https://github.com/unoplatform/uno-private/issues/2263) (Tier 2 — surface actionable state in `uno_health`).

## PR Type:

✨ Feature

## What changed? 🚀

> **Draft / POC for review.**

Surfaces an **"Uno.Sdk update available"** signal through the DevServer — mirroring what the IDE extensions do — so agent/CLI users (who have no extension) learn when their project is on an outdated SDK and how to update.

- New `SdkManifest` helper reads the **same curated manifest the IDE extensions use** (`aka.platform.uno/uno-sdk-manifest`, from `unoplatform/uno-assets`) and compares it against the project's pinned `Uno.Sdk` (numeric, per-segment; pre-release suffix ignored). Same source ⇒ consistent recommendations — deliberately **not** raw NuGet "latest". Uses source-generated JSON; each fetch is bounded by a per-request linked `CancellationTokenSource` (configurable timeout).
- `uno_health` (MCP tool) **and** `uno.devserver health` now report `unoSdkPackage` / `unoSdkVersion` / `latestUnoSdkVersion` / `unoSdkUpdateAvailable`, plus an **actionable Warning advisory** (with remediation) when an update exists.
- **Public `Uno.Sdk` only:** an `Uno.Sdk.Private` workspace is never compared/advised against the public manifest; the health label uses the discovered package id rather than a hardcoded "Uno.Sdk".
- The advisory is **non-degrading**: it never moves an otherwise-healthy server to `Degraded` (a real `Warning`/`Fatal` alongside it still degrades/fails as usual).
- Manifest fetched **non-blocking** on the MCP path (`Lazy<Task>`, exactly-once) with the injected `ILogger` threaded through for traceability; inline on the one-shot command. Offline → `null` → simply no advisory (never throws).

Spec: `specs/052-mcp-sdk-update-detection/spec.md`. Diagnostics doc updated: `src/Uno.UI.DevServer.Cli/health-diagnostics.md`.

### Validation

- **Compile** — `Uno.UI.DevServer.Cli` builds clean (0 warnings / 0 errors).
- **Tests** — all green locally (`dotnet test … --filter …`):
  - `Given_SdkManifest`, `Given_HealthReportFactory_SdkUpdate`, `Given_HealthReportFormatter` (incl. up-to-date/ahead, `Uno.Sdk.Private`, manifest-unavailable, Fatal+advisory→Unhealthy, real-Warning+advisory→Degraded, JSON fields).
  - Existing `HealthService`/`McpStdioServer`/`ProxyLifecycleManager` tests still pass after the new ctor parameter.
- **Runtime** — modified `uno.devserver health`:
  - project pinned `6.4.12` → `Recommended Uno.Sdk: 6.5.31 (update available)` + advisory; JSON `unoSdkUpdateAvailable: true`.
  - project at/ahead (`6.5.31` / `6.6.29`) → no advisory, status unaffected.

### Follow-ups (out of scope here)

- `uno_update_sdk` action tool that rewrites `global.json` (the extension's "Update" button).
- Uno Studio app banner (reuses the same manifest) — tracked separately for the Studio app.
- Per-version "ignore" preferences (as the extensions persist).

## PR Checklist ✅

- [x] 🧪 Added unit tests (SdkManifest / factory / formatter) — all passing locally
- [x] 📚 Docs — spec added; `health-diagnostics.md` updated for the new issue code + status semantics
- [x] 🖼️ N/A — no UI surface
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests
