### PR TITLE
docs: Fix Native AOT notes, benchmark table, and dropped GTK references

### DIFF
--- a/doc/articles/features/native-aot.md
+++ b/doc/articles/features/native-aot.md
@@ -8,18 +8,21 @@ Uno Platform 6.6 introduces support for [.NET Native AOT deployment](https://lea
 
 Enabling Native AOT enables faster app startup and improves performance, typically at the cost of larger app sizes. Consider the [Uno.Chefs sample app](xref:Uno.Chefs.Overview):
 
-| **Sample**                                            | **Environment**   | **Runtime** |          **Publish Size** |     **Startup Times (s)** |
-| ----------------------------------------------------- | ----------------- | ----------- | ------------------------: | ------------------------: |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | Android, .NET 10  | MonoVM      |   93M                     | 0.895s |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | Android, .NET 10  | NativeAOT   |  109M <br> (117% MonoVM)  | 0.348s <br> (39% MonoVM)  |
-| [Uno.Chefs][chefs-ios] <!-- with Uno.Sdk 6.6.10 -->   | iOS, .NET 10      | MonoVM      |  138M                     | 0.940s |
-| [Uno.Chefs][chefs-ios] <!-- with Uno.Sdk 6.6.10 -->   | iOS, .NET 10      | NativeAOT   |  122M <br> (88% MonoVM)   | 0.742s <br> (79% MonoVM)  |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | Linux, .NET 10    | CoreCLR     |  541M                     | 0.87s |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | Linux, .NET 10    | NativeAOT   |  625M <br> (118% CoreCLR) | 0.35s <br> (40% CoreCLR)  |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | macOS, .NET 10    | CoreCLR     |  547M                     | 1.347s |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | macOS, .NET 10    | NativeAOT   |  720M <br> (141% CoreCLR) | 0.555s <br> (41% CoreCLR) |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | Windows, .NET 10  | CoreCLR     |  725M                     | 1.605s |
-| [Uno.Chefs][chefs]     <!-- with Uno.Sdk 6.6.16 -->   | Windows, .NET 10  | NativeAOT   |  970M <br> (139% CoreCLR) | 0.824s <br> (51% CoreCLR) |
+| **Environment**   | **Baseline Runtime** | **Baseline Publish Size** | **NativeAOT Publish Size** | **Publish Size Change** | **Baseline Startup** | **NativeAOT Startup** | **Startup Improvement** |
+| ----------------- | -------------------- | ------------------------: | -------------------------: | ----------------------: | -------------------: | --------------------: | ----------------------: |
+| Android, .NET 10  | MonoVM               |                     93 MB |                     109 MB |                    +17% |               0.895s |                0.348s |          **61% faster** |
+| iOS, .NET 10      | MonoVM               |                    138 MB |                     122 MB |                    -12% |               0.940s |                0.742s |          **21% faster** |
+| Linux, .NET 10    | CoreCLR              |                    541 MB |                     625 MB |                    +16% |               0.870s |                0.350s |          **60% faster** |
+| macOS, .NET 10    | CoreCLR              |                    547 MB |                     720 MB |                    +32% |               1.347s |                0.555s |          **59% faster** |
+| Windows, .NET 10  | CoreCLR              |                    725 MB |                     970 MB |                    +34% |               1.605s |                0.824s |          **49% faster** |
+
+<!--
+  Benchmark provenance (kept out of the rendered page so hardcoded version numbers don't go stale for readers):
+  - Android / Linux / macOS / Windows: Uno.Sdk 6.6.16, Uno.Chefs @ 873fae67 (https://github.com/unoplatform/uno.chefs/commit/873fae67cef3d12fb55b69c6f3fcebcc0f0101f9)
+  - iOS: Uno.Sdk 6.6.10, Uno.Chefs @ 4bbc0569 (https://github.com/unoplatform/uno.chefs/commit/4bbc0569dc7ac0ddefe8b0de4be31beb3706a90b)
+  - Runtime and SkiaSharp are equivalent to public Uno.Sdk 6.6.29 (verified: no AOT/runtime/SkiaSharp changes between 6.6.16 and 6.6.29), so these figures represent the shipping 6.6 release.
+-->
+*Measured on the Uno.Chefs sample app on .NET 10. Publish sizes are Release builds; "Startup Improvement" is the reduction in cold-start time versus each platform's default runtime (MonoVM on mobile, CoreCLR on desktop).*
 
 > [!NOTE]
 > App startup times are provided for comparison purposes.  Actual startup times will vary depending on hardware.
@@ -412,6 +415,3 @@ index 764886bb..f146a16f 100644
 ```
 
 *All* use of `DependencyProperty.RegisterAttached()` is potentially suspect and should be reviewed.
-
-[chefs]: https://github.com/unoplatform/uno.chefs/commit/873fae67cef3d12fb55b69c6f3fcebcc0f0101f9
-[chefs-ios]: https://github.com/unoplatform/uno.chefs/commit/4bbc0569dc7ac0ddefe8b0de4be31beb3706a90b

--- a/doc/articles/features/native-aot.md
+++ b/doc/articles/features/native-aot.md
@@ -8,13 +8,13 @@ Uno Platform 6.6 introduces support for [.NET Native AOT deployment](https://lea
 
 Enabling Native AOT enables faster app startup and improves performance, typically at the cost of larger app sizes. Consider the [Uno.Chefs sample app](xref:Uno.Chefs.Overview):
 
-| **Environment**   | **Baseline Runtime** | **Baseline Publish Size** | **NativeAOT Publish Size** | **Publish Size Change** | **Baseline Startup** | **NativeAOT Startup** | **Startup Improvement** |
-| ----------------- | -------------------- | ------------------------: | -------------------------: | ----------------------: | -------------------: | --------------------: | ----------------------: |
-| Android, .NET 10  | MonoVM               |                     93 MB |                     109 MB |                    +17% |               0.895s |                0.348s |          **61% faster** |
-| iOS, .NET 10      | MonoVM               |                    138 MB |                     122 MB |                    -12% |               0.940s |                0.742s |          **21% faster** |
-| Linux, .NET 10    | CoreCLR              |                    541 MB |                     625 MB |                    +16% |               0.870s |                0.350s |          **60% faster** |
-| macOS, .NET 10    | CoreCLR              |                    547 MB |                     720 MB |                    +32% |               1.347s |                0.555s |          **59% faster** |
-| Windows, .NET 10  | CoreCLR              |                    725 MB |                     970 MB |                    +34% |               1.605s |                0.824s |          **49% faster** |
+| **Environment**  | **Baseline Runtime** | **Baseline Publish Size** | **Native AOT Publish Size** | **Publish Size Change** | **Baseline Startup** | **Native AOT Startup** | **Startup Improvement** |
+| ---------------- | -------------------- | ------------------------: | --------------------------: | ----------------------: | -------------------: | ---------------------: | ----------------------: |
+| Android, .NET 10 | MonoVM               |                     93 MB |                      109 MB |                    +17% |               0.895s |                 0.348s |          **61% faster** |
+| iOS, .NET 10     | MonoVM               |                    138 MB |                      122 MB |                    -12% |               0.940s |                 0.742s |          **21% faster** |
+| Linux, .NET 10   | CoreCLR              |                    541 MB |                      625 MB |                    +16% |               0.870s |                 0.350s |          **60% faster** |
+| macOS, .NET 10   | CoreCLR              |                    547 MB |                      720 MB |                    +32% |               1.347s |                 0.555s |          **59% faster** |
+| Windows, .NET 10 | CoreCLR              |                    725 MB |                      970 MB |                    +34% |               1.605s |                 0.824s |          **49% faster** |
 
 <!--
   Benchmark provenance (kept out of the rendered page so hardcoded version numbers don't go stale for readers):

--- a/doc/articles/features/using-skia-desktop.md
+++ b/doc/articles/features/using-skia-desktop.md
@@ -162,7 +162,7 @@ To build an app with this feature enabled:
    ```
 
    > [!NOTE]
-   > Cross-OS native compilation is not supported. To build a Native AOT app for a given OS (Windows, Linux, or macOS), you'll need to build on that OS — for example on a physical machine, a virtual machine, or a per-OS CI agent. Cross-*architecture* compilation on the same OS (for example x64 to arm64) is supported when the matching native toolchain is installed.
+   > Cross-OS native compilation is not supported. To build a Native AOT app for a given OS (Windows, Linux, or macOS), you'll need to build on that OS — for example on a physical machine, a virtual machine, or a per-OS CI agent. Cross-architecture compilation on the same OS (for example x64 to arm64) is supported when the matching native toolchain is installed.
 
 ### Automatic Binding Preservation
 

--- a/doc/articles/features/using-skia-desktop.md
+++ b/doc/articles/features/using-skia-desktop.md
@@ -162,9 +162,7 @@ To build an app with this feature enabled:
    ```
 
    > [!NOTE]
-   > Cross-compilation support is not supported as of .NET 7. To build a Native AOT app for Linux or Mac, you'll need to build on the corresponding host.
-   > [!NOTE]
-   > .NET Native AOT on Windows is not yet supported as WPF does not support it at this time.
+   > Cross-OS native compilation is not supported. To build a Native AOT app for a given OS (Windows, Linux, or macOS), you'll need to build on that OS — for example on a physical machine, a virtual machine, or a per-OS CI agent. Cross-*architecture* compilation on the same OS (for example x64 to arm64) is supported when the matching native toolchain is installed.
 
 ### Automatic Binding Preservation
 

--- a/doc/articles/guides/xf-migration/custom-drawn-controls.md
+++ b/doc/articles/guides/xf-migration/custom-drawn-controls.md
@@ -34,7 +34,7 @@ Because of this, you probably don't need to change any of the SkiaSharp drawing 
 2. Hook up the drawing logic from your Xamarin.Forms control
 
 > [!NOTE]
-> While `SKXamlCanvas` is the most straightforward option for migrating existing Xamarin.Forms controls (because its API closely matches `SKCanvasView`), the Uno Platform documentation recommends using `SKCanvasElement` on Skia-based targets when possible. `SKCanvasElement` is designed for Uno's Skia renderers, providing hardware acceleration and avoiding additional buffer copies, which can improve performance on platforms such as WebAssembly, Skia GTK, and Skia WPF.
+> While `SKXamlCanvas` is the most straightforward option for migrating existing Xamarin.Forms controls (because its API closely matches `SKCanvasView`), the Uno Platform documentation recommends using `SKCanvasElement` on Skia-based targets when possible. `SKCanvasElement` is designed for Uno's Skia renderers, providing hardware acceleration and avoiding additional buffer copies, which can improve performance on platforms such as WebAssembly and Skia Desktop.
 
 ## Migration Example: Microcharts
 
@@ -329,7 +329,7 @@ using (var paint = new SKPaint())
 The Microcharts.Samples.Uno project demonstrates how to use Microcharts in an Uno Platform app. The project structure:
 
 - **Shared project**: Contains XAML and code-behind for the app
-- **Platform projects**: Windows, Mobile, Skia.GTK, WebAssembly
+- **Platform projects**: Windows, Mobile, Skia Desktop, WebAssembly
 - **Samples project**: Contains example data used by all sample projects
 
 This shows how easy it is to share or port code between different .NET platforms, as all the logic is platform-agnostic.

--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -190,7 +190,7 @@ The method `InitializeComponent` should always be called in class constructor. A
 Some components like `ProgressRing` and `MediaPlayerElement` requires you to reference a specific NuGet package for them to work correctly.
 
 - For `ProgressRing`, it requires Lottie dependency. For more information about adding Lottie to your project, see [Lottie for Uno](xref:Uno.Features.Lottie).
-- For `MediaPlayerElement` on WebAssembly or Gtk, it requires `Uno.WinUI.MediaPlayer.WebAssembly` or `Uno.WinUI.MediaPlayer.Skia.Gtk` NuGet package. For more information, see [MediaPlayerElement](xref:Uno.Controls.MediaPlayerElement).
+- For `MediaPlayerElement` on WebAssembly or Skia Desktop, it requires the matching NuGet package: `Uno.WinUI.MediaPlayer.WebAssembly`, `Uno.WinUI.MediaPlayer.Skia.Win32`, or `Uno.WinUI.MediaPlayer.Skia.X11`. For more information, see [MediaPlayerElement](xref:Uno.Controls.MediaPlayerElement).
 
 ### UNO0008
 

--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -190,7 +190,7 @@ The method `InitializeComponent` should always be called in class constructor. A
 Some components like `ProgressRing` and `MediaPlayerElement` requires you to reference a specific NuGet package for them to work correctly.
 
 - For `ProgressRing`, it requires Lottie dependency. For more information about adding Lottie to your project, see [Lottie for Uno](xref:Uno.Features.Lottie).
-- For `MediaPlayerElement` on WebAssembly or Skia Desktop, it requires the matching NuGet package: `Uno.WinUI.MediaPlayer.WebAssembly`, `Uno.WinUI.MediaPlayer.Skia.Win32`, or `Uno.WinUI.MediaPlayer.Skia.X11`. For more information, see [MediaPlayerElement](xref:Uno.Controls.MediaPlayerElement).
+- For `MediaPlayerElement`, reference the NuGet package that matches your target: `Uno.WinUI.MediaPlayer.WebAssembly` (WebAssembly), `Uno.WinUI.MediaPlayer.Skia.Win32` (Windows), or `Uno.WinUI.MediaPlayer.Skia.X11` (Linux). For more information, see [MediaPlayerElement](xref:Uno.Controls.MediaPlayerElement).
 
 ### UNO0008
 


### PR DESCRIPTION
**GitHub Issue:** N/A — documentation-only change (exempt from the issue requirement per the PR template).

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Documentation fixes that are **safe to backport to `release/stable/6.6`** (all are correct on both master and 6.6). Master-only WPF cleanup lives in #23849.

### 1. Fix stale Windows Native AOT notes — `using-skia-desktop.md`

- **Removed** the note *".NET Native AOT on Windows is not yet supported as WPF does not support it at this time."* — Windows Native AOT is supported/benchmarked as of 6.6, and the Windows Skia head is the **Win32** shell.
- **Reworded** the cross-compilation note: dropped the misleading *"as of .NET 7"* stamp (cross-**OS** native compilation is still unsupported on .NET 10 — see [dotnet/runtime#109284](https://github.com/dotnet/runtime/issues/109284)) and clarified cross-**architecture** on the same OS works.

### 2. Restructure the Native AOT benchmark table — `native-aot.md`

One row per platform, baseline vs NativeAOT side by side, with explicit **Publish Size Change** / **Startup Improvement** columns. Existing measurements kept (verified equivalent to public Uno.Sdk 6.6.29 / core 6.6.166); Uno.Sdk version provenance moved to an HTML comment so hardcoded versions don't go stale in the rendered page.

### 3. Remove references to the dropped **Skia GTK** target

The Skia GTK Desktop runtime was removed before 6.6, so these stale references (present on both branches) are corrected:

- `uno-build-error-codes.md` — `MediaPlayerElement` now points to `Uno.WinUI.MediaPlayer.Skia.Win32` / `.Skia.X11` instead of the removed `Uno.WinUI.MediaPlayer.Skia.Gtk`.
- `guides/xf-migration/custom-drawn-controls.md` — "Skia GTK, and Skia WPF" and a "Skia.GTK" platform-project reference generalized to "Skia Desktop".

## Related to the dropped targets

- **WPF drop** (context for §1–2): unoplatform/uno#23260 (issue) · unoplatform/uno#23261 (PR, *feat!: Drop WPF targets*)
- **GTK drop** (context for §3): unoplatform/uno#19752 (PR, includes *feat!: Drop GTK*)

> 📝 One open data question for the table author is tracked as a **review comment on the table** (below) — to be resolved before/at merge.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample — N/A (documentation only)
- [x] 📚 Docs have been added/updated following the documentation template
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A (documentation only)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
