### PR TITLE
feat(webview): Implement CoreWebView2Environment and CoreWebView2Profile on Skia Win32

### DIFF
--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -205,6 +205,74 @@ public App()
 }
 ```
 
+## Querying the environment and the profile (Windows)
+
+On Windows (Skia Desktop) a subset of `CoreWebView2Environment` and `CoreWebView2Profile` is implemented. On every other target these members throw `NotImplementedException`, as they did before.
+
+> [!NOTE]
+> This is implemented by the default WebView2 backend, which requires .NET 10 or later. An app targeting .NET 9, or one that opts into the other backend with `UNO_WEBVIEW2_BACKEND=microsoft.web.webview2`, keeps the previous `NotImplementedException` behavior.
+
+### Which browser is installed
+
+`CoreWebView2Environment.GetAvailableBrowserVersionString` and `CompareBrowserVersionString` are static and need no `WebView2` at all, so they can be used as a preflight check before showing any web content:
+
+```csharp
+try
+{
+    var version = CoreWebView2Environment.GetAvailableBrowserVersionString();
+    var isRecentEnough = CoreWebView2Environment.CompareBrowserVersionString(version, "110.0.0.0") >= 0;
+}
+catch (FileNotFoundException)
+{
+    // No WebView2 Runtime is installed.
+}
+```
+
+Passing a `browserExecutableFolder` is authoritative: if no browser is found there, the call fails rather than falling back to the installed one. The version string carries a channel suffix on non-stable channels (for example `120.0.2210.91 beta`), so parse only the leading token. Note that these are static members, resolved through the Skia host — call them after the application host has started.
+
+The overload taking `CoreWebView2EnvironmentOptions` is **not** implemented, because that options type is itself unimplemented and could not be honored.
+
+### Environment and profile of a running WebView2
+
+`CoreWebView2.Environment`, `CoreWebView2.Profile` and `CoreWebView2.BrowserProcessId` become available once the WebView is initialized:
+
+```csharp
+await webView.EnsureCoreWebView2Async();
+
+var environment = webView.CoreWebView2.Environment;
+// environment.BrowserVersionString, environment.UserDataFolder, environment.FailureReportFolderPath
+// environment.GetProcessInfos() returns a snapshot of the browser, renderer and GPU processes.
+
+var profile = webView.CoreWebView2.Profile;
+// profile.ProfileName, profile.ProfilePath, profile.IsInPrivateModeEnabled,
+// profile.DefaultDownloadFolderPath, profile.PreferredColorScheme
+```
+
+`FailureReportFolderPath` is created lazily by the browser, so the directory may not exist yet.
+
+> [!NOTE]
+> `ProfileName` is currently always empty on Windows. Uno creates the WebView without controller options, so no profile name is requested — the profile still resolves to the default one, and `ProfilePath` (a directory under `UserDataFolder`) is the reliable way to identify it.
+
+### Clearing browsing data
+
+`ClearBrowsingDataAsync` removes stored state for the profile, which is what a sign-out flow usually needs:
+
+```csharp
+// Everything the profile holds.
+await webView.CoreWebView2.Profile.ClearBrowsingDataAsync();
+
+// Just cookies. AllSite and AllProfile include cookies too.
+await webView.CoreWebView2.Profile.ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds.Cookies);
+
+// Only what was created in the last hour.
+await webView.CoreWebView2.Profile.ClearBrowsingDataAsync(
+    CoreWebView2BrowsingDataKinds.Cookies,
+    DateTimeOffset.UtcNow.AddHours(-1),
+    DateTimeOffset.UtcNow);
+```
+
+Clearing a large profile can take several seconds and the displayed content may reload underneath. `CoreWebView2CookieManager` is not implemented, so reading cookies or deleting an individual cookie by name is not available — only bulk clearing.
+
 ## Linux specifics
 
 In order to use WebView2 on Linux, you'll need to install `libwebkit2gtk` and `libgtk3-0`:

--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -210,7 +210,7 @@ public App()
 On Windows (Skia Desktop) a subset of `CoreWebView2Environment` and `CoreWebView2Profile` is implemented. On every other target these members throw `NotImplementedException`, as they did before.
 
 > [!NOTE]
-> This is implemented by the default WebView2 backend, which requires .NET 10 or later. An app targeting .NET 9, or one that opts into the other backend with `UNO_WEBVIEW2_BACKEND=microsoft.web.webview2`, keeps the previous `NotImplementedException` behavior.
+> This requires .NET 10 or later. An app targeting .NET 9 keeps the previous `NotImplementedException` behavior for all of the members below.
 
 ### Which browser is installed
 
@@ -249,6 +249,9 @@ var profile = webView.CoreWebView2.Profile;
 ```
 
 `FailureReportFolderPath` is created lazily by the browser, so the directory may not exist yet.
+
+> [!NOTE]
+> Unlike the static members above, these three are provided by the default WebView2 backend only. An app that opts into the other backend with `UNO_WEBVIEW2_BACKEND=microsoft.web.webview2` gets `NotImplementedException` from them.
 
 > [!NOTE]
 > `ProfileName` is currently always empty on Windows. Uno creates the WebView without controller options, so no profile name is requested — the profile still resolves to the default one, and `ProfilePath` (a directory under `UserDataFolder`) is the reliable way to identify it.

--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -252,8 +252,7 @@ var profile = webView.CoreWebView2.Profile;
 
 > [!NOTE]
 > Unlike the static members above, these three are provided by the default WebView2 backend only. An app that opts into the other backend with `UNO_WEBVIEW2_BACKEND=microsoft.web.webview2` gets `NotImplementedException` from them.
