### PR TITLE
chore: Update selected package versions in packages.json to match latest stable versions after 6.6 Release

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.0-dev.56" />
+		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -94,7 +94,7 @@
 	},
 	{
 		"group": "hotdesign",
-		"version": "1.18.66",
+		"version": "1.19.175",
 		"packages": [
 			"Uno.UI.HotDesign"
 		]
@@ -128,7 +128,7 @@
 	},
 	{
 		"group": "WinAppSdkBuildTools",
-		"version": "10.0.28000.1721",
+		"version": "10.0.28000.2270",
 		"packages": [
 			"Microsoft.Windows.SDK.BuildTools"
 		]
@@ -142,27 +142,27 @@
 	},
 	{
 		"group": "MicrosoftLoggingConsole",
-		"version": "9.0.14",
+		"version": "9.0.18",
 		"packages": [
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.5"
+			"net10.0": "10.0.10"
 		}
 	},
 	{
 		"group": "WindowsCompatibility",
-		"version": "9.0.14",
+		"version": "9.0.18",
 		"packages": [
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.5"
+			"net10.0": "10.0.10"
 		}
 	},
 	{
 		"group": "MsalClient",
-		"version": "4.83.1",
+		"version": "4.83.3",
 		"packages": [
 			"Microsoft.Identity.Client",
 			"Microsoft.Identity.Client.Extensions.Msal"
@@ -170,7 +170,7 @@
 	},
 	{
 		"group": "Mvvm",
-		"version": "8.4.0",
+		"version": "8.4.2",
 		"packages": [
 			"CommunityToolkit.Mvvm"
 		]
@@ -346,12 +346,12 @@
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.50"
+			"net10.0": "10.0.60"
 		}
 	},
 	{
 		"group": "CSharpMarkup",
-		"version": "6.6.0-dev.5",
+		"version": "6.6.27",
 		"packages": [
 			"Uno.WinUI.Markup",
 			"Uno.Extensions.Markup.Generators"
@@ -359,7 +359,7 @@
 	},
 	{
 		"group": "Extensions",
-		"version": "7.2.0-dev.44",
+		"version": "7.2.3",
 		"packages": [
 			"Uno.Extensions.Authentication.WinUI",
 			"Uno.Extensions.Authentication.MSAL.WinUI",
@@ -421,7 +421,7 @@
 	},
 	{
 		"group": "MicrosoftWebView2",
-		"version": "1.0.3856.49",
+		"version": "1.0.4078.44",
 		"packages": [
 			"Microsoft.Web.WebView2"
 		]

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
 		<PackageReference Include="StreamJsonRpc" Version="2.17.11" />
 		<PackageReference Include="ModelContextProtocol" Version="1.1.0" />
-		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.0-dev.56">
+		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.3">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
 		<PackageReference Include="StreamJsonRpc" Version="2.14.24" />
 		<PackageReference Include="MessagePack" Version="3.1.7" />
-		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.0-dev.56" />
+		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.3" />
 		<PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
 
 		<!-- StreamJsonRpc 2.14.24 brings in Microsoft.VisualStudio.Threading (and in turn -->

--- a/src/Uno.UI.RemoteControl.Server/Uno.UI.RemoteControl.Server.csproj
+++ b/src/Uno.UI.RemoteControl.Server/Uno.UI.RemoteControl.Server.csproj
@@ -10,7 +10,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.0-dev.56" />
+		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.3.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />


### PR DESCRIPTION
Related item: https://github.com/unoplatform/private/issues/1082
(Other versions untouched are already using an above dev version that the current latest [6.6 release-related packages](https://github.com/unoplatform/private/issues/1076))

## Add-in version alignment follow-up

Bumping `Uno.UI.HotDesign` to `1.19.175` tripped the **Add-in Version Alignment** CI stage (`AddInLoadGraphMustResolveAgainstHostTpaWithoutDowngrade`): the newer Hot Design add-in depends on / bundles `Uno.DevTools.Telemetry` **1.3.3.0**, while the DevServer host still referenced **1.3.0-dev.56** (assembly `1.3.0.0`). That drift is a latent runtime-blocking conflict — the add-in's bundled copy would load into the Default ALC alongside the host's, leaving two versions of the same assembly coexisting.

Fix: aligned the host's telemetry reference to the matching stable **1.3.3** across the DevServer host projects:

- `src/Uno.UI.RemoteControl.Server/Uno.UI.RemoteControl.Server.csproj`
- `src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj`
- `src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj`
- `src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj`

Validated locally — the alignment test now passes (`total: 1, succeeded: 1`).
