### PR TITLE
fix(resources): make AddLookupAssembly transactional on parse failure

### DIFF
--- a/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
@@ -9,6 +9,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.Globalization;
 using _ResourceLoader = Windows.ApplicationModel.Resources.ResourceLoader;
@@ -319,6 +320,176 @@ public class Given_ResourceLoader_Alc
 		}
 	}
 
+	[TestMethod]
+	public void When_AddLookupAssembly_Truncated_Upri_Then_Throws_And_Partial_Value_Not_Observable()
+	{
+		// Issue scenario: a .upri with a VALID header that declares two key/value pairs, carries one
+		// complete pair, then truncates before the second. ProcessResourceFile used to merge each
+		// pair directly into the live loader as it read, so BinaryReader.ReadString throwing
+		// EndOfStreamException on the second pair left the FIRST pair's value observable even after
+		// the AddLookupAssembly rollback removed the registration and its parsed markers — an
+		// unregistered assembly's partially parsed resource value survived. A failed
+		// AddLookupAssembly must be fully transactional: no registration, marker, or value remains.
+		const string defaultLanguage = "en";
+		const string uiTestResources = "Uno.UI.UnitTests/Resources";
+		const string truncatedLoaderName = "Uno.UI.Tests.TruncatedUpri/Resources";
+		const string hostValue = "App70-en";
+
+		var previousCulture = CultureInfo.CurrentUICulture;
+		var previousPlo = ApplicationLanguages.PrimaryLanguageOverride;
+		var previousDefault = _ResourceLoader.DefaultLanguage;
+
+		var defaultAlcAssembly = typeof(Given_ResourceLoader_Alc).Assembly;
+		var collectibleAlc = new AssemblyLoadContext("Given_ResourceLoader_Alc.truncated", isCollectible: true);
+		try
+		{
+			// Establish the loader context BEFORE the failing registration: with an unchanged
+			// context no later GetString call reloads (and incidentally wipes) the loaders, so a
+			// leaked partial value would remain observable for the rest of the process lifetime.
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			ApplicationLanguages.PrimaryLanguageOverride = defaultLanguage;
+			_ResourceLoader.DefaultLanguage = defaultLanguage;
+
+			_ResourceLoader.AddLookupAssembly(defaultAlcAssembly);
+			Assert.AreEqual(
+				hostValue,
+				_ResourceLoader.GetForCurrentView(uiTestResources).GetString("ApplicationName"),
+				"Pre-condition: the host resource resolves before the failing registration.");
+
+			var truncated = LoadAssemblyWithUpri(
+				collectibleAlc,
+				"Uno.UI.Tests.TruncatedUpri",
+				BuildTruncatedUpriPayload(truncatedLoaderName, defaultLanguage));
+
+			Assert.ThrowsExactly<EndOfStreamException>(
+				() => _ResourceLoader.AddLookupAssembly(truncated),
+				"A .upri truncated in the middle of its declared pairs must surface BinaryReader's EndOfStreamException.");
+
+			Assert.IsFalse(
+				_ResourceLoader.ContainsLookupAssembly(truncated),
+				"A failed registration must be rolled back.");
+			Assert.AreEqual(
+				string.Empty,
+				_ResourceLoader.GetForCurrentView(truncatedLoaderName).GetString("TruncatedKey"),
+				"The first pair of a truncated .upri must NOT remain observable after the failed registration — the rollback must cover partially merged values, not just the registration and markers.");
+			Assert.AreEqual(
+				hostValue,
+				_ResourceLoader.GetForCurrentView(uiTestResources).GetString("ApplicationName"),
+				"Surviving registrations must still resolve after the failed registration is rolled back.");
+		}
+		finally
+		{
+			_ResourceLoader.ClearNonDefaultAlcAssemblies();
+			collectibleAlc.Unload();
+			CultureInfo.CurrentUICulture = previousCulture;
+			ApplicationLanguages.PrimaryLanguageOverride = previousPlo;
+			_ResourceLoader.DefaultLanguage = previousDefault;
+		}
+	}
+
+	[TestMethod]
+	public void When_AddLookupAssembly_Truncated_Upri_With_Changed_Context_Then_Live_Loaders_Untouched()
+	{
+		// Same truncated .upri as above, but through AddLookupAssembly's OTHER branch: when the
+		// loader context changed since it was last established, the new assembly is parsed on its
+		// own (no full reload). That parse used to write each pair straight into the live loader
+		// too; it must instead parse into temporaries so a failure leaves the live loaders
+		// completely untouched. Observed at the merged-dictionary seam (no GetString) because a
+		// later GetString reloads for the new context and would mask the leak.
+		const string truncatedLoaderName = "Uno.UI.Tests.TruncatedUpriChangedContext/Resources";
+
+		var previousCulture = CultureInfo.CurrentUICulture;
+		var previousPlo = ApplicationLanguages.PrimaryLanguageOverride;
+		var previousDefault = _ResourceLoader.DefaultLanguage;
+
+		var collectibleAlc = new AssemblyLoadContext("Given_ResourceLoader_Alc.truncatedChangedContext", isCollectible: true);
+		try
+		{
+			// Establish a French loader context...
+			CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+			ApplicationLanguages.PrimaryLanguageOverride = "fr";
+			_ResourceLoader.DefaultLanguage = "fr";
+
+			// ...then flip the environment to English WITHOUT the ResourceLoader observing it
+			// (neither setter below re-enters the loader), so the next AddLookupAssembly sees a
+			// significantly changed context and takes the single-assembly parse branch.
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			ApplicationLanguages.PrimaryLanguageOverride = "en";
+
+			var truncated = LoadAssemblyWithUpri(
+				collectibleAlc,
+				"Uno.UI.Tests.TruncatedUpriChangedContext",
+				BuildTruncatedUpriPayload(truncatedLoaderName, "en"));
+
+			Assert.ThrowsExactly<EndOfStreamException>(
+				() => _ResourceLoader.AddLookupAssembly(truncated),
+				"A .upri truncated in the middle of its declared pairs must surface BinaryReader's EndOfStreamException.");
+
+			Assert.IsFalse(
+				_ResourceLoader.ContainsLookupAssembly(truncated),
+				"A failed registration must be rolled back.");
+			Assert.IsFalse(
+				TryGetMergedResource(truncatedLoaderName, "en", "TruncatedKey", out var leaked),
+				$"The failed single-assembly parse must not leave any value in the live loaders (found '{leaked}').");
+		}
+		finally
+		{
+			_ResourceLoader.ClearNonDefaultAlcAssemblies();
+			collectibleAlc.Unload();
+			CultureInfo.CurrentUICulture = previousCulture;
+			ApplicationLanguages.PrimaryLanguageOverride = previousPlo;
+			_ResourceLoader.DefaultLanguage = previousDefault;
+		}
+	}
+
+	/// <summary>
+	/// Builds a <c>.upri</c> payload with a valid header (magic, version 3, loader name, culture)
+	/// that declares TWO key/value pairs, carries one complete pair, then truncates — matching
+	/// <c>ProcessResourceFile</c>'s binary layout so the parser fails on the second
+	/// <see cref="BinaryReader.ReadString"/> AFTER the first pair parsed successfully.
+	/// </summary>
+	private static byte[] BuildTruncatedUpriPayload(string loaderName, string culture)
+	{
+		using var payload = new MemoryStream();
+		using (var writer = new BinaryWriter(payload, Encoding.UTF8, leaveOpen: true))
+		{
+			writer.Write("uno"u8); // magic
+			writer.Write(3); // version
+			writer.Write(loaderName);
+			writer.Write(culture);
+			writer.Write(2); // resourceCount: declares two pairs...
+			writer.Write("TruncatedKey");
+			writer.Write("TruncatedValue");
+			// ...but the stream ends before the second pair.
+		}
+
+		return payload.ToArray();
+	}
+
+	/// <summary>
+	/// Reads a merged resource value at the private per-loader dictionary seam
+	/// (<c>ResourceLoader._resources[culture][key]</c>) WITHOUT going through
+	/// <c>GetString</c> — which re-establishes the loader context (reloading, and thereby wiping,
+	/// the loaders when the culture changed) and would mask a leaked value.
+	/// </summary>
+	private static bool TryGetMergedResource(string loaderName, string culture, string key, out string? value)
+	{
+		value = null;
+
+		var loadersField = typeof(_ResourceLoader).GetField("_loaders", BindingFlags.Static | BindingFlags.NonPublic)
+			?? throw new InvalidOperationException("ResourceLoader._loaders field was not found.");
+		var loaders = (Dictionary<string, _ResourceLoader>)loadersField.GetValue(null)!;
+		if (!loaders.TryGetValue(loaderName, out var loader))
+		{
+			return false;
+		}
+
+		var resourcesField = typeof(_ResourceLoader).GetField("_resources", BindingFlags.Instance | BindingFlags.NonPublic)
+			?? throw new InvalidOperationException("ResourceLoader._resources field was not found.");
+		var resources = (Dictionary<string, Dictionary<string, string>>)resourcesField.GetValue(loader)!;
+		return resources.TryGetValue(culture, out var map) && map.TryGetValue(key, out value);
+	}
+
 	/// <summary>
 	/// Emits (in memory, via <see cref="ManagedPEBuilder"/>) a minimal assembly whose single
 	/// manifest resource is a malformed <c>.upri</c> (payload does not start with the expected
