### PR TITLE
fix(hr): reject UpdateFile requests issued before the first hot-reload status

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/Given_ClientUpdateFileGate.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/Given_ClientUpdateFileGate.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RemoteControl.HotReload;
+using Uno.UI.RemoteControl.HotReload.Messages;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests.HotReload;
+
+/// <summary>
+/// Unit tests for the <see cref="ClientHotReloadProcessor.TryUpdateFilesAsync"/> initialization
+/// gate: a request issued before the first hot-reload status notification must fail with a
+/// typed error in the result instead of throwing (startup timing window).
+/// </summary>
+[TestClass]
+public class Given_ClientUpdateFileGate
+{
+	[TestMethod]
+	[DataRow(false, DisplayName = "write/persist-only request (WaitForHotReload = false)")]
+	[DataRow(true, DisplayName = "hot-reload request (WaitForHotReload = true)")]
+	public async Task When_UpdateFileBeforeFirstStatus_Then_FailsWithTypedError(bool waitForHotReload)
+	{
+		// A processor that never received any status notification from the engine.
+		var sut = new ClientHotReloadProcessor(new NoOpRemoteControlClient());
+		var req = new ClientHotReloadProcessor.UpdateRequest("some/File.xaml", OldText: null, NewText: "<Page />", WaitForHotReload: waitForHotReload);
+
+		var result = await sut.TryUpdateFilesAsync(req, CancellationToken.None);
+
+		result.Error.Should().BeOfType<InvalidOperationException>(
+			because: "the gate must reject un-trackable requests with an actionable error, not an NRE");
+	}
+
+	private sealed class NoOpRemoteControlClient : IRemoteControlClient
+	{
+		public Type AppType => typeof(Given_ClientUpdateFileGate);
+
+		// Never reached: the initialization gate returns before any server exchange.
+		public Task SendMessage(IMessage message) => Task.CompletedTask;
+	}
+}

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/Given_ClientUpdateFileGate.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/HotReload/Given_ClientUpdateFileGate.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -11,31 +13,97 @@ namespace Uno.UI.RemoteControl.DevServer.Tests.HotReload;
 /// <summary>
 /// Unit tests for the <see cref="ClientHotReloadProcessor.TryUpdateFilesAsync"/> initialization
 /// gate: a request issued before the first hot-reload status notification must fail with a
