### PR TITLE
feat(skills): Add wasm-device-test skill for on-device WASM testing

### DIFF
--- a/.claude/skills/wasm-device-test/SKILL.md
+++ b/.claude/skills/wasm-device-test/SKILL.md
@@ -1,0 +1,157 @@
+---
+description: Publish an Uno WebAssembly app and serve it on the local network so it can be opened on a phone, tablet, or another machine. Use when testing WASM behaviour that cannot be reproduced on a desktop browser — touch input, mobile GPUs, device refresh rates, small viewports.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+---
+
+## Overview
+
+You are executing the **WASM Device Test Skill**. It publishes an Uno Platform WebAssembly app and
+serves the published output over HTTP **bound to all network interfaces**, so a phone or tablet on
+the same network can load it.
+
+This exists because the two obvious approaches both fail for device testing:
+
+- `dotnet run` serves on `localhost` only — a phone cannot reach it.
+- `python -m http.server` binds loopback only *and* does not know the `.wasm` MIME type, so the
+  browser cannot use `WebAssembly.instantiateStreaming`.
+
+Use it when the thing under test is device-specific: touch and gesture handling, inertia and fling
+behaviour, display refresh rate (many phones idle at 60 Hz and boost to 120 Hz only while touch is
+active), GPU rasterization, safe-area insets, or on-screen keyboard behaviour.
+
+---
+
+## Execution Workflow
+
+### Phase 0: Parse User Input
+
+| Input | Meaning | Default |
+|---|---|---|
+| a project path or name | the WASM head to publish | auto-detect (below) |
+| `debug` | publish Configuration=Debug | **Release** |
+| `port <n>` | HTTP port | `8123` |
+| `no-build` / `serve-only` | skip publish, serve the existing output | publish first |
+
+**Always publish Release unless the user explicitly asks for Debug.** A Debug WebAssembly build is
+dominated by interpreter overhead, so any conclusion about smoothness, frame rate, or responsiveness
+drawn from it is meaningless.
+
+**Auto-detecting the project.** Look for a WebAssembly head in this order:
+
+1. A project the user named.
+2. `**/*.Skia.WebAssembly.Browser/*.csproj` (the Uno Platform repo's own SamplesApp head is
+   `src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/`).
+3. Any `.csproj` whose `TargetFramework` contains `browserwasm`, or that references
+   `Uno.Sdk` with a `WebAssembly` head.
+
+If more than one candidate exists, ask which one rather than guessing.
+
+### Phase 1: Publish
+
+**CRITICAL**: WASM publish is slow (several minutes, and much longer with AOT). Set a timeout of
+20+ minutes and **never cancel it**. Run it in the background and continue with Phase 2 setup.
+
+```bash
+dotnet publish <project> -c Release -f <tfm> -p:UnoFastDevBuild=true
+```
+
+Notes:
+
+- `publish` is required, not `build` — only publish produces the complete static web asset set.
+- In the Uno Platform repo, add `-p:UnoTargetFrameworkOverride=net10.0` (or whichever single TFM you
+  are iterating on) to skip redundant cross-targeted outputs.
+- The published site root is
+  `<project>/bin/<Configuration>/<tfm>/publish/wwwroot`. Verify `index.html` and `_framework/` exist
+  before serving; if they do not, the publish did not complete.
+
+If the publish fails, read the error and fix or report it. Do not fall back to serving a stale
+output — the user will test the wrong bits and the result will be misleading.
+
+### Phase 2: Serve
+
+```bash
+python scripts/serve-wasm.py <wwwroot> [port]
+```
+
+Run it in the **background** — it blocks until stopped. The script prints the URLs to use:
+
+```
+Serving …/publish/wwwroot
+  this machine : http://localhost:8123/
+  other devices: http://192.168.1.20:8123/
+```
+
+It binds `0.0.0.0`, registers the `.wasm`/`.dat`/`.blat` MIME types, and sends
+`Cache-Control: no-store` so a republished app is picked up without the service worker serving a
+stale build.
+
+### Phase 3: Verify before handing over the URL
+
+Do not give the user a URL you have not checked. Confirm all three:
+
+```bash
+# 1. the app is served
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:<port>/index.html
+
+# 2. .wasm has the right MIME type (must be application/wasm)
+curl -s -I "http://localhost:<port>/_framework/$(ls <wwwroot>/_framework/*.wasm | head -1 | xargs basename)" | grep -i content-type
+
+# 3. the LAN address actually answers — this is the one that catches a blocking firewall
+curl -s -m 4 -o /dev/null -w "%{http_code}\n" http://<lan-ip>:<port>/index.html
+```
+
+The script prints every non-loopback IPv4 address it can find, which on a developer machine usually
+includes VPN, WSL, and Hyper-V adapters that a phone cannot reach. Probe them and report the one
+that answered, rather than listing all of them.
+
+**If the LAN probe fails**, it is almost always the host firewall. Report it and give the user the
+command to fix it — do not attempt it silently, since it needs elevation and changes the host's
+network exposure:
+
+```powershell
+New-NetFirewallRule -DisplayName "Uno WASM device test" -Direction Inbound -LocalPort <port> -Protocol TCP -Action Allow
+```
+
+Remind the user to remove the rule when finished:
+
+```powershell
+Remove-NetFirewallRule -DisplayName "Uno WASM device test"
+```
+
+### Phase 4: Report
+
+Give the user:
+
+- the **device URL** (the one that passed the probe), and the localhost URL for desktop comparison
+- the configuration that was published, so they know whether the numbers mean anything
+- a note that first load transfers the full asset set (often 200 MB+ uncompressed) and will be slow
+- what you expect to be better or unchanged, if this run is testing a specific change — so a result
+  that contradicts it is recognisable as new information rather than noise
+
+Tell the user the server is still running and offer to stop it. It holds the port until stopped.
+
+---
+
+## Notes and Limitations
+
+- **HTTP only.** Browser APIs gated on a secure context (clipboard, geolocation, service workers on
+  some browsers, `SharedArrayBuffer`) will not work over a plain LAN address. If the user needs
+  those, they need HTTPS with a trusted certificate or a tunnel; say so rather than debugging the
+  symptom.
+- **Same network required.** Guest/isolated Wi-Fi and many corporate networks block client-to-client
+  traffic even when both devices are online. If the phone cannot connect but the desktop can, and
+  the firewall rule is present, suspect AP isolation.
+- **Not the runtime-test runner.** For automated WASM runtime tests use the `/runtime-tests` skill,
+  which drives the test harness and collects results. This skill is for a human driving the app by
+  hand on a device.
+- **Serving is not deploying.** The service worker caches aggressively; `no-store` covers the normal
+  republish case, but if a device seems stuck on an old build, have the user clear site data.

