### PR TITLE
iOS `TextBox` caret seek gesture

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxFloatingCursor.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxFloatingCursor.cs
@@ -1,0 +1,49 @@
+#nullable enable
+
+using CoreGraphics;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation;
+
+namespace Uno.WinUI.Runtime.Skia.AppleUIKit.Controls;
+
+/// <summary>
+/// Translates the iOS floating cursor (space-bar trackpad gesture) into cumulative offsets for the
+/// managed <see cref="TextBox"/>. Shared by both invisible proxies, which derive from
+/// <see cref="UIKit.UITextField"/> and <see cref="UIKit.UITextView"/> and so have no common base.
+/// </summary>
+internal sealed class InvisibleTextBoxFloatingCursor
+{
+	private CGPoint _origin;
+
+	public bool IsActive { get; private set; }
+
+	/// <remarks>
+	/// UIKit can send unbalanced Begin/Begin/End sequences, so this re-anchors rather than counting.
+	/// </remarks>
+	public void Begin(InvisibleTextBoxViewExtension? extension, CGPoint point)
+	{
+		_origin = point;
+		IsActive = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default) == true;
+	}
+
+	public void Update(InvisibleTextBoxViewExtension? extension, CGPoint point)
+	{
+		if (!IsActive)
+		{
+			return;
+		}
+
+		// iOS points map 1:1 to WinUI DIPs — no LogicalToPhysicalPixels conversion here.
+		var offset = new Point(point.X - _origin.X, point.Y - _origin.Y);
+		IsActive = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, offset) == true;
+	}
+
+	public void End(InvisibleTextBoxViewExtension? extension)
+	{
+		if (IsActive)
+		{
+			IsActive = false;
+			extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxFloatingCursor.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxFloatingCursor.cs
@@ -43,7 +43,7 @@ internal sealed class InvisibleTextBoxFloatingCursor
 		if (IsActive)
 		{
 			IsActive = false;
-			extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			_ = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxFloatingCursor.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxFloatingCursor.cs
@@ -23,7 +23,7 @@ internal sealed class InvisibleTextBoxFloatingCursor
 	public void Begin(InvisibleTextBoxViewExtension? extension, CGPoint point)
 	{
 		_origin = point;
-		IsActive = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default) == true;
+		IsActive = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default) ?? false;
 	}
 
 	public void Update(InvisibleTextBoxViewExtension? extension, CGPoint point)
@@ -35,7 +35,7 @@ internal sealed class InvisibleTextBoxFloatingCursor
 
 		// iOS points map 1:1 to WinUI DIPs — no LogicalToPhysicalPixels conversion here.
 		var offset = new Point(point.X - _origin.X, point.Y - _origin.Y);
-		IsActive = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, offset) == true;
+		IsActive = extension?.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, offset) ?? false;
 	}
 
 	public void End(InvisibleTextBoxViewExtension? extension)

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -227,6 +227,23 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 		}
 	}
 
+	// While a caret drag is running, UIKit's own selection updates are computed against the proxy's
+	// system-font layout, which bears no relation to the Skia-rendered text. The managed side owns
+	// the caret for the duration of the gesture.
+	internal bool IsCaretDragActive => _owner?.TextBox?.IsCaretDragActive == true;
+
+	internal bool ProcessCaretDragGesture(TextBox.CaretDragPhase phase, Windows.Foundation.Point cumulativeOffset)
+	{
+		// Re-resolved on every callback: EndEntry() clears _textBoxView without resigning first
+		// responder, so a discarded proxy can still receive the gesture.
+		if (_textBoxView?.Owner?.TextBox is not { } textBox || AppleUIKitImeTextBoxExtension.Instance.IsComposing)
+		{
+			return false;
+		}
+
+		return textBox.ProcessCaretDragGesture(phase, cumulativeOffset);
+	}
+
 	internal void ProcessNativeTextInput(string? text)
 	{
 		// During IME composition, text updates are managed by the shared

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/MultilineInvisibleTextBoxView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 using UIKit;
@@ -140,13 +141,30 @@ internal partial class MultilineInvisibleTextBoxView : UITextView, IInvisibleTex
 			if (textBoxView != null && SelectedTextRange != value)
 			{
 				NativeTextSelection.SetSelectedTextRange(SuperHandle, value);
-				if (!_settingSelectionFromManaged)
+				if (!_settingSelectionFromManaged && !textBoxView.IsCaretDragActive)
 				{
 					textBoxView.SyncSelectionToTextBox();
 				}
 			}
 		}
 	}
