### PR TITLE
fix(x11): Stable pointer ids under a WM + DisplayInformation init race

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
@@ -309,7 +309,10 @@ internal partial class X11PointerInputSource
 
 		var timeInMicroseconds = (ulong)(data.time * 1000); // Time is given in milliseconds since system boot. See also: https://github.com/unoplatform/uno/issues/14535
 		var deviceType = data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? PointerDeviceType.Touch : PointerDeviceType.Mouse;
-		var pointerId = (uint)(data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? data.detail : data.sourceid); // for touch, data.detail is the touch ID
+		// For touch, data.detail is the touch ID. For mouse, we use the master device id (not sourceid):
+		// WM-generated crossing events (map-under-pointer, grab activation) carry sourceid = master while
+		// regular events carry sourceid = slave, so keying on sourceid splits one cursor into two pointer ids.
+		var pointerId = (uint)(data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? data.detail : data.deviceid);
 		var point = new PointerPoint(
 			frameId: (uint)data.time, // UNO TODO: How should we set the frame, timestamp may overflow.
 			timestamp: timeInMicroseconds,
@@ -361,7 +364,7 @@ internal partial class X11PointerInputSource
 			frameId: (uint)data.time, // UNO TODO: How should we set the frame, timestamp may overflow.
 			timestamp: timestampInMicroseconds,
 			PointerDevice.For(PointerDeviceType.Mouse),
-			(uint)data.sourceid,
+			(uint)data.deviceid, // master device id, must match the id used for button/motion events
 			new Point(data.event_x / scale, data.event_y / scale),
 			new Point(data.event_x / scale, data.event_y / scale),
 			properties.HasPressedButton,

--- a/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11PointerInputSource.XInput.cs
@@ -309,9 +309,12 @@ internal partial class X11PointerInputSource
 
 		var timeInMicroseconds = (ulong)(data.time * 1000); // Time is given in milliseconds since system boot. See also: https://github.com/unoplatform/uno/issues/14535
 		var deviceType = data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? PointerDeviceType.Touch : PointerDeviceType.Mouse;
-		// For touch, data.detail is the touch ID. For mouse, we use the master device id (not sourceid):
-		// WM-generated crossing events (map-under-pointer, grab activation) carry sourceid = master while
-		// regular events carry sourceid = slave, so keying on sourceid splits one cursor into two pointer ids.
+		// For touch, data.detail is the touch ID. For mouse, we use data.deviceid: we only process the
+		// master-delivered copies of device events (cf. the deviceid == sourceid filtering in HandleXI2Event),
+		// so deviceid here is always the master pointer, giving one stable id per cursor. sourceid (the
+		// originating slave) is not stable: WM-generated crossing events (map-under-pointer, grab
+		// activation/deactivation) carry sourceid = the master itself while regular events carry
+		// sourceid = the slave, which would split one cursor into two pointer ids.
 		var pointerId = (uint)(data.evtype is XiEventType.XI_TouchBegin or XiEventType.XI_TouchEnd or XiEventType.XI_TouchUpdate ? data.detail : data.deviceid);
 		var point = new PointerPoint(
 			frameId: (uint)data.time, // UNO TODO: How should we set the frame, timestamp may overflow.
@@ -363,7 +366,7 @@ internal partial class X11PointerInputSource
 		var point = new PointerPoint(
 			frameId: (uint)data.time, // UNO TODO: How should we set the frame, timestamp may overflow.
 			timestamp: timestampInMicroseconds,
-			PointerDevice.For(PointerDeviceType.Mouse),
+			PointerDevice.For(pointerType),
 			(uint)data.deviceid, // master device id, must match the id used for button/motion events
 			new Point(data.event_x / scale, data.event_y / scale),
 			new Point(data.event_x / scale, data.event_y / scale),

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -125,11 +125,15 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		_windowToHost[winUIWindow] = this;
 		XamlRootMap.Register(xamlRoot, this);
 
+		// The frame pacer must exist before UpdateWindowPropertiesFromPackage: reading the DPI
+		// creates the DisplayInformation extension, whose UpdateDetails reports the screen
+		// refresh rate through UpdateRenderTimerFps.
+		_framePacer = CreateFramePacer();
+
 		UpdateWindowPropertiesFromPackage();
 
 		// only start listening to events after we're done setting everything up
 		InitializeX11EventsThread();
-		_framePacer = CreateFramePacer();
 		_renderThread = InitRenderThread();
 
 		var windowBackgroundDisposable = _window.RegisterBackgroundChangedEvent((_, _) => UpdateRendererBackground());
@@ -180,7 +184,11 @@ internal partial class X11XamlRootHost : IXamlRootHost
 
 	private void UpdateWindowPropertiesFromPackage()
 	{
-		Task.Run(SetWindowIcon);
+		// Icon path resolution must stay on the UI thread: BitmapImage.GetScaledPath reads
+		// DisplayInformation, and creating it from another thread races the one created for
+		// the window (X11DisplayInformationExtension would then be "set twice"). Only the
+		// decoding and the X11 calls are offloaded, inside SetWindowIcon.
+		SetWindowIcon();
 
 		if (!string.IsNullOrEmpty(Windows.ApplicationModel.Package.Current.DisplayName))
 		{
@@ -212,7 +220,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 					this.Log().Info($"Loading icon file [{iconPath}] from Package.appxmanifest file");
 				}
 
-				SetIconFromFile(iconPath);
+				BeginSetIconFromFile(iconPath);
 			}
 			else if (Microsoft.UI.Xaml.Media.Imaging.BitmapImage.GetScaledPath(basePath) is { } scaledPath && File.Exists(scaledPath))
 			{
@@ -221,7 +229,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 					this.Log().Info($"Loading icon file [{scaledPath}] scaled logo from Package.appxmanifest file");
 				}
 
-				SetIconFromFile(scaledPath);
+				BeginSetIconFromFile(scaledPath);
 			}
 			else
 			{
@@ -231,6 +239,21 @@ internal partial class X11XamlRootHost : IXamlRootHost
 				}
 			}
 		}