@@ -326,6 +497,15 @@ public class Given_ResourceLoader_Alc
 	/// exercised with a REAL <see cref="Assembly"/> — no fake seam in the product code.
 	/// </summary>
 	private static Assembly LoadAssemblyWithMalformedUpri(AssemblyLoadContext alc, string assemblyName)
+		=> LoadAssemblyWithUpri(alc, assemblyName, "BAD-upri-payload"u8.ToArray()); // does not start with the "uno" magic
+
+	/// <summary>
+	/// Emits (in memory, via <see cref="ManagedPEBuilder"/>) a minimal assembly whose single
+	/// manifest resource is a <c>.upri</c> with the given <paramref name="upriPayload"/>, and
+	/// loads it into <paramref name="alc"/>. Lets the malformed/truncated-resource paths be
+	/// exercised with a REAL <see cref="Assembly"/> — no fake seam in the product code.
+	/// </summary>
+	private static Assembly LoadAssemblyWithUpri(AssemblyLoadContext alc, string assemblyName, byte[] upriPayload)
 	{
 		var metadata = new MetadataBuilder();
 		metadata.AddAssembly(
@@ -343,14 +523,13 @@ public class Given_ResourceLoader_Alc
 			encBaseId: default);
 
 		// ECMA-335 II.24.2.4: each manifest resource is a 4-byte length prefix followed by the data.
-		var payload = "BAD-upri-payload"u8.ToArray(); // does not start with the "uno" magic
 		var resources = new BlobBuilder();
-		resources.WriteInt32(payload.Length);
-		resources.WriteBytes(payload);
+		resources.WriteInt32(upriPayload.Length);
+		resources.WriteBytes(upriPayload);
 
 		metadata.AddManifestResource(
 			ManifestResourceAttributes.Public,
-			metadata.GetOrAddString("Malformed.upri"),
+			metadata.GetOrAddString("Embedded.upri"),
 			implementation: default,
 			offset: 0);
 

--- a/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
@@ -457,6 +457,83 @@ public class Given_ResourceLoader_Alc
 		}
 	}
 
+	[TestMethod]
+	[Description(
+		"A .upri truncated BEFORE its declared resource count must surface the same documented " +
+		"InvalidDataException naming the file as one truncated mid pair — the count read must not sit " +
+		"outside the normalizing catch, or one truncation point leaks BinaryReader's context-free " +
+		"EndOfStreamException while every other one is named.")]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23959")]
+	public void When_AddLookupAssembly_Upri_Truncated_Before_ResourceCount_Then_Throws_InvalidDataException()
+	{
+		const string defaultLanguage = "en";
+		const string truncatedLoaderName = "Uno.UI.Tests.CountTruncatedUpri/Resources";
+
+		var previousCulture = CultureInfo.CurrentUICulture;
+		var previousPlo = ApplicationLanguages.PrimaryLanguageOverride;
+		var previousDefault = _ResourceLoader.DefaultLanguage;
+
+		var collectibleAlc = new AssemblyLoadContext("Given_ResourceLoader_Alc.countTruncated", isCollectible: true);
+		try
+		{
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			ApplicationLanguages.PrimaryLanguageOverride = defaultLanguage;
+			_ResourceLoader.DefaultLanguage = defaultLanguage;
+
+			var truncated = LoadAssemblyWithUpri(
+				collectibleAlc,
+				"Uno.UI.Tests.CountTruncatedUpri",
+				BuildCountTruncatedUpriPayload(truncatedLoaderName, defaultLanguage));
+
+			var error = Assert.ThrowsExactly<InvalidDataException>(
+				() => _ResourceLoader.AddLookupAssembly(truncated),
+				"A .upri whose stream ends before its resource count is just as malformed as one ending mid pair, so it must surface as InvalidDataException too — not as the raw EndOfStreamException.");
+
+			Assert.IsTrue(
+				error.Message.Contains(truncatedLoaderName.Split('/')[0], StringComparison.Ordinal)
+					|| error.Message.Contains("resource count", StringComparison.Ordinal),
+				$"The message must identify the truncated file rather than being context-free (got '{error.Message}').");
+			Assert.IsInstanceOfType<EndOfStreamException>(
+				error.InnerException,
+				"The original EndOfStreamException must be preserved as the inner exception.");
+
+			Assert.IsFalse(
+				_ResourceLoader.ContainsLookupAssembly(truncated),
+				"A failed registration must be rolled back.");
+			Assert.IsFalse(
+				_ResourceLoader.ContainsNamedLoader(truncatedLoaderName),
+				"The failed parse must not create the truncated .upri's loader.");
+		}
+		finally
+		{
+			_ResourceLoader.ClearNonDefaultAlcAssemblies();
+			collectibleAlc.Unload();
+			CultureInfo.CurrentUICulture = previousCulture;
+			ApplicationLanguages.PrimaryLanguageOverride = previousPlo;
+			_ResourceLoader.DefaultLanguage = previousDefault;
+		}
+	}
+
+	/// <summary>
+	/// Builds a <c>.upri</c> payload with a valid header that truncates BEFORE its resource count,
+	/// so the failure lands on the <see cref="BinaryReader.ReadInt32"/> that reads the count rather
+	/// than on a pair.
+	/// </summary>
+	private static byte[] BuildCountTruncatedUpriPayload(string loaderName, string culture)
+	{
+		using var payload = new MemoryStream();
+		using (var writer = new BinaryWriter(payload, Encoding.UTF8, leaveOpen: true))
+		{
+			writer.Write("uno"u8); // magic
+			writer.Write(3); // version
+			writer.Write(loaderName);
+			writer.Write(culture);
+			// ...and the stream ends before the resource count.
+		}
+
+		return payload.ToArray();
+	}
+
 	/// <summary>
 	/// Builds a <c>.upri</c> payload with a valid header (magic, version 3, loader name, culture)
 	/// that declares TWO key/value pairs, carries one complete pair, then truncates — matching

--- a/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
@@ -321,15 +321,19 @@ public class Given_ResourceLoader_Alc
 	}
 
 	[TestMethod]
+	[Description(
+		"A .upri truncated mid key/value pair, registered while the loader context is unchanged (the " +
+		"full-reload branch), must leave no registration, no parsed marker and no partially merged " +
+		"value observable — not even the loader instance the failed parse would have created.")]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23959")]
 	public void When_AddLookupAssembly_Truncated_Upri_Then_Throws_And_Partial_Value_Not_Observable()
 	{
 		// Issue scenario: a .upri with a VALID header that declares two key/value pairs, carries one
 		// complete pair, then truncates before the second. ProcessResourceFile used to merge each
-		// pair directly into the live loader as it read, so BinaryReader.ReadString throwing
-		// EndOfStreamException on the second pair left the FIRST pair's value observable even after
-		// the AddLookupAssembly rollback removed the registration and its parsed markers — an
-		// unregistered assembly's partially parsed resource value survived. A failed
-		// AddLookupAssembly must be fully transactional: no registration, marker, or value remains.
+		// pair directly into the live loader as it read, so failing on the second pair left the FIRST
+		// pair's value observable even after the AddLookupAssembly rollback removed the registration
+		// and its parsed markers — an unregistered assembly's partially parsed resource value
+		// survived. A failed AddLookupAssembly must be fully transactional.
 		const string defaultLanguage = "en";
 		const string uiTestResources = "Uno.UI.UnitTests/Resources";
 		const string truncatedLoaderName = "Uno.UI.Tests.TruncatedUpri/Resources";
@@ -361,13 +365,16 @@ public class Given_ResourceLoader_Alc
 				"Uno.UI.Tests.TruncatedUpri",
 				BuildTruncatedUpriPayload(truncatedLoaderName, defaultLanguage));
 
