### PR TITLE
test: Disable flaky WebView2 test on Skia UIKit

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
@@ -311,7 +311,7 @@ public class Given_WebView2
 	[Ignore("Crashes")]
 #endif
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit)] // Flaky on UIKit - #9080
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit | RuntimeTestPlatforms.SkiaUIKit)] // Flaky on UIKit - #9080
 	public async Task When_LocalFolder_File()
 	{
 		async Task Do()


### PR DESCRIPTION
**GitHub Issue:** #9080 (tracking epic — intentionally *not* auto-closed by this PR)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Given_WebView2.When_LocalFolder_File` is flaky on UIKit. The `[PlatformCondition]` exclusion on that test only covered `RuntimeTestPlatforms.NativeUIKit`, so the test still ran — and intermittently failed — on Skia UIKit.

This extends the exclusion to `NativeUIKit | SkiaUIKit`, matching the precedent already set for the same flakiness in the same file: `When_Navigate_Unsupported_Scheme` (line 596) is excluded on both the Skia iOS leg and native UIKit under #9080.

```diff
-[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit)] // Flaky on UIKit - #9080
+[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeUIKit | RuntimeTestPlatforms.SkiaUIKit)] // Flaky on UIKit - #9080
```

Attribute-only change — no product code touched, and no behavior change on any platform other than skipping this one test on Skia UIKit. Validated by inspection (`RuntimeTestPlatforms.SkiaUIKit` is defined at `src/Uno.UI.RuntimeTests/Helpers/RuntimeTestPlatforms.cs:32`); no local compile or runtime run, since the affected leg is Skia-iOS CI.

Possible follow-up (out of scope here): a few other tests carry the same `Exclude, NativeUIKit` + `#9080` comment without `SkiaUIKit` — `Given_CalendarView.cs:317,331` and `Given_ImageBrush.cs:39` — and may need the same treatment if they turn out to be flaky on the Skia leg too.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, this change only adjusts an existing runtime test's platform condition
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, no user-facing change
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A, no rendering change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
