### PR TITLE
fix(skia): Restore Compositor.IsSoftwareRenderer

### DIFF
--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -29,6 +29,12 @@ public partial class Compositor
 		UnoSkiaApi.Initialize();
 	}
 
+	/// <summary>
+	/// Whether the scene is rasterized on the CPU rather than by a GPU-backed surface.
+	/// Set by the active render backend once its renderer is selected; null until then.
+	/// Consulted while recording (e.g. by effect brushes to generate filters the target
+	/// surface can rasterize) and temporarily overridden by RenderTargetBitmap.
+	/// </summary>
 	internal bool? IsSoftwareRenderer { get; set; }
 
 	internal static bool SkipVisualTreePainting { get; set; }

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -34,6 +34,9 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 		SetEGLContextClientVersion(2);
 		SetEGLConfigChooser(8, 8, 8, 8, 0, 8);
 		SetRenderer(_renderer = new InternalRenderer());
+		// The scene is still presented through GL, but when not hardware-accelerated it is
+		// rasterized on the CPU first, which is what IsSoftwareRenderer reflects.
+		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = !_renderer.HardwareAccelerated;
 		ExploreByTouchHelper = new UnoExploreByTouchHelper(this);
 		TextInputPlugin = new TextInputPlugin(this);
 		ViewCompat.SetAccessibilityDelegate(this, ExploreByTouchHelper);
@@ -142,6 +145,8 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 		private const GRSurfaceOrigin SurfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
 		private readonly bool _hardwareAccelerated = FeatureConfiguration.Rendering.UseOpenGLOnSkiaAndroid;
+
+		internal bool HardwareAccelerated => _hardwareAccelerated;
 
 		private GRContext? _context;
 		private GRGlFramebufferInfo _glInfo;

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -52,6 +52,8 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 
 		SetWillNotDraw(false);
 		Holder!.AddCallback(this);
+
+		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = false;
 	}
 
 	public void InvalidateRender()

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Rendering/UnoSKMetalView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Rendering/UnoSKMetalView.cs
@@ -60,6 +60,8 @@ namespace Uno.UI.Runtime.Skia.AppleUIKit
 
 			_queue = queue;
 
+			Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = false;
+
 			ColorPixelFormat = MTLPixelFormat.BGRA8Unorm;
 			DepthStencilPixelFormat = MTLPixelFormat.Depth32Float_Stencil8;
 			SampleCount = 1;

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Hosting/FramebufferHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Hosting/FramebufferHost.cs
@@ -208,6 +208,8 @@ namespace Uno.UI.Runtime.Skia.Linux.FrameBuffer
 				_renderer = CreateSoftwareRenderer(mouseIndicatorOptions);
 			}
 
+			Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = _renderer is SoftwareRenderer;
+
 			WUX.Application.Start(CreateApp);
 		}
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
@@ -212,6 +212,7 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 					RenderSurfaceType = RenderSurfaceType.Software;
 					break;
 			}
+			Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = RenderSurfaceType == RenderSurfaceType.Software;
 			return result;
 		}
 		catch (Exception e)

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Rendering/BrowserRenderer.cs
@@ -40,6 +40,8 @@ internal partial class BrowserRenderer
 		{
 			throw new InvalidOperationException("Unable to create renderer");
 		}
+
+		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = _renderer is SoftwareBrowserRenderer;
 	}
 
 	internal void InvalidateRender()

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -113,6 +113,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 				? (IRenderer?)GlRenderer.TryCreateGlRenderer(_hwnd) ?? new SoftwareRenderer(_hwnd)
 				: new SoftwareRenderer(_hwnd);
 
+		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = _renderer.IsSoftware();
+
 		InitializeRenderThread();
 
 		RegisterForBackgroundColor();

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -499,6 +499,8 @@ internal partial class X11XamlRootHost : IXamlRootHost
 			_renderer = new X11SoftwareRenderer(this, TopX11Window);
 		}
 
+		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = _renderer is X11SoftwareRenderer;
+
 		// Only XI2.2 has touch events, and that's pretty much the only reason we're using XI2,
 		// so to make our assumptions simpler, we assume XI >= 2.2 or no XI at all.
 		var usingXi2 = GetXI2Details(display).version >= XIVersion.XI2_2;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Compositor.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Compositor.cs
@@ -1,0 +1,18 @@
+#if __SKIA__
+using Microsoft.UI.Composition;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
+
+[TestClass]
+public class Given_Compositor
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_Skia_Backend_Then_IsSoftwareRenderer_Populated()
+	{
+		// Every Skia render backend must report whether it rasterizes on the CPU as soon as
+		// its renderer is selected; effect brushes rely on this while recording the scene.
+		Assert.IsNotNull(Compositor.GetSharedCompositor().IsSoftwareRenderer);
+	}
+}
+#endif


### PR DESCRIPTION
**GitHub Issue:** closes #23896

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Compositor.IsSoftwareRenderer` has been permanently `null` since the rendering refactor to the record/replay architecture (b96ad06bba) dropped the per-paint setters, so every consumer — `CompositionEffectBrush`, `SkiaAcrylicBrush`, `CompositionCapabilities.AreEffectsFast()` — has been treating all targets as hardware-rendered, even when the scene is rasterized on the CPU. Only `RenderTargetBitmap` still set it, temporarily, around software re-records.

This PR makes every Skia backend set the flag at the point it commits to a renderer, including GPU-init fallback paths:

| Backend | Set where | Value |
|---|---|---|
| Win32 | `Win32WindowWrapper` after the Vulkan → OpenGL → Software cascade | existing `IRenderer.IsSoftware()` (previously unconsumed) |
| X11 | `X11XamlRootHost` after the Vulkan → GLX/EGL → Software cascade | `renderer is X11SoftwareRenderer` |
| macOS | `MacSkiaHost.InitializeMac` once `RenderSurfaceType` resolves | `RenderSurfaceType == Software` |
| WASM | `BrowserRenderer` ctor after WebGL/Software selection | `renderer is SoftwareBrowserRenderer` |
| Linux FrameBuffer | `FrameBufferHost` after DRM/Software selection | `renderer is SoftwareRenderer` |
| Android (GL) | `UnoSKCanvasView` ctor | `!UseOpenGLOnSkiaAndroid` — the scene is CPU-rasterized then blitted through GL, so it reports software |
| Android (Vulkan) | `UnoSKVulkanView` ctor | `false` |
| Apple UIKit | `UnoSKMetalView` ctor after Metal context creation | `false` (Metal-only) |

The flag matters at SKPicture **recording** time on the UI thread (effect brushes consult it to generate filters the target surface can rasterize), so setting it once at renderer selection is sufficient — renderer choice is fixed after startup on all backends. The `bool?` type and `RenderTargetBitmap`'s save/restore semantics are preserved, and the property now carries doc comments describing the contract.

Also adds a runtime test asserting the flag is populated on all Skia targets (fails before this change everywhere, passes after).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