-/// typed error in the result instead of throwing (startup timing window).
+/// typed error in the result instead of throwing (startup timing window), while requests issued
+/// after a status — including a Disabled one — must still reach the server.
 /// </summary>
 [TestClass]
 public class Given_ClientUpdateFileGate
 {
 	[TestMethod]
+	[Description(
+		"Requests issued before the first hot-reload status must fail with a typed, actionable error "
+		+ "(HotReloadNotInitializedException) instead of an NRE, without any server exchange — for both "
+		+ "persist-only and hot-reload requests.")]
 	[DataRow(false, DisplayName = "write/persist-only request (WaitForHotReload = false)")]
 	[DataRow(true, DisplayName = "hot-reload request (WaitForHotReload = true)")]
 	public async Task When_UpdateFileBeforeFirstStatus_Then_FailsWithTypedError(bool waitForHotReload)
 	{
 		// A processor that never received any status notification from the engine.
-		var sut = new ClientHotReloadProcessor(new NoOpRemoteControlClient());
+		var client = new RecordingRemoteControlClient();
+		var sut = new ClientHotReloadProcessor(client);
 		var req = new ClientHotReloadProcessor.UpdateRequest("some/File.xaml", OldText: null, NewText: "<Page />", WaitForHotReload: waitForHotReload);
 
 		var result = await sut.TryUpdateFilesAsync(req, CancellationToken.None);
 
-		result.Error.Should().BeOfType<InvalidOperationException>(
+		result.Error.Should().BeOfType<HotReloadNotInitializedException>(
 			because: "the gate must reject un-trackable requests with an actionable error, not an NRE");
+		client.SentMessages.Should().BeEmpty(
+			because: "the gate must reject the request before any server exchange");
 	}
 
-	private sealed class NoOpRemoteControlClient : IRemoteControlClient
+	[TestMethod]
+	[Description(
+		"Once the first hot-reload status has been received, the initialization gate must let requests "
+		+ "through: the request reaches the server (and only fails here because the fake server never replies).")]
+	public async Task When_UpdateFileAfterFirstStatus_Then_PassesGate()
 	{
+		var client = new RecordingRemoteControlClient();
+		var sut = new ClientHotReloadProcessor(client);
+		await PublishStatus(sut, HotReloadState.Ready);
+		var req = new ClientHotReloadProcessor.UpdateRequest("some/File.xaml", OldText: null, NewText: "<Page />", WaitForHotReload: false)
+		{
+			ServerUpdateTimeout = TimeSpan.FromMilliseconds(100),
+		};
+
+		var result = await sut.TryUpdateFilesAsync(req, CancellationToken.None);
+
+		result.Error.Should().BeOfType<TimeoutException>(
+			because: "a received status un-gates the call, which then fails only on the unanswered server exchange");
+		client.SentMessages.Should().ContainSingle(msg => msg is UpdateFileRequest,
+			because: "the request must be sent to the server once the gate is open");
+	}
+
+	[TestMethod]
+	[Description(
+		"When hot reload is disabled for the session, updates must NOT be rejected: the request is still "
+		+ "forwarded to the server so files can be written/persisted (the disabled state is surfaced in logs only).")]
+	public async Task When_UpdateFileWhileDisabled_Then_StillProcessed()
+	{
+		var client = new RecordingRemoteControlClient();
+		var sut = new ClientHotReloadProcessor(client);
+		await PublishStatus(sut, HotReloadState.Disabled);
+		var req = new ClientHotReloadProcessor.UpdateRequest("some/File.xaml", OldText: null, NewText: "<Page />", WaitForHotReload: false)
+		{
+			ServerUpdateTimeout = TimeSpan.FromMilliseconds(100),
+		};
+
+		var result = await sut.TryUpdateFilesAsync(req, CancellationToken.None);
+
+		result.Error.Should().NotBeOfType<HotReloadNotInitializedException>(
+			because: "a Disabled status is still a status — the initialization gate must not fire");
+		client.SentMessages.Should().ContainSingle(msg => msg is UpdateFileRequest,
+			because: "with hot reload disabled the update must still be forwarded so files can be persisted");
+	}
+
+	private static async Task PublishStatus(ClientHotReloadProcessor sut, HotReloadState state)
+	{
+		var status = new HotReloadStatusMessage(state, ImmutableList<HotReloadServerOperationData>.Empty);
+
+		await sut.ProcessFrame(Frame.Create(1, status.Scope, HotReloadStatusMessage.Name, status));
+	}
+
+	private sealed class RecordingRemoteControlClient : IRemoteControlClient
+	{
+		private readonly List<IMessage> _sentMessages = [];
+
 		public Type AppType => typeof(Given_ClientUpdateFileGate);
 
-		// Never reached: the initialization gate returns before any server exchange.
-		public Task SendMessage(IMessage message) => Task.CompletedTask;
+		public IReadOnlyList<IMessage> SentMessages => _sentMessages;
+
+		public Task SendMessage(IMessage message)
+		{
+			_sentMessages.Add(message);
+			return Task.CompletedTask;
+		}
 	}
 }

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -185,6 +185,17 @@ public partial class ClientHotReloadProcessor
 	public Task<UpdateResult> TryUpdateFileAsync(UpdateRequest req, CancellationToken ct)
 		=> TryUpdateFilesAsync(req, ct);
 
+	/// <summary>
+	/// Applies a batch of file edits through the dev-server, optionally waiting for the
+	/// resulting hot-reload to be applied locally.
+	/// </summary>
+	/// <remarks>
+	/// Must not be called before the first <see cref="StatusChanged"/> notification: until the
+	/// hot-reload engine has published its initial status, the request cannot be tracked and
+	/// the call fails with an <see cref="InvalidOperationException"/> in the result's
+	/// <c>Error</c> — regardless of <c>WaitForHotReload</c> (the gate also applies to
+	/// write/persist-only usages).
+	/// </remarks>
 	public async Task<UpdateResult> TryUpdateFilesAsync(UpdateRequest req, CancellationToken ct)
 	{
 		var result = default(UpdateResult);
@@ -199,14 +210,21 @@ public partial class ClientHotReloadProcessor
 			}
 
 			// Client-side gate: until the first status notification, the hot-reload engine is not
-			// initialized yet and cannot track this request (CurrentStatus is null, cf. StatusSink).
-			// Fail with an explicit, actionable error instead of an accidental NullReferenceException
-			// deeper in the pipeline — client-side counterpart of the server-side workspace gate.
-			if (CurrentStatus is null)
+			// initialized yet and cannot track this request — fail with an explicit, actionable
+			// error instead of an accidental NullReferenceException deeper in the pipeline
+			// (client-side counterpart of the server-side workspace gate). CurrentStatus is
+			// declared non-nullable but is legitimately null until that first notification
+			// (StatusSink.Current starts as null!): capture through a nullable local so the
+			// check reads truthfully under nullable analysis.
+			Status? currentStatus = _status.Current;
+			if (currentStatus is null)
 			{
-				return result with { Error = new InvalidOperationException(
-					"Hot reload is not initialized yet (no status has been received from the hot-reload engine). "
-					+ "Wait for the first ClientHotReloadProcessor.StatusChanged notification before sending file updates.") };
+				return result with
+				{
+					Error = new InvalidOperationException(
+						"Hot reload is not initialized yet (no status has been received from the hot-reload engine). "
+						+ "Wait for the first ClientHotReloadProcessor.StatusChanged notification before sending file updates.")
+				};
 			}
 
 			var log = this.Log();
@@ -214,12 +232,15 @@ public partial class ClientHotReloadProcessor
 			var debug = log.IsDebugEnabled() ? log : default;
 			var tag = $"[{Interlocked.Increment(ref _reqId):D2}-{Path.GetFileName(req.Edits.First().FilePath)}]";
 
-			if (CurrentStatus.State is HotReloadState.Disabled)
+			if (currentStatus.State is HotReloadState.Disabled)
 			{
 				// Do not reject: with hot-reload disabled a file update is still a legitimate
 				// way to persist changes (files are written / forwarded to the IDE) — but no
 				// hot-reload should be expected, so surface the state to the caller's logs.
-				log.Warn($"{tag} Hot reload is disabled for this session — the update will still be processed (files may be written), but no hot-reload is expected to be applied.");
+				if (log.IsEnabled(LogLevel.Warning))
+				{
+					log.Warn($"{tag} Hot reload is disabled for this session — the update will still be processed (files may be written), but no hot-reload is expected to be applied.");
+				}
 			}
 
 			debug?.Debug($"{tag} Updating {req.Edits.Length} file(s).");

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -198,10 +198,29 @@ public partial class ClientHotReloadProcessor
 				return result with { Error = new ArgumentOutOfRangeException(nameof(req.Edits), "Invalid edits (no edits or edit.FilePath is null or empty).") };
 			}
 
