### PR TITLE
fix(skia): don't paint unarranged elements, and report clip-change damage

### DIFF
--- a/src/Uno.UI.Composition/Composition/Visual.Damage.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.Damage.skia.cs
@@ -13,6 +13,7 @@ public partial class Visual
 	private SKRect _lastRenderBounds;
 	private Matrix4x4 _lastRenderMatrix;
 	private bool _hasLastRenderBounds;
+	private SKRect _lastClipBounds;
 
 	private bool _subtreeChangedThisFrame;
 
@@ -36,7 +37,15 @@ public partial class Visual
 
 		var shadowSilhouetteChanged = ShadowState is not null && _subtreeChangedThisFrame;
 
-		if (!contentChanged && !moved && !shadowSilhouetteChanged)
+		// The accumulated clip can grow or shrink while this visual's own content and transform stay
+		// identical (e.g. an ancestor re-clipping to a new size), revealing or hiding part of it. Nothing
+		// else would report that as damage, so the newly exposed pixels would keep the previous frame's
+		// content. Compared by bounds to stay cheap on this per-visual, per-frame path.
+		var clipBounds = clip.Bounds;
+		var clipChanged = clipBounds != _lastClipBounds;
+		_lastClipBounds = clipBounds;
+
+		if (!contentChanged && !moved && !clipChanged && !shadowSilhouetteChanged)
 		{
 			return;
 		}

--- a/src/Uno.UI.Composition/Composition/Visual.Damage.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.Damage.skia.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System;
 using System.Numerics;
@@ -25,7 +25,7 @@ public partial class Visual
 
 	internal virtual float DamageRegionSamplingMargin => 0;
 
-	private void ContributeDamageOnPaint(bool contentChanged, SKPath? damage, SKPath clip)
+	private void ContributeDamageOnPaint(bool contentChanged, SKPath? damage, SKPath clip, bool clipChanged)
 	{
 		if (damage is null)
 		{
@@ -38,11 +38,14 @@ public partial class Visual
 		var shadowSilhouetteChanged = ShadowState is not null && _subtreeChangedThisFrame;
 
 		// The accumulated clip can grow or shrink while this visual's own content and transform stay
-		// identical (e.g. an ancestor re-clipping to a new size), revealing or hiding part of it. Nothing
-		// else would report that as damage, so the newly exposed pixels would keep the previous frame's
-		// content. Compared by bounds to stay cheap on this per-visual, per-frame path.
+		// identical (e.g. an ancestor re-clipping to a new size), revealing or hiding part of it, and nothing
+		// else would report that as damage. Two independent signals, because neither covers the other:
+		// clipChanged is raised where a Clip/LayoutClip is mutated, so it catches a shape change inside
+		// unchanged bounds; the bounds fingerprint catches clips this visual never sees mutate, such as the
+		// frame's root clip. Bounds are compared rather than the path, to stay cheap on this per-visual,
+		// per-frame path.
 		var clipBounds = clip.Bounds;
-		var clipChanged = clipBounds != _lastClipBounds;
+		clipChanged |= clipBounds != _lastClipBounds;
 		_lastClipBounds = clipBounds;
 
 		if (!contentChanged && !moved && !clipChanged && !shadowSilhouetteChanged)

--- a/src/Uno.UI.Composition/Composition/Visual.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.cs
@@ -204,6 +204,15 @@ namespace Microsoft.UI.Composition
 					DamageLastRenderedRegion(target);
 				}
 			}
