### PR TITLE
feat(textbox): Touch/pen text selection flyout on Skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -1449,6 +1449,50 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		}
 
+		// Regression: tapping a selection gripper re-sampled the finger point, which sits on the thumb below the
+		// caret line, so GetIndexAt spilled onto the text and reselected a different word. Tapping a selection
+		// handle must keep the selection.
+		[TestMethod]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_IsTextSelectionEnabled_Tap_Gripper_Keeps_Selection()
+		{
+#if !__SKIA__
+			Assert.Inconclusive("Touch selection grippers are only implemented on Skia.");
+#else
+			var sut = new TextBlock
+			{
+				Text = "hello uno",
+				IsTextSelectionEnabled = true,
+			};
+
+			var bounds = await UITestHelper.Load(sut);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Tap the first word to select it and show the grippers.
+			finger.Press(new Point(bounds.X + bounds.Width / 4, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("hello", sut.SelectedText.TrimEnd());
+			var grippers = sut.SelectionGrippersForTesting;
+			Assert.IsNotNull(grippers);
+
+			// Tap the end gripper's thumb near its bottom edge (below the caret line) — the geometry that used to
+			// reselect the word under the thumb instead of leaving the selection alone.
+			var endThumb = grippers.Value.end.GetAbsoluteBounds();
+			finger.Press(new Point(endThumb.GetCenter().X, endThumb.Bottom - 2));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("hello", sut.SelectedText.TrimEnd(), "tapping a selection gripper must keep the selection, not reselect a word under the thumb");
+			Assert.IsNotNull(sut.SelectionGrippersForTesting, "the grippers should remain visible after tapping one");
+#endif
+		}
+
 		[TestMethod]
 #if !HAS_INPUT_INJECTOR
 		[Ignore("InputInjector is not supported on this platform.")]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.ContextFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.ContextFlyout.cs
@@ -348,6 +348,33 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Clipboard.Clear();
 		}
 
+		// Waits on the OS clipboard itself rather than on a control's CanPasteClipboardContent: macOS writes the
+		// pasteboard on a later dispatcher turn (SetContent is fire-and-forget) and only refreshes that property from a
+		// ContentChanged raised by a 1s NSPasteboard poll, which races any wait shorter than the poll. Focusing the
+		// control after this returns reads the clipboard live, so the property lands without waiting for a tick.
+		private async Task SetClipboardText(string text)
+		{
+			Clipboard.Clear();
+			await WindowHelper.WaitFor(() => !ClipboardHasText(), timeoutMS: 5000, message: "the clipboard should start out empty");
+
+			var dataPackage = new DataPackage();
+			dataPackage.SetText(text);
+			Clipboard.SetContent(dataPackage);
+			await WindowHelper.WaitFor(ClipboardHasText, timeoutMS: 5000, message: "the clipboard should carry the seeded text");
+		}
+
+		private bool ClipboardHasText()
+		{
+			try
+			{
+				return Clipboard.GetContent()?.Contains(StandardDataFormats.Text) == true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		private (bool hasSelectAll, bool hasCut, bool hasCopy, bool hasPaste) GetAvailableCommands(TextCommandBarFlyout flyout)
 		{
 			var allCommands = flyout.PrimaryCommands.Concat(flyout.SecondaryCommands).ToList();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5208,6 +5208,64 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode);
 		}
 
+		// Regression: tapping the single Android insertion handle re-sampled the finger point, which sits on the
+		// thumb a line below the caret, so GetIndexAt spilled onto the next render line and jumped the caret to the
+		// end of the text. A tap on the handle must keep the caret where the handle already is. Sister (no-drag case)
+		// of When_Touch_Single_Handle_Drag_From_Thumb_Keeps_Caret_In_Line.
+		[TestMethod]
+		public async Task When_Touch_Tap_Handle_From_Thumb_Keeps_Caret_Android()
+		{
+			var SUT = new TextBox
+			{
+				Width = 300,
+				Text = "The quick brown fox jumps over",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			// Single Android tap mid-text -> collapsed caret + single insertion handle (EndOnly).
+			finger.Press(new Point(bounds.Left + 90, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "tap should place the single insertion handle");
+
+			await WindowHelper.WaitFor(
+				() =>
+				{
+					if (SUT.VisibleGrippersForTesting is not { } vg)
+					{
+						return false;
+					}
+					var g = vg.end.GetAbsoluteBoundsRect();
+					var s = SUT.GetAbsoluteBoundsRect();
+					return g.Width > 0 && g.Left < s.Right && s.Left < g.Right && g.Top < s.Bottom && s.Top < g.Bottom;
+				},
+				timeoutMS: 3000,
+				message: "insertion handle should be positioned over the TextBox before tapping it");
+
+			var caretBeforeTap = SUT.SelectionStart;
+			Assert.IsTrue(caretBeforeTap < SUT.Text.Length, $"the first tap should place the caret mid-text (len {SUT.Text.Length}, was {caretBeforeTap})");
+
+			// Wait past the 500ms multi-tap window so tapping the handle is a single tap (not double-tap-to-select-word).
+			await Task.Delay(600);
+
+			// Tap the THUMB near its bottom edge (what a real finger hits) — the geometry that used to jump the caret.
+			var gripperBounds = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(gripperBounds.GetCenter().X, gripperBounds.Bottom - 2));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			// The tap keeps a collapsed caret exactly where the handle was — it must NOT jump to the end of the text.
+			Assert.AreEqual(0, SUT.SelectionLength, "tapping the handle keeps a collapsed caret");
+			Assert.AreEqual(caretBeforeTap, SUT.SelectionStart, $"tapping the insertion handle must not move the caret (len {SUT.Text.Length}, was {caretBeforeTap}, now {SUT.SelectionStart})");
+		}
+
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
 		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5321,13 +5321,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finger.Press(new Point(handle.GetCenter().X, handle.Bottom - 2));
 			finger.Release();
 			await WindowHelper.WaitForIdle();
-			await Task.Delay(150); // the flyout visibility update is queued to the dispatcher
+			// The flyout visibility update is queued to the dispatcher; wait for it to actually open instead of a fixed delay.
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "tapping the insertion handle should open the selection flyout over the collapsed caret, even with an empty clipboard");
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual("", SUT.SelectedText, "tapping the handle keeps a collapsed caret (no word selected)");
 
-			var flyout = SUT.SelectionFlyout as TextCommandBarFlyout;
-			Assert.IsTrue(flyout?.IsOpen == true, "tapping the insertion handle should open the selection flyout over the collapsed caret, even with an empty clipboard");
+			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
+			{
+				Assert.Fail("the selection flyout should be a TextCommandBarFlyout");
+				return;
+			}
 
 			// Select All keeps the flyout usable with an empty clipboard; Copy and Paste are absent (nothing is
 			// selected, nothing to paste).
@@ -5338,14 +5344,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			// Select All must sit in the primary bar (so the flyout has a primary command and stays open) and, like
 			// Cut/Copy/Paste, must show its text label there — not render as a bare icon — so it reads as a command.
-			var selectAllButton = flyout!.PrimaryCommands
+			var selectAllButton = flyout.PrimaryCommands
 				.OfType<AppBarButton>()
 				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.A && ka.Modifiers.HasFlag(_platformCtrlKey)));
 			Assert.IsNotNull(selectAllButton, "Select All should be a primary (bar) command so the flyout stays open");
 			Assert.IsNotNull(selectAllButton.Icon, "the primary Select All button should have an icon, matching Cut/Copy/Paste");
 
-			var selectAllLabel = selectAllButton.FindVisualChildByName("TextLabel") as TextBlock;
-			Assert.IsNotNull(selectAllLabel, "the primary Select All button template should expose a TextLabel");
+			if (selectAllButton.FindVisualChildByName("TextLabel") is not TextBlock selectAllLabel)
+			{
+				Assert.Fail("the primary Select All button template should expose a TextLabel");
+				return;
+			}
 			Assert.AreEqual(Visibility.Visible, selectAllLabel.Visibility, "the primary Select All button must show its text label (like Cut/Copy/Paste), not just an icon");
 			Assert.IsFalse(string.IsNullOrEmpty(selectAllLabel.Text), "the primary Select All button label must have text");
 
@@ -5353,12 +5362,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// not appear (it would otherwise show a dangling "..." over an empty menu, because the labelled primary bar
 			// is taller than the command bar's compact height). See TextCommandBarFlyout.UpdateButtons.
 			Assert.AreEqual(0, flyout.SecondaryCommands.Count, "the insertion-caret flyout should have no secondary commands");
-			var commandBar = VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)
-				.Select(p => p.Child?.FindVisualChildByType<CommandBarFlyoutCommandBar>())
-				.FirstOrDefault(c => c is not null);
-			Assert.IsNotNull(commandBar, "the open selection flyout should host a CommandBarFlyoutCommandBar");
-			var moreButton = commandBar.FindVisualChildByName("MoreButton") as FrameworkElement;
-			Assert.IsNotNull(moreButton, "the command bar template should expose a MoreButton");
+			if (VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)
+					.Select(p => p.Child?.FindVisualChildByType<CommandBarFlyoutCommandBar>())
+					.FirstOrDefault(c => c is not null) is not { } commandBar)
+			{
+				Assert.Fail("the open selection flyout should host a CommandBarFlyoutCommandBar");
+				return;
+			}
+			if (commandBar.FindVisualChildByName("MoreButton") is not FrameworkElement moreButton)
+			{
+				Assert.Fail("the command bar template should expose a MoreButton");
+				return;
+			}
 			Assert.AreEqual(Visibility.Collapsed, moreButton.Visibility, "the overflow (\"...\") button must be hidden when the flyout has no secondary commands");
 		}
 
@@ -5424,7 +5439,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Task.Delay(1200); // cross the 800ms Holding-gesture threshold
 			finger.Release();
 			await WindowHelper.WaitForIdle();
-			await Task.Delay(150);
+			// The flyout visibility update is queued to the dispatcher; wait for a flyout to actually open instead of a fixed delay.
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true
+					|| (SUT.ContextFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "a text command flyout should open after the long-press");
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual("Text", SUT.SelectedText, "the long-press should have selected the word");
@@ -5470,8 +5489,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Task.Delay(150);
 			await WindowHelper.WaitForIdle();
 
-			var contextFlyout = SUT.ContextFlyout as TextCommandBarFlyout;
-			Assert.IsTrue(contextFlyout?.IsOpen == true, "the ContextFlyout should open on right-click over the text");
+			if (SUT.ContextFlyout is not TextCommandBarFlyout contextFlyout || !contextFlyout.IsOpen)
+			{
+				Assert.Fail("the ContextFlyout should open on right-click over the text");
+				return;
+			}
 
 			var (_, hasCut, hasCopy, _) = GetAvailableCommands(contextFlyout);
 			Assert.IsTrue(hasCopy, $"Copy should be available (selectedText='{SUT.SelectedText}')");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5266,14 +5266,26 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(caretBeforeTap, SUT.SelectionStart, $"tapping the insertion handle must not move the caret (len {SUT.Text.Length}, was {caretBeforeTap}, now {SUT.SelectionStart})");
 		}
 
-		// Native Android: tapping the single insertion handle re-opens the selection flyout (Paste / Select-all)
-		// even over a collapsed caret, mirroring the native insertion-handle popup. This is an Uno addition beyond
-		// the WinUI port, which shows the SelectionFlyout only for a non-empty selection.
+		// Native Android: tapping the single insertion handle re-opens the selection flyout even over a collapsed
+		// caret (no selection), mirroring the native insertion-handle popup. This is an Uno addition beyond the WinUI
+		// port, which shows the SelectionFlyout only for a non-empty selection. The clipboard is cleared so Paste is
+		// unavailable: Select All alone must keep the flyout open, since a transient flyout with no primary command
+		// self-hides (see TextCommandBarFlyout's Opened handler).
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
 		public async Task When_Touch_Tap_Insertion_Handle_Opens_Flyout_Android()
 		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
 			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+			{
+				ClearClipboard();
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false);
+			});
 
 			var SUT = new TextBox
 			{
@@ -5296,6 +5308,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				message: "the first Android tap should place the single insertion handle");
 			Assert.IsNotNull(SUT.VisibleGrippersForTesting, "the insertion handle should be visible after the first Android tap");
 
+			// Empty the clipboard so Paste is unavailable — Select All is then the only command, the scenario that
+			// used to leave the flyout with no primary command and self-hide.
+			Clipboard.Clear();
+			await WindowHelper.WaitFor(() => !SUT.CanPasteClipboardContent, message: "the clipboard should read empty so Paste is unavailable");
+
 			// Wait past the 500ms multi-tap window so the handle tap is a single tap (not a double-tap-to-select-word).
 			await Task.Delay(600);
 
@@ -5310,13 +5327,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual("", SUT.SelectedText, "tapping the handle keeps a collapsed caret (no word selected)");
 
 			var flyout = SUT.SelectionFlyout as TextCommandBarFlyout;
-			Assert.IsTrue(flyout?.IsOpen == true, "tapping the insertion handle should open the selection flyout over the collapsed caret");
+			Assert.IsTrue(flyout?.IsOpen == true, "tapping the insertion handle should open the selection flyout over the collapsed caret, even with an empty clipboard");
 
-			// The flyout must be populated/useful, not empty: Select All is present (there is text), while Copy is
-			// absent (nothing is selected).
-			var (hasSelectAll, _, hasCopy, _) = GetAvailableCommands(flyout);
+			// Select All keeps the flyout usable with an empty clipboard; Copy and Paste are absent (nothing is
+			// selected, nothing to paste).
+			var (hasSelectAll, _, hasCopy, hasPaste) = GetAvailableCommands(flyout);
 			Assert.IsTrue(hasSelectAll, "Select All should be available over a collapsed caret (there is text to select)");
 			Assert.IsFalse(hasCopy, "Copy should NOT be available over a collapsed caret (nothing is selected)");
+			Assert.IsFalse(hasPaste, "Paste should NOT be available with an empty clipboard");
 		}
 
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5335,6 +5335,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsTrue(hasSelectAll, "Select All should be available over a collapsed caret (there is text to select)");
 			Assert.IsFalse(hasCopy, "Copy should NOT be available over a collapsed caret (nothing is selected)");
 			Assert.IsFalse(hasPaste, "Paste should NOT be available with an empty clipboard");
