### PR TITLE
fix(packaging)!: Drop native TFM groups from the DevServer nuspec

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -208,10 +208,16 @@
 	<!-- 7.0 is Skia-only: fail the pack if a native UI rendering head package is produced. -->
 	<Target Name="ValidateNoNativeUIHeadPackages" AfterTargets="BuildNuGetPackage" Condition="'$(BuildingInsideVisualStudio)'=='' and '$(Configuration)'=='Release'">
 		<ItemGroup>
-			<_ForbiddenNativeHeadPackage Include="Uno.WinUI.WebAssembly;Uno.WinUI.Runtime.WebAssembly" />
+			<!-- nuspec-produced packages land next to this project; csproj-produced ones in the staging directory. -->
+			<_ProducedPackage Include="$(MSBuildThisFileDirectory)*.nupkg" />
+			<_ProducedPackage Include="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest\*.nupkg" Condition="'$(BUILD_ARTIFACTSTAGINGDIRECTORY)'!=''" />
+
+			<!-- Anchored so Uno.WinUI.Runtime.Skia.WebAssembly.Browser and Uno.Foundation.Runtime.WebAssembly do not match. -->
+			<_ForbiddenNativeHeadPackage Include="@(_ProducedPackage)"
+				Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Filename)', '^Uno\.WinUI(\.Runtime)?\.(WebAssembly|Wasm)\.'))" />
 		</ItemGroup>
-		<Error Condition="Exists('%(_ForbiddenNativeHeadPackage.Identity).$(NBGV_SemVer2).nupkg')"
-			   Text="Native UI head package '%(_ForbiddenNativeHeadPackage.Identity)' was produced but must not ship in 7.0 (Skia is the only renderer). Remove it from the pack pipeline." />
+		<Error Condition="'@(_ForbiddenNativeHeadPackage)'!=''"
+			   Text="Native UI head package(s) produced but must not ship in 7.0 (Skia is the only renderer): @(_ForbiddenNativeHeadPackage->'%(Filename)', ', '). Remove them from the pack pipeline." />
 	</Target>
 
 	<!--

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -208,9 +208,12 @@
 	<!-- 7.0 is Skia-only: fail the pack if a native UI rendering head package is produced. -->
 	<Target Name="ValidateNoNativeUIHeadPackages" AfterTargets="BuildNuGetPackage" Condition="'$(BuildingInsideVisualStudio)'=='' and '$(Configuration)'=='Release'">
 		<ItemGroup>
-			<!-- nuspec-produced packages land next to this project; csproj-produced ones in the staging directory. -->
-			<_ProducedPackage Include="$(MSBuildThisFileDirectory)*.nupkg" />
-			<_ProducedPackage Include="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest\*.nupkg" Condition="'$(BUILD_ARTIFACTSTAGINGDIRECTORY)'!=''" />
+			<!--
+				nuspec-produced packages land next to this project; csproj-produced ones in the staging directory.
+				Scoped to the version being built so stale packages left on a self-hosted agent cannot trip the guard.
+			-->
+			<_ProducedPackage Include="$(MSBuildThisFileDirectory)*$(NBGV_SemVer2).nupkg" />
+			<_ProducedPackage Include="$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest\*$(NBGV_SemVer2).nupkg" Condition="'$(BUILD_ARTIFACTSTAGINGDIRECTORY)'!=''" />
 
 			<!-- Anchored so Uno.WinUI.Runtime.Skia.WebAssembly.Browser and Uno.Foundation.Runtime.WebAssembly do not match. -->
 			<_ForbiddenNativeHeadPackage Include="@(_ProducedPackage)"

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -16,62 +16,16 @@
 
 		<dependencies>
 
-			<!-- net10.0-ios26.0 -->
-			<group targetFramework="net10.0-ios26.0">
-				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
-				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-			</group>
-
-			<!-- net10.0-tvos26.0 -->
-			<group targetFramework="net10.0-tvos26.0">
-				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
-				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-			</group>
-
-			<!-- net10.0-android -->
-			<group targetFramework="net10.0-android">
-				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
-				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-			</group>
-
-			<!-- net11.0-ios26.5 -->
-			<group targetFramework="net11.0-ios26.5">
-				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
-				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-			</group>
-
-			<!-- net11.0-tvos26.0 -->
-			<group targetFramework="net11.0-tvos26.5">
-				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
-				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-			</group>
-
-			<!-- net11.0-android -->
-			<group targetFramework="net11.0-android">
-				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
-				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-			</group>
-
-			<!-- .NET 11.0 (Reference API) -->
+			<!-- .NET 11.0 — Skia desktop, Skia mobile and Skia browser-wasm heads -->
 			<group targetFramework="net11.0">
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
 			</group>
 
-			<!-- .NET 10.0 (Reference API) -->
+			<!-- .NET 10.0 — Skia desktop, Skia mobile and Skia browser-wasm heads -->
 			<group targetFramework="net10.0">
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
-
-				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
 			</group>
 
 			<!-- .NET 11.0 (WinUI) -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -132,7 +132,6 @@
 		<PackageReference Update="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
 
 		<PackageReference Update="Uno.MonoAnalyzers" Version="1.0.0" PrivateAssets="all" />
-		<PackageReference Update="Uno.Wasm.WebSockets" Version="1.1.0" />
 		<PackageReference Update="Microsoft.TypeScript.MSBuild" Version="4.3.5" />
 		<PackageReference Update="NUnit" Version="3.14.0" />
 		<PackageReference Update="NUnit3TestAdapter" Version="6.2.0" />


