### PR TITLE
fix(sdk): Align AndroidX.Wear pins and Wear minSdk

### DIFF
--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -1,12 +1,17 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Validates that all package IDs and versions in src/Uno.Sdk/packages.json exist on NuGet.org.
+    Validates that all package IDs and versions in src/Uno.Sdk/packages.json exist on NuGet.org,
+    and that the pinned Xamarin.* package set is mutually dependency-coherent.
 
 .DESCRIPTION
     Parses packages.json, skips groups with placeholder versions (e.g. "DefaultUnoVersion"),
     and verifies each package ID + version (including versionOverride entries) against NuGet.org.
-    Exits with code 1 if any package/version is missing.
+    Then, for each TFM pin set (base and each versionOverride TFM), walks the nuspec dependency
+    floors of every pinned Xamarin.* package (recursing through unpinned intermediates) and fails
+    when a pinned package is below a floor required by another pin - the NU1605 downgrade class
+    that broke the AndroidWear feature (#23991).
+    Exits with code 1 if any package/version is missing or any dependency floor is violated.
 
 .PARAMETER PackagesJsonPath
     Path to the packages.json file. Defaults to src/Uno.Sdk/packages.json relative to repo root.
@@ -131,6 +136,138 @@ foreach ($group in $json) {
 
 Write-Host ""
 Write-Host "Checked $checked package/version combinations." -ForegroundColor Cyan
+
+# ---------------------------------------------------------------------------
+# Dependency coherence: every pinned Xamarin.* package's nuspec dependency
+# floors must be satisfied by the other pins of the same TFM set, otherwise
+# consumers restore with NU1605 (warning-as-error) downgrade failures.
+# ---------------------------------------------------------------------------
+
+$script:nuspecCache = @{}
+$script:reportedConflicts = [System.Collections.Generic.HashSet[string]]::new()
+
+function Get-NuspecXml([string]$Id, [string]$Version) {
+    $key = "$($Id.ToLowerInvariant())|$($Version.ToLowerInvariant())"
+    if ($script:nuspecCache.ContainsKey($key)) { return $script:nuspecCache[$key] }
+    $url = "https://api.nuget.org/v3-flatcontainer/$($Id.ToLowerInvariant())/$($Version.ToLowerInvariant())/$($Id.ToLowerInvariant()).nuspec"
+    $xml = $null
+    try {
+        $response = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 30 `
+            -MaximumRetryCount 3 -RetryIntervalSec 2 -ErrorAction Stop
+        $xml = [xml]$response.Content
+    }
+    catch {
+        Write-Host "  [WARN] Could not fetch nuspec for $Id $Version - skipping its subtree" -ForegroundColor Yellow
+    }
+    $script:nuspecCache[$key] = $xml
+    return $xml
+}
+
+# Lower bound of a nuspec version range ("1.4.0.5", "[1.4.0.1, 1.4.1)", ...), or $null.
+function Get-MinVersion([string]$Range) {
+    if ([string]::IsNullOrWhiteSpace($Range)) { return $null }
+    $v = $Range.Trim()
+    if ($v.StartsWith('[') -or $v.StartsWith('(')) {
+        $v = $v.TrimStart('[', '(').Split(',')[0].Trim()
+        if (-not $v) { return $null }
+    }
+    $v = $v.Split('-')[0].Split('+')[0]
+    if ($v -notmatch '\.') { $v = "$v.0" }
+    try { return [version]$v } catch { return $null }
+}
+
+# Pick the nuspec dependency group matching the TFM pin set being validated.
+function Select-DependencyGroup($NuspecXml, [string]$TfmPrefix) {
+    $groups = @($NuspecXml.package.metadata.dependencies.group) | Where-Object { $_ }
+    if (-not $groups) { return $null }
+    $exact = $groups | Where-Object { $_.targetFramework -like "$TfmPrefix-android*" } | Select-Object -First 1
+    if ($exact) { return $exact }
+    $requestedMajor = [int]([regex]::Match($TfmPrefix, '\d+').Value)
+    $android = $groups |
+        Where-Object { $_.targetFramework -match '^net(\d+)\.0-android' } |
+        Sort-Object { [int][regex]::Match($_.targetFramework, '^net(\d+)').Groups[1].Value }
+    if (-not $android) { return $groups[0] }
+    $below = @($android | Where-Object { [int][regex]::Match($_.targetFramework, '^net(\d+)').Groups[1].Value -le $requestedMajor })
+    if ($below) { return $below[-1] }
+    return $android[0]
+}
+
+# Walk dependency floors of ($Id, $Version): a pinned dependency must satisfy its floor
+# (NuGet uses the pin from there on, so recursion stops); an unpinned Xamarin.* dependency
+# resolves to at least its floor, so recurse through it at the floor version.
+function Test-DependencyFloors($Pinned, [string]$SetLabel, [string]$TfmPrefix, [string]$Id, [string]$Version, [string]$Chain, [int]$Depth, $Visited) {
+    if ($Depth -gt 8) { return }
+    $key = "$($Id.ToLowerInvariant())|$Version"
+    if (-not $Visited.Add($key)) { return }
+    $nuspec = Get-NuspecXml $Id $Version
+    if (-not $nuspec) { return }
+    $depGroup = Select-DependencyGroup $nuspec $TfmPrefix
+    if (-not $depGroup) { return }
+    foreach ($dep in @($depGroup.dependency)) {
+        if (-not $dep -or -not $dep.id) { continue }
+        $floor = Get-MinVersion $dep.version
+        if (-not $floor) { continue }
+        $depIdLower = $dep.id.ToLowerInvariant()
+        if ($Pinned.ContainsKey($depIdLower)) {
+            $pinnedVersion = Get-MinVersion $Pinned[$depIdLower]
+            if ($pinnedVersion -and $pinnedVersion -lt $floor) {
+                # Report each violated (package, floor) once per set; extra chains add noise, not information.
+                $conflictKey = "$SetLabel|$depIdLower|$floor"
+                if ($script:reportedConflicts.Add($conflictKey)) {
+                    Write-Host "  [CONFLICT] ($SetLabel) $Chain -> $($dep.id) >= $($dep.version), but pinned at $($Pinned[$depIdLower])" -ForegroundColor Red
+                    $script:errors += "Dependency conflict ($SetLabel): $Chain requires $($dep.id) >= $($dep.version), but packages.json pins $($Pinned[$depIdLower])"
+                }
+            }
+        }
+        elseif ($dep.id.StartsWith('Xamarin.', [System.StringComparison]::OrdinalIgnoreCase)) {
+            Test-DependencyFloors $Pinned $SetLabel $TfmPrefix $dep.id $floor.ToString() "$Chain -> $($dep.id) $floor" ($Depth + 1) $Visited
+        }
+    }
+}
+
+# Effective pin sets: base versions (net9.0 apps) plus one set per versionOverride TFM.
+$overrideTfms = @()
+foreach ($group in $json) {
+    if ($group.PSObject.Properties['versionOverride'] -and $null -ne $group.versionOverride) {
+        $overrideTfms += $group.versionOverride.PSObject.Properties.Name
+    }
+}
+$tfmSets = @(@{ Label = 'base/net9.0'; Tfm = 'net9.0'; OverrideKey = $null })
+foreach ($tfm in ($overrideTfms | Sort-Object -Unique)) {
+    $tfmSets += @{ Label = $tfm; Tfm = $tfm; OverrideKey = $tfm }
+}
+
+$coherenceChecked = 0
+foreach ($set in $tfmSets) {
+    $pinned = @{}
+    foreach ($group in $json) {
+        $effective = $group.version
+        if ($set.OverrideKey -and $group.PSObject.Properties['versionOverride'] -and $null -ne $group.versionOverride) {
+            $override = $group.versionOverride.PSObject.Properties[$set.OverrideKey]
+            if ($override) { $effective = $override.Value }
+        }
+        if ($placeholderVersions -contains $effective) { continue }
+        foreach ($pkg in $group.packages) {
+            $pinned[$pkg.ToLowerInvariant()] = $effective
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Validating dependency coherence for pin set '$($set.Label)'..." -ForegroundColor Cyan
+    foreach ($group in $json) {
+        foreach ($pkg in $group.packages) {
+            if (-not $pkg.StartsWith('Xamarin.', [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+            $version = $pinned[$pkg.ToLowerInvariant()]
+            if (-not $version) { continue }
+            $coherenceChecked++
+            $visited = [System.Collections.Generic.HashSet[string]]::new()
+            Test-DependencyFloors $pinned $set.Label $set.Tfm $pkg $version "$pkg $version" 0 $visited
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Checked dependency coherence for $coherenceChecked pinned package/set combinations." -ForegroundColor Cyan
 
 if ($errors.Count -gt 0) {
     Write-Host ""

--- a/doc/articles/features/android-wear.md
+++ b/doc/articles/features/android-wear.md
@@ -18,7 +18,9 @@ This automatically adds references to the `Xamarin.AndroidX.Wear` and `Xamarin.A
 
 ## What gets configured
 
-When the `AndroidWear` feature is enabled, the template stamps the following declaration into your `AndroidManifest.xml`:
+When the `AndroidWear` feature is enabled, `SupportedOSPlatformVersion` (Android `minSdkVersion`) defaults to `26.0` instead of `21.0`, unless you set it explicitly — the `androidx.wear.protolayout` libraries referenced by `Xamarin.AndroidX.Wear.Tiles` require API 26 or higher.
+
+Additionally, the template stamps the following declaration into your `AndroidManifest.xml`:
 
 ```xml
 <uses-feature android:name="android.hardware.type.watch" android:required="false" />

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -295,12 +295,12 @@
 	},
 	{
 		"group": "AndroidXWear",
-		"version": "1.3.0.16",
+		"version": "1.3.0.14",
 		"packages": [
 			"Xamarin.AndroidX.Wear"
 		],
 		"versionOverride": {
-			"net10.0": "1.4.0.1"
+			"net10.0": "1.3.0.15"
 		}
 	},
 	{

--- a/src/Uno.Sdk/targets/Uno.Common.Android.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Android.targets
@@ -1,6 +1,8 @@
 <Project>
 	<PropertyGroup>
 		<IsAndroid>true</IsAndroid>
+		<!-- androidx.wear.protolayout (Xamarin.AndroidX.Wear.Tiles) requires minSdk 26 -->
+		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' AND $(UnoFeatures.Contains(';androidwear;')) ">26.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">21.0</SupportedOSPlatformVersion>
 		<EnableDefaultAndroidItems Condition="$(EnableDefaultAndroidItems) == ''">false</EnableDefaultAndroidItems>
 


### PR DESCRIPTION
**GitHub Issue:** closes #23991

## PR Type:

🐞 Bugfix

## What changed? 🚀

A new `unoapp` with the **Wear OS** feature enabled fails to restore for `net10.0-android` with three `NU1605` package-downgrade errors: `Uno.Sdk` pins `Xamarin.AndroidX.Wear` to 1.4.0.1 for net10.0, but that revision's dependency floors (RecyclerView ≥ 1.4.0.5, SwipeRefreshLayout ≥ 1.2.0.2, Fragment 1.8.9.2 → Activity ≥ 1.12.4.1) are all above the versions the SDK pins. The base (net9.0) pin `1.3.0.16` has the same problem against the base pin set, so net9.0-android was equally broken.

This PR makes the `AndroidWear` feature restore **and build** out of the box:

- **`packages.json`**: pin `AndroidXWear` to the revisions that ship in the same dotnet/android-libraries wave as the rest of the pinned set — `1.3.0.14` (base) / `1.3.0.15` (net10.0). Down-pinning Wear keeps the change scoped to the Wear feature; raising the other AndroidX pins up to Wear 1.4.0.1's floors was validated and rejected, because Activity 1.12.x floors `androidx.lifecycle` 2.10 (minSdk 23), which breaks **every** default (minSdk 21) Android app, and on net9.0 it drags in the broken `Compose.Runtime.Annotation` 1.10.0.1 packaging wave (D8 duplicate-class failure).
- **`Uno.Common.Android.targets`**: when the `androidwear` feature is enabled and `SupportedOSPlatformVersion` is not set explicitly, default it to `26.0` instead of `21.0` — `Xamarin.AndroidX.Wear.Tiles` brings in `androidx.wear.protolayout`, whose AAR requires minSdk 26 (manifest-merge `AMM0000` otherwise).
- **`validate-packages-json.ps1`** (CI guard, second commit): in addition to the existing exists-on-NuGet check, validate that the pinned `Xamarin.*` set is *mutually dependency-coherent* per TFM pin set, by walking nuspec dependency floors (recursing through unpinned intermediates such as `Fragment`). This is exactly the gap the existing guard could not catch: `1.4.0.1` exists on NuGet, but is incoherent with the surrounding pins. On the pre-fix manifest the check reports 8 conflicts (4 per TFM set — including a `Collection` floor violation that a default app cannot surface); on this PR's manifest it passes.
- **`android-wear.md`**: document the minSdk 26 default.

### Validation (all runtime, Uno.Sdk 6.7.0-dev.165 with the changed files injected)

| Scenario | Before | After |
|---|---|---|
| `dotnet new unoapp -platforms android --includeAndroidWear`, net10.0-android | restore fails, 3× NU1605 | restore + build clean (0 errors, 0 warnings) |
| Same app on net9.0-android | restore fails, 3× NU1605 | restore + build clean |
| Plain `unoapp` (no Wear), net10.0-android | builds | builds (pins for non-Wear apps unchanged — no blast radius) |
| CI guard on pre-fix `packages.json` | passes (misses the bug) | fails with 8 dependency conflicts, exit 1 |
| CI guard on this PR's `packages.json` | — | passes, exit 0 |

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — covered by the CI guard's new dependency-coherence check, which fails on the pre-fix manifest and passes on this one
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- Note: apps that enabled AndroidWear and worked around the restore failure by overriding package versions manually may want to remove those overrides. The minSdk 26 default only applies when the AndroidWear feature is enabled and SupportedOSPlatformVersion is not set explicitly. -->
