### PR TITLE
fix(skia): Outset damage clip to cover AA fringe at fractional scales

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -232,6 +232,7 @@ public partial class CompositionTarget
 
 		// The stroke straddles the edge, so a width of 2 device pixels outsets the fill by 1.
 		_damageOutsetPaint.StrokeWidth = 2 / rasterizationScale;
+		_damageOutsetBand.Rewind();
 		_damageOutsetPaint.GetFillPath(damage, _damageOutsetBand);
 		_outsetDamage.Rewind();
 		damage.Op(_damageOutsetBand, SKPathOp.Union, _outsetDamage);

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -213,6 +213,31 @@ public partial class CompositionTarget
 		_pendingDamage.Union(region);
 	}
 
+	private readonly SKPaint _damageOutsetPaint = new() { Style = SKPaintStyle.Stroke, StrokeJoin = SKStrokeJoin.Round, StrokeCap = SKStrokeCap.Round };
+	private readonly SKPath _damageOutsetBand = new();
+	private readonly SKPath _outsetDamage = new();
+
+	// Rendering is antialiased: it writes device pixels whose centers lie outside the drawn geometry,
+	// while the non-AA damage clip only includes pixels whose centers lie inside the damage region.
+	// When a damage edge lands between device pixels (fractional rasterization scale), that AA fringe
+	// is written but never replayed and accumulates as stale artifacts. Outsetting the clip by one
+	// device pixel covers every pixel the damaged content may have touched; the replayed picture is
+	// the full frame, so over-covering is always correct.
+	private SKPath OutsetDamageForPresent(SKPath damage, float rasterizationScale)
+	{
+		if (damage.IsEmpty)
+		{
+			return damage;
+		}
+
+		// The stroke straddles the edge, so a width of 2 device pixels outsets the fill by 1.
+		_damageOutsetPaint.StrokeWidth = 2 / rasterizationScale;
+		_damageOutsetPaint.GetFillPath(damage, _damageOutsetBand);
+		_outsetDamage.Rewind();
+		damage.Op(_damageOutsetBand, SKPathOp.Union, _outsetDamage);
+		return _outsetDamage;
+	}
+
 	private static readonly SKPaint _damageOverlayFill = new() { Color = new SKColor(0xFF, 0x00, 0x00, 0x30), Style = SKPaintStyle.Fill };
 	private static readonly SKPaint _damageOverlayStroke = new() { Color = new SKColor(0xFF, 0x00, 0x00, 0xB0), Style = SKPaintStyle.Stroke, StrokeWidth = 1 };
 
@@ -292,7 +317,7 @@ public partial class CompositionTarget
 
 			if (useDamageRegion && !overlayEnabled)
 			{
-				canvas.ClipPath(damage, antialias: false);
+				canvas.ClipPath(OutsetDamageForPresent(damage, rasterizationScale), antialias: false);
 			}
 
 			using var fpsHelperDisposable = _fpsHelper.BeginFrame();


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#534

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior:** at fractional rasterization scales (e.g. 150% display scale) on GPU-backed Skia hosts, a translate-animated element inside a `Popup` — with an ancestor clip cutting its damage region and static content drawn above it — leaves stale ≤1px stripe artifacts across the vacated area (see the linked issue: TabBar `Slide` selection indicator).

**Root cause:** the per-present damage clip in `CompositionTarget.Draw` is intentionally non-antialiased (so boundary pixels aren't blended against the retained surface), which means it includes only device pixels whose *centers* lie inside the damage region. Rendering, however, is antialiased and also writes fringe pixels whose centers lie *outside* the drawn geometry. The record side already outsets content edges by 2px (`OutsetForAntialiasing`), but wherever `TryGetPaintDamageRegion` intersects the damage region with an ancestor clip, the damage edge coincides *exactly* with an AA-rendered clip edge — zero margin. At integer scales those edges are device-pixel-aligned so no fringe exists (the "regions are pixel-snapped" premise of the original non-AA choice); at fractional scales they land between device pixels, and the written AA fringe is permanently excluded from every replay, accumulating as stripes.

**This PR:** outsets the present-time damage clip by exactly one device pixel (stroke-and-union, `OutsetDamageForPresent`). The clip stays non-antialiased, preserving the original rationale; the replayed picture is always the full frame, so over-covering is correct by construction.

**Validation:** runtime A/B on a 150%-scale machine with a real GPU (Win32 `GlRenderer`): stripes reproduce with the raw clip and disappear with the outset applied, in the same binary with the outset toggled.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: the repro requires a real GPU at fractional display scale, which CI test environments don't provide; validated manually as described above (existing `DirtyRectangles_*` manual samples cover the damage-region pipeline)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — not applicable, internal rendering fix
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
