### PR TITLE
fix(skia): Set Vulkan GRContext MaxAPIVersion

### DIFF
--- a/src/Uno.UI/Vulkan/Interop/VulkanInstance.skia.cs
+++ b/src/Uno.UI/Vulkan/Interop/VulkanInstance.skia.cs
@@ -14,6 +14,11 @@ namespace Uno.UI.Runtime.Skia.Vulkan.Interop;
 
 internal class VulkanInstance : IVulkanInstance
 {
+	// Skia m140+ requires Vulkan 1.1 as a hard minimum. GRVkBackendContext.MaxAPIVersion
+	// must match this value (see VulkanContext.CreateGrContext), otherwise Skia resolves
+	// the version from the loader and requests entry points the instance doesn't have.
+	internal static readonly uint ApiVersion = VulkanHelpers.MakeVersion(1, 1, 0);
+
 	private readonly VkGetInstanceProcAddressDelegate _getProcAddress;
 	private readonly VulkanInstanceApi _api;
 	private readonly string[] _enabledExtensions;
@@ -40,7 +45,7 @@ internal class VulkanInstance : IVulkanInstance
 		var appInfo = new VkApplicationInfo()
 		{
 			sType = VkStructureType.VK_STRUCTURE_TYPE_APPLICATION_INFO,
-			apiVersion = VulkanHelpers.MakeVersion(1, 1, 0),
+			apiVersion = ApiVersion,
 			applicationVersion = VulkanHelpers.MakeVersion(1, 0, 0),
 			engineVersion = VulkanHelpers.MakeVersion(1, 0, 0),
 			pApplicationName = name,

--- a/src/Uno.UI/Vulkan/VulkanBindings.skia.cs
+++ b/src/Uno.UI/Vulkan/VulkanBindings.skia.cs
@@ -16,5 +16,7 @@ static class VulkanHelpers
         return (uint)((major << 22) | (minor << 12) | patch);
     }
 
+    public static string FormatVersion(uint version) => $"{version >> 22}.{(version >> 12) & 0x3FF}.{version & 0xFFF}";
+
     public const uint QueueFamilyIgnored = 4294967295;
 }

--- a/src/Uno.UI/Vulkan/VulkanContext.skia.cs
+++ b/src/Uno.UI/Vulkan/VulkanContext.skia.cs
@@ -119,11 +119,20 @@ internal sealed class VulkanContext : IVulkanPlatformGraphicsContext, IDisposabl
 			VkDevice = _device.Handle,
 			VkQueue = _device.MainQueueHandle,
 			GraphicsQueueIndex = _device.GraphicsQueueFamilyIndex,
+			// Must match VkApplicationInfo.apiVersion. If left at 0, Skia m148+ resolves the
+			// version from the loader instead of the instance and GRContext creation fails
+			// on strict loaders (https://github.com/unoplatform/uno/issues/23958).
+			MaxAPIVersion = VulkanInstance.ApiVersion,
 			GetProcedureAddress = GetProcAddressWrapper
 		};
 
-		_grContext = GRContext.CreateVulkan(ctx)
-			?? throw new VulkanException("Unable to create SkiaSharp GRContext from Vulkan device");
+		_grContext = GRContext.CreateVulkan(ctx);
+		if (_grContext == null)
+		{
+			_instanceApi!.GetPhysicalDeviceProperties(PhysicalDeviceHandle, out var properties);
+			throw new VulkanException(
+				$"Unable to create SkiaSharp GRContext from Vulkan device (instance apiVersion {VulkanHelpers.FormatVersion(VulkanInstance.ApiVersion)}, device apiVersion {VulkanHelpers.FormatVersion(properties.apiVersion)})");
+		}
 	}
 
 	/// <summary>

