### PR TITLE
chore: use Mono.Cecil 0.11.6

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.43" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.43" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.43" ExcludeAssets="runtime" />
-		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 		
 		<!-- https://github.com/NuGet/Home/issues/7344 -->
 		<PackageReference Include="System.Private.Uri" Version="4.3.2" />

--- a/src/Uno.NUnitTransformTool/Uno.NUnitTransformTool.csproj
+++ b/src/Uno.NUnitTransformTool/Uno.NUnitTransformTool.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mono.Cecil" Version="0.10.1" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.ReferenceImplComparer/Uno.ReferenceImplComparer.csproj
+++ b/src/Uno.ReferenceImplComparer/Uno.ReferenceImplComparer.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mono.Cecil" Version="0.10.1" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.ResourceTrimmingValidator/Uno.ResourceTrimmingValidator.csproj
+++ b/src/Uno.ResourceTrimmingValidator/Uno.ResourceTrimmingValidator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 

--- a/src/Uno.XamlTrimmingValidator/Uno.XamlTrimmingValidator.csproj
+++ b/src/Uno.XamlTrimmingValidator/Uno.XamlTrimmingValidator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/pull/23966
Context: https://github.com/dotnet/macios/issues/26428
Context: https://github.com/unoplatform/uno/issues/24036
Context: https://github.com/dotnet/cecil/pull/504
Context: https://github.com/jbevain/cecil/pull/982
Context: https://github.com/jbevain/cecil/compare/0.11.4...0.11.6
Context: https://github.com/jbevain/cecil/compare/0.10.1...0.11.6

In The Beginning™ was a simple idea: why don't we have an iOS+Native AOT test stage?  Thus began #23966, which promptly fell over, caught on fire, and sank into the swamp.

There are two issues with #23966:

 1. CI was unhappy; it errors out with

        …/Xamarin.Shared.targets(2073,3): error : No valid iOS code signing keys found in keychain. You need to request a codesigning certificate from https://developer.apple.com.

    Not sure what's happening there.  It doesn't happen locally…

 2. It couldn't build locally either!

The initial attempt to build locally would fail in `ilc`:

	# note: using changes from #23966
	% TFM=net11.0-ios \
	  NAOT=1 \
	  BUILD_SOURCESDIRECTORY=`pwd` \
	  BUILD_ARTIFACTSTAGINGDIRECTORY=`pwd`/artifacts \
	  sh build/test-scripts/skia-ios-uitest-build.sh
	…
	    …/unoplatform/uno/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets(487,3): warning Failed to resolve assembly `JetBrains.Annotations, Version=4242.42.42.42, Culture=neutral, PublicKeyToken=1010a0d8d6380325`: Failed to resolve assembly: 'JetBrains.Annotations, Version=4242.42.42.42, Culture=neutral, PublicKeyToken=1010a0d8d6380325'
	    EXEC : error Sequence point value is out of range.
	    $HOME/.nuget/packages/microsoft.dotnet.ilcompiler/11.0.0-preview.6.26359.118/build/Microsoft.NETCore.Native.targets(359,5): error MSB3073: The command ""$HOME/.nuget/packages/runtime.osx-arm64.microsoft.dotnet.ilcompiler/11.0.0-preview.6.26359.118/tools/ilc" @"obj/Release/net11.0-ios/ios-arm64/native/SamplesApp.ilc.rsp"" exited with code 1.

Thus began a fair bit of investigation, some of which is mentioned in #24036 and dotnet/cecil#504.

What happened was a "failure cascade":

 1. The `<Csc/>` task produced a `.pdb` file.

 2. Uno's `<EmbeddedResourceInjectorTask_v0/>` task would use Cecil to process the assembly and `.pdb` file from (1). Uno was using, at most, Mono.Cecil 0.11.4, which had a bug around the encoding of "compressed" integers within `.pdb` files.

    (This is later fixed in jbevain/cecil#982, and released as part of Mono.Cecil 0.11.6.)

    The updated `.pdb` file would contain "Invalid compressed integer" values.

 3. Later, `illink` would run, which has it's own separate copy of Mono.Cecil -- from dotnet/cecil -- which would *also* update the `.pdb` files from (2).  When `illink` ran, any "Invalid compressed integer" values would be further corrupted.

 4. Later still, when `ilc` runs, it would process the `.pdb` files produced by (3), and at this point instead of "silently corrupting" data, it would error out entirely:

        Error: Sequence point value is out of range.
        System.BadImageFormatException: Sequence point value is out of range.
           at System.Reflection.Throw.SequencePointValueOutOfRange() in /_/src/runtime/src/libraries/System.Reflection.Metadata/src/System/Reflection/Throw.cs:line 239
           at System.Reflection.Metadata.SequencePointCollection.Enumerator.MoveNext() in /_/src/runtime/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/SequencePointCollection.cs:line 86
           at Internal.TypeSystem.Ecma.PortablePdbSymbolReader.<GetSequencePointsForMethod>d__10.MoveNext() in /_/src/runtime/src/coreclr/tools/Common/TypeSystem/Ecma/SymbolReader/PortablePdbSymbolReader.cs:line 147
           at ILCompiler.Logging.MessageOrigin..ctor(MethodIL, Int32) in /_/src/runtime/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageOrigin.cs:line 65

(Failure cascades are fun!)

*Part* of the fix here is to update Uno to use Mono.Cecil 0.11.6, which contains the fix for reading and writing "compressed" integers in `.pdb` files.  That is done here.

Additionally, I found it *incredibly* helpful in debugging all of this to have "before" and "after" versions of the files processed by `<EmbeddedResourceInjectorTask_v0/>`.  (For too long, I thought that (3) was caused by a Roslyn bug, as I didn't see (2)!)

Update the `<EmbeddedResourceInjectorTask_v0/>` task so that it preseves the original assembly and `.pdb` files to have a `.bk-EmbeddedResourceInjector` extension, e.g.
`SamplesApp.dll.bk-EmbeddedResourceInjector` and
`SamplesApp.pdb.bk-EmbeddedResourceInjector`.

All of this will *not* fix #23966, but is a partial prerequisite. A full fix will require dotnet/cecil#504 to be merged and released, `illink` updated to use dotnet/cecil#504, and *then* there's dotnet/macios#26428, in which `clang++` crashes when trying to link everything even if we get past the whole `.pdb` mess.

(Aside: the `.pdb` mess can be avoided by NOT USING `.pdb` FILES, e.g. buil with `-p:DebugType=none`.  However, who wants to do that?)

…which still leaves the original "how do we get this building on CI" question…

Baby steps!

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🏗️ Build or CI related changes
<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
