### PR TITLE
feat: ALC-scoped AdaptiveTrigger window-size override

### DIFF
--- a/doc/articles/features/AdaptiveTrigger.md
+++ b/doc/articles/features/AdaptiveTrigger.md
@@ -151,7 +151,7 @@ The `LargeScreen` setter target is triggered when the window width is `>=` 1000 
 
 ## Simulating a Window Size (Uno-specific)
 
-Uno Platform exposes an `SetWindowSizeOverride` extensibility hook, primarily intended for hosts (such as design-time tooling) that simulate a form factor by resizing hosted content rather than the window itself. This API has no WinUI equivalent and is hidden from IntelliSense (`EditorBrowsable(Never)`).
+Uno Platform exposes a `SetWindowSizeOverride` extensibility hook, primarily intended for hosts (such as design-time tooling) that simulate a form factor by resizing hosted content rather than the window itself. This API has no WinUI equivalent and is hidden from IntelliSense (`EditorBrowsable(Never)`).
 
 ```csharp
 // Make every AdaptiveTrigger evaluate against a simulated size instead of the window bounds.

--- a/doc/articles/features/AdaptiveTrigger.md
+++ b/doc/articles/features/AdaptiveTrigger.md
@@ -148,3 +148,28 @@ The following demonstrates the same code, but re-written in a sequential order t
 In the above example, the `VisualState` blocks are sequential, ordered from `LargeScreen` to `MediumScreen` to `SmallScreen`. Because of this, the compiler will execute the first true occurrence in the order written.
 
 The `LargeScreen` setter target is triggered when the window width is `>=` 1000 pixels. When this statement becomes false, the `VisualState` executes the next setter target that matches, i.e. the `MediumScreen` block. When the `MediumScreen` adaptive trigger is false, the `VisualState` finally executes the setter target for the `SmallScreen` block.
+
+## Simulating a Window Size (Uno-specific)
+
+Uno Platform exposes an `SetWindowSizeOverride` extensibility hook, primarily intended for hosts (such as design-time tooling) that simulate a form factor by resizing hosted content rather than the window itself. This API has no WinUI equivalent and is hidden from IntelliSense (`EditorBrowsable(Never)`).
+
+```csharp
+// Make every AdaptiveTrigger evaluate against a simulated size instead of the window bounds.
+AdaptiveTrigger.SetWindowSizeOverride(new Size(400, 640));
+
+// Clear it: triggers evaluate against the window bounds again.
+AdaptiveTrigger.SetWindowSizeOverride(null);
+```
+
+When a host loads a guest application into its own (collectible) `AssemblyLoadContext`, the global override would also re-evaluate the host's own triggers. To simulate a size for the guest only, scope the override to the guest's load context:
+
+```csharp
+// Only affects triggers whose owner element originates from guestLoadContext
+// (i.e. has an ancestor whose type is loaded in that context).
+AdaptiveTrigger.SetWindowSizeOverride(new Size(400, 640), guestLoadContext);
+
+// Clear just that scope.
+AdaptiveTrigger.SetWindowSizeOverride(null, guestLoadContext);
+```
+
+Each trigger evaluates against the most specific value available: the override scoped to its owner's load context first, then the global override, then the window (`XamlRoot`) bounds. A scoped override never keeps a collectible load context alive, and is dropped automatically when the context unloads. Both overloads must be called on the UI thread, as they synchronously re-evaluate every live trigger.

--- a/doc/articles/features/AdaptiveTrigger.md
+++ b/doc/articles/features/AdaptiveTrigger.md
@@ -164,8 +164,8 @@ AdaptiveTrigger.SetWindowSizeOverride(null);
 When a host loads a guest application into its own (collectible) `AssemblyLoadContext`, the global override would also re-evaluate the host's own triggers. To simulate a size for the guest only, scope the override to the guest's load context:
 
 ```csharp
-// Only affects triggers whose owner element originates from guestLoadContext
-// (i.e. has an ancestor whose type is loaded in that context).
+// Only affects triggers whose nearest non-default-load-context ancestor
+// belongs to guestLoadContext (nested contexts resolve to the innermost one).
 AdaptiveTrigger.SetWindowSizeOverride(new Size(400, 640), guestLoadContext);
 
 // Clear just that scope.