### PR DESCRIPTION
**GitHub Issue:** Part of epic [unoplatform/uno-private#2049](https://github.com/unoplatform/uno-private/issues/2049) — _🦋 Drop native targets_. Closes unoplatform/uno-private#2058, addresses unoplatform/uno-private#2101.

## PR Type:

🏗️ Build or CI related changes · 💬 Breaking change (packaging)

## What changed? 🚀

`Uno.WinUI.DevServer.nuspec` declared eight native-TFM dependency groups (`net10.0-ios26.0`, `-tvos26.0`, `-maccatalyst26.0`, `-android` and the four `net11.0-*` equivalents). This removes them, matching `Uno.WinUI.nuspec`, which already ships **no** mobile groups and serves the same Skia-on-mobile heads.

### The ordering matters, so it is one commit

The native groups were **not** simply dead. Skia-on-mobile heads are retained in 7.0 (`Uno.UI.Runtime.Skia.Android` → `net10.0-android`/`net11.0-android`; `Uno.UI.Runtime.Skia.AppleUIKit` → `net10.0-ios26.0`/`-maccatalyst26.0`/`-tvos26.0`), and `Uno.Sdk` adds `Uno.WinUI.DevServer` implicitly to every head, so those groups resolve today.

They differed from the `netX.0` fallback groups by exactly two dependencies:

- `Uno.Wasm.WebSockets` — dead. It existed for the WASM-DOM client `Uno.UI.RemoteControl.Wasm.csproj`, deleted in `c3608f48c4`. Repo-wide it had no `PackageReference Include`, only an inert `Update` pin in `src/Directory.Build.targets`, removed here too.
- `Newtonsoft.Json` on the two maccatalyst groups — unused; `Uno.UI.RemoteControl` and `.Messaging` have zero Newtonsoft references.

**Dropping the groups first would have been a regression**: every Skia mobile head would have fallen back to the `netX.0` group and started pulling a WASM-only package. Dropping the two dead dependencies first makes the groups dependency-identical, after which removing them is a no-op for every consumer. Hence one commit, in that order.

Incidentally this also fixes a live case: the nuspec declares `net11.0-ios26.5`/`-tvos26.5`/`-maccatalyst26.5`, so a consumer on `net11.0-ios26.0` was **already** falling through to `net11.0` and picking up `Uno.Wasm.WebSockets`.

### What deliberately stays

#2101's scope also called for removing the `net10.0`/`net11.0` "Reference API" groups and `Uno.UI.RemoteControl.Reference.csproj`. **That part is not done here, because it would break every Skia target.**

Those groups are mislabelled, not dead — `Uno.UI.RemoteControl.Skia.csproj` targets `$(NetSkiaPreviousAndCurrent)` = `net10.0;net11.0`, and the browser head is plain `netX.0` too, so Skia desktop *and* Skia browser-wasm both land in them. And `lib\net10.0` / `lib\net11.0` is the compile-time reference assembly the runtime-asset swap binds against: `RuntimeAssetsSelectorTask.GetReferenceDirectory` resolves `<runtimeDir>/../lib/netX.0` and throws when it is absent. Removing it breaks Skia desktop, mobile and browser at once. That work is blocked on the Reference→Skia collapse (unoplatform/uno-private#2150).

### Pack guard hardening

`ValidateNoNativeUIHeadPackages` was half-inert: `Exists('<Id>.<version>.nupkg')` is relative to `build/`, where **nuspec**-produced packages land, but `Uno.WinUI.Runtime.WebAssembly` was **csproj**-produced and goes to `$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest`. That half could never fire. It now enumerates both locations and matches an anchored pattern.

## Validation

- **Code review:** the surviving `<dependencies>` is four groups — `net11.0` and `net10.0` (`Uno.WinUI` + `Uno.WinUI.DevServer.Messaging`), and the two `net*-windows10.0.19041.0` groups (`Uno.WinUI`). Every Skia head — desktop, browser-wasm, android, ios/maccatalyst/tvos — resolves the `netX.0` group with the same closure as today, minus the two dead packages. `<files>` is untouched.
- **Compile:** XML well-formedness checked. Nothing here is exercised by `dotnet build`.
- **Runtime:** the pack-guard regex was run against fixtures — **fails** on `Uno.WinUI.WebAssembly` and `Uno.WinUI.Runtime.WebAssembly`, and **passes** on `Uno.WinUI`, `Uno.WinUI.DevServer`, `Uno.WinUI.Svg`, `Uno.WinUI.Runtime.Skia.Android`, and the two dangerous look-alikes `Uno.WinUI.Runtime.Skia.WebAssembly.Browser` and `Uno.Foundation.Runtime.WebAssembly`. The nuspec change itself has **not** been runtime-validated locally — a Release pack is required.

**Please confirm on CI before merging:** Release pack succeeds (watch for `NU5128` — `build/Uno.UI.Build.csproj` sets `NoWarn=NU5100,NU5105,NU5131;NU5123`, which does not include it), then restore a Skia-on-Android head and a Skia browser-wasm head and check that `Uno.UI.RemoteControl.dll` still resolves from `uno-runtime/netX.0/skia` and that `Uno.Wasm.WebSockets` is absent from the mobile restore graph.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, packaging metadata
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

Package metadata change: consumers on a native TFM resolve the `netX.0` dependency group instead of a TFM-specific one, and `Uno.Wasm.WebSockets` is no longer a transitive dependency.
