### PR TITLE
fix(hr): a re-observed up-to-date file must be a silent no-op (spec 055)

### DIFF
--- a/specs/055-hotreload-noop-pass-dedup/spec.md
+++ b/specs/055-hotreload-noop-pass-dedup/spec.md
@@ -1,0 +1,118 @@
+# Hot-Reload: No-Op Watcher Passes Must Not Complete (or Fail) Operations
+
+**Repo**: `uno` (Uno.HotReload)
+**Created**: 2026-07-23
+**Status**: Approved — ready for implementation
+**Related**: [spec 054](../054-hotreload-audit-changeset-scope/spec.md) (the audit the
+no-op pass lands in), [spec 053](../053-hotreload-workspace-analyzer-flavor-skew/spec.md),
+[spec 050](../050-hotreload-updatefile-workspace-gate/spec.md) (R6 — the per-request
+info file)
+
+## Overview & Objectives
+
+`FileUpdater.UpdateAsync` (`src/Uno.HotReload/IO/FileUpdater.cs`) writes the request's
+edits **and** the per-request hot-reload info file while holding the `BufferGate`, so
+the `FileSystemObserver`'s 250 ms buffer flushes them as **one** batch — one pass, one
+solution update, one emit. That is the design and it works in the nominal case.
+
+But the file-system is not transactional: **trailing events** for the same files
+(e.g. a close-write notification delivered after the buffer already closed, observed
+on Linux/inotify during a long first pass) open a **new** watcher batch whose files'
+on-disk content is *already* in the solution. That parasite pass then:
+
+1. forks the solution anyway (`WithDocumentText` with byte-identical text still
+   produces a new snapshot — reference inequality), so it does **not** take the
+   `result.Solution == originalSolution` → `NoChanges` shortcut;
+2. emits (`Found 0 metadata updates after 0.007s` — measured) and falls into the
+   `(no rude edit, 0 update)` audit branch (spec 054);
+3. worst of all, if it arrived while the originating request's operation was still
+   open, `TryMerge` folds it into **that** operation — and since *"operations are
+   completed by the pass that processes them"* (`HotReloadManager.ProcessFileChanges`,
+   merge-under-gate comment), the parasite pass's outcome **overwrites the real one**.
+   Observed live: batch pass applies the request's edits successfully, parasite pass
+   completes the merged operation as `Failed` (via the audit), and the request — which
+   correlates to that operation id through the info file (spec 050 R6) — reports
+   failure for a change that was applied.
+
+Objective: a batch whose content brings nothing new must be a **silent no-op** — it
+must not fork the solution, must not emit, must not run the audit, and must never
+degrade the outcome of an operation it merged into.
+
+## Requirements
+
+### R1 — content-level no-op detection in the solution update
+
+Where the changed files' on-disk content is applied to the solution (the
+`_solutionUpdater.UpdateAsync(originalSolution, changeSet, ct)` step of
+`HotReloadManager.ProcessSolutionChanged`, and the updater implementation(s) it
+dispatches to): before replacing a document's text, compare the new content with the
+document's current text and **skip identical writes**.
+
+- Comparison: `SourceText.ContentEquals` (or checksum comparison via
+  `SourceText.GetChecksum()` when both sides expose one) — not string comparison on
+  decoded text, so encodings/BOM handled by the existing load path stay authoritative.
+- Applies to regular documents **and** additional documents (a XAML additional
+  document re-observed with identical bytes is the same no-op).
+- A batch where **every** file was skipped must return the *original* solution
+  instance (reference-equal), so the existing
+  `result.Solution == originalSolution` → `NoChanges` branch in
+  `ProcessSolutionChanged` short-circuits everything downstream (no emit, no audit).
+- Log one debug/verbose line: `No-op batch: {N} file(s) already up to date ({names})`.
+
+### R2 — a no-op continuation must not overwrite a real outcome
+
+Guard the operation lifecycle around merged batches (`HotReloadManager.ProcessFileChanges`
+merge block + `HotReloadOperation.Complete`):
+
+- If a pass resolves to *no effective change* (R1) **and** it merged into an operation
+  that another pass is completing (or has completed) with a substantive outcome
+  (`Success`, `RudeEdit`, `Failed` with diagnostics), the no-op pass must not replace
+  that outcome — `NoChanges` from a no-op continuation is a *silent* completion at
+  most, never a downgrade of `Success` nor an upgrade to `Failed`.
+- The existing rule *"a batch must not merge into an operation that completes before
+  the batch's own pass runs"* stays; this requirement covers the complementary case —
+  the batch merged in time but turned out to be vacuous.
+- Keep the `NoChanges` auto-retry semantics intact for *real* no-change passes on
+  requests that armed `EnableAutoRetryIfNoChanges` (`ForceHotReloadAttempts/Delay`):
+  R1's skip must not swallow the retry when the request's own batch legitimately
+  produced no delta (retry decision happens in `HotReloadOperation.Complete` —
+  unchanged).
+
+### R3 — the info file stays a first-class change
+
+No special-casing of the hot-reload info file path: its content **does** change on
+every request (new operation id) and that change must keep flowing exactly as today —
+within the request's batch. The dedup is strictly content-based and file-agnostic;
+only byte-identical re-observations are suppressed.
+
+## Non-goals
+
+- Redesigning the watcher/debounce (the 250 ms `To2StepsObservable` buffer and the
+  `BufferGate` batching are untouched).
+- The audit itself (spec 054) and the generator-loading skew (spec 053).
+- De-duplicating *semantic* no-ops (identical AST after reformat, etc.) — bytes only.
+
+## Test plan
+
+Unit tests in `src/Uno.HotReload.Tests/`:
+
+1. **Updater skip**: document with text `T`; process a change-set claiming the file
+   changed while disk still contains `T` → returned solution is reference-equal to
+   the input; with a genuinely different `T'` → forked solution, document text `T'`.
+2. **AdditionalDocument skip**: same as (1) for an additional document.
+3. **Mixed batch**: two files, one identical + one changed → solution forked, only the
+   changed document differs.
+4. **Manager short-circuit**: full-reduced batch → outcome `NoChanges`, no emit
+   invoked (assert via the watch-service test double), no audit output line.
+5. **Merged-operation protection (R2)**: operation completed `Success` by pass A;
+   pass B (vacuous continuation of the same operation) processes → operation result
+   stays `Success`; symmetric test with pass A `Failed` (real diagnostics) — B must
+   not clear it.
+
+## Resolved decisions
+
+- Suppression happens at solution-update level (content compare), not at watcher
+  level: the watcher cannot know whether bytes changed without reading files, and the
+  updater already reads them.
+- `NoChanges` from a vacuous continuation is silent: no retry consumption, no
+  completion overwrite — the operation belongs to the pass that did real work.

--- a/specs/055-hotreload-noop-pass-dedup/spec.md
+++ b/specs/055-hotreload-noop-pass-dedup/spec.md
@@ -3,10 +3,9 @@
 **Repo**: `uno` (Uno.HotReload)
 **Created**: 2026-07-23
 **Status**: Resolved — implemented on this branch
-**Related**: [spec 054](../054-hotreload-audit-changeset-scope/spec.md) (the audit the
-parasite pass lands in), [spec 053](../053-hotreload-workspace-analyzer-flavor-skew/spec.md),
-[spec 050](../050-hotreload-updatefile-workspace-gate/spec.md) (R6 — the per-request
-info file)
+**Related**: [#23861](https://github.com/unoplatform/uno/issues/23861) (the blocked-compilation
+audit the parasite pass lands in), [spec 050](../050-hotreload-updatefile-workspace-gate/spec.md)
+(R6 — the per-request info file)
 
 ## Overview & Objectives
 