+			// Client-side gate: until the first status notification, the hot-reload engine is not
+			// initialized yet and cannot track this request (CurrentStatus is null, cf. StatusSink).
+			// Fail with an explicit, actionable error instead of an accidental NullReferenceException
+			// deeper in the pipeline — client-side counterpart of the server-side workspace gate.
+			if (CurrentStatus is null)
+			{
+				return result with { Error = new InvalidOperationException(
+					"Hot reload is not initialized yet (no status has been received from the hot-reload engine). "
+					+ "Wait for the first ClientHotReloadProcessor.StatusChanged notification before sending file updates.") };
+			}
+
 			var log = this.Log();
 			var trace = log.IsTraceEnabled() ? log : default;
 			var debug = log.IsDebugEnabled() ? log : default;
 			var tag = $"[{Interlocked.Increment(ref _reqId):D2}-{Path.GetFileName(req.Edits.First().FilePath)}]";
+
+			if (CurrentStatus.State is HotReloadState.Disabled)
+			{
+				// Do not reject: with hot-reload disabled a file update is still a legitimate
+				// way to persist changes (files are written / forwarded to the IDE) — but no
+				// hot-reload should be expected, so surface the state to the caller's logs.
+				log.Warn($"{tag} Hot reload is disabled for this session — the update will still be processed (files may be written), but no hot-reload is expected to be applied.");
+			}
 
 			debug?.Debug($"{tag} Updating {req.Edits.Length} file(s).");
 			if (debug?.IsTraceEnabled() ?? false)
