### PR TITLE
ci: add stage Tests - iOS+NativeAOT Skia

### DIFF
--- a/build/ci/tests/.azure-devops-tests-ios-nativeaot-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-ios-nativeaot-skia-build.yml
@@ -1,0 +1,86 @@
+parameters:
+  vmImage: ''
+  vmMacImage: ''
+  vmMacImageTest: ''
+  vmLinuxImage: ''
+  vmLinuxPool: ''
+  xCodeRootTest: ''
+  xCodeRootBuild: ''
+  poolName: ''
+  XAML_FLAVOR_BUILD: ''
+
+jobs:
+
+- job: Skia_Tests_Build_iOS_NativeAOT
+  displayName: 'Build Samples App'
+  timeoutInMinutes: 60
+  cancelTimeoutInMinutes: 0
+
+  pool:
+    vmImage: ${{ parameters.vmMacImage }}
+
+  variables:
+    CombinedConfiguration: Release|Any CPU
+    CI_Build: true
+    NUGET_PACKAGES: $(Agent.WorkFolder)/.nuget
+    XAML_FLAVOR_BUILD: ${{ parameters.XAML_FLAVOR_BUILD }}
+
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - template: ../templates/gitversion.yml
+  - template: ../templates/dotnet-mobile-install-mac.yml
+    parameters:
+      UnoCheckParameters: '--preview-major --tfm $(netCurrentTargetFramework)-ios'
+
+  - template: ../templates/nuget-cache.yml
+    parameters:
+      nugetPackages: $(NUGET_PACKAGES)
+
+  - template: ../templates/ios-build-select-version.yml
+    parameters:
+      xCodeRoot: ${{ parameters.xCodeRootBuild }}
+
+  - bash: |
+      chmod +x $(build.sourcesdirectory)/build/test-scripts/skia-ios-uitest-build.sh
+      TFM="$(netCurrentTargetFramework)-ios" NAOT=1 $(build.sourcesdirectory)/build/test-scripts/skia-ios-uitest-build.sh
+    displayName: Build iOS Skia Head
+    env:
+      BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
+      BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
+      UNO_DISABLE_ANALYZERS_IN_SAMPLES: "true"
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Skia.netcoremobile/bin/Release/$(netCurrentTargetFramework)-ios/iossimulator-x64/SamplesApp.app
+      Contents: '**'
+      TargetFolder: $(build.artifactstagingdirectory)/bin/SamplesApp.app
+      CleanTargetFolder: false
+      OverWrite: false
+      flattenFolders: false
+
+  - pwsh: |
+      $artifactName = "samplesapp-ios-nativeaot-skia"
+      if ([int]$env:SYSTEM_JOBATTEMPT -gt 1) { $artifactName += "-attempt$env:SYSTEM_JOBATTEMPT" }
+      Write-Host "Publishing iOS Samples artifact: $artifactName"
+      Write-Host "##vso[task.setvariable variable=SamplesAppArtifactName]$artifactName"
+      Write-Host "##vso[task.setvariable variable=SamplesAppArtifactName;isOutput=true]$artifactName"
+    name: set_ios_artifact
+    displayName: 'Set iOS Samples Artifact Name'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish iOS Binaries'
+    retryCountOnTaskFailure: 3
+    inputs:
+      targetPath: $(build.artifactstagingdirectory)/bin
+      ArtifactName: $(SamplesAppArtifactName)
+
+  - task: PublishBuildArtifacts@1
+    retryCountOnTaskFailure: 3
+    condition: always()
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)
+      ArtifactName: samplesapp-ios-nativeaot-skia-logs
+      ArtifactType: Container