@@ -29,10 +28,16 @@ parasite pass then:
    new snapshot — reference inequality), so it does **not** take the
    `result.Solution == originalSolution` → `NoChanges` shortcut;
 2. emits (`Found 0 metadata updates after 0.007s` — measured) and falls into the
-   `(no rude edit, 0 update)` audit branch (spec 054) — observed completing as `Failed`;
-3. worst of all, if it merged into the originating request's still-open operation, its
-   outcome **overwrites the real one** (observed live: the request's edits applied
-   successfully, the request reported `Failed`).
+   `(no rude edit, 0 update)` audit branch ([#23861](https://github.com/unoplatform/uno/issues/23861))
+   — observed completing as `Failed`;
+3. if it merged into the originating request's **still-open** operation, its outcome degrades
+   the real one. The normal path is already guarded: post-`8076b444aa` the batch↔operation
+   merge decision is under the solution-update gate, so an operation completed by its own pass
+   routes the parasite to a *fresh* operation (no overwrite). What remains exposed is the
+   window where the origin operation is still open when the parasite runs under the gate — the
+   `ProcessFileChanges` exception path (which completes the operation *after* the gate is
+   released) and the auto-retry / deferred-completion window. Observed live: the request's
+   edits applied successfully, yet it reported `Failed`.
 
 Objective: a batch whose content brings nothing new must resolve to a **silent no-op** — it
 must not fork the solution, must not emit, and must not run the audit. The fix is
@@ -48,13 +53,20 @@ on-disk content with the document's current text and **skip identical writes**.
 
 - Comparison: `SourceText.ContentEquals` — regular documents **and** additional documents
   (a XAML additional document re-observed with identical bytes is the same no-op).
+  `ContentEquals` (rather than `GetChecksum`) is deliberate for this access pattern: the
+  compared disk text is read fresh every cycle (`SourceText.From(stream)`), so it never
+  carries a cached checksum — a checksum path would pay a full hash over the fresh text on
+  every cycle, whereas `ContentEquals` short-circuits on length and first difference (the
+  common *actually-changed* case bails immediately), and each document is compared at most
+  once per pass, so there is no repeated-comparison amortisation for a cached hash to exploit.
 - Only *realized* texts are compared (`TryGetText`): an unrealized text means the document
   was never read into this snapshot, so the batch cannot be a re-observation of it — the
   edit is applied unconditionally (never swallow a first edit).
 - A batch where **every** entry was skipped returns the *original* solution instance
   (reference-equal), so the existing `result.Solution == originalSolution` → `NoChanges`
   branch in `ProcessSolutionChanged` short-circuits everything downstream — **before the
-  emit**, so no metadata-update roundtrip and no blocked-compilation audit (spec 054).
+  emit**, so no metadata-update roundtrip and no blocked-compilation audit
+  ([#23861](https://github.com/unoplatform/uno/issues/23861)).
 - Skipped entries are surfaced on the result as `SolutionUpdateResult.UpToDateChanges`
   (a `ChangeSet`) — they were **consumed** (their content is in the solution), *not*
   ignored. The manager reports them with a single verbose line.
@@ -82,7 +94,8 @@ normally.
   untouched).
 - Touching the operation lifecycle: `TryMerge` and the merge-under-gate decision
   (`8076b444aa`) are untouched.
-- The audit itself (spec 054) and the generator-loading skew (spec 053).
+- The audit itself ([#23861](https://github.com/unoplatform/uno/issues/23861)) and the
+  analyzer/generator flavor-loading skew.
 - De-duplicating *semantic* no-ops (identical AST after reformat, etc.) — bytes only.
 
 ## Known residual (accepted)

--- a/specs/055-hotreload-noop-pass-dedup/spec.md
+++ b/specs/055-hotreload-noop-pass-dedup/spec.md
@@ -1,118 +1,181 @@
-# Hot-Reload: No-Op Watcher Passes Must Not Complete (or Fail) Operations
+# Hot-Reload: A Re-Observed Up-To-Date File Must Be a Silent No-Op
 
 **Repo**: `uno` (Uno.HotReload)
 **Created**: 2026-07-23
-**Status**: Approved — ready for implementation
+**Status**: Resolved — implemented on this branch
 **Related**: [spec 054](../054-hotreload-audit-changeset-scope/spec.md) (the audit the
-no-op pass lands in), [spec 053](../053-hotreload-workspace-analyzer-flavor-skew/spec.md),
+parasite pass lands in), [spec 053](../053-hotreload-workspace-analyzer-flavor-skew/spec.md),
 [spec 050](../050-hotreload-updatefile-workspace-gate/spec.md) (R6 — the per-request
 info file)
 
 ## Overview & Objectives
 
-`FileUpdater.UpdateAsync` (`src/Uno.HotReload/IO/FileUpdater.cs`) writes the request's
-edits **and** the per-request hot-reload info file while holding the `BufferGate`, so
-the `FileSystemObserver`'s 250 ms buffer flushes them as **one** batch — one pass, one
-solution update, one emit. That is the design and it works in the nominal case.
+`FileUpdater.UpdateAsync` (`src/Uno.HotReload/IO/FileUpdater.cs`) writes a request's edits
+**and** its per-request hot-reload info file (`HotReloadInfo.g.cs`) while holding the
+`BufferGate`, so the `FileSystemObserver`'s 250 ms buffer flushes them as **one** batch —
+one pass, one solution update, one emit. That is the design and it works in the nominal
+case; the info file's new content (the operation id) rides that batch and reaches the
+application (spec 050 R6, pinned by the `Given_HotReloadInfo` runtime test).
 
-But the file-system is not transactional: **trailing events** for the same files
-(e.g. a close-write notification delivered after the buffer already closed, observed
-on Linux/inotify during a long first pass) open a **new** watcher batch whose files'
-on-disk content is *already* in the solution. That parasite pass then:
+The problem: the file-system is **not transactional**. A single `File.WriteAllTextAsync`
+emits several inotify notifications (`IN_MODIFY`, `IN_CLOSE_WRITE`); the pipeline's own
+`WaitForFileUpdated` only synchronises on the **first** one. A **trailing** event —
+typically the close-write for a file the pipeline *just wrote itself*, delivered after the
+250 ms buffer already closed (observed on Linux/inotify during a long first pass) — opens a
+**new** watcher batch for a file whose on-disk content is *already* in the solution. That
+parasite pass then:
 
-1. forks the solution anyway (`WithDocumentText` with byte-identical text still
-   produces a new snapshot — reference inequality), so it does **not** take the
+1. forks the solution anyway (`WithDocumentText` with byte-identical text still produces a
+   new snapshot — reference inequality), so it does **not** take the
    `result.Solution == originalSolution` → `NoChanges` shortcut;
 2. emits (`Found 0 metadata updates after 0.007s` — measured) and falls into the
-   `(no rude edit, 0 update)` audit branch (spec 054);
-3. worst of all, if it arrived while the originating request's operation was still
-   open, `TryMerge` folds it into **that** operation — and since *"operations are
-   completed by the pass that processes them"* (`HotReloadManager.ProcessFileChanges`,
-   merge-under-gate comment), the parasite pass's outcome **overwrites the real one**.
-   Observed live: batch pass applies the request's edits successfully, parasite pass
-   completes the merged operation as `Failed` (via the audit), and the request — which
-   correlates to that operation id through the info file (spec 050 R6) — reports
-   failure for a change that was applied.
+   `(no rude edit, 0 update)` audit branch (spec 054) — observed completing as `Failed`;
+3. worst of all, if it merged into the originating request's still-open operation, its
+   outcome **overwrites the real one** (observed live: the request's edits applied
+   successfully, the request reported `Failed`).
 
-Objective: a batch whose content brings nothing new must be a **silent no-op** — it
-must not fork the solution, must not emit, must not run the audit, and must never
-degrade the outcome of an operation it merged into.
+Objective: a batch whose content brings nothing new must resolve to a **silent no-op** — it
+must not fork the solution, must not emit, and must not run the audit. The fix is
+**content-based and file-agnostic**; it lives in the solution update, where files are
+already read.
 
 ## Requirements
 
 ### R1 — content-level no-op detection in the solution update
 
-Where the changed files' on-disk content is applied to the solution (the
-`_solutionUpdater.UpdateAsync(originalSolution, changeSet, ct)` step of
-`HotReloadManager.ProcessSolutionChanged`, and the updater implementation(s) it
-dispatches to): before replacing a document's text, compare the new content with the
-document's current text and **skip identical writes**.
+In `SolutionUpdater.UpdateAsync`: before replacing a document's text, compare the new
+on-disk content with the document's current text and **skip identical writes**.
 
-- Comparison: `SourceText.ContentEquals` (or checksum comparison via
-  `SourceText.GetChecksum()` when both sides expose one) — not string comparison on
-  decoded text, so encodings/BOM handled by the existing load path stay authoritative.
-- Applies to regular documents **and** additional documents (a XAML additional
-  document re-observed with identical bytes is the same no-op).
-- A batch where **every** file was skipped must return the *original* solution
-  instance (reference-equal), so the existing
-  `result.Solution == originalSolution` → `NoChanges` branch in
-  `ProcessSolutionChanged` short-circuits everything downstream (no emit, no audit).
-- Log one debug/verbose line: `No-op batch: {N} file(s) already up to date ({names})`.
+- Comparison: `SourceText.ContentEquals` — regular documents **and** additional documents
+  (a XAML additional document re-observed with identical bytes is the same no-op).
+- Only *realized* texts are compared (`TryGetText`): an unrealized text means the document
+  was never read into this snapshot, so the batch cannot be a re-observation of it — the
+  edit is applied unconditionally (never swallow a first edit).
+- A batch where **every** entry was skipped returns the *original* solution instance
+  (reference-equal), so the existing `result.Solution == originalSolution` → `NoChanges`
+  branch in `ProcessSolutionChanged` short-circuits everything downstream — **before the
+  emit**, so no metadata-update roundtrip and no blocked-compilation audit (spec 054).
+- Skipped entries are surfaced on the result as `SolutionUpdateResult.UpToDateChanges`
+  (a `ChangeSet`) — they were **consumed** (their content is in the solution), *not*
+  ignored. The manager reports them with a single verbose line.
 
-### R2 — a no-op continuation must not overwrite a real outcome
+### R2 — the info file stays a first-class change
 
-Guard the operation lifecycle around merged batches (`HotReloadManager.ProcessFileChanges`
-merge block + `HotReloadOperation.Complete`):
-
-- If a pass resolves to *no effective change* (R1) **and** it merged into an operation
-  that another pass is completing (or has completed) with a substantive outcome
-  (`Success`, `RudeEdit`, `Failed` with diagnostics), the no-op pass must not replace
-  that outcome — `NoChanges` from a no-op continuation is a *silent* completion at
-  most, never a downgrade of `Success` nor an upgrade to `Failed`.
-- The existing rule *"a batch must not merge into an operation that completes before
-  the batch's own pass runs"* stays; this requirement covers the complementary case —
-  the batch merged in time but turned out to be vacuous.
-- Keep the `NoChanges` auto-retry semantics intact for *real* no-change passes on
-  requests that armed `EnableAutoRetryIfNoChanges` (`ForceHotReloadAttempts/Delay`):
-  R1's skip must not swallow the retry when the request's own batch legitimately
-  produced no delta (retry decision happens in `HotReloadOperation.Complete` —
-  unchanged).
-
-### R3 — the info file stays a first-class change
-
-No special-casing of the hot-reload info file path: its content **does** change on
-every request (new operation id) and that change must keep flowing exactly as today —
-within the request's batch. The dedup is strictly content-based and file-agnostic;
-only byte-identical re-observations are suppressed.
+No special-casing of the hot-reload info file path: its content **does** change on every
+request (new operation id) and that change must keep flowing exactly as today — within the
+request's batch, applied and emitted so the application observes the new `VersionId`. The
+dedup is strictly content-based; only byte-identical re-observations are suppressed. On the
+request's own batch the info file's content differs from the solution, so it is applied
+normally.
 
 ## Non-goals
 
-- Redesigning the watcher/debounce (the 250 ms `To2StepsObservable` buffer and the
-  `BufferGate` batching are untouched).
+- **No watcher-level trigger exclusion.** An earlier draft made the info file "unable to
+  open a batch" in the observer (a `canTriggerBatch` predicate). Rejected: making a specific
+  file unable to open the update gate is conceptually wrong (the observer should not carry
+  per-file lifecycle policy), it does not generalise (any self-written or trailing
+  re-observation of *any* file has the same hazard), and the file system is not
+  transactional — you cannot know when the last trailing event has arrived, so this can only
+  ever be probabilistic. Content-level dedup addresses the whole class at the layer that
+  already reads the files.
+- Redesigning the watcher/debounce (the 250 ms buffer and the `BufferGate` batching are
+  untouched).
+- Touching the operation lifecycle: `TryMerge` and the merge-under-gate decision
+  (`8076b444aa`) are untouched.
 - The audit itself (spec 054) and the generator-loading skew (spec 053).
 - De-duplicating *semantic* no-ops (identical AST after reformat, etc.) — bytes only.
+
+## Known residual (accepted)
+
+A trailing event still *opens* a batch and runs a pass; R1 only guarantees that pass is a
+**silent `NoChanges`** (reference-equal solution, no emit, no audit) rather than a spurious
+`Failed`. So an intermittent trailing event can still surface an extra `NoChanges` operation
+in the tracker/history. This is cosmetic and strictly better than the observed failure; the
+request itself correlates to its own operation id (returned in the response), which the real
+pass completes with the substantive outcome before any trailing pass runs (the merge
+decision is under the gate — `8076b444aa`).
 
 ## Test plan
 
 Unit tests in `src/Uno.HotReload.Tests/`:
 
-1. **Updater skip**: document with text `T`; process a change-set claiming the file
-   changed while disk still contains `T` → returned solution is reference-equal to
-   the input; with a genuinely different `T'` → forked solution, document text `T'`.
+1. **Updater skip** (`Given_SolutionUpdater`): document with realized text `T`; process a
+   change-set claiming the file changed while disk still contains `T` → returned solution is
+   reference-equal to the input and the document appears in `UpToDateChanges`; with a
+   genuinely different `T'` → forked solution, document text `T'`, empty `UpToDateChanges`.
 2. **AdditionalDocument skip**: same as (1) for an additional document.
 3. **Mixed batch**: two files, one identical + one changed → solution forked, only the
-   changed document differs.
-4. **Manager short-circuit**: full-reduced batch → outcome `NoChanges`, no emit
-   invoked (assert via the watch-service test double), no audit output line.
-5. **Merged-operation protection (R2)**: operation completed `Success` by pass A;
-   pass B (vacuous continuation of the same operation) processes → operation result
-   stays `Success`; symmetric test with pass A `Failed` (real diagnostics) — B must
-   not clear it.
+   changed document differs, the identical one in `UpToDateChanges`.
+4. **Unrealized-text guard**: a document whose text was never realized is applied even when
+   disk content is identical (no false skip).
+5. **Manager short-circuit** (`Given_HotReloadManager`): a fully-reduced batch (updater
+   returns the original solution + non-empty `UpToDateChanges`) → outcome `NoChanges`, the
+   emitter is never invoked, no blocked-compilation audit line, and the up-to-date entries
+   are reported.
 
 ## Resolved decisions
 
-- Suppression happens at solution-update level (content compare), not at watcher
-  level: the watcher cannot know whether bytes changed without reading files, and the
-  updater already reads them.
-- `NoChanges` from a vacuous continuation is silent: no retry consumption, no
-  completion overwrite — the operation belongs to the pass that did real work.
+- Suppression happens at solution-update level (content compare), not at watcher level: the
+  watcher cannot know whether bytes changed without reading files, and the updater already
+  reads them.
+- Up-to-date entries are reported via `UpToDateChanges` (not `IgnoredChanges`): they were
+  consumed — their content is in the solution.
+
+## Discussion & decision log
+
+The path to the decision above, recorded so the rejected branches are not re-explored:
+
+1. **Root cause is a file we wrote ourselves.** `FileUpdater` writes `HotReloadInfo.g.cs`
+   on every request; a trailing inotify event for *that* file re-triggers hot reload for
+   our own bookkeeping write. This was surfaced (not caused) by `8076b444aa`
+   (*decide batch merge under the update gate*): before it, the trailing batch was
+   silently absorbed into the originating operation; after it, the originating operation
+   has already completed by the time the trailing batch runs under the gate, so `TryMerge`
+   refuses and the batch spawns a **fresh, user-visible** parasite operation.
+
+2. **First draft — rejected.** Two-part fix: (R1) a watcher-level `canTriggerBatch`
+   predicate so the info file could *join* a batch but never *open* one, plus (R2) a
+   `HotReloadManager` lifecycle guard so a "vacuous continuation" could not overwrite a
+   real outcome. Rejected because:
+   - making a specific file "unable to open the update gate" is conceptually wrong — the
+     observer would carry per-file lifecycle policy;
+   - it does not generalise — any self-written or trailing re-observation of *any* file has
+     the same hazard, not just the info file;
+   - it can only ever be probabilistic (see 4).
+
+3. **Why the info file cannot simply be excluded from the watcher.** `HasInterest` already
+   has an *exception that keeps* the info file (it lives under `obj/`, otherwise filtered).
+   It is kept on purpose: `ChangesDetector.DiscoverChangesAsync` only classifies files that
+   are **in the batch** (it does not diff the whole solution against disk), and
+   `HotReloadInfo.VersionId` is a *compiled constant* — for the app to observe the bump, the
+   info-file change must be applied to the solution and emitted. Fully excluding it from the
+   watcher would break the `VersionId` bump (spec 050 R6, `Given_HotReloadInfo` runtime
+   test). So the file genuinely must be observed to *join* the request's batch.
+
+4. **"Do we release the `BufferGate` too early?" — not fixable by timing.** `FileUpdater`
+   holds the gate across all its writes, and `WaitForFileUpdated` synchronises on the
+   **first** inotify event of each write — so in the nominal path the info file *is* in the
+   request's batch. The parasite is a **trailing** event (a later `IN_CLOSE_WRITE` for the
+   same write). You cannot know how many trailing events the kernel will still emit, nor
+   when, so holding the gate longer is a probabilistic band-aid, not a fix. The file system
+   is not transactional — any fix that lives in watcher/gate timing is chasing a race it
+   cannot win.
+
+5. **Options weighed.**
+   - **(A)** Keep the observe-but-don't-trigger asymmetry, but inline the check instead of
+     threading a delegate. Still watcher-level lifecycle policy.
+   - **(B)** Stop observing the info file entirely and have `FileUpdater` inject its change
+     into the request's processing directly. Cleanest conceptually, but couples `FileUpdater`
+     to the update path — a coupling deliberately avoided (the two are decoupled via the file
+     system).
+   - **(C)** Chosen: **content-level no-op only.** Let any file (info file included) trigger
+     if the OS says so; the updater skips byte-identical re-writes, so a re-observation of
+     content already in the solution collapses to a reference-equal solution →
+     `NoChanges` before the emit. Treats the whole class at the layer that already reads the
+     files, adds no watcher policy, no `FileUpdater`↔manager coupling.
+
+6. **Accepted trade-off.** (C) does not stop the parasite pass from *running*; it guarantees
+   the pass is a silent `NoChanges` rather than a spurious `Failed`. The intermittent
+   `NoChanges` operation that may appear in history (see *Known residual*) is cosmetic and
+   strictly better than the observed failure — an acceptable price for the simplest, safest
+   fix.

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -17,6 +17,8 @@ public class Given_HotReloadManager
 	// a project that genuinely compiles clean (so the scoped audit finds no errors in it).
 	private static readonly MetadataReference _coreLib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
 
+	public TestContext TestContext { get; set; } = null!;
+
 	[TestMethod]
 	[Description(
 		"A batch whose files intersect an in-flight operation merges into it, but its compile " +
@@ -446,6 +448,38 @@ public class Given_HotReloadManager
 		harness.Reporter.Outputs.Should().Contain(
 			o => o.Contains("Hot reload blocked") && o.Contains("Broken.cs"),
 			"the blocked line names the resolved edited file");
+	}
+
+	// ── Spec 055: the pipeline's own info-file write must never re-trigger a pass ──
+
+	[TestMethod]
+	[Description(
+		"Spec 055 R2: a batch fully reduced by the updater (reference-equal solution, entries reported " +
+		"in UpToDateChanges) short-circuits as a NoChanges completion — the emitter is never invoked " +
+		"and no blocked-compilation audit line is produced.")]
+	public async Task When_FullyReducedBatch_Then_NoChangesWithoutEmitNorAudit()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		var emitInvoked = false;
+		using var harness = new HotReloadManagerHarness(
+			_ =>
+			{
+				emitInvoked = true;
+				return Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], []));
+			},
+			onUpdate: solution => new SolutionUpdateResult(solution, ChangeSet.IgnoreAll([]))
+			{
+				UpToDateChanges = ChangeSet.IgnoreAll(["/work/Model.cs"]),
+			});
+
+		var batch = ImmutableHashSet.Create("/work/Model.cs");
+		await harness.Manager.ProcessFileChanges(Task.FromResult(batch), ct).WaitAsync(_testTimeout);
+
+		harness.Tracker.Last!.Result.Should().Be(HotReloadOperationResult.NoChanges);
+		emitInvoked.Should().BeFalse("a fully-reduced batch must not reach the emitter");
+		harness.Reporter.Outputs.Should().NotContain(m => m.Contains("Hot reload blocked"), "a no-op batch must not land in the blocked-compilation audit");
+		harness.Reporter.Outputs.Should().Contain(m => m.Contains("No changes found"));
+		harness.Reporter.VerboseMessages.Should().Contain(m => m.Contains("already up to date") && m.Contains("Model.cs"));
 	}
 
 	private sealed record MarkerSolutionUpdateResult(Solution Solution, ChangeSet IgnoredChanges, string Marker)

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.cs
@@ -454,7 +454,7 @@ public class Given_HotReloadManager
 
 	[TestMethod]
 	[Description(
-		"Spec 055 R2: a batch fully reduced by the updater (reference-equal solution, entries reported " +
+		"Spec 055 R1: a batch fully reduced by the updater (reference-equal solution, entries reported " +
 		"in UpToDateChanges) short-circuits as a NoChanges completion — the emitter is never invoked " +
 		"and no blocked-compilation audit line is produced.")]
 	public async Task When_FullyReducedBatch_Then_NoChangesWithoutEmitNorAudit()
