### PR TITLE
build: rename Hot Design SDK property HotDesignStoriesFolder to HotDesignPreviewsFolder

### DIFF
--- a/specs/055-hotdesign-previews-folder-rename/spec.md
+++ b/specs/055-hotdesign-previews-folder-rename/spec.md
@@ -1,0 +1,49 @@
+# Feature Specification: Align Hot Design Previews Folder MSBuild Property
+
+**Repo**: `uno` (Uno.Sdk)
+**Created**: 2026-07-30
+**Status**: Documenting current behavior
+**Issue**: unoplatform/uno#23907 (related: unoplatform/uno.hotdesign#7408)
+**Input**: The Uno SDK still emits the legacy MSBuild property `HotDesignStoriesFolder`, a leftover from the pre-rename "Stories" era. Hot Design (`uno.hotdesign`) has since moved to `HotDesignPreviewsFolder`, and today the combination only works because Hot Design carries a compatibility fallback that bridges the old name to the new one.
+
+---
+
+## Overview
+
+The Uno SDK defines a single MSBuild property that names the folder holding a project's Hot Design design-time content, and excludes that folder from compilation in Release (Optimize) builds. This property is the SDK-facing input that Hot Design consumes to locate an application's Previews folder at runtime.
+
+## Current behavior
+
+Two SDK targets files reference the folder property, both under the legacy `HotDesignStoriesFolder` name:
+
+- `src/Uno.Sdk/targets/Uno.Common.targets` — defines the default:
+
+  ```xml
+  <!-- Define the default folder for Hot Design Stories, so they can be excluded in Release -->
+  <PropertyGroup Condition="'$(UnoDisableHotDesign)' != 'true'">
+    <HotDesignStoriesFolder Condition="'$(HotDesignStoriesFolder)' == ''">HotDesignStories</HotDesignStoriesFolder>
+  </PropertyGroup>
+  ```
+
+- `src/Uno.Sdk/targets/Uno.DefaultItems.targets` — excludes the folder in Optimize builds:
+
+  ```xml
+  <!-- Exclude the Stories folder when in Optimize (aka Release) build configuration -->
+  <DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoriesFolder)' != '' ">$(DefaultItemExcludes);$(HotDesignStoriesFolder)/**</DefaultItemExcludes>
+  ```
+
+## Downstream dependency (Hot Design)
+
+Hot Design's `Uno.UI.HotDesign.props` expects `HotDesignPreviewsFolder`. Because the SDK sets only `HotDesignStoriesFolder`, Hot Design bridges the names:
+
+```xml
+<HotDesignPreviewsFolder Condition="'$(HotDesignPreviewsFolder)' == '' AND '$(HotDesignStoriesFolder)' != ''">$(HotDesignStoriesFolder)</HotDesignPreviewsFolder>
+```
+
+It then computes an absolute `ApplicationPreviewsFolder` from that value, bakes it into assembly metadata, and reads it at runtime.
+
+## The misalignment
+
+The SDK exposes `HotDesignStoriesFolder`; Hot Design's real contract is `HotDesignPreviewsFolder`. The two only line up because of the bridge. The bridge is scheduled for removal (unoplatform/uno.hotdesign#7408), which makes the SDK-side rename a prerequisite.
+
+This document records the current state; the target state is captured in the following revision.

--- a/specs/055-hotdesign-previews-folder-rename/spec.md
+++ b/specs/055-hotdesign-previews-folder-rename/spec.md
@@ -2,9 +2,9 @@
 
 **Repo**: `uno` (Uno.Sdk)
 **Created**: 2026-07-30
-**Status**: Documenting current behavior
+**Status**: Approved — target design
 **Issue**: unoplatform/uno#23907 (related: unoplatform/uno.hotdesign#7408)
