### PR TITLE
docs: Remove dropped WPF Skia-target references

### DIFF
--- a/doc/articles/features/using-skia-desktop.md
+++ b/doc/articles/features/using-skia-desktop.md
@@ -112,20 +112,6 @@ Each platform exposes its own `RenderingBackend` enum with only the backends it 
 
 Alternatively, you can use `FeatureConfiguration.Rendering` flags for backwards compatibility. The builder API takes precedence when both are used.
 
-## Windows Specifics
-
-### RDP Hardware Acceleration
-
-The Uno Platform Skia Desktop runtime on Windows uses a WPF shell internally. By default, Uno Platform enables RDP hardware acceleration in order to get good performance, yet this feature is disabled by default in standard WPF apps with .NET 8.
-
-If you're having issues with the Windows support for Skia Desktop over RDP, add the following to your project:
-
-```xml
-<ItemGroup>
-    <RuntimeHostConfigurationOption Include="Switch.System.Windows.Media.EnableHardwareAccelerationInRdp" Value="false" />
-</ItemGroup>
-```
-
 ## X11 Specifics
 
 When running using X11 Wayland compatibility (e.g. recent Ubuntu releases), DPI scaling cannot be determined in a reliable way. In order to specify the scaling to be used by Uno Platform, set the `UNO_DISPLAY_SCALE_OVERRIDE` environment variable. The default value is `1.0`.

--- a/doc/articles/features/using-skia-hosting-native-controls.md
+++ b/doc/articles/features/using-skia-hosting-native-controls.md
@@ -7,14 +7,13 @@ uid: Uno.Skia.Embedding.Native
 > [!NOTE]
 > This document describes Skia renderer native embedding, for other platforms/renderers see the [native views](xref:Uno.Development.NativeViews) documentation.
 
-In an Uno Platform app with a Skia renderer, i.e. using `net10.0-desktop` or adding `SkiaRenderer` to the `UnoFeatures` MSBuild property, you can embed native controls in your Skia app. This is useful if you want to use a native control for a specific task, for instance, to integrate an existing WPF control.
+In an Uno Platform app with a Skia renderer, i.e. using `net10.0-desktop` or adding `SkiaRenderer` to the `UnoFeatures` MSBuild property, you can embed native controls in your Skia app. This is useful if you want to use a native control for a specific task, for instance, to integrate an existing native platform control.
 
 Each target platform has its own idea of a native element.
 
 | Platform                        | Native element                                                                     | Description                                  |
 |---------------------------------|------------------------------------------------------------------------------------|----------------------------------------------|
 | Skia Desktop (Win32)            | Uno.UI.NativeElementHosting.Win32NativeWindow                                      | A native Windows window with a unique `Hwnd` |
-| Skia Desktop (WPF)              | System.Windows.UIElement                                                           | A WPF control                                |
 | Skia Desktop (X11)              | Uno.UI.NativeElementHosting.X11NativeWindow                                        | A native X11 window with a unique `XID`      |
 | Skia Desktop (macOS)            | Not yet supported.                                                                 | Not yet supported as of Uno Platform 6.0     |
 | WebAssembly with `SkiaRenderer` | [Uno.UI.NativeElementHosting.BrowserHtmlElement](xref:Uno.Interop.WasmJavaScript1) | An HTML element with a unique `id`.          |

--- a/doc/articles/features/working-with-assets.md
+++ b/doc/articles/features/working-with-assets.md
@@ -21,7 +21,7 @@ At the moment, the following image file types are supported as `Content` assets:
 | iOS 13      |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ❌   |  ✔️   |
 | macOS       |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ✔️   |  ❌   |
 | WebAssembly†       |       ✔️        |  ✔️‡   |      ❌†       |          ✔️          |  ✔️   |  ❌†   |  ❌†  |  ✔️   |
-| Skia WPF    |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Skia Desktop|       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
 
 * † Actual WebAssembly image format support is browser dependent. For example, `.webp` is not working on Safari on macOS, but works on Chromium-based browsers. Check-marks (✔️) indicates a format that can safely expected to work on all browsers able to run Wasm applications.
 * ‡ **Gif animation support**:

