### PR TITLE
fix(hr): scope the blocked-compilation audit to the pass change-set (spec 054)

### DIFF
--- a/specs/054-hotreload-audit-changeset-scope/spec.md
+++ b/specs/054-hotreload-audit-changeset-scope/spec.md
@@ -3,9 +3,9 @@
 **Repo**: `uno` (Uno.HotReload)
 **Created**: 2026-07-23
 **Status**: Approved — ready for implementation
-**Related**: [spec 053](../053-hotreload-workspace-analyzer-flavor-skew/spec.md) (the
-generator-loading skew this audit surfaced), [spec 055](../055-hotreload-noop-pass-dedup/spec.md)
-(the no-op pass that lands in this audit), [spec 050](../050-hotreload-updatefile-workspace-gate/spec.md)
+**Related**: spec 053 (forthcoming — the generator-loading skew this audit surfaced),
+spec 055 (forthcoming — the no-op pass that lands in this audit),
+[spec 050](../050-hotreload-updatefile-workspace-gate/spec.md)
 
 ## Overview & Objectives
 
@@ -55,11 +55,16 @@ GetCompilationErrors(result.Solution, files, ct)
 where `files` is the pass's change-set (the `ImmutableHashSet<string>` already flowing
 through `ProcessSolutionChanged`). Project resolution, per file:
 
-- `solution.GetDocumentIdsWithFilePath(file)` → `documentId.ProjectId`;
-- plus projects where the file is an **AdditionalDocument**
-  (`project.AdditionalDocuments.Any(d => PathComparer.PathEquals(d.FilePath, file))`) —
-  XAML and other generator inputs are additional documents, and an edit to one can
-  block compilation exactly like a source edit;
+- a project owns the file when any of its **documents** or **additional documents** has a
+  matching path, matched through `PathComparer.PathEquals` — the same separator/case-agnostic
+  comparison the rest of the hot-reload pipeline (`ChangesDetector`, `SolutionUpdater`, …)
+  uses. Do **not** resolve regular documents through Roslyn's `GetDocumentIdsWithFilePath`
+  index: its comparator can silently miss a source document on Linux when the workspace
+  stored a different casing/separator than the change event carried, while the additional-
+  document scan would still match it — an asymmetry the whole pipeline avoids by always
+  going through `PathComparer`;
+- **AdditionalDocuments** matter because XAML and other generator inputs are additional
+  documents, and an edit to one can block compilation exactly like a source edit;
 - union over all files, distinct.
 
 Rules:
@@ -69,19 +74,23 @@ Rules:
 - If the resolved set is **empty** (e.g. every file of the pass is outside the
   solution), **skip the audit entirely** and fall through to the `NoChanges` outcome —
   never fail a pass on foreign projects.
-- Inside the scoped projects, keep the existing behavior byte-for-byte: same
-  `TryGetCompilation` + `GetDiagnostics` walk, same error formatting/colors, same
-  WASM cap (`MaxCompilationErrorsPerCycle`), same `Failed` outcome when errors exist.
+- Inside the scoped projects, keep the **diagnostic walk and per-error formatting**
+  byte-for-byte: same `TryGetCompilation` + `GetDiagnostics` walk, same error
+  formatting/colors, same WASM cap (`MaxCompilationErrorsPerCycle`), same `Failed`
+  outcome when errors exist. (The byte-for-byte constraint covers the walk and the
+  colored per-error lines — the single summary line necessarily changes per R2.)
 
 ### R2 — keep the reason visible
 
 The `"Hot reload blocked by N compilation error(s)."` output line must additionally
-name the audited projects, e.g.:
+name the project(s) that produced the errors and the edited files, e.g.:
 
 `Hot reload blocked by 3 compilation error(s) in MyApp (edited: MainPage.xaml.cs).`
 
-(project names joined with `, `; file names via `Path.GetFileName`, capped to the
-first 3 with `+N more` beyond.)
+(Only the projects that actually produced an error are named — a scoped project can be
+clean — joined with `, ` and ordered so the line is deterministic. Project names are
+**uncapped**: a change-set spans very few projects in practice. File names via
+`Path.GetFileName`, ordered and capped to the first 3 with `+N more` beyond.)
 
 ### R3 — do not touch the other outcomes
 