-**Input**: The Uno SDK still emits the legacy MSBuild property `HotDesignStoriesFolder`, a leftover from the pre-rename "Stories" era. Hot Design (`uno.hotdesign`) has since moved to `HotDesignPreviewsFolder`, and today the combination only works because Hot Design carries a compatibility fallback that bridges the old name to the new one.
+**Input**: The Uno SDK emits the legacy MSBuild property `HotDesignStoriesFolder`, a leftover from the pre-rename "Stories" era. Hot Design (`uno.hotdesign`) has moved to `HotDesignPreviewsFolder` and today only works via a compatibility bridge. This spec aligns the SDK-facing name to `HotDesignPreviewsFolder`.
 
 ---
 
@@ -12,38 +12,44 @@
 
 The Uno SDK defines a single MSBuild property that names the folder holding a project's Hot Design design-time content, and excludes that folder from compilation in Release (Optimize) builds. This property is the SDK-facing input that Hot Design consumes to locate an application's Previews folder at runtime.
 
-## Current behavior
+## Target (aligned) behavior
 
-Two SDK targets files reference the folder property, both under the legacy `HotDesignStoriesFolder` name:
+Both SDK targets files reference the folder property under the aligned `HotDesignPreviewsFolder` name, with a default of `HotDesignPreviews`:
 
 - `src/Uno.Sdk/targets/Uno.Common.targets` — defines the default:
 
   ```xml
-  <!-- Define the default folder for Hot Design Stories, so they can be excluded in Release -->
+  <!-- Define the default folder for Hot Design previews, so they can be excluded in Release -->
   <PropertyGroup Condition="'$(UnoDisableHotDesign)' != 'true'">
-    <HotDesignStoriesFolder Condition="'$(HotDesignStoriesFolder)' == ''">HotDesignStories</HotDesignStoriesFolder>
+    <HotDesignPreviewsFolder Condition="'$(HotDesignPreviewsFolder)' == ''">HotDesignPreviews</HotDesignPreviewsFolder>
   </PropertyGroup>
   ```
 
 - `src/Uno.Sdk/targets/Uno.DefaultItems.targets` — excludes the folder in Optimize builds:
 
   ```xml
-  <!-- Exclude the Stories folder when in Optimize (aka Release) build configuration -->
-  <DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoriesFolder)' != '' ">$(DefaultItemExcludes);$(HotDesignStoriesFolder)/**</DefaultItemExcludes>
+  <!-- Exclude the previews folder when in Optimize (aka Release) build configuration -->
+  <DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignPreviewsFolder)' != '' ">$(DefaultItemExcludes);$(HotDesignPreviewsFolder)/**</DefaultItemExcludes>
   ```
 
 ## Downstream dependency (Hot Design)
 
-Hot Design's `Uno.UI.HotDesign.props` expects `HotDesignPreviewsFolder`. Because the SDK sets only `HotDesignStoriesFolder`, Hot Design bridges the names:
+With the SDK setting `HotDesignPreviewsFolder` directly, Hot Design's `Uno.UI.HotDesign.props` no longer needs its compatibility bridge (removed in unoplatform/uno.hotdesign#7408). Hot Design continues to compute the internal absolute `ApplicationPreviewsFolder` from `HotDesignPreviewsFolder`, bake it into assembly metadata, and read it at runtime — that contract is unchanged.
 
-```xml
-<HotDesignPreviewsFolder Condition="'$(HotDesignPreviewsFolder)' == '' AND '$(HotDesignStoriesFolder)' != ''">$(HotDesignStoriesFolder)</HotDesignPreviewsFolder>
-```
+## Decision: hard rename, no fallback
 
-It then computes an absolute `ApplicationPreviewsFolder` from that value, bakes it into assembly metadata, and reads it at runtime.
+The rename is a **hard rename**: the SDK stops emitting `HotDesignStoriesFolder` entirely rather than keeping a permanent alias. This removes the dual-name ambiguity at the source. The consequence is a coordinated, breaking change (see below), accepted deliberately over carrying a long-lived compatibility alias.
 
-## The misalignment
+## Breaking change and migration
 
-The SDK exposes `HotDesignStoriesFolder`; Hot Design's real contract is `HotDesignPreviewsFolder`. The two only line up because of the bridge. The bridge is scheduled for removal (unoplatform/uno.hotdesign#7408), which makes the SDK-side rename a prerequisite.
+- Projects that explicitly set `HotDesignStoriesFolder` must rename the property to `HotDesignPreviewsFolder`.
+- Apps relying on the default folder name will see the auto-excluded folder change from `HotDesignStories` to `HotDesignPreviews`. Rename the folder, or set `HotDesignPreviewsFolder` explicitly, to keep it excluded from Release builds.
 
