### PR TITLE
fix: update UnoICUVersion to 77.3.2

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -76,7 +76,7 @@
 		<MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
 		<SkiaSharpVersion>3.119.0</SkiaSharpVersion>
 		<HarfbuzzSharpVersion>8.3.1.1</HarfbuzzSharpVersion>
-		<UnoICUVersion>77.3.0-dev.4</UnoICUVersion>
+		<UnoICUVersion>77.3.2</UnoICUVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request updates the ICU library version used in the project to ensure compatibility and access to the latest fixes.

Dependency update:

* Upgraded the `UnoICUVersion` property from `77.3.0-dev.4` to `77.3.2` in `src/Directory.Build.targets` to use a stable and more recent ICU package version.