### PR TITLE
feat(devserver): Add Kimi Code as MCP setup client

### DIFF
--- a/build/cSpell.json
+++ b/build/cSpell.json
@@ -57,6 +57,7 @@
 	"hotswap",
 	"Inlines",
 	"Junie",
+	"Kimi",
 	"Kiro",
 	"keychain",
 	"laggy",

--- a/doc/articles/features/using-the-uno-mcps.md
+++ b/doc/articles/features/using-the-uno-mcps.md
@@ -224,6 +224,7 @@ The App MCP uses [MCP roots](https://modelcontextprotocol.io/docs/concepts/roots
 | junie-rider | No |
 | JetBrains Air | No |
 | OpenCode | Unknown |
+| Kimi Code | No |
 
 For agents without roots support, the DevServer CLI auto-detects the missing capability and exposes the `uno_app_initialize` tool, allowing the agent to specify the workspace directory manually. No additional configuration is required. The legacy `--force-roots-fallback` flag is still accepted as an explicit override, but is rarely needed.
 

--- a/src/Uno.UI.DevServer.Cli.Tests/Mcp/Setup/Given_DefinitionsLoader.cs
+++ b/src/Uno.UI.DevServer.Cli.Tests/Mcp/Setup/Given_DefinitionsLoader.cs
@@ -18,6 +18,7 @@ public class Given_DefinitionsLoader
 			"cursor",
 			"windsurf",
 			"kiro",
+			"kimi-code",
 			"gemini-antigravity",
 			"gemini-cli",
 			"junie-rider",
@@ -143,6 +144,18 @@ public class Given_DefinitionsLoader
 		profile.ConfigPaths.Should().Contain("{workspace}/.junie/mcp/mcp.json");
 		profile.ConfigPaths.Should().Contain("{home}/.junie/mcp/mcp.json");
 		profile.WriteTarget.Should().Be("{workspace}/.junie/mcp/mcp.json");
+	}
+
+	[TestMethod]
+	public void Load_EmbeddedResources_KimiCodeUsesKimiCodeConfigFile()
+	{
+		var defs = DefinitionsLoader.Load();
+		var profile = defs.Ides["kimi-code"];
+
+		profile.ConfigPaths.Should().Contain("{workspace}/.kimi-code/mcp.json");
+		profile.ConfigPaths.Should().Contain("{home}/.kimi-code/mcp.json");
+		profile.WriteTarget.Should().Be("{workspace}/.kimi-code/mcp.json");
+		profile.JsonRootKey.Should().Be("mcpServers");
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.DevServer.Cli/Mcp/Setup/ide-profiles.json
+++ b/src/Uno.UI.DevServer.Cli/Mcp/Setup/ide-profiles.json
@@ -92,6 +92,14 @@
     "writeTarget": "{workspace}/.kiro/settings/mcp.json",
     "jsonRootKey": "mcpServers"
   },
+  "kimi-code": {
+    "configPaths": [
+      "{workspace}/.kimi-code/mcp.json",
+      "{home}/.kimi-code/mcp.json"
+    ],
+    "writeTarget": "{workspace}/.kimi-code/mcp.json",
+    "jsonRootKey": "mcpServers"
+  },
   "jetbrains-air": {
     "configPaths": [
       "{workspace}/.air/mcp.json",

--- a/src/Uno.UI.DevServer.Cli/Program.cs
+++ b/src/Uno.UI.DevServer.Cli/Program.cs
@@ -48,7 +48,7 @@ internal class Program
 			WriteCommand("mcp uninstall", "Remove MCP servers from client config files");
 			Console.WriteLine();
 			Console.WriteLine("MCP setup options:");
-			WriteOption("<client>", "Target client (positional, or use --all-ides): copilot-vscode, copilot-vs, copilot-cli, cursor, windsurf, kiro, gemini-antigravity, gemini-cli, junie-rider, claude-code, claude-desktop, codex-cli, jetbrains-air, opencode, unknown");
+			WriteOption("<client>", "Target client (positional, or use --all-ides): copilot-vscode, copilot-vs, copilot-cli, cursor, windsurf, kiro, kimi-code, gemini-antigravity, gemini-cli, junie-rider, claude-code, claude-desktop, codex-cli, jetbrains-air, opencode, unknown");
 			WriteOption("--workspace <path>", "Workspace root (default: current directory)");
 			WriteOption("--channel <stable|prerelease>", "Select the Uno MCP definition channel");
 			WriteOption("--tool-version <ver>", "Pin the Uno MCP tool definition to a specific version");


### PR DESCRIPTION
**GitHub Issue:** closes #23858

## PR Type:

✨ Feature

## What changed? 🚀

The `uno.devserver mcp install` / `mcp status` / `mcp uninstall` commands did not know about [Kimi Code](https://www.kimi.com/code/docs/en/), so users of that agent had to hand-write their MCP config.

This PR adds a `kimi-code` client profile:

- `ide-profiles.json`: new file-based profile. Kimi Code reads `mcp.json` with an `mcpServers` root key at the project level (`.kimi-code/mcp.json`) and user level (`~/.kimi-code/mcp.json`), using `command`/`args` for stdio servers and `url` for HTTP servers — matching the default schema, so no `cli` block, `includeType`, or `urlKey` is needed (Kimi Code has no MCP registration CLI; only the interactive `/mcp-config` TUI command).
- `Program.cs`: `kimi-code` added to the `<client>` help text.
- Docs: Kimi Code added to the MCP roots compatibility table as **No** — verified against kimi-code 0.29.0, whose `initialize` handshake advertises `"capabilities": {}`. The DevServer roots auto-detection fallback (`uno_app_initialize`) applies, same as other agents without roots support.

Validated by running `mcp install kimi-code` against a scratch workspace; the generated `.kimi-code/mcp.json` matches Kimi Code's documented schema exactly (`UnoApp` stdio via `dotnet dnx`, `UnoDocs` HTTP URL).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — added `Load_EmbeddedResources_KimiCodeUsesKimiCodeConfigFile` to `Given_DefinitionsLoader`; all 18 loader tests pass
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — updated `using-the-uno-mcps.md` roots compatibility table
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. (N/A — no UI changes)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
