### PR TITLE
fix(wasm): iPad soft-keyboard focus (dismiss, LostFocus, bring-into-view)

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SoftKeyboardFocusTests.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SoftKeyboardFocusTests.xaml
@@ -1,0 +1,58 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_ViewManagement.SoftKeyboardFocusTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel
+            Grid.Row="0"
+            Padding="12"
+            Spacing="8">
+            <TextBlock FontWeight="SemiBold" Text="Uno Platform — Skia WASM soft-keyboard focus (test on a real iPad)" />
+            <TextBlock TextWrapping="Wrap">
+                1) Tap the field below several times — the keyboard must stay open.
+                2) Dismiss it — LostFocus must fire (counter increments).
+                3) Scroll down and focus the bottom field — it must move above the keyboard.
+            </TextBlock>
+            <TextBox
+                x:Name="FocusTextBox"
+                GotFocus="OnFocusTextBoxGotFocus"
+                LostFocus="OnFocusTextBoxLostFocus"
+                PlaceholderText="Tap here repeatedly" />
+            <TextBlock
+                x:Name="FocusStateTextBlock"
+                FontFamily="Consolas"
+                Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1">
+            <StackPanel Padding="12" Spacing="12">
+                <TextBlock Text="Scroll down to the field at the very bottom, then focus it." />
+                <Border Height="900" Background="{ThemeResource SystemControlBackgroundBaseLowBrush}">
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Text="(spacer to push the field below the fold)" />
+                </Border>
+                <TextBox PlaceholderText="Bottom field — should scroll above the keyboard" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <TextBlock
+            x:Name="OccludedRectTextBlock"
+            Grid.Row="2"
+            Padding="12"
+            FontFamily="Consolas"
+            Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SoftKeyboardFocusTests.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_ViewManagement/SoftKeyboardFocusTests.xaml.cs
@@ -1,0 +1,70 @@
+using System;
+using Windows.Foundation;
+using Windows.UI.ViewManagement;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_ViewManagement
+{
+	// Manual, on-device sample for the Skia WASM iPad soft-keyboard focus fixes:
+	//  1. Tapping a TextBox must keep the keyboard open (no self-dismiss).
+	//  2. LostFocus must fire when the keyboard is dismissed / focus leaves the field.
+	//  3. The focused field near the bottom must scroll above the on-screen keyboard.
+	// These reproduce only on a real touch device (iPad Safari/Chrome), not desktop or the iOS Simulator.
+	[Sample("Windows.UI.ViewManagement", Description = "On-device checks for Skia WASM soft-keyboard focus (auto-dismiss, LostFocus, bring-into-view).", IsManualTest = true, IgnoreInSnapshotTests = true)]
+	public sealed partial class SoftKeyboardFocusTests : Page
+	{
+		private int _gotFocusCount;
+		private int _lostFocusCount;
+
+		public SoftKeyboardFocusTests()
+		{
+			this.InitializeComponent();
+			this.Loaded += OnLoaded;
+			this.Unloaded += OnUnloaded;
+		}
+
+		private void OnFocusTextBoxGotFocus(object sender, RoutedEventArgs e)
+		{
+			_gotFocusCount++;
+			UpdateFocusState();
+		}
+
+		private void OnFocusTextBoxLostFocus(object sender, RoutedEventArgs e)
+		{
+			_lostFocusCount++;
+			UpdateFocusState();
+		}
+
+		private void UpdateFocusState()
+		{
+			FocusStateTextBlock.Text =
+				$"GotFocus: {_gotFocusCount}   LostFocus: {_lostFocusCount}   IsFocused: {FocusTextBox.FocusState != FocusState.Unfocused}";
+		}
+
+		private void OnInputPaneShowing(InputPane sender, InputPaneVisibilityEventArgs args)
+			=> UpdateOccludedRect(sender.OccludedRect, "Showing");
+
+		private void OnInputPaneHiding(InputPane sender, InputPaneVisibilityEventArgs args)
+			=> UpdateOccludedRect(sender.OccludedRect, "Hiding");
+
+		private void UpdateOccludedRect(Rect occludedRect, string eventType)
+			=> OccludedRectTextBlock.Text = $"Last event: {eventType}   OccludedRect: {occludedRect}";
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			var inputPane = InputPane.GetForCurrentView();
+			inputPane.Showing += OnInputPaneShowing;
+			inputPane.Hiding += OnInputPaneHiding;
+			UpdateFocusState();
+		}
+
+		private void OnUnloaded(object sender, RoutedEventArgs e)
+		{
+			var inputPane = InputPane.GetForCurrentView();
+			inputPane.Showing -= OnInputPaneShowing;
+			inputPane.Hiding -= OnInputPaneHiding;
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/TextBox/BrowserInvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/TextBox/BrowserInvisibleTextBoxViewExtension.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Uno.Foundation.Logging;
 using Uno.UI.Xaml.Controls;
 using Uno.UI.Xaml.Controls.Extensions;
 using Windows.System;
@@ -53,6 +54,32 @@ internal partial class BrowserInvisibleTextBoxViewExtension : IOverlayTextBoxVie
 		if (FocusManager.GetFocusedElement(xamlRoot!) is TextBox textBox)
 		{
 			textBox.SelectInternal(selectionStart, selectionLength);
+		}
+	}
+
+	[JSExport]
+	private static void OnNativeBlur()
+	{
+		try
+		{
+			var xamlRoot = WebAssemblyWindowWrapper.Instance.XamlRoot;
+			// Fired only for browser-initiated blurs of the shared native input (managed-initiated
+			// blurs are suppressed on the JS side). In that case managed focus is still stale on the
+			// TextBox, so clearing it here is what finally raises LostFocus and re-syncs FocusManager.
+			var focused = FocusManager.GetFocusedElement(xamlRoot!);
+			if (typeof(BrowserInvisibleTextBoxViewExtension).Log().IsEnabled(LogLevel.Trace))
+			{
+				typeof(BrowserInvisibleTextBoxViewExtension).Log().Trace($"OnNativeBlur: focused element is {focused?.GetType().Name ?? "null"}");
+			}
+			if (focused is TextBox textBox)
+			{
+				textBox.Unfocus();
+			}
+		}
+		catch (Exception e)
+		{
+			// A managed exception must not cross back into the JS DOM-event callback.
+			Application.Current.RaiseRecoverableUnhandledException(e);
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/TextBox/BrowserInvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/TextBox/BrowserInvisibleTextBoxViewExtension.cs
@@ -121,7 +121,9 @@ internal partial class BrowserInvisibleTextBoxViewExtension : IOverlayTextBoxVie
 		{
 			if (NativeMethods.HasInput())
 			{
-				NativeMethods.Blur();
+				// The handle lets the JS side ignore this blur when another TextBox has already
+				// taken over the shared input (focus moving between TextBoxes).
+				NativeMethods.Blur(_view.TextBox?.Visual.Handle ?? 0);
 			}
 			_isNativeInputActive = false;
 		}
@@ -233,7 +235,7 @@ internal partial class BrowserInvisibleTextBoxViewExtension : IOverlayTextBoxVie
 		public static partial bool Focus(IntPtr handle, bool isPassword, string? text, bool acceptsReturn, string inputMode, string enterKeyHint);
 
 		[JSImport("globalThis.Uno.UI.Runtime.Skia.BrowserInvisibleTextBoxViewExtension.blur")]
-		public static partial void Blur();
+		public static partial void Blur(IntPtr handle);
 
 		[JSImport("globalThis.Uno.UI.Runtime.Skia.BrowserInvisibleTextBoxViewExtension.detach")]
 		public static partial void Detach();

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/TextBox/BrowserInvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/TextBox/BrowserInvisibleTextBoxViewExtension.cs
@@ -62,11 +62,17 @@ internal partial class BrowserInvisibleTextBoxViewExtension : IOverlayTextBoxVie
 	{
 		try
 		{
-			var xamlRoot = WebAssemblyWindowWrapper.Instance.XamlRoot;
+			var xamlRoot = WebAssemblyWindowWrapper.Instance?.XamlRoot;
+			if (xamlRoot is null)
+			{
+				// Fired before the window/XamlRoot exists or during teardown: no managed focus to re-sync.
+				return;
+			}
+
 			// Fired only for browser-initiated blurs of the shared native input (managed-initiated
 			// blurs are suppressed on the JS side). In that case managed focus is still stale on the
 			// TextBox, so clearing it here is what finally raises LostFocus and re-syncs FocusManager.
-			var focused = FocusManager.GetFocusedElement(xamlRoot!);
+			var focused = FocusManager.GetFocusedElement(xamlRoot);
 			if (typeof(BrowserInvisibleTextBoxViewExtension).Log().IsEnabled(LogLevel.Trace))
 			{
 				typeof(BrowserInvisibleTextBoxViewExtension).Log().Trace($"OnNativeBlur: focused element is {focused?.GetType().Name ?? "null"}");

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
@@ -113,9 +113,9 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 					? new Rect(0, viewportHeight - occludedHeight, viewportWidth, occludedHeight)
 					: new Rect(0, 0, 0, 0);
 
-				if (_instance!.Log().IsEnabled(LogLevel.Trace))
+				if (wrapper.Log().IsEnabled(LogLevel.Trace))
 				{
-					_instance.Log().Trace($"OnViewportOcclusionChanged: occludedHeight={occludedHeight}, OccludedRect={inputPane.OccludedRect}");
+					wrapper.Log().Trace($"OnViewportOcclusionChanged: occludedHeight={occludedHeight}, OccludedRect={inputPane.OccludedRect}");
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
@@ -4,6 +4,7 @@ using System;
 using Windows.Foundation;
 using Windows.Graphics.Display;
 using Windows.UI.Core;
+using Windows.UI.ViewManagement;
 using Uno.Foundation.Logging;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
@@ -24,6 +25,7 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 {
 	private static WebAssemblyWindowWrapper? _instance;
 	private DisplayInformation? _displayInformation;
+	private InputPane? _inputPane;
 
 	internal static WebAssemblyWindowWrapper Instance => _instance!;
 
@@ -37,6 +39,7 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 		_instance._displayInformation = DisplayInformation.GetForCurrentView();
 		_instance.RasterizationScale = (float)_instance._displayInformation.RawPixelsPerViewPixel;
 		_instance._displayInformation.DpiChanged += (_, _) => _instance.RasterizationScale = (float)_instance._displayInformation.RawPixelsPerViewPixel;
+		_instance._inputPane = InputPane.GetForCurrentView();
 	}
 
 	private WebAssemblyWindowWrapper()
@@ -91,6 +94,35 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 		else
 		{
 			Console.WriteLine($"RaiseNativeSizeChanged target for {instance} does not exist");
+		}
+	}
+
+	// Fed from a visualViewport listener on the JS side. occludedHeight is the height (in the
+	// same logical/CSS pixels as the window bounds) the on-screen keyboard covers at the bottom
+	// of the viewport, already gated on the invisible text input being focused, so browser-chrome
+	// resizes don't reach here. Setting OccludedRect is what drives the shared Skia bring-into-view
+	// path (InputPane.OnOccludedRectChanged -> EnsureFocusedElementInViewPartial).
+	[JSExport]
+	private static void OnViewportOcclusionChanged([JSMarshalAs<JSType.Any>] object instance, double viewportWidth, double viewportHeight, double occludedHeight)
+	{
+		try
+		{
+			if (instance is WebAssemblyWindowWrapper wrapper && wrapper._inputPane is { } inputPane)
+			{
+				inputPane.OccludedRect = occludedHeight > 0
+					? new Rect(0, viewportHeight - occludedHeight, viewportWidth, occludedHeight)
+					: new Rect(0, 0, 0, 0);
+
+				if (_instance!.Log().IsEnabled(LogLevel.Trace))
+				{
+					_instance.Log().Trace($"OnViewportOcclusionChanged: occludedHeight={occludedHeight}, OccludedRect={inputPane.OccludedRect}");
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			// A managed exception must not cross back into the JS DOM-event callback.
+			Application.Current.RaiseRecoverableUnhandledException(e);
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
@@ -14,6 +14,15 @@
 		// could clear focus on the wrong TextBox during a focus switch). Genuine, browser-
 		// initiated blurs happen with this false and ARE reported (see OnNativeBlur).
 		private static suppressBlurNotification: boolean;
+
+		// Visual handle of the TextBox that currently owns the shared input, so a stale managed
+		// blur from a TextBox that already lost it cannot detach its successor's input.
+		private static currentHandle: number = 0;
+
+		// Bumped by focus()/detachCore() to supersede the deferred detach scheduled by blur():
+		// a blur immediately followed by a focus is a TextBox-to-TextBox move, and detaching
+		// would needlessly dismiss the soft keyboard (see blur).
+		private static detachGeneration: number = 0;
 		private static isInSelectionChange: boolean;
 		private static acceptsReturn: boolean;
 		private static isComposing: boolean;
@@ -102,7 +111,14 @@
 
 		private static createInput(isPasswordBox: boolean, text: string, acceptsReturn: boolean, inputMode: string, enterKeyHint: string) {
 			BrowserInvisibleTextBoxViewExtension.acceptsReturn = acceptsReturn;
+			// A previous input may have been removed mid-composition without a compositionend;
+			// never carry that state over to a fresh element.
+			BrowserInvisibleTextBoxViewExtension.isComposing = false;
+			BrowserInvisibleTextBoxViewExtension.suppressNextInput = false;
 			const input = document.createElement(acceptsReturn && !isPasswordBox ? "textarea" : "input");
+			// The keydown/keyup handlers capture acceptsReturn by closure; record it so canRetarget
+			// only reuses the element when the captured behavior still matches.
+			(input as any).__unoAcceptsReturn = acceptsReturn;
 			if (isPasswordBox) {
 				(input as HTMLInputElement).type = "password";
 				input.autocomplete = "password";
@@ -294,30 +310,77 @@
 		}
 
 		public static focus(handle: number, isPassword: boolean, text: string, acceptsReturn: boolean, inputMode: string, enterKeyHint: string): boolean {
+			// Supersede any detach a preceding managed blur scheduled: focus is moving between
+			// TextBoxes, and detaching in between would dismiss the soft keyboard (see blur).
+			BrowserInvisibleTextBoxViewExtension.detachGeneration++;
+
 			const semanticElement = document.getElementById(`uno-semantics-${handle}`);
 			if (semanticElement && document.activeElement === semanticElement) {
 				BrowserInvisibleTextBoxViewExtension.detach();
 				return false;
 			}
 
-			// NOTE: We can get focused as true while we have inputElement.
-			// This happens when TextBox is focused twice with different FocusStates (e.g, Pointer, Programmatic, Keyboard)
-			// For such case, we do call StartEntry twice without any EndEntry in between.
-			// So, cleanup the existing inputElement and create a new one.
-			// Removing a focused input fires a native blur; suppress it since this is a managed re-focus.
-			BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(BrowserInvisibleTextBoxViewExtension.detachCore);
-			this.createInput(isPassword, text, acceptsReturn, inputMode, enterKeyHint);
+			const existingInput = BrowserInvisibleTextBoxViewExtension.inputElement;
+			if (existingInput != null && BrowserInvisibleTextBoxViewExtension.canRetarget(existingInput, isPassword, acceptsReturn)) {
+				// Reuse the shared input in place: mobile browsers keep the soft keyboard up across
+				// a TextBox-to-TextBox move only while an editable element stays focused throughout.
+				BrowserInvisibleTextBoxViewExtension.acceptsReturn = acceptsReturn;
+				existingInput.setAttribute("inputmode", inputMode);
+				existingInput.setAttribute("enterkeyhint", enterKeyHint);
+				BrowserInvisibleTextBoxViewExtension.setText(text);
 
-			// It's necessary to actually focus the native input, not just make it visible. This is particularly
-			// important to mobile browsers (to open the software keyboard) and for assistive technology to not steal
-			// events and properly recognize password inputs to not read it.
-			BrowserInvisibleTextBoxViewExtension.inputElement.focus();
+				// It's necessary to actually focus the native input, not just make it visible. This is particularly
+				// important to mobile browsers (to open the software keyboard) and for assistive technology to not steal
+				// events and properly recognize password inputs to not read it.
+				if (document.activeElement !== existingInput) {
+					existingInput.focus();
+				}
+			}
+			else {
+				// The element kind must change (input/textarea/password), or an IME composition is in
+				// progress and must not leak into the next TextBox. Focus the new element BEFORE
+				// removing the old one so focus hands off editable-to-editable without a gap that
+				// would dismiss the soft keyboard. The implicit blur of the old element is
+				// managed-initiated, so suppress its notification.
+				existingInput?.removeAttribute("id");
+				this.createInput(isPassword, text, acceptsReturn, inputMode, enterKeyHint);
+				BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(() => {
+					BrowserInvisibleTextBoxViewExtension.inputElement.focus();
+					existingInput?.remove();
+				});
+			}
+
+			BrowserInvisibleTextBoxViewExtension.currentHandle = Number(handle);
+
+			// The retarget path keeps the input focused, so no focusin fires and the trailing-click
+			// guard never arms; arm it here for both paths (see installTrailingClickGuard).
+			if (BrowserInvisibleTextBoxViewExtension.lastPointerType === "touch"
+				|| BrowserInvisibleTextBoxViewExtension.lastPointerType === "pen") {
+				BrowserInvisibleTextBoxViewExtension.swallowNextCanvasClick = true;
+			}
 			return true;
 		}
 
+		// The shared input can be handed to another TextBox without being recreated only when the
+		// element kind it was created with still matches the target TextBox.
+		private static canRetarget(input: HTMLInputElement | HTMLTextAreaElement, isPassword: boolean, acceptsReturn: boolean): boolean {
+			if (BrowserInvisibleTextBoxViewExtension.isComposing) {
+				return false;
+			}
+			const needsTextArea = acceptsReturn && !isPassword;
+			if (input instanceof HTMLTextAreaElement) {
+				return needsTextArea;
+			}
+			return !needsTextArea
+				&& (input.type === "password") === isPassword
+				&& (input as any).__unoAcceptsReturn === acceptsReturn;
+		}
+
 		// Runs a managed-initiated focus mutation with the blur listener muted, so it isn't
-		// reported back to the FocusManager (which already drove the change). Callers that
-		// remove the input do so via detachCore, which blurs it explicitly first.
+		// reported back to the FocusManager (which already drove the change). Callers make the
+		// blur dispatch synchronously inside the window: detachCore blurs explicitly before
+		// removing, and the swap path in focus() focuses the successor (implicitly blurring the
+		// old input) before removing it.
 		private static runSuppressingBlur(action: () => void) {
 			BrowserInvisibleTextBoxViewExtension.suppressBlurNotification = true;
 			try {
@@ -328,6 +391,8 @@
 		}
 
 		private static detachCore() {
+			BrowserInvisibleTextBoxViewExtension.detachGeneration++;
+			BrowserInvisibleTextBoxViewExtension.currentHandle = 0;
 			// Blur explicitly before removing: the .blur() method dispatches synchronously, so it
 			// lands inside the suppression window. WebKit can otherwise defer the implicit blur that
 			// fires on element removal past that window, which would clear the wrong TextBox's focus.
@@ -336,11 +401,26 @@
 			BrowserInvisibleTextBoxViewExtension.inputElement = null;
 		}
 
-		public static blur() {
+		public static blur(handle: number) {
 			// Managed-initiated blur (EndEntry): the FocusManager already knows focus is leaving.
-			BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(() => {
-				(document.activeElement as HTMLElement)?.blur();
-				BrowserInvisibleTextBoxViewExtension.detachCore();
+			const blurredHandle = Number(handle);
+			if (blurredHandle !== 0
+				&& BrowserInvisibleTextBoxViewExtension.currentHandle !== 0
+				&& blurredHandle !== BrowserInvisibleTextBoxViewExtension.currentHandle) {
+				// Stale blur from a TextBox that no longer owns the shared input; detaching now
+				// would tear down its successor's entry session.
+				return;
+			}
+
+			// Don't detach synchronously: when focus is moving to another TextBox, EndEntry runs
+			// before StartEntry in the same task, and detaching in between commits the soft-keyboard
+			// dismissal on iOS even though another TextBox is about to take over. Defer by one
+			// microtask; an intervening focus()/detach() supersedes this via detachGeneration.
+			const generation = ++BrowserInvisibleTextBoxViewExtension.detachGeneration;
+			queueMicrotask(() => {
+				if (generation === BrowserInvisibleTextBoxViewExtension.detachGeneration) {
+					BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(BrowserInvisibleTextBoxViewExtension.detachCore);
+				}
 			});
 		}
 
@@ -383,8 +463,8 @@
 		public static updateSize(width: number, height: number) {
 			const input = BrowserInvisibleTextBoxViewExtension.inputElement;
 			if (input != null) {
-				input.style.width = `${width}`;
-				input.style.height = `${height}`;
+				input.style.width = `${width}px`;
+				input.style.height = `${height}px`;
 			}
 		}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserInvisibleTextBoxViewExtension.ts
@@ -2,9 +2,18 @@
 	export class BrowserInvisibleTextBoxViewExtension {
 		private static _exports: any;
 		private static _imeExports: any;
-		private static readonly inputElementId = "uno-input";
 		private static readonly isMacOS = navigator?.platform.toUpperCase().includes('MAC') ?? false;
 		private static inputElement: HTMLInputElement | HTMLTextAreaElement | null;
+
+		// Issue-1 trailing-click guard state (see installTrailingClickGuard).
+		private static swallowNextCanvasClick: boolean;
+		private static lastPointerType: string;
+
+		// Set while a managed-initiated blur/detach is in progress so the input's own blur
+		// listener doesn't report it back to the FocusManager (that would be redundant and
+		// could clear focus on the wrong TextBox during a focus switch). Genuine, browser-
+		// initiated blurs happen with this false and ARE reported (see OnNativeBlur).
+		private static suppressBlurNotification: boolean;
 		private static isInSelectionChange: boolean;
 		private static acceptsReturn: boolean;
 		private static isComposing: boolean;
@@ -26,6 +35,8 @@
 
 				BrowserInvisibleTextBoxViewExtension._exports = browserExports.Uno.UI.Runtime.Skia.BrowserInvisibleTextBoxViewExtension;
 				BrowserInvisibleTextBoxViewExtension._imeExports = browserExports.Uno.UI.Runtime.Skia.WasmImeTextBoxExtension;
+
+				BrowserInvisibleTextBoxViewExtension.installTrailingClickGuard();
 
 				document.onselectionchange = () => {
 					let input = document.activeElement;
@@ -50,6 +61,45 @@
 			}
 		}
 
+		// Neutralizes the touch-only, WebKit-internal race that dismisses the soft keyboard right
+		// after a TextBox tap (see swallowNextCanvasClick). Uno already preventDefaults pointer
+		// events, but per the Pointer Events spec that does NOT suppress the compatibility
+		// mouse events touch browsers synthesize, so the trailing mousedown still reaches the
+		// canvas and blurs #uno-input. We can't preventDefault it from the pointer path, so we
+		// intercept the mouse event itself, scoped to the single tap that just focused the input.
+		private static installTrailingClickGuard() {
+			// Any new pointer gesture disarms a stale flag, so only the mouse events synthesized
+			// from the very tap that focused the input are ever swallowed. Also records the pointer
+			// type: the bug is exclusive to touch/pen, where the compat mousedown is deferred until
+			// after focus. With a mouse, mousedown precedes focus, so there is nothing to guard.
+			document.addEventListener("pointerdown", (ev: PointerEvent) => {
+				BrowserInvisibleTextBoxViewExtension.lastPointerType = ev.pointerType;
+				BrowserInvisibleTextBoxViewExtension.swallowNextCanvasClick = false;
+			}, { capture: true });
+
+			// focusin bubbles (unlike focus), so a single document-level listener catches the
+			// invisible input regardless of when it is (re)created.
+			document.addEventListener("focusin", (ev: FocusEvent) => {
+				const target = ev.target as HTMLElement;
+				if (target?.id === UnoDomIds.input
+					&& (BrowserInvisibleTextBoxViewExtension.lastPointerType === "touch"
+						|| BrowserInvisibleTextBoxViewExtension.lastPointerType === "pen")) {
+					BrowserInvisibleTextBoxViewExtension.swallowNextCanvasClick = true;
+				}
+			}, { capture: true });
+
+			const swallow = (ev: Event) => {
+				if (BrowserInvisibleTextBoxViewExtension.swallowNextCanvasClick
+					&& (ev.target as HTMLElement)?.id === UnoDomIds.canvas) {
+					ev.preventDefault();
+					ev.stopImmediatePropagation();
+					BrowserInvisibleTextBoxViewExtension.swallowNextCanvasClick = false;
+				}
+			};
+			document.addEventListener("mousedown", swallow, { capture: true });
+			document.addEventListener("click", swallow, { capture: true });
+		}
+
 		private static createInput(isPasswordBox: boolean, text: string, acceptsReturn: boolean, inputMode: string, enterKeyHint: string) {
 			BrowserInvisibleTextBoxViewExtension.acceptsReturn = acceptsReturn;
 			const input = document.createElement(acceptsReturn && !isPasswordBox ? "textarea" : "input");
@@ -58,7 +108,7 @@
 				input.autocomplete = "password";
 			}
 
-			input.id = BrowserInvisibleTextBoxViewExtension.inputElementId;
+			input.id = UnoDomIds.input;
 			input.tabIndex = -1;
 			input.spellcheck = false;
 			input.style.whiteSpace = "pre-wrap";
@@ -102,6 +152,17 @@
 				BrowserInvisibleTextBoxViewExtension._exports.OnNativePaste(ev.clipboardData.getData("text"));
 				ev.preventDefault();
 			};
+
+			// C# drives focus one-way (StartEntry/EndEntry call focus()/blur()), so a blur the
+			// browser initiates on its own — e.g. tapping outside, or the touch-synthesized
+			// mousedown in issue 1 — is otherwise invisible to the FocusManager and LostFocus
+			// never fires. Report only those; managed-initiated blurs set suppressBlurNotification.
+			input.addEventListener("blur", () => {
+				if (BrowserInvisibleTextBoxViewExtension.suppressBlurNotification) {
+					return;
+				}
+				BrowserInvisibleTextBoxViewExtension._exports.OnNativeBlur();
+			});
 
 			// Handle Enter key from Android virtual keyboards which don't fire keydown events.
 			// Android keyboards typically fire beforeinput with inputType "insertLineBreak" or "insertParagraph" instead.
@@ -243,7 +304,8 @@
 			// This happens when TextBox is focused twice with different FocusStates (e.g, Pointer, Programmatic, Keyboard)
 			// For such case, we do call StartEntry twice without any EndEntry in between.
 			// So, cleanup the existing inputElement and create a new one.
-			BrowserInvisibleTextBoxViewExtension.inputElement?.remove();
+			// Removing a focused input fires a native blur; suppress it since this is a managed re-focus.
+			BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(BrowserInvisibleTextBoxViewExtension.detachCore);
 			this.createInput(isPassword, text, acceptsReturn, inputMode, enterKeyHint);
 
 			// It's necessary to actually focus the native input, not just make it visible. This is particularly
@@ -253,15 +315,37 @@
 			return true;
 		}
 
+		// Runs a managed-initiated focus mutation with the blur listener muted, so it isn't
+		// reported back to the FocusManager (which already drove the change). Callers that
+		// remove the input do so via detachCore, which blurs it explicitly first.
+		private static runSuppressingBlur(action: () => void) {
+			BrowserInvisibleTextBoxViewExtension.suppressBlurNotification = true;
+			try {
+				action();
+			} finally {
+				BrowserInvisibleTextBoxViewExtension.suppressBlurNotification = false;
+			}
+		}
+
+		private static detachCore() {
+			// Blur explicitly before removing: the .blur() method dispatches synchronously, so it
+			// lands inside the suppression window. WebKit can otherwise defer the implicit blur that
+			// fires on element removal past that window, which would clear the wrong TextBox's focus.
+			BrowserInvisibleTextBoxViewExtension.inputElement?.blur();
+			BrowserInvisibleTextBoxViewExtension.inputElement?.remove();
+			BrowserInvisibleTextBoxViewExtension.inputElement = null;
+		}
+
 		public static blur() {
-			// reset focus
-			(document.activeElement as HTMLElement)?.blur();
-			BrowserInvisibleTextBoxViewExtension.detach();
+			// Managed-initiated blur (EndEntry): the FocusManager already knows focus is leaving.
+			BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(() => {
+				(document.activeElement as HTMLElement)?.blur();
+				BrowserInvisibleTextBoxViewExtension.detachCore();
+			});
 		}
 
 		public static detach() {
-			BrowserInvisibleTextBoxViewExtension.inputElement?.remove();
-			BrowserInvisibleTextBoxViewExtension.inputElement = null;
+			BrowserInvisibleTextBoxViewExtension.runSuppressingBlur(BrowserInvisibleTextBoxViewExtension.detachCore);
 		}
 
 		public static hasInput(): boolean {

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/UnoDomIds.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/UnoDomIds.ts
@@ -1,0 +1,10 @@
+namespace Uno.UI.Runtime.Skia {
+
+	// Single source of truth for the well-known DOM element ids of the browser head.
+	// Multiple modules (window wrapper, text-box view) key behaviour off these ids, so a
+	// rename must happen in exactly one place.
+	export class UnoDomIds {
+		public static readonly canvas = "uno-canvas";
+		public static readonly input = "uno-input";
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/WebAssemblyWindowWrapper.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/WebAssemblyWindowWrapper.ts
@@ -4,7 +4,9 @@ namespace Uno.UI.Runtime.Skia {
 		private containerElement: HTMLDivElement;
 		private canvasElement: HTMLCanvasElement;
 		private onResize: any;
+		private onViewportOcclusionChanged: any;
 		private owner: any;
+		private lastReportedOcclusion: number = -1;
 		private static readonly unoPersistentLoaderClassName = "uno-persistent-loader";
 		private static readonly loadingElementId = "uno-loading";
 		private static readonly unoKeepLoaderClassName = "uno-keep-loader";
@@ -38,6 +40,7 @@ namespace Uno.UI.Runtime.Skia {
 		private async build() {
 			WebAssemblyWindowWrapper.assemblyExports = await (<any>window).Module.getAssemblyExports("Uno.UI.Runtime.Skia.WebAssembly.Browser");
 			this.onResize = WebAssemblyWindowWrapper.assemblyExports.Uno.UI.Runtime.Skia.WebAssemblyWindowWrapper.OnResize;
+			this.onViewportOcclusionChanged = WebAssemblyWindowWrapper.assemblyExports.Uno.UI.Runtime.Skia.WebAssemblyWindowWrapper.OnViewportOcclusionChanged;
 
 			this.containerElement = (document.getElementById("uno-body") as HTMLDivElement);
 
@@ -50,7 +53,7 @@ namespace Uno.UI.Runtime.Skia {
 			}
 
 			this.canvasElement = document.createElement("canvas");
-			this.canvasElement.id = "uno-canvas";
+			this.canvasElement.id = UnoDomIds.canvas;
 			this.canvasElement.setAttribute("aria-hidden", "true");
 			this.containerElement.appendChild(this.canvasElement);
 
@@ -62,7 +65,46 @@ namespace Uno.UI.Runtime.Skia {
 				x.preventDefault();
 			})
 
+			// The on-screen keyboard shrinks the visual viewport without firing window "resize",
+			// so track it separately to report keyboard occlusion to the InputPane (issue 3).
+			if (window.visualViewport) {
+				window.visualViewport.addEventListener("resize", () => this.reportKeyboardOcclusion());
+				window.visualViewport.addEventListener("scroll", () => this.reportKeyboardOcclusion());
+			}
+
 			this.resize();
+		}
+
+		// Reports how much of the viewport the on-screen keyboard occludes, in the same CSS pixels
+		// as the window bounds. Gated on the invisible text input (#uno-input) being the active
+		// element: the soft keyboard is only up during text entry, so viewport changes at any other
+		// time (e.g. the mobile address bar collapsing) are deliberately reported as no occlusion.
+		private reportKeyboardOcclusion() {
+			const viewport = window.visualViewport;
+			if (!viewport || !this.onViewportOcclusionChanged) {
+				return;
+			}
+
+			// Check focus before touching layout: visualViewport scroll/resize fires per frame during
+			// momentum scroll and keyboard animation, and getBoundingClientRect forces a reflow. When
+			// no text input is focused there is no keyboard, so skip the reflow entirely and report a
+			// single zero only if the last report was non-zero.
+			if (document.activeElement?.id !== UnoDomIds.input) {
+				if (this.lastReportedOcclusion !== 0) {
+					this.lastReportedOcclusion = 0;
+					this.onViewportOcclusionChanged(this.owner, 0, 0, 0);
+				}
+				return;
+			}
+
+			const layout = document.documentElement.getBoundingClientRect();
+			const occludedHeight = Math.max(0, layout.height - viewport.height - viewport.offsetTop);
+			if (occludedHeight === this.lastReportedOcclusion) {
+				return;
+			}
+
+			this.lastReportedOcclusion = occludedHeight;
+			this.onViewportOcclusionChanged(this.owner, layout.width, layout.height, occludedHeight);
 		}
 
 		public static removeLoading() {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -60,6 +60,10 @@ public class Given_InputPane
 			await WindowHelper.WaitFor(
 				() => scrollViewer.VerticalOffset > offsetBeforeOcclusion + 1,
 				message: $"Focused TextBox was not scrolled above the keyboard (offset stayed at {offsetBeforeOcclusion}).");
+
+			await WindowHelper.WaitFor(
+				() => GetBottom(textBox) <= occludedTop + 0.5,
+				message: $"Focused TextBox (bottom {GetBottom(textBox)}) was left below the keyboard top ({occludedTop}).");
 		}
 		finally
 		{
@@ -67,4 +71,127 @@ public class Given_InputPane
 			WindowHelper.WindowContent = null;
 		}
 	}
+
+	// The regression OP hit with a TextBox mid-content (e.g. inside a side panel): the pad used to be
+	// reduced by the space below the focused element, leaving it partially behind the keyboard.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_Focused_TextBox_Has_Content_Below_Then_Scrolled_Above_Occlusion()
+	{
+		var textBox = new TextBox { Height = 40, PlaceholderText = "middle" };
+		var scrollViewer = new ScrollViewer
+		{
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Stretch,
+			Content = new StackPanel
+			{
+				Children =
+				{
+					new Border { Height = 1200 },
+					textBox,
+					new Border { Height = 800 },
+				},
+			},
+		};
+
+		var inputPane = InputPane.GetForCurrentView();
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+
+			// Position the TextBox inside the viewport with a large gap below it (~45% of the
+			// viewport), then occlude the bottom half: the gap is what the old padding formula
+			// subtracted, leaving the TextBox behind the keyboard.
+			var viewportHeight = scrollViewer.ActualHeight;
+			scrollViewer.ChangeView(null, 1240 - (0.55 * viewportHeight), null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(textBox.Focus(FocusState.Programmatic), "TextBox failed to take focus.");
+			await WindowHelper.WaitForIdle();
+
+			var scrollViewerTopLeft = scrollViewer.TransformToVisual(null).TransformPoint(default);
+			var occludedTop = scrollViewerTopLeft.Y + (viewportHeight / 2);
+			Assert.IsTrue(GetBottom(textBox) > occludedTop, "Test setup: the TextBox must start below the keyboard top.");
+
+			inputPane.OccludedRect = new Rect(scrollViewerTopLeft.X, occludedTop, scrollViewer.ActualWidth, viewportHeight);
+
+			await WindowHelper.WaitFor(
+				() => GetBottom(textBox) <= occludedTop + 0.5,
+				message: $"Focused TextBox (bottom {GetBottom(textBox)}) was left below the keyboard top ({occludedTop}).");
+
+			// The scroll must stay minimal: flush with the keyboard top, not over-scrolled.
+			Assert.IsTrue(
+				GetBottom(textBox) > occludedTop - textBox.ActualHeight - 40,
+				$"Focused TextBox (bottom {GetBottom(textBox)}) was over-scrolled way above the keyboard top ({occludedTop}).");
+		}
+		finally
+		{
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	// The occlusion pad is applied through ScrollViewer.Padding; clearing the occlusion used to
+	// reset it to zero, silently wiping an app-set Padding.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_OccludedRect_Cleared_Then_ScrollViewer_Padding_Restored()
+	{
+		var appPadding = new Thickness(10, 20, 30, 40);
+		var textBox = new TextBox { Height = 40, PlaceholderText = "bottom" };
+		var scrollViewer = new ScrollViewer
+		{
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Stretch,
+			Padding = appPadding,
+			Content = new StackPanel
+			{
+				Children =
+				{
+					new Border { Height = 2000 },
+					textBox,
+				},
+			},
+		};
+
+		var inputPane = InputPane.GetForCurrentView();
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+
+			scrollViewer.ChangeView(null, scrollViewer.ScrollableHeight, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(textBox.Focus(FocusState.Programmatic), "TextBox failed to take focus.");
+			await WindowHelper.WaitForIdle();
+
+			var scrollViewerTopLeft = scrollViewer.TransformToVisual(null).TransformPoint(default);
+			var occludedTop = scrollViewerTopLeft.Y + (scrollViewer.ActualHeight / 2);
+			inputPane.OccludedRect = new Rect(scrollViewerTopLeft.X, occludedTop, scrollViewer.ActualWidth, scrollViewer.ActualHeight);
+
+			// The pad adds to the app padding instead of replacing it.
+			await WindowHelper.WaitFor(
+				() => scrollViewer.Padding.Bottom > appPadding.Bottom,
+				message: "The occlusion pad was not applied on top of the app padding.");
+			Assert.AreEqual(appPadding.Left, scrollViewer.Padding.Left);
+			Assert.AreEqual(appPadding.Top, scrollViewer.Padding.Top);
+			Assert.AreEqual(appPadding.Right, scrollViewer.Padding.Right);
+
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+
+			await WindowHelper.WaitFor(
+				() => scrollViewer.Padding == appPadding,
+				message: $"ScrollViewer.Padding was not restored to the app value (got {scrollViewer.Padding}).");
+		}
+		finally
+		{
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	private static double GetBottom(FrameworkElement element)
+		=> element.TransformToVisual(null).TransformPoint(default).Y + element.ActualHeight;
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -1,3 +1,6 @@
+// These tests drive the InputPane.OccludedRect setter, which is Uno-internal:
+// on native WinUI the property is read-only (the OS owns the input pane).
+#if HAS_UNO
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -195,3 +198,4 @@ public class Given_InputPane
 	private static double GetBottom(FrameworkElement element)
 		=> element.TransformToVisual(null).TransformPoint(default).Y + element.ActualHeight;
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -1,0 +1,70 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using Windows.UI.ViewManagement;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement;
+
+[TestClass]
+public class Given_InputPane
+{
+	// Validates the Skia bring-into-view path that InputPane.OccludedRect drives
+	// (InputPane.skia.cs -> EnsureFocusedElementInViewPartial -> ScrollContentPresenter.Pad +
+	// StartBringIntoView). This is the device-independent half of the WASM soft-keyboard fix:
+	// the WASM head now feeds OccludedRect, and this asserts the shared consumer reacts to it.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_OccludedRect_Set_Then_Focused_TextBox_Scrolled_Into_View()
+	{
+		var textBox = new TextBox { Height = 40, PlaceholderText = "bottom" };
+		var scrollViewer = new ScrollViewer
+		{
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Stretch,
+			Content = new StackPanel
+			{
+				Children =
+				{
+					new Border { Height = 2000 },
+					textBox,
+				},
+			},
+		};
+
+		var inputPane = InputPane.GetForCurrentView();
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+
+			// Bring the bottom TextBox fully into view, then focus it.
+			scrollViewer.ChangeView(null, scrollViewer.ScrollableHeight, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(textBox.Focus(FocusState.Programmatic), "TextBox failed to take focus.");
+			await WindowHelper.WaitForIdle();
+
+			var offsetBeforeOcclusion = scrollViewer.VerticalOffset;
+
+			// Simulate the on-screen keyboard occluding the bottom half of the ScrollViewer,
+			// where the focused TextBox now sits.
+			var scrollViewerTopLeft = scrollViewer.TransformToVisual(null).TransformPoint(default);
+			var occludedTop = scrollViewerTopLeft.Y + (scrollViewer.ActualHeight / 2);
+			inputPane.OccludedRect = new Rect(scrollViewerTopLeft.X, occludedTop, scrollViewer.ActualWidth, scrollViewer.ActualHeight);
+
+			// OccludedRect -> OnOccludedRectChanged schedules the pad + StartBringIntoView across
+			// two dispatcher hops and a layout pass, so wait for the resulting scroll.
+			await WindowHelper.WaitFor(
+				() => scrollViewer.VerticalOffset > offsetBeforeOcclusion + 1,
+				message: $"Focused TextBox was not scrolled above the keyboard (offset stayed at {offsetBeforeOcclusion}).");
+		}
+		finally
+		{
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+			WindowHelper.WindowContent = null;
+		}
+	}
+}

--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
@@ -44,7 +44,7 @@ namespace Windows.UI.ViewManagement
 						scp = outerScv;
 					}
 
-					_padScrollContentPresenter = scp.Pad(OccludedRect, Rect.Empty);
+					_padScrollContentPresenter = scp.Pad(OccludedRect);
 				}
 				focusedElement.StartBringIntoView();
 			}

--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.skia.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.skia.cs
@@ -18,7 +18,8 @@ namespace Windows.UI.ViewManagement;
 partial class InputPane
 {
 	private Lazy<IInputPaneExtension?>? _inputPaneExtension;
-	private IDisposable _padScrollContentPresenter;
+	private IDisposable? _padScrollContentPresenter;
+	private ScrollContentPresenter? _paddedScrollContentPresenter;
 
 	partial void InitializePlatform()
 	{
@@ -35,8 +36,6 @@ partial class InputPane
 
 	partial void EnsureFocusedElementInViewPartial()
 	{
-		_padScrollContentPresenter?.Dispose(); // Restore padding
-
 		var initialWindow = Window.InitialWindow;
 		if (initialWindow is null)
 		{
@@ -45,35 +44,55 @@ partial class InputPane
 
 		var xamlRoot = initialWindow.Content?.XamlRoot;
 
-		if (xamlRoot is not null && Visible && FocusManager.GetFocusedElement(xamlRoot) is UIElement focusedElement)
+		UIElement? focusedElement = null;
+		ScrollContentPresenter? scp = null;
+
+		if (xamlRoot is not null && Visible)
 		{
-			if (focusedElement.FindFirstParent<ScrollContentPresenter>() is { } scp)
+			focusedElement = FocusManager.GetFocusedElement(xamlRoot) as UIElement;
+			scp = focusedElement?.FindFirstParent<ScrollContentPresenter>();
+
+			// ScrollViewer can be nested, but the outer-most SV isn't necessarily the one to handle this "padded" scroll.
+			// Only the first SV that is constrained would be the one, as unconstrained SV can just expand freely.
+			while (scp is not null
+				&& double.IsPositiveInfinity(scp.m_previousAvailableSize.Height)
+				&& scp.FindFirstParent<ScrollContentPresenter>(includeCurrent: false) is { } outerScv)
 			{
-				// ScrollViewer can be nested, but the outer-most SV isn't necessarily the one to handle this "padded" scroll.
-				// Only the first SV that is constrained would be the one, as unconstrained SV can just expand freely.
-				while (double.IsPositiveInfinity(scp.m_previousAvailableSize.Height)
-					&& scp.FindFirstParent<ScrollContentPresenter>(includeCurrent: false) is { } outerScv)
-				{
-					scp = outerScv;
-				}
-
-				var focusedElementPoint = focusedElement.TransformToVisual(scp).TransformPoint(new Point());
-				Size focusedElementSize = focusedElement.ActualSize.ToSize();
-				Rect focusedElementRect = new(
-					focusedElementPoint.X,
-					focusedElementPoint.Y,
-					focusedElementSize.Width,
-					focusedElementSize.Height
-				);
-
-				_padScrollContentPresenter = scp.Pad(OccludedRect, focusedElementRect);
+				scp = outerScv;
 			}
-
-			// As we changed the layout properties of the ScrollContentPresenter, we need to wait for the next layout pass for
-			// the scrollable height to be updated.
-			_ = UI.Core.CoreDispatcher.Main.RunAsync(
-				UI.Core.CoreDispatcherPriority.Normal, () => focusedElement.StartBringIntoView()
-			);
 		}
+
+		if (_paddedScrollContentPresenter is not null && _paddedScrollContentPresenter != scp)
+		{
+			// The occlusion no longer targets this presenter (focus moved or the pane hid): restore it.
+			_padScrollContentPresenter?.Dispose();
+			_padScrollContentPresenter = null;
+			_paddedScrollContentPresenter = null;
+		}
+
+		if (focusedElement is null)
+		{
+			return;
+		}
+
+		if (scp is not null)
+		{
+			// Deliberately no restore-then-re-pad for the same presenter: the occlusion is reported
+			// continuously while the keyboard animates, and restoring first would make Pad measure a
+			// viewport whose layout still reflects the previous padding. Pad compensates internally.
+			scp.UpdateLayout();
+			_padScrollContentPresenter = scp.Pad(OccludedRect);
+			_paddedScrollContentPresenter = scp;
+		}
+
+		// As we changed the layout properties of the ScrollContentPresenter, we need to wait for the next layout pass for
+		// the scrollable height to be updated.
+		_ = UI.Core.CoreDispatcher.Main.RunAsync(
+			UI.Core.CoreDispatcherPriority.Normal, () =>
+			{
+				focusedElement.UpdateLayout();
+				focusedElement.StartBringIntoView();
+			}
+		);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.OccludedPadding.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.OccludedPadding.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Uno.Disposables;
 using Windows.Foundation;
@@ -14,46 +10,60 @@ partial class ScrollContentPresenter
 	private Thickness _oldPadding;
 	private Thickness _occludedRectPadding;
 
-	internal IDisposable Pad(Rect occludedRect, Rect focusedElementRect)
+	internal IDisposable Pad(Rect occludedRect)
 	{
 #if __ANDROID__
 		var viewPortPoint = UIElement.TransformToVisual(this, null).TransformPoint(new Point());
 #else
 		var viewPortPoint = this.TransformToVisual(null).TransformPoint(new Point());
 #endif
-		var viewPortSize = new Size(ActualWidth, ActualHeight);
+		// A previous Pad can still be applied (the keyboard occlusion changes while it animates);
+		// it shrinks this presenter, so always reason on the unpadded viewport.
+		var viewPortSize = new Size(ActualWidth, ActualHeight + _occludedRectPadding.Bottom);
 		var viewPortRect = new Rect(viewPortPoint, viewPortSize);
 		var intersection = viewPortRect;
 		intersection.Intersect(occludedRect);
 
 		if (intersection.IsEmpty)
 		{
-			SetOccludedRectPadding(new Thickness());
+			RestoreOccludedRectPadding();
 		}
 		else
 		{
+			if (_occludedRectPadding == default)
+			{
 #if __ANDROID__
-			_oldPadding = Native.Padding;
+				_oldPadding = Native.Padding;
 #else
-			_oldPadding = Scroller.Padding;
+				_oldPadding = Scroller.Padding;
 #endif
-			var bottom = focusedElementRect.IsEmpty ?
-				intersection.Height :
-				Math.Max(intersection.Height - (viewPortRect.Height - focusedElementRect.Bottom), 0);
+			}
 
-			SetOccludedRectPadding(new Thickness(_oldPadding.Left, _oldPadding.Top, _oldPadding.Right, bottom));
+			// Shrink the viewport by the full occluded overlap: the minimal BringIntoView that
+			// follows then scrolls the focused element flush with the new bottom edge, which sits
+			// right above the keyboard.
+			ApplyPadding(new Thickness(_oldPadding.Left, _oldPadding.Top, _oldPadding.Right, _oldPadding.Bottom + intersection.Height));
+			_occludedRectPadding = new Thickness(0, 0, 0, intersection.Height);
 		}
 
-		return Disposable.Create(() => SetOccludedRectPadding(new Thickness()));
+		return Disposable.Create(RestoreOccludedRectPadding);
 	}
 
-	private void SetOccludedRectPadding(Thickness occludedRectPadding)
+	private void RestoreOccludedRectPadding()
 	{
-		_occludedRectPadding = occludedRectPadding;
+		if (_occludedRectPadding != default)
+		{
+			_occludedRectPadding = default;
+			ApplyPadding(_oldPadding);
+		}
+	}
+
+	private void ApplyPadding(Thickness padding)
+	{
 #if __ANDROID__
-		Native.Padding = occludedRectPadding;
+		Native.Padding = padding;
 #else
-		Scroller.Padding = occludedRectPadding;
+		Scroller.Padding = padding;
 #endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.mux.cs
@@ -98,7 +98,10 @@ public partial class ScrollContentPresenter
 		var viewportHeight = ViewportHeight;
 		var zoomFactor = Scroller.ZoomFactor;
 
-#if __ANDROID__ || __SKIA__ // Adjust for region blocked by keyboard.
+		// Adjust for region blocked by keyboard. Only needed where the occlusion padding is
+		// applied to the native view: on Skia it goes through Scroller.Padding -> Margin, which
+		// ViewportHeight already accounts for (subtracting it again would double-count).
+#if __ANDROID__
 		viewportHeight -= _occludedRectPadding.Bottom;
 #endif
 
@@ -191,7 +194,9 @@ public partial class ScrollContentPresenter
 		var viewportHeight = ViewportHeight;
 		var zoomFactor = Scroller.ZoomFactor;
 
-#if __ANDROID__ || __SKIA__ // Adjust for region blocked by keyboard.
+		// Adjust for region blocked by keyboard. Android-only: on Skia the occlusion padding
+		// flows into Margin, which ViewportHeight already subtracts (see OnBringIntoViewRequested).
+#if __ANDROID__
 		viewportHeight -= _occludedRectPadding.Bottom;
 #endif
 


### PR DESCRIPTION
**GitHub Issue:** Associated with an internal tracking issue (customer-reported).

## PR Type:

🐞 Bugfix

## What changed? 🚀

Fixes focus-related bugs specific to the **Skia WebAssembly** head on **touch devices (iPad Safari/Chrome)**. They stem from the single shared, invisible `<input id="uno-input">` that is positioned over the one `<canvas>` used for all text entry. None of them affect WinUI or the native (non-Skia) heads.

**1. Soft keyboard opens on a `TextBox` tap, then immediately dismisses itself.**
Touch browsers synthesize a trailing compatibility `mousedown` after a tap's focus change; it lands on the non-focusable canvas and its default action blurs the just-focused `#uno-input`, closing the keyboard. Uno already `preventDefault`s pointer events, but per the Pointer Events spec that does **not** suppress the synthesized mouse-compatibility events. Fix: a one-shot, touch/pen-scoped guard that swallows the single trailing canvas `mousedown`/`click` following the input's `focusin` (armed on focus, disarmed on the next `pointerdown`). Desktop mouse is unaffected — there `mousedown` precedes focus, so the guard never arms.

**2. `LostFocus` never fires when the keyboard is dismissed this way.**
Focus was driven one-way (managed → native): nothing listened for the browser blurring `#uno-input` on its own, so `FocusManager` stayed out of sync and `LostFocus` never fired. Fix: a `blur` listener on the input reports genuine, browser-initiated blurs to a new `OnNativeBlur` export, which calls `TextBox.Unfocus()` — the same terminal focus-clearing path the iOS and native WASM heads already use. Managed-initiated blurs are suppressed so a focus switch never clears the wrong control.

**3. A focused field near the bottom is not scrolled above the keyboard.**
The Skia WASM head had no `InputPane` producer — nothing ever set `InputPane.OccludedRect`, so the shared bring-into-view path never ran. Fix: a `visualViewport` listener computes the keyboard occlusion (gated on the invisible input being focused, so browser-chrome resizes don't count) and feeds `InputPane.OccludedRect`, mirroring the iOS/Android heads. This also makes `InputPane.Showing`/`Hiding` fire on this head, matching the other platforms.

### Follow-up fixes from on-device testing feedback

**4. Bring-into-view could leave the focused field partially (or fully) behind the keyboard — e.g. inside a side panel with its own `ScrollViewer`.**
Three compounding defects in the shared occlusion-padding path (`__SKIA__`; the consuming code, not the new producer):
- `ScrollContentPresenter.Pad` reduced the padding by the space below the focused element inside the viewport, so the minimal `BringIntoView` landed the element exactly that gap below the keyboard top. It now pads the **full** occluded overlap — which is what the Android head has always done (it passed `Rect.Empty`), so the parameter is gone and both platforms share one behavior.
- The `OnBringIntoViewRequested` path subtracted `_occludedRectPadding.Bottom` from the viewport on `__SKIA__` as well as `__ANDROID__`. On Skia the padding flows through `ScrollViewer.Padding` → presenter `Margin`, which `ViewportHeight` already reflects — subtracting again double-counted. Now Android-only (there the padding goes to the native view, invisible to managed layout).
- On WASM the occlusion streams per animation frame, and the old restore-then-re-pad cycle measured a viewport whose layout still reflected the previous pad — converging to roughly half the needed padding. `InputPane.skia.cs` now keeps the pad applied across re-pads of the same presenter (`Pad` compensates internally), settles layout before measuring and before `StartBringIntoView`, and only restores when the target presenter changes or the pane hides. Restoring now puts back the app's original `Padding` instead of resetting it to zero.

**5. Tapping another `TextBox` while the keyboard is up dismissed it.**
Moving focus A→B destroyed the shared input (`EndEntry(A)` blurred + removed it) before `StartEntry(B)` recreated it — a "nothing editable focused" gap that commits the soft-keyboard dismissal on iPadOS. Reworked lifecycle:
- `focus()` now **retargets the existing input in place** (value, `inputmode`, `enterkeyhint`) when the element kind matches — it never blurs, so the keyboard stays up.
- When the kind must change (input ↔ textarea ↔ password, or an IME composition is active), the new element is focused **before** the old one is removed — an editable-to-editable handoff with no gap.
- A managed blur (`EndEntry`) defers the real detach by one microtask; the `focus()` of a TextBox-to-TextBox move supersedes it. Genuine dismissals (tap outside, Done key) detach as before.
- `Blur` now carries the owning TextBox's handle so a stale blur can never tear down a successor's entry session, and the retarget path re-arms the fix-1 guard (it fires no `focusin`).

Drive-by: `updateSize()` set the invisible input's `width`/`height` without `px` units, so the styles were ignored; the input rect is what Safari uses as its scroll-reveal target, so it now gets real dimensions.

### Validation
- Compiles clean: the runtime head and the full `SamplesApp.Skia.WebAssembly.Browser` app (TS + C#).
- **Fix 4** is device-independent and covered by runtime tests on Skia Desktop, verified fail-before/pass-after by running them against the pre-fix code:
  - `Given_InputPane.When_Focused_TextBox_Has_Content_Below_Then_Scrolled_Above_Occlusion` — the reported side-panel geometry distilled: old code left the field ~38 px under the keyboard; now asserts the field rect ends fully above the occlusion.
  - `Given_InputPane.When_OccludedRect_Cleared_Then_ScrollViewer_Padding_Restored` — app-set `ScrollViewer.Padding` survives an occlusion cycle (additive pad, restore on clear).
  - `Given_InputPane.When_OccludedRect_Set_Then_Focused_TextBox_Scrolled_Into_View` strengthened with the same geometric assertion.
  - Regression sweep: all 55 `Given_ScrollViewer`/`Given_ScrollViewer_Zoom` runtime tests pass (outside keyboard scenarios the removed subtraction was always zero).
- **Fix 5**: full `Given_TextBox` runtime suite executed on Skia WASM in a browser — 148 passed / 27 skipped, and the only 2 failures are sub-pixel rounding assertions that fail **byte-identically on a baseline build without these changes** (pre-existing, environment-specific).
- Manual on-device sample `SoftKeyboardFocusTests` (GotFocus/LostFocus counters, live `OccludedRect` readout, bottom field). Fixes 1, 2, and 5, and the on-device occlusion math, reproduce **only on a real iPad**, so final device validation there is still required — this PR is a draft pending that.
- Android note: `Pad` keeps Android's existing full-intersection behavior; the additive padding and restore-on-clear are shared improvements validated by code review + the Skia runtime tests (no Android runtime run here).

Known remaining item from the same feedback (tracked for a follow-up): Safari auto-pans its visual viewport to reveal the DOM input when it sits below the keyboard, which can fight the XAML-level scroll (most visible with the taller multi-tab Safari header) and let the whole page pan instead of inner ScrollViewers.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
