### PR TITLE
fix(hr): report suppressed source-generator errors on the operation

### DIFF
--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -256,7 +256,18 @@ public sealed class HotReloadManager : IDisposable
 			_tracker.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
 
 			// Emit (EnC) diagnostics carry on every outcome of this branch; deltas are populated on Success only.
-			diagnostics = emitDiagnostics;
+			//
+			// The suppressed generator errors carry too. Suppressing them keeps hot reload running (that is
+			// the point), but they remain the reason the generated code is stale, and for the file the user
+			// just edited they are the ONLY actionable message: invalid XAML reports UXAML0001 here, while
+			// the emit sees a degraded generated tree and reports something like ENC0020 naming a generated
+			// member the user never wrote. Reporting them to the console alone left consumers with the
+			// misleading half.
+			//
+			// No dedup needed, unlike the compilation-error case below: generator diagnostics never appear in
+			// compilation.GetDiagnostics(), so they cannot already be present in emitDiagnostics. They are
+			// also already scoped to the change set's projects via auditedProjects.
+			diagnostics = emitDiagnostics.AddRange(generatorErrors);
 
 			switch (rudeEdits.IsEmpty, updates.IsEmpty)
 			{


### PR DESCRIPTION
Fixes #24022

## Problem

#24012 suppresses source-generator errors for the EnC emit so a non-fatal generator error degrades to stale generated output instead of freezing hot reload — that part works. It reports them via `diagnosticsReporter.ReportAnalyzerDiagnostics(generatorErrors)`, which routes to `IReporter.Verbose`. But a few lines later:

```csharp
// Emit (EnC) diagnostics carry on every outcome of this branch; deltas are populated on Success only.
diagnostics = emitDiagnostics;
```

assigns outright, so the suppressed generator errors never reach the operation's `diagnostics` — the collection consumers actually read.

For a broken input **outside** the change set (the corrupt `.resw` case #24012 targets) that is harmless. For the file the user **just edited** it removes the only actionable message:

```
HR result: RudeEdit, Diagnostics: 1
DIAG: …/XamlCodeGenerator/MainPage_eb076510….cs(156,4):
      error ENC0020: Renaming method 'IMainPage_Bindings.UpdateResources()' requires restarting the application.
```

while the real error exists but is confined to the trace:

```
…/Presentation/MainPage.xaml(6,2): error UXAML0001: Name cannot begin with the '<' character,
   hexadecimal value 0x3C. Line 6, position 2.
```

So a user who mistypes XAML is told a generated `IMainPage_Bindings` member was renamed — code they never wrote and cannot see — instead of the line and column of their typo.

## Fix

Carry the suppressed generator errors alongside the emit diagnostics:

```csharp
diagnostics = emitDiagnostics.AddRange(generatorErrors);
```

The suppression still applies to the **emit** — hot reload keeps running, which is #24012's behaviour — but the diagnostics are no longer dropped from what is reported.

**No dedup required**, unlike the compilation-error `FIXME` a few lines below ("Needs dedup before fixing"): generator diagnostics never appear in `compilation.GetDiagnostics()`, so they cannot already be present in `emitDiagnostics`. The two sets are disjoint by construction.

**Scope is already correct**: `generatorErrors` comes from `GetGeneratorErrorsAsync(auditedProjects, …)`, already limited to the change set's projects (spec 054), so this does not surface errors from projects the pass never touched.

The `ENC` diagnostic is retained, not replaced — consumers get both the rude-edit reason and the generator error that caused it.

## Alternative considered

The issue suggested only suppressing diagnostics whose source file is **outside** the change set, which would separate the two cases at file granularity. I did not take that: it changes the *suppression* semantics #24012 deliberately chose, whereas this change only fixes the *reporting*, which is the actual defect. If you would rather have the finer-grained suppression, this PR does not conflict with it.

## Verification

- `dotnet build src/Uno.HotReload/Uno.HotReload.csproj -c Debug` — **succeeds, 0 warnings, 0 errors**.
- **Not** verified end-to-end against the failing consumer test: that needs a dev SDK carrying this change. The expected effect is that `operation.Diagnostics` contains `UXAML0001` **and** the `ENC` rude-edit diagnostic, where today it contains only the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)