### PR TITLE
fix(skia): Support Windows Alt codes in TextBox via CharacterReceived

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/ImplementedRoutedEvents/ImplementedRoutedEventsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/ImplementedRoutedEvents/ImplementedRoutedEventsGenerator.cs
@@ -101,6 +101,9 @@ public class ImplementedRoutedEventsGenerator : ISourceGenerator
 			_events.Add("OnKeyDown", keyRoutedEventArgs);
 			_events.Add("OnKeyUp", keyRoutedEventArgs);
 
+			var characterReceivedRoutedEventArgs = GetRequiredTypeByMetadataName(XamlConstants.Types.CharacterReceivedRoutedEventArgs);
+			_events.Add("OnCharacterReceived", characterReceivedRoutedEventArgs);
+
 			var routedEventArgs = GetRequiredTypeByMetadataName(XamlConstants.Types.RoutedEventArgs);
 			_events.Add("OnLostFocus", routedEventArgs);
 			_events.Add("OnGotFocus", routedEventArgs);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -173,6 +173,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string DragEventArgs = Namespaces.Base + ".DragEventArgs";
 			public const string RoutedEventArgs = Namespaces.Base + ".RoutedEventArgs";
 			public const string KeyRoutedEventArgs = Namespaces.Input + ".KeyRoutedEventArgs";
+			public const string CharacterReceivedRoutedEventArgs = Namespaces.Input + ".CharacterReceivedRoutedEventArgs";
 			public const string BringIntoViewRequestedEventArgs = Namespaces.Base + ".BringIntoViewRequestedEventArgs";
 
 			// Documents

