### PR TITLE
fix(GLCanvasElement): blank canvas on physical iOS devices — probe GLES BGRA readback support

### DIFF
--- a/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
@@ -55,6 +55,9 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 	// internally), so this stays false there.
 	private bool _readbackAsRgbaWithSwap;
 
+	// Rate-limits the pending-GL-error warning in Render to once per element.
+	private bool _warnedPendingGlError;
+
 	// valid if and only if GLCanvasElement was loaded at least once and OpenGL is available on the running platform
 	private INativeOpenGLWrapper? _nativeOpenGlWrapper;
 	// These are valid if and only if IsLoaded and _nativeOpenGlWrapper is not null
@@ -100,7 +103,7 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 	/// OpenGL errors raised by user code should be checked and handled within <see cref="Init"/>
 	/// and <see cref="RenderOverride"/>. Errors still pending before the framebuffer readback are
 	/// drained (GL errors are sticky and would otherwise be misattributed to the readback check)
-	/// and logged as warnings.
+	/// and logged — as a warning on the first occurrence, then at Debug level.
 	/// </remarks>
 	protected abstract void RenderOverride(GL gl);
 
@@ -510,9 +513,16 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 					break;
 				}
 
-				if (this.Log().IsEnabled(LogLevel.Warning))
+				// Warn once per element: with Invalidate() called from RenderOverride, a persistent
+				// user error would otherwise flood the logs at frame rate.
+				if (!_warnedPendingGlError && this.Log().IsEnabled(LogLevel.Warning))
 				{
-					this.Log().Warn($"GL error {pendingError} was pending before the framebuffer readback, most likely raised by {nameof(RenderOverride)} (or {nameof(Init)} on the first frame); GL errors should be checked and handled within user code.");
+					_warnedPendingGlError = true;
+					this.Log().Warn($"GL error {pendingError} was pending before the framebuffer readback, most likely raised by {nameof(RenderOverride)} (or {nameof(Init)} on the first frame); GL errors should be checked and handled within user code. Further occurrences will be logged at Debug level.");
+				}
+				else if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"GL error {pendingError} was pending before the framebuffer readback.");
 				}
 			}
 

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
@@ -587,6 +587,10 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 		// lost context.
 		for (var i = 0; i < 8 && gl.GetError() is not GLEnum.NoError; i++) { }
 
+		// Select the read buffer explicitly so the probe mirrors the readback in Render and
+		// doesn't depend on the caller having just bound a freshly created framebuffer.
+		gl.ReadBuffer(GLEnum.ColorAttachment0);
+
 		Span<byte> probe = stackalloc byte[BytesPerPixel];
 		gl.ReadPixels(0, 0, 1, 1, GLEnum.Bgra, GLEnum.UnsignedByte, probe);
 		return gl.GetError() is not GLEnum.NoError;

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
@@ -493,6 +493,13 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 
 			_gl.ReadBuffer(GLEnum.ColorAttachment0);
 
+			// glReadPixels doesn't throw on failure (e.g. an unsupported readback format); it only
+			// sets a GL error and leaves the destination buffer untouched, which shows up as a
+			// permanently blank canvas. Drain errors left over from user code first so the check
+			// after the readback is attributable to the readback itself. The drain is bounded
+			// because GetError can keep returning GL_CONTEXT_LOST forever on a lost context.
+			for (var i = 0; i < 8 && _gl.GetError() is not GLEnum.NoError; i++) { }
+
 #if WINAPPSDK
 			_gl.ReadPixels(0, 0, (uint)RenderSize.Width, (uint)RenderSize.Height, GLEnum.Bgra, GLEnum.UnsignedByte, (void*)_pixels);
 			using (var stream = _backBuffer.PixelBuffer.AsStream())
@@ -514,6 +521,13 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 			});
 			_backBuffer.PixelBuffer.Length = (uint)RenderSize.Width * (uint)RenderSize.Height * BytesPerPixel;
 #endif
