### PR TITLE
fix(ci): Pin SDK from the PR head branch in apply workflow

### DIFF
--- a/.github/workflows/winappsdk-sync-apply.yml
+++ b/.github/workflows/winappsdk-sync-apply.yml
@@ -88,9 +88,12 @@ jobs:
           ref: ${{ steps.pr.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # This workflow file always comes from the default branch, but the checkout
+      # above is the PR head — so take the newest pin present in that tree rather
+      # than hardcoding one (`feature/breakingchanges` PRs need net11, not net10).
       - name: Pin .NET Version
         shell: bash
-        run: cp build/ci/net10/_global.json global.json
+        run: cp "$(ls -d build/ci/net* | sort -V | tail -1)/_global.json" global.json
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5.3.0


### PR DESCRIPTION
**GitHub Issue:** closes #23921

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`/apply-sync-gen` failed with `NETSDK1045` ("The current .NET SDK does not support targeting .NET 11.0") on every PR based on `feature/breakingchanges` — for example [this run](https://github.com/unoplatform/uno/actions/runs/30531333194).

`issue_comment` events always run the workflow definition from the **default branch**, while the job checks out the **PR head**. `winappsdk-sync-apply.yml` on `master` hardcoded `cp build/ci/net10/_global.json global.json`, so a .NET 10 SDK was installed and then used to restore a tree whose projects target `net11.0`. `build/ci/net11/` doesn't exist on `master` at all, so simply bumping the path there is not an option.

The pin is now taken from the newest `build/ci/net*` directory present in the checked-out tree:

```yaml
run: cp "$(ls -d build/ci/net* | sort -V | tail -1)/_global.json" global.json
```

Verified against both layouts: `master` resolves to `build/ci/net10/_global.json` (10.0.105), `feature/breakingchanges` resolves to `build/ci/net11/_global.json` (11.0.100-preview.5).

`winappsdk-sync-check.yml` is deliberately left alone — it is `pull_request`-triggered, so its workflow file and its checkout always come from the same branch and its hardcoded pin is always correct. Same for `codeql.yml` (push / pull_request / schedule) and the XAML Styler workflows, which never evaluate a project's target framework.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, CI-only change; the pin command was executed against both branch layouts instead
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