@@ -115,6 +124,10 @@ existing `HotReloadManager`/`WorkspaceGatedFileUpdater` tests):
    A is audited (arrange an error in A to observe `Failed`).
 4. **Out-of-solution files**: change-set = one unknown path → audit skipped, outcome
    `NoChanges`.
+5. **Mixed change-set (some resolve, some don't)**: change-set = one in-solution file
+   whose project has an error + one unknown path → outcome `Failed` (the audit runs on
+   the resolved subset; the unknown file contributes nothing), guarding against an
+   implementation that short-circuits on the first unresolvable file.
 
 ## Resolved decisions
 

--- a/specs/054-hotreload-audit-changeset-scope/spec.md
+++ b/specs/054-hotreload-audit-changeset-scope/spec.md
@@ -1,0 +1,124 @@
+# Hot-Reload: Scope the Blocked-Compilation Audit to the Pass's Change-Set
+
+**Repo**: `uno` (Uno.HotReload)
+**Created**: 2026-07-23
+**Status**: Approved — ready for implementation
+**Related**: [spec 053](../053-hotreload-workspace-analyzer-flavor-skew/spec.md) (the
+generator-loading skew this audit surfaced), [spec 055](../055-hotreload-noop-pass-dedup/spec.md)
+(the no-op pass that lands in this audit), [spec 050](../050-hotreload-updatefile-workspace-gate/spec.md)
+
+## Overview & Objectives
+
+`HotReloadManager.ProcessSolutionChanged` (`src/Uno.HotReload/HotReloadManager.cs`)
+ends a pass that produced **no rude edits and no metadata updates** with a
+last-chance audit:
+
+```csharp
+case (true, true) when GetCompilationErrors(result.Solution, ct) is { IsEmpty: false } compilationErrors:
+    _tracker.Output($"Hot reload blocked by {compilationErrors.Length} compilation error(s).");
+    outcome = HotReloadOperationResult.Failed;
+```
+
+`GetCompilationErrors` iterates **every project of the solution** and reads
+`project.TryGetCompilation(...)` — i.e. whatever compilation state happens to be
+cached for each project at that instant. Two structural problems:
+
+1. **It judges projects unrelated to the pass.** A pass whose change-set is a single
+   file in project A can complete `Failed` because project B — untouched by the pass,
+   possibly never compiled by the engine before — reports errors. Observed live: a
+   no-op pass over the per-request hot-reload info file completed `Failed` with ~2,400
+   errors from seven *unrelated* library projects (root cause of those errors: spec
+   053), while the actual user change had already applied successfully. Because the
+   info file correlates the pass to the originating `UpdateFile` request (R6 in spec
+   050), **the request reported failure for a change that was applied** — the
+   user-facing "failed" toast for a successful operation.
+2. **`TryGetCompilation` is not a truth source.** It returns cached, possibly partial
+   compilation states and never forces a real compile; auditing arbitrary projects on
+   those states reports transient artifacts as errors.
+
+Objective: the audit keeps its purpose — *"your edited file does not compile, that is
+why there is no delta"* — but only ever judges **the projects owning the pass's
+changed files**.
+
+## Requirements
+
+### R1 — audit only the change-set's projects
+
+In the `(rudeEdits.IsEmpty, updates.IsEmpty) == (true, true)` branch, replace the
+whole-solution `GetCompilationErrors(result.Solution, ct)` with an overload scoped to
+the pass:
+
+```csharp
+GetCompilationErrors(result.Solution, files, ct)
+```
+
+where `files` is the pass's change-set (the `ImmutableHashSet<string>` already flowing
+through `ProcessSolutionChanged`). Project resolution, per file:
+
+- `solution.GetDocumentIdsWithFilePath(file)` → `documentId.ProjectId`;
+- plus projects where the file is an **AdditionalDocument**
+  (`project.AdditionalDocuments.Any(d => PathComparer.PathEquals(d.FilePath, file))`) —
+  XAML and other generator inputs are additional documents, and an edit to one can
+  block compilation exactly like a source edit;
+- union over all files, distinct.
+
+Rules:
+
+- A file resolving to **no** project contributes nothing (it was already reported via
+  `NotifyIgnored`).
+- If the resolved set is **empty** (e.g. every file of the pass is outside the
+  solution), **skip the audit entirely** and fall through to the `NoChanges` outcome —
+  never fail a pass on foreign projects.
+- Inside the scoped projects, keep the existing behavior byte-for-byte: same
+  `TryGetCompilation` + `GetDiagnostics` walk, same error formatting/colors, same
+  WASM cap (`MaxCompilationErrorsPerCycle`), same `Failed` outcome when errors exist.
+
+### R2 — keep the reason visible
+
+The `"Hot reload blocked by N compilation error(s)."` output line must additionally
+name the audited projects, e.g.:
+
+`Hot reload blocked by 3 compilation error(s) in MyApp (edited: MainPage.xaml.cs).`
+
+(project names joined with `, `; file names via `Path.GetFileName`, capped to the
+first 3 with `+N more` beyond.)
+
+### R3 — do not touch the other outcomes
+
+`Success`, `RudeEdit`, `NoChanges` (reference-equal solution) branches are unchanged.
+The pre-existing `FIXME` above the audit (diagnostics not populated into the
+operation's `diagnostics`) is explicitly **out of scope** — do not attempt it in this
+PR (it needs the dedup discussed in the FIXME).
+
+## Non-goals
+
+- Fixing *why* unrelated projects can carry phantom errors (spec 053).
+- Preventing the no-op pass that most often lands in this branch (spec 055).
+- Making the audit force real compilations (`GetCompilationAsync`): scoping makes the
+  cheap cached read acceptable; forcing compiles here would reintroduce the
+  design-time-build starvation documented in spec 052's readiness work.
+
+## Test plan
+
+Unit tests next to the existing manager/updater tests (`src/Uno.HotReload.Tests/`),
+using `AdhocWorkspace` (the manager takes a solution provider — follow the pattern of
+existing `HotReloadManager`/`WorkspaceGatedFileUpdater` tests):
+
+1. **Foreign errors do not fail the pass**: solution with project A (healthy) and
+   project B (a source with a deliberate `CS0103`, compilation realized via
+   `GetCompilationAsync` beforehand so `TryGetCompilation` serves it). Process a
+   change-set touching only A whose emit yields no updates (identical-content write) →
+   outcome must be `NoChanges`, not `Failed`.
+2. **Own errors still block**: change-set file belongs to project B (the broken one),
+   0 updates → outcome `Failed`, output line names B and the edited file.
+3. **AdditionalDocument resolution**: change-set file is an AdditionalDocument of A →
+   A is audited (arrange an error in A to observe `Failed`).
+4. **Out-of-solution files**: change-set = one unknown path → audit skipped, outcome
+   `NoChanges`.
+
+## Resolved decisions
+
+- Skip (rather than whole-solution fallback) when the change-set resolves to no
+  project: a pass that touched nothing known can never be "blocked by" anything.
+- Scoping is by project, not by document: an edit can break *other* documents of the
+  same project, so project-level diagnostics inside the scope are the right grain.

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -419,6 +419,35 @@ public class Given_HotReloadManager
 		harness.Reporter.Outputs.Should().NotContain(o => o.Contains("Hot reload blocked"));
 	}
 
