### PR TITLE
docs: add skills plugin setup to agent guides

### DIFF
--- a/doc/articles/explore-your-app-ai-agents.md
+++ b/doc/articles/explore-your-app-ai-agents.md
@@ -47,7 +47,7 @@ In other words: while traditional Uno tests are written and maintained by develo
 
 ## Using the Uno Platform Skills
 
-Alongside the MCPs, Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, your agent selects the relevant skills automatically as it works on your prompts; no special command is required.
+Alongside the MCPs, Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — installed through the `uno-platform-studio` plugin, or as standalone skill folders. Once installed, your agent selects the relevant skills automatically as it works on your prompts; no special command is required.
 
 See [Skills & Plugins](xref:Uno.PlatformStudio.Skills) for the full catalog and the installation steps for each agent.
 

--- a/doc/articles/explore-your-app-ai-agents.md
+++ b/doc/articles/explore-your-app-ai-agents.md
@@ -45,6 +45,12 @@ It allows tools and agents to:
 
 In other words: while traditional Uno tests are written and maintained by developers, Uno App MCP opens the door for AI agents or other automation systems to drive and reason about the app autonomously, with deeper context and less manual scripting, across all Uno-supported platforms.
 
+## Using the Uno Platform Skills
+
+Alongside the MCPs, Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, your agent selects the relevant skills automatically as it works on your prompts; no special command is required.
+
+See [Skills & Plugins](xref:Uno.PlatformStudio.Skills) for the full catalog and the installation steps for each agent.
+
 ## Sample prompts for MCP tools
 
 In your agent, there are some phrases that can be used to nudge the agent to use the tools.

