### PR TITLE
fix(hr): harden the collectible analyzer loader (review follow-up of #23863)

### DIFF
--- a/src/Uno.HotReload.Tests/Roslyn/Given_CollectibleAnalyzerAssemblyLoader.cs
+++ b/src/Uno.HotReload.Tests/Roslyn/Given_CollectibleAnalyzerAssemblyLoader.cs
@@ -39,6 +39,7 @@ public sealed class Given_CollectibleAnalyzerAssemblyLoader
 			Assert.IsNotNull(context);
 			Assert.IsTrue(context.IsCollectible, "analyzer contexts must be collectible");
 			Assert.AreSame(context, AssemblyLoadContext.GetLoadContext(assembly2), "same directory must share one context");
+			Assert.AreSame(assembly1, loader.LoadFromPath(payload1), "same path must keep yielding the same assembly instance");
 		}
 		finally
 		{
@@ -141,7 +142,7 @@ public sealed class Given_CollectibleAnalyzerAssemblyLoader
 	{
 		var root = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
 		var csharpPath = typeof(CSharpCompilation).Assembly.Location;
-		var compilerContext = new OnDemandContext(new() { ["Microsoft.CodeAnalysis.CSharp"] = csharpPath });
+		var compilerContext = new OnDemandContext(new Dictionary<string, string> { ["Microsoft.CodeAnalysis.CSharp"] = csharpPath });
 		try
 		{
 			var payload = CopyTo(root, typeof(Given_CollectibleAnalyzerAssemblyLoader).Assembly.Location);
@@ -224,6 +225,66 @@ public sealed class Given_CollectibleAnalyzerAssemblyLoader
 		}
 	}
 
+	[TestMethod]
+	[Description(
+		"A registered candidate whose identity does not match the request (public key token) " +
+		"must be skipped — not force-loaded because its file name matches — leaving the " +
+		"request to the runtime's own resolution.")]
+	public void When_RequestedTokenDoesNotMatch_Then_CandidatesAreSkipped()
+	{
+		var root = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
+		try
+		{
+			var v1 = EmitAssembly(Path.Join(root, "v1", "Dep.dll"), "Dep", new Version(1, 0, 0, 0));
+			var v2 = EmitAssembly(Path.Join(root, "v2", "Dep.dll"), "Dep", new Version(2, 0, 0, 0));
+			var payload = CopyTo(Directory.CreateDirectory(Path.Join(root, "analyzer")).FullName, typeof(Given_CollectibleAnalyzerAssemblyLoader).Assembly.Location);
+
+			var loader = new CollectibleAnalyzerAssemblyLoader();
+			loader.AddDependencyLocation(v1);
+			loader.AddDependencyLocation(v2);
+			var analyzerContext = AssemblyLoadContext.GetLoadContext(loader.LoadFromPath(payload))!;
+
+			// Both candidates are unsigned: a request carrying a public key token must skip them
+			// (and then fail in the runtime's own resolution, since nobody can provide it).
+			Assert.ThrowsExactly<FileNotFoundException>(() =>
+				analyzerContext.LoadFromAssemblyName(new AssemblyName("Dep, Version=2.0.0.0, PublicKeyToken=b03f5f7f11d50a3a")));
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	[Description(
+		"A shadow directory holding partial state — an orphaned staging file and a pdb " +
+		"published without its dll, i.e. a process killed mid-publish — must not prevent the " +
+		"load: the dll's atomic publish is what completes the bundle.")]
+	public void When_ShadowDirectoryHoldsPartialState_Then_LoadRecovers()
+	{
+		var root = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
+		try
+		{
+			var payload = CopyTo(root, typeof(Given_CollectibleAnalyzerAssemblyLoader).Assembly.Location);
+
+			// Re-create the debris a kill between the pdb and dll publishes would leave behind.
+			var shadowPath = CollectibleAnalyzerAssemblyLoader.GetShadowCopyPath(payload);
+			Assert.IsFalse(File.Exists(shadowPath), "premise: this (path, timestamp, size) key must be fresh");
+			Directory.CreateDirectory(Path.GetDirectoryName(shadowPath)!);
+			File.WriteAllText($"{shadowPath}.{Guid.NewGuid():N}.staging", "debris from a killed copy");
+			File.WriteAllBytes(Path.ChangeExtension(shadowPath, ".pdb"), [1, 2, 3]);
+
+			var loaded = new CollectibleAnalyzerAssemblyLoader().LoadFromPath(payload);
+
+			Assert.IsNotNull(loaded);
+			Assert.IsTrue(File.Exists(shadowPath), "the dll must have been published despite the pre-existing debris");
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
 	private static string CopyTo(string directory, string sourcePath, string? fileName = null)
 	{
 		var target = Path.Join(directory, fileName ?? Path.GetFileName(sourcePath));
@@ -254,7 +315,7 @@ public sealed class Given_CollectibleAnalyzerAssemblyLoader
 	/// A compiler-side context that — like the dev-server's per-application context — can
 	/// RESOLVE assemblies it has not loaded yet (lazy, on demand).
 	/// </summary>
-	private sealed class OnDemandContext(Dictionary<string, string> resolvable)
+	private sealed class OnDemandContext(IReadOnlyDictionary<string, string> resolvable)
 		: AssemblyLoadContext("test-on-demand-compiler", isCollectible: true)
 	{
 		protected override Assembly? Load(AssemblyName assemblyName)

--- a/src/Uno.HotReload.Tests/Roslyn/Given_CollectibleAnalyzerAssemblyLoader.cs
+++ b/src/Uno.HotReload.Tests/Roslyn/Given_CollectibleAnalyzerAssemblyLoader.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Uno.HotReload.Roslyn;
 using Uno.HotReload.Tests.TestUtils;
@@ -131,11 +132,103 @@ public sealed class Given_CollectibleAnalyzerAssemblyLoader
 		Assert.IsTrue(AssemblyLoadContext.GetLoadContext(loaded)!.IsCollectible, "the swapped loader must load collectible");
 	}
 
+	[TestMethod]
+	[Description(
+		"Resolution must be DELEGATED to the compiler's context (LoadFromAssemblyName) so its " +
+		"load policy can materialize dependencies it has not loaded YET: probing only its " +
+		"already-loaded assemblies would fall through and load a split-identity local copy.")]
+	public void When_CompilerContextResolvesLazily_Then_AnalyzerRequestsUnifyToIt()
+	{
+		var root = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
+		var csharpPath = typeof(CSharpCompilation).Assembly.Location;
+		var compilerContext = new OnDemandContext(new() { ["Microsoft.CodeAnalysis.CSharp"] = csharpPath });
+		try
+		{
+			var payload = CopyTo(root, typeof(Given_CollectibleAnalyzerAssemblyLoader).Assembly.Location);
+			CopyTo(root, csharpPath); // A same-directory copy that must NOT win over the compiler's.
+			var loader = new CollectibleAnalyzerAssemblyLoader(compilerContext);
+			var analyzerContext = AssemblyLoadContext.GetLoadContext(loader.LoadFromPath(payload))!;
+
+			Assert.IsFalse(compilerContext.Assemblies.Any(), "premise: the compiler context resolves lazily, nothing loaded yet");
+
+			var resolved = analyzerContext.LoadFromAssemblyName(new AssemblyName("Microsoft.CodeAnalysis.CSharp"));
+
+			Assert.AreSame(compilerContext, AssemblyLoadContext.GetLoadContext(resolved),
+				"the request must materialize the dependency IN the compiler's context, not load the analyzer-local copy");
+		}
+		finally
+		{
+			compilerContext.Unload();
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	[Description(
+		"AddDependencyLocation must retain EVERY location registered for a file name (distinct " +
+		"projects may use distinct versions of the same analyzer package): resolution picks the " +
+		"version matching the request, not whichever project registered that file name first.")]
+	public void When_MultipleVersionsRegistered_Then_RequestedVersionWins()
+	{
+		var root = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
+		try
+		{
+			var v1 = EmitAssembly(Path.Join(root, "v1", "Dep.dll"), "Dep", new Version(1, 0, 0, 0));
+			var v2 = EmitAssembly(Path.Join(root, "v2", "Dep.dll"), "Dep", new Version(2, 0, 0, 0));
+			var payload = CopyTo(Directory.CreateDirectory(Path.Join(root, "analyzer")).FullName, typeof(Given_CollectibleAnalyzerAssemblyLoader).Assembly.Location);
+
+			var loader = new CollectibleAnalyzerAssemblyLoader();
+			loader.AddDependencyLocation(v1); // Registered FIRST: "first file name wins" would pick this one.
+			loader.AddDependencyLocation(v2);
+			var analyzerContext = AssemblyLoadContext.GetLoadContext(loader.LoadFromPath(payload))!;
+
+			var resolved = analyzerContext.LoadFromAssemblyName(new AssemblyName("Dep, Version=2.0.0.0"));
+
+			Assert.AreEqual(new Version(2, 0, 0, 0), resolved.GetName().Version, "the exact requested version must win over the first registered one");
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
 	private static string CopyTo(string directory, string sourcePath, string? fileName = null)
 	{
-		var target = Path.Combine(directory, fileName ?? Path.GetFileName(sourcePath));
+		var target = Path.Join(directory, fileName ?? Path.GetFileName(sourcePath));
 		File.Copy(sourcePath, target);
 		return target;
+	}
+
+	/// <summary>
+	/// Emits a minimal assembly with the requested identity — the best-candidate resolution
+	/// reads the real <see cref="AssemblyName"/> from disk, so the fixture needs real PE files.
+	/// </summary>
+	private static string EmitAssembly(string path, string name, Version version)
+	{
+		Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+		var compilation = CSharpCompilation.Create(
+			name,
+			[CSharpSyntaxTree.ParseText($"""[assembly: System.Reflection.AssemblyVersion("{version}")]""")],
+			references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+			options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		var emit = compilation.Emit(path);
+		Assert.IsTrue(emit.Success, $"Fixture assembly emit failed: {string.Join(", ", emit.Diagnostics)}");
+		return path;
+	}
+
+	/// <summary>
+	/// A compiler-side context that — like the dev-server's per-application context — can
+	/// RESOLVE assemblies it has not loaded yet (lazy, on demand).
+	/// </summary>
+	private sealed class OnDemandContext(Dictionary<string, string> resolvable)
+		: AssemblyLoadContext("test-on-demand-compiler", isCollectible: true)
+	{
+		protected override Assembly? Load(AssemblyName assemblyName)
+			=> assemblyName.Name is { } name && resolvable.TryGetValue(name, out var path)
+				? LoadFromAssemblyPath(path)
+				: null;
 	}
 
 	private sealed class PassthroughLoader : IAnalyzerAssemblyLoader

--- a/src/Uno.HotReload.Tests/Roslyn/Given_CollectibleAnalyzerAssemblyLoader.cs
+++ b/src/Uno.HotReload.Tests/Roslyn/Given_CollectibleAnalyzerAssemblyLoader.cs
@@ -192,6 +192,38 @@ public sealed class Given_CollectibleAnalyzerAssemblyLoader
 		}
 	}
 
+	[TestMethod]
+	[Description(
+		"When the exact requested version is not registered, resolution must fall back to the " +
+		"highest registered version with a compatible identity — a fresh context is required " +
+		"here: once a context has loaded a simple name, its own by-name cache answers (or " +
+		"rejects) later requests without ever calling Load() again.")]
+	public void When_RequestedVersionNotRegistered_Then_HighestCompatibleWins()
+	{
+		var root = Directory.CreateTempSubdirectory("uno-hr-tests").FullName;
+		try
+		{
+			var v1 = EmitAssembly(Path.Join(root, "v1", "Dep.dll"), "Dep", new Version(1, 0, 0, 0));
+			var v2 = EmitAssembly(Path.Join(root, "v2", "Dep.dll"), "Dep", new Version(2, 0, 0, 0));
+			var payload = CopyTo(Directory.CreateDirectory(Path.Join(root, "analyzer")).FullName, typeof(Given_CollectibleAnalyzerAssemblyLoader).Assembly.Location);
+
+			var loader = new CollectibleAnalyzerAssemblyLoader();
+			loader.AddDependencyLocation(v1);
+			loader.AddDependencyLocation(v2);
+			var analyzerContext = AssemblyLoadContext.GetLoadContext(loader.LoadFromPath(payload))!;
+
+			// 1.5 is not registered: the scan must pick the highest compatible version (2.0) —
+			// which also satisfies the runtime's own version validation on the returned assembly.
+			var resolved = analyzerContext.LoadFromAssemblyName(new AssemblyName("Dep, Version=1.5.0.0"));
+
+			Assert.AreEqual(new Version(2, 0, 0, 0), resolved.GetName().Version, "the highest compatible registered version must win");
+		}
+		finally
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
 	private static string CopyTo(string directory, string sourcePath, string? fileName = null)
 	{
 		var target = Path.Join(directory, fileName ?? Path.GetFileName(sourcePath));

--- a/src/Uno.HotReload/Roslyn/CollectibleAnalyzerAssemblyLoader.cs
+++ b/src/Uno.HotReload/Roslyn/CollectibleAnalyzerAssemblyLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.IO;
@@ -8,6 +9,7 @@ using System.Runtime.Loader;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Uno.HotReload.Tracking;
 using Uno.HotReload.Utils;
 
 namespace Uno.HotReload.Roslyn;
@@ -40,18 +42,25 @@ namespace Uno.HotReload.Roslyn;
 internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
 {
 	private readonly AssemblyLoadContext _compilerContext;
+	private readonly IReporter? _reporter;
 	private readonly ConcurrentDictionary<string, DirectoryLoadContext> _contexts = new(PathComparer.Comparer);
 	private readonly ConcurrentDictionary<string, ImmutableHashSet<string>> _knownPathsByFileName = new(StringComparer.OrdinalIgnoreCase);
-	private static readonly string _shadowCopyRoot = Path.Join(Path.GetTempPath(), "uno-devserver", "analyzers");
+	private static readonly SearchValues<char> _invalidSimpleNameChars = SearchValues.Create(Path.GetInvalidFileNameChars());
+	private static readonly Lazy<string> _shadowCopyRoot = new(CreateShadowCopyRoot);
 
-	public CollectibleAnalyzerAssemblyLoader()
-		: this(AssemblyLoadContext.GetLoadContext(typeof(Compilation).Assembly)
-			?? throw new InvalidOperationException("Unable to determine the embedded Roslyn's AssemblyLoadContext."))
+	public CollectibleAnalyzerAssemblyLoader(IReporter? reporter = null)
+		: this(
+			AssemblyLoadContext.GetLoadContext(typeof(Compilation).Assembly)
+				?? throw new InvalidOperationException("Unable to determine the embedded Roslyn's AssemblyLoadContext."),
+			reporter)
 	{
 	}
 
-	internal CollectibleAnalyzerAssemblyLoader(AssemblyLoadContext compilerContext)
-		=> _compilerContext = compilerContext;
+	internal CollectibleAnalyzerAssemblyLoader(AssemblyLoadContext compilerContext, IReporter? reporter = null)
+	{
+		_compilerContext = compilerContext;
+		_reporter = reporter;
+	}
 
 	/// <inheritdoc />
 	public void AddDependencyLocation(string fullPath)
@@ -76,8 +85,9 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 
 	/// <summary>
 	/// Picks the registered dependency location that best satisfies <paramref name="requested"/>,
-	/// mirroring Roslyn's own loader: an exact version match wins, otherwise the highest version
-	/// whose identity is compatible — never just "whichever project registered that file name
+	/// mirroring Roslyn's own loader: every candidate must match the requested identity (simple
+	/// name, and public key token when one is requested), an exact version match wins, otherwise
+	/// the highest matching version — never just "whichever project registered that file name
 	/// first". Returns <c>null</c> when nothing usable was registered.
 	/// </summary>
 	private string? GetBestKnownPath(string simpleName, AssemblyName requested)
@@ -87,17 +97,12 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			return null;
 		}
 
-		if (candidates.Count == 1)
-		{
-			// Single registered location: load it by name like the same-directory probe does
-			// (identity inspection only matters when there are alternatives to pick between).
-			var single = candidates.First();
-			return File.Exists(single) ? single : null;
-		}
-
 		var requestedToken = requested.GetPublicKeyToken();
 		string? bestPath = null;
 		Version? bestVersion = null;
+
+		// Ordinal order is load-bearing, not cosmetic: ImmutableHashSet enumeration order is
+		// unspecified, and a deterministic scan keeps the winner stable when candidates tie.
 		foreach (var path in candidates.OrderBy(static p => p, StringComparer.Ordinal))
 		{
 			AssemblyName candidate;
@@ -105,11 +110,14 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			{
 				candidate = AssemblyName.GetAssemblyName(path);
 			}
-			catch (Exception e) when (e is IOException or BadImageFormatException)
+			catch (Exception e) when (e is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException)
 			{
-				continue; // Deleted since it was registered, or not a loadable assembly.
+				continue; // Deleted since it was registered, unreadable, or not a loadable assembly.
 			}
 
+			// The identity check applies to EVERY candidate, even a lone one: a stale
+			// registration whose file name happens to match must fall through to the runtime's
+			// own resolution instead of being force-loaded.
 			if (!string.Equals(candidate.Name, simpleName, StringComparison.OrdinalIgnoreCase)
 				|| (requestedToken is { Length: > 0 } && !requestedToken.AsSpan().SequenceEqual(candidate.GetPublicKeyToken().AsSpan())))
 			{
@@ -119,7 +127,9 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			var candidateVersion = candidate.Version ?? new Version(0, 0);
 			if (candidateVersion == requested.Version)
 			{
-				return path;
+				bestPath = path;
+				bestVersion = candidateVersion;
+				break;
 			}
 
 			if (bestVersion is null || candidateVersion > bestVersion)
@@ -129,25 +139,98 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			}
 		}
 
+		if (candidates.Count > 1)
+		{
+			// The ambiguous case is worth a trace: when the picked version turns out binary-
+			// incompatible downstream, this is the only record of what the decision was.
+			_reporter?.Verbose(bestPath is null
+				? $"None of the {candidates.Count} locations registered for '{simpleName}.dll' matches '{requested}'."
+				: $"'{requested}' resolved to '{bestPath}' (v{bestVersion}) among {candidates.Count} registered locations.");
+		}
+
 		return bestPath;
 	}
 
-	private static string GetShadowCopyPath(string fullPath)
+	private static string CreateShadowCopyRoot()
 	{
-		// One shadow directory per (path, timestamp): reused while the file is unchanged, naturally
-		// re-copied after a rebuild. The original file is never memory-mapped, so it never locks.
-		var timestamp = File.GetLastWriteTimeUtc(fullPath).Ticks;
-		var key = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"{fullPath}|{timestamp}")))[..16];
-		var directory = Path.Join(_shadowCopyRoot, key);
-		var shadowPath = Path.Join(directory, Path.GetFileName(fullPath));
+		// Per-user, NOT under the shared temp root: %TEMP% is per-user on Windows but /tmp is
+		// world-writable on Unix, and with deterministic keys a shared root would let any local
+		// process pre-plant or swap entries (first-writer-owns). LocalApplicationData descends
+		// from the user's profile on every OS — other accounts can neither pre-create nor swap
+		// entries there (user-only mode on Unix for good measure). Moving OFF the historical
+		// temp-rooted path also retires, wholesale, anything a pre-atomic-publish version of
+		// this cache may have left truncated at a still-reachable key.
+		var root = Path.Join(
+			Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create),
+			"uno-devserver",
+			"analyzers");
 
+		if (OperatingSystem.IsWindows())
+		{
+			Directory.CreateDirectory(root);
+		}
+		else
+		{
+			Directory.CreateDirectory(root, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+		}
+
+		SweepOrphanedStagingFiles(root);
+		return root;
+	}
+
+	private static void SweepOrphanedStagingFiles(string root)
+	{
+		// Best effort, once per process: staging files normally live milliseconds (published or
+		// cleaned up), so anything older than a day is debris from a killed process. The keyed
+		// directories themselves are kept — their liveness across processes is unknowable.
+		try
+		{
+			var cutoff = DateTime.UtcNow.AddDays(-1);
+			foreach (var staging in Directory.EnumerateFiles(root, "*.staging", SearchOption.AllDirectories))
+			{
+				try
+				{
+					if (File.GetLastWriteTimeUtc(staging) < cutoff)
+					{
+						File.Delete(staging);
+					}
+				}
+				catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+				{
+					// Ignore: in use or protected — reconsidered at the next process start.
+				}
+			}
+		}
+		catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+		{
+			// The enumeration itself failed — nothing to sweep.
+		}
+	}
+
+	internal static string GetShadowCopyPath(string fullPath)
+	{
+		// One shadow directory per (path, timestamp, size): reused while the file is unchanged,
+		// naturally re-keyed after a rebuild. The size guards the common timestamp-preserving
+		// rewrites; a same-time same-size content swap still reuses the stale copy — hashing
+		// every analyzer at every load would cost what the cache exists to save.
+		var timestamp = File.GetLastWriteTimeUtc(fullPath).Ticks;
+		var length = new FileInfo(fullPath).Length;
+		var key = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"{fullPath}|{timestamp}|{length}")))[..16];
+		return Path.Join(_shadowCopyRoot.Value, key, Path.GetFileName(fullPath));
+	}
+
+	private static string EnsureShadowCopy(string fullPath)
+	{
+		// The original file is only ever read for the copy, never memory-mapped: it never locks.
+		var shadowPath = GetShadowCopyPath(fullPath);
 		if (!File.Exists(shadowPath))
 		{
-			Directory.CreateDirectory(directory);
+			Directory.CreateDirectory(Path.GetDirectoryName(shadowPath)!);
 
 			// Keep the symbols next to the shadow copy so analyzer stack traces stay resolvable.
 			// Published before the assembly: once the .dll is visible the bundle is complete.
-			if (Path.ChangeExtension(fullPath, ".pdb") is { } pdb && File.Exists(pdb))
+			var pdb = Path.ChangeExtension(fullPath, ".pdb");
+			if (File.Exists(pdb))
 			{
 				Publish(pdb, Path.ChangeExtension(shadowPath, ".pdb"));
 			}
@@ -163,30 +246,40 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 	/// only ever becomes visible COMPLETE: the bytes land in a unique staging file first, then
 	/// are published with an atomic rename. A bare <c>File.Copy</c> creates the destination
 	/// before the content is through — and since the shadow key is deterministic, a concurrent
-	/// load (another thread, or another dev-server process sharing the same temp root) treating
+	/// load (another thread, or another dev-server process sharing the same root) treating
 	/// existence as completion would load a partial PE; a process killed mid-copy would even
-	/// poison the key until the source file's timestamp changes.
+	/// poison the key until the source file changes.
 	/// </summary>
 	private static void Publish(string sourcePath, string targetPath)
 	{
 		var staging = $"{targetPath}.{Guid.NewGuid():N}.staging";
-		File.Copy(sourcePath, staging);
 		try
 		{
+			File.Copy(sourcePath, staging);
 			File.Move(staging, targetPath);
 		}
-		catch (IOException) when (File.Exists(targetPath))
+		catch (Exception e) when (e is IOException or UnauthorizedAccessException)
 		{
-			// Lost the publish race with another thread or process — the winner's copy is
-			// equivalent (the key embeds the source path and timestamp).
+			// Whatever went wrong, never leak the staging file (File.Copy preserves the
+			// read-only attribute, hence the attribute reset and the access filter).
 			try
 			{
+				File.SetAttributes(staging, FileAttributes.Normal);
 				File.Delete(staging);
 			}
-			catch (IOException)
+			catch (Exception cleanup) when (cleanup is IOException or UnauthorizedAccessException)
 			{
-				// Best effort: an orphaned staging file in the keyed directory is harmless.
+				// Best effort: an orphaned staging file is inert and swept at a later start.
 			}
+
+			if (!File.Exists(targetPath))
+			{
+				// Genuine failure (disk full, protected directory, ...), not a lost race.
+				throw;
+			}
+
+			// Lost the publish race with another thread or process — the winner's copy is
+			// equivalent (the key embeds the source path, timestamp and size).
 		}
 	}
 
@@ -205,11 +298,16 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 		}
 
 		public Assembly LoadShadowCopy(string fullPath)
-			=> LoadFromAssemblyPath(GetShadowCopyPath(fullPath));
+			=> LoadFromAssemblyPath(EnsureShadowCopy(fullPath));
 
 		protected override Assembly? Load(AssemblyName assemblyName)
 		{
-			if (assemblyName.Name is not { Length: > 0 } simpleName || simpleName.EndsWith(".resources", StringComparison.Ordinal))
+			if (assemblyName.Name is not { Length: > 0 } simpleName
+				|| simpleName.EndsWith(".resources", StringComparison.Ordinal)
+				// The simple name becomes a FILE name below: reject separators and other invalid
+				// file-name characters so a hostile reference cannot probe — and shadow-load —
+				// outside the analyzer directory (Roslyn's loader rejects these too).
+				|| simpleName.AsSpan().ContainsAny(_invalidSimpleNameChars))
 			{
 				return null;
 			}
@@ -221,20 +319,27 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			// assemblies) so its own load policy can materialize dependencies it has not loaded
 			// yet — probing would fall through and load a split-identity duplicate below — and so
 			// it stays correct when assemblies keep appearing at runtime (e.g. NuGet packages
-			// added to the application through hot reload).
+			// added to the application through hot reload). Two Roslyn-parity trade-offs come
+			// with the delegation: it probes the Default context too, so a Default-resolvable
+			// simple name shadows any registered analyzer-local copy; and a dependency the
+			// compiler's context CAN provide materializes into that longer-lived context.
 			try
 			{
 				return _loader._compilerContext.LoadFromAssemblyName(assemblyName);
 			}
-			catch
+			catch (Exception e) when (e is not OperationCanceledException)
 			{
-				// Not something the compiler's context can provide (same bare catch as Roslyn's
-				// loader) — resolve it as an analyzer-local dependency below.
+				// Not something the compiler's context can provide — resolve it as an analyzer-
+				// local dependency below. Broad on purpose (like Roslyn's own loader): the throw
+				// may also come from a custom Resolving handler on that context, and a handler
+				// bug must not take analyzer resolution down with it.
+				_loader._reporter?.Verbose($"The compiler's context could not provide '{assemblyName}' ({e.GetType().Name}); resolving as an analyzer-local dependency.");
 			}
 
 			// Then the analyzer's own directory, then the registered dependency locations.
-			// Anything else returns null: the runtime then probes the default context and
-			// raises this context's Resolving event (framework assemblies land there).
+			// Anything else returns null: the runtime then re-probes the default context
+			// (redundantly — the delegation above already covered it) and finally raises this
+			// context's Resolving event.
 			var candidate = Path.Join(_directory, simpleName + ".dll");
 			if (File.Exists(candidate))
 			{

--- a/src/Uno.HotReload/Roslyn/CollectibleAnalyzerAssemblyLoader.cs
+++ b/src/Uno.HotReload/Roslyn/CollectibleAnalyzerAssemblyLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -29,8 +30,8 @@ namespace Uno.HotReload.Roslyn;
 /// </para>
 /// <para>
 /// This loader restores the 4.x semantics: analyzer contexts are collectible (a collectible
-/// assembly may reference both collectible and non-collectible ones), and any assembly already
-/// present in the embedded Roslyn's own context is unified to it (an analyzer built against
+/// assembly may reference both collectible and non-collectible ones), and any assembly the
+/// embedded Roslyn's own context can provide is unified to it (an analyzer built against
 /// Microsoft.CodeAnalysis 4.x binds to the loaded 5.x, exactly like Roslyn's own loader does).
 /// Analyzer files are shadow-copied before loading so the originals never get locked while the
 /// IDE or a build rebuilds them.
@@ -40,8 +41,8 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 {
 	private readonly AssemblyLoadContext _compilerContext;
 	private readonly ConcurrentDictionary<string, DirectoryLoadContext> _contexts = new(PathComparer.Comparer);
-	private readonly ConcurrentDictionary<string, string> _knownPathsByFileName = new(StringComparer.OrdinalIgnoreCase);
-	private static readonly string _shadowCopyRoot = Path.Combine(Path.GetTempPath(), "uno-devserver", "analyzers");
+	private readonly ConcurrentDictionary<string, ImmutableHashSet<string>> _knownPathsByFileName = new(StringComparer.OrdinalIgnoreCase);
+	private static readonly string _shadowCopyRoot = Path.Join(Path.GetTempPath(), "uno-devserver", "analyzers");
 
 	public CollectibleAnalyzerAssemblyLoader()
 		: this(AssemblyLoadContext.GetLoadContext(typeof(Compilation).Assembly)
@@ -56,7 +57,14 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 	public void AddDependencyLocation(string fullPath)
 		// Same-directory sibling assemblies resolve through the directory probe; out-of-directory
 		// dependencies (rare, but AnalyzerFileReference registers them) are indexed by file name.
-		=> _knownPathsByFileName.TryAdd(Path.GetFileName(fullPath), fullPath);
+		// Distinct projects may register distinct copies under the same file name (e.g. two
+		// versions of the same analyzer package), so every location is retained and the best
+		// match for the requested identity is picked at resolution time.
+		=> _knownPathsByFileName.AddOrUpdate(
+			Path.GetFileName(fullPath),
+			static (_, path) => ImmutableHashSet.Create(PathComparer.PathEqualityComparer, path),
+			static (_, paths, path) => paths.Add(path),
+			fullPath);
 
 	/// <inheritdoc />
 	public Assembly LoadFromPath(string fullPath)
@@ -66,35 +74,120 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 		return context.LoadShadowCopy(fullPath);
 	}
 
+	/// <summary>
+	/// Picks the registered dependency location that best satisfies <paramref name="requested"/>,
+	/// mirroring Roslyn's own loader: an exact version match wins, otherwise the highest version
+	/// whose identity is compatible — never just "whichever project registered that file name
+	/// first". Returns <c>null</c> when nothing usable was registered.
+	/// </summary>
+	private string? GetBestKnownPath(AssemblyName requested)
+	{
+		if (!_knownPathsByFileName.TryGetValue(requested.Name + ".dll", out var candidates))
+		{
+			return null;
+		}
+
+		if (candidates.Count == 1)
+		{
+			// Single registered location: load it by name like the same-directory probe does
+			// (identity inspection only matters when there are alternatives to pick between).
+			var single = candidates.First();
+			return File.Exists(single) ? single : null;
+		}
+
+		var requestedToken = requested.GetPublicKeyToken();
+		string? bestPath = null;
+		Version? bestVersion = null;
+		foreach (var path in candidates.OrderBy(static p => p, StringComparer.Ordinal))
+		{
+			AssemblyName candidate;
+			try
+			{
+				candidate = AssemblyName.GetAssemblyName(path);
+			}
+			catch (Exception e) when (e is IOException or BadImageFormatException)
+			{
+				continue; // Deleted since it was registered, or not a loadable assembly.
+			}
+
+			if (!string.Equals(candidate.Name, requested.Name, StringComparison.OrdinalIgnoreCase)
+				|| (requestedToken is { Length: > 0 } && !requestedToken.AsSpan().SequenceEqual(candidate.GetPublicKeyToken().AsSpan())))
+			{
+				continue;
+			}
+
+			var candidateVersion = candidate.Version ?? new Version(0, 0);
+			if (candidateVersion == requested.Version)
+			{
+				return path;
+			}
+
+			if (bestVersion is null || candidateVersion > bestVersion)
+			{
+				bestPath = path;
+				bestVersion = candidateVersion;
+			}
+		}
+
+		return bestPath;
+	}
+
 	private static string GetShadowCopyPath(string fullPath)
 	{
 		// One shadow directory per (path, timestamp): reused while the file is unchanged, naturally
 		// re-copied after a rebuild. The original file is never memory-mapped, so it never locks.
 		var timestamp = File.GetLastWriteTimeUtc(fullPath).Ticks;
 		var key = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"{fullPath}|{timestamp}")))[..16];
-		var directory = Path.Combine(_shadowCopyRoot, key);
-		var shadowPath = Path.Combine(directory, Path.GetFileName(fullPath));
+		var directory = Path.Join(_shadowCopyRoot, key);
+		var shadowPath = Path.Join(directory, Path.GetFileName(fullPath));
 
 		if (!File.Exists(shadowPath))
 		{
 			Directory.CreateDirectory(directory);
-			try
-			{
-				File.Copy(fullPath, shadowPath, overwrite: false);
 
-				// Keep the symbols next to the shadow copy so analyzer stack traces stay resolvable.
-				if (Path.ChangeExtension(fullPath, ".pdb") is { } pdb && File.Exists(pdb))
-				{
-					File.Copy(pdb, Path.ChangeExtension(shadowPath, ".pdb"), overwrite: false);
-				}
-			}
-			catch (IOException) when (File.Exists(shadowPath))
+			// Keep the symbols next to the shadow copy so analyzer stack traces stay resolvable.
+			// Published before the assembly: once the .dll is visible the bundle is complete.
+			if (Path.ChangeExtension(fullPath, ".pdb") is { } pdb && File.Exists(pdb))
 			{
-				// Lost a copy race with another thread — the winner's copy is equivalent.
+				Publish(pdb, Path.ChangeExtension(shadowPath, ".pdb"));
 			}
+
+			Publish(fullPath, shadowPath);
 		}
 
 		return shadowPath;
+	}
+
+	/// <summary>
+	/// Copies <paramref name="sourcePath"/> to <paramref name="targetPath"/> so that the target
+	/// only ever becomes visible COMPLETE: the bytes land in a unique staging file first, then
+	/// are published with an atomic rename. A bare <c>File.Copy</c> creates the destination
+	/// before the content is through — and since the shadow key is deterministic, a concurrent
+	/// load (another thread, or another dev-server process sharing the same temp root) treating
+	/// existence as completion would load a partial PE; a process killed mid-copy would even
+	/// poison the key until the source file's timestamp changes.
+	/// </summary>
+	private static void Publish(string sourcePath, string targetPath)
+	{
+		var staging = $"{targetPath}.{Guid.NewGuid():N}.staging";
+		File.Copy(sourcePath, staging);
+		try
+		{
+			File.Move(staging, targetPath);
+		}
+		catch (IOException) when (File.Exists(targetPath))
+		{
+			// Lost the publish race with another thread or process — the winner's copy is
+			// equivalent (the key embeds the source path and timestamp).
+			try
+			{
+				File.Delete(staging);
+			}
+			catch (IOException)
+			{
+				// Best effort: an orphaned staging file in the keyed directory is harmless.
+			}
+		}
 	}
 
 	private sealed class DirectoryLoadContext : AssemblyLoadContext
@@ -122,22 +215,33 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			}
 
 			// Unify to the embedded Roslyn's context first (Microsoft.CodeAnalysis.* and anything
-			// else it already loaded): mirrors Roslyn's own compiler-context redirect, including
+			// else it can provide): mirrors Roslyn's own compiler-context redirect, including
 			// binding an analyzer built against an older Microsoft.CodeAnalysis to the loaded one.
-			if (_loader._compilerContext.Assemblies.FirstOrDefault(a => string.Equals(a.GetName().Name, simpleName, StringComparison.OrdinalIgnoreCase)) is { } fromCompiler)
+			// The resolution is DELEGATED to that context (not probed against its already-loaded
+			// assemblies) so its own load policy can materialize dependencies it has not loaded
+			// yet — probing would fall through and load a split-identity duplicate below — and so
+			// it stays correct when assemblies keep appearing at runtime (e.g. NuGet packages
+			// added to the application through hot reload).
+			try
 			{
-				return fromCompiler;
+				return _loader._compilerContext.LoadFromAssemblyName(assemblyName);
+			}
+			catch
+			{
+				// Not something the compiler's context can provide (same bare catch as Roslyn's
+				// loader) — resolve it as an analyzer-local dependency below.
 			}
 
 			// Then the analyzer's own directory, then the registered dependency locations.
-			// Anything else falls back to the default context (framework assemblies).
-			var candidate = Path.Combine(_directory, simpleName + ".dll");
-			if (!File.Exists(candidate) && !_loader._knownPathsByFileName.TryGetValue(simpleName + ".dll", out candidate!))
+			// Anything else returns null: the runtime then probes the default context and
+			// raises this context's Resolving event (framework assemblies land there).
+			var candidate = Path.Join(_directory, simpleName + ".dll");
+			if (File.Exists(candidate))
 			{
-				return null;
+				return LoadShadowCopy(candidate);
 			}
 
-			return File.Exists(candidate) ? LoadShadowCopy(candidate) : null;
+			return _loader.GetBestKnownPath(assemblyName) is { } known ? LoadShadowCopy(known) : null;
 		}
 
 		protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
@@ -145,7 +249,7 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 			// Deliberate scope boundary: native DLLs are loaded from their original location, NOT
 			// shadow-copied (so a rebuild while loaded can fail to replace them on Windows).
 			// Native analyzer dependencies are rare and Roslyn's own loaders share the limitation.
-			var candidate = Path.Combine(_directory, unmanagedDllName + ".dll");
+			var candidate = Path.Join(_directory, unmanagedDllName + ".dll");
 			return File.Exists(candidate) ? LoadUnmanagedDllFromPath(candidate) : IntPtr.Zero;
 		}
 	}

--- a/src/Uno.HotReload/Roslyn/CollectibleAnalyzerAssemblyLoader.cs
+++ b/src/Uno.HotReload/Roslyn/CollectibleAnalyzerAssemblyLoader.cs
@@ -80,9 +80,9 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 	/// whose identity is compatible — never just "whichever project registered that file name
 	/// first". Returns <c>null</c> when nothing usable was registered.
 	/// </summary>
-	private string? GetBestKnownPath(AssemblyName requested)
+	private string? GetBestKnownPath(string simpleName, AssemblyName requested)
 	{
-		if (!_knownPathsByFileName.TryGetValue(requested.Name + ".dll", out var candidates))
+		if (!_knownPathsByFileName.TryGetValue(simpleName + ".dll", out var candidates))
 		{
 			return null;
 		}
@@ -110,7 +110,7 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 				continue; // Deleted since it was registered, or not a loadable assembly.
 			}
 
-			if (!string.Equals(candidate.Name, requested.Name, StringComparison.OrdinalIgnoreCase)
+			if (!string.Equals(candidate.Name, simpleName, StringComparison.OrdinalIgnoreCase)
 				|| (requestedToken is { Length: > 0 } && !requestedToken.AsSpan().SequenceEqual(candidate.GetPublicKeyToken().AsSpan())))
 			{
 				continue;
@@ -241,7 +241,7 @@ internal sealed class CollectibleAnalyzerAssemblyLoader : IAnalyzerAssemblyLoade
 				return LoadShadowCopy(candidate);
 			}
 
-			return _loader.GetBestKnownPath(assemblyName) is { } known ? LoadShadowCopy(known) : null;
+			return _loader.GetBestKnownPath(simpleName, assemblyName) is { } known ? LoadShadowCopy(known) : null;
 		}
 
 		protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)

