### PR TITLE
fix(automation): Stop master syncs resurrecting deleted native heads

### DIFF
--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -234,6 +234,25 @@ jobs:
           elif git ls-files -u | grep -q .; then
             CONFLICT=1
             conflict_files="$(git diff --name-only --diff-filter=U || true)"
+
+            # A modify/delete conflict has no "ours" stage (2) when the feature branch is
+            # the side that deleted the file. `git add -A` below would then stage master's
+            # copy, silently resurrecting it with no conflict markers for a reviewer to
+            # catch. Keep the deletion and surface it in the PR body instead.
+            readded=""
+            while IFS= read -r f; do
+              [ -z "${f:-}" ] && continue
+              if ! git ls-files -u -- "$f" | awk '{print $3}' | grep -qx 2; then
+                readded="${readded}${f}"$'\n'
+                git rm -f -q -- "$f"   # -f: plain `git rm` refuses unmerged paths
+              fi
+            done < <(git diff --name-only --diff-filter=U)
+
+            if [ -n "$readded" ]; then
+              conflict_files="$(printf '%s\n%s' "$conflict_files" \
+                "$(printf '%s' "$readded" | sed 's|^|  (deleted here, modified on master — deletion kept): |')")"
+            fi
+
             git add -A
             git commit --no-edit || { git merge --abort 2>/dev/null || true; note "❌ conflict commit failed"; exit 1; }
           else

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -46,6 +46,12 @@ stages:
         pwsh: true
         filePath: build/ci/scripts/determine-test-scope.ps1
 
+    - task: PowerShell@2
+      displayName: Check for native UI rendering regressions
+      inputs:
+        pwsh: true
+        filePath: build/ci/scripts/check-native-drop-regressions.ps1
+
 - template: setup/.azure-devops-master-health.yml
   parameters:
     vmImage: '$(linuxVMImage)'