@@ -467,9 +467,19 @@ public class Given_HotReloadManager
 				emitInvoked = true;
 				return Task.FromResult<(ImmutableArray<Update>, ImmutableArray<Diagnostic>)>(([], []));
 			},
-			onUpdate: solution => new SolutionUpdateResult(solution, ChangeSet.IgnoreAll([]))
+			onUpdate: solution =>
 			{
-				UpToDateChanges = ChangeSet.IgnoreAll(["/work/Model.cs"]),
+				// Mirror the real updater: up-to-date entries are surfaced via EditedDocuments (with
+				// their file path), never IgnoredFiles. Build a document to reference but return the
+				// original solution unchanged, so the reference-equality NoChanges short-circuit fires.
+				var docId = DocumentId.CreateNewId(solution.ProjectIds[0]);
+				var upToDateDoc = solution
+					.AddDocument(docId, "Model.cs", "class Model { }", filePath: "/work/Model.cs")
+					.GetDocument(docId)!;
+				return new SolutionUpdateResult(solution, ChangeSet.IgnoreAll([]))
+				{
+					UpToDateChanges = ChangeSet.Empty with { EditedDocuments = [upToDateDoc] },
+				};
 			});
 
 		var batch = ImmutableHashSet.Create("/work/Model.cs");

--- a/src/Uno.HotReload.Tests/Given_SolutionUpdater.cs
+++ b/src/Uno.HotReload.Tests/Given_SolutionUpdater.cs
@@ -14,7 +14,7 @@ public class Given_SolutionUpdater
 
 	[TestMethod]
 	[Description(
-		"Spec 055 R2: a change-set entry whose on-disk content is byte-identical to the document's " +
+		"Spec 055 R1: a change-set entry whose on-disk content is byte-identical to the document's " +
 		"current text is not re-applied — a fully-reduced batch returns the original solution " +
 		"instance (reference-equal), enabling the manager's NoChanges short-circuit — and the " +
 		"skipped entry is surfaced through UpToDateChanges.")]