--- a/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidKeyboardInputSource.cs
@@ -21,6 +21,7 @@ internal sealed class AndroidKeyboardInputSource : IUnoKeyboardInputSource
 
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? IUnoKeyboardInputSource.CharacterReceived { add { } remove { } }
 
 	internal bool OnNativeKeyEvent(KeyEvent e)
 	{

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/UnoKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/UnoKeyboardInputSource.cs
@@ -25,6 +25,7 @@ internal sealed class UnoKeyboardInputSource : IUnoKeyboardInputSource
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
 #pragma warning restore CS0067
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? IUnoKeyboardInputSource.CharacterReceived { add { } remove { } }
 
 	public bool TryHandlePresses(NSSet<UIPress> presses, UIPressesEvent evt, AppleUIKitWindow window)
 	{

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Devices/Input/FrameBufferKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Devices/Input/FrameBufferKeyboardInputSource.cs
@@ -22,6 +22,7 @@ internal class FrameBufferKeyboardInputSource : IUnoKeyboardInputSource
 
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? IUnoKeyboardInputSource.CharacterReceived { add { } remove { } }
 
 	private readonly IntPtr _xkbState;
 	private HashSet<libinput_key> _pressedKeys = new HashSet<libinput_key>();

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -390,6 +390,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? IUnoKeyboardInputSource.CharacterReceived { add { } remove { } }
 
 	private static KeyEventArgs CreateArgs(VirtualKey key, VirtualKeyModifiers mods, uint scanCode, ushort unicode)
 	{

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserKeyboardInputSource.cs
@@ -15,6 +15,7 @@ internal partial class BrowserKeyboardInputSource : IUnoKeyboardInputSource
 
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? IUnoKeyboardInputSource.CharacterReceived { add { } remove { } }
 
 	internal static bool LastTabWasForward { get; private set; } = true;
 
@@ -39,7 +40,7 @@ internal partial class BrowserKeyboardInputSource : IUnoKeyboardInputSource
 	{
 		if (_log.IsEnabled(LogLevel.Debug))
 		{
-			_log.Debug($"Native Keyboard Event: down={down}, ctrl={ctrl}, shift={shift}, meta={meta}, code={code}, key=${key}");
+			_log.Debug($"Native Keyboard Event: down={down}, ctrl={ctrl}, shift={shift}, alt={alt}, meta={meta}, code={code}, key={key}");
 		}
 
 		// Ensure that the async context is set properly, since we're raising

--- a/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Keyboard.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Keyboard.cs
@@ -11,6 +11,7 @@ internal partial class Win32WindowWrapper : IUnoKeyboardInputSource
 {
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+	public event TypedEventHandler<object, CharacterReceivedEventArgs>? CharacterReceived;
 
 	private void OnKey(WPARAM wParam, LPARAM lParam, bool down)
 	{
@@ -48,6 +49,22 @@ internal partial class Win32WindowWrapper : IUnoKeyboardInputSource
 			}
 		}
 
+		// A WM_CHAR paired with a key *release* can't be delivered through KeyDown — in practice
+		// it's an Alt+numpad code, composed by TranslateMessage when Alt is released. Deliver it
+		// through CharacterReceived and keep it out of the key-up args (WinUI key-up events don't
+		// carry a character).
+		char? keyUpCommitChar = null;
+		if (!down && unicodeKey is { } keyUpChar)
+		{
+			// Unlike the keydown filter above, don't deliver '\r'/'\n' (e.g. Alt+013) —
+			// Enter handling is keydown-based.
+			if (!char.IsControl(keyUpChar))
+			{
+				keyUpCommitChar = keyUpChar;
+			}
+			unicodeKey = null;
+		}
+
 		var args = new KeyEventArgs(
 			"keyboard",
 			key,
@@ -62,6 +79,20 @@ internal partial class Win32WindowWrapper : IUnoKeyboardInputSource
 		else
 		{
 			KeyUp?.Invoke(this, args);
+
+			if (keyUpCommitChar is { } c)
+			{
+				// IsKeyReleased mirrors the real WM_CHAR's lParam transition bit (that of the Alt
+				// key-up) and lets consumers distinguish this from key-press-composed characters.
+				CharacterReceived?.Invoke(this, new CharacterReceivedEventArgs(
+					c,
+					new CorePhysicalKeyStatus
+					{
+						ScanCode = (uint)((lParam.Value & 0x00FF0000) >> 16),
+						RepeatCount = 1,
+						IsKeyReleased = true,
+					}));
+			}
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Keyboard.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Devices/Input/Win32WindowWrapper.Keyboard.cs
@@ -82,8 +82,9 @@ internal partial class Win32WindowWrapper : IUnoKeyboardInputSource
 
 			if (keyUpCommitChar is { } c)
 			{
-				// IsKeyReleased mirrors the real WM_CHAR's lParam transition bit (that of the Alt
-				// key-up) and lets consumers distinguish this from key-press-composed characters.
+				// IsKeyReleased and WasKeyDown mirror the real WM_CHAR's lParam transition and
+				// previous-key-state bits (those of the Alt key-up), and let consumers distinguish
+				// this from key-press-composed characters.
 				CharacterReceived?.Invoke(this, new CharacterReceivedEventArgs(
 					c,
 					new CorePhysicalKeyStatus
@@ -91,6 +92,7 @@ internal partial class Win32WindowWrapper : IUnoKeyboardInputSource
 						ScanCode = (uint)((lParam.Value & 0x00FF0000) >> 16),
 						RepeatCount = 1,
 						IsKeyReleased = true,
+						WasKeyDown = true,
 					}));
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11KeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Devices/Input/X11KeyboardInputSource.cs
@@ -10,6 +10,7 @@ internal class X11KeyboardInputSource : IUnoKeyboardInputSource
 {
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? IUnoKeyboardInputSource.CharacterReceived { add { } remove { } }
 
 	private readonly X11XamlRootHost _host;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -22,6 +23,7 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI;
+using Windows.UI.Core;
 using Windows.UI.Input.Preview.Injection;
 using Uno.ApplicationModel.DataTransfer;
 using Uno.Foundation.Extensibility;
@@ -5950,6 +5952,266 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_IME_Direct_Commit_Without_Composition()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			var fake = new FakeImeTextBoxExtension();
+			using var imeDisposable = TextBox.SetImeExtensionForTesting(fake);
+
+			var SUT = new TextBox { Text = "ab" };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			SUT.SelectionStart = 1;
+			await WindowHelper.WaitForIdle();
+
+			// An Alt+numpad code on Win32 (or a single-key IME commit on X11/macOS) is
+			// delivered as Started → Completed → Ended with no intermediate updates.
+			fake.SimulateDirectCommit("š");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("ašb", SUT.Text);
+			Assert.AreEqual(2, SUT.SelectionStart);
+			Assert.IsFalse(SUT.IsComposing);
+
+			// A direct commit replaces the active selection, like regular typing.
+			SUT.SelectAll();
+			await WindowHelper.WaitForIdle();
+			fake.SimulateDirectCommit("é");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("é", SUT.Text);
+			Assert.AreEqual(1, SUT.SelectionStart);
+			Assert.IsFalse(SUT.IsComposing);
+		}
+
+		[TestMethod]
+		public async Task When_IME_Direct_Commit_ReadOnly()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			var fake = new FakeImeTextBoxExtension();
+			using var imeDisposable = TextBox.SetImeExtensionForTesting(fake);
+
+			var SUT = new TextBox { Text = "ab", IsReadOnly = true };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			fake.SimulateDirectCommit("š");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("ab", SUT.Text);
+			Assert.IsFalse(SUT.IsComposing);
+		}
+
+		[TestMethod]
+		public async Task When_IME_Direct_Commit_Without_Focused_TextBox()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			var fake = new FakeImeTextBoxExtension();
+			using var imeDisposable = TextBox.SetImeExtensionForTesting(fake);
+
+			var SUT = new TextBox { Text = "ab" };
+			var button = new Button { Content = "other" };
+			WindowHelper.WindowContent = new StackPanel { Children = { SUT, button } };
+			await WindowHelper.WaitForLoaded(SUT);
+			button.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			fake.SimulateDirectCommit("š");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("ab", SUT.Text);
+			Assert.IsFalse(SUT.IsComposing);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22254")]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
+		public async Task When_Win32_AltCode_Char_Arrives_On_KeyUp()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var compositionEvents = 0;
+			SUT.TextCompositionStarted += (_, _) => compositionEvents++;
+			SUT.TextCompositionEnded += (_, _) => compositionEvents++;
+
+			CharacterReceivedRoutedEventArgs characterReceivedArgs = null;
+			SUT.AddHandler(
+				UIElement.CharacterReceivedEvent,
+				new TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs>((_, e) => characterReceivedArgs = e),
+				handledEventsToo: true);
+
+			var hwnd = ((Uno.UI.NativeElementHosting.Win32NativeWindow)WindowHelper.CurrentTestWindow.NativeWindow!).Hwnd;
+
+			// An Alt+numpad code (e.g. Alt+0154 → 'š') reaches the app as a WM_CHAR that
+			// TranslateMessage queues behind the Alt key-up, not behind a keydown. Post that
+			// exact message pair so the real WndProc/event-loop path handles it.
+			const uint WM_KEYUP = 0x0101;
+			const uint WM_CHAR = 0x0102;
+			const nuint VK_MENU = 0x12;
+			PostMessage(hwnd, WM_KEYUP, VK_MENU, 0);
+			PostMessage(hwnd, WM_CHAR, 'š', 0);
+
+			await WindowHelper.WaitFor(() => SUT.Text.Length > 0);
+			Assert.AreEqual("š", SUT.Text);
+			Assert.IsFalse(SUT.IsComposing);
+
+			// The character is delivered through CharacterReceived, not through a fake IME composition.
+			Assert.AreEqual(0, compositionEvents);
+			Assert.IsNotNull(characterReceivedArgs);
+			Assert.AreEqual('š', characterReceivedArgs.Character);
+			Assert.IsTrue(characterReceivedArgs.KeyStatus.IsKeyReleased);
+			Assert.IsTrue(characterReceivedArgs.Handled);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22254")]
+		public async Task When_CharacterReceived_On_KeyRelease_Inserts()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox { Text = "ab" };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			SUT.SelectionStart = 1;
+			await WindowHelper.WaitForIdle();
+
+			var compositionEvents = 0;
+			SUT.TextCompositionStarted += (_, _) => compositionEvents++;
+			SUT.TextCompositionEnded += (_, _) => compositionEvents++;
+
+			// A character composed on a key release (Windows Alt+numpad code) arrives without
+			// an associated keydown; TextBox inserts it from CharacterReceived.
+			var args = new CharacterReceivedRoutedEventArgs(SUT, 'š', new CorePhysicalKeyStatus { IsKeyReleased = true, RepeatCount = 1 });
+			SUT.SafeRaiseEvent(UIElement.CharacterReceivedEvent, args);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("ašb", SUT.Text);
+			Assert.AreEqual(2, SUT.SelectionStart);
+			Assert.IsTrue(args.Handled);
+			Assert.AreEqual(0, compositionEvents);
+
+			// A key-release character replaces the active selection, like regular typing.
+			SUT.SelectAll();
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.CharacterReceivedEvent, new CharacterReceivedRoutedEventArgs(SUT, 'é', new CorePhysicalKeyStatus { IsKeyReleased = true, RepeatCount = 1 }));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("é", SUT.Text);
+			Assert.AreEqual(1, SUT.SelectionStart);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22254")]
+		public async Task When_CharacterReceived_On_KeyRelease_ReadOnly()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox { Text = "ab", IsReadOnly = true };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var args = new CharacterReceivedRoutedEventArgs(SUT, 'š', new CorePhysicalKeyStatus { IsKeyReleased = true, RepeatCount = 1 });
+			SUT.SafeRaiseEvent(UIElement.CharacterReceivedEvent, args);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("ab", SUT.Text);
+			Assert.IsFalse(args.Handled);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/22254")]
+		public async Task When_CharacterReceived_On_KeyRelease_PasswordBox()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new PasswordBox();
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			// Alt+numpad codes work in PasswordBox on WinUI; CharacterReceived doesn't depend
+			// on an IME session, so the same path serves PasswordBox.
+			SUT.SafeRaiseEvent(UIElement.CharacterReceivedEvent, new CharacterReceivedRoutedEventArgs(SUT, 'š', new CorePhysicalKeyStatus { IsKeyReleased = true, RepeatCount = 1 }));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("š", SUT.Password);
+		}
+
+		[TestMethod]
+		public async Task When_CharacterReceived_On_KeyPress_Does_Not_Insert()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			// Characters delivered with a key press are inserted by the KeyDown path; the
+			// CharacterReceived class handler must not insert them a second time.
+			var args = new CharacterReceivedRoutedEventArgs(SUT, 'a', new CorePhysicalKeyStatus { RepeatCount = 1 });
+			SUT.SafeRaiseEvent(UIElement.CharacterReceivedEvent, args);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("", SUT.Text);
+			Assert.IsFalse(args.Handled);
+		}
+
+		[TestMethod]
+		public async Task When_Typing_Raises_CharacterReceived_After_KeyDown()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var sequence = new List<string>();
+			SUT.AddHandler(
+				UIElement.KeyDownEvent,
+				new KeyEventHandler((_, _) => sequence.Add("KeyDown")),
+				handledEventsToo: true);
+			SUT.AddHandler(
+				UIElement.CharacterReceivedEvent,
+				new TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs>((_, e) => sequence.Add($"CharacterReceived:{e.Character}")),
+				handledEventsToo: true);
+
+			var keyboard = WindowHelper.XamlRoot.VisualTree.ContentRoot.InputManager.Keyboard;
+			keyboard.OnKeyTestingOnly(new KeyEventArgs("test", VirtualKey.A, VirtualKeyModifiers.None, new CorePhysicalKeyStatus(), unicodeKey: 'a'), true);
+			await WindowHelper.WaitForIdle();
+			keyboard.OnKeyTestingOnly(new KeyEventArgs("test", VirtualKey.A, VirtualKeyModifiers.None, new CorePhysicalKeyStatus(), unicodeKey: 'a'), false);
+			await WindowHelper.WaitForIdle();
+
+			// The character is inserted exactly once (by the KeyDown path), and CharacterReceived
+			// is raised after KeyDown, matching the WM_KEYDOWN → WM_CHAR ordering on Windows.
+			Assert.AreEqual("a", SUT.Text);
+			CollectionAssert.AreEqual(new[] { "KeyDown", "CharacterReceived:a" }, sequence);
+		}
+
+		[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+		private static extern bool PostMessage(nint hWnd, uint msg, nuint wParam, nint lParam);
+
+		[TestMethod]
 		public async Task When_IME_Composition_Cancelled()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -6310,6 +6572,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			public void SimulateCompositionComplete(string text)
 			{
 				IsComposing = false;
+				CompositionCompleted?.Invoke(this, new ImeCompositionEventArgs(text));
+				CompositionEnded?.Invoke(this, EventArgs.Empty);
+			}
+
+			public void SimulateDirectCommit(string text)
+			{
+				CompositionStarted?.Invoke(this, EventArgs.Empty);
 				CompositionCompleted?.Invoke(this, new ImeCompositionEventArgs(text));
 				CompositionEnded?.Invoke(this, EventArgs.Empty);
 			}

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/Control.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/Control.cs
@@ -223,13 +223,7 @@ namespace Microsoft.UI.Xaml.Controls
 #endif
 		// Skipping already declared method Microsoft.UI.Xaml.Controls.Control.OnGotFocus(Microsoft.UI.Xaml.RoutedEventArgs)
 		// Skipping already declared method Microsoft.UI.Xaml.Controls.Control.OnLostFocus(Microsoft.UI.Xaml.RoutedEventArgs)
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		protected virtual void OnCharacterReceived(global::Microsoft.UI.Xaml.Input.CharacterReceivedRoutedEventArgs e)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Controls.Control", "OnCharacterReceived(CharacterReceivedRoutedEventArgs e)");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.Controls.Control.OnCharacterReceived(Microsoft.UI.Xaml.Input.CharacterReceivedRoutedEventArgs)
 		// Skipping already declared method Microsoft.UI.Xaml.Controls.Control.OnDragEnter(Microsoft.UI.Xaml.DragEventArgs)
 		// Skipping already declared method Microsoft.UI.Xaml.Controls.Control.OnDragLeave(Microsoft.UI.Xaml.DragEventArgs)
 		// Skipping already declared method Microsoft.UI.Xaml.Controls.Control.OnDragOver(Microsoft.UI.Xaml.DragEventArgs)

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/UIElement.cs
@@ -36,16 +36,7 @@ namespace Microsoft.UI.Xaml
 #endif
 		// Skipping already declared property CanBeScrollAnchorProperty
 		// Skipping already declared property CanDragProperty
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static global::Microsoft.UI.Xaml.RoutedEvent CharacterReceivedEvent
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.UI.Xaml.UIElement", "CharacterReceivedEvent");
-			}
-		}
-#endif
+		// Skipping already declared property CharacterReceivedEvent
 		// Skipping already declared property ClipProperty
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
@@ -1099,22 +1090,7 @@ namespace Microsoft.UI.Xaml
 #endif
 		// Skipping already declared event Microsoft.UI.Xaml.UIElement.AccessKeyInvoked
 		// Skipping already declared event Microsoft.UI.Xaml.UIElement.BringIntoViewRequested
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public event global::Windows.Foundation.TypedEventHandler<global::Microsoft.UI.Xaml.UIElement, global::Microsoft.UI.Xaml.Input.CharacterReceivedRoutedEventArgs> CharacterReceived
-		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.UIElement", "event CharacterReceived");
-			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.UIElement", "event CharacterReceived");
-			}
-		}
-#endif
+		// Skipping already declared event Microsoft.UI.Xaml.UIElement.CharacterReceived
 		// Skipping already declared event Microsoft.UI.Xaml.UIElement.ContextCanceled
 		// Skipping already declared event Microsoft.UI.Xaml.UIElement.ContextRequested
 		// Skipping already declared event Microsoft.UI.Xaml.UIElement.DoubleTapped

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -466,6 +466,11 @@ namespace Microsoft.UI.Xaml.Controls
 				KeyUp += OnKeyUpHandler;
 			}
 