+
+			if (_gl.GetError() is var readbackError && readbackError is not GLEnum.NoError)
+			{
+				throw new InvalidOperationException(
+					$"glReadPixels failed with {readbackError} while copying the framebuffer to the back buffer.");
+			}
+
 			_backBuffer.Invalidate();
 		}
 		catch (Exception e)

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
@@ -96,6 +96,12 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 	/// the end if you choose to enable it.
 	/// Some of this may be done for you automatically.
 	/// </remarks>
+	/// <remarks>
+	/// OpenGL errors raised by your rendering logic should be checked and handled within
+	/// <see cref="RenderOverride"/>. Errors still pending when it returns are drained (GL errors
+	/// are sticky and would otherwise be misattributed to the framebuffer readback that follows)
+	/// and logged as warnings.
+	/// </remarks>
 	protected abstract void RenderOverride(GL gl);
 
 	/// <param name="getWindowFunc">A function that returns the Window object that this element belongs to. This parameter is only used on WinUI. On Uno Platform, it can be set to null.</param>
@@ -491,14 +497,26 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 
 			RenderOverride(_gl);
 
-			_gl.ReadBuffer(GLEnum.ColorAttachment0);
+			// GL errors are sticky and context-global, so anything RenderOverride leaves behind
+			// would be misattributed to the readback check below. Handling GL errors is the
+			// user's job (see the RenderOverride docs); surface what they left instead of
+			// failing the readback on it. The drain is bounded because GetError can keep
+			// returning GL_CONTEXT_LOST forever on a lost context.
+			for (var i = 0; i < 8; i++)
+			{
+				var pendingError = _gl.GetError();
+				if (pendingError is GLEnum.NoError)
+				{
+					break;
+				}
 
-			// glReadPixels doesn't throw on failure (e.g. an unsupported readback format); it only
-			// sets a GL error and leaves the destination buffer untouched, which shows up as a
-			// permanently blank canvas. Drain errors left over from user code first so the check
-			// after the readback is attributable to the readback itself. The drain is bounded
-			// because GetError can keep returning GL_CONTEXT_LOST forever on a lost context.
-			for (var i = 0; i < 8 && _gl.GetError() is not GLEnum.NoError; i++) { }
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn($"{nameof(RenderOverride)} left GL error {pendingError} unhandled; GL errors should be checked and handled within {nameof(RenderOverride)}.");
+				}
+			}
+
+			_gl.ReadBuffer(GLEnum.ColorAttachment0);
 
 #if WINAPPSDK
 			_gl.ReadPixels(0, 0, (uint)RenderSize.Width, (uint)RenderSize.Height, GLEnum.Bgra, GLEnum.UnsignedByte, (void*)_pixels);
@@ -522,10 +540,13 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 			_backBuffer.PixelBuffer.Length = (uint)RenderSize.Width * (uint)RenderSize.Height * BytesPerPixel;
 #endif
 
+			// glReadPixels doesn't throw on failure (e.g. an unsupported readback format); it only
+			// sets a GL error and leaves the destination buffer untouched, which would show up as
+			// a permanently blank canvas.
 			if (_gl.GetError() is var readbackError && readbackError is not GLEnum.NoError)
 			{
 				throw new InvalidOperationException(
-					$"glReadPixels failed with {readbackError} while copying the framebuffer to the back buffer.");
+					$"The framebuffer readback failed with {readbackError} while copying the framebuffer to the back buffer.");
 			}
 
 			_backBuffer.Invalidate();

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
@@ -97,9 +97,9 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 	/// Some of this may be done for you automatically.
 	/// </remarks>
 	/// <remarks>
-	/// OpenGL errors raised by your rendering logic should be checked and handled within
-	/// <see cref="RenderOverride"/>. Errors still pending when it returns are drained (GL errors
-	/// are sticky and would otherwise be misattributed to the framebuffer readback that follows)
+	/// OpenGL errors raised by user code should be checked and handled within <see cref="Init"/>
+	/// and <see cref="RenderOverride"/>. Errors still pending before the framebuffer readback are
+	/// drained (GL errors are sticky and would otherwise be misattributed to the readback check)
 	/// and logged as warnings.
 	/// </remarks>
 	protected abstract void RenderOverride(GL gl);