@@ -36,13 +36,13 @@ public class Given_SolutionUpdater
 
 		var result = await new SolutionUpdater().UpdateAsync(solution, Edits([solution.GetDocument(documentId)!]), ct);
 
-		result.Solution.Should().BeSameAs(solution, "byte-identical content must not fork the snapshot (spec 055 R2)");
+		result.Solution.Should().BeSameAs(solution, "byte-identical content must not fork the snapshot (spec 055 R1)");
 		result.UpToDateChanges.EditedDocuments.Should().ContainSingle()
 			.Which.Id.Should().Be(documentId);
 	}
 
 	[TestMethod]
-	[Description("Spec 055 R2: genuinely different on-disk content still forks the solution and applies the new text.")]
+	[Description("Spec 055 R1: genuinely different on-disk content still forks the solution and applies the new text.")]
 	public async Task When_DiskContentDiffers_Then_TextIsApplied()
 	{
 		var ct = TestContext.CancellationTokenSource.Token;
@@ -68,7 +68,7 @@ public class Given_SolutionUpdater
 
 	[TestMethod]
 	[Description(
-		"Spec 055 R2: the up-to-date skip applies to additional documents too — a XAML additional " +
+		"Spec 055 R1: the up-to-date skip applies to additional documents too — a XAML additional " +
 		"document re-observed with identical bytes is the same no-op.")]
 	public async Task When_AdditionalDocumentContentIsIdentical_Then_OriginalSolutionInstanceReturned()
 	{
@@ -91,14 +91,14 @@ public class Given_SolutionUpdater
 			Edits([], [solution.GetAdditionalDocument(documentId)!]),
 			ct);
 
-		result.Solution.Should().BeSameAs(solution, "byte-identical additional-document content must not fork the snapshot (spec 055 R2)");
+		result.Solution.Should().BeSameAs(solution, "byte-identical additional-document content must not fork the snapshot (spec 055 R1)");
 		result.UpToDateChanges.EditedAdditionalDocuments.Should().ContainSingle()
 			.Which.Id.Should().Be(documentId);
 	}
 
 	[TestMethod]
 	[Description(
-		"Spec 055 R2: a mixed batch (one file already up to date, one genuinely changed) forks the " +
+		"Spec 055 R1: a mixed batch (one file already up to date, one genuinely changed) forks the " +
 		"solution but only re-applies the changed document; the identical one is reported up to date.")]
 	public async Task When_MixedBatch_Then_OnlyChangedDocumentIsApplied()
 	{
@@ -135,7 +135,7 @@ public class Given_SolutionUpdater
 
 	[TestMethod]
 	[Description(
-		"Spec 055 R2 boundary: the skip only compares realized texts. A document whose text was " +
+		"Spec 055 R1 boundary: the skip only compares realized texts. A document whose text was " +
 		"never read into the snapshot cannot be a re-observation, so the edit is applied (never " +
 		"swallow a first edit).")]
 	public async Task When_DocumentTextNotRealized_Then_EditIsApplied()

--- a/src/Uno.HotReload.Tests/Given_SolutionUpdater.cs
+++ b/src/Uno.HotReload.Tests/Given_SolutionUpdater.cs
@@ -1,0 +1,171 @@
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Uno.HotReload.Diffing;
+using Uno.HotReload.Tests.TestUtils;
+
+namespace Uno.HotReload.Tests;
+
+[TestClass]
+public class Given_SolutionUpdater
+{
+	public TestContext TestContext { get; set; } = null!;
+
+	[TestMethod]
+	[Description(
+		"Spec 055 R2: a change-set entry whose on-disk content is byte-identical to the document's " +
+		"current text is not re-applied — a fully-reduced batch returns the original solution " +
+		"instance (reference-equal), enabling the manager's NoChanges short-circuit — and the " +
+		"skipped entry is surfaced through UpToDateChanges.")]
+	public async Task When_DiskContentIsIdentical_Then_OriginalSolutionInstanceReturned()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		var path = await temp.WriteFileAsync("Model.cs", "class Model { }", ct);
+
+		using var workspace = new AdhocWorkspace();
+		var projectId = ProjectId.CreateNewId();
+		var documentId = DocumentId.CreateNewId(projectId);
+		var solution = workspace.CurrentSolution
+			.AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+			.AddDocument(documentId, "Model.cs", SourceText.From("class Model { }"), filePath: path);
+
+		// Realize the text, as the initial compilation does on the real workspace.
+		_ = await solution.GetDocument(documentId)!.GetTextAsync(ct);
+
+		var result = await new SolutionUpdater().UpdateAsync(solution, Edits([solution.GetDocument(documentId)!]), ct);
+
+		result.Solution.Should().BeSameAs(solution, "byte-identical content must not fork the snapshot (spec 055 R2)");
+		result.UpToDateChanges.EditedDocuments.Should().ContainSingle()
+			.Which.Id.Should().Be(documentId);
+	}
+
+	[TestMethod]
+	[Description("Spec 055 R2: genuinely different on-disk content still forks the solution and applies the new text.")]
+	public async Task When_DiskContentDiffers_Then_TextIsApplied()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		var path = await temp.WriteFileAsync("Model.cs", "class Model { int A; }", ct);
+
+		using var workspace = new AdhocWorkspace();
+		var projectId = ProjectId.CreateNewId();
+		var documentId = DocumentId.CreateNewId(projectId);
+		var solution = workspace.CurrentSolution
+			.AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+			.AddDocument(documentId, "Model.cs", SourceText.From("class Model { }"), filePath: path);
+
+		// Realize the text so the update exercises the content comparison, not the unrealized-text bypass.
+		_ = await solution.GetDocument(documentId)!.GetTextAsync(ct);
+
+		var result = await new SolutionUpdater().UpdateAsync(solution, Edits([solution.GetDocument(documentId)!]), ct);
+
+		result.Solution.Should().NotBeSameAs(solution);
+		(await result.Solution.GetDocument(documentId)!.GetTextAsync(ct)).ToString().Should().Be("class Model { int A; }");
+		result.UpToDateChanges.GetAllPaths().Should().BeEmpty("an applied edit is not up to date");
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 055 R2: the up-to-date skip applies to additional documents too — a XAML additional " +
+		"document re-observed with identical bytes is the same no-op.")]
+	public async Task When_AdditionalDocumentContentIsIdentical_Then_OriginalSolutionInstanceReturned()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		var path = await temp.WriteFileAsync("Page.xaml", "<Page />", ct);
+
+		using var workspace = new AdhocWorkspace();
+		var projectId = ProjectId.CreateNewId();
+		var documentId = DocumentId.CreateNewId(projectId);
+		var solution = workspace.CurrentSolution
+			.AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+			.AddAdditionalDocument(documentId, "Page.xaml", SourceText.From("<Page />"), filePath: path);
+
+		// Realize the text, as the initial compilation does on the real workspace.
+		_ = await solution.GetAdditionalDocument(documentId)!.GetTextAsync(ct);
+
+		var result = await new SolutionUpdater().UpdateAsync(
+			solution,
+			Edits([], [solution.GetAdditionalDocument(documentId)!]),
+			ct);
+
+		result.Solution.Should().BeSameAs(solution, "byte-identical additional-document content must not fork the snapshot (spec 055 R2)");
+		result.UpToDateChanges.EditedAdditionalDocuments.Should().ContainSingle()
+			.Which.Id.Should().Be(documentId);
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 055 R2: a mixed batch (one file already up to date, one genuinely changed) forks the " +
+		"solution but only re-applies the changed document; the identical one is reported up to date.")]
+	public async Task When_MixedBatch_Then_OnlyChangedDocumentIsApplied()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		var samePath = await temp.WriteFileAsync("Same.cs", "class Same { }", ct);
+		var changedPath = await temp.WriteFileAsync("Changed.cs", "class Changed { int A; }", ct);
+
+		using var workspace = new AdhocWorkspace();
+		var projectId = ProjectId.CreateNewId();
+		var sameId = DocumentId.CreateNewId(projectId);
+		var changedId = DocumentId.CreateNewId(projectId);
+		var solution = workspace.CurrentSolution
+			.AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+			.AddDocument(sameId, "Same.cs", SourceText.From("class Same { }"), filePath: samePath)
+			.AddDocument(changedId, "Changed.cs", SourceText.From("class Changed { }"), filePath: changedPath);
+
+		// Realize the texts, as the initial compilation does on the real workspace.
+		_ = await solution.GetDocument(sameId)!.GetTextAsync(ct);
+		_ = await solution.GetDocument(changedId)!.GetTextAsync(ct);
+
+		var result = await new SolutionUpdater().UpdateAsync(
+			solution,
+			Edits([solution.GetDocument(sameId)!, solution.GetDocument(changedId)!]),
+			ct);
+
+		result.Solution.Should().NotBeSameAs(solution, "the batch contains a real change");
+		(await result.Solution.GetDocument(changedId)!.GetTextAsync(ct)).ToString().Should().Be("class Changed { int A; }");
+		(await result.Solution.GetDocument(sameId)!.GetTextAsync(ct))
+			.Should().BeSameAs(await solution.GetDocument(sameId)!.GetTextAsync(ct), "the up-to-date document's state must be left untouched");
+		result.UpToDateChanges.EditedDocuments.Should().ContainSingle()
+			.Which.Id.Should().Be(sameId);
+	}
+
+	[TestMethod]
+	[Description(
+		"Spec 055 R2 boundary: the skip only compares realized texts. A document whose text was " +
+		"never read into the snapshot cannot be a re-observation, so the edit is applied (never " +
+		"swallow a first edit).")]
+	public async Task When_DocumentTextNotRealized_Then_EditIsApplied()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		var path = await temp.WriteFileAsync("Model.cs", "class Model { }", ct);
+
+		using var workspace = new AdhocWorkspace();
+		var projectId = ProjectId.CreateNewId();
+		var documentId = DocumentId.CreateNewId(projectId);
+		var solution = workspace.CurrentSolution
+			.AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+			.AddDocument(DocumentInfo.Create(
+				documentId,
+				"Model.cs",
+				loader: TextLoader.From(TextAndVersion.Create(SourceText.From("class Model { }"), VersionStamp.Create(), path)),
+				filePath: path));
+
+		// Note: the document's text is deliberately NOT realized (no GetTextAsync before the update).
+		var result = await new SolutionUpdater().UpdateAsync(solution, Edits([solution.GetDocument(documentId)!]), ct);
+
+		result.Solution.Should().NotBeSameAs(solution, "an unrealized text cannot be proven up to date, so the edit must be applied");
+		result.UpToDateChanges.GetAllPaths().Should().BeEmpty();
+	}
+
+	private static ChangeSet Edits(ImmutableArray<Document> documents, ImmutableArray<TextDocument> additionalDocuments = default)
+		=> ChangeSet.Empty with
+		{
+			EditedDocuments = documents,
+			EditedAdditionalDocuments = additionalDocuments.IsDefault ? [] : additionalDocuments,
+		};
+}