-
-> [!NOTE]
+>
 > `ProfileName` is currently always empty on Windows. Uno creates the WebView without controller options, so no profile name is requested — the profile still resolves to the default one, and `ProfilePath` (a directory under `UserDataFolder`) is the reliable way to identify it.
 
 ### Clearing browsing data

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentAndProfile.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentAndProfile.xaml
@@ -1,0 +1,91 @@
+﻿<Page
+    x:Class="SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests.WebView2_EnvironmentAndProfile"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Padding="12" Spacing="6">
+            <TextBlock
+                FontWeight="SemiBold"
+                Text="CoreWebView2Environment statics (no WebView2 required)"
+                TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Button
+                    AutomationProperties.AutomationId="GetVersionButton"
+                    Click="GetAvailableVersionClick"
+                    Content="Get available version" />
+                <TextBox
+                    x:Name="FolderInput"
+                    Width="320"
+                    PlaceholderText="browserExecutableFolder (blank = installed browser)" />
+                <Button
+                    AutomationProperties.AutomationId="GetVersionFromFolderButton"
+                    Click="GetAvailableVersionFromFolderClick"
+                    Content="Get version from folder" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBox
+                    x:Name="VersionLeftInput"
+                    Width="140"
+                    Text="1.0.0.0" />
+                <TextBox
+                    x:Name="VersionRightInput"
+                    Width="140"
+                    Text="2.0.0.0" />
+                <Button
+                    AutomationProperties.AutomationId="CompareVersionsButton"
+                    Click="CompareVersionsClick"
+                    Content="Compare" />
+            </StackPanel>
+
+            <TextBlock
+                Margin="0,6,0,0"
+                FontWeight="SemiBold"
+                Text="Environment and profile of the WebView2 below"
+                TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Button Click="ReadEnvironmentClick" Content="Read environment" />
+                <Button Click="ReadProfileClick" Content="Read profile" />
+                <Button Click="ToggleColorSchemeClick" Content="Toggle color scheme" />
+                <Button Click="DumpProcessInfosClick" Content="Dump GetProcessInfos()" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Button Click="ClearAllClick" Content="Clear all" />
+                <Button Click="ClearKindsClick" Content="Clear AllProfile" />
+                <Button Click="ClearRangeClick" Content="Clear cookies (last hour)" />
+            </StackPanel>
+        </StackPanel>
+
+        <Border
+            Grid.Row="1"
+            Margin="12,0,12,12"
+            Padding="8"
+            Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
+            CornerRadius="4">
+            <ScrollViewer MaxHeight="220" HorizontalScrollBarVisibility="Auto">
+                <TextBlock
+                    x:Name="OutputText"
+                    AutomationProperties.AutomationId="OutputTextBlock"
+                    FontFamily="Consolas"
+                    Text="(nothing run yet)"
+                    TextWrapping="Wrap" />
+            </ScrollViewer>
+        </Border>
+
+        <mux:WebView2
+            x:Name="SUT"
+            Grid.Row="2"
+            Source="https://platform.uno/" />
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentAndProfile.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_EnvironmentAndProfile.xaml.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Web.WebView2.Core;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests
+{
+	/// <remarks>
+	/// Not gated to non-Windows: these APIs exist natively on WinAppSDK, so running the same page on both heads
+	/// is how their behaviour is compared. Every call is therefore behind a button and reports the exception it
+	/// gets, which is what a target that does not implement them will show.
+	/// </remarks>
+	[Sample("WebView", Name = "WebView2_EnvironmentAndProfile", Description = "Exercises the CoreWebView2Environment statics and the CoreWebView2.Environment / CoreWebView2.Profile surface, including ClearBrowsingDataAsync. Implemented on Skia Desktop for Windows; other targets report the exception they throw.", IsManualTest = true, IgnoreInSnapshotTests = true)]
+	public sealed partial class WebView2_EnvironmentAndProfile : Page
+	{
+		public WebView2_EnvironmentAndProfile()
+		{
+			this.InitializeComponent();
+		}
+
+		private void GetAvailableVersionClick(object sender, RoutedEventArgs e)
+			=> Report("GetAvailableBrowserVersionString()", () => CoreWebView2Environment.GetAvailableBrowserVersionString() ?? "(null)");
+
+		private void GetAvailableVersionFromFolderClick(object sender, RoutedEventArgs e)
+			=> Report(
+				$"GetAvailableBrowserVersionString(\"{FolderInput.Text}\")",
+				() => CoreWebView2Environment.GetAvailableBrowserVersionString(FolderInput.Text) ?? "(null)");
+
+		private void CompareVersionsClick(object sender, RoutedEventArgs e)
+			=> Report("CompareBrowserVersionString", () =>
+			{
+				var result = CoreWebView2Environment.CompareBrowserVersionString(VersionLeftInput.Text, VersionRightInput.Text);
+				return $"{result} (sign {Math.Sign(result)})";
+			});
+
+		private void ReadEnvironmentClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("CoreWebView2.Environment", core =>
+			{
+				var environment = core.Environment;
+				return Task.FromResult(string.Join(
+					Environment.NewLine,
+					$"BrowserVersionString    = {environment.BrowserVersionString}",
+					$"UserDataFolder          = {environment.UserDataFolder}",
+					$"FailureReportFolderPath = {environment.FailureReportFolderPath}",
+					$"BrowserProcessId        = {core.BrowserProcessId}"));
+			});
+
+		private void ReadProfileClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("CoreWebView2.Profile", core =>
+			{
+				var profile = core.Profile;
+				return Task.FromResult(string.Join(
+					Environment.NewLine,
+					$"ProfileName               = {profile.ProfileName}",
+					$"ProfilePath               = {profile.ProfilePath}",
+					$"IsInPrivateModeEnabled    = {profile.IsInPrivateModeEnabled}",
+					$"DefaultDownloadFolderPath = {profile.DefaultDownloadFolderPath}",
+					$"PreferredColorScheme      = {profile.PreferredColorScheme}"));
+			});
+
+		private void ToggleColorSchemeClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("Profile.PreferredColorScheme", core =>
+			{
+				var profile = core.Profile;
+				profile.PreferredColorScheme = profile.PreferredColorScheme switch
+				{
+					CoreWebView2PreferredColorScheme.Auto => CoreWebView2PreferredColorScheme.Light,
+					CoreWebView2PreferredColorScheme.Light => CoreWebView2PreferredColorScheme.Dark,
+					_ => CoreWebView2PreferredColorScheme.Auto,
+				};
+
+				return Task.FromResult(profile.PreferredColorScheme.ToString());
+			});
+
+		private void DumpProcessInfosClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("Environment.GetProcessInfos()", core => Task.FromResult(
+				string.Join(Environment.NewLine, core.Environment.GetProcessInfos().Select(info => $"{info.Kind} = {info.ProcessId}"))));
+
+		private void ClearAllClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("Profile.ClearBrowsingDataAsync()", async core =>
+			{
+				await core.Profile.ClearBrowsingDataAsync();
+				return "OK";
+			});
+
+		private void ClearKindsClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("Profile.ClearBrowsingDataAsync(AllProfile)", async core =>
+			{
+				await core.Profile.ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds.AllProfile);
+				return "OK";
+			});
+
+		private void ClearRangeClick(object sender, RoutedEventArgs e)
+			=> ReportCoreAsync("Profile.ClearBrowsingDataAsync(Cookies, -1h, now)", async core =>
+			{
+				await core.Profile.ClearBrowsingDataAsync(
+					CoreWebView2BrowsingDataKinds.Cookies,
+					DateTimeOffset.UtcNow.AddHours(-1),
+					DateTimeOffset.UtcNow);
+				return "OK";
+			});
+
+		private void Report(string operation, Func<string> action)
+		{
+			try
+			{
+				OutputText.Text = $"{operation}:{Environment.NewLine}{action()}";
+			}
+			catch (Exception ex)
+			{
+				OutputText.Text = $"{operation}:{Environment.NewLine}{ex.GetType().FullName}: {ex.Message}";
+			}
+		}
+
+		private async void ReportCoreAsync(string operation, Func<CoreWebView2, Task<string>> action)
+		{
+			OutputText.Text = $"{operation}:{Environment.NewLine}(running)";
+
+			try
+			{
+				await SUT.EnsureCoreWebView2Async();
+				OutputText.Text = $"{operation}:{Environment.NewLine}{await action(SUT.CoreWebView2)}";
+			}
+			catch (Exception ex)
+			{
+				OutputText.Text = $"{operation}:{Environment.NewLine}{ex.GetType().FullName}: {ex.Message}";
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Hosting/Win32Host.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Hosting/Win32Host.cs
@@ -91,6 +91,12 @@ public class Win32Host : SkiaHost, ISkiaApplicationHost
 		ApiExtensibility.Register<DragDropManager>(typeof(IDragDropExtension), manager => new Win32DragDropExtension(manager));
 		ApiExtensibility.Register<ContentPresenter>(typeof(ContentPresenter.INativeElementHostingExtension), o => new Win32NativeElementHostingExtension(o));
 		ApiExtensibility.Register<CoreWebView2>(typeof(INativeWebViewProvider), o => new Win32NativeWebViewProvider(o));
+#if NET10_0_OR_GREATER
+		// The statics are backed by WebView2Loader.dll through the WebView2Aot package, which is only referenced
+		// from net10.0. On net9.0 the WebView runs on the Microsoft.Web.WebView2 backend instead, and these stay
+		// NotImplemented.
+		ApiExtensibility.Register(typeof(ICoreWebView2EnvironmentStaticsExtension), _ => Win32CoreWebView2EnvironmentStaticsExtension.Instance);
+#endif
 		// We used to do this ApiExtensibility with ApiExtensionAttribute and a condition that makes it only run
 		// on Windows, but this causes problem on Wpf because we're registering Win32's MPE implementation even on WPF.
 		// This way, the Win32 MPE implementation is only registered when we're using

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32CoreWebView2EnvironmentStaticsExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32CoreWebView2EnvironmentStaticsExtension.cs
@@ -1,0 +1,71 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Runtime.InteropServices;
+
+using DirectN;
+
+using Microsoft.Web.WebView2.Core;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+/// <remarks>
+/// Intentionally holds no reference to <see cref="Win32NativeAotWebView"/>: these members exist to answer
+/// whether a browser is installed, so a missing WebView2 runtime must surface as a failure of the individual
+/// call rather than of anything created earlier.
+/// </remarks>
+internal class Win32CoreWebView2EnvironmentStaticsExtension : ICoreWebView2EnvironmentStaticsExtension
+{
+	public static Win32CoreWebView2EnvironmentStaticsExtension Instance { get; } = new();
+
+	private Win32CoreWebView2EnvironmentStaticsExtension() { }
+
+	public unsafe string GetAvailableBrowserVersionString(string? browserExecutableFolder)
+	{
+		Win32WebView2Loader.Ensure();
+
+		PWSTR versionInfo;
+		// A null pointer selects the installed browser; a non-empty folder is authoritative and the loader
+		// reports ERROR_FILE_NOT_FOUND rather than falling back when no browser is found there.
+		fixed (char* p_browserExecutableFolder = browserExecutableFolder)
+		{
+			Throw(WebView2.Functions
+				.GetAvailableCoreWebView2BrowserVersionString(new PWSTR(p_browserExecutableFolder), out versionInfo));
+		}
+
+		return versionInfo.ToStringAndDispose()!;
+	}
+
+	public unsafe int CompareBrowserVersionString(string browserVersionString1, string browserVersionString2)
+	{
+		Win32WebView2Loader.Ensure();
+
+		var result = 0;
+		fixed (char* p_browserVersionString1 = browserVersionString1, p_browserVersionString2 = browserVersionString2)
+		{
+			Throw(WebView2.Functions
+				.CompareBrowserVersions(new PWSTR(p_browserVersionString1), new PWSTR(p_browserVersionString2), ref result));
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Throws the CLR's exception for a failed <paramref name="hresult"/>, rather than DirectN's
+	/// <see cref="System.ComponentModel.Win32Exception"/>.
+	/// </summary>
+	/// <remarks>
+	/// These two members are how an app asks whether a browser is installed, so the exception type is part of the
+	/// contract rather than an implementation detail: WinAppSDK surfaces the CLR mapping, which turns
+	/// ERROR_FILE_NOT_FOUND into <see cref="System.IO.FileNotFoundException"/>. Keeping that mapping is what makes
+	/// a <c>catch (FileNotFoundException)</c> written against Windows behave the same here. The -1 ignores any
+	/// IErrorInfo left on the thread by an unrelated COM call; these are plain C exports and set none.
+	/// </remarks>
+	private static void Throw(HRESULT hresult)
+	{
+		if (hresult.IsError)
+		{
+			Marshal.ThrowExceptionForHR(hresult.Value, new IntPtr(-1));
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Profile.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.Profile.cs
@@ -1,0 +1,212 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using DirectN;
+
+using Microsoft.Web.WebView2.Core;
+
+using Uno.UI.Xaml.Controls;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+/// <remarks>
+/// Every member here is affine to the thread owning the WebView2 HWND, like the rest of this class. Calling
+/// them from another thread yields RPC_E_WRONG_THREAD.
+/// </remarks>
+internal sealed partial class Win32NativeAotWebView : ISupportsBrowsingDataClearing, ISupportsWebViewProfile, ISupportsWebViewEnvironmentInfo
+{
+	private WebView2.ICoreWebView2Profile2? _profile;
+	private WebView2.ICoreWebView2Environment11? _environment;
+
+	// The core WebView is obtained as ICoreWebView2_22 (WebView2 SDK 1.0.2792), which is newer than every
+	// interface used here - ICoreWebView2Profile2 and ICoreWebView2Environment11 both predate it. A runtime
+	// able to create the WebView at all satisfies these casts, so there is no version ladder to walk.
+	private WebView2.ICoreWebView2Profile2 NativeProfile
+	{
+		get
+		{
+			if (_profile is null)
+			{
+				_nativeWebView.get_Profile(out var profile).ThrowOnError();
+				_profile = (WebView2.ICoreWebView2Profile2)profile;
+			}
+
+			return _profile;
+		}
+	}
+
+	private WebView2.ICoreWebView2Environment11 NativeEnvironment
+	{
+		get
+		{
+			if (_environment is null)
+			{
+				_nativeWebView.get_Environment(out var environment).ThrowOnError();
+				_environment = (WebView2.ICoreWebView2Environment11)environment;
+			}
+
+			return _environment;
+		}
+	}
+
+	public uint BrowserProcessId
+	{
+		get
+		{
+			uint browserProcessId = default;
+			_nativeWebView.get_BrowserProcessId(ref browserProcessId).ThrowOnError();
+			return browserProcessId;
+		}
+	}
+
+	public string BrowserVersionString
+	{
+		get
+		{
+			NativeEnvironment.get_BrowserVersionString(out var browserVersionString).ThrowOnError();
+			return browserVersionString.ToStringAndDispose()!;
+		}
+	}
+
+	public string UserDataFolder
+	{
+		get
+		{
+			NativeEnvironment.get_UserDataFolder(out var userDataFolder).ThrowOnError();
+			return userDataFolder.ToStringAndDispose()!;
+		}
+	}
+
+	public string FailureReportFolderPath
+	{
+		get
+		{
+			NativeEnvironment.get_FailureReportFolderPath(out var failureReportFolderPath).ThrowOnError();
+			return failureReportFolderPath.ToStringAndDispose()!;
+		}
+	}
+
+	public IReadOnlyList<CoreWebView2ProcessInfo> GetProcessInfos()
+	{
+		NativeEnvironment.GetProcessInfos(out var collection).ThrowOnError();
+
+		uint count = default;
+		collection.get_Count(ref count).ThrowOnError();
+
+		var processInfos = new CoreWebView2ProcessInfo[count];
+		for (var i = 0u; i < count; i++)
+		{
+			collection.GetValueAtIndex(i, out var processInfo).ThrowOnError();
+
+			var processId = 0;
+			WebView2.COREWEBVIEW2_PROCESS_KIND kind = default;
+			processInfo.get_ProcessId(ref processId).ThrowOnError();
+			processInfo.get_Kind(ref kind).ThrowOnError();
+
+			processInfos[i] = new CoreWebView2ProcessInfo(processId, (CoreWebView2ProcessKind)(int)kind);
+		}
+
+		return processInfos;
+	}
+
+	public string ProfileName
+	{
+		get
+		{
+			NativeProfile.get_ProfileName(out var profileName).ThrowOnError();
+			return profileName.ToStringAndDispose()!;
+		}
+	}
+
+	public string ProfilePath
+	{
+		get
+		{
+			NativeProfile.get_ProfilePath(out var profilePath).ThrowOnError();
+			return profilePath.ToStringAndDispose()!;
+		}
+	}
+
+	public bool IsInPrivateModeEnabled
+	{
+		get
+		{
+			BOOL isInPrivateModeEnabled = default;
+			NativeProfile.get_IsInPrivateModeEnabled(ref isInPrivateModeEnabled).ThrowOnError();
+			return isInPrivateModeEnabled.Value != 0;
+		}
+	}
+
+	public unsafe string DefaultDownloadFolderPath
+	{
+		get
+		{
+			NativeProfile.get_DefaultDownloadFolderPath(out var defaultDownloadFolderPath).ThrowOnError();
+			return defaultDownloadFolderPath.ToStringAndDispose()!;
+		}
+		set
+		{
+			fixed (char* p_value = value)
+			{
+				NativeProfile.put_DefaultDownloadFolderPath(new PWSTR(p_value)).ThrowOnError();
+			}
+		}
+	}
+
+	public CoreWebView2PreferredColorScheme PreferredColorScheme
+	{
+		get
+		{
+			WebView2.COREWEBVIEW2_PREFERRED_COLOR_SCHEME preferredColorScheme = default;
+			NativeProfile.get_PreferredColorScheme(ref preferredColorScheme).ThrowOnError();
+			return (CoreWebView2PreferredColorScheme)(int)preferredColorScheme;
+		}
+		set => NativeProfile
+			.put_PreferredColorScheme((WebView2.COREWEBVIEW2_PREFERRED_COLOR_SCHEME)(int)value)
+			.ThrowOnError();
+	}
+
+	public Task ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds? dataKinds, DateTimeOffset? startTime, DateTimeOffset? endTime)
+	{
+		// RunContinuationsAsynchronously: the handler runs while the WebView2 message loop is being pumped, and
+		// continuations after clearing routinely call straight back into the WebView (Reload, Navigate).
+		var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var handler = new WebView2.Utilities.CoreWebView2ClearBrowsingDataCompletedHandler(errorCode =>
+		{
+			if (errorCode.IsError)
+			{
+				tcs.TrySetException(errorCode.GetException() ?? new InvalidOperationException("Failed to clear the browsing data."));
+			}
+			else
+			{
+				tcs.TrySetResult();
+			}
+		});
+
+		var profile = NativeProfile;
+		if (dataKinds is not { } kinds)
+		{
+			profile.ClearBrowsingDataAll(handler).ThrowOnError();
+		}
+		else if (startTime is null && endTime is null)
+		{
+			profile.ClearBrowsingData((WebView2.COREWEBVIEW2_BROWSING_DATA_KINDS)(int)kinds, handler).ThrowOnError();
+		}
+		else
+		{
+			profile.ClearBrowsingDataInTimeRange(
+				(WebView2.COREWEBVIEW2_BROWSING_DATA_KINDS)(int)kinds,
+				ToUnixSeconds(startTime ?? DateTimeOffset.UnixEpoch),
+				ToUnixSeconds(endTime ?? DateTimeOffset.MaxValue),
+				handler).ThrowOnError();
+		}
+
+		return tcs.Task;
+	}
+
+	// The native time range is expressed in seconds since the UNIX epoch.
+	private static double ToUnixSeconds(DateTimeOffset value) => value.ToUnixTimeMilliseconds() / 1000d;
+}
+#endif

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32NativeAotWebView.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,11 +22,9 @@ using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Xaml.Controls;
 
-using WebView2Utilities = WebView2.Utilities.WebView2Utilities;
-
 namespace Uno.UI.Runtime.Skia.Win32;
 
-internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsVirtualHostMapping, ISupportsWebResourceRequested
+internal sealed partial class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsVirtualHostMapping, ISupportsWebResourceRequested
 {
 	private readonly CoreWebView2 _coreWebView;
 	private readonly WebView2.ICoreWebView2_22 _nativeWebView;
@@ -37,17 +33,7 @@ internal sealed class Win32NativeAotWebView : Win32NativeWebViewBase, ISupportsV
 	private Dictionary<ulong, string> _navigationIdToUriMap = new();
 	private string _documentTitle = string.Empty;
 
-	static Win32NativeAotWebView()
-	{
-		// WebView2Utilities.Initialize probes only next to Environment.ProcessPath, which is the
-		// dotnet host's directory when launched as `dotnet app.dll`. In that case, fall back to
-		// resolving through the runtime, which honors deps.json and AppContext.BaseDirectory.
-		if (WebView2Utilities.Initialize(Assembly.GetEntryAssembly(), throwOnError: false).IsError
-			&& !NativeLibrary.TryLoad("WebView2Loader.dll", typeof(WebView2.Functions).Assembly, null, out _))
-		{
-			throw new DllNotFoundException("Cannot load WebView2Loader.dll. Make sure it's deployed next to the application or resolvable through its deps.json.");
-		}
-	}
+	static Win32NativeAotWebView() => Win32WebView2Loader.Ensure();
 
 	public Win32NativeAotWebView(CoreWebView2 owner, ContentPresenter presenter)
 	: base(presenter)

--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32WebView2Loader.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Controls/WebView/Win32WebView2Loader.cs
@@ -1,0 +1,47 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using WebView2Utilities = WebView2.Utilities.WebView2Utilities;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+internal static class Win32WebView2Loader
+{
+	private static readonly object _gate = new();
+	private static bool _loaded;
+
+	/// <summary>
+	/// Loads WebView2Loader.dll, at most once per process.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately not a static constructor: a type initializer caches its failure, so the first
+	/// <see cref="DllNotFoundException"/> would be wrapped in a TypeInitializationException and replayed for the
+	/// rest of the process. An explicit guard reports the real error on every attempt. This is reachable without
+	/// any WebView2 instance, because <see cref="Microsoft.Web.WebView2.Core.CoreWebView2Environment"/>'s statics
+	/// answer whether a browser is installed at all.
+	/// </remarks>
+	internal static void Ensure()
+	{
+		lock (_gate)
+		{
+			if (_loaded)
+			{
+				return;
+			}
+
+			// WebView2Utilities.Initialize probes only next to Environment.ProcessPath, which is the
+			// dotnet host's directory when launched as `dotnet app.dll`. In that case, fall back to
+			// resolving through the runtime, which honors deps.json and AppContext.BaseDirectory.
+			if (WebView2Utilities.Initialize(Assembly.GetEntryAssembly(), throwOnError: false).IsError
+				&& !NativeLibrary.TryLoad("WebView2Loader.dll", typeof(WebView2.Functions).Assembly, null, out _))
+			{
+				throw new DllNotFoundException("Cannot load WebView2Loader.dll. Make sure it's deployed next to the application or resolvable through its deps.json.");
+			}
+
+			_loaded = true;
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Environment.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Environment.cs
@@ -37,22 +37,10 @@ public class Given_CoreWebView2Environment
 	{
 		var missingFolder = Path.Combine(Path.GetTempPath(), "uno-webview2-missing-" + Guid.NewGuid().ToString("N"));
 
-		Exception caught = null;
-		try
-		{
-			CoreWebView2Environment.GetAvailableBrowserVersionString(missingFolder);
-		}
-		catch (Exception ex)
-		{
-			caught = ex;
-		}
-
 		// An explicit folder is authoritative: it must fail rather than fall back to the installed browser.
-		Assert.IsNotNull(caught, "Expected a missing browserExecutableFolder to fail.");
-
 		// The type is the contract, not an implementation detail: this is how an app detects a missing runtime,
 		// so it has to match what WinAppSDK surfaces for the same ERROR_FILE_NOT_FOUND.
-		Assert.IsInstanceOfType<FileNotFoundException>(caught, $"Got {caught.GetType().FullName}: {caught.Message}");
+		Assert.Throws<FileNotFoundException>(() => CoreWebView2Environment.GetAvailableBrowserVersionString(missingFolder));
 	}
 
 	[TestMethod]
@@ -77,6 +65,8 @@ public class Given_CoreWebView2Environment
 		}
 		catch (Exception ex)
 		{
+			// Deliberately broad: a missing runtime is FileNotFoundException, a missing loader DllNotFoundException,
+			// and a target without the extension NotImplementedException. All of them mean inconclusive, not failed.
 			failure = ex;
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Environment.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Environment.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using Microsoft.Web.WebView2.Core;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_Web_WebView2_Core;
+
+/// <remarks>
+/// These members are statics over the browser loader, so nothing here needs a WebView2 in the visual tree.
+/// That is exactly what makes them worth testing: they must answer before any WebView2 exists.
+/// </remarks>
+[TestClass]
+[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
+public class Given_CoreWebView2Environment
+{
+	[TestMethod]
+	public void When_GetAvailableBrowserVersionString_Returns_Parsable_Version()
+	{
+		var version = RequireBrowserVersion();
+
+		// Non-stable channels append a space-separated suffix, for example "120.0.2210.91 beta".
+		var versionToken = version.Split(' ')[0];
+
+		Assert.IsTrue(Version.TryParse(versionToken, out var parsed), $"'{version}' does not start with a parsable version.");
+		Assert.IsTrue(parsed.Major > 0, $"'{version}' has an unexpected major version.");
+	}
+
+	[TestMethod]
+	[DataRow(null)]
+	[DataRow("")]
+	public void When_GetAvailableBrowserVersionString_Default_Folder_Matches(string browserExecutableFolder)
+	{
+		Assert.AreEqual(RequireBrowserVersion(), CoreWebView2Environment.GetAvailableBrowserVersionString(browserExecutableFolder));
+	}
+
+	[TestMethod]
+	public void When_GetAvailableBrowserVersionString_Missing_Folder_Throws()
+	{
+		var missingFolder = Path.Combine(Path.GetTempPath(), "uno-webview2-missing-" + Guid.NewGuid().ToString("N"));
+
+		Exception caught = null;
+		try
+		{
+			CoreWebView2Environment.GetAvailableBrowserVersionString(missingFolder);
+		}
+		catch (Exception ex)
+		{
+			caught = ex;
+		}
+
+		// An explicit folder is authoritative: it must fail rather than fall back to the installed browser.
+		Assert.IsNotNull(caught, "Expected a missing browserExecutableFolder to fail.");
+
+		// The type is the contract, not an implementation detail: this is how an app detects a missing runtime,
+		// so it has to match what WinAppSDK surfaces for the same ERROR_FILE_NOT_FOUND.
+		Assert.IsInstanceOfType<FileNotFoundException>(caught, $"Got {caught.GetType().FullName}: {caught.Message}");
+	}
+
+	[TestMethod]
+	[DataRow("1.0.0.0", "2.0.0.0", -1)]
+	[DataRow("2.0.0.0", "1.0.0.0", 1)]
+	[DataRow("1.0.0.0", "1.0.0.0", 0)]
+	[DataRow("120.0.2210.91", "120.0.2210.133", -1)]
+	public void When_CompareBrowserVersionString_Orders_Versions(string left, string right, int expectedSign)
+	{
+		// The contract is a sign, not a magnitude. This needs the loader but no installed browser.
+		Assert.AreEqual(expectedSign, Math.Sign(CoreWebView2Environment.CompareBrowserVersionString(left, right)));
+	}
+
+	private static string RequireBrowserVersion()
+	{
+		string version = null;
+		Exception failure = null;
+
+		try
+		{
+			version = CoreWebView2Environment.GetAvailableBrowserVersionString();
+		}
+		catch (Exception ex)
+		{
+			failure = ex;
+		}
+
+		// Outside the catch, so the AssertInconclusiveException is not swallowed.
+		if (failure is not null)
+		{
+			Assert.Inconclusive($"The WebView2 Runtime is unavailable: {failure.GetType().FullName}: {failure.Message}");
+		}
+
+		if (string.IsNullOrEmpty(version))
+		{
+			Assert.Inconclusive("The WebView2 Runtime reported no version.");
+		}
+
+		return version;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Profile.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Profile.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Web.WebView2.Core;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_Web_WebView2_Core;
+
+[TestClass]
+[RunsOnUIThread]
+[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaWin32)]
+public class Given_CoreWebView2Profile
+{
+	private static readonly TimeSpan ClearBrowsingDataTimeout = TimeSpan.FromSeconds(30);
+
+	/// <summary>
+	/// Undoes the footprint <see cref="CreateCoreWebView2Async"/> leaves in the visual tree.
+	/// </summary>
+	/// <remarks>
+	/// Every test here loads a live WebView2, which is a whole browser process tree rather than an ordinary
+	/// element. The harness only unloads test content when IsUnloadingTestContent is set, and the headless
+	/// runner behind --runtime-tests builds its config without it, so nothing would clear these. Left in place
+	/// they stay loaded and pumping messages for the remainder of the run, which is both a leak and a way for
+	/// these tests to destabilize unrelated ones.
+	/// </remarks>
+	[TestCleanup]
+	public void Cleanup() => TestServices.WindowHelper.WindowContent = null;
+
+	[TestMethod]
+	public async Task When_Profile_And_Environment_Are_Available()
+	{
+		var coreWebView = await CreateCoreWebView2Async();
+
+		Assert.IsNotNull(coreWebView.Profile);
+		Assert.IsNotNull(coreWebView.Environment);
+
+#if HAS_UNO
+		// Uno caches both facades per CoreWebView2. A WinRT projection may hand back distinct wrappers,
+		// so this identity guarantee is Uno-specific.
+		Assert.AreSame(coreWebView.Profile, coreWebView.Profile);
+		Assert.AreSame(coreWebView.Environment, coreWebView.Environment);
+#endif
+	}
+
+	[TestMethod]
+	public async Task When_Environment_Reports_Paths_And_Version()
+	{
+		var environment = (await CreateCoreWebView2Async()).Environment;
+
+		Assert.IsTrue(Path.IsPathRooted(environment.UserDataFolder), $"'{environment.UserDataFolder}' is not rooted.");
+		Assert.IsTrue(Directory.Exists(environment.UserDataFolder), $"'{environment.UserDataFolder}' does not exist.");
+
+		// Created lazily on the first crash, so only the shape is asserted.
+		Assert.IsFalse(string.IsNullOrEmpty(environment.FailureReportFolderPath));
+		Assert.IsTrue(Path.IsPathRooted(environment.FailureReportFolderPath));
+
+		// The environment is created without an explicit browserExecutableFolder, so it must resolve to
+		// the same browser the static reports.
+		Assert.AreEqual(CoreWebView2Environment.GetAvailableBrowserVersionString(), environment.BrowserVersionString);
+	}
+
+	[TestMethod]
+	public async Task When_Profile_Paths_Are_Consistent_With_Environment()
+	{
+		var coreWebView = await CreateCoreWebView2Async();
+		var profile = coreWebView.Profile;
+
+		// Empty, not "Default": the controller is created without ICoreWebView2ControllerOptions, so no
+		// profile name is ever requested even though the profile directory resolves to "Default".
+		Assert.IsNotNull(profile.ProfileName);
+		Assert.IsTrue(Path.IsPathRooted(profile.ProfilePath), $"'{profile.ProfilePath}' is not rooted.");
+		Assert.IsTrue(
+			profile.ProfilePath.StartsWith(coreWebView.Environment.UserDataFolder, StringComparison.OrdinalIgnoreCase),
+			$"'{profile.ProfilePath}' is not under '{coreWebView.Environment.UserDataFolder}'.");
+		Assert.IsFalse(profile.IsInPrivateModeEnabled);
+		Assert.IsTrue(Path.IsPathRooted(profile.DefaultDownloadFolderPath), $"'{profile.DefaultDownloadFolderPath}' is not rooted.");
+	}
+
+	[TestMethod]
+	public async Task When_PreferredColorScheme_Round_Trips()
+	{
+		var profile = (await CreateCoreWebView2Async()).Profile;
+		var original = profile.PreferredColorScheme;
+
+		try
+		{
+			profile.PreferredColorScheme = CoreWebView2PreferredColorScheme.Dark;
+			Assert.AreEqual(CoreWebView2PreferredColorScheme.Dark, profile.PreferredColorScheme);
+
+			profile.PreferredColorScheme = CoreWebView2PreferredColorScheme.Light;
+			Assert.AreEqual(CoreWebView2PreferredColorScheme.Light, profile.PreferredColorScheme);
+		}
+		finally
+		{
+			// Unlike the visual tree, this is persisted on disk and outlives the process, so it cannot be
+			// left to Cleanup: it must be restored or it leaks into every later test and into manual runs.
+			profile.PreferredColorScheme = original;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_BrowserProcessId_Is_Reported()
+	{
+		Assert.AreNotEqual(0u, (await CreateCoreWebView2Async()).BrowserProcessId);
+	}
+
+	[TestMethod]
+	public async Task When_GetProcessInfos_Includes_The_Browser_Process()
+	{
+		var coreWebView = await CreateCoreWebView2Async();
+		var processInfos = coreWebView.Environment.GetProcessInfos();
+
+		Assert.IsNotNull(processInfos);
+
+		// Renderer, GPU and utility processes appear asynchronously, so neither the count nor the set of
+		// kinds is deterministic. Only the browser process is guaranteed once the controller exists.
+		Assert.IsTrue(
+			processInfos.Any(info => info.Kind == CoreWebView2ProcessKind.Browser && (uint)info.ProcessId == coreWebView.BrowserProcessId),
+			"GetProcessInfos did not report the browser process.");
+		Assert.IsTrue(processInfos.All(info => info.ProcessId != 0));
+	}
+
+	[TestMethod]
+	[DataRow(0)]
+	[DataRow(1)]
+	[DataRow(2)]
+	public async Task When_ClearBrowsingDataAsync_Completes(int overload)
+	{
+		var profile = (await CreateCoreWebView2Async()).Profile;
+
+		// There is no cheap positive observable for "the data is gone", so the assertion is that the
+		// operation completes rather than hangs. The bound turns a native hang into one failed test
+		// instead of a stalled run.
+		var clearing = overload switch
+		{
+			0 => profile.ClearBrowsingDataAsync(),
+			1 => profile.ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds.AllProfile),
+			_ => profile.ClearBrowsingDataAsync(
+				CoreWebView2BrowsingDataKinds.Cookies,
+				DateTimeOffset.UtcNow.AddHours(-1),
+				DateTimeOffset.UtcNow),
+		};
+
+		await clearing.AsTask().WaitAsync(ClearBrowsingDataTimeout);
+	}
+
+	/// <remarks>
+	/// The WebView2 this loads is removed by <see cref="Cleanup"/>.
+	/// </remarks>
+	private static async Task<CoreWebView2> CreateCoreWebView2Async()
+	{
+		var border = new Border();
+		var webView = new WebView2 { Width = 200, Height = 200 };
+		border.Child = webView;
+
+		await UITestHelper.Load(border);
+		await webView.EnsureCoreWebView2Async();
+
+		Assert.IsNotNull(webView.CoreWebView2, "The CoreWebView2 was not initialized.");
+		return webView.CoreWebView2;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Profile.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_Web_WebView2_Core/Given_CoreWebView2Profile.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
 using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_Web_WebView2_Core;
 
@@ -15,6 +14,10 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_Web_WebView2_Core;
 public class Given_CoreWebView2Profile
 {
 	private static readonly TimeSpan ClearBrowsingDataTimeout = TimeSpan.FromSeconds(30);
+
+	// The Win32 WebView2 constructor blocks the UI thread in a nested pump while the environment and
+	// controller are created; that cold start outlasts the 1s default on CI.
+	private const int LoadTimeoutMS = 10_000;
 
 	/// <summary>
 	/// Undoes the footprint <see cref="CreateCoreWebView2Async"/> leaves in the visual tree.
@@ -156,7 +159,10 @@ public class Given_CoreWebView2Profile
 		var webView = new WebView2 { Width = 200, Height = 200 };
 		border.Child = webView;
 
-		await UITestHelper.Load(border);
+		TestServices.WindowHelper.WindowContent = border;
+		await TestServices.WindowHelper.WaitForLoaded(border, timeoutMS: LoadTimeoutMS);
+		await TestServices.WindowHelper.WaitForIdle();
+
 		await webView.EnsureCoreWebView2Async();
 
 		Assert.IsNotNull(webView.CoreWebView2, "The CoreWebView2 was not initialized.");

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2.cs
@@ -8,16 +8,7 @@ namespace Microsoft.Web.WebView2.Core
 #endif
 	public partial class CoreWebView2
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public uint BrowserProcessId
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2", "BrowserProcessId");
-			}
-		}
-#endif
+		// Skipping already declared property BrowserProcessId
 		// Skipping already declared property CanGoBack
 		// Skipping already declared property CanGoForward
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
@@ -69,16 +60,7 @@ namespace Microsoft.Web.WebView2.Core
 		}
 #endif
 		// Skipping already declared property DocumentTitle
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.Web.WebView2.Core.CoreWebView2Environment Environment
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2", "Environment");
-			}
-		}
-#endif
+		// Skipping already declared property Environment
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public string FaviconUri
@@ -167,16 +149,7 @@ namespace Microsoft.Web.WebView2.Core
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.Web.WebView2.Core.CoreWebView2Profile Profile
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2", "Profile");
-			}
-		}
-#endif
+		// Skipping already declared property Profile
 		// Skipping already declared property Settings
 		// Skipping already declared property Source
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2Environment.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2Environment.cs
@@ -3,46 +3,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.Web.WebView2.Core
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class CoreWebView2Environment
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		internal CoreWebView2Environment()
-		{
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public string BrowserVersionString
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "BrowserVersionString");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public string FailureReportFolderPath
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "FailureReportFolderPath");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public string UserDataFolder
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "UserDataFolder");
-			}
-		}
-#endif
+		// Skipping already declared property BrowserVersionString
+		// Skipping already declared property FailureReportFolderPath
+		// Skipping already declared property UserDataFolder
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public static global::Windows.Foundation.IAsyncOperation<global::Microsoft.Web.WebView2.Core.CoreWebView2Environment> CreateAsync()
@@ -57,27 +25,9 @@ namespace Microsoft.Web.WebView2.Core
 			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "CreateWithOptionsAsync(string browserExecutableFolder, string userDataFolder, CoreWebView2EnvironmentOptions options)");
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static string GetAvailableBrowserVersionString()
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "GetAvailableBrowserVersionString()");
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static string GetAvailableBrowserVersionString(string browserExecutableFolder)
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "GetAvailableBrowserVersionString(string browserExecutableFolder)");
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public static int CompareBrowserVersionString(string browserVersionString1, string browserVersionString2)
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "CompareBrowserVersionString(string browserVersionString1, string browserVersionString2)");
-		}
-#endif
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Environment.GetAvailableBrowserVersionString()
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Environment.GetAvailableBrowserVersionString(string)
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Environment.CompareBrowserVersionString(string, string)
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public static string GetAvailableBrowserVersionString(string browserExecutableFolder, global::Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions options)
@@ -157,13 +107,7 @@ namespace Microsoft.Web.WebView2.Core
 			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "CreatePrintSettings()");
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::System.Collections.Generic.IReadOnlyList<global::Microsoft.Web.WebView2.Core.CoreWebView2ProcessInfo> GetProcessInfos()
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Environment", "GetProcessInfos()");
-		}
-#endif
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Environment.GetProcessInfos()
 		// Forced skipping of method Microsoft.Web.WebView2.Core.CoreWebView2Environment.ProcessInfosChanged.add
 		// Forced skipping of method Microsoft.Web.WebView2.Core.CoreWebView2Environment.ProcessInfosChanged.remove
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2ProcessInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2ProcessInfo.cs
@@ -3,36 +3,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.Web.WebView2.Core
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class CoreWebView2ProcessInfo
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		internal CoreWebView2ProcessInfo()
-		{
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.Web.WebView2.Core.CoreWebView2ProcessKind Kind
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2ProcessInfo", "Kind");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public int ProcessId
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2ProcessInfo", "ProcessId");
-			}
-		}
-#endif
+		// Skipping already declared property Kind
+		// Skipping already declared property ProcessId
 		// Forced skipping of method Microsoft.Web.WebView2.Core.CoreWebView2ProcessInfo.Kind.get
 		// Forced skipping of method Microsoft.Web.WebView2.Core.CoreWebView2ProcessInfo.ProcessId.get
 	}

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2Profile.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.Web.WebView2.Core/CoreWebView2Profile.cs
@@ -3,16 +3,11 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.Web.WebView2.Core
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class CoreWebView2Profile
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		internal CoreWebView2Profile()
-		{
-		}
-#endif
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public global::Microsoft.Web.WebView2.Core.CoreWebView2CookieManager CookieManager
@@ -23,20 +18,7 @@ namespace Microsoft.Web.WebView2.Core
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public string DefaultDownloadFolderPath
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "DefaultDownloadFolderPath");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "DefaultDownloadFolderPath");
-			}
-		}
-#endif
+		// Skipping already declared property DefaultDownloadFolderPath
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public bool IsGeneralAutofillEnabled
@@ -51,16 +33,7 @@ namespace Microsoft.Web.WebView2.Core
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public bool IsInPrivateModeEnabled
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "IsInPrivateModeEnabled");
-			}
-		}
-#endif
+		// Skipping already declared property IsInPrivateModeEnabled
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public bool IsPasswordAutosaveEnabled
@@ -75,20 +48,7 @@ namespace Microsoft.Web.WebView2.Core
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Microsoft.Web.WebView2.Core.CoreWebView2PreferredColorScheme PreferredColorScheme
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "PreferredColorScheme");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "PreferredColorScheme");
-			}
-		}
-#endif
+		// Skipping already declared property PreferredColorScheme
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public global::Microsoft.Web.WebView2.Core.CoreWebView2TrackingPreventionLevel PreferredTrackingPreventionLevel
@@ -103,40 +63,10 @@ namespace Microsoft.Web.WebView2.Core
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public string ProfileName
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "ProfileName");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public string ProfilePath
-		{
-			get
-			{
-				throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "ProfilePath");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Windows.Foundation.IAsyncAction ClearBrowsingDataAsync(global::Microsoft.Web.WebView2.Core.CoreWebView2BrowsingDataKinds dataKinds, global::System.DateTimeOffset startTime, global::System.DateTimeOffset endTime)
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds dataKinds, DateTimeOffset startTime, DateTimeOffset endTime)");
-		}
-#endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Windows.Foundation.IAsyncAction ClearBrowsingDataAsync()
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "ClearBrowsingDataAsync()");
-		}
-#endif
+		// Skipping already declared property ProfileName
+		// Skipping already declared property ProfilePath
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Profile.ClearBrowsingDataAsync(Microsoft.Web.WebView2.Core.CoreWebView2BrowsingDataKinds, System.DateTimeOffset, System.DateTimeOffset)
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Profile.ClearBrowsingDataAsync()
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Microsoft.Web.WebView2.Core.CoreWebView2PermissionSetting>> GetNonDefaultPermissionSettingsAsync()
@@ -151,13 +81,7 @@ namespace Microsoft.Web.WebView2.Core
 			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "GetBrowserExtensionsAsync()");
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Windows.Foundation.IAsyncAction ClearBrowsingDataAsync(global::Microsoft.Web.WebView2.Core.CoreWebView2BrowsingDataKinds dataKinds)
-		{
-			throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException("Microsoft.Web.WebView2.Core.CoreWebView2Profile", "ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds dataKinds)");
-		}
-#endif
+		// Skipping already declared method Microsoft.Web.WebView2.Core.CoreWebView2Profile.ClearBrowsingDataAsync(Microsoft.Web.WebView2.Core.CoreWebView2BrowsingDataKinds)
 #if __ANDROID__ || __IOS__ || __TVOS__ || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public global::Windows.Foundation.IAsyncAction SetPermissionStateAsync(global::Microsoft.Web.WebView2.Core.CoreWebView2PermissionKind PermissionKind, string origin, global::Microsoft.Web.WebView2.Core.CoreWebView2PermissionState State)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.Properties.cs
