### PR TITLE
fix(hr): create missing parent directories when writing a new file

### DIFF
--- a/src/Uno.HotReload.Tests/IO/Given_OnDiskFileEditor.cs
+++ b/src/Uno.HotReload.Tests/IO/Given_OnDiskFileEditor.cs
@@ -1,0 +1,54 @@
+using AwesomeAssertions;
+using Uno.HotReload.IO;
+
+namespace Uno.HotReload.Tests.IO;
+
+[TestClass]
+public class Given_OnDiskFileEditor
+{
+	public TestContext TestContext { get; set; } = null!;
+
+	[TestMethod]
+	[Description(
+		"A file creation must also create its missing parent directories: Hot Design creates pages " +
+		"in folders that may not exist yet, and File.WriteAllTextAsync fails with " +
+		"DirectoryNotFoundException otherwise.")]
+	public async Task When_CreateFileInMissingDirectory_Then_ParentDirectoriesAreCreated()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		var root = Directory.CreateTempSubdirectory().FullName;
+		try
+		{
+			var filePath = Path.Combine(root, "New", "Nested", "Page.xaml");
+
+			var (result, error) = await new OnDiskFileEditor().EditAsync(
+				new FileEdit(filePath, OldText: null, NewText: "<Page />", IsCreateDeleteAllowed: true),
+				forceSaveOnDisk: null,
+				ct);
+
+			error.Should().BeNull();
+			result.Should().Be(FileUpdateResult.Success);
+			(await File.ReadAllTextAsync(filePath, ct)).Should().Be("<Page />");
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	[Description("A write to a missing file without create permission must keep reporting FileNotFound.")]
+	public async Task When_WriteToMissingFileWithoutCreate_Then_FileNotFound()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		var filePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "Page.xaml");
+
+		var (result, _) = await new OnDiskFileEditor().EditAsync(
+			new FileEdit(filePath, OldText: null, NewText: "<Page />"),
+			forceSaveOnDisk: null,
+			ct);
+
+		result.Should().Be(FileUpdateResult.FileNotFound);
+		Directory.Exists(Path.GetDirectoryName(filePath)).Should().BeFalse("the guard must not create directories");
+	}
+}

--- a/src/Uno.HotReload.Tests/IO/Given_OnDiskFileEditor.cs
+++ b/src/Uno.HotReload.Tests/IO/Given_OnDiskFileEditor.cs
@@ -41,7 +41,7 @@ public class Given_OnDiskFileEditor
 	public async Task When_WriteToMissingFileWithoutCreate_Then_FileNotFound()
 	{
 		var ct = TestContext.CancellationTokenSource.Token;
-		var filePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "Page.xaml");
+		var filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "Page.xaml");
 
 		var (result, _) = await new OnDiskFileEditor().EditAsync(
 			new FileEdit(filePath, OldText: null, NewText: "<Page />"),

--- a/src/Uno.HotReload/IO/FileSystemHelper.cs
+++ b/src/Uno.HotReload/IO/FileSystemHelper.cs
@@ -39,13 +39,20 @@ internal static class FileSystemHelper
 
 		var tcs = new TaskCompletionSource();
 		using var watcher = new FileSystemWatcher(dir.FullName);
-		watcher.Changed += (snd, e) =>
+
+		// Watch both Changed (edits to an existing file) and Created (a fresh file, e.g. Hot Design
+		// adding a page): some platforms only raise Created on creation, so subscribing to Changed
+		// alone would never resolve and always wait the full timeout below.
+		void OnFileEvent(object snd, FileSystemEventArgs e)
 		{
 			if (e.FullPath.Equals(file.FullName, StringComparison.OrdinalIgnoreCase))
 			{
 				tcs.TrySetResult();
 			}
-		};
+		}
+
+		watcher.Changed += OnFileEvent;
+		watcher.Created += OnFileEvent;
 		watcher.EnableRaisingEvents = true;
 
 		if (await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5))) != tcs.Task)

--- a/src/Uno.HotReload/IO/OnDiskFileEditor.cs
+++ b/src/Uno.HotReload/IO/OnDiskFileEditor.cs
@@ -54,6 +54,13 @@ public class OnDiskFileEditor(IReporter? reporter = null) : IFileEditor
 			return (FileUpdateResult.FileNotFound, $"Requested file '{edit.FilePath}' does not exist.");
 		}
 
+		// A file creation may target a folder that does not exist yet (e.g. Hot Design creating a
+		// page in a new directory); File.WriteAllTextAsync does not create it.
+		if (edit.IsCreateDeleteAllowed && Path.GetDirectoryName(edit.FilePath) is { Length: > 0 } directory)
+		{
+			Directory.CreateDirectory(directory);
+		}
+
 		var effectiveUpdate = FileSystemHelper.WaitForFileUpdated(edit.FilePath, reporter);
 		await File.WriteAllTextAsync(edit.FilePath, edit.NewText!);
 		await effectiveUpdate;


### PR DESCRIPTION
**GitHub Issue:** closes #23866

## PR Type:

🐞 Bugfix

## What changed? 🚀

`OnDiskFileEditor.WriteAsync` now creates the missing parent directories before writing
when the edit is a creation (`IsCreateDeleteAllowed`), instead of letting
`File.WriteAllTextAsync` throw `DirectoryNotFoundException` (surfaced as the trimmed
`IO_PathNotFound_Path` resource key on WASM). This unblocks Hot Design page creation in
Studio Live (WASM), where file creations take the on-disk editor path — no IDE fallback —
and target folders (e.g. `HotDesignStories/`) that may not exist yet.

Covered by two new tests in `Given_OnDiskFileEditor`: creation in a missing nested
directory succeeds, and a plain write without create permission still reports
`FileNotFound` without creating directories.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)