### PR TITLE
fix(msal): Deploy platform MSAL assets under SkiaRenderer

### DIFF
--- a/build/nuget/Uno.WinUI.MSAL.nuspec
+++ b/build/nuget/Uno.WinUI.MSAL.nuspec
@@ -68,19 +68,19 @@
 			</group>
 			<group targetFramework="net10.0-android36.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net10.0-ios26.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net10.0-tvos26.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net10.0-maccatalyst26.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/src/SourceGenerators/Uno.UI.Tasks/RuntimeAssetsSelector/RuntimeAssetsSelectorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/RuntimeAssetsSelector/RuntimeAssetsSelectorTask.cs
@@ -185,7 +185,7 @@ namespace Uno.UI.Tasks.RuntimeAssetsSelector
 			if (isTwoLayer)
 			{
 				// Two layer mode.
-				// We use Skia, except for Uno.dll, Uno.Foundation.dll, and Uno.Dispatching.dll
+				// We use Skia, except for WinRT assemblies (see IsWinRTAssembly).
 				// We will adjust for those dlls later.
 				if (UnoUIRuntimeIdentifier != "skia")
 				{
@@ -258,8 +258,10 @@ namespace Uno.UI.Tasks.RuntimeAssetsSelector
 			throw new Exception($"Unable to find reference directory from runtime directory '{runtimeDirectory}'");
 		}
 
+		// Uno.UI.MSAL only depends on the WinRT layer (Uno.UWP), so it must follow the
+		// WinRT layer selection to keep its platform-specific helpers (https://github.com/unoplatform/uno/issues/20601).
 		private bool IsWinRTAssembly(string fileNameWithoutExtension)
-			=> fileNameWithoutExtension.ToLower(CultureInfo.InvariantCulture) is "uno" or "uno.ui.dispatching" or "uno.foundation";
+			=> fileNameWithoutExtension.ToLower(CultureInfo.InvariantCulture) is "uno" or "uno.ui.dispatching" or "uno.foundation" or "uno.ui.msal";
 
 		private string GetWinRTAssembly(string runtimeDirectory, string assembly, Version targetFrameworkVersion)
 		{
@@ -269,7 +271,13 @@ namespace Uno.UI.Tasks.RuntimeAssetsSelector
 			var unoRuntimeTfmDirectory = Path.GetDirectoryName(Path.GetDirectoryName(assembly));
 			if (UnoWinRTRuntimeIdentifier == "webassembly")
 			{
-				return Path.GetFullPath(Path.Combine(unoRuntimeTfmDirectory, "webassembly", Path.GetFileName(assembly)));
+				var webAssemblyAsset = Path.GetFullPath(Path.Combine(unoRuntimeTfmDirectory, "webassembly", Path.GetFileName(assembly)));
+				if (!File.Exists(webAssemblyAsset))
+				{
+					throw new Exception($"Cannot get WinRT assembly for '{assembly}', the expected asset '{webAssemblyAsset}' does not exist");
+				}
+
+				return webAssemblyAsset;
 			}
 
 			if (!IsSkiaMobileRuntimeIdentifier(UnoWinRTRuntimeIdentifier))
@@ -303,7 +311,13 @@ namespace Uno.UI.Tasks.RuntimeAssetsSelector
 				throw new Exception($"Cannot get WinRT assembly for '{assembly}'");
 			}
 
-			return Path.GetFullPath(Path.Combine(lib, bestTfmMatch, Path.GetFileName(assembly)));
+			var winRTAssembly = Path.GetFullPath(Path.Combine(lib, bestTfmMatch, Path.GetFileName(assembly)));
+			if (!File.Exists(winRTAssembly))
+			{
+				throw new Exception($"Cannot get WinRT assembly for '{assembly}', the expected asset '{winRTAssembly}' does not exist");
+			}
+
+			return winRTAssembly;
 		}
 
 		private void HandleForRuntimeEnabled(
@@ -350,6 +364,7 @@ namespace Uno.UI.Tasks.RuntimeAssetsSelector
 				if (isWinRTAssembly)
 				{
 					adjustedAssembly = GetWinRTAssembly(runtimeDirectory, assembly, targetFrameworkVersion);
+					this.Log.LogMessage($"Assembly '{assemblyFileNameWithoutExtension}' follows the WinRT layer: replacing '{assembly}' with '{adjustedAssembly}'");
 				}
 
 				this.Log.LogMessage($"Processing assembly: {adjustedAssembly}");


### PR DESCRIPTION
**GitHub Issue:** closes #20601

## PR Type:

🐞 Bugfix

## What changed? 🚀

Under `SkiaRenderer`, the two-layer runtime asset selection (`RuntimeAssetsSelectorTask`) replaced `Uno.UI.MSAL.dll` with the no-op `skia` flavor on **every** head, because `IsWinRTAssembly` only recognized `uno`, `uno.ui.dispatching`, and `uno.foundation`. As a result `WithUnoHelpers()` silently did nothing: no parent `Activity`/`UIViewController` on Android/iOS (MSAL fails with `activity_required`), and no `WasmWebUi`/`WasmHttpFactory` on WebAssembly (no popup flow at all). Full root-cause analysis in [this issue comment](https://github.com/unoplatform/uno/issues/20601#issuecomment-5260795942).

This PR:

- Adds `uno.ui.msal` to the WinRT assembly allowlist in `RuntimeAssetsSelectorTask`. `Uno.UI.MSAL` only depends on the WinRT layer (`Uno.UWP`) — verified: the shipped android flavor references only `Uno`/`Mono.Android`/MSAL, the webassembly flavor references no Uno assemblies at all — so under the two-layer mode Android/iOS/tvOS/Catalyst heads now deploy (and compile against) the `lib/netX.0-<platform>` flavor, and WebAssembly deploys the `uno-runtime/<tfm>/webassembly` flavor.
- Fails fast with a descriptive error when an expected WinRT-layer asset is missing from a package (previously a late, opaque copy failure), and logs the WinRT-layer redirection for diagnosability.
- Aligns the `Microsoft.Identity.Client` dependency floor for the net10 mobile groups in `Uno.WinUI.MSAL.nuspec` (4.61.3 → 4.72.1, the version the assemblies are compiled against).

No app-side or `Uno.WinUI.MSAL` package changes are required — the fix acts at app build time. This also transitively revives `Uno.Extensions.Authentication.MSAL` interactive sign-in on Skia heads (its `MsalAuthenticationProvider` calls `WithUnoHelpers()` on both the builder and the interactive request); the remaining desktop issues there (e.g. unoplatform/uno.extensions#3025 macOS token-cache setup) are a separate storage-layer concern.

### Validation

- **Task-level**: `RuntimeAssetsSelectorTask_v0` driven directly against a synthetic `uno.winui.msal` package layout — skia+android → `lib/net10.0-android`, skia+ios → `lib/net10.0-ios26.0`, skia+webassembly → `uno-runtime/net10.0/webassembly`, single-layer skia (desktop) unchanged, non-allowlisted assemblies keep the pre-fix routing, missing declared flavor throws.
- **End-to-end** (real app, Uno.Sdk 6.8.0-dev.10 / uno.winui 6.8.0-dev.21 with the patched task, `UnoFeatures=SkiaRenderer`, all four heads): SHA-256 of the deployed `Uno.UI.MSAL.dll` matches the platform flavor on android/ios/wasm and stays on the skia flavor for desktop; app compiles with bare `.WithUnoHelpers()` (no `#if` workarounds).
- **Live runtime**: interactive sign-in verified on Skia-Android (Chrome custom tab opens with the parent activity supplied) and on Skia-WASM (popup flow via `WasmWebUi` completes; `MSAL.WebUI.js` embedded script is extracted and registered in `uno-config.js` under the Skia renderer). Desktop verified unaffected (system browser + loopback).

Follow-ups intentionally not in this PR: checked-in unit tests for `Uno.UI.Tasks` (no test project exists today), extending `RuntimeAssetsValidatorTask` to cover WinRT-layer assemblies, and the browserwasm `__UNO__`/`HAS_UNO_*` define gaps (#20875 / #17684) noted in the issue.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — validated via task-level scenario harness + end-to-end app validation on all four heads (see Validation above); no `Uno.UI.Tasks` test project exists to host a checked-in test today
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5xeAHcheZNYf9xE8CzhYJ
