### PR TITLE
fix(skia): Drain finished Vulkan command buffers

### DIFF
--- a/src/Uno.UI/Vulkan/Interop/VulkanCommandBuffer.skia.cs
+++ b/src/Uno.UI/Vulkan/Interop/VulkanCommandBuffer.skia.cs
@@ -72,11 +72,12 @@ internal class VulkanCommandBuffer : IDisposable
 	public unsafe void Submit(
 		ReadOnlySpan<VulkanSemaphore> waitSemaphores,
 		ReadOnlySpan<VkPipelineStageFlags> waitDstStageMask,
-		ReadOnlySpan<VulkanSemaphore> signalSemaphores,
-		VulkanFence? fence = null)
+		ReadOnlySpan<VulkanSemaphore> signalSemaphores)
 	{
 		EndRecording();
-		VkFence fenceHandle = (fence ?? _fence).Handle;
+		// The pool reclaims this buffer once _fence signals (IsFinished); submitting with any
+		// other fence would leave _fence signaled and let the drain free a buffer still on the GPU.
+		VkFence fenceHandle = _fence.Handle;
 		_context.DeviceApi.ResetFences(_context.DeviceHandle, 1, &fenceHandle)
 			.ThrowOnError("vkResetFences");
 

--- a/src/Uno.UI/Vulkan/Interop/VulkanCommandBufferPool.skia.cs
+++ b/src/Uno.UI/Vulkan/Interop/VulkanCommandBufferPool.skia.cs
@@ -2,6 +2,7 @@
 // Original source: https://github.com/AvaloniaUI/Avalonia/tree/master/src/Avalonia.Vulkan
 using System;
 using System.Collections.Generic;
+using Uno.Foundation.Logging;
 using Uno.UI.Runtime.Skia.Vulkan;
 using Uno.UI.Runtime.Skia.Vulkan.UnmanagedInterop;
 
@@ -10,15 +11,14 @@ namespace Uno.UI.Runtime.Skia.Vulkan.Interop;
 internal class VulkanCommandBufferPool : IDisposable
 {
 	private readonly IVulkanPlatformGraphicsContext _context;
-	private readonly bool _autoFree;
 	private readonly Queue<VulkanCommandBuffer> _commandBuffers = new();
+	private bool _pendingGrowthWarned;
 	private VkCommandPool _handle;
 	public VkCommandPool Handle => _handle;
 
-	public VulkanCommandBufferPool(IVulkanPlatformGraphicsContext context, bool autoFree = false)
+	public VulkanCommandBufferPool(IVulkanPlatformGraphicsContext context)
 	{
 		_context = context;
-		_autoFree = autoFree;
 		var createInfo = new VkCommandPoolCreateInfo
 		{
 			sType = VkStructureType.VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
@@ -58,8 +58,21 @@ internal class VulkanCommandBufferPool : IDisposable
 
 	public unsafe VulkanCommandBuffer CreateCommandBuffer()
 	{
-		if (_autoFree)
-			FreeFinishedCommandBuffers();
+		// Submitted buffers (and their fences) are only reclaimed here; without this drain
+		// every presented frame leaks one VkCommandBuffer and one VkFence. Upstream Avalonia
+		// drains from a render-target layer this port doesn't have — do not re-gate this call.
+		FreeFinishedCommandBuffers();
+
+		// Steady state leaves only frames-in-flight pending; sustained growth means fences
+		// stopped signaling and buffers are no longer reclaimed.
+		if (!_pendingGrowthWarned && _commandBuffers.Count > 8)
+		{
+			_pendingGrowthWarned = true;
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn($"{_commandBuffers.Count} submitted Vulkan command buffers are pending reclamation; fences may not be signaling.");
+			}
+		}
 
 		var commandBufferAllocateInfo = new VkCommandBufferAllocateInfo
 		{


### PR DESCRIPTION
**GitHub Issue:** closes #23937

## PR Type:

🐞 Bugfix

## What changed? 🚀

Every presented frame on the Vulkan render path leaked one `VkCommandBuffer` and one `VkFence`: `VulkanCommandBuffer.Submit()` enqueues each buffer into `VulkanCommandBufferPool._commandBuffers`, but the only drain (`FreeFinishedCommandBuffers()`) was gated behind a `bool autoFree = false` constructor flag that the sole construction site never enabled. Sustained rendering (~7,200 leaked pairs/min at 120 fps) exhausts mappable driver memory and aborts the process (observed on Android/Adreno, but the leaking code is shared by the Android, Win32 and X11 Skia Vulkan targets).

Root cause: the pool is ported from Avalonia, where the per-frame drain lives in a layer (`VulkanKhrSurfaceRenderTarget.BeginDraw` → `FreeUsedCommandBuffers()`) that this port replaced with `VulkanContext` — the drain call was lost in the port.

This PR (label: root-cause fix):
- Removes the dead `autoFree` flag and drains `FreeFinishedCommandBuffers()` unconditionally at the top of `CreateCommandBuffer()`, covering all creation sites (`VulkanDisplay.StartPresentation`, `VulkanContext.BlitAndPresent`, `VulkanImage` transitions). The drain is non-blocking (frees only fence-signaled buffers), so no frame-pacing impact.
- Adds a once-per-pool warning if the pending queue grows abnormally (fences no longer signaling, e.g. device loss), so a regression of this class is diagnosable in the field instead of manifesting as slow memory creep (label: defensive hardening).
- Removes the unused external-fence parameter from `VulkanCommandBuffer.Submit(...)`: submitting with a caller-supplied fence would leave the internal `_fence` in its created-signaled state, and the now-active drain would free a buffer the GPU is still executing. No caller passed it; removing it eliminates the latent use-after-free trap (label: defensive hardening).

### Validation

- **Runtime (fail-before/pass-after)** — instrumented `SamplesApp.Skia.Generic` on the X11 Vulkan renderer (WSLg + Mesa lavapipe/llvmpipe), animated `Progress/WinUIProgressRingPage` sample at ~60 fps for ~90 s, logging the pool queue depth every 120 `CreateCommandBuffer` calls:
  - Before: queue depth grew strictly 1:1 with presented frames — 5,399 pending after 5,400 frames (the reported leak signature).
  - After: queue depth bounded at exactly 1 across 5,760 frames.
- **Compile** — `SamplesApp.Skia.Generic` (net10.0, Debug) builds with 0 warnings / 0 errors.
- **Evidence caveat** — runtime validation ran on X11 + software Vulkan only. On real GPUs with mailbox present and 2–3 frames in flight, the expected steady state is "bounded at frames-in-flight" rather than 1; Android/Adreno (where the crash was reported) and Win32 Vulkan were validated by code review only, since all paths share this pool.
- **No automated test** — no Vulkan test infrastructure exists in the repo and the pool requires a live `VkDevice`; the manual repro above is documented so the fail-before/pass-after check is repeatable.

### Pre-existing issues noticed but out of scope (left as-is)

- A buffer created but never submitted (exception between `CreateCommandBuffer` and `Submit`, e.g. the swallowed catch in `VulkanContext.BlitAndPresent`) is only reclaimed at pool disposal.
- `VulkanFence.IsSignaled` conflates error `VkResult`s (e.g. `VK_ERROR_DEVICE_LOST`) with `VK_NOT_READY`.
- Per-frame `vkAllocateCommandBuffers`/`vkCreateFence` + free could become a small reusable ring (`VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT` is already set).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: no Vulkan test infrastructure exists (a live `VkDevice` is required); manual fail-before/pass-after repro documented above.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — not applicable: internal rendering fix, no user-facing behavior change.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
