### PR TITLE
fix(win32): Return reliable UIA click points

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/ClickablePoint_Visualizer.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/ClickablePoint_Visualizer.xaml
@@ -1,0 +1,87 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Automation.ClickablePoint_Visualizer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid Padding="24" RowSpacing="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Spacing="8">
+            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="UI Automation clickable-point visualizer" />
+            <TextBlock
+                MaxWidth="760"
+                Text="The outlined marker is the expected button center. The solid marker is the point returned by AutomationPeer.GetClickablePoint. On Skia Win32, the readout also shows the raw provider point in physical screen pixels."
+                TextWrapping="Wrap" />
+            <Button
+                x:Name="RefreshButton"
+                HorizontalAlignment="Left"
+                AutomationProperties.AutomationId="ClickablePointVisualizerRefresh"
+                Click="OnRefreshClick"
+                Content="Refresh measurement" />
+        </StackPanel>
+
+        <Border
+            Grid.Row="1"
+            Padding="16"
+            Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
+            BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}"
+            BorderThickness="1"
+            CornerRadius="{ThemeResource ControlCornerRadius}">
+            <Grid
+                x:Name="VisualizationRoot"
+                MinWidth="620"
+                MinHeight="300"
+                SizeChanged="OnVisualizationSizeChanged">
+                <Button
+                    x:Name="TargetButton"
+                    Width="240"
+                    Height="80"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    AutomationProperties.AutomationId="ClickablePointVisualizerTarget"
+                    Content="UIA target button" />
+
+                <Canvas x:Name="MarkerCanvas" IsHitTestVisible="False">
+                    <Ellipse
+                        x:Name="ExpectedMarker"
+                        Width="32"
+                        Height="32"
+                        Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                        StrokeDashArray="2,2"
+                        StrokeThickness="3" />
+                    <Ellipse
+                        x:Name="ActualMarker"
+                        Width="18"
+                        Height="18"
+                        Fill="{ThemeResource SystemControlHighlightAccentBrush}"
+                        Visibility="Collapsed" />
+                    <Border
+                        x:Name="MissingPointBadge"
+                        Canvas.Left="12"
+                        Canvas.Top="12"
+                        Padding="10,6"
+                        Background="{ThemeResource SystemControlErrorTextForegroundBrush}"
+                        CornerRadius="{ThemeResource ControlCornerRadius}"
+                        Visibility="Collapsed">
+                        <TextBlock Foreground="{ThemeResource SystemControlForegroundAltHighBrush}" Text="Actual point is (0,0) - outside this page" />
+                    </Border>
+                </Canvas>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="2" Spacing="4">
+            <TextBlock x:Name="ResultText" Style="{StaticResource SubtitleTextBlockStyle}" />
+            <TextBlock x:Name="BoundsText" FontFamily="Consolas" />
+            <TextBlock x:Name="PeerPointText" FontFamily="Consolas" />
+            <TextBlock x:Name="ProviderPointText" FontFamily="Consolas" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/ClickablePoint_Visualizer.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/ClickablePoint_Visualizer.xaml.cs
@@ -1,0 +1,158 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Shapes;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+
+namespace UITests.Shared.Windows_UI_Xaml_Automation;
+
+[Sample(
+	"Automation",
+	Name = "ClickablePoint_Visualizer",
+	Description = "Visualizes AutomationPeer and Win32 UIA clickable-point coordinates.",
+	IsManualTest = true,
+	IgnoreInSnapshotTests = true)]
+public sealed partial class ClickablePoint_Visualizer : UserControl
+{
+	private const int UiaClickablePointPropertyId = 30014;
+
+	public ClickablePoint_Visualizer()
+	{
+		this.InitializeComponent();
+		Loaded += OnLoaded;
+	}
+
+	private void OnLoaded(object sender, RoutedEventArgs e)
+		=> DispatcherQueue.TryEnqueue(UpdateVisualization);
+
+	private void OnRefreshClick(object sender, RoutedEventArgs e)
+		=> UpdateVisualization();
+
+	private void OnVisualizationSizeChanged(object sender, SizeChangedEventArgs e)
+		=> DispatcherQueue.TryEnqueue(UpdateVisualization);
+
+	private void UpdateVisualization()
+	{
+		if (!IsLoaded || VisualizationRoot.ActualWidth <= 0 || VisualizationRoot.ActualHeight <= 0)
+		{
+			return;
+		}
+
+		var peer = FrameworkElementAutomationPeer.CreatePeerForElement(TargetButton);
+		if (peer is null)
+		{
+			ResultText.Text = "Automation peer is not available.";
+			return;
+		}
+
+		var bounds = peer.GetBoundingRectangle();
+		var point = peer.GetClickablePoint();
+		var rootOrigin = VisualizationRoot.TransformToVisual(null).TransformPoint(default);
+		var expectedX = bounds.X + bounds.Width / 2 - rootOrigin.X;
+		var expectedY = bounds.Y + bounds.Height / 2 - rootOrigin.Y;
+
+		PositionMarker(ExpectedMarker, expectedX, expectedY);
+
+		var hasPeerPoint = point.X != 0 || point.Y != 0;
+		ActualMarker.Visibility = hasPeerPoint ? Visibility.Visible : Visibility.Collapsed;
+		MissingPointBadge.Visibility = hasPeerPoint ? Visibility.Collapsed : Visibility.Visible;
+
+		if (hasPeerPoint)
+		{
+			PositionMarker(ActualMarker, point.X - rootOrigin.X, point.Y - rootOrigin.Y);
+		}
+
+		var providerMeasurement = GetWin32ProviderPoint(TargetButton);
+		ResultText.Text = !providerMeasurement.IsAvailable
+			? "Win32 provider comparison is not available on this target."
+			: providerMeasurement.Point is null
+				? "BEFORE behavior: Uno exposes no provider point, so UIA must choose a fallback."
+				: "AFTER behavior: Uno exposes the clipped center directly to UIA.";
+		BoundsText.Text = $"Button bounds: X={bounds.X:F1}, Y={bounds.Y:F1}, Width={bounds.Width:F1}, Height={bounds.Height:F1}";
+		PeerPointText.Text = $"AutomationPeer.GetClickablePoint: X={point.X:F1}, Y={point.Y:F1}";
+		ProviderPointText.Text = !providerMeasurement.IsAvailable
+			? "Win32 UIA_ClickablePoint (physical screen): <not applicable>"
+			: providerMeasurement.Point is { } rawPoint
+				? $"Win32 UIA_ClickablePoint (physical screen): X={rawPoint.X:F1}, Y={rawPoint.Y:F1}"
+				: "Win32 UIA_ClickablePoint (physical screen): <unset>";
+	}
+
+	private static void PositionMarker(FrameworkElement marker, double x, double y)
+	{
+		Canvas.SetLeft(marker, x - marker.Width / 2);
+		Canvas.SetTop(marker, y - marker.Height / 2);
+	}
+
+	private static (bool IsAvailable, Point? Point) GetWin32ProviderPoint(UIElement element)
+	{
+		try
+		{
+			var accessibilityRouter = FindType("Uno.UI.Runtime.Skia.AccessibilityRouter");
+			var resolve = accessibilityRouter?.GetMethod(
+				"Resolve",
+				BindingFlags.Static | BindingFlags.Public,
+				binder: null,
+				types: new[] { typeof(UIElement) },
+				modifiers: null);
+			var accessibility = resolve?.Invoke(null, new object[] { element });
+			if (accessibility is null)
+			{
+				return (false, null);
+			}
+
+			var getProvider = accessibility.GetType().GetMethod(
+				"GetOrCreateProvider",
+				BindingFlags.Instance | BindingFlags.NonPublic,
+				binder: null,
+				types: new[] { typeof(UIElement) },
+				modifiers: null);
+			var provider = getProvider?.Invoke(accessibility, new object[] { element });
+			if (provider is null)
+			{
+				return (false, null);
+			}
+
+			var getPropertyValue = provider.GetType().GetMethod(
+				"GetPropertyValue",
+				BindingFlags.Instance | BindingFlags.Public,
+				binder: null,
+				types: new[] { typeof(int) },
+				modifiers: null);
+
+			if (getPropertyValue is null)
+			{
+				return (false, null);
+			}
+
+			return getPropertyValue.Invoke(provider, new object[] { UiaClickablePointPropertyId }) is double[] { Length: 2 } point
+				? (true, new Point(point[0], point[1]))
+				: (true, null);
+		}
+		catch (TargetInvocationException)
+		{
+			return (false, null);
+		}
+		catch (ArgumentException)
+		{
+			return (false, null);
+		}
+	}
+
+	private static Type? FindType(string fullName)
+	{
+		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+		{
+			if (assembly.GetType(fullName, throwOnError: false) is { } type)
+			{
+				return type;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/ClickablePoint_Visualizer.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI.Xaml_Automation/ClickablePoint_Visualizer.xaml.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Linq;
 using System.Reflection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
@@ -144,15 +145,7 @@ public sealed partial class ClickablePoint_Visualizer : UserControl
 	}
 
 	private static Type? FindType(string fullName)
-	{
-		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-		{
-			if (assembly.GetType(fullName, throwOnError: false) is { } type)
-			{
-				return type;
-			}
-		}
-
-		return null;
-	}
+		=> AppDomain.CurrentDomain.GetAssemblies()
+			.Select(assembly => assembly.GetType(fullName, throwOnError: false))
+			.FirstOrDefault(type => type is not null);
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -479,7 +479,7 @@ internal class Win32RawElementProvider :
 
 					// Clip to ancestor scroll/clip regions so Narrator doesn't report
 					// bounds for content that is scrolled out of view.
-					logicalRect = ClipToAncestors(_owner, logicalRect);
+					logicalRect = ClipToElementAndAncestors(_owner, logicalRect);
 
 					if (logicalRect.Width <= 0 || logicalRect.Height <= 0)
 					{
@@ -1621,17 +1621,17 @@ internal class Win32RawElementProvider :
 	}
 
 	/// <summary>
-	/// Clips a logical rect to ancestor elements that have Clip set (e.g., ScrollViewer).
+	/// Clips a logical rect to the element and ancestors that have Clip set (e.g., ScrollViewer).
 	/// This prevents Narrator from reporting bounds for content scrolled out of view.
 	/// </summary>
-	private static Windows.Foundation.Rect ClipToAncestors(UIElement element, Windows.Foundation.Rect rect)
+	private static Windows.Foundation.Rect ClipToElementAndAncestors(UIElement element, Windows.Foundation.Rect rect)
 	{
-		var ancestor = element.GetParent() as UIElement;
-		while (ancestor is not null)
+		UIElement? current = element;
+		while (current is not null)
 		{
-			if (ancestor.Clip is RectangleGeometry clip)
+			if (current.Clip is RectangleGeometry clip)
 			{
-				var clipTransform = UIElement.GetTransform(from: ancestor, to: null);
+				var clipTransform = UIElement.GetTransform(from: current, to: null);
 				var clipRect = clipTransform.Transform(clip.Rect);
 				rect.Intersect(clipRect);
 				if (rect.IsEmpty)
@@ -1639,7 +1639,7 @@ internal class Win32RawElementProvider :
 					return new Windows.Foundation.Rect(0, 0, 0, 0);
 				}
 			}
-			ancestor = ancestor.GetParent() as UIElement;
+			current = current.GetParent() as UIElement;
 		}
 		return rect;
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Accessibility/Win32RawElementProvider.cs
@@ -467,19 +467,13 @@ internal class Win32RawElementProvider :
 				}
 				else
 				{
-					var visual = _owner.Visual;
-					var size = visual.Size;
-
-					// Compute the full element-to-root transform, then transform the
-					// local rect to get the axis-aligned bounding box in window coords.
-					// This correctly handles rotation, scale, and skew transforms.
-					var transform = UIElement.GetTransform(from: _owner, to: null);
-					var localRect = new Windows.Foundation.Rect(0, 0, size.X, size.Y);
-					logicalRect = transform.Transform(localRect);
-
-					// Clip to ancestor scroll/clip regions so Narrator doesn't report
-					// bounds for content that is scrolled out of view.
-					logicalRect = ClipToElementAndAncestors(_owner, logicalRect);
+					// Clipped global bounds — the same machinery as IsOffscreen and GetClickablePoint,
+					// so composition-level clips (e.g. the ScrollViewer viewport InsetClip and layout
+					// clips) are honored, not just the Clip DP.
+					logicalRect = _owner.GetGlobalBoundsWithOptions(
+						ignoreClipping: false,
+						ignoreClippingOnScrollContentPresenters: false,
+						useTargetInformation: false);
 
 					if (logicalRect.Width <= 0 || logicalRect.Height <= 0)
 					{
@@ -1618,30 +1612,6 @@ internal class Win32RawElementProvider :
 	public void AdviseEventRemoved(int eventId, int[]? propertyIds)
 	{
 		_accessibility.OnAdviseEventRemoved(eventId, propertyIds);
-	}
-
-	/// <summary>
-	/// Clips a logical rect to the element and ancestors that have Clip set (e.g., ScrollViewer).
-	/// This prevents Narrator from reporting bounds for content scrolled out of view.
-	/// </summary>
-	private static Windows.Foundation.Rect ClipToElementAndAncestors(UIElement element, Windows.Foundation.Rect rect)
-	{
-		UIElement? current = element;
-		while (current is not null)
-		{
-			if (current.Clip is RectangleGeometry clip)
-			{
-				var clipTransform = UIElement.GetTransform(from: current, to: null);
-				var clipRect = clipTransform.Transform(clip.Rect);
-				rect.Intersect(clipRect);
-				if (rect.IsEmpty)
-				{
-					return new Windows.Foundation.Rect(0, 0, 0, 0);
-				}
-			}
-			current = current.GetParent() as UIElement;
-		}
-		return rect;
 	}
 
 	private AutomationPeer? GetAutomationPeer()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -1,11 +1,14 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using static Private.Infrastructure.TestServices;
@@ -112,6 +115,211 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 			var automationPeer = new TestAutomationPeer();
 			var result = automationPeer.GetClickablePoint();
 			Assert.AreEqual(default, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_FrameworkElementAutomationPeer_GetClickablePoint()
+		{
+			var button = new Button
+			{
+				Content = "Subject",
+				Width = 120,
+				Height = 40,
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
+				Margin = new Thickness(40, 30, 0, 0),
+			};
+
+			try
+			{
+				await UITestHelper.Load(new Grid
+				{
+					Width = 300,
+					Height = 200,
+					Children = { button },
+				});
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(peer);
+
+				var bounds = peer.GetBoundingRectangle();
+				var point = peer.GetClickablePoint();
+
+				Assert.AreEqual(bounds.X + bounds.Width / 2, point.X, 0.5);
+				Assert.AreEqual(bounds.Y + bounds.Height / 2, point.Y, 0.5);
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_PartiallyClipped_FrameworkElementAutomationPeer_GetClickablePoint()
+		{
+			var button = new Button
+			{
+				Content = "Subject",
+				Width = 120,
+				Height = 40,
+			};
+			var scrollViewer = new ScrollViewer
+			{
+				Width = 80,
+				Height = 20,
+				HorizontalScrollMode = ScrollMode.Enabled,
+				HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
+				VerticalScrollMode = ScrollMode.Enabled,
+				VerticalScrollBarVisibility = ScrollBarVisibility.Hidden,
+				Content = button,
+			};
+
+			try
+			{
+				await UITestHelper.Load(scrollViewer);
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(peer);
+
+				var bounds = peer.GetBoundingRectangle();
+				var point = peer.GetClickablePoint();
+
+				Assert.IsTrue(bounds.Width < button.ActualWidth);
+				Assert.IsTrue(bounds.Height < button.ActualHeight);
+				Assert.AreEqual(bounds.X + bounds.Width / 2, point.X, 0.5);
+				Assert.AreEqual(bounds.Y + bounds.Height / 2, point.Y, 0.5);
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_SelfClipped_FrameworkElementAutomationPeer_GetClickablePoint()
+		{
+			var button = new Button
+			{
+				Content = "Subject",
+				Width = 120,
+				Height = 40,
+				Clip = new RectangleGeometry { Rect = new Rect(0, 0, 20, 40) },
+			};
+
+			try
+			{
+				await UITestHelper.Load(button);
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+				Assert.IsNotNull(peer);
+
+				var clippedBounds = button
+					.TransformToVisual(null)
+					.TransformBounds(new Rect(0, 0, 20, 40));
+				var point = peer.GetClickablePoint();
+
+				Assert.AreEqual(clippedBounds.X + clippedBounds.Width / 2, point.X, 0.5);
+				Assert.AreEqual(clippedBounds.Y + clippedBounds.Height / 2, point.Y, 0.5);
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWinUI)]
+		public async Task When_ToggleSwitchAutomationPeer_GetClickablePoint()
+		{
+			var toggleSwitch = new ToggleSwitch
+			{
+				Header = "Subject",
+				Width = 160,
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
+				Margin = new Thickness(40, 30, 0, 0),
+			};
+
+			try
+			{
+				await UITestHelper.Load(new Grid
+				{
+					Width = 300,
+					Height = 200,
+					Children = { toggleSwitch },
+				});
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(toggleSwitch);
+				Assert.IsNotNull(peer);
+
+				var thumb = toggleSwitch.FindFirstDescendant<Thumb>();
+				Assert.IsNotNull(thumb);
+
+				var thumbPeer = FrameworkElementAutomationPeer.CreatePeerForElement(thumb);
+				Assert.IsNotNull(thumbPeer);
+
+				var thumbBounds = thumbPeer.GetBoundingRectangle();
+				var point = peer.GetClickablePoint();
+
+				Assert.AreEqual(thumbBounds.X + thumbBounds.Width / 2, point.X, 0.5);
+				Assert.AreEqual(thumbBounds.Y + thumbBounds.Height / 2, point.Y, 0.5);
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+		public async Task When_ColorSpectrumAutomationPeer_GetClickablePoint()
+		{
+			var colorSpectrum = new ColorSpectrum
+			{
+				Width = 300,
+				Height = 160,
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
+				Margin = new Thickness(40, 30, 0, 0),
+			};
+
+			try
+			{
+				await UITestHelper.Load(new Grid
+				{
+					Width = 400,
+					Height = 240,
+					Children = { colorSpectrum },
+				});
+				await WindowHelper.WaitForIdle();
+
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(colorSpectrum);
+				Assert.IsNotNull(peer);
+
+				var inputTarget = colorSpectrum.FindFirstDescendant<FrameworkElement>("InputTarget")
+					?? throw new InvalidOperationException("ColorSpectrum InputTarget not found.");
+				var inputBounds = inputTarget
+					.TransformToVisual(null)
+					.TransformBounds(new Rect(0, 0, inputTarget.ActualWidth, inputTarget.ActualHeight));
+				var point = peer.GetClickablePoint();
+
+				Assert.IsTrue(inputBounds.Width > 0);
+				Assert.IsTrue(inputBounds.Height > 0);
+				Assert.AreEqual(inputBounds.X + inputBounds.Width / 2, point.X, 0.5);
+				Assert.AreEqual(inputBounds.Y + inputBounds.Height / 2, point.Y, 0.5);
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using static Private.Infrastructure.TestServices;
@@ -22,6 +24,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation;
 [PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
 public class Given_Win32Accessibility
 {
+	private const int UiaClickablePointPropertyId = 30014;
 	// UIA_NamePropertyId; Win32UIAutomationInterop is internal to the runtime assembly.
 	private const int UiaNamePropertyId = 30005;
 
@@ -71,6 +74,180 @@ public class Given_Win32Accessibility
 
 			AutomationProperties.SetName(unnamedButton, "Settings");
 			Assert.AreEqual("Settings", GetPropertyValue(unnamedProvider, UiaNamePropertyId));
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_Button_ClickablePoint_Is_Center_Of_BoundingRectangle()
+	{
+		var button = new Button
+		{
+			Content = "Subject",
+			Width = 120,
+			Height = 40,
+			HorizontalAlignment = HorizontalAlignment.Left,
+			VerticalAlignment = VerticalAlignment.Top,
+			Margin = new Thickness(40, 30, 0, 0),
+		};
+
+		try
+		{
+			await UITestHelper.Load(new Grid
+			{
+				Width = 300,
+				Height = 200,
+				Children = { button },
+			});
+
+			var accessibility = ResolveAccessibility(button)
+				?? throw new InvalidOperationException("Win32Accessibility instance not found.");
+			var provider = GetOrCreateProvider(accessibility, button)
+				?? throw new InvalidOperationException("Button provider not found.");
+			var clickablePoint = GetPropertyValue(provider, UiaClickablePointPropertyId) as double[]
+				?? throw new InvalidOperationException("Button clickable point not found.");
+			var bounds = GetBoundingRectangle(provider);
+
+			Assert.AreEqual(2, clickablePoint.Length);
+			Assert.AreEqual(bounds.Left + bounds.Width / 2, clickablePoint[0], 1);
+			Assert.AreEqual(bounds.Top + bounds.Height / 2, clickablePoint[1], 1);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_SelfClipped_Button_ClickablePoint_Uses_Clipped_Center()
+	{
+		var button = new Button
+		{
+			Content = "Subject",
+			Width = 120,
+			Height = 40,
+			HorizontalAlignment = HorizontalAlignment.Left,
+			VerticalAlignment = VerticalAlignment.Top,
+			Margin = new Thickness(40, 30, 0, 0),
+			Clip = new RectangleGeometry { Rect = new Rect(0, 0, 20, 40) },
+		};
+
+		try
+		{
+			await UITestHelper.Load(new Grid
+			{
+				Width = 300,
+				Height = 200,
+				Children = { button },
+			});
+
+			var accessibility = ResolveAccessibility(button)
+				?? throw new InvalidOperationException("Win32Accessibility instance not found.");
+			var provider = GetOrCreateProvider(accessibility, button)
+				?? throw new InvalidOperationException("Button provider not found.");
+			var clickablePoint = GetPropertyValue(provider, UiaClickablePointPropertyId) as double[]
+				?? throw new InvalidOperationException("Button clickable point not found.");
+			var providerBounds = GetBoundingRectangle(provider);
+			var logicalOwnerBounds = button
+				.TransformToVisual(null)
+				.TransformBounds(new Rect(0, 0, button.ActualWidth, button.ActualHeight));
+			var logicalClippedBounds = button
+				.TransformToVisual(null)
+				.TransformBounds(new Rect(0, 0, 20, 40));
+			var rasterizationScale = button.XamlRoot?.RasterizationScale
+				?? throw new InvalidOperationException("Button XamlRoot not found.");
+			var clientOriginX = providerBounds.Left - logicalOwnerBounds.X * rasterizationScale;
+			var clientOriginY = providerBounds.Top - logicalOwnerBounds.Y * rasterizationScale;
+
+			Assert.AreEqual(2, clickablePoint.Length);
+			Assert.AreEqual(clientOriginX + (logicalClippedBounds.X + logicalClippedBounds.Width / 2) * rasterizationScale, clickablePoint[0], 1);
+			Assert.AreEqual(clientOriginY + (logicalClippedBounds.Y + logicalClippedBounds.Height / 2) * rasterizationScale, clickablePoint[1], 1);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_FullySelfClipped_Button_Has_No_ClickablePoint_Or_Bounds()
+	{
+		var button = new Button
+		{
+			Content = "Subject",
+			Width = 120,
+			Height = 40,
+			Clip = new RectangleGeometry { Rect = new Rect(200, 0, 20, 40) },
+		};
+
+		try
+		{
+			await UITestHelper.Load(button);
+
+			var accessibility = ResolveAccessibility(button)
+				?? throw new InvalidOperationException("Win32Accessibility instance not found.");
+			var provider = GetOrCreateProvider(accessibility, button)
+				?? throw new InvalidOperationException("Button provider not found.");
+			var bounds = GetBoundingRectangle(provider);
+
+			Assert.IsNull(GetPropertyValue(provider, UiaClickablePointPropertyId));
+			Assert.AreEqual(0, bounds.Width);
+			Assert.AreEqual(0, bounds.Height);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_ColorSpectrum_ClickablePoint_Uses_Single_Dpi_Conversion()
+	{
+		var colorSpectrum = new ColorSpectrum
+		{
+			Width = 300,
+			Height = 160,
+			HorizontalAlignment = HorizontalAlignment.Left,
+			VerticalAlignment = VerticalAlignment.Top,
+			Margin = new Thickness(40, 30, 0, 0),
+		};
+
+		try
+		{
+			await UITestHelper.Load(new Grid
+			{
+				Width = 400,
+				Height = 240,
+				Children = { colorSpectrum },
+			});
+			await WindowHelper.WaitForIdle();
+
+			var accessibility = ResolveAccessibility(colorSpectrum)
+				?? throw new InvalidOperationException("Win32Accessibility instance not found.");
+			var provider = GetOrCreateProvider(accessibility, colorSpectrum)
+				?? throw new InvalidOperationException("ColorSpectrum provider not found.");
+			var clickablePoint = GetPropertyValue(provider, UiaClickablePointPropertyId) as double[]
+				?? throw new InvalidOperationException("ColorSpectrum clickable point not found.");
+			var providerBounds = GetBoundingRectangle(provider);
+			var logicalOwnerBounds = colorSpectrum
+				.TransformToVisual(null)
+				.TransformBounds(new Rect(0, 0, colorSpectrum.ActualWidth, colorSpectrum.ActualHeight));
+			var inputTarget = colorSpectrum.FindFirstDescendant<FrameworkElement>("InputTarget")
+				?? throw new InvalidOperationException("ColorSpectrum InputTarget not found.");
+			var logicalInputBounds = inputTarget
+				.TransformToVisual(null)
+				.TransformBounds(new Rect(0, 0, inputTarget.ActualWidth, inputTarget.ActualHeight));
+			var rasterizationScale = colorSpectrum.XamlRoot?.RasterizationScale
+				?? throw new InvalidOperationException("ColorSpectrum XamlRoot not found.");
+			var clientOriginX = providerBounds.Left - logicalOwnerBounds.X * rasterizationScale;
+			var clientOriginY = providerBounds.Top - logicalOwnerBounds.Y * rasterizationScale;
+
+			Assert.AreEqual(2, clickablePoint.Length);
+			Assert.AreEqual(clientOriginX + (logicalInputBounds.X + logicalInputBounds.Width / 2) * rasterizationScale, clickablePoint[0], 1);
+			Assert.AreEqual(clientOriginY + (logicalInputBounds.Y + logicalInputBounds.Height / 2) * rasterizationScale, clickablePoint[1], 1);
 		}
 		finally
 		{
@@ -167,6 +344,26 @@ public class Given_Win32Accessibility
 			?? throw new InvalidOperationException("Win32RawElementProvider.GetPropertyValue(int) not found.");
 		return getPropertyValue.Invoke(provider, new object[] { propertyId });
 	}
+
+	private static (double Left, double Top, double Width, double Height) GetBoundingRectangle(object provider)
+	{
+		var property = provider.GetType().GetProperty("BoundingRectangle", BindingFlags.Instance | BindingFlags.Public)
+			?? throw new InvalidOperationException("Win32RawElementProvider.BoundingRectangle not found.");
+		var rectangle = property.GetValue(provider)
+			?? throw new InvalidOperationException("Win32RawElementProvider.BoundingRectangle returned null.");
+		var rectangleType = rectangle.GetType();
+
+		return (
+			GetFieldValue(rectangleType, rectangle, "Left"),
+			GetFieldValue(rectangleType, rectangle, "Top"),
+			GetFieldValue(rectangleType, rectangle, "Width"),
+			GetFieldValue(rectangleType, rectangle, "Height"));
+	}
+
+	private static double GetFieldValue(Type type, object instance, string name)
+		=> Convert.ToDouble(
+			type.GetField(name, BindingFlags.Instance | BindingFlags.Public)?.GetValue(instance)
+				?? throw new InvalidOperationException($"{type.Name}.{name} not found."));
 
 	private static Type? FindType(string fullName)
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_Win32Accessibility.cs
@@ -256,6 +256,77 @@ public class Given_Win32Accessibility
 	}
 
 	[TestMethod]
+	public async Task When_Scrolled_Partially_Out_Of_View_BoundingRectangle_Is_Clipped()
+	{
+		var button = new Button
+		{
+			Width = 150,
+			Height = 60,
+			HorizontalAlignment = HorizontalAlignment.Left,
+			Content = "target",
+		};
+		var scrollViewer = new ScrollViewer
+		{
+			Width = 200,
+			Height = 200,
+			Content = new StackPanel
+			{
+				Children =
+				{
+					new Border { Height = 170 },
+					button,
+					new Border { Height = 400 },
+				},
+			},
+		};
+
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+			// Button occupies [170, 230] in content coordinates; viewport becomes [200, 400],
+			// leaving only the bottom 30 logical pixels of the button visible.
+			scrollViewer.ChangeView(null, 200, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+
+			var accessibility = ResolveAccessibility(button)
+				?? throw new InvalidOperationException("Win32Accessibility instance not found.");
+			var buttonProvider = GetOrCreateProvider(accessibility, button)
+				?? throw new InvalidOperationException("Button provider not found.");
+			var scrollViewerProvider = GetOrCreateProvider(accessibility, scrollViewer)
+				?? throw new InvalidOperationException("ScrollViewer provider not found.");
+
+			var scale = scrollViewer.XamlRoot?.RasterizationScale
+				?? throw new InvalidOperationException("XamlRoot not found.");
+			var buttonBounds = GetBoundingRectangle(buttonProvider);
+			var scrollViewerBounds = GetBoundingRectangle(scrollViewerProvider);
+
+			// Derive the client origin from the fully-visible ScrollViewer, then compare the
+			// button's provider bounds against the visible intersection in logical coordinates.
+			var logicalScrollViewerBounds = scrollViewer
+				.TransformToVisual(null)
+				.TransformBounds(new Rect(0, 0, scrollViewer.ActualWidth, scrollViewer.ActualHeight));
+			var logicalButtonBounds = button
+				.TransformToVisual(null)
+				.TransformBounds(new Rect(0, 0, button.ActualWidth, button.ActualHeight));
+			var expectedVisible = logicalButtonBounds;
+			expectedVisible.Intersect(logicalScrollViewerBounds);
+			var clientOriginX = scrollViewerBounds.Left - logicalScrollViewerBounds.X * scale;
+			var clientOriginY = scrollViewerBounds.Top - logicalScrollViewerBounds.Y * scale;
+
+			Assert.IsFalse(expectedVisible.IsEmpty, "The button should be partially visible.");
+			Assert.IsTrue(expectedVisible.Height < logicalButtonBounds.Height, "The button should be partially scrolled out of view.");
+			Assert.AreEqual(clientOriginX + expectedVisible.X * scale, buttonBounds.Left, 2 * scale);
+			Assert.AreEqual(clientOriginY + expectedVisible.Y * scale, buttonBounds.Top, 2 * scale);
+			Assert.AreEqual(expectedVisible.Width * scale, buttonBounds.Width, 2 * scale);
+			Assert.AreEqual(expectedVisible.Height * scale, buttonBounds.Height, 2 * scale);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
 	public void When_Traversing_Deep_Cyclic_Descendants()
 	{
 		var accessibilityType = FindType("Uno.UI.Runtime.Skia.Win32.Win32Accessibility")

--- a/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorSpectrum.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorSpectrum.cs
@@ -562,15 +562,20 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 		public Rect GetBoundingRectangle()
 		{
-			Rect localRect = new Rect(0, 0, 0, 0);
-
-			if (m_inputTarget is FrameworkElement inputTarget)
+			if (m_inputTarget is not FrameworkElement inputTarget)
 			{
-				localRect.Width = inputTarget.ActualWidth;
-				localRect.Height = inputTarget.ActualHeight;
+				return default;
 			}
 
-			var globalBounds = TransformToVisual(null).TransformBounds(localRect);
+#if __SKIA__
+			var globalBounds = inputTarget.GetGlobalBoundsWithOptions(
+				ignoreClipping: false,
+				ignoreClippingOnScrollContentPresenters: false,
+				useTargetInformation: false);
+#else
+			var localRect = new Rect(0, 0, inputTarget.ActualWidth, inputTarget.ActualHeight);
+			var globalBounds = inputTarget.TransformToVisual(null).TransformBounds(localRect);
+#endif
 			return SharedHelpers.ConvertDipsToPhysical(this, globalBounds);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorSpectrumAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorSpectrumAutomationPeer.cs
@@ -67,7 +67,11 @@ public partial class ColorSpectrumAutomationPeer : FrameworkElementAutomationPee
 	protected override Rect GetBoundingRectangleCore()
 	{
 		var boundingRectangle = ColorSpectrumOwner.GetBoundingRectangle();
+#if __SKIA__
+		return SharedHelpers.ConvertPhysicalToDips(ColorSpectrumOwner, boundingRectangle);
+#else
 		return boundingRectangle;
+#endif
 	}
 
 	protected override Point GetClickablePointCore()

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
@@ -360,20 +360,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal Point AutomationGetClickablePoint()
 		{
-			//UNO TODO: Implement AutomationGetClickablePoint on ToggleSwitch
-			return new Point();
-
-			//	auto clickableElement =
-			//		_tpThumb ?
-			//		static_cast<UIElement*>(_tpThumb.Cast<Thumb>()) :
-			//		static_cast<UIElement*>(this);
-
-			//	XPOINTF point;
-			//	static_cast<CUIElement*>(clickableElement.GetHandle()).GetClickablePointRasterizedClient(&point));
-
-			//	*result = { point.x, point.y };
-
-			//	return S_OK;
+			var clickableElement = _tpThumb is not null ? (UIElement)_tpThumb : this;
+			return clickableElement.GetClickablePointRasterizedClient();
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer() =>

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -156,10 +156,21 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		//UNO TODO: Implement GetClickablePointRasterizedClient on UIElement
 		internal Point GetClickablePointRasterizedClient()
 		{
-			return new Point();
+#if __SKIA__
+			var bounds = GetGlobalBoundsWithOptions(
+				ignoreClipping: false,
+				ignoreClippingOnScrollContentPresenters: false,
+				useTargetInformation: false,
+				skipPostPaintingClipping: false);
+
+			return bounds.Width > 0 && bounds.Height > 0
+				? new Point(bounds.X + bounds.Width / 2, bounds.Y + bounds.Height / 2)
+				: default;
+#else
+			return default;
+#endif
 		}
 
 		//TODO:MZ: Implement all these in appropriate places :-)
@@ -835,6 +846,17 @@ namespace Microsoft.UI.Xaml
 #endif
 
 		internal Rect GetGlobalBoundsWithOptions(bool ignoreClipping, bool ignoreClippingOnScrollContentPresenters, bool useTargetInformation)
+			=> GetGlobalBoundsWithOptions(
+				ignoreClipping,
+				ignoreClippingOnScrollContentPresenters,
+				useTargetInformation,
+				skipPostPaintingClipping: true);
+
+		private Rect GetGlobalBoundsWithOptions(
+			bool ignoreClipping,
+			bool ignoreClippingOnScrollContentPresenters,
+			bool useTargetInformation,
+			bool skipPostPaintingClipping)
 		{
 #if __SKIA__
 			if (!IsInLiveTree)
@@ -859,10 +881,8 @@ namespace Microsoft.UI.Xaml
 				// wrongly considered on-screen (IsOffscreen == false).
 				// TODO: ignoreClippingOnScrollContentPresenters is not yet honored separately. Every caller
 				// currently passes false, so the full ancestor clip (including ScrollContentPresenters) applies.
-				// skipPostPaintingClipping: true — a visual's own post-painting clip only affects its children,
-				// not the visual itself. Ancestor post-painting clips are still applied via the parent recursion.
 				var clipPath = _globalBoundsClipScratch ??= new SkiaSharp.SKPath();
-				Visual.GetTotalClipPath(clipPath, skipPostPaintingClipping: true);
+				Visual.GetTotalClipPath(clipPath, skipPostPaintingClipping);
 				var clip = clipPath.Bounds;
 
 				var left = Math.Max(globalBounds.Left, clip.Left);


### PR DESCRIPTION
**GitHub Issue:** unoplatform/kahua-private#494 (internal)

## PR Type:

🐞 Bugfix

## What changed? 🚀

UI Automation clients (Narrator, FlaUI-based test suites) intermittently received unusable click points from Uno apps on Skia/Win32: `IUIAutomationElement::GetClickablePoint` could fail with `UIA_E_NOCLICKABLEPOINT`, or return points on the very edge of an element (top edge / far-left) that miss the actual control.

**Root cause:** `UIElement.GetClickablePointRasterizedClient()` was an unimplemented stub returning `(0,0)`. `FrameworkElementAutomationPeer.GetClickablePointCore()` therefore produced `(0,0)` for every element, which the Win32 UIA provider treats as "unset" (`VT_EMPTY`). With no provider-supplied `UIA_ClickablePoint`, UIA clients fall back to their own bounding-rectangle heuristics, which are unreliable — producing edge points or no point at all.

**Changes:**

- Implement `UIElement.GetClickablePointRasterizedClient()` on Skia: returns the center of the element's clipped global bounds (empty bounds → `(0,0)`, i.e. no point). Adds a `skipPostPaintingClipping` overload of `GetGlobalBoundsWithOptions` so the element's own post-painting clip is honored for this calculation.
- `Win32RawElementProvider`: `BoundingRectangle` is now computed via `UIElement.GetGlobalBoundsWithOptions` (i.e. `Visual.GetTotalClipPath`), replacing the manual `UIElement.Clip` DP walk which missed composition-level clips — the ScrollViewer viewport `InsetClip`, layout/arrange clips, and ancestor post-painting clips. `BoundingRectangle`, `IsOffscreen`, and `GetClickablePoint` now share the same clipping machinery. Covered by a runtime test asserting clipped bounds for a button scrolled partially out of a ScrollViewer viewport (fails before, passes after).
- Implement `ToggleSwitch.AutomationGetClickablePoint()` (previously a stub) — returns the thumb's clickable point, matching WinUI.
- `ColorSpectrum` / `ColorSpectrumAutomationPeer`: `GetBoundingRectangle()` now uses clipped global bounds on Skia, and the peer converts the physical-pixel rect back to DIPs before deriving the clickable point (previously the rect was double-converted), so the reported point — center of the spectrum's input target, as in WinUI — is in the correct coordinate space.
- Runtime tests (`Given_AutomationPeer`, `Given_Win32Accessibility`) and a manual SamplesApp sample (`ClickablePoint_Visualizer`) that visualizes expected vs. reported points.

**Validation:** in addition to the runtime tests, the fix was validated against a customer app (Skia/Win32, Uno.WinUI 6.7.0-dev.857 with these binaries overridden) using a FlaUI 4.0 probe comparing `BoundingRectangle` centers against the raw `UIA_ClickablePoint` property and `GetClickablePoint`:

| | Raw `UIA_ClickablePoint` supplied | `GetClickablePoint` result |
|---|---|---|
| Before | 0/10 elements | UIA fallback; 2/10 points on the element's top edge (15–17 px off center) |
| After | 10/10 elements | Exact center of visible bounds (delta 0.0) for all elements |

Clicks performed at the reported points land correctly (verified via checkbox toggle state), and points remain exact centers after window resize / re-layout.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzMfZhd8E9NgJnzfTxsHZN
