### PR TITLE
test: Guard When_MsAppData against an indefinite hang

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -104,7 +104,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			TaskCompletionSource<bool> tcs = new();
 			sut.ImageOpened += (s, e) => tcs.TrySetResult(true);
 
-			await tcs.Task;
+			// ImageOpened never fires on some Skia legs (#23967). Without a timeout the bare await
+			// hangs until the 60-minute job cap, which loses the results file for the whole suite.
+			await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
 		}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -88,6 +88,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaFrameBuffer)]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23967")]
+		// Backstop for the storage calls below, which the inner WaitAsync does not cover.
+		[Timeout(60000)]
 		public async Task When_MsAppData()
 		{
 			var file = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/ingredient3.png"));
@@ -103,8 +105,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 
 			TaskCompletionSource<bool> tcs = new();
 			sut.ImageOpened += (s, e) => tcs.TrySetResult(true);
+			sut.ImageFailed += (s, e) => tcs.TrySetException(new Exception($"Image failed to load: {e.ErrorMessage}"));
 
-			// ImageOpened never fires on some Skia legs (#23967). Without a timeout the bare await
+			// Neither event fires on some Skia legs (#23967). Without a timeout the bare await
 			// hangs until the 60-minute job cap, which loses the results file for the whole suite.
 			await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #23967

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Given_BitmapSource.When_MsAppData` awaited its `ImageOpened` `TaskCompletionSource` with a bare `await tcs.Task` — no timeout, no cancellation token. On Skia legs where the image never opens, the test does not fail; it blocks forever.

The cost of that is much larger than one test:

* the job runs until the **60-minute cap** and is killed,
* **no results XML is written**, so `PublishTestResults` fails and every result from the ~650 tests that already ran is lost,
* the remaining tests in the shard never execute,
* a CI agent is occupied for an hour producing nothing.

This bounds the wait to 30 seconds, so the underlying bug surfaces as a single deterministic test failure with the rest of the suite intact.

```
before: "Running test When_MsAppData()" -> 50 min of silence -> agent killed at 60 min -> no results xml
after:  test fails in 30 s with a real message -> results xml written -> suite continues
```

Observed on build 226708 (`Uno.UI - CI`), where the stage was killed on **attempts 1 and 3**, both ending on exactly the same line. In that same build the `Tests - Desktop Skia Linux Framebuffer` stage passed, because the existing `[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaFrameBuffer)]` skips the test there — the X11 leg has no such exclusion and is still exposed.

### Scope

This is a **containment fix, not a root-cause fix**. It does not make `ms-appdata` image loading work on the affected leg — `#23967` stays open for that. The `SkiaFrameBuffer` exclusion is left untouched. Expect the X11 Linux leg to now report `When_MsAppData` as a *failing* test rather than hanging.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — the change is itself in a runtime test
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, test-only change
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