--- a/doc/articles/features/working-with-assets.md
+++ b/doc/articles/features/working-with-assets.md
@@ -23,7 +23,7 @@ At the moment, the following image file types are supported as `Content` assets:
 | WebAssembly†       |       ✔️        |  ✔️‡   |      ❌†       |          ✔️          |  ✔️   |  ❌†   |  ❌†  |  ✔️   |
 | Skia Desktop |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
 
-* † Actual WebAssembly image format support is browser dependent. For example, `.webp` is not working on Safari on macOS, but works on Chromium-based browsers. Check-marks (✔️) indicates a format that can safely expected to work on all browsers able to run Wasm applications.
+* † Actual WebAssembly image format support is browser dependent. For example, `.webp` is not working on Safari on macOS, but works on Chromium-based browsers. Check-marks (✔️) indicate a format that can safely be expected to work on all browsers able to run Wasm applications.
 * ‡ **Gif animation support**:
   * Play/Pause not implemented in Uno yet
   * Always animated on Wasm

--- a/doc/articles/features/working-with-assets.md
+++ b/doc/articles/features/working-with-assets.md
@@ -21,7 +21,7 @@ At the moment, the following image file types are supported as `Content` assets:
 | iOS 13      |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ❌   |  ✔️   |
 | macOS       |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ✔️   |  ❌   |
 | WebAssembly†       |       ✔️        |  ✔️‡   |      ❌†       |          ✔️          |  ✔️   |  ❌†   |  ❌†  |  ✔️   |
-| Skia Desktop|       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Skia Desktop |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
 
 * † Actual WebAssembly image format support is browser dependent. For example, `.webp` is not working on Safari on macOS, but works on Chromium-based browsers. Check-marks (✔️) indicates a format that can safely expected to work on all browsers able to run Wasm applications.
 * ‡ **Gif animation support**:


### PR DESCRIPTION
**GitHub Issue:** N/A — documentation-only change (exempt from the issue requirement per the PR template).

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Removes **master-only** references to the dropped WPF Skia Desktop target from the uno core docs. These are **not** backportable as-is: on `release/stable/6.6` the WPF host still ships, so there they need a *reword*, not removal.

- `features/using-skia-desktop.md` — removed the **"RDP Hardware Acceleration"** section. It documented the WPF-only `Switch.System.Windows.Media.EnableHardwareAccelerationInRdp` host switch and claimed the Windows Skia runtime "uses a WPF shell internally". On master the Windows head is **Win32**, WPF is dropped, and the switch no longer exists in source (a no-op).
- `features/using-skia-hosting-native-controls.md` — removed the **"Skia Desktop (WPF)"** native-element-hosting row (WPF host gone; Win32 row covers Windows) and generalized the intro example.
- `features/working-with-assets.md` — relabeled the **"Skia WPF"** capability-matrix row to **"Skia Desktop"**.

(The backportable, both-branches-stale fixes — the Native AOT notes, the benchmark table, and the dropped-**GTK** references — are in #23847.)

## Related to the dropped target

- **WPF drop**: unoplatform/uno#23260 (issue, *Drop support for the WPF targets*) · unoplatform/uno#23261 (PR, *feat!: Drop WPF targets* — removes `Uno.WinUI.Skia.Wpf` / `Uno.WinUI.Runtime.Skia.Wpf` and the `UnoXamlHost` WPF Islands control, superseded by the native Win32/X11/macOS/Linux-FrameBuffer Skia Desktop runtimes)

## Backport note

Do **not** cherry-pick to `release/stable/6.6`. The WPF host still ships on 6.6, so the RDP section, the hosting row, and the assets row are all still valid there and should be *reworded* (scoped to the legacy WPF host) rather than deleted.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample — N/A (documentation only)
- [x] 📚 Docs have been added/updated following the documentation template
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A (documentation only)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