+	[TestMethod]
+	[Description(
+		"Spec 054 R1: a change-set mixing an in-solution file and an unknown path audits the resolved subset " +
+		"only — the unknown file contributes nothing, and the resolved file's broken project still blocks the pass. " +
+		"Guards against an implementation that bails on the first unresolvable file instead of unioning over all.")]
+	public async Task When_ChangeSetMixed_InSolutionAndUnknown_Then_AuditRunsOnResolvedSubset()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
+			onUpdate: solution =>
+			{
+				var projectId = solution.ProjectIds[0];
+				var broken = solution.AddDocument(DocumentId.CreateNewId(projectId), "Broken.cs", "public class Broken {", filePath: "/work/Broken.cs");
+				return new SolutionUpdateResult(broken, ChangeSet.IgnoreAll([]));
+			},
+			warmCompilation: true);
+
+		// One file resolves (owns the broken project), the other is outside the solution.
+		var batch = ImmutableHashSet.Create("/work/Broken.cs", "/elsewhere/Unknown.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(
+			HotReloadOperationResult.Failed,
+			"the resolved file's project has errors; the unresolved file is silently skipped, not a short-circuit");
+		harness.Reporter.Outputs.Should().Contain(
+			o => o.Contains("Hot reload blocked") && o.Contains("Broken.cs"),
+			"the blocked line names the resolved edited file");
+	}
+
 	private sealed record MarkerSolutionUpdateResult(Solution Solution, ChangeSet IgnoredChanges, string Marker)
 		: SolutionUpdateResult(Solution, IgnoredChanges, []);
 }

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using AwesomeAssertions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Uno.HotReload.Diffing;
 using Uno.HotReload.Tests.TestUtils;
 using Uno.HotReload.Tracking;