+
+		void BeginSetIconFromFile(string path) => Task.Run(() =>
+		{
+			try
+			{
+				SetIconFromFile(path);
+			}
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().Error($"Failed to set the window icon from [{path}].", e);
+				}
+			}
+		});
 
 		unsafe void SetIconFromFile(string iconPath)
 		{


### PR DESCRIPTION
**GitHub Issue:** #23159 (fixes the "can't click anything in the left-hand tree" regression; the WebView rendering problems tracked in that issue are separate and remain open)

## PR Type:

🐞 Bugfix

## What changed? 🚀

**1. NavigationView items didn't expand/navigate on click on Linux under a window manager (`fix(x11): Use master device id for mouse pointer id`)**

The X11 host derived `PointerId` from the XI2 `sourceid`. Under a WM (reproduced with mutter; does not reproduce on bare Xvfb), crossing events generated by the WM — map-under-pointer `XI_Enter`, grab activation/deactivation `XI_Leave`/`XI_Enter` — arrive with `sourceid` = the **master** pointer, while button/motion events carry `sourceid` = the slave device. One physical cursor therefore produced two different pointer ids.

`NavigationViewItem` tracks a single pointer id (`m_trackedPointerId`, ported WinUI logic) and early-returns on id mismatch in every handler — including `PointerExited`, the only place the tracked id is reset. Once an item saw a master-sourced crossing, it ignored every subsequent real pointer event, permanently. Controls without per-pointer-id tracking (`ButtonBase`: chevron, `CheckBox`, `ToggleSwitch`) kept working, as did keyboard invoke, which is why this presented as "NavigationView expansion is broken" (Uno.Gallery left nav, SamplesApp `NavigationView_Pane_Automated`).

Fix: derive the mouse pointer id from `deviceid` (the master device — the X11 "one cursor" concept, matching the master-delivered event copies the handler already keeps). Touch ids are unchanged (`detail`).

Instrumented capture of a poisoned click (Uno.Gallery `6.7.0-dev.815` artifact under Xvfb + mutter), before the fix:

```
XI_Enter  dev=2 src=2                       ← WM crossing at map, phantom pointer 2
'Theming' IgnorePointerId: tracking pointer 2
XI_ButtonPress dev=2 src=4                  ← real click is pointer 4
'Theming' PRESS id=4 → IGNORING pointer 4   (tracked=2)
'Theming' RELEASE id=4 → IGNORING pointer 4 → invoke never fires
```

After the fix, the same scenario invokes and expands correctly (validated at runtime by swapping the rebuilt assemblies into the same Gallery artifact under the same Xvfb + mutter setup).

**2. Startup crash `X11DisplayInformationExtension is set twice` (`fix(x11): Keep DisplayInformation init off the thread pool`)**

`SetWindowIcon` ran inside `Task.Run` and resolved the scaled icon path via `BitmapImage.GetScaledPath`, which reads `DisplayInformation`. On cold starts the task could win the race against the rest of the `X11XamlRootHost` constructor:

1. `GetForCurrentView()` created the window's `DisplayInformation`; its `X11DisplayInformationExtension` registered itself on the host, then `UpdateDetails()` reported the XRandR refresh rate via `UpdateRenderTimerFps`, which dereferenced the not-yet-assigned `_framePacer` → `NullReferenceException`.
2. The NRE unwound through the `DisplayInformation` constructor, so `GetOrCreateForWindowId` never cached the instance — but the host kept the half-initialized extension. `Task.Run` swallowed the exception, so nothing was logged.
3. The subsequent legitimate `DisplayInformation` creation from `X11WindowWrapper..ctor` then hit `InvalidOperationException: X11DisplayInformationExtension is set twice` → unhandled → app aborts at startup.

Fix: resolve the icon path on the UI thread (only the PNG decode and the `_NET_WM_ICON` X11 calls — which take `XLock` — are offloaded, and their failures are now logged instead of swallowed), and create the frame pacer before `UpdateWindowPropertiesFromPackage()` so reporting the refresh rate during DPI initialization can't NRE.

Validation: making the call synchronous surfaced the previously-swallowed NRE deterministically at the exact call site; with the frame-pacer reorder the app starts cleanly, the extension is created once on the UI thread, and window-icon behavior is unchanged.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not practical to automate: both bugs require a real window manager delivering grab/crossing events (reproduced with `Xvfb` + `mutter --x11`); bare Xvfb (as used by CI) does not reproduce. Manual repro steps documented above.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