+			if (HasFlag(implementedEvents, RoutedEventFlag.CharacterReceived))
+			{
+				CharacterReceived += OnCharacterReceivedHandler;
+			}
+
 			if (HasFlag(implementedEvents, RoutedEventFlag.GotFocus))
 			{
 				GotFocus += OnGotFocusHandler;
@@ -1112,6 +1117,7 @@ namespace Microsoft.UI.Xaml.Controls
 		protected virtual void OnKeyDown(KeyRoutedEventArgs e) { }
 		private protected virtual void OnPostKeyDown(KeyRoutedEventArgs e) { }
 		protected virtual void OnKeyUp(KeyRoutedEventArgs e) { }
+		protected virtual void OnCharacterReceived(CharacterReceivedRoutedEventArgs e) { }
 		protected virtual void OnGotFocus(RoutedEventArgs e) { }
 		protected virtual void OnLostFocus(RoutedEventArgs e) { }
 
@@ -1202,6 +1208,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static readonly KeyEventHandler OnKeyUpHandler =
 			(object sender, KeyRoutedEventArgs args) => ((Control)sender).OnKeyUp(args);
+
+		private static readonly TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs> OnCharacterReceivedHandler =
+			(UIElement sender, CharacterReceivedRoutedEventArgs args) => ((Control)sender).OnCharacterReceived(args);
 
 		private static readonly RoutedEventHandler OnGotFocusHandler =
 			(object sender, RoutedEventArgs args) => ((Control)sender).OnGotFocus(args);
@@ -1336,6 +1345,11 @@ namespace Microsoft.UI.Xaml.Controls
 			if (GetIsEventOverrideImplemented<KeyRoutedEventArgs>(OnKeyUp))
 			{
 				result |= RoutedEventFlag.KeyUp;
+			}
+
+			if (GetIsEventOverrideImplemented(OnCharacterReceived))
+			{
+				result |= RoutedEventFlag.CharacterReceived;
 			}
 
 			if (GetIsEventOverrideImplemented(OnLostFocus))

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -1210,6 +1210,15 @@ namespace Microsoft.UI.Xaml.Controls
 			OnKeyDownPartial(args);
 		}
 
