### PR TITLE
fix(docs): Stop Sass emitting a BOM into concatenated main.css

### DIFF
--- a/doc/gulpfile.js
+++ b/doc/gulpfile.js
@@ -24,7 +24,11 @@ function styles(done) {
     src([`${assets}/**/*.scss`, `${assets}/**/*.sass`])
         .pipe(sourcemaps.init())
         .pipe(
-            sass({includePaths: ['./node_modules/'], outputStyle: output}).on(
+            // charset: false is required because these stylesheets are concatenated below.
+            // Sass prepends a BOM to any compressed output containing non-ASCII characters
+            // (navbar.scss has a FontAwesome glyph), which is only valid at the start of a
+            // file — mid-file it invalidates the rule that follows it.
+            sass({includePaths: ['./node_modules/'], outputStyle: output, charset: false}).on(
                 'error',
                 sass.logError
             )


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno-private#2268

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

**Current behavior.** On the docs site the `COMMUNITY` and `RESOURCES` top-nav dropdowns render expanded on page load and stay expanded, surviving a refresh. Visible today on the dev docs site (built from `master`).

**Cause.** `doc/gulpfile.js` compiles each `.scss` separately in `compressed` mode and then concatenates the results into `main.css`. Sass prepends a BOM (U+FEFF) to any compressed output containing non-ASCII characters, and `doc/templates/uno/component/navbar.scss` contains a FontAwesome glyph (`content: "\f078"`). Its compiled chunk therefore began with a BOM, which after concatenation sat at byte offset 17318 — mid-file — immediately before:

```css
@media(min-width: 1024px){
  .visibility-opacity-transition,
  #header-container nav>ul>li.menu-item-has-children>ul ul,
  #header-container nav>ul>li.menu-item-has-children>ul
  { visibility:hidden; opacity:0; … }
}
```

A BOM is only meaningful at the start of a file. Mid-file it is a stray character that makes the following at-rule unparseable, so the browser discards the whole block — and that block is the only thing hiding the nav submenus on desktop. `COMMUNITY` and `RESOURCES` are the two `menu-item-has-children` entries, which is why exactly those two are affected.

**This change.** Passes `charset: false` to Sass so it never emits the BOM. The stylesheets are served as UTF-8, so no charset declaration is needed — this matches what the currently-working production CSS effectively does.

## Validation

**Runtime (browser, Playwright)** — dev vs prod, same page, before the fix:

| | `main.css` rules parsed | hide-rule present | submenu computed style |
|---|---|---|---|
| dev | 251 | ❌ absent | `visibility: visible`, `opacity: 1` |
| prod | 252 | ✅ present | `visibility: hidden`, `opacity: 0` |

Exactly one rule dropped. All other assets (`docfx.css`, `docfx.vendor.min.css`, `main.js`, `docfx.js`) are byte-identical across environments and the page HTML is identical — only `main.css` differs (dev 25917 bytes / 2 BOMs, prod 25910 / 0). The BOM is already present in the `docs` artifact of docs build 224805, confirming this originates in the build, not the deployment.

**Sass behaviour** — compiling `navbar.scss` standalone with the locked sass 1.69.5:

| | BOM | bytes |
|---|---|---|
| default | ✅ present | 7750 |
| `--no-charset` | ❌ absent | 7747 |

Byte-identical apart from the BOM, so the option removes the BOM without altering any CSS.

**Build** — ran the `styles` task from this branch with the output deleted first: `main.css` regenerates with **0 BOMs**, no `@charset`, and the `@media` menu rule intact and preceded by a newline. `gulp-sass` accepts the option without warnings.

One caveat, stated plainly: the BOM itself does **not** reproduce on a local Node 24 build (a downstream package strips it there), so the fix is validated against the mechanism — Sass emitting the BOM — rather than against a locally reproduced failure. `charset: false` acts upstream of everything else in the pipeline, so it holds regardless of which downstream version does or does not strip. Final confirmation is the next docs deployment.

## Recommended follow-up (not in this PR)

The underlying reason this appeared on `master` but not on the older stable build is that **the docs asset build is non-deterministic**. `build/ci/templates/docfx-intermediary-assets.yml` pins Node 14.17.1 (npm 6) and runs `npm install` rather than `npm ci`; npm 6 predates `lockfileVersion 3`, which is what `doc/package-lock.json` uses, so the lock is ignored and `sass: ^1.69.5` floats to whatever is latest at build time. `master` and `release/stable/6.5` lock the same Sass version yet produce different Sass colour formats (`rgb(39.47%,…)` vs `rgb(100.6698,…)`), which proves the lock is not honoured in CI.

This PR fixes the defect; it does not make the build reproducible. Raising Node and switching to `npm ci` is worth doing separately, since it carries its own risk of disturbing the docs build and deserves its own CI run. Noted in unoplatform/uno-private#2268.

Note this is not `master`-only — `release/stable/6.6` will produce the same broken CSS on its next docs deploy, so this is worth backporting.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a: docs-site build config; validated by rebuilding the stylesheet and by browser inspection, as described above
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a: no content change; the rationale is captured in a code comment
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a: does not affect the framework or samples app
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
