### PR TITLE
feat(ci): Capture diagnostics when runtime tests stall

### DIFF
--- a/build/ci/tests/.azure-devops-tests-linux-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-linux-skia.yml
@@ -131,3 +131,13 @@ jobs:
       PathtoPublish: $(build.sourcesdirectory)/build/uitests-failure-results
       ArtifactName: runtime-tests-desktop-skia-linux-failures
       ArtifactType: Container
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    displayName: Publish Stall Diagnostics
+    continueOnError: true
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.sourcesdirectory)/build/uitests-diagnostics
+      ArtifactName: runtime-tests-desktop-skia-linux${{ parameters.testResultLabel }}-diagnostics
+      ArtifactType: Container

--- a/build/ci/tests/.azure-devops-tests-linux-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-linux-skia.yml
@@ -137,3 +137,13 @@ jobs:
       PathtoPublish: $(build.sourcesdirectory)/build/uitests-failure-results
       ArtifactName: runtime-tests-desktop-skia-linux-failures
       ArtifactType: Container
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    displayName: Publish Stall Diagnostics
+    continueOnError: true
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.sourcesdirectory)/build/uitests-diagnostics
+      ArtifactName: runtime-tests-desktop-skia-linux${{ parameters.testResultLabel }}-diagnostics
+      ArtifactType: Container

--- a/build/ci/tests/.azure-devops-tests-macos-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-macos-skia.yml
@@ -79,3 +79,13 @@ jobs:
       PathtoPublish: $(build.sourcesdirectory)/build/uitests-failure-results
       ArtifactName: runtime-tests-desktop-skia-macos-failures
       ArtifactType: Container
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    displayName: Publish Stall Diagnostics
+    continueOnError: true
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.sourcesdirectory)/build/uitests-diagnostics
+      ArtifactName: runtime-tests-desktop-skia-macos-diagnostics
+      ArtifactType: Container

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -25,12 +25,25 @@ USE_XVFB=${1:-true}
 sudo chmod a+rw /dev/dri/card* 2>/dev/null || true
 sudo chmod a+rw /dev/fb* 2>/dev/null || true
 
+export UITEST_DIAGNOSTICS_DIR=$BUILD_SOURCESDIRECTORY/build/uitests-diagnostics
+export UNO_WATCHDOG_HARD_TIMEOUT_SECONDS=${UNO_WATCHDOG_HARD_TIMEOUT_SECONDS:-3300}
+mkdir -p $UITEST_DIAGNOSTICS_DIR
+APP_LOG=$UITEST_DIAGNOSTICS_DIR/runtime-tests-console.log
+
+chmod +x $BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh
+$BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh \
+	"$APP_LOG" "$UITEST_DIAGNOSTICS_DIR" "dotnet.*SamplesApp\.Skia\.Generic\.dll" &
+WATCHDOG_PID=$!
+trap 'kill $WATCHDOG_PID 2>/dev/null || true' EXIT
+
 cd $SamplesAppArtifactPath
 if [ "$USE_XVFB" = "true" ]; then
-	xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE' || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
+	xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE' 2>&1 | tee "$APP_LOG" || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
 else
-	dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE || true
+	dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE 2>&1 | tee "$APP_LOG" || true
 fi
+
+kill $WATCHDOG_PID 2>/dev/null || true
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/linux-skia-runtime-tests.sh
+++ b/build/test-scripts/linux-skia-runtime-tests.sh
@@ -35,12 +35,25 @@ USE_XVFB=${1:-true}
 sudo chmod a+rw /dev/dri/card* 2>/dev/null || true
 sudo chmod a+rw /dev/fb* 2>/dev/null || true
 
+export UITEST_DIAGNOSTICS_DIR=$BUILD_SOURCESDIRECTORY/build/uitests-diagnostics
+export UNO_WATCHDOG_HARD_TIMEOUT_SECONDS=${UNO_WATCHDOG_HARD_TIMEOUT_SECONDS:-3300}
+mkdir -p $UITEST_DIAGNOSTICS_DIR
+APP_LOG=$UITEST_DIAGNOSTICS_DIR/runtime-tests-console.log
+
+chmod +x $BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh
+$BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh \
+	"$APP_LOG" "$UITEST_DIAGNOSTICS_DIR" "dotnet.*SamplesApp\.dll" &
+WATCHDOG_PID=$!
+trap 'kill $WATCHDOG_PID 2>/dev/null || true' EXIT
+
 cd $SamplesAppArtifactPath
 if [ "$USE_XVFB" = "true" ]; then
-	xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.dll --runtime-tests=$TEST_RESULTS_FILE' || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
+	xvfb-run --auto-servernum --server-args='-screen 0 1280x1024x24' sh -c '{ fluxbox & } ; dotnet SamplesApp.dll --runtime-tests=$TEST_RESULTS_FILE' 2>&1 | tee "$APP_LOG" || true # sometimes we crash during app shutdown, so we're forcing a 0 exit code
 else
-	dotnet SamplesApp.dll --runtime-tests=$TEST_RESULTS_FILE || true
+	dotnet SamplesApp.dll --runtime-tests=$TEST_RESULTS_FILE 2>&1 | tee "$APP_LOG" || true
 fi
+
+kill $WATCHDOG_PID 2>/dev/null || true
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -17,8 +17,28 @@ if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
 	fi
 fi
 
+export UITEST_DIAGNOSTICS_DIR=$BUILD_SOURCESDIRECTORY/build/uitests-diagnostics
+export UNO_WATCHDOG_HARD_TIMEOUT_SECONDS=${UNO_WATCHDOG_HARD_TIMEOUT_SECONDS:-3300}
+mkdir -p $UITEST_DIAGNOSTICS_DIR
+APP_LOG=$UITEST_DIAGNOSTICS_DIR/runtime-tests-console.log
+
+chmod +x $BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh
+$BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh \
+	"$APP_LOG" "$UITEST_DIAGNOSTICS_DIR" "dotnet.*SamplesApp\.Skia\.Generic\.dll" &
+WATCHDOG_PID=$!
+trap 'kill $WATCHDOG_PID 2>/dev/null || true' EXIT
+
 cd $SamplesAppArtifactPath
-dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE
+
+## The app exit code must not abort the script: the failed-test list below is what lets a
+## pipeline retry run only the failures instead of the whole suite.
+set +e
+dotnet SamplesApp.Skia.Generic.dll --runtime-tests=$TEST_RESULTS_FILE 2>&1 | tee "$APP_LOG"
+APP_EXIT=${PIPESTATUS[0]}
+set -e
+
+kill $WATCHDOG_PID 2>/dev/null || true
+echo "Runtime tests app exited with code $APP_EXIT"
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/macos-skia-runtime-tests.sh
+++ b/build/test-scripts/macos-skia-runtime-tests.sh
@@ -29,6 +29,17 @@ if [ -f "$UNO_TESTS_FAILED_LIST" ]; then
 	fi
 fi
 
+export UITEST_DIAGNOSTICS_DIR=$BUILD_SOURCESDIRECTORY/build/uitests-diagnostics
+export UNO_WATCHDOG_HARD_TIMEOUT_SECONDS=${UNO_WATCHDOG_HARD_TIMEOUT_SECONDS:-3300}
+mkdir -p $UITEST_DIAGNOSTICS_DIR
+APP_LOG=$UITEST_DIAGNOSTICS_DIR/runtime-tests-console.log
+
+chmod +x $BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh
+$BUILD_SOURCESDIRECTORY/build/test-scripts/stall-watchdog.sh \
+	"$APP_LOG" "$UITEST_DIAGNOSTICS_DIR" "dotnet.*SamplesApp\.dll" &
+WATCHDOG_PID=$!
+trap 'kill $WATCHDOG_PID 2>/dev/null || true' EXIT
+
 cd $SamplesAppArtifactPath
 
 mkdir -p "$BUILD_SOURCESDIRECTORY/build/uitests-failure-results"
@@ -40,7 +51,15 @@ export DOTNET_CreateDumpDiagnostics=1
 export DOTNET_CreateDumpLogToFile="$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/createdump-macos.log"
 export DOTNET_EnableCrashReport=1
 