+
+			// Select All must sit in the primary bar (so the flyout has a primary command and stays open) and, like
+			// Cut/Copy/Paste, must show its text label there — not render as a bare icon — so it reads as a command.
+			var selectAllButton = flyout!.PrimaryCommands
+				.OfType<AppBarButton>()
+				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.A && ka.Modifiers.HasFlag(_platformCtrlKey)));
+			Assert.IsNotNull(selectAllButton, "Select All should be a primary (bar) command so the flyout stays open");
+			Assert.IsNotNull(selectAllButton.Icon, "the primary Select All button should have an icon, matching Cut/Copy/Paste");
 		}
 
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5266,6 +5266,59 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(caretBeforeTap, SUT.SelectionStart, $"tapping the insertion handle must not move the caret (len {SUT.Text.Length}, was {caretBeforeTap}, now {SUT.SelectionStart})");
 		}
 
+		// Native Android: tapping the single insertion handle re-opens the selection flyout (Paste / Select-all)
+		// even over a collapsed caret, mirroring the native insertion-handle popup. This is an Uno addition beyond
+		// the WinUI port, which shows the SelectionFlyout only for a non-empty selection.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
+		public async Task When_Touch_Tap_Insertion_Handle_Opens_Flyout_Android()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// First tap: Android places a collapsed caret with the single insertion handle.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			finger.Press(new Point(bounds.Left + 20, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "the first Android tap should place the single insertion handle");
+			Assert.IsNotNull(SUT.VisibleGrippersForTesting, "the insertion handle should be visible after the first Android tap");
+
+			// Wait past the 500ms multi-tap window so the handle tap is a single tap (not a double-tap-to-select-word).
+			await Task.Delay(600);
+
+			// Tap the insertion handle itself (grab near its bottom edge, what a real finger hits).
+			var handle = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(handle.GetCenter().X, handle.Bottom - 2));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			await Task.Delay(150); // the flyout visibility update is queued to the dispatcher
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.SelectedText, "tapping the handle keeps a collapsed caret (no word selected)");
+
+			var flyout = SUT.SelectionFlyout as TextCommandBarFlyout;
+			Assert.IsTrue(flyout?.IsOpen == true, "tapping the insertion handle should open the selection flyout over the collapsed caret");
+
+			// The flyout must be populated/useful, not empty: Select All is present (there is text), while Copy is
+			// absent (nothing is selected).
+			var (hasSelectAll, _, hasCopy, _) = GetAvailableCommands(flyout);
+			Assert.IsTrue(hasSelectAll, "Select All should be available over a collapsed caret (there is text to select)");
+			Assert.IsFalse(hasCopy, "Copy should NOT be available over a collapsed caret (nothing is selected)");
+		}
+
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
 		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5244,6 +5244,88 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		public Task When_Touch_LongPress_Keeps_ContextMenu_Desktop()
 			=> AssertTouchLongPress(TextBox.TouchTextSelectionConvention.Desktop, expectWordSelected: false);
 
+		// A touch long-press on a mobile convention must select the word BEFORE the text control's flyout
+		// computes its commands. Regression: the inner DisplayBlock's ContextRequested class handler used to
+		// open the ContextFlyout with an empty selection (Cut/Copy omitted) before OnContextRequestedImpl
+		// selected the word. Driven with a real injected hold so the whole bubbling path is exercised.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
+		public async Task When_Touch_LongPress_Flyout_Includes_Copy_Android()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			await Task.Delay(1200); // cross the 800ms Holding-gesture threshold
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			await Task.Delay(150);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("Text", SUT.SelectedText, "the long-press should have selected the word");
+
+			var openFlyout =
+				(SUT.SelectionFlyout as TextCommandBarFlyout) is { IsOpen: true } sel ? sel :
+				(SUT.ContextFlyout as TextCommandBarFlyout) is { IsOpen: true } ctx ? ctx :
+				null;
+
+			Assert.IsNotNull(openFlyout, "a text command flyout should be open after the long-press");
+
+			var (_, hasCut, hasCopy, _) = GetAvailableCommands(openFlyout);
+
+			Assert.IsTrue(hasCopy, "Copy should be available: the word is selected");
+			Assert.IsTrue(hasCut, "Cut should be available: the word is selected");
+		}
+
+		// Sibling guard for the desktop/mouse path: a right-click over the text (whose ContextRequested
+		// originates on the inner DisplayBlock and bubbles to the TextBox) must still open the ContextFlyout,
+		// reflecting the current selection. Guards the OnContextRequestedCore DisplayBlock deferral.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
+		public async Task When_RightClick_Over_Selection_Flyout_Includes_Copy()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox { Width = 400, Text = "Some Text" };
+			await UITestHelper.Load(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SelectAll();
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var overText = new Point(bounds.Left + 20, bounds.GetCenter().Y); // inside "Some Text" and inside the selection
+			mouse.PressRight(overText);
+			mouse.ReleaseRight();
+			await WindowHelper.WaitForIdle();
+			await Task.Delay(150);
+			await WindowHelper.WaitForIdle();
+
+			var contextFlyout = SUT.ContextFlyout as TextCommandBarFlyout;
+			Assert.IsTrue(contextFlyout?.IsOpen == true, "the ContextFlyout should open on right-click over the text");
+
+			var (_, hasCut, hasCopy, _) = GetAvailableCommands(contextFlyout);
+			Assert.IsTrue(hasCopy, $"Copy should be available (selectedText='{SUT.SelectedText}')");
+			Assert.IsTrue(hasCut, $"Cut should be available (selectedText='{SUT.SelectedText}')");
+
+			contextFlyout.Hide();
+		}
+
 		// Native Android: a touch long-press selects the word (and suppresses the context menu).
 		// The Desktop convention keeps the default context-menu behavior (no auto word selection).
 		private static async Task AssertTouchLongPress(TextBox.TouchTextSelectionConvention convention, bool expectWordSelected)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5348,6 +5348,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsNotNull(selectAllLabel, "the primary Select All button template should expose a TextLabel");
 			Assert.AreEqual(Visibility.Visible, selectAllLabel.Visibility, "the primary Select All button must show its text label (like Cut/Copy/Paste), not just an icon");
 			Assert.IsFalse(string.IsNullOrEmpty(selectAllLabel.Text), "the primary Select All button label must have text");
+
+			// With Select All in the primary bar there is nothing in the overflow, so the "..." overflow button must
+			// not appear (it would otherwise show a dangling "..." over an empty menu, because the labelled primary bar
+			// is taller than the command bar's compact height). See TextCommandBarFlyout.UpdateButtons.
+			Assert.AreEqual(0, flyout.SecondaryCommands.Count, "the insertion-caret flyout should have no secondary commands");
+			var commandBar = VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)
+				.Select(p => p.Child?.FindVisualChildByType<CommandBarFlyoutCommandBar>())
+				.FirstOrDefault(c => c is not null);
+			Assert.IsNotNull(commandBar, "the open selection flyout should host a CommandBarFlyoutCommandBar");
+			var moreButton = commandBar.FindVisualChildByName("MoreButton") as FrameworkElement;
+			Assert.IsNotNull(moreButton, "the command bar template should expose a MoreButton");
+			Assert.AreEqual(Visibility.Collapsed, moreButton.Visibility, "the overflow (\"...\") button must be hidden when the flyout has no secondary commands");
 		}
 
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5343,6 +5343,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.A && ka.Modifiers.HasFlag(_platformCtrlKey)));
 			Assert.IsNotNull(selectAllButton, "Select All should be a primary (bar) command so the flyout stays open");
 			Assert.IsNotNull(selectAllButton.Icon, "the primary Select All button should have an icon, matching Cut/Copy/Paste");
+
+			var selectAllLabel = selectAllButton.FindVisualChildByName("TextLabel") as TextBlock;
+			Assert.IsNotNull(selectAllLabel, "the primary Select All button template should expose a TextLabel");
+			Assert.AreEqual(Visibility.Visible, selectAllLabel.Visibility, "the primary Select All button must show its text label (like Cut/Copy/Paste), not just an icon");
+			Assert.IsFalse(string.IsNullOrEmpty(selectAllLabel.Text), "the primary Select All button label must have text");
 		}
 
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6304,7 +6304,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// originates on the inner DisplayBlock and bubbles to the TextBox) must still open the ContextFlyout,
 		// reflecting the current selection. Guards the OnContextRequestedCore DisplayBlock deferral.
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mouse path: run on Desktop (dev) + real Android only
 		public async Task When_RightClick_Over_Selection_Flyout_Includes_Copy()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -6345,7 +6345,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// the overflow, where CommandBarFlyout already closes the flyout on Click. Guards that the touch/pen primary-bar
 		// close doesn't alter (or become needed by) the mouse path.
 		[TestMethod]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
+		// Skia-iOS is excluded: there a mouse is not the real device, and the selection collapses when the flyout
+		// closes - pre-existing behavior this mouse path does not change.
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
 		public async Task When_RightClick_Flyout_Copy_Closes_Flyout()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Combinatorial.MSTest;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -6188,6 +6189,70 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsTrue(hasCut, "Cut should be available: the word is selected");
 		}
 
+		// A touch/pen flyout routes Cut/Copy/Paste into the primary bar, which CommandBarFlyout does not close on
+		// invoke (it only wires that up for secondary commands). Copy is what exposes it: unlike Cut/Paste it leaves
+		// the text untouched, so nothing else closed the flyout and it lingered over the text after copying.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
+		public async Task When_Touch_Flyout_Copy_Closes_Flyout_Android()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			await Task.Delay(1200); // cross the 800ms Holding-gesture threshold
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			// The flyout visibility update is queued to the dispatcher; wait for a flyout to actually open instead of a fixed delay.
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true
+					|| (SUT.ContextFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "a text command flyout should open after the long-press");
+			await WindowHelper.WaitForIdle();
+
+			var openFlyout =
+				(SUT.SelectionFlyout as TextCommandBarFlyout) is { IsOpen: true } sel ? sel :
+				(SUT.ContextFlyout as TextCommandBarFlyout) is { IsOpen: true } ctx ? ctx :
+				null;
+
+			Assert.IsNotNull(openFlyout, "a text command flyout should be open after the long-press");
+			Assert.AreEqual("Text", SUT.SelectedText, "the long-press should have selected the word");
+
+			// On touch/pen, Copy sits in the primary bar (see TextCommandBarFlyout.UpdateButtons) - the path under test.
+			var copyButton = openFlyout.PrimaryCommands
+				.OfType<AppBarButton>()
+				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.C && ka.Modifiers.HasFlag(_platformCtrlKey)));
+			Assert.IsNotNull(copyButton, "Copy should be a primary (bar) command on a touch-opened flyout");
+
+			// Invoke it through AppBarButton.OnClick, the same path a tap takes, without hit-testing inside the popup.
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(copyButton) is not ButtonAutomationPeer copyPeer)
+			{
+				Assert.Fail("the Copy button should expose a ButtonAutomationPeer");
+				return;
+			}
+			copyPeer.Invoke();
+
+			await WindowHelper.WaitFor(
+				() => !openFlyout.IsOpen,
+				message: "invoking Copy should close the touch selection flyout");
+
+			// Copy must not disturb what it copied.
+			Assert.AreEqual("Text", SUT.SelectedText, "the selection should survive Copy");
+		}
+
 		// Repro for the long-press gripper path: after a touch long-press selects the word on the Android
 		// convention, BOTH selection thumbs must actually lay out and stay visible (not just the flyout).
 		// Sister of When_Touch_LongPress_Flyout_Includes_Copy_Android, which only checks the flyout commands
@@ -6273,6 +6338,64 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsTrue(hasCut, $"Cut should be available (selectedText='{SUT.SelectedText}')");
 
 			contextFlyout.Hide();
+		}
+
+		// Mouse counterpart of When_Touch_Flyout_Copy_Closes_Flyout_Android: with a pointer, Cut/Copy/Paste stay in
+		// the overflow, where CommandBarFlyout already closes the flyout on Click. Guards that the touch/pen primary-bar
+		// close doesn't alter (or become needed by) the mouse path.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
+		public async Task When_RightClick_Flyout_Copy_Closes_Flyout()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new TextBox { Width = 400, Text = "Some Text" };
+			await UITestHelper.Load(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SelectAll();
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			mouse.PressRight(new Point(bounds.Left + 20, bounds.GetCenter().Y)); // inside "Some Text" and the selection
+			mouse.ReleaseRight();
+			await WindowHelper.WaitForIdle();
+			await Task.Delay(150);
+			await WindowHelper.WaitForIdle();
+
+			if (SUT.ContextFlyout is not TextCommandBarFlyout contextFlyout || !contextFlyout.IsOpen)
+			{
+				Assert.Fail("the ContextFlyout should open on right-click over the text");
+				return;
+			}
+
+			// A mouse-opened flyout keeps Cut/Copy/Paste in the overflow (see TextCommandBarFlyout.UpdateButtons).
+			var copyButton = contextFlyout.SecondaryCommands
+				.OfType<AppBarButton>()
+				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.C && ka.Modifiers.HasFlag(_platformCtrlKey)));
+			Assert.IsNotNull(copyButton, "Copy should be a secondary (overflow) command on a mouse-opened flyout");
+			Assert.AreEqual(0, contextFlyout.PrimaryCommands.OfType<AppBarButton>().Count(
+				b => b.KeyboardAccelerators.Any(ka => ka.Key is VirtualKey.X or VirtualKey.C or VirtualKey.V && ka.Modifiers.HasFlag(_platformCtrlKey))),
+				"Cut/Copy/Paste must not reach the primary bar on a mouse-opened flyout");
+
+			if (FrameworkElementAutomationPeer.CreatePeerForElement(copyButton) is not ButtonAutomationPeer copyPeer)
+			{
+				Assert.Fail("the Copy button should expose a ButtonAutomationPeer");
+				return;
+			}
+			copyPeer.Invoke();
+
+			await WindowHelper.WaitFor(
+				() => !contextFlyout.IsOpen,
+				message: "invoking Copy should close the mouse-opened context flyout");
+
+			Assert.AreEqual("Some Text", SUT.SelectedText, "the selection should survive Copy");
 		}
 
 		// Native Android: a touch long-press selects the word (and suppresses the context menu).

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5457,6 +5457,152 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse(string.IsNullOrEmpty(pasteLabel.Text), "the primary Paste button label must have text");
 		}
 
