### PR TITLE
fix(itemcontainer): mute internal pointer capture release

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/ItemContainerTests/ItemContainer_In_ListView_ItemTemplate.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/ItemContainerTests/ItemContainer_In_ListView_ItemTemplate.xaml
@@ -1,0 +1,95 @@
+<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.ItemContainerTests.ItemContainer_In_ListView_ItemTemplate"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.ItemContainerTests"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid Margin="16" ColumnSpacing="16">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Grid.Column="0"
+            FontWeight="SemiBold"
+            Text="ListView with ItemContainer in ItemTemplate"
+            TextWrapping="Wrap" />
+
+        <ListView
+            x:Name="ItemContainerListView"
+            Grid.Row="1"
+            Grid.Column="0"
+            Height="200"
+            AutomationProperties.AutomationId="ItemContainerListView"
+            SelectionMode="Single">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ItemContainer Padding="12">
+                        <TextBlock Text="{Binding}" />
+                    </ItemContainer>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <TextBlock
+            Grid.Row="0"
+            Grid.Column="1"
+            FontWeight="SemiBold"
+            Text="Standard ListView (reference)"
+            TextWrapping="Wrap" />
+
+        <ListView
+            x:Name="StandardListView"
+            Grid.Row="1"
+            Grid.Column="1"
+            Height="200"
+            AutomationProperties.AutomationId="StandardListView"
+            SelectionMode="Single">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <Border Padding="12">
+                        <TextBlock Text="{Binding}" />
+                    </Border>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <TextBlock
+            x:Name="ItemContainerListViewStatus"
+            Grid.Row="2"
+            Grid.Column="0"
+            AutomationProperties.AutomationId="ItemContainerListViewStatus"
+            Text="Selected: None / SelectionChanged: 0"
+            TextWrapping="Wrap" />
+
+        <TextBlock
+            x:Name="StandardListViewStatus"
+            Grid.Row="2"
+            Grid.Column="1"
+            AutomationProperties.AutomationId="StandardListViewStatus"
+            Text="Selected: None / SelectionChanged: 0"
+            TextWrapping="Wrap" />
+
+        <TextBlock
+            x:Name="PointerDiagnostics"
+            Grid.Row="3"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Margin="0,12,0,0"
+            AutomationProperties.AutomationId="PointerDiagnostics"
+            Text="No pointer interaction recorded."
+            TextWrapping="Wrap" />
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/ItemContainerTests/ItemContainer_In_ListView_ItemTemplate.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/ItemContainerTests/ItemContainer_In_ListView_ItemTemplate.xaml.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.ItemContainerTests
+{
+	[Sample("ItemContainer", "ListView", Description = "ItemContainer as the root of a ListView ItemTemplate: clicking an item must select it and raise SelectionChanged (issue #23892).")]
+	public sealed partial class ItemContainer_In_ListView_ItemTemplate : Page
+	{
+		private int _itemContainerSelectionCount;
+		private int _standardSelectionCount;
+		private int _pressedCount;
+		private int _releasedCount;
+		private int _captureLostCount;
+
+		public ItemContainer_In_ListView_ItemTemplate()
+		{
+			this.InitializeComponent();
+
+			var items = Enumerable.Range(1, 10).Select(i => $"Item {i}").ToArray();
+			ItemContainerListView.ItemsSource = items;
+			StandardListView.ItemsSource = items;
+
+			ItemContainerListView.SelectionChanged += (s, e) =>
+			{
+				_itemContainerSelectionCount++;
+				ItemContainerListViewStatus.Text = $"Selected: {ItemContainerListView.SelectedItem ?? "None"} / SelectionChanged: {_itemContainerSelectionCount}";
+			};
+
+			StandardListView.SelectionChanged += (s, e) =>
+			{
+				_standardSelectionCount++;
+				StandardListViewStatus.Text = $"Selected: {StandardListView.SelectedItem ?? "None"} / SelectionChanged: {_standardSelectionCount}";
+			};
+
+			ItemContainerListView.AddHandler(PointerPressedEvent, new PointerEventHandler((s, e) => OnPointerDiagnostic(nameof(PointerPressedEvent), ref _pressedCount)), handledEventsToo: true);
+			ItemContainerListView.AddHandler(PointerReleasedEvent, new PointerEventHandler((s, e) => OnPointerDiagnostic(nameof(PointerReleasedEvent), ref _releasedCount)), handledEventsToo: true);
+			ItemContainerListView.AddHandler(PointerCaptureLostEvent, new PointerEventHandler((s, e) => OnPointerDiagnostic(nameof(PointerCaptureLostEvent), ref _captureLostCount)), handledEventsToo: true);
+		}
+
+		private void OnPointerDiagnostic(string eventName, ref int count)
+		{
+			count++;
+			PointerDiagnostics.Text = $"Last event: {eventName} / Pressed: {_pressedCount} Released: {_releasedCount} CaptureLost: {_captureLostCount}";
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ItemContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ItemContainer.cs
@@ -1,0 +1,166 @@
+#if HAS_UNO
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Private.Infrastructure;
+using Uno.UI;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using Windows.UI.Input.Preview.Injection;
+using Uno.UI.Toolkit.DevTools.Input;
+using ItemContainer = Microsoft.UI.Xaml.Controls.ItemContainer;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
+
+[TestClass]
+public class Given_ItemContainer
+{
+	[TestMethod]
+	[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23892")]
+	public async Task When_ItemContainer_In_ListView_ItemTemplate_Mouse_Click_Selects_Item()
+	{
+		var listView = CreateListViewWithItemContainerTemplate();
+
+		var pressedReceived = false;
+		var releasedReceived = false;
+		var captureLostReceived = false;
+		listView.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler((_, _) => pressedReceived = true), handledEventsToo: true);
+		listView.AddHandler(UIElement.PointerReleasedEvent, new PointerEventHandler((_, _) => releasedReceived = true), handledEventsToo: true);
+		listView.AddHandler(UIElement.PointerCaptureLostEvent, new PointerEventHandler((_, _) => captureLostReceived = true), handledEventsToo: true);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var mouse = injector.GetMouse();
+
+		try
+		{
+			await UITestHelper.Load(listView);
+
+			Assert.IsNull(listView.SelectedItem);
+
+			var center = GetItemCenter(listView, 1);
+
+			mouse.MoveTo(center);
+			await TestServices.WindowHelper.WaitForIdle();
+			mouse.Press();
+			await TestServices.WindowHelper.WaitForIdle();
+			mouse.Release();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(pressedReceived, "PointerPressed should bubble up to the ListView.");
+			Assert.IsTrue(releasedReceived, "PointerReleased should bubble up to the ListView.");
+			// WinUI's ItemContainer doesn't capture the pointer, so a simple click must not surface a PointerCaptureLost.
+			Assert.IsFalse(captureLostReceived, "PointerCaptureLost should not be raised for a simple click.");
+			Assert.AreEqual("Item2", listView.SelectedItem, "Item should be selected after a mouse press+release on it.");
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23892")]
+	public async Task When_ItemContainer_In_ListView_ItemTemplate_Touch_Tap_Selects_Item()
+	{
+		var listView = CreateListViewWithItemContainerTemplate();
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		try
+		{
+			await UITestHelper.Load(listView);
+
+			Assert.IsNull(listView.SelectedItem);
+
+			var center = GetItemCenter(listView, 1);
+
+			finger.Press(center);
+			await TestServices.WindowHelper.WaitForIdle();
+			finger.Release();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual("Item2", listView.SelectedItem, "Item should be selected after a touch press+release on it.");
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23892")]
+	public async Task When_ItemContainer_In_ListView_ItemTemplate_Touch_Scroll_Does_Not_Select_Item()
+	{
+		var listView = CreateListViewWithItemContainerTemplate(itemsCount: 20);
+		listView.Height = 150;
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		try
+		{
+			await UITestHelper.Load(listView);
+
+			Assert.IsNull(listView.SelectedItem);
+
+			var center = GetItemCenter(listView, 1);
+
+			finger.Press(center);
+			await TestServices.WindowHelper.WaitForIdle();
+			finger.MoveBy(0, -80);
+			await TestServices.WindowHelper.WaitForIdle();
+			finger.Release();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsNull(listView.SelectedItem, "Scrolling with a finger pressed on an item should not select it.");
+		}
+		finally
+		{
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+
+	private static ListView CreateListViewWithItemContainerTemplate(int itemsCount = 3)
+		=> new ListView
+		{
+			SelectionMode = ListViewSelectionMode.Single,
+			ItemsSource = Enumerable.Range(1, itemsCount).Select(i => $"Item{i}").ToArray(),
+			ItemTemplate = new DataTemplate(() =>
+			{
+				var textBlock = new TextBlock();
+				textBlock.SetBinding(TextBlock.TextProperty, new Binding());
+
+				return new ItemContainer
+				{
+					Child = textBlock,
+				};
+			}),
+		};
+
+	private static Point GetItemCenter(ListView listView, int index)
+	{
+		var item = (ListViewItem)listView.ContainerFromIndex(index);
+		Assert.IsNotNull(item, $"Container for index {index} should exist.");
+
+		var bounds = item.GetAbsoluteBoundsRect();
+		return new Point(bounds.GetMidX(), bounds.GetMidY());
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemContainer/ItemContainer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemContainer/ItemContainer.cs
@@ -470,11 +470,12 @@ partial class ItemContainer : Control
 		}
 
 		m_pointerInfo.ResetTrackedPointerId();
-		// Uno Doc: Snapshot before releasing the capture: on managed pointers ReleasePointerCapture
-		// synchronously raises PointerCaptureLost, which resets the touch/pen over state.
 		bool isPointerOver = m_pointerInfo.IsPointerOver();
 		// Uno Doc: WinUI doesn't track the pointer and therefore has visual states bugs due to inaccurate pointer state. c.f. https://github.com/unoplatform/private/issues/1074
-		ReleasePointerCapture(args.Pointer);
+		// The capture is released muted as it doesn't exist on WinUI: raising PointerCaptureLost would make
+		// ancestors (e.g. a ListViewItem hosting this ItemContainer) treat the interaction as canceled and
+		// skip their pending click. c.f. https://github.com/unoplatform/uno/issues/23892
+		ReleasePointerCapture(args.Pointer.UniqueId, muteEvent: true);
 
 		bool canRaiseItemInvoked = CanRaiseItemInvoked();
 		var pointerDeviceType = args.Pointer.PointerDeviceType;
@@ -519,7 +520,9 @@ partial class ItemContainer : Control
 		base.OnPointerCanceled(args);
 
 		// Uno Doc: WinUI doesn't track the pointer and therefore has visual states bugs due to inaccurate pointer state. c.f. https://github.com/unoplatform/private/issues/1074
-		ReleasePointerCapture(args.Pointer);
+		// Muted for the same reason as in OnPointerReleased: this capture doesn't exist on WinUI and
+		// ancestors already receive the PointerCanceled event itself.
+		ReleasePointerCapture(args.Pointer.UniqueId, muteEvent: true);
 		ProcessPointerCanceled(args);
 	}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1625,6 +1625,9 @@ namespace Microsoft.UI.Xaml
 		internal void ReleasePointerCapture(global::Windows.Devices.Input.PointerIdentifier pointer, bool muteEvent = false, PointerCaptureKind kinds = PointerCaptureKind.Explicit)
 		{
 			if (!Release(pointer, kinds, muteEvent: muteEvent)
+				// Release reports whether the CaptureLost event was raised, so it's always false when muted:
+				// don't log the misleading "not captured" trace for a successful muted release.
+				&& !muteEvent
 				&& this.Log().IsEnabled(LogLevel.Information))
 			{
 				this.Log().Info($"{this}: Cannot release pointer {pointer}: not captured by this control.");


### PR DESCRIPTION
**GitHub Issue:** closes #23892

## PR Type:

🐞 Bugfix

## What changed? 🚀

When an `ItemContainer` is used as the root element of a `ListView.ItemTemplate`, clicking an item no longer selected it on Skia targets (regression vs 6.5.36, related to #23841).

Root cause: unlike WinUI, Uno's `ItemContainer` explicitly captures the pointer on press to keep its visual states accurate (#23056). On release, `ReleasePointerCapture` synchronously raised `PointerCaptureLost`, which bubbled to the hosting `ListViewItem` during the `PointerReleased` dispatch. `SelectorItem` subscribes to `PointerCaptureLost` (with `handledEventsToo`) to clean up scroller-canceled interactions, so it treated the click as canceled and never raised the selection.

The fix releases the Uno-internal capture with `muteEvent: true` in `OnPointerReleased` and `OnPointerCanceled` — this capture doesn't exist on WinUI, so no `PointerCaptureLost` should surface from it (same approach as `Hyperlink`). The scroll-steal cancellation path (`CanceledByDirectManipulation`) is unaffected and still aborts clicks while panning.

Validation:
- New `Given_ItemContainer` runtime tests (mouse click, touch tap, touch scroll-must-not-select) fail before the fix and pass after, and assert `PointerPressed`/`PointerReleased` bubble to the `ListView` while no `PointerCaptureLost` is raised for a simple click.
- `SelectorBarTests` and `ItemsViewTests` suites pass, guarding the previous fixes in this area (#23208, #23877).
- New manual-test sample `ItemContainer_In_ListView_ItemTemplate` (ItemContainer ListView vs standard ListView side by side, with pointer diagnostics), manually validated on Skia macOS desktop.

Note: after mixed left+right mouse button presses on the same container, the pressed state can remain stale — verified this matches upstream WinUI `ItemContainer.cpp` behavior verbatim (parity), so it is intentionally not changed here.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
