### PR TITLE
chore: Update to .NET 11 Preview 7

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -30,8 +30,8 @@ variables:
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.35.0-dev.33'
-  DotNetSdkVersion: '11.0.100-preview.6.26359.118'
+  GlobalUnoCheckVersion: '1.35.0-dev.65'
+  DotNetSdkVersion: '11.0.100-preview.7.26381.103'
 
   netCurrentTargetFramework: 'net11.0'
   netPreviousTargetFramework: 'net10.0'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -70,8 +70,8 @@ variables:
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.35.0-dev.33'
-  DotNetSdkVersion: '11.0.100-preview.6.26359.118'
+  GlobalUnoCheckVersion: '1.35.0-dev.65'
+  DotNetSdkVersion: '11.0.100-preview.7.26381.103'
 
   netCurrentTargetFramework: 'net11.0'
   netPreviousTargetFramework: 'net10.0'

--- a/build/ci/net11/_global.json
+++ b/build/ci/net11/_global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "11.0.100-preview.6.26359.118",
+		"version": "11.0.100-preview.7.26381.103",
 		"allowPrerelease": true,
 		"rollForward": "disable"
 	},
@@ -8,7 +8,7 @@
 		"runner": "Microsoft.Testing.Platform"
 	},
 	"tools": {
-		"dotnet": "11.0.100-preview.6.26359.118"
+		"dotnet": "11.0.100-preview.7.26381.103"
 	},
 	"msbuild-sdks": {
 		"Microsoft.Build.NoTargets": "3.7.56"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -171,7 +171,7 @@
 		<PackageReference Update="harfbuzzsharp.nativeassets.tvos" Version="$(HarfbuzzSharpVersion)" />
 
 		<PackageReference Condition=" '$(TargetFramework)' == '$(NetPrevious)' "  Update="Microsoft.Win32.SystemEvents" Version="10.0.9" />
-		<PackageReference Condition=" '$(TargetFramework)' == '$(NetCurrent)' "   Update="Microsoft.Win32.SystemEvents" Version="11.0.0-preview.6.26359.118" />
+		<PackageReference Condition=" '$(TargetFramework)' == '$(NetCurrent)' "   Update="Microsoft.Win32.SystemEvents" Version="11.0.0-preview.7.26381.103" />
 
 		<PackageReference Update="Svg.Skia" Version="3.0.6" />
 		<PackageReference Update="GtkSharp" Version="3.24.24.38" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/_Dotnet.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/_Dotnet.cs
@@ -12,7 +12,7 @@ internal record class _Dotnet(string Moniker, ReferenceAssemblies ReferenceAssem
 		"net11.0",
 		new PackageIdentity(
 			"Microsoft.NETCore.App.Ref",
-			"11.0.0-preview.6.26359.118"),
+			"11.0.0-preview.7.26381.103"),
 		Path.Combine("ref", "net11.0")
 	);
 
@@ -21,7 +21,7 @@ internal record class _Dotnet(string Moniker, ReferenceAssemblies ReferenceAssem
 	private static ReferenceAssemblies Net110Android = Net110
 		.AddPackages(
 			ImmutableArray.Create(
-				new PackageIdentity("Microsoft.Android.Ref.37", "37.0.0-preview.6.59")));
+				new PackageIdentity("Microsoft.Android.Ref.37", "37.0.0-preview.7.2131")));
 
 	public ReferenceAssemblies WithUnoPackage(string version = "5.0.118")
 		=> ReferenceAssemblies.AddPackages([new PackageIdentity("Uno.WinUI", version)]);

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
-		<PackageReference Include="Mono.Cecil" Version="0.11.4" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 		
 		<!-- https://github.com/NuGet/Home/issues/7344 -->
 		<PackageReference Include="System.Private.Uri" Version="4.3.2" />

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -102,6 +102,19 @@
 		<SupportedOSPlatformVersion>24.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
+	<!--
+	  Android+NativeAOT fails with .NET 11 Preview 7 with error NU1102:
+	    Unable to find package Microsoft.NETCore.App.Runtime.NativeAOT.android-arm64 with version (= 11.0.0-preview.7.26378.119)
+	  …because there is no published 11.0.0-preview.7.26378.119 package; it should be 11.0.0-preview.7.26381.103.
+
+	  This is the upstream fix: https://github.com/dotnet/android/pull/12356
+
+	  For now, Update `$(MicrosoftNETCoreAppRefPackageVersion)` to the correct version so that NuGet versions are correct.
+	  -->
+	<PropertyGroup Condition=" $(IsAndroid) And '$(BundledNETCoreAppPackageVersion)' == '11.0.0-preview.7.26381.103' ">
+		<MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.7.26381.103</MicrosoftNETCoreAppRefPackageVersion>
+	</PropertyGroup>
+
 	<PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.19041' and $(TargetFramework.EndsWith('-windows10.0.19041.0')) != 'true' and '$(TargetPlatformIdentifier)' != 'UAP'">
 		<DefineConstants>$(DefineConstants);HAS_UNO;HAS_UNO_WINUI</DefineConstants>
 

--- a/src/Uno.NUnitTransformTool/Uno.NUnitTransformTool.csproj
+++ b/src/Uno.NUnitTransformTool/Uno.NUnitTransformTool.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mono.Cecil" Version="0.10.1" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.ReferenceImplComparer/Uno.ReferenceImplComparer.csproj
+++ b/src/Uno.ReferenceImplComparer/Uno.ReferenceImplComparer.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Mono.Cecil" Version="0.10.1" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.ResourceTrimmingValidator/Uno.ResourceTrimmingValidator.csproj
+++ b/src/Uno.ResourceTrimmingValidator/Uno.ResourceTrimmingValidator.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -143,7 +143,7 @@
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net11.0": "11.0.0-preview.6.26359.118"
+			"net11.0": "11.0.0-preview.7.26381.103"
 		}
 	},
 	{
@@ -153,7 +153,7 @@
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net11.0": "11.0.0-preview.6.26359.118"
+			"net11.0": "11.0.0-preview.7.26381.103"
 		}
 	},
 	{
@@ -342,7 +342,7 @@
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net11.0": "11.0.0-preview.6.26360.8"
+			"net11.0": "11.0.0-preview.7.26406.9"
 		}
 	},
 	{

--- a/src/Uno.XamlTrimmingValidator/Uno.XamlTrimmingValidator.csproj
+++ b/src/Uno.XamlTrimmingValidator/Uno.XamlTrimmingValidator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/issues/22745

Update version numbers accordingly.

To sanity-check locally, try:

	\cp build/ci/net11/_global.json global.json

	dotnet build -f net11.0-ios26.5 src/Uno.Foundation/Uno.Foundation.netcoremobile.csproj
	dotnet build -f net11.0 src/Uno.UI/Uno.UI.csproj
	dotnet publish -f net11.0-android src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -p:UnoTargetFrameworkOverride=net11.0-android -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true -bl
	dotnet build -f net11.0-ios -c Release -p:UnoTargetFrameworkOverride=net11.0-ios -bl src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

✨ Feature
🏗️ Build or CI related changes

<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