+			else if (propertyName is nameof(Clip) or LayoutClipPropertyName)
+			{
+				// The clip reveals or hides part of this subtree while descendants keep their content and
+				// transform, so they would report no damage on their own. Raise the signal Render carries down
+				// to them, and drop this visual's own cached children picture — otherwise the subtree is not
+				// walked at all, and no descendant gets the chance to report it.
+				_clipChangedSincePaint = true;
+				InvalidateParentChildrenPicture(includeSelf: true);
+			}
 
 			void RecursiveInvalidate(Visual visual)
 			{

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -53,6 +53,16 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	private IntPtr _childrenPicture;
 	private int _framesSinceSubtreeNotChanged;
 
+	// Raised when this visual's own Clip/LayoutClip changes, and carried down the render walk so
+	// descendants report damage for the region the clip revealed or hid. Cleared once consumed by Render.
+	private bool _clipChangedSincePaint;
+
+	/// <summary>
+	/// ContainerVisual.LayoutClip is declared in a partial that isn't compiled for every target, so the
+	/// clip-change hook in Visual.OnPropertyChangedCore matches it by name.
+	/// </summary>
+	private const string LayoutClipPropertyName = "LayoutClip";
+
 	private VisualFlags _flags = VisualFlags.MatrixDirty | VisualFlags.PaintDirty | VisualFlags.ChildrenSKPictureInvalid;
 
 	private const int SK_MaxS32FitsInFloat = 2147483520;
@@ -416,7 +426,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	/// Position a sub visual on the canvas and draw its content.
 	/// </summary>
 	/// <param name="parentSession">The drawing session of the <see cref="Parent"/> visual.</param>
-	private void Render(in PaintingSession parentSession, SKPath clipInRoot, bool applyChildOptimization = true)
+	private void Render(in PaintingSession parentSession, SKPath clipInRoot, bool applyChildOptimization = true, bool ancestorClipChanged = false)
 	{
 #if TRACE_COMPOSITION
 		var indent = int.TryParse(Comment?.Split(new char[] { '-' }, 2, StringSplitOptions.TrimEntries).FirstOrDefault(), out var depth)
@@ -429,6 +439,12 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 		{
 			return;
 		}
+
+		// A clip change alters what this subtree contributes to the frame without touching any descendant's
+		// content or transform, so the signal has to reach them: it is raised where the clip is mutated and
+		// carried down this walk. Consumed here so it is reported exactly once.
+		var clipChanged = ancestorClipChanged || _clipChangedSincePaint;
+		_clipChangedSincePaint = false;
 
 		if ((_flags & VisualFlags.ChildrenSKPictureInvalid) == 0)
 		{
@@ -485,9 +501,9 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 
 			if (ShadowState is null || TryRenderAnalyticShadow(canvas, ShadowState))
 			{
-				PaintStep(this, session, ownClip);
+				PaintStep(this, session, ownClip, clipChanged);
 				PostPaintingClipStep(this, canvas);
-				RenderChildrenStep(this, session, childClip, applyChildOptimization);
+				RenderChildrenStep(this, session, childClip, applyChildOptimization, clipChanged);
 			}
 			else
 			{
@@ -498,9 +514,9 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 				_factory.CreateInstance(this, recordingCanvas, ref rootTransform, session.Opacity, session.Damage, out var childSession);
 				using (childSession)
 				{
-					PaintStep(this, childSession, ownClip);
+					PaintStep(this, childSession, ownClip, clipChanged);
 					PostPaintingClipStep(this, recordingCanvas);
-					RenderChildrenStep(this, childSession, childClip, applyChildOptimization);
+					RenderChildrenStep(this, childSession, childClip, applyChildOptimization, clipChanged);
 				}
 
 				unsafe
@@ -515,7 +531,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			}
 		}
 
-		static void PaintStep(Visual visual, in PaintingSession session, SKPath clip)
+		static void PaintStep(Visual visual, in PaintingSession session, SKPath clip, bool clipChanged)
 		{
 			// Rendering shouldn't depend on matrix or clip adjustments happening in a visual's Paint. That should
 			// be specific to that visual and should not affect the rendering of any other visual.
@@ -526,7 +542,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			{
 				visual.InvalidateParentChildrenPicture(includeSelf: false);
 				// why bother with a recorder when it's going to get repainted next frame? just paint directly
-				visual.ContributeDamageOnPaint(contentChanged: true, session.Damage, clip);
+				visual.ContributeDamageOnPaint(contentChanged: true, session.Damage, clip, clipChanged);
 				visual._ownContentPath = visual.Paint(session);
 			}
 			else
@@ -546,7 +562,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 					visual._picture = picture;
 				}
 
-				visual.ContributeDamageOnPaint(contentChanged, session.Damage, clip);
+				visual.ContributeDamageOnPaint(contentChanged, session.Damage, clip, clipChanged);
 				unsafe
 				{
 					UnoSkiaApi.sk_canvas_draw_picture(session.Canvas.Handle, visual._picture, null, IntPtr.Zero);
@@ -575,7 +591,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 #endif
 		}
 
-		static void RenderChildrenStep(Visual visual, PaintingSession session, SKPath childClip, bool applyChildOptimization)
+		static void RenderChildrenStep(Visual visual, PaintingSession session, SKPath childClip, bool applyChildOptimization, bool clipChanged)
 		{
 			if (visual._childrenPicture != IntPtr.Zero)
 			{
@@ -591,7 +607,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			{
 				foreach (var child in visual.GetChildrenInRenderOrder())
 				{
-					child.Render(in session, childClip, applyChildOptimization);
+					child.Render(in session, childClip, applyChildOptimization, clipChanged);
 				}
 			}
 			else
@@ -605,7 +621,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 				{
 					foreach (var child in visual.GetChildrenInRenderOrder())
 					{
-						child.Render(in childSession, childClip, applyChildOptimization: false);
+						child.Render(in childSession, childClip, applyChildOptimization: false, ancestorClipChanged: clipChanged);
 					}
 				}
 

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -153,12 +153,21 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 				// never cleared (Render returns before that).
 				InvalidateParentChildrenPicture(includeSelf: false);
 
-				// Becoming suppressed leaves whatever was painted on screen, so damage it like
-				// OnIsVisibleChanged does. The reverse direction self-heals: the visual is walked again
-				// with no _lastRenderBounds, which reports it as moved.
-				if (value && CompositionTarget is { } target)
+				if (CompositionTarget is { } target)
 				{
-					DamageLastRenderedRegion(target);
+					// Becoming suppressed leaves whatever was painted on screen, so damage it like
+					// OnIsVisibleChanged does. The reverse direction self-heals: the visual is walked again
+					// with no _lastRenderBounds, which reports it as moved.
+					if (value)
+					{
+						DamageLastRenderedRegion(target);
+					}
+
+					// This is not a composition property, so nothing requests a frame on our behalf. An
+					// arrange landing on the previous offset and size (a re-parented element re-added to the
+					// same slot) changes no property at all, so without this the damage above, or the newly
+					// unsuppressed subtree, would wait for an unrelated invalidation.
+					target.RequestNewFrame();
 				}
 			}
 		}

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -118,14 +118,15 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	/// In the future, we should accurately set <see cref="_requiresRepaint"/> to
 	/// only be true when we really have something to paint (and that painting needs to be updated).
 	/// </summary>
-	private bool _isArrangePending;
+	internal virtual bool CanPaint() => false;
 
 	/// <summary>
-	/// Set while the owning element has never been arranged. Such a visual has no layout slot yet
-	/// (<see cref="ArrangeOffset"/>/<see cref="Size"/> are unset) and a visual's content is not bounded by
-	/// its Size, so painting it would draw at the parent's origin, unclipped. WinUI never renders an element
-	/// its parent didn't arrange. Defaults to <see langword="false"/> so visuals created directly through the
-	/// Composition API (which are never arranged by the layout system) keep rendering.
+	/// Set while the owning element has no layout slot, i.e. it has never been arranged (or was
+	/// re-parented and not arranged since). <see cref="ArrangeOffset"/>/<see cref="Size"/> are unset then,
+	/// and a visual's content is not bounded by its Size, so painting would draw at the parent's origin,
+	/// unclipped. WinUI never renders an element its parent didn't arrange. Defaults to
+	/// <see langword="false"/> so visuals created directly through the Composition API (which the layout
+	/// system never arranges) keep rendering.
 	/// </summary>
 	internal bool IsArrangePending
 	{
@@ -135,13 +136,31 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			if (_isArrangePending != value)
 			{
 				_isArrangePending = value;
-				// Becoming paintable has to re-collect this visual into any cached parent picture.
-				InvalidateParentChildrenPicture(includeSelf: true);
+
+				// Mirrors the visibility transitions: the ancestors' cached children pictures must be
+				// rebuilt either way (to drop or to re-collect this subtree). Passing includeSelf would
+				// stop the walk immediately, since a suppressed visual's own ChildrenSKPictureInvalid is
+				// never cleared (Render returns before that).
+				InvalidateParentChildrenPicture(includeSelf: false);
+
+				// Becoming suppressed leaves whatever was painted on screen, so damage it like
+				// OnIsVisibleChanged does. The reverse direction self-heals: the visual is walked again
+				// with no _lastRenderBounds, which reports it as moved.
+				if (value && CompositionTarget is { } target)
+				{
+					DamageLastRenderedRegion(target);
+				}
 			}
 		}
 	}
 
-	internal virtual bool CanPaint() => false;
+	private bool _isArrangePending;
+
+	/// <summary>
+	/// Nothing this visual or its subtree paints may reach the frame. Kept in one place so the paint
+	/// walks below cannot drift apart on which suppression reasons they honor.
+	/// </summary>
+	private bool IsRenderSuppressed => Opacity == 0f || !IsVisible || IsArrangePending;
 
 	/// <summary>
 	/// When true, this visual guarantees that everything <em>it itself</em> paints stays inside
@@ -348,7 +367,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	/// <param name="offsetOverride">The offset (from the origin) to render the Visual at. If null, the offset properties on the Visual like <see cref="Offset"/> and <see cref="AnchorPoint"/> are used.</param>
 	internal void RenderRootVisual(SKCanvas canvas, Vector2? offsetOverride, SKPath? damage = null)
 	{
-		if (this is { Opacity: 0 } or { IsVisible: false })
+		if (IsRenderSuppressed)
 		{
 			return;
 		}
@@ -406,7 +425,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 		global::System.Diagnostics.Debug.WriteLine($"{indent}{Comment} (Opacity:{parentSession.Opacity:F2}x{Opacity:F2} | IsVisible:{IsVisible})");
 #endif
 
-		if (this is { Opacity: 0 } or { IsVisible: false } or { IsArrangePending: true })
+		if (IsRenderSuppressed)
 		{
 			return;
 		}
@@ -816,7 +835,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 		ShadowPathAccumulator accumulator)
 	{
 		var scratch = _spareShadowContributions;
-		if (visual.Opacity == 0f || !visual.IsVisible)
+		if (visual.IsRenderSuppressed)
 		{
 			return true;
 		}

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -118,6 +118,29 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 	/// In the future, we should accurately set <see cref="_requiresRepaint"/> to
 	/// only be true when we really have something to paint (and that painting needs to be updated).
 	/// </summary>
+	private bool _isArrangePending;
+
+	/// <summary>
+	/// Set while the owning element has never been arranged. Such a visual has no layout slot yet
+	/// (<see cref="ArrangeOffset"/>/<see cref="Size"/> are unset) and a visual's content is not bounded by
+	/// its Size, so painting it would draw at the parent's origin, unclipped. WinUI never renders an element
+	/// its parent didn't arrange. Defaults to <see langword="false"/> so visuals created directly through the
+	/// Composition API (which are never arranged by the layout system) keep rendering.
+	/// </summary>
+	internal bool IsArrangePending
+	{
+		get => _isArrangePending;
+		set
+		{
+			if (_isArrangePending != value)
+			{
+				_isArrangePending = value;
+				// Becoming paintable has to re-collect this visual into any cached parent picture.
+				InvalidateParentChildrenPicture(includeSelf: true);
+			}
+		}
+	}
+
 	internal virtual bool CanPaint() => false;
 
 	/// <summary>
@@ -383,7 +406,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 		global::System.Diagnostics.Debug.WriteLine($"{indent}{Comment} (Opacity:{parentSession.Opacity:F2}x{Opacity:F2} | IsVisible:{IsVisible})");
 #endif
 
-		if (this is { Opacity: 0 } or { IsVisible: false })
+		if (this is { Opacity: 0 } or { IsVisible: false } or { IsArrangePending: true })
 		{
 			return;
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.Foundation;
+using Windows.UI;
+
+#if __SKIA__
+using Uno.UI.RuntimeTests.Helpers;
+#endif
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
+
+[TestClass]
+public class Given_Visual_ArrangePending
+{
+	// A child its parent measured but never arranged has no layout slot, and a visual's content is not
+	// bounded by its Size, so painting it would draw at the parent's origin, unclipped — several such
+	// children stack into one another. WinUI never renders an element its parent didn't arrange.
+	[TestMethod]
+	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("Only Skia renders the visual tree through Uno's compositor.")]
+#endif
+	public async Task When_Child_Never_Arranged_Then_It_Does_Not_Paint()
+	{
+#if __SKIA__
+		var sentinel = new Border
+		{
+			Width = 60,
+			Height = 60,
+			Background = new SolidColorBrush(Colors.Magenta),
+		};
+
+		var host = new NeverArrangesChildrenPanel
+		{
+			Background = new SolidColorBrush(Colors.White),
+		};
+		host.Children.Add(sentinel);
+
+		await UITestHelper.Load(host);
+
+		var screenshot = await UITestHelper.ScreenShot(host);
+
+		// The sentinel would paint at the panel's origin if unarranged children were rendered.
+		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 5, Colors.Magenta, tolerance: 10);
+		ImageAssert.DoesNotHaveColorAt(screenshot, 30, 30, Colors.Magenta, tolerance: 10);
+#else
+		await Task.CompletedTask;
+#endif
+	}
+
+	private partial class NeverArrangesChildrenPanel : Panel
+	{
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			foreach (var child in Children)
+			{
+				child.Measure(availableSize);
+			}
+
+			return new Size(120, 120);
+		}
+
+		// Deliberately arranges nothing.
+		protected override Size ArrangeOverride(Size finalSize) => finalSize;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
@@ -25,8 +25,9 @@ public class Given_Visual_ArrangePending
 	// so its ink exists independently of any arrange, and a visual's content is not bounded by its Size —
 	// several such children would stack at the parent's origin. WinUI paints nothing for an element its
 	// parent didn't arrange, so this runs on the WinUI head too and pins that parity.
-	// A TextBlock (not a Border) is required: a Border paints only inside its Size, which is 0x0 while
-	// unarranged, so it would pass whether or not the suppression works.
+	// A TextBlock is required: text ink comes from measure, so it exists without an arrange. A Border,
+	// Rectangle or Path paints only within its arranged size (0x0 here), so any of those would pass
+	// whether or not the suppression works.
 	[TestMethod]
 	[RunsOnUIThread]
 	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid | RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.NativeWasm)]