--- a/src/Uno.UI/Vulkan/VulkanContext.skia.cs
+++ b/src/Uno.UI/Vulkan/VulkanContext.skia.cs
@@ -90,7 +90,7 @@ internal sealed class VulkanContext : IVulkanPlatformGraphicsContext, IDisposabl
 
 	private void CreateGrContext()
 	{
-		if (_device == null || _instance == null)
+		if (_device == null || _instance == null || _instanceApi == null)
 			throw new InvalidOperationException("Vulkan device not initialized");
 
 		IntPtr GetProcAddressWrapper(string name, IntPtr instance, IntPtr device)
@@ -129,7 +129,7 @@ internal sealed class VulkanContext : IVulkanPlatformGraphicsContext, IDisposabl
 		_grContext = GRContext.CreateVulkan(ctx);
 		if (_grContext == null)
 		{
-			_instanceApi!.GetPhysicalDeviceProperties(PhysicalDeviceHandle, out var properties);
+			_instanceApi.GetPhysicalDeviceProperties(PhysicalDeviceHandle, out var properties);
 			throw new VulkanException(
 				$"Unable to create SkiaSharp GRContext from Vulkan device (instance apiVersion {VulkanHelpers.FormatVersion(VulkanInstance.ApiVersion)}, device apiVersion {VulkanHelpers.FormatVersion(properties.apiVersion)})");
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #23958

## PR Type:

🐞 Bugfix

## What changed? 🚀

With SkiaSharp 4.x, Vulkan rendering always fails on hosts with a spec-strict Vulkan loader and silently falls back to OpenGL (`Vulkan rendering not available: Unable to create SkiaSharp GRContext from Vulkan device`). Root cause per #23958: `VulkanContext.CreateGrContext()` left `GRVkBackendContext.MaxAPIVersion` at `0` while `VulkanInstance.Create()` creates the `VkInstance` with `VkApplicationInfo.apiVersion = 1.1`. With `MaxAPIVersion = 0`, Skia m148+ resolves the API version from the loader (`vkEnumerateInstanceVersion`, 1.3/1.4 on current hosts) and requests core 1.2+ entry points that spec-compliant loaders return `NULL` for on a 1.1 instance; Skia's interface validation then fails and `GRContext.CreateVulkan` returns `null`. Skia documents that `fMaxAPIVersion` "should match the value set in `VkApplicationInfo::apiVersion`".

This PR:

- introduces a single `VulkanInstance.ApiVersion` constant (Vulkan 1.1 — Skia m140+'s hard minimum) used both for `VkApplicationInfo.apiVersion` and `GRVkBackendContext.MaxAPIVersion`, so the two values can never drift;
- enriches the `GRContext` failure message with the instance and physical-device API versions, since the missing version context is what made this failure host-dependent and hard to triage from logs.

### Validation (runtime)

The failure is host-dependent: it needs a strict loader (current AMD Windows drivers, the Linux Khronos loader ≥ 1.3); lenient loaders hand out the promoted entry points anyway and mask the bug (reproduced: Intel UHD 620 on Windows passes with and without the fix). Deterministic reproduction on WSLg with lavapipe (Khronos loader 1.3.275, llvmpipe API 1.4.318), X11 head of `SamplesApp.Skia.Generic` with the Vulkan backend forced, swapping in SkiaSharp 4.151.0 (managed + native) over the 3.119-built output — the same mixed graph an app gets from a `SkiaSharpVersion` override:

| Uno.UI | SkiaSharp | Result |
|---|---|---|
| unfixed (master `2fc0049a25`) | 4.151.0 | ❌ `Unable to create SkiaSharp GRContext from Vulkan device. Falling back to OpenGL.` |
| fixed | 4.151.0 | ✅ `Vulkan rendering initialized: llvmpipe (LLVM 20.1.2, 256 bits), 25.2.8` |
| fixed | 3.119.0 (repo pin) | ✅ `Vulkan rendering initialized` — no regression |

Note the fix is not a strict no-op on SkiaSharp 3.x either: Skia m119 defaulted an unset `fMaxAPIVersion` to 1.0, so the pinned configuration now runs Skia at the 1.1 the instance actually requests (runtime-validated above). Android-Skia shares the identical `VulkanContext` code path but was not runtime-tested here.

### Notes for reviewers

- No automated regression test: reproducing requires a strict Vulkan loader plus a Vulkan-capable device, which CI agents don't have; a runtime test would be permanently environment-skipped. The invariant is instead enforced structurally by the shared constant.
- The 1.1 pin is a deliberate floor (Skia m140+ `SK_ABORT`s below Vulkan 1.1), not version negotiation. Negotiating `min(loader, device)` upward — as Avalonia does — is a possible follow-up, but Skia's Ganesh backend gates its fast paths on device extensions (all 1.1-core) rather than core version, and our `VulkanDevice.Create` currently enables only `VK_KHR_swapchain`, so there is no measured win to chase yet. The single constant makes that bump a one-line change if profiling ever justifies it.
- `feature/breakingchanges` (SkiaSharp 4.148, Vulkan by default) has the identical pattern and needs this fix too — without it, every strict-loader host silently runs OpenGL while Vulkan is nominally the default.
- The device-side half of the invariant (a hypothetical 1.0-only physical device) is covered by Skia itself, which mins against `VkPhysicalDeviceProperties.apiVersion`.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: failure requires a strict Vulkan loader + real Vulkan device, unavailable on CI (see Notes); manually runtime-validated fail-before/pass-after.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — not applicable: internal rendering fix, no user-facing API or behavior to document.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — will check after CI runs.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