+		partial void OnCharacterReceivedPartial(CharacterReceivedRoutedEventArgs e);
+
+		protected override void OnCharacterReceived(CharacterReceivedRoutedEventArgs e)
+		{
+			base.OnCharacterReceived(e);
+
+			OnCharacterReceivedPartial(e);
+		}
+
 		private protected override void OnPostKeyDown(KeyRoutedEventArgs args)
 		{
 #if __SKIA__

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -933,10 +933,8 @@ public partial class TextBox : ITextSelectionGripperHost
 		}
 	}
 
-	protected override void OnCharacterReceived(CharacterReceivedRoutedEventArgs e)
+	partial void OnCharacterReceivedPartial(CharacterReceivedRoutedEventArgs e)
 	{
-		base.OnCharacterReceived(e);
-
 		// Characters produced by a key press are inserted by OnKeyDownSkia. Only characters
 		// that can't be delivered through a key press — composed on a key release, i.e.
 		// Windows Alt+numpad codes — arrive solely through this event.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -933,6 +933,42 @@ public partial class TextBox : ITextSelectionGripperHost
 		}
 	}
 
+	protected override void OnCharacterReceived(CharacterReceivedRoutedEventArgs e)
+	{
+		base.OnCharacterReceived(e);
+
+		// Characters produced by a key press are inserted by OnKeyDownSkia. Only characters
+		// that can't be delivered through a key press — composed on a key release, i.e.
+		// Windows Alt+numpad codes — arrive solely through this event.
+		if (!_isSkiaTextBox || e.Handled || e.OriginalSource != this || !e.KeyStatus.IsKeyReleased)
+		{
+			return;
+		}
+
+		if (IsReadOnly || HasPointerCapture || ShouldSwallowKeyDuringComposition || char.IsControl(e.Character))
+		{
+			return;
+		}
+
+		e.Handled = true;
+		TrySetCurrentlyTyping(true);
+
+		var (selectionStart, selectionLength) = _selection.selectionEndsAtTheStart
+			? (_selection.start + _selection.length, -_selection.length)
+			: (_selection.start, _selection.length);
+		var text = Text;
+		var start = Math.Min(selectionStart, selectionStart + selectionLength);
+		var end = Math.Max(selectionStart, selectionStart + selectionLength);
+		text = text[..start] + e.Character + text[end..];
+
+		_suppressCurrentlyTyping = true;
+		_clearHistoryOnTextChanged = false;
+		_pendingSelection = (start + 1, 0);
+		ProcessTextInput(text);
+		_clearHistoryOnTextChanged = true;
+		_suppressCurrentlyTyping = false;
+	}
+
 	private void OnKeyDownSkia(KeyRoutedEventArgs args)
 	{
 		if (SelectionFlyout?.IsOpen == true)

--- a/src/Uno.UI/UI/Xaml/Input/CharacterReceivedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/CharacterReceivedRoutedEventArgs.cs
@@ -14,6 +14,13 @@ namespace Microsoft.UI.Xaml.Input
 			KeyStatus = keyStatus;
 		}
 
