### PR TITLE
refactor(android): Make Skia-Android multi-window-ready

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2352,6 +2352,8 @@
 		  <Member fullName="Uno.UI.Runtime.Skia.Android.AndroidHost" reason="AndroidHost reduced to internal; use UseAndroid() on the host builder (breaking changes for 7.0)" />
 		  <!-- Legacy WinRTFeatureConfiguration holder removed with its sole flag (accessors paired in <Properties>/<Methods> below). -->
 		  <Member fullName="Uno.WinRTFeatureConfiguration/ApplicationLanguages" reason="Removed empty WinRTFeatureConfiguration.ApplicationLanguages holder after deleting UseLegacyPrimaryLanguageOverride (BC50, breaking changes for 7.0)" />
+		  <!-- Skia-Android de-singletoning: this Java listener is constructed by the host with its owning activity and was never usable by app code, which had no way to supply one. -->
+		  <Member fullName="Uno.UI.OnSystemUiVisibilityChangeListener" reason="OnSystemUiVisibilityChangeListener reduced to internal; it is bound to the activity that owns the window (breaking changes for 7.0)" />
 	  </Types>
 	  <Fields>
 		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -410,6 +410,23 @@ Two related behavior changes:
 
 See [Customizing the `Application` class on Android](xref:Uno.Features.CustomizingAndroidApplication).
 
+### Android context APIs
+
+Skia-on-Android no longer keeps the window, its render stack, or its input sources in
+process-wide statics, so the ambient Android context APIs changed shape:
+
+- **`Uno.UI.ContextHelper.Current` is now typed `Android.Content.Context?`.** It has always been
+  able to be `null` — before any activity is created — but the property was annotated non-null,
+  so the compiler never surfaced it. Code that dereferences it directly will now warn under
+  nullable reference types. Guard it, or use the new `ContextHelper.ApplicationContext` when a
+  process-wide context is all that is needed (system services, resources, package info).
+- **`Uno.UI.ContextHelper.Current` now tracks the foreground activity.** It previously kept the
+  last activity ever assigned, including one that had already been destroyed. Code relying on
+  reading a stale activity after teardown should resolve the activity from the relevant window's
+  `XamlRoot` instead.
+- **`Uno.UI.OnSystemUiVisibilityChangeListener` is now `internal`.** It is constructed by the host
+  with the activity that owns the window; app code had no way to supply one.
+
 ### Templates and project heads
 
 New apps get Skia heads only. Existing apps should drop native `*.Mobile` / native

--- a/specs/053-android-multiwindow-ready/plan.md
+++ b/specs/053-android-multiwindow-ready/plan.md
@@ -11,16 +11,20 @@ per-window ownership pattern the Skia desktop runtimes (Win32/X11/macOS) and the
 Apple UIKit runtime already use, making the architecture **multi-window-ready**.
 
 **In scope (this work):**
-- Per-window `NativeWindowWrapper` instances (one per `Window`/`XamlRoot`), not a singleton.
+- `NativeWindowWrapper` instances bound to the activity driving a window, not a `Lazy<>`
+  singleton. Note this lands as **per-activity**, not yet strictly per-`Window`: the activity
+  still adopts the wrapper through the ambient current window, because an explicit
+  activity⇄window binding needs the lifecycle orchestration deferred below. Marked `TODO #13827`.
 - Per-window render stack on `ApplicationActivity` (render view, native-layer host,
   root layout) — instance state, not `static`.
 - A per-window `IXamlRootHost` that resolves its own `RootElement`, render view and
   input sources instead of reaching `Window.Current` / `ApplicationActivity.Instance`.
 - Per-window input sources (pointer + keyboard), resolved from the host (the Win32 pattern).