-			Assert.ThrowsExactly<EndOfStreamException>(
+			Assert.ThrowsExactly<InvalidDataException>(
 				() => _ResourceLoader.AddLookupAssembly(truncated),
-				"A .upri truncated in the middle of its declared pairs must surface BinaryReader's EndOfStreamException.");
+				"A .upri truncated in the middle of its declared pairs must surface as InvalidDataException naming the file — the contract ProcessResourceFile documents for malformed content.");
 
 			Assert.IsFalse(
 				_ResourceLoader.ContainsLookupAssembly(truncated),
 				"A failed registration must be rolled back.");
+			Assert.IsFalse(
+				_ResourceLoader.ContainsNamedLoader(truncatedLoaderName),
+				"The failed parse must not even create the truncated .upri's loader — a created loader proves the parse wrote into the live state. Checked before GetForCurrentView below, which creates it on purpose.");
 			Assert.AreEqual(
 				string.Empty,
 				_ResourceLoader.GetForCurrentView(truncatedLoaderName).GetString("TruncatedKey"),
@@ -388,6 +395,11 @@ public class Given_ResourceLoader_Alc
 	}
 
 	[TestMethod]
+	[Description(
+		"The same truncated .upri through AddLookupAssembly's OTHER branch — a changed loader context, " +
+		"where only the new assembly is parsed — must leave the live loaders completely untouched: no " +
+		"loader instance created and no value merged, pinning the single-assembly transactional parse.")]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23959")]
 	public void When_AddLookupAssembly_Truncated_Upri_With_Changed_Context_Then_Live_Loaders_Untouched()
 	{
 		// Same truncated .upri as above, but through AddLookupAssembly's OTHER branch: when the
@@ -421,15 +433,18 @@ public class Given_ResourceLoader_Alc
 				"Uno.UI.Tests.TruncatedUpriChangedContext",
 				BuildTruncatedUpriPayload(truncatedLoaderName, "en"));
 
-			Assert.ThrowsExactly<EndOfStreamException>(
+			Assert.ThrowsExactly<InvalidDataException>(
 				() => _ResourceLoader.AddLookupAssembly(truncated),
-				"A .upri truncated in the middle of its declared pairs must surface BinaryReader's EndOfStreamException.");
+				"A .upri truncated in the middle of its declared pairs must surface as InvalidDataException naming the file — the contract ProcessResourceFile documents for malformed content.");
 
 			Assert.IsFalse(
 				_ResourceLoader.ContainsLookupAssembly(truncated),
 				"A failed registration must be rolled back.");
 			Assert.IsFalse(
-				TryGetMergedResource(truncatedLoaderName, "en", "TruncatedKey", out var leaked),
+				_ResourceLoader.ContainsNamedLoader(truncatedLoaderName),
+				"The failed single-assembly parse must not even CREATE the truncated .upri's loader. Absence (not just emptiness) is what pins this branch: were branch selection to regress to the full reload, its rebuild recovery would empty the loader but the instance would still exist.");
+			Assert.IsFalse(
+				_ResourceLoader.TryGetMergedResourceForTests(truncatedLoaderName, "en", "TruncatedKey", out var leaked),
 				$"The failed single-assembly parse must not leave any value in the live loaders (found '{leaked}').");
 		}
 		finally
@@ -464,30 +479,6 @@ public class Given_ResourceLoader_Alc
 		}
 
 		return payload.ToArray();
-	}
-
-	/// <summary>
-	/// Reads a merged resource value at the private per-loader dictionary seam
-	/// (<c>ResourceLoader._resources[culture][key]</c>) WITHOUT going through
-	/// <c>GetString</c> — which re-establishes the loader context (reloading, and thereby wiping,
-	/// the loaders when the culture changed) and would mask a leaked value.
-	/// </summary>
-	private static bool TryGetMergedResource(string loaderName, string culture, string key, out string? value)
-	{
-		value = null;
-
-		var loadersField = typeof(_ResourceLoader).GetField("_loaders", BindingFlags.Static | BindingFlags.NonPublic)
-			?? throw new InvalidOperationException("ResourceLoader._loaders field was not found.");
-		var loaders = (Dictionary<string, _ResourceLoader>)loadersField.GetValue(null)!;
-		if (!loaders.TryGetValue(loaderName, out var loader))
-		{
-			return false;
-		}
-
-		var resourcesField = typeof(_ResourceLoader).GetField("_resources", BindingFlags.Instance | BindingFlags.NonPublic)
-			?? throw new InvalidOperationException("ResourceLoader._resources field was not found.");
-		var resources = (Dictionary<string, Dictionary<string, string>>)resourcesField.GetValue(loader)!;
-		return resources.TryGetValue(culture, out var map) && map.TryGetValue(key, out value);
 	}
 
 	/// <summary>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader_Alc.cs
@@ -293,6 +293,101 @@ public class Given_ResourceLoader_Alc
 	}
 
 	[TestMethod]