@@ -1,11 +1,58 @@
 ﻿using Windows.Foundation;
 using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Xaml.Controls;
 
 namespace Microsoft.Web.WebView2.Core;
 #pragma warning disable CS0067 // TODO:MZ: Undo this
 public partial class CoreWebView2
 {
+	private const string CoreWebView2TypeName = "Microsoft.Web.WebView2.Core.CoreWebView2";
+
 	private string _source = "";
+	private CoreWebView2Profile _profile;
+	private CoreWebView2Environment _environment;
+
+	/// <summary>
+	/// Gets the process ID of the browser process that hosts the WebView.
+	/// </summary>
+	public uint BrowserProcessId
+		=> RequireCapability<ISupportsWebViewEnvironmentInfo>(CoreWebView2TypeName, nameof(BrowserProcessId)).BrowserProcessId;
+
+	/// <summary>
+	/// Gets the CoreWebView2Environment this CoreWebView2 was created from.
+	/// </summary>
+	public CoreWebView2Environment Environment
+	{
+		get
+		{
+			if (_nativeWebView is not ISupportsWebViewEnvironmentInfo)
+			{
+				throw CapabilityUnavailable(CoreWebView2TypeName, nameof(Environment));
+			}
+
+			return _environment ??= new CoreWebView2Environment(this);
+		}
+	}
+
+	/// <summary>
+	/// Gets the profile this CoreWebView2 is running under.
+	/// </summary>
+	/// <remarks>
+	/// A platform may implement profile metadata, browsing-data clearing, or both, so the facade is handed out
+	/// when either is available and the individual members report what is missing.
+	/// </remarks>
+	public CoreWebView2Profile Profile
+	{
+		get
+		{
+			if (_nativeWebView is not (ISupportsWebViewProfile or ISupportsBrowsingDataClearing))
+			{
+				throw CapabilityUnavailable(CoreWebView2TypeName, nameof(Profile));
+			}
+
+			return _profile ??= new CoreWebView2Profile(this);
+		}
+	}
 
 	/// <summary>
 	/// True if the WebView is able to navigate to a previous page in the navigation history.

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.Properties.cs
@@ -9,8 +9,13 @@ public partial class CoreWebView2
 	private const string CoreWebView2TypeName = "Microsoft.Web.WebView2.Core.CoreWebView2";
 
 	private string _source = "";
-	private CoreWebView2Profile _profile;
-	private CoreWebView2Environment _environment;
+
+	// Scoped rather than file-wide: the events below are nullable-oblivious and flipping the whole file
+	// would annotate the public surface.
+#nullable enable
+	private CoreWebView2Profile? _profile;
+	private CoreWebView2Environment? _environment;
+#nullable restore
 
 	/// <summary>
 	/// Gets the process ID of the browser process that hosts the WebView.

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
@@ -114,6 +114,25 @@ public partial class CoreWebView2
 		}
 	}
 
