### PR TITLE
[WIP] fix(dispatcher): count low and idle work in the render budget

### DIFF
--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -33,7 +33,7 @@ namespace Uno.UI.Dispatching
 
 		private readonly object _gate = new();
 
-		private readonly Dictionary<object, (Action? renderAction, int normalItemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
+		private readonly Dictionary<object, (Action? renderAction, int itemsToProcessBeforeNextRenderAction)> _compositionTargets = new();
 
 		/// <summary>
 		/// Removes composition-target render registrations matching the predicate. Nothing else
@@ -125,6 +125,10 @@ namespace Uno.UI.Dispatching
 		}
 
 #if __ANDROID__ || __WASM__ || __SKIA__ || __APPLE_UIKIT__ || IS_UNIT_TESTS
+		// Bounds how long a deep Low/Idle backlog can hold rendering back. Normal items stay uncapped, which
+		// keeps the existing Normal-vs-render pacing unchanged.
+		private const int MaxLowPriorityItemsBeforeRender = 2;
+
 		private static void DispatchItems()
 		{
 			// Currently, we have a singleton NativeDispatcher.
@@ -147,22 +151,27 @@ namespace Uno.UI.Dispatching
 
 							@this._currentPriority = (NativeDispatcherPriority)p;
 
+							// High is excluded on purpose: the render pipeline posts a High item of its own on every
+							// frame (CompositionTarget.RaiseRendering), so counting it would let rendering consume
+							// the budget that exists to let the other queues through. Applied before EnqueueNative,
+							// which dispatches inline (and re-entrantly) under IS_UNIT_TESTS.
+							if (@this._currentPriority != NativeDispatcherPriority.High)
+							{
+								foreach (var (compositionTarget, details) in @this._compositionTargets)
+								{
+									if (details.itemsToProcessBeforeNextRenderAction > 0)
+									{
+										@this._compositionTargets[compositionTarget] = details with { itemsToProcessBeforeNextRenderAction = details.itemsToProcessBeforeNextRenderAction - 1 };
+									}
+								}
+							}
+
 							@this.LogTrace()?.Trace($"Running next job in dispatcher queue: priority: {@this._currentPriority} queue states=[{string.Join("] [", @this._queues.Select(q => q.Count))}]");
 							if (Interlocked.Decrement(ref @this._globalCount) > 0)
 							{
 								@this.EnqueueNative(@this._currentPriority);
 							}
 
-							if (@this._currentPriority == NativeDispatcherPriority.Normal)
-							{
-								foreach (var (compositionTarget, details) in @this._compositionTargets)
-								{
-									if (details.normalItemsToProcessBeforeNextRenderAction > 0)
-									{
-										@this._compositionTargets[compositionTarget] = details with { normalItemsToProcessBeforeNextRenderAction = details.normalItemsToProcessBeforeNextRenderAction - 1 };
-									}
-								}
-							}
 							break;
 						}
 					}
