### PR TITLE
docs: document solution-less builds, .slnx, and CPM with implicit packages

### DIFF
--- a/doc/articles/additional-vscode-topics.md
+++ b/doc/articles/additional-vscode-topics.md
@@ -57,6 +57,13 @@ An existing application needs additional changes to be debugged properly.
 3. Replace all instances of `MyExtensionsApp._1` with your application's name in `launch.json`.
 4. Inside this folder, create a file named `tasks.json` and copy the [contents of this file](https://github.com/unoplatform/uno.templates/blob/main/src/Uno.Templates/content/unoapp/.vscode/tasks.json).
 
+## Working with solution-less workspaces
+
+A `.sln`/`.slnx` file is not required to work in VS Code. When you open a folder that contains a project but no solution file, the Uno Platform extension (0.25.3 or later, together with the C# Dev Kit extension) discovers the projects in the workspace and lets you pick the active one from the status bar, just as it does for solutions.
+
+> [!NOTE]
+> Dev Server and Hot Reload tooling on solution-less workspaces requires the application to use **Uno.Sdk 6.6 or later**. Make sure the `global.json` file declaring the `Uno.Sdk` version is in the opened folder (or a parent directory). See [Solution-less projects](xref:Uno.Features.Uno.Sdk#solution-less-projects-and-slnx-solutions) for building from the command line.
+
 ## Advanced debugging
 
 You can find [advanced Code debugging topic here](xref:uno.vscode.mobile.advanced.debugging).

--- a/doc/articles/common-issues-ai-agents.md
+++ b/doc/articles/common-issues-ai-agents.md
@@ -40,7 +40,7 @@ In Visual Studio, the App MCP might turn red on some occasions. To fix this issu
 
 The Uno Platform App MCP may fail to start in Claude/Codex/Copilot CLI when it is started in a folder that does not contain an Uno Platform project.
 
-To fix this issue, change directories to a folder that contains the `.sln` or `.slnx` file of your project.
+To fix this issue, change directories to a folder that contains the `.sln` or `.slnx` file of your project — or, for solution-less projects, the folder containing the `global.json` file that declares your `Uno.Sdk` version.
 
 ## Diagnosing Dev Server issues
 

--- a/doc/articles/common-issues-ai-agents.md
+++ b/doc/articles/common-issues-ai-agents.md
@@ -45,6 +45,6 @@ To fix this issue, change directories to a folder that contains the `.sln` or `.
 ## Diagnosing Dev Server issues
 
 > [!TIP]
-> When the App MCP fails to start, run `uno-devserver disco` from your solution directory.
+> When the App MCP fails to start, run `uno-devserver disco` from your workspace directory (the folder containing your solution file or, for solution-less projects, your `global.json`).
 > Check that **hostPath** is resolved and that there are no **errors**. Pass `--json` for machine-readable output.
 > See [Diagnostics (disco)](xref:Uno.Features.DevServerDisco) for a full guide.

--- a/doc/articles/dev-server.md
+++ b/doc/articles/dev-server.md
@@ -25,7 +25,7 @@ The Dev Server is the local development companion that enables productive inner-
 > [!NOTE]
 > The Dev Server won't start until NuGet package restore has completed successfully (a failed or pending restore prevents startup).
 
-1. Open the solution: the IDE reserves a free TCP port and writes it to each project's .csproj.user file under the UnoRemoteControlPort property.
+1. Open the solution (or, for solution-less workspaces, the folder containing your project): the IDE reserves a free TCP port and writes it to each project's .csproj.user file under the UnoRemoteControlPort property.
 2. Build/run in Debug: the app is built with the Dev Server connection information.
 3. Launch the app (Debug): the app connects back to the Dev Server.
 4. Develop: the IDE and app exchange development-time messages (e.g., Hot Reload updates).
@@ -50,7 +50,14 @@ You can manage the Dev Server from the command line using the dotnet tool `Uno.D
 - `--mcp-wait-tools-list`: Wait for the upstream Uno App tools to become available before responding to clients. Use this when working with MCP agents that do not react to `tools/list_changed` (for example, Codex or Claude Code).
 - `--force-roots-fallback`: Legacy explicit override. The DevServer auto-detects when the client does not advertise the MCP roots capability and exposes the `uno_app_initialize` tool automatically, so this flag is rarely needed.
 - `--force-generate-tool-cache`: Deprecated (no-op). Kept for backward compatibility.
-- `--solution-dir <path>`: Explicit solution directory Uno.DevServer should monitor. Useful when starting the DevServer manually (e.g., CI agents). Defaults to the current working directory when omitted.
+- `--solution-dir <path>`: Explicit workspace directory Uno.DevServer should monitor. Useful when starting the DevServer manually (e.g., CI agents), or for solution-less workspaces where no `.sln`/`.slnx` can be discovered. Defaults to the current working directory when omitted.
+
+### Solution-less workspaces
+
+A solution file is not required to use the Dev Server. When no `.sln` or `.slnx` file is present, the workspace is resolved from the `global.json` file that declares your `Uno.Sdk` version — run `uno-devserver start` from the project directory, or pass `--solution-dir <path>` to select it explicitly.
+
+> [!NOTE]
+> Solution-less workspaces are supported starting with **Uno.Sdk 6.6**. On earlier versions the Dev Server starts, but Uno Platform Studio add-ins are not loaded.
 
 For more information about Uno MCP registration, native-client alternatives, and supported MCP workflows, see [The Uno Platform MCPs](xref:Uno.Features.Uno.MCPs).
 

--- a/doc/articles/features/devserver-disco.md
+++ b/doc/articles/features/devserver-disco.md
@@ -167,6 +167,18 @@ globalJsonPath     <null> (missing global.json in working directory or parents)
 
 You are running `disco` outside of an Uno Platform workspace. Change to a directory that contains — or is beneath — the `global.json` file declaring your `Uno.Sdk` version. A solution file is not required: solution-less workspaces are resolved through `global.json`.
 
+If your workspace genuinely has no `global.json`, create one next to your project that declares the `Uno.Sdk` version:
+
+```json
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.6.29"
+  }
+}
+```
+
+See [Updating the Uno Platform version](xref:Uno.Development.UpgradeUnoNuget) for details.
+
 ### SDK package not restored
 
 ```text

--- a/doc/articles/features/devserver-disco.md
+++ b/doc/articles/features/devserver-disco.md
@@ -165,7 +165,7 @@ uno-devserver disco --addins-only --json
 globalJsonPath     <null> (missing global.json in working directory or parents)
 ```
 
-You are running `disco` outside of an Uno Platform project directory. Change to the directory containing your `.sln` or `.slnx` file.
+You are running `disco` outside of an Uno Platform workspace. Change to a directory that contains — or is beneath — the `global.json` file declaring your `Uno.Sdk` version. A solution file is not required: solution-less workspaces are resolved through `global.json`.
 
 ### SDK package not restored
 

--- a/doc/articles/features/devserver-disco.md
+++ b/doc/articles/features/devserver-disco.md
@@ -179,6 +179,9 @@ If your workspace genuinely has no `global.json`, create one next to your projec
 
 See [Updating the Uno Platform version](xref:Uno.Development.UpgradeUnoNuget) for details.
 
+> [!NOTE]
+> Declaring the version inline in the project file (`<Project Sdk="Uno.Sdk/6.6.29">`) is enough to build, but the Dev Server tooling resolves the `Uno.Sdk` version from `global.json` only — a `global.json` is still required for `disco` and the dev loop.
+
 ### SDK package not restored
 
 ```text

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -15,6 +15,40 @@ This document explains the many features of this SDK and how to configure its be
 
 Updating the Uno.Sdk is [done through the global.json file](xref:Uno.Development.UpgradeUnoNuget).
 
+## Solution-less projects and `.slnx` solutions
+
+Uno.Sdk projects are standard .NET SDK-style projects: a single `.csproj` is all you need to build, run, and publish an application. A solution file is a convenience for IDEs and multi-project repositories — it is not a requirement of the Uno.Sdk or the .NET CLI.
+
+From the directory containing your project file:
+
+```bash
+dotnet build -f net10.0-desktop
+dotnet run -f net10.0-desktop
+dotnet publish -f net10.0-desktop -c Release
+```
+
+> [!IMPORTANT]
+> The `global.json` file that selects your `Uno.Sdk` version applies to projects, not solutions. When working without a solution file, keep `global.json` in the project directory or in any parent directory.
+
+> [!NOTE]
+> IDE dev-loop tooling (Hot Reload, the [Dev Server](xref:Uno.DevServer), and Uno Platform Studio add-ins) supports solution-less workspaces starting with **Uno.Sdk 6.6**. In VS Code, this additionally requires the Uno Platform extension 0.25.3 or later together with the C# Dev Kit extension. On earlier Uno.Sdk versions the Dev Server still starts, but the Studio add-ins are not loaded.
+
+### Using the `.slnx` solution format
+
+The XML-based [`.slnx` solution format](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/) is fully supported — by the .NET CLI, by the Uno Platform IDE extensions, and by the Dev Server (workspace discovery enumerates both `.sln` and `.slnx` files):
+
+```xml
+<Solution>
+  <Project Path="MyApp/MyApp.csproj" />
+</Solution>
+```
+
+To convert an existing solution, run:
+
+```bash
+dotnet sln MyApp.sln migrate
+```
+
 ## Uno Platform Features
 
 As Uno Platform can be used in many different ways, in order to reduce the build time and avoid downloading many packages, the Uno.Sdk offers a way to simplify which Uno Platform features should be enabled.
@@ -178,6 +212,65 @@ Those properties can be set from `Directory.Build.props` or may be set in the `c
 ```
 
 In the sample above, we are overriding the default versions of the `UnoToolkit`, `MicrosoftLogging`, and `CommunityToolkitMvvm` packages.
+
+## Using Central Package Management with implicit packages
+
+Uno Platform templates use [NuGet Central Package Management](https://learn.microsoft.com/nuget/consume-packages/central-package-management) (CPM) by default: package versions live in a `Directory.Packages.props` file at the root of the repository, and `<PackageReference>` items in project files carry no `Version` attribute.
+
+CPM and the Uno.Sdk implicit packages coexist automatically:
+
+- The SDK keeps managing the versions of its implicit packages (based on the Uno Platform version from `global.json` and the `*Version` properties above).
+- If your `Directory.Packages.props` contains a `<PackageVersion>` entry for a package the SDK already references implicitly, the SDK removes that central entry during restore, so it cannot conflict with the SDK-managed version. To change the version of an implicit package, use the matching `*Version` property or take over the package with an explicit reference (see below) — a lone `<PackageVersion>` entry has no effect.
+- If your project declares its own `<PackageReference>` for a package the SDK would otherwise add implicitly — versioned centrally, via `Version`, or via `VersionOverride` — the SDK backs off and your reference wins.
+
+A typical `Directory.Packages.props` only needs entries for the packages *you* add — implicit packages need none:
+
+```xml
+<Project ToolsVersion="15.0">
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Your own dependencies -->
+    <PackageVersion Include="AutoMapper" Version="13.0.1" />
+    <PackageVersion Include="FluentValidation" Version="11.9.0" />
+    <!-- Takes over an otherwise-implicit package (requires a matching
+         PackageReference in the project file) -->
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+  </ItemGroup>
+</Project>
+```
+
+### Overriding the version of a single package
+
+Under CPM, the standard NuGet [`VersionOverride`](https://learn.microsoft.com/nuget/consume-packages/central-package-management#overriding-package-versions) metadata overrides the centrally-defined version for one project, and is honored by the Uno.Sdk when deciding whether to back off from an implicit package:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="CommunityToolkit.Mvvm" VersionOverride="8.3.2" />
+</ItemGroup>
+```
+
+For Uno-managed packages, prefer the `*Version` MSBuild properties documented above (`UnoToolkitVersion`, `CommunityToolkitMvvmVersion`, …) — they adjust the implicit reference itself, without needing a `PackageReference`/`PackageVersion` pair.
+
+### Per-TargetFramework package versions
+
+A single `<PackageVersion>` entry cannot express different versions per target framework, but `Directory.Packages.props` is evaluated once per target framework, so conditional item groups work:
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+  <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
+</ItemGroup>
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
+  <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.200" />
+</ItemGroup>
+```
+
+The same pattern works with a `Choose`/`When` block, as shown in [Supported OS Platform versions](#supported-os-platform-versions).
+
+### NuGet audit
+
+Implicit packages are turned into ordinary `<PackageReference>` items before restore runs, so [NuGet audit](https://learn.microsoft.com/nuget/concepts/auditing-packages) evaluates them exactly like packages you reference yourself: known vulnerabilities in implicit packages are reported as direct-dependency warnings, and `NuGetAudit*` properties apply to them as usual.
 
 ## Disabling Implicit Uno Packages
 

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -30,8 +30,7 @@ dotnet publish -f net10.0-desktop -c Release
 > [!IMPORTANT]
 > The `global.json` file that selects your `Uno.Sdk` version applies to projects, not solutions. When working without a solution file, keep `global.json` in the project directory or in any parent directory.
 
-> [!NOTE]
-> IDE dev-loop tooling (Hot Reload, the [Dev Server](xref:Uno.DevServer), and Uno Platform Studio add-ins) supports solution-less workspaces starting with **Uno.Sdk 6.6**. In VS Code, this additionally requires the Uno Platform extension 0.25.3 or later together with the C# Dev Kit extension. On earlier Uno.Sdk versions the Dev Server still starts, but the Studio add-ins are not loaded.
+IDE dev-loop tooling (Hot Reload, the [Dev Server](xref:Uno.DevServer), and Uno Platform Studio add-ins) supports solution-less workspaces starting with **Uno.Sdk 6.6**. In VS Code, this additionally requires the Uno Platform extension 0.25.3 or later together with the C# Dev Kit extension. On earlier Uno.Sdk versions the Dev Server still starts, but the Studio add-ins are not loaded.
 
 ### Using the `.slnx` solution format
 


### PR DESCRIPTION
**GitHub Issue:** Internal — unoplatform/uno-private#2167 (part of epic unoplatform/uno-private#2166)

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Documents the already-working frictionless paths of the Uno.Sdk, which were previously invisible to users (docs only showed the `.sln` + `global.json` flow):

- **`using-the-uno-sdk.md`**:
  - New **Solution-less projects and `.slnx` solutions** section: a single `.csproj` builds/runs/publishes without a solution file, `global.json` placement, and the tooling version requirements (Uno.Sdk 6.6+ for Dev Server add-ins, VS Code extension 0.25.3+ with C# Dev Kit) — validated against a real solution-less project on Uno.Sdk 6.5/6.6/6.7-dev.
  - New **Using Central Package Management with implicit packages** section: documents the coexistence behavior implemented by `ImplicitPackagesResolver` (colliding `<PackageVersion>` entries are removed at restore; explicit `PackageReference`s versioned via CPM/`Version`/`VersionOverride` win), with a worked `Directory.Packages.props` example.
  - New subsections for **`VersionOverride`**, **per-TargetFramework versions under CPM** (conditional item groups), and **NuGet audit** behavior for implicit packages.
- **`dev-server.md`**: solution-less workspace resolution via `global.json`, updated `--solution-dir` description, and a note on the Uno.Sdk 6.6+ requirement for Studio add-ins.
- **`devserver-disco.md` / `common-issues-ai-agents.md`**: troubleshooting entries no longer instruct users to locate a `.sln` when a solution file is not required (the disco "No global.json found" fix now correctly points at `global.json`).
- **`additional-vscode-topics.md`**: new **Working with solution-less workspaces** section for VS Code users.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests, UI tests, or a manual test sample — N/A (docs only)
- [x] 📚 Docs have been added/updated
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A (docs only)
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017J78oYYJ7rSMaewD9b9Fhs