### PR TITLE
fix(ios): Defer pasteboard read until paste intent

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
@@ -46,7 +46,8 @@ partial class Given_Clipboard
 	[TestMethod]
 	[RunsOnUIThread]
 	// note: do not enable this for wasm, without adjust default clipboard permission
-	[PlatformCondition(Include, NativeIOS | NativeAndroid | SkiaWin32)]
+	[PlatformCondition(Include, NativeIOS | NativeAndroid | SkiaWin32 | SkiaIOS)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23962")]
 	public async Task When_GetSet_Clipboard_Text()
 	{
 		var package = new DataPackage();
@@ -57,6 +58,9 @@ partial class Given_Clipboard
 		await DelayForClipboard();
 
 		var view = Clipboard.GetContent();
+
+		Assert.IsTrue(view.Contains(StandardDataFormats.Text));
+
 		var text = await view.GetTextAsync();
 
 		Assert.AreEqual(TestString, text);

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.iOS.cs
@@ -39,10 +39,12 @@ namespace Windows.ApplicationModel.DataTransfer
 		{
 			var dataPackage = new DataPackage();
 
-			var clipText = UIPasteboard.General.String;
-			if (clipText != null)
+			// Reading UIPasteboard.General.String eagerly triggers the iOS paste-permission
+			// prompt. HasStrings is prompt-free, so defer the actual read until the content
+			// is requested, matching a real paste intent.
+			if (UIPasteboard.General.HasStrings)
 			{
-				dataPackage.SetText(clipText);
+				dataPackage.SetDataProvider(StandardDataFormats.Text, ct => Task.FromResult<object>(UIPasteboard.General.String ?? string.Empty));
 			}
 
 			return dataPackage.GetView();


### PR DESCRIPTION
**GitHub Issue:** closes #23962

## PR Type:

🐞 Bugfix

## What changed? 🚀

On iOS 16+, launching an app with a `TextBox` on the first page showed the system *"'XXX' would like to paste from …"* prompt with no user interaction.

Root cause: `Page.OnLoaded` sets initial focus on the first focusable element, and on focus the Skia `TextBox` refreshes `CanPasteClipboardContent`, which called `Clipboard.GetContent()`. The iOS implementation eagerly read `UIPasteboard.General.String`, and reading pasteboard *content* is exactly what triggers the iOS paste-permission prompt. The same read also fired every time the user simply tapped into a `TextBox`.

This PR makes the iOS `Clipboard.GetContent()` lazy, mirroring the existing WASM implementation:

- Text availability is now checked with `UIPasteboard.General.HasStrings`, which is prompt-free by design.
- The actual `UIPasteboard.General.String` read is deferred via `SetDataProvider`, so it only happens when `GetTextAsync()` is invoked — i.e. on a real paste — which is where the iOS prompt legitimately belongs.

Applies to both Skia and native iOS (both consume the same iOS `Uno` assembly).

Validation (iPhone 17 simulator, iOS 26.3, Skia renderer, foreign pasteboard content seeded via `simctl pbcopy`):

- Before: stock packages show the paste prompt during launch, before first render.
- After: same app with this fix shows no prompt at startup or on focus; the deferred read path is exercised by the existing `When_GetSet_Clipboard_Text` runtime test, now also enabled on Skia iOS.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