+		// Repro: with a full selection's touch flyout open (both thumbs showing), Select All sits in the OVERFLOW
+		// (it's a secondary command while text is selected). Opening the overflow ("...") realizes it there; then
+		// tapping the LEFT thumb collapses the selection and reopens the flyout with Select All promoted to the lone
+		// primary command. That overflow-realized-then-promoted button must still show BOTH its icon and its text
+		// label, like Cut/Copy/Paste - not render as a bare icon. The overflow->primary re-parent is the path the
+		// creation-time style workaround misses, distinct from When_Touch_Tap_Insertion_Handle_Opens_Flyout_Android
+		// (which never realizes Select All in the overflow first).
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
+		public async Task When_Touch_SelectAll_Overflow_Then_Tap_Left_Thumb_Flyout_Shows_SelectAll_Label()
+		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+			{
+				ClearClipboard();
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false);
+			});
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "asd",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Select all: "asd" is a single word, so a touch double-tap selects the whole text, shows both thumbs, and
+			// opens the selection flyout - the touch path that surfaces it (a programmatic SelectAll never sets the
+			// touch input mode nor the thumbs).
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var wordPoint = new Point(bounds.Left + 15, bounds.GetCenter().Y);
+			finger.Press(wordPoint);
+			finger.Release();
+			finger.Press(wordPoint);
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.SelectedText == "asd" && SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				message: "the double-tap should select all the text and show both thumbs");
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "the selection flyout should open over the full selection");
+			await WindowHelper.WaitForIdle();
+
+			// Empty the clipboard so Paste is unavailable - over the collapsed caret Select All is then the lone command.
+			Clipboard.Clear();
+			await WindowHelper.WaitFor(() => !SUT.CanPasteClipboardContent, message: "the clipboard should read empty so Paste is unavailable");
+
+			// Click the overflow ("...") button: expand the bar so Select All (a secondary command while the selection
+			// stands) is realized in the overflow.
+			if (VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)
+					.Select(p => p.Child?.FindVisualChildByType<CommandBarFlyoutCommandBar>())
+					.FirstOrDefault(c => c is not null) is not { } commandBar)
+			{
+				Assert.Fail("the open selection flyout should host a CommandBarFlyoutCommandBar");
+				return;
+			}
+			if (commandBar.FindVisualChildByName("MoreButton") is not FrameworkElement moreButton)
+			{
+				Assert.Fail("the command bar template should expose a MoreButton");
+				return;
+			}
+			await WindowHelper.WaitFor(() => moreButton.Visibility == Visibility.Visible && moreButton.GetAbsoluteBoundsRect().Width > 0, message: "the overflow (\"...\") button should be shown while the full selection keeps Select All in the overflow");
+			await Task.Delay(600); // clear the multi-tap window from the double-tap before tapping the MoreButton
+			finger.Press(moreButton.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitFor(() => commandBar.IsOpen, message: "tapping the overflow button should open the command bar (realizing Select All in the overflow)");
+			await WindowHelper.WaitForIdle();
+
+			// Select All has now been realized once in the overflow. Fully hide the flyout so the collapsing thumb tap
+			// opens it cleanly from a closed state - reopening an already-open flyout via the gripper races its async
+			// Hide (worse after the overflow toggle) and no-ops.
+			SUT.SelectionFlyout?.Hide();
+			await WindowHelper.WaitFor(() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen != true, message: "the selection flyout should close before the collapsing thumb tap");
+			await WindowHelper.WaitForIdle();
+
+			// The gripper popups are (re)positioned on a later frame, so GetAbsoluteBoundsRect is stale right after the
+			// selection. Wait until the LEFT (start) thumb is actually placed over the control before tapping it.
+			await WindowHelper.WaitFor(
+				() =>
+				{
+					if (SUT.VisibleGrippersForTesting is not { } vg)
+					{
+						return false;
+					}
+					var g = vg.start.GetAbsoluteBoundsRect();
+					var s = SUT.GetAbsoluteBoundsRect();
+					return g.Width > 0 && g.Left < s.Right && s.Left < g.Right && g.Top < s.Bottom && s.Top < g.Bottom;
+				},
+				timeoutMS: 3000,
+				message: "the left thumb should be positioned over the TextBox before tapping it");
+
+			// Wait past the 500ms multi-tap window so tapping the thumb is a single tap (collapses to a caret) rather
+			// than a double-tap-to-select-word.
+			await Task.Delay(600);
+
+			// Tap the LEFT thumb (grab near its bottom edge, what a real finger hits) to collapse the selection and
+			// open the flyout over the caret - now with Select All promoted from the overflow to the lone primary command.
+			var leftThumb = SUT.VisibleGrippersForTesting!.Value.start.GetAbsoluteBoundsRect();
+			finger.Press(new Point(leftThumb.GetCenter().X, leftThumb.Bottom - 2));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "tapping the left thumb should open the selection flyout over the collapsed caret");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.SelectedText, "tapping the thumb collapses the selection to a caret");
+
+			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
+			{
+				Assert.Fail("the selection flyout should be a TextCommandBarFlyout");
+				return;
+			}
+
+			// Empty clipboard + collapsed caret => Select All is the lone command (no Cut/Copy, no Paste).
+			var (hasSelectAll, _, hasCopy, hasPaste) = GetAvailableCommands(flyout);
+			Assert.IsTrue(hasSelectAll, "Select All should be available over a collapsed caret (there is text to select)");
+			Assert.IsFalse(hasCopy, "Copy should NOT be available over a collapsed caret (nothing is selected)");
+			Assert.IsFalse(hasPaste, "Paste should NOT be available with an empty clipboard");
+
+			// Select All must sit in the primary bar and, like Cut/Copy/Paste, must show BOTH its icon and its text
+			// label there - not render as a bare icon. This is the reported bug on the overflow -> primary path.
+			var selectAllButton = flyout.PrimaryCommands
+				.OfType<AppBarButton>()
+				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.A && ka.Modifiers.HasFlag(_platformCtrlKey)));
+			Assert.IsNotNull(selectAllButton, "Select All should be a primary (bar) command so the flyout stays open");
+			Assert.IsNotNull(selectAllButton.Icon, "the primary Select All button should have an icon, matching Cut/Copy/Paste");
+
+			if (selectAllButton.FindVisualChildByName("TextLabel") is not TextBlock selectAllLabel)
+			{
+				Assert.Fail("the primary Select All button template should expose a TextLabel");
+				return;
+			}
+			Assert.AreEqual(Visibility.Visible, selectAllLabel.Visibility, "the primary Select All button must show its text label (like Cut/Copy/Paste), not just an icon");
+			Assert.IsFalse(string.IsNullOrEmpty(selectAllLabel.Text), "the primary Select All button label must have text");
+		}
+
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
 		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
 		{
@@ -5539,6 +5685,52 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.IsTrue(hasCopy, "Copy should be available: the word is selected");
 			Assert.IsTrue(hasCut, "Cut should be available: the word is selected");
+		}
+
+		// Repro for the long-press gripper path: after a touch long-press selects the word on the Android
+		// convention, BOTH selection thumbs must actually lay out and stay visible (not just the flyout).
+		// Sister of When_Touch_LongPress_Flyout_Includes_Copy_Android, which only checks the flyout commands
+		// and so would pass even if the flyout-focus path hid the thumbs.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
+		public async Task When_Touch_LongPress_Shows_Grippers_Android()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			await Task.Delay(1200); // cross the 800ms Holding-gesture threshold
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			// The word-select + flyout-visibility update are queued to the dispatcher; wait for the selection to settle.
+			await WindowHelper.WaitFor(() => SUT.SelectedText == "Text", message: "the long-press should have selected the word");
+			// Force the selection flyout to actually open (the user's real scenario) so the flyout-focus path runs...
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true
+					|| (SUT.ContextFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "a text command flyout should open after the long-press");
+			await WindowHelper.WaitForIdle(); // ...and let it settle before checking the steady state.
+
+			// Steady state (Assert, not WaitFor): after the flyout opens, the word must stay selected AND both
+			// thumbs must remain — a bug that flips CaretMode back to thumbless leaves the highlight but drops the thumbs.
+			Assert.AreEqual("Text", SUT.SelectedText, "selection should persist while the flyout is open");
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode, "both thumbs must survive the flyout opening");
+			Assert.IsTrue(
+				SUT.VisibleGrippersForTesting is { } vg
+					&& vg.start.GetAbsoluteBoundsRect().Width > 0
+					&& vg.end.GetAbsoluteBoundsRect().Width > 0,
+				"both selection thumbs should stay laid out and visible while the flyout is open");
 		}
 
 		// Sibling guard for the desktop/mouse path: a right-click over the text (whose ContextRequested

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5672,16 +5672,92 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty password box");
 		}
 
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mobile conventions: run on Desktop (dev) + real Android only
+		public Task When_Touch_Tap_Selection_Thumb_Keeps_Selection_Android()
+			=> AssertTouchTapSelectionThumbKeepsSelection(TextBox.TouchTextSelectionConvention.Android, tapStartThumb: false);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Tap_Start_Selection_Thumb_Keeps_Selection_Android()
+			=> AssertTouchTapSelectionThumbKeepsSelection(TextBox.TouchTextSelectionConvention.Android, tapStartThumb: true);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Tap_Selection_Thumb_Keeps_Selection_iOS()
+			=> AssertTouchTapSelectionThumbKeepsSelection(TextBox.TouchTextSelectionConvention.iOS, tapStartThumb: false);
+
+		// Native iOS/Android: with a range selected (both thumbs showing), tapping either thumb must KEEP the
+		// selection - the thumb is a selection edge, not a caret. It used to route through the caret-placing tap path
+		// and collapse the selection to length 0, wiping the user's selection on a stray tap.
+		// The tap is delivered through the gripper host seam instead of by injecting at the thumb's coordinates:
+		// grippers live in popups clipped to the TextBox, so in the (short) test host the thumb hangs outside the
+		// control and a coordinate-aimed tap silently lands on the text - or on nothing - rather than the gripper.
+		private static async Task AssertTouchTapSelectionThumbKeepsSelection(TextBox.TouchTextSelectionConvention convention, bool tapStartThumb)
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Double-tap the first word to select it and show both thumbs.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var wordPoint = new Point(bounds.Left + 15, bounds.GetCenter().Y);
+			finger.Press(wordPoint);
+			finger.Release();
+			finger.Press(wordPoint);
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.SelectedText == "Some" && SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				message: "the double-tap should select the word and show both thumbs");
+
+			Assert.IsNotNull(SUT.VisibleGrippersForTesting, "both selection thumbs should be showing before tapping one");
+
+			// A real thumb tap arrives as a single tap well after the double-tap, so stamp the pointer point past the
+			// multi-tap window - otherwise the gripper folds it into the double-tap and selects a word instead.
+			var last = PointerRoutedEventArgs.LastPointerEvent?.GetCurrentPoint(null)
+				?? throw new InvalidOperationException("the injected taps should have left a pointer point");
+			var press = new Microsoft.UI.Input.PointerPoint(
+				last.FrameId,
+				last.Timestamp + 1_000_000, // +1s, past the 500ms multi-tap window
+				last.PointerDevice,
+				last.PointerId,
+				last.RawPosition,
+				last.Position,
+				last.IsInContact,
+				last.Properties);
+
+			// The presenter pins a gripper tap to the selection edge the thumb points at, never to the finger's
+			// position on the thumb (see TextSelectionGripperPresenter.OnGripperPointerReleased).
+			var anchorIndex = tapStartThumb ? SUT.SelectionStart : SUT.SelectionStart + SUT.SelectionLength;
+			((ITextSelectionGripperHost)SUT).OnGripperTapped(press, anchorIndex);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("Some", SUT.SelectedText, $"tapping the {(tapStartThumb ? "start" : "end")} thumb (anchor {anchorIndex}) must keep the selection, not collapse it");
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing, SUT.CaretMode, "both thumbs must remain after tapping one of them");
+		}
+
 		// Repro: with a full selection's touch flyout open (both thumbs showing), Select All sits in the OVERFLOW
 		// (it's a secondary command while text is selected). Opening the overflow ("...") realizes it there; then
-		// tapping the LEFT thumb collapses the selection and reopens the flyout with Select All promoted to the lone
-		// primary command. That overflow-realized-then-promoted button must still show BOTH its icon and its text
-		// label, like Cut/Copy/Paste - not render as a bare icon. The overflow->primary re-parent is the path the
+		// collapsing the selection to a caret and reopening the flyout promotes Select All to the lone primary
+		// command. That overflow-realized-then-promoted button must still show BOTH its icon and its text label,
+		// like Cut/Copy/Paste - not render as a bare icon. The overflow->primary re-parent is the path the
 		// creation-time style workaround misses, distinct from When_Touch_Tap_Insertion_Handle_Opens_Flyout_Android
 		// (which never realizes Select All in the overflow first).
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
-		public async Task When_Touch_SelectAll_Overflow_Then_Tap_Left_Thumb_Flyout_Shows_SelectAll_Label()
+		public async Task When_Touch_SelectAll_Overflow_Then_Collapse_Flyout_Shows_SelectAll_Label()
 		{
 			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
 			{
@@ -5698,7 +5774,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var SUT = new TextBox
 			{
 				Width = 400,
-				Text = "asd",
+				Text = "asd qwertyuiopasdfghjkl",
 				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
 			};
 
@@ -5707,11 +5783,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();
 
-			// Select all: "asd" is a single word, so a touch double-tap selects the whole text, shows both thumbs, and
-			// opens the selection flyout - the touch path that surfaces it (a programmatic SelectAll never sets the
-			// touch input mode nor the thumbs).
+			// A touch double-tap selects the word, shows both thumbs and opens the selection flyout - the touch path
+			// that surfaces the bug (a programmatic SelectAll sets neither the touch input mode nor the thumbs).
 			var bounds = SUT.GetAbsoluteBoundsRect();
 			var wordPoint = new Point(bounds.Left + 15, bounds.GetCenter().Y);
+			// Well right of both thumbs (which sit at the "asd" edges) but still over text, so the collapsing tap
+			// lands on plain text rather than on a thumb - tapping a thumb keeps the selection.
+			var farPoint = new Point(bounds.Left + 140, bounds.GetCenter().Y);
 			finger.Press(wordPoint);
 			finger.Release();
 			finger.Press(wordPoint);
@@ -5749,15 +5827,27 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => commandBar.IsOpen, message: "tapping the overflow button should open the command bar (realizing Select All in the overflow)");
 			await WindowHelper.WaitForIdle();
 
-			// Select All has now been realized once in the overflow. Fully hide the flyout so the collapsing thumb tap
-			// opens it cleanly from a closed state - reopening an already-open flyout via the gripper races its async
-			// Hide (worse after the overflow toggle) and no-ops.
+			// Select All has now been realized once in the overflow. Fully hide the flyout so the reopening tap works
+			// from a closed state - reopening an already-open flyout via the gripper races its async Hide (worse after
+			// the overflow toggle) and no-ops.
 			SUT.SelectionFlyout?.Hide();
-			await WindowHelper.WaitFor(() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen != true, message: "the selection flyout should close before the collapsing thumb tap");
+			await WindowHelper.WaitFor(() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen != true, message: "the selection flyout should close before collapsing the selection");
 			await WindowHelper.WaitForIdle();
 
+			// Wait past the 500ms multi-tap window so the next tap is a single tap (collapse to a caret) rather than a
+			// double-tap-to-select-word.
+			await Task.Delay(600);
+
+			// A plain tap in the text collapses the selection to a caret with the single insertion handle (native
+			// Android). Tapping a selection thumb would NOT do this - it keeps the selection.
+			finger.Press(farPoint);
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.SelectedText == "" && SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "a plain tap should collapse the selection to the single insertion handle");
+
 			// The gripper popups are (re)positioned on a later frame, so GetAbsoluteBoundsRect is stale right after the