@@ -11,6 +12,10 @@ namespace Uno.HotReload.Tests;
 public class Given_HotReloadManager
 {
 	private static readonly TimeSpan _testTimeout = TimeSpan.FromSeconds(30);
+
+	// A single core reference is enough for the trivial types these tests compile; used to build
+	// a project that genuinely compiles clean (so the scoped audit finds no errors in it).
+	private static readonly MetadataReference _coreLib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
 
 	[TestMethod]
 	[Description(
@@ -279,10 +284,10 @@ public class Given_HotReloadManager
 
 	[TestMethod]
 	[Description(
-		"Spec 045 §1: an emitted cycle that produces no metadata updates and no rude edits, but whose solution " +
-		"carries compilation errors, completes as Failed (not NoChanges) — the manager probes the committed " +
-		"solution's compilation via GetCompilationErrors. The handler is invoked with Failed so consumers see the " +
-		"blocked reload.")]
+		"Spec 045 §1 + spec 054 R1/R2: an emitted cycle that produces no metadata updates and no rude edits, but " +
+		"whose own change-set project does not compile, completes as Failed (not NoChanges). The manager audits the " +
+		"committed solution's compilation via GetCompilationErrors, scoped to the changed file's project; the handler " +
+		"is invoked with Failed and the output line names the audited project and edited file.")]
 	public async Task When_CompilationErrors_Then_HandlerInvokedWithFailed()
 	{
 		using var harness = new HotReloadManagerHarness(
@@ -290,11 +295,12 @@ public class Given_HotReloadManager
 			// that probes the committed solution's compilation for blocking errors.
 			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
 			// Mutate the solution (so it isn't the NoChanges fast-path) by adding a document with a
-			// reference-independent syntax error (CS1513 '}' expected).
+			// reference-independent syntax error (CS1513 '}' expected). Its file path matches the pass's
+			// change-set, so the file resolves to this project and the scoped audit judges it.
 			onUpdate: solution =>
 			{
 				var projectId = solution.ProjectIds[0];
-				var broken = solution.AddDocument(DocumentId.CreateNewId(projectId), "Broken.cs", "public class Broken {");
+				var broken = solution.AddDocument(DocumentId.CreateNewId(projectId), "Broken.cs", "public class Broken {", filePath: "/work/Broken.cs");
 				return new SolutionUpdateResult(broken, ChangeSet.IgnoreAll([]));
 			},
 			// GetCompilationErrors reads TryGetCompilation (the cached compilation), so the result
@@ -307,6 +313,110 @@ public class Given_HotReloadManager
 		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.Failed, "a solution that does not compile blocks the reload");
 		harness.Handler.Calls.Should().ContainSingle()
 			.Which.Result.Should().Be(HotReloadOperationResult.Failed);
+		harness.Reporter.Outputs.Should().Contain(
+			o => o.Contains("Hot reload blocked") && o.Contains("TestProject") && o.Contains("Broken.cs"),
+			"the blocked-compilation line names the audited project and the edited file (spec 054 R2)");
+	}
+
+	// ── Spec 054: scope the blocked-compilation audit to the pass's change-set ──
+
+	[TestMethod]
+	[Description(
+		"Spec 054 R1: a pass whose change-set touches only a healthy project must not complete Failed because an " +
+		"unrelated project carries compilation errors. The audit is scoped to the change-set's projects, so a foreign " +
+		"project's errors never block the reload.")]
+	public async Task When_ChangeSetTouchesHealthyProject_Then_ForeignErrorsDoNotBlock()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
+			onUpdate: solution =>
+			{
+				// Project A (the default test project): a healthy, compiling library owning the edited file.
+				var projectA = solution.ProjectIds[0];
+				solution = solution
+					.WithProjectCompilationOptions(projectA, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+					.AddMetadataReference(projectA, _coreLib)
+					.AddDocument(DocumentId.CreateNewId(projectA), "A.cs", "namespace App { public class A { } }", filePath: "/work/A.cs");
+
+				// Project B: unrelated to the pass and does not compile (CS0103). It must never be audited.
+				var projectB = ProjectId.CreateNewId();
+				solution = solution
+					.AddProject(ProjectInfo.Create(
+						projectB, VersionStamp.Default, "LibraryB", "LibraryB", LanguageNames.CSharp,
+						compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)))
+					.AddMetadataReference(projectB, _coreLib)
+					.AddDocument(DocumentId.CreateNewId(projectB), "B.cs", "namespace Lib { public class B { public void M() { Missing(); } } }", filePath: "/lib/B.cs");
+
+				return new SolutionUpdateResult(solution, ChangeSet.IgnoreAll([]));
+			},
+			// Realize both projects' compilations so the manager's TryGetCompilation audit could observe B's error.
+			warmCompilation: true);
+
+		var batch = ImmutableHashSet.Create("/work/A.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(
+			HotReloadOperationResult.NoChanges,
+			"the pass touched only the healthy project A; project B's errors are foreign and must not block the reload");
+		harness.Reporter.Outputs.Should().NotContain(
+			o => o.Contains("Hot reload blocked"),
+			"no blocked-compilation line is emitted when the change-set's own projects compile");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 054 R1: an edit to an AdditionalDocument (e.g. XAML, a generator input) resolves to its owning project, " +
+		"which is then audited. When that project does not compile, the reload is blocked and the line names the edit.")]
+	public async Task When_ChangeSetIsAdditionalDocument_Then_OwningProjectIsAudited()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
+			onUpdate: solution =>
+			{
+				var projectId = solution.ProjectIds[0];
+				// The project does not compile (broken source)...
+				solution = solution.AddDocument(DocumentId.CreateNewId(projectId), "Broken.cs", "public class Broken {", filePath: "/work/Broken.cs");
+				// ...and the pass's changed file is one of its XAML additional documents.
+				solution = solution.AddAdditionalDocument(DocumentId.CreateNewId(projectId), "View.xaml", "<Page />", filePath: "/work/View.xaml");
+				return new SolutionUpdateResult(solution, ChangeSet.IgnoreAll([]));
+			},
+			warmCompilation: true);
+
+		var batch = ImmutableHashSet.Create("/work/View.xaml");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(
+			HotReloadOperationResult.Failed,
+			"the edited XAML file is an additional document of a project that does not compile, so the pass is blocked");
+		harness.Reporter.Outputs.Should().Contain(
+			o => o.Contains("Hot reload blocked") && o.Contains("View.xaml"),
+			"the blocked line names the edited additional document");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 054 R1: when the change-set resolves to no project in the solution, the audit is skipped entirely and " +
+		"the pass completes NoChanges — even if an unrelated project in the solution does not compile.")]
+	public async Task When_ChangeSetIsOutsideSolution_Then_AuditSkipped()
+	{
+		using var harness = new HotReloadManagerHarness(
+			_ => Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], [])),
+			onUpdate: solution =>
+			{
+				var projectId = solution.ProjectIds[0];
+				// The (only) project does not compile, but the pass's file does not belong to it.
+				var broken = solution.AddDocument(DocumentId.CreateNewId(projectId), "Broken.cs", "public class Broken {", filePath: "/work/Broken.cs");
+				return new SolutionUpdateResult(broken, ChangeSet.IgnoreAll([]));
+			},
+			warmCompilation: true);
+
+		var batch = ImmutableHashSet.Create("/elsewhere/Unknown.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), CancellationToken.None).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(
+			HotReloadOperationResult.NoChanges,
+			"the change-set resolves to no project, so the audit is skipped and the broken untouched project does not fail the pass");
+		harness.Reporter.Outputs.Should().NotContain(o => o.Contains("Hot reload blocked"));
 	}
 
 	private sealed record MarkerSolutionUpdateResult(Solution Solution, ChangeSet IgnoredChanges, string Marker)

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -237,7 +237,7 @@ public sealed class HotReloadManager : IDisposable
 				case (true, true) when GetCompilationErrors(result.Solution, files, ct) is { Errors.IsEmpty: false } audit:
 					_tracker.Output(
 						$"Hot reload blocked by {audit.Errors.Length} compilation error(s) in " +
-						$"{string.Join(", ", audit.AuditedProjects.Select(project => project.Name))} " +
+						$"{string.Join(", ", audit.BlockingProjects)} " +
 						$"(edited: {FormatEditedFiles(files)}).");
 					outcome = HotReloadOperationResult.Failed;
 					break;
