### PR TITLE
fix: extend Android Surface lifetime to avoid GC-related crash

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/Accessibility/AccessibilityNodeInfoCompatJni.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Accessibility/AccessibilityNodeInfoCompatJni.cs
@@ -49,6 +49,7 @@ internal static class AccessibilityNodeInfoCompatJni
 		}
 		// else: neither signature exists on the loaded binding — skip silently rather than
 		// crash. This shouldn't happen in practice but keeps the helper safe by construction.
+		GC.KeepAlive(node);
 	}
 
 	private static void EnsureInitialized()

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -173,6 +173,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 		_nativeWindow = ANativeWindow_fromSurface(
 			JNIEnv.Handle,
 			surface.Handle);
+		GC.KeepAlive(surface);
 
 		if (_nativeWindow == IntPtr.Zero)
 			throw new InvalidOperationException("Failed to get ANativeWindow from Surface");


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/uno/issues/23923

Context: https://learn.microsoft.com/en-us/archive/blogs/cbrumme/lifetime-gc-keepalive-handle-recycling
Context: https://github.com/mono/SkiaSharp/issues/3393

Through (good? bad? dumb?) luck, when running SamplesApp on my handy emulator, building SamplesApp from a commit on the feature/breakingchanges branch:

	# note: commit 0ebec is on the feature/breakingchanges branch
	git checkout 0ebec1e321fc5ff5c21ed166130f69241ddcfbb8
	# note: feature/breakingchanges is on .NET 11 P5
	export PATH=path/to/dotnet-sdk-11.0.100-preview.5.26302.115:$PATH
	\cp build/ci/net11/_global.json global.json
	dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -r android-arm64 -f net11.0-android -p:UnoTargetFrameworkOverride=net11.0-android
	adb install src/SamplesApp/SamplesApp.Skia.netcoremobile/bin/Release/net11.0-android/android-arm64/publish/uno.platform.samplesapp.skia-Signed.apk
	adb shell am start uno.platform.samplesapp.skia/crc6448f3b0362cbf4bc9.MainActivity

Immediatley after launching the app, it would crash, with `adb logcat` containing:

	ActivityManager: Displayed uno.platform.samplesapp.skia/crc6448f3b0362cbf4bc9.MainActivity: +1s380ms
	samplesapp.ski: indirect_reference_table.cc:59] JNI ERROR (app bug): attempt to use stale Global 0x3916 (should be 0x391a)
	samplesapp.ski: runtime.cc:558] Runtime aborting...
	samplesapp.ski: runtime.cc:558] Dumping all threads without appropriate locks held: thread list lock
	samplesapp.ski: runtime.cc:558] All threads:
	samplesapp.ski: runtime.cc:558] DALVIK THREADS (20):
	samplesapp.ski: runtime.cc:558] "Thread-8" prio=10 tid=19 Runnable
	samplesapp.ski: runtime.cc:558]   | group="" sCount=0 dsCount=0 flags=0 obj=0x12d01368 self=0x6f186fa800
	samplesapp.ski: runtime.cc:558]   | sysTid=7366 nice=-10 cgrp=default sched=0/0 handle=0x6f1993f4f0
	samplesapp.ski: runtime.cc:558]   | state=R schedstat=( 3289249 4228251 22 ) utm=0 stm=0 core=2 HZ=100
	samplesapp.ski: runtime.cc:558]   | stack=0x6f19844000-0x6f19846000 stackSize=1009KB
	samplesapp.ski: runtime.cc:558]   | held mutexes= "abort lock" "mutator lock"(shared held)
	samplesapp.ski: runtime.cc:558]   native: #00 pc 00000000003b49a0  /system/lib64/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+216)
	samplesapp.ski: runtime.cc:558]   native: #01 pc 0000000000480e20  /system/lib64/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, bool, BacktraceMap*, bool) const+348)
	samplesapp.ski: runtime.cc:558]   native: #02 pc 000000000049a598  /system/lib64/libart.so (art::DumpCheckpoint::Run(art::Thread*)+812)
	samplesapp.ski: runtime.cc:558]   native: #03 pc 000000000049350c  /system/lib64/libart.so (art::ThreadList::RunCheckpoint(art::Closure*, art::Closure*)+464)
	samplesapp.ski: runtime.cc:558]   native: #04 pc 00000000004927d4  /system/lib64/libart.so (art::ThreadList::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, bool)+504)
	samplesapp.ski: runtime.cc:558]   native: #05 pc 00000000004564dc  /system/lib64/libart.so (art::Runtime::Abort(char const*)+380)
	samplesapp.ski: runtime.cc:558]   native: #06 pc 0000000000008cb0  /system/lib64/libbase.so (android::base::LogMessage::~LogMessage()+724)
	samplesapp.ski: runtime.cc:558]   native: #07 pc 00000000002356e0  /system/lib64/libart.so (art::IndirectReferenceTable::AbortIfNoCheckJNI(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)+236)
	samplesapp.ski: runtime.cc:558]   native: #08 pc 00000000002e2790  /system/lib64/libart.so (art::IndirectReferenceTable::GetChecked(void*) const+436)
	samplesapp.ski: runtime.cc:558]   native: #09 pc 00000000002ddabc  /system/lib64/libart.so (art::JavaVMExt::DecodeGlobal(void*)+24)
	samplesapp.ski: runtime.cc:558]   native: #10 pc 0000000000486734  /system/lib64/libart.so (art::Thread::DecodeJObject(_jobject*) const+152)
	samplesapp.ski: runtime.cc:558]   native: #11 pc 00000000003439c4  /system/lib64/libart.so (art::JNI::GetObjectField(_JNIEnv*, _jobject*, _jfieldID*)+596)
	samplesapp.ski: runtime.cc:558]   native: #12 pc 00000000000ff6bc  /system/lib64/libandroid_runtime.so (android::android_view_Surface_getSurface(_JNIEnv*, _jobject*)+52)
	samplesapp.ski: runtime.cc:558]   native: #13 pc 00000000000ff64c  /system/lib64/libandroid_runtime.so (android::android_view_Surface_getNativeWindow(_JNIEnv*, _jobject*)+36)
	samplesapp.ski: runtime.cc:558]   native: #14 pc 0000000000012394  /system/lib64/libandroid.so (ANativeWindow_fromSurface+32)
	samplesapp.ski: runtime.cc:558]   native: #15 pc 00000000064927d0  <anonymous:6fd9e70000> (???)
	samplesapp.ski: runtime.cc:558]   (no managed stack frames)