--- a/.claude/skills/wasm-device-test/scripts/serve-wasm.py
+++ b/.claude/skills/wasm-device-test/scripts/serve-wasm.py
@@ -88,7 +88,8 @@ def main():
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        pass
+        # Expected on Ctrl+C: exit cleanly without printing a traceback.
+        return 0
     return 0
 
 

--- a/.claude/skills/wasm-device-test/scripts/serve-wasm.py
+++ b/.claude/skills/wasm-device-test/scripts/serve-wasm.py
@@ -1,0 +1,96 @@
+"""Static file server for a published Uno WebAssembly app, reachable from other devices.
+
+`python -m http.server` almost works, but two of its defaults break this use case:
+
+* it binds loopback only, so a phone on the same network cannot reach it;
+* it does not know the `.wasm` MIME type, so the browser refuses
+  `WebAssembly.instantiateStreaming` and falls back to a slower path (or fails outright,
+  depending on the browser).
+
+Usage:
+    python serve-wasm.py <wwwroot> [port]
+"""
+
+import functools
+import mimetypes
+import socket
+import sys
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+DEFAULT_PORT = 8123
+
+# Python's mimetypes DB is incomplete for the .NET WebAssembly asset set, and on Windows it is
+# partly driven by the registry, so it varies per machine. Pin the ones that matter.
+_MIME_TYPES = {
+    ".wasm": "application/wasm",
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".json": "application/json",
+    ".dat": "application/octet-stream",
+    ".blat": "application/octet-stream",
+    ".pdb": "application/octet-stream",
+    ".dll": "application/octet-stream",
+    ".webcil": "application/octet-stream",
+}
+
+
+class Handler(SimpleHTTPRequestHandler):
+    """Adds no-store so a republished app is picked up without clearing the service worker."""
+
+    _base_end_headers = SimpleHTTPRequestHandler.end_headers
+
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store, must-revalidate")
+        Handler._base_end_headers(self)
+
+    def log_message(self, fmt, *args):
+        # One line per asset is thousands of lines for a single page load.
+        pass
+
+
+def _lan_addresses():
+    """Best-effort list of addresses another device on the network could use.
+
+    Excludes loopback and link-local. Virtual adapters (VPN, WSL, Hyper-V) cannot be told
+    apart reliably here, so all candidates are printed and the user picks the reachable one.
+    """
+    addresses = []
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
+            address = info[4][0]
+            if not address.startswith(("127.", "169.254.")) and address not in addresses:
+                addresses.append(address)
+    except socket.gaierror:
+        pass
+    return addresses
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 1
+
+    root = sys.argv[1]
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_PORT
+
+    for extension, mime in _MIME_TYPES.items():
+        mimetypes.add_type(mime, extension)
+
+    handler = functools.partial(Handler, directory=root)
+    server = ThreadingHTTPServer(("0.0.0.0", port), handler)
+
+    print(f"Serving {root}")
+    print(f"  this machine : http://localhost:{port}/")
+    for address in _lan_addresses():
+        print(f"  other devices: http://{address}:{port}/")
+    print("Ctrl+C to stop.", flush=True)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+﻿# AGENTS.md
 
 This file provides guidance to AI Agents when working with code in this repository.
 
