### PR TITLE
fix(itemcontainer): snapshot isOver before capture release

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SelectorBar/SelectorBarTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SelectorBar/SelectorBarTests.cs
@@ -298,6 +298,38 @@ public class SelectorBarTests : MUXApiTestBase
 		Verify.AreEqual(item, selectorBar.SelectedItem,
 			"SelectorBarItem should be selected after a mouse press+release inside its bounds.");
 	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	public async Task VerifySelectorBarItemBecomesSelectedAfterTouchTap()
+	{
+		var selectorBar = new SelectorBar();
+		selectorBar.Items.Add(new SelectorBarItem { Text = "Item1" });
+		selectorBar.Items.Add(new SelectorBarItem { Text = "Item2" });
+		selectorBar.Items.Add(new SelectorBarItem { Text = "Item3" });
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		await UITestHelper.Load(selectorBar);
+
+		Verify.IsNull(selectorBar.SelectedItem);
+
+		var item = selectorBar.Items[1];
+		var bounds = item.GetAbsoluteBoundsRect();
+		var center = new Point(bounds.GetMidX(), bounds.GetMidY());
+
+		finger.Press(center);
+		await TestServices.WindowHelper.WaitForIdle();
+		finger.Release();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Verify.AreEqual(item, selectorBar.SelectedItem,
+			"SelectorBarItem should be selected after a touch press+release inside its bounds.");
+	}
 #endif
 
 	private string GetStringFromSelectorBarItem(SelectorBarItem selectorBarItem)

--- a/src/Uno.UI/UI/Xaml/Controls/ItemContainer/ItemContainer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemContainer/ItemContainer.cs
@@ -470,6 +470,9 @@ partial class ItemContainer : Control
 		}
 
 		m_pointerInfo.ResetTrackedPointerId();
+		// Uno Doc: Snapshot before releasing the capture: on managed pointers ReleasePointerCapture
+		// synchronously raises PointerCaptureLost, which resets the touch/pen over state.
+		bool isPointerOver = m_pointerInfo.IsPointerOver();
 		// Uno Doc: WinUI doesn't track the pointer and therefore has visual states bugs due to inaccurate pointer state. c.f. https://github.com/unoplatform/private/issues/1074
 		ReleasePointerCapture(args.Pointer);
 
@@ -501,7 +504,7 @@ partial class ItemContainer : Control
 			!args.Handled &&
 			!m_pointerInfo.IsPressed() &&
 			// Uno Doc: If pointer is not over, the item should not be clicked. This is a WinUI bug.
-			m_pointerInfo.IsPointerOver())
+			isPointerOver)
 		{
 			args.Handled = RaiseItemInvoked(ItemContainerInteractionTrigger.PointerReleased, args.OriginalSource);
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #23876

## PR Type:

🐞 Bugfix

## What changed? 🚀

Tapping a `SelectorBarItem` (or any `ItemsView`-based selection) with **touch or pen** does nothing on Skia targets, while mouse clicks work. #23208 fixed the mouse path only.

`ItemContainer.OnPointerReleased` calls `ReleasePointerCapture` before evaluating the item-invoke gate. On managed pointers that release synchronously raises `PointerCaptureLost` → `ProcessPointerCanceled`, which resets the touch/pen pointer-over state — so the gate's `IsPointerOver()` check fails and `ItemInvoked(PointerReleased)` (the only trigger `ItemsView` selects on; `Tap` is a selection no-op) is never raised.

This PR snapshots the pointer-over state before releasing the capture and uses the snapshot in the invoke gate. This fixes the re-entrancy at its source for all pointer device types, while keeping WinUI's genuine-cancel semantics (a real cancellation, e.g. a scroll stealing the pointer, still resets the touch/pen over-state and its visual state).

Validation (Skia Desktop macOS, Release):
- New runtime test `SelectorBarTests.VerifySelectorBarItemBecomesSelectedAfterTouchTap` (touch-injection twin of the #23208 mouse test): fails before the fix, passes after.
- `SelectorBarTests` 6/6 passed (including the mouse test and the release-outside-bounds visual-state guard — no regression).
- `ItemsViewTests` 10/10 passed.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cwnh87BjMzYGmCtEcVYhf