@@ -101,9 +102,11 @@ public class Given_Visual_ArrangePending
 #endif
 	}
 
+	// Plain Latin letters, not a block glyph: the ink only has to come from measure, and WASM's bundled
+	// font has no U+2588 FULL BLOCK, so it laid out at the right size but painted nothing there.
 	private static TextBlock MakeInk() => new()
 	{
-		Text = "██████",
+		Text = "MMMMMM",
 		FontSize = 24,
 		Foreground = new SolidColorBrush(Colors.Black),
 	};

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
@@ -2,53 +2,72 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
 using Windows.Foundation;
 using Windows.UI;
-
-#if __SKIA__
-using Uno.UI.RuntimeTests.Helpers;
-#endif
+using Rectangle = System.Drawing.Rectangle;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 
 [TestClass]
 public class Given_Visual_ArrangePending
 {
-	// A child its parent measured but never arranged has no layout slot, and a visual's content is not
-	// bounded by its Size, so painting it would draw at the parent's origin, unclipped — several such
-	// children stack into one another. WinUI never renders an element its parent didn't arrange.
+	// A child its parent measured but never arranged has no layout slot. Text is laid out from measure,
+	// so its ink exists independently of any arrange, and a visual's content is not bounded by its Size —
+	// several such children would stack at the parent's origin. WinUI paints nothing for an element its
+	// parent didn't arrange, so this runs on the WinUI head too and pins that parity.
+	// A TextBlock (not a Border) is required: a Border paints only inside its Size, which is 0x0 while
+	// unarranged, so it would pass whether or not the suppression works.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Only Skia renders the visual tree through Uno's compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid | RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.NativeWasm)]
 	public async Task When_Child_Never_Arranged_Then_It_Does_Not_Paint()
 	{
-#if __SKIA__
-		var sentinel = new Border
-		{
-			Width = 60,
-			Height = 60,
-			Background = new SolidColorBrush(Colors.Magenta),
-		};
-
-		var host = new NeverArrangesChildrenPanel
+		var suppressed = new NeverArrangesChildrenPanel
 		{
 			Background = new SolidColorBrush(Colors.White),
+			Children = { MakeInk() },
 		};
-		host.Children.Add(sentinel);
 
-		await UITestHelper.Load(host);
+		// Same content in a panel that arranges normally: proves the assertion below can fail, and that
+		// the suppression is not simply hiding everything.
+		var control = new StackPanel
+		{
+			Background = new SolidColorBrush(Colors.White),
+			Children = { MakeInk() },
+		};
 
-		var screenshot = await UITestHelper.ScreenShot(host);
+		try
+		{
+			await UITestHelper.Load(new StackPanel { Children = { suppressed, control } });
 
-		// The sentinel would paint at the panel's origin if unarranged children were rendered.
-		ImageAssert.DoesNotHaveColorAt(screenshot, 5, 5, Colors.Magenta, tolerance: 10);
-		ImageAssert.DoesNotHaveColorAt(screenshot, 30, 30, Colors.Magenta, tolerance: 10);
-#else
-		await Task.CompletedTask;
-#endif
+			var controlShot = await UITestHelper.ScreenShot(control);
+			ImageAssert.HasColorInRectangle(
+				controlShot,
+				new Rectangle(0, 0, (int)controlShot.Width, (int)controlShot.Height),
+				Colors.Black,
+				tolerance: 100);
+
+			var suppressedShot = await UITestHelper.ScreenShot(suppressed);
+			ImageAssert.DoesNotHaveColorInRectangle(
+				suppressedShot,
+				new Rectangle(0, 0, (int)suppressedShot.Width, (int)suppressedShot.Height),
+				Colors.Black,
+				tolerance: 100);
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
 	}
+
+	private static TextBlock MakeInk() => new()
+	{
+		Text = "██████",
+		FontSize = 24,
+		Foreground = new SolidColorBrush(Colors.Black),
+	};
 
 	private partial class NeverArrangesChildrenPanel : Panel
 	{
@@ -59,7 +78,7 @@ public class Given_Visual_ArrangePending
 				child.Measure(availableSize);
 			}
 
-			return new Size(120, 120);
+			return new Size(200, 60);
 		}
 
 		// Deliberately arranges nothing.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
@@ -8,6 +8,14 @@ using Windows.Foundation;
 using Windows.UI;
 using Rectangle = System.Drawing.Rectangle;
 
+#if __SKIA__
+using System;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.Interactions;
+using SkiaSharp;
+using Uno.UI.Composition;
+#endif
+
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 
 [TestClass]
@@ -62,6 +70,37 @@ public class Given_Visual_ArrangePending
 		}
 	}
 
