### PR TITLE
refactor: Strip dead native #if blocks from Uno.UI sources

### DIFF
--- a/src/Uno.UI/Extensions/DoubleExtensions.cs
+++ b/src/Uno.UI/Extensions/DoubleExtensions.cs
@@ -7,21 +7,13 @@ namespace Uno.Extensions
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsFinite(this double value)
 		{
-#if !XAMARIN
 			return !double.IsInfinity(value) && !double.IsNaN(value);
-#else
-			return double.IsFinite(value);
-#endif
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static bool IsFinite(this float value)
 		{
-#if !XAMARIN
 			return !float.IsInfinity(value) && !float.IsNaN(value);
-#else
-			return float.IsFinite(value);
-#endif
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.cs
@@ -3,9 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.UI.Xaml.Controls;
-#if !__WASM__
 using Uno.UI.Xaml.Core;
-#endif
 
 namespace Microsoft.UI.Xaml.Documents
 {
@@ -121,9 +119,6 @@ namespace Microsoft.UI.Xaml.Documents
 		}
 
 		/// <inheritdoc />
-#if __WASM__
-		public void Clear() => _collection.Clear();
-#else
 		public void Clear()
 		{
 			foreach (var inline in _collection)
@@ -136,7 +131,6 @@ namespace Microsoft.UI.Xaml.Documents
 
 			_collection.Clear();
 		}
-#endif
 
 		/// <inheritdoc />
 		public bool Contains(Inline item) => _collection.Contains(item);
@@ -174,15 +168,11 @@ namespace Microsoft.UI.Xaml.Documents
 		}
 
 		/// <inheritdoc />
-#if __WASM__
-		public void RemoveAt(int index) => _collection.RemoveAt(index);
-#else
 		public void RemoveAt(int index)
 		{
 			ClearFocusForRemovedInline(_collection[index]);
 			_collection.RemoveAt(index);
 		}
-#endif
 
 		/// <inheritdoc />
 		public Inline this[int index]
@@ -191,32 +181,28 @@ namespace Microsoft.UI.Xaml.Documents
 			set
 			{
 				ValidateInline(value, nameof(value));
-#if !__WASM__
 				if (!ReferenceEquals(_collection[index], value))
 				{
 					ClearFocusForRemovedInline(_collection[index]);
 				}
-#endif
 
 				_collection[index] = value;
 			}
 		}
 
-#if !__WASM__
 		private static bool ClearFocusForRemovedInline(Inline inline)
 		{
 			var focusManager = VisualTree.GetFocusManagerForElement(inline, VisualTree.LookupOptions.NoFallback);
 			if (focusManager?.FocusedElement is Inline focusedInline &&
 				inline.Enumerate().Any(candidate => ReferenceEquals(candidate, focusedInline)))
 			{
-				// Non-WASM inline collections do not run a live Leave walk when an item is removed.
+				// Inline collections do not run a live Leave walk when an item is removed.
 				focusManager.ClearFocus(canCancel: false);
 				return true;
 			}
 
 			return false;
 		}
-#endif
 
 		/// <summary>
 		/// WinUI only supports <see cref="InlineUIContainer"/> within a <see cref="RichTextBlock"/>; adding one to a
@@ -264,12 +250,7 @@ namespace Microsoft.UI.Xaml.Documents
 
 		private bool IsOwnedByTextBlock()
 		{
-			var current =
-#if __WASM__
-				(object)_collection.Owner;
-#else
-				_collection.GetParent();
-#endif
+			var current = _collection.GetParent();
 
 			// Walk up through Span/Hyperlink/etc. to find the owning control.
 			while (current is Inline inline)


### PR DESCRIPTION
**GitHub Issue:** Part of epic [unoplatform/uno-private#2049](https://github.com/unoplatform/uno-private/issues/2049) — _🦋 Drop native targets_. Closes unoplatform/uno-private#2096.

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

Strips the dead native `#if` branches left in shared `src/Uno.UI` sources after the native drop.

### `InlineCollection.cs` — a sync regression

Six `__WASM__` directives. #23671 removed them; master-sync merge `0edfe5fa75` (2026-07-29) put them back, because master had edited the file while this branch had rewritten it.

They are provably dead:

- `src/Uno.UI` has exactly two heads — `Uno.UI.Skia.csproj` (`UnoRuntimeIdentifier=Skia`) and `Uno.UI.Reference.csproj` (`UnoRuntimeIdentifier=Reference`). There is no `Uno.UI.Wasm.csproj`.
- `src/Uno.CrossTargetting.targets:73` is the only repo-source definition of `__WASM__`, gated on `'$(UnoRuntimeIdentifier)'=='WebAssembly'`. Neither head qualifies.
- The browser head does not compile this file either: `Uno.UI.Runtime.Skia.WebAssembly.Browser.csproj` defines `WASM_SKIA` (not `__WASM__`), and its `Compile Include` list is four `.wasm.cs` files. The `__WASM__` define in that project's `build/*.targets` runs in the *consuming app*, never in `Uno.UI`.
- Decisive: the `IsOwnedByTextBlock()` arm calls `_collection.Owner`, and `DependencyObjectCollection` has no `Owner` member. That branch could not have compiled under any configuration in this tree.

Every `!__WASM__` body is kept verbatim — the focus-clearing `Clear()`/`RemoveAt(int)`, the indexer guard, and `ClearFocusForRemovedInline`. The only prose change is dropping "Non-WASM" from a comment that no longer has a WASM flavour to contrast against.

### `DoubleExtensions.cs`

Two `!XAMARIN` directives. `XAMARIN` is defined only for the native Apple and Android targets (`Uno.CrossTargetting.targets:91,95,96,105`), none of which `Uno.UI` builds. Kept the `!XAMARIN` bodies.

## Validation

- **Code review:** repo-wide sweep for native `#if` symbols under `src/Uno.UI`. The remaining ones are in the WebView interop files that `Uno.UI.Runtime.Skia.Android.csproj` and `.AppleUIKit.csproj` `<Compile Include>`-link — live there, deliberately untouched. The ~76 `[Uno.NotImplemented("__ANDROID__", "__WASM__", …)]` attribute *strings* are also untouched; they are data, not directives.
- **Compile:** `dotnet build src/Uno.UI/Uno.UI.Skia.csproj` and `src/Uno.UI/Uno.UI.Reference.csproj`, both with `-p:UnoTargetFrameworkOverride=net10.0 -p:UnoFastDevBuild=true` — **0 errors** on both.
- **Runtime:** not run, and not needed here. Removing a directive whose other arm was never compiled leaves the two heads with byte-identical source; there is no behaviour to exercise. If a reviewer wants belt-and-braces, `Given_FocusManager_DetachedElements` and `Given_TextBlock` cover the un-guarded focus path.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, no behaviour change
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