-			// selection. Wait until the LEFT (start) thumb is actually placed over the control before tapping it.
+			// collapse. Wait until the insertion handle is actually placed over the control before tapping it.
 			await WindowHelper.WaitFor(
 				() =>
 				{
@@ -5765,29 +5855,27 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 					{
 						return false;
 					}
-					var g = vg.start.GetAbsoluteBoundsRect();
+					var g = vg.end.GetAbsoluteBoundsRect();
 					var s = SUT.GetAbsoluteBoundsRect();
 					return g.Width > 0 && g.Left < s.Right && s.Left < g.Right && g.Top < s.Bottom && s.Top < g.Bottom;
 				},
 				timeoutMS: 3000,
-				message: "the left thumb should be positioned over the TextBox before tapping it");
+				message: "the insertion handle should be positioned over the TextBox before tapping it");
 
-			// Wait past the 500ms multi-tap window so tapping the thumb is a single tap (collapses to a caret) rather
-			// than a double-tap-to-select-word.
-			await Task.Delay(600);
+			await Task.Delay(600); // a single tap on the handle, not a double-tap-to-select-word
 
-			// Tap the LEFT thumb (grab near its bottom edge, what a real finger hits) to collapse the selection and
-			// open the flyout over the caret - now with Select All promoted from the overflow to the lone primary command.
-			var leftThumb = SUT.VisibleGrippersForTesting!.Value.start.GetAbsoluteBoundsRect();
-			finger.Press(new Point(leftThumb.GetCenter().X, leftThumb.Bottom - 2));
+			// Tap the insertion handle (grab near its bottom edge, what a real finger hits) to reopen the flyout over
+			// the caret - now with Select All promoted from the overflow to the lone primary command.
+			var handle = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			finger.Press(new Point(handle.GetCenter().X, handle.Bottom - 2));
 			finger.Release();
 			await WindowHelper.WaitForIdle();
 			await WindowHelper.WaitFor(
 				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
-				message: "tapping the left thumb should open the selection flyout over the collapsed caret");
+				message: "tapping the insertion handle should reopen the selection flyout over the collapsed caret");
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual("", SUT.SelectedText, "tapping the thumb collapses the selection to a caret");
+			Assert.AreEqual("", SUT.SelectedText, "the reopened flyout should sit over a collapsed caret");
 
 			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5457,6 +5457,221 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse(string.IsNullOrEmpty(pasteLabel.Text), "the primary Paste button label must have text");
 		}
 
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mobile conventions: run on Desktop (dev) + real Android only
+		public Task When_Touch_DoubleTap_Empty_Opens_Flyout_Android()
+			=> AssertTouchGestureOnEmptyBoxOpensFlyout(TextBox.TouchTextSelectionConvention.Android, longPress: false);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_DoubleTap_Empty_Opens_Flyout_iOS()
+			=> AssertTouchGestureOnEmptyBoxOpensFlyout(TextBox.TouchTextSelectionConvention.iOS, longPress: false);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_LongPress_Empty_Opens_Flyout_Android()
+			=> AssertTouchGestureOnEmptyBoxOpensFlyout(TextBox.TouchTextSelectionConvention.Android, longPress: true);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_LongPress_Empty_Opens_Flyout_iOS()
+			=> AssertTouchGestureOnEmptyBoxOpensFlyout(TextBox.TouchTextSelectionConvention.iOS, longPress: true);
+
+		// Native iOS/Android pop the text flyout (Paste) over an EMPTY field on a double-tap or a long-press. Neither
+		// gesture has a word to select nor a caret to drag there, so the mobile conventions used to swallow it and show
+		// nothing at all. The clipboard is populated so Paste exists: with no command the flyout self-hides (correctly).
+		private async Task AssertTouchGestureOnEmptyBoxOpensFlyout(TextBox.TouchTextSelectionConvention convention, bool longPress)
+		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+			{
+				ClearClipboard();
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false);
+			});
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			// Focus so the clipboard subscription is live, then put text on the clipboard so Paste is available.
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			var dp = new DataPackage();
+			dp.SetText("clipboard text");
+			Clipboard.SetContent(dp);
+			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+			var center = SUT.GetAbsoluteBoundsRect().GetCenter();
+
+			if (longPress)
+			{
+				finger.Press(center);
+				await Task.Delay(1200); // cross the 800ms Holding-gesture threshold
+				finger.Release();
+			}
+			else
+			{
+				// Two back-to-back taps (no idle between) fall inside the multi-tap window.
+				finger.Press(center);
+				finger.Release();
+				finger.Press(center);
+				finger.Release();
+			}
+
+			await WindowHelper.WaitForIdle();
+			// The flyout visibility update is queued to the dispatcher; wait for it to actually open.
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: $"the {(longPress ? "long-press" : "double-tap")} should open the selection flyout over the empty box");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.SelectedText, "there is nothing to select in an empty box");
+			Assert.AreEqual(
+				convention == TextBox.TouchTextSelectionConvention.Android
+					? TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing
+					: TextBox.CaretDisplayMode.ThumblessCaretShowing,
+				SUT.CaretMode,
+				"the gesture should leave the convention's collapsed caret");
+
+			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
+			{
+				Assert.Fail("the selection flyout should be a TextCommandBarFlyout");
+				return;
+			}
+
+			var (hasSelectAll, hasCut, hasCopy, hasPaste) = GetAvailableCommands(flyout);
+			Assert.IsTrue(hasPaste, "Paste should be available over an empty box when the clipboard has content");
+			Assert.IsFalse(hasCopy, "Copy should NOT be available over an empty box (nothing is selected)");
+			Assert.IsFalse(hasCut, "Cut should NOT be available over an empty box (nothing is selected)");
+			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty box (there is no text to select)");
+		}
+
+		// An empty field with an empty clipboard has no command at all, so the gesture must not open the flyout —
+		// opening it would only flash an empty popup before it self-hides. The caret is still placed.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public async Task When_Touch_DoubleTap_Empty_Without_Clipboard_Shows_No_Flyout_Android()
+		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			Clipboard.Clear();
+			await WindowHelper.WaitFor(() => !SUT.CanPasteClipboardContent, message: "the clipboard should read empty so Paste is unavailable");
+
+			// Counting Opened is what separates "never opened" from "opened then self-hid" — the latter leaves
+			// IsOpen false too, but flashes an empty popup on screen.
+			var openedCount = 0;
+			void onOpened(object sender, object e) => openedCount++;
+			SUT.SelectionFlyout.Opened += onOpened;
+			using var ___ = new DisposableAction(() => SUT.SelectionFlyout.Opened -= onOpened);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+			var center = SUT.GetAbsoluteBoundsRect().GetCenter();
+			finger.Press(center);
+			finger.Release();
+			finger.Press(center);
+			finger.Release();
+
+			// Give any queued flyout-visibility update time to run before asserting nothing opened.
+			await WindowHelper.WaitForIdle();
+			await Task.Delay(200);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, openedCount, "an empty box with an empty clipboard has no command, so the flyout must never open (not even to self-hide)");
+			Assert.IsFalse((SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true, "an empty box with an empty clipboard has no command, so no flyout should open");
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing, SUT.CaretMode, "the gesture should still place the Android insertion caret");
+		}
+
+		// PasswordBox derives from TextBox and shares the touch gesture path, so the empty-field flyout runs there too:
+		// it must open with Paste over the masked (here empty) display text rather than throw or show nothing.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public async Task When_Touch_LongPress_Empty_PasswordBox_Opens_Flyout_Android()
+		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+			{
+				ClearClipboard();
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false);
+			});
+
+			var SUT = new PasswordBox
+			{
+				Width = 400,
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			var dp = new DataPackage();
+			dp.SetText("clipboard text");
+			Clipboard.SetContent(dp);
+			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			await Task.Delay(1200); // cross the 800ms Holding-gesture threshold
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "the long-press should open the selection flyout over the empty password box");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.Password, "a long-press must not alter the password");
+
+			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
+			{
+				Assert.Fail("the selection flyout should be a TextCommandBarFlyout");
+				return;
+			}
+
+			var (hasSelectAll, hasCut, hasCopy, hasPaste) = GetAvailableCommands(flyout);
+			Assert.IsTrue(hasPaste, "Paste should be available over an empty password box when the clipboard has content");
+			Assert.IsFalse(hasCopy, "Copy is never offered on a PasswordBox");
+			Assert.IsFalse(hasCut, "Cut is never offered on a PasswordBox");
+			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty password box");
+		}
+
 		// Repro: with a full selection's touch flyout open (both thumbs showing), Select All sits in the OVERFLOW
 		// (it's a secondary command while text is selected). Opening the overflow ("...") realizes it there; then
 		// tapping the LEFT thumb collapses the selection and reopens the flyout with Select All promoted to the lone

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5408,13 +5408,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await UITestHelper.Load(SUT);
 
-			// Focus so the clipboard subscription is live, then put text on the clipboard so Paste is available.
+			// Seed the clipboard before focusing: focus reads it live, so Paste is available without waiting for the
+			// ContentChanged notification (a 1s poll on macOS).
+			await SetClipboardText("clipboard text");
+
 			SUT.Focus(FocusState.Programmatic);
 			await WindowHelper.WaitForIdle();
-			var dp = new DataPackage();
-			dp.SetText("clipboard text");
-			Clipboard.SetContent(dp);
-			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
+			Assert.IsTrue(SUT.CanPasteClipboardContent, "the clipboard should read non-empty so Paste is available");
 
 			// A touch tap sets the last input device to Touch so the flyout opens in primary-commands mode (Paste on the
 			// bar). The tap only places a caret in the empty box (no selection), matching how a touch-opened context
@@ -5554,13 +5554,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await UITestHelper.Load(SUT);
 
-			// Focus so the clipboard subscription is live, then put text on the clipboard so Paste is available.
+			// Seed the clipboard before focusing: focus reads it live, so Paste is available without waiting for the
+			// ContentChanged notification (a 1s poll on macOS).
+			await SetClipboardText("clipboard text");
+
 			SUT.Focus(FocusState.Programmatic);
 			await WindowHelper.WaitForIdle();
-			var dp = new DataPackage();
-			dp.SetText("clipboard text");
-			Clipboard.SetContent(dp);
-			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
+			Assert.IsTrue(SUT.CanPasteClipboardContent, "the clipboard should read non-empty so Paste is available");
 
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();
@@ -5748,12 +5748,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await UITestHelper.Load(SUT);
 
+			// Seed the clipboard before focusing: focus reads it live, so Paste is available without waiting for the
+			// ContentChanged notification (a 1s poll on macOS).
+			await SetClipboardText("clipboard text");
+
 			SUT.Focus(FocusState.Programmatic);
 			await WindowHelper.WaitForIdle();
-			var dp = new DataPackage();
-			dp.SetText("clipboard text");
-			Clipboard.SetContent(dp);
-			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
+			Assert.IsTrue(SUT.CanPasteClipboardContent, "the clipboard should read non-empty so Paste is available");
 
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5416,8 +5416,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
 
 			// A touch tap sets the last input device to Touch so the flyout opens in primary-commands mode (Paste on the
-			// bar). The empty box swallows the tap (its tap-to-caret path is gated on non-empty text), so it only sets the
-			// input mode — matching how a touch-opened context flyout reaches this state on device.
+			// bar). The tap only places a caret in the empty box (no selection), matching how a touch-opened context
+			// flyout reaches this state on device.
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();
 			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
@@ -5455,6 +5455,56 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 			Assert.AreEqual(Visibility.Visible, pasteLabel.Visibility, "the lone primary Paste button must show its text label, not just an icon");
 			Assert.IsFalse(string.IsNullOrEmpty(pasteLabel.Text), "the primary Paste button label must have text");
+		}
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mobile conventions: run on Desktop (dev) + real Android only
+		public Task When_Touch_Tap_Empty_Places_Caret_Android()
+			=> AssertTouchTapOnEmptyBoxPlacesCaret(TextBox.TouchTextSelectionConvention.Android, TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Tap_Empty_Places_Caret_iOS()
+			=> AssertTouchTapOnEmptyBoxPlacesCaret(TextBox.TouchTextSelectionConvention.iOS, TextBox.CaretDisplayMode.ThumblessCaretShowing);
+
+		// Native iOS/Android: a single tap in an EMPTY field places the caret - Android with its insertion handle, iOS
+		// as a bare caret. The empty box used to swallow the tap entirely (the tap-to-caret path was gated on non-empty
+		// text), leaving no caret affordance and no handle to open the flyout from. A single tap must NOT pop the
+		// flyout though: that belongs to the double-tap / long-press / handle-tap.
+		private static async Task AssertTouchTapOnEmptyBoxPlacesCaret(TextBox.TouchTextSelectionConvention convention, TextBox.CaretDisplayMode expectedCaret)
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "",
+				TouchSelectionConvention = convention
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitFor(() => SUT.CaretMode == expectedCaret, message: $"a tap in the empty box should leave the {convention} caret");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart, "the caret should sit at the only available index");
+			Assert.AreEqual(0, SUT.SelectionLength, "there is nothing to select in an empty box");
+			if (convention == TextBox.TouchTextSelectionConvention.Android)
+			{
+				Assert.IsNotNull(SUT.VisibleGrippersForTesting, "Android should show the insertion handle so it can open the flyout");
+			}
+
+			// A single tap is not a flyout gesture.
+			await Task.Delay(200);
+			await WindowHelper.WaitForIdle();
+			Assert.IsFalse((SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true, "a single tap must not open the selection flyout");
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5377,6 +5377,86 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(Visibility.Collapsed, moreButton.Visibility, "the overflow (\"...\") button must be hidden when the flyout has no secondary commands");
 		}
 