+
+	#region Floating cursor (space-bar trackpad gesture)
+
+	private readonly InvisibleTextBoxFloatingCursor _floatingCursor = new();
+
+	// No base call on purpose: UIKit would map the point against this view's system-font layout,
+	// which has no relation to the Skia-rendered text.
+	public override void BeginFloatingCursor(CGPoint point)
+		=> _floatingCursor.Begin(TextBoxViewExtension, point);
+
+	public override void UpdateFloatingCursor(CGPoint point)
+		=> _floatingCursor.Update(TextBoxViewExtension, point);
+
+	public override void EndFloatingCursor()
+		=> _floatingCursor.End(TextBoxViewExtension);
+
+	#endregion
 
 	#region IME Composition (UITextInput overrides)
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -222,13 +222,30 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 			if (textBoxView != null && SelectedTextRange != value)
 			{
 				NativeTextSelection.SetSelectedTextRange(SuperHandle, value);
-				if (!_settingSelectionFromManaged)
+				if (!_settingSelectionFromManaged && !textBoxView.IsCaretDragActive)
 				{
 					textBoxView.SyncSelectionToTextBox();
 				}
 			}
 		}
 	}
+
+	#region Floating cursor (space-bar trackpad gesture)
+
+	private readonly InvisibleTextBoxFloatingCursor _floatingCursor = new();
+
+	// No base call on purpose: UIKit would map the point against this field's system-font layout,
+	// which has no relation to the Skia-rendered text.
+	public override void BeginFloatingCursor(CGPoint point)
+		=> _floatingCursor.Begin(TextBoxViewExtension, point);
+
+	public override void UpdateFloatingCursor(CGPoint point)
+		=> _floatingCursor.Update(TextBoxViewExtension, point);
+
+	public override void EndFloatingCursor()
+		=> _floatingCursor.End(TextBoxViewExtension);
+
+	#endregion
 
 	#region IME Composition (UITextInput overrides)
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6323,6 +6323,361 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		#endregion
 
