### PR TITLE
feat(devserver): run the settings app as a CLI for `login --headless`

### DIFF
--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -358,7 +358,8 @@ internal class CliManager
 		// `login --headless` runs the settings app as a CLI rather than opening its window. It prints the
 		// loopback redirect URI the sign-in has to complete on, and exits with a meaningful code. Both are
 		// lost on the windowed path below, which buffers the child's streams and treats "still running after
-		// the grace period" as success — so let the child own the console and wait for it to finish.
+		// the grace period" as success — so let the child own the console and wait for it to finish,
+		// forwarding its exit code without adding parent output that would interleave with the prompt.
 		if (originalArgs.Any(a => string.Equals(a, "--headless", StringComparison.OrdinalIgnoreCase)))
 		{
 			var headlessStartInfo = DevServerProcessHelper.CreateDotnetProcessStartInfo(
@@ -367,7 +368,7 @@ internal class CliManager
 				workingDirectory,
 				redirectOutput: false);
 
-			return await DevServerProcessHelper.RunConsoleProcessAsync(headlessStartInfo, _logger);
+			return await DevServerProcessHelper.RunInteractiveProcessAsync(headlessStartInfo, _logger);
 		}
 
 		var startInfo = DevServerProcessHelper.CreateDotnetProcessStartInfo(studioExecutable, originalArgs, workingDirectory, redirectOutput: true);

--- a/src/Uno.UI.DevServer.Cli/CliManager.cs
+++ b/src/Uno.UI.DevServer.Cli/CliManager.cs
@@ -355,6 +355,21 @@ internal class CliManager
 			return 1; // errors already logged
 		}
 
+		// `login --headless` runs the settings app as a CLI rather than opening its window. It prints the
+		// loopback redirect URI the sign-in has to complete on, and exits with a meaningful code. Both are
+		// lost on the windowed path below, which buffers the child's streams and treats "still running after
+		// the grace period" as success — so let the child own the console and wait for it to finish.
+		if (originalArgs.Any(a => string.Equals(a, "--headless", StringComparison.OrdinalIgnoreCase)))
+		{
+			var headlessStartInfo = DevServerProcessHelper.CreateDotnetProcessStartInfo(
+				studioExecutable,
+				originalArgs,
+				workingDirectory,
+				redirectOutput: false);
+
+			return await DevServerProcessHelper.RunConsoleProcessAsync(headlessStartInfo, _logger);
+		}
+
 		var startInfo = DevServerProcessHelper.CreateDotnetProcessStartInfo(studioExecutable, originalArgs, workingDirectory, redirectOutput: true);
 
 		var (exitCode, stdOut, stdErr) = await DevServerProcessHelper.RunGuiProcessAsync(startInfo, _logger, TimeSpan.FromSeconds(3));

--- a/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
+++ b/src/Uno.UI.DevServer.Cli/Helpers/DevServerProcessHelper.cs
@@ -352,6 +352,34 @@ internal static class DevServerProcessHelper
 	}
 
 	/// <summary>
+	/// Starts a child that owns the console, waits for it, and returns its exit code verbatim.
+	/// </summary>
+	/// <remarks>
+	/// For interactive children whose own stdout is the user-facing output — the settings app's headless
+	/// sign-in, which prints the loopback redirect URI to complete on and its own result. Unlike
+	/// <see cref="RunConsoleProcessAsync"/> this emits nothing above <see cref="LogLevel.Debug"/>, so parent
+	/// lines cannot interleave with the child's output or break parsing of it, and it does not reinterpret
+	/// the exit code: a non-zero code here can be an ordinary outcome (the user cancelled the sign-in)
+	/// rather than a failure, so classifying it is the caller's business.
+	/// </remarks>
+	public static async Task<int> RunInteractiveProcessAsync(ProcessStartInfo startInfo, ILogger logger)
+	{
+		logger.LogDebug("Starting interactive process: {File} {Args}", startInfo.FileName, startInfo.Arguments);
+
+		using Process process = new() { StartInfo = startInfo };
+
+		process.Start();
+
+		logger.LogDebug("Started interactive process: {Pid}", process.Id);
+
+		await process.WaitForExitAsync();
+
+		logger.LogDebug("Interactive process exited (code: {ExitCode})", process.ExitCode);
+
+		return process.ExitCode;
+	}
+
+	/// <summary>
 	/// Spawns the host in direct mode (no <c>--command</c>) and waits for
 	/// the HTTP port to become reachable.  The result's <c>ExitCode</c> is 0 on
 	/// success and 1 on timeout or process failure; the failure kind, host exit


### PR DESCRIPTION
Closes #24043

## What

`Uno.Settings` is gaining a headless mode so a user can be signed in without the app showing a window — [unoplatform/uno.licensing#781](https://github.com/unoplatform/uno.licensing/issues/781), implemented in [unoplatform/uno.licensing#782](https://github.com/unoplatform/uno.licensing/pull/782). The intended invocation is:

```
uno-devserver login --headless
```

This makes that usable. **Bare `uno-devserver login` is unchanged** and still opens the window.

## Why a change is needed at all

No change was needed for the flag to *arrive*: `ExtractSolutionDirectory` strips only `--solution-dir`, nothing validates unknown options, and the `login` branch passes `originalArgs` verbatim to `tools/manager/Uno.Settings.dll`. So `--headless` already reaches the settings app.

The problem is `OpenSettings` launching through `RunGuiProcessAsync` with a 3-second grace period. That is right for a window and wrong for a CLI child, in three ways:

1. **Output is buffered and effectively discarded.** `RunGuiProcessAsync` uses `CaptureOutputs`, so the child's streams accumulate into StringBuilders rather than being relayed. `OpenSettings` prints them only when the process exited inside the grace period, and stdout only at `Debug`. The headless app prints the loopback redirect URI it is listening on — the port is chosen per run — so without this the user has no way to know which port the sign-in completes on.

2. **The grace period inverts the outcome.** An interactive sign-in always outlives 3s, so the exit code comes back `null`, `OpenSettings` logs "Settings application started successfully" and returns 0, and the dev-server exits — orphaning the child mid-sign-in with its output going nowhere.

3. **Any exit inside the grace period is reported as failure.** `if (exitCode is not null) { LogError(…); return 1; }` never compares the code to 0, so a fast successful run is reported as an error, and the app's exit codes (`0` success, `1` error, `2` not signed in, `3` cancelled/timed out) never propagate.

## Change

In `OpenSettings`, when the args contain `--headless`, create the start info with `redirectOutput: false` and await completion through `RunConsoleProcessAsync`, returning the child's exit code — the same helper `list`/`cleanup` already use.

`redirectOutput: false` rather than a live relay through the logger, because this is an interactive prompt: the child should own the console so the redirect URI appears immediately and unfiltered by log level. `CreateNoWindow = true` is already set, so the child inherits the parent console rather than spawning one.

## Verification

`dotnet build src/Uno.UI.DevServer.Cli` succeeds.

Not verified end-to-end: exercising `uno-devserver login --headless` needs a `uno.settings.devserver` package containing the headless-capable `Uno.Settings.dll`, which does not exist until uno.licensing#782 ships. Against a current package, `login --headless` reaches an app that ignores the flag and opens the window — this change only affects how the child is launched and waited on, so that path stays harmless.