@@ -211,9 +220,9 @@ namespace Uno.UI.Dispatching
 				{
 					if (details.renderAction is not null)
 					{
-						if (details.normalItemsToProcessBeforeNextRenderAction == 0)
+						if (details.itemsToProcessBeforeNextRenderAction == 0)
 						{
-							_compositionTargets[compositionTarget] = (renderAction: null, normalItemsToProcessBeforeNextRenderAction: _queues[(int)NativeDispatcherPriority.Normal].Count);
+							_compositionTargets[compositionTarget] = (renderAction: null, itemsToProcessBeforeNextRenderAction: GetItemsToProcessBeforeNextRenderAction());
 
 							_currentPriority = NativeDispatcherPriority.High;
 
@@ -232,6 +241,20 @@ namespace Uno.UI.Dispatching
 
 			return null;
 		}
+
+		/// <summary>
+		/// Number of queued items that must run before the next render action. Must be called under <see cref="_gate"/>.
+		/// </summary>
+		/// <remarks>
+		/// A render action outranks every queue and usually requests the next frame as it runs, so on a host without
+		/// a frame pacer this budget is the only thing that lets queued work run at all. Low and Idle were not
+		/// counted here, which starved <see cref="EnqueueIdleOperation"/> continuations indefinitely.
+		/// </remarks>
+		private int GetItemsToProcessBeforeNextRenderAction()
+			=> _queues[(int)NativeDispatcherPriority.Normal].Count
+				+ Math.Min(
+					_queues[(int)NativeDispatcherPriority.Low].Count + _queues[(int)NativeDispatcherPriority.Idle].Count,
+					MaxLowPriorityItemsBeforeRender);
 #endif
 
 		public void EnqueueRender(object compositionTarget, Action handler)

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Dispatching/Given_NativeDispatcher.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Dispatching/Given_NativeDispatcher.cs
@@ -1,0 +1,75 @@
+#nullable enable
+
+#if HAS_UNO
+
+using System;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+using Uno.UI.Dispatching;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.ConditionMode;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.RuntimeTestPlatforms;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Dispatching;
+
+/// <summary>
+/// Host-level counterpart to the deterministic Uno.UI.UnitTests coverage: exercises the real dispatcher on the
+/// real windowing host, which is where the starvation was observed (macOS has no frame pacer, so a render
+/// action is pending on nearly every turn).
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_NativeDispatcher
+{
+	private const int TimeoutMs = 5000;
+
+	[TestMethod]
+	[PlatformCondition(Include, SkiaWin32 | SkiaX11 | SkiaMacOS)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24032")]
+	public async Task When_Render_Requested_Continuously_Then_Idle_Work_Runs()
+	{
+		var dispatcher = NativeDispatcher.Main;
+		var renderTarget = new object();
+		var keepRendering = true;
+		var raiseRenderingScheduled = false;
+
+		// Models an unpaced host: the next frame is requested straight away, and each frame posts
+		// CompositionTarget.RaiseRendering at High priority.
+		void RequestNextFrame()
+		{
+			if (!keepRendering)
+			{
+				return;
+			}
+
+			if (!raiseRenderingScheduled)
+			{
+				raiseRenderingScheduled = true;
+				dispatcher.Enqueue(() => raiseRenderingScheduled = false, NativeDispatcherPriority.High);
+			}
+
+			dispatcher.EnqueueRender(renderTarget, RequestNextFrame);
+		}
+
+		try
+		{
+			dispatcher.EnqueueRender(renderTarget, RequestNextFrame);
+
+			var idleRan = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+			_ = TestServices.WindowHelper.RootElementDispatcher.RunIdleAsync(_ => idleRan.TrySetResult(true));
+
+			var completed = await Task.WhenAny(idleRan.Task, Task.Delay(TimeoutMs));
+
+			Assert.AreSame(
+				idleRan.Task,
+				completed,
+				$"Idle-priority work did not run within {TimeoutMs}ms while frames were continuously requested.");
+		}
+		finally
+		{
+			keepRendering = false;
+			dispatcher.RemoveCompositionTargets(target => ReferenceEquals(target, renderTarget));
+		}
+	}
+}
+
+#endif

--- a/src/Uno.UI.UnitTests/Uno_UI_Dispatching/Given_NativeDispatcher.cs
+++ b/src/Uno.UI.UnitTests/Uno_UI_Dispatching/Given_NativeDispatcher.cs
@@ -1,0 +1,156 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Dispatching;
+
+namespace Uno.UI.Tests.Uno_UI_Dispatching
+{
+	[TestClass]
+	public class Given_NativeDispatcher
+	{
+		private const int MaxTurns = 100;
+
+		/// <summary>
+		/// On a host without a frame pacer a render action is pending on nearly every dispatcher turn, and each
+		/// frame posts CompositionTarget.RaiseRendering at High priority. Renders outrank every queue, so queued
+		/// work must still be let through or anything awaiting RunIdleAsync never completes.
+		/// </summary>
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24032")]
+		public void When_Render_Loop_Is_Active_Then_Idle_Work_Runs()
+		{
+			using var pump = new DispatcherPump();
+
+			var renders = 0;
+			var idleRan = false;
+
+			pump.Dispatcher.Enqueue(() => idleRan = true, NativeDispatcherPriority.Idle);
+			pump.StartRenderLoop(() => renders++);
+
+			var turns = pump.Run(MaxTurns, () => idleRan);
+
+			Assert.IsTrue(idleRan, $"Idle work never ran ({renders} render actions over {turns} dispatcher turns).");
+
+			var rendersWhenIdleRan = renders;
+			pump.Run(10, () => false);
+
+			Assert.IsTrue(renders > rendersWhenIdleRan, "Rendering stopped once queued work was let through.");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24032")]
+		public void When_Idle_Queue_Is_Deep_Then_Rendering_Is_Not_Starved()
+		{
+			using var pump = new DispatcherPump();
+
+			var renders = 0;
+			var idleItems = 0;
+
+			for (var i = 0; i < 20; i++)
+			{
+				pump.Dispatcher.Enqueue(() => idleItems++, NativeDispatcherPriority.Idle);
+			}
+
+			pump.StartRenderLoop(() => renders++);
+			pump.Run(30, () => false);
+
+			Assert.IsTrue(renders >= 4, $"Rendering was starved by the idle backlog ({renders} renders, {idleItems} idle items).");
+			Assert.IsTrue(idleItems >= 4, $"Idle work was starved by rendering ({idleItems} idle items, {renders} renders).");
+		}
+
+		/// <summary>
+		/// Owns the dispatcher's native pump for the duration of a test, so dispatch order is fully deterministic.
+		/// </summary>
+		private sealed class DispatcherPump : IDisposable
+		{
+			private readonly Action<Action, NativeDispatcherPriority> _previousDispatch;
+			private readonly Func<bool> _previousHasThreadAccess;
+			private readonly Queue<Action> _pending = new();
+			private readonly object _renderTarget = new();
+
+			private Action? _onRender;
+			private bool _renderLoopRunning;
+			private bool _raiseRenderingScheduled;
+
+			public DispatcherPump()
+			{
+				_previousDispatch = NativeDispatcher.DispatchOverride;
+				_previousHasThreadAccess = NativeDispatcher.HasThreadAccessOverride;
+
+				NativeDispatcher.HasThreadAccessOverride = () => true;
+				NativeDispatcher.DispatchOverride = (action, _) => _pending.Enqueue(action);
+
+				Dispatcher.RemoveCompositionTargets(_ => true);
+
+				var primed = false;
+				Dispatcher.Enqueue(() => primed = true);
+				Drain();
+
+				Assert.IsTrue(primed, "Another test left work pending on the dispatcher.");
+			}
+
+			public NativeDispatcher Dispatcher => NativeDispatcher.Main;
+
+			public void StartRenderLoop(Action onRender)
+			{
+				_onRender = onRender;
+				_renderLoopRunning = true;
+
+				Dispatcher.EnqueueRender(_renderTarget, OnRender);
+			}
+
+			/// <summary>Runs at most <paramref name="maxTurns"/> dispatcher turns, stopping early when <paramref name="until"/> is met.</summary>
+			public int Run(int maxTurns, Func<bool> until)
+			{
+				var turns = 0;
+				while (turns < maxTurns && _pending.Count > 0 && !until())
+				{
+					_pending.Dequeue()();
+					turns++;
+				}
+
+				return turns;
+			}
+
+			public void Dispose()
+			{
+				try
+				{
+					_renderLoopRunning = false;
+					Dispatcher.RemoveCompositionTargets(target => ReferenceEquals(target, _renderTarget));
+
+					// The dispatcher is a process-wide singleton: leaving items queued would keep _globalCount
+					// elevated and break the 0->1 posting transition for every later test.
+					Drain();
+				}
+				finally
+				{
+					NativeDispatcher.DispatchOverride = _previousDispatch;
+					NativeDispatcher.HasThreadAccessOverride = _previousHasThreadAccess;
+				}
+			}
+
+			// Models an unpaced host: the frame is drawn on the dispatcher thread, so the next frame is requested
+			// straight away, and each recorded frame posts CompositionTarget.RaiseRendering at High priority.
+			private void OnRender()
+			{
+				_onRender?.Invoke();
+
+				if (!_raiseRenderingScheduled)
+				{
+					_raiseRenderingScheduled = true;
+					Dispatcher.Enqueue(() => _raiseRenderingScheduled = false, NativeDispatcherPriority.High);
+				}
+
+				if (_renderLoopRunning)
+				{
+					Dispatcher.EnqueueRender(_renderTarget, OnRender);
+				}
+			}
+
+			private void Drain() => Run(1000, () => false);
+		}
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** closes #24032

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior.** `NativeDispatcher.DispatchItems` consults `TryGetRenderAction()` *before* it scans the four priority queues, so a pending render action outranks every queued item. The only anti-starvation guard, `normalItemsToProcessBeforeNextRenderAction`, was seeded from the **Normal** queue alone (`:216`) and decremented only when a Normal item was dispatched (`:156`). With the Normal queue empty — the ordinary state on a settled visual tree — the budget was re-seeded to `0` on every render, so the next render action was immediately eligible again and **Low and Idle never got a turn**. Anything awaiting `CoreDispatcher.RunIdleAsync` therefore never resumed.

Hosts that pace their frames rarely notice: Win32 (`Win32RenderPacer.cs`) and X11 (`FramePacer`) produce frames on a separate paced thread, so a render action is pending only briefly. macOS has neither — `MacOSWindowHost.InvalidateRender()` is a bare `uno_window_invalidate` → `needsDisplay = YES` and AppKit draws on the dispatcher's own thread — so a render action is pending on nearly every turn and the starvation is total.

**Change.** Repair the accounting at the mutation point rather than guarding downstream:

- seed the budget from `Normal.Count + min(Low.Count + Idle.Count, 2)` (`GetItemsToProcessBeforeNextRenderAction`)
- decrement it on every **non-High** dispatch
- rename `normalItemsToProcessBeforeNextRenderAction` → `itemsToProcessBeforeNextRenderAction`, since it is no longer Normal-only

High is excluded deliberately: the render pipeline posts `CompositionTarget.RaiseRendering` at High priority on every frame, so counting it would let rendering consume the budget that exists to yield to the other queues. Normal stays uncapped, leaving today's Normal-vs-render pacing bit-for-bit unchanged.

**Why not the simpler options.** Widening the budget to all queues while leaving the decrement in the `_currentPriority == Normal` branch *deadlocks rendering* — once Normal drains, the budget never returns to `0`. An earlier "let one queued item through after K consecutive renders" floor was also drafted and rejected: `RaiseRendering` regenerates a High item each frame and consumes exactly the slot the floor releases, so Idle still starves. The `When_Render_Loop_Is_Active_Then_Idle_Work_Runs` test below fails against that design.

**Invariants.** `budget ≤ Normal.Count + Low.Count + Idle.Count` holds at every mutation, so `budget > 0` implies some non-High queue is non-empty; the scan that follows always dequeues, and the still-pending render keeps `_globalCount > 0` so `EnqueueNative` always re-posts — no lost wakeup. Renders are deferred by at most `Normal.Count + 2` items plus the one outstanding `RaiseRendering`, and no new render work is produced while renders are deferred — no render starvation in the other direction.

### WinUI parity

WinUI does not schedule rendering through `CoreDispatcher`'s priority queues at all — the compositor rasterizes off-thread and `CompositionTarget.Rendering` is a vsync-paced UI-thread callback, so a running animation or a scrolling `ScrollViewer` can never prevent an idle callback from firing. Total idle starvation has no WinUI analogue and is plainly wrong against `RunIdleAsync`'s contract, so this moves Uno toward parity. Routing renders through the dispatcher is Uno-specific (`CompositionTarget.RenderScheduling.skia.cs:172`), so this is a repair of an Uno invariant rather than a port of a WinUI mechanism — the genuinely WinUI-faithful fix is macOS frame pacing, tracked separately.

One bounded divergence is introduced knowingly: a frame can now be deferred behind up to 2 Low/Idle items, which WinUI would not do. That is why the share is capped rather than counting the whole backlog; a 2-item frame delay is far closer to WinUI than indefinite idle starvation. Once macOS frame pacing lands the budget rarely binds at all.

### Blast radius

The changed region is inside `#if __ANDROID__ || __WASM__ || __SKIA__ || __APPLE_UIKIT__ || IS_UNIT_TESTS`, so it compiles for the maintenance-only native targets too. `EnqueueRender` has exactly one production caller (`CompositionTarget.RenderScheduling.skia.cs:172`, a `.skia.cs` file); on native Android, native iOS and native WASM `_compositionTargets` is never populated, `TryGetRenderAction` returns `null` immediately and the budget can never leave `0`, so the change is inert there. Observable pacing change is concentrated on the unpaced hosts: macOS, FrameBuffer, Headless.

### Validation

- **Runtime** (macOS Skia, `SamplesApp.Skia.Generic`, local): `Given_NativeDispatcher.When_Render_Requested_Continuously_Then_Idle_Work_Runs` **fails on `master`**, passes with the fix. `Given_SystemFocusVisual` (one of the classes that stalls in CI) passes 5/5.
- **Runtime** (unit tests): both new tests **fail on `master`** — *"Idle work never ran (100 render actions over 100 dispatcher turns)"* and *"Idle work was starved by rendering (0 idle items, 30 renders)"* — and pass with the fix.
- **Compile**: `Uno.UI.Dispatching` Skia, Wasm and Reference flavors clean. `netcoremobile` was not built locally; relying on CI.
- A full local macOS runtime-suite pass was **not** obtained — the run aborts in the HotReload tests because the spawned secondary app fails to load `libicudata` on this machine, unrelated to this change. Relying on CI for full-suite coverage; please check the macOS leg before merging.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