-This document records the current state; the target state is captured in the following revision.
+## Coordination
+
+The SDK change ships **first**. Hot Design's bridge removal (unoplatform/uno.hotdesign#7408) only becomes safe once an aligned SDK is in use; until then Hot Design's bridge keeps older SDKs working.
+
+## Changes in this repo
+
+- `src/Uno.Sdk/targets/Uno.Common.targets` — rename `HotDesignStoriesFolder` → `HotDesignPreviewsFolder`; default `HotDesignStories` → `HotDesignPreviews`.
+- `src/Uno.Sdk/targets/Uno.DefaultItems.targets` — rename the property reference in the Optimize-build `DefaultItemExcludes`.

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -149,8 +149,8 @@
 		<ProjectCapability Include="DotNetWslLaunch" />
 	</ItemGroup>
 
-	<!-- Define the default folder for Hot Design Stories, so they can be excluded in Release -->
+	<!-- Define the default folder for Hot Design previews, so they can be excluded in Release -->
 	<PropertyGroup Condition="'$(UnoDisableHotDesign)' != 'true'">
-		<HotDesignStoriesFolder Condition="'$(HotDesignStoriesFolder)' == ''">HotDesignStories</HotDesignStoriesFolder>
+		<HotDesignPreviewsFolder Condition="'$(HotDesignPreviewsFolder)' == ''">HotDesignPreviews</HotDesignPreviewsFolder>
 	</PropertyGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.DefaultItems.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.targets
@@ -5,8 +5,8 @@
 		<DefaultItemExcludes Condition="!$(DefaultItemExcludes.Contains('bin/**'))">$(DefaultItemExcludes);bin/**</DefaultItemExcludes>
 		<DefaultItemExcludes Condition="!$(DefaultItemExcludes.Contains('obj/**'))">$(DefaultItemExcludes);obj/**</DefaultItemExcludes>
 
-		<!-- Exclude the Stories folder when in Optimize (aka Release) build configuration -->
-		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoriesFolder)' != '' ">$(DefaultItemExcludes);$(HotDesignStoriesFolder)/**</DefaultItemExcludes>
+		<!-- Exclude the previews folder when in Optimize (aka Release) build configuration -->
+		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignPreviewsFolder)' != '' ">$(DefaultItemExcludes);$(HotDesignPreviewsFolder)/**</DefaultItemExcludes>
 	</PropertyGroup>
 
 	<!-- Default Includes-->


### PR DESCRIPTION
**GitHub Issue:** closes #23907

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Renames the SDK MSBuild property `HotDesignStoriesFolder` → `HotDesignPreviewsFolder` in `src/Uno.Sdk/targets/Uno.Common.targets` and `src/Uno.Sdk/targets/Uno.DefaultItems.targets`, aligning the SDK-facing name with Hot Design's `HotDesignPreviewsFolder` contract. The default folder value changes from `HotDesignStories` to `HotDesignPreviews`. This is a hard rename with no fallback.

Coordinates with removal of the compatibility bridge in unoplatform/uno.hotdesign#7408. The SDK change ships **first**; the bridge is only a no-op once this is in.

**⚠️ Breaking change / migration:**

- Projects that explicitly set `HotDesignStoriesFolder` must rename the property to `HotDesignPreviewsFolder`.
- Apps that relied on the default folder name will see the auto-excluded folder change from `HotDesignStories` to `HotDesignPreviews`; rename the folder (or set the property explicitly) to keep it excluded from Release builds.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample (MSBuild property-only change)
- [x] 📚 Docs have been added/updated (`specs/055-hotdesign-previews-folder-rename/spec.md`)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

This PR **does** contain a breaking change (hard property rename); see the migration notes above. Chosen deliberately to remove the dual-name ambiguity rather than carry a permanent alias.