+		internal CharacterReceivedRoutedEventArgs(object originalSource, char character, CorePhysicalKeyStatus keyStatus)
+			: base(originalSource)
+		{
+			Character = character;
+			KeyStatus = keyStatus;
+		}
+
 		/// <summary>
 		/// Gets or sets a value that marks the routed event as handled.
 		/// A true value for Handled prevents most handlers along the event

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
@@ -47,6 +47,7 @@ partial class InputManager
 
 			_source.KeyDown += (_, e) => OnKey(e, true);
 			_source.KeyUp += (_, e) => OnKey(e, false);
+			_source.CharacterReceived += (_, e) => OnCharacterReceived(e);
 		}
 
 		private void OnKey(KeyEventArgs args, bool down)
@@ -97,6 +98,15 @@ partial class InputManager
 					args.KeyboardModifiers);
 			}
 
+			// On Windows a character produced by a key press is delivered as a separate message
+			// (WM_CHAR follows WM_KEYDOWN), so CharacterReceived is raised after KeyDown completed,
+			// targeting whichever element is focused by then. Note: raised regardless of the KeyDown
+			// Handled state, as WM_CHAR generation is independent of app-side key handling.
+			if (down && args.UnicodeKey is { } character)
+			{
+				RaiseCharacterReceived(character, args.KeyStatus);
+			}
+
 			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
 				var methodName = down ? "CoreWindow_KeyDown" : "CoreWindow_KeyUp";