@@ -294,12 +294,15 @@ public sealed class HotReloadManager : IDisposable
 		var auditedProjects = ResolveAuditProjects(solution, files);
 		if (auditedProjects.IsEmpty)
 		{
-			return new CompilationAudit(ImmutableArray<string>.Empty, ImmutableArray<Project>.Empty);
+			return new CompilationAudit([], []);
 		}
 
 		// ALC-hosted workspaces always have a single project — sequential iteration avoids
 		// Parallel.ForEach overhead (thread pool work items, partitioner, lambda closures).
-		var builder = ImmutableArray.CreateBuilder<string>();
+		// Only the projects that actually produce an error are named in the output line (a scoped
+		// project can be clean), and the names are ordered so the blocked line is deterministic.
+		var errors = ImmutableArray.CreateBuilder<string>();
+		var blockingProjects = new SortedSet<string>(StringComparer.Ordinal);
 		foreach (var project in auditedProjects)
 		{
 			if (!project.TryGetCompilation(out var compilation))
@@ -319,69 +322,60 @@ public sealed class HotReloadManager : IDisposable
 				{
 					var diagnostic = CSharpDiagnosticFormatter.Instance.Format(item, CultureInfo.InvariantCulture);
 					_tracker.Output("\x1B[40m\x1B[31m" + diagnostic);
-					builder.Add(diagnostic);
+					errors.Add(diagnostic);
+					blockingProjects.Add(project.Name);
 
 					// On WASM, memory.grow() is irreversible — cap diagnostic formatting
 					// to avoid unbounded string allocations when code is heavily broken.
 					// On desktop, report all errors for full IDE-like diagnostics.
-					if (OperatingSystem.IsBrowser() && builder.Count >= MaxCompilationErrorsPerCycle)
+					if (OperatingSystem.IsBrowser() && errors.Count >= MaxCompilationErrorsPerCycle)
 					{
 						_tracker.Output($"... and more errors (capped at {MaxCompilationErrorsPerCycle}).");
-						return new CompilationAudit(builder.ToImmutable(), auditedProjects);
+						return new CompilationAudit(errors.ToImmutable(), [.. blockingProjects]);
 					}
 				}
 			}
 		}
 
