### PR TITLE
fix(ios): Spacebar trackpad gesture support for Skia TextBox

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/IInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/IInvisibleTextBoxView.cs
@@ -21,6 +21,8 @@ internal interface IInvisibleTextBoxView
 
 	void Select(int start, int length);
 
+	UIFont? Font { get; set; }
+
 	UITextAutocapitalizationType AutocapitalizationType { get; set; }
 
 	UIKeyboardType KeyboardType { get; set; }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/IInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/IInvisibleTextBoxView.cs
@@ -44,4 +44,8 @@ internal interface IInvisibleTextBoxView
 	TextBoxView? Owner { get; }
 
 	bool IsComposing { get; }
+
+	bool IsSettingTextFromManaged { get; }
+
+	bool IsSettingSelectionFromManaged { get; }
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -227,6 +227,37 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 		}
 	}
 
+	// Invoked from textFieldDidChangeSelection:/textViewDidChangeSelection:. UIKit mutates the
+	// selection through internal controllers for some interactions (e.g. the spacebar trackpad-
+	// mode drag), bypassing the setSelectedTextRange: override in the views, so the delegate
+	// callback is the only notification that covers every native selection change.
+	internal void OnNativeSelectionChanged()
+	{
+		if (_textBoxView is not { } textBoxView
+			|| textBoxView.IsSettingTextFromManaged
+			|| textBoxView.IsSettingSelectionFromManaged
+			|| textBoxView.IsComposing)
+		{
+			return;
+		}
+
+		if (_owner?.TextBox is not { } textBox)
+		{
+			return;
+		}
+
+		// While a native edit is in flight the native text is ahead of the managed text, so
+		// selection offsets don't map onto it; ProcessNativeTextInput applies the post-edit
+		// selection itself (see SetPendingSelection).
+		var nativeText = GetNativeText()?.Replace('\n', '\r') ?? string.Empty;
+		if (nativeText != (textBox.Text ?? string.Empty))
+		{
+			return;
+		}
+
+		SyncSelectionToTextBox();
+	}
+
 	internal void ProcessNativeTextInput(string? text)
 	{
 		// During IME composition, text updates are managed by the shared

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -52,6 +52,11 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 		EnsureTextBoxView(textBox);
 		SetSoftKeyboardTheme();
 
+		// The proxy wraps its text at its frame width and iOS keyboard interactions
+		// (e.g. the spacebar trackpad drag) map vertical movement through that layout,
+		// so the frame must track the TextBox size while editing.
+		textBox.SizeChanged += OnTextBoxSizeChanged;
+
 		AddViewToTextInputLayer(textBox.XamlRoot);
 
 		// change FirstResponder's View before removing the previous view to avoid flickering
@@ -68,10 +73,17 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 	{
 		if (_textBoxView is not null)
 		{
+			if (_owner.TextBox is { } textBox)
+			{
+				textBox.SizeChanged -= OnTextBoxSizeChanged;
+			}
+
 			RemoveViewFromTextInputLayer();
 			_textBoxView = null;
 		}
 	}
+
+	private void OnTextBoxSizeChanged(object sender, SizeChangedEventArgs args) => InvalidateLayout();
 
 	public void UpdateSize() => InvalidateLayout();
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -20,6 +20,7 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 	private readonly TextBoxView _owner;
 	private UIView? _latestNativeView;
 	private IInvisibleTextBoxView? _textBoxView;
+	private bool _isStartingEntry;
 
 	public InvisibleTextBoxViewExtension(TextBoxView view)
 	{
@@ -30,7 +31,23 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 
 	public bool IsOverlayLayerInitialized(XamlRoot xamlRoot) => true;
 
+	// Taking first responder makes UIKit park the caret at the end of the document and
+	// report it through the selection delegate. That is an internal mutation, not a user
+	// intent, so it must not be synced back to the TextBox.
 	public void StartEntry()
+	{
+		try
+		{
+			_isStartingEntry = true;
+			StartEntryCore();
+		}
+		finally
+		{
+			_isStartingEntry = false;
+		}
+	}
+
+	private void StartEntryCore()
 	{
 		// StartEntry can be called twice without any EndEntry.
 		// This happens when the managed TextBox receives Focus
@@ -60,13 +77,16 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 
 		AddViewToTextInputLayer(textBox.XamlRoot);
 
+		// Read the intended selection before taking first responder, which moves the
+		// native caret to the end of the document.
+		var start = textBox.SelectionStart;
+		var length = textBox.SelectionLength;
+
 		// change FirstResponder's View before removing the previous view to avoid flickering
 		_textBoxView.BecomeFirstResponder();
 
 		RemovePreviousViewFromTextInputLayer();
 
-		var start = textBox?.SelectionStart ?? 0;
-		var length = textBox?.SelectionLength ?? 0;
 		_textBoxView.Select(start, length);
 	}
 
@@ -253,6 +273,7 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 	internal void OnNativeSelectionChanged()
 	{
 		if (_textBoxView is not { } textBoxView
+			|| _isStartingEntry
 			|| textBoxView.IsSettingTextFromManaged
 			|| textBoxView.IsSettingSelectionFromManaged
 			|| textBoxView.IsComposing)

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -268,13 +268,36 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 		// While a native edit is in flight the native text is ahead of the managed text, so
 		// selection offsets don't map onto it; ProcessNativeTextInput applies the post-edit
 		// selection itself (see SetPendingSelection).
-		var nativeText = GetNativeText()?.Replace('\n', '\r') ?? string.Empty;
-		if (nativeText != (textBox.Text ?? string.Empty))
+		if (!NativeTextEquals(GetNativeText(), textBox.Text))
 		{
 			return;
 		}
 
 		SyncSelectionToTextBox();
+	}
+
+	// Equivalent to nativeText.Replace('\n', '\r') == managedText (native uses \n, managed
+	// uses \r — see SetText), without allocating: this runs on every native selection change.
+	private static bool NativeTextEquals(string? nativeText, string? managedText)
+	{
+		nativeText ??= string.Empty;
+		managedText ??= string.Empty;
+
+		if (nativeText.Length != managedText.Length)
+		{
+			return false;
+		}
+
+		for (var i = 0; i < nativeText.Length; i++)
+		{
+			var nativeChar = nativeText[i] == '\n' ? '\r' : nativeText[i];
+			if (nativeChar != managedText[i])
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	internal void ProcessNativeTextInput(string? text)

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using UIKit;
 using Uno.UI;
+using Uno.UI.Extensions;
 using Uno.UI.Hosting;
 using Uno.UI.Runtime.Skia.AppleUIKit;
 using Uno.UI.Runtime.Skia.AppleUIKit.Hosting;
@@ -169,6 +170,12 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 
 		_textBoxView.SpellCheckingType = textBox.IsSpellCheckEnabled ? UITextSpellCheckingType.Yes : UITextSpellCheckingType.No;
 		_textBoxView.AutocorrectionType = textBox.IsSpellCheckEnabled ? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
+
+		// The proxy lays out its own copy of the text and iOS keyboard interactions
+		// (e.g. the spacebar trackpad drag) constrain horizontal caret movement to the
+		// proxy's layout lines. Match the font size so its wrap points stay close to
+		// the Skia-rendered text.
+		_textBoxView.Font = UIFont.SystemFontOfSize((float)textBox.FontSize);
 
 		var inputReturnType = TextBoxExtensions.GetInputReturnType(textBox);
 		_textBoxView.ReturnKeyType = inputReturnType.ToUIReturnKeyType();
@@ -372,6 +379,23 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 		var y = rect?.Y ?? 0;
 		var width = rect?.Width ?? 10;
 		var height = rect?.Height ?? 10;
+
+		// For the off-screen proxy, wrap fidelity matters more than the control
+		// bounds: size it to the text area so its line breaks stay close to the
+		// Skia layout (see the font-size match in UpdateProperties).
+		if (!ShouldAnchorToTextBox() && textBox?.ContentElement is { } contentElement)
+		{
+			var contentWidth = contentElement.ActualWidth - contentElement.Padding.Horizontal();
+			var contentHeight = contentElement.ActualHeight - contentElement.Padding.Vertical();
+			if (contentWidth > 0)
+			{
+				width = contentWidth;
+			}
+			if (contentHeight > 0)
+			{
+				height = contentHeight;
+			}
+		}
 
 		// Only iPad shows a floating numeric keypad that needs an anchor
 		// view. For all other cases we push the native view off-screen so

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxDelegate.cs
@@ -83,6 +83,9 @@ internal partial class MultilineInvisibleTextBoxDelegate : UITextViewDelegate
 		return true;
 	}
 
+	public override void SelectionChanged(UITextView textView)
+		=> _textBoxViewExtension.GetTarget()?.OnNativeSelectionChanged();
+
 	public override bool ShouldEndEditing(UITextView textView)
 	{
 		return true;

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxView.cs
@@ -67,6 +67,10 @@ internal partial class MultilineInvisibleTextBoxView : UITextView, IInvisibleTex
 
 	public bool IsComposing => AppleUIKitImeTextBoxExtension.Instance.IsComposing;
 
+	public bool IsSettingTextFromManaged => _settingTextFromManaged;
+
+	public bool IsSettingSelectionFromManaged => _settingSelectionFromManaged;
+
 	internal InvisibleTextBoxViewExtension TextBoxViewExtension => _textBoxViewExtension.GetTarget();
 
 	public override string? Text

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxDelegate.cs
@@ -75,6 +75,9 @@ internal partial class SinglelineInvisibleTextBoxDelegate : UITextFieldDelegate
 		return true;
 	}
 
+	public override void DidChangeSelection(UITextField textField)
+		=> _textBoxViewExtension.GetTarget()?.OnNativeSelectionChanged();
+
 	public override bool ShouldReturn(UITextField textField)
 	{
 		if (IsKeyboardHiddenOnEnter)

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -111,6 +111,10 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 
 	public bool IsComposing => AppleUIKitImeTextBoxExtension.Instance.IsComposing;
 
+	public bool IsSettingTextFromManaged => _settingTextFromManaged;
+
+	public bool IsSettingSelectionFromManaged => _settingSelectionFromManaged;
+
 	internal InvisibleTextBoxViewExtension TextBoxViewExtension => _textBoxViewExtension.GetTarget();
 
 	public override string? Text


### PR DESCRIPTION
**GitHub Issue:** closes #23871

## PR Type: 🐞 Bugfix

## What changed? 🚀

On Skia iOS, the software keyboard's spacebar trackpad mode (long-press space, then drag) did not move the `TextBox` caret: UIKit mutates the hidden proxy view's selection through internal controllers, which bypass the `setSelectedTextRange:` override that the existing native→managed selection sync relies on (#22533 / #22638), so the managed `TextBox` was never notified.

Three fixes, validated on a physical device (iPhone 14 Pro, iOS 26.5) with a Skia-renderer app:

1. **Sync trackpad selection to Skia TextBox** — re-adds the `textFieldDidChangeSelection:` / `textViewDidChangeSelection:` delegate callbacks (originally introduced in #22533, removed in #22638 because they fired unguarded mid-keystroke) routed through a new `InvisibleTextBoxViewExtension.OnNativeSelectionChanged()` guarded against managed-initiated text/selection changes, IME composition, and in-flight native edits (native text ≠ managed text ⇒ `ProcessNativeTextInput`/`SetPendingSelection` owns the selection). The delegate callback observes every native selection change regardless of which internal UIKit path produced it.

2. **Track TextBox size on invisible proxy view** — `XamlRoot.InvalidateOverlays()` lost its per-frame callers in an earlier rendering refactor, so the proxy's frame was only set at focus time. A `TextBox` growing while focused left the proxy wrapping its text at a stale width, making vertical trackpad movement cross the wrong lines. The extension now subscribes to `TextBox.SizeChanged` during entry and re-runs `InvalidateLayout()`.

3. **Match invisible proxy wrap metrics to TextBox** — trackpad horizontal movement is constrained to the proxy's layout lines, so wrap-point divergence from the rendered text creates invisible mid-line "walls". The off-screen proxy is now sized to the content element's text area (instead of the full control bounds) and adopts the `TextBox`'s font size, keeping its line breaks aligned with the Skia layout.

Known limitation: the proxy lays out with the iOS system font at the matched size; apps rendering with a custom font can still see rare wrap divergence around long words at line boundaries. Projecting the Skia layout geometry through `closestPositionToPoint:`/`caretRectForPosition:` (as already done for `firstRectForRange:`) would remove that residual gap and is left as a follow-up.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — manual-validation-only: the gesture requires the iOS software keyboard's trackpad mode on a device; validated manually (single-line and multiline, horizontal and vertical movement, typing/autocorrect/undo regression pass)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