--- a/src/Uno.HotReload/Utils/RoslynExtensions.AnalyzerReferences.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.AnalyzerReferences.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Uno.HotReload.Roslyn;
+using Uno.HotReload.Tracking;
 
 namespace Uno.HotReload.Utils;
 
@@ -18,11 +19,11 @@ public static partial class RoslynExtensions
 	/// <see cref="CollectibleAnalyzerAssemblyLoader"/>. Pure snapshot transform: the underlying
 	/// workspace (and the .csproj files an applied change would rewrite) is never touched.
 	/// </summary>
-	internal static Solution WithCollectibleAnalyzerReferences(this Solution solution)
+	internal static Solution WithCollectibleAnalyzerReferences(this Solution solution, IReporter? reporter = null)
 	{
 		// One loader (and one set of per-directory contexts) per solution snapshot lineage: every
 		// project sharing an analyzer path shares its loaded assembly, mirroring Roslyn's caching.
-		var loader = new CollectibleAnalyzerAssemblyLoader();
+		var loader = new CollectibleAnalyzerAssemblyLoader(reporter);
 
 		foreach (var projectId in solution.ProjectIds)
 		{

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -109,7 +109,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						var solution = workspace.CurrentSolution
 							.FilterHeadProjectTargetFramework(configureServer.ProjectPath, runtimeTargetFramework, _reporter)
 							.AlignHeadProjectCompilationOutputs(configureServer.ProjectPath, runtimeIdentifier, _reporter, ct2)
-							.WithCollectibleAnalyzerReferences();
+							.WithCollectibleAnalyzerReferences(_reporter);
 
 						EmbeddedRoslyn.WarnOnAnalyzerLoadFailures(solution, _reporter, ct2);
 


### PR DESCRIPTION
Follow-up to #23863 — the review-round-4 changes: the PR auto-merged the moment its last review conversations were resolved, before these fixes were pushed, so the "Done" replies on those threads describe the changes delivered here.

## Changes (all on `CollectibleAnalyzerAssemblyLoader`)

- **Delegate resolution to the compiler context** (https://github.com/unoplatform/uno/pull/23863#discussion_r3692410010): `Load` now tries `_compilerContext.LoadFromAssemblyName(assemblyName)` (bare-catch fall-through, the exact shape of Roslyn's own loader) instead of probing the context's already-loaded `Assemblies`. Dependencies the compiler context can resolve but has not loaded yet materialize in it — no split-identity analyzer-local copy — and resolution stays correct when assemblies keep appearing at runtime (e.g. NuGet packages added to the app through hot reload). This also removes the per-`Load` linear scan discussed in https://github.com/unoplatform/uno/pull/23863#discussion_r3686034480 without any cache to invalidate: the ALC's internal by-name lookup is authoritative and re-probed by the runtime on every miss.
- **Shadow copies only ever become visible complete** (https://github.com/unoplatform/uno/pull/23863#discussion_r3692410015): the copy lands in a unique staging file and is published with an atomic `File.Move`; the PDB is published before the DLL so a visible DLL means the bundle is whole. Rename-publish was chosen over an in-process `ConcurrentDictionary<string, Task<string>>` because the shadow key is deterministic and the temp root shared: the race also exists across dev-server processes, and a process killed mid-copy would otherwise poison the key with a permanent partial file.
- **Best-candidate dependency resolution** (https://github.com/unoplatform/uno/pull/23863#discussion_r3692410019): `AddDependencyLocation` retains every location registered for a file name (distinct projects may carry distinct versions of the same analyzer package), and resolution mirrors Roslyn's `GetBestPath`: exact requested version wins, otherwise the highest version with a compatible identity (simple name + public key token when requested).
- **`Path.Join` throughout** the file and the test helper (CodeQL findings).

## Validation

- `Uno.HotReload.Tests`: 120/120 passing, including two new regression tests — `When_CompilerContextResolvesLazily_Then_AnalyzerRequestsUnifyToIt` (lazily-resolving compiler context + same-directory copy of the assembly: the request must materialize in the compiler context; fails on the previous enumeration-based code) and `When_MultipleVersionsRegistered_Then_RequestedVersionWins` (two registered versions: the exact requested one must win over the first registered).
- `Uno.HotReload` compiles warning-free on both flavors: net9.0 (Roslyn 4.14) and net10.0 (Roslyn 5.6).
