### PR TITLE
fix(text): improve app-local ICU loading on Linux

### DIFF
--- a/doc/articles/common-issues-skia.md
+++ b/doc/articles/common-issues-skia.md
@@ -13,6 +13,17 @@ Unhandled exception. System.TypeInitializationException: The type initializer fo
 ---> System.DllNotFoundException: Gtk: libgtk-3-0.dll, libgtk-3.so.0, libgtk-3.0.dylib, gtk-3.dll
 ```
 
+## Failed to load ICU on Linux
+
+At startup, the following error may happen (`Failed to load icuuc.` on older Uno Platform versions):
+
+```console
+Unhandled exception. System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.Exception: Failed to load ICU on Linux. Attempted: [...]
+```
+
+Uno Platform uses the system ICU libraries on Linux for text rendering, and the machine running the app doesn't have them installed — common on minimal, server, or embedded images. Install the distribution's ICU package (e.g. `sudo apt install libicu74`), or ship ICU inside the app with app-local ICU. See [Publishing Your App for Linux](xref:uno.publishing.desktop.linux) for both options. Setting `InvariantGlobalization` to `true` does not remove this requirement.
+
 ## Linux
 
 [!include[linux-setup](includes/additional-linux-setup-inline.md)]

--- a/doc/articles/features/using-linux-framebuffer.md
+++ b/doc/articles/features/using-linux-framebuffer.md
@@ -184,3 +184,4 @@ If your device is significantly trimmed down for installed packages, you'll need
 - `libfontconfig`
 - `libfreetype`
 - `libinput`
+- `libicu` (versioned on Debian/Ubuntu, e.g. `libicu74`; alternatively ship [app-local ICU](xref:uno.publishing.desktop.linux))

--- a/doc/articles/includes/additional-linux-setup-inline.md
+++ b/doc/articles/includes/additional-linux-setup-inline.md
@@ -7,6 +7,12 @@
     sudo apt install mesa-utils libgl1-mesa-glx ttf-mscorefonts-installer dbus libfontconfig1 libxrandr2 libxi-dev
     ```
 
+- Install ICU, used for text rendering (usually preinstalled on desktop images, but often missing from minimal ones). The package name is versioned per release:
+
+    ```bash
+    sudo apt install libicu66 # Ubuntu 20.04; use libicu70 on 22.04, libicu74 on 24.04
+    ```
+
 ## [**ArchLinux 5.8.14 or later / Manjaro**](#tab/archlinux2004)
 
 - Update system and packages
@@ -18,7 +24,7 @@
 - Install the necessary dependencies
 
     ```bash
-    sudo pacman -S dotnet-targeting-pack dotnet-sdk dotnet-host dotnet-runtime python ninja gn aspnet-runtime dbus libxrandr libxi
+    sudo pacman -S dotnet-targeting-pack dotnet-sdk dotnet-host dotnet-runtime python ninja gn aspnet-runtime dbus libxrandr libxi icu
     ```
 
 ---

--- a/doc/articles/uno-publishing-desktop.linux.md
+++ b/doc/articles/uno-publishing-desktop.linux.md
@@ -4,6 +4,30 @@ uid: uno.publishing.desktop.linux
 
 # Publishing Your App for Linux
 