@@ -111,6 +121,25 @@ partial class InputManager
 			}
 
 			args.Handled = routedArgs.Handled;
+		}
+
+		/// <summary>
+		/// Handles a composed character that never went through a key press,
+		/// e.g. a Windows Alt+numpad code composed when Alt is released.
+		/// </summary>
+		private void OnCharacterReceived(CharacterReceivedEventArgs args)
+			=> RaiseCharacterReceived((char)args.KeyCode, args.KeyStatus);
+
+		private void RaiseCharacterReceived(char character, CorePhysicalKeyStatus keyStatus)
+		{
+			var originalSource = FocusManager.GetFocusedElement(_inputManager.ContentRoot.XamlRoot) as UIElement ?? _inputManager.ContentRoot.VisualTree.RootElement;
+
+			var routedArgs = new CharacterReceivedRoutedEventArgs(originalSource, character, keyStatus)
+			{
+				CanBubbleNatively = false,
+			};
+
+			originalSource.RaiseEvent(UIElement.CharacterReceivedEvent, routedArgs);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
@@ -23,7 +23,9 @@ namespace Uno.UI.Xaml
 		KeyDown = 1UL << 13,
 		PreviewKeyUp = 1UL << 14,
 		KeyUp = 1UL << 15,
-		// CharacterReceived = 1UL << 16,
+		// Note: CharacterReceived is deliberately not part of _isKey — the key-event
+		// bubbling path hard-casts args to KeyRoutedEventArgs.
+		CharacterReceived = 1UL << 16,
 		// ProcessKeyboardAccelerators = 1UL << 17, => Reserved for future use (even if it is not an actual standard RoutedEvent)
 		// AccessKeyInvoked = 1UL << 18, => Reserved for future use (even if it is not an actual standard RoutedEvent)
 		// AccessKeyDisplayRequested = 1UL << 19, => Reserved for future use (even if it is not an actual standard RoutedEvent)

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -159,6 +159,11 @@ namespace Microsoft.UI.Xaml
 
 		public static RoutedEvent KeyUpEvent { get; } = new RoutedEvent(RoutedEventFlag.KeyUp);
 
+		/// <summary>
+		/// Gets the identifier for the CharacterReceived routed event.
+		/// </summary>
+		public static RoutedEvent CharacterReceivedEvent { get; } = new RoutedEvent(RoutedEventFlag.CharacterReceived);
+
 		internal static RoutedEvent GotFocusEvent { get; } = new RoutedEvent(RoutedEventFlag.GotFocus);
 
 		internal static RoutedEvent LostFocusEvent { get; } = new RoutedEvent(RoutedEventFlag.LostFocus);
@@ -464,6 +469,15 @@ namespace Microsoft.UI.Xaml
 		{
 			add => AddHandler(KeyDownEvent, value, false);
 			remove => RemoveHandler(KeyDownEvent, value);
+		}
+
+		/// <summary>
+		/// Occurs when a single, composed character is received by the input queue.
+		/// </summary>
+		public event TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs> CharacterReceived
+		{
+			add => AddHandler(CharacterReceivedEvent, value, false);
+			remove => RemoveHandler(CharacterReceivedEvent, value);
 		}
 
 		internal event KeyEventHandler PostKeyDown;
@@ -1079,6 +1093,9 @@ namespace Microsoft.UI.Xaml
 					break;
 				case TypedEventHandler<UIElement, ContextRequestedEventArgs> contextRequestedHandler:
 					contextRequestedHandler(this, (ContextRequestedEventArgs)args);
+					break;
+				case TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs> characterReceivedHandler:
+					characterReceivedHandler(this, (CharacterReceivedRoutedEventArgs)args);
 					break;
 				case TypedEventHandler<UIElement, RoutedEventArgs> typedRoutedEventHandler:
 					typedRoutedEventHandler(this, args);

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CharacterReceivedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CharacterReceivedEventArgs.cs
@@ -3,6 +3,9 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
+#if false || false || false || false || false || false
+	[global::Uno.NotImplemented]
+#endif
 	public partial class CharacterReceivedEventArgs : global::Windows.UI.Core.ICoreWindowEventArgs
 	{
 		// Skipping already declared property Handled

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CharacterReceivedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CharacterReceivedEventArgs.cs
@@ -3,50 +3,11 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-	[global::Uno.NotImplemented]
-#endif
 	public partial class CharacterReceivedEventArgs : global::Windows.UI.Core.ICoreWindowEventArgs
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		internal CharacterReceivedEventArgs()
-		{
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public bool Handled
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Windows.UI.Core.CharacterReceivedEventArgs", "Handled");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Core.CharacterReceivedEventArgs", "Handled");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public uint KeyCode
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Windows.UI.Core.CharacterReceivedEventArgs", "KeyCode");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Windows.UI.Core.CorePhysicalKeyStatus KeyStatus
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Windows.UI.Core.CharacterReceivedEventArgs", "KeyStatus");
-			}
-		}
-#endif
+		// Skipping already declared property Handled
+		// Skipping already declared property KeyCode
+		// Skipping already declared property KeyStatus
 		// Forced skipping of method Windows.UI.Core.CharacterReceivedEventArgs.Handled.get
 		// Forced skipping of method Windows.UI.Core.CharacterReceivedEventArgs.Handled.set
 		// Forced skipping of method Windows.UI.Core.CharacterReceivedEventArgs.KeyCode.get

