### PR TITLE
fix(hr): suppress Debug assembly version attributes via the DevServer targets

### DIFF
--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -17,13 +17,19 @@
 
 	<!--
 		The generated assembly-info file can surface an ENC0033 rude edit ("Deleting attribute requires
-		restarting the application") which then blocks every hot-reload apply of the session (#23839).
-		Bake in the documented workaround (https://github.com/unoplatform/uno.templates/issues/376) for
-		any project referencing this package: opt out by setting UnoDisableGenerateAssemblyInfoWorkaround
-		to true (or by setting GenerateAssemblyInfo explicitly).
+		restarting the application") which then blocks every hot-reload apply of the session (#23839),
+		and version-attribute mismatches between build contexts fail every hot-reload compile with
+		CS7038. Suppress only the version attributes in Debug — the volatile part of the generated
+		file — rather than disabling GenerateAssemblyInfo wholesale (the historically documented csproj
+		workaround, https://github.com/unoplatform/uno.templates/issues/376): a full disable also strips
+		AssemblyMetadata (e.g. UnoMCPProcessorPath, required by the app MCP client) and csproj-declared
+		InternalsVisibleTo. Opt out by setting UnoDisableGenerateAssemblyInfoWorkaround to true (or any
+		of the individual properties explicitly).
 	-->
-	<PropertyGroup>
-		<GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == '' and '$(Configuration)' == 'Debug' and '$(UnoDisableGenerateAssemblyInfoWorkaround)' != 'true'">false</GenerateAssemblyInfo>
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug' and '$(UnoDisableGenerateAssemblyInfoWorkaround)' != 'true'">
+		<GenerateAssemblyVersionAttribute Condition="'$(GenerateAssemblyVersionAttribute)' == ''">false</GenerateAssemblyVersionAttribute>
+		<GenerateAssemblyFileVersionAttribute Condition="'$(GenerateAssemblyFileVersionAttribute)' == ''">false</GenerateAssemblyFileVersionAttribute>
+		<GenerateAssemblyInformationalVersionAttribute Condition="'$(GenerateAssemblyInformationalVersionAttribute)' == ''">false</GenerateAssemblyInformationalVersionAttribute>
 	</PropertyGroup>
 
 	<Target Name="GetRemoteControlHostPath">

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -15,6 +15,16 @@
 		<UnoRemoteControlProcessorsPath Condition="'$(SolutionFileName)'!='Uno.UI.slnx'">$(MSBuildThisFileDirectory)../tools/rc/processors</UnoRemoteControlProcessorsPath>
 	</PropertyGroup>
 
+	<!--
+		The generated assembly-info file can surface an ENC0033 rude edit ("Deleting attribute requires
+		restarting the application") which then blocks every hot-reload apply of the session (#23839).
+		Bake in the documented workaround (https://github.com/unoplatform/uno.templates/issues/376) for
+		any project referencing this package: opt out by setting GenerateAssemblyInfo explicitly.
+	-->
+	<PropertyGroup>
+		<GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == '' and '$(Configuration)' == 'Debug'">false</GenerateAssemblyInfo>
+	</PropertyGroup>
+
 	<Target Name="GetRemoteControlHostPath">
 		<PropertyGroup>
 			<_IsRCClientRemote>false</_IsRCClientRemote>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -19,10 +19,11 @@
 		The generated assembly-info file can surface an ENC0033 rude edit ("Deleting attribute requires
 		restarting the application") which then blocks every hot-reload apply of the session (#23839).
 		Bake in the documented workaround (https://github.com/unoplatform/uno.templates/issues/376) for
-		any project referencing this package: opt out by setting GenerateAssemblyInfo explicitly.
+		any project referencing this package: opt out by setting UnoDisableGenerateAssemblyInfoWorkaround
+		to true (or by setting GenerateAssemblyInfo explicitly).
 	-->
 	<PropertyGroup>
-		<GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == '' and '$(Configuration)' == 'Debug'">false</GenerateAssemblyInfo>
+		<GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == '' and '$(Configuration)' == 'Debug' and '$(UnoDisableGenerateAssemblyInfoWorkaround)' != 'true'">false</GenerateAssemblyInfo>
 	</PropertyGroup>
 
 	<Target Name="GetRemoteControlHostPath">


### PR DESCRIPTION
**GitHub Issue:** closes #23839

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior:** the assembly-info file generated in `obj/` can surface an ENC0033 rude
edit ("Deleting attribute requires restarting the application") pointing at generated code;
once it happens, every subsequent hot-reload apply of the session is rejected ("Changes not
supported" dialog). The documented workaround
(unoplatform/uno.templates#376 — `GenerateAssemblyInfo=false` in Debug) only helps apps whose
csproj carries it: migrated apps, hand-written csproj and older template output all hit a fully
blocked hot-reload session that is hard to diagnose.

**New behavior:** the DevServer package bakes a **narrower** variant of the workaround into its
`buildTransitive` targets, so every project referencing the package gets it automatically:

```xml
<PropertyGroup Condition="'$(Configuration)' == 'Debug' and '$(UnoDisableGenerateAssemblyInfoWorkaround)' != 'true'">
  <GenerateAssemblyVersionAttribute Condition="'$(GenerateAssemblyVersionAttribute)' == ''">false</GenerateAssemblyVersionAttribute>
  <GenerateAssemblyFileVersionAttribute Condition="'$(GenerateAssemblyFileVersionAttribute)' == ''">false</GenerateAssemblyFileVersionAttribute>
  <GenerateAssemblyInformationalVersionAttribute Condition="'$(GenerateAssemblyInformationalVersionAttribute)' == ''">false</GenerateAssemblyInformationalVersionAttribute>
</PropertyGroup>
```

- Only the three **version attributes** are suppressed — the volatile part of the generated file
  (`AssemblyInformationalVersion` carries `SourceRevisionId`), i.e. what ENC0033 sees change and
  what makes hot-reload recompiles fail with `CS7038` when two build contexts disagree on
  versions. `GenerateAssemblyInfo` itself stays on, so `AssemblyMetadata` (e.g.
  `UnoMCPProcessorPath`, required by the app MCP client to initialize) and csproj-declared
  `InternalsVisibleTo` keep flowing — disabling generation wholesale (the historically documented
  csproj workaround) silently breaks both.
- Debug-only; Release keeps the SDK defaults.
- On-demand opt-out via `UnoDisableGenerateAssemblyInfoWorkaround=true`, following the existing
  convention (e.g. `UnoDisableWebView2Workarounds`); any explicit per-attribute value set by the
  project also wins — NuGet package targets are imported after the project body and before the
  SDK applies its own defaults.
- Landing it in the `.targets` rather than the `.props` is deliberate: package props are
  evaluated before `Microsoft.NET.Sdk.props` defaults `Configuration` to `Debug`, so a
  `'$(Configuration)'=='Debug'` condition there would silently miss plain `dotnet build`
  invocations (no `-c`), where `Configuration` is not yet set.

Validated by MSBuild evaluation and builds on a scratch project with the modified targets
injected at the NuGet package import point: Debug → the three switches evaluate `false` and the
generated `AssemblyInfo.cs` contains no version attributes while a csproj `AssemblyMetadata`
item still lands in it; Release → all three stay `true`;
`UnoDisableGenerateAssemblyInfoWorkaround=true` + Debug → untouched.

Follow-up: the docs and templates that carry the wholesale `GenerateAssemblyInfo=false` snippet
(unoplatform/uno.templates#376) can drop it once this ships.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)