@@ -425,7 +444,7 @@ public partial class ClientHotReloadProcessor
 	}
 
 	private int GetCurrentLocalHotReloadId()
-		=> CurrentStatus.Local.Operations is { Count: > 0 } ops ? ops.Max(op => op.Id) : -1;
+		=> CurrentStatus?.Local.Operations is { Count: > 0 } ops ? ops.Max(op => op.Id) : -1;
 
 	private async ValueTask<HotReloadClientOperation> WaitForLocalHotReloadAsync(int hotReloadId, TimeSpan timeout, CancellationToken ct)
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -171,6 +171,12 @@ public partial class ClientHotReloadProcessor
 	public Task UpdateFileAsync(string filePath, string? oldText, string newText, bool waitForHotReload, bool forceSaveToDisk, CancellationToken ct)
 		=> UpdateFileAsync(new UpdateRequest(filePath, oldText, newText, waitForHotReload) { ForceSaveToDisk = forceSaveToDisk }, ct);
 
+	/// <summary>
+	/// Applies a batch of file edits through the dev-server, throwing on failure — the thrown
+	/// error is the one reported by <see cref="TryUpdateFilesAsync"/>, including
+	/// <see cref="HotReloadNotInitializedException"/> when called before the first
+	/// <see cref="StatusChanged"/> notification.
+	/// </summary>
 	public async Task UpdateFileAsync(UpdateRequest req, CancellationToken ct)
 	{
 		if (await TryUpdateFileAsync(req, ct) is { Error: { } error })
@@ -192,7 +198,7 @@ public partial class ClientHotReloadProcessor
 	/// <remarks>
 	/// Must not be called before the first <see cref="StatusChanged"/> notification: until the
 	/// hot-reload engine has published its initial status, the request cannot be tracked and
-	/// the call fails with an <see cref="InvalidOperationException"/> in the result's
+	/// the call fails with a <see cref="HotReloadNotInitializedException"/> in the result's
 	/// <c>Error</c> — regardless of <c>WaitForHotReload</c> (the gate also applies to
 	/// write/persist-only usages).
 	/// </remarks>
@@ -209,34 +215,32 @@ public partial class ClientHotReloadProcessor
 				return result with { Error = new ArgumentOutOfRangeException(nameof(req.Edits), "Invalid edits (no edits or edit.FilePath is null or empty).") };
 			}
 
