### PR TITLE
SwipeItems: Implement GetView compatibility API

### DIFF
--- a/src/Uno.UI.UnitTests/Windows_UI_XAML_Controls/SwipeItemsTests/Given_SwipeItems.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_XAML_Controls/SwipeItemsTests/Given_SwipeItems.cs
@@ -10,6 +10,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SwipeItemsTests
 	public class Given_SwipeItems
 	{
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23883")]
 		public void When_GetView_Then_ReturnsViewWithSameItemsAndOrder()
 		{
 			var item1 = new SwipeItem { Text = "Item1" };
@@ -26,6 +27,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SwipeItemsTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23883")]
 		public void When_GetView_Then_ReturnsIReadOnlyList()
 		{
 			var SUT = new SwipeItems();
@@ -38,6 +40,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SwipeItemsTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23883")]
 		public void When_ItemsEmpty_Then_GetViewIsEmpty()
 		{
 			var SUT = new SwipeItems();
@@ -49,6 +52,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SwipeItemsTests
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23883")]
 		public void When_ItemAppendedAfterGetView_Then_ViewReflectsLiveState()
 		{
 			// WinUI's SwipeItems::GetView() forwards to the backing Vector<T>'s GetView(),
@@ -68,12 +72,9 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SwipeItemsTests
 		}
 
 		[TestMethod]
-		public void When_GetView_Then_CannotBeDowncastToMutateTheCollection()
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23883")]
+		public void When_GetView_Then_ViewIsReadOnly()
 		{
-			// The native WinRT IVectorView<T> is a distinct object that cannot be cast back to a
-			// mutable IVector<T>. The .NET port must preserve this: a caller must not be able to
-			// downcast the returned view to bypass SwipeItems' own validation (e.g. the
-			// SwipeMode.Execute single-item constraint) or its VectorChanged notifications.
 			var SUT = new SwipeItems { new SwipeItem { Text = "Item1" } };
 
 			var view = SUT.GetView();

--- a/src/Uno.UI.UnitTests/Windows_UI_XAML_Controls/SwipeItemsTests/Given_SwipeItems.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_XAML_Controls/SwipeItemsTests/Given_SwipeItems.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SwipeItemsTests
+{
+	[TestClass]
+	public class Given_SwipeItems
+	{
+		[TestMethod]
+		public void When_GetView_Then_ReturnsViewWithSameItemsAndOrder()
+		{
+			var item1 = new SwipeItem { Text = "Item1" };
+			var item2 = new SwipeItem { Text = "Item2" };
+
+			var SUT = new SwipeItems { item1, item2 };
+
+			var view = SUT.GetView();
+
+			Assert.IsNotNull(view);
+			Assert.AreEqual(2, view.Count);
+			Assert.AreSame(item1, view[0]);
+			Assert.AreSame(item2, view[1]);
+		}
+
+		[TestMethod]
+		public void When_GetView_Then_ReturnsIReadOnlyList()
+		{
+			var SUT = new SwipeItems();
+
+			// The WinUI API surface for SwipeItems.GetView is `IReadOnlyList<SwipeItem>` on .NET
+			// (the .NET projection of the native `IVectorView<SwipeItem>`).
+			IReadOnlyList<SwipeItem> view = SUT.GetView();
+
+			Assert.IsNotNull(view);
+		}
+
+		[TestMethod]
+		public void When_ItemsEmpty_Then_GetViewIsEmpty()
+		{
+			var SUT = new SwipeItems();
+
+			var view = SUT.GetView();
+
+			Assert.IsNotNull(view);
+			Assert.AreEqual(0, view.Count);
+		}
+
+		[TestMethod]
+		public void When_ItemAppendedAfterGetView_Then_ViewReflectsLiveState()
+		{
+			// WinUI's SwipeItems::GetView() forwards to the backing Vector<T>'s GetView(),
+			// which is a live view over the same underlying storage (not a point-in-time copy).
+			var item1 = new SwipeItem { Text = "Item1" };
+			var item2 = new SwipeItem { Text = "Item2" };
+
+			var SUT = new SwipeItems { item1 };
+
+			var view = SUT.GetView();
+			Assert.AreEqual(1, view.Count);
+
+			SUT.Add(item2);
+
+			Assert.AreEqual(2, view.Count);
+			Assert.AreSame(item2, view[1]);
+		}
+
+		[TestMethod]
+		public void When_GetView_Then_CannotBeDowncastToMutateTheCollection()
+		{
+			// The native WinRT IVectorView<T> is a distinct object that cannot be cast back to a
+			// mutable IVector<T>. The .NET port must preserve this: a caller must not be able to
+			// downcast the returned view to bypass SwipeItems' own validation (e.g. the
+			// SwipeMode.Execute single-item constraint) or its VectorChanged notifications.
+			var SUT = new SwipeItems { new SwipeItem { Text = "Item1" } };
+
+			var view = SUT.GetView();
+
+			Assert.IsNotInstanceOfType<ObservableCollection<SwipeItem>>(view);
+			Assert.ThrowsExactly<NotSupportedException>(() => ((IList<SwipeItem>)view).Add(new SwipeItem()));
+			Assert.AreEqual(1, SUT.Count);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/SwipeControl/SwipeItems.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SwipeControl/SwipeItems.cs
@@ -136,9 +136,9 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		/// <summary>
-		/// Gets an immutable view into the collection.
+		/// Returns a live, read-only view over the backing collection.
+		/// Mutations to <see cref="SwipeItems"/> are immediately reflected in the returned view.
 		/// </summary>
-		/// <returns>An object representing the immutable collection view.</returns>
 		public IReadOnlyList<SwipeItem> GetView() => new ReadOnlyObservableCollection<SwipeItem>(m_items);
 
 		public event VectorChangedEventHandler<SwipeItem> VectorChanged

--- a/src/Uno.UI/UI/Xaml/Controls/SwipeControl/SwipeItems.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SwipeControl/SwipeItems.cs
@@ -135,11 +135,11 @@ namespace Microsoft.UI.Xaml.Controls
 			m_vectorChangedEventSource?.Invoke(this, null);
 		}
 
-		// TODO Uno
-		//public IVectorView<SwipeItem> GetView()
-		//{
-		//	return m_items.GetView();
-		//}
+		/// <summary>
+		/// Gets an immutable view into the collection.
+		/// </summary>
+		/// <returns>An object representing the immutable collection view.</returns>
+		public IReadOnlyList<SwipeItem> GetView() => new ReadOnlyObservableCollection<SwipeItem>(m_items);
 
 		public event VectorChangedEventHandler<SwipeItem> VectorChanged
 		{


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/23883

Fixes https://github.com/unoplatform/uno/issues/23883

## PR Type:

✨ Feature

## What changed? 🚀

Ports `SwipeItems.GetView` as a live read-only view over the backing collection, matching the WinRT vector-view behavior without bypassing SwipeItems validation. Adds focused unit coverage for type, ordering, liveness, and empty collections.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample (5 focused unit tests pass)
- [ ] 📚 Docs have been added/updated following the documentation template (not applicable)
- [ ] 🖼️ Validated PR Screenshots Compare Test Run (not applicable)
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional)

## Source fidelity status

Compared against `microsoft-ui-xaml` main commit `b8cfb849061c00df624ebb29ac4727b9e58ea99c`. `SwipeItems::GetView` delegates to the backing vector, whose current `GetView` implementation still throws. The read-only live view in this PR is therefore an Uno compatibility implementation, not a literal WinUI3 source port, so the PR remains draft.