--- a/build/ci/tests/.azure-devops-tests-ios-nativeaot-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-ios-nativeaot-skia.yml
@@ -1,0 +1,49 @@
+parameters:
+  vmImage: ''
+  vmMacImage: ''
+  vmMacImageTest: ''
+  vmLinuxImage: ''
+  vmLinuxPool: ''
+  xCodeRootTest: ''
+  xCodeRootBuild: ''
+  poolName: ''
+  XAML_FLAVOR_BUILD: ''
+
+  # Runtime Test Groups
+  IOS_RUNTIME_TEST_GROUP_COUNT: 4
+  IOS_RUNTIME_TESTS_GROUPS:
+  - key: '0'
+    value: '01'
+  - key: '1'
+    value: '02'
+  - key: '2'
+    value: '03'
+  - key: '3'
+    value: '04'
+
+jobs:
+##
+## Runtime tests
+##
+- ${{ each RuntimeTestGroup in parameters.IOS_RUNTIME_TESTS_GROUPS }}:
+  - template: .azure-devops-tests-ios-runner.yml
+    parameters:
+      nugetPackages: $(NUGET_PACKAGES)
+      JobName: 'Skia_iOS_Runtime_Tests_group_${{ RuntimeTestGroup.value }}'
+      JobDisplayName: 'Runtime Tests ${{ RuntimeTestGroup.key }}'
+      TestRunName: 'iOS Skia Runtime Tests ${{ RuntimeTestGroup.key }}'
+      JobTimeoutInMinutes: 90
+      vmImage: ${{ parameters.vmMacImageTest }}
+      UITEST_SNAPSHOTS_ONLY: false
+      UITEST_TEST_TIMEOUT: '90m'
+      UITEST_AUTOMATED_GROUP: RuntimeTests
+      UITEST_RUNTIME_TEST_GROUP: ${{ RuntimeTestGroup.key }}
+      UITEST_RUNTIME_TEST_GROUP_COUNT: ${{ parameters.IOS_RUNTIME_TEST_GROUP_COUNT }}
+      UITEST_ALLOW_RERUN: 'false'
+      SAMPLESAPP_BUNDLE_ID: 'uno.platform.samplesapp.skia'
+      UITEST_VARIANT: 'skia'
+      TEST_KIND: runtime
+      xCodeRoot: ${{ parameters.xCodeRootTest }}
+      dependsOn:
+        - Skia_Tests_Build_iOS_NativeAOT
+      BuildJobName: 'Skia_Tests_Build_iOS_NativeAOT'

--- a/build/ci/tests/.azure-devops-tests-skia-stages.yml
+++ b/build/ci/tests/.azure-devops-tests-skia-stages.yml
@@ -96,6 +96,35 @@ stages:
       poolName: '${{ parameters.poolName }}'
       XAML_FLAVOR_BUILD: '${{ parameters.XAML_FLAVOR_BUILD }}'
 
+- stage: runtime_tests_skia_ios_nativeaot
+  displayName: Tests - iOS+NativeAOT Skia
+  dependsOn:
+    - binaries_build_native_macos
+
+  jobs:
+  - template: .azure-devops-tests-ios-nativeaot-skia-build.yml
+    parameters:
+      vmImage: '${{ parameters.vmImage }}'
+      vmMacImage: '${{ parameters.vmMacImage }}'
+      vmMacImageTest: '${{ parameters.vmMacImageTest }}'
+      vmLinuxImage: '${{ parameters.vmLinuxImage }}'
+      vmLinuxPool: '${{ parameters.vmLinuxPool }}'
+      xCodeRootTest: '${{ parameters.xCodeRootTest }}'
+      xCodeRootBuild: '${{ parameters.xCodeRootBuild }}'
+      poolName: '${{ parameters.poolName }}'
+      XAML_FLAVOR_BUILD: '${{ parameters.XAML_FLAVOR_BUILD }}'
+  - template: .azure-devops-tests-ios-nativeaot-skia.yml
+    parameters:
+      vmImage: '${{ parameters.vmImage }}'
+      vmMacImage: '${{ parameters.vmMacImage }}'
+      vmMacImageTest: '${{ parameters.vmMacImageTest }}'
+      vmLinuxImage: '${{ parameters.vmLinuxImage }}'
+      vmLinuxPool: '${{ parameters.vmLinuxPool }}'
+      xCodeRootTest: '${{ parameters.xCodeRootTest }}'
+      xCodeRootBuild: '${{ parameters.xCodeRootBuild }}'
+      poolName: '${{ parameters.poolName }}'
+      XAML_FLAVOR_BUILD: '${{ parameters.XAML_FLAVOR_BUILD }}'
+
 - stage: runtime_tests_skia_linux
   displayName: Tests - Desktop Skia Linux
   dependsOn:

--- a/build/test-scripts/skia-ios-uitest-build.sh
+++ b/build/test-scripts/skia-ios-uitest-build.sh
@@ -6,4 +6,8 @@ _TFM="${TFM:=net10.0-ios}"
 
 cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Skia.netcoremobile
 
-dotnet build -f "$_TFM" -c Release "-p:UnoTargetFrameworkOverride=$_TFM" -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog
+if [ "${NAOT:=}" = "1" ]; then
+    dotnet build -f "$_TFM" -c Release "-p:UnoTargetFrameworkOverride=$_TFM" -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-nativeaot-netcoremobile-sampleapp.binlog -p:SkiaPublishAot=true -p:_IsPublishing=true
+else
+    dotnet build -f "$_TFM" -c Release "-p:UnoTargetFrameworkOverride=$_TFM" -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true /bl:$BUILD_ARTIFACTSTAGINGDIRECTORY/skia-ios-netcoremobile-sampleapp.binlog
+fi


### PR DESCRIPTION
iOS supports Native AOT, and has since .NET 9.

It might be a good idea to actually *test* this on CI?

**GitHub Issue:** closes https://github.com/unoplatform/uno-private/issues/2279

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🏗️ Build or CI related changes

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
