### PR TITLE
test(textbox): De-flake iOS single-tap caret assert

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5145,7 +5145,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual("", SUT.SelectedText);
-			Assert.AreEqual(expectedCaret, SUT.CaretMode);
+			// The thumbless iOS caret blinks on a 500 ms timer, so sampling CaretMode once fails when the assert
+			// lands on the hidden half; the thumbed Android mode stops the timer and matches immediately.
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == expectedCaret,
+				timeoutMS: 3000,
+				message: $"tap should settle the caret in {expectedCaret}");
 		}
 
 		// Native iOS/Android: a double-tap selects the word under the tap.
@@ -5591,12 +5596,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual("", SUT.SelectedText, "there is nothing to select in an empty box");
-			Assert.AreEqual(
-				convention == TextBox.TouchTextSelectionConvention.Android
-					? TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing
-					: TextBox.CaretDisplayMode.ThumblessCaretShowing,
-				SUT.CaretMode,
-				"the gesture should leave the convention's collapsed caret");
+			// The thumbless iOS caret blinks on a 500 ms timer, so it can be mid-blink by the time the flyout opens.
+			var expectedCaret = convention == TextBox.TouchTextSelectionConvention.Android
+				? TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing
+				: TextBox.CaretDisplayMode.ThumblessCaretShowing;
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == expectedCaret,
+				timeoutMS: 3000,
+				message: $"the gesture should leave the convention's collapsed caret ({expectedCaret})");
 
 			if (SUT.SelectionFlyout is not TextCommandBarFlyout flyout)
 			{


### PR DESCRIPTION
**GitHub Issue:** #9080 (tracking epic — intentionally *not* auto-closed by this PR)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Given_TextBox.When_Touch_SingleTap_Places_Caret_iOS` failed the *Tests - iOS Skia Runtime Tests 3* shard:

```
Assert.AreEqual failed. Expected:<ThumblessCaretShowing>. Actual:<ThumblessCaretHidden>.
'expected' expression: 'expectedCaret', 'actual' expression: 'SUT.CaretMode'.
  at Given_TextBox.AssertTouchSingleTapPlacesCaret(TouchTextSelectionConvention, CaretDisplayMode)
```

`ThumblessCaretShowing` / `ThumblessCaretHidden` are the two halves of the caret **blink** cycle, not two
different outcomes. A 500 ms `DispatcherTimer` flips between them (`TextBox.skia.cs:79`, `TimerOnTick` at
`:1504-1517`), and `Select()` restarts that timer on every caret move (`:548-555`). The test tapped, awaited a
bare `WaitForIdle()`, then sampled `CaretMode` exactly **once** — so any tap→assert gap longer than one blink
period legitimately observes the hidden half and fails. It is the only runtime test that asserted a blinking
mode without a wait.

That gap only opens on the iOS simulator, where focus drives a full native keyboard/IME handshake that
`WaitForIdle` has to drain (`StartImeSession()`; the device log shows a keyboard dismiss + show cycle per focus,
`UIKeyboardAnimationDuration = 0.25` plus a 0.4 s `BSAnimationSettings`). Desktop and Android Skia have no
per-focus keyboard cost, which is why the test is green there. On the failing run the shard's agent was
unusually slow — 1 h 4 m vs 29–52 m for the other three iOS shards — and all three in-process retries failed,
so it was reproducible on that agent rather than a one-off.

This waits for the expected mode instead of sampling it:

```diff
 			Assert.AreEqual("", SUT.SelectedText);
-			Assert.AreEqual(expectedCaret, SUT.CaretMode);
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == expectedCaret,
+				timeoutMS: 3000,
+				message: $"tap should settle the caret in {expectedCaret}");
```

Notes on the choices:

- The explicit `timeoutMS: 3000` matters — `WindowHelper.WaitFor` defaults to **1000 ms**
  (`TestServices.WindowHelper.cs:314`), only two blink periods on the one platform that stalls. Line 5072 of
  the same file already passes 3000.
- Both conventions stay correct: the Android expectation is a *thumbed* mode, for which the setter **stops** the
  timer (`TextBox.skia.cs:113-117`), so it still matches on the first evaluation with no added pumping.
- Deliberately **not** relaxed to "either thumbless phase": `_caretMode` initializes to `ThumblessCaretHidden`
  (`TextBox.skia.cs:55`), so that variant would pass vacuously if the tap never registered. Waiting for
  `Showing` requires focus *plus* a running timer.
- `Assert.AreEqual("", SUT.SelectedText)` is kept ahead of the wait, so a tap ever mis-read as a double-tap
  still fails there with a clear message instead of timing out.
- No `[PlatformCondition]` added. Gating this off Skia-UIKit would drop coverage on the very platform whose
  convention the test emulates — worse than the flake it would hide. A genuine focus loss also still fails
  after the timeout with the same symptom (`TimerOnTick` no-ops when unfocused), so this does not mask a
  regression.

The same wait is applied to `AssertTouchGestureOnEmptyBoxOpensFlyout`, the one remaining single-shot assert on
a blinking mode. It samples `CaretMode` after a `Task.Delay(1200)` and a flyout-open wait — well past one blink
period — and is green today only because its callers are gated to `SkiaDesktop | SkiaAndroid`, not because the
assert is safe. (The third `ThumblessCaret` site, `AssertTouchTapOnEmptyBoxPlacesCaret`, already used
`WaitFor`.)

Test-only change — no product code touched. The caret is *supposed* to blink; the test had to tolerate it.

**Validation:** compile — `Uno.UI.RuntimeTests.Skia` net10.0, 0 errors / 0 warnings. Runtime — not run locally;
a Skia Desktop run cannot reproduce an iOS-simulator timing flake, so the iOS shards on this PR are the real
gate. Per the investigation this should not be called *proven* until those shards come back green.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, this hardens two existing runtime-test assertions
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, no user-facing change
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — N/A, no rendering change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