--- a/doc/articles/get-started-ai-claude.md
+++ b/doc/articles/get-started-ai-claude.md
@@ -31,6 +31,21 @@ This guide will walk you through the setup process for getting started with Clau
     > [!IMPORTANT]
     > The `uno-app` MCP [may fail to load](https://github.com/anthropics/claude-code/issues/4384) unless Claude is opened in a folder containing an Uno Platform app.
 
+## Setting up the Uno Platform Skills
+
+Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, Claude Code automatically selects the relevant skills as it works on your prompts.
+
+1. Install the plugin:
+
+    ```text
+    /plugin marketplace add unoplatform/studio
+    /plugin install uno-platform-studio@uno-platform
+    ```
+
+1. If Claude Code prompts you to run `/reload-plugins`, do so to apply the new plugin.
+
+For the full skill catalog, update instructions, and other installation options, see [Skills & Plugins](xref:Uno.PlatformStudio.Skills).
+
 ## Next Steps
 
 Now that you are set up, let's [create your first app](xref:Uno.GettingStarted.CreateAnApp.AI.Claude).

--- a/doc/articles/get-started-ai-claude.md
+++ b/doc/articles/get-started-ai-claude.md
@@ -35,7 +35,7 @@ This guide will walk you through the setup process for getting started with Clau
 
 Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, Claude Code automatically selects the relevant skills as it works on your prompts.
 
-1. Install the plugin:
+1. In Claude Code, install the plugin:
 
     ```text
     /plugin marketplace add unoplatform/studio

--- a/doc/articles/get-started-ai-codex.md
+++ b/doc/articles/get-started-ai-codex.md
@@ -38,6 +38,19 @@ This guide will walk you through the setup process for getting started with Code
     > [!IMPORTANT]
     > The uno-app MCP may fail to load unless Codex is opened in a folder containing an Uno Platform app.
 
+## Setting up the Uno Platform Skills
+
+Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, Codex automatically selects the relevant skills as it works on your prompts.
+
+Install the plugin:
+
+```text
+codex plugin marketplace add unoplatform/studio
+codex plugin install uno-platform-studio@uno-platform
+```
+
+For the full skill catalog, update instructions, and other installation options, see [Skills & Plugins](xref:Uno.PlatformStudio.Skills).
+
 ## Next Steps
 
 Now that you are set up, let's [create your first app](xref:Uno.GettingStarted.CreateAnApp.AI.Codex).

--- a/doc/articles/get-started-ai-codex.md
+++ b/doc/articles/get-started-ai-codex.md
@@ -42,7 +42,7 @@ This guide will walk you through the setup process for getting started with Code
 
 Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, Codex automatically selects the relevant skills as it works on your prompts.
 
-Install the plugin:
+From a terminal, install the plugin:
 
 ```text
 codex plugin marketplace add unoplatform/studio

--- a/doc/articles/get-started-ai-cursor.md
+++ b/doc/articles/get-started-ai-cursor.md
@@ -17,7 +17,7 @@ Install [Cursor](https://cursor.com/docs).
 > [!NOTE]
 > The Uno Platform extension is not functional in Cursor at this time.
 
-There is nothing specific to set up for Cursor. You can proceed to the next section to create your first app and use the Uno MCPs.
+There is nothing specific to set up for Cursor itself. Optionally install the Uno Platform Skills below, then create your first app and use the Uno MCPs.
 
 ## Setting up the Uno Platform Skills
 

--- a/doc/articles/get-started-ai-cursor.md
+++ b/doc/articles/get-started-ai-cursor.md
@@ -19,6 +19,20 @@ Install [Cursor](https://cursor.com/docs).
 
 There is nothing specific to set up for Cursor. You can proceed to the next section to create your first app and use the Uno MCPs.
 
+## Setting up the Uno Platform Skills
+
+Uno Platform ships a catalog of agent skills covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing. Cursor doesn't support the plugin format at this time, so copy the skills into Cursor's skills directory instead:
+
+```bash
+git clone https://github.com/unoplatform/studio.git
+mkdir -p ~/.cursor/skills
+cp -r studio/skills/uno-* ~/.cursor/skills/
+```
+
+To make the skills available in a single project only, copy them to `.cursor/skills/` at the project root instead.
+
+Once installed, Cursor automatically selects the relevant skills as it works on your prompts. For the full skill catalog and other installation options, see [Skills & Plugins](xref:Uno.PlatformStudio.Skills).
+
 ## Next Steps
 
 Now that you are set up, let's [create your first app](xref:Uno.GettingStarted.CreateAnApp.AI.Cursor).

--- a/doc/articles/get-started-ai-gh-copilot-cli.md
+++ b/doc/articles/get-started-ai-gh-copilot-cli.md
@@ -30,6 +30,19 @@ To get started with GitHub Copilot CLI:
 > [!IMPORTANT]
 > The uno-app MCP may fail to load unless Copilot is opened in a folder containing an Uno Platform app.
 
+## Setting up the Uno Platform Skills
+
+Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, Copilot CLI automatically selects the relevant skills as it works on your prompts.
+
+Install the plugin:
+
+```text
+copilot plugin marketplace add unoplatform/studio
+copilot plugin install uno-platform-studio@uno-platform
+```
+
+For the full skill catalog, update instructions, and other installation options, see [Skills & Plugins](xref:Uno.PlatformStudio.Skills).
+
 ## Next Steps
 
 Now that you are set up, let's [create your first app](xref:Uno.GettingStarted.CreateAnApp.AI.CopilotCli).

--- a/doc/articles/get-started-ai-gh-copilot-cli.md
+++ b/doc/articles/get-started-ai-gh-copilot-cli.md
@@ -34,7 +34,7 @@ To get started with GitHub Copilot CLI:
 
 Uno Platform ships a catalog of agent skills — covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing — bundled in the `uno-platform-studio` plugin. Once installed, Copilot CLI automatically selects the relevant skills as it works on your prompts.
 
-Install the plugin:
+From a terminal, install the plugin:
 
 ```text
 copilot plugin marketplace add unoplatform/studio

--- a/doc/articles/get-started-ai-google-antigravity.md
+++ b/doc/articles/get-started-ai-google-antigravity.md
@@ -73,6 +73,20 @@ This guide walks you through configuring the Uno Platform MCPs for Google Antigr
 
     See [The Uno Platform MCPs](xref:Uno.Features.Uno.MCPs) for additional details about MCP registration and diagnostics.
 
+## Setting up the Uno Platform Skills
+
+Uno Platform ships a catalog of agent skills covering areas such as MVUX, navigation, Uno Toolkit controls, theming, and UI testing. Antigravity doesn't support the plugin format at this time, so copy the skills into an [Antigravity skills directory](https://antigravity.google/docs/skills) instead:
+
+```bash
+git clone https://github.com/unoplatform/studio.git
+mkdir -p ~/.gemini/config/skills
+cp -r studio/skills/uno-* ~/.gemini/config/skills/
+```
+
+To make the skills available in a single project only, copy them to `.agents/skills/` at the workspace root instead.
+
+Once installed, Antigravity automatically selects the relevant skills as it works on your prompts. For the full skill catalog and other installation options, see [Skills & Plugins](xref:Uno.PlatformStudio.Skills).
+
 ## Next Steps
 
 You are now ready to [create your first app with Google Antigravity](xref:Uno.GettingStarted.CreateAnApp.AI.GoogleAntigravity).


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/studio/issues/141

## PR Type:

📚 Documentation content changes

## What changed? 🚀

The AI agent getting-started guides (Claude Code, Codex CLI, GitHub Copilot CLI, Cursor, Google Antigravity) only covered MCP setup and never mentioned the Uno Platform Skills, so newcomers following "Getting Started with Agentic Development" never discovered them.

Each guide now has a "Setting up the Uno Platform Skills" section with the agent-appropriate install steps — the `uno-platform-studio` plugin for agents that support it, standalone skill folders for Cursor and Antigravity — linking to the existing [Skills & Plugins](https://platform.uno/docs/articles/studio/Agent/uno-platform-studio-skills.html) page for the full catalog. "Prompting in your App" also gets a short skills mention alongside the MCPs.