-		return new CompilationAudit(builder.ToImmutable(), auditedProjects);
+		return new CompilationAudit(errors.ToImmutable(), [.. blockingProjects]);
 	}
 
 	/// <summary>
 	/// Resolves the pass's change-set to the distinct set of projects that own those files — as source
-	/// <see cref="Document"/>s (via <see cref="Solution.GetDocumentIdsWithFilePath(string)"/>) or as
-	/// <see cref="AdditionalDocument"/>s (XAML and other generator inputs, whose edits can block
-	/// compilation exactly like a source edit). A file belonging to no project contributes nothing, so a
-	/// change-set touching only foreign/out-of-solution files resolves to an empty set.
+	/// <see cref="Document"/>s or as <see cref="AdditionalDocument"/>s (XAML and other generator inputs,
+	/// whose edits can block compilation exactly like a source edit). Both document kinds are matched
+	/// through <see cref="PathComparer"/> — the same separator/case-agnostic comparison the rest of the
+	/// hot-reload pipeline uses — so a document never escapes the scope because the workspace stored its
+	/// path with a different separator or casing than the change event carried. A file belonging to no
+	/// project contributes nothing, so a change-set touching only foreign/out-of-solution files resolves
+	/// to an empty set.
 	/// </summary>
 	private static ImmutableArray<Project> ResolveAuditProjects(Solution solution, ImmutableHashSet<string> files)
 	{
-		var projectIds = new HashSet<ProjectId>();
-		foreach (var file in files)
-		{
-			foreach (var documentId in solution.GetDocumentIdsWithFilePath(file))
-			{
-				projectIds.Add(documentId.ProjectId);
-			}
+		// Index the change-set once through the pipeline's path comparer so each project's documents are
+		// matched with a single O(1) lookup instead of an O(files) scan per document.
+		var changeSet = files.ToHashSet(PathComparer.PathEqualityComparer);
 
-			foreach (var project in solution.Projects)
-			{
-				if (project.AdditionalDocuments.Any(document => PathComparer.PathEquals(document.FilePath, file)))
-				{
-					projectIds.Add(project.Id);
-				}
-			}
-		}
-
-		var builder = ImmutableArray.CreateBuilder<Project>(projectIds.Count);
-		foreach (var projectId in projectIds)
-		{
-			if (solution.GetProject(projectId) is { } project)
-			{
-				builder.Add(project);
-			}
-		}
-
-		return builder.ToImmutable();
+		return solution.Projects
+			.Where(project =>
+				project.Documents.Any(document => document.FilePath is { } path && changeSet.Contains(path))
+				|| project.AdditionalDocuments.Any(document => document.FilePath is { } path && changeSet.Contains(path)))
+			.ToImmutableArray();
 	}
 
 	/// <summary>
 	/// Formats the pass's edited file names for the blocked-compilation output line: base names only
