### PR TITLE
fix(xaml): don't abort type resolution when one assembly fails to resolve a name

### DIFF
--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using Uno;
 using Uno.Extensions;
+using Uno.Foundation.Logging;
 using Uno.UI.Helpers;
 using Uno.Xaml;
 using Windows.UI;
@@ -435,13 +436,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				// the default ALC's — avoiding stale per-app ALCs that AppDomain.GetAssemblies
 				// would otherwise still expose. Falls back to AppDomain.GetAssemblies otherwise.
 				() => ContextualAssemblyResolver.GetRelevantAssemblies()
-					.Select(
-
-						[UnconditionalSuppressMessage("Trimming","IL2026", Justification = "Types may be removed or not present as part of the normal operations of that method")]
-						(a) =>
-							(name != null ? a.GetType(name) : null) ??
-							a.GetType(originalName)
-					)
+					.Select(a => TryGetTypeFromAssembly(a, name, originalName))
 					.Trim()
 					.FirstOrDefault(),
 			};
@@ -451,6 +446,46 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				.Trim()
 				.FirstOrDefault();
 		}
+
+		/// <summary>
+		/// Resolves <paramref name="name"/> (falling back to <paramref name="originalName"/>) in a single
+		/// assembly, treating any resolution failure as "not found in this assembly".
+		/// </summary>
+		/// <remarks>
+		/// <see cref="Assembly.GetType(string)"/> returns <see langword="null"/> for a type it cannot find,
+		/// and the caller relies on that to keep scanning the remaining assemblies. It can however still
+		/// <em>throw</em> while parsing a name — observed as an <see cref="InvalidOperationException"/> out of
+		/// <c>RuntimeType.DeclaringMethod</c> ("Method may only be called on a Type for which
+		/// Type.IsGenericParameter is true") on the Linux Skia head. Because that throw escaped the enclosing
+		/// <c>Select</c>, a single uncooperative assembly aborted the whole lookup — including assemblies not
+		/// yet reached, one of which may hold the type — surfacing to callers as a <c>XamlParseException</c>
+		/// from <c>XamlReader.Load</c>.
+		/// <para>
+		/// Containing the failure per assembly restores the intended behaviour: a name this assembly cannot
+		/// resolve yields <see langword="null"/> and the scan continues.
+		/// </para>
+		/// </remarks>
+		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Types may be removed or not present as part of the normal operations of that method")]
+		private static Type? TryGetTypeFromAssembly(Assembly assembly, string? name, string originalName)
+		{
+			try
+			{
+				return (name != null ? assembly.GetType(name) : null)
+					?? assembly.GetType(originalName);
+			}
+			catch (Exception error)
+			{
+				if (typeof(XamlTypeResolver).Log().IsEnabled(LogLevel.Debug))
+				{
+					typeof(XamlTypeResolver).Log().Debug(
+						$"Unable to resolve type '{name ?? originalName}' in assembly '{assembly.FullName}'; " +
+						$"continuing with the remaining assemblies. ({error})");
+				}
+
+				return null;
+			}
+		}
+
 		private static bool SourceIsAttachedProperty(
 			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
 			Type type,


### PR DESCRIPTION
Fixes #24018

## Problem

`XamlReader.Load(...)` can die with a `XamlParseException` wrapping an `InvalidOperationException` thrown from `RuntimeType.get_DeclaringMethod()`:

```
InvalidOperationException: Method may only be called on a Type for which Type.IsGenericParameter is true.
  at System.RuntimeType.get_DeclaringMethod()
  at XamlTypeResolver.<>c__DisplayClass36_0.<SourceFindType>b__8(Assembly a)
  at System.Linq.Enumerable.ArraySelectIterator`2.MoveNext()
  ...
  at XamlObjectBuilder.Build(Object component, Boolean createInstanceFromXClass)
  at XamlReader.Load(String xaml)
```

`SourceFindType`'s final resolver scans every relevant assembly:

```csharp
() => ContextualAssemblyResolver.GetRelevantAssemblies()
    .Select((a) => (name != null ? a.GetType(name) : null) ?? a.GetType(originalName))
    .Trim()
    .FirstOrDefault(),
```

`Assembly.GetType(string)` returns `null` for a type it cannot find, and this resolver depends on that to keep scanning. It can nonetheless **throw** while parsing certain names. Because the throw escapes the `Select`, one uncooperative assembly aborts the entire lookup — **including the assemblies not yet visited**, one of which may well hold the type — and the failure surfaces to callers as a parse error.

## Fix

Extract the lambda into `TryGetTypeFromAssembly` and contain the failure per assembly: a name this assembly cannot resolve yields `null` and the scan continues, which is the behaviour the surrounding code already assumes. The swallowed exception is logged at `Debug` with the assembly and name, so the underlying cause stays diagnosable rather than disappearing.

Net effect: resolution succeeds whenever *any* assembly can resolve the name, instead of depending on enumeration order relative to whichever assembly trips the parser.

## Scope and honesty about what this does not do

This is a **robustness fix, not a root-cause fix.** I did not identify which assembly/name pair provokes `DeclaringMethod` — that needs a Linux repro I do not have. The change is defensible independently (it restores the documented `GetType` contract the caller relies on), but if a maintainer would rather fix the triggering name-parse at source, this PR does not preclude that and the issue keeps the full stack.

## How it presented (useful for triage)

`XamlTypeResolver.FindType` is memoized. Lookups that populate the cache *before* the problematic assembly loads succeed and stay cached; only later, still-uncached lookups throw.

In a downstream consumer's UI runtime tests this produced a stable 4-of-9 failure split inside one test class where several tests feed **byte-identical** inputs through the same helper — the difference being purely which names were already cached. It reproduces exactly run to run while looking content-dependent, which is a misleading signal worth knowing about.

## Verification

- `dotnet build src/Uno.UI/Uno.UI.Skia.csproj -c Debug` — **succeeds, 0 warnings, 0 errors** on `net9.0` and `net10.0`.
- **Not** verified against the original failure: the crash does not reproduce on the Windows desktop head (9/9 of the affected tests pass there with the same SDK), so confirmation requires a Linux Skia run against a build carrying this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)