+		// Over an EMPTY textbox with clipboard content, Paste is the only available command and, under a touch/pen flyout,
+		// is promoted to the primary bar with nothing in the overflow — the lone-primary/no-secondary case. Like Cut/Copy/
+		// Paste in a selection flyout, that primary Paste button must show its text label, not render as a bare icon — the
+		// same primary-bar label miss that hit a lone Select All.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // touch flyout path: run on Desktop (dev) + real Android only
+		public async Task When_Touch_Paste_Only_Flyout_Shows_Label()
+		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+			{
+				ClearClipboard();
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false);
+			});
+
+			// Empty textbox: with nothing to select there is no Select All, so a populated clipboard leaves Paste as the
+			// sole command — the lone-primary/no-secondary flyout.
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = ""
+			};
+
+			await UITestHelper.Load(SUT);
+
+			// Focus so the clipboard subscription is live, then put text on the clipboard so Paste is available.
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			var dp = new DataPackage();
+			dp.SetText("clipboard text");
+			Clipboard.SetContent(dp);
+			await WindowHelper.WaitFor(() => SUT.CanPasteClipboardContent, message: "the clipboard should read non-empty so Paste is available");
+
+			// A touch tap sets the last input device to Touch so the flyout opens in primary-commands mode (Paste on the
+			// bar). The empty box swallows the tap (its tap-to-caret path is gated on non-empty text), so it only sets the
+			// input mode — matching how a touch-opened context flyout reaches this state on device.
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			var flyout = (TextCommandBarFlyout)SUT.ContextFlyout;
+			flyout.ShowAt(SUT);
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => flyout.IsOpen, message: "the context flyout should open over the empty box");
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(flyout.InputDevicePrefersPrimaryCommands, "the touch tap should open the flyout in primary-commands mode (Paste on the bar)");
+
+			// Empty box + clipboard content: Paste is the only command (no selection → no Copy; no text → no Select All),
+			// sitting alone in the primary bar with an empty overflow.
+			var (hasSelectAll, _, hasCopy, hasPaste) = GetAvailableCommands(flyout);
+			Assert.IsTrue(hasPaste, "Paste should be available over an empty box when the clipboard has content");
+			Assert.IsFalse(hasCopy, "Copy should NOT be available over an empty box (nothing is selected)");
+			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty box (there is no text to select)");
+			Assert.AreEqual(1, flyout.PrimaryCommands.Count, "Paste should be the lone primary command over an empty box");
+			Assert.AreEqual(0, flyout.SecondaryCommands.Count, "the Paste-only flyout should have no secondary commands");
+
+			var pasteButton = flyout.PrimaryCommands
+				.OfType<AppBarButton>()
+				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.V && ka.Modifiers.HasFlag(_platformCtrlKey)));
+			Assert.IsNotNull(pasteButton, "Paste should be a primary (bar) command over an empty box with clipboard content");
+			Assert.IsNotNull(pasteButton.Icon, "the primary Paste button should have an icon");
+
+			// The lone primary Paste button must show its text label, not just its icon — the reported bug.
+			if (pasteButton.FindVisualChildByName("TextLabel") is not TextBlock pasteLabel)
+			{
+				Assert.Fail("the primary Paste button template should expose a TextLabel");
+				return;
+			}
+			Assert.AreEqual(Visibility.Visible, pasteLabel.Visibility, "the lone primary Paste button must show its text label, not just an icon");
+			Assert.IsFalse(string.IsNullOrEmpty(pasteLabel.Text), "the primary Paste button label must have text");
+		}
+
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
 		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5377,13 +5377,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(Visibility.Collapsed, moreButton.Visibility, "the overflow (\"...\") button must be hidden when the flyout has no secondary commands");
 		}
 
-		// Over an EMPTY textbox with clipboard content, Paste is the only available command and, under a touch/pen flyout,
-		// is promoted to the primary bar with nothing in the overflow — the lone-primary/no-secondary case. Like Cut/Copy/
-		// Paste in a selection flyout, that primary Paste button must show its text label, not render as a bare icon — the
-		// same primary-bar label miss that hit a lone Select All.
+		// Over an EMPTY PasswordBox with clipboard content, Paste is the only available command and, under a touch/pen
+		// flyout, is promoted to the primary bar with nothing in the overflow — the lone-primary/no-secondary case. Like
+		// Cut/Copy/Paste in a selection flyout, that primary Paste button must show its text label, not render as a bare
+		// icon — the same primary-bar label miss that hit a lone Select All. A PasswordBox is used because a TextBox
+		// always offers Select All on touch, so it can no longer reach a lone-primary bar.
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // touch flyout path: run on Desktop (dev) + real Android only
-		public async Task When_Touch_Paste_Only_Flyout_Shows_Label()
+		public async Task When_Touch_Paste_Only_PasswordBox_Flyout_Shows_Label()
 		{
 			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
 			{
@@ -5397,12 +5398,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false);
 			});
 
-			// Empty textbox: with nothing to select there is no Select All, so a populated clipboard leaves Paste as the
+			// Empty PasswordBox: its Select All needs Password.Length > 0, so a populated clipboard leaves Paste as the
 			// sole command — the lone-primary/no-secondary flyout.
-			var SUT = new TextBox
+			var SUT = new PasswordBox
 			{
-				Width = 400,
-				Text = ""
+				Width = 400
 			};
 
 			await UITestHelper.Load(SUT);
@@ -5435,16 +5435,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// Empty box + clipboard content: Paste is the only command (no selection → no Copy; no text → no Select All),
 			// sitting alone in the primary bar with an empty overflow.
 			var (hasSelectAll, _, hasCopy, hasPaste) = GetAvailableCommands(flyout);
-			Assert.IsTrue(hasPaste, "Paste should be available over an empty box when the clipboard has content");
-			Assert.IsFalse(hasCopy, "Copy should NOT be available over an empty box (nothing is selected)");
-			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty box (there is no text to select)");
-			Assert.AreEqual(1, flyout.PrimaryCommands.Count, "Paste should be the lone primary command over an empty box");
+			Assert.IsTrue(hasPaste, "Paste should be available over an empty password box when the clipboard has content");
+			Assert.IsFalse(hasCopy, "Copy should NOT be available over an empty password box (nothing is selected)");
+			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty password box");
+			Assert.AreEqual(1, flyout.PrimaryCommands.Count, "Paste should be the lone primary command over an empty password box");
 			Assert.AreEqual(0, flyout.SecondaryCommands.Count, "the Paste-only flyout should have no secondary commands");
 
 			var pasteButton = flyout.PrimaryCommands
 				.OfType<AppBarButton>()
 				.FirstOrDefault(b => b.KeyboardAccelerators.Any(ka => ka.Key == VirtualKey.V && ka.Modifiers.HasFlag(_platformCtrlKey)));
-			Assert.IsNotNull(pasteButton, "Paste should be a primary (bar) command over an empty box with clipboard content");
+			Assert.IsNotNull(pasteButton, "Paste should be a primary (bar) command over an empty password box with clipboard content");
 			Assert.IsNotNull(pasteButton.Icon, "the primary Paste button should have an icon");
 
 			// The lone primary Paste button must show its text label, not just its icon — the reported bug.
@@ -5605,14 +5605,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsTrue(hasPaste, "Paste should be available over an empty box when the clipboard has content");
 			Assert.IsFalse(hasCopy, "Copy should NOT be available over an empty box (nothing is selected)");
 			Assert.IsFalse(hasCut, "Cut should NOT be available over an empty box (nothing is selected)");
-			Assert.IsFalse(hasSelectAll, "Select All should NOT be available over an empty box (there is no text to select)");
+			Assert.IsTrue(hasSelectAll, "Select All stays available on touch even over an empty box, so the gesture always has a command");
 		}
 
-		// An empty field with an empty clipboard has no command at all, so the gesture must not open the flyout —
-		// opening it would only flash an empty popup before it self-hides. The caret is still placed.
+		// On touch, Select All is available even over an empty box, so a double-tap opens the flyout with Select All
+		// alone - no Paste (empty clipboard), no Copy/Cut (nothing selected).
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
-		public async Task When_Touch_DoubleTap_Empty_Without_Clipboard_Shows_No_Flyout_Android()
+		public async Task When_Touch_DoubleTap_Empty_Without_Clipboard_Opens_Flyout_Android()
 		{
 			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
 			{
@@ -5627,6 +5627,66 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			{
 				Width = 400,
 				Text = "",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			Clipboard.Clear();
+			await WindowHelper.WaitFor(() => !SUT.CanPasteClipboardContent, message: "the clipboard should read empty so Paste is unavailable");
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+			var center = SUT.GetAbsoluteBoundsRect().GetCenter();
+			finger.Press(center);
+			finger.Release();
+			finger.Press(center);
+			finger.Release();
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "Select All alone should keep the empty-box flyout open with an empty clipboard");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing, SUT.CaretMode, "the gesture should still place the Android insertion caret");
+
+			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
+			{
+				Assert.Fail("the selection flyout should be a TextCommandBarFlyout");
+				return;
+			}
+
+			var (hasSelectAll, hasCut, hasCopy, hasPaste) = GetAvailableCommands(flyout);
+			Assert.IsTrue(hasSelectAll, "Select All is available on touch even over an empty box");
+			Assert.IsFalse(hasPaste, "Paste should NOT be available with an empty clipboard");
+			Assert.IsFalse(hasCopy, "Copy should NOT be available (nothing is selected)");
+			Assert.IsFalse(hasCut, "Cut should NOT be available (nothing is selected)");
+			Assert.AreEqual(1, flyout.PrimaryCommands.Count, "Select All should be the lone primary command");
+			Assert.AreEqual(0, flyout.SecondaryCommands.Count, "nothing should land in the overflow");
+		}
+
+		// The counterpart that keeps HasTouchPrimaryCommandsFor honest: an empty PasswordBox with an empty clipboard is
+		// the remaining case with genuinely no primary command (its Select All needs Password.Length > 0 and routes to
+		// the overflow anyway), so the gesture must not open a flyout at all there.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public async Task When_Touch_DoubleTap_Empty_PasswordBox_Without_Clipboard_Shows_No_Flyout()
+		{
+			if (!Uno.Foundation.Extensibility.ApiExtensibility.IsRegistered<Uno.ApplicationModel.DataTransfer.IClipboardExtension>())
+			{
+				Assert.Inconclusive("Clipboard is not available on this platform.");
+			}
+
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new PasswordBox
+			{
+				Width = 400,
 				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
 			};
 
@@ -5657,9 +5717,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Task.Delay(200);
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(0, openedCount, "an empty box with an empty clipboard has no command, so the flyout must never open (not even to self-hide)");
-			Assert.IsFalse((SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true, "an empty box with an empty clipboard has no command, so no flyout should open");
-			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing, SUT.CaretMode, "the gesture should still place the Android insertion caret");
+			Assert.AreEqual(0, openedCount, "an empty password box with an empty clipboard has no command, so the flyout must never open (not even to self-hide)");
+			Assert.IsFalse((SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true, "no flyout should open with nothing to show");
 		}
 
 		// PasswordBox derives from TextBox and shares the touch gesture path, so the empty-field flyout runs there too:

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5603,6 +5603,95 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse(string.IsNullOrEmpty(selectAllLabel.Text), "the primary Select All button label must have text");
 		}
 
+		// Repro: touch-select a misspelled word so the selection flyout (Transient) includes the "proofing" submenu
+		// button in its overflow. Expanding the overflow ("...") must NOT auto-open the proofing submenu - the WinUI
+		// auto-open only belongs to the context menu (Standard show mode) that opens already expanded. In the Transient
+		// selection flyout the proofing button only loads once the user taps the overflow, and auto-opening there
+		// hijacks that tap.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // Android convention: run on Desktop (dev) + real Android only
+		public async Task When_Touch_Flyout_Overflow_Does_Not_AutoOpen_Proofing()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "helllo", // a single misspelled word, so a touch double-tap selects it whole
+				IsSpellCheckEnabled = true,
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Double-tap the word to select it whole, show both thumbs and open the (Transient) selection flyout.
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			var wordPoint = new Point(bounds.Left + 15, bounds.GetCenter().Y);
+			finger.Press(wordPoint);
+			finger.Release();
+			finger.Press(wordPoint);
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.SelectedText == "helllo",
+				message: "the double-tap should select the whole misspelled word");
+			await WindowHelper.WaitFor(
+				() => (SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true,
+				message: "the selection flyout should open over the selected word");
+			await WindowHelper.WaitForIdle();
+
+			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
+			{
+				Assert.Fail("the selection flyout should be a TextCommandBarFlyout");
+				return;
+			}
+
+			// The proofing button is the only secondary command carrying a (MenuFlyout) submenu. If spell-check is
+			// unavailable on this host or the word yielded no suggestions, the button is absent - nothing to assert.
+			if (flyout.SecondaryCommands.OfType<AppBarButton>().FirstOrDefault(b => b.Flyout is MenuFlyout) is not { } proofingButton
+				|| proofingButton.Flyout is not MenuFlyout proofingMenu
+				|| proofingMenu.Items.Count == 0)
+			{
+				Assert.Inconclusive("The proofing menu was not populated (spell-check service unavailable or no suggestions for the test word).");
+				return;
+			}
+
+			// Find the command bar and its overflow ("...") button.
+			if (VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)
+					.Select(p => p.Child?.FindVisualChildByType<CommandBarFlyoutCommandBar>())
+					.FirstOrDefault(c => c is not null) is not { } commandBar)
+			{
+				Assert.Fail("the open selection flyout should host a CommandBarFlyoutCommandBar");
+				return;
+			}
+			if (commandBar.FindVisualChildByName("MoreButton") is not FrameworkElement moreButton)
+			{
+				Assert.Fail("the command bar template should expose a MoreButton");
+				return;
+			}
+			await WindowHelper.WaitFor(() => moreButton.Visibility == Visibility.Visible && moreButton.GetAbsoluteBoundsRect().Width > 0, message: "the overflow (\"...\") button should be shown while the proofing button sits in the overflow");
+
+			// Tap the overflow to expand the bar - this realizes the proofing button (firing its Loaded handler, the
+			// code path under test). Wait past the multi-tap window from the double-tap first.
+			await Task.Delay(600);
+			finger.Press(moreButton.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitFor(() => commandBar.IsOpen, message: "tapping the overflow button should expand the command bar");
+			// Confirm the proofing button actually loaded, so the assertion below is not vacuous.
+			await WindowHelper.WaitFor(() => proofingButton.IsLoaded, message: "the proofing button should be realized once the overflow is expanded");
+			await WindowHelper.WaitForIdle();
+
+			// The auto-open (when it misfires) is scheduled ~100ms after the button loads; wait well past that.
+			await Task.Delay(500);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(proofingMenu.IsOpen, "the proofing submenu must not auto-open when the overflow is expanded in a Transient selection flyout");
+		}
+
 		// Native iOS/Android: tapping collapses an existing selection to a caret (Windows keeps it).
 		private static async Task AssertTouchTapCollapsesSelection(TextBox.TouchTextSelectionConvention convention)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.h.mux.cs
@@ -44,4 +44,13 @@ partial class TextCommandBarFlyout
 	private DispatcherHelper m_dispatcherHelper;
 
 	private bool m_isSettingToggleButtonState;