--- a/build/ci/scripts/check-native-drop-regressions.ps1
+++ b/build/ci/scripts/check-native-drop-regressions.ps1
@@ -1,0 +1,120 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+	Fails the build when native UI rendering artifacts reappear in the tree.
+
+.DESCRIPTION
+	7.0 drops the native UI renderers, but `master` still carries them, so every
+	master -> feature/* sync can re-offer a deleted file. A modify/delete conflict
+	resolved in master's favour silently restores it (see the sync workflow at
+	.github/workflows/master-sync.yml).
+
+	Three checks, none of which needs a hand-maintained list of deleted paths:
+
+	  1. No project under src/ references a .csproj that does not exist. A
+	     resurrected head is orphaned by definition, so its references dangle.
+	  2. No Uno.UI-and-higher project declares UnoRuntimeIdentifier=WebAssembly.
+	     The retained non-UI platform assemblies still legitimately do.
+	  3. No src/Uno.UI source file branches on a native-only symbol that its two
+	     remaining heads (Skia, Reference) never define.
+#>
+
+[CmdletBinding()]
+param(
+	[string]$RepositoryRoot = (Resolve-Path "$PSScriptRoot/../../..")
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path $RepositoryRoot).Path.TrimEnd('\', '/')
+$srcRoot = Join-Path $repoRoot "src"
+if (-not (Test-Path $srcRoot)) {
+	throw "Scan root '$srcRoot' not found. This script needs a full checkout, not a sparse one."
+}
+
+# Non-UI platform APIs are still built for the browser: the Skia heads consume them.
+$webAssemblyRuntimeAllowList = @(
+	"src/Uno.Foundation",
+	"src/Uno.Foundation.Runtime.WebAssembly",
+	"src/Uno.UI.Dispatching",
+	"src/Uno.UWP"
+)
+
+# Vendored Mono sources that reference the Mono class libraries, absent by design.
+$danglingReferenceAllowList = @(
+	"src/SourceGenerators/System.Xaml/System.Xaml-net_4_x.csproj"
+)
+
+# Symbols no src/Uno.UI head defines. Native symbols still live in the WebView interop
+# files linked into the Skia Android/AppleUIKit heads, so they are deliberately not listed.
+$deadSymbolPattern = '^\s*#\s*(if|elif)\b.*(__WASM__|XAMARIN)'
+$liveSkiaHostPattern = 'ANDROID_SKIA|UIKIT_SKIA|WASM_SKIA'
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Get-RelativePath([string]$path) {
+	return $path.Substring($repoRoot.Length + 1).Replace('\', '/')
+}
+
+# --- 1. Dangling ProjectReference -------------------------------------------------
+foreach ($proj in Get-ChildItem $srcRoot -Recurse -Include *.csproj -File) {
+	$rel = Get-RelativePath $proj.FullName
+	if ($danglingReferenceAllowList -contains $rel) { continue }
+
+	$content = (Get-Content $proj.FullName -Raw) ?? ""
+	foreach ($m in [regex]::Matches($content, '<ProjectReference\s+Include\s*=\s*"([^"]+)"')) {
+		$include = $m.Groups[1].Value
+		# Globs and MSBuild expressions are resolved at build time, not here.
+		if ($include -match '[\*\$%]') { continue }
+
+		$target = Join-Path $proj.Directory.FullName $include.Replace('\', [IO.Path]::DirectorySeparatorChar)
+		if (-not (Test-Path $target)) {
+			$failures.Add("$rel references a project that does not exist: $include")
+		}
+	}
+}
+
+# --- 2. Native WASM-DOM runtime identifier in the UI layer ------------------------
+foreach ($proj in Get-ChildItem $srcRoot -Recurse -Include *.csproj -File) {
+	if ((((Get-Content $proj.FullName -Raw) ?? "")) -notmatch '<UnoRuntimeIdentifier>\s*WebAssembly\s*</UnoRuntimeIdentifier>') { continue }
+
+	$rel = Get-RelativePath $proj.FullName
+	if ($webAssemblyRuntimeAllowList | Where-Object { $rel.StartsWith("$_/") }) { continue }
+
+	$failures.Add("$rel declares UnoRuntimeIdentifier=WebAssembly; the native WASM-DOM UI heads were removed in 7.0.")
+}
+
+# --- 3. Dead native #if in src/Uno.UI --------------------------------------------
+foreach ($file in Get-ChildItem (Join-Path $srcRoot "Uno.UI") -Recurse -Include *.cs -File) {
+	$lineNumber = 0
+	foreach ($line in Get-Content $file.FullName) {
+		$lineNumber++
+		# Case-sensitive: XAMARIN the symbol, not "xamarin" in a comment or URL.
+		if ($line -cmatch $deadSymbolPattern -and $line -cnotmatch $liveSkiaHostPattern) {
+			$failures.Add("$(Get-RelativePath $file.FullName):$lineNumber branches on a symbol no Uno.UI head defines: $($line.Trim())")
+		}
+	}
+}
+
+# --- Report ----------------------------------------------------------------------
+if ($failures.Count -eq 0) {
+	Write-Host "No native UI rendering regressions found."
+	exit 0
+}
+
+foreach ($failure in $failures) {
+	if ($env:TF_BUILD) {
+		Write-Host "##vso[task.logissue type=error]$failure"
+	}
+	elseif ($env:GITHUB_ACTIONS) {
+		Write-Host "::error::$failure"
+	}
+	else {
+		Write-Host "ERROR: $failure"
+	}
+}
+
+Write-Host ""
+Write-Host "$($failures.Count) native UI rendering regression(s) found."
+Write-Host "These artifacts were removed for 7.0. If a master sync restored them, keep the deletion."
+exit 1


### PR DESCRIPTION
**GitHub Issue:** Part of epic [unoplatform/uno-private#2049](https://github.com/unoplatform/uno-private/issues/2049) — _🦋 Drop native targets_. Closes unoplatform/uno-private#2059.

> [!IMPORTANT]
> **Merge this last.** The CI check added here is red until the unoplatform/uno-private#2097 and unoplatform/uno-private#2096 PRs land — by design; those are the regressions it detects. See *Validation*.

## PR Type:

🐞 Bugfix · 🏗️ Build or CI related changes · 🤖 Project automation

## What changed? 🚀

Stops master→`feature/*` syncs from resurrecting files this branch deleted, and adds a backstop that catches it if they do.

### Root cause — `.github/workflows/master-sync.yml`

On a **modify/delete** conflict, where `master` edited a file this branch deleted, git leaves master's version in the tree with no conflict markers. The sync job then ran `git add -A`, which staged that copy and committed it as the resolution. The file came back looking like a normal merge, and the reviewer of a draft sync PR had nothing to notice.

That is exactly how two things landed on `feature/breakingchanges`:

- `Uno.UI.RuntimeTests.Wasm.csproj` — deleted by `c3608f48c4`, restored by merge `8d5e55db9f` (#23800, pulling master's `47bce13e28`).
- the dead `__WASM__` directives in `InlineCollection.cs` — restored by merge `0edfe5fa75`.

The fix detects the missing "ours" stage (stage 2 in `git ls-files -u`), keeps the deletion with `git rm -f`, and folds the paths into `conflict_files` so they are listed in the PR body. `git rm -f` is required — plain `git rm` refuses unmerged paths, and `set -euo pipefail` would abort the job.

This is self-maintaining: it protects every file a branch deletes, with no list to keep current. Accepted trade-off — a genuine master bugfix to a deleted file is dropped. That is correct by construction for a branch whose purpose is deleting those files, `CONFLICT=1` already forces the PR to open as a **draft** with auto-merge disabled, and the path is now named explicitly in the body, so a human still decides.

### Backstop — `build/ci/scripts/check-native-drop-regressions.ps1`

Three checks, wired into the existing `DetermineScope` job in `build/ci/.azure-devops-stages.yml` (a full `checkout: self`; the `Validations` job's sparse checkout excludes `src/**`, so a check there would pass vacuously forever). Azure Pipelines runs via a GitHub App and sees bot-authored sync PRs, which a GitHub Actions workflow would not under the default token.

1. **Dangling `<ProjectReference>`** under `src/`. A resurrected head is orphaned by definition, so its references dangle. Skips glob/MSBuild-expression includes; allowlists the vendored Mono `System.Xaml-net_4_x.csproj`.
2. **`UnoRuntimeIdentifier=WebAssembly` outside the retained non-UI assemblies.** `Uno.Foundation`, `Uno.Foundation.Runtime.WebAssembly`, `Uno.UI.Dispatching` and `Uno.UWP` still legitimately build for the browser — the Skia heads consume them. Anything else is a WASM-DOM UI head.
3. **Native `#if` symbols no `src/Uno.UI` head defines** (`__WASM__`, `XAMARIN`), skipping directives that also mention `*_SKIA` — those are the WebView interop files linked into the Skia Android/AppleUIKit heads, where the branches are live.

No manifest of deleted paths anywhere; all three derive from the tree, so nothing rots.

## Validation

- **Runtime (fails-before / passes-after), the sync fix:** built a throwaway repo reproducing the exact scenario — feature deletes `head.csproj`, master modifies it, plus an ordinary content conflict alongside. Git reports *"CONFLICT (modify/delete): head.csproj deleted in HEAD and modified in master. Version master of head.csproj left in tree"* — the original bug. With the fix: the file **stays deleted** and untracked, it is **reported** in `conflict_files`, the unrelated file **keeps its real conflict markers**, and `CONFLICT=1` still holds so the PR opens as a draft. 5/5 assertions pass.
- **Runtime (fails-before / passes-after), the CI check:** run against `feature/breakingchanges` as-is it reports **14 regressions** — the 5 dangling references and the WASM runtime identifier from the #2097 PR's file, and the 8 dead directives from the #2096 PR's files. Applied on top of those two branches it reports **0** and exits 0. No false positives: `Uno.Foundation`, `Uno.Foundation.Runtime.WebAssembly`, `Uno.UI.Dispatching`, `Uno.UWP`, the vendored Mono project and the WebView interop files are all correctly left alone.

  Two bugs were caught by that exercise and fixed before this PR: a broken relative-path computation, and `-match` being case-insensitive in PowerShell, which made `XAMARIN` match the word "xamarin" in a comment URL in `UnoWKWebView.iOS.cs`. It now uses `-cmatch`.
- **Compile:** n/a — YAML and PowerShell.

## Heads-up for whoever babysits `automation/master-sync/*`

Once this lands, sync PRs that hit a modify/delete conflict will (a) keep the deletion and say so in the body, and (b) trip the new Azure check if anything else slipped through. That is the gate working — better to read it here than in a red build at 5am.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — fail-before/pass-after controls above
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — the script documents itself
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
