### PR TITLE
fix(ios): report UserCancel when web auth sheet is dismissed

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows_Security/Authentication_Web/AuthenticationBroker_Cancel.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_Security/Authentication_Web/AuthenticationBroker_Cancel.xaml
@@ -1,0 +1,27 @@
+<Page
+    x:Class="SamplesApp.UITests.Windows_Security_Authentication_Web.AuthenticationBroker_Cancel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:SamplesApp.UITests.Windows_Security_Authentication_Web"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <StackPanel Padding="12" Spacing="6">
+        <TextBlock TextWrapping="Wrap">
+            Tap Authenticate, then dismiss the web authentication sheet without signing in.
+            The result must be UserCancel, and the app must not crash.
+        </TextBlock>
+        <Button
+            x:Name="btnAuthenticate"
+            AutomationProperties.AutomationId="AuthenticateButton"
+            Click="Authenticate_Clicked">
+            Authenticate
+        </Button>
+        <TextBlock
+            x:Name="resultTxt"
+            AutomationProperties.AutomationId="AuthenticationResult"
+            TextWrapping="Wrap" />
+    </StackPanel>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_Security/Authentication_Web/AuthenticationBroker_Cancel.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_Security/Authentication_Web/AuthenticationBroker_Cancel.xaml.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using Windows.Security.Authentication.Web;
+
+namespace SamplesApp.UITests.Windows_Security_Authentication_Web
+{
+	[Sample("Windows.Security", IsManualTest = true, Description = "Dismissing the authentication sheet must report UserCancel instead of crashing.")]
+	public sealed partial class AuthenticationBroker_Cancel : Page
+	{
+		// Registered as a CFBundleURLSchemes entry of the iOS SamplesApp heads.
+		private static readonly Uri _callbackUri = new("uno-samples-test://callback");
+
+		public AuthenticationBroker_Cancel()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void Authenticate_Clicked(object sender, RoutedEventArgs e)
+		{
+			resultTxt.Text = "Authenticating...";
+
+			try
+			{
+				var result = await WebAuthenticationBroker.AuthenticateAsync(
+					WebAuthenticationOptions.None,
+					new Uri("https://example.com/"),
+					_callbackUri);
+
+				resultTxt.Text = $"{result.ResponseStatus} {result.ResponseData}";
+			}
+			catch (Exception ex)
+			{
+				resultTxt.Text = $"Error {ex}";
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Security_Authentication_Web/Given_WebAuthenticationBrokerProvider.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Security_Authentication_Web/Given_WebAuthenticationBrokerProvider.cs
@@ -1,0 +1,64 @@
+#if __APPLE_UIKIT__ && !__TVOS__
+#nullable enable
+using Foundation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.AuthenticationBroker;
+using Windows.Security.Authentication.Web;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Security_Authentication_Web;
+
+[TestClass]
+public class Given_WebAuthenticationBrokerProvider
+{
+	private const string ASWebAuthenticationSessionErrorDomain = "com.apple.AuthenticationServices.WebAuthenticationSession";
+	private const string SFAuthenticationErrorDomain = "com.apple.SafariServices.Authentication";
+	private const int CanceledLoginErrorCode = 1;
+	private const int PresentationContextNotProvidedErrorCode = 2;
+
+	[TestMethod]
+	public void When_ASWebAuthenticationSession_Canceled_By_User()
+	{
+		var error = new NSError((NSString)ASWebAuthenticationSessionErrorDomain, CanceledLoginErrorCode);
+
+		var result = WebAuthenticationBrokerProvider.CreateResult(null, error);
+
+		Assert.AreEqual(WebAuthenticationStatus.UserCancel, result.ResponseStatus);
+		Assert.IsNull(result.ResponseData);
+	}
+
+#if __IOS__
+	[TestMethod]
+	public void When_SFAuthenticationSession_Canceled_By_User()
+	{
+		var error = new NSError((NSString)SFAuthenticationErrorDomain, CanceledLoginErrorCode);
+
+		var result = WebAuthenticationBrokerProvider.CreateResult(null, error);
+
+		Assert.AreEqual(WebAuthenticationStatus.UserCancel, result.ResponseStatus);
+		Assert.IsNull(result.ResponseData);
+	}
+#endif
+
+	[TestMethod]
+	public void When_Session_Fails()
+	{
+		var error = new NSError((NSString)ASWebAuthenticationSessionErrorDomain, PresentationContextNotProvidedErrorCode);
+
+		var result = WebAuthenticationBrokerProvider.CreateResult(null, error);
+
+		Assert.AreEqual(WebAuthenticationStatus.ErrorHttp, result.ResponseStatus);
+		Assert.IsNotNull(result.ResponseData);
+	}
+
+	[TestMethod]
+	public void When_Session_Succeeds()
+	{
+		var callbackUrl = new NSUrl("my-app://callback?code=42");
+
+		var result = WebAuthenticationBrokerProvider.CreateResult(callbackUrl, null);
+
+		Assert.AreEqual(WebAuthenticationStatus.Success, result.ResponseStatus);
+		Assert.AreEqual("my-app://callback?code=42", result.ResponseData);
+	}
+}
+#endif

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOS.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOS.cs
@@ -30,36 +30,11 @@ namespace Uno.AuthenticationBroker
 		{
 			var tcs = new TaskCompletionSource<WebAuthenticationResult>();
 
+			// TrySetResult: the session can invoke the callback more than once (e.g. a late
+			// completion racing the Cancel() below), and throwing from this native
+			// trampoline is an unrecoverable NSException.
 			void AuthSessionCallback(NSUrl? callbackUrl, NSError? error)
-			{
-				if (error != null)
-				{
-					if ((error.Domain == asWebAuthenticationSessionErrorDomain &&
-						error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin)
-#if __IOS__
-						|| (error.Domain == sfAuthenticationErrorDomain &&
-							error.Code == sfAuthenticationErrorCanceledLogin)
-#endif
-						)
-					{
-						tcs.SetResult(new WebAuthenticationResult(
-							null,
-							0,
-							WebAuthenticationStatus.UserCancel));
-					}
-					tcs.SetResult(new WebAuthenticationResult(
-						error.ToString(),
-						0,
-						WebAuthenticationStatus.ErrorHttp));
-				}
-				else
-				{
-					tcs.SetResult(new WebAuthenticationResult(
-						callbackUrl?.AbsoluteString,
-						0,
-						WebAuthenticationStatus.Success));
-				}
-			}
+				=> tcs.TrySetResult(CreateResult(callbackUrl, error));
 
 			IDisposable? was = default;
 
@@ -167,6 +142,39 @@ namespace Uno.AuthenticationBroker
 				Cancel();
 			}
 		}
+
+		internal static WebAuthenticationResult CreateResult(NSUrl? callbackUrl, NSError? error)
+		{
+			if (error is null)
+			{
+				return new WebAuthenticationResult(
+					callbackUrl?.AbsoluteString,
+					0,
+					WebAuthenticationStatus.Success);
+			}
+
+			if (IsUserCanceledLogin(error))
+			{
+				return new WebAuthenticationResult(
+					null,
+					0,
+					WebAuthenticationStatus.UserCancel);
+			}
+
+			return new WebAuthenticationResult(
+				error.ToString(),
+				0,
+				WebAuthenticationStatus.ErrorHttp);
+		}
+
+		private static bool IsUserCanceledLogin(NSError error)
+			=> (error.Domain == asWebAuthenticationSessionErrorDomain &&
+				error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin)
+#if __IOS__
+				|| (error.Domain == sfAuthenticationErrorDomain &&
+					error.Code == sfAuthenticationErrorCanceledLogin)
+#endif
+				;
 
 		private class PresentationContextProviderToSharedKeyWindow : NSObject, IASWebAuthenticationPresentationContextProviding
 		{

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOS.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOS.cs
@@ -28,7 +28,10 @@ namespace Uno.AuthenticationBroker
 			Uri callbackUri,
 			CancellationToken ct)
 		{
-			var tcs = new TaskCompletionSource<WebAuthenticationResult>();
+			// RunContinuationsAsynchronously so completing the task never runs the awaiter's
+			// finally inline on the native trampoline, which would Cancel() and Dispose() the
+			// session from inside its own completion handler.
+			var tcs = new TaskCompletionSource<WebAuthenticationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			// TrySetResult: the session can invoke the callback more than once (e.g. a late
 			// completion racing the Cancel() below), and throwing from this native


### PR DESCRIPTION
**GitHub Issue:** closes #19666

## PR Type:

🐞 Bugfix

## What changed? 🚀

Dismissing the `ASWebAuthenticationSession` sheet on iOS crashed the app instead of returning a `UserCancel` result.

`WebAuthenticationBrokerProvider.AuthenticateAsyncCore` called `tcs.SetResult` twice in the `error != null` branch — the canceled-login case set `UserCancel` and then fell through to the `ErrorHttp` result, because there was no `return` between them. The second call threw `InvalidOperationException` ("An attempt was made to transition a task to a final state when it had already completed") inside the Objective-C completion-handler trampoline, where nothing can catch it, so it was marshalled to an `NSException` and the app died with `SIGABRT`. Every sign-in cancel was a guaranteed crash, and the caller never saw the `UserCancel` result it would have handled gracefully.

The callback now maps the native result through a single, mutually exclusive `CreateResult(callbackUrl, error)`:

- no error → `Success`
- canceled-login error (`ASWebAuthenticationSession`, or `SFAuthenticationSession` on iOS) → `UserCancel`
- any other error → `ErrorHttp`

It also completes the task with `TrySetResult` rather than `SetResult`. The session can invoke the callback more than once — a late completion can race the `Cancel()` in the `finally` — and throwing from that native trampoline is unrecoverable, so the callback must never be the thing that throws.

Validated on the iOS simulator (iPhone 16 Pro, iOS 18.4): cancelling the sheet now reports `UserCancel` and the app stays alive.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

Tests: `Given_WebAuthenticationBrokerProvider` pins the four result mappings (it compiles on the Apple UIKit heads, since it builds an `NSError` directly). A `Windows.Security` / `AuthenticationBroker_Cancel` manual sample drives the real sheet — the cancel path itself needs a human tap, so it can't be covered by an automated runtime test.