-dotnet SamplesApp.dll --runtime-tests=$TEST_RESULTS_FILE
+## The app exit code must not abort the script: the failed-test list below is what lets a
+## pipeline retry run only the failures instead of the whole suite.
+set +e
+dotnet SamplesApp.dll --runtime-tests=$TEST_RESULTS_FILE 2>&1 | tee "$APP_LOG"
+APP_EXIT=${PIPESTATUS[0]}
+set -e
+
+kill $WATCHDOG_PID 2>/dev/null || true
+echo "Runtime tests app exited with code $APP_EXIT"
 
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/stall-watchdog.sh
+++ b/build/test-scripts/stall-watchdog.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# Background watchdog for the desktop Skia runtime tests.
+#
+# Watches a log file for output. When the log goes quiet for longer than the stall threshold,
+# it captures native and managed stacks of the test process so a frozen run leaves evidence
+# instead of being killed silently by the job timeout.
+#
+# Usage: stall-watchdog.sh <log-file> <output-dir> <pgrep-pattern>
+#
+# Environment:
+#   UNO_WATCHDOG_STALL_SECONDS         quiet period before a capture       (default 180)
+#   UNO_WATCHDOG_POLL_SECONDS          poll interval                       (default 15)
+#   UNO_WATCHDOG_MAX_CAPTURES          cap on captures per run             (default 6)
+#   UNO_WATCHDOG_HARD_TIMEOUT_SECONDS  terminate the app after this        (default 0 = never)
+#
+# Deliberately never exits non-zero: this observes a run, it must not be able to fail one.
+
+set -uo pipefail
+
+LOG_FILE="${1:?log file required}"
+OUT_DIR="${2:?output dir required}"
+PROC_PATTERN="${3:?process pattern required}"
+
+STALL_SECONDS=${UNO_WATCHDOG_STALL_SECONDS:-180}
+POLL_SECONDS=${UNO_WATCHDOG_POLL_SECONDS:-15}
+MAX_CAPTURES=${UNO_WATCHDOG_MAX_CAPTURES:-6}
+HARD_TIMEOUT_SECONDS=${UNO_WATCHDOG_HARD_TIMEOUT_SECONDS:-0}
+
+mkdir -p "$OUT_DIR"
+export PATH="$PATH:$HOME/.dotnet/tools"
+
+log() { echo "[watchdog] $*"; }
+
+file_age_seconds() {
+	local f=$1
+	[ -f "$f" ] || { echo 0; return; }
+	local now mtime
+	now=$(date +%s)
+	if mtime=$(stat -f %m "$f" 2>/dev/null); then :
+	elif mtime=$(stat -c %Y "$f" 2>/dev/null); then :
+	else echo 0; return; fi
+	echo $(( now - mtime ))
+}
+
+install_tools() {
+	# Best effort: the watchdog still reports ps/sample output without these.
+	if ! command -v dotnet-stack >/dev/null 2>&1; then
+		log "installing dotnet-stack..."
+		dotnet tool install -g dotnet-stack >/dev/null 2>&1 || log "dotnet-stack install failed (continuing)"
+	fi
+}
+
+capture() {
+	local reason=$1 index=$2 pid=$3
+	local dir="$OUT_DIR/stall-$(printf '%02d' "$index")-$(date +%Y%m%d-%H%M%S)"
+	mkdir -p "$dir"
+
+	log "capturing diagnostics ($reason) for pid $pid -> $dir"
+
+	{
+		echo "reason:        $reason"
+		echo "captured at:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+		echo "pid:           $pid"
+		echo "log quiet for: $(file_age_seconds "$LOG_FILE")s"
+		echo "uname:         $(uname -a)"
+	} > "$dir/context.txt" 2>&1
+
+	tail -n 60 "$LOG_FILE" > "$dir/log-tail.txt" 2>&1 || true
+	ps -o pid,ppid,stat,%cpu,%mem,etime,command -p "$pid" > "$dir/ps.txt" 2>&1 || true
+
+	# Managed stacks — the primary artefact for a managed deadlock or a hung await.
+	if command -v dotnet-stack >/dev/null 2>&1; then
+		timeout 120 dotnet-stack report --process-id "$pid" > "$dir/dotnet-stack.txt" 2>&1 \
+			|| log "dotnet-stack failed (see $dir/dotnet-stack.txt)"
+	fi
+
+	case "$(uname -s)" in
+		Darwin)
+			# Native stacks for every thread, including AppKit/CoreAnimation frames that
+			# managed stacks cannot show. This is the artefact for a host-level livelock.
+			timeout 120 sample "$pid" 10 -f "$dir/sample.txt" >/dev/null 2>&1 \
+				|| log "sample failed"
+			timeout 60 vmmap --summary "$pid" > "$dir/vmmap.txt" 2>&1 || true
+			;;
+		Linux)
+			if command -v eu-stack >/dev/null 2>&1; then
+				timeout 120 eu-stack -p "$pid" > "$dir/eu-stack.txt" 2>&1 || true
+			fi
+			cat "/proc/$pid/status" > "$dir/proc-status.txt" 2>&1 || true
+			cat "/proc/$pid/wchan" > "$dir/proc-wchan.txt" 2>&1 || true
+			for t in /proc/"$pid"/task/*; do
+				[ -d "$t" ] || continue
+				{ echo "== $t"; cat "$t/stat" 2>/dev/null; cat "$t/wchan" 2>/dev/null; echo; }
+			done > "$dir/proc-threads.txt" 2>&1 || true
+			;;
+	esac
+
+	log "capture complete: $dir"
+}
+
+find_pid() {
+	pgrep -f "$PROC_PATTERN" 2>/dev/null | head -n 1
+}
+
+install_tools
+log "watching '$LOG_FILE' (stall=${STALL_SECONDS}s poll=${POLL_SECONDS}s maxCaptures=${MAX_CAPTURES} hardTimeout=${HARD_TIMEOUT_SECONDS}s)"
+
+STARTED_AT=$(date +%s)
+CAPTURES=0
+CAPTURED_THIS_STALL=0
+
+while true; do
+	sleep "$POLL_SECONDS"
+
+	PID=$(find_pid)
+	if [ -z "$PID" ]; then
+		# App not started yet, or already gone. Either way there is nothing to sample.
+		continue
+	fi
+
+	AGE=$(file_age_seconds "$LOG_FILE")
+	ELAPSED=$(( $(date +%s) - STARTED_AT ))
+
+	if [ "$AGE" -ge "$STALL_SECONDS" ]; then
+		if [ "$CAPTURED_THIS_STALL" -eq 0 ] && [ "$CAPTURES" -lt "$MAX_CAPTURES" ]; then
+			CAPTURES=$(( CAPTURES + 1 ))
+			CAPTURED_THIS_STALL=1
+			capture "log quiet for ${AGE}s" "$CAPTURES" "$PID"
+		fi
+	else
+		# Output resumed — re-arm so the next stall is captured too.
+		CAPTURED_THIS_STALL=0
+	fi
+
+	if [ "$HARD_TIMEOUT_SECONDS" -gt 0 ] && [ "$ELAPSED" -ge "$HARD_TIMEOUT_SECONDS" ]; then
+		log "hard timeout reached after ${ELAPSED}s — capturing then terminating pid $PID"
+		CAPTURES=$(( CAPTURES + 1 ))
+		capture "hard timeout after ${ELAPSED}s" "$CAPTURES" "$PID"
+
+		# SIGTERM first so the app can still write its results XML, then escalate.
+		kill -TERM "$PID" 2>/dev/null || true
+		for _ in $(seq 1 30); do
+			kill -0 "$PID" 2>/dev/null || break
+			sleep 1
+		done
+		kill -KILL "$PID" 2>/dev/null || true
+		log "terminated pid $PID"
+		exit 0
+	fi
+done

--- a/build/test-scripts/stall-watchdog.sh
+++ b/build/test-scripts/stall-watchdog.sh
@@ -2,17 +2,22 @@
 
 # Background watchdog for the desktop Skia runtime tests.
 #
-# Watches a log file for output. When the log goes quiet for longer than the stall threshold,
-# it captures native and managed stacks of the test process so a frozen run leaves evidence
-# instead of being killed silently by the job timeout.
+# Watches the runtime test log for progress. When no new test starts for longer than the stall
+# threshold, it captures native and managed stacks of the test process so a frozen run leaves
+# evidence instead of being killed silently by the job timeout.
+#
+# Progress is the count of test-start lines, not the log's mtime: the in-process stall monitor
+# writes a heartbeat to this same log every 30s, so by mtime the file is never quiet and no
+# stall could ever be captured.
 #
 # Usage: stall-watchdog.sh <log-file> <output-dir> <pgrep-pattern>
 #
 # Environment:
-#   UNO_WATCHDOG_STALL_SECONDS         quiet period before a capture       (default 180)
+#   UNO_WATCHDOG_STALL_SECONDS         no-progress period before a capture (default 180)
 #   UNO_WATCHDOG_POLL_SECONDS          poll interval                       (default 15)
 #   UNO_WATCHDOG_MAX_CAPTURES          cap on captures per run             (default 6)
 #   UNO_WATCHDOG_HARD_TIMEOUT_SECONDS  terminate the app after this        (default 0 = never)
+#   UNO_WATCHDOG_PROGRESS_PATTERN      line that marks progress            (default 'Running test ')
 #
 # Deliberately never exits non-zero: this observes a run, it must not be able to fail one.
 
@@ -26,21 +31,19 @@ STALL_SECONDS=${UNO_WATCHDOG_STALL_SECONDS:-180}
 POLL_SECONDS=${UNO_WATCHDOG_POLL_SECONDS:-15}
 MAX_CAPTURES=${UNO_WATCHDOG_MAX_CAPTURES:-6}
 HARD_TIMEOUT_SECONDS=${UNO_WATCHDOG_HARD_TIMEOUT_SECONDS:-0}
+PROGRESS_PATTERN=${UNO_WATCHDOG_PROGRESS_PATTERN:-Running test }
 
 mkdir -p "$OUT_DIR"
 export PATH="$PATH:$HOME/.dotnet/tools"
 
 log() { echo "[watchdog] $*"; }
 
-file_age_seconds() {
+# Number of tests started so far. Re-scanning the whole log each poll costs little next to a
+# 15s interval, and needs no state to survive the app being restarted mid-run.
+progress_count() {
 	local f=$1
 	[ -f "$f" ] || { echo 0; return; }
-	local now mtime
-	now=$(date +%s)
-	if mtime=$(stat -f %m "$f" 2>/dev/null); then :
-	elif mtime=$(stat -c %Y "$f" 2>/dev/null); then :
-	else echo 0; return; fi
-	echo $(( now - mtime ))
+	grep -c "$PROGRESS_PATTERN" "$f" 2>/dev/null || echo 0
 }
 
 install_tools() {
@@ -62,7 +65,7 @@ capture() {
 		echo "reason:        $reason"
 		echo "captured at:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 		echo "pid:           $pid"
-		echo "log quiet for: $(file_age_seconds "$LOG_FILE")s"
+		echo "tests started so far: $(progress_count "$LOG_FILE")"
 		echo "uname:         $(uname -a)"
 	} > "$dir/context.txt" 2>&1
 
@@ -109,6 +112,8 @@ log "watching '$LOG_FILE' (stall=${STALL_SECONDS}s poll=${POLL_SECONDS}s maxCapt
 STARTED_AT=$(date +%s)
 CAPTURES=0
 CAPTURED_THIS_STALL=0
+LAST_PROGRESS=-1
+LAST_PROGRESS_AT=$STARTED_AT
 
 while true; do
 	sleep "$POLL_SECONDS"
@@ -119,18 +124,24 @@ while true; do
 		continue
 	fi
 
-	AGE=$(file_age_seconds "$LOG_FILE")
-	ELAPSED=$(( $(date +%s) - STARTED_AT ))
+	NOW=$(date +%s)
+	PROGRESS=$(progress_count "$LOG_FILE")
+	if [ "$PROGRESS" != "$LAST_PROGRESS" ]; then
+		LAST_PROGRESS=$PROGRESS
+		LAST_PROGRESS_AT=$NOW
+		# The run moved on — re-arm so the next stall is captured too.
+		CAPTURED_THIS_STALL=0
+	fi
+
+	AGE=$(( NOW - LAST_PROGRESS_AT ))
+	ELAPSED=$(( NOW - STARTED_AT ))
 
 	if [ "$AGE" -ge "$STALL_SECONDS" ]; then
 		if [ "$CAPTURED_THIS_STALL" -eq 0 ] && [ "$CAPTURES" -lt "$MAX_CAPTURES" ]; then
 			CAPTURES=$(( CAPTURES + 1 ))
 			CAPTURED_THIS_STALL=1
-			capture "log quiet for ${AGE}s" "$CAPTURES" "$PID"
+			capture "no test started for ${AGE}s" "$CAPTURES" "$PID"
 		fi
-	else
-		# Output resumed — re-arm so the next stall is captured too.
-		CAPTURED_THIS_STALL=0
 	fi
 
 	if [ "$HARD_TIMEOUT_SECONDS" -gt 0 ] && [ "$ELAPSED" -ge "$HARD_TIMEOUT_SECONDS" ]; then

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/TestRunStallMonitor.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/TestRunStallMonitor.cs
@@ -1,0 +1,217 @@
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.UI.Samples.Tests;
+
+/// <summary>
+/// Emits a periodic heartbeat while runtime tests execute, so a CI run that freezes
+/// leaves evidence of *what* froze rather than just going silent until the job timeout.
+/// </summary>
+/// <remarks>
+/// The heartbeat runs on a dedicated thread rather than a timer or the thread pool: if the
+/// pool is starved the heartbeat must still be emitted, otherwise it cannot be distinguished
+/// from a fully frozen process. Each tick probes the UI dispatcher and the thread pool
+/// separately, which separates "UI thread blocked" from "thread pool starved" from
+/// "whole process stopped" (no heartbeat line at all).
+/// </remarks>
+internal sealed class TestRunStallMonitor : IDisposable
+{
+	internal const string LogPrefix = "[stall-monitor]";
+
+	private const string IntervalVariable = "UNO_TEST_STALL_MONITOR_INTERVAL_SECONDS";
+	private const string StallThresholdVariable = "UNO_TEST_STALL_MONITOR_THRESHOLD_SECONDS";
+
+	private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(5);
+
+	private readonly TimeSpan _interval;
+	private readonly TimeSpan _stallThreshold;
+	private readonly Func<Task>? _dispatcherProbe;
+	private readonly Stopwatch _runElapsed = Stopwatch.StartNew();
+	private readonly CancellationTokenSource _cts = new();
+	private readonly Thread _thread;
+
+	private volatile string _currentTest = "(none)";
+	private long _currentTestStartedAt;
+	private bool _disposed;
+
+	private TestRunStallMonitor(TimeSpan interval, TimeSpan stallThreshold, Func<Task>? dispatcherProbe)
+	{
+		_interval = interval;
+		_stallThreshold = stallThreshold;
+		_dispatcherProbe = dispatcherProbe;
+		_currentTestStartedAt = _runElapsed.ElapsedMilliseconds;
+
+		_thread = new Thread(Loop)
+		{
+			IsBackground = true,
+			Name = "UnoTestStallMonitor",
+			Priority = ThreadPriority.AboveNormal,
+		};
+		_thread.Start();
+	}
+
+	/// <summary>
+	/// Starts a monitor, or returns <c>null</c> when disabled. Enabled by default on CI;
+	/// set <c>UNO_TEST_STALL_MONITOR_INTERVAL_SECONDS</c> to opt in locally, or to 0 to disable.
+	/// </summary>
+	public static TestRunStallMonitor? TryStart(Func<Task>? dispatcherProbe)
+	{
+		var interval = GetSeconds(IntervalVariable, defaultSeconds: DefaultIntervalSeconds);
+		if (interval <= 0)
+		{
+			return null;
+		}
+
+		var threshold = GetSeconds(StallThresholdVariable, defaultSeconds: 120);
+
+		Console.WriteLine(
+			$"{LogPrefix} enabled: interval={interval}s stallThreshold={threshold}s " +
+			$"pid={GetProcessIdSafe()} os={RuntimeDescription()}");
+
+		return new TestRunStallMonitor(
+			TimeSpan.FromSeconds(interval),
+			TimeSpan.FromSeconds(threshold),
+			dispatcherProbe);
+	}
+
+	private static int DefaultIntervalSeconds =>
+#if IS_CI
+		30;
+#else
+		0;
+#endif
+
+	public void SetCurrentTest(string testName)
+	{
+		_currentTest = testName;
+		Interlocked.Exchange(ref _currentTestStartedAt, _runElapsed.ElapsedMilliseconds);
+	}
+
+	private void Loop()
+	{
+		var previousGcPause = TimeSpan.Zero;
+
+		while (!_cts.IsCancellationRequested)
+		{
+			try
+			{
+				if (_cts.Token.WaitHandle.WaitOne(_interval))
+				{
+					return;
+				}
+
+				var inCurrentTest = TimeSpan.FromMilliseconds(
+					_runElapsed.ElapsedMilliseconds - Interlocked.Read(ref _currentTestStartedAt));
+
+				var (dispatcher, threadPool) = (ProbeDispatcher(), ProbeThreadPool());
+				var gcPause = TotalGcPause();
+				var gcDelta = gcPause - previousGcPause;
+				previousGcPause = gcPause;
+
+				var stalled = inCurrentTest >= _stallThreshold;
+
+				Console.WriteLine(
+					$"{LogPrefix}{(stalled ? " STALL" : "")} " +
+					$"elapsed={Format(_runElapsed.Elapsed)} " +
+					$"inTest={Format(inCurrentTest)} " +
+					$"dispatcher={dispatcher} " +
+					$"threadPool={threadPool} " +
+					$"gcPauseDelta={gcDelta.TotalMilliseconds.ToString("F0", CultureInfo.InvariantCulture)}ms " +
+					$"test='{_currentTest}'");
+			}
+			catch (Exception e)
+			{
+				// The monitor must never be able to fail a run it is only observing.
+				Console.WriteLine($"{LogPrefix} probe error: {e.GetType().Name}: {e.Message}");
+			}
+		}
+	}
+
+	private string ProbeDispatcher()
+	{
+		if (_dispatcherProbe is null)
+		{
+			return "n/a";
+		}
+
+		var sw = Stopwatch.StartNew();
+		try
+		{
+			var task = _dispatcherProbe();
+			return task.Wait(ProbeTimeout)
+				? $"{sw.ElapsedMilliseconds}ms"
+				: $"BLOCKED(>{ProbeTimeout.TotalSeconds:F0}s)";
+		}
+		catch (Exception e)
+		{
+			return $"error({e.GetType().Name})";
+		}
+	}
+
+	private static string ProbeThreadPool()
+	{
+		var sw = Stopwatch.StartNew();
+		var signal = new ManualResetEventSlim(false);
+
+		if (!ThreadPool.UnsafeQueueUserWorkItem(_ => signal.Set(), null))
+		{
+			return "queue-failed";
+		}
+
+		return signal.Wait(ProbeTimeout)
+			? $"{sw.ElapsedMilliseconds}ms"
+			: $"STARVED(>{ProbeTimeout.TotalSeconds:F0}s)";
+	}
+
+	private static TimeSpan TotalGcPause()
+	{
+#if NET7_0_OR_GREATER
+		return GC.GetTotalPauseDuration();
+#else
+		return TimeSpan.Zero;
+#endif
+	}
+
+	private static int GetSeconds(string variable, int defaultSeconds)
+		=> int.TryParse(Environment.GetEnvironmentVariable(variable), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+			? value
+			: defaultSeconds;
+
+	private static string Format(TimeSpan value)
+		=> value.ToString(@"hh\:mm\:ss", CultureInfo.InvariantCulture);
+
+	private static string GetProcessIdSafe()
+	{
+		try
+		{
+			return Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+		}
+		catch (Exception)
+		{
+			return "?";
+		}
+	}
+
+	private static string RuntimeDescription()
+		=> $"{Environment.OSVersion.Platform}/{System.Runtime.InteropServices.RuntimeInformation.OSArchitecture}";
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_disposed = true;
+		_cts.Cancel();
+		_thread.Join(TimeSpan.FromSeconds(2));
+		_cts.Dispose();
+
+		Console.WriteLine($"{LogPrefix} stopped after {Format(_runElapsed.Elapsed)}");
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/TestRunStallMonitor.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/TestRunStallMonitor.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System;
 using System.Diagnostics;
@@ -18,6 +18,13 @@ namespace Uno.UI.Samples.Tests;
 /// from a fully frozen process. Each tick probes the UI dispatcher and the thread pool
 /// separately, which separates "UI thread blocked" from "thread pool starved" from
 /// "whole process stopped" (no heartbeat line at all).
+///
+/// The dispatcher is probed at two priorities because they can starve independently. Almost
+/// every wait in the runtime tests funnels through <c>WindowHelper.WaitForIdle</c>, which
+/// enqueues at <see cref="Windows.UI.Core.CoreDispatcherPriority.Idle"/> -- the lowest of the
+/// dispatcher's four queues, and one that is only served when every higher queue is empty. A
+/// steady stream of normal-priority work therefore leaves <c>dispatcher</c> looking healthy
+/// while every test wait blocks forever, so a normal-priority probe alone cannot see it.
 /// </remarks>
 internal sealed class TestRunStallMonitor : IDisposable
 {
@@ -31,6 +38,7 @@ internal sealed class TestRunStallMonitor : IDisposable
 	private readonly TimeSpan _interval;
 	private readonly TimeSpan _stallThreshold;
 	private readonly Func<Task>? _dispatcherProbe;
+	private readonly Func<Task>? _idleProbe;
 	private readonly Stopwatch _runElapsed = Stopwatch.StartNew();
 	private readonly CancellationTokenSource _cts = new();
 	private readonly Thread _thread;
@@ -39,11 +47,18 @@ internal sealed class TestRunStallMonitor : IDisposable
 	private long _currentTestStartedAt;
 	private bool _disposed;
 
-	private TestRunStallMonitor(TimeSpan interval, TimeSpan stallThreshold, Func<Task>? dispatcherProbe)
+	// A blocked idle queue never completes its probe, so exactly one stays outstanding and its
+	// age is reported. Enqueuing a fresh one per tick would pile up work that all runs at once
+	// the moment the queue drains.
+	private Task? _idleProbeTask;
+	private long _idleProbeStartedAt;
+
+	private TestRunStallMonitor(TimeSpan interval, TimeSpan stallThreshold, Func<Task>? dispatcherProbe, Func<Task>? idleProbe)
 	{
 		_interval = interval;
 		_stallThreshold = stallThreshold;
 		_dispatcherProbe = dispatcherProbe;
+		_idleProbe = idleProbe;
 		_currentTestStartedAt = _runElapsed.ElapsedMilliseconds;
 
 		_thread = new Thread(Loop)
@@ -59,7 +74,7 @@ internal sealed class TestRunStallMonitor : IDisposable
 	/// Starts a monitor, or returns <c>null</c> when disabled. Enabled by default on CI;
 	/// set <c>UNO_TEST_STALL_MONITOR_INTERVAL_SECONDS</c> to opt in locally, or to 0 to disable.
 	/// </summary>
-	public static TestRunStallMonitor? TryStart(Func<Task>? dispatcherProbe)
+	public static TestRunStallMonitor? TryStart(Func<Task>? dispatcherProbe, Func<Task>? idleProbe)
 	{
 		var interval = GetSeconds(IntervalVariable, defaultSeconds: DefaultIntervalSeconds);
 		if (interval <= 0)
@@ -76,7 +91,8 @@ internal sealed class TestRunStallMonitor : IDisposable
 		return new TestRunStallMonitor(
 			TimeSpan.FromSeconds(interval),
 			TimeSpan.FromSeconds(threshold),
-			dispatcherProbe);
+			dispatcherProbe,
+			idleProbe);
 	}
 
 	private static int DefaultIntervalSeconds =>
@@ -108,7 +124,7 @@ internal sealed class TestRunStallMonitor : IDisposable
 				var inCurrentTest = TimeSpan.FromMilliseconds(
 					_runElapsed.ElapsedMilliseconds - Interlocked.Read(ref _currentTestStartedAt));
 
-				var (dispatcher, threadPool) = (ProbeDispatcher(), ProbeThreadPool());
+				var (dispatcher, dispatcherIdle, threadPool) = (ProbeDispatcher(), ProbeIdleQueue(), ProbeThreadPool());
 				var gcPause = TotalGcPause();
 				var gcDelta = gcPause - previousGcPause;
 				previousGcPause = gcPause;
@@ -120,6 +136,7 @@ internal sealed class TestRunStallMonitor : IDisposable
 					$"elapsed={Format(_runElapsed.Elapsed)} " +
 					$"inTest={Format(inCurrentTest)} " +
 					$"dispatcher={dispatcher} " +
+					$"dispatcherIdle={dispatcherIdle} " +
 					$"threadPool={threadPool} " +
 					$"gcPauseDelta={gcDelta.TotalMilliseconds.ToString("F0", CultureInfo.InvariantCulture)}ms " +
 					$"test='{_currentTest}'");
@@ -149,6 +166,44 @@ internal sealed class TestRunStallMonitor : IDisposable
 		}
 		catch (Exception e)
 		{
+			return $"error({e.GetType().Name})";
+		}
+	}
+
+	/// <summary>
+	/// Round-trip of an idle-priority work item -- the queue every <c>WaitForIdle</c> waits on.
+	/// </summary>
+	private string ProbeIdleQueue()
+	{
+		if (_idleProbe is null)
+		{
+			return "n/a";
+		}
+
+		if (_idleProbeTask is { IsCompleted: false })
+		{
+			var blockedFor = TimeSpan.FromMilliseconds(_runElapsed.ElapsedMilliseconds - _idleProbeStartedAt);
+			return $"BLOCKED({Format(blockedFor)})";
+		}
+
+		var sw = Stopwatch.StartNew();
+		try
+		{
+			_idleProbeStartedAt = _runElapsed.ElapsedMilliseconds;
+			var task = _idleProbe();
+			_idleProbeTask = task;
+
+			if (!task.Wait(ProbeTimeout))
+			{
+				return $"BLOCKED(>{ProbeTimeout.TotalSeconds:F0}s)";
+			}
+
+			_idleProbeTask = null;
+			return $"{sw.ElapsedMilliseconds}ms";
+		}
+		catch (Exception e)
+		{
+			_idleProbeTask = null;
 			return $"error({e.GetType().Name})";
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -69,6 +69,7 @@ namespace Uno.UI.Samples.Tests
 		private List<TestCaseResult> _testCases = new();
 		private TestRun _currentRun;
 		private long _scrollableHeightCallbackToken;
+		private TestRunStallMonitor _stallMonitor;
 
 		// On WinUI/UWP dependency properties cannot be accessed outside of
 		// UI thread. This field caches the current value so it can be accessed
@@ -749,6 +750,11 @@ namespace Uno.UI.Samples.Tests
 				StartTime = DateTimeOffset.UtcNow
 			};
 
+			// Resolved here rather than inside the probe: the monitor calls it from its own
+			// thread, and resolving the dispatcher touches the visual tree.
+			var dispatcher = TestServices.WindowHelper.RootElementDispatcher;
+			_stallMonitor = TestRunStallMonitor.TryStart(() => dispatcher.RunAsync(() => { }));
+
 			try
 			{
 				_ = ReportMessage("Enumerating tests");
@@ -782,6 +788,8 @@ namespace Uno.UI.Samples.Tests
 			}
 			finally
 			{
+				Interlocked.Exchange(ref _stallMonitor, null)?.Dispose();
+
 				await TestServices.WindowHelper.RootElementDispatcher.RunAsync(() =>
 				{
 					testFilter.IsEnabled = runButton.IsEnabled = true; // Disable the testFilter to avoid SIP to re-open
@@ -865,6 +873,7 @@ namespace Uno.UI.Samples.Tests
 					var fullTestName = testName + testCase.ToString();
 
 					_currentRun.Run++;
+					_stallMonitor?.SetCurrentTest(fullTestName);
 
 					// We await this to make sure the UI is updated before running the test.
 					// This will help developers to identify faulty tests when the app is crashing.

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -753,7 +753,9 @@ namespace Uno.UI.Samples.Tests
 			// Resolved here rather than inside the probe: the monitor calls it from its own
 			// thread, and resolving the dispatcher touches the visual tree.
 			var dispatcher = TestServices.WindowHelper.RootElementDispatcher;
-			_stallMonitor = TestRunStallMonitor.TryStart(() => dispatcher.RunAsync(() => { }));
+			_stallMonitor = TestRunStallMonitor.TryStart(
+				() => dispatcher.RunAsync(() => { }),
+				async () => await dispatcher.RunIdleAsync(_ => { }));
 
 			try
 			{


### PR DESCRIPTION
**GitHub Issue:** closes #24006

Related: #24005 (macOS host freeze), #23967 (`When_MsAppData` Linux hang) — this PR does not fix either, it makes them diagnosable.

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

macOS and Linux desktop Skia runtime tests freeze mid-test and get killed by the 60-minute job timeout, leaving **no evidence of what blocked**. The log just stops. There is no stack, no dump, and no way to tell whether the UI thread, the thread pool, or the whole process stopped.

This adds two complementary instruments. They answer different halves of the question, which is why both are here.

### 1. `TestRunStallMonitor` — in-process heartbeat

`src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/TestRunStallMonitor.cs`

Emits one line per interval (30 s on CI) while tests run:

```
[stall-monitor] elapsed=00:21:14 inTest=00:00:03 dispatcher=2ms threadPool=0ms gcPauseDelta=41ms test='…When_Focused_Element_In_Scaled_Viewbox'
[stall-monitor] STALL elapsed=00:24:14 inTest=00:03:03 dispatcher=BLOCKED(>5s) threadPool=0ms gcPauseDelta=0ms test='…When_Focused_Element_In_Scaled_Viewbox'
```

The design point is that the three signals are **independent**, so the shape of the output identifies the culprit:

| observation | conclusion |
|---|---|
| heartbeat continues, `dispatcher=BLOCKED`, `threadPool` fine | UI thread is blocked |
| heartbeat continues, `threadPool=STARVED` | thread-pool starvation (e.g. sync-over-async) |
| heartbeat continues, both fine, `inTest` climbing | the test's own `await` never completes — a test bug |
| large `gcPauseDelta` | a GC pause, not a hang |
| **no heartbeat line at all** | the whole process/runtime stopped (kernel, GC, host) |

The heartbeat runs on a **dedicated thread**, not a timer or the thread pool — a pool-starvation hang must still produce output, otherwise it is indistinguishable from a fully frozen process. That distinction is the entire point of the instrument.

Enabled automatically under `IS_CI`; locally it is off unless you set `UNO_TEST_STALL_MONITOR_INTERVAL_SECONDS`.

### 2. `stall-watchdog.sh` — out-of-process stack capture

`build/test-scripts/stall-watchdog.sh`, wired into the macOS and Linux drivers.

Watches the console log. When it goes quiet past a threshold (default 180 s) it captures, while the process is still stuck:

- `dotnet-stack report` — managed stacks
- macOS: `sample <pid> 10` — native stacks for every thread, including AppKit/CoreAnimation frames that managed stacks cannot show
- Linux: `eu-stack`, `/proc/<pid>/status`, `/wchan`, and per-thread `stat`/`wchan`
- `ps` snapshot, and the log tail so the capture records which test was running

It **re-arms**, so a run that stalls three times yields three captures (capped, default 6). Published as a new `runtime-tests-desktop-skia-{macos,linux[-framebuffer]}-diagnostics` artifact via `condition: always()` + `continueOnError: true`.

`UNO_WATCHDOG_HARD_TIMEOUT_SECONDS` (default **3300 s = 55 min**, against the 60-minute job wall) captures a final snapshot and then `SIGTERM`s the app so the results XML and failed-test list are still written. 55 min was chosen deliberately: the longest observed *successful* macOS run is ~52 min, so this rescues diagnostics from runs that would have been killed at 60 while leaving every currently-passing run untouched.

### 3. macOS driver no longer aborts on a non-zero app exit

`macos-skia-runtime-tests.sh` ran under `set -e`, so a crash or non-zero exit skipped `list-failed` entirely and the retry re-ran the whole ~8.5k-test suite. It now captures the exit code and continues, matching what the Linux driver already does. (`fail-empty` still fails the build when no results could be read, so a crash with no results is still red.)

## Validation ✅

**Runtime** — `stall-watchdog.sh` executed end-to-end against a simulated stalling process on Ubuntu 24.04 (WSL), driving two distinct stalls plus a hard-timeout case:

```
=== TEST 1: two stalls, observe-only ===
captures: 2 (one per stall, proving re-arm works)
  stall-01-…: context.txt log-tail.txt proc-status.txt proc-threads.txt proc-wchan.txt ps.txt
  stall-02-…: context.txt log-tail.txt proc-status.txt proc-threads.txt proc-wchan.txt ps.txt
--- log-tail.txt of first capture ---
Running test Alpha_3                     <- correctly identifies the test that was running
--- watchdog output ---
[watchdog] dotnet-stack install failed (continuing)   <- degrades gracefully without the tool
=== TEST 2: hard timeout ===
RESULT: app terminated by watchdog (hard timeout OK)
```

**Compile** — `SamplesApp.Skia.csproj` builds clean (`net10.0`, 0 errors). Verified the new type is actually in the output rather than silently excluded: `TestRunStallMonitor`, `[stall-monitor]`, `UnoTestStallMonitor` and `STARVED(>` are all present in `SamplesApp.Skia.dll`.

**Not validated at runtime:** the in-process heartbeat has not run on a real macOS/Linux CI agent — that only happens once this is merged. It is logging-only and disabled off-CI, so the blast radius is a few extra stdout lines per run.

## Notes for reviewers

- The two Linux stages (X11 and Framebuffer) share one template, so the diagnostics artifact name is suffixed with `testResultLabel` to avoid a collision. (The pre-existing `…-linux-failures` artifact is *not* suffixed and so does collide between those two stages — flagging it, not fixing it here.)
- The watchdog never exits non-zero and every capture step is individually tolerant: it observes a run and must not be able to fail one.
- Cost when nothing stalls: one stdout line per 30 s, plus a `pgrep` and a `stat` per 15 s.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, CI diagnostics; validated by executing the watchdog against a simulated stall (above)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, no user-facing behaviour change
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)



---

## Update: two defects found by running this instrumentation against real CI data

Both instruments have now been exercised against the macOS runs this PR's own CI produced. Two
things prevented them from answering the question they were built for; both are fixed here.

### 1. The watchdog could never fire (`abb52d5`)

The watchdog used the console log's **mtime** as the liveness signal — but the in-process heartbeat
writes to that same log every 30 s. The file is therefore never quiet for the 180 s threshold, so
no capture could ever happen. The two instruments cancelled each other out.

This is not a theoretical interaction. Build **229532**, attempt 1 — a full instrumented suite — hit
a real freeze and reported it correctly:

```
19:07:08 [stall-monitor] STALL elapsed=00:29:06 inTest=00:02:16 dispatcher=35ms ...
19:10:09 [stall-monitor] STALL elapsed=00:32:07 inTest=00:05:16 dispatcher=54ms ...
```

The `runtime-tests-desktop-skia-macos-diagnostics` artifact for that build contains **no stacks**.
The one run that reproduced the freeze under instrumentation still produced no evidence of it.

Progress is now the count of test-start lines, which the heartbeat does not affect. Verified against
a process that stalls while a heartbeat keeps writing — unchanged watchdog captures nothing, this
one captures the stall.

### 2. The dispatcher was probed at the wrong priority (`954ff36`)

The probe was `dispatcher.RunAsync(...)` — **normal** priority. Nearly every wait in the runtime
tests funnels through `WindowHelper.WaitForIdle`, which enqueues at **idle** priority: the lowest of
`NativeDispatcher`'s four queues, and one that is served only when every higher queue is empty
(`NativeDispatcher.DispatchItems`, `for (var p = 0; p <= 3; p++)`). A steady stream of
normal-priority work leaves the normal probe reporting single-digit milliseconds while every test
wait blocks indefinitely.

The same build shows exactly that shape. Throughout a 5m16s freeze in
`Given_TextBlock.When_Focus_Changes_Selection_Is_Not_Shown` — a test whose only waits are
`WaitForIdle` and `WaitForRender` — every instrument reported healthy:

| signal | during the freeze |
|---|---|
| `dispatcher` (normal priority) | 31–60 ms |
| `threadPool` | 0 ms |
| `gcPauseDelta` | 0 ms |
| heartbeat itself | never missed a 30 s tick |

So the freeze is **not** a blocked UI thread, not GC, not pool starvation, and not a stopped
process — the four things this monitor could already distinguish. The idle queue was the one thing
it did not measure, and it is the queue every one of those waits depends on.

`dispatcherIdle=` now reports it. One probe stays outstanding at a time and its age is reported, so
a blocked queue neither piles up work nor hides how long it has been blocked.

### Why this matters for #24005

#24005 is blocked on "no stack dump exists for a stalled process". With these two fixes, one
instrumented macOS run should settle it:

- `dispatcher` healthy + `dispatcherIdle=BLOCKED(...)` → the idle queue is starved; `WaitForIdle`
  can never return, and the follow-up question is what floods the higher-priority queues on macOS.
- both healthy → the hang is inside the test's own await, and the watchdog's `sample`/`dotnet-stack`
  captures (which can now actually fire) say where.

### Added validation

- **Runtime, watchdog** — fail-before/pass-after against a process that stalls while a heartbeat
  keeps writing to the log: unchanged script captures 0, fixed script captures the stall
  (`capturing diagnostics (no test started for 5s)`).
- **Runtime, idle probe** — `SamplesApp.Skia.Generic` on Windows, `Given_ContentPresenter`, monitor
  at a 2 s interval: `dispatcher=0..67ms dispatcherIdle=0..52ms` across 12 heartbeats, run exits 0.
- **Compile** — `SamplesApp.Skia.csproj`, `net10.0`, 0 warnings / 0 errors.

Still not validated on a macOS agent — that is what merging this is for.