+	[Description(
+		"A SURVIVOR whose .upri truncates mid key/value pair must contribute NOTHING to the rebuild: " +
+		"the marker and the pairs it had already read must roll back with it, so the rebuild never " +
+		"publishes a value from a survivor it decided to skip.")]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23959")]
+	public void When_ClearAlcAssemblies_With_Truncated_Survivor_Then_Partial_Value_Not_Published()
+	{
+		// Reviewer scenario: the rebuild's per-assembly guard used to share ONE TransactionalParse
+		// across the whole survivor loop, so a survivor whose .upri declares two pairs, carries one,
+		// then truncates had already added its marker and its first pair to that shared temporary
+		// when it threw. The guard caught, the loop continued, and ReplaceLiveLoaders published the
+		// REJECTED survivor's partial state. The bad-magic survivor test above cannot catch this:
+		// bad magic throws before anything enters the temporaries. Each survivor must therefore
+		// parse into its OWN scratch, folded into the aggregate only once it parsed completely.
+		const string defaultLanguage = "en";
+		const string uiTestResources = "Uno.UI.UnitTests/Resources";
+		const string truncatedLoaderName = "Uno.UI.Tests.TruncatedUpriSurvivor/Resources";
+		const string overrideValue = "Collectible-Override-TruncatedSurvivor";
+		const string hostValue = "App70-en";
+
+		var previousCulture = CultureInfo.CurrentUICulture;
+		var previousPlo = ApplicationLanguages.PrimaryLanguageOverride;
+		var previousDefault = _ResourceLoader.DefaultLanguage;
+
+		var defaultAlcAssembly = typeof(Given_ResourceLoader_Alc).Assembly;
+		var survivorAlc = new AssemblyLoadContext("Given_ResourceLoader_Alc.truncatedSurvivor", isCollectible: true);
+		var dyingAlc = new AssemblyLoadContext("Given_ResourceLoader_Alc.dyingWithTruncatedSurvivor", isCollectible: true);
+		try
+		{
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			ApplicationLanguages.PrimaryLanguageOverride = defaultLanguage;
+			_ResourceLoader.DefaultLanguage = defaultLanguage;
+
+			_ResourceLoader.AddLookupAssembly(defaultAlcAssembly);
+			Assert.AreEqual(
+				hostValue,
+				_ResourceLoader.GetForCurrentView(uiTestResources).GetString("ApplicationName"),
+				"Pre-condition: the host resource resolves before the collectible override.");
+
+			// A dying collectible app that overrides a host key (same seam as the tests above).
+			var dyingAssembly = dyingAlc.LoadFromAssemblyPath(defaultAlcAssembly.Location);
+			_ResourceLoader.AddLookupAssembly(dyingAssembly);
+			OverrideMergedResource(uiTestResources, defaultLanguage, "ApplicationName", overrideValue);
+			Assert.AreEqual(
+				overrideValue,
+				_ResourceLoader.GetForCurrentView(uiTestResources).GetString("ApplicationName"),
+				"Pre-condition: the collectible override must win while its assembly is registered.");
+
+			// A surviving lookup assembly whose .upri parses one complete pair and THEN truncates.
+			// The AddLookupAssembly rollback keeps a malformed assembly from lingering through the
+			// public path, so inject it at the private list seam — the rebuild guard is what covers
+			// survivors whose .upri only fails at rebuild time.
+			var truncatedSurvivor = LoadAssemblyWithUpri(
+				survivorAlc,
+				"Uno.UI.Tests.TruncatedUpriSurvivor",
+				BuildTruncatedUpriPayload(truncatedLoaderName, defaultLanguage));
+			InjectLookupAssembly(truncatedSurvivor);
+
+			// Tear the dying app down: this drives RebuildLoaderResourcesFromSurvivors across the
+			// truncated survivor. It must not throw...
+			_ResourceLoader.ClearAlcAssemblies(dyingAlc);
+
+			// ...and it must publish nothing of that survivor's. Read at the merged-dictionary seam
+			// before any GetString, which could reload and mask a leaked value.
+			Assert.IsFalse(
+				_ResourceLoader.TryGetMergedResourceForTests(truncatedLoaderName, defaultLanguage, "TruncatedKey", out var leaked),
+				$"The pair read before the truncation must roll back with the rest of the skipped survivor's scratch, not reach the live loaders (found '{leaked}').");
+			Assert.IsFalse(
+				_ResourceLoader.ContainsNamedLoader(truncatedLoaderName),
+				"The skipped survivor must not even materialize its loader: an instance proves its partial state reached the aggregate and was applied.");
+
+			// The counterpart guard: discarding the skipped survivor must not cost the GOOD survivors
+			// their contributions, so the rebuild must still have reached its apply phase and
+			// republished the host value in place of the dying app's override.
+			Assert.IsTrue(
+				_ResourceLoader.TryGetMergedResourceForTests(uiTestResources, defaultLanguage, "ApplicationName", out var republished),
+				"A good survivor's values MUST be published by the rebuild — a fix that discarded too much would otherwise pass.");
+			Assert.AreEqual(
+				hostValue,
+				republished,
+				"After the dying ALC is swept the key must hold the host value again: its override must not outlive its ALC.");
+		}
+		finally
+		{
+			// Drop the injected truncated survivor and any leftover non-default registrations.
+			_ResourceLoader.ClearNonDefaultAlcAssemblies();
+			survivorAlc.Unload();
+			dyingAlc.Unload();
+			CultureInfo.CurrentUICulture = previousCulture;
+			ApplicationLanguages.PrimaryLanguageOverride = previousPlo;
+			_ResourceLoader.DefaultLanguage = previousDefault;
+		}
+	}
+
+	[TestMethod]
 	public void When_AddLookupAssembly_Malformed_Then_Throws_And_Registration_Rolled_Back()
 	{
 		// AddLookupAssembly registers the assembly BEFORE parsing; without a rollback a malformed

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
@@ -74,113 +74,59 @@ partial class ResourceLoader
 	{
 		_lookupAssemblies.Add(assembly);
 
-		// Tracks whether the parse below merged directly into the LIVE loaders (the reload path
-		// processes every lookup assembly straight into them), so the rollback knows whether the
-		// merged state must be re-derived from the surviving registrations.
-		var liveLoadersTouched = false;
+		// Diagnostics only, never drives the rollback: the reload branch re-parses EVERY registered
+		// assembly, so a failure there can come from a pre-existing registration's .upri.
+		var reloadedEverything = false;
 
 		try
 		{
 			if (HasContextChangedSignificantly(out var context))
 			{
-				// The cache is still valid, we only have to load resources from the given assembly.
-				// Parse into temporaries and merge only on success, so a malformed .upri (e.g. a
-				// stream truncated in the middle of a key/value pair) can never leave a partially
-				// parsed value or marker in the live state.
+				// The context moved on since the cache was established: parse only this assembly for
+				// the new preferences, the first later resolve reloads the rest.
 				ProcessAssemblyTransactionally(assembly, context.LanguagePreferences);
 			}
 			else
 			{
-				// The current culture was altered, rebuild the whole/missing cache
-				liveLoadersTouched = true;
+				// The cache matches the current context, so rebuilding it as a whole is what merges
+				// the new assembly in.
+				reloadedEverything = true;
 				ReloadResources(context);
 			}
 		}
-		catch (Exception)
+		catch (Exception error)
 		{
 			// A failed registration must not linger: the list is re-enumerated by every later
 			// rebuild (culture change, ALC sweep), so a malformed assembly left registered would
-			// re-hit the same parse failure forever. Roll back the just-added entry before
-			// rethrowing to the caller.
+			// re-hit the same parse failure forever. Both branches parse into temporaries and apply
+			// only on success, so dropping the list entry is the whole rollback.
 			var lastIndex = _lookupAssemblies.LastIndexOf(assembly);
 			if (lastIndex >= 0)
 			{
 				_lookupAssemblies.RemoveAt(lastIndex);
 			}
 
-			if (liveLoadersTouched)
+			if (_log.IsEnabled(LogLevel.Error))
 			{
-				// The reload merged each assembly's pairs (and parsed markers) straight into the
-				// live state as it read, so the failed assembly may have left partially parsed
-				// values behind. Re-derive the merged values and the markers from the surviving
-				// registrations — the same recovery the ALC sweep uses — so nothing contributed by
-				// the failed attempt remains observable.
-				RebuildLoaderResourcesFromSurvivors();
+				_log.LogError($"AddLookupAssembly failed for '{assembly.FullName}' (whole cache reloaded: {reloadedEverything}); registration rolled back, live resources unchanged.", error);
 			}
 
 			throw;
 		}
 	}
 
-	private static void ProcessAssembly(Assembly assembly, string[] languagePreferences)
-		=> ProcessAssembly(assembly, languagePreferences, GetOrCreateNamedLoaderResources, _parsedResources);
-
 	/// <summary>
-	/// Parses <paramref name="assembly"/>'s .upri resources into TEMPORARY structures and merges
-	/// them into the live loaders only once every file parsed successfully — the same
-	/// temp-then-apply pattern as <see cref="RebuildLoaderResourcesFromSurvivors"/>. A malformed
-	/// .upri therefore throws without any partially parsed value or marker becoming observable.
+	/// Parses <paramref name="assembly"/>'s .upri resources and merges them into the live loaders
+	/// only once every file parsed successfully.
 	/// </summary>
 	private static void ProcessAssemblyTransactionally(Assembly assembly, string[] languagePreferences)
 	{
-		var parsedResources = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>(StringComparer.OrdinalIgnoreCase);
+		// Seeded with this assembly's already-parsed files so they are skipped exactly as a parse
+		// against the live markers would skip them.
+		var parse = new TransactionalParse(_parsedResources.Where(marker => marker.Assembly == assembly));
 
-		// Seed the temporary marker set with the assembly's already-parsed files so they are
-		// skipped exactly as a parse against the live markers would skip them.
-		var parsedMarkers = new HashSet<(Assembly Assembly, string ResourceName)>();
-		foreach (var marker in _parsedResources)
-		{
-			if (marker.Assembly == assembly)
-			{
-				parsedMarkers.Add(marker);
-			}
-		}
-
-		Dictionary<string, Dictionary<string, string>> ResolveParsedLoader(string name)
-		{
-			if (!parsedResources.TryGetValue(name, out var cultures))
-			{
-				parsedResources[name] = cultures = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
-			}
-
-			return cultures;
-		}
-
-		ProcessAssembly(assembly, languagePreferences, ResolveParsedLoader, parsedMarkers);
-
-		// Apply phase: parsing succeeded, merge into the live loaders with the same
-		// last-writer-wins semantics ProcessResourceFile uses when writing to them directly.
-		foreach (var parsed in parsedResources)
-		{
-			var loaderResources = GetOrCreateNamedLoaderResources(parsed.Key);
-			foreach (var culture in parsed.Value)
-			{
-				if (!loaderResources.TryGetValue(culture.Key, out var resources))
-				{
-					loaderResources[culture.Key] = resources = new Dictionary<string, string>();
-				}
-
-				foreach (var pair in culture.Value)
-				{
-					resources[pair.Key] = pair.Value;
-				}
-			}
-		}
-
-		foreach (var marker in parsedMarkers)
-		{
-			_parsedResources.Add(marker);
-		}
+		parse.Parse(assembly, languagePreferences);
+		parse.MergeIntoLiveLoaders();
 	}
 
 	private static void ProcessAssembly(
@@ -201,27 +147,138 @@ partial class ResourceLoader
 
 	private static void ReloadResources(LoaderContext context)
 	{
-		if (!WinRTFeatureConfiguration.ResourceLoader.PreserveParsedResources)
-		{
-			ClearResources();
-			_parsedResources.Clear();
-		}
+		var preserveParsedResources = WinRTFeatureConfiguration.ResourceLoader.PreserveParsedResources;
 
+		// Preserving keeps what earlier language preferences already contributed, so the live markers
+		// are carried over and the newly parsed values are merged on top rather than replacing them.
+		var parse = preserveParsedResources ? new TransactionalParse(_parsedResources) : new TransactionalParse();
 		foreach (var assembly in _lookupAssemblies)
 		{
-			ProcessAssembly(assembly, context.LanguagePreferences);
+			parse.Parse(assembly, context.LanguagePreferences);
+		}
+
+		if (preserveParsedResources)
+		{
+			parse.MergeIntoLiveLoaders();
+		}
+		else
+		{
+			parse.ReplaceLiveLoaders();
 		}
 
 		_loaderContext = context;
 	}
 
-	private static void ClearResources()
+	/// <summary>
+	/// Accumulates .upri parse results into TEMPORARY structures so the live loaders are mutated only
+	/// once every file has parsed successfully. Every path that mutates the live state
+	/// (<see cref="AddLookupAssembly"/>, <see cref="ReloadResources"/> — hence the culture-change
+	/// path through <see cref="EnsureLoadersCultures"/> — and
+	/// <see cref="RebuildLoaderResourcesFromSurvivors"/>) goes through this, so a malformed .upri
+	/// (e.g. a stream truncated in the middle of a key/value pair) throws without leaving a partially
+	/// parsed value or marker observable.
+	/// </summary>
+	private sealed class TransactionalParse
 	{
-		// We clear each loader independently instead of clearing the '_loaders'
-		// so if a loader instance has been captured, it will be updated
-		foreach (var loader in _loaders.Values)
+		private readonly Dictionary<string, Dictionary<string, Dictionary<string, string>>> _loaderResources = new(StringComparer.OrdinalIgnoreCase);
+		private readonly HashSet<(Assembly Assembly, string ResourceName)> _markers;
+
+		public TransactionalParse()
+			: this(Array.Empty<(Assembly Assembly, string ResourceName)>())
 		{
-			loader._resources.Clear();
+		}
+
+		/// <param name="alreadyParsed">
+		/// Files to seed the marker set with, so they are skipped exactly as a parse against the live
+		/// <see cref="_parsedResources"/> would skip them.
+		/// </param>
+		public TransactionalParse(IEnumerable<(Assembly Assembly, string ResourceName)> alreadyParsed)
+			=> _markers = new HashSet<(Assembly Assembly, string ResourceName)>(alreadyParsed);
+
+		/// <summary>
+		/// Parses <paramref name="assembly"/>'s .upri files into the temporaries; throws (leaving the
+		/// live state untouched) when one of them is malformed.
+		/// </summary>
+		public void Parse(Assembly assembly, string[] languagePreferences)
+			=> ProcessAssembly(assembly, languagePreferences, ResolveLoaderResources, _markers);
+
+		/// <summary>
+		/// Merges the parsed state into the live loaders with the same last-writer-wins semantics
+		/// <see cref="ProcessResourceFile"/> uses when writing to them directly, and records the
+		/// parsed markers.
+		/// </summary>
+		public void MergeIntoLiveLoaders()
+		{
+			foreach (var parsed in _loaderResources)
+			{
+				var liveResources = GetOrCreateNamedLoaderResources(parsed.Key);
+				foreach (var culture in parsed.Value)
+				{
+					if (liveResources.TryGetValue(culture.Key, out var resources))
+					{
+						foreach (var pair in culture.Value)
+						{
+							resources[pair.Key] = pair.Value;
+						}
+					}
+					else
+					{
+						// Nothing live to merge with: hand the temporary over instead of copying it.
+						liveResources[culture.Key] = culture.Value;
+					}
+				}
+			}
+
+			foreach (var marker in _markers)
+			{
+				_parsedResources.Add(marker);
+			}
+		}
+
+		/// <summary>
+		/// Makes the parsed state the loaders' entire content and replaces the live markers with the
+		/// parsed ones. Each live loader is cleared in place (instead of clearing
+		/// <see cref="_loaders"/>) so already-captured <see cref="ResourceLoader"/> instances see the
+		/// update; loader names with no live instance yet are materialized.
+		/// </summary>
+		public void ReplaceLiveLoaders()
+		{
+			foreach (var loader in _loaders.Values)
+			{
+				loader._resources.Clear();
+				if (_loaderResources.TryGetValue(loader.LoaderName, out var cultures))
+				{
+					foreach (var culture in cultures)
+					{
+						loader._resources[culture.Key] = culture.Value;
+					}
+				}
+			}
+
+			foreach (var parsed in _loaderResources.Where(parsed => !_loaders.ContainsKey(parsed.Key)))
+			{
+				var liveResources = GetOrCreateNamedLoaderResources(parsed.Key);
+				foreach (var culture in parsed.Value)
+				{
+					liveResources[culture.Key] = culture.Value;
+				}
+			}
+
+			_parsedResources.Clear();
+			foreach (var marker in _markers)
+			{
+				_parsedResources.Add(marker);
+			}
+		}
+
+		private Dictionary<string, Dictionary<string, string>> ResolveLoaderResources(string name)
+		{
+			if (!_loaderResources.TryGetValue(name, out var cultures))
+			{
+				_loaderResources[name] = cultures = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+			}
+
+			return cultures;
 		}
 	}
 
@@ -292,11 +349,18 @@ partial class ResourceLoader
 
 	/// <summary>
 	/// Re-derives every named loader's merged culture/key/value entries from the surviving
-	/// <see cref="_lookupAssemblies"/> (called after a dying ALC's assemblies have been removed).
-	/// Parses into TEMPORARY dictionaries first and only copies the result into the live loaders
-	/// once every survivor has been processed, wrapping each assembly in try/catch, so a single
-	/// malformed .upri (logged and skipped) can never leave a live loader empty.
+	/// <see cref="_lookupAssemblies"/> (called after a dying ALC's assemblies have been removed),
+	/// through the <see cref="TransactionalParse"/> temp-then-apply pattern with a per-assembly guard
+	/// so a single malformed .upri is logged and skipped instead of leaving a live loader empty.
 	/// </summary>
+	/// <remarks>
+	/// The re-derivation only covers the last established context's language preferences, so with
+	/// <see cref="WinRTFeatureConfiguration.ResourceLoader.PreserveParsedResources"/> enabled, values
+	/// preserved for OTHER cultures by earlier language changes are dropped here; they are re-parsed
+	/// the next time those languages become active. Attributing a merged value back to a single
+	/// assembly is impossible (see <see cref="ClearAlcAssembliesCore"/>), so re-deriving from the
+	/// survivors is the only way to stop a dying ALC's override outliving it.
+	/// </remarks>
 	private static void RebuildLoaderResourcesFromSurvivors()
 	{
 		// The loaders were merged for the last established context's language preferences. Reuse
@@ -309,35 +373,22 @@ partial class ResourceLoader
 			languagePreferences = context.LanguagePreferences;
 		}
 
-		var rebuiltResources = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>(StringComparer.OrdinalIgnoreCase);
-		var rebuiltMarkers = new HashSet<(Assembly Assembly, string ResourceName)>();
-
-		Dictionary<string, Dictionary<string, string>> ResolveRebuiltLoader(string name)
-		{
-			if (!rebuiltResources.TryGetValue(name, out var cultures))
-			{
-				rebuiltResources[name] = cultures = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
-			}
-
-			return cultures;
-		}
-
-		// Parse only into the temporaries here — the phase that can throw (malformed .upri) must not
-		// touch the live loaders. A per-assembly guard keeps one bad file from aborting the rebuild.
+		// Started from an empty marker set: the rebuilt state replaces the live one wholesale.
+		var parse = new TransactionalParse();
 		foreach (var assembly in _lookupAssemblies)
 		{
 			try
 			{
-				ProcessAssembly(assembly, languagePreferences, ResolveRebuiltLoader, rebuiltMarkers);
+				parse.Parse(assembly, languagePreferences);
 			}
 			catch (Exception error) when (error is global::System.IO.InvalidDataException or global::System.IO.IOException or NotSupportedException or BadImageFormatException or global::System.IO.FileLoadException or ArgumentException or FormatException)
 			{
 				// Recoverable per-assembly parse/reflection failure: skip this survivor and keep
 				// rebuilding. ProcessResourceFile surfaces malformed .upri content (bad magic,
-				// unsupported version, unreadable stream) as InvalidDataException, so every parser
-				// failure is covered here. Fatal exceptions are intentionally not caught; the live
-				// loaders are untouched until the apply phase
-				// below, so an escaping exception here cannot leave a loader empty.
+				// unsupported version, truncated/unreadable stream) as InvalidDataException, so every
+				// parser failure is covered here. Fatal exceptions are intentionally not caught: the
+				// live loaders are untouched until the apply phase, so an escaping exception here
+				// cannot leave a loader empty.
 				if (_log.IsEnabled(LogLevel.Error))
 				{
 					_log.LogError($"[ALC-CLEANUP] ResourceLoader: skipping lookup assembly '{assembly.FullName}' while rebuilding merged resources after ALC unload.", error);
@@ -345,39 +396,7 @@ partial class ResourceLoader
 			}
 		}
 
-		// Apply the rebuilt state to the live loaders in place. Copying into the existing _resources
-		// dictionaries (rather than swapping the readonly field) preserves the shared references that
-		// captured ResourceLoader instances rely on. Parsing already succeeded into the temporaries,
-		// so this phase only mutates dictionaries and cannot throw partway and leave a loader empty.
-		foreach (var loader in _loaders.Values)
-		{
-			loader._resources.Clear();
-			if (rebuiltResources.TryGetValue(loader.LoaderName, out var cultures))
-			{
-				foreach (var culture in cultures)
-				{
-					loader._resources[culture.Key] = culture.Value;
-				}
-			}
-		}
-
-		// A survivor may contribute a loader name with no live instance yet; materialize it.
-		foreach (var rebuilt in rebuiltResources.Where(rebuilt => !_loaders.ContainsKey(rebuilt.Key)))
-		{
-			var loaderResources = GetOrCreateNamedResourceLoader(rebuilt.Key)._resources;
-			foreach (var culture in rebuilt.Value)
-			{
-				loaderResources[culture.Key] = culture.Value;
-			}
-		}
-
-		// Replace the parsed markers with the survivor-derived set so a later AddLookupAssembly of
-		// the same logical app re-parses correctly.
-		_parsedResources.Clear();
-		foreach (var marker in rebuiltMarkers)
-		{
-			_parsedResources.Add(marker);
-		}
+		parse.ReplaceLiveLoaders();
 	}
 
 	private static bool IsFromNonDefaultAlc(Assembly assembly)
@@ -392,6 +411,27 @@ partial class ResourceLoader
 	/// <see cref="_lookupAssemblies"/> field.
 	/// </summary>
 	internal static bool ContainsLookupAssembly(Assembly assembly) => _lookupAssemblies.Contains(assembly);
+
+	/// <summary>
+	/// Test seam: whether a loader instance exists for <paramref name="loaderName"/>, so a test can
+	/// tell "no loader was ever created" from "a loader exists but holds no value" — the difference
+	/// between a parse that never touched the live state and one that did and was cleaned up after.
+	/// </summary>
+	internal static bool ContainsNamedLoader(string loaderName) => _loaders.ContainsKey(loaderName);
+
+	/// <summary>
+	/// Test seam: reads a merged value straight from the per-loader dictionaries, without going
+	/// through <c>GetString</c> — which re-establishes the loader context and therefore reloads (and
+	/// wipes) the loaders when the culture changed, masking a value leaked by a failed parse.
+	/// </summary>
+	internal static bool TryGetMergedResourceForTests(string loaderName, string culture, string key, out string? value)
+	{
+		value = null;
+
+		return _loaders.TryGetValue(loaderName, out var loader)
+			&& loader._resources.TryGetValue(culture, out var resources)
+			&& resources.TryGetValue(key, out value);
+	}
 
 	private static bool HasContextChangedSignificantly(out LoaderContext context)
 	{
@@ -495,34 +535,44 @@ partial class ResourceLoader
 
 			var resourceCount = reader.ReadInt32();
 			StringBuilder sb = new();
-			for (var i = 0; i < resourceCount; i++)
+			try
 			{
-				var key = reader.ReadString();
-				var value = reader.ReadString();
-
-				if (version == 2)
+				for (var i = 0; i < resourceCount; i++)
 				{
-					// Restore the original format
-					key = key.Replace("/", ".");
+					var key = reader.ReadString();
+					var value = reader.ReadString();
 
-					var firstDotIndex = key.IndexOf('.');
-					if (firstDotIndex != -1)
+					if (version == 2)
 					{
-						sb.Clear();
-						sb.Append(key);
+						// Restore the original format
+						key = key.Replace("/", ".");
 
-						sb[firstDotIndex] = '/';
+						var firstDotIndex = key.IndexOf('.');
+						if (firstDotIndex != -1)
+						{
+							sb.Clear();
+							sb.Append(key);
 
-						key = sb.ToString();
+							sb[firstDotIndex] = '/';
+
+							key = sb.ToString();
+						}
 					}
-				}
 
-				if (_log.IsEnabled(LogLevel.Debug))
-				{
-					_log.LogDebug($"[{name}, {culture}, {fileName}] Adding resource: {key}={value}");
-				}
+					if (_log.IsEnabled(LogLevel.Debug))
+					{
+						_log.LogDebug($"[{name}, {culture}, {fileName}] Adding resource: {key}={value}");
+					}
 
-				resources[key] = value;
+					resources[key] = value;
+				}
+			}
+			catch (EndOfStreamException error)
+			{
+				// A stream that ends mid pair surfaces as BinaryReader's context-free
+				// EndOfStreamException; restate it as the documented InvalidDataException naming the
+				// file, like every other malformed-.upri case.
+				throw new InvalidDataException($"Truncated resource file {fileName}: it declares {resourceCount} resource(s) but the stream ended early.", error);
 			}
 		}
 	}

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
@@ -533,10 +533,13 @@ partial class ResourceLoader
 				loaderResources[culture] = resources = new Dictionary<string, string>();
 			}
 
-			var resourceCount = reader.ReadInt32();
 			StringBuilder sb = new();
+			int? declaredCount = null;
 			try
 			{
+				var resourceCount = reader.ReadInt32();
+				declaredCount = resourceCount;
+
 				for (var i = 0; i < resourceCount; i++)
 				{
 					var key = reader.ReadString();
@@ -569,10 +572,15 @@ partial class ResourceLoader
 			}
 			catch (EndOfStreamException error)
 			{
-				// A stream that ends mid pair surfaces as BinaryReader's context-free
-				// EndOfStreamException; restate it as the documented InvalidDataException naming the
-				// file, like every other malformed-.upri case.
-				throw new InvalidDataException($"Truncated resource file {fileName}: it declares {resourceCount} resource(s) but the stream ended early.", error);
+				// A stream that ends anywhere in the entry list — mid pair, or inside the declared
+				// count itself — surfaces as BinaryReader's context-free EndOfStreamException;
+				// restate it as the documented InvalidDataException naming the file, like every
+				// other malformed-.upri case.
+				throw new InvalidDataException(
+					declaredCount is { } count
+						? $"Truncated resource file {fileName}: it declares {count} resource(s) but the stream ended early."
+						: $"Truncated resource file {fileName}: the stream ended before its resource count could be read.",
+					error);
 			}
 		}
 	}

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
@@ -74,16 +74,25 @@ partial class ResourceLoader
 	{
 		_lookupAssemblies.Add(assembly);
 
+		// Tracks whether the parse below merged directly into the LIVE loaders (the reload path
+		// processes every lookup assembly straight into them), so the rollback knows whether the
+		// merged state must be re-derived from the surviving registrations.
+		var liveLoadersTouched = false;
+
 		try
 		{
 			if (HasContextChangedSignificantly(out var context))
 			{
-				// The cache is still valid, we only have to load resources from the given assembly
-				ProcessAssembly(assembly, context.LanguagePreferences);
+				// The cache is still valid, we only have to load resources from the given assembly.
+				// Parse into temporaries and merge only on success, so a malformed .upri (e.g. a
+				// stream truncated in the middle of a key/value pair) can never leave a partially
+				// parsed value or marker in the live state.
+				ProcessAssemblyTransactionally(assembly, context.LanguagePreferences);
 			}
 			else
 			{
 				// The current culture was altered, rebuild the whole/missing cache
+				liveLoadersTouched = true;
 				ReloadResources(context);
 			}
 		}
@@ -91,17 +100,22 @@ partial class ResourceLoader
 		{
 			// A failed registration must not linger: the list is re-enumerated by every later
 			// rebuild (culture change, ALC sweep), so a malformed assembly left registered would
-			// re-hit the same parse failure forever. Roll back the just-added entry (and any
-			// parsed markers it contributed) before rethrowing to the caller.
+			// re-hit the same parse failure forever. Roll back the just-added entry before
+			// rethrowing to the caller.
 			var lastIndex = _lookupAssemblies.LastIndexOf(assembly);
 			if (lastIndex >= 0)
 			{
 				_lookupAssemblies.RemoveAt(lastIndex);
 			}
 
-			if (!_lookupAssemblies.Contains(assembly))
+			if (liveLoadersTouched)
 			{
-				_parsedResources.RemoveWhere(marker => marker.Assembly == assembly);
+				// The reload merged each assembly's pairs (and parsed markers) straight into the
+				// live state as it read, so the failed assembly may have left partially parsed
+				// values behind. Re-derive the merged values and the markers from the surviving
+				// registrations — the same recovery the ALC sweep uses — so nothing contributed by
+				// the failed attempt remains observable.
+				RebuildLoaderResourcesFromSurvivors();
 			}
 
 			throw;
@@ -110,6 +124,64 @@ partial class ResourceLoader
 
 	private static void ProcessAssembly(Assembly assembly, string[] languagePreferences)
 		=> ProcessAssembly(assembly, languagePreferences, GetOrCreateNamedLoaderResources, _parsedResources);
+
+	/// <summary>
+	/// Parses <paramref name="assembly"/>'s .upri resources into TEMPORARY structures and merges
+	/// them into the live loaders only once every file parsed successfully — the same
+	/// temp-then-apply pattern as <see cref="RebuildLoaderResourcesFromSurvivors"/>. A malformed
+	/// .upri therefore throws without any partially parsed value or marker becoming observable.
+	/// </summary>
+	private static void ProcessAssemblyTransactionally(Assembly assembly, string[] languagePreferences)
+	{
+		var parsedResources = new Dictionary<string, Dictionary<string, Dictionary<string, string>>>(StringComparer.OrdinalIgnoreCase);
+
+		// Seed the temporary marker set with the assembly's already-parsed files so they are
+		// skipped exactly as a parse against the live markers would skip them.
+		var parsedMarkers = new HashSet<(Assembly Assembly, string ResourceName)>();
+		foreach (var marker in _parsedResources)
+		{
+			if (marker.Assembly == assembly)
+			{
+				parsedMarkers.Add(marker);
+			}
+		}
+
+		Dictionary<string, Dictionary<string, string>> ResolveParsedLoader(string name)
+		{
+			if (!parsedResources.TryGetValue(name, out var cultures))
+			{
+				parsedResources[name] = cultures = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+			}
+
+			return cultures;
+		}
+
+		ProcessAssembly(assembly, languagePreferences, ResolveParsedLoader, parsedMarkers);
+
+		// Apply phase: parsing succeeded, merge into the live loaders with the same
+		// last-writer-wins semantics ProcessResourceFile uses when writing to them directly.
+		foreach (var parsed in parsedResources)
+		{
+			var loaderResources = GetOrCreateNamedLoaderResources(parsed.Key);
+			foreach (var culture in parsed.Value)
+			{
+				if (!loaderResources.TryGetValue(culture.Key, out var resources))
+				{
+					loaderResources[culture.Key] = resources = new Dictionary<string, string>();
+				}
+
+				foreach (var pair in culture.Value)
+				{
+					resources[pair.Key] = pair.Value;
+				}
+			}
+		}
+
+		foreach (var marker in parsedMarkers)
+		{
+			_parsedResources.Add(marker);
+		}
+	}
 
 	private static void ProcessAssembly(
 		Assembly assembly,

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.static.cs
@@ -176,7 +176,10 @@ partial class ResourceLoader
 	/// path through <see cref="EnsureLoadersCultures"/> — and
 	/// <see cref="RebuildLoaderResourcesFromSurvivors"/>) goes through this, so a malformed .upri
 	/// (e.g. a stream truncated in the middle of a key/value pair) throws without leaving a partially
-	/// parsed value or marker observable.
+	/// parsed value or marker observable. A caller that must reject ONE contributor without rolling
+	/// the others back (<see cref="RebuildLoaderResourcesFromSurvivors"/>) parses each contributor
+	/// into its own <see cref="CreateScratch"/> and <see cref="AbsorbScratch"/>es only those that
+	/// parsed completely.
 	/// </summary>
 	private sealed class TransactionalParse
 	{
@@ -209,29 +212,41 @@ partial class ResourceLoader
 		/// </summary>
 		public void MergeIntoLiveLoaders()
 		{
-			foreach (var parsed in _loaderResources)
-			{
-				var liveResources = GetOrCreateNamedLoaderResources(parsed.Key);
-				foreach (var culture in parsed.Value)
-				{
-					if (liveResources.TryGetValue(culture.Key, out var resources))
-					{
-						foreach (var pair in culture.Value)
-						{
-							resources[pair.Key] = pair.Value;
-						}
-					}
-					else
-					{
-						// Nothing live to merge with: hand the temporary over instead of copying it.
-						liveResources[culture.Key] = culture.Value;
-					}
-				}
-			}
+			MergeInto(GetOrCreateNamedLoaderResources);
 
 			foreach (var marker in _markers)
 			{
 				_parsedResources.Add(marker);
+			}
+		}
+
+		/// <summary>
+		/// Creates an EMPTY parse seeded with the markers accumulated here so far, so a .upri an
+		/// earlier contributor already parsed is skipped exactly as a parse sharing this instance
+		/// would skip it. The result is independent: parsing into it and then DISCARDING it (rather
+		/// than handing it to <see cref="AbsorbScratch"/>) leaves this instance — and therefore the
+		/// live state — untouched, which is what lets one contributor be rejected without rolling
+		/// the others back.
+		/// </summary>
+		public TransactionalParse CreateScratch() => new(_markers);
+
+		/// <summary>
+		/// Folds a scratch parse's values AND markers into this instance, with the same
+		/// last-writer-wins-per-key semantics <see cref="MergeIntoLiveLoaders"/> uses, so
+		/// contributor ordering behaves exactly as it does in a single shared parse.
+		/// Temporary-to-temporary only: no live state is touched. Call it ONLY once
+		/// <paramref name="scratch"/> has returned from <see cref="Parse"/> — a scratch that threw
+		/// must be discarded whole, because a leaked marker is as wrong as a leaked value (it makes
+		/// a later parse skip a file it should have read).
+		/// </summary>
+		public void AbsorbScratch(TransactionalParse scratch)
+		{
+			// The method group binds to THIS instance's temporaries, not to the scratch's.
+			scratch.MergeInto(ResolveLoaderResources);
+
+			foreach (var marker in scratch._markers)
+			{
+				_markers.Add(marker);
 			}
 		}
 
@@ -268,6 +283,37 @@ partial class ResourceLoader
 			foreach (var marker in _markers)
 			{
 				_parsedResources.Add(marker);
+			}
+		}
+
+		/// <summary>
+		/// Copies the parsed state into the dictionaries <paramref name="resolveTargetResources"/>
+		/// hands out, overwriting per key (last writer wins) — the semantics
+		/// <see cref="ProcessResourceFile"/> has when writing to a target directly. The target is
+		/// either the live loaders (<see cref="MergeIntoLiveLoaders"/>) or another
+		/// <see cref="TransactionalParse"/>'s temporaries (<see cref="AbsorbScratch"/>).
+		/// </summary>
+		private void MergeInto(Func<string, Dictionary<string, Dictionary<string, string>>> resolveTargetResources)
+		{
+			foreach (var parsed in _loaderResources)
+			{
+				var targetResources = resolveTargetResources(parsed.Key);
+				foreach (var culture in parsed.Value)
+				{
+					if (targetResources.TryGetValue(culture.Key, out var resources))
+					{
+						foreach (var pair in culture.Value)
+						{
+							resources[pair.Key] = pair.Value;
+						}
+					}
+					else
+					{
+						// Nothing in the target to merge with: hand the temporary over instead of
+						// copying it.
+						targetResources[culture.Key] = culture.Value;
+					}
+				}
 			}
 		}
 
@@ -350,8 +396,11 @@ partial class ResourceLoader
 	/// <summary>
 	/// Re-derives every named loader's merged culture/key/value entries from the surviving
 	/// <see cref="_lookupAssemblies"/> (called after a dying ALC's assemblies have been removed),
-	/// through the <see cref="TransactionalParse"/> temp-then-apply pattern with a per-assembly guard
-	/// so a single malformed .upri is logged and skipped instead of leaving a live loader empty.
+	/// through the <see cref="TransactionalParse"/> temp-then-apply pattern, with each survivor
+	/// parsing into its own scratch that is folded into the aggregate only after it parsed
+	/// completely. A single malformed .upri is therefore logged and skipped — contributing nothing,
+	/// not even a pair or marker read before the failure — instead of aborting the rebuild and
+	/// leaving a live loader empty.
 	/// </summary>
 	/// <remarks>
 	/// The re-derivation only covers the last established context's language preferences, so with
@@ -374,29 +423,40 @@ partial class ResourceLoader
 		}
 
 		// Started from an empty marker set: the rebuilt state replaces the live one wholesale.
-		var parse = new TransactionalParse();
+		var aggregate = new TransactionalParse();
 		foreach (var assembly in _lookupAssemblies)
 		{
+			// Each survivor parses into its OWN scratch, seeded with the markers the aggregate has
+			// accumulated so far so a .upri an earlier survivor already parsed is still skipped.
+			// Only a scratch whose Parse RETURNED is folded in, so a survivor that throws part-way
+			// through — after a marker and some pairs already landed in its scratch, and possibly
+			// after earlier .upri files of the SAME assembly parsed fine — contributes neither
+			// values nor markers.
+			var scratch = aggregate.CreateScratch();
 			try
 			{
-				parse.Parse(assembly, languagePreferences);
+				scratch.Parse(assembly, languagePreferences);
 			}
 			catch (Exception error) when (error is global::System.IO.InvalidDataException or global::System.IO.IOException or NotSupportedException or BadImageFormatException or global::System.IO.FileLoadException or ArgumentException or FormatException)
 			{
-				// Recoverable per-assembly parse/reflection failure: skip this survivor and keep
-				// rebuilding. ProcessResourceFile surfaces malformed .upri content (bad magic,
-				// unsupported version, truncated/unreadable stream) as InvalidDataException, so every
-				// parser failure is covered here. Fatal exceptions are intentionally not caught: the
-				// live loaders are untouched until the apply phase, so an escaping exception here
-				// cannot leave a loader empty.
+				// Recoverable per-assembly parse/reflection failure: discard this survivor's scratch
+				// whole and keep rebuilding. ProcessResourceFile surfaces malformed .upri content
+				// (bad magic, unsupported version, truncated/unreadable stream) as
+				// InvalidDataException, so every parser failure is covered here. Fatal exceptions are
+				// intentionally not caught: the live loaders are untouched until the apply phase, so
+				// an escaping exception here cannot leave a loader empty.
 				if (_log.IsEnabled(LogLevel.Error))
 				{
 					_log.LogError($"[ALC-CLEANUP] ResourceLoader: skipping lookup assembly '{assembly.FullName}' while rebuilding merged resources after ALC unload.", error);
 				}
+
+				continue;
 			}
+
+			aggregate.AbsorbScratch(scratch);
 		}
 
-		parse.ReplaceLiveLoaders();
+		aggregate.ReplaceLiveLoaders();
 	}
 
 	private static bool IsFromNonDefaultAlc(Assembly assembly)


### PR DESCRIPTION
**GitHub Issue:** closes #23959

## PR Type:

🐞 Bugfix

## What changed? 🚀

Follow-up to #23707. `AddLookupAssembly` rolled back the `_lookupAssemblies` registration and parsed-resource markers when parsing threw, but `ProcessResourceFile` merges each key/value pair straight into the live loader dictionaries as it reads. A `.upri` with a valid header that declares two pairs, carries one complete pair, then truncates fails on the second pair — after the rollback, the unregistered assembly's first pair remained observable through `GetString` (permanently, when the loader context was already established, since no later lookup reloads).

Every path that mutates the live loader state now goes through a single transactional parse.

- **`TransactionalParse`** (new private nested type) owns the temp dictionaries, the temp marker set, the loader resolver, and the two apply phases (`MergeIntoLiveLoaders`, `ReplaceLiveLoaders`). It replaces the three hand-rolled copies of the temp-then-apply pattern the file had grown.
- **`AddLookupAssembly` — single-assembly branch** (changed loader context): `ProcessAssemblyTransactionally` parses into temporaries with the marker set seeded from the assembly's already-parsed markers, so skip semantics are unchanged, and merges only after every file parsed successfully.
- **`AddLookupAssembly` — full-reload branch**: `ReloadResources` is itself transactional now, so the failure never touches the live state. That also makes the **culture-change path** (`EnsureLoadersCultures` → `ReloadResources`) transactional, which the earlier revision did not cover.
- Consequently the `liveLoadersTouched` control flag, the `RebuildLoaderResourcesFromSurvivors()` recovery call in the catch, and the live-marker rollback (`_parsedResources.RemoveWhere`) are all gone: removing the list entry is the whole rollback. `RebuildLoaderResourcesFromSurvivors` keeps its per-assembly guard and is still used by the ALC sweep. `ClearResources()` and the two-argument `ProcessAssembly` overload became unused and were removed.
- **Rollback logging**: the catch now names the exception and logs before rethrowing (gated on `_log.IsEnabled(LogLevel.Error)`), reporting the assembly whose registration was rolled back and whether the whole cache was being reloaded — in that branch the faulting `.upri` can belong to a pre-existing registration rather than to the assembly being rolled back.
- **Exception contract**: a `.upri` truncated in the middle of its declared pairs surfaced `BinaryReader`'s context-free `EndOfStreamException`. `ProcessResourceFile` now restates it as `InvalidDataException($"Truncated resource file {fileName}: …", error)`, matching what it already does (and documents) for every other malformed-`.upri` case. `InvalidDataException` is already in the rebuild guard's filter, so recovery semantics are unchanged.
- **Allocation**: the merge apply hands the parsed dictionary over on a `TryGetValue` miss instead of allocating an empty dictionary and copying every pair — the zero-copy ownership transfer `RebuildLoaderResourcesFromSurvivors` already used.
- **Documented narrowing**: `RebuildLoaderResourcesFromSurvivors` re-derives values only for the last established context's language preferences, so with `PreserveParsedResources` enabled it drops values preserved for other cultures (they are re-parsed the next time those languages become active). That is now stated in its XML docs.

The `HasContextChangedSignificantly` branch selection in `AddLookupAssembly` is unchanged; the two comments describing those branches were swapped and are now accurate.

### Red/green regression tests

Two new tests in `Given_ResourceLoader_Alc` emit (in memory, via `ManagedPEBuilder`) an assembly embedding a `.upri` with valid magic/version/name/culture, `resourceCount = 2`, one complete pair, truncated before the second pair. Both carry `[Description]` and `[GitHubWorkItem]`:

- `When_AddLookupAssembly_Truncated_Upri_Then_Throws_And_Partial_Value_Not_Observable` — established loader context (full-reload branch): asserts `AddLookupAssembly` throws `InvalidDataException`, `ContainsLookupAssembly` is false, the truncated `.upri`'s loader instance was never created, the first pair's value is **not** returned by `GetString`, and surviving registrations still resolve.
- `When_AddLookupAssembly_Truncated_Upri_With_Changed_Context_Then_Live_Loaders_Untouched` — changed loader context (single-assembly branch): asserts the throw, the rollback, that the loader instance was never created (absence, not emptiness, so a regression to the full-reload branch cannot keep the test green), and that no value reached the live loaders.

Live state is observed through two new `internal` test seams next to `ContainsLookupAssembly` — `TryGetMergedResourceForTests` and `ContainsNamedLoader` — replacing the private-field reflection helper the earlier revision used. `GetString` cannot be used for these assertions: it re-establishes the loader context and would reload (and wipe) the loaders, masking the leak.

Both tests fail on the pre-fix code with the leaked `TruncatedValue` observable in both branches, and on the loader-instance assertions, and pass with the fix. Full `Given_ResourceLoader_Alc` (8 tests) and `Given_AlcCacheSweep` (4 tests) pass; the full `Uno.UI.UnitTests` run is 4074 total / 12 failed, and those 12 `When_Gregorian_FixedDate*` failures reproduce identically on the unmodified merge commit `2fc0049a256` (4072 total / same 12) — environment-dependent, unrelated.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