+## Runtime Dependencies
+
+Uno Platform apps use the system [ICU](https://icu.unicode.org/) libraries on Linux for text rendering (BiDi and line breaking). Most desktop distributions include ICU, but minimal, server, or embedded images often don't — the app then fails at startup with `Failed to load ICU on Linux`.
+
+Either install the distribution's ICU package on the target machine:
+
+```bash
+sudo apt install libicu74 # Debian/Ubuntu; the package name is versioned (libicu66 on Ubuntu 20.04, libicu70 on 22.04, libicu74 on 24.04)
+sudo dnf install libicu   # Fedora/RHEL
+sudo pacman -S icu        # Arch
+```
+
+Or ship ICU with your app ([app-local ICU](https://learn.microsoft.com/dotnet/core/extensions/globalization-icu#app-local-icu)), which requires nothing on the target machine:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+  <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" />
+</ItemGroup>
+```
+
+> [!IMPORTANT]
+> Setting `InvariantGlobalization` to `true` does not remove this requirement — ICU is still needed for text rendering. Also note that the `Microsoft.ICU.ICU4C.Runtime` package only ships `linux-x64` and `linux-arm64` binaries (no musl/Alpine support).
+
 ## Snap Packages
 
 We support creating .snap packages on **Ubuntu 20.04** or later.

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -108,7 +108,10 @@ internal readonly partial struct UnicodeText
 							// some environments only have a versioned library and don't symlink it to libicuuc.so
 							var name = $"libicuuc.so.{j}";
 							attempts.Add(name);
-							if (NativeLibrary.TryLoad(name, typeof(ICU).Assembly, DllImportSearchPath.UserDirectories, out libicuuc))
+							// Use the same search directories as the primary attempt: a versioned ICU shipped
+							// app-locally (e.g. the Microsoft.ICU.ICU4C.Runtime package, the standard remedy for
+							// minimal images without a system ICU) sits next to the assembly, not in UserDirectories.
+							if (NativeLibrary.TryLoad(name, typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
 							{
 								break;
 							}

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -21,6 +21,9 @@ internal readonly partial struct UnicodeText
 		// The version number of ICU is important because the exported symbols have their names appended by
 		// the version number. For example, there's a ubrk_open_74 in ICU v74, but not a ubrk_open.
 		private static int _icuVersion;
+		// Custom-suffixed app-local ICU builds (System.Globalization.AppLocalIcu = "suffix:version") rename
+		// exports with the suffix too, e.g. ubrk_open_67_myapp. Empty for regular builds.
+		private static string _icuSymbolSuffix = "";
 		private static IntPtr _libicuuc;
 		private static readonly Dictionary<Type, object> _lookupCache = new();
 
@@ -96,24 +99,40 @@ internal readonly partial struct UnicodeText
 				}
 				// Track every candidate we attempt so the final exception can report exactly
 				// what was tried. On Android the real fallback is "libicu.so", not "libicuuc".
-				var attempts = new List<string> { "icuuc" };
+				var attempts = new List<string>();
 				Exception? lastError = null;
+				string? customSuffix = null;
 
-				if (!NativeLibrary.TryLoad("icuuc", typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
+				libicuuc = IntPtr.Zero;
+				if (OperatingSystem.IsLinux())
+				{
+					// Honor .NET's own app-local ICU configuration first, so Uno resolves the same
+					// libraries as the runtime, including custom-suffixed builds.
+					TryLoadConfiguredAppLocalIcu(attempts, out libicuuc, out customSuffix);
+				}
+
+				attempts.Add("icuuc");
+				if (libicuuc == IntPtr.Zero
+					&& !NativeLibrary.TryLoad("icuuc", typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
 				{
 					if (OperatingSystem.IsLinux())
 					{
-						for (int j = MaxSupportedIcuucVersion; j >= MinSupportedIcuucVersion; j--)
+						// App-local ICU (e.g. the Microsoft.ICU.ICU4C.Runtime package) ships fully-versioned
+						// file names like libicuuc.so.72.1.0.3 that name probing cannot guess, so scan the
+						// app directories before falling back to blind version probing.
+						if (!TryLoadAppLocalIcuFromDirectories(attempts, ref lastError, out libicuuc))
 						{
-							// some environments only have a versioned library and don't symlink it to libicuuc.so
-							var name = $"libicuuc.so.{j}";
-							attempts.Add(name);
-							// Use the same search directories as the primary attempt: a versioned ICU shipped
-							// app-locally (e.g. the Microsoft.ICU.ICU4C.Runtime package, the standard remedy for
-							// minimal images without a system ICU) sits next to the assembly, not in UserDirectories.
-							if (NativeLibrary.TryLoad(name, typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
+							for (int j = MaxSupportedIcuucVersion; j >= MinSupportedIcuucVersion; j--)
 							{
-								break;
+								// some environments only have a versioned library and don't symlink it to
+								// libicuuc.so; a versioned name also matches by soname when the runtime has
+								// already loaded an ICU into the process (e.g. app-local ICU).
+								var name = $"libicuuc.so.{j}";
+								attempts.Add(name);
+								if (NativeLibrary.TryLoad(name, typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
+								{
+									break;
+								}
 							}
 						}
 					}
@@ -170,6 +189,10 @@ internal readonly partial struct UnicodeText
 					{
 						hint = " Android's NDK-stable ICU (libicu.so) requires API 31+; libicuuc.so was attempted as a best-effort fallback for API 21-23.";
 					}
+					else if (OperatingSystem.IsLinux())
+					{
+						hint = GetLinuxIcuLoadFailureDetails();
+					}
 					else
 					{
 						hint = string.Empty;
@@ -180,20 +203,32 @@ internal readonly partial struct UnicodeText
 						lastError);
 				}
 
-				// Since libicuuc not installed by us, we have no control over the specific version number, so
-				// we try a wide range of versions.
-				for (int i = MaxSupportedIcuucVersion; i >= MinSupportedIcuucVersion; i--)
+				_icuSymbolSuffix = customSuffix is null ? "" : $"_{customSuffix}";
+
+				if (NativeLibrary.TryGetExport(libicuuc, "u_getVersion", out var getVersionExport))
 				{
-					if (NativeLibrary.TryGetExport(libicuuc, $"u_getVersion_{i}", out _))
+					// ICU built with --disable-renaming exports unversioned symbols; read the version
+					// from the library itself instead of probing renamed symbol names.
+					Marshal.GetDelegateForFunctionPointer<u_getVersion>(getVersionExport)(out var unversionedInfo);
+					_icuVersion = unversionedInfo.byte1;
+				}
+				else
+				{
+					// Since libicuuc is not installed by us, we have no control over the specific version
+					// number, so we try a wide range of versions.
+					for (int i = MaxSupportedIcuucVersion; i >= MinSupportedIcuucVersion; i--)
 					{
-						_icuVersion = i;
-						break;
+						if (NativeLibrary.TryGetExport(libicuuc, $"u_getVersion_{i}{_icuSymbolSuffix}", out _))
+						{
+							_icuVersion = i;
+							break;
+						}
 					}
 				}
 
 				if (_icuVersion == 0)
 				{
-					throw new Exception($"Loaded icuuc, but could not find symbol `u_getVersion_N`, where N is in range [{MinSupportedIcuucVersion}-{MaxSupportedIcuucVersion}].");
+					throw new Exception($"Loaded icuuc, but could not find symbol `u_getVersion` or `u_getVersion_N{_icuSymbolSuffix}`, where N is in range [{MinSupportedIcuucVersion}-{MaxSupportedIcuucVersion}].");
 				}
 			}
 			else if (OperatingSystem.IsBrowser())
@@ -235,6 +270,160 @@ internal readonly partial struct UnicodeText
 			}
 		}
 
+		// Same configuration CoreLib reads for app-local ICU; the AppContext switch wins over the env var.
+		private static string? GetAppLocalIcuConfigValue()
+			=> AppContext.GetData("System.Globalization.AppLocalIcu") as string
+				?? Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU");
+
+		private static bool TryLoadConfiguredAppLocalIcu(List<string> attempts, out IntPtr libicuuc, out string? customSuffix)
+		{
+			libicuuc = IntPtr.Zero;
+			customSuffix = null;
+
+			var value = GetAppLocalIcuConfigValue();
+			if (string.IsNullOrEmpty(value))
+			{
+				return false;
+			}
+
+			// The value is "<version>" or "<suffix>:<version>", e.g. "72.1.0.3" or "myapp:67.1".
+			var version = value;
+			var suffix = "";
+			var separatorIndex = value.IndexOf(':');
+			if (separatorIndex >= 0)
+			{
+				suffix = value.Substring(0, separatorIndex);
+				version = value.Substring(separatorIndex + 1);
+			}
+
+			// The app-local binaries carry no rpath and reference each other by major-only soname,
+			// so libicudata must be loaded before libicuuc, like CoreLib does.
+			NativeLibrary.TryLoad($"libicudata{suffix}.so.{version}", typeof(ICU).Assembly, NativeLibrarySearchDirectories, out _);
+
+			var name = $"libicuuc{suffix}.so.{version}";
+			attempts.Add(name);
+			if (NativeLibrary.TryLoad(name, typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
+			{
+				customSuffix = suffix.Length == 0 ? null : suffix;
+				typeof(ICU).LogDebug()?.Debug($"Loaded app-local ICU '{name}' (System.Globalization.AppLocalIcu).");
+				return true;
+			}
+			return false;
+		}
+
+		private static bool TryLoadAppLocalIcuFromDirectories(List<string> attempts, ref Exception? lastError, out IntPtr libicuuc)
+		{
+			foreach (var directory in GetIcuProbingDirectories())
+			{
+				string? candidate;
+				try
+				{
+					candidate = Directory
+						.EnumerateFiles(directory, "libicuuc.so.*")
+						.Select(path => (Path: path, Version: ParseIcuFileVersion(Path.GetFileName(path))))
+						.Where(c => c.Version is not null)
+						.OrderByDescending(c => c.Version)
+						.FirstOrDefault().Path;
+				}
+				catch (Exception e)
+				{
+					lastError = e;
+					continue;
+				}
+				if (candidate is null)
+				{
+					continue;
+				}
+
+				attempts.Add(candidate);
+				// The app-local binaries carry no rpath and reference each other by major-only soname,
+				// so libicudata must already be in the process for the libicuuc load to resolve.
+				var dataPath = Path.Combine(directory, Path.GetFileName(candidate).Replace("libicuuc", "libicudata"));
+				if (File.Exists(dataPath))
+				{
+					NativeLibrary.TryLoad(dataPath, out _);
+				}
+				try
+				{
+					// Use Load so the dlopen error is preserved for diagnostics.
+					libicuuc = NativeLibrary.Load(candidate);
+					typeof(ICU).LogDebug()?.Debug($"Loaded app-local ICU '{candidate}'.");
+					return true;
+				}
+				catch (Exception e)
+				{
+					lastError = e;
+				}
+			}
+			libicuuc = IntPtr.Zero;
+			return false;
+		}
+
+		// Mirrors where the .NET host resolves app-local native assets: the app directory itself
+		// (self-contained and no-deps.json layouts), runtimes/<rid>/native (framework-dependent
+		// layouts), and the Uno.UI assembly directory.
+		private static IEnumerable<string> GetIcuProbingDirectories()
+		{
+			var baseDirectory = AppContext.BaseDirectory;
+			if (!string.IsNullOrEmpty(baseDirectory) && Directory.Exists(baseDirectory))
+			{
+				yield return baseDirectory;
+
+				var runtimesDirectory = Path.Combine(baseDirectory, "runtimes");
+				if (Directory.Exists(runtimesDirectory))
+				{
+					foreach (var ridDirectory in Directory.EnumerateDirectories(runtimesDirectory, "linux*"))
+					{
+						var nativeDirectory = Path.Combine(ridDirectory, "native");
+						if (Directory.Exists(nativeDirectory))
+						{
+							yield return nativeDirectory;
+						}
+					}
+				}
+			}
+
+#pragma warning disable IL3000
+			var assemblyDirectory = Path.GetDirectoryName(typeof(ICU).Assembly.Location);
+#pragma warning restore IL3000
+			if (!string.IsNullOrEmpty(assemblyDirectory)
+				&& Directory.Exists(assemblyDirectory)
+				&& (string.IsNullOrEmpty(baseDirectory) || !string.Equals(Path.TrimEndingDirectorySeparator(baseDirectory), assemblyDirectory, StringComparison.Ordinal)))
+			{
+				yield return assemblyDirectory;
+			}
+		}
+
+		private static Version? ParseIcuFileVersion(string fileName)
+		{
+			var versionPart = fileName.Substring("libicuuc.so.".Length);
+			// Version.TryParse needs at least two components; major-only files like libicuuc.so.66 are valid.
+			return Version.TryParse(versionPart.Contains('.') ? versionPart : $"{versionPart}.0", out var version) ? version : null;
+		}
+
+		private static string GetLinuxIcuLoadFailureDetails()
+		{
+			var builder = new StringBuilder();
+			builder.AppendLine().Append($"- System.Globalization.AppLocalIcu: {GetAppLocalIcuConfigValue() ?? "(not set)"}");
+			foreach (var directory in GetIcuProbingDirectories())
+			{
+				string[] icuFiles;
+				try
+				{
+					icuFiles = Directory.GetFiles(directory, "libicu*");
+				}
+				catch (Exception)
+				{
+					continue;
+				}
+				builder.AppendLine().Append($"- {directory}: {(icuFiles.Length == 0 ? "(no libicu* files)" : string.Join(", ", icuFiles.Select(Path.GetFileName)))}");
+			}
+			return builder
+				.AppendLine()
+				.Append("Install the distribution ICU package (e.g. 'apt install libicu74', 'dnf install libicu'), or ship ICU app-locally by referencing the Microsoft.ICU.ICU4C.Runtime package and setting the System.Globalization.AppLocalIcu runtime option. Note that InvariantGlobalization does not remove this requirement: ICU is used for BiDi and line breaking.")
+				.ToString();
+		}
+
 		public static T GetMethod<T>()
 		{
 			if (!_lookupCache.TryGetValue(typeof(T), out var value))
@@ -257,7 +446,7 @@ internal readonly partial struct UnicodeText
 				{
 					value = Marshal.GetDelegateForFunctionPointer<T>(originalNameFunc)!;
 				}
-				else if (NativeLibrary.TryGetExport(_libicuuc, $"{typeof(T).Name}_{_icuVersion}", out var versionPostfixedFunc))
+				else if (NativeLibrary.TryGetExport(_libicuuc, $"{typeof(T).Name}_{_icuVersion}{_icuSymbolSuffix}", out var versionPostfixedFunc))
 				{
 					value = Marshal.GetDelegateForFunctionPointer<T>(versionPostfixedFunc)!;
 				}

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -108,7 +108,7 @@ internal readonly partial struct UnicodeText
 				{
 					// Honor .NET's own app-local ICU configuration first, so Uno resolves the same
 					// libraries as the runtime, including custom-suffixed builds.
-					TryLoadConfiguredAppLocalIcu(attempts, out libicuuc, out customSuffix);
+					TryLoadConfiguredAppLocalIcu(attempts, ref lastError, out libicuuc, out customSuffix);
 				}
 
 				attempts.Add("icuuc");
@@ -275,7 +275,7 @@ internal readonly partial struct UnicodeText
 			=> AppContext.GetData("System.Globalization.AppLocalIcu") as string
 				?? Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU");
 
-		private static bool TryLoadConfiguredAppLocalIcu(List<string> attempts, out IntPtr libicuuc, out string? customSuffix)
+		private static bool TryLoadConfiguredAppLocalIcu(List<string> attempts, ref Exception? lastError, out IntPtr libicuuc, out string? customSuffix)
 		{
 			libicuuc = IntPtr.Zero;
 			customSuffix = null;
@@ -302,13 +302,21 @@ internal readonly partial struct UnicodeText
 
 			var name = $"libicuuc{suffix}.so.{version}";
 			attempts.Add(name);
-			if (NativeLibrary.TryLoad(name, typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
+			try
 			{
-				customSuffix = suffix.Length == 0 ? null : suffix;
-				typeof(ICU).LogDebug()?.Debug($"Loaded app-local ICU '{name}' (System.Globalization.AppLocalIcu).");
-				return true;
+				// Use Load so a failure of the explicitly configured library is preserved for diagnostics.
+				libicuuc = NativeLibrary.Load(name, typeof(ICU).Assembly, NativeLibrarySearchDirectories);
 			}
-			return false;
+			catch (Exception e)
+			{
+				lastError = e;
+				libicuuc = IntPtr.Zero;
+				typeof(ICU).LogWarn()?.Warn($"System.Globalization.AppLocalIcu is set but '{name}' failed to load; falling back to other ICU sources. {e.Message}");
+				return false;
+			}
+			customSuffix = suffix.Length == 0 ? null : suffix;
+			typeof(ICU).LogDebug()?.Debug($"Loaded app-local ICU '{name}' (System.Globalization.AppLocalIcu).");
+			return true;
 		}
 
 		private static bool TryLoadAppLocalIcuFromDirectories(List<string> attempts, ref Exception? lastError, out IntPtr libicuuc)
@@ -396,7 +404,14 @@ internal readonly partial struct UnicodeText
 
 		private static Version? ParseIcuFileVersion(string fileName)
 		{
-			var versionPart = fileName.Substring("libicuuc.so.".Length);
+			// The default Win32-style enumeration pattern also matches a bare "libicuuc.so"
+			// (a trailing ".*" matches end-of-name too), so guard before taking the version part.
+			const string prefix = "libicuuc.so.";
+			if (fileName.Length <= prefix.Length || !fileName.StartsWith(prefix, StringComparison.Ordinal))
+			{
+				return null;
+			}
+			var versionPart = fileName.Substring(prefix.Length);
 			// Version.TryParse needs at least two components; major-only files like libicuuc.so.66 are valid.
 			return Version.TryParse(versionPart.Contains('.') ? versionPart : $"{versionPart}.0", out var version) ? version : null;
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #23540

## PR Type:

🐞 Bugfix

## What changed? 🚀

Linux is the only Skia target without a bundled ICU package, so text rendering relies on a system-installed ICU. On minimal/embedded images (the scenario in #23540), no ICU is present and the app dies at startup with an error that doesn't say what was probed or how to fix it. Shipping ICU app-locally didn't help either: the `Microsoft.ICU.ICU4C.Runtime` package ships only fully-versioned file names (e.g. `libicuuc.so.72.1.0.3`) that the existing major-only name probing can never find.

The Linux loader in `UnicodeText.ICU.skia.cs` now resolves ICU in this order:

1. **.NET's app-local ICU configuration** — honors the `System.Globalization.AppLocalIcu` switch / `DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU` env var (`[suffix:]version` format, same precedence as CoreLib), loading `libicudata` before `libicuuc` (the MS binaries have no rpath and major-only sonames). Custom-suffixed builds are supported by wiring the suffix into native symbol lookup.
2. **`icuuc`** — the existing unversioned attempt, unchanged.
3. **Directory scan** — probes `AppContext.BaseDirectory`, `runtimes/linux*/native`, and the assembly directory for fully-versioned `libicuuc.so.*` files and loads the best candidate by absolute path (with its `libicudata` sibling first). This makes "copy the ICU package files next to the app" work even without the runtime switch.
4. **Versioned name probe** `libicuuc.so.[100..50]` — the existing last resort, unchanged.

Additionally:

- Version detection now accepts an unversioned `u_getVersion` export (ICU built with `--disable-renaming`) and reads the version from the library itself.
- On failure, the exception now reports the AppLocalIcu state, each probed directory with the `libicu*` files actually found there, the last dlopen error, and remediation guidance (distro package vs app-local ICU) — the previous message could not distinguish "no ICU installed" from "exotic version" from "stale binary", which cost a full round-trip on #23540.
- Docs: `libicu` added to the Linux setup prerequisites and the FrameBuffer trimmed-device list; new *Runtime Dependencies* section in the Linux publishing doc (distro package names + app-local ICU recipe); new troubleshooting entry in the Skia common-issues page.

**Validation so far:** compile (Uno.UI.Skia, net10.0). Draft until runtime validation on Linux is done:

- [ ] Runtime matrix on Linux containers: system ICU only / app-local with switch / app-local without switch / no ICU (diagnostics output)
- [x] Address remaining code-review follow-ups (guard the file-version parse against a bare `libicuuc.so` match; surface configured-AppLocalIcu load failures in the diagnostics)

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