-	/// (<see cref="Path.GetFileName(string)"/>), capped to the first 3 with a <c>+N more</c> suffix beyond.
+	/// (<see cref="Path.GetFileName(string)"/>), ordered for a deterministic message, capped to the first
+	/// 3 with a <c>+N more</c> suffix beyond.
 	/// </summary>
 	private static string FormatEditedFiles(ImmutableHashSet<string> files)
 	{
 		const int maxNamed = 3;
-		var names = files.Select(Path.GetFileName).ToArray();
+		var names = files
+			.Select(Path.GetFileName)
+			.OfType<string>()
+			.OrderBy(name => name, StringComparer.Ordinal)
+			.ToArray();
 		var named = string.Join(", ", names.Take(maxNamed));
 
 		return names.Length > maxNamed
@@ -391,9 +385,10 @@ public sealed class HotReloadManager : IDisposable
 
 	/// <summary>
 	/// Outcome of the change-set-scoped blocked-compilation audit: the formatted compilation errors found
-	/// in the audited projects, and the projects that were audited (named in the blocked output line).
+	/// in the audited projects, and the distinct, ordered names of the projects that actually produced
+	/// those errors (named in the blocked output line).
 	/// </summary>
-	private readonly record struct CompilationAudit(ImmutableArray<string> Errors, ImmutableArray<Project> AuditedProjects);
+	private readonly record struct CompilationAudit(ImmutableArray<string> Errors, ImmutableArray<string> BlockingProjects);
 
 	/// <inheritdoc />
 	public void Dispose()

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
@@ -228,10 +229,16 @@ public sealed class HotReloadManager : IDisposable
 					break;
 
 				// No metadata updates, but the solution does not compile: the reload is blocked, not a no-op.
+				// The audit is scoped to the projects owning this pass's changed files (spec 054): a pass must
+				// never complete Failed on errors from projects it never touched. When the change-set resolves
+				// to no project the audit yields no errors and we fall through to NoChanges below.
 				// FIXME: GetCompilationErrors side-effects into _tracker but doesn't populate `diagnostics`;
 				// consumers see Failed without the reason (asymmetric with rude edits). Needs dedup before fixing.
-				case (true, true) when GetCompilationErrors(result.Solution, ct) is { IsEmpty: false } compilationErrors:
-					_tracker.Output($"Hot reload blocked by {compilationErrors.Length} compilation error(s).");
+				case (true, true) when GetCompilationErrors(result.Solution, files, ct) is { Errors.IsEmpty: false } audit:
+					_tracker.Output(
+						$"Hot reload blocked by {audit.Errors.Length} compilation error(s) in " +
+						$"{string.Join(", ", audit.AuditedProjects.Select(project => project.Name))} " +
+						$"(edited: {FormatEditedFiles(files)}).");
 					outcome = HotReloadOperationResult.Failed;
 					break;
 
@@ -278,12 +285,22 @@ public sealed class HotReloadManager : IDisposable
 	/// </summary>
 	private const int MaxCompilationErrorsPerCycle = 20;
 
-	private ImmutableArray<string> GetCompilationErrors(Solution solution, CancellationToken cancellationToken)
+	private CompilationAudit GetCompilationErrors(Solution solution, ImmutableHashSet<string> files, CancellationToken cancellationToken)
 	{
+		// Scope the audit to the projects owning the pass's changed files. A file that resolves to no
+		// project contributes nothing (it was already surfaced via NotifyIgnored); when the whole
+		// change-set resolves to nothing there is no project to judge, so we return an empty audit and
+		// the caller falls through to NoChanges rather than failing the pass on foreign projects.
+		var auditedProjects = ResolveAuditProjects(solution, files);
+		if (auditedProjects.IsEmpty)
+		{
+			return new CompilationAudit(ImmutableArray<string>.Empty, ImmutableArray<Project>.Empty);
+		}
+
 		// ALC-hosted workspaces always have a single project — sequential iteration avoids
 		// Parallel.ForEach overhead (thread pool work items, partitioner, lambda closures).
 		var builder = ImmutableArray.CreateBuilder<string>();
-		foreach (var project in solution.Projects)
+		foreach (var project in auditedProjects)
 		{
 			if (!project.TryGetCompilation(out var compilation))
 			{
@@ -310,14 +327,73 @@ public sealed class HotReloadManager : IDisposable
 					if (OperatingSystem.IsBrowser() && builder.Count >= MaxCompilationErrorsPerCycle)
 					{
 						_tracker.Output($"... and more errors (capped at {MaxCompilationErrorsPerCycle}).");
-						return builder.ToImmutable();
+						return new CompilationAudit(builder.ToImmutable(), auditedProjects);
 					}
 				}
 			}
 		}
 
+		return new CompilationAudit(builder.ToImmutable(), auditedProjects);
+	}
+
+	/// <summary>
+	/// Resolves the pass's change-set to the distinct set of projects that own those files — as source
+	/// <see cref="Document"/>s (via <see cref="Solution.GetDocumentIdsWithFilePath(string)"/>) or as
+	/// <see cref="AdditionalDocument"/>s (XAML and other generator inputs, whose edits can block
+	/// compilation exactly like a source edit). A file belonging to no project contributes nothing, so a
+	/// change-set touching only foreign/out-of-solution files resolves to an empty set.
+	/// </summary>
+	private static ImmutableArray<Project> ResolveAuditProjects(Solution solution, ImmutableHashSet<string> files)
+	{
+		var projectIds = new HashSet<ProjectId>();
+		foreach (var file in files)
+		{
+			foreach (var documentId in solution.GetDocumentIdsWithFilePath(file))
+			{
+				projectIds.Add(documentId.ProjectId);
+			}
+
+			foreach (var project in solution.Projects)
+			{
+				if (project.AdditionalDocuments.Any(document => PathComparer.PathEquals(document.FilePath, file)))
+				{
+					projectIds.Add(project.Id);
+				}
+			}
+		}
+
+		var builder = ImmutableArray.CreateBuilder<Project>(projectIds.Count);
+		foreach (var projectId in projectIds)
+		{
+			if (solution.GetProject(projectId) is { } project)
+			{
+				builder.Add(project);
+			}
+		}
+
 		return builder.ToImmutable();
 	}