@@ -173,3 +173,6 @@ AdaptiveTrigger.SetWindowSizeOverride(null, guestLoadContext);
 ```
 
 Each trigger evaluates against the most specific value available: the override scoped to its owner's load context first, then the global override, then the window (`XamlRoot`) bounds. A scoped override never keeps a collectible load context alive, and is dropped automatically when the context unloads. Both overloads must be called on the UI thread, as they synchronously re-evaluate every live trigger.
+
+> [!NOTE]
+> The scope matches only triggers that have at least one ancestor whose type is loaded in the given context. Guest content composed solely of shared framework types — including popup and flyout subtrees, which are re-parented under the host's popup root — cannot be attributed to the guest context and falls back to the global override.

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/MainPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/MainPage.xaml
@@ -8,6 +8,19 @@
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="AdaptiveStates">
+                <!-- Inactive under any real test window; only a (scoped) window-size override can activate it. -->
+                <VisualState x:Name="SimulatedWideState">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="4000"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="AdaptiveStateProbe.Visibility" Value="Visible"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
             <TextBlock x:Name="TitleTextBlock"
                        Text="ALC Test App"
@@ -19,6 +32,10 @@
                        Text="App loaded successfully"
                        HorizontalAlignment="Center"
                        Style="{StaticResource TestTextBlockStyle}"/>
+            <TextBlock x:Name="AdaptiveStateProbe"
+                       Text="Simulated wide state active"
+                       HorizontalAlignment="Center"
+                       Visibility="Collapsed"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.AdaptiveTrigger.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.AdaptiveTrigger.cs
@@ -1,0 +1,108 @@
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Windows.Foundation;
+
+namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
+
+// AdaptiveTrigger ALC-scoped window-size override coverage in the real hosted-app topology: the
+// guest page's triggers live inside the HOST's visual tree (shared XamlRoot), so these tests
+// validate that a scoped override resolves through ancestor type identity, not through the tree
+// root. Isolated storage/leak semantics are unit-tested in Given_AdaptiveTrigger.
+public partial class Given_AlcContentHost
+{
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
+	public async Task When_ScopedWindowSizeOverride_Then_AppliesToGuestTriggersOnly()
+	{
+		var contentHost = await StartSecondaryAlcAppAsync();
+		var probe = GetAdaptiveStateProbe(contentHost);
+
+		Assert.AreEqual(Visibility.Collapsed, probe.Visibility,
+			"Pre-condition: the guest adaptive state must be inactive under the real window size");
+
+		// A host-side trigger in the same visual tree, owned by host-typed elements only.
+		var hostState = new VisualState { Name = "hostSimulatedWide" };
+		hostState.StateTriggers.Add(new AdaptiveTrigger { MinWindowWidth = 4000 });
+		var hostGroup = new VisualStateGroup();
+		hostGroup.States.Add(hostState);
+		VisualStateManager.SetVisualStateGroups(contentHost, new List<VisualStateGroup> { hostGroup });
+		Assert.IsNull(hostGroup.CurrentState, "Pre-condition: the host trigger must be inactive under the real window size");
+
+		try
+		{
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(5000, 5000), _testAlc!);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(Visibility.Visible, probe.Visibility,
+				"The scoped override must activate the guest's adaptive state");
+			Assert.IsNull(hostGroup.CurrentState,
+				"The scoped override must not affect triggers owned by host-typed elements");
+
+			AdaptiveTrigger.SetWindowSizeOverride(null, _testAlc!);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(Visibility.Collapsed, probe.Visibility,
+				"Clearing the scoped override must revert the guest to the real window size");
+		}
+		finally
+		{
+			AdaptiveTrigger.SetWindowSizeOverride(null, _testAlc!);
+		}
+	}
+
+	[TestMethod]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
+	public async Task When_ScopedAndGlobalWindowSizeOverride_Then_ScopedWinsForGuest()
+	{
+		var contentHost = await StartSecondaryAlcAppAsync();
+		var probe = GetAdaptiveStateProbe(contentHost);
+
+		try
+		{
+			// Without a scoped override the guest follows the global one…
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(5000, 5000));
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.AreEqual(Visibility.Visible, probe.Visibility,
+				"The global override must apply to guest triggers when no scoped override exists");
+
+			// …a scoped override then wins over the global one…
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(100, 100), _testAlc!);
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.AreEqual(Visibility.Collapsed, probe.Visibility,
+				"A scoped override must take precedence over the global override for guest triggers");
+
+			// …and clearing the scoped override falls back to the global one.
+			AdaptiveTrigger.SetWindowSizeOverride(null, _testAlc!);
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.AreEqual(Visibility.Visible, probe.Visibility,
+				"Clearing the scoped override must fall back to the global override");
+		}
+		finally
+		{
+			AdaptiveTrigger.SetWindowSizeOverride(null, _testAlc!);
+			AdaptiveTrigger.SetWindowSizeOverride(null);
+		}
+	}
+
+	private static TextBlock GetAdaptiveStateProbe(Uno.UI.Xaml.Controls.AlcContentHost contentHost)
+	{
+		var root = contentHost.Content as FrameworkElement;
+		Assert.IsNotNull(root, "Secondary content should be a FrameworkElement");
+
+		var probe = root!.FindName("AdaptiveStateProbe") as TextBlock;
+		Assert.IsNotNull(probe, "AdaptiveStateProbe should be discoverable via FindName");
+
+		return probe!;
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/Given_AlcContentHost.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.RuntimeTests.Tests.AssemblyLoadContext;
 [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Types manipulated here have been marked earlier")]
 [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
 [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Types manipulated here have been marked earlier")]
-public class Given_AlcContentHost
+public partial class Given_AlcContentHost
 {
 	private TestAssemblyLoadContext? _testAlc;
 	private TestAssemblyLoadContext? _testAlcSecondary;

--- a/src/Uno.UI.Tests.ViewLibrary/MyExtBorder.cs
+++ b/src/Uno.UI.Tests.ViewLibrary/MyExtBorder.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.ViewLibrary;
+
+/// <summary>
+/// A guest-typed container: tests load a copy of this library into a collectible
+/// AssemblyLoadContext and parent shared-framework subtrees under this element.
+/// </summary>
+public partial class MyExtBorder : Border
+{
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
@@ -374,6 +374,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		// Scoped (per-AssemblyLoadContext) override tests — https://github.com/unoplatform/uno/issues/23721
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_AppliesOnlyToOwningAlcTrigger()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));
@@ -399,6 +400,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_WinsOverGlobal()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));
@@ -422,6 +424,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_Cleared_RevertsToGlobal_ThenWindow()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));
@@ -451,6 +454,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_SetBeforeAttach_AppliesOnAttach()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));
@@ -471,14 +475,17 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_NullAlc_Throws()
 			=> Assert.ThrowsExactly<ArgumentNullException>(() => AdaptiveTrigger.SetWindowSizeOverride(new Size(10, 10), null));
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_DefaultAlc_Throws()
 			=> Assert.ThrowsExactly<ArgumentException>(() => AdaptiveTrigger.SetWindowSizeOverride(new Size(10, 10), AssemblyLoadContext.Default));
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_ForForeignAlc_DoesNotAffectHost()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));
@@ -501,6 +508,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_AlcUnloaded_Then_NotRootedByOverride()
 		{
 			var weakAlc = StageScopedOverrideOnCollectibleAlc();
@@ -518,6 +526,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_AlcUnloaded_Then_ScopeSelfClears()
 		{
 			var alc = new AssemblyLoadContext(nameof(When_ScopedOverride_AlcUnloaded_Then_ScopeSelfClears), isCollectible: true);
@@ -533,6 +542,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_ForUnloadingAlc_IsIgnored()
 		{
 			var alc = new AssemblyLoadContext(nameof(When_ScopedOverride_ForUnloadingAlc_IsIgnored), isCollectible: true);
@@ -547,6 +557,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_TwoScopedOverrides_EachAppliesToItsOwnAlc()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));
@@ -575,6 +586,33 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
+		public void When_NestedScopedAlcs_InnermostWins()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (outerAlc, outerElement) = CreateCollectibleGuestElement(typeof(ViewLibrary.MyExtBorder));
+			var (innerAlc, innerElement) = CreateCollectibleGuestElement(typeof(ViewLibrary.MyExtBorder));
+
+			((Border)outerElement).Child = innerElement;
+			outerElement.ForceLoaded();
+			innerElement.ForceLoaded();
+
+			var (group, state) = BuildTriggeredGroup(innerElement);
+			group.CurrentState.Should().Be(state);
+
+			// A trigger nested under two guest-typed ancestors belongs to the INNERMOST context: the
+			// outer guest's simulated size must not leak into content hosted within a nested guest…
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), outerAlc);
+			group.CurrentState.Should().Be(state);
+
+			// …while the inner context's own override does apply.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), innerAlc);
+			group.CurrentState.Should().Be(null);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23721")]
 		public void When_ScopedOverride_OwnerResolvedBeforeParenting_ReresolvesOnAttach()
 		{
 			Window.Current.SetWindowSize(new Size(1000, 1000));

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Loader;
 using Windows.Foundation;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -11,6 +13,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 	[TestClass]
 	public class Given_AdaptiveTrigger
 	{
+		private readonly List<AssemblyLoadContext> _scopedAlcs = new();
+
 		[TestInitialize]
 		public void Initialize()
 		{
@@ -19,7 +23,17 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 
 		[TestCleanup]
 		public void Cleanup()
-			=> AdaptiveTrigger.SetWindowSizeOverride(null);
+		{
+			AdaptiveTrigger.SetWindowSizeOverride(null);
+
+			foreach (var alc in _scopedAlcs)
+			{
+				AdaptiveTrigger.SetWindowSizeOverride(null, alc);
+				alc.Unload();
+			}
+
+			_scopedAlcs.Clear();
+		}
 
 		[TestMethod]
 		public void When_SingleActiveState()
@@ -348,6 +362,209 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			// Clearing the override reverts evaluation to the real window size (1000x1000) -> active.
 			AdaptiveTrigger.SetWindowSizeOverride(null);
 			group.CurrentState.Should().Be(state);
+		}
+
+		// Scoped (per-AssemblyLoadContext) override tests — https://github.com/unoplatform/uno/issues/23721
+
+		[TestMethod]
+		public void When_ScopedOverride_AppliesOnlyToOwningAlcTrigger()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (alc, guestElement) = CreateCollectibleGuestElement();
+
+			var hostBorder = new Border();
+			hostBorder.ForceLoaded();
+			var (hostGroup, hostState) = BuildTriggeredGroup(hostBorder);
+
+			guestElement.ForceLoaded();
+			var (guestGroup, guestState) = BuildTriggeredGroup(guestElement);
+
+			hostGroup.CurrentState.Should().Be(hostState);
+			guestGroup.CurrentState.Should().Be(guestState);
+
+			// A size scoped to the guest ALC deactivates the guest trigger only — the host trigger
+			// keeps evaluating against the real window (the "host chrome must not collapse" scenario).
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+
+			guestGroup.CurrentState.Should().Be(null);
+			hostGroup.CurrentState.Should().Be(hostState);
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_WinsOverGlobal()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (alc, guestElement) = CreateCollectibleGuestElement();
+
+			var hostBorder = new Border();
+			hostBorder.ForceLoaded();
+			var (hostGroup, hostState) = BuildTriggeredGroup(hostBorder);
+
+			guestElement.ForceLoaded();
+			var (guestGroup, _) = BuildTriggeredGroup(guestElement);
+
+			// Global override satisfies the triggers, scoped override does not: the guest trigger must
+			// use the scoped value while the host trigger keeps using the global one.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200));
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+
+			guestGroup.CurrentState.Should().Be(null);
+			hostGroup.CurrentState.Should().Be(hostState);
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_Cleared_RevertsToGlobal_ThenWindow()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (alc, guestElement) = CreateCollectibleGuestElement();
+
+			guestElement.ForceLoaded();
+			var (guestGroup, guestState) = BuildTriggeredGroup(guestElement);
+
+			guestGroup.CurrentState.Should().Be(guestState);
+
+			// Without a scoped override the guest trigger follows the global override…
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50));
+			guestGroup.CurrentState.Should().Be(null);
+
+			// …a scoped override then takes precedence over the global one…
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200), alc);
+			guestGroup.CurrentState.Should().Be(guestState);
+
+			// …clearing the scoped override falls back to the global override…
+			AdaptiveTrigger.SetWindowSizeOverride(null, alc);
+			guestGroup.CurrentState.Should().Be(null);
+
+			// …and clearing the global override reverts to the real window size.
+			AdaptiveTrigger.SetWindowSizeOverride(null);
+			guestGroup.CurrentState.Should().Be(guestState);
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_SetBeforeAttach_AppliesOnAttach()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (alc, guestElement) = CreateCollectibleGuestElement();
+
+			// The scoped override is set before the guest trigger ever attaches — the host scenario
+			// where a simulated form factor is active while guest pages load.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+
+			guestElement.ForceLoaded();
+			var (guestGroup, guestState) = BuildTriggeredGroup(guestElement);
+
+			guestGroup.CurrentState.Should().Be(null);
+
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200), alc);
+			guestGroup.CurrentState.Should().Be(guestState);
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_NullAlc_Throws()
+			=> Assert.ThrowsExactly<ArgumentNullException>(() => AdaptiveTrigger.SetWindowSizeOverride(new Size(10, 10), null));
+
+		[TestMethod]
+		public void When_ScopedOverride_DefaultAlc_Throws()
+			=> Assert.ThrowsExactly<ArgumentException>(() => AdaptiveTrigger.SetWindowSizeOverride(new Size(10, 10), AssemblyLoadContext.Default));
+
+		[TestMethod]
+		public void When_ScopedOverride_ForForeignAlc_DoesNotAffectHost()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var hostBorder = new Border();
+			hostBorder.ForceLoaded();
+			var (hostGroup, hostState) = BuildTriggeredGroup(hostBorder);
+
+			hostGroup.CurrentState.Should().Be(hostState);
+
+			// An override scoped to an ALC no element belongs to must leave every trigger alone.
+			var foreignAlc = new AssemblyLoadContext(nameof(When_ScopedOverride_ForForeignAlc_DoesNotAffectHost), isCollectible: true);
+			_scopedAlcs.Add(foreignAlc);
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), foreignAlc);
+
+			hostGroup.CurrentState.Should().Be(hostState);
+
+			Window.Current.SetWindowSize(new Size(20, 20));
+			hostGroup.CurrentState.Should().Be(null);
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_AlcUnloaded_Then_NotRootedByOverride()
+		{
+			var weakAlc = StageScopedOverrideOnCollectibleAlc();
+
+			for (var i = 0; i < 10 && weakAlc.IsAlive; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsFalse(
+				weakAlc.IsAlive,
+				"A scoped window-size override must never keep the target AssemblyLoadContext alive; " +
+				"otherwise a collectible guest app could no longer unload.");
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_AlcUnloaded_Then_ScopeSelfClears()
+		{
+			var flagField = typeof(AdaptiveTrigger).GetField(
+				"_hasScopedWindowSizeOverrides",
+				System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+			Assert.IsNotNull(flagField, "AdaptiveTrigger._hasScopedWindowSizeOverrides must exist (fast-path gate)");
+
+			var alc = new AssemblyLoadContext(nameof(When_ScopedOverride_AlcUnloaded_Then_ScopeSelfClears), isCollectible: true);
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+			Assert.IsTrue((bool)flagField.GetValue(null), "Setting a scoped override must engage the scoped-resolution path");
+
+			// Unloading fires synchronously on the calling thread and must drop the scope even when the
+			// host never cleared it, restoring the no-scoped-overrides fast path.
+			alc.Unload();
+			Assert.IsFalse((bool)flagField.GetValue(null), "Unloading the scoped ALC must restore the fast path");
+		}
+
+		[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+		private static WeakReference StageScopedOverrideOnCollectibleAlc()
+		{
+			var alc = new AssemblyLoadContext(nameof(StageScopedOverrideOnCollectibleAlc), isCollectible: true);
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+			alc.Unload();
+			return new WeakReference(alc);
+		}
+
+		/// <summary>
+		/// Loads a second copy of the view library into a collectible <c>AssemblyLoadContext</c> (Uno
+		/// assemblies unify from the default context) and instantiates its <c>MyExtControl</c>, giving a
+		/// live element whose type belongs to that context — the shape of a hosted guest app's page.
+		/// </summary>
+		private (AssemblyLoadContext Alc, FrameworkElement GuestElement) CreateCollectibleGuestElement()
+		{
+			var alc = new AssemblyLoadContext($"{nameof(Given_AdaptiveTrigger)}-guest", isCollectible: true);
+			_scopedAlcs.Add(alc);
+
+			var guestAssembly = alc.LoadFromAssemblyPath(typeof(ViewLibrary.MyExtControl).Assembly.Location);
+			var guestType = guestAssembly.GetType(typeof(ViewLibrary.MyExtControl).FullName, throwOnError: true);
+			var guestElement = (FrameworkElement)Activator.CreateInstance(guestType);
+
+			return (alc, guestElement);
+		}
+
+		private static (VisualStateGroup Group, VisualState State) BuildTriggeredGroup(FrameworkElement element)
+		{
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(new AdaptiveTrigger { MinWindowHeight = 100, MinWindowWidth = 100 });
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			VisualStateManager.SetVisualStateGroups(element, new List<VisualStateGroup>() { group });
+
+			return (group, state);
 		}
 	}
 }

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
@@ -29,7 +29,14 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			foreach (var alc in _scopedAlcs)
 			{
 				AdaptiveTrigger.SetWindowSizeOverride(null, alc);
-				alc.Unload();
+				try
+				{
+					alc.Unload();
+				}
+				catch (InvalidOperationException)
+				{
+					// Already unloaded by the test itself.
+				}
 			}
 
 			_scopedAlcs.Clear();
@@ -513,19 +520,90 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		[TestMethod]
 		public void When_ScopedOverride_AlcUnloaded_Then_ScopeSelfClears()
 		{
-			var flagField = typeof(AdaptiveTrigger).GetField(
-				"_hasScopedWindowSizeOverrides",
-				System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-			Assert.IsNotNull(flagField, "AdaptiveTrigger._hasScopedWindowSizeOverrides must exist (fast-path gate)");
-
 			var alc = new AssemblyLoadContext(nameof(When_ScopedOverride_AlcUnloaded_Then_ScopeSelfClears), isCollectible: true);
+			_scopedAlcs.Add(alc);
+
 			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
-			Assert.IsTrue((bool)flagField.GetValue(null), "Setting a scoped override must engage the scoped-resolution path");
+			Assert.IsTrue(AdaptiveTrigger.HasScopedWindowSizeOverrides, "Setting a scoped override must engage the scoped-resolution path");
 
 			// Unloading fires synchronously on the calling thread and must drop the scope even when the
 			// host never cleared it, restoring the no-scoped-overrides fast path.
 			alc.Unload();
-			Assert.IsFalse((bool)flagField.GetValue(null), "Unloading the scoped ALC must restore the fast path");
+			Assert.IsFalse(AdaptiveTrigger.HasScopedWindowSizeOverrides, "Unloading the scoped ALC must restore the fast path");
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_ForUnloadingAlc_IsIgnored()
+		{
+			var alc = new AssemblyLoadContext(nameof(When_ScopedOverride_ForUnloadingAlc_IsIgnored), isCollectible: true);
+			_scopedAlcs.Add(alc);
+			alc.Unload();
+
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+
+			Assert.IsFalse(
+				AdaptiveTrigger.HasScopedWindowSizeOverrides,
+				"An override for an already-unloading ALC must be ignored: its Unloading event can never fire again to clean it up");
+		}
+
+		[TestMethod]
+		public void When_TwoScopedOverrides_EachAppliesToItsOwnAlc()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (alc1, guest1) = CreateCollectibleGuestElement();
+			var (alc2, guest2) = CreateCollectibleGuestElement();
+
+			guest1.ForceLoaded();
+			var (group1, state1) = BuildTriggeredGroup(guest1);
+
+			guest2.ForceLoaded();
+			var (group2, state2) = BuildTriggeredGroup(guest2);
+
+			// Two guests simulated at different sizes at the same time: each trigger follows the
+			// override of its own load context.
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc1);
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200), alc2);
+
+			group1.CurrentState.Should().Be(null);
+			group2.CurrentState.Should().Be(state2);
+
+			AdaptiveTrigger.SetWindowSizeOverride(null, alc1);
+
+			group1.CurrentState.Should().Be(state1);
+			group2.CurrentState.Should().Be(state2);
+		}
+
+		[TestMethod]
+		public void When_ScopedOverride_OwnerResolvedBeforeParenting_ReresolvesOnAttach()
+		{
+			Window.Current.SetWindowSize(new Size(1000, 1000));
+
+			var (alc, guestElement) = CreateCollectibleGuestElement(typeof(ViewLibrary.MyExtBorder));
+
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(50, 50), alc);
+
+			// Build the triggered subtree BEFORE parenting it under the guest element: the property
+			// change forces an evaluation whose ancestor walk finds no guest-typed ancestor yet.
+			var grid = new Grid();
+			var sut = new AdaptiveTrigger { MinWindowHeight = 100 };
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+			VisualStateManager.SetVisualStateGroups(grid, new List<VisualStateGroup>() { group });
+
+			sut.MinWindowWidth = 100;
+
+			// Parenting the subtree under a guest-typed ancestor fires no owner hook on the trigger —
+			// the attach that follows must re-resolve the ancestry instead of trusting a cached miss.
+			((Border)guestElement).Child = grid;
+			guestElement.ForceLoaded();
+
+			group.CurrentState.Should().Be(null);
+
+			AdaptiveTrigger.SetWindowSizeOverride(new Size(200, 200), alc);
+			group.CurrentState.Should().Be(state);
 		}
 
 		[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -543,12 +621,15 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		/// live element whose type belongs to that context — the shape of a hosted guest app's page.
 		/// </summary>
 		private (AssemblyLoadContext Alc, FrameworkElement GuestElement) CreateCollectibleGuestElement()
+			=> CreateCollectibleGuestElement(typeof(ViewLibrary.MyExtControl));
+
+		private (AssemblyLoadContext Alc, FrameworkElement GuestElement) CreateCollectibleGuestElement(Type viewLibraryType)
 		{
 			var alc = new AssemblyLoadContext($"{nameof(Given_AdaptiveTrigger)}-guest", isCollectible: true);
 			_scopedAlcs.Add(alc);
 
-			var guestAssembly = alc.LoadFromAssemblyPath(typeof(ViewLibrary.MyExtControl).Assembly.Location);
-			var guestType = guestAssembly.GetType(typeof(ViewLibrary.MyExtControl).FullName, throwOnError: true);
+			var guestAssembly = alc.LoadFromAssemblyPath(viewLibraryType.Assembly.Location);
+			var guestType = guestAssembly.GetType(viewLibraryType.FullName, throwOnError: true);
 			var guestElement = (FrameworkElement)Activator.CreateInstance(guestType);
 
 			return (alc, guestElement);

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.alc.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.alc.cs
@@ -24,6 +24,9 @@ partial class AdaptiveTrigger
 
 	// Weakly keyed by the ALC so a scoped override can never keep a collectible guest context alive.
 	private static readonly ConditionalWeakTable<AssemblyLoadContext, ScopedSizeOverride> _scopedWindowSizeOverrides = new();
+
+	// Guards writers only — set/clear/unload, all cold control-plane paths. The per-evaluation read
+	// path (GetEffectiveWindowSizeOverride) is deliberately lock-free.
 	private static readonly object _scopedOverridesGate = new();
 
 	// One WeakReference per ALC, shared by every trigger's owner cache, so re-resolution after
@@ -32,6 +35,8 @@ partial class AdaptiveTrigger
 
 	// Fast-path gate: while false (no scoped override anywhere in the process), triggers never walk
 	// their ancestry nor touch the table — single-ALC apps pay one volatile read per evaluation.
+	// Can stay latched true if an ALC unloads between the IsUnloadInitiated check and the Unloading
+	// subscription (the weak entry is still collected) — a perf-only cost, never a correctness one.
 	private static volatile bool _hasScopedWindowSizeOverrides;
 
 	internal static bool HasScopedWindowSizeOverrides => _hasScopedWindowSizeOverrides;
@@ -41,8 +46,11 @@ partial class AdaptiveTrigger
 
 	// null = unresolved | _noSecondaryAlc | WeakReference<AssemblyLoadContext>. Weak so a trigger
 	// instance leaked past its guest app's unload can never root the collectible ALC. Reset on
-	// detach AND attach, so every (re-)entry into a live tree re-resolves the current ancestry.
+	// detach AND attach (ResetOwnerAlcCache): re-parenting can move the trigger across an ALC
+	// boundary, and a pre-parenting evaluation may have cached "no ALC".
 	private object? _ownerAlcCache;
+
+	private void ResetOwnerAlcCache() => _ownerAlcCache = null;
 
 	/// <summary>
 	/// Overrides the size used by <see cref="AdaptiveTrigger"/>s owned by elements originating from
@@ -149,9 +157,9 @@ partial class AdaptiveTrigger
 	/// </summary>
 	internal static void ClearScopedWindowSizeOverridesForNonDefaultAlc()
 	{
+		List<AssemblyLoadContext>? toRemove = null;
 		lock (_scopedOverridesGate)
 		{
-			List<AssemblyLoadContext>? toRemove = null;
 			foreach (var (alc, _) in _scopedWindowSizeOverrides)
 			{
 				// Only strip dying contexts: another guest app may still be live with its own override.
@@ -175,6 +183,19 @@ partial class AdaptiveTrigger
 
 				RecomputeHasScopedOverrides();
 			}
+		}
+
+		if (toRemove is not null)
+		{
+			if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(AdaptiveTrigger).Log().Debug(
+					$"Scoped window-size overrides dropped for {toRemove.Count} unloading ALC(s) during application cleanup");
+			}
+
+			// Same reason as the Unloading path: still-live guest triggers must not stay frozen at
+			// the simulated size once their scope is gone.
+			RaiseWindowSizeOverrideChangedOnUIThread();
 		}
 	}
 
@@ -209,22 +230,43 @@ partial class AdaptiveTrigger
 			// detached (the wrong-order host case); without a re-evaluation they'd stay frozen in the
 			// simulated-size state. Re-evaluate on the UI thread — never from here directly, as this
 			// can run on an arbitrary or finalizer thread.
-			static void RaiseChanged() => WindowSizeOverrideChanged?.Invoke(null, EventArgs.Empty);
-			if (global::Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess)
-			{
-				RaiseChanged();
-			}
-			else
-			{
-				global::Uno.UI.Dispatching.NativeDispatcher.Main.Enqueue(static () => RaiseChanged());
-			}
+			RaiseWindowSizeOverrideChangedOnUIThread();
 		}
 		catch (Exception ex)
 		{
 			if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Warning))
 			{
-				typeof(AdaptiveTrigger).Log().Warn($"Failed to drop the scoped window-size override for unloading ALC '{alc.Name}'", ex);
+				typeof(AdaptiveTrigger).Log().Warn($"Failure while handling the unload of ALC '{alc.Name}'", ex);
 			}
+		}
+	}
+
+	private static void RaiseWindowSizeOverrideChangedOnUIThread()
+	{
+		// Contained: when this runs enqueued (or on the finalizer thread), an escaping subscriber
+		// exception would surface as an unhandled dispatcher exception with no ALC-unload context.
+		static void RaiseChanged()
+		{
+			try
+			{
+				WindowSizeOverrideChanged?.Invoke(null, EventArgs.Empty);
+			}
+			catch (Exception ex)
+			{
+				if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Warning))
+				{
+					typeof(AdaptiveTrigger).Log().Warn("Failed to re-evaluate adaptive triggers after a scoped window-size override was dropped", ex);
+				}
+			}
+		}
+
+		if (global::Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess)
+		{
+			RaiseChanged();
+		}
+		else
+		{
+			global::Uno.UI.Dispatching.NativeDispatcher.Main.Enqueue(static () => RaiseChanged());
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.alc.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.alc.cs
@@ -1,0 +1,231 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Uno.Foundation.Logging;
+using Uno.UI.Xaml.Core;
+using Windows.Foundation;
+
+namespace Microsoft.UI.Xaml;
+
+partial class AdaptiveTrigger
+{
+	// Reference-type holder for a scoped override value (ConditionalWeakTable values must be reference types).
+	private sealed class ScopedSizeOverride
+	{
+		public Size Size;
+	}
+
+	// Weakly keyed by the ALC so a scoped override can never keep a collectible guest context alive.
+	private static readonly ConditionalWeakTable<AssemblyLoadContext, ScopedSizeOverride> _scopedWindowSizeOverrides = new();
+	private static readonly object _scopedOverridesGate = new();
+
+	// Fast-path gate: while false (no scoped override anywhere in the process), triggers never walk
+	// their ancestry nor touch the table — single-ALC apps pay one volatile read per evaluation.
+	private static volatile bool _hasScopedWindowSizeOverrides;
+
+	// Sentinel for "resolved, no secondary-ALC owner" so the ancestor walk runs at most once per attach.
+	private static readonly object _noSecondaryAlc = new();
+
+	// null = unresolved | _noSecondaryAlc | WeakReference<AssemblyLoadContext>. Weak so a trigger
+	// instance leaked past its guest app's unload can never root the collectible ALC. Reset on
+	// detach (owner/element changes); an ancestor re-parented above the owner element without an
+	// owner hook firing keeps a stale value until the next detach/attach — hosts swap guests at the
+	// content-host boundary, which unloads the subtree, so that path re-resolves in practice.
+	private object? _ownerAlcCache;
+
+	/// <summary>
+	/// Overrides the size used by <see cref="AdaptiveTrigger"/>s owned by elements originating from
+	/// <paramref name="assemblyLoadContext"/> (i.e. having an ancestor whose type is loaded in that
+	/// context), instead of the window bounds. Passing a <c>null</c> size clears that scoped override.
+	/// </summary>
+	/// <remarks>
+	/// Uno-specific host-extensibility hook complementing the global <c>SetWindowSizeOverride(Size?)</c>
+	/// overload: a host that loads a guest app into its own <c>AssemblyLoadContext</c> can simulate a
+	/// form factor for the guest's triggers without affecting its own UI. A scoped override takes
+	/// precedence over the global override for the triggers it applies to. The association is weak:
+	/// it never keeps a collectible context alive, and is dropped automatically when the context
+	/// unloads. Call it on the UI thread: it synchronously re-evaluates every live trigger.
+	/// </remarks>
+	/// <param name="size">The simulated window size, or <c>null</c> to clear the scoped override.</param>
+	/// <param name="assemblyLoadContext">The load context whose triggers the override applies to.</param>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static void SetWindowSizeOverride(Size? size, AssemblyLoadContext assemblyLoadContext)
+	{
+		ArgumentNullException.ThrowIfNull(assemblyLoadContext);
+		if (ReferenceEquals(assemblyLoadContext, AssemblyLoadContext.Default))
+		{
+			throw new ArgumentException(
+				"The default AssemblyLoadContext cannot be used as an override scope; use SetWindowSizeOverride(Size?) for a process-wide override.",
+				nameof(assemblyLoadContext));
+		}
+
+		lock (_scopedOverridesGate)
+		{
+			var hasExisting = _scopedWindowSizeOverrides.TryGetValue(assemblyLoadContext, out var existing);
+
+			if (size is { } newSize)
+			{
+				if (hasExisting && existing!.Size == newSize)
+				{
+					return;
+				}
+
+				if (hasExisting)
+				{
+					existing!.Size = newSize;
+				}
+				else
+				{
+					_scopedWindowSizeOverrides.Add(assemblyLoadContext, new ScopedSizeOverride { Size = newSize });
+					if (assemblyLoadContext.IsCollectible)
+					{
+						// Self-cleaning even if the host never clears the override: drop the entry (and
+						// restore the fast path) when the guest context unloads. Symmetric with the
+						// unsubscription in the clearing branch below, so at most one subscription exists.
+						assemblyLoadContext.Unloading += OnScopedOverrideAlcUnloading;
+					}
+				}
+
+				_hasScopedWindowSizeOverrides = true;
+			}
+			else
+			{
+				if (!hasExisting)
+				{
+					return;
+				}
+
+				_scopedWindowSizeOverrides.Remove(assemblyLoadContext);
+				if (assemblyLoadContext.IsCollectible)
+				{
+					assemblyLoadContext.Unloading -= OnScopedOverrideAlcUnloading;
+				}
+
+				RecomputeHasScopedOverrides();
+			}
+		}
+
+		if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+		{
+			typeof(AdaptiveTrigger).Log().Debug(
+				$"Window-size override {(size is { } s ? $"set to {s}" : "cleared")} for ALC '{assemblyLoadContext.Name}'");
+		}
+
+		WindowSizeOverrideChanged?.Invoke(null, EventArgs.Empty);
+	}
+
+	/// <summary>
+	/// Removes scoped overrides whose ALC is unloading. Called from <c>Application.CleanupNonDefaultAlcCaches</c>
+	/// during ALC teardown, as a backstop to the per-ALC <c>Unloading</c> subscription.
+	/// </summary>
+	internal static void ClearScopedWindowSizeOverridesForNonDefaultAlc()
+	{
+		lock (_scopedOverridesGate)
+		{
+			List<AssemblyLoadContext>? toRemove = null;
+			foreach (var (alc, _) in _scopedWindowSizeOverrides)
+			{
+				// Only strip dying contexts: another guest app may still be live with its own override.
+				// Leak-safe either way — the table is weakly keyed, so a missed entry cannot pin the ALC.
+				if (AlcStateHelper.IsUnloadInitiated(alc, valueIfUnknown: false))
+				{
+					(toRemove ??= new()).Add(alc);
+				}
+			}
+
+			if (toRemove is not null)
+			{
+				foreach (var alc in toRemove)
+				{
+					_scopedWindowSizeOverrides.Remove(alc);
+					if (alc.IsCollectible)
+					{
+						alc.Unloading -= OnScopedOverrideAlcUnloading;
+					}
+				}
+
+				RecomputeHasScopedOverrides();
+			}
+		}
+	}
+
+	private static void OnScopedOverrideAlcUnloading(AssemblyLoadContext alc)
+	{
+		// Only mutates the table/flag (no DP access), so no UI-thread marshaling is needed, and no
+		// change event is raised: the guest tree is dying and no other trigger matched that scope.
+		lock (_scopedOverridesGate)
+		{
+			_scopedWindowSizeOverrides.Remove(alc);
+			RecomputeHasScopedOverrides();
+		}
+
+		if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+		{
+			typeof(AdaptiveTrigger).Log().Debug($"Scoped window-size override dropped for unloading ALC '{alc.Name}'");
+		}
+	}
+
+	// Invoked under _scopedOverridesGate.
+	private static void RecomputeHasScopedOverrides()
+	{
+		foreach (var _ in _scopedWindowSizeOverrides)
+		{
+			_hasScopedWindowSizeOverrides = true;
+			return;
+		}
+
+		_hasScopedWindowSizeOverrides = false;
+	}
+
+	private Size? GetEffectiveWindowSizeOverride()
+	{
+		if (_hasScopedWindowSizeOverrides
+			&& ResolveOwnerAssemblyLoadContext() is { } ownerAlc
+			&& _scopedWindowSizeOverrides.TryGetValue(ownerAlc, out var scoped))
+		{
+			return scoped.Size;
+		}
+
+		return _windowSizeOverride;
+	}
+
+	private AssemblyLoadContext? ResolveOwnerAssemblyLoadContext()
+	{
+		if (_ownerAlcCache is WeakReference<AssemblyLoadContext> weak)
+		{
+			if (weak.TryGetTarget(out var cached))
+			{
+				return cached;
+			}
+
+			// The cached ALC was collected (its tree is gone); re-resolve against the current ancestry.
+			_ownerAlcCache = null;
+		}
+		else if (ReferenceEquals(_ownerAlcCache, _noSecondaryAlc))
+		{
+			return null;
+		}
+
+		// Walk up from the trigger (VisualState → VisualStateGroup → owner element → ancestors) to the
+		// nearest node whose type comes from a non-default ALC. The owner element itself is typically a
+		// shared framework type (Grid, Border) from the default ALC, while a hosted guest app's pages
+		// are types loaded in the guest ALC — nearest hit wins so nested hosts resolve to the innermost
+		// guest. Runs once per attach (cached) and only while a scoped override exists.
+		for (var node = (object)this; node is IDependencyObjectStoreProvider provider; node = provider.GetParent())
+		{
+			if (AssemblyLoadContext.GetLoadContext(node.GetType().Assembly) is { } alc
+				&& !ReferenceEquals(alc, AssemblyLoadContext.Default))
+			{
+				_ownerAlcCache = new WeakReference<AssemblyLoadContext>(alc);
+				return alc;
+			}
+		}
+
+		_ownerAlcCache = _noSecondaryAlc;
+		return null;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.alc.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.alc.cs
@@ -13,42 +13,52 @@ namespace Microsoft.UI.Xaml;
 
 partial class AdaptiveTrigger
 {
-	// Reference-type holder for a scoped override value (ConditionalWeakTable values must be reference types).
+	// Immutable holder for a scoped override value (ConditionalWeakTable values must be reference
+	// types). Updates replace the holder so the lock-free read path always sees a consistent Size.
 	private sealed class ScopedSizeOverride
 	{
-		public Size Size;
+		public ScopedSizeOverride(Size size) => Size = size;
+
+		public Size Size { get; }
 	}
 
 	// Weakly keyed by the ALC so a scoped override can never keep a collectible guest context alive.
 	private static readonly ConditionalWeakTable<AssemblyLoadContext, ScopedSizeOverride> _scopedWindowSizeOverrides = new();
 	private static readonly object _scopedOverridesGate = new();
 
+	// One WeakReference per ALC, shared by every trigger's owner cache, so re-resolution after
+	// list-recycling detach/attach cycles doesn't allocate a fresh weak GC handle per trigger.
+	private static readonly ConditionalWeakTable<AssemblyLoadContext, WeakReference<AssemblyLoadContext>> _sharedAlcWeakReferences = new();
+
 	// Fast-path gate: while false (no scoped override anywhere in the process), triggers never walk
 	// their ancestry nor touch the table — single-ALC apps pay one volatile read per evaluation.
 	private static volatile bool _hasScopedWindowSizeOverrides;
+
+	internal static bool HasScopedWindowSizeOverrides => _hasScopedWindowSizeOverrides;
 
 	// Sentinel for "resolved, no secondary-ALC owner" so the ancestor walk runs at most once per attach.
 	private static readonly object _noSecondaryAlc = new();
 
 	// null = unresolved | _noSecondaryAlc | WeakReference<AssemblyLoadContext>. Weak so a trigger
 	// instance leaked past its guest app's unload can never root the collectible ALC. Reset on
-	// detach (owner/element changes); an ancestor re-parented above the owner element without an
-	// owner hook firing keeps a stale value until the next detach/attach — hosts swap guests at the
-	// content-host boundary, which unloads the subtree, so that path re-resolves in practice.
+	// detach AND attach, so every (re-)entry into a live tree re-resolves the current ancestry.
 	private object? _ownerAlcCache;
 
 	/// <summary>
 	/// Overrides the size used by <see cref="AdaptiveTrigger"/>s owned by elements originating from
-	/// <paramref name="assemblyLoadContext"/> (i.e. having an ancestor whose type is loaded in that
-	/// context), instead of the window bounds. Passing a <c>null</c> size clears that scoped override.
+	/// <paramref name="assemblyLoadContext"/> — those whose nearest ancestor typed in a non-default
+	/// load context belongs to it. Passing a <c>null</c> size clears that scoped override.
 	/// </summary>
 	/// <remarks>
 	/// Uno-specific host-extensibility hook complementing the global <c>SetWindowSizeOverride(Size?)</c>
 	/// overload: a host that loads a guest app into its own <c>AssemblyLoadContext</c> can simulate a
 	/// form factor for the guest's triggers without affecting its own UI. A scoped override takes
-	/// precedence over the global override for the triggers it applies to. The association is weak:
-	/// it never keeps a collectible context alive, and is dropped automatically when the context
-	/// unloads. Call it on the UI thread: it synchronously re-evaluates every live trigger.
+	/// precedence over the global override for the triggers it applies to; nested contexts resolve
+	/// to the innermost one. Triggers whose ancestry contains no guest-typed element — content built
+	/// solely from shared framework types, including popup and flyout subtrees re-parented under the
+	/// host's popup root — cannot be attributed and fall back to the global override. The association
+	/// is weak: it never keeps a collectible context alive, and is dropped automatically when the
+	/// context unloads. Call it on the UI thread: it synchronously re-evaluates every live trigger.
 	/// </remarks>
 	/// <param name="size">The simulated window size, or <c>null</c> to clear the scoped override.</param>
 	/// <param name="assemblyLoadContext">The load context whose triggers the override applies to.</param>
@@ -69,23 +79,38 @@ partial class AdaptiveTrigger
 
 			if (size is { } newSize)
 			{
-				if (hasExisting && existing!.Size == newSize)
-				{
-					return;
-				}
-
 				if (hasExisting)
 				{
-					existing!.Size = newSize;
+					if (existing!.Size == newSize)
+					{
+						return;
+					}
+
+					// Replace rather than mutate: GetEffectiveWindowSizeOverride reads lock-free.
+					_scopedWindowSizeOverrides.Remove(assemblyLoadContext);
+					_scopedWindowSizeOverrides.Add(assemblyLoadContext, new ScopedSizeOverride(newSize));
 				}
 				else
 				{
-					_scopedWindowSizeOverrides.Add(assemblyLoadContext, new ScopedSizeOverride { Size = newSize });
+					// A post-Unloading entry could never self-clean (the event won't fire again) and
+					// would silently never apply while latching the scoped-resolution path on for good.
+					if (AlcStateHelper.IsUnloadInitiated(assemblyLoadContext, valueIfUnknown: false))
+					{
+						if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Warning))
+						{
+							typeof(AdaptiveTrigger).Log().Warn(
+								$"Ignoring window-size override for ALC '{assemblyLoadContext.Name}': its unload has already been initiated");
+						}
+
+						return;
+					}
+
+					_scopedWindowSizeOverrides.Add(assemblyLoadContext, new ScopedSizeOverride(newSize));
 					if (assemblyLoadContext.IsCollectible)
 					{
 						// Self-cleaning even if the host never clears the override: drop the entry (and
 						// restore the fast path) when the guest context unloads. Symmetric with the
-						// unsubscription in the clearing branch below, so at most one subscription exists.
+						// unsubscriptions on the clearing paths, so at most one subscription exists.
 						assemblyLoadContext.Unloading += OnScopedOverrideAlcUnloading;
 					}
 				}
@@ -155,17 +180,51 @@ partial class AdaptiveTrigger
 
 	private static void OnScopedOverrideAlcUnloading(AssemblyLoadContext alc)
 	{
-		// Only mutates the table/flag (no DP access), so no UI-thread marshaling is needed, and no
-		// change event is raised: the guest tree is dying and no other trigger matched that scope.
-		lock (_scopedOverridesGate)
+		// May run on the caller's thread OR the finalizer thread (GC-initiated unload of a dropped
+		// collectible ALC) — an escaping exception there is process-fatal, so contain everything.
+		try
 		{
-			_scopedWindowSizeOverrides.Remove(alc);
-			RecomputeHasScopedOverrides();
-		}
+			bool removed;
+			lock (_scopedOverridesGate)
+			{
+				removed = _scopedWindowSizeOverrides.TryGetValue(alc, out _);
+				if (removed)
+				{
+					_scopedWindowSizeOverrides.Remove(alc);
+					RecomputeHasScopedOverrides();
+				}
+			}
 
-		if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+			if (!removed)
+			{
+				return;
+			}
+
+			if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(AdaptiveTrigger).Log().Debug($"Scoped window-size override dropped for unloading ALC '{alc.Name}'");
+			}
+
+			// Guest triggers can still be live when unload is initiated before the guest tree is
+			// detached (the wrong-order host case); without a re-evaluation they'd stay frozen in the
+			// simulated-size state. Re-evaluate on the UI thread — never from here directly, as this
+			// can run on an arbitrary or finalizer thread.
+			static void RaiseChanged() => WindowSizeOverrideChanged?.Invoke(null, EventArgs.Empty);
+			if (global::Uno.UI.Dispatching.NativeDispatcher.Main.HasThreadAccess)
+			{
+				RaiseChanged();
+			}
+			else
+			{
+				global::Uno.UI.Dispatching.NativeDispatcher.Main.Enqueue(static () => RaiseChanged());
+			}
+		}
+		catch (Exception ex)
 		{
-			typeof(AdaptiveTrigger).Log().Debug($"Scoped window-size override dropped for unloading ALC '{alc.Name}'");
+			if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Warning))
+			{
+				typeof(AdaptiveTrigger).Log().Warn($"Failed to drop the scoped window-size override for unloading ALC '{alc.Name}'", ex);
+			}
 		}
 	}
 
@@ -220,12 +279,25 @@ partial class AdaptiveTrigger
 			if (AssemblyLoadContext.GetLoadContext(node.GetType().Assembly) is { } alc
 				&& !ReferenceEquals(alc, AssemblyLoadContext.Default))
 			{
-				_ownerAlcCache = new WeakReference<AssemblyLoadContext>(alc);
+				_ownerAlcCache = _sharedAlcWeakReferences.GetValue(alc, static a => new WeakReference<AssemblyLoadContext>(a));
+
+				if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Trace))
+				{
+					typeof(AdaptiveTrigger).Log().Trace($"AdaptiveTrigger attributed to ALC '{alc.Name}' via ancestor '{node.GetType().Name}'");
+				}
+
 				return alc;
 			}
 		}
 
 		_ownerAlcCache = _noSecondaryAlc;
+
+		if (typeof(AdaptiveTrigger).Log().IsEnabled(LogLevel.Debug))
+		{
+			typeof(AdaptiveTrigger).Log().Debug(
+				"AdaptiveTrigger has no ancestor typed in a non-default AssemblyLoadContext; scoped window-size overrides will not apply to it");
+		}
+
 		return null;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -62,7 +62,7 @@ namespace Microsoft.UI.Xaml
 		private void UpdateState()
 		{
 			double w, h;
-			if (_windowSizeOverride is { } overrideSize)
+			if (GetEffectiveWindowSizeOverride() is { } overrideSize)
 			{
 				w = overrideSize.Width;
 				h = overrideSize.Height;
@@ -174,6 +174,11 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		private void DetachSizeChanged() => _sizeChangedSubscription.Disposable = null;
+		private void DetachSizeChanged()
+		{
+			// Re-parenting (owner/element change) can move the trigger across an ALC boundary.
+			_ownerAlcCache = null;
+			_sizeChangedSubscription.Disposable = null;
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -14,8 +14,9 @@ namespace Microsoft.UI.Xaml
 
 		private static Size? _windowSizeOverride;
 
-		// Raised when the global window-size override set through SetWindowSizeOverride changes, so that
-		// every live AdaptiveTrigger re-evaluates its active state (the same role XamlRoot.Changed plays).
+		// Raised when a window-size override set through SetWindowSizeOverride (global or ALC-scoped)
+		// changes, so every live AdaptiveTrigger re-evaluates its active state (the same role
+		// XamlRoot.Changed plays).
 		private static event EventHandler WindowSizeOverrideChanged;
 
 		public AdaptiveTrigger()
@@ -157,6 +158,10 @@ namespace Microsoft.UI.Xaml
 
 		private void AttachSizeChanged()
 		{
+			// Every (re-)attach re-resolves the owner ALC: an evaluation while the owner subtree was not
+			// yet parented under its guest-typed ancestor may have cached "no ALC".
+			_ownerAlcCache = null;
+
 			// Only subscribe while a XamlRoot exists (the trigger is in a live tree): subscribing the static
 			// override event any earlier would root never-loaded triggers for the process lifetime.
 			if (XamlRoot is { } xamlRoot)

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -158,9 +158,7 @@ namespace Microsoft.UI.Xaml
 
 		private void AttachSizeChanged()
 		{
-			// Every (re-)attach re-resolves the owner ALC: an evaluation while the owner subtree was not
-			// yet parented under its guest-typed ancestor may have cached "no ALC".
-			_ownerAlcCache = null;
+			ResetOwnerAlcCache();
 
 			// Only subscribe while a XamlRoot exists (the trigger is in a live tree): subscribing the static
 			// override event any earlier would root never-loaded triggers for the process lifetime.
@@ -181,8 +179,7 @@ namespace Microsoft.UI.Xaml
 
 		private void DetachSizeChanged()
 		{
-			// Re-parenting (owner/element change) can move the trigger across an ALC boundary.
-			_ownerAlcCache = null;
+			ResetOwnerAlcCache();
 			_sizeChangedSubscription.Disposable = null;
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Application.Alc.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Alc.cs
@@ -380,6 +380,10 @@ partial class Application
 		// FrameworkElementHelper — remove CWT entries for ALC DependencyObjects
 		FrameworkElementHelper.ClearNonDefaultAlcEntries();
 
+		// AdaptiveTrigger — drop window-size overrides scoped to unloading ALCs (backstop to their
+		// own Unloading subscription; weakly keyed, so this is hygiene rather than leak prevention).
+		RunCleanupStep(nameof(AdaptiveTrigger.ClearScopedWindowSizeOverridesForNonDefaultAlc), AdaptiveTrigger.ClearScopedWindowSizeOverridesForNonDefaultAlc);
+
 		// ResourceResolver — remove Func delegates whose Target is from a non-default ALC
 		ResourceResolver.ClearNonDefaultAlcRegistrations();
 


### PR DESCRIPTION
**GitHub Issue:** closes #23721

## PR Type:

✨ Feature

## What changed? 🚀

`AdaptiveTrigger.SetWindowSizeOverride(Size?)` (added in #23445 for #23444) is a process-global static override: because a host and its hosted guest apps share the same Uno.UI instance from the default `AssemblyLoadContext`, simulating a form factor for a guest also re-evaluated every `AdaptiveTrigger` in the host's own UI, collapsing/expanding the host chrome based on the guest's simulated size.

This PR adds an ALC-scoped overload, `SetWindowSizeOverride(Size?, AssemblyLoadContext)`, so a host can apply a simulated size to the triggers of a guest app loaded in a (collectible) ALC without affecting its own UI:

- **Owner resolution**: each trigger walks its ancestry (VisualState → VisualStateGroup → owner element → ancestors) to the nearest element typed in a non-default ALC, lazily and cached per attach; nested contexts resolve to the innermost one. The cache is reset on every attach/detach so re-parenting re-resolves.
- **Precedence**: scoped override → global override → window (`XamlRoot`) bounds. The existing global overload's behavior is unchanged.
- **No rooting of the guest ALC**: storage is a weakly keyed `ConditionalWeakTable`, and trigger-side caching uses shared `WeakReference`s. The scope self-clears via the ALC's `Unloading` event (with an `Application` ALC-cleanup backstop), re-evaluating any still-live guest triggers so they don't stay frozen at the simulated size. Overrides for an ALC whose unload has already been initiated are ignored.
- **Fast path preserved**: while no scoped override exists anywhere in the process, trigger evaluation pays a single volatile bool read — no ancestor walk, no table lookup.
- Docs: `doc/articles/features/AdaptiveTrigger.md` documents both overloads, the precedence chain, and the attribution limits (guest content composed solely of shared framework types — e.g. popup/flyout subtrees re-parented under the host's popup root — falls back to the global override).

**Validation**: unit tests `Given_AdaptiveTrigger` 32/32 passed (guest-only application, scoped-over-global precedence, revert-on-clear chains, pre-attach and pre-parenting overrides, two concurrent scoped ALCs, nested-ALC innermost-wins, argument validation, foreign-scope isolation, no-rooting, self-clear on unload, unloading-ALC rejection); runtime tests `Given_AlcContentHost` 39/39 passed on Skia desktop (X11), including two new hosted-topology tests where guest triggers live inside the host's visual tree sharing its `XamlRoot`. An eight-lens review panel ran on the branch; all actionable findings are addressed in the last commit. Non-Skia heads are compile-verified by CI only (the new code uses `System.Runtime.Loader` and `NativeDispatcher`, both available on all heads).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