+
+	// Uno specific: the show mode captured when the flyout opens, before the CommandBar's Opened
+	// handler flips a Transient flyout to Standard. Used to auto-open the proofing menu only for a
+	// context menu (opened Standard), never for a Transient selection flyout the user expands.
+	private bool m_openedAsContextMenu;
+
+	// Uno specific: whether touch opened the flyout, captured at open time. The proofing auto-open is
+	// only suppressed for a touch-driven selection flyout; pen/mouse keep the WinUI default.
+	private bool m_openedByTouch;
 }

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -340,10 +340,19 @@ partial class TextCommandBarFlyout
 		// Uno specific: on a touch/pen insertion-caret flyout (no selection), Select All is the only command with an
 		// empty clipboard — and a transient flyout with no primary command self-hides (see the Opened handler). Put
 		// it in the primary bar there so tapping the insertion handle always opens a usable flyout.
-		var selectAllCommands = InputDevicePrefersPrimaryCommands && Target is TextBox { SelectionLength: 0 } and not PasswordBox
+
+		var commandListForSelectAll = InputDevicePrefersPrimaryCommands && Target is TextBox { SelectionLength: 0 } and not PasswordBox
 			? PrimaryCommands
 			: SecondaryCommands;
-		addButtonToCommandsIfPresent(TextControlButtons.SelectAll, selectAllCommands);
+		if ((buttonsToAdd & TextControlButtons.SelectAll) != TextControlButtons.None &&
+			GetButton(TextControlButtons.SelectAll) is AppBarButton selectAllButton)
+		{
+			// In the primary bar Select All is shown like Cut/Copy/Paste (icon + label), so restore the icon its
+			// command clears (see GetButton). The button instance is cached and reused, so clear the icon again when
+			// it routes back to the overflow menu, which stays text-only.
+			selectAllButton.Icon = commandListForSelectAll == PrimaryCommands ? new SymbolIcon(Symbol.SelectAll) : null;
+		}
+		addButtonToCommandsIfPresent(TextControlButtons.SelectAll, commandListForSelectAll);
 	}
 
 	private TextControlButtons GetButtonsToAdd()

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -945,6 +945,16 @@ partial class TextCommandBarFlyout
 
 						InitializeButtonWithUICommand(button, command, executeFunc);
 
+						// Uno specific: promoted to the primary bar of a transient insertion-caret flyout, Select All can be
+						// hosted directly under the command bar instead of its PrimaryItemsControl, so the implicit
+						// CommandBarFlyoutAppBarButtonStyle never reaches it and its text label stays collapsed. Assign that
+						// style explicitly so the button always carries the flyout template (Cut/Copy/Paste get it implicitly).
+						if (Application.Current?.Resources.TryGetValue("CommandBarFlyoutAppBarButtonStyle", out var flyoutButtonStyle) == true &&
+							flyoutButtonStyle is Style style)
+						{
+							button.Style = style;
+						}
+
 						m_buttons[TextControlButtons.SelectAll] = button;
 						return button;
 					}

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -336,7 +336,14 @@ partial class TextCommandBarFlyout
 
 		addButtonToCommandsIfPresent(TextControlButtons.Undo, SecondaryCommands);
 		addButtonToCommandsIfPresent(TextControlButtons.Redo, SecondaryCommands);
-		addButtonToCommandsIfPresent(TextControlButtons.SelectAll, SecondaryCommands);
+
+		// Uno specific: on a touch/pen insertion-caret flyout (no selection), Select All is the only command with an
+		// empty clipboard — and a transient flyout with no primary command self-hides (see the Opened handler). Put
+		// it in the primary bar there so tapping the insertion handle always opens a usable flyout.
+		var selectAllCommands = InputDevicePrefersPrimaryCommands && Target is TextBox { SelectionLength: 0 } and not PasswordBox
+			? PrimaryCommands
+			: SecondaryCommands;
+		addButtonToCommandsIfPresent(TextControlButtons.SelectAll, selectAllCommands);
 	}
 
 	private TextControlButtons GetButtonsToAdd()

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -348,9 +348,16 @@ partial class TextCommandBarFlyout
 			GetButton(TextControlButtons.SelectAll) is AppBarButton selectAllButton)
 		{
 			// In the primary bar Select All is shown like Cut/Copy/Paste (icon + label), so restore the icon its
-			// command clears (see GetButton). The button instance is cached and reused, so clear the icon again when
-			// it routes back to the overflow menu, which stays text-only.
-			selectAllButton.Icon = commandListForSelectAll == PrimaryCommands ? new SymbolIcon(Symbol.SelectAll) : null;
+			// command clears (see GetButton). The button instance is cached and reused, so reuse the existing icon
+			// (allocate only once) in the primary bar and clear it again when it routes back to the text-only overflow.
+			if (commandListForSelectAll == PrimaryCommands)
+			{
+				selectAllButton.Icon ??= new SymbolIcon(Symbol.SelectAll);
+			}
+			else
+			{
+				selectAllButton.Icon = null;
+			}
 		}
 		addButtonToCommandsIfPresent(TextControlButtons.SelectAll, commandListForSelectAll);
 

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -353,6 +353,18 @@ partial class TextCommandBarFlyout
 			selectAllButton.Icon = commandListForSelectAll == PrimaryCommands ? new SymbolIcon(Symbol.SelectAll) : null;
 		}
 		addButtonToCommandsIfPresent(TextControlButtons.SelectAll, commandListForSelectAll);
+
+		// Uno specific: the command bar shows the overflow ("...") button whenever its primary bar is taller than the
+		// compact height (i.e. its buttons carry labels), even with nothing in the overflow — which dangles a "..." over
+		// an empty menu on the label-carrying touch/pen selection flyout (most visibly the touch insertion-caret flyout,
+		// where Select All is promoted to the primary bar and nothing is secondary). For that touch/pen UX, gate the
+		// overflow button on the actual secondary-command count; keep WinUI's default (Auto) for mouse/keyboard.
+		if (m_commandBar is { } commandBar)
+		{
+			commandBar.OverflowButtonVisibility = InputDevicePrefersPrimaryCommands && SecondaryCommands.Count == 0
+				? CommandBarOverflowButtonVisibility.Collapsed
+				: CommandBarOverflowButtonVisibility.Auto;
+		}
 	}
 
 	private TextControlButtons GetButtonsToAdd()

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -867,6 +867,17 @@ partial class TextCommandBarFlyout
 	{
 		if (m_buttons.TryGetValue(textControlButton, out var result))
 		{
+			// Uno specific: CommandBarOverflowPresenter.ClearContainerForItemOverride clears an item's Style when it
+			// leaves the overflow, wiping the flyout style assigned at creation. Re-apply it to a cached button before
+			// it is (re)realized in the primary bar so it carries the flyout template (with PrimaryLabelStates) - a
+			// no-op when already styled. Without this, a button that transited overflow->primary (e.g. Select All after
+			// the "..." overflow is opened over a full selection, then promoted on caret-collapse) falls back to the
+			// default AppBarButton template and its text label stays collapsed.
+			if (result is AppBarButton cachedButton &&
+				textControlButton is TextControlButtons.Cut or TextControlButtons.Copy or TextControlButtons.Paste or TextControlButtons.SelectAll)
+			{
+				ApplyCommandBarFlyoutButtonStyle(cachedButton);
+			}
 			return result;
 		}
 		else

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -850,6 +850,19 @@ partial class TextCommandBarFlyout
 		}
 	}
 
+	// Uno specific: a command button promoted to the primary bar of a transient touch/pen selection flyout can be hosted
+	// directly under the command bar instead of its PrimaryItemsControl, so the implicit CommandBarFlyoutAppBarButtonStyle
+	// never reaches it and its text label stays collapsed. Assign it explicitly so the button always carries the flyout
+	// template (which drives both the primary-bar label and the overflow layout) regardless of where it is hosted.
+	private static void ApplyCommandBarFlyoutButtonStyle(AppBarButton button)
+	{
+		if (Application.Current?.Resources.TryGetValue("CommandBarFlyoutAppBarButtonStyle", out var flyoutButtonStyle) == true &&
+			flyoutButtonStyle is Style style)
+		{
+			button.Style = style;
+		}
+	}
+
 	private ICommandBarElement GetButton(TextControlButtons textControlButton)
 	{
 		if (m_buttons.TryGetValue(textControlButton, out var result))
@@ -867,6 +880,7 @@ partial class TextCommandBarFlyout
 
 						InitializeButtonWithUICommand(button, new StandardUICommand(StandardUICommandKind.Cut), executeFunc);
 
+						ApplyCommandBarFlyoutButtonStyle(button);
 						m_buttons[TextControlButtons.Cut] = button;
 						return button;
 					}
@@ -877,6 +891,7 @@ partial class TextCommandBarFlyout
 
 						InitializeButtonWithUICommand(button, new StandardUICommand(StandardUICommandKind.Copy), executeFunc);
 
+						ApplyCommandBarFlyoutButtonStyle(button);
 						m_buttons[TextControlButtons.Copy] = button;
 						return button;
 					}
@@ -887,6 +902,7 @@ partial class TextCommandBarFlyout
 
 						InitializeButtonWithUICommand(button, new StandardUICommand(StandardUICommandKind.Paste), executeFunc);
 
+						ApplyCommandBarFlyoutButtonStyle(button);
 						m_buttons[TextControlButtons.Paste] = button;
 						return button;
 					}
@@ -964,15 +980,7 @@ partial class TextCommandBarFlyout
 
 						InitializeButtonWithUICommand(button, command, executeFunc);
 
-						// Uno specific: promoted to the primary bar of a transient insertion-caret flyout, Select All can be
-						// hosted directly under the command bar instead of its PrimaryItemsControl, so the implicit
-						// CommandBarFlyoutAppBarButtonStyle never reaches it and its text label stays collapsed. Assign that
-						// style explicitly so the button always carries the flyout template (Cut/Copy/Paste get it implicitly).
-						if (Application.Current?.Resources.TryGetValue("CommandBarFlyoutAppBarButtonStyle", out var flyoutButtonStyle) == true &&
-							flyoutButtonStyle is Style style)
-						{
-							button.Style = style;
-						}
+						ApplyCommandBarFlyoutButtonStyle(button);
 
 						m_buttons[TextControlButtons.SelectAll] = button;
 						return button;

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -393,8 +393,8 @@ partial class TextCommandBarFlyout
 
 	// Uno specific: a transient flyout whose primary bar would be empty hides itself the moment it opens (see the
 	// Opened handler), which flashes an empty popup. Let a touch/pen caller ask up-front whether it is worth opening.
-	// The primary-bar routing mirrors UpdateButtons for InputDevicePrefersPrimaryCommands (which is only assigned
-	// once the flyout is opening, so it can't be read here).
+	// The primary-bar routing mirrors UpdateButtons for InputDevicePrefersPrimaryCommands, which is only assigned once
+	// the flyout is opening - hence passing the touch/pen preference explicitly so both agree on the command set.
 	internal bool HasTouchPrimaryCommandsFor(FrameworkElement target)
 	{
 		var primaryBarButtons = TextControlButtons.Cut | TextControlButtons.Copy | TextControlButtons.Paste
@@ -404,18 +404,18 @@ partial class TextCommandBarFlyout
 			primaryBarButtons |= TextControlButtons.SelectAll;
 		}
 
-		return (GetButtonsToAdd(target) & primaryBarButtons) != TextControlButtons.None;
+		return (GetButtonsToAdd(target, prefersPrimaryCommands: true) & primaryBarButtons) != TextControlButtons.None;
 	}
 
-	private TextControlButtons GetButtonsToAdd() => GetButtonsToAdd(Target);
+	private TextControlButtons GetButtonsToAdd() => GetButtonsToAdd(Target, InputDevicePrefersPrimaryCommands);
 
-	private TextControlButtons GetButtonsToAdd(FrameworkElement target)
+	private TextControlButtons GetButtonsToAdd(FrameworkElement target, bool prefersPrimaryCommands)
 	{
 		TextControlButtons buttonsToAdd = TextControlButtons.None;
 
 		if (target is TextBox textBoxTarget and not PasswordBox) // PasswordBox derives from TextBox in Uno Platform
 		{
-			buttonsToAdd = GetTextBoxButtonsToAdd(textBoxTarget);
+			buttonsToAdd = GetTextBoxButtonsToAdd(textBoxTarget, prefersPrimaryCommands);
 		}
 		else if (target is TextBlock textBlockTarget)
 		{
@@ -444,7 +444,7 @@ partial class TextCommandBarFlyout
 		return buttonsToAdd;
 	}
 
-	private TextControlButtons GetTextBoxButtonsToAdd(TextBox textBox)
+	private TextControlButtons GetTextBoxButtonsToAdd(TextBox textBox, bool prefersPrimaryCommands)
 	{
 		TextControlButtons buttonsToAdd = TextControlButtons.None;
 
@@ -476,7 +476,9 @@ partial class TextCommandBarFlyout
 			buttonsToAdd |= TextControlButtons.Copy;
 		}
 
-		if (textBox.Text.Length > 0)
+		// Uno specific: on touch/pen Select All stays available even with no text, so a touch gesture on an empty box
+		// always has a command and opens a usable flyout. WinUI drops it there (nothing to select).
+		if (textBox.Text.Length > 0 || prefersPrimaryCommands)
 		{
 			buttonsToAdd |= TextControlButtons.SelectAll;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -28,7 +28,14 @@ partial class TextCommandBarFlyout
 		//__RP_Marker_ClassById(RuntimeProfiler.ProfId_TextCommandBarFlyout);
 		m_dispatcherHelper = new DispatcherHelper(this);
 
-		Opening += (s, e) => UpdateButtons();
+		Opening += (s, e) =>
+		{
+			// Uno specific: capture the show mode now, before CommandBarFlyout's CommandBar.Opened handler
+			// flips a Transient flyout to Standard on expand. Only a context menu opens Standard from the start.
+			m_openedAsContextMenu = ShowMode == FlyoutShowMode.Standard;
+			m_openedByTouch = WasOpenedByTouch;
+			UpdateButtons();
+		};
 
 		Opened += (s, e) =>
 		{
@@ -220,6 +227,16 @@ partial class TextCommandBarFlyout
 
 			void onProofingButtonLoaded(object sender, object eventArgs)
 			{
+				// Uno specific: suppress the auto-open only for a touch-driven selection flyout. There the
+				// proofing button loads only once the user taps the overflow, and auto-opening the submenu
+				// would hijack that tap. A context menu (Standard show mode) still auto-opens, and pen/mouse
+				// keep the WinUI default. The show mode is read from the value captured at open time because
+				// the CommandBar's Opened handler flips the live ShowMode to Standard on expand.
+				if (!m_openedAsContextMenu && m_openedByTouch)
+				{
+					return;
+				}
+
 				// If we have a proofing menu, we'll start with it open by invoking the button
 				// as soon as the CommandBar opening animation completes.
 				// We invoke the button instead of just showing the flyout to make the button

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -607,6 +607,19 @@ partial class TextCommandBarFlyout
 		return wasFound;
 	}
 
+	// Uno specific: CommandBarFlyout only closes itself when a *secondary* command is invoked (MUX extends that to the
+	// proofing menu - "interactions with any proofing menu element ... close the entire flyout, same as interactions
+	// with secondary commands"), never for the primary bar - where UpdateButtons puts Cut/Copy/Paste for a touch/pen
+	// flyout, and only there. Close it in that case too, so it doesn't linger over the text after the command ran.
+	// The device check is redundant with the primary-bar membership, but keeps the touch/pen scope explicit here.
+	private void HideAfterPrimaryBarInvoke(TextControlButtons button)
+	{
+		if (IsButtonInPrimaryCommands(button) && InputDevicePrefersPrimaryCommands)
+		{
+			Hide();
+		}
+	}
+
 	private void ExecuteCutCommand()
 	{
 		var target = Target;
@@ -633,10 +646,7 @@ partial class TextCommandBarFlyout
 			// if the app isn't the foreground window when we try to execute a clipboard operation.			
 		}
 
-		if (IsButtonInPrimaryCommands(TextControlButtons.Cut))
-		{
-			UpdateButtons();
-		}
+		HideAfterPrimaryBarInvoke(TextControlButtons.Cut);
 	}
 
 	private void ExecuteCopyCommand()
@@ -685,10 +695,7 @@ partial class TextCommandBarFlyout
 			// if the app isn't the foreground window when we try to execute a clipboard operation.
 		}
 
-		if (IsButtonInPrimaryCommands(TextControlButtons.Copy))
-		{
-			UpdateButtons();
-		}
+		HideAfterPrimaryBarInvoke(TextControlButtons.Copy);
 	}
 
 	private void ExecutePasteCommand()