--- a/src/Uno.HotReload.Tests/TestUtils/RecordingReporter.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/RecordingReporter.cs
@@ -14,6 +14,17 @@ internal sealed class RecordingReporter : IReporter
 	private readonly List<string> _errors = [];
 	private readonly Lock _gate = new();
 
+	public IReadOnlyList<string> VerboseMessages
+	{
+		get
+		{
+			lock (_gate)
+			{
+				return [.. _verbose];
+			}
+		}
+	}
+
 	public IReadOnlyList<string> Outputs
 	{
 		get

--- a/src/Uno.HotReload.Tests/TestUtils/TempDirectory.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/TempDirectory.cs
@@ -23,9 +23,9 @@ internal sealed class TempDirectory : IDisposable
 		{
 			Directory.Delete(Path, recursive: true);
 		}
-		catch (IOException)
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
 		{
-			// Best effort: leftover temp dirs are harmless.
+			// Best effort: leftover temp dirs are harmless (files can be transiently locked on Windows).
 		}
 	}
 }

--- a/src/Uno.HotReload.Tests/TestUtils/TempDirectory.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/TempDirectory.cs
@@ -1,0 +1,31 @@
+namespace Uno.HotReload.Tests.TestUtils;
+
+/// <summary>
+/// A disposable temp directory for tests that exercise real file-system content
+/// (the solution updater reads edited files from disk, the file-system observer
+/// watches project directories).
+/// </summary>
+internal sealed class TempDirectory : IDisposable
+{
+	public string Path { get; } = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
+
+	public async Task<string> WriteFileAsync(string relativePath, string content, CancellationToken ct)
+	{
+		var path = System.IO.Path.Combine(Path, relativePath);
+		Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+		await File.WriteAllTextAsync(path, content, ct);
+		return path;
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			Directory.Delete(Path, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Best effort: leftover temp dirs are harmless.
+		}
+	}
+}

