### PR TITLE
Version bump after 6.7 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.7-dev.{height}",
+  "version": "6.7",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.7-dev.{height}",
+  "version": "6.8-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
## Summary

Batch 1 of managed sweeps that release **collectible-`AssemblyLoadContext`** pins for a downstream host that loads previewed apps into their own collectible AssemblyLoadContexts and unloads them on reload. On WebAssembly `AssemblyLoadContext.Unloading` is never raised, so process-lifetime static caches that key on (or reference) an app's `Assembly`/`Type`/delegate keep the context alive after `Unload()`. Each cache is swept from the existing ALC cleanup hook (`Application.CleanupNonDefaultAlcCaches`, invoked from `Window.CloseAlcWindow`) or exposes an ALC-scoped removal called from a reachable teardown path — matching the established `Style.ClearCachesForNonDefaultAlc` / `RemoveNonDefaultAlcEntries` pattern.

Closes #23706

## Sweeps landed

1. **`ResourceLoader`** — `ClearNonDefaultAlcAssemblies()` drops previewed-app lookup assemblies (and their parsed-resource markers) from the process-lifetime `_lookupAssemblies` list; wired into the cleanup hook.
2. **`UIElementNativeRegistrar._classNames`** (WASM) — `ClearNonDefaultAlcEntries()` drops the collectible-ALC `Type` keys of the element-type→registration-id map (invisible to a desktop-only guard). The JS-side registration map holds only strings (no ALC pin) and is intentionally left intact — its ids come from a shared counter, so deleting entries there could collide with live registrations.
3. **WindowId maps** — `AppWindow` / `ApplicationView` / `CoreDragDropManager` each gain `DestroyForWindowId`, mirroring `DisplayInformation.DestroyForWindowId`, called from `Window.CloseAlcWindow`. These retained the closed window's instance and its event subscribers.
4. **`CompositionTarget.Rendering`** (WASM) — `ClearNonDefaultAlcHandlers()` drops non-default-ALC subscribers from the static handler list; the per-frame dispatch now reuses a snapshot buffer instead of allocating a fresh `List` every frame.
6. **Hot-reload client status history** — a terminal `HotReloadClientOperation` releases its raw `Type[]` (keeping the curated string list), and the local-operation history is capped to a ~100-entry ring buffer, so retained operations no longer pin every hot-reloaded collectible type.
7. **`PagePool`** (WASM/managed Frame) — collapsed to a single lazily-created process-wide instance (each `Frame` previously overwrote a shared static with a new pool, orphaning the old one while its eternal 30s scavenger kept it alive); the scavenger is scheduled at most once and only when pooling is enabled; `ClearNonDefaultAlcEntries()` drops collectible page-type keys.
8. **Residual `Type`-keyed statics** — `HtmlElementHelper._cache` (WASM) and `FeatureConfiguration.Style.UseUWPDefaultStylesOverride` gain a collectible-ALC key sweep.

## Skipped (verified not an ALC pin)

- **Finding 5 — `ImageBrush._naturalSizeCache`**: keyed by data-URI/URL **strings**, which carry no ALC identity — a memory-bloat concern, not a pin. Out of scope here; noted as a follow-up (hash/LRU the data-URI keys).
- **`UnicodeText.ICU._lookupCache`**: keyed by native-delegate types declared inside the framework (default ALC); app types are never keys. Left unchanged.
- **Finding 2 JS map**: strings only, no managed reference. See #2 above.

## Out of scope (follow-ups)

Hot-reload delta pipeline retention; image Blob URL lifetime; `FontFamilyLoader` caches.

## Tests (red/green)

Each sweep is guarded by a test asserting a collectible-ALC-keyed entry is dropped while default-ALC / framework entries are kept:

- `Given_ResourceLoader_Alc` (unit) — proven red by neutering the sweep (fails at the removal assertion), green with it.
- `Given_WindowId_Maps_Alc` (unit)
- `Given_ResidualTypeStatics_Alc` (unit)
- `Given_HotReloadClientOperation_Alc` (runtime, HAS_UNO_WINUI)
- WASM-only sweeps (2, 4, HtmlElementHelper) validated by the WASM build; runtime coverage tracked with the batch.

## Notes

Local environment is flaky (package churn / Cecil locks); build+test were run where possible and CI validates the rest. See `specs/048-wasm-alc-pin-sweeps/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This is an automated version bump of the  **master** branch after the creation of the release branch release/stable/6.7, based on #23707