@@ -721,10 +728,7 @@ partial class TextCommandBarFlyout
 			// if the app isn't the foreground window when we try to execute a clipboard operation.
 		}
 
-		if (IsButtonInPrimaryCommands(TextControlButtons.Paste))
-		{
-			UpdateButtons();
-		}
+		HideAfterPrimaryBarInvoke(TextControlButtons.Paste);
 	}
 
 	private void ExecuteBoldCommand()

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs
@@ -391,10 +391,27 @@ partial class TextCommandBarFlyout
 		}
 	}
 
-	private TextControlButtons GetButtonsToAdd()
+	// Uno specific: a transient flyout whose primary bar would be empty hides itself the moment it opens (see the
+	// Opened handler), which flashes an empty popup. Let a touch/pen caller ask up-front whether it is worth opening.
+	// The primary-bar routing mirrors UpdateButtons for InputDevicePrefersPrimaryCommands (which is only assigned
+	// once the flyout is opening, so it can't be read here).
+	internal bool HasTouchPrimaryCommandsFor(FrameworkElement target)
+	{
+		var primaryBarButtons = TextControlButtons.Cut | TextControlButtons.Copy | TextControlButtons.Paste
+			| TextControlButtons.Bold | TextControlButtons.Italic | TextControlButtons.Underline;
+		if (target is TextBox { SelectionLength: 0 } and not PasswordBox)
+		{
+			primaryBarButtons |= TextControlButtons.SelectAll;
+		}
+
+		return (GetButtonsToAdd(target) & primaryBarButtons) != TextControlButtons.None;
+	}
+
+	private TextControlButtons GetButtonsToAdd() => GetButtonsToAdd(Target);
+
+	private TextControlButtons GetButtonsToAdd(FrameworkElement target)
 	{
 		TextControlButtons buttonsToAdd = TextControlButtons.None;
-		var target = Target;
 
 		if (target is TextBox textBoxTarget and not PasswordBox) // PasswordBox derives from TextBox in Uno Platform
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -73,6 +73,11 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 		private InputDeviceType m_inputDeviceTypeUsedToOpen;
 
+		/// <summary>
+		/// Whether touch was the input device that opened this flyout. Set before <see cref="Opening"/> fires.
+		/// </summary>
+		private protected bool WasOpenedByTouch => m_inputDeviceTypeUsedToOpen == InputDeviceType.Touch;
+
 		internal FlyoutPlacementMode EffectivePlacement => m_hasPlacementOverride ? m_placementOverride : Placement;
 
 		protected FlyoutBase()

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -64,8 +64,13 @@ internal interface ITextSelectionGripperHost
 	/// <summary>The gripper was long-pressed: open the context menu.</summary>
 	void RequestGripperContextMenu(PointerRoutedEventArgs args);
 
-	/// <summary>A gripper interaction ended: queue a selection-flyout visibility update.</summary>
-	void QueueGripperSelectionFlyout(PointerRoutedEventArgs args);
+	/// <summary>
+	/// A gripper interaction ended: queue a selection-flyout visibility update. <paramref name="allowEmptySelection"/>
+	/// is set when the gripper was tapped (not dragged), so the flyout re-opens even over a collapsed caret (the single
+	/// insertion handle) — mirroring the native iOS/Android insertion-handle popup. The host still restricts this to its
+	/// mobile touch conventions.
+	/// </summary>
+	void QueueGripperSelectionFlyout(PointerRoutedEventArgs args, bool allowEmptySelection);
 
 	/// <summary>
 	/// The gripper was tapped (not dragged or held): treat it like a tap on the text at the character the gripper
@@ -296,12 +301,13 @@ internal sealed class TextSelectionGripperPresenter
 			// jump to the end of the text — the same hazard the drag path avoids with GrabOffsetY.
 			var anchorIndex = gripper == _startGripper ? _host.SelectionLowerIndex : _host.SelectionUpperIndex;
 			_host.OnGripperTapped(previous, anchorIndex);
-			_host.QueueGripperSelectionFlyout(args);
+			// A tap on the (single) insertion handle re-opens the flyout even over a collapsed caret.
+			_host.QueueGripperSelectionFlyout(args, allowEmptySelection: true);
 		}
 		else
 		{
 			// The gripper was dragged to adjust the selection: keep the thumbs and re-show the selection toolbar.
-			_host.QueueGripperSelectionFlyout(args);
+			_host.QueueGripperSelectionFlyout(args, allowEmptySelection: false);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -68,11 +68,14 @@ internal interface ITextSelectionGripperHost
 	void QueueGripperSelectionFlyout(PointerRoutedEventArgs args);
 
 	/// <summary>
-	/// The gripper was tapped (not dragged or held): treat it like a tap on the text. <paramref name="press"/>
-	/// is the tap's <em>press</em> point, so the host can fold it into its multi-tap counter (a tap landing on
-	/// the insertion handle is still the second tap of a double-tap-to-select-word).
+	/// The gripper was tapped (not dragged or held): treat it like a tap on the text at the character the gripper
+	/// points at. <paramref name="anchorIndex"/> is that character index (the gripper's own selection edge / caret),
+	/// so the tap pins there instead of re-sampling the finger — which sits on the thumb below the caret line and
+	/// would spill onto the line below (on a single-line box, the end of the text). <paramref name="press"/> is the
+	/// tap's <em>press</em> point, so the host can fold it into its multi-tap counter (a tap landing on the insertion
+	/// handle is still the second tap of a double-tap-to-select-word).
 	/// </summary>
-	void OnGripperTapped(PointerPoint press, PointerRoutedEventArgs args);
+	void OnGripperTapped(PointerPoint press, int anchorIndex);
 }
 
 /// <summary>
@@ -288,7 +291,11 @@ internal sealed class TextSelectionGripperPresenter
 		else if (IsMultiTapGesture((previous.PointerId, previous.Timestamp, previous.Position), current))
 		{
 			args.Handled = true;
-			_host.OnGripperTapped(previous, args);
+			// Pin the tap to the character this gripper points at (its selection edge / caret). The finger grabbed
+			// the thumb below the caret line, so re-sampling the release point would spill onto the line below and
+			// jump to the end of the text — the same hazard the drag path avoids with GrabOffsetY.
+			var anchorIndex = gripper == _startGripper ? _host.SelectionLowerIndex : _host.SelectionUpperIndex;
+			_host.OnGripperTapped(previous, anchorIndex);
 			_host.QueueGripperSelectionFlyout(args);
 		}
 		else

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -749,7 +749,9 @@ namespace Microsoft.UI.Xaml.Controls
 			OnContextRequested(this, contextArgs);
 		}
 
-		void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args)
+		// A TextBlock only ever shows Both-mode grippers over a real selection, so there's never a collapsed
+		// caret to re-open the flyout over; allowEmptySelection is irrelevant here.
+		void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args, bool allowEmptySelection)
 			=> QueueUpdateSelectionFlyoutVisibility(args.Pointer.PointerDeviceType, args.GetCurrentPoint(this).Position);
 
 		// Both grippers sit on the current selection's edges, so tapping either one keeps the selection and

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -752,10 +752,11 @@ namespace Microsoft.UI.Xaml.Controls
 		void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args)
 			=> QueueUpdateSelectionFlyoutVisibility(args.Pointer.PointerDeviceType, args.GetCurrentPoint(this).Position);
 
-		// A TextBlock only ever shows Both-mode grippers (at the selection edges), so there's no insertion
-		// handle to fold into a double-tap counter; the press point is unused here.
-		void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, PointerRoutedEventArgs args)
-			=> TouchTap(args.GetCurrentPoint(this).Position);
+		// Both grippers sit on the current selection's edges, so tapping either one keeps the selection and
+		// re-shows the grippers/flyout — there's no insertion handle (or editable caret) to re-place, so press
+		// and anchorIndex are unused here.
+		void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, int anchorIndex)
+			=> ShowGrippers();
 		#endregion
 		#endregion
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -250,9 +250,10 @@ public partial class TextBox
 	}
 
 	private void TouchTap(Point point, bool wasFocused)
-	{
-		var index = Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point, true, true));
+		=> TouchTapAt(Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point, true, true)));
 
+	private void TouchTapAt(int index)
+	{
 		switch (TouchSelectionConvention)
 		{
 			case TouchTextSelectionConvention.Android:
@@ -289,9 +290,11 @@ public partial class TextBox
 	}
 
 	private void TouchSelectWord(Point point)
+		=> TouchSelectWordAt(Math.Max(0, TextBoxView.DisplayBlock.ParsedText.GetIndexAt(point, true, true)));
+
+	private void TouchSelectWordAt(int index)
 	{
 		var displayBlock = TextBoxView.DisplayBlock;
-		var index = Math.Max(0, displayBlock.ParsedText.GetIndexAt(point, true, true));
 		var chunk = displayBlock.ParsedText.GetWordAt(index, true);
 
 		// GetWordAt bundles the trailing space into the word chunk; native iOS/Android select just the word,

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -231,22 +231,49 @@ public partial class TextBox
 			// context menu should have already been opened through UIElement-level ContextRequested handling.
 			return;
 		}
-		else if (!Text.IsNullOrEmpty()) // Touch tap
+
+		// Touch tap
+		var isMobileMultiTap = TouchSelectionConvention != TouchTextSelectionConvention.Desktop && _lastPointerDown.repeatedPresses >= 1;
+
+		if (Text.IsNullOrEmpty())
 		{
-			var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
-			if (TouchSelectionConvention != TouchTextSelectionConvention.Desktop && _lastPointerDown.repeatedPresses >= 1)
+			if (isMobileMultiTap)
 			{
-				// Native iOS/Android: a double-tap selects the word under the tap.
-				TouchSelectWord(displayBlockPoint);
+				HandleEmptyTextTouchGesture(args.GetCurrentPoint(this).Position);
 			}
-			else
-			{
-				TouchTap(displayBlockPoint, wasFocused);
-			}
-			// Ported from: microsoft-ui-xaml2/src/dxaml/xcp/core/native/text/Controls/TextBoxBase.cpp (line 2088)
-			// OnPointerReleased - queue SelectionFlyout visibility update after pointer release
-			QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, args.GetCurrentPoint(this).Position);
+
+			return;
 		}
+
+		var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
+		if (isMobileMultiTap)
+		{
+			// Native iOS/Android: a double-tap selects the word under the tap.
+			TouchSelectWord(displayBlockPoint);
+		}
+		else
+		{
+			TouchTap(displayBlockPoint, wasFocused);
+		}
+		// Ported from: microsoft-ui-xaml2/src/dxaml/xcp/core/native/text/Controls/TextBoxBase.cpp (line 2088)
+		// OnPointerReleased - queue SelectionFlyout visibility update after pointer release
+		QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, args.GetCurrentPoint(this).Position);
+	}
+
+	// Native iOS/Android pop the text flyout (Paste) over an empty field on a double-tap or a long-press. There is
+	// no word to select there, so place the caret and let the flyout carry the gesture.
+	private void HandleEmptyTextTouchGesture(Point textBoxPoint)
+	{
+		TouchTapAt(0);
+
+		// An empty field offers no Cut/Copy/Select All, so the flyout can end up with nothing to show at all
+		// (nothing on the clipboard). Opening it then would only flash an empty popup before it self-hides.
+		if (SelectionFlyout is TextCommandBarFlyout flyout && !flyout.HasTouchPrimaryCommandsFor(this))
+		{
+			return;
+		}
+
+		QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, textBoxPoint, allowEmptySelection: true);
 	}
 
 	private void TouchTap(Point point, bool wasFocused)
@@ -316,8 +343,8 @@ public partial class TextBox
 
 	// On iOS/Android a touch-and-hold does native text selection instead of opening a context menu:
 	// Android selects the word under the press (the selection toolbar then appears via the selection