--- a/src/Uno.HotReload.Tests/TestUtils/TempDirectory.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/TempDirectory.cs
@@ -2,8 +2,7 @@ namespace Uno.HotReload.Tests.TestUtils;
 
 /// <summary>
 /// A disposable temp directory for tests that exercise real file-system content
-/// (the solution updater reads edited files from disk, the file-system observer
-/// watches project directories).
+/// (the solution updater reads edited files from disk).
 /// </summary>
 internal sealed class TempDirectory : IDisposable
 {
@@ -11,6 +10,13 @@ internal sealed class TempDirectory : IDisposable
 
 	public async Task<string> WriteFileAsync(string relativePath, string content, CancellationToken ct)
 	{
+		// Guard against a rooted path silently discarding the temp root in Path.Combine
+		// (Path.Combine(root, "/abs") == "/abs"): callers must pass a path relative to Path.
+		if (System.IO.Path.IsPathRooted(relativePath))
+		{
+			throw new ArgumentException("Path must be relative to the temp directory.", nameof(relativePath));
+		}
+
 		var path = System.IO.Path.Combine(Path, relativePath);
 		Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
 		await File.WriteAllTextAsync(path, content, ct);

--- a/src/Uno.HotReload/Diffing/ChangeSet.cs
+++ b/src/Uno.HotReload/Diffing/ChangeSet.cs
@@ -30,6 +30,11 @@ public record ChangeSet(
 
 	public bool HasProjectEdits => !EditedProjects.IsEmpty || !AddedProjects.IsEmpty || !RemovedProjects.IsEmpty;
 
+	/// <summary>
+	/// A change-set with no entry at all.
+	/// </summary>
+	public static ChangeSet Empty { get; } = new([], [], [], [], [], [], [], [], [], []);
+
 	public static ChangeSet IgnoreAll(ImmutableHashSet<string> ignoredFiles)
 		=> new([], [], [], [], [], [], [], [], [], ignoredFiles);
 

--- a/src/Uno.HotReload/Diffing/SolutionUpdateResult.cs
+++ b/src/Uno.HotReload/Diffing/SolutionUpdateResult.cs
@@ -37,4 +37,13 @@ public record SolutionUpdateResult(
 	/// </summary>
 	public SolutionUpdateResult(Solution solution, ChangeSet ignoredChanges)
 		: this(solution, ignoredChanges, []) { }
+
+	/// <summary>
+	/// The subset of the input <see cref="ChangeSet"/> whose on-disk content was found
+	/// byte-identical to the solution's current content and was therefore not re-applied
+	/// (e.g. a trailing file-system event re-observing a file the pipeline just applied).
+	/// Unlike <see cref="IgnoredChanges"/>, these entries were consumed — their content is
+	/// in the solution; they are surfaced for diagnosability only.
+	/// </summary>
+	public ChangeSet UpToDateChanges { get; init; } = ChangeSet.Empty;
 }

--- a/src/Uno.HotReload/Diffing/SolutionUpdater.cs
+++ b/src/Uno.HotReload/Diffing/SolutionUpdater.cs
@@ -27,16 +27,40 @@ public sealed class SolutionUpdater : ISolutionUpdater
 		ChangeSet changeSet,
 		CancellationToken ct)
 	{
-		// Update existing documents
+		// Update existing documents and additional documents, skipping texts that are already
+		// up to date: a file-system event can re-observe a file whose content is already in the
+		// solution (e.g. an event joining a batch right after its content was applied), and
+		// re-applying byte-identical text would fork the snapshot — defeating the caller's
+		// reference-equality NoChanges short-circuit. Only realized texts are compared: an
+		// unrealized text means the document was never read into this snapshot, so the batch
+		// cannot be a re-observation of it. Skipped entries are surfaced through
+		// <see cref="SolutionUpdateResult.UpToDateChanges"/>.
+		var upToDateDocuments = ImmutableArray.CreateBuilder<Document>();
 		foreach (var document in changeSet.EditedDocuments)
 		{
-			solution = solution.WithDocumentText(document.Id, await GetSourceTextAsync(document.FilePath!, ct).ConfigureAwait(false));
+			var text = await GetSourceTextAsync(document.FilePath!, ct).ConfigureAwait(false);
+			if (document.TryGetText(out var current) && current.ContentEquals(text))
+			{
+				upToDateDocuments.Add(document);
+			}
+			else
+			{
+				solution = solution.WithDocumentText(document.Id, text);
+			}
 		}
 
-		// Update existing additional documents
+		var upToDateAdditionalDocuments = ImmutableArray.CreateBuilder<TextDocument>();
 		foreach (var additionalDocument in changeSet.EditedAdditionalDocuments)
 		{
-			solution = solution.WithAdditionalDocumentText(additionalDocument.Id, await GetSourceTextAsync(additionalDocument.FilePath!, ct).ConfigureAwait(false));
+			var text = await GetSourceTextAsync(additionalDocument.FilePath!, ct).ConfigureAwait(false);
+			if (additionalDocument.TryGetText(out var current) && current.ContentEquals(text))
+			{
+				upToDateAdditionalDocuments.Add(additionalDocument);
+			}
+			else
+			{
+				solution = solution.WithAdditionalDocumentText(additionalDocument.Id, text);
+			}
 		}
 
 		// Added documents has been detected using a temporary solution.
@@ -112,7 +136,8 @@ public sealed class SolutionUpdater : ISolutionUpdater
 		// `with` semantics: zero out only the fields this updater consumed. Anything
 		// else (project-level edits, the upstream-detected IgnoredFiles, and any new
 		// ChangeSet member added in the future) flows through to the caller as
-		// ignored automatically.
+		// ignored automatically. Up-to-date files were consumed (their content is in
+		// the solution) — they are reported through UpToDateChanges, not as ignored.
 		var ignored = changeSet with
 		{
 			EditedDocuments = [],
@@ -123,7 +148,14 @@ public sealed class SolutionUpdater : ISolutionUpdater
 			RemovedAdditionalDocuments = [],
 		};
 
-		return new SolutionUpdateResult(solution, ignored);
+		return new SolutionUpdateResult(solution, ignored)
+		{
+			UpToDateChanges = ChangeSet.Empty with
+			{
+				EditedDocuments = upToDateDocuments.ToImmutable(),
+				EditedAdditionalDocuments = upToDateAdditionalDocuments.ToImmutable(),
+			},
+		};
 	}
 
 	private static async ValueTask<SourceText> GetSourceTextAsync(string filePath, CancellationToken ct)

--- a/src/Uno.HotReload/Diffing/SolutionUpdater.cs
+++ b/src/Uno.HotReload/Diffing/SolutionUpdater.cs
@@ -34,7 +34,7 @@ public sealed class SolutionUpdater : ISolutionUpdater
 		// reference-equality NoChanges short-circuit. Only realized texts are compared: an
 		// unrealized text means the document was never read into this snapshot, so the batch
 		// cannot be a re-observation of it. Skipped entries are surfaced through
-		// <see cref="SolutionUpdateResult.UpToDateChanges"/>.
+		// SolutionUpdateResult.UpToDateChanges.
 		var upToDateDocuments = ImmutableArray.CreateBuilder<Document>();
 		foreach (var document in changeSet.EditedDocuments)
 		{
@@ -148,14 +148,17 @@ public sealed class SolutionUpdater : ISolutionUpdater
 			RemovedAdditionalDocuments = [],
 		};
 
-		return new SolutionUpdateResult(solution, ignored)
-		{
-			UpToDateChanges = ChangeSet.Empty with
+		// Keep the common (nothing-skipped) path allocation-free: only build a ChangeSet when at
+		// least one entry was actually up to date, otherwise reuse the shared empty instance.
+		var upToDate = upToDateDocuments.Count is 0 && upToDateAdditionalDocuments.Count is 0
+			? ChangeSet.Empty
+			: ChangeSet.Empty with
 			{
 				EditedDocuments = upToDateDocuments.ToImmutable(),
 				EditedAdditionalDocuments = upToDateAdditionalDocuments.ToImmutable(),
-			},
-		};
+			};
+
+		return new SolutionUpdateResult(solution, ignored) { UpToDateChanges = upToDate };
 	}
 
 	private static async ValueTask<SourceText> GetSourceTextAsync(string filePath, CancellationToken ct)

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -129,16 +129,20 @@ public sealed class HotReloadManager : IDisposable
 		var hotReload = await _tracker.StartOrContinueHotReload().ConfigureAwait(false);
 		var files = await filesAsync.ConfigureAwait(false);
 