--- a/src/Uno.UWP/UI/Core/CharacterReceivedEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/CharacterReceivedEventArgs.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace Windows.UI.Core;
+
+public partial class CharacterReceivedEventArgs
+{
+	internal CharacterReceivedEventArgs(uint keyCode, CorePhysicalKeyStatus keyStatus)
+	{
+		KeyCode = keyCode;
+		KeyStatus = keyStatus;
+	}
+
+	public bool Handled { get; set; }
+
+	public uint KeyCode { get; }
+
+	public CorePhysicalKeyStatus KeyStatus { get; }
+}

--- a/src/Uno.UWP/UI/Core/CharacterReceivedEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/CharacterReceivedEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace Windows.UI.Core;
 
-public partial class CharacterReceivedEventArgs
+public partial class CharacterReceivedEventArgs : ICoreWindowEventArgs
 {
 	internal CharacterReceivedEventArgs(uint keyCode, CorePhysicalKeyStatus keyStatus)
 	{

--- a/src/Uno.UWP/UI/Core/Internal/IUnoKeyboardInputSource.cs
+++ b/src/Uno.UWP/UI/Core/Internal/IUnoKeyboardInputSource.cs
@@ -9,4 +9,11 @@ internal interface IUnoKeyboardInputSource
 {
 	event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	event TypedEventHandler<object, KeyEventArgs>? KeyUp;
+
+	/// <summary>
+	/// Raised for a composed character that cannot be delivered through a key press,
+	/// e.g. a Windows Alt+numpad code composed when Alt is released. Characters produced
+	/// by a key press are delivered through <see cref="KeyDown"/> instead.
+	/// </summary>
+	event TypedEventHandler<object, CharacterReceivedEventArgs>? CharacterReceived;
 }


### PR DESCRIPTION
**GitHub Issue:** closes #22254

## PR Type:

🐞 Bugfix

## What changed? 🚀

On the Skia Desktop (Windows) target, Windows Alt codes (hold <kbd>Alt</kbd>, type numpad digits, release <kbd>Alt</kbd> — e.g. <kbd>Alt</kbd>+`0154` → `š`) never inserted anything into `TextBox`. The composed `WM_CHAR` is synthesized by `TranslateMessage` while translating the **Alt key-up**, so it was attached to the KeyUp `KeyEventArgs`, which nothing consumes (TextBox inserts on KeyDown only) — the character was silently destroyed.

This PR implements `UIElement.CharacterReceived` as a real routed event on Skia (it was a `[NotImplemented]` stub) and delivers Alt codes through it:

- `UIElement.CharacterReceived` + `Control.OnCharacterReceived` are implemented following the `ContextRequested` precedent (flag, routed event registration, `InvokeHandler` case, generated-stub removal, `ImplementedRoutedEventsGenerator` entry, Control class-handler wiring).
- Characters produced by a **key press** (regular typing) are raised after `KeyDown` from `InputManager`, matching the `WM_KEYDOWN` → `WM_CHAR` ordering on Windows.
- Characters composed on a **key release** (Alt+numpad codes) are delivered by the Win32 host through a new internal `IUnoKeyboardInputSource.CharacterReceived` channel, with `KeyStatus.IsKeyReleased` set — mirroring the real `WM_CHAR`'s lParam transition bit. `Windows.UI.Core.CharacterReceivedEventArgs` is implemented as the channel payload.
- `TextBox` inserts key-release characters from `OnCharacterReceived`. The path doesn't depend on an IME session, so Alt codes now also work in `PasswordBox`.
- No IME/composition machinery is involved: `TextCompositionStarted/Changed/Ended` do **not** fire for Alt codes (the end-to-end test asserts this).

The WASM half of the issue (digits being typed alongside the character) was already fixed on master by aa9f15b33f and is unreleased; the composed-character delivery on WASM was verified working via a CDP-driven emulation of the exact browser event stream.

Also includes a one-line fix to the browser keyboard debug log (missing `alt` modifier and a `key=$` interpolation typo).

**Validation (runtime):** full `Given_TextBox` + `Given_ComboBox` suites pass on Skia Desktop (263/263); new runtime tests cover the typing path (raised once, after KeyDown), key-release insertion incl. selection replacement, read-only/key-press no-ops, PasswordBox, and a Win32-only end-to-end test that posts the real `WM_KEYUP(VK_MENU)`+`WM_CHAR` pair to the app's own HWND. Manually validated with physical keyboard Alt codes on Windows.

**Notes / known limitations:**
- `CoreWindow.CharacterReceived` and `InputKeyboardSource.CharacterReceived` remain unimplemented; native (non-Skia) targets declare the routed event but don't raise it yet.
- ComboBox's `#if HAS_UNO` typeahead workaround (synthesized `CharacterReceived`) is left in place and can migrate to the real event as a follow-up; its popup-child subscription now activates with the real event (no double-fire with the workaround — verified by the ComboBox suite).
- Characters beyond the BMP entered via hex-numpad (`EnableHexNumpad`) arrive as two `WM_CHAR`s and only the first is delivered — pre-existing limitation shared with the key-press path.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