+		#region Caret drag gesture (iOS space-bar trackpad / floating cursor)
+
+		private static async Task<TextBox> SetUpCaretDragTextBox(string text, bool acceptsReturn = false)
+		{
+			var SUT = new TextBox
+			{
+				// AcceptsReturn must precede Text: a single-line TextBox truncates to the first line.
+				AcceptsReturn = acceptsReturn,
+				Text = text,
+				Width = 300,
+				Height = acceptsReturn ? 200 : double.NaN,
+				FontSize = 16,
+			};
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			return SUT;
+		}
+
+		// Horizontal distance that reliably crosses several characters at the sizes used above.
+		private const double CaretDragStep = 60;
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Previews_Without_Committing_Selection()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			var selectionChangedCount = 0;
+			SUT.SelectionChanged += (_, _) => selectionChangedCount++;
+
+			Assert.IsTrue(SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default));
+			Assert.IsTrue(SUT.IsCaretDragActive);
+
+			Assert.IsTrue(SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0)));
+			await WindowHelper.WaitForIdle();
+
+			// The whole point of the design: the drag previews, it does not commit.
+			Assert.AreEqual(25, SUT.SelectionStart);
+			Assert.AreEqual(0, selectionChangedCount);
+
+			Assert.IsTrue(SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default));
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(SUT.IsCaretDragActive);
+			Assert.IsTrue(SUT.SelectionStart < 25, $"Caret should have moved left, but SelectionStart is {SUT.SelectionStart}.");
+			Assert.AreEqual(0, SUT.SelectionLength);
+			Assert.AreEqual(1, selectionChangedCount, "A whole gesture must raise exactly one SelectionChanged.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Moves_Right_And_Left()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(12, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(CaretDragStep, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			var afterRight = SUT.SelectionStart;
+			Assert.IsTrue(afterRight > 12, $"Dragging right should advance the caret, got {afterRight}.");
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(SUT.SelectionStart < afterRight, $"Dragging left should retreat the caret, got {SUT.SelectionStart}.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Uses_Cumulative_Offset()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(0, 0);
+			await WindowHelper.WaitForIdle();
+
+			// One update at 3x the step must land where three updates ramping to 3x land, because
+			// the offset is measured from the gesture origin rather than the previous callback.
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(CaretDragStep * 3, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			var single = SUT.SelectionStart;
+			Assert.IsTrue(single > 0, "The drag did not move the caret at all, so the comparison below would be vacuous.");
+
+			SUT.Select(0, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(CaretDragStep, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(CaretDragStep * 2, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(CaretDragStep * 3, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(single, SUT.SelectionStart);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Ends_Without_Update_Then_NoOp()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(4, 11);
+			await WindowHelper.WaitForIdle();
+
+			var selectionChangedCount = 0;
+			SUT.SelectionChanged += (_, _) => selectionChangedCount++;
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			// A tap-and-release on the space bar must not collapse an existing selection.
+			Assert.AreEqual(4, SUT.SelectionStart);
+			Assert.AreEqual(11, SUT.SelectionLength);
+			Assert.AreEqual(0, selectionChangedCount);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Cancelled_Then_Selection_Unchanged()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Cancel, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(SUT.IsCaretDragActive);
+			Assert.AreEqual(25, SUT.SelectionStart);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Overshoots_Then_Clamps_Into_Text()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var text = "The quick brown fox jumps";
+			var SUT = await SetUpCaretDragTextBox(text);
+			SUT.Select(12, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-100000, -100000));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			// GetIndexAt returns -1 on a miss; a clamped drag must never produce a negative index.
+			Assert.AreEqual(0, SUT.SelectionStart);
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(100000, 100000));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(text.Length, SUT.SelectionStart);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Vertical_On_Multiline_Then_Changes_Line()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("first line here\rsecond line here\rthird line here", acceptsReturn: true);
+			Assert.AreEqual(3, SUT.Text.Split('\r').Length, "The multiline set-up did not keep its line breaks.");
+			SUT.Select(5, 0); // on the first line
+			await WindowHelper.WaitForIdle();
+
+			var firstLineRect = SUT.TextBoxView.DisplayBlock.ParsedText.GetRectForIndex(5);
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(0, firstLineRect.Height));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(SUT.SelectionStart > 15, $"Caret should have dropped past the first line break, got {SUT.SelectionStart}.");
+
+			var landedRect = SUT.TextBoxView.DisplayBlock.ParsedText.GetRectForIndex(SUT.SelectionStart);
+			Assert.IsTrue(landedRect.Top > firstLineRect.Top, "Caret should be on a lower line.");
+			// A vertical-only drag should keep roughly the same column.
+			Assert.IsTrue(Math.Abs(landedRect.Left - firstLineRect.Left) < 12, $"Column drifted: {firstLineRect.Left} -> {landedRect.Left}.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Then_Caret_Stops_Blinking()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			FeatureConfiguration.TextBox.HideCaret = false;
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+
+			// The blink interval is 500ms; the caret must stay visible across several of them.
+			for (var i = 0; i < 8; i++)
+			{
+				await Task.Delay(200);
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(TextBox.CaretDisplayMode.ThumblessCaretShowing, SUT.CaretMode, $"Caret blinked away at iteration {i}.");
+				Assert.IsNotNull(SUT.TextBoxView.DisplayBlock.RenderCaret);
+			}
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			// ...and blinking must resume afterwards.
+			var blinkedOff = false;
+			for (var i = 0; i < 20 && !blinkedOff; i++)
+			{
+				await Task.Delay(100);
+				await WindowHelper.WaitForIdle();
+				blinkedOff = SUT.CaretMode == TextBox.CaretDisplayMode.ThumblessCaretHidden;
+			}
+
+			Assert.IsTrue(blinkedOff, "Blinking did not resume after the gesture ended.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Previews_Caret_Without_Moving_Selection()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			FeatureConfiguration.TextBox.HideCaret = false;
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+			await WindowHelper.WaitForIdle();
+
+			var renderCaret = SUT.TextBoxView.DisplayBlock.RenderCaret;
+			Assert.IsNotNull(renderCaret);
+			Assert.IsTrue(renderCaret.Value.index < 25, $"The rendered caret should preview the drag, but it is at {renderCaret.Value.index}.");
+			Assert.AreEqual(25, SUT.SelectionStart, "The selection must not follow the preview.");
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Cancel, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(25, SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.index, "Cancelling must restore the caret to the selection.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Declined()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var readOnly = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			readOnly.IsReadOnly = true;
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(readOnly.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default), "Read-only should decline.");
+			Assert.IsFalse(readOnly.IsCaretDragActive);
+
+			// An Update without a Begin must not throw or move anything.
+			readOnly.IsReadOnly = false;
+			readOnly.Select(7, 0);
+			await WindowHelper.WaitForIdle();
+			Assert.IsFalse(readOnly.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(CaretDragStep, 0)));
+			Assert.AreEqual(7, readOnly.SelectionStart);
+
+			var unfocused = new TextBox { Text = "The quick brown fox jumps", Width = 300 };
+			WindowHelper.WindowContent = unfocused;
+			await WindowHelper.WaitForLoaded(unfocused);
+			Assert.IsFalse(unfocused.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default), "Unfocused should decline.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Rebegins_Without_End()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			// UIKit is known to send unbalanced Begin/Begin/End sequences.
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			// The second Begin re-anchors and drops the pending preview, so End commits nothing.
+			Assert.IsFalse(SUT.IsCaretDragActive);
+			Assert.AreEqual(25, SUT.SelectionStart);
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Then_Unfocus_Cancels()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			var other = new Button { Content = "other" };
+			var panel = new StackPanel();
+			WindowHelper.WindowContent = panel;
+			panel.Children.Add(SUT);
+			panel.Children.Add(other);
+			await WindowHelper.WaitForLoaded(other);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+
+			other.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(SUT.IsCaretDragActive, "Losing focus must cancel an in-flight drag.");
+			Assert.AreEqual(25, SUT.SelectionStart);
+		}
+
+		#endregion
+
 		private class TextBoxFeatureConfigDisposable : IDisposable
 		{
 			private bool _useOverlay;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6602,32 +6602,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
-		public async Task When_CaretDrag_Then_Preview_Uses_SelectionHighlightColor()
+		public async Task When_CaretDrag_Beyond_Viewport_Then_Scrolls_To_Follow_Preview()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
 			FeatureConfiguration.TextBox.HideCaret = false;
 
-			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
-			SUT.SelectionHighlightColor = new SolidColorBrush(Colors.Magenta);
-			SUT.Foreground = new SolidColorBrush(Colors.Green);
-			SUT.Select(25, 0);
+			var SUT = await SetUpCaretDragTextBox(
+				"The quick brown fox jumps over the lazy dog while the caret keeps travelling right past the edge");
+			SUT.Select(0, 0);
 			await WindowHelper.WaitForIdle();
 
-			var restingBrush = SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.brush;
+			var sv = (ScrollViewer)SUT.ContentElement;
+			Assert.IsGreaterThan(0, sv.ScrollableWidth, "The text must overflow for this test to mean anything.");
+			Assert.AreEqual(0, sv.HorizontalOffset);
+
+			// Drag to the far end of the text, expressed in the same text coordinates the gesture uses.
+			var parsedText = SUT.TextBoxView.DisplayBlock.ParsedText;
+			var travel = parsedText.GetRectForIndex(SUT.Text.Length).Left - parsedText.GetRectForIndex(0).Left;
 
 			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
-			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(travel, 0));
 			await WindowHelper.WaitForIdle();
 
-			var dragBrush = SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.brush;
-			Assert.AreNotSame(restingBrush, dragBrush, "The dragged caret should not reuse the Foreground caret brush.");
-			Assert.AreEqual(Colors.Magenta, ((Microsoft.UI.Composition.CompositionColorBrush)dragBrush).Color);
+			var previewIndex = SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.index;
+			var caretRect = parsedText.GetRectForIndex(previewIndex);
+
+			// ChangeView animates, so poll on the invariant that matters: the previewed caret ends up
+			// inside the visible viewport.
+			await WindowHelper.WaitFor(
+				() => caretRect.Left >= sv.HorizontalOffset - 1
+					&& caretRect.Right <= sv.HorizontalOffset + sv.ViewportWidth + 1,
+				message: $"Caret at {caretRect.Left} never came into the viewport (width {sv.ViewportWidth})");
+
+			Assert.IsGreaterThan(0, sv.HorizontalOffset, "The viewport should have followed the previewed caret.");
 
 			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(Colors.Green, ((Microsoft.UI.Composition.CompositionColorBrush)SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.brush).Color,
-				"The caret should return to the Foreground colour once the gesture ends.");
+			Assert.AreEqual(previewIndex, SUT.SelectionStart);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6601,6 +6601,74 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_Then_Preview_Uses_SelectionHighlightColor()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			FeatureConfiguration.TextBox.HideCaret = false;
+
+			var SUT = await SetUpCaretDragTextBox("The quick brown fox jumps");
+			SUT.SelectionHighlightColor = new SolidColorBrush(Colors.Magenta);
+			SUT.Foreground = new SolidColorBrush(Colors.Green);
+			SUT.Select(25, 0);
+			await WindowHelper.WaitForIdle();
+
+			var restingBrush = SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.brush;
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
+			await WindowHelper.WaitForIdle();
+
+			var dragBrush = SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.brush;
+			Assert.AreNotSame(restingBrush, dragBrush, "The dragged caret should not reuse the Foreground caret brush.");
+			Assert.AreEqual(Colors.Magenta, ((Microsoft.UI.Composition.CompositionColorBrush)dragBrush).Color);
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(Colors.Green, ((Microsoft.UI.Composition.CompositionColorBrush)SUT.TextBoxView.DisplayBlock.RenderCaret!.Value.brush).Color,
+				"The caret should return to the Foreground colour once the gesture ends.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
+		public async Task When_CaretDrag_On_Touch_Then_Insertion_Handle_Survives()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			// The iOS convention taps to a bare caret, so the Android one is what exercises a
+			// caret drag starting from a mode that carries a handle.
+			var SUT = new TextBox
+			{
+				Width = 300,
+				Text = "The quick brown fox jumps over",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var bounds = SUT.GetAbsoluteBoundsRect();
+			finger.Press(new Point(bounds.Left + 90, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "tap should place the insertion handle");
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
+			Assert.AreEqual(TextBox.CaretDisplayMode.ThumblessCaretShowing, SUT.CaretMode, "The thumb should be hidden while dragging.");
+
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-40, 0));
+			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing, SUT.CaretMode,
+				"The insertion handle must come back after the gesture.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23871")]
 		public async Task When_CaretDrag_Declined()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6549,8 +6549,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Begin, default);
 			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.Update, new Point(-CaretDragStep, 0));
 
-			// The blink interval is 500ms; the caret must stay visible across several of them.
-			for (var i = 0; i < 8; i++)
+			// The blink interval is 500ms; the caret must stay visible across a few of them.
+			for (var i = 0; i < 4; i++)
 			{
 				await Task.Delay(200);
 				await WindowHelper.WaitForIdle();
@@ -6561,9 +6561,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.ProcessCaretDragGesture(TextBox.CaretDragPhase.End, default);
 			await WindowHelper.WaitForIdle();
 
-			// ...and blinking must resume afterwards.
+			// ...and blinking must resume afterwards. Generous headroom over the 500ms interval so a
+			// loaded CI shard doesn't turn this flaky.
 			var blinkedOff = false;
-			for (var i = 0; i < 20 && !blinkedOff; i++)
+			for (var i = 0; i < 40 && !blinkedOff; i++)
 			{
 				await Task.Delay(100);
 				await WindowHelper.WaitForIdle();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -267,6 +267,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal (int index, CompositionBrush brush)? RenderCaret
 		{
+			get => _caretPaint;
 			set
 			{
 				if (_caretPaint != value)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
@@ -1,0 +1,151 @@
+#nullable enable
+
+using System;
+using Windows.Foundation;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+public partial class TextBox
+{
+	/// <summary>
+	/// The phases of a platform caret-drag gesture, mirroring the iOS floating cursor
+	/// (begin/update/endFloatingCursor).
+	/// </summary>
+	internal enum CaretDragPhase
+	{
+		Begin,
+		Update,
+		End,
+		Cancel,
+	}
+
+	// Centre of the caret rect when the gesture began, in DisplayBlock coordinates.
+	private Point? _caretDragAnchor;
+
+	// Caret position previewed during the gesture. The selection itself stays untouched until End,
+	// so a drag raises a single SelectionChanged instead of one per callback.
+	private int? _caretDragPreviewIndex;
+
+	internal bool IsCaretDragActive => _caretDragAnchor is not null;
+
+	/// <summary>
+	/// Drives a platform caret-drag gesture, such as the iOS space-bar trackpad gesture.
+	/// </summary>
+	/// <param name="cumulativeOffset">
+	/// Offset from the point captured at <see cref="CaretDragPhase.Begin"/>, in DIPs. This is always
+	/// measured against the gesture origin, never against the previous callback — accumulating
+	/// per-callback increments drifts.
+	/// </param>
+	/// <returns>False when the gesture is declined, so the caller can stop forwarding it.</returns>
+	internal bool ProcessCaretDragGesture(CaretDragPhase phase, Point cumulativeOffset)
+	{
+		switch (phase)
+		{
+			case CaretDragPhase.Begin:
+				return BeginCaretDrag();
+			case CaretDragPhase.Update:
+				return UpdateCaretDrag(cumulativeOffset);
+			case CaretDragPhase.End:
+				return EndCaretDrag(commit: true);
+			case CaretDragPhase.Cancel:
+				return EndCaretDrag(commit: false);
+			default:
+				return false;
+		}
+	}
+
+	internal void CancelCaretDrag()
+	{
+		if (IsCaretDragActive)
+		{
+			EndCaretDrag(commit: false);
+		}
+	}
+
+	private bool BeginCaretDrag()
+	{
+		if (!_isSkiaTextBox ||
+			IsReadOnly ||
+			FocusState == FocusState.Unfocused ||
+			GetParsedTextForCaretDrag() is not { } parsedText)
+		{
+			return false;
+		}
+
+		var caretIndex = IsBackwardSelection ? SelectionStart : SelectionStart + SelectionLength;
+		var caretRect = parsedText.GetRectForIndex(caretIndex);
+		_caretDragAnchor = new Point(caretRect.Left, caretRect.Top + (caretRect.Height / 2));
+
+		// The caret must not blink away mid-drag. CaretMode restarts the timer when it changes,
+		// so stop it afterwards.
+		CaretMode = CaretDisplayMode.ThumblessCaretShowing;
+		_timer.Stop();
+
+		// Left null on purpose: an End with no intervening Update must not move the caret.
+		_caretDragPreviewIndex = null;
+		UpdateDisplaySelection();
+		return true;
+	}
+
+	private bool UpdateCaretDrag(Point cumulativeOffset)
+	{
+		if (_caretDragAnchor is not { } anchor)
+		{
+			return false;
+		}
+
+		if (GetParsedTextForCaretDrag() is not { } parsedText)
+		{
+			EndCaretDrag(commit: false);
+			return false;
+		}
+
+		var textLength = Text.Length;
+
+		// Clamping to the first and last line centres keeps an over-shooting drag on the text
+		// instead of returning a miss. iOS has no autoscroll during this gesture, so neither do we.
+		var firstLine = parsedText.GetRectForIndex(0);
+		var lastLine = parsedText.GetRectForIndex(textLength);
+		var minY = firstLine.Top + (firstLine.Height / 2);
+		var maxY = lastLine.Top + (lastLine.Height / 2);
+
+		var x = anchor.X + cumulativeOffset.X;
+		var y = Math.Clamp(anchor.Y + cumulativeOffset.Y, Math.Min(minY, maxY), Math.Max(minY, maxY));
+
+		// GetIndexAt returns -1 on a miss, hence the Math.Max, matching every other call site.
+		var index = Math.Max(0, parsedText.GetIndexAt(new Point(x, y), true, true));
+		_caretDragPreviewIndex = Math.Clamp(index, 0, textLength);
+
+		UpdateDisplaySelection();
+		return true;
+	}
+
+	private bool EndCaretDrag(bool commit)
+	{
+		if (!IsCaretDragActive)
+		{
+			return false;
+		}
+
+		var previewIndex = _caretDragPreviewIndex;
+
+		_caretDragAnchor = null;
+		_caretDragPreviewIndex = null;
+
+		if (CaretMode is CaretDisplayMode.ThumblessCaretShowing)
+		{
+			_timer.Start(); // resume blinking
+		}
+
+		if (commit && previewIndex is { } index)
+		{
+			SelectInternal(Math.Clamp(index, 0, Text.Length), 0);
+		}
+
+		UpdateDisplaySelection();
+		return true;
+	}
+
+	private Documents.IParsedText? GetParsedTextForCaretDrag()
+		=> DisplayBlockInlines is null ? null : TextBoxView?.DisplayBlock?.ParsedText;
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
@@ -144,7 +144,7 @@ public partial class TextBox
 		var maxY = lastLine.Top + (lastLine.Height / 2);
 
 		var x = anchor.X + cumulativeOffset.X;
-		var y = Math.Clamp(anchor.Y + cumulativeOffset.Y, Math.Min(minY, maxY), Math.Max(minY, maxY));
+		var y = Math.Clamp(anchor.Y + cumulativeOffset.Y, minY, maxY);
 
 		// GetIndexAt returns -1 on a miss, hence the Math.Max, matching every other call site.
 		var index = Math.Max(0, parsedText.GetIndexAt(new Point(x, y), true, true));

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
@@ -2,9 +2,6 @@
 
 using System;
 using Windows.Foundation;
-using Windows.UI;
-using Microsoft.UI.Composition;
-using Uno.UI.Xaml.Media;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -33,32 +30,7 @@ public partial class TextBox
 	// touch platforms carries the selection thumbs — is put back when it ends.
 	private CaretDisplayMode? _caretModeBeforeCaretDrag;
 
-	private CompositionBrush? _cachedCaretDragBrush;
-	private Color _cachedCaretDragColor;
-
 	internal bool IsCaretDragActive => _caretDragAnchor is not null;
-
-	/// <summary>
-	/// Brush for the previewed caret. It follows SelectionHighlightColor rather than the Foreground
-	/// so the dragged caret reads as a transient selection affordance.
-	/// </summary>
-	private CompositionBrush GetCaretDragBrush()
-	{
-		var color = (SelectionHighlightColor ?? DefaultBrushes.SelectionHighlightColor).Color;
-		if (color.A < 255)
-		{
-			color = Color.FromArgb(255, color.R, color.G, color.B);
-		}
-
-		if (_cachedCaretDragBrush is not null && _cachedCaretDragColor == color)
-		{
-			return _cachedCaretDragBrush;
-		}
-
-		_cachedCaretDragColor = color;
-		_cachedCaretDragBrush = Compositor.GetSharedCompositor().CreateColorBrush(color);
-		return _cachedCaretDragBrush;
-	}
 
 	/// <summary>
 	/// Drives a platform caret-drag gesture, such as the iOS space-bar trackpad gesture.
@@ -137,7 +109,7 @@ public partial class TextBox
 		var textLength = Text.Length;
 
 		// Clamping to the first and last line centres keeps an over-shooting drag on the text
-		// instead of returning a miss. iOS has no autoscroll during this gesture, so neither do we.
+		// instead of returning a miss.
 		var firstLine = parsedText.GetRectForIndex(0);
 		var lastLine = parsedText.GetRectForIndex(textLength);
 		var minY = firstLine.Top + (firstLine.Height / 2);
@@ -150,6 +122,9 @@ public partial class TextBox
 		var index = Math.Max(0, parsedText.GetIndexAt(new Point(x, y), true, true));
 		_caretDragPreviewIndex = Math.Clamp(index, 0, textLength);
 
+		// Both the anchor and the hit-test work in text coordinates, which are independent of the
+		// scroll offset, so scrolling mid-gesture cannot skew the mapping.
+		UpdateScrolling();
 		UpdateDisplaySelection();
 		return true;
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.CaretDrag.skia.cs
@@ -2,6 +2,9 @@
 
 using System;
 using Windows.Foundation;
+using Windows.UI;
+using Microsoft.UI.Composition;
+using Uno.UI.Xaml.Media;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -26,7 +29,36 @@ public partial class TextBox
 	// so a drag raises a single SelectionChanged instead of one per callback.
 	private int? _caretDragPreviewIndex;
 
+	// The gesture needs a thumbless, non-blinking caret, so the mode in effect beforehand — which on
+	// touch platforms carries the selection thumbs — is put back when it ends.
+	private CaretDisplayMode? _caretModeBeforeCaretDrag;
+
+	private CompositionBrush? _cachedCaretDragBrush;
+	private Color _cachedCaretDragColor;
+
 	internal bool IsCaretDragActive => _caretDragAnchor is not null;
+
+	/// <summary>
+	/// Brush for the previewed caret. It follows SelectionHighlightColor rather than the Foreground
+	/// so the dragged caret reads as a transient selection affordance.
+	/// </summary>
+	private CompositionBrush GetCaretDragBrush()
+	{
+		var color = (SelectionHighlightColor ?? DefaultBrushes.SelectionHighlightColor).Color;
+		if (color.A < 255)
+		{
+			color = Color.FromArgb(255, color.R, color.G, color.B);
+		}
+
+		if (_cachedCaretDragBrush is not null && _cachedCaretDragColor == color)
+		{
+			return _cachedCaretDragBrush;
+		}
+
+		_cachedCaretDragColor = color;
+		_cachedCaretDragBrush = Compositor.GetSharedCompositor().CreateColorBrush(color);
+		return _cachedCaretDragBrush;
+	}
 
 	/// <summary>
 	/// Drives a platform caret-drag gesture, such as the iOS space-bar trackpad gesture.
@@ -75,6 +107,8 @@ public partial class TextBox
 		var caretIndex = IsBackwardSelection ? SelectionStart : SelectionStart + SelectionLength;
 		var caretRect = parsedText.GetRectForIndex(caretIndex);
 		_caretDragAnchor = new Point(caretRect.Left, caretRect.Top + (caretRect.Height / 2));
+
+		_caretModeBeforeCaretDrag ??= CaretMode;
 
 		// The caret must not blink away mid-drag. CaretMode restarts the timer when it changes,
 		// so stop it afterwards.
@@ -128,9 +162,17 @@ public partial class TextBox
 		}
 
 		var previewIndex = _caretDragPreviewIndex;
+		var previousMode = _caretModeBeforeCaretDrag;
 
 		_caretDragAnchor = null;
 		_caretDragPreviewIndex = null;
+		_caretModeBeforeCaretDrag = null;
+
+		// Restored before committing so the selection transitions in SelectPartial see the real mode.
+		if (previousMode is { } mode)
+		{
+			CaretMode = mode;
+		}
 
 		if (CaretMode is CaretDisplayMode.ThumblessCaretShowing)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -593,9 +593,9 @@ public partial class TextBox : ITextSelectionGripperHost
 				// is always visible regardless of theme. Uno doesn't support DestInvert,
 				// so we use the TextBox's own Foreground (element-theme-aware via
 				// ThemeResource) with fully opaque alpha for maximum caret visibility.
+				var caretBrush = GetOpaqueCaretBrush();
 				// A caret drag previews its position without committing the selection until the
 				// gesture ends, so the preview wins while it is active. Text can shrink mid-drag.
-				var caretBrush = _caretDragPreviewIndex is not null ? GetCaretDragBrush() : GetOpaqueCaretBrush();
 				var caretIndex = _caretDragPreviewIndex is { } previewIndex
 					? Math.Clamp(previewIndex, 0, Text.Length)
 					: (IsBackwardSelection ? SelectionStart : SelectionStart + SelectionLength);
@@ -842,6 +842,13 @@ public partial class TextBox : ITextSelectionGripperHost
 
 			var (selectionStart, selectionEnd) = _selection.selectionEndsAtTheStart ? (_selection.start + _selection.length, _selection.start) : (_selection.start, _selection.start + _selection.length);
 			var index = putSelectionEndInVisibleViewport ? selectionEnd : selectionStart;
+
+			// A caret drag moves the previewed caret without committing the selection, so the
+			// viewport has to follow the preview instead.
+			if (_caretDragPreviewIndex is { } caretDragIndex)
+			{
+				index = Math.Clamp(caretDragIndex, 0, Text.Length);
+			}
 
 			var caretRect = TextBoxView.DisplayBlock.ParsedText.GetRectForIndex(index) with { Width = TextBlock.CaretThickness };
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -584,7 +584,7 @@ public partial class TextBox : ITextSelectionGripperHost
 			var isFocused = FocusState != FocusState.Unfocused || _forceFocusedVisualState;
 			displayBlock.RenderSelection = isFocused;
 			if (CaretMode is CaretDisplayMode.ThumblessCaretShowing &&
-				SelectionLength == 0 &&
+				(SelectionLength == 0 || _caretDragPreviewIndex is not null) &&
 				isFocused &&
 				!IsReadOnly &&
 				!FeatureConfiguration.TextBox.HideCaret)
@@ -594,7 +594,12 @@ public partial class TextBox : ITextSelectionGripperHost
 				// so we use the TextBox's own Foreground (element-theme-aware via
 				// ThemeResource) with fully opaque alpha for maximum caret visibility.
 				var caretBrush = GetOpaqueCaretBrush();
-				displayBlock.RenderCaret = (IsBackwardSelection ? SelectionStart : SelectionStart + SelectionLength, caretBrush);
+				// A caret drag previews its position without committing the selection until the
+				// gesture ends, so the preview wins while it is active. Text can shrink mid-drag.
+				var caretIndex = _caretDragPreviewIndex is { } previewIndex
+					? Math.Clamp(previewIndex, 0, Text.Length)
+					: (IsBackwardSelection ? SelectionStart : SelectionStart + SelectionLength);
+				displayBlock.RenderCaret = (caretIndex, caretBrush);
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -593,9 +593,9 @@ public partial class TextBox : ITextSelectionGripperHost
 				// is always visible regardless of theme. Uno doesn't support DestInvert,
 				// so we use the TextBox's own Foreground (element-theme-aware via
 				// ThemeResource) with fully opaque alpha for maximum caret visibility.
-				var caretBrush = GetOpaqueCaretBrush();
 				// A caret drag previews its position without committing the selection until the
 				// gesture ends, so the preview wins while it is active. Text can shrink mid-drag.
+				var caretBrush = _caretDragPreviewIndex is not null ? GetCaretDragBrush() : GetOpaqueCaretBrush();
 				var caretIndex = _caretDragPreviewIndex is { } previewIndex
 					? Math.Clamp(previewIndex, 0, Text.Length)
 					: (IsBackwardSelection ? SelectionStart : SelectionStart + SelectionLength);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -116,6 +116,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal void OnFocusStateChanged(FocusState focusState)
 		{
+			if (focusState == FocusState.Unfocused)
+			{
+				TextBox?.CancelCaretDrag();
+			}
+
 			if (_isSkiaTextBox && _useInvisibleNativeTextView)
 			{
 				// We don't care about actual entry here, just making


### PR DESCRIPTION
Fixes #23871

## PR Type:

✨ Feature

## What changed? 🚀

Caret seek gesture on software keyboard is now supported


https://github.com/user-attachments/assets/5f3a04a5-4f6d-4a9e-a441-ba37498884d1



## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)