+		// Hold the solution-update gate across the WHOLE pass, including the catch: an operation is
+		// completed by the pass that processes it, and that completion — the terminal outcome on
+		// success, or the catch's InternalError on failure — must happen under the gate. Were the
+		// gate released before the catch completed (the failure path releases it as the exception
+		// unwinds out of the try), a queued batch could acquire it, merge into the still-open
+		// operation (TryMerge sees _result == -1) and complete it first, dropping this pass's
+		// outcome — reporting a failed pass as a clean reload.
+		using var _ = await _solutionUpdateGate.LockAsync(ct).ConfigureAwait(false);
+
 		// Process the batch of files (sequentially!)
 		try
 		{
-			using var _ = await _solutionUpdateGate.LockAsync(ct).ConfigureAwait(false);
-
-			// The merge decision must be made under the gate: operations are completed by the
-			// pass that processes them, which runs while holding this gate. Deciding earlier
-			// allows a batch to merge into an operation that completes before the batch's own
-			// pass runs — that pass's outcome (e.g. Failed + diagnostics) would then be dropped
-			// by the already-completed operation, reporting broken content as a clean reload.
+			// The merge decision is made under the gate (see above): deciding it earlier would let a
+			// batch merge into an operation that completes before the batch's own pass runs.
 			if (!hotReload.TryMerge(files))
 			{
 				hotReload = await _tracker.StartHotReload(files).ConfigureAwait(false);

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -169,6 +169,14 @@ public sealed class HotReloadManager : IDisposable
 		// before any short-circuit so the report reflects skipped inputs.
 		hotReload.NotifyIgnored(result.IgnoredChanges.GetAllPaths());
 
+		// Up-to-date entries were consumed (their content is already in the solution) — not
+		// ignored. Surface them for diagnosability only: they are how a re-observation of
+		// content the pipeline just applied resolves to a plain NoChanges instead of forking.
+		if (result.UpToDateChanges.GetAllPaths().ToImmutableArray() is { IsEmpty: false } upToDate)
+		{
+			_tracker.Verbose($"{upToDate.Length} file(s) already up to date ({string.Join(", ", upToDate.Select(Path.GetFileName))})");
+		}
+
 		// Commit unconditionally, ahead of every terminal branch (spec 045 §2): an updater may have
 		// rebound metadata/analyzer references (e.g. newly resolved packages) onto result.Solution.
 		// If a cycle exited early without committing, those references would be lost and the next

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -172,8 +172,11 @@ public sealed class HotReloadManager : IDisposable
 		// Up-to-date entries were consumed (their content is already in the solution) — not
 		// ignored. Surface them for diagnosability only: they are how a re-observation of
 		// content the pipeline just applied resolves to a plain NoChanges instead of forking.
-		if (result.UpToDateChanges.GetAllPaths().ToImmutableArray() is { IsEmpty: false } upToDate)
+		// Guard on the cheap struct-field check so the common (nothing-skipped) path builds
+		// neither the enumerator nor the array.
+		if (!result.UpToDateChanges.EditedDocuments.IsEmpty || !result.UpToDateChanges.EditedAdditionalDocuments.IsEmpty)
 		{
+			var upToDate = result.UpToDateChanges.GetAllPaths().ToImmutableArray();
 			_tracker.Verbose($"{upToDate.Length} file(s) already up to date ({string.Join(", ", upToDate.Select(Path.GetFileName))})");
 		}
 


### PR DESCRIPTION
**GitHub Issue:** closes #23862

## PR Type:

🐞 Bugfix

## What changed? 🚀

A trailing file-system event for a file the hot-reload pipeline **wrote itself** — the
per-request `HotReloadInfo.g.cs`, whose late `IN_CLOSE_WRITE` (Linux/inotify) arrives after
the 250 ms watcher buffer already closed — re-opened a watcher batch for content that was
*already* in the solution. That parasite pass forked the solution (a byte-identical
`WithDocumentText` still produces a new snapshot), emitted 0 updates, landed in the
blocked-compilation audit, and — when it merged into the originating request's still-open
operation — **overwrote the real outcome** (observed live: the request reported `Failed`
after its edits had applied successfully).

**Fix — content-level no-op detection in `SolutionUpdater`.** Before replacing a document's
text, the new on-disk content is compared with the current text (`SourceText.ContentEquals`,
documents *and* additional documents) and identical writes are skipped. Only *realized*
texts are compared, so a document that was never read is always applied (a first edit is
never swallowed). A fully-reduced batch returns the original `Solution` instance, so the
manager's reference-equality `NoChanges` short-circuit fires **before the emit** — no
metadata roundtrip, no audit, no spurious `Failed`. Skipped entries are surfaced on
`SolutionUpdateResult.UpToDateChanges` (consumed, *not* ignored) and reported by the manager.

The info file stays a first-class change: on the request's own batch its content genuinely
differs from the solution, so it is applied and emitted normally and the app's
`HotReloadInfo.VersionId` keeps bumping (spec 050 R6). The operation lifecycle, `TryMerge`,
and the merge-under-gate decision (`8076b444aa`) are untouched. No watcher-level trigger
exclusion — making a specific file "unable to open the update gate" is conceptually wrong
and cannot be made reliable (the file system is not transactional). Full reasoning and the
rejected alternatives are recorded in `specs/055-hotreload-noop-pass-dedup/spec.md`.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)