-			// Client-side gate: until the first status notification, the hot-reload engine is not
-			// initialized yet and cannot track this request — fail with an explicit, actionable
-			// error instead of an accidental NullReferenceException deeper in the pipeline
-			// (client-side counterpart of the server-side workspace gate). CurrentStatus is
-			// declared non-nullable but is legitimately null until that first notification
-			// (StatusSink.Current starts as null!): capture through a nullable local so the
-			// check reads truthfully under nullable analysis.
-			Status? currentStatus = _status.Current;
-			if (currentStatus is null)
-			{
-				return result with
-				{
-					Error = new InvalidOperationException(
-						"Hot reload is not initialized yet (no status has been received from the hot-reload engine). "
-						+ "Wait for the first ClientHotReloadProcessor.StatusChanged notification before sending file updates.")
-				};
-			}
-
 			var log = this.Log();
 			var trace = log.IsTraceEnabled() ? log : default;
 			var debug = log.IsDebugEnabled() ? log : default;
 			var tag = $"[{Interlocked.Increment(ref _reqId):D2}-{Path.GetFileName(req.Edits.First().FilePath)}]";
+
+			// Client-side gate (counterpart of the server-side workspace gate): until the first status
+			// notification the request cannot be tracked. CurrentStatus is declared non-nullable but is
+			// legitimately null until then (StatusSink.Current starts as null!), hence the nullable local.
+			Status? currentStatus = CurrentStatus;
+			if (currentStatus is null)
+			{
+				if (log.IsEnabled(LogLevel.Warning))
+				{
+					log.Warn($"{tag} Rejecting the update: hot reload is not initialized yet — wait for the first StatusChanged notification before sending file updates.");
+				}
+
+				return result with { Error = new HotReloadNotInitializedException() };
+			}
 
 			if (currentStatus.State is HotReloadState.Disabled)
 			{
 				// Do not reject: with hot-reload disabled a file update is still a legitimate
 				// way to persist changes (files are written / forwarded to the IDE) — but no
 				// hot-reload should be expected, so surface the state to the caller's logs.
+				// This client-side check is advisory only: the server remains the authoritative
+				// enforcement point when hot reload is disabled.
 				if (log.IsEnabled(LogLevel.Warning))
 				{
 					log.Warn($"{tag} Hot reload is disabled for this session — the update will still be processed (files may be written), but no hot-reload is expected to be applied.");

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadNotInitializedException.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadNotInitializedException.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+using System;
+
+namespace Uno.UI.RemoteControl.HotReload;
+
+/// <summary>
+/// Reported when a file-update request is issued before the hot-reload engine has published its
+/// first status notification, i.e. before the first
+/// <see cref="ClientHotReloadProcessor.StatusChanged"/> event. This is a transient startup
+/// condition: wait for that notification, then retry the request.
+/// </summary>
+/// <remarks>
+/// Derives from <see cref="InvalidOperationException"/> so existing handlers keep working, while
+/// letting tooling distinguish this transient "not initialized yet" rejection from the terminal
+/// update failures that also surface as <see cref="InvalidOperationException"/>.
+/// </remarks>
+public sealed class HotReloadNotInitializedException : InvalidOperationException
+{
+	internal HotReloadNotInitializedException()
+		: base(
+			"Hot reload is not initialized yet (no status has been received from the hot-reload engine). "
+			+ "Wait for the first ClientHotReloadProcessor.StatusChanged notification before sending file updates.")
+	{
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** closes #23838

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior:** a `TryUpdateFilesAsync` call issued before the hot-reload engine has
published its first status notification crashes with a `NullReferenceException` in
`GetCurrentLocalHotReloadId` (`CurrentStatus` is still `null`), and the request is silently
untrackable — the caller gets an exception instead of an actionable result.

**New behavior:**

- `GetCurrentLocalHotReloadId()` is null-safe.
- `TryUpdateFilesAsync` now explicitly gates on initialization: until the first status
  notification is received from the hot-reload engine, the request is rejected with a typed
  `InvalidOperationException` in the result (`Error`), telling the caller to wait for
  `StatusChanged` before sending file updates — instead of throwing from the middle of the
  pipeline.
- When hot reload is *disabled* for the session, a warning is logged and the update is still
  processed (files are written), so tooling can distinguish "not ready yet" from "disabled".

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)