### PR TITLE
fix(docs): hide feedback box when it overlaps the footer / back-to-top link

### DIFF
--- a/doc/templates/uno/component/affix.js
+++ b/doc/templates/uno/component/affix.js
@@ -121,7 +121,24 @@ function renderAffix() {
                     );
                 }
             }
-            
+
+            // Check overlap with the footer (the "back to top" link lives here,
+            // and the fixed box otherwise covers it when scrolled to the bottom).
+            if (!hasOverlap) {
+                const footer = $('footer');
+                if (footer.length > 0) {
+                    const footerRect = footer[0].getBoundingClientRect();
+                    if (footerRect.height > 0) {
+                        hasOverlap = !(
+                            feedbackRect.right < footerRect.left ||
+                            feedbackRect.left > footerRect.right ||
+                            feedbackRect.bottom < footerRect.top ||
+                            feedbackRect.top > footerRect.bottom
+                        );
+                    }
+                }
+            }
+
             if (hasOverlap) {
                 feedbackBox.addClass('hidden-with-overlap');
             } else {


### PR DESCRIPTION
## Problem

The floating **"Edit this page / Send feedback"** box (`.feedback-box`, `position: fixed; bottom; right`) overlaps the footer's **"back to top"** link when the page is scrolled to the bottom.

## Cause

`checkFeedbackBoxOverlap()` in `doc/templates/uno/component/affix.js` hides the box (`.hidden-with-overlap`) when it overlaps the "In this article" affix or the main article — but it never checks the **footer**, where the back-to-top link lives.

## Fix

Add the `<footer>` element to the overlap check, so the box hides when it would cover the footer / back-to-top link (a `height > 0` guard avoids false positives while the footer is faded out).

## Note

`styles/docfx.js` is regenerated from `component/*.js` by CI (`gulp build` in `build/ci/templates/docfx-intermediary-assets.yml`), so only the `affix.js` source change is committed here — the bundle is rebuilt at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