For expository purposes, the relevant code is:

	/* 1 */ var surface = holder.Surface;
	/* 2 */ IntPtr __env = JNIEnv.Handle;
	/* 3 */ IntPtr __surface = surface.Handle;
	/* 4 */ _nativeWindow = ANativeWindow_fromSurface(__env, __surface);

What appears to be happening is the following:

 1. .NET 11 P5 changes the default Android runtime to CoreCLR. (.NET 11 P6 makes using MonoVM an *error*…)

    This means that we're now using a different GC than .NET 10+MonoVM.

 2. The `surface` instance created on line 1 is not referenced again after line 3, which means it is eligible for collection immediately after the `surface.Handle` property invocation.

 4. If the GC collects the `surface` instance between lines 3 and 4, then `__surface` will be an *invalid JNI handle*, as the GC collecting `surface` will invalidate it.

 5. If `__surface` is an invalid handle, then `ANativeWindow_fromSurface()` will (rightfully!) crash with the "use [of] stale Global [JNI object reference].""

The fix for this, in a manner similar to that mentioned in mono/SkiaSharp#3393, is to extend the lifetime of `surface` so that the GC doesn't attempt to collect it before/during the `ANativeWindow_fromSurface()` invocation, by using `GC.KeepAlive()`:

	var surface = holder.Surface;
	IntPtr __env = JNIEnv.Handle;
	IntPtr __surface = surface.Handle;
	_nativeWindow = ANativeWindow_fromSurface(__env, __surface);
	GC.KeepAlive(surface);

With this understanding in mind, review other use of JNI-backed `.Handle` use within src/Uno.UI.Runtime.Skia.Android:

	git grep '\.Handle\>' src/Uno.UI.Runtime.Skia.Android

and add `GC.KeepAlive()` invocations to ensure that the instance upon which `.Handle` is invoked is kept alive around the method call using `.Handle`.

**GitHub Issue:** closes #23923

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
🐞 Bugfix

<!--
Copy the label that applies to this PR and paste it above:

✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
🏗️ Build or CI related changes
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