@@ -497,11 +497,11 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 
 			RenderOverride(_gl);
 
-			// GL errors are sticky and context-global, so anything RenderOverride leaves behind
-			// would be misattributed to the readback check below. Handling GL errors is the
-			// user's job (see the RenderOverride docs); surface what they left instead of
-			// failing the readback on it. The drain is bounded because GetError can keep
-			// returning GL_CONTEXT_LOST forever on a lost context.
+			// GL errors are sticky and context-global, so anything user code leaves behind
+			// (RenderOverride, or Init on the first frame) would be misattributed to the readback
+			// check below. Handling GL errors is the user's job (see the RenderOverride docs);
+			// surface what they left instead of failing the readback on it. The drain is bounded
+			// because GetError can keep returning GL_CONTEXT_LOST forever on a lost context.
 			for (var i = 0; i < 8; i++)
 			{
 				var pendingError = _gl.GetError();
@@ -512,7 +512,7 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 
 				if (this.Log().IsEnabled(LogLevel.Warning))
 				{
-					this.Log().Warn($"{nameof(RenderOverride)} left GL error {pendingError} unhandled; GL errors should be checked and handled within {nameof(RenderOverride)}.");
+					this.Log().Warn($"GL error {pendingError} was pending before the framebuffer readback, most likely raised by {nameof(RenderOverride)} (or {nameof(Init)} on the first frame); GL errors should be checked and handled within user code.");
 				}
 			}
 

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/GLCanvasElement.cs
@@ -47,9 +47,12 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 
 	private bool _changingGlInitialized;
 
-	// On GLES (Android), glReadPixels with BGRA is the optional GL_EXT_read_format_bgra extension.
-	// When it's absent we read RGBA and swap R/B into the BGRA back buffer. Desktop GL/ANGLE keep
-	// BGRA (core), and WASM keeps BGRA too (its JS shim swaps internally), so this stays false there.
+	// On GLES, glReadPixels with BGRA is optional and driver metadata about it can't be trusted:
+	// Apple's GLES-on-Metal driver advertises GL_EXT_read_format_bgra yet rejects BGRA reads from
+	// the element's framebuffer (and reports an RGBA implementation-defined read pair). When an
+	// actual BGRA read doesn't work we read RGBA (always legal on GLES) and swap R/B into the
+	// BGRA back buffer. Desktop GL keeps BGRA (core), and WASM keeps BGRA too (its JS shim swaps
+	// internally), so this stays false there.
 	private bool _readbackAsRgbaWithSwap;
 
 	// valid if and only if GLCanvasElement was loaded at least once and OpenGL is available on the running platform
@@ -524,25 +527,34 @@ public abstract partial class GLCanvasElement : Grid, INativeContext
 		}
 	}
 
-	// Decides the readback format once, while the context is current. Only GLES (Android) can lack
-	// BGRA read support; everywhere else BGRA is used directly (see _readbackAsRgbaWithSwap).
+	// Decides the readback format once, while the context is current and the element's framebuffer
+	// is bound (see OnLoaded). Any GLES context can lack BGRA read support, and extension strings
+	// can't be trusted for it (Apple's GLES-on-Metal driver advertises GL_EXT_read_format_bgra yet
+	// rejects BGRA reads from the element's framebuffer), so on GLES we probe with an actual 1x1
+	// BGRA read; everywhere else BGRA is used directly (see _readbackAsRgbaWithSwap).
 	private static bool NeedsRgbaReadbackSwap(GL gl)
 	{
-		if (!OperatingSystem.IsAndroid())
+		// WASM readback stays BGRA regardless of what the context reports: the JS shim swaps
+		// internally and doesn't surface the native readback capabilities.
+		if (OperatingSystem.IsBrowser())
 		{
 			return false;
 		}
 
-		gl.GetInteger(GLEnum.NumExtensions, out var extensionCount);
-		for (uint i = 0; i < extensionCount; i++)
+		// GLES version strings are mandated to start with "OpenGL ES"; desktop GL version strings
+		// never have this prefix. BGRA readback is core on desktop GL.
+		if (!(gl.GetStringS(StringName.Version)?.StartsWith("OpenGL ES", StringComparison.Ordinal) ?? false))
 		{
-			if (gl.GetStringS(StringName.Extensions, i) == "GL_EXT_read_format_bgra")
-			{
-				return false;
-			}
+			return false;
 		}
 
-		return true;
+		// The drain is bounded because GetError can keep returning GL_CONTEXT_LOST forever on a
+		// lost context.
+		for (var i = 0; i < 8 && gl.GetError() is not GLEnum.NoError; i++) { }
+
+		Span<byte> probe = stackalloc byte[BytesPerPixel];
+		gl.ReadPixels(0, 0, 1, 1, GLEnum.Bgra, GLEnum.UnsignedByte, probe);
+		return gl.GetError() is not GLEnum.NoError;
 	}
 
 	private static unsafe void SwapRedBlue(byte* pixels, int pixelCount)