-	// flyout); iOS starts dragging the caret. Mouse/pen right-click and the Desktop convention keep
-	// the default context flyout.
+	// flyout); iOS starts dragging the caret; an empty field has neither, and just opens the flyout.
+	// Mouse/pen right-click and the Desktop convention keep the default context flyout.
 	private protected override void OnContextRequestedImpl(ContextRequestedEventArgs args)
 	{
 		if (_isSkiaTextBox
@@ -325,16 +352,25 @@ public partial class TextBox
 			&& TouchSelectionConvention != TouchTextSelectionConvention.Desktop
 			&& args.TryGetPosition(TextBoxView.DisplayBlock, out var displayBlockPoint))
 		{
-			switch (TouchSelectionConvention)
+			args.TryGetPosition(this, out var textBoxPoint);
+
+			if (Text.IsNullOrEmpty())
 			{
-				case TouchTextSelectionConvention.Android:
-					TouchSelectWord(displayBlockPoint);
-					args.TryGetPosition(this, out var textBoxPoint);
-					QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, textBoxPoint);
-					break;
-				case TouchTextSelectionConvention.iOS:
-					BeginTouchCaretDrag(displayBlockPoint);
-					break;
+				// Neither convention has anything to select or to drag the caret through in an empty field.
+				HandleEmptyTextTouchGesture(textBoxPoint);
+			}
+			else
+			{
+				switch (TouchSelectionConvention)
+				{
+					case TouchTextSelectionConvention.Android:
+						TouchSelectWord(displayBlockPoint);
+						QueueUpdateSelectionFlyoutVisibility(PointerDeviceType.Touch, textBoxPoint);
+						break;
+					case TouchTextSelectionConvention.iOS:
+						BeginTouchCaretDrag(displayBlockPoint);
+						break;
+				}
 			}
 
 			// suppress the default context flyout on iOS/Android

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -241,6 +241,12 @@ public partial class TextBox
 			{
 				HandleEmptyTextTouchGesture(args.GetCurrentPoint(this).Position);
 			}
+			else if (TouchSelectionConvention != TouchTextSelectionConvention.Desktop)
+			{
+				// A single tap in an empty field has no word to select, but must still place the caret (and Android's
+				// insertion handle) so the field shows where typing will go - and so the handle can open the flyout.
+				TouchTapAt(0);
+			}
 
 			return;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -272,8 +272,9 @@ public partial class TextBox
 	{
 		TouchTapAt(0);
 
-		// An empty field offers no Cut/Copy/Select All, so the flyout can end up with nothing to show at all
-		// (nothing on the clipboard). Opening it then would only flash an empty popup before it self-hides.
+		// A TextBox always carries Select All in the touch primary bar, but a PasswordBox keeps its Select All in the
+		// overflow (and only with a password), so an empty one with an empty clipboard has no primary command at all.
+		// Opening the flyout then would only flash an empty popup before it self-hides.
 		if (SelectionFlyout is TextCommandBarFlyout flyout && !flyout.HasTouchPrimaryCommandsFor(this))
 		{
 			return;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -680,16 +680,20 @@ public partial class TextBox : ITextSelectionGripperHost
 	private PointerDeviceType _lastInputDeviceType;
 	private Point _lastPointerPosition;
 	private bool _isSelectionFlyoutUpdateQueued;
+	// Uno addition (not part of the WinUI port): lets the flyout re-open over a collapsed caret when the single
+	// insertion handle is tapped. See QueueGripperSelectionFlyout / OnGripperTapped.
+	private bool _allowEmptySelectionFlyout;
 
 	// Ported from: microsoft-ui-xaml2/src/dxaml/xcp/core/native/text/Controls/TextBoxBase.cpp (lines 5292-5302)
 	private bool HasSelectionFlyout() => SelectionFlyout is not null;
 
 	// Ported from: microsoft-ui-xaml2/src/dxaml/xcp/core/native/text/Controls/TextBoxBase.cpp (lines 5349-5377)
 	// QueueUpdateSelectionFlyoutVisibility - queues async visibility update
-	private void QueueUpdateSelectionFlyoutVisibility(PointerDeviceType deviceType, Point position)
+	private void QueueUpdateSelectionFlyoutVisibility(PointerDeviceType deviceType, Point position, bool allowEmptySelection = false)
 	{
 		_lastInputDeviceType = deviceType;
 		_lastPointerPosition = position;
+		_allowEmptySelectionFlyout = allowEmptySelection;
 
 		// Line 5358-5360: Prevent duplicate queued updates
 		if (!_isSelectionFlyoutUpdateQueued)
@@ -725,8 +729,11 @@ public partial class TextBox : ITextSelectionGripperHost
 
 			case PointerDeviceType.Pen:
 			case PointerDeviceType.Touch:
-				// Line 5403-5411: Pen/Touch - show if selection exists
-				if (selectionLength > 0)
+				// Line 5403-5411: Pen/Touch - show if selection exists.
+				// Uno addition (beyond the WinUI port): also show over a collapsed caret when the single insertion
+				// handle was tapped, matching the native iOS/Android Paste/Select-all popup (gated to those
+				// conventions by the caller).
+				if (selectionLength > 0 || _allowEmptySelectionFlyout)
 				{
 					shouldShow = true;
 					showMode = FlyoutShowMode.Transient;
@@ -780,6 +787,7 @@ public partial class TextBox : ITextSelectionGripperHost
 
 		// Line 5450: Reset input device type after processing
 		_lastInputDeviceType = default;
+		_allowEmptySelectionFlyout = default;
 	}
 
 	#endregion
@@ -1923,8 +1931,13 @@ public partial class TextBox : ITextSelectionGripperHost
 		OnContextRequested(this, contextArgs);
 	}
 
-	void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args)
-		=> QueueUpdateSelectionFlyoutVisibility(args.Pointer.PointerDeviceType, args.GetCurrentPoint(this).Position);
+	void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args, bool allowEmptySelection)
+		=> QueueUpdateSelectionFlyoutVisibility(
+			args.Pointer.PointerDeviceType,
+			args.GetCurrentPoint(this).Position,
+			// The single insertion handle only exists under the mobile (iOS/Android) conventions; tapping it
+			// re-opens the flyout even over a collapsed caret. Desktop never gets the empty-selection flyout.
+			allowEmptySelection: allowEmptySelection && TouchSelectionConvention != TouchTextSelectionConvention.Desktop);
 
 	void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, int anchorIndex)
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1926,7 +1926,7 @@ public partial class TextBox : ITextSelectionGripperHost
 	void ITextSelectionGripperHost.QueueGripperSelectionFlyout(PointerRoutedEventArgs args)
 		=> QueueUpdateSelectionFlyoutVisibility(args.Pointer.PointerDeviceType, args.GetCurrentPoint(this).Position);
 
-	void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, PointerRoutedEventArgs args)
+	void ITextSelectionGripperHost.OnGripperTapped(PointerPoint press, int anchorIndex)
 	{
 		// The insertion handle (EndOnly gripper) sits over the character it points at, so the second tap of
 		// a double-tap lands on the handle instead of the text. Fold it into the same multi-tap counter as
@@ -1936,14 +1936,15 @@ public partial class TextBox : ITextSelectionGripperHost
 			: 0;
 		_lastPointerDown = (press, repeatedPresses);
 
-		var displayBlockPoint = args.GetCurrentPoint(TextBoxView.DisplayBlock).Position;
+		// Act on the character the handle points at, not the finger's position on the thumb (which hangs below
+		// the caret line and would jump the caret to the end of the text).
 		if (TouchSelectionConvention != TouchTextSelectionConvention.Desktop && repeatedPresses >= 1)
 		{
-			TouchSelectWord(displayBlockPoint);
+			TouchSelectWordAt(anchorIndex);
 		}
 		else
 		{
-			TouchTap(displayBlockPoint, true);
+			TouchTapAt(anchorIndex);
 		}
 	}
 	#endregion

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1955,10 +1955,12 @@ public partial class TextBox : ITextSelectionGripperHost
 		{
 			TouchSelectWordAt(anchorIndex);
 		}
-		else
+		else if (_caretMode != CaretDisplayMode.CaretWithThumbsBothEndsShowing)
 		{
 			TouchTapAt(anchorIndex);
 		}
+		// Both thumbs showing: the tap grabbed a selection edge, so keep the selection (native iOS/Android)
+		// instead of collapsing it to a caret. The presenter re-shows the selection flyout on release.
 	}
 	#endregion
 

--- a/src/Uno.UI/UI/Xaml/UIElement.ContextRequested.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.ContextRequested.cs
@@ -43,10 +43,14 @@ partial class UIElement
 		ContextRequestedEventArgs args)
 	{
 #if __SKIA__
-		if (sender is TextBlock { OwningTextBox: { } ownerTextBox })
+		if (sender is TextBlock { OwningTextBox: not null })
 		{
-			sender = ownerTextBox;
-			contextFlyoutObject = ownerTextBox;
+			// This is the inner DisplayBlock of a TextBox/PasswordBox. Showing the owning control's
+			// flyout here (as the DisplayBlock's ContextRequested class handler) would compute its
+			// commands before the control commits its touch selection: on a mobile long-press the word
+			// is selected by TextBox.OnContextRequestedImpl, which runs later as the same event bubbles
+			// up. Defer to that handler so the flyout reflects the final selection (Cut/Copy included).
+			return;
 		}
 #endif
 		if (sender is not UIElement uiElement)


### PR DESCRIPTION
**GitHub Issue:** Tracked internally (no public issue).

## PR Type:

✨ Feature

## What changed? 🚀

Brings the **touch/pen text selection flyout** on Skia in line with the mobile selection experience. Before, a touch/pen interaction on a `TextBox`/`TextBlock` did not reliably surface a usable selection flyout, and when it did the command set and chrome were off.

### Gestures & selection

- **Open the selection flyout on insertion-handle tap** — tapping the single insertion handle (collapsed caret, no selection) now opens the selection flyout, mirroring the native insertion-handle popup. This is an Uno addition beyond the WinUI port (which only shows the flyout for a non-empty selection).
- **Long-press flyout includes Cut/Copy** — a touch long-press selects the word *before* the flyout computes its commands, so Cut/Copy are present. Fixes the inner `DisplayBlock`'s `ContextRequested` firing with an empty selection.
- **Empty field: a tap places the caret** — the touch tap-to-caret path was gated on non-empty text, so under the mobile (iOS/Android) conventions an empty `TextBox` showed no caret affordance at all — and on Android no insertion handle, hence no way to reach the flyout. A single tap now places the convention's caret, and deliberately does *not* open the flyout (that stays with the double-tap, the long-press and the handle tap).
- **Empty field: double-tap / long-press opens the flyout** — both gesture paths dead-ended on an empty field: the release handler gated all touch-tap handling on non-empty text, and `OnContextRequestedImpl` suppressed the default context flyout before substituting `TouchSelectWord`/`BeginTouchCaretDrag`, which are no-ops with no text. Both now place the convention's collapsed caret and open the selection flyout over it (via the same `allowEmptySelection` hook the insertion-handle tap uses), matching the native mobile Paste popup. Scoped to the mobile conventions — the Desktop convention keeps opening its `ContextFlyout` through base `OnContextRequestedImpl`.
- **Pin gripper tap to the anchor index** — a tap on a selection gripper no longer drifts the caret off the anchor.
- **Tapping a selection thumb keeps the selection** — with a range selected (both thumbs showing), a tap on either thumb routed through the caret-placing path and collapsed the selection to length 0. A thumb is a selection edge, not a caret, so caret placement is now skipped while both thumbs show; the presenter still re-shows the selection flyout on release, and the single insertion handle keeps placing its caret.

### Flyout commands & chrome

- **Select All is always offered on touch/pen** — it now survives an empty `TextBox`, so a touch gesture there always has a command and opens a usable flyout. `GetButtonsToAdd` takes the touch/pen preference explicitly rather than reading `InputDevicePrefersPrimaryCommands`, which is only assigned in `OnOpening`: the pre-open `HasTouchPrimaryCommandsFor` gate and the post-open `UpdateButtons` must agree on the command set, or the gate would suppress the very flyout `UpdateButtons` was about to fill. Observable delta: an empty box with an empty clipboard now **opens**, with Select All as its lone primary command, where it previously stayed closed. `PasswordBox` is unchanged — its Select All still needs `Password.Length > 0`.
  - Two deliberate departures: WinUI drops Select All with no text, and native mobile shows only Paste on an empty field. An empty box — **including a read-only one** — therefore now opens a flyout whose Select All does nothing. `IsReadOnly` is not carved out: in `GetTextBoxButtonsToAdd` it gates the mutating commands only, and Copy/Select All sit outside it by design.
- **Never open a flyout that would immediately self-hide** — a transient flyout whose primary bar is empty hides itself the moment it opens, flashing an empty popup. The new `TextCommandBarFlyout.HasTouchPrimaryCommandsFor` lets a touch/pen caller ask up-front whether opening is worth it; the caret is still placed when the answer is no. It tests the primary-bar mask rather than "any command", since secondary commands (Undo/Redo) don't prevent the self-hide. A custom `SelectionFlyout` is never suppressed — its commands can't be inspected.
- **Primary-bar command buttons show an icon + label** — when Cut/Copy/Paste/Select All is the lone primary command of a transient touch/pen flyout, it can be hosted directly under the command bar instead of its `PrimaryItemsControl`, so the implicit `CommandBarFlyoutAppBarButtonStyle` never reaches it and the text label stays collapsed. A shared `ApplyCommandBarFlyoutButtonStyle` helper now assigns that style explicitly to all four, so every primary-bar command button carries the flyout template regardless of hosting. This is a workaround — the underlying `CommandBarFlyoutCommandBar` hosting nondeterminism remains.
- **Re-style a button promoted out of the overflow** — `CommandBarOverflowPresenter` clears `StyleProperty` as an item leaves the overflow, so a button first realized as a secondary command (e.g. Select All while a full selection stands) fell back to the default `AppBarButton` template — no `PrimaryLabelStates`, collapsed label. The flyout style is re-applied on `GetButton`'s cached-return path, before the button is re-realized in the primary bar (a no-op when already styled, so the never-overflowed path is unchanged).
- **Don't auto-open the proofing menu on the overflow tap** — in a touch selection flyout the proofing button loads only once the user taps the overflow ("..."), and WinUI's auto-open then hijacked that tap by opening the spelling-suggestions submenu. The show mode and input device are now captured at open time — the `CommandBar`'s `Opened` handler flips a `Transient` flyout's live `ShowMode` to `Standard` on expand, so the live value can't discriminate — and the auto-open is suppressed only for a touch-driven selection flyout. Context menus (`Standard`) still auto-open, and pen/mouse keep the WinUI default.
- **Hide the overflow ("...") button when there is no overflow** — for the touch/pen text flyout with no secondary commands, the overflow button is collapsed instead of dangling over an empty menu. WinUI's default (`Auto`) is preserved for mouse/keyboard and for general `CommandBarFlyout` (native WinUI *does* show the "..." there — verified on WinAppSDK — so that behavior is intentionally left unchanged).

Touched areas: `TextCommandBarFlyout`, `FlyoutBase` (new `WasOpenedByTouch`), `TextBox`/`TextBlock` Skia pointer & selection handling, `TextSelectionGripperPresenter`, and `UIElement.ContextRequested`.

Runtime tests cover each gesture for both mobile conventions (tap / double-tap / long-press, empty and non-empty), the gripper and thumb taps, `PasswordBox` as the inherited path, the empty-clipboard cases, the primary-bar labels including the overflow→primary promotion, and the proofing auto-open suppression. The empty-clipboard tests count `Opened` rather than checking `IsOpen`, since `IsOpen` cannot distinguish "never opened" from "opened then self-hid"; the thumb-tap tests deliver the tap through the gripper host seam rather than at the thumb's coordinates, because grippers live in popups clipped to the `TextBox` and a coordinate-aimed tap can silently land on the text — a false pass.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