+	/// <summary>
+	/// Resolves an optional capability of the native WebView, or throws describing why it is unavailable.
+	/// </summary>
+	internal T RequireCapability<T>(string typeName, string memberName)
+		where T : class
+		=> _nativeWebView as T ?? throw CapabilityUnavailable(typeName, memberName);
+
+	/// <summary>
+	/// Builds the exception for a capability the native WebView cannot serve, distinguishing "not initialized
+	/// yet" from "this platform does not implement it". The latter reproduces the generated stub exactly, so
+	/// platforms that do not opt in keep their current behaviour and not-implemented reporting.
+	/// </summary>
+	internal Exception CapabilityUnavailable(string typeName, string memberName)
+		=> _nativeWebView is null
+			? new InvalidOperationException(
+				$"The native WebView is not initialized, so {typeName}.{memberName} is unavailable. " +
+				"Await WebView2.EnsureCoreWebView2Async() before using this member.")
+			: global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException(typeName, memberName);
+
 	internal void NavigateWithHttpRequestMessage(global::Windows.Web.Http.HttpRequestMessage requestMessage)
 	{
 		if (requestMessage?.RequestUri is null)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
@@ -130,7 +130,7 @@ public partial class CoreWebView2
 		=> _nativeWebView is null
 			? new InvalidOperationException(
 				$"The native WebView is not initialized, so {typeName}.{memberName} is unavailable. " +
-				"Await WebView2.EnsureCoreWebView2Async() before using this member.")
+				"Await the WebView2 control's EnsureCoreWebView2Async() before using this member.")
 			: global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException(typeName, memberName);
 
 	internal void NavigateWithHttpRequestMessage(global::Windows.Web.Http.HttpRequestMessage requestMessage)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2Environment.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2Environment.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Uno.Foundation.Extensibility;