-- `ContextHelper` **split + foreground fallback**: an explicit app-global
-  `ApplicationContext`, and `Current` that tracks the *foreground* activity via the
-  existing `BaseActivity` registry (fixing today's sticky "last-ever-set" behaviour)
-  and falls back to the application context.
+- `ContextHelper` **split**: an explicit app-global `ApplicationContext`, and `Current` that
+  tracks the *foreground* activity via the existing `BaseActivity` registry (fixing today's
+  sticky "last-ever-set" behaviour). `Current` stays **activity-scoped and does not fall back
+  to the application context** — falling back would break the `(Activity)Current` hard-casts and
+  `Current == null` guards in existing callers — and is typed `Context?` to say so honestly.
 
 **Out of scope (deliberate follow-ups):**
 - Flipping `SupportsMultipleWindows` to `true` and driving a *live* second Activity —
@@ -72,13 +76,13 @@ consolidation; the `Uno.UWP`/`Uno.Foundation` Android assemblies must keep compi
   activity/render view via `XamlRoot → XamlRootMap.GetHostForRoot → host`.
 - Input sources registered `ApiExtensibility.Register<IXamlRootHost>(typeof(IUnoCorePointerInputSource), host => …)`.
 - `ContextHelper`: `ApplicationContext` (app-global) + `Current` = foreground activity
-  (registry-backed) with app-context fallback.
+  (registry-backed), typed `Context?`, no app-context fallback.
 
 ## Phases (each compiles for `net10.0-android`; committed separately)
 
-1. **ContextHelper split + foreground fallback.** `ContextHelper.ApplicationContext`;
-   faithful foreground tracking driven from `BaseActivity` (`SetAsCurrent`/`ResignCurrent`
-   repoint to the next live activity or app context). Unit-testable in isolation.
+1. **ContextHelper split.** `ContextHelper.ApplicationContext`; faithful foreground tracking
+   driven from `BaseActivity` (`SetAsCurrent`/`ResignCurrent` repoint to the next live activity
+   only, so single-window keeps last-activity behaviour).
 2. **Per-window host.** `AndroidSkiaXamlRootHost` captures its `Window` + `ApplicationActivity`;
    `RootElement`/`InvalidateRender` become per-window; `AndroidSkiaWindowFactory` wires owner.
 3. **Per-window wrapper.** `NativeWindowWrapper.Android` singleton → instance bound to its
@@ -97,8 +101,11 @@ consolidation; the `Uno.UWP`/`Uno.Foundation` Android assemblies must keep compi
   after each phase (the only assembly that compiles `__ANDROID__` Skia code).
 - **Unit:** the foreground-repoint and context-split logic lives on Android types
   (`BaseActivity : AppCompatActivity`, `Android.Content.Context`) that the net-based
-  `Uno.UI.UnitTests` cannot instantiate, so it is not unit-testable off-device. The
-  `XamlRoot→host` resolution is exercisable only under the Android runtime.
+  `Uno.UI.UnitTests` cannot instantiate, so it is not unit-testable off-device.
+- **Runtime tests:** the `XamlRoot→host` resolution *is* coverable — CI runs an Android Skia
+  runtime-test lane (`build/ci/tests/.azure-devops-tests-android-skia.yml`), so
+  `Given_AndroidSkiaXamlRootHost` asserts host registration, activity resolution and per-window
+  input-source identity under `[PlatformCondition(… RuntimeTestPlatforms.SkiaAndroid)]`.
 - **Runtime:** single-window smoke on an emulator/device — **not executed in the dev
   environment used for this change** (no reachable emulator/adb). Run with:
   `cd src/SamplesApp/SamplesApp.Skia.netcoremobile/Android && dotnet run -f net10.0-android`.

--- a/specs/053-android-multiwindow-ready/plan.md
+++ b/specs/053-android-multiwindow-ready/plan.md
@@ -1,0 +1,96 @@
+# Android multi-window-ready architecture
+
+Tracking: Android multi-window support (public issue **#13827**).
+
+## Goal & scope
+
+Skia-on-Android currently bakes "one window" into three process-wide static anchors.
+This work **de-singletons** those anchors so Android converges onto the same
+per-window ownership pattern the Skia desktop runtimes (Win32/X11/macOS) and the
+Apple UIKit runtime already use, making the architecture **multi-window-ready**.
+
+**In scope (this work):**
+- Per-window `NativeWindowWrapper` instances (one per `Window`/`XamlRoot`), not a singleton.
+- Per-window render stack on `ApplicationActivity` (render view, native-layer host,
+  root layout) — instance state, not `static`.
+- A per-window `IXamlRootHost` that resolves its own `RootElement`, render view and
+  input sources instead of reaching `Window.Current` / `ApplicationActivity.Instance`.
+- Per-window input sources (pointer + keyboard), resolved from the host (the Win32 pattern).
+- `ContextHelper` **split + foreground fallback**: an explicit app-global
+  `ApplicationContext`, and `Current` that tracks the *foreground* activity via the
+  existing `BaseActivity` registry (fixing today's sticky "last-ever-set" behaviour)
+  and falls back to the application context.
+
+**Out of scope (deliberate follow-ups):**
+- Flipping `SupportsMultipleWindows` to `true` and driving a *live* second Activity —
+  that needs Activity↔Window lifecycle orchestration and on-device validation, and
+  mirrors how iOS staged its own multi-window behind scene adoption (#8341).
+- Threading an explicit owning-window `Context` through every `Uno.UWP`/AddIn
+  `ContextHelper.Current` consumer. While only one window is live this is a no-op;
+  those callers stay on the (now-correct) foreground fallback until live multi-window lands.
+
+`SupportsMultipleWindows` stays **`false`**. Definition of done for this work is:
+**per-window instances everywhere, and zero single-window regressions.**
+
+## Current architecture — the three anchors
+
+The framework layer (`Window → DesktopWindow → DesktopWindowXamlSource → XamlIslandRoot →
+ContentRoot/VisualTree → XamlRoot`, plus `XamlRootMap` and `NativeWindowWrapperBase`) is
+**already per-window**. Single-window-ness lives entirely in:
+
+1. **`NativeWindowWrapper.Instance`** — `Lazy<>` singleton in
+   `src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs` (linked into the
+   Skia.Android assembly), returned by `AndroidSkiaWindowFactory.CreateWindow` for
+   *every* window; its `NativeWindow`/`Title`/`ShowCore` defer to `ApplicationActivity.Instance`.
+2. **`ApplicationActivity.Instance`** + `static _renderView` / `_renderViewAsView` /
+   `_nativeLayerHost` / `RelativeLayout` / `_started`
+   (`src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs`).
+3. **`ContextHelper.Current`** — app-global `Android.Content.Context`
+   (`src/Uno.UWP/ContextHelper.cs`); ~40 activity-specific reads, ~55 app-context reads.
+
+`BaseActivity` (`src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs`) already
+maintains a multi-activity registry (`_instances`, `Current`, `CurrentChanged`) — the seed
+the foreground fallback and per-window ownership build on.
+
+Reference: native Android UI is dropped on this branch — this is purely a Skia-Android host
+consolidation; the `Uno.UWP`/`Uno.Foundation` Android assemblies must keep compiling.
+
+## Target shape (mirrors Win32/X11/iOS)
+
+- `AndroidSkiaWindowFactory.CreateWindow(window, xamlRoot)` → `new NativeWindowWrapper(...)`
+  bound to the owning `ApplicationActivity`, registered in `XamlRootMap` via a per-window
+  `AndroidSkiaXamlRootHost`.
+- `AndroidSkiaXamlRootHost` owns/references its window's `ApplicationActivity`, render view,
+  native-layer host and input sources; `RootElement => <its window>.RootElement`;
+  `InvalidateRender()` invalidates *its* view.
+- Consumers (`ContentPresenter` native hosting, TextBox notifications, IME) resolve the owning
+  activity/render view via `XamlRoot → XamlRootMap.GetHostForRoot → host`.
+- Input sources registered `ApiExtensibility.Register<IXamlRootHost>(typeof(IUnoCorePointerInputSource), host => …)`.
+- `ContextHelper`: `ApplicationContext` (app-global) + `Current` = foreground activity
+  (registry-backed) with app-context fallback.
+
+## Phases (each compiles for `net10.0-android`; committed separately)
+
+1. **ContextHelper split + foreground fallback.** `ContextHelper.ApplicationContext`;
+   faithful foreground tracking driven from `BaseActivity` (`SetAsCurrent`/`ResignCurrent`
+   repoint to the next live activity or app context). Unit-testable in isolation.
+2. **Per-window host.** `AndroidSkiaXamlRootHost` captures its `Window` + `ApplicationActivity`;
+   `RootElement`/`InvalidateRender` become per-window; `AndroidSkiaWindowFactory` wires owner.
+3. **Per-window wrapper.** `NativeWindowWrapper.Android` singleton → instance bound to its
+   activity; drop `Instance`; `BaseActivity` lifecycle drives *its* wrapper (activity→wrapper map).
+4. **De-static the render stack.** `ApplicationActivity` `Instance`/render fields → instance;
+   native-element hosting, TextBox provider, IME resolve via `XamlRoot`→host.
+5. **Per-window input sources.** Host owns pointer + keyboard sources; register keyed on
+   `IXamlRootHost`; `ApplicationActivity` dispatch targets its own host.
+6. **Validate.** `net10.0-android` compile after every phase; unit tests for the registry /
+   foreground-fallback / resolution logic; single-window runtime smoke where a device is
+   available. Live two-window validation is explicitly deferred (see out of scope).
+
+## Validation strategy
+
+- **Compile:** `dotnet build …Skia.Android.csproj -p:UnoTargetFrameworkOverride=net10.0-android`
+  after each phase (the only assembly that compiles `__ANDROID__` Skia code).
+- **Unit:** logic tests for the activity registry foreground fallback and `XamlRoot→host`
+  resolution where they can run without a device.
+- **Runtime:** single-window smoke on an emulator/device where available; report honestly
+  when device runtime validation isn't executed here. Two live windows is a follow-up.

--- a/specs/053-android-multiwindow-ready/plan.md
+++ b/specs/053-android-multiwindow-ready/plan.md
@@ -1,6 +1,7 @@
 # Android multi-window-ready architecture
 
-Tracking: Android multi-window support (public issue **#13827**).
+Tracking: multi-window support (public issue **#8341**); the Android-specific issue
+**#13827** was folded into it as a duplicate.
 
 ## Goal & scope
 
@@ -27,7 +28,11 @@ Apple UIKit runtime already use, making the architecture **multi-window-ready**.
   mirrors how iOS staged its own multi-window behind scene adoption (#8341).
 - Threading an explicit owning-window `Context` through every `Uno.UWP`/AddIn
   `ContextHelper.Current` consumer. While only one window is live this is a no-op;
-  those callers stay on the (now-correct) foreground fallback until live multi-window lands.
+  those callers stay on the (now-correct) foreground activity until live multi-window lands.
+- `XamlRootMap.Unregister` on window close. There is no window-close path while
+  `SupportsMultipleWindows` is false (the app keeps one window for its lifetime), and the
+  other single-window Skia hosts (macOS, Linux.FrameBuffer, WASM, AppleUIKit) likewise don't
+  unregister. Needed only once a close/reopen cycle exists.
 
 `SupportsMultipleWindows` stays **`false`**. Definition of done for this work is:
 **per-window instances everywhere, and zero single-window regressions.**
@@ -39,9 +44,9 @@ ContentRoot/VisualTree → XamlRoot`, plus `XamlRootMap` and `NativeWindowWrappe
 **already per-window**. Single-window-ness lives entirely in:
 
 1. **`NativeWindowWrapper.Instance`** — `Lazy<>` singleton in
-   `src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs` (linked into the
-   Skia.Android assembly), returned by `AndroidSkiaWindowFactory.CreateWindow` for
-   *every* window; its `NativeWindow`/`Title`/`ShowCore` defer to `ApplicationActivity.Instance`.
+   `src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs`,
+   returned by `AndroidSkiaWindowFactory.CreateWindow` for *every* window; its
+   `NativeWindow`/`Title`/`ShowCore` defer to `ApplicationActivity.Instance`.
 2. **`ApplicationActivity.Instance`** + `static _renderView` / `_renderViewAsView` /
    `_nativeLayerHost` / `RelativeLayout` / `_started`
    (`src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs`).
@@ -90,7 +95,13 @@ consolidation; the `Uno.UWP`/`Uno.Foundation` Android assemblies must keep compi
 
 - **Compile:** `dotnet build …Skia.Android.csproj -p:UnoTargetFrameworkOverride=net10.0-android`
   after each phase (the only assembly that compiles `__ANDROID__` Skia code).
-- **Unit:** logic tests for the activity registry foreground fallback and `XamlRoot→host`
-  resolution where they can run without a device.
-- **Runtime:** single-window smoke on an emulator/device where available; report honestly
-  when device runtime validation isn't executed here. Two live windows is a follow-up.
+- **Unit:** the foreground-repoint and context-split logic lives on Android types
+  (`BaseActivity : AppCompatActivity`, `Android.Content.Context`) that the net-based
+  `Uno.UI.UnitTests` cannot instantiate, so it is not unit-testable off-device. The
+  `XamlRoot→host` resolution is exercisable only under the Android runtime.
+- **Runtime:** single-window smoke on an emulator/device — **not executed in the dev
+  environment used for this change** (no reachable emulator/adb). Run with:
+  `cd src/SamplesApp/SamplesApp.Skia.netcoremobile/Android && dotnet run -f net10.0-android`.
+  Exercise: launch/render, touch + text input (soft keyboard, IME composition), rotation,
+  background→foreground, and a config-change re-creation (system font-size/locale change).
+  Two live windows is a follow-up.

--- a/src/AddIns/Uno.UI.GooglePlay/StoreContextExtension.cs
+++ b/src/AddIns/Uno.UI.GooglePlay/StoreContextExtension.cs
@@ -61,13 +61,24 @@ public class StoreContextExtension : IStoreContextExtension
 
 		public void OnComplete(Xamarin.Google.Android.Play.Core.Tasks.Task task)
 		{
-			var context = ContextHelper.Current;
-			var activity = (Activity)context;
-
 			if (!task.IsSuccessful || _forceReturn)
 			{
 				_inAppRateTcs?.TrySetResult(new(_forceReturn ? StoreRateAndReviewStatus.Succeeded : StoreRateAndReviewStatus.Error));
 				_launchTask?.Dispose();
+
+				return;
+			}
+
+			// The review flow must be hosted by the foreground activity, which may be gone by the
+			// time the request completes (backgrounded app, activity re-creation).
+			if (ContextHelper.Current is not Activity activity)
+			{
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().LogError("Cannot launch the in-app review flow, no foreground activity is available.");
+				}
+
+				_inAppRateTcs?.TrySetResult(new(StoreRateAndReviewStatus.Error));
 
 				return;
 			}

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -257,8 +257,7 @@ namespace Microsoft.UI.Xaml
 
 			Wrapper.OnActivityCreated();
 
-			// Track and observe this activity's window system UI visibility. Moved here from
-			// NativePage so it can reach this activity's per-window wrapper.
+			// Track and observe this activity's window system UI visibility on its per-window wrapper.
 			var decorView = this.Window!.DecorView;
 #pragma warning disable 618
 #pragma warning disable CA1422 // Validate platform compatibility
@@ -416,7 +415,13 @@ namespace Microsoft.UI.Xaml
 
 			CleanupBackPressedCallback();
 
-			Wrapper.OnNativeClosed();
+			// Only signal the managed window as closing when this activity is genuinely finishing.
+			// On configuration-change re-creation the window survives and is taken over by the new
+			// activity, so raising Closing here would be spurious.
+			if (IsFinishing)
+			{
+				Wrapper.OnNativeClosed();
+			}
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -146,7 +146,7 @@ namespace Microsoft.UI.Xaml
 				return base.DispatchKeyEvent(e);
 			}
 
-			var handled = AndroidKeyboardInputSource.Instance.OnNativeKeyEvent(e);
+			var handled = Wrapper.KeyboardSource.OnNativeKeyEvent(e);
 
 			if (!handled)
 			{
@@ -179,7 +179,7 @@ namespace Microsoft.UI.Xaml
 			}
 
 			_renderViewAsView?.GetLocationInWindow(_locationInWindow);
-			AndroidCorePointerInputSource.Instance.OnNativeMotionEvent(ev, _locationInWindow, nativelyHandled);
+			Wrapper.PointerSource.OnNativeMotionEvent(ev, _locationInWindow, nativelyHandled);
 
 			// As the AndroidCorePointerInputSource can dispatch event asynchronously, we always return true to prevent the system from dispatching the event
 			// as we assume that anyway we are the fully opaque (i.e. the pointer should not be dispatch to any element under this current ApplicationActivity).
@@ -206,7 +206,7 @@ namespace Microsoft.UI.Xaml
 			}
 
 			_renderViewAsView?.GetLocationInWindow(_locationInWindow);
-			AndroidCorePointerInputSource.Instance.OnNativeMotionEvent(ev, _locationInWindow, nativelyHandled);
+			Wrapper.PointerSource.OnNativeMotionEvent(ev, _locationInWindow, nativelyHandled);
 
 			// As the AndroidCorePointerInputSource can dispatch event asynchronously, we always return true to prevent the system from dispatching the event
 			// as we assume that anyway we are the fully opaque (i.e. the pointer should not be dispatch to any element under this current ApplicationActivity).

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -32,27 +32,52 @@ namespace Microsoft.UI.Xaml
 	[Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode, WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden)]
 	public partial class ApplicationActivity : Controls.NativePage
 	{
-		private static IUnoSkiaRenderView? _renderView;
-		private static View? _renderViewAsView;
-		private static ClippedRelativeLayout? _nativeLayerHost;
+		private IUnoSkiaRenderView? _renderView;
+		private View? _renderViewAsView;
+		private ClippedRelativeLayout? _nativeLayerHost;
 
-		internal static IUnoSkiaRenderView? RenderView => _renderView;
+		internal IUnoSkiaRenderView? RenderView => _renderView;
 
 		private InputPane _inputPane;
 
-		private static bool _started;
+		private bool _started;
 		private bool _isContentViewSet;
 
-		/// <summary>
-		/// The windows model implies only one managed activity.
-		/// </summary>
-		internal static ApplicationActivity Instance { get; private set; } = null!;
+		private NativeWindowWrapper? _wrapper;
 
-		internal static RelativeLayout RelativeLayout { get; private set; } = null!;
+		/// <summary>
+		/// The native wrapper for the window this activity drives. Created lazily so the early
+		/// lifecycle callbacks (which run before the managed Window exists) can drive it. On
+		/// activity re-creation the wrapper already bound to the window is reused and re-pointed
+		/// at this activity, since the managed Window outlives individual activities.
+		/// </summary>
+		internal NativeWindowWrapper Wrapper
+		{
+			get
+			{
+				if (_wrapper is null)
+				{
+					// SupportsMultipleWindows is false, so there is a single window: on re-creation
+					// reuse the wrapper already bound to it rather than orphaning it.
+					_wrapper = Microsoft.UI.Xaml.Window.CurrentSafe?.NativeWrapper as NativeWindowWrapper
+						?? new NativeWindowWrapper(this);
+					_wrapper.CurrentActivity = this;
+				}
+
+				return _wrapper;
+			}
+		}
+
+		/// <summary>
+		/// The root element of the window hosted by this activity, once the window has been created.
+		/// </summary>
+		internal UIElement? RootElement => _wrapper?.Window?.RootElement;
+
+		internal RelativeLayout RelativeLayout { get; private set; } = null!;
 
 		internal LayoutProvider LayoutProvider { get; private set; } = null!;
 
-		internal static ClippedRelativeLayout? NativeLayerHost => _nativeLayerHost;
+		internal ClippedRelativeLayout? NativeLayerHost => _nativeLayerHost;
 
 		public ApplicationActivity(IntPtr ptr, JniHandleOwnership owner) : base(ptr, owner)
 		{
@@ -67,8 +92,6 @@ namespace Microsoft.UI.Xaml
 		[MemberNotNull(nameof(_inputPane))]
 		private void Initialize()
 		{
-			Instance = this;
-
 			_inputPane = InputPane.GetForCurrentView();
 			_inputPane.Showing += OnInputPaneVisibilityChanged;
 			_inputPane.Hiding += OnInputPaneVisibilityChanged;
@@ -110,31 +133,10 @@ namespace Microsoft.UI.Xaml
 		{
 		}
 
+		// Content attach and reactivation on activity re-creation happen in OnStart, once this
+		// activity has built its own render surface.
 		protected override void InitializeComponent()
 		{
-			// The app was previously running, but application activity
-			// changed. Reparent content.
-			if (RelativeLayout is not null)
-			{
-				// Reparent the current layout to this activity
-				if (RelativeLayout.Parent is ViewGroup parent)
-				{
-					parent.RemoveView(RelativeLayout);
-				}
-
-				this.SetContentView(RelativeLayout);
-
-				// Ensure the render view is reset
-				_renderView?.ResetRendererContext();
-
-				var winUIWindow = Microsoft.UI.Xaml.Window.CurrentSafe ?? Microsoft.UI.Xaml.Window.InitialWindow;
-				if (winUIWindow?.RootElement is { } root)
-				{
-					// Reactivate the window
-					winUIWindow.Activate();
-					InvalidateRender();
-				}
-			}
 		}
 
 		public override bool DispatchKeyEvent(KeyEvent? e)
@@ -241,7 +243,7 @@ namespace Microsoft.UI.Xaml
 
 		private void OnKeyboardChanged(Rect keyboard)
 		{
-			NativeWindowWrapper.Instance.RaiseNativeSizeChanged();
+			Wrapper.RaiseNativeSizeChanged();
 			_inputPane.OccludedRect = ViewHelper.PhysicalToLogicalPixels(keyboard);
 		}
 
@@ -253,7 +255,17 @@ namespace Microsoft.UI.Xaml
 
 			base.OnCreate(bundle);
 
-			NativeWindowWrapper.Instance.OnActivityCreated();
+			Wrapper.OnActivityCreated();
+
+			// Track and observe this activity's window system UI visibility. Moved here from
+			// NativePage so it can reach this activity's per-window wrapper.
+			var decorView = this.Window!.DecorView;
+#pragma warning disable 618
+#pragma warning disable CA1422 // Validate platform compatibility
+			Wrapper.SystemUiVisibility = (int)decorView.SystemUiVisibility;
+			decorView.SetOnSystemUiVisibilityChangeListener(new OnSystemUiVisibilityChangeListener(this));
+#pragma warning restore CA1422 // Validate platform compatibility
+#pragma warning restore 618
 
 			LayoutProvider = new LayoutProvider(this);
 			LayoutProvider.KeyboardChanged += OnKeyboardChanged;
@@ -291,6 +303,17 @@ namespace Microsoft.UI.Xaml
 					ViewGroup.LayoutParams.MatchParent,
 					ViewGroup.LayoutParams.MatchParent);
 				RelativeLayout.AddView(NativeLayerHost);
+			}
+
+			// On activity re-creation (deep-link, process restore) the managed Window already
+			// exists with its content loaded, but CreateWindow won't run again for this new
+			// activity. Attach this activity's freshly-built surface and reactivate the window.
+			if (!_isContentViewSet && Microsoft.UI.Xaml.Window.CurrentSafe is { RootElement: not null } existingWindow)
+			{
+				EnsureContentView();
+				_renderView?.ResetRendererContext();
+				existingWindow.Activate();
+				InvalidateRender();
 			}
 		}
 
@@ -332,7 +355,7 @@ namespace Microsoft.UI.Xaml
 
 		private void OnInsetsChanged(Thickness insets)
 		{
-			NativeWindowWrapper.Instance.RaiseNativeSizeChanged();
+			Wrapper.RaiseNativeSizeChanged();
 		}
 
 		public override void SetContentView(View? view)
@@ -393,7 +416,7 @@ namespace Microsoft.UI.Xaml
 
 			CleanupBackPressedCallback();
 
-			NativeWindowWrapper.Instance.OnNativeClosed();
+			Wrapper.OnNativeClosed();
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)
@@ -405,7 +428,7 @@ namespace Microsoft.UI.Xaml
 
 		private void RaiseConfigurationChanges()
 		{
-			NativeWindowWrapper.Instance.RaiseNativeSizeChanged();
+			Wrapper.RaiseNativeSizeChanged();
 			//ViewHelper.RefreshFontScale();
 			DisplayInformation.GetForCurrentView().HandleConfigurationChange();
 			SystemThemeHelper.RefreshSystemTheme();

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -57,6 +57,9 @@ namespace Microsoft.UI.Xaml
 			{
 				if (_wrapper is null)
 				{
+					// TODO #13827: adopting the wrapper through the ambient current window makes this
+					// binding per-activity rather than per-window. Replacing it needs an explicit
+					// activity<->window binding, which lands with the live second-activity work.
 					// SupportsMultipleWindows is false, so there is a single window: on re-creation
 					// reuse the wrapper already bound to it rather than orphaning it.
 					_wrapper = Microsoft.UI.Xaml.Window.CurrentSafe?.NativeWrapper as NativeWindowWrapper
@@ -116,7 +119,11 @@ namespace Microsoft.UI.Xaml
 			// Cannot call this in ctor: see
 			// https://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview#10603714
 			RaiseConfigurationChanges();
-			SimpleOrientationSensor.GetDefault()!.OrientationChanged += OnSensorOrientationChanged;
+
+			// OnAttachedToWindow can run more than once per activity, so keep the subscription single.
+			var orientationSensor = SimpleOrientationSensor.GetDefault()!;
+			orientationSensor.OrientationChanged -= OnSensorOrientationChanged;
+			orientationSensor.OrientationChanged += OnSensorOrientationChanged;
 
 			// Note: Deep-linking will cause a new instance of this Activity and its DecorView to be created.
 			// This means any event handlers or listeners attached to these objects in previous instances will not be present.
@@ -277,11 +284,10 @@ namespace Microsoft.UI.Xaml
 
 		protected override void OnStart()
 		{
-			base.OnStart();
-
-			// OnStart gets fired either after onCreate (first launch) or after onRestart
-			// (go out of app then back again). We only want to do this once, hence
-			// the flag.
+			// The render stack must exist before base.OnStart(): that call synchronously reaches
+			// Application.Start -> OnLaunched -> CreateWindow, after which the host is registered
+			// and InvalidateRender() can run against RelativeLayout. This state is per-activity, so
+			// unlike the previous process-wide stack it is null again on every re-creation.
 			if (!_started)
 			{
 				_started = true;
@@ -304,10 +310,12 @@ namespace Microsoft.UI.Xaml
 				RelativeLayout.AddView(NativeLayerHost);
 			}
 
+			base.OnStart();
+
 			// On activity re-creation (deep-link, process restore) the managed Window already
 			// exists with its content loaded, but CreateWindow won't run again for this new
 			// activity. Attach this activity's freshly-built surface and reactivate the window.
-			if (!_isContentViewSet && Microsoft.UI.Xaml.Window.CurrentSafe is { RootElement: not null } existingWindow)
+			if (!_isContentViewSet && Wrapper.Window is { RootElement: not null } existingWindow)
 			{
 				EnsureContentView();
 				_renderView?.ResetRendererContext();
@@ -413,14 +421,28 @@ namespace Microsoft.UI.Xaml
 			LayoutProvider.KeyboardChanged -= OnKeyboardChanged;
 			LayoutProvider.InsetsChanged -= OnInsetsChanged;
 
+			// These are subscribed on process-wide singletons, so a missing -= keeps this activity
+			// (and its render stack) alive for the life of the process, once per re-creation.
+			_inputPane.Showing -= OnInputPaneVisibilityChanged;
+			_inputPane.Hiding -= OnInputPaneVisibilityChanged;
+			SimpleOrientationSensor.GetDefault()!.OrientationChanged -= OnSensorOrientationChanged;
+
 			CleanupBackPressedCallback();
 
-			// Only signal the managed window as closing when this activity is genuinely finishing.
-			// On configuration-change re-creation the window survives and is taken over by the new
-			// activity, so raising Closing here would be spurious.
-			if (IsFinishing)
+			// The render stack is per-activity and the peer finalizer never runs the managed
+			// dispose path, so the GL/Vulkan context has to be released explicitly.
+			_renderView?.TeardownRenderer();
+			_renderView = null;
+			_renderViewAsView = null;
+			_nativeLayerHost = null;
+
+			// Only signal the managed window as closing when this activity is not being re-created
+			// and still owns the window. IsChangingConfigurations — not IsFinishing — is the
+			// complement of "being re-created": a finishing activity is also the one replaced by
+			// the StartActivity/Finish restart idiom, where the successor already took the wrapper.
+			if (!IsChangingConfigurations && _wrapper is { } wrapper && ReferenceEquals(wrapper.CurrentActivity, this))
 			{
-				Wrapper.OnNativeClosed();
+				wrapper.OnNativeClosed();
 			}
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidCorePointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidCorePointerInputSource.cs
@@ -17,8 +17,6 @@ namespace Uno.UI.Runtime.Skia.Android;
 
 internal sealed class AndroidCorePointerInputSource : IUnoCorePointerInputSource
 {
-	public static AndroidCorePointerInputSource Instance { get; } = new();
-
 	//private readonly Action<string>? _trace = Console.WriteLine;
 	private readonly Action<string>? _trace = typeof(AndroidCorePointerInputSource).Log().IsEnabled(LogLevel.Trace)
 		? msg => typeof(AndroidCorePointerInputSource).Log().Trace(msg)
@@ -26,7 +24,7 @@ internal sealed class AndroidCorePointerInputSource : IUnoCorePointerInputSource
 
 	private IAsyncAction? _pendingAsyncHoverExit;
 
-	private AndroidCorePointerInputSource()
+	internal AndroidCorePointerInputSource()
 	{
 	}
 

--- a/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Devices/Input/AndroidKeyboardInputSource.cs
@@ -13,9 +13,7 @@ namespace Uno.UI.Runtime.Skia.Android;
 
 internal sealed class AndroidKeyboardInputSource : IUnoKeyboardInputSource
 {
-	public static AndroidKeyboardInputSource Instance { get; } = new();
-
-	private AndroidKeyboardInputSource()
+	internal AndroidKeyboardInputSource()
 	{
 	}
 

--- a/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
@@ -20,6 +20,10 @@ internal class AndroidSkiaXamlRootHost : IXamlRootHost
 	// driving the window across activity re-creation.
 	internal ApplicationActivity Activity => _wrapper.CurrentActivity;
 
+	internal AndroidCorePointerInputSource PointerSource => _wrapper.PointerSource;
+
+	internal AndroidKeyboardInputSource KeyboardSource => _wrapper.KeyboardSource;
+
 	void IXamlRootHost.InvalidateRender() => Activity.InvalidateRender();
 
 	UIElement? IXamlRootHost.RootElement => _window.RootElement;

--- a/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Hosting/AndroidSkiaXamlRootHost.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
-using Uno.Foundation.Extensibility;
 using Uno.UI.Hosting;
 using Uno.UI.Xaml.Controls;
 
@@ -9,15 +6,29 @@ namespace Uno.UI.Runtime.Skia.Android;
 
 internal class AndroidSkiaXamlRootHost : IXamlRootHost
 {
-	public AndroidSkiaXamlRootHost(XamlRoot xamlRoot)
+	private readonly Window _window;
+	private readonly NativeWindowWrapper _wrapper;
+
+	public AndroidSkiaXamlRootHost(Window window, XamlRoot xamlRoot, NativeWindowWrapper wrapper)
 	{
+		_window = window;
+		_wrapper = wrapper;
 		XamlRootMap.Register(xamlRoot, this);
 	}
 
-	void IXamlRootHost.InvalidateRender()
-	{
-		ApplicationActivity.Instance?.InvalidateRender();
-	}
+	// Resolved through the wrapper (not stored) so it follows the activity currently
+	// driving the window across activity re-creation.
+	internal ApplicationActivity Activity => _wrapper.CurrentActivity;
 
-	UIElement? IXamlRootHost.RootElement => Window.Current!.RootElement;
+	void IXamlRootHost.InvalidateRender() => Activity.InvalidateRender();
+
+	UIElement? IXamlRootHost.RootElement => _window.RootElement;
+
+	/// <summary>
+	/// Resolves the <see cref="ApplicationActivity"/> that owns the window hosting the given <see cref="XamlRoot"/>.
+	/// </summary>
+	internal static ApplicationActivity? GetActivity(XamlRoot? xamlRoot)
+		=> xamlRoot is not null && XamlRootMap.GetHostForRoot(xamlRoot) is AndroidSkiaXamlRootHost host
+			? host.Activity
+			: null;
 }

--- a/src/Uno.UI.Runtime.Skia.Android/Hosting/ExtensionsRegistrar.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Hosting/ExtensionsRegistrar.cs
@@ -1,11 +1,13 @@
 ﻿#nullable enable
 
+using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents.TextFormatting;
 using Microsoft.Web.WebView2.Core;
 using Uno.Foundation.Extensibility;
 using Uno.Graphics;
+using Uno.UI.Hosting;
 using Uno.UI.Xaml.Controls;
 using Uno.UI.Xaml.Controls.Extensions;
 using Uno.WinUI.Runtime.Skia.Android;
@@ -27,8 +29,10 @@ internal static class ExtensionsRegistrar
 		}
 
 		ApiExtensibility.Register(typeof(INativeWindowFactoryExtension), o => new AndroidSkiaWindowFactory());
-		ApiExtensibility.Register(typeof(IUnoCorePointerInputSource), o => AndroidCorePointerInputSource.Instance);
-		ApiExtensibility.Register(typeof(IUnoKeyboardInputSource), o => AndroidKeyboardInputSource.Instance);
+		ApiExtensibility.Register<IXamlRootHost>(typeof(IUnoCorePointerInputSource),
+			host => (host as AndroidSkiaXamlRootHost)?.PointerSource ?? throw new ArgumentException($"{nameof(host)} must be an {nameof(AndroidSkiaXamlRootHost)} instance"));
+		ApiExtensibility.Register<IXamlRootHost>(typeof(IUnoKeyboardInputSource),
+			host => (host as AndroidSkiaXamlRootHost)?.KeyboardSource ?? throw new ArgumentException($"{nameof(host)} must be an {nameof(AndroidSkiaXamlRootHost)} instance"));
 		ApiExtensibility.Register(typeof(ITextBoxNotificationsProviderSingleton), _ => AndroidSkiaTextBoxNotificationsProviderSingleton.Instance);
 		ApiExtensibility.Register<ContentPresenter>(typeof(ContentPresenter.INativeElementHostingExtension), o => new AndroidSkiaNativeElementHostingExtension(o));
 		ApiExtensibility.Register<CoreWebView2>(typeof(INativeWebViewProvider), o => new AndroidNativeWebViewProvider(o));

--- a/src/Uno.UI.Runtime.Skia.Android/Native/AndroidSkiaNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Native/AndroidSkiaNativeElementHostingExtension.cs
@@ -33,11 +33,14 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 		}
 	}
 
+	private ApplicationActivity.ClippedRelativeLayout? NativeLayerHost
+		=> AndroidSkiaXamlRootHost.GetActivity(_owner.XamlRoot)?.NativeLayerHost;
+
 	public void AttachNativeElement(object content)
 	{
 		if (content is View view)
 		{
-			if (ApplicationActivity.NativeLayerHost is { } host)
+			if (NativeLayerHost is { } host)
 			{
 				host.AddView(view);
 			}
@@ -45,7 +48,7 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 			{
 				if (this.Log().IsEnabled(LogLevel.Error))
 				{
-					this.Log().Error($"Cannot attach native element because {nameof(ApplicationActivity.Instance.NativeLayerHost)} is null.");
+					this.Log().Error($"Cannot attach native element because {nameof(ApplicationActivity.NativeLayerHost)} is null.");
 				}
 			}
 		}
@@ -55,7 +58,7 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 	{
 		if (content is View view)
 		{
-			if (ApplicationActivity.NativeLayerHost is { } host)
+			if (NativeLayerHost is { } host)
 			{
 				host.RemoveView(view);
 			}
@@ -63,7 +66,7 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 			{
 				if (this.Log().IsEnabled(LogLevel.Error))
 				{
-					this.Log().Error($"Cannot detach native element because {nameof(ApplicationActivity.Instance.NativeLayerHost)} is null.");
+					this.Log().Error($"Cannot detach native element because {nameof(ApplicationActivity.NativeLayerHost)} is null.");
 				}
 			}
 		}
@@ -79,7 +82,7 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 
 	public object? CreateSampleComponent(string text)
 	{
-		if (ApplicationActivity.NativeLayerHost is not { } host)
+		if (NativeLayerHost is not { } host)
 		{
 			if (this.Log().IsEnabled(LogLevel.Error))
 			{

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/IUnoSkiaRenderView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/IUnoSkiaRenderView.cs
@@ -8,6 +8,14 @@ internal interface IUnoSkiaRenderView
 {
 	void InvalidateRender();
 	void ResetRendererContext();
+
+	/// <summary>
+	/// Releases the GPU resources backing this view. Required on activity teardown: the peer
+	/// finalizer never runs <c>Dispose(disposing: true)</c>, so without this each re-created
+	/// activity strands its GL/Vulkan context.
+	/// </summary>
+	void TeardownRenderer();
+
 	UnoExploreByTouchHelper ExploreByTouchHelper { get; }
 	TextInputPlugin TextInputPlugin { get; }
 }

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -172,8 +172,14 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 				_context = GRContext.CreateGl(glInterface);
 			}
 
+			if (_activity.RootElement?.Visual.CompositionTarget is not CompositionTarget compositionTarget)
+			{
+				// The window isn't ready (e.g. mid teardown during activity re-creation); skip the frame.
+				return;
+			}
+
 			var renderSurface = _hardwareAccelerated ? _retainedLayer.Surface : _softwareSurface;
-			var nativeClipPath = ((CompositionTarget)_activity.RootElement!.Visual.CompositionTarget!).OnNativePlatformFrameRequested(renderSurface?.Canvas,
+			var nativeClipPath = compositionTarget.OnNativePlatformFrameRequested(renderSurface?.Canvas,
 			size =>
 			{
 				// read the info from the buffer
@@ -212,7 +218,10 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 				return _softwareSurface.Canvas;
 			});
 
-			_activity.NativeLayerHost!.Path = nativeClipPath;
+			if (_activity.NativeLayerHost is { } nativeLayerHost)
+			{
+				nativeLayerHost.Path = nativeClipPath;
+			}
 
 			if (_hardwareAccelerated)
 			{

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -27,6 +27,10 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 	public UnoExploreByTouchHelper ExploreByTouchHelper { get; }
 	public TextInputPlugin TextInputPlugin { get; }
 
+	// Matches the Vulkan render loop's wake interval, so both backends retry a skipped frame
+	// at the same cadence while the window isn't ready.
+	private const long RenderRetryDelayMs = 100;
+
 	private readonly ApplicationActivity _activity;
 	private readonly InternalRenderer _renderer;
 
@@ -35,7 +39,7 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 		_activity = activity;
 		SetEGLContextClientVersion(2);
 		SetEGLConfigChooser(8, 8, 8, 8, 0, 8);
-		SetRenderer(_renderer = new InternalRenderer(activity));
+		SetRenderer(_renderer = new InternalRenderer(this));
 		// The scene is still presented through GL, but when not hardware-accelerated it is
 		// rasterized on the CPU first, which is what IsSoftwareRenderer reflects.
 		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = !_renderer.HardwareAccelerated;
@@ -58,6 +62,12 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 	public void ResetRendererContext()
 	{
 		_renderer.ResetContext();
+	}
+
+	public void TeardownRenderer()
+	{
+		_renderer.ResetContext();
+		_renderer.Dispose();
 	}
 
 	public void InvalidateRender()
@@ -141,9 +151,10 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 	// Copied from https://github.com/mono/SkiaSharp/blob/main/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Android/SKGLSurfaceView.cs
 	// and modified to also add rendering without OpenGL
-	private class InternalRenderer(ApplicationActivity activity) : Java.Lang.Object, IRenderer
+	private class InternalRenderer(UnoSKCanvasView view) : Java.Lang.Object, IRenderer
 	{
-		private readonly ApplicationActivity _activity = activity;
+		private readonly UnoSKCanvasView _view = view;
+		private readonly ApplicationActivity _activity = view._activity;
 
 		private const SKColorType ColorType = SKColorType.Rgba8888;
 		private const GRSurfaceOrigin SurfaceOrigin = GRSurfaceOrigin.BottomLeft;
@@ -174,7 +185,12 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 			if (_activity.RootElement?.Visual.CompositionTarget is not CompositionTarget compositionTarget)
 			{
-				// The window isn't ready (e.g. mid teardown during activity re-creation); skip the frame.
+				// The window isn't ready (e.g. mid teardown during activity re-creation). Skipping is
+				// only safe if we re-arm: OnNativePlatformFrameRequested below is the only thing that
+				// clears the target's RenderRequested flag, so a bare return would make every later
+				// RequestNewFrame a no-op and the window would never repaint again. RenderMode is
+				// WhenDirty, so re-request on a delay rather than spinning the GL thread.
+				_view.PostDelayed(_view.RequestRender, RenderRetryDelayMs);
 				return;
 			}
 

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -27,13 +27,15 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 	public UnoExploreByTouchHelper ExploreByTouchHelper { get; }
 	public TextInputPlugin TextInputPlugin { get; }
 
+	private readonly ApplicationActivity _activity;
 	private readonly InternalRenderer _renderer;
 
-	public UnoSKCanvasView(Context context) : base(context)
+	public UnoSKCanvasView(ApplicationActivity activity) : base(activity)
 	{
+		_activity = activity;
 		SetEGLContextClientVersion(2);
 		SetEGLConfigChooser(8, 8, 8, 8, 0, 8);
-		SetRenderer(_renderer = new InternalRenderer());
+		SetRenderer(_renderer = new InternalRenderer(activity));
 		// The scene is still presented through GL, but when not hardware-accelerated it is
 		// rasterized on the CPU first, which is what IsSoftwareRenderer reflects.
 		Microsoft.UI.Composition.Compositor.GetSharedCompositor().IsSoftwareRenderer = !_renderer.HardwareAccelerated;
@@ -139,8 +141,10 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 
 	// Copied from https://github.com/mono/SkiaSharp/blob/main/source/SkiaSharp.Views/SkiaSharp.Views/Platform/Android/SKGLSurfaceView.cs
 	// and modified to also add rendering without OpenGL
-	private class InternalRenderer() : Java.Lang.Object, IRenderer
+	private class InternalRenderer(ApplicationActivity activity) : Java.Lang.Object, IRenderer
 	{
+		private readonly ApplicationActivity _activity = activity;
+
 		private const SKColorType ColorType = SKColorType.Rgba8888;
 		private const GRSurfaceOrigin SurfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
@@ -169,7 +173,7 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 			}
 
 			var renderSurface = _hardwareAccelerated ? _retainedLayer.Surface : _softwareSurface;
-			var nativeClipPath = ((CompositionTarget)Microsoft.UI.Xaml.Window.CurrentSafe!.RootElement!.Visual.CompositionTarget!).OnNativePlatformFrameRequested(renderSurface?.Canvas,
+			var nativeClipPath = ((CompositionTarget)_activity.RootElement!.Visual.CompositionTarget!).OnNativePlatformFrameRequested(renderSurface?.Canvas,
 			size =>
 			{
 				// read the info from the buffer
@@ -208,7 +212,7 @@ internal sealed partial class UnoSKCanvasView : GLSurfaceView, IUnoSkiaRenderVie
 				return _softwareSurface.Canvas;
 			});
 
-			ApplicationActivity.NativeLayerHost!.Path = nativeClipPath;
+			_activity.NativeLayerHost!.Path = nativeClipPath;
 
 			if (_hardwareAccelerated)
 			{

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -222,7 +222,10 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 					size => skSurface.Canvas);
 
 				// Update the native layer host clip path
-				_activity.NativeLayerHost!.Path = nativeClipPath;
+				if (_activity.NativeLayerHost is { } nativeLayerHost)
+				{
+					nativeLayerHost.Path = nativeClipPath;
+				}
 			});
 		}
 		catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -38,9 +38,12 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 	private readonly object _renderLock = new();
 	private IntPtr _nativeWindow; // Must stay alive while Vulkan surfaces reference it
 	private readonly AndroidVulkanSurfaceFactory _surfaceFactory = new();
+	private readonly ApplicationActivity _activity;
 
-	public UnoSKVulkanView(Context context) : base(context)
+	public UnoSKVulkanView(ApplicationActivity activity) : base(activity)
 	{
+		_activity = activity;
+
 		// Create the window-independent Vulkan resources (instance, device, GRContext) right away:
 		// this throws when the driver is unusable, letting the caller fall back to the OpenGL ES view.
 		// The window-scoped part (swapchain) is completed on the render thread once a surface exists.
@@ -204,7 +207,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 		{
 			_vulkanContext.RenderFrame(skSurface =>
 			{
-				var compositionTarget = Microsoft.UI.Xaml.Window.CurrentSafe?.RootElement?.Visual.CompositionTarget as CompositionTarget;
+				var compositionTarget = _activity.RootElement?.Visual.CompositionTarget as CompositionTarget;
 				if (compositionTarget == null)
 					return;
 
@@ -213,7 +216,7 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 					size => skSurface.Canvas);
 
 				// Update the native layer host clip path
-				ApplicationActivity.NativeLayerHost!.Path = nativeClipPath;
+				_activity.NativeLayerHost!.Path = nativeClipPath;
 			});
 		}
 		catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKVulkanView.cs
@@ -209,7 +209,13 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 			{
 				var compositionTarget = _activity.RootElement?.Visual.CompositionTarget as CompositionTarget;
 				if (compositionTarget == null)
+				{
+					// OnNativePlatformFrameRequested is the only thing that clears the target's
+					// RenderRequested flag, so dropping the frame outright would make every later
+					// RequestNewFrame a no-op. Re-arm so the loop retries once the window is ready.
+					_renderRequested = true;
 					return;
+				}
 
 				var nativeClipPath = compositionTarget.OnNativePlatformFrameRequested(
 					skSurface.Canvas,
@@ -301,20 +307,31 @@ internal sealed partial class UnoSKVulkanView : SurfaceView, ISurfaceHolderCallb
 
 	#endregion
 
+	public void TeardownRenderer()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		_disposed = true;
+		_renderEvent.Set();
+		_renderThread?.Join(TimeSpan.FromSeconds(2));
+		_renderThread = null;
+		_vulkanContext.Dispose();
+		if (_nativeWindow != IntPtr.Zero)
+		{
+			ANativeWindow_release(_nativeWindow);
+			_nativeWindow = IntPtr.Zero;
+		}
+		_renderEvent.Dispose();
+	}
+
 	protected override void Dispose(bool disposing)
 	{
 		if (disposing)
 		{
-			_disposed = true;
-			_renderEvent.Set();
-			_renderThread?.Join(TimeSpan.FromSeconds(2));
-			_vulkanContext.Dispose();
-			if (_nativeWindow != IntPtr.Zero)
-			{
-				ANativeWindow_release(_nativeWindow);
-				_nativeWindow = IntPtr.Zero;
-			}
-			_renderEvent.Dispose();
+			TeardownRenderer();
 		}
 		base.Dispose(disposing);
 	}

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs
@@ -332,8 +332,10 @@ namespace Uno.UI
 		{
 			ResignCurrent();
 
-			// Don't leave a destroyed activity as the ambient foreground context: repoint to
-			// another live activity, or clear it so ContextHelper falls back to the application context.
+			// Don't leave a destroyed activity as the ambient foreground context when another
+			// live activity can take over. If this is the last one, keep it so callers that
+			// hard-cast Current to Activity keep working as before (rather than falling back to
+			// the non-Activity application context).
 			if (ContextHelper.TryGetCurrent(out var current) && ReferenceEquals(current, this))
 			{
 				BaseActivity? next;
@@ -342,7 +344,10 @@ namespace Uno.UI
 					next = _instances.Values.FirstOrDefault(activity => !ReferenceEquals(activity, this));
 				}
 
-				ContextHelper.SetForeground(next);
+				if (next is not null)
+				{
+					ContextHelper.SetForeground(next);
+				}
 			}
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs
@@ -237,7 +237,7 @@ namespace Uno.UI
 
 			Microsoft.UI.Xaml.Application.Current?.RaiseLeavingBackground(() =>
 			{
-				NativeWindowWrapper.Instance.OnNativeVisibilityChanged(true);
+				(this as ApplicationActivity)?.Wrapper.OnNativeVisibilityChanged(true);
 			});
 		}
 
@@ -264,7 +264,7 @@ namespace Uno.UI
 			SetAsCurrent();
 
 			Microsoft.UI.Xaml.Application.Current?.RaiseResuming();
-			NativeWindowWrapper.Instance.OnNativeActivated(CoreWindowActivationState.CodeActivated);
+			(this as ApplicationActivity)?.Wrapper.OnNativeActivated(CoreWindowActivationState.CodeActivated);
 		}
 
 		public override void OnTopResumedActivityChanged(bool isTopResumedActivity)
@@ -277,7 +277,7 @@ namespace Uno.UI
 
 		partial void InnerTopResumedActivityChanged(bool isTopResumedActivity)
 		{
-			NativeWindowWrapper.Instance.OnNativeActivated(
+			(this as ApplicationActivity)?.Wrapper.OnNativeActivated(
 				isTopResumedActivity ?
 					CoreWindowActivationState.CodeActivated :
 					CoreWindowActivationState.Deactivated);
@@ -295,7 +295,7 @@ namespace Uno.UI
 		{
 			ResignCurrent();
 
-			NativeWindowWrapper.Instance.OnNativeActivated(CoreWindowActivationState.Deactivated);
+			(this as ApplicationActivity)?.Wrapper.OnNativeActivated(CoreWindowActivationState.Deactivated);
 		}
 
 		protected override void OnStop()
@@ -316,7 +316,7 @@ namespace Uno.UI
 		{
 			ResignCurrent();
 
-			NativeWindowWrapper.Instance.OnNativeVisibilityChanged(false);
+			(this as ApplicationActivity)?.Wrapper.OnNativeVisibilityChanged(false);
 			Microsoft.UI.Xaml.Application.Current?.RaiseEnteredBackground(() => Microsoft.UI.Xaml.Application.Current?.RaiseSuspending());
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/BaseActivity.cs
@@ -328,7 +328,23 @@ namespace Uno.UI
 
 		partial void InnerDestroy();
 
-		partial void InnerDestroy() => ResignCurrent();
+		partial void InnerDestroy()
+		{
+			ResignCurrent();
+
+			// Don't leave a destroyed activity as the ambient foreground context: repoint to
+			// another live activity, or clear it so ContextHelper falls back to the application context.
+			if (ContextHelper.TryGetCurrent(out var current) && ReferenceEquals(current, this))
+			{
+				BaseActivity? next;
+				lock (_instances)
+				{
+					next = _instances.Values.FirstOrDefault(activity => !ReferenceEquals(activity, this));
+				}
+
+				ContextHelper.SetForeground(next);
+			}
+		}
 
 		private void SetAsCurrent()
 		{

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/NativePage.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/NativePage.cs
@@ -25,15 +25,6 @@ namespace Microsoft.UI.Xaml.Controls
 			base.OnCreate(bundle);
 
 			InitializeComponent();
-
-			var decorView = (ContextHelper.Current as Activity)!.Window!.DecorView;
-
-#pragma warning disable 618
-#pragma warning disable CA1422 // Validate platform compatibility
-			NativeWindowWrapper.Instance.SystemUiVisibility = (int)decorView.SystemUiVisibility;
-			decorView.SetOnSystemUiVisibilityChangeListener(new OnSystemUiVisibilityChangeListener());
-#pragma warning restore CA1422 // Validate platform compatibility
-#pragma warning restore 618
 		}
 
 		protected override void OnDestroy()

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/OnSystemUiVisibilityChangeListener.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/OnSystemUiVisibilityChangeListener.cs
@@ -1,18 +1,23 @@
-﻿using Android.App;
+using Android.App;
 using Android.Runtime;
 using Android.Views;
 using Uno.UI.Xaml.Controls;
-using Window = Microsoft.UI.Xaml.Window;
 
 namespace Uno.UI;
 
 public class OnSystemUiVisibilityChangeListener
 	: Java.Lang.Object, View.IOnSystemUiVisibilityChangeListener
 {
+	private readonly Microsoft.UI.Xaml.ApplicationActivity _activity;
+
+	public OnSystemUiVisibilityChangeListener(Microsoft.UI.Xaml.ApplicationActivity activity)
+	{
+		_activity = activity;
+	}
+
 	public void OnSystemUiVisibilityChange([GeneratedEnum] StatusBarVisibility visibility)
 	{
-		var activity = ContextHelper.Current as Activity;
-		var decorView = activity!.Window!.DecorView;
+		var decorView = _activity.Window!.DecorView;
 #pragma warning disable 618
 #pragma warning disable CA1422 // Validate platform compatibility
 		var newUiOptions = (int)decorView.SystemUiVisibility;
@@ -34,8 +39,8 @@ public class OnSystemUiVisibilityChangeListener
 		// - LayoutHideNavigation : User can show the navigation bar by sliding up from the bottom of the screen and have the option to dock it / undock it
 		// In the case we set the navigation bar to LayoutHideNavigation, when the user hide the bar, HideNavigation will be triggered.
 		// But we don't want to inject it in the decorView.SystemUiVisibility to let the navigation bar dockable again
-		NativeWindowWrapper.Instance.SystemUiVisibility = newUiOptions;
+		_activity.Wrapper.SystemUiVisibility = newUiOptions;
 
-		activity.OnConfigurationChanged(activity!.Resources!.Configuration!);
+		_activity.OnConfigurationChanged(_activity.Resources!.Configuration!);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/OnSystemUiVisibilityChangeListener.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/OnSystemUiVisibilityChangeListener.cs
@@ -5,7 +5,7 @@ using Uno.UI.Xaml.Controls;
 
 namespace Uno.UI;
 
-public class OnSystemUiVisibilityChangeListener
+internal class OnSystemUiVisibilityChangeListener
 	: Java.Lang.Object, View.IOnSystemUiVisibilityChangeListener
 {
 	private readonly Microsoft.UI.Xaml.ApplicationActivity _activity;

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidImeTextBoxExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidImeTextBoxExtension.cs
@@ -39,6 +39,7 @@ internal sealed class AndroidImeTextBoxExtension : IImeTextBoxExtension
 	public event EventHandler<ImeCompositionEventArgs>? CompositionCompleted;
 	public event EventHandler? CompositionEnded;
 
+	// TODO #13827: the foreground-activity fallback is ambiguous once multiple windows exist.
 	private TextInputPlugin? Plugin
 		=> (AndroidSkiaXamlRootHost.GetActivity(_xamlRoot) ?? BaseActivity.Current as ApplicationActivity)?.RenderView?.TextInputPlugin;
 

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidImeTextBoxExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidImeTextBoxExtension.cs
@@ -30,6 +30,7 @@ internal sealed class AndroidImeTextBoxExtension : IImeTextBoxExtension
 	private int _lastFullTextLength;
 	private bool _sessionActive;
 	private TextInputConnection? _subscribedConnection;
+	private XamlRoot? _xamlRoot;
 
 	public bool IsComposing => _isComposing;
 
@@ -38,7 +39,8 @@ internal sealed class AndroidImeTextBoxExtension : IImeTextBoxExtension
 	public event EventHandler<ImeCompositionEventArgs>? CompositionCompleted;
 	public event EventHandler? CompositionEnded;
 
-	private static TextInputPlugin? Plugin => ApplicationActivity.RenderView?.TextInputPlugin;
+	private TextInputPlugin? Plugin
+		=> (AndroidSkiaXamlRootHost.GetActivity(_xamlRoot) ?? BaseActivity.Current as ApplicationActivity)?.RenderView?.TextInputPlugin;
 
 	public void StartImeSession(TextBoxCore core)
 	{
@@ -47,6 +49,7 @@ internal sealed class AndroidImeTextBoxExtension : IImeTextBoxExtension
 			return;
 		}
 
+		_xamlRoot = core.Owner.XamlRoot;
 		_sessionActive = true;
 
 		if (Plugin is { } plugin)

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidSkiaTextBoxNotificationsProviderSingleton.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidSkiaTextBoxNotificationsProviderSingleton.cs
@@ -19,8 +19,8 @@ internal sealed class AndroidSkiaTextBoxNotificationsProviderSingleton : ITextBo
 	{
 	}
 
-	// Resolves the text input plugin of the render view owning the given XamlRoot's window,
-	// falling back to the foreground activity when no specific window is known.
+	// Resolves the text input plugin of the render view owning the given XamlRoot's window.
+	// TODO #13827: the foreground-activity fallback is ambiguous once multiple windows exist.
 	private static TextInputPlugin? GetTextInputPlugin(XamlRoot? xamlRoot = null)
 	{
 		var activity = AndroidSkiaXamlRootHost.GetActivity(xamlRoot)

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidSkiaTextBoxNotificationsProviderSingleton.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/AndroidSkiaTextBoxNotificationsProviderSingleton.cs
@@ -19,9 +19,18 @@ internal sealed class AndroidSkiaTextBoxNotificationsProviderSingleton : ITextBo
 	{
 	}
 
+	// Resolves the text input plugin of the render view owning the given XamlRoot's window,
+	// falling back to the foreground activity when no specific window is known.
+	private static TextInputPlugin? GetTextInputPlugin(XamlRoot? xamlRoot = null)
+	{
+		var activity = AndroidSkiaXamlRootHost.GetActivity(xamlRoot)
+			?? BaseActivity.Current as ApplicationActivity;
+		return activity?.RenderView?.TextInputPlugin;
+	}
+
 	public void OnFocused(TextBoxCore core)
 	{
-		if (ApplicationActivity.RenderView?.TextInputPlugin is { } textInputPlugin)
+		if (GetTextInputPlugin(core.Owner.XamlRoot) is { } textInputPlugin)
 		{
 			if (CouldRequireKeyboard(core))
 			{
@@ -33,7 +42,7 @@ internal sealed class AndroidSkiaTextBoxNotificationsProviderSingleton : ITextBo
 
 	public void OnUnfocused(TextBoxCore core)
 	{
-		if (ApplicationActivity.RenderView?.TextInputPlugin is { } textInputPlugin)
+		if (GetTextInputPlugin(core.Owner.XamlRoot) is { } textInputPlugin)
 		{
 			// Hide the keyboard only when the next element to be focused is not an Element that
 			// could require the keyboard (TextBox, AutoSuggestBox, NumberBox, etc.).
@@ -73,7 +82,7 @@ internal sealed class AndroidSkiaTextBoxNotificationsProviderSingleton : ITextBo
 
 	public void FinishAutofillContext(bool shouldSave)
 	{
-		if (ApplicationActivity.RenderView?.TextInputPlugin is { } textInputPlugin)
+		if (GetTextInputPlugin() is { } textInputPlugin)
 		{
 			textInputPlugin.FinishAutofillContext(shouldSave);
 		}
@@ -81,7 +90,7 @@ internal sealed class AndroidSkiaTextBoxNotificationsProviderSingleton : ITextBo
 
 	public void NotifyValueChanged(TextBoxCore core)
 	{
-		if (ApplicationActivity.RenderView?.TextInputPlugin is { } textInputPlugin)
+		if (GetTextInputPlugin(core.Owner.XamlRoot) is { } textInputPlugin)
 		{
 			textInputPlugin.NotifyValueChanged(core.GetHashCode(), core.Text);
 		}

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/TextInputPlugin.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/TextBox/TextInputPlugin.cs
@@ -305,7 +305,7 @@ internal sealed class TextInputPlugin
 				// add this hack here specifically to support InputExtensions in
 				// Toolkit, which listens to KeyUp/KeyDown events to operate, but it would
 				// be more reasonable to treat Enter like any other key.
-				return ApplicationActivity.Instance.DispatchKeyEvent(keyEvent);
+				return (_view.Context as global::Android.App.Activity)?.DispatchKeyEvent(keyEvent) ?? false;
 			}
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/WebView/AndroidNativeWebViewProvider.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/WebView/AndroidNativeWebViewProvider.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using System;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
 using Uno.UI.Xaml.Controls;
 
@@ -18,7 +19,12 @@ internal sealed class AndroidNativeWebViewProvider : INativeWebViewProvider
 		var content = contentPresenter.Content as global::Android.Webkit.WebView;
 		if (content is null)
 		{
-			content = new global::Android.Webkit.WebView(ContextHelper.Current);
+			// Prefer the owning window's activity over the ambient foreground one.
+			var context = (global::Android.Content.Context?)AndroidSkiaXamlRootHost.GetActivity(contentPresenter.XamlRoot)
+				?? ContextHelper.Current
+				?? throw new InvalidOperationException("No Android context is available to create the native WebView.");
+
+			content = new global::Android.Webkit.WebView(context);
 			contentPresenter.Content = content;
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/AndroidSkiaWindowFactory.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/AndroidSkiaWindowFactory.cs
@@ -12,6 +12,8 @@ internal sealed class AndroidSkiaWindowFactory : INativeWindowFactoryExtension
 
 	public INativeWindowWrapper CreateWindow(Window window, XamlRoot xamlRoot)
 	{
+		// TODO #13827: with multiple windows this must resolve the activity that owns the window
+		// being created rather than the current foreground one.
 		var activity = BaseActivity.Current as ApplicationActivity
 			?? throw new InvalidOperationException("No foreground ApplicationActivity is available to host the window.");
 

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/AndroidSkiaWindowFactory.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/AndroidSkiaWindowFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml;
+using System;
+using Microsoft.UI.Xaml;
 using Uno.UI.Xaml.Controls;
 
 namespace Uno.UI.Runtime.Skia.Android;
@@ -11,10 +12,16 @@ internal sealed class AndroidSkiaWindowFactory : INativeWindowFactoryExtension
 
 	public INativeWindowWrapper CreateWindow(Window window, XamlRoot xamlRoot)
 	{
-		// While we are currently not having something very useful in the root host, instantiating it has side effects that we need.
-		// So this line isn't unnecessary ;)
-		_ = new AndroidSkiaXamlRootHost(xamlRoot);
-		NativeWindowWrapper.Instance.SetWindow(window, xamlRoot);
-		return NativeWindowWrapper.Instance;
+		var activity = BaseActivity.Current as ApplicationActivity
+			?? throw new InvalidOperationException("No foreground ApplicationActivity is available to host the window.");
+
+		var wrapper = activity.Wrapper;
+		wrapper.SetWindow(window, xamlRoot);
+
+		// Registering the host adds it to the XamlRootMap, which is how consumers resolve the
+		// owning activity from a XamlRoot.
+		_ = new AndroidSkiaXamlRootHost(window, xamlRoot, wrapper);
+
+		return wrapper;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
@@ -230,6 +230,11 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.R)
 		{
 			var windowMetrics = activity.WindowManager?.CurrentWindowMetrics;
+			if (windowMetrics is null)
+			{
+				return default;
+			}
+
 			displaySize = new Size(windowMetrics.Bounds.Width(), windowMetrics.Bounds.Height());
 		}
 		else

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
@@ -17,6 +17,7 @@ using Windows.UI.ViewManagement;
 using Size = Windows.Foundation.Size;
 using MUX = Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml;
+using Uno.UI.Runtime.Skia.Android;
 
 namespace Uno.UI.Xaml.Controls;
 
@@ -51,6 +52,12 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		get => _activity;
 		set => _activity = value;
 	}
+
+	// Per-window input sources, resolved by each window's InputManager via its IXamlRootHost
+	// and fed by the driving activity's native event dispatch.
+	internal AndroidCorePointerInputSource PointerSource { get; } = new();
+
+	internal AndroidKeyboardInputSource KeyboardSource { get; } = new();
 
 	private void DispatchDpiChanged() =>
 		RasterizationScale = (float)_displayInformation.RawPixelsPerViewPixel;

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Window/NativeWindowWrapper.Android.cs
@@ -22,16 +22,16 @@ namespace Uno.UI.Xaml.Controls;
 
 internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapper
 {
-	private static readonly Lazy<NativeWindowWrapper> _instance = new(() => new NativeWindowWrapper());
-
+	private ApplicationActivity _activity;
 	private readonly ActivationPreDrawListener _preDrawListener;
 	private readonly DisplayInformation _displayInformation;
 	private bool _contentViewAttachedToWindow;
 
 	private Rect _previousTrueVisibleBounds;
 
-	public NativeWindowWrapper()
+	public NativeWindowWrapper(ApplicationActivity activity)
 	{
+		_activity = activity;
 		_preDrawListener = new ActivationPreDrawListener(this);
 		CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBarChanged += RaiseNativeSizeChanged;
 
@@ -40,17 +40,25 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		DispatchDpiChanged();
 	}
 
-	public override object NativeWindow => Microsoft.UI.Xaml.ApplicationActivity.Instance?.Window;
+	public override object NativeWindow => _activity.Window;
 
-	internal static NativeWindowWrapper Instance => _instance.Value;
+	/// <summary>
+	/// The activity currently driving this window. Updated on activity re-creation, since the
+	/// managed Window (and this wrapper) outlive individual activities on Android.
+	/// </summary>
+	internal ApplicationActivity CurrentActivity
+	{
+		get => _activity;
+		set => _activity = value;
+	}
 
 	private void DispatchDpiChanged() =>
 		RasterizationScale = (float)_displayInformation.RawPixelsPerViewPixel;
 
 	public override string Title
 	{
-		get => Microsoft.UI.Xaml.ApplicationActivity.Instance.Title;
-		set => Microsoft.UI.Xaml.ApplicationActivity.Instance.Title = value;
+		get => _activity.Title;
+		set => _activity.Title = value;
 	}
 
 	internal int SystemUiVisibility { get; set; }
@@ -102,8 +110,8 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 			}
 		};
 
-		ApplicationActivity.Instance.ContentViewAttachedToWindow += Instance_ContentViewAttachedToWindow;
-		ApplicationActivity.Instance.EnsureContentView();
+		_activity.ContentViewAttachedToWindow += Instance_ContentViewAttachedToWindow;
+		_activity.EnsureContentView();
 		ApplySystemOverlaysTheming();
 	}
 
@@ -112,7 +120,8 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 	private (Size windowSize, Rect visibleBounds) GetVisualBounds()
 	{
-		if (ContextHelper.Current is not Activity activity)
+		var activity = _activity;
+		if (activity.Window is null)
 		{
 			return default;
 		}
@@ -189,13 +198,11 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		{
 			// In edge-to-edge experience we want to adjust the theming of status bar to match the app theme.
 			if (Microsoft.UI.Xaml.Application.Current is { } application &&
-				(ContextHelper.TryGetCurrent(out var context)) &&
-				context is Activity activity &&
-				activity.Window?.DecorView is { FitsSystemWindows: false } decorView)
+				_activity.Window?.DecorView is { FitsSystemWindows: false } decorView)
 			{
 				var requestedTheme = application.RequestedTheme;
 
-				var insetsController = WindowCompat.GetInsetsController(activity.Window, decorView);
+				var insetsController = WindowCompat.GetInsetsController(_activity.Window, decorView);
 
 				// "appearance light" refers to status bar set to light theme == dark foreground
 				insetsController.AppearanceLightStatusBars = requestedTheme == Microsoft.UI.Xaml.ApplicationTheme.Light;
@@ -205,7 +212,8 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 	private Size GetWindowSize()
 	{
-		if (ContextHelper.Current is not Activity activity)
+		var activity = _activity;
+		if (activity.Window is null)
 		{
 			return default;
 		}
@@ -214,7 +222,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 		if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.R)
 		{
-			var windowMetrics = (ContextHelper.Current as Activity)?.WindowManager?.CurrentWindowMetrics;
+			var windowMetrics = activity.WindowManager?.CurrentWindowMetrics;
 			displaySize = new Size(windowMetrics.Bounds.Width(), windowMetrics.Bounds.Height());
 		}
 		else
@@ -242,7 +250,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 	private void UpdateFullScreenMode(bool isFullscreen)
 	{
 #pragma warning disable 618
-		var activity = ContextHelper.Current as Activity;
+		var activity = _activity;
 #pragma warning disable CA1422 // Validate platform compatibility
 		var uiOptions = (int)activity.Window.DecorView.SystemUiVisibility;
 #pragma warning restore CA1422 // Validate platform compatibility
@@ -270,8 +278,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 	private void AddPreDrawListener()
 	{
-		if (Uno.UI.ContextHelper.Current is Android.App.Activity activity &&
-			activity.Window.DecorView is { } decorView)
+		if (_activity.Window?.DecorView is { } decorView)
 		{
 			decorView.ViewTreeObserver.AddOnPreDrawListener(_preDrawListener);
 		}
@@ -279,8 +286,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 
 	private void RemovePreDrawListener()
 	{
-		if (Uno.UI.ContextHelper.Current is Android.App.Activity activity &&
-			activity.Window.DecorView is { } decorView)
+		if (_activity.Window?.DecorView is { } decorView)
 		{
 			decorView.ViewTreeObserver.RemoveOnPreDrawListener(_preDrawListener);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AndroidSkiaXamlRootHost.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AndroidSkiaXamlRootHost.cs
@@ -1,0 +1,108 @@
+#if __SKIA__
+#nullable enable
+using System;
+using System.Reflection;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Windowing;
+
+/// <summary>
+/// Guards the Skia-on-Android de-singletoning: the window's host, its driving activity and its
+/// input sources must be resolvable per window rather than from process-wide statics.
+///
+/// Uses reflection because the RuntimeTests project takes no compile-time dependency on
+/// Uno.UI.Runtime.Skia.Android — only the Android Skia host loads it.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaAndroid)]
+public class Given_AndroidSkiaXamlRootHost
+{
+	[TestMethod]
+	public void When_Window_Then_Host_Is_Registered_For_Its_XamlRoot()
+	{
+		var host = GetHostForCurrentWindow();
+
+		Assert.IsNotNull(host, "The window's XamlRoot must resolve to a host through XamlRootMap.");
+		Assert.AreEqual(
+			"AndroidSkiaXamlRootHost",
+			host.GetType().Name,
+			"The Android Skia host must be the registered IXamlRootHost.");
+	}
+
+	[TestMethod]
+	public void When_Host_Then_Activity_Is_The_Foreground_Activity()
+	{
+		var host = GetHostForCurrentWindow();
+		Assert.IsNotNull(host);
+
+		var activity = GetMember(host, "Activity");
+		Assert.IsNotNull(activity, "The host must resolve the activity currently driving its window.");
+
+		// ContextHelper.Current is the foreground activity; with a single window it is the same
+		// instance the host resolves. This is what breaks first if the wrapper stops being
+		// re-pointed at the activity driving the window.
+		var contextHelper = FindType("Uno.UI.ContextHelper");
+		Assert.IsNotNull(contextHelper, "Uno.UI.ContextHelper must be present on Android.");
+		var current = contextHelper.GetProperty("Current", BindingFlags.Static | BindingFlags.Public)?.GetValue(null);
+
+		Assert.AreSame(current, activity, "The host's activity must be the foreground activity.");
+	}
+
+	[TestMethod]
+	public void When_Host_Then_Input_Sources_Are_Stable_Per_Window()
+	{
+		var host = GetHostForCurrentWindow();
+		Assert.IsNotNull(host);
+
+		var pointer = GetMember(host, "PointerSource");
+		var keyboard = GetMember(host, "KeyboardSource");
+
+		Assert.IsNotNull(pointer, "The window's host must expose its own pointer source.");
+		Assert.IsNotNull(keyboard, "The window's host must expose its own keyboard source.");
+
+		// Owned by the window's wrapper, so repeated resolution must yield the same instances
+		// rather than newly created (or globally shared) ones.
+		Assert.AreSame(pointer, GetMember(host, "PointerSource"));
+		Assert.AreSame(keyboard, GetMember(host, "KeyboardSource"));
+	}
+
+	private static object? GetHostForCurrentWindow()
+	{
+		var xamlRoot = TestServices.WindowHelper.CurrentTestWindow.Content?.XamlRoot;
+		if (xamlRoot is null)
+		{
+			return null;
+		}
+
+		var xamlRootMapType = typeof(XamlRoot).Assembly.GetType("Uno.UI.Hosting.XamlRootMap")
+			?? throw new InvalidOperationException("XamlRootMap type not found.");
+		var getHost = xamlRootMapType.GetMethod(
+			"GetHostForRoot",
+			BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+			?? throw new InvalidOperationException("XamlRootMap.GetHostForRoot not found.");
+
+		return getHost.Invoke(null, new object[] { xamlRoot });
+	}
+
+	private static object? GetMember(object instance, string name)
+		=> instance.GetType()
+			.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+			?.GetValue(instance);
+
+	private static Type? FindType(string fullName)
+	{
+		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+		{
+			if (assembly.GetType(fullName, throwOnError: false) is { } type)
+			{
+				return type;
+			}
+		}
+
+		return null;
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataTransferManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataTransferManager.Android.cs
@@ -55,7 +55,7 @@ namespace Windows.ApplicationModel.DataTransfer
 			var chooserIntent = Intent.CreateChooser(intent, title ?? string.Empty);
 			var flags = ActivityFlags.ClearTop | ActivityFlags.NewTask;
 			chooserIntent?.SetFlags(flags);
-			ContextHelper.Current.StartActivity(chooserIntent);
+			ContextHelper.Current!.StartActivity(chooserIntent);
 
 			return true;
 		}

--- a/src/Uno.UWP/ContextHelper.cs
+++ b/src/Uno.UWP/ContextHelper.cs
@@ -1,55 +1,75 @@
 #if __ANDROID__
+#nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using Android.App;
 using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
-using Uno.Extensions;
 using Uno.Foundation.Logging;
 
 namespace Uno.UI
 {
 	public static class ContextHelper
 	{
-		private static Android.Content.Context _current;
+		private static Android.Content.Context? _current;
 
 		/// <summary>
-		/// Get the current android content context
+		/// Gets or sets the context of the foreground activity.
 		/// </summary>
+		/// <remarks>
+		/// The setter is driven by the activity lifecycle: the foreground activity registers
+		/// itself here, and clears/repoints on teardown so a destroyed activity is never left
+		/// as "current". When no activity is in the foreground, the getter falls back to
+		/// <see cref="ApplicationContext"/> so app-scoped callers always get a usable context.
+		/// Callers that need a specific window's activity must resolve it from that window's
+		/// <see cref="XamlRoot"/> rather than relying on this ambient value.
+		/// </remarks>
 		public static Android.Content.Context Current
 		{
 			get
 			{
-				if (_current == null)
+				if (_current is { } current)
 				{
-					typeof(ContextHelper)
-						.Log()
-						.Warn(
-							"ContextHelper.Current not defined. " +
-							"For compatibility with Uno, you should ensure your `MainActivity` " +
-							"is deriving from Windows.UI.Xaml.ApplicationActivity.");
+					return current;
 				}
-				return _current;
+
+				if (ApplicationContext is { } applicationContext)
+				{
+					return applicationContext;
+				}
+
+				typeof(ContextHelper)
+					.Log()
+					.Warn(
+						"ContextHelper.Current not defined. " +
+						"For compatibility with Uno, you should ensure your `MainActivity` " +
+						"is deriving from Microsoft.UI.Xaml.ApplicationActivity.");
+
+				return null!;
 			}
 			set => _current = value;
 		}
 
 		/// <summary>
-		/// Tries getting the current context.
+		/// Gets the process-wide application context. Safe for app-scoped usage that does not
+		/// depend on a specific window or foreground activity (system services, resources, package info).
 		/// </summary>
-		/// <param name="context">The context if available</param>
-		/// <returns>true if the current context is available, otherwise false.</returns>
-		internal static bool TryGetCurrent(out Android.Content.Context context)
+		public static Android.Content.Context? ApplicationContext => Android.App.Application.Context;
+
+		/// <summary>
+		/// Tries getting the current foreground activity context.
+		/// </summary>
+		/// <param name="context">The foreground activity context if available.</param>
+		/// <returns>true if a foreground activity context is available, otherwise false.</returns>
+		internal static bool TryGetCurrent(out Android.Content.Context? context)
 		{
 			context = _current;
-			return _current != null;
+			return _current is not null;
 		}
+
+		/// <summary>
+		/// Repoints the foreground context, used by the activity lifecycle when the current
+		/// activity is torn down. Passing <c>null</c> lets <see cref="Current"/> fall back to
+		/// <see cref="ApplicationContext"/>.
+		/// </summary>
+		internal static void SetForeground(Android.Content.Context? context) => _current = context;
 	}
 }
 #endif

--- a/src/Uno.UWP/ContextHelper.cs
+++ b/src/Uno.UWP/ContextHelper.cs
@@ -15,34 +15,28 @@ namespace Uno.UI
 		/// </summary>
 		/// <remarks>
 		/// The setter is driven by the activity lifecycle: the foreground activity registers
-		/// itself here, and clears/repoints on teardown so a destroyed activity is never left
-		/// as "current". When no activity is in the foreground, the getter falls back to
-		/// <see cref="ApplicationContext"/> so app-scoped callers always get a usable context.
-		/// Callers that need a specific window's activity must resolve it from that window's
-		/// <see cref="XamlRoot"/> rather than relying on this ambient value.
+		/// itself here, and repoints on teardown (when another activity is alive) so a destroyed
+		/// activity is not left as "current". This value is activity-scoped and may be
+		/// <c>null</c> before any activity is created — app-scoped callers that only need a
+		/// process context should use <see cref="ApplicationContext"/>, and callers that need a
+		/// specific window's activity should resolve it from that window's <see cref="XamlRoot"/>
+		/// rather than relying on this ambient value.
 		/// </remarks>
 		public static Android.Content.Context Current
 		{
 			get
 			{
-				if (_current is { } current)
+				if (_current is null)
 				{
-					return current;
+					typeof(ContextHelper)
+						.Log()
+						.Warn(
+							"ContextHelper.Current not defined. " +
+							"For compatibility with Uno, you should ensure your `MainActivity` " +
+							"is deriving from Microsoft.UI.Xaml.ApplicationActivity.");
 				}
 
-				if (ApplicationContext is { } applicationContext)
-				{
-					return applicationContext;
-				}
-
-				typeof(ContextHelper)
-					.Log()
-					.Warn(
-						"ContextHelper.Current not defined. " +
-						"For compatibility with Uno, you should ensure your `MainActivity` " +
-						"is deriving from Microsoft.UI.Xaml.ApplicationActivity.");
-
-				return null!;
+				return _current!;
 			}
 			set => _current = value;
 		}
@@ -51,7 +45,7 @@ namespace Uno.UI
 		/// Gets the process-wide application context. Safe for app-scoped usage that does not
 		/// depend on a specific window or foreground activity (system services, resources, package info).
 		/// </summary>
-		public static Android.Content.Context? ApplicationContext => Android.App.Application.Context;
+		public static Android.Content.Context ApplicationContext => Android.App.Application.Context;
 
 		/// <summary>
 		/// Tries getting the current foreground activity context.
@@ -66,8 +60,8 @@ namespace Uno.UI
 
 		/// <summary>
 		/// Repoints the foreground context, used by the activity lifecycle when the current
-		/// activity is torn down. Passing <c>null</c> lets <see cref="Current"/> fall back to
-		/// <see cref="ApplicationContext"/>.
+		/// activity is torn down. Passing <c>null</c> leaves <see cref="Current"/> without a
+		/// foreground activity; app-scoped callers should use <see cref="ApplicationContext"/>.
 		/// </summary>
 		internal static void SetForeground(Android.Content.Context? context) => _current = context;
 	}

--- a/src/Uno.UWP/ContextHelper.cs
+++ b/src/Uno.UWP/ContextHelper.cs
@@ -22,11 +22,11 @@ namespace Uno.UI
 		/// specific window's activity should resolve it from that window's <see cref="XamlRoot"/>
 		/// rather than relying on this ambient value.
 		/// </remarks>
-		public static Android.Content.Context Current
+		public static Android.Content.Context? Current
 		{
 			get
 			{
-				if (_current is null)
+				if (_current is null && typeof(ContextHelper).Log().IsEnabled(LogLevel.Warning))
 				{
 					typeof(ContextHelper)
 						.Log()
@@ -36,7 +36,7 @@ namespace Uno.UI
 							"is deriving from Microsoft.UI.Xaml.ApplicationActivity.");
 				}
 
-				return _current!;
+				return _current;
 			}
 			set => _current = value;
 		}

--- a/src/Uno.UWP/Devices/Sensors/SimpleOrientationSensor.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/SimpleOrientationSensor.Android.cs
@@ -48,7 +48,7 @@ namespace Windows.Devices.Sensors
 			{
 				if (_defaultDeviceOrientation == Orientation.Undefined)
 				{
-					var context = ContextHelper.Current;
+					var context = ContextHelper.Current!;
 
 					if (context != null)
 					{
@@ -78,7 +78,7 @@ namespace Windows.Devices.Sensors
 		partial void Initialize()
 		{
 			var mainLooper = Looper.MainLooper;
-			var context = ContextHelper.Current;
+			var context = ContextHelper.Current!;
 
 			// Thread pool is used to avoid startup
 			// cost of threads creation.
@@ -121,7 +121,7 @@ namespace Windows.Devices.Sensors
 		partial void StartListeningOrientationChanged()
 		{
 			var mainLooper = Looper.MainLooper;
-			var context = ContextHelper.Current;
+			var context = ContextHelper.Current!;
 
 			// Thread pool is used to avoid startup
 			// cost of threads creation.
@@ -164,7 +164,7 @@ namespace Windows.Devices.Sensors
 
 		partial void StopListeningOrientationChanged()
 		{
-			var context = ContextHelper.Current;
+			var context = ContextHelper.Current!;
 
 			if (Application.Context.GetSystemService(Context.SensorService) is SensorManager sensorManager)
 			{
@@ -278,7 +278,7 @@ namespace Windows.Devices.Sensors
 			{
 				try
 				{
-					return Settings.System.GetInt(ContextHelper.Current.ContentResolver, Settings.System.AccelerometerRotation, 0) == 1;
+					return Settings.System.GetInt(ContextHelper.Current!.ContentResolver, Settings.System.AccelerometerRotation, 0) == 1;
 				}
 				catch (SettingNotFoundException)
 				{
@@ -309,7 +309,7 @@ namespace Windows.Devices.Sensors
 		{
 			private Action<int> _orientationChanged;
 
-			public SimpleOrientationEventListener(Action<int> orientationChanged) : base(ContextHelper.Current, SensorDelay.Normal)
+			public SimpleOrientationEventListener(Action<int> orientationChanged) : base(ContextHelper.Current!, SensorDelay.Normal)
 			{
 				_orientationChanged = orientationChanged;
 			}

--- a/src/Uno.UWP/Gaming/Input/Gamepad.Android.cs
+++ b/src/Uno.UWP/Gaming/Input/Gamepad.Android.cs
@@ -185,7 +185,7 @@ public partial class Gamepad
 	{
 		if (_inputManager == null)
 		{
-			_inputManager = (InputManager?)ContextHelper.Current.GetSystemService(Context.InputService);
+			_inputManager = (InputManager?)ContextHelper.Current!.GetSystemService(Context.InputService);
 
 			if (_inputManager == null)
 			{

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using Android.App;
 using Android.Content;
@@ -123,7 +123,7 @@ namespace Windows.Graphics.Display
 		{
 			using (var windowManager = CreateWindowManager())
 			{
-				var orientation = ContextHelper.Current.Resources!.Configuration!.Orientation;
+				var orientation = ContextHelper.Current!.Resources!.Configuration!.Orientation;
 				if (orientation == Android.Content.Res.Orientation.Undefined)
 				{
 					return DisplayOrientations.None;
@@ -210,7 +210,7 @@ namespace Windows.Graphics.Display
 
 		private IWindowManager CreateWindowManager()
 		{
-			if (ContextHelper.Current.GetSystemService(Context.WindowService) is { } windowService)
+			if (ContextHelper.Current!.GetSystemService(Context.WindowService) is { } windowService)
 			{
 				return windowService.JavaCast<IWindowManager>();
 			}

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.Android.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.Android.cs
@@ -25,7 +25,7 @@ namespace Uno.AuthenticationBroker
 		{
 			if (_schemes == null)
 			{
-				var appType = ContextHelper.Current.GetType();
+				var appType = ContextHelper.Current!.GetType();
 				var applicationTypes = appType.Assembly.GetTypes();
 
 				static IEnumerable<string> ExtractSchemes(IntentFilterAttribute a)

--- a/src/Uno.UWP/Services/Store/StoreContext.Android.cs
+++ b/src/Uno.UWP/Services/Store/StoreContext.Android.cs
@@ -30,7 +30,7 @@ public sealed partial class StoreContext
 	{
 		return AsyncOperation.FromTask(ct =>
 		{
-			var storeId = ContextHelper.Current.PackageName;
+			var storeId = ContextHelper.Current!.PackageName;
 
 			return Task.FromResult(new StoreProductResult
 			{

--- a/src/Uno.UWP/Storage/StorageFile.Android.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Android.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System;
 using System.Globalization;
@@ -63,7 +63,7 @@ namespace Windows.Storage
 				{
 					if (DrawableHelper.FindResourceIdFromPath(path, logFailure: false) is { } resourceId)
 					{
-						return ContextHelper.Current.Resources!.OpenRawResource(resourceId);
+						return ContextHelper.Current!.Resources!.OpenRawResource(resourceId);
 					}
 					else
 					{
@@ -89,7 +89,7 @@ namespace Windows.Storage
 				var packageVersion = ApplicationModel.Package.Current.Id.Version;
 
 				_currentAppID =
-					ContextHelper.Current.GetType().Assembly.GetModules().First().ModuleVersionId.ToString()
+					ContextHelper.Current!.GetType().Assembly.GetModules().First().ModuleVersionId.ToString()
 					+ $"_{packageVersion.Major}.{packageVersion.Minor}.{packageVersion.Build}.{packageVersion.Revision}";
 			}
 		}

--- a/src/Uno.UWP/System/MemoryManager.Android.cs
+++ b/src/Uno.UWP/System/MemoryManager.Android.cs
@@ -52,7 +52,7 @@ namespace Windows.System
 				_appMemoryUsage = (ulong)totalMemory;
 
 				_memoryInfo ??= new ActivityManager.MemoryInfo();
-				ActivityManager.FromContext(ContextHelper.Current)?.GetMemoryInfo(_memoryInfo);
+				ActivityManager.FromContext(ContextHelper.Current!)?.GetMemoryInfo(_memoryInfo);
 
 				_appMemoryUsageLimit = _appMemoryUsage + (ulong)_memoryInfo.AvailMem - (ulong)_memoryInfo.Threshold;
 			}


### PR DESCRIPTION
**GitHub Issue:** #8341

<!-- This is a preparatory step for multi-window support, so it intentionally does not close
     the umbrella issue. The Android-specific issue #13827 was closed as a duplicate of #8341. -->

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

> **Review status:** an eight-lens review panel found two blockers and eight high findings on the
> first pass; those are fixed in the commits following the initial series. Remaining medium/low
> findings are listed at the bottom as follow-ups. Still draft pending the on-device pass.

## What changed? 🚀

Skia-on-Android baked "one window" into three process-wide static anchors. This PR
**de-singletons** them so Android converges onto the same per-window ownership pattern the
Skia desktop runtimes (Win32/X11/macOS) and the Apple UIKit runtime already use — making
the architecture **multi-window-ready**.

`SupportsMultipleWindows` deliberately stays `false`. The definition of done here is
*per-window instances everywhere, and zero single-window regressions* — not a live second window.

### The three anchors that went away

1. **`NativeWindowWrapper.Instance`** — was a process-wide `Lazy<>` singleton returned by
   `AndroidSkiaWindowFactory.CreateWindow` for *every* window. It is now an instance bound to
   its window, tracking the activity currently driving it (`CurrentActivity`), since the managed
   `Window` outlives individual activities across re-creation.
2. **`ApplicationActivity.Instance` + the `static` render stack** (render view, native-layer host,
   root layout) — now per-activity instance state. A new activity rebuilds its surface and
   re-attaches on re-creation.
3. **`ContextHelper.Current`** — split into an explicit app-global `ApplicationContext` and an
   activity-scoped `Current` that tracks the *foreground* activity via the existing `BaseActivity`
   registry, instead of today's sticky "last-ever-set" behaviour.

### Supporting changes

- **`AndroidSkiaXamlRootHost` is per-window**: it resolves its own `RootElement` and driving
  activity, and registers in `XamlRootMap` so consumers (native element hosting, TextBox
  notifications, IME) resolve the owning activity from a `XamlRoot` rather than a global.
- **Per-window input sources**: pointer and keyboard sources are owned by the window's wrapper and
  registered via `ApiExtensibility.Register<IXamlRootHost>(…)`, matching the Win32 runtime. Each
  window's `InputManager` resolves its own sources through its host.
- **Lifecycle correctness**: the managed window's `Closing` is raised only when the activity is
  actually finishing, so a configuration-change re-creation no longer spuriously closes the
  surviving window.
- **Render-frame null guards**: `UnoSKCanvasView` now skips a frame when the window's
  root/composition target isn't ready (e.g. mid-teardown during activity re-creation), matching
  the Vulkan backend, instead of dereferencing with `!`.

### API surface

**Not additive — this PR contains two deliberate public-surface breaks**, both recorded in
`doc/articles/migrating-to-uno-7.md` and `build/PackageDiffIgnore.xml`:

- **`Uno.UI.ContextHelper.Current` is re-typed `Android.Content.Context?`.** It could always be
  `null` before any activity exists, but was annotated non-null and returned `_current!`, so the
  compiler never surfaced it. Typing it honestly changed no runtime behaviour and immediately
  exposed 13 unguarded dereferences in `Uno.UWP`. Its semantics also change: it now tracks the
  *foreground* activity rather than the last one ever assigned.
- **`Uno.UI.OnSystemUiVisibilityChangeListener` is narrowed to `internal`.** It is constructed by
  the host with the activity owning the window; app code had no way to supply one.

`ContextHelper.ApplicationContext` is new and additive. Everything else in this PR is `internal`.

### Design notes

`specs/053-android-multiwindow-ready/plan.md` documents the architecture, the phase breakdown,
and the deliberate follow-ups — chiefly flipping `SupportsMultipleWindows` to `true` (needs
Activity↔Window lifecycle orchestration and on-device validation, mirroring how iOS staged its
own multi-window behind scene adoption) and threading an explicit owning-window `Context` through
the remaining ambient `ContextHelper.Current` consumers.

### Validation

- **Compile:** `Uno.UI.Runtime.Skia.Android` builds clean for `net10.0-android`
  (0 errors; the 2 `XA0101` warnings are pre-existing and unrelated). This is the only assembly
  that compiles the `__ANDROID__` Skia code.
- **Runtime:** **not executed** — no emulator/device was reachable in the environment used for
  this change. Reviewers/CI should smoke-test single-window behaviour:
  `cd src/SamplesApp/SamplesApp.Skia.netcoremobile/Android && dotnet run -f net10.0-android`,
  exercising launch/render, touch + text input (soft keyboard, IME composition), rotation,
  background→foreground, and a config-change re-creation (system font-size/locale change).

Kept as a **draft** until that on-device pass is done.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — `Given_AndroidSkiaXamlRootHost` runs on the Android Skia CI lane and asserts host registration, activity resolution and per-window input-source identity. The foreground-repoint logic itself lives on `BaseActivity : AppCompatActivity`, which the net-based `Uno.UI.UnitTests` cannot instantiate.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — the two public-surface breaks are recorded in `migrating-to-uno-7.md`; the in-repo spec covers the architecture.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — pending CI.
- [ ] ❗ Contains **NO** breaking changes — **it does**; see the API surface section above. Both are deliberate and recorded.
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

## Known follow-ups

Carried from the review panel, deliberately not in this PR:

- The wrapper is per-*activity*, not strictly per-`Window` — the activity still adopts it through
  the ambient current window. An explicit activity⇄window binding needs the lifecycle
  orchestration that lands with the live second activity. Marked `TODO #13827`.
- `ContextHelper.ApplicationContext` still has no consumers; migrating the app-scoped
  `Uno.UWP` callers off `Current` is the documented follow-up (several read `Resources`,
  `WindowManager` or assembly identity, where the two contexts are not interchangeable).
- Diagnosability: the zero-size bail-outs in `NativeWindowWrapper` and the new lifecycle
  branches emit no trace; `OnDrawFrame` lacks the try/catch its Vulkan sibling has.
- `_contentViewAttachedToWindow` survives re-creation, so a new activity's first pre-draw
  short-circuits; the fix must move the `ContentViewAttachedToWindow` subscription out of the
  `WasShown`-gated `ShowCore` rather than just resetting the flag.
- `BaseActivity` prunes `_instances` in `Dispose` rather than `OnDestroy`, so the foreground
  repoint can select an already-destroyed activity.
- Pre-existing: `TextInputPlugin.NotifyValueChanged` logs full text at Debug, and
  `PasswordBox : TextBox`, so passwords can reach logcat.