### PR TITLE
docs: Document Themes 7.0 / Toolkit 9.0 upgrade in the 6.6 migration notes

### DIFF
--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -44,6 +44,25 @@ If your code references the generated bindable type by name directly, update tho
 
 This change was introduced in [Uno.Extensions PR #3055](https://github.com/unoplatform/uno.extensions/pull/3055).
 
+### Uno Themes 7.0 and Uno Toolkit 9.0
+
+The Uno Platform 6.6 service release moves the design system packages referenced implicitly by the Uno SDK up a major version: Uno Themes from 6.1 to 7.0, and Uno Toolkit from 8.4 to 9.0. Apps that initialize their theme with a single `<MaterialToolkitTheme />` (or `<MaterialTheme />` without the Toolkit), as the templates do, need no changes: every lightweight styling resource key is preserved and the default appearance is unchanged.
+
+The following changes require attention when upgrading:
+
+- The deprecated `MaterialToolkitResourcesV1` and `MaterialToolkitResourcesV2` dictionaries now fail at startup with `Cannot locate resource from 'ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml'`. Replace them with `<MaterialToolkitTheme />`.
+- The generated dictionary URIs of `Uno.Toolkit.WinUI` and `Uno.Toolkit.WinUI.Material` no longer carry the `WinUI` suffix — `mergedpages.WinUI.v2.xaml` is now `mergedpages.v2.xaml`. This only affects code merging those dictionaries by URI.
+- `MaterialToolkitTheme` now derives from `MaterialTheme` and already initializes it, so remove any `<MaterialTheme />` declared alongside it to avoid initializing the theme twice.
+- `ColorOverrideSource` and `ColorOverrideDictionary` are obsolete, superseded by the `Colors` property — use `<ut:ThemeColors OverrideSource="ms-appx:///Styles/ColorPaletteOverride.xaml" />` for a file override, or `ThemeColors.OverrideDictionary` for an inline `ResourceDictionary` (`ut` being `using:Uno.Themes`). Both properties still work, with unchanged precedence.
+- Themes deriving from `BaseTheme` must replace the removed `GenerateSpecificResources()` override with the parameterless `AddThemeSpecificResources()` hook, adding their dictionaries through `AddThemeDictionary()`.
+- The legacy Material v1 `CommandBar` and `ToggleSwitch` styles lost their iOS and Android variants, and now render with the shared XAML styles on those platforms. The Material Design 3 styles used by default are unaffected.
+- The UWP-flavored `Uno.Toolkit.UI` and `Uno.Toolkit.UI.Material` packages stop at 8.4.2, and neither library ships `net9.0-maccatalyst` or `net9.0-macos` assets anymore.
+- Minimum dependencies are raised to `Uno.WinUI` 6.5 for the Toolkit and 6.4 for Themes, and Uno Toolkit 9.0 requires Uno Themes 7.0. Remove or update explicit pins of those packages.
+
+For the per-library details, see the [Uno Toolkit](xref:Toolkit.Migration) and [Uno Material](xref:Uno.Themes.Material.Migration) upgrade guides.
+
+These changes were introduced in [Uno Toolkit PR #1544](https://github.com/unoplatform/uno.toolkit.ui/pull/1544) and [Uno Themes PR #1609](https://github.com/unoplatform/Uno.Themes/pull/1609), [PR #1620](https://github.com/unoplatform/Uno.Themes/pull/1620), and [PR #1680](https://github.com/unoplatform/Uno.Themes/pull/1680).
+
 ## Uno Platform 6.5
 
 Uno Platform 6.5 does not contain breaking changes that require attention when upgrading


### PR DESCRIPTION
**GitHub Issue:** related to https://github.com/unoplatform/private/issues/1102

## PR Type:

📚 Documentation content changes

## What changed? 🚀

The 6.6 migration notes covered the core and Uno.Extensions changes from the initial 6.6 release, but not the design system packages moving up a major version in the service release: the SDK's implicit pins go from **Uno.Themes 6.1.1 → 7.0.3** and **Uno.Toolkit 8.4.2 → 9.0.3**.

This adds a short **"Uno Themes 7.0 and Uno Toolkit 9.0"** entry under *Uno Platform 6.6*, matching the length and style of the other breaking-change entries in the file — one paragraph plus a bullet list of what breaks and what to do, with links out to the per-library upgrade guides:

- Deprecated `MaterialToolkitResourcesV1`/`V2` dictionaries now fail at startup → use `<MaterialToolkitTheme />`.
- Generated dictionary URIs dropped the `WinUI` suffix (affects URI-based merges).
- `MaterialToolkitTheme` derives from `MaterialTheme` → don't declare `<MaterialTheme />` alongside it.
- `ColorOverrideSource`/`ColorOverrideDictionary` obsolete → the `Colors` property: `ThemeColors.OverrideSource` for a file override, `ThemeColors.OverrideDictionary` for an inline `ResourceDictionary`.
- `BaseTheme.GenerateSpecificResources()` removed → the parameterless `AddThemeSpecificResources()` hook, with dictionaries added through `AddThemeDictionary()`.
- Material v1 `CommandBar` and `ToggleSwitch` lost their iOS/Android variants.
- UWP-flavored Toolkit packages stop at 8.4.2; `net9.0-maccatalyst` / `net9.0-macos` assets dropped.
- Raised dependency floors and the Toolkit 9.0 ⇄ Themes 7.0 coupling.

It states up front that apps using the template pattern (`<MaterialToolkitTheme />`) need **no changes**, so a major version bump inside a service release doesn't read as more disruptive than it is.

### Validation

Verified against the shipped packages rather than commit messages:

- Diffed the XAML resource-key sets and public API surfaces of Uno.Material.WinUI 6.1.1 → 7.0.3 and Uno.Toolkit.WinUI 8.4.2 → 9.0.3, plus nuspec dependency groups. No resource keys were removed from the shipped WinUI dictionaries other than `NativeCommandBarTemplate` — the other missing keys live in a `NavigationView/WUX/**` folder the WinUI package excludes, so they never shipped.
- Confirmed the Material Design 3 styles switched to design token resources (`ButtonMinHeight` → `ControlHeightMedium`, `ButtonPadding` → `Space400HorizontalThickness`, …) and traced `BaseTheme.ScaleGeneration.cs` to verify the token defaults equal the literals they replaced (40, 16, 20, …) at the default density and corner radius — hence "default appearance unchanged".
- Checked the `lib/` assets of all 11 Themes and Toolkit packages: `net9.0-maccatalyst` and `net9.0-macos` present at 6.1.1/8.4.2, absent at 7.0.3/9.0.3. Last stable UWP-flavored Toolkit release is 8.4.2.
- Compared `BaseTheme.UpdateSource()` at both versions to confirm color override precedence is *unchanged* for apps that don't opt into seed colors.
- Built and ran a template-generated app (recommended preset, `net10.0-desktop`) on both stacks — baseline (6.1.1 / 8.4.2) and upgraded (7.0.3 / 9.0.3): both build with 0 warnings / 0 errors and launch cleanly.
- Reproduced the legacy-dictionary failure in that same app by swapping `<MaterialToolkitTheme />` for `<MaterialToolkitResourcesV2 />`: runs on 8.4.2, crashes on 9.0.3 with `Cannot locate resource from 'ms-appx:///Uno.Toolkit.WinUI.Material/Generated/mergedpages.WinUI.v2.xaml'`.
- `cspell --config ./build/cSpell.json` passes on the edited file, and the previous push was green on **Uno.UI - docs** and **Check Docs links**, so both `xref` links resolve in a real docs build.

Following the automated review round, two points were folded in and one was declined on the evidence:

- The `AddThemeSpecificResources` signature is now given in the doc. Note it is **parameterless** (`BaseTheme.cs:468` at tag `7.0.3`) and implementers layer resources via the `protected void AddThemeDictionary(ResourceDictionary)` helper — the reviewer-suggested `AddThemeSpecificResources(ResourceDictionary dictionary)` overload does not exist.
- The inline-dictionary migration path was missing; `ThemeColors.OverrideDictionary` is confirmed against the shipped API and is now covered alongside `OverrideSource`.
- Windows App SDK 1.7 and the new `SkiaSharp.Views` dependency are intentionally **not** listed as floors a reader must act on: `Uno.Sdk` 6.6.33 already pins `Microsoft.WindowsAppSDK` to `1.7.250909003` (the exact floor Toolkit 9.0.3 declares) and `SkiaSharp.Views.Uno.WinUI`/`.WinUI` are already implicit SDK packages at `3.119.2`, above the new `3.119.1` floor.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, documentation-only
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A, documentation-only
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

