### PR TITLE
fix(hr): pin re-bound metadata references to their baseline identity for the EnC emit

### DIFF
--- a/specs/056-hotreload-reference-identity-pinning/spec.md
+++ b/specs/056-hotreload-reference-identity-pinning/spec.md
@@ -1,0 +1,107 @@
+# Hot-Reload: Pin Re-Bound Metadata References to the Session Baseline for the EnC Emit
+
+**Repo**: `uno` (Uno.HotReload)
+**Created**: 2026-08-10
+**Status**: Resolved — implemented on this branch
+**Related**: [#24023](https://github.com/unoplatform/uno/issues/24023) (the report),
+[#24012](https://github.com/unoplatform/uno/pull/24012) (sibling Roslyn-5.6 fallout: generator-error
+emit gate), [spec 054](../054-hotreload-audit-changeset-scope/spec.md) (the audit scope the aligned
+solution now feeds)
+
+## Overview & Objectives
+
+Adding a `PackageReference` and using one of its types in XAML, in a single coalesced hot-reload
+change set, degenerates to a rude edit with **zero deltas** on the Roslyn 5.6 line (SDK
+`6.8.0-dev.x`, also stable 6.7 for net10 hosts) while it produced a working delta on Roslyn 4.14
+(`6.7.0-dev.914`). Package resolution and staging succeed (`packages=True` — the assemblies ship);
+the failure is entirely in the EnC emit.
+
+Root cause (verified by decompiling `Microsoft.CodeAnalysis.Features` 5.6.0 and by real-EnC
+tests): `EditSession.EmitSolutionUpdateAsync` now runs `HasReferenceRudeEdits`, comparing the
+emitted compilation's `ReferencedAssemblyNames` against the `InitiallyReferencedAssemblies` the
+project's EnC baseline captured (the baseline compilation's full reference identity set, frozen at
+the module's first emit). Any already-known simple name appearing at a **different identity**
+reports `ENC1099` ("Changing project or package reference caused the identity of referenced
+assembly to change from '{0}' to '{1}'…", Error) and the project is skipped — the shim then
+returns zero updates with the diagnostics. Referencing a **brand-new** simple name is explicitly
+supported (`HasAddedReference` → `projectsToRedeploy`, delta emitted). Roslyn 4.14 had no
+reference checks at all.
+
+A mid-session package add hits the unsupported half routinely: the updater (Studio Live's
+`AdhocSolutionUpdater` → `MsBuildNugetWorkspaceBinder.Bind`) binds **every** assembly of the
+resolved closure onto the project, and real closures overlap the app's built graph — e.g.
+`Mapsui.Uno.WinUI 5.0.2` resolving SkiaSharp 3.x against an app built on SkiaSharp 4.148, or a
+released `Uno.WinUI` against a dev-build app. One overlapped identity kills the whole cycle.
+
+Objective: restore the 4.14-era capability — a package add during hot reload produces a delta and
+the new control materializes — without fighting Roslyn: make the emitted solution *agree* with the
+baseline on every already-known reference identity.
+
+## Design
+
+`HotReloadManager` snapshots, at construction, each project's file-backed
+`PortableExecutableReference`s keyed by assembly simple name (the file name — identical for every
+build/NuGet asset). Before every emit, `WithBaselineReferenceIdentities` rewrites the updater's
+solution: a PE reference whose simple name exists in the snapshot but whose path differs is
+replaced by the **baseline instance** (added-alongside duplicates collapse to one occurrence);
+new names and non-PE references flow through untouched. The emitted delta therefore binds the
+identities the running application actually loaded — which is also the only thing the runtime
+can resolve without a restart.
+
+Decisions and their reasons:
+
+- **Emit-scoped, not committed to `CurrentSolution`** — the manager keeps the updater's faithful
+  result (spec 045 §2: rebinds must persist); pinning happens at the same seam as the
+  generator-error suppression (#24012). EnC commits the *pinned* snapshot; the next cycle re-pins
+  deterministically, so committed-vs-emitted reference identities always agree (guarded by the
+  two-cycle E2E test).
+- **Audits run on the aligned solution** — `ResolveAuditProjects` / generator-error collection /
+  the blocked-compilation audit all see the graph the emit compiles. Only the pinned fork can
+  explain a pin-induced compile failure (an edit using v2-only API fails against pinned v1 —
+  a real error the user must see).
+- **Multi-version baseline names are excluded** from pinning (surfaced as Verbose at session
+  start): pinning cannot pick a side; Roslyn owns that case (ENC1098).
+- **Reporting**: pin events print an Output summary naming up to 3 assemblies ("…at the identity
+  the application was built with; changing a referenced assembly requires a rebuild") only when
+  the pin set *changes* — the re-bind persists, so an unchanged set would repeat verbatim every
+  cycle for the rest of the session. Per-pin old→new paths print at Verbose on every cycle. A
+  pin-free emit clears the dedup so a revert→re-add reports again.
+- **`HotReloadUpdate.PinnedReferences`** exposes the pinned set to handlers: deltas bind the
+  baseline files, NOT the conflicting ones, so a handler staging assembly files must not
+  overwrite a baseline file with a same-named conflicting one (see Residual risks).
+
+## Requirements
+
+- **R1** — Referencing a brand-new assembly mid-session emits a delta (Roslyn-supported path,
+  canary: `When_NewAssemblyReferenceAdded_Then_UpdateIsEmitted`).
+- **R2** — Roslyn 5.x blocks a same-name identity change with ENC1099 at the shim level
+  (canary documenting the raw behavior — if a Roslyn update relaxes it, revisit the pinning:
+  `When_ReferencedAssemblyIdentityChanges_Then_EmitIsBlockedWithENC1099`).
+- **R3** — A package add whose closure re-binds an already-referenced assembly still hot
+  reloads end-to-end: Success, one delta, no ENC errors, pin surfaced on the update and named
+  at Output (`When_PackageAddRebindsExistingAssembly_Then_UpdateIsStillEmitted`).
+- **R4** — The re-bind persisting in `CurrentSolution` while EnC committed the pinned solution
+  is stable across cycles: a later plain edit re-pins and emits; the Output summary does not
+  repeat for an unchanged pin set (`When_RebindPersistsAcrossCycles_Then_NextEditStillEmits`).
+- **R5** — Pinning primitives: replace → pinned back; added-alongside → collapses to one
+  baseline occurrence; new name → untouched (same solution instance); multi-version baseline
+  name → excluded and surfaced; unknown project → untouched; names match case-insensitively
+  (`Given_ReferenceIdentityPinning`).
+
+## Residual risks / follow-ups
+
+- **Staging overwrite (studio.live)** — `AdhocHotReloadProcessor` stages resolved package files
+  with an unconditional write into the running app's output directory; a conflicting same-named
+  file can overwrite the baseline file the deltas bind against (loaded assemblies are unaffected,
+  but a relaunch starts from the downgraded file). Pre-fix the cycle died in ENC1099 (staging
+  still ran); post-fix the session is otherwise healthy, so the divergence is silent.
+  `HotReloadUpdate.PinnedReferences` carries what staging must skip; the exclusion belongs in
+  studio.live's handler chain.
+- **Reference-only breakage audit** (pre-existing, spec 054 scope) — a csproj-only cycle that
+  *removes* a still-used assembly completes as NoChanges (the audit scope matches documents
+  only); the compile error surfaces on the next document edit. Folding `ChangeSet.EditedProjects`
+  into the audit scope is a follow-up.
+- **Same-path identity drift** — a reference rebuilt in place (same path, new `AssemblyVersion`)
+  is invisible to path-keyed pinning and still ENC1099s (a genuine rebuild scenario); the raw
+  rude edit is reported. Mapping ENC1099 to the friendlier rebuild guidance is a possible
+  refinement.

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.References.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.References.cs
@@ -1,0 +1,156 @@
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Diffing;
+using Uno.HotReload.Tests.TestUtils;
+using Uno.HotReload.Tracking;
+
+namespace Uno.HotReload.Tests;
+
+/// <summary>
+/// End-to-end coverage of issue #24023 through the real EnC pipeline: a solution updater that
+/// re-binds metadata references mid-session — what a <c>PackageReference</c> add does when the
+/// package's transitive closure overlaps the running application's graph — must not turn the
+/// cycle into a rude edit. The manager pins re-bound identities back to the session baseline
+/// before the emit; genuinely new assemblies keep flowing through.
+/// </summary>
+[TestClass]
+public sealed class Given_HotReloadManager_References
+{
+	public TestContext TestContext { get; set; } = null!;
+
+	[TestMethod]
+	[Description(
+		"The #24023 scenario: one cycle adds a brand-new assembly (the added package), blindly " +
+		"re-binds an already-referenced assembly at another version (an overlapping transitive) " +
+		"and edits a document to use the new package's type. Roslyn 5.x alone refuses the emit " +
+		"with ENC1099/0 deltas; with baseline-identity pinning the delta must be produced.")]
+	public async Task When_PackageAddRebindsExistingAssembly_Then_UpdateIsStillEmitted()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		using var enc = await EnCHarness.CreateAsync(temp, ct);
+
+		var packageLib = EnCHarness.EmitLibrary(temp, "FreshLib", "1.0.0.0", """
+			namespace Fresh;
+			public static class Info
+			{
+				public static string Name => "fresh";
+			}
+			""");
+		var conflictV2 = EnCHarness.EmitLibrary(temp, "ConflictLib", "2.0.0.0", EnCHarness.ConflictLibSource, subdir: "v2");
+
+		// What the Studio Live updater does on a PackageReference add: every assembly of the
+		// resolved closure is bound onto the project (no same-name filtering), and the document
+		// edit lands on top of the re-bound solution.
+		var updater = new DelegateSolutionUpdater(solution => new SolutionUpdateResult(
+			solution
+				.AddMetadataReference(enc.ProjectId, MetadataReference.CreateFromFile(packageLib))
+				.AddMetadataReference(enc.ProjectId, MetadataReference.CreateFromFile(conflictV2))
+				.WithDocumentText(enc.DocumentId, EnCHarness.AppText("Fresh.Info.Name + Conflict.Info.Version")),
+			ChangeSet.IgnoreAll([])));
+
+		var reporter = new RecordingReporter();
+		var handler = new HotReloadManagerHarness.RecordingHandler();
+		using var manager = new HotReloadManager(
+			enc.Workspace,
+			enc.Watch,
+			handler,
+			new DelegateChangesDetector(),
+			updater,
+			new HotReloadTracker((_, _) => ValueTask.CompletedTask, reporter: reporter),
+			enc.Solution);
+
+		await manager.ProcessFileChanges(
+			Task.FromResult(ImmutableHashSet.Create("/work/MainPage.xaml")),
+			ct);
+
+		var (result, update) = handler.Calls.Should().ContainSingle().Subject;
+		result.Should().Be(
+			HotReloadOperationResult.Success,
+			"a package add whose closure overlaps the app's graph must hot reload, not rude-edit (#24023)");
+		update.Deltas.Should().HaveCount(1, "the document edit compiles against the added assembly");
+		update.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+		update.PinnedReferences.Should().ContainSingle(
+			"the handler must be able to exclude the conflicting file from staging")
+			.Which.AssemblyName.Should().Be("ConflictLib");
+
+		reporter.Outputs.Should().Contain(
+			o => o.Contains("ConflictLib", StringComparison.Ordinal) && o.Contains("rebuild", StringComparison.Ordinal),
+			"the pinned re-bind must be surfaced to the user, naming the pinned assembly");
+	}
+
+	[TestMethod]
+	[Description(
+		"The re-bind persists in the manager's CurrentSolution while EnC committed the PINNED " +
+		"solution — the seam at the center of the fix. A later plain document edit must re-pin " +
+		"and emit cleanly (no ENC1099 against the committed baseline), with the pin surfaced on " +
+		"the update but the Output summary printed only once for the unchanged pin set.")]
+	public async Task When_RebindPersistsAcrossCycles_Then_NextEditStillEmits()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		using var enc = await EnCHarness.CreateAsync(temp, ct);
+
+		var packageLib = EnCHarness.EmitLibrary(temp, "FreshLib", "1.0.0.0", """
+			namespace Fresh;
+			public static class Info
+			{
+				public static string Name => "fresh";
+			}
+			""");
+		var conflictV2 = EnCHarness.EmitLibrary(temp, "ConflictLib", "2.0.0.0", EnCHarness.ConflictLibSource, subdir: "v2");
+
+		// Cycle 1 re-binds (package add); cycle 2 is a plain document edit on top of the
+		// persisting re-bound solution.
+		var cycle = 0;
+		var updater = new DelegateSolutionUpdater(solution => new SolutionUpdateResult(
+			++cycle == 1
+				? solution
+					.AddMetadataReference(enc.ProjectId, MetadataReference.CreateFromFile(packageLib))
+					.AddMetadataReference(enc.ProjectId, MetadataReference.CreateFromFile(conflictV2))
+					.WithDocumentText(enc.DocumentId, EnCHarness.AppText("Fresh.Info.Name + Conflict.Info.Version"))
+				: solution
+					.WithDocumentText(enc.DocumentId, EnCHarness.AppText("Fresh.Info.Name + \"!\" + Conflict.Info.Version")),
+			ChangeSet.IgnoreAll([])));
+
+		var reporter = new RecordingReporter();
+		var handler = new HotReloadManagerHarness.RecordingHandler();
+		using var manager = new HotReloadManager(
+			enc.Workspace,
+			enc.Watch,
+			handler,
+			new DelegateChangesDetector(),
+			updater,
+			new HotReloadTracker((_, _) => ValueTask.CompletedTask, reporter: reporter),
+			enc.Solution);
+
+		await manager.ProcessFileChanges(Task.FromResult(ImmutableHashSet.Create("/work/MainPage.xaml")), ct);
+		await manager.ProcessFileChanges(Task.FromResult(ImmutableHashSet.Create("/work/MainPage.xaml")), ct);
+
+		handler.Calls.Should().HaveCount(2);
+		foreach (var (result, update) in handler.Calls)
+		{
+			result.Should().Be(HotReloadOperationResult.Success, "both cycles must emit against the pinned baseline");
+			update.Deltas.Should().HaveCount(1);
+			update.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+			update.PinnedReferences.Should().ContainSingle("the persisting re-bind is re-pinned on every emit");
+		}
+
+		reporter.Outputs
+			.Count(o => o.Contains("ConflictLib", StringComparison.Ordinal) && o.Contains("rebuild", StringComparison.Ordinal))
+			.Should().Be(1, "an unchanged pin set must not repeat the Output summary on every cycle");
+	}
+
+	private sealed class DelegateChangesDetector : IChangesDetector
+	{
+		public ValueTask<ChangeSet> DiscoverChangesAsync(Solution solution, ImmutableHashSet<string> files, CancellationToken ct)
+			=> ValueTask.FromResult(ChangeSet.IgnoreAll([]));
+	}
+
+	private sealed class DelegateSolutionUpdater(Func<Solution, SolutionUpdateResult> update) : ISolutionUpdater
+	{
+		public ValueTask<SolutionUpdateResult> UpdateAsync(Solution solution, ChangeSet changeSet, CancellationToken ct)
+			=> ValueTask.FromResult(update(solution));
+	}
+}

--- a/src/Uno.HotReload.Tests/Given_HotReloadManager.References.cs
+++ b/src/Uno.HotReload.Tests/Given_HotReloadManager.References.cs
@@ -52,6 +52,7 @@ public sealed class Given_HotReloadManager_References
 
 		var reporter = new RecordingReporter();
 		var handler = new HotReloadManagerHarness.RecordingHandler();
+		enc.OwnsSession = false; // the manager's Dispose ends the EnC session
 		using var manager = new HotReloadManager(
 			enc.Workspace,
 			enc.Watch,
@@ -116,6 +117,7 @@ public sealed class Given_HotReloadManager_References
 
 		var reporter = new RecordingReporter();
 		var handler = new HotReloadManagerHarness.RecordingHandler();
+		enc.OwnsSession = false; // the manager's Dispose ends the EnC session
 		using var manager = new HotReloadManager(
 			enc.Workspace,
 			enc.Watch,

--- a/src/Uno.HotReload.Tests/Microsoft/Given_WatchHotReloadService.References.cs
+++ b/src/Uno.HotReload.Tests/Microsoft/Given_WatchHotReloadService.References.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Tests.TestUtils;
+
+namespace Uno.HotReload.Tests.Microsoft;
+
+/// <summary>
+/// Documents how the embedded Roslyn's EnC treats metadata-reference changes between the
+/// session baseline and the emitted solution (issue #24023). Roslyn 5.x allows referencing a
+/// brand-new assembly (the update is emitted and the project is marked for redeploy) but
+/// blocks the emit with ENC1099 when the identity of an already-referenced assembly changes —
+/// the exact shape a mid-session <c>PackageReference</c> add produces when the package's
+/// transitive closure re-binds an assembly the app was built against at another version.
+/// These tests are the shim-level canary: if a Roslyn update relaxes the behavior, they fail
+/// and the manager-level identity pinning can be reconsidered.
+/// </summary>
+[TestClass]
+public sealed class Given_WatchHotReloadService_References
+{
+	public TestContext TestContext { get; set; } = null!;
+
+	[TestMethod]
+	[Description(
+		"Referencing an assembly the baseline never knew (a plain package add) is NOT a rude " +
+		"edit for Roslyn 5.x: the delta is emitted with the new AssemblyRef. Guards the " +
+		"supported half of the mid-session package-add scenario.")]
+	public async Task When_NewAssemblyReferenceAdded_Then_UpdateIsEmitted()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		using var harness = await EnCHarness.CreateAsync(temp, ct);
+
+		var newLib = EnCHarness.EmitLibrary(temp, "FreshLib", "1.0.0.0", """
+			namespace Fresh;
+			public static class Info
+			{
+				public static string Name => "fresh";
+			}
+			""");
+
+		var changed = harness.Solution
+			.AddMetadataReference(harness.ProjectId, MetadataReference.CreateFromFile(newLib))
+			.WithDocumentText(harness.DocumentId, EnCHarness.AppText("Fresh.Info.Name"));
+
+		var (updates, diagnostics) = await harness.Watch.EmitSolutionUpdateAsync(changed, ct);
+
+		diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+		updates.Should().HaveCount(1, "the edit compiles against the added assembly and must produce a delta");
+	}
+
+	[TestMethod]
+	[Description(
+		"Re-binding an already-referenced assembly to another version (what a package add does " +
+		"when its transitive closure overlaps the app's graph) makes Roslyn 5.x refuse the " +
+		"whole emit with ENC1099 — 0 deltas. This is the raw behavior behind issue #24023; the " +
+		"manager neutralizes it by pinning identities to the baseline before the emit.")]
+	public async Task When_ReferencedAssemblyIdentityChanges_Then_EmitIsBlockedWithENC1099()
+	{
+		var ct = TestContext.CancellationTokenSource.Token;
+		using var temp = new TempDirectory();
+		using var harness = await EnCHarness.CreateAsync(temp, ct);
+
+		// Same simple name as the baseline's ConflictLib, different version, different file.
+		var v2 = EnCHarness.EmitLibrary(temp, "ConflictLib", "2.0.0.0", EnCHarness.ConflictLibSource, subdir: "v2");
+
+		var project = harness.Solution.GetProject(harness.ProjectId)!;
+		var rebound = project.MetadataReferences
+			.Where(r => r is not PortableExecutableReference { FilePath: { } p } || !p.EndsWith("ConflictLib.dll", StringComparison.Ordinal))
+			.Append(MetadataReference.CreateFromFile(v2))
+			.ToImmutableArray();
+
+		var changed = harness.Solution
+			.WithProjectMetadataReferences(harness.ProjectId, rebound)
+			.WithDocumentText(harness.DocumentId, EnCHarness.AppText("\"v:\" + Conflict.Info.Version"));
+
+		var (updates, diagnostics) = await harness.Watch.EmitSolutionUpdateAsync(changed, ct);
+
+		updates.Should().BeEmpty();
+		diagnostics.Should().Contain(
+			d => d.Id == "ENC1099",
+			"changing the identity of a referenced assembly is a project-level rude edit for Roslyn 5.x");
+	}
+}

--- a/src/Uno.HotReload.Tests/TestUtils/EnCHarness.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/EnCHarness.cs
@@ -1,0 +1,127 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Uno.HotReload.Microsoft;
+using Uno.HotReload.Utils;
+
+namespace Uno.HotReload.Tests.TestUtils;
+
+/// <summary>
+/// Minimal real-EnC session: a single-project solution whose baseline module is genuinely
+/// compiled to disk (embedded PDB, exactly like the manager's <c>EmitCompilationOutputAsync</c>
+/// bootstrap) so <see cref="WatchHotReloadService"/> runs the actual Roslyn EnC pipeline, not a
+/// stub. The baseline references ConflictLib v1 and uses it from the single document.
+/// </summary>
+internal sealed class EnCHarness : IDisposable
+{
+	public const string ConflictLibSource = """
+		namespace Conflict;
+		public static class Info
+		{
+			public static string Version => "1";
+		}
+		""";
+
+	// The exact capability set reported by the .NET 10 CoreCLR (MetadataUpdater.GetCapabilities()).
+	private static readonly string[] _capabilities =
+		"Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters GenericUpdateMethod GenericAddMethodToExistingType GenericAddFieldToExistingType"
+			.Split(' ');
+
+	public required AdhocWorkspace Workspace { get; init; }
+	public required WatchHotReloadService Watch { get; init; }
+	public required Solution Solution { get; init; }
+	public required ProjectId ProjectId { get; init; }
+	public required DocumentId DocumentId { get; init; }
+
+	public static string AppSource(string expression)
+		=> $$"""
+		public class C
+		{
+			public static string M() => {{expression}};
+		}
+		""";
+
+	public static SourceText AppText(string expression)
+		=> SourceText.From(AppSource(expression), Encoding.UTF8);
+
+	public static async Task<EnCHarness> CreateAsync(TempDirectory temp, CancellationToken ct)
+	{
+		var v1 = EmitLibrary(temp, "ConflictLib", "1.0.0.0", ConflictLibSource, subdir: "v1");
+
+		var projectId = ProjectId.CreateNewId();
+		var documentId = DocumentId.CreateNewId(projectId);
+		var appPath = Path.Combine(temp.Path, "App.cs");
+		var appDll = Path.Combine(temp.Path, "bin", "App.dll");
+
+		var projectInfo = ProjectInfo.Create(
+				projectId,
+				VersionStamp.Create(),
+				name: "App",
+				assemblyName: "App",
+				language: LanguageNames.CSharp,
+				filePath: Path.Combine(temp.Path, "App.csproj"),
+				compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+				documents:
+				[
+					DocumentInfo.Create(
+						documentId,
+						name: "App.cs",
+						loader: TextLoader.From(TextAndVersion.Create(
+							AppText("\"v\" + Conflict.Info.Version"),
+							VersionStamp.Create(),
+							appPath)),
+						filePath: appPath),
+				],
+				metadataReferences:
+				[
+					MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+					MetadataReference.CreateFromFile(v1),
+				])
+			.WithCompilationOutputInfo(default(CompilationOutputInfo).WithAssemblyPath(appDll));
+
+		var workspace = new AdhocWorkspace();
+		workspace.AddProject(projectInfo);
+		var solution = workspace.CurrentSolution;
+
+		var emitted = await solution.EmitCompilationOutputAsync(ct);
+		emitted.EnsureSuccess();
+
+		var watch = await WatchHotReloadService.CreateAsync(solution, _capabilities, ct);
+
+		return new EnCHarness
+		{
+			Workspace = workspace,
+			Watch = watch,
+			Solution = solution,
+			ProjectId = projectId,
+			DocumentId = documentId,
+		};
+	}
+
+	public static string EmitLibrary(TempDirectory temp, string name, string version, string source, string? subdir = null)
+	{
+		var compilation = CSharpCompilation.Create(
+			name,
+			[
+				CSharpSyntaxTree.ParseText(source, cancellationToken: CancellationToken.None),
+				CSharpSyntaxTree.ParseText($"[assembly: System.Reflection.AssemblyVersion(\"{version}\")]", cancellationToken: CancellationToken.None),
+			],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		var dir = subdir is null ? temp.Path : Path.Combine(temp.Path, subdir);
+		Directory.CreateDirectory(dir);
+		var path = Path.Combine(dir, $"{name}.dll");
+		var emit = compilation.Emit(path);
+		if (!emit.Success)
+		{
+			throw new InvalidOperationException($"Failed to emit {name}: {string.Join(", ", emit.Diagnostics)}");
+		}
+
+		return path;
+	}
+
+	public void Dispose()
+		=> Workspace.Dispose();
+}

--- a/src/Uno.HotReload.Tests/TestUtils/EnCHarness.cs
+++ b/src/Uno.HotReload.Tests/TestUtils/EnCHarness.cs
@@ -34,6 +34,14 @@ internal sealed class EnCHarness : IDisposable
 	public required ProjectId ProjectId { get; init; }
 	public required DocumentId DocumentId { get; init; }
 
+	/// <summary>
+	/// Whether disposing the harness ends the EnC session. Defaults to <see langword="true"/>
+	/// (shim-level tests drive <see cref="Watch"/> directly); tests that hand <see cref="Watch"/>
+	/// to a <see cref="HotReloadManager"/> must set this to <see langword="false"/> — the
+	/// manager's <c>Dispose</c> ends the session, and ending it twice throws.
+	/// </summary>
+	public bool OwnsSession { get; set; } = true;
+
 	public static string AppSource(string expression)
 		=> $$"""
 		public class C
@@ -51,8 +59,8 @@ internal sealed class EnCHarness : IDisposable
 
 		var projectId = ProjectId.CreateNewId();
 		var documentId = DocumentId.CreateNewId(projectId);
-		var appPath = Path.Combine(temp.Path, "App.cs");
-		var appDll = Path.Combine(temp.Path, "bin", "App.dll");
+		var appPath = Path.Join(temp.Path, "App.cs");
+		var appDll = Path.Join(temp.Path, "bin", "App.dll");
 
 		var projectInfo = ProjectInfo.Create(
 				projectId,
@@ -60,7 +68,7 @@ internal sealed class EnCHarness : IDisposable
 				name: "App",
 				assemblyName: "App",
 				language: LanguageNames.CSharp,
-				filePath: Path.Combine(temp.Path, "App.csproj"),
+				filePath: Path.Join(temp.Path, "App.csproj"),
 				compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
 				documents:
 				[
@@ -110,9 +118,9 @@ internal sealed class EnCHarness : IDisposable
 			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
 			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-		var dir = subdir is null ? temp.Path : Path.Combine(temp.Path, subdir);
+		var dir = subdir is null ? temp.Path : Path.Join(temp.Path, subdir);
 		Directory.CreateDirectory(dir);
-		var path = Path.Combine(dir, $"{name}.dll");
+		var path = Path.Join(dir, $"{name}.dll");
 		var emit = compilation.Emit(path);
 		if (!emit.Success)
 		{
@@ -123,5 +131,12 @@ internal sealed class EnCHarness : IDisposable
 	}
 
 	public void Dispose()
-		=> Workspace.Dispose();
+	{
+		if (OwnsSession)
+		{
+			Watch.EndSession();
+		}
+
+		Workspace.Dispose();
+	}
 }

--- a/src/Uno.HotReload.Tests/Utils/Given_ReferenceIdentityPinning.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_ReferenceIdentityPinning.cs
@@ -1,0 +1,166 @@
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Uno.HotReload.Tests.TestUtils;
+using Uno.HotReload.Utils;
+
+namespace Uno.HotReload.Tests.Utils;
+
+/// <summary>
+/// Unit coverage of the reference-identity pinning primitives
+/// (<see cref="RoslynExtensions.SnapshotReferenceIdentities"/> /
+/// <see cref="RoslynExtensions.WithBaselineReferenceIdentities"/>) the manager uses to
+/// neutralize Roslyn 5.x's ENC1099 on re-bound references (#24023).
+/// </summary>
+[TestClass]
+public sealed class Given_ReferenceIdentityPinning
+{
+	private static TempDirectory _temp = null!;
+	private static string _v1 = null!;
+	private static string _v2 = null!;
+	private static string _fresh = null!;
+
+	[ClassInitialize]
+	public static void ClassInitialize(TestContext _)
+	{
+		_temp = new TempDirectory();
+		_v1 = EnCHarness.EmitLibrary(_temp, "ConflictLib", "1.0.0.0", EnCHarness.ConflictLibSource, subdir: "v1");
+		_v2 = EnCHarness.EmitLibrary(_temp, "ConflictLib", "2.0.0.0", EnCHarness.ConflictLibSource, subdir: "v2");
+		_fresh = EnCHarness.EmitLibrary(_temp, "FreshLib", "1.0.0.0", "namespace Fresh; public static class Info { }");
+	}
+
+	[ClassCleanup]
+	public static void ClassCleanup()
+		=> _temp.Dispose();
+
+	private static AppProject CreateProject(params MetadataReference[] references)
+	{
+		var workspace = new AdhocWorkspace();
+		var project = workspace.AddProject("App", LanguageNames.CSharp);
+		workspace.TryApplyChanges(project.Solution.WithProjectMetadataReferences(project.Id, references));
+		return new AppProject(workspace, project.Id);
+	}
+
+	private static IEnumerable<string?> PathsOf(Solution solution, ProjectId projectId)
+		=> solution.GetProject(projectId)!.MetadataReferences
+			.OfType<PortableExecutableReference>()
+			.Select(r => r.FilePath);
+
+	[TestMethod]
+	[Description(
+		"A reference REPLACED by a same-named file at another path (a re-resolution) is pinned " +
+		"back to the baseline file.")]
+	public void When_ReferenceReplaced_Then_PinnedBackToBaseline()
+	{
+		using var app = CreateProject(MetadataReference.CreateFromFile(_v1));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out _);
+
+		var changed = app.Solution.WithProjectMetadataReferences(
+			app.ProjectId,
+			[MetadataReference.CreateFromFile(_v2)]);
+
+		var aligned = changed.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		PathsOf(aligned, app.ProjectId).Should().BeEquivalentTo([_v1]);
+		pinned.Should().ContainSingle().Which.Should().Be(
+			new PinnedReference("App", "ConflictLib", _v2, _v1));
+	}
+
+	[TestMethod]
+	[Description(
+		"A same-named file added ALONGSIDE the baseline reference (a blind closure bind) is " +
+		"dropped, keeping a single occurrence of the baseline file.")]
+	public void When_ReferenceAddedAlongside_Then_DuplicateCollapsesToBaseline()
+	{
+		using var app = CreateProject(MetadataReference.CreateFromFile(_v1));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out _);
+
+		var changed = app.Solution.AddMetadataReference(app.ProjectId, MetadataReference.CreateFromFile(_v2));
+
+		var aligned = changed.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		PathsOf(aligned, app.ProjectId).Should().BeEquivalentTo([_v1]);
+		pinned.Should().ContainSingle();
+	}
+
+	[TestMethod]
+	[Description("A reference whose simple name the baseline never knew — a genuine add — flows through untouched.")]
+	public void When_NewNameAdded_Then_Untouched()
+	{
+		using var app = CreateProject(MetadataReference.CreateFromFile(_v1));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out _);
+
+		var changed = app.Solution.AddMetadataReference(app.ProjectId, MetadataReference.CreateFromFile(_fresh));
+
+		var aligned = changed.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		aligned.Should().BeSameAs(changed, "nothing needed pinning");
+		pinned.Should().BeEmpty();
+		PathsOf(aligned, app.ProjectId).Should().BeEquivalentTo([_v1, _fresh]);
+	}
+
+	[TestMethod]
+	[Description(
+		"A name mapped to two different files in the baseline (multi-version baseline) is " +
+		"excluded from pinning — Roslyn owns that case (ENC1098).")]
+	public void When_BaselineHasMultiVersionName_Then_NameIsNotPinned()
+	{
+		using var app = CreateProject(
+			MetadataReference.CreateFromFile(_v1),
+			MetadataReference.CreateFromFile(_v2));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out var multiVersionNames);
+		multiVersionNames.Should().BeEquivalentTo(["ConflictLib"], "the declined coverage must surface to the caller");
+
+		var v3Path = EnCHarness.EmitLibrary(_temp, "ConflictLib", "3.0.0.0", EnCHarness.ConflictLibSource, subdir: "v3");
+		var changed = app.Solution.AddMetadataReference(app.ProjectId, MetadataReference.CreateFromFile(v3Path));
+
+		var aligned = changed.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		aligned.Should().BeSameAs(changed);
+		pinned.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("A project the baseline never captured (added mid-session) is left alone — EnC skips it anyway.")]
+	public void When_ProjectNotInBaseline_Then_Untouched()
+	{
+		using var app = CreateProject(MetadataReference.CreateFromFile(_v1));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out _);
+
+		var late = app.Solution
+			.AddProject("Late", "Late", LanguageNames.CSharp)
+			.AddMetadataReference(MetadataReference.CreateFromFile(_v2))
+			.Solution;
+
+		var aligned = late.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		aligned.Should().BeSameAs(late);
+		pinned.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	[Description("Assembly simple names match case-insensitively (nuget ids and file systems disagree on casing).")]
+	public void When_CasingDiffers_Then_StillPinned()
+	{
+		var upper = EnCHarness.EmitLibrary(_temp, "CONFLICTLIB", "2.0.0.0", EnCHarness.ConflictLibSource, subdir: "upper");
+
+		using var app = CreateProject(MetadataReference.CreateFromFile(_v1));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out _);
+
+		var changed = app.Solution.WithProjectMetadataReferences(
+			app.ProjectId,
+			[MetadataReference.CreateFromFile(upper)]);
+
+		var aligned = changed.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		PathsOf(aligned, app.ProjectId).Should().BeEquivalentTo([_v1]);
+		pinned.Should().ContainSingle();
+	}
+
+	private sealed record AppProject(AdhocWorkspace Workspace, ProjectId ProjectId) : IDisposable
+	{
+		public Solution Solution => Workspace.CurrentSolution;
+
+		public void Dispose()
+			=> Workspace.Dispose();
+	}
+}

--- a/src/Uno.HotReload.Tests/Utils/Given_ReferenceIdentityPinning.cs
+++ b/src/Uno.HotReload.Tests/Utils/Given_ReferenceIdentityPinning.cs
@@ -156,6 +156,37 @@ public sealed class Given_ReferenceIdentityPinning
 		pinned.Should().ContainSingle();
 	}
 
+	[TestMethod]
+	[Description(
+		"Simple-name keying splits on both separator styles regardless of OS: a Windows-style " +
+		"path string reaching the workspace on Unix must key as its file name, not its full string.")]
+	public void When_PathUsesForeignSeparators_Then_StillPinned()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			// '\' is a real separator on Windows: the foreign-style file cannot exist there.
+			Assert.Inconclusive("Unix-only scenario: requires a file whose name contains a backslash.");
+		}
+
+		// A file whose NAME literally contains a backslash (legal on Unix) is how a
+		// Windows-style path string presents to path APIs on another OS.
+		var emitted = EnCHarness.EmitLibrary(_temp, "ConflictLib", "2.0.0.0", EnCHarness.ConflictLibSource, subdir: "foreign");
+		var foreignStyle = Path.Join(Path.GetDirectoryName(emitted), @"sub\ConflictLib.dll");
+		File.Move(emitted, foreignStyle);
+
+		using var app = CreateProject(MetadataReference.CreateFromFile(_v1));
+		var baseline = app.Solution.SnapshotReferenceIdentities(out _);
+
+		var changed = app.Solution.WithProjectMetadataReferences(
+			app.ProjectId,
+			[MetadataReference.CreateFromFile(foreignStyle)]);
+
+		var aligned = changed.WithBaselineReferenceIdentities(baseline, out var pinned);
+
+		PathsOf(aligned, app.ProjectId).Should().BeEquivalentTo([_v1]);
+		pinned.Should().ContainSingle();
+	}
+
 	private sealed record AppProject(AdhocWorkspace Workspace, ProjectId ProjectId) : IDisposable
 	{
 		public Solution Solution => Workspace.CurrentSolution;

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -128,8 +128,9 @@ public sealed class HotReloadManager : IDisposable
 		foreach (var name in multiVersionNames)
 		{
 			_tracker.Verbose(
-				$"Reference identity pinning is disabled for '{name}': the session baseline references " +
-				"multiple identities of it (a re-bind of it during hot reload requires a rebuild).");
+				$"Reference identity pinning is partially disabled for '{name}': one or more projects in the " +
+				"session baseline reference multiple identities of it (a re-bind of it in those projects " +
+				"during hot reload requires a rebuild).");
 		}
 	}
 

--- a/src/Uno.HotReload/HotReloadManager.cs
+++ b/src/Uno.HotReload/HotReloadManager.cs
@@ -97,6 +97,10 @@ public sealed class HotReloadManager : IDisposable
 	private readonly IHotReloadTracker _tracker;
 	private readonly IChangesDetector _changesDetector;
 	private readonly ISolutionUpdater _solutionUpdater;
+	private readonly ImmutableDictionary<ProjectId, ImmutableDictionary<string, PortableExecutableReference>> _baselineReferences;
+
+	// The last pin set reported at Output level; guarded by _solutionUpdateGate (single-flight passes).
+	private ImmutableHashSet<PinnedReference>? _reportedPins;
 
 	// Internal (not private) so unit tests can drive the manager with a stub
 	// IWatchHotReloadService; production code goes through CreateAsync.
@@ -117,6 +121,16 @@ public sealed class HotReloadManager : IDisposable
 		_solutionUpdater = solutionUpdater;
 
 		CurrentSolution = initialSolution ?? innerWorkspace.CurrentSolution;
+
+		// The reference set the EnC baseline of each project's module captures at session start;
+		// every emit is pinned back onto it (see the alignment step in ProcessSolutionChanged).
+		_baselineReferences = CurrentSolution.SnapshotReferenceIdentities(out var multiVersionNames);
+		foreach (var name in multiVersionNames)
+		{
+			_tracker.Verbose(
+				$"Reference identity pinning is disabled for '{name}': the session baseline references " +
+				"multiple identities of it (a re-bind of it during hot reload requires a rebuild).");
+		}
 	}
 
 	public Solution CurrentSolution { get; private set; }
@@ -202,6 +216,7 @@ public sealed class HotReloadManager : IDisposable
 		HotReloadOperationResult outcome;
 		var deltas = ImmutableArray<Update>.Empty;
 		var diagnostics = ImmutableArray<Diagnostic>.Empty;
+		var pinnedReferences = ImmutableArray<PinnedReference>.Empty;
 
 		if (result.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
 		{
@@ -218,10 +233,47 @@ public sealed class HotReloadManager : IDisposable
 		}
 		else
 		{
+			// Roslyn 5.x refuses to emit any EnC update for a project that references an assembly at
+			// another identity than the one its baseline captured (ENC1099, a rude edit with zero
+			// deltas) — 4.x had no such check, and the runtime accepts deltas binding assemblies the
+			// baseline never referenced. A package added mid-session routinely re-binds part of its
+			// transitive closure onto assemblies the application was already built against (#24023),
+			// so pin those back to their baseline identity for this pass: genuinely new assemblies
+			// flow through (their files are staged by the handler), and the emitted delta binds
+			// against the identities the running application actually loaded.
+			var alignedSolution = result.Solution.WithBaselineReferenceIdentities(_baselineReferences, out pinnedReferences);
+			if (!pinnedReferences.IsEmpty)
+			{
+				// The updater's re-bind persists in CurrentSolution, so the same pins recur on every
+				// later cycle; the Output summary would repeat verbatim for the rest of the session
+				// (unlike the generator-error report below, the condition is not fixable mid-session).
+				// Report it at Output only when the pin set changes — a NEW pin must not drown in the
+				// repetition — and keep the per-cycle detail at Verbose.
+				var pins = pinnedReferences.ToImmutableHashSet();
+				if (_reportedPins is null || !_reportedPins.SetEquals(pins))
+				{
+					_reportedPins = pins;
+					_tracker.Output(
+						$"Hot reload keeps {FormatPinnedReferences(pinnedReferences)} at the identity the " +
+						"application was built with; changing a referenced assembly requires a rebuild.");
+				}
+
+				foreach (var pin in pinnedReferences)
+				{
+					_tracker.Verbose($"{pin.AssemblyName} ({pin.ProjectName}): '{pin.ConflictingPath}' -> '{pin.BaselinePath}'");
+				}
+			}
+			else
+			{
+				// A pin-free emit means the re-bind is gone (e.g. the csproj edit was reverted):
+				// forget the last-reported set so a later identical re-bind reports at Output again.
+				_reportedPins = null;
+			}
+
 			// The projects owning the pass's changed files (spec 054) — resolved once and shared by the
 			// generator-error suppression below and the blocked-compilation audit in the (true, true)
 			// branch, so neither judges a project the pass never touched.
-			var auditedProjects = ResolveAuditProjects(result.Solution, files);
+			var auditedProjects = ResolveAuditProjects(alignedSolution, files);
 
 			// A source generator can report an Error WITHOUT the C# compilation failing: a corrupt .resw
 			// makes the Uno XAML generator emit UXAML0003 (Error) while the assembly still compiles. Roslyn
@@ -245,7 +297,7 @@ public sealed class HotReloadManager : IDisposable
 				diagnosticsReporter.ReportAnalyzerDiagnostics(generatorErrors);
 			}
 			// Attempt to emit anyway ...
-			var emitSolution = result.Solution.WithSuppressedDiagnostics(generatorErrors);
+			var emitSolution = alignedSolution.WithSuppressedDiagnostics(generatorErrors);
 
 			// Compile the solution with those generator errors suppressed, and get deltas.
 			var (updates, emitDiagnostics) = await _watchService.EmitSolutionUpdateAsync(emitSolution, ct).ConfigureAwait(false);
@@ -303,7 +355,7 @@ public sealed class HotReloadManager : IDisposable
 		// across a worker→main boundary). A handler exception is a hot-reload failure for THIS
 		// operation, distinct from a manager-internal fault (spec 045 §3). Cancellation is not a
 		// failure and propagates to the ProcessFileChanges catch.
-		var update = new HotReloadUpdate(files, changeSet, result, diagnostics, deltas);
+		var update = new HotReloadUpdate(files, changeSet, result, diagnostics, deltas, pinnedReferences);
 		try
 		{
 			await _handler.OnHotReloadAsync(outcome, update, ct).ConfigureAwait(false);
@@ -407,6 +459,26 @@ public sealed class HotReloadManager : IDisposable
 				project.Documents.Any(document => document.FilePath is { } path && changeSet.Contains(path))
 				|| project.AdditionalDocuments.Any(document => document.FilePath is { } path && changeSet.Contains(path)))
 			.ToImmutableArray();
+	}
+
+	/// <summary>
+	/// Names the pinned assemblies for the pin summary line: distinct simple names, ordered for a
+	/// deterministic message, capped to the first 3 with a <c>+N more</c> suffix beyond (mirrors
+	/// <see cref="FormatEditedFiles"/>).
+	/// </summary>
+	private static string FormatPinnedReferences(ImmutableArray<PinnedReference> pinned)
+	{
+		const int maxNamed = 3;
+		var names = pinned
+			.Select(pin => pin.AssemblyName)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+		var named = string.Join(", ", names.Take(maxNamed));
+
+		return names.Length > maxNamed
+			? $"{named} +{names.Length - maxNamed} more"
+			: named;
 	}
 
 	/// <summary>

--- a/src/Uno.HotReload/HotReloadUpdate.cs
+++ b/src/Uno.HotReload/HotReloadUpdate.cs
@@ -18,10 +18,19 @@ namespace Uno.HotReload;
 /// information visible to the handler without growing the manager's surface.
 /// Handlers downcast via pattern matching.
 /// </para>
+/// <para>
+/// <see cref="PinnedReferences"/> lists the metadata references the emit pinned back to their
+/// session-baseline identity (see <see cref="PinnedReference"/>): <see cref="Deltas"/> bind the
+/// baseline files, NOT the conflicting ones listed there. A handler staging assembly files
+/// should skip any file whose path matches a <see cref="PinnedReference.ConflictingPath"/> —
+/// writing it over the baseline file would diverge the on-disk application from what the
+/// deltas bind against.
+/// </para>
 /// </remarks>
 public sealed record HotReloadUpdate(
 	ImmutableHashSet<string> Files,
 	ChangeSet ChangeSet,
 	SolutionUpdateResult SolutionUpdate,
 	ImmutableArray<Diagnostic> Diagnostics,
-	ImmutableArray<Update> Deltas);
+	ImmutableArray<Update> Deltas,
+	ImmutableArray<PinnedReference> PinnedReferences);

--- a/src/Uno.HotReload/PinnedReference.cs
+++ b/src/Uno.HotReload/PinnedReference.cs
@@ -1,0 +1,12 @@
+namespace Uno.HotReload;
+
+/// <summary>
+/// A metadata reference re-pointed by the manager's baseline-identity pinning before an EnC emit
+/// (see <see cref="Utils.RoslynExtensions.WithBaselineReferenceIdentities"/>):
+/// <paramref name="ConflictingPath"/> shared the simple name of a baseline reference and was pinned
+/// back to <paramref name="BaselinePath"/>, so the emitted delta binds the identity the running
+/// application actually loaded. Carried on <see cref="HotReloadUpdate.PinnedReferences"/> so
+/// handlers that stage assembly files can avoid overwriting a baseline file with the conflicting
+/// same-named one the emit just pinned away.
+/// </summary>
+public readonly record struct PinnedReference(string ProjectName, string AssemblyName, string ConflictingPath, string BaselinePath);

--- a/src/Uno.HotReload/Utils/RoslynExtensions.ReferencePinning.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.ReferencePinning.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -9,6 +8,21 @@ namespace Uno.HotReload.Utils;
 
 public static partial class RoslynExtensions
 {
+	private static readonly char[] _referencePathSeparators = ['/', '\\'];
+
+	// Assembly simple name == file name without extension for every build/NuGet asset. Split on
+	// BOTH separator styles regardless of OS — paths reaching the workspace may carry either style
+	// (see PathComparer) and Path.GetFileNameWithoutExtension is separator-agnostic only on
+	// Windows — so a foreign-style path never silently keys as its full string.
+	private static string? GetReferenceSimpleName(string path)
+	{
+		var fileName = path.AsSpan(path.LastIndexOfAny(_referencePathSeparators) + 1);
+		var extension = fileName.LastIndexOf('.');
+		var name = extension < 0 ? fileName : fileName[..extension];
+
+		return name.IsEmpty ? null : name.ToString();
+	}
+
 	/// <summary>
 	/// Captures, per project, the file-backed metadata references of <paramref name="solution"/>
 	/// keyed by assembly simple name (the file name, which is the assembly's simple name for every
@@ -32,7 +46,7 @@ public static partial class RoslynExtensions
 			foreach (var reference in project.MetadataReferences)
 			{
 				if (reference is not PortableExecutableReference { FilePath: { Length: > 0 } path } peReference
-					|| Path.GetFileNameWithoutExtension(path) is not { Length: > 0 } name)
+					|| GetReferenceSimpleName(path) is not { } name)
 				{
 					continue;
 				}
@@ -99,7 +113,7 @@ public static partial class RoslynExtensions
 			foreach (var reference in references)
 			{
 				if (reference is PortableExecutableReference { FilePath: { Length: > 0 } path }
-					&& Path.GetFileNameWithoutExtension(path) is { Length: > 0 } name
+					&& GetReferenceSimpleName(path) is { } name
 					&& baselineByName.TryGetValue(name, out var baselineReference)
 					&& !PathComparer.PathEquals(path, baselineReference.FilePath))
 				{
@@ -114,7 +128,14 @@ public static partial class RoslynExtensions
 						updated.Add(baselineReference);
 					}
 
-					pins.Add(new PinnedReference(project.Name, name, path, baselineReference.FilePath!));
+					// The same conflicting file can appear more than once (duplicate reference
+					// instances are legal at the workspace level); record the pin once so
+					// HotReloadUpdate.PinnedReferences stays canonical for handlers.
+					var pin = new PinnedReference(project.Name, name, path, baselineReference.FilePath!);
+					if (!pins.Contains(pin))
+					{
+						pins.Add(pin);
+					}
 				}
 			}
 

--- a/src/Uno.HotReload/Utils/RoslynExtensions.ReferencePinning.cs
+++ b/src/Uno.HotReload/Utils/RoslynExtensions.ReferencePinning.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Uno.HotReload.Utils;
+
+public static partial class RoslynExtensions
+{
+	/// <summary>
+	/// Captures, per project, the file-backed metadata references of <paramref name="solution"/>
+	/// keyed by assembly simple name (the file name, which is the assembly's simple name for every
+	/// build/NuGet asset). This is the reference set the EnC baseline of each project's module
+	/// captures when hot reload starts; <see cref="WithBaselineReferenceIdentities"/> pins later
+	/// solutions back onto it. A name mapped to two different files in the same project (an
+	/// intentionally multi-version baseline) is excluded: pinning cannot pick a side, and Roslyn
+	/// owns that case (ENC1098). The excluded names surface through
+	/// <paramref name="multiVersionNames"/> so the caller can log the declined coverage.
+	/// </summary>
+	internal static ImmutableDictionary<ProjectId, ImmutableDictionary<string, PortableExecutableReference>> SnapshotReferenceIdentities(
+		this Solution solution,
+		out ImmutableArray<string> multiVersionNames)
+	{
+		var byProject = ImmutableDictionary.CreateBuilder<ProjectId, ImmutableDictionary<string, PortableExecutableReference>>();
+		HashSet<string>? allAmbiguous = null;
+		foreach (var project in solution.Projects)
+		{
+			var byName = new Dictionary<string, PortableExecutableReference>(StringComparer.OrdinalIgnoreCase);
+			HashSet<string>? ambiguous = null;
+			foreach (var reference in project.MetadataReferences)
+			{
+				if (reference is not PortableExecutableReference { FilePath: { Length: > 0 } path } peReference
+					|| Path.GetFileNameWithoutExtension(path) is not { Length: > 0 } name)
+				{
+					continue;
+				}
+
+				if (!byName.TryAdd(name, peReference) && !PathComparer.PathEquals(byName[name].FilePath, path))
+				{
+					(ambiguous ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).Add(name);
+				}
+			}
+
+			if (ambiguous is not null)
+			{
+				foreach (var name in ambiguous)
+				{
+					byName.Remove(name);
+				}
+
+				(allAmbiguous ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase)).UnionWith(ambiguous);
+			}
+
+			byProject.Add(project.Id, byName.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase));
+		}
+
+		multiVersionNames = allAmbiguous is null
+			? []
+			: [.. allAmbiguous.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)];
+		return byProject.ToImmutable();
+	}
+
+	/// <summary>
+	/// Returns <paramref name="solution"/> with every file-backed metadata reference whose assembly
+	/// simple name exists in <paramref name="baseline"/> but points to another file replaced by the
+	/// baseline reference (duplicates collapsing to a single entry). References whose name the
+	/// baseline never knew — a genuinely new assembly — are left untouched, as are projects absent
+	/// from the baseline. When nothing needs pinning the solution is returned unchanged (same
+	/// reference) and <paramref name="pinned"/> is empty.
+	/// </summary>
+	/// <remarks>
+	/// Roslyn 5.x refuses to emit any EnC update for a project whose compilation references an
+	/// assembly at another identity than the one its baseline captured (ENC1099 — a rude edit with
+	/// zero deltas), while referencing a brand-new assembly is supported. A package added during
+	/// hot reload routinely re-binds part of its transitive closure onto assemblies the application
+	/// was already built against (issue #24023), so before the emit the manager pins those back to
+	/// the identities the running application actually loaded — which is also what the emitted
+	/// delta must bind against at runtime.
+	/// </remarks>
+	internal static Solution WithBaselineReferenceIdentities(
+		this Solution solution,
+		ImmutableDictionary<ProjectId, ImmutableDictionary<string, PortableExecutableReference>> baseline,
+		out ImmutableArray<PinnedReference> pinned)
+	{
+		var pins = ImmutableArray.CreateBuilder<PinnedReference>();
+		foreach (var projectId in solution.ProjectIds)
+		{
+			if (!baseline.TryGetValue(projectId, out var baselineByName)
+				|| baselineByName.IsEmpty
+				|| solution.GetProject(projectId) is not { } project)
+			{
+				continue;
+			}
+
+			var references = project.MetadataReferences;
+			List<MetadataReference>? updated = null;
+			foreach (var reference in references)
+			{
+				if (reference is PortableExecutableReference { FilePath: { Length: > 0 } path }
+					&& Path.GetFileNameWithoutExtension(path) is { Length: > 0 } name
+					&& baselineByName.TryGetValue(name, out var baselineReference)
+					&& !PathComparer.PathEquals(path, baselineReference.FilePath))
+				{
+					updated ??= [.. references];
+					updated.Remove(reference);
+
+					// Keep a single occurrence of the baseline reference: the conflicting file may
+					// have been added ALONGSIDE the baseline one (a blind closure bind) or have
+					// REPLACED it (a re-resolution) — both pin to the same baseline identity.
+					if (!updated.Any(r => r is PortableExecutableReference pe && PathComparer.PathEquals(pe.FilePath, baselineReference.FilePath)))
+					{
+						updated.Add(baselineReference);
+					}
+
+					pins.Add(new PinnedReference(project.Name, name, path, baselineReference.FilePath!));
+				}
+			}
+
+			if (updated is not null)
+			{
+				solution = solution.WithProjectMetadataReferences(projectId, updated);
+			}
+		}
+
+		pinned = pins.ToImmutable();
+		return solution;
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** closes #24023

## PR Type:

🐞 Bugfix

## Problem

Follow-up to the Roslyn `4.14` → `5.6` move (like #24012, but an independent mechanism). Adding a `PackageReference` and using its type in XAML in one coalesced hot-reload change set produces a rude edit with **zero deltas** on the 5.6 line, while `6.7.0-dev.914` (Roslyn 4.14) emitted a working delta.

**Root cause** (verified by decompiling `Microsoft.CodeAnalysis.Features` 5.6.0 and by real-EnC tests): Roslyn 5.x's `EditSession.EmitSolutionUpdateAsync` now runs `HasReferenceRudeEdits`, comparing the emitted compilation's `ReferencedAssemblyNames` against the reference identities the project's EnC baseline captured at its first emit. Any already-known simple name at a **different identity** reports `ENC1099` (*"Changing project or package reference caused the identity of referenced assembly to change from '{0}' to '{1}', which requires restarting the application"*) and the emit is refused. Referencing a **brand-new** name is explicitly supported (`HasAddedReference` → `projectsToRedeploy`, the delta carries the new AssemblyRef). Roslyn 4.14 had no reference checks at all.

A mid-session package add hits the unsupported half routinely because the updater binds the package's **whole resolved closure** onto the project, and real closures overlap the app's built graph. In the reported Mapsui repro the actual culprits (captured live) are:

```
error ENC1099: … 'System.Text.Json, Version=10.0.0.0' to 'System.Text.Json, Version=9.0.0.0' …
error ENC1099: … 'System.Text.Encodings.Web, Version=10.0.0.0' to 'System.Text.Encodings.Web, Version=6.0.0.0' …
```

(`Mapsui.Uno.WinUI 5.0.2` ships net9.0 assets whose closure re-binds those assemblies over the app's net10 graph.)

Answering #24023's open question: this was **not** a deliberate tightening in Uno — it is an incidental Roslyn 5.x change, independent of #24012's emit gate.

## Fix

`HotReloadManager` snapshots each project's file-backed metadata references (assembly simple name → `PortableExecutableReference`) at session start and, before **every** emit, pins any same-named reference that moved to another file back onto its baseline instance (`WithBaselineReferenceIdentities`, collapsing blind added-alongside duplicates). Genuinely new assemblies flow through untouched — Roslyn supports them and their files are staged by the handler — and the emitted delta binds the identities the running application actually loaded, which is the only thing the runtime can resolve without a restart. Names with multiple baseline identities are excluded (Roslyn keeps owning that case, ENC1098).

Reporting: an Output summary names up to 3 pinned assemblies (*"Hot reload keeps X, Y at the identity the application was built with; changing a referenced assembly requires a rebuild."*), deduped on the pin set since the re-bind recurs every cycle; per-pin old→new paths at Verbose. The pinned set is exposed as `HotReloadUpdate.PinnedReferences` so staging handlers can skip the conflicting files (`PinnedReference.ConflictingPath`) instead of overwriting the baseline files the deltas bind against — the corresponding staging-side exclusion is a studio.live follow-up. (`HotReloadUpdate` gains a positional parameter; it is only constructed by the manager — no downstream constructor found in uno or studio.live.)

Design record: `specs/056-hotreload-reference-identity-pinning/spec.md` (incl. residual risks: staging overwrite, the reference-only audit blind spot, same-path identity drift).

## Verification

- **Real-world scenario (studio.live, Uno SDK 6.8.0-dev.6, Desktop)** — `TemplateBuildRuntimeTests.When_AddNugetPackageDuringHotReload_Then_PackageIsResolvedAndControlMaterializes`:
  - before: `Dispatching RudeEdit (0 delta(s), packages=True)` + 2× ENC1099 (above) — the exact failure from the issue;
  - after (this branch's `Uno.HotReload.dll` overridden into the devserver package): **Passed (33 s)** — `Hot reload keeps System.Text.Encodings.Web, System.Text.Json at the identity the application was built with…` → `Dispatching Success (1 delta(s), packages=True)` → `Mapsui.UI.WinUI.MapControl` materialized in the visual tree.
- `Uno.HotReload.Tests` — **145/145** pass, including new coverage:
  - shim-level canaries against the real EnC pipeline: a brand-new reference emits a delta; a same-name identity change is blocked with ENC1099 (documents the raw Roslyn behavior — fails if a Roslyn update relaxes it);
  - manager E2E through real EnC: the #24023 scenario (new package + conflicting transitive + XAML edit) → Success, 1 delta, pin surfaced;
  - two-cycle manager E2E: EnC commits the pinned solution while the manager keeps the updater's re-bound one — a later plain edit still emits, and the Output summary does not repeat for an unchanged pin set;
  - 6 unit tests on the pinning primitives (replace, added-alongside collapse, new-name untouched, multi-version exclusion, unknown project, case-insensitive names).

## PR Checklist ✅

- [x] 🧪 Added tests (shim canaries + manager E2E against the real EnC pipeline + pinning unit tests)
- [ ] 📚 Docs have been added/updated following the documentation template (design recorded in `specs/056`)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)