+
+	/// <summary>
+	/// Formats the pass's edited file names for the blocked-compilation output line: base names only
+	/// (<see cref="Path.GetFileName(string)"/>), capped to the first 3 with a <c>+N more</c> suffix beyond.
+	/// </summary>
+	private static string FormatEditedFiles(ImmutableHashSet<string> files)
+	{
+		const int maxNamed = 3;
+		var names = files.Select(Path.GetFileName).ToArray();
+		var named = string.Join(", ", names.Take(maxNamed));
+
+		return names.Length > maxNamed
+			? $"{named} +{names.Length - maxNamed} more"
+			: named;
+	}
+
+	/// <summary>
+	/// Outcome of the change-set-scoped blocked-compilation audit: the formatted compilation errors found
+	/// in the audited projects, and the projects that were audited (named in the blocked output line).
+	/// </summary>
+	private readonly record struct CompilationAudit(ImmutableArray<string> Errors, ImmutableArray<Project> AuditedProjects);
 
 	/// <inheritdoc />
 	public void Dispose()


### PR DESCRIPTION
**GitHub Issue:** closes #23861

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Spec-first draft** — this PR currently carries
`specs/054-hotreload-audit-changeset-scope/spec.md`; the implementation lands on this
branch by following it.

Summary: on a (no rude edit, 0 update) pass, `HotReloadManager` audits **every project of
the solution** through `TryGetCompilation` — a pass can complete `Failed` on thousands of
errors from projects it never touched, and when that pass is the one correlated to the
originating `UpdateFile` request, the request reports failure for a change that was
applied. Planned per the spec: scope the audit to the projects owning the pass's changed
files (documents + additional documents), skip it when nothing resolves, and name the
audited projects in the blocked output line.
## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)