### PR TITLE
fix(navview): Keep overflow button after overflow selection

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -484,6 +484,135 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23903")]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop)]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_TopNav_Select_Overflow_Item_Overflow_Button_Remains()
+		{
+#if HAS_INPUT_INJECTOR
+			// Issue #23903: in Top mode with MenuItemsSource + MenuItemTemplate, selecting the widest
+			// item from the overflow flyout made the overflow button disappear even though not all
+			// items fit in the top bar. Inherited from WinUI (microsoft/microsoft-ui-xaml#6626).
+
+			var titles = new List<string>
+			{
+				"First Tab with large text",
+				"Second Tab with large text",
+				"Third Tab with large text",
+				"Fourth Tab with large text",
+				"Fifth Tab with large text and the last is larger then the other",
+			};
+
+			var template = (DataTemplate)XamlReader.Load("""
+				<DataTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+							  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+							  xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
+					<muxc:NavigationViewItem Content="{Binding}" />
+				</DataTemplate>
+				""");
+
+			var failures = new List<string>();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			foreach (var width in new double[] { 1240, 1180, 1120, 1060, 1000, 940, 880, 820, 760, 700 })
+			{
+				var nv = new MUXC.NavigationView
+				{
+					PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Top,
+					IsBackButtonVisible = MUXC.NavigationViewBackButtonVisible.Collapsed,
+					IsSettingsVisible = false,
+					IsPaneToggleButtonVisible = false,
+					MenuItemsSource = titles,
+					MenuItemTemplate = template,
+					Width = 1400,
+					Height = 80,
+				};
+
+				try
+				{
+					await UITestHelper.Load(nv);
+
+					// Shrink gradually, like a user dragging the window edge.
+					for (var w = 1380d; w >= width; w -= 20)
+					{
+						nv.Width = w;
+						nv.UpdateLayout();
+					}
+					await WindowHelper.WaitForIdle();
+
+					var overflowButton = nv.FindFirstDescendant<Button>(b => b.Name == "TopNavOverflowButton");
+					if (overflowButton is null || overflowButton.Visibility == Visibility.Collapsed)
+					{
+						// All items fit at this width, nothing to test.
+						continue;
+					}
+
+					// Open the overflow flyout by tapping the overflow button, like a user would.
+					finger.Tap(overflowButton.GetAbsoluteBounds().GetCenter());
+					await WindowHelper.WaitForIdle();
+
+					// Find the widest item's container inside the flyout and tap it.
+					var popups = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot);
+					MUXC.NavigationViewItem flyoutItem = null;
+					foreach (var popup in popups)
+					{
+						flyoutItem = (popup.Child as FrameworkElement)?.FindFirstDescendant<MUXC.NavigationViewItem>(
+							i => Equals(i.Content, titles[4]));
+						if (flyoutItem is not null)
+						{
+							break;
+						}
+					}
+
+					if (flyoutItem is null)
+					{
+						failures.Add($"width={width}: widest item not found in overflow flyout");
+						continue;
+					}
+
+					finger.Tap(flyoutItem.GetAbsoluteBounds().GetCenter());
+					await WindowHelper.WaitForIdle();
+
+					if (!Equals(nv.SelectedItem, titles[4]))
+					{
+						failures.Add($"width={width}: selection did not stick (SelectedItem={nv.SelectedItem ?? "<null>"})");
+						continue;
+					}
+
+					// All five items cannot fit, so the overflow button must remain visible.
+					overflowButton = nv.FindFirstDescendant<Button>(b => b.Name == "TopNavOverflowButton");
+					if (overflowButton is null)
+					{
+						failures.Add($"width={width}: overflow button not found after selection");
+					}
+					else if (overflowButton.Visibility == Visibility.Collapsed)
+					{
+						failures.Add($"width={width}: overflow button collapsed after selecting the overflow item");
+					}
+				}
+				finally
+				{
+					foreach (var popup in Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot))
+					{
+						popup.IsOpen = false;
+					}
+					WindowHelper.WindowContent = null;
+					await WindowHelper.WaitForIdle();
+				}
+			}
+
+			Assert.IsTrue(failures.Count == 0, $"Overflow button visibility failures:{Environment.NewLine}{string.Join(Environment.NewLine, failures)}");
+#else
+			await Task.CompletedTask;
+#endif
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/19482")]
 		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
 		public async Task When_BackButtonVisible_PaneToggleButton_Not_Clipped()

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -4098,8 +4098,11 @@ public partial class NavigationView : ContentControl
 			{
 				// Exchange items between Primary and Overflow
 				{
-					m_topDataProvider.MoveItemsToPrimaryList(itemsToBeAdded);
+					// Uno workaround: move items out of primary first so the overflow list never becomes
+					// empty mid-exchange — OnOverflowItemsSourceCollectionChanged would collapse the overflow
+					// button for good (upstream bug: https://github.com/microsoft/microsoft-ui-xaml/issues/6626).
 					m_topDataProvider.MoveItemsOutOfPrimaryList(itemsToBeRemoved);
+					m_topDataProvider.MoveItemsToPrimaryList(itemsToBeAdded);
 				}
 
 				if (NeedRearrangeOfTopElementsAfterOverflowSelectionChanged(selectedOverflowItemIndex))


### PR DESCRIPTION
**GitHub Issue:** closes #23903

## PR Type:

🐞 Bugfix

## What changed? 🚀

In Top mode, selecting an item from the overflow flyout could permanently collapse the overflow button even though not all items fit in the top bar, leaving the remaining items unreachable until the window was resized wider and back.

**Root cause:** the two-phase exchange in `NavigationView.SelectOverflowItem` moves items into the primary list before moving others out. When the selected item is the only overflow item, the overflow list transiently empties mid-exchange; `OnOverflowItemsSourceCollectionChanged` reacts to that transient state by collapsing the overflow button, and nothing re-shows it afterwards (the subsequent measure pass doesn't reach `ArrangeTopNavItems`, the only place that sets it back to `Visible`).

**Fix:** reorder the exchange to move items out of the primary list first, so the overflow list only becomes empty when it genuinely ends empty (in which case collapsing is correct). Marked as an Uno workaround, since this is an inherited **WinUI bug** ([microsoft/microsoft-ui-xaml#6626](https://github.com/microsoft/microsoft-ui-xaml/issues/6626), open since 2022) — running the same repro test against native WinAppSDK fails the same way, which is why the new runtime test is Skia-only.

**Validation (runtime):** new runtime test `Given_NavigationView.When_TopNav_Select_Overflow_Item_Overflow_Button_Remains` mirrors the issue's repro (MenuItemsSource + MenuItemTemplate, gradual width shrink, InputInjector taps on the overflow button and flyout item across 10 widths) — fails at 6 widths before the fix, passes after. Full `Given_NavigationView` (27) and MUX `NavigationViewTests` (14) suites pass on Skia Desktop. Also validated manually with the issue's attached repro app (stock 6.5.31 reproduces; local build with the fix does not).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