@@ -18,6 +18,7 @@ Uno Platform is an open-source .NET UI cross-platform framework for building .NE
 | WinUI Porting | `/winui-port` | Porting WinUI C++ code to Uno Platform C# (full deep reference) |
 | DevServer | `/devserver` | DevServer CLI/Host build, test, MCP proxy, add-in discovery |
 | Docs Build | `/docs-build` | Building, previewing & validating the docs website (DocFX), incl. external-doc commit bumps in `import_external_docs.ps1` |
+| WASM Device Test | `/wasm-device-test` | Publishing a WebAssembly head and serving it on the LAN so it can be opened on a phone or tablet |
 
 #### Pre-commit review (invoke via `/review-panel`)
 


### PR DESCRIPTION
**GitHub Issue:** closes #23930

## PR Type:

🤖 Project automation

## What changed? 🚀

Adds a `/wasm-device-test` skill that publishes an Uno Platform WebAssembly head and serves the published output on the local network, so it can be opened on a phone, tablet, or another machine.

Neither existing option works for this:

- `dotnet run` serves on `localhost` only, so a device cannot reach it.
- `python -m http.server` (used by `build/test-scripts/wasm-run-skia-runtime-tests.sh`) binds loopback only, *and* does not register the `.wasm` MIME type, so the browser cannot use `WebAssembly.instantiateStreaming`.

The skill covers the whole loop — publish, serve, verify, report:

- **Publishes Release by default.** A Debug WebAssembly build is dominated by interpreter overhead, so any conclusion about responsiveness or frame rate drawn from it is meaningless. Debug is opt-in.
- **Serves on all interfaces** with the .NET WebAssembly MIME types registered, and `Cache-Control: no-store` so a republished app is picked up without clearing the service worker.
- **Probes the LAN address before reporting a URL.** A blocking host firewall is the usual failure and is otherwise indistinguishable from the app not loading. The skill reports the address that actually answered rather than listing every adapter, and gives the `New-NetFirewallRule` command rather than silently elevating.

It documents the limitations that bite in practice: HTTP only (so secure-context APIs are unavailable), AP isolation on guest and corporate Wi-Fi, and that this is for driving an app by hand — automated WASM runtime tests remain the `/runtime-tests` skill's job.

Contributor tooling only; no product code is touched. `AGENTS.md` gains a row in the skills table.

### Verification

The bundled `scripts/serve-wasm.py` was exercised against a published `SamplesApp.Skia.WebAssembly.Browser` output:

- `index.html` → 200 on both `localhost` and the LAN address
- `_framework/*.wasm` → `Content-Type: application/wasm`
- `Cache-Control: no-store, must-revalidate` present
- the app was loaded and driven by hand from a phone browser on the same network

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, contributor tooling; the script was validated manually as described above
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — the skill is self-documenting and is registered in `AGENTS.md`
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A, no product code
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