+using Uno.UI.Xaml.Controls;
+
+namespace Microsoft.Web.WebView2.Core;
+
+/// <summary>
+/// Represents the browser environment a WebView runs under.
+/// </summary>
+/// <remarks>
+/// The members fall into two groups with different requirements. The statics report which browser is installed
+/// and must answer before any WebView exists, so they resolve through <see cref="ICoreWebView2EnvironmentStaticsExtension"/>.
+/// The instance members describe the environment of a live WebView and resolve through the owning
+/// <see cref="CoreWebView2"/>. Because <see cref="CreateAsync"/> is not implemented, the only way to obtain an
+/// instance is <see cref="CoreWebView2.Environment"/>.
+/// </remarks>
+public partial class CoreWebView2Environment
+{
+	private const string TypeName = "Microsoft.Web.WebView2.Core.CoreWebView2Environment";
+
+	private readonly CoreWebView2 _owner;
+
+	internal CoreWebView2Environment(CoreWebView2 owner) => _owner = owner;
+
+	/// <summary>
+	/// Gets the version of the browser currently used by this environment.
+	/// </summary>
+	public string BrowserVersionString => Native(nameof(BrowserVersionString)).BrowserVersionString;
+
+	/// <summary>
+	/// Gets the user data folder this environment was created with.
+	/// </summary>
+	public string UserDataFolder => Native(nameof(UserDataFolder)).UserDataFolder;
+
+	/// <summary>
+	/// Gets the folder crash dumps are written to. The folder is created lazily and may not exist yet.
+	/// </summary>
+	public string FailureReportFolderPath => Native(nameof(FailureReportFolderPath)).FailureReportFolderPath;
+
+	/// <summary>
+	/// Gets a snapshot of the processes backing this environment.
+	/// </summary>
+	public IReadOnlyList<CoreWebView2ProcessInfo> GetProcessInfos() => Native("GetProcessInfos()").GetProcessInfos();
+
+	/// <summary>
+	/// Gets the version of the installed browser, or of the browser in the default location.
+	/// </summary>
+	/// <exception cref="NotImplementedException">The current platform cannot report a browser version.</exception>
+	public static string GetAvailableBrowserVersionString()
+		=> Statics("GetAvailableBrowserVersionString()").GetAvailableBrowserVersionString(null);
+
+	/// <summary>
+	/// Gets the version of the browser in <paramref name="browserExecutableFolder"/>, or of the installed
+	/// browser when it is null or empty.
+	/// </summary>
+	/// <remarks>
+	/// A non-empty <paramref name="browserExecutableFolder"/> is authoritative: when no browser is found there,
+	/// the call fails rather than falling back to the installed one.
+	/// </remarks>
+	public static string GetAvailableBrowserVersionString(string browserExecutableFolder)
+		=> Statics("GetAvailableBrowserVersionString(string browserExecutableFolder)")
+			.GetAvailableBrowserVersionString(browserExecutableFolder);
+
+	/// <summary>
+	/// Compares two browser version strings, returning a negative value, zero, or a positive value when
+	/// <paramref name="browserVersionString1"/> is respectively older than, the same as, or newer than
+	/// <paramref name="browserVersionString2"/>.
+	/// </summary>
+	public static int CompareBrowserVersionString(string browserVersionString1, string browserVersionString2)
+	{
+		if (browserVersionString1 is null)
+		{
+			throw new ArgumentNullException(nameof(browserVersionString1));
+		}
+
+		if (browserVersionString2 is null)
+		{
+			throw new ArgumentNullException(nameof(browserVersionString2));
+		}
+
+		return Statics("CompareBrowserVersionString(string browserVersionString1, string browserVersionString2)")
+			.CompareBrowserVersionString(browserVersionString1, browserVersionString2);
+	}
+
+	private ISupportsWebViewEnvironmentInfo Native(string memberName)
+		=> _owner.RequireCapability<ISupportsWebViewEnvironmentInfo>(TypeName, memberName);
+
+	private static ICoreWebView2EnvironmentStaticsExtension Statics(string memberName)
+		=> ApiExtensibility.CreateInstance<ICoreWebView2EnvironmentStaticsExtension>(typeof(CoreWebView2Environment), out var extension)
+			? extension
+			: throw global::Windows.Foundation.Metadata.ApiInformation.CreateNotImplementedException(TypeName, memberName);
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2Environment.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2Environment.cs
@@ -60,7 +60,7 @@ public partial class CoreWebView2Environment
 	/// A non-empty <paramref name="browserExecutableFolder"/> is authoritative: when no browser is found there,
 	/// the call fails rather than falling back to the installed one.
 	/// </remarks>
-	public static string GetAvailableBrowserVersionString(string browserExecutableFolder)
+	public static string GetAvailableBrowserVersionString(string? browserExecutableFolder)
 		=> Statics("GetAvailableBrowserVersionString(string browserExecutableFolder)")
 			.GetAvailableBrowserVersionString(browserExecutableFolder);
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2ProcessInfo.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2ProcessInfo.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+namespace Microsoft.Web.WebView2.Core;
+
+/// <summary>
+/// Provides a snapshot of a process backing a WebView. The values are captured when the instance is created
+/// and are never refreshed, matching the WinUI behaviour of CoreWebView2Environment.GetProcessInfos.
+/// </summary>
+public partial class CoreWebView2ProcessInfo
+{
+	internal CoreWebView2ProcessInfo(int processId, CoreWebView2ProcessKind kind)
+	{
+		ProcessId = processId;
+		Kind = kind;
+	}
+
+	/// <summary>
+	/// Gets the kind of the process.
+	/// </summary>
+	public CoreWebView2ProcessKind Kind { get; }
+
+	/// <summary>
+	/// Gets the process ID of the process.
+	/// </summary>
+	public int ProcessId { get; }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2Profile.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2Profile.cs
@@ -1,0 +1,100 @@
+#nullable enable
+
+using System;
+using Uno.UI.Xaml.Controls;
+using Windows.Foundation;
+
+namespace Microsoft.Web.WebView2.Core;
+
+/// <summary>
+/// Provides access to the profile the WebView is running under.
+/// </summary>
+/// <remarks>
+/// This is a stateless facade over the owning <see cref="CoreWebView2"/>: the native view it resolves is
+/// replaced whenever the control is re-templated, so the capability is looked up on every access rather than
+/// captured once.
+/// </remarks>
+public partial class CoreWebView2Profile
+{
+	private const string TypeName = "Microsoft.Web.WebView2.Core.CoreWebView2Profile";
+
+	private readonly CoreWebView2 _owner;
+
+	internal CoreWebView2Profile(CoreWebView2 owner) => _owner = owner;
+
+	/// <summary>
+	/// Gets the name of the profile, which is empty when the host did not request a named profile.
+	/// </summary>
+	/// <remarks>
+	/// On Windows this is currently always empty: the WebView is created without controller options, so no
+	/// profile name is requested, even though <see cref="ProfilePath"/> resolves to the default profile
+	/// directory. Use <see cref="ProfilePath"/> to identify the profile.
+	/// </remarks>
+	public string ProfileName => Native(nameof(ProfileName)).ProfileName;
+
+	/// <summary>
+	/// Gets the full path of the profile directory.
+	/// </summary>
+	public string ProfilePath => Native(nameof(ProfilePath)).ProfilePath;
+
+	/// <summary>
+	/// Gets whether the profile is in InPrivate mode.
+	/// </summary>
+	public bool IsInPrivateModeEnabled => Native(nameof(IsInPrivateModeEnabled)).IsInPrivateModeEnabled;
+
+	/// <summary>
+	/// Gets or sets the default download folder path.
+	/// </summary>
+	public string DefaultDownloadFolderPath
+	{
+		get => Native(nameof(DefaultDownloadFolderPath)).DefaultDownloadFolderPath;
+		set => Native(nameof(DefaultDownloadFolderPath)).DefaultDownloadFolderPath =
+			value ?? throw new ArgumentNullException(nameof(value));
+	}
+
+	/// <summary>
+	/// Gets or sets the preferred color scheme for the WebViews associated with this profile.
+	/// </summary>
+	public CoreWebView2PreferredColorScheme PreferredColorScheme
+	{
+		get => Native(nameof(PreferredColorScheme)).PreferredColorScheme;
+		set => Native(nameof(PreferredColorScheme)).PreferredColorScheme = value;
+	}
+
+	/// <summary>
+	/// Clears every kind of browsing data from the profile.
+	/// </summary>
+	public IAsyncAction ClearBrowsingDataAsync()
+		=> ClearBrowsingDataCore("ClearBrowsingDataAsync()", null, null, null);
+
+	/// <summary>
+	/// Clears the specified kinds of browsing data from the profile.
+	/// </summary>
+	public IAsyncAction ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds dataKinds)
+		=> ClearBrowsingDataCore("ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds dataKinds)", dataKinds, null, null);
+
+	/// <summary>
+	/// Clears the specified kinds of browsing data created between <paramref name="startTime"/> and <paramref name="endTime"/>.
+	/// </summary>
+	public IAsyncAction ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds dataKinds, DateTimeOffset startTime, DateTimeOffset endTime)
+		=> ClearBrowsingDataCore(
+			"ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds dataKinds, DateTimeOffset startTime, DateTimeOffset endTime)",
+			dataKinds,
+			startTime,
+			endTime);
+
+	private IAsyncAction ClearBrowsingDataCore(string memberName, CoreWebView2BrowsingDataKinds? dataKinds, DateTimeOffset? startTime, DateTimeOffset? endTime)
+		=> AsyncAction.FromTask(async _ =>
+		{
+			await _owner.EnsureNativeWebViewAsync();
+
+			// Resolved after the await: EnsureNativeWebViewAsync stays completed across re-templating, so the
+			// native view may have been replaced (or removed) since the task was created.
+			await _owner
+				.RequireCapability<ISupportsBrowsingDataClearing>(TypeName, memberName)
+				.ClearBrowsingDataAsync(dataKinds, startTime, endTime);
+		});
+
+	private ISupportsWebViewProfile Native(string memberName)
+		=> _owner.RequireCapability<ISupportsWebViewProfile>(TypeName, memberName);
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/ICoreWebView2EnvironmentStaticsExtension.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/ICoreWebView2EnvironmentStaticsExtension.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+namespace Microsoft.Web.WebView2.Core;
+
+/// <remarks>
+/// The static members of <see cref="CoreWebView2Environment"/> answer "which browser is installed", so they must
+/// work before any <see cref="CoreWebView2"/> exists. That rules out <see cref="INativeWebViewProvider"/>, which
+/// is registered with a <see cref="CoreWebView2"/> owner.
+/// </remarks>
+internal interface ICoreWebView2EnvironmentStaticsExtension
+{
+	/// <param name="browserExecutableFolder">null or empty uses the installed browser.</param>
+	string GetAvailableBrowserVersionString(string? browserExecutableFolder);
+
+	int CompareBrowserVersionString(string browserVersionString1, string browserVersionString2);
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/ISupportsBrowsingDataClearing.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/ISupportsBrowsingDataClearing.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Web.WebView2.Core;
+
+namespace Uno.UI.Xaml.Controls;
+
+internal interface ISupportsBrowsingDataClearing
+{
+	/// <param name="dataKinds">null clears every kind, matching CoreWebView2Profile.ClearBrowsingDataAsync().</param>
+	/// <param name="startTime">null is unbounded in the past.</param>
+	/// <param name="endTime">null is unbounded in the future.</param>
+	/// <remarks>
+	/// An implementer that cannot honour a bounded range must throw <see cref="NotSupportedException"/> rather
+	/// than widen it: reporting a narrower deletion than was performed is a privacy defect. Win32 maps all three
+	/// shapes onto distinct native calls, so that path is unreachable there.
+	/// </remarks>
+	Task ClearBrowsingDataAsync(CoreWebView2BrowsingDataKinds? dataKinds, DateTimeOffset? startTime, DateTimeOffset? endTime);
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/ISupportsWebViewEnvironmentInfo.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/ISupportsWebViewEnvironmentInfo.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+using System.Collections.Generic;
+using Microsoft.Web.WebView2.Core;
+
+namespace Uno.UI.Xaml.Controls;
+
+/// <remarks>
+/// Bundles two portable members (<see cref="BrowserVersionString"/>, <see cref="UserDataFolder"/>) with three
+/// that only a multi-process Chromium host can answer. Kept as one interface while Win32 is the sole
+/// implementer; split it the moment a WebKit-based host wants the portable half.
+/// </remarks>
+internal interface ISupportsWebViewEnvironmentInfo
+{
+	string BrowserVersionString { get; }
+
+	string UserDataFolder { get; }
+
+	string FailureReportFolderPath { get; }
+
+	uint BrowserProcessId { get; }
+
+	IReadOnlyList<CoreWebView2ProcessInfo> GetProcessInfos();
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/ISupportsWebViewProfile.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/ISupportsWebViewProfile.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using Microsoft.Web.WebView2.Core;
+
+namespace Uno.UI.Xaml.Controls;
+
+internal interface ISupportsWebViewProfile
+{
+	string ProfileName { get; }
+
+	string ProfilePath { get; }
+
+	bool IsInPrivateModeEnabled { get; }
+
+	string DefaultDownloadFolderPath { get; set; }
+
+	CoreWebView2PreferredColorScheme PreferredColorScheme { get; set; }
+}


### PR DESCRIPTION
**GitHub Issue:** tracked internally

## PR Type:

✨ Feature

## What changed? 🚀

`CoreWebView2Environment` and `CoreWebView2Profile` were whole-type `[Uno.NotImplemented]` stubs. They are now
implemented on the Skia Windows head:

| Vertical | Members |
|---|---|
| Environment statics | `GetAvailableBrowserVersionString()`, `GetAvailableBrowserVersionString(string)`, `CompareBrowserVersionString(string, string)` |
| Profile | `CoreWebView2.Profile`; `ClearBrowsingDataAsync()` / `(kinds)` / `(kinds, start, end)`, `ProfileName`, `ProfilePath`, `IsInPrivateModeEnabled`, `DefaultDownloadFolderPath`, `PreferredColorScheme` |
| Environment + diagnostics | `CoreWebView2.Environment`; `BrowserVersionString`, `UserDataFolder`, `FailureReportFolderPath`, `GetProcessInfos()`; `CoreWebView2.BrowserProcessId` |

Every other target keeps throwing exactly the `NotImplementedException` it threw before, with the same
type/member strings, so the `aka.platform.uno/notimplemented#m=` telemetry keys are unchanged.

### Design

Two seams, because the members have two different lifetimes:

- **Statics** must answer "is a browser installed?" before any `WebView2` exists, so they cannot ride
  `INativeWebView`. They resolve through an owner-less `ApiExtensibility` extension
  (`ICoreWebView2EnvironmentStaticsExtension`). The existing WebView registration uses the typed-owner
  overload, which throws on a mismatched owner, so reusing it was not an option.
- **Instance members** are bound to a live native view and resolve through three opt-in capability interfaces
  on `INativeWebView`, next to the existing `ISupportsVirtualHostMapping` / `ISupportsWebResourceRequested`.

The capabilities are split three ways rather than bundled because the split *is* the portability
documentation: data clearing has a real analogue on every head (`WKWebsiteDataStore.removeData`,
`WebKitWebsiteDataManager`, Android `WebStorage`), profile metadata maps partially, and multi-process
diagnostics is Chromium-only. A macOS implementer appends one interface to `MacOSNativeWebView` and writes one
method — nothing in `Uno.UI` changes.

The façades hold the owning `CoreWebView2`, never the native view, and re-resolve on every access:
`_nativeWebView` is assigned in `OnOwnerApplyTemplate` and reassigned on every re-template. The async path
re-resolves *after* its await too, because `_nativeWebViewInitializedTcs` is never reset, so
`EnsureNativeWebViewAsync()` stays completed even after re-templating into a template with no native view.

`ClearBrowsingDataAsync` throws when the native view is absent rather than following the graceful in-memory
fallback used three lines away by `SetVirtualHostNameToFolderMapping`. A host mapping that quietly buffers is
harmless; a data-clearing call that quietly resolves without clearing is a privacy defect.

## Reviewer notes — things not visible in the diff

- **The sync generator could not be run locally.** `dotnet restore` on
  `build/filters/Uno.UI-top-projects-for-sync-gen.slnf` fails with `NETSDK1147`, because the `wasm-tools`
  workload is not installed on the dev machine. The `Generated/` edits were instead
  verified against the generator's own rules — type guard flipped to `#if false || false || false || false ||
  false || false`, each removed member replaced **in place** by `// Skipping already declared property {Name}`
  or `// Skipping already declared method {fully-qualified signature}`, all `// Forced skipping of method`
  lines untouched — and cross-checked against `CoreWebView2Settings.cs`, which the generator authored in the
  same shape. The new comments sit alongside pre-existing generator-authored ones in the same files with
  identical formatting. **`winappsdk-sync-check` is the real gate here.**
- **Same cause: `Uno.UI.netcoremobile` was not compile-verified locally.** Everything else was, on **both**
  TFM bands with analyzers enabled: `Uno.UI.Skia`, `Uno.UI.Reference`, `Uno.UI.Wasm`,
  `Uno.UI.Runtime.Skia.Win32`, `Uno.UI.RuntimeTests` and `SamplesApp` all build clean at net9.0 and net10.0.
  The new `Uno.UI` files are unguarded (matching `CoreWebView2Settings.cs`) and reference only generated enums
  that exist on all six platform slots, so the mobile variant should be safe too — but CI is the check.

  Note the net9.0 split: `WebView2Aot` is only referenced from net10.0, so the Win32 statics registration is
  behind `#if NET10_0_OR_GREATER` and the whole feature stays `NotImplemented` on net9.0. That guard becomes
  vacuously true once net9 is dropped (`feature/breakingchanges` already has `NetPrevious=net10.0`), and can
  be removed then.
- **`ProfileName` is always empty on Windows.** Not a marshalling bug: `ProfilePath` correctly returns
  `…\LocalState\WebView2\EBWebView\Default` and `DefaultDownloadFolderPath` returns the user's Downloads
  folder. It is empty because the controller is created without `ICoreWebView2ControllerOptions`, so no profile
  name is ever requested. The test asserts the true contract and the doc explains it; making it non-empty means
  passing controller options, which changes on-disk profile layout and deserves its own decision.
- **`CompareBrowserVersionString(null, …)` throws `ArgumentNullException`** where the WebView2 stack throws
  `ArgumentException`. `ArgumentNullException` derives from `ArgumentException`, so a `catch (ArgumentException)`
  written against Windows still works — the parity direction that matters holds. The explicit guard also avoids
  handing a null pointer to a native export whose null behaviour is unverified.
- **The type-level `[Uno.NotImplemented]` attribute is gone** from `CoreWebView2Environment`,
  `CoreWebView2Profile` and `CoreWebView2ProcessInfo`, which changes IDE/analyzer surfacing for them. Members
  that remain unimplemented keep their per-member attributes. This is the correct outcome of the types no
  longer being wholly unimplemented, but it is a visible change.
- **`When_ClearBrowsingDataAsync_Completes(1)` destroys real state** in the app's own WebView2 user-data
  folder. It is scoped to `LocalState` so it is acceptable, but unlike the `PreferredColorScheme` test there is
  no `finally` that can restore it.
- **Exception-type parity is derived, not observed end-to-end.** Verified: `Marshal.GetExceptionForHR(0x80070002)`
  is `FileNotFoundException`; DirectN's `ThrowOnError` does not use the CLR mapping (it builds a
  `Win32Exception`); `WebView2RuntimeNotFoundException` exists only in the WebView2 .NET wrapper and has no
  WinAppSDK/WinRT counterpart, so it is not the parity target. What was *not* done is running a WinAppSDK app
  to observe it directly. Relatedly, the `0x80070002` observation comes from pointing at a folder with no
  browser; a machine with no runtime installed at all was not available to test.
- **Behaviour change worth noting:** the loader probe moved out of `Win32NativeAotWebView`'s static
  constructor into `Win32WebView2Loader.Ensure()`. The instance path is unchanged, but the new static path
  surfaces a direct `DllNotFoundException` rather than one wrapped in a `TypeInitializationException`.

## Scope deliberately left out

- `GetAvailableBrowserVersionString(string, CoreWebView2EnvironmentOptions)` — `CoreWebView2EnvironmentOptions`
  is an unbacked stub whose getters throw, so the options cannot be honoured and ignoring them would return a
  wrong answer. Unblocks once that type gets real backing fields, which is also the right time to retire the
  `FeatureConfiguration.WebView2.*` injection point.
- `CoreWebView2CookieManager` / `CoreWebView2Cookie`. Verified independent of this work:
  `ICoreWebView2Profile2.ClearBrowsingData` takes only `(kinds, handler)` and does the work inside the browser
  process, so `ClearBrowsingDataAsync(Cookies)` never touches the cookie manager. What is therefore still not
  possible: reading cookies, and targeted delete by name/domain/path. Adding it later is one more capability
  interface — no reshaping.
- `CreateAsync` / `CreateWithOptionsAsync`, `Profile.CookieManager` / `.Delete()` /
  `.IsGeneralAutofillEnabled` / `.IsPasswordAutosaveEnabled` / `.PreferredTrackingPreventionLevel`, and the
  `BrowserProcessExited` / `ProcessInfosChanged` / `NewBrowserVersionAvailable` / `Deleted` events.

## Pre-existing issues found while working here (not fixed in this PR)

- `get_Source`, `get_DocumentTitle`, `get_Uri`, `get_WebMessageAsJson` and the `.Request.cs` accessors in
  `Win32NativeAotWebView` all leak caller-owned `PWSTR`s via a bare `.ToString()`.
- `ExecuteScriptAsync` lacks `RunContinuationsAsynchronously`, the same hazard this PR guards against in
  `ClearBrowsingDataAsync`.
- `Given_WebView2`'s `SkiaWin32` exclusion predates the `WebView2Aot` backend. This PR demonstrates a live
  `WebView2` runs fine under the runtime-test harness on Skia Win32, so that exclusion now looks stale.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests and a manual test sample
- [x] 📚 Docs have been added/updated
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests
