### PR TITLE
fix(android): Fall back to OpenGL ES when Vulkan initialization fails

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -304,6 +304,9 @@ namespace Microsoft.UI.Xaml
 				}
 				else
 				{
+					// Vulkan feature flags are static device configuration and can be declared even when
+					// the driver cannot actually render (common on emulators) — the view constructor
+					// creates the Vulkan device and throws when the driver is unusable.
 					try
 					{
 						return new UnoSKVulkanView(this);

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -37,9 +37,15 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 	private readonly ManualResetEventSlim _renderEvent = new(false);
 	private readonly object _renderLock = new();
 	private IntPtr _nativeWindow; // Must stay alive while Vulkan surfaces reference it
+	private readonly AndroidVulkanSurfaceFactory _surfaceFactory = new();
 
 	public UnoSKVulkanView(Context context) : base(context)
 	{
+		// Create the window-independent Vulkan resources (instance, device, GRContext) right away:
+		// this throws when the driver is unusable, letting the caller fall back to the OpenGL ES view.
+		// The window-scoped part (swapchain) is completed on the render thread once a surface exists.
+		_vulkanContext.InitializeDevice(_surfaceFactory);
+
 		ExploreByTouchHelper = new UnoExploreByTouchHelper(this);
 		TextInputPlugin = new TextInputPlugin(this);
 		ViewCompat.SetAccessibilityDelegate(this, ExploreByTouchHelper);
@@ -113,8 +119,9 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 		_renderThread?.Join(TimeSpan.FromSeconds(2));
 		_renderThread = null;
 
-		// Dispose Vulkan context first, then release the native window
-		_vulkanContext.Dispose();
+		// Dispose the window-scoped Vulkan resources first (the device and GRContext are kept
+		// for the next surface), then release the native window
+		_vulkanContext.DisposeSurfaceResources();
 
 		if (_nativeWindow != IntPtr.Zero)
 		{
@@ -133,7 +140,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 
 		try
 		{
-			// Initialize Vulkan on the render thread
+			// Complete the window-scoped Vulkan initialization on the render thread
 			InitializeVulkan(holder);
 
 			while (_surfaceReady && !_disposed)
@@ -176,8 +183,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 			throw new InvalidOperationException("Failed to get ANativeWindow from Surface");
 
 		var rect = holder.SurfaceFrame;
-		var factory = new AndroidVulkanSurfaceFactory();
-		_vulkanContext.Initialize(factory, _nativeWindow, rect!.Width(), rect.Height());
+		_vulkanContext.InitializeSurface(_nativeWindow, rect!.Width(), rect.Height());
 
 		var (deviceName, driverVersion) = _vulkanContext.GetDeviceInfo();
 		if (this.Log().IsEnabled(LogLevel.Information))

--- a/src/Uno.UI/Vulkan/VulkanContext.skia.cs
+++ b/src/Uno.UI/Vulkan/VulkanContext.skia.cs
@@ -88,6 +88,69 @@ internal sealed class VulkanContext : IVulkanPlatformGraphicsContext, IDisposabl
 		}
 	}
 
+	/// <summary>
+	/// Creates the window-independent resources: instance, device and SkiaSharp GRContext.
+	/// Throws when the driver cannot provide a usable device, letting callers fall back to another
+	/// renderer before committing to Vulkan. Device feature flags alone are not reliable: emulators
+	/// declare Vulkan features even when the driver cannot render.
+	/// </summary>
+	public void InitializeDevice(IVulkanPlatformSurfaceFactory factory)
+	{
+		_factory = factory;
+
+		var getProcAddr = factory.GetVkGetInstanceProcAddr();
+		_instance = VulkanInstance.Create(getProcAddr, factory.RequiredInstanceExtensions);
+		_instanceApi = new VulkanInstanceApi(_instance);
+		_device = VulkanDevice.Create((VulkanInstance)_instance, _instanceApi);
+		_deviceApi = new VulkanDeviceApi(_device);
+
+		using (_device.Lock())
+		{
+			CreateGrContext();
+		}
+	}
+
+	/// <summary>
+	/// Completes initialization for a native window: creates the swapchain and the intermediate
+	/// render image. Requires <see cref="InitializeDevice"/> to have succeeded; may be called again
+	/// with a new window after <see cref="DisposeSurfaceResources"/>.
+	/// </summary>
+	public void InitializeSurface(IntPtr nativeWindowHandle, int width, int height)
+	{
+		if (_device == null || _factory == null)
+			throw new InvalidOperationException("Vulkan device not initialized");
+
+		_nativeWindowHandle = nativeWindowHandle;
+
+		using (_device.Lock())
+		{
+			var platformSurface = new DirectVulkanSurface(nativeWindowHandle, new SKSizeI(width, height), _factory);
+			_display = VulkanDisplay.CreateDisplay(this, platformSurface);
+			_renderImage = new VulkanImage(this, _display.CommandBufferPool,
+				_display.SurfaceFormat.format, new SKSizeI(width, height));
+		}
+	}
+
+	/// <summary>
+	/// Disposes the window-scoped resources (swapchain, render image, cached Skia surfaces) while
+	/// keeping the instance, device and GRContext for reuse with a new surface.
+	/// </summary>
+	public void DisposeSurfaceResources()
+	{
+		if (_device == null)
+			return;
+
+		using (_device.Lock())
+		{
+			_deviceApi?.DeviceWaitIdle(DeviceHandle);
+			DisposeCachedSkiaSurface();
+			_renderImage?.Dispose();
+			_renderImage = null;
+			_display?.Dispose();
+			_display = null;
+		}
+	}
+
 	private void CreateGrContext()
 	{
 		if (_device == null || _instance == null)


### PR DESCRIPTION
**GitHub Issue:** closes #23940

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Android with the Skia renderer, any Vulkan initialization failure left a **permanent black screen**: the only fallback to OpenGL ES was a `try/catch` around the `UnoSKVulkanView` constructor, but the constructor did no Vulkan work — actual initialization happened later on the render thread, where failures were logged and swallowed. The `HasSystemFeature(FEATURE_VULKAN_HARDWARE_LEVEL)` gate doesn't help because emulator images declare Vulkan feature flags as static configuration even when the driver can't render (see #23940 for the three reproduced failure flavors, including a stock API-33 emulator with `-gpu swiftshader_indirect`).

This PR makes the Vulkan/GL decision sequential and synchronous by splitting `VulkanContext` initialization into a window-independent and a window-scoped phase:

- `VulkanContext.InitializeDevice(factory)` creates the instance, device, and SkiaSharp `GRContext`, and **throws when the driver is unusable**. It is called directly in the `UnoSKVulkanView` constructor, so the existing `try/catch` in `ApplicationActivity.CreateRenderView()` becomes a real fallback site: all three failure flavors from #23940 now surface there and the app falls back to `UnoSKCanvasView` (OpenGL ES).
- `VulkanContext.InitializeSurface(window, width, height)` creates the swapchain and intermediate render image on the render thread once the surface exists, reusing the device created by the constructor (previously the context was fully re-initialized).
- `SurfaceDestroyed` now disposes only the window-scoped resources (`DisposeSurfaceResources`), keeping the instance/device/`GRContext` alive across surface destroy/recreate cycles (e.g. backgrounding).

The pre-existing `VulkanContext.Initialize(...)` single-shot path used by the Win32/X11 hosts is unchanged.

Runtime-validated on Android emulators (API 33 x86_64, `-gpu swiftshader_indirect`, where `GRContext` creation fails on the SwiftShader guest device): before — black screen with a dead render thread; after — logcat shows `Vulkan rendering not available: Unable to create SkiaSharp GRContext from Vulkan device. Falling back to OpenGL ES.` and SamplesApp renders and responds to input. The API-28 path (image declares no Vulkan features → existing feature-flag fallback) still behaves as before.

Known limitation (by design, to keep the fallback decision synchronous): a failure in the window-scoped phase on the render thread (`vkCreateAndroidSurfaceKHR`/swapchain creation) is logged but does not fall back; no such failure was observed across the tested configurations, which all fail during device/`GRContext` creation.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: the behavior depends on the host's Vulkan driver failing, which can't be arranged from a runtime test; validated manually on emulators as described above.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — not applicable: no public API or documented behavior change; the fix makes the existing `UseVulkanOnSkiaAndroid` documented fallback behavior actually work.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