+	// The flag is set from the layout system, not through the composition property pipeline, so nothing
+	// requests a frame on its behalf. The composition target is the only observation point for that: the
+	// screenshot helpers render synchronously and would pass whether or not a frame was ever scheduled.
+	[TestMethod]
+	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("Render suppression before the first arrange is specific to the Skia compositor.")]
+#endif
+	public void When_ArrangePending_Changes_Then_A_New_Frame_Is_Requested()
+	{
+#if __SKIA__
+		var compositor = Compositor.GetSharedCompositor();
+		var visual = compositor.CreateSpriteVisual();
+		var target = new FrameRequestRecorder();
+		visual.CompositionTarget = target;
+
+		// A regular composition property does request a frame; proves the recorder observes requests at all,
+		// so the assertions below can't pass vacuously.
+		visual.Opacity = 0.5f;
+		Assert.AreNotEqual(0, target.NewFrameRequests, "A composition property change requested no frame, the test is not observing frame requests.");
+
+		var baseline = target.NewFrameRequests;
+		visual.IsArrangePending = true;
+		Assert.AreNotEqual(baseline, target.NewFrameRequests, "Suppressing requested no frame, so the vacated region would keep the previous frame's pixels until an unrelated invalidation.");
+
+		baseline = target.NewFrameRequests;
+		visual.IsArrangePending = false;
+		Assert.AreNotEqual(baseline, target.NewFrameRequests, "Unsuppressing requested no frame, so the element would stay unpainted until an unrelated invalidation.");
+#endif
+	}
+
 	private static TextBlock MakeInk() => new()
 	{
 		Text = "██████",
@@ -84,4 +123,27 @@ public class Given_Visual_ArrangePending
 		// Deliberately arranges nothing.
 		protected override Size ArrangeOverride(Size finalSize) => finalSize;
 	}