### PR DESCRIPTION
**GitHub Issue:** closes #23873

## PR Type:

🐞 Bugfix

## What changed? 🚀

On **physical iOS devices**, `GLCanvasElement` presented a permanently blank canvas while the same build worked in the iOS simulator and on desktop. The scene was actually rendered correctly into the offscreen FBO every frame — the failure was the FBO → `WriteableBitmap` copy: `Render()` reads back with `glReadPixels(GL_BGRA, GL_UNSIGNED_BYTE)`, which Apple's GLES-on-Metal driver rejects for the element's framebuffer. Since a failed `glReadPixels` only sets a GL error and never throws, the back buffer stayed zeroed and the element silently presented nothing.

Two changes, one per commit:

1. **Probe GLES BGRA readback support with a real read** — `NeedsRgbaReadbackSwap` previously engaged the RGBA+swap fallback only on Android, via an extension-string check. Neither is sufficient: on-device probing shows Apple's driver **advertises `GL_EXT_read_format_bgra` but still rejects BGRA reads** from the element's FBO (unsized `GL_RGB` color attachment; `GL_IMPLEMENTATION_COLOR_READ_FORMAT/TYPE` reports `GL_RGBA`/`GL_UNSIGNED_BYTE`). The detection now runs on any GLES context (identified by the mandated `"OpenGL ES"` version-string prefix) and performs an actual 1×1 BGRA `glReadPixels` against the element's framebuffer, which is bound at the call site: if it errors, readback falls back to `GL_RGBA` + R/B swap (always legal on GLES). Desktop GL (BGRA is core) and WASM (the JS shim swaps internally) keep their current behavior.

2. **Surface `glReadPixels` failures** — `Render()` now drains pre-existing GL errors before the readback (bounded, since `GetError` can return `GL_CONTEXT_LOST` forever) and throws `InvalidOperationException` naming the GL error if the readback failed. This lands in the existing catch that logs and sets `IsGLInitialized = false`, so this class of failure can never again present as a silent blank canvas.

**Validation** (iPad Pro 11" 3rd gen (M1), iPadOS 26.5, `net10.0-ios`, instrumented app inspecting both the FBO and the presented back buffer; the issue also reproduced on an iPhone 16 Pro-class device, A18 Pro):

| Configuration | Readback path chosen | Presented back buffer | Result |
|---|---|---|---|
| Current package (`6.7.0-dev.815`) | BGRA | all zeros | blank canvas, no error ❌ |
| Extension-string detection (rejected approach) | BGRA (extension is advertised!) | all zeros | fails — extension can't be trusted ❌ |
| **This PR (1×1 probe read)** | RGBA + swap | correct pixels | renders ✅ |

## PR Checklist ✅

- [x] 🧪 Validated manually on physical hardware (iPad Pro M1 / iPadOS 26.5) and on the iOS simulator + Skia Desktop (no regression); existing GLCanvasElement samples apply
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BdoX4X8eXiY1CuyXdhjqC