+
+#if __SKIA__
+	private sealed class FrameRequestRecorder : ICompositionTarget
+	{
+		public int NewFrameRequests { get; private set; }
+
+		public double RasterizationScale => 1;
+
+		public event EventHandler RasterizationScaleChanged
+		{
+			add { }
+			remove { }
+		}
+
+		public void RequestNewFrame() => NewFrameRequests++;
+
+		public void AddDamage(SKRect bounds) { }
+
+		public void AddDamage(SKPath region) { }
+
+		public void TryRedirectForManipulation(Windows.UI.Input.PointerPoint pointerPoint, InteractionTracker tracker) { }
+	}
+#endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_ArrangePending.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -134,7 +136,7 @@ public class Given_Visual_ArrangePending
 
 		public double RasterizationScale => 1;
 
-		public event EventHandler RasterizationScaleChanged
+		public event EventHandler? RasterizationScaleChanged
 		{
 			add { }
 			remove { }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -1,14 +1,10 @@
 using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.UI.Composition;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Hosting;
 using Windows.UI;
 
 #if __SKIA__
-using Private.Infrastructure;
 using Uno.UI.Helpers;
-using Uno.UI.RuntimeTests.Helpers;
 using SkiaSharp;
 #endif
 
@@ -17,7 +13,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 [TestClass]
 public class Given_Visual_Damage
 {
-#if __SKIA__
 	// Damage-region rendering only repaints the regions reported as damaged, so every change that alters
 	// what a visual contributes to the frame has to report one. Growing an ancestor's clip reveals part of
 	// a child whose own content and transform are untouched; if that isn't reported, the revealed pixels
@@ -26,13 +21,13 @@ public class Given_Visual_Damage
 	// height) hit this whenever the clip grows.
 	[TestMethod]
 	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
+#endif
 	public async Task When_Ancestor_Clip_Grows_Then_Revealed_Region_Is_Damaged()
 	{
-		// A loaded element only to obtain a live Compositor; the probed tree below is standalone.
-		var anchor = new Border { Width = 10, Height = 10 };
-		await UITestHelper.Load(anchor);
-
-		var compositor = ElementCompositionPreview.GetElementVisual(anchor).Compositor;
+#if __SKIA__
+		var compositor = Compositor.GetSharedCompositor();
 
 		var root = compositor.CreateContainerVisual();
 		root.Size = new Vector2(200, 200);
@@ -61,8 +56,18 @@ public class Given_Visual_Damage
 		Assert.IsTrue(
 			damage.Bounds.Bottom >= 98,
 			$"Damage does not cover the revealed strip down to y=100 (damage bounds: {damage.Bounds}).");
+
+		// Reporting the whole surface would satisfy the assertions above while erasing the point of
+		// partial repaint, so bound the reported region to the child plus antialiasing slack.
+		Assert.IsTrue(
+			damage.Bounds.Right <= 140,
+			$"Damage is far wider than the revealed strip, partial repaint is being defeated (damage bounds: {damage.Bounds}).");
+#else
+		await Task.CompletedTask;
+#endif
 	}
 
+#if __SKIA__
 	private static void RenderFrame(ContainerVisual root, SKPath damage)
 	{
 		var (picture, _, _) = SkiaRenderHelper.RecordPictureAndReturnPath(200, 200, root, invertPath: false, damage: damage);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -1,0 +1,72 @@
+using System.Numerics;
+using System.Threading.Tasks;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
+using Windows.UI;
+
+#if __SKIA__
+using Private.Infrastructure;
+using Uno.UI.Helpers;
+using Uno.UI.RuntimeTests.Helpers;
+using SkiaSharp;
+#endif
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
+
+[TestClass]
+public class Given_Visual_Damage
+{
+#if __SKIA__
+	// Damage-region rendering only repaints the regions reported as damaged, so every change that alters
+	// what a visual contributes to the frame has to report one. Growing an ancestor's clip reveals part of
+	// a child whose own content and transform are untouched; if that isn't reported, the revealed pixels
+	// keep the previous frame's content until something else happens to damage them (e.g. a hover state).
+	// Controls that re-clip on every arrange (a virtualizing rows panel sizing its clip to the content
+	// height) hit this whenever the clip grows.
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Ancestor_Clip_Grows_Then_Revealed_Region_Is_Damaged()
+	{
+		// A loaded element only to obtain a live Compositor; the probed tree below is standalone.
+		var anchor = new Border { Width = 10, Height = 10 };
+		await UITestHelper.Load(anchor);
+
+		var compositor = ElementCompositionPreview.GetElementVisual(anchor).Compositor;
+
+		var root = compositor.CreateContainerVisual();
+		root.Size = new Vector2(200, 200);
+
+		var child = compositor.CreateSpriteVisual();
+		child.Brush = compositor.CreateColorBrush(Colors.Magenta);
+		child.Size = new Vector2(100, 100);
+		root.Children.InsertAtTop(child);
+
+		// Clip away the bottom half of the child.
+		root.Clip = compositor.CreateRectangleClip(top: 0, left: 0, bottom: 50, right: 100);
+
+		using var damage = new SKPath();
+		RenderFrame(root, damage);
+
+		damage.Rewind();
+
+		// The only change: the clip grows to reveal the bottom half.
+		root.Clip = compositor.CreateRectangleClip(top: 0, left: 0, bottom: 100, right: 100);
+		RenderFrame(root, damage);
+
+		Assert.IsFalse(
+			damage.IsEmpty,
+			"Growing the clip reported no damage, so the revealed strip would keep the previous frame's pixels.");
+
+		Assert.IsTrue(
+			damage.Bounds.Bottom >= 98,
+			$"Damage does not cover the revealed strip down to y=100 (damage bounds: {damage.Bounds}).");
+	}
+
+	private static void RenderFrame(ContainerVisual root, SKPath damage)
+	{
+		var (picture, _, _) = SkiaRenderHelper.RecordPictureAndReturnPath(200, 200, root, invertPath: false, damage: damage);
+		picture.Dispose();
+	}
+#endif
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -1,6 +1,7 @@
-using System.Numerics;
+﻿using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.UI.Composition;
+using Uno.UI;
 using Windows.UI;
 
 #if __SKIA__
@@ -62,6 +63,70 @@ public class Given_Visual_Damage
 		Assert.IsTrue(
 			damage.Bounds.Right <= 140,
 			$"Damage is far wider than the revealed strip, partial repaint is being defeated (damage bounds: {damage.Bounds}).");
+#else
+		await Task.CompletedTask;
+#endif
+	}
+
+	// Same bounds, different clip shape: only the corner radii change, so a comparison of the clip's
+	// bounding box sees nothing while the corners must in fact be repainted. The subtree is also forced to
+	// be collapsed into a cached children picture first, since descendants are not walked at all then and
+	// nothing would get the chance to report the damage.
+	[TestMethod]
+	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
+#endif
+	public async Task When_Clip_Shape_Changes_Within_Same_Bounds_Then_It_Is_Damaged()
+	{
+#if __SKIA__
+		var frameThreshold = FeatureConfiguration.Rendering.VisualSubtreeSkippingOptimizationCleanFramesThreshold;
+		var countThreshold = FeatureConfiguration.Rendering.VisualSubtreeSkippingOptimizationVisualCountThreshold;
+		var enabled = FeatureConfiguration.Rendering.EnableVisualSubtreeSkippingOptimization;
+
+		try
+		{
+			// Force the collapsing optimization to apply to this small tree immediately.
+			FeatureConfiguration.Rendering.EnableVisualSubtreeSkippingOptimization = true;
+			FeatureConfiguration.Rendering.VisualSubtreeSkippingOptimizationCleanFramesThreshold = 1;
+			FeatureConfiguration.Rendering.VisualSubtreeSkippingOptimizationVisualCountThreshold = 1;
+
+			var compositor = Compositor.GetSharedCompositor();
+
+			var root = compositor.CreateContainerVisual();
+			root.Size = new Vector2(200, 200);
+
+			var child = compositor.CreateSpriteVisual();
+			child.Brush = compositor.CreateColorBrush(Colors.Magenta);
+			child.Size = new Vector2(100, 100);
+			root.Children.InsertAtTop(child);
+
+			root.Clip = compositor.CreateRectangleClip(left: 0, top: 0, right: 100, bottom: 100);
+
+			using var damage = new SKPath();
+
+			// Render enough unchanged frames for the subtree to be cached.
+			for (var i = 0; i < 5; i++)
+			{
+				RenderFrame(root, damage);
+				damage.Rewind();
+			}
+
+			// Identical bounds, rounded corners: the corner pixels are no longer inside the clip.
+			var radius = new Vector2(50, 50);
+			root.Clip = compositor.CreateRectangleClip(0, 0, 100, 100, radius, radius, radius, radius);
+			RenderFrame(root, damage);
+
+			Assert.IsFalse(
+				damage.IsEmpty,
+				"A clip whose shape changed within unchanged bounds reported no damage, so the clipped-away corners would keep the previous frame's pixels.");
+		}
+		finally
+		{
+			FeatureConfiguration.Rendering.EnableVisualSubtreeSkippingOptimization = enabled;
+			FeatureConfiguration.Rendering.VisualSubtreeSkippingOptimizationCleanFramesThreshold = frameThreshold;
+			FeatureConfiguration.Rendering.VisualSubtreeSkippingOptimizationVisualCountThreshold = countThreshold;
+		}
 #else
 		await Task.CompletedTask;
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.cs
@@ -151,6 +151,11 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (m_animatedVisual is { } visual)
 			{
+				// Uno-specific: IconElement hosts content in a synthetic root Grid that has no WinUI
+				// counterpart, and the animated visual is attached to it as a composition child visual. It
+				// still has to go through layout, or it never gets a slot and nothing renders.
+				base.MeasureOverride(availableSize);
+
 				// Animated Icon scales using the Uniform strategy, meaning that it scales the horizonal and vertical
 				// dimensions equally by the maximum amount that doesn't exceed the available size in either dimension.
 				// If the available size is infinite in both dimensions then we don't scale the visual. Otherwise, we
@@ -194,6 +199,9 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (m_animatedVisual is { } visual)
 			{
+				// See MeasureOverride: the synthetic root Grid hosting the animated visual needs a layout slot.
+				base.ArrangeOverride(finalSize);
+
 				var visualSize = visual.Size;
 
 				Vector2 GetScale(Size finalSize, Vector2 visualSize)

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -95,8 +95,9 @@ namespace Microsoft.UI.Xaml
 					// Suppress painting until the first arrange gives this element a layout slot; see
 					// Visual.IsArrangePending. Set directly rather than through Visibility/IsVisible, which
 					// would raise property-changed and accessibility callbacks while the element is still
-					// being constructed.
-					_visual.IsArrangePending = !IsFirstArrangeDone;
+					// being constructed. Only FrameworkElements reach ArrangeVisual (UIElement.Arrange
+					// returns early otherwise), so anything else must never be suppressed.
+					_visual.IsArrangePending = _isFrameworkElement && !IsFirstArrangeDone;
 				}
 
 				return _visual;
@@ -159,6 +160,14 @@ namespace Microsoft.UI.Xaml
 
 			// Reset to original (invalidated) state
 			child.ResetLayoutFlags();
+
+			// ResetLayoutFlags clears FirstArrangeDone, so the child has no layout slot under this parent
+			// until it is arranged again — re-suppress it, otherwise it would keep painting at its stale
+			// slot (or at the new parent's origin) in the meantime.
+			if (child._isFrameworkElement)
+			{
+				child.Visual.IsArrangePending = true;
+			}
 
 			if (IsMeasureDirtyPathDisabled)
 			{

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -91,6 +91,12 @@ namespace Microsoft.UI.Xaml
 					_visual.Comment = $"{this.GetDebugDepth():D2}-{this.GetDebugName()}";
 #endif
 					_visual.Owner = new WeakReference(this);
+
+					// Suppress painting until the first arrange gives this element a layout slot; see
+					// Visual.IsArrangePending. Set directly rather than through Visibility/IsVisible, which
+					// would raise property-changed and accessibility callbacks while the element is still
+					// being constructed.
+					_visual.IsArrangePending = !IsFirstArrangeDone;
 				}
 
 				return _visual;
@@ -310,6 +316,11 @@ namespace Microsoft.UI.Xaml
 		internal void ArrangeVisual(Rect finalRect, Rect? clippedFrame = default)
 		{
 			LayoutSlotWithMarginsAndAlignments = finalRect;
+
+			// This element now has a layout slot, so it may paint. Cleared before the no-change check
+			// below, which would otherwise leave a first arrange that happens to match the default rect
+			// permanently suppressed.
+			Visual.IsArrangePending = false;
 
 			var oldFinalRect = _lastFinalRect;
 			var oldClippedFrame = _lastClippedFrame;


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Tracked internally (customer-reported). No public issue exists for either defect; happy to open
one if maintainers prefer a public tracking item. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

Two independent Skia rendering defects, found while chasing one symptom: a persistent garbled strip
of overlapping text at the top of a virtualizing grid's rows area, appearing after navigating away
and back, and clearing as soon as the row underneath was hovered.

### 1. Elements are painted before they have a layout slot

On Skia, a child that its parent *measured* but never *arranged* is still painted — at the parent's
origin, unclipped and with its full ink extent — so several such children overdraw into a single
garbled strip. Native WinUI renders nothing for an element its parent didn't arrange.

Verified by compiling the same source for `net9.0-desktop` (Uno Skia) and
`net9.0-windows10.0.26100` (native WinUI): Skia painted every unarranged child, WinUI painted none.

`Visual.IsArrangePending` now suppresses painting until the owning element is arranged:

- `Visual.Render` / `RenderRootVisual` / the shadow-silhouette walk share one
  `Visual.IsRenderSuppressed` predicate, so the reasons a visual is skipped can't drift apart.
- `UIElement` raises it when the visual is created and clears it at the top of `ArrangeVisual`, and
  re-raises it in `AddChild` — `ResetLayoutFlags()` clears `FirstArrangeDone`, so a re-parented
  element has no slot under its new parent until it is arranged again.
- It defaults to `false`, so visuals created directly through the Composition API (which the layout
  system never arranges) keep rendering, as do non-`FrameworkElement` elements, which never reach
  `ArrangeVisual`.

### 2. A clip change reports no damage

With damage-region rendering, only damaged regions are repainted, so a mutation that reports no
damage leaves the previous frame's pixels on screen indefinitely. `ContributeDamageOnPaint`
returned early whenever a visual's own content and transform were unchanged, without ever
considering the clip — so growing an ancestor's clip revealed a region that was never repainted.
Controls that re-clip on every arrange (a rows panel sizing its clip to the content height) hit
this whenever the clip grows.

A clip change is only known where the clip is mutated, but the damage decision is made per
descendant during the render walk, so the signal is now carried there:
`Visual.OnPropertyChangedCore` raises it on a `Clip`/`LayoutClip` change and drops the visual's own
cached children picture (otherwise a collapsed subtree isn't walked at all and no descendant gets
the chance to report anything); `Render` threads it down to children. It is combined with a
comparison of the accumulated clip's bounds, because neither signal covers the other — the raised
signal catches a shape change inside unchanged bounds, the bounds comparison catches clips a visual
never sees mutate, such as the frame's root clip.

### Behavior change worth reviewing

Fix 1 changes observable behavior: content that Uno previously painted for a never-arranged element
is no longer painted. That is WinUI parity and it is what the reported artifact was made of, but an
app that (knowingly or not) relied on the old behavior will now render nothing for such an element.
Called out here rather than in the checklist so it gets attention.

### Validation

- `Given_Visual_ArrangePending.When_Child_Never_Arranged_Then_It_Does_Not_Paint` — fails without
  fix 1 (`Color 'FF000000' was found at (0, 9)`), passes with it. It uses a `TextBlock`, not a
  `Border`: a `Border` paints only inside its `Size`, which is `0x0` while unarranged, so it would
  pass either way. Includes a positive control so it cannot pass vacuously.
- `Given_Visual_Damage.When_Ancestor_Clip_Grows_Then_Revealed_Region_Is_Damaged` — fails without
  fix 2 ("Growing the clip reported no damage"), passes with it, and bounds the reported damage so a
  change that over-damages the whole surface can't satisfy it.
- `Given_Visual_Damage.When_Clip_Shape_Changes_Within_Same_Bounds_Then_It_Is_Damaged` — changes only
  the corner radii, which a bounds comparison provably cannot see, and forces the subtree-skipping
  optimization on so the collapsed-picture path is exercised. Fails without the raised signal.
- `Windows_UI_Composition` suite: 51/51.
- Every runtime-test class using `RenderTargetBitmap` (the scenario most at risk from fix 1):
  1251 tests, 1247 passed, 2 failed — both failures reproduce unchanged on `master`
  (`Given_ListViewBase.When_ThemeChange`, `Given_TextBlock.When_Inlines_Transitively_Change`).
- Both fixes were also run in the customer application that reported the symptom, which no longer
  reproduces at any point.

### Not yet measured

- No performance numbers. The damage guard now reads the accumulated clip's bounds per visual per
  frame, and a clip change damages the affected descendants, so the damaged-pixel ratio during
  scrolling and with an animating clip is worth measuring before this is considered settled.
- The parity test is not gated off native WinUI, but I have not run it on the WinUI head.
- No WASM run.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- Docs: not added — both changes are internal rendering-correctness fixes with no new API.
     Screenshots Compare: to be validated once CI has run.
     Breaking changes: left unchecked deliberately — see "Behavior change worth reviewing" above. -->
