### PR TITLE
fix(logging): weak-key the per-type logger cache so collectible ALCs can unload

### DIFF
--- a/src/Uno.Foundation.Logging/LogExtensionPoint.cs
+++ b/src/Uno.Foundation.Logging/LogExtensionPoint.cs
@@ -1,14 +1,22 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace Uno.Foundation.Logging
 {
 	internal static class LogExtensionPoint
 	{
 		private static LoggerFactory _loggerFactory = new LoggerFactory();
-		private static ConcurrentDictionary<Type, Logger> _loggers = new();
+
+		/// <summary>
+		/// Per-type logger memoization. Weak-keyed: a <see cref="Type"/> key roots the
+		/// LoaderAllocator of its AssemblyLoadContext, so a strongly keyed process-lifetime cache
+		/// would keep a collectible context resident forever as soon as one of its types logged
+		/// once. The cache is a pure memoization (evicted entries simply rebuild), which makes weak
+		/// keys sufficient — no unload hook or ALC-scoped purge is needed.
+		/// </summary>
+		private static readonly ConditionalWeakTable<Type, Logger> _loggers = new();
 
 		public static LoggerFactory Factory => _loggerFactory;
 
@@ -29,7 +37,7 @@ namespace Uno.Foundation.Logging
 		public static Logger Log<T>(this T instance)
 		{
 			var type = instance as Type ?? typeof(T);
-			return _loggers.GetOrAdd(type, static t => _loggerFactory.CreateLogger(t));
+			return _loggers.GetValue(type, static t => _loggerFactory.CreateLogger(t));
 		}
 
 		private static Logger? Log<T>(this T instance, LogLevel level)

--- a/src/Uno.UI.UnitTests/Foundation/Given_LogExtensionPoint_Alc.cs
+++ b/src/Uno.UI.UnitTests/Foundation/Given_LogExtensionPoint_Alc.cs
@@ -1,0 +1,121 @@
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Foundation.Logging;
+
+namespace Uno.UI.Tests.Foundation
+{
+	/// <summary>
+	/// <see cref="LogExtensionPoint"/> memoizes one <see cref="Logger"/> per <see cref="Type"/> in a
+	/// process-lifetime cache. A <see cref="Type"/> key from a collectible
+	/// <see cref="AssemblyLoadContext"/> roots that context's LoaderAllocator, so with a strongly
+	/// keyed cache any type of a previewed app that logs even once keeps the app's whole context —
+	/// assemblies, metadata and everything they reference — resident for the process lifetime. The
+	/// cache is a pure memoization, so its keys must be weak.
+	/// </summary>
+	[TestClass]
+	public class Given_LogExtensionPoint_Alc
+	{
+		[TestMethod]
+		public void When_Collectible_Alc_Type_Logs_Then_Alc_Is_Collected()
+		{
+			var weakAlc = LogFromCollectibleAlcAndUnload();
+
+			Assert.IsTrue(
+				TryWaitUntilCollected(weakAlc),
+				"A type that logged once must not keep its collectible AssemblyLoadContext alive: a strongly keyed logger cache holds the Type key, which roots the context's LoaderAllocator.");
+		}
+
+		[TestMethod]
+		public void When_Live_Type_Logs_Twice_Then_Weak_Cache_Memoizes_Logger()
+		{
+			// Non-regression guard for the memoization itself: LoggerFactory also caches by type
+			// NAME, so comparing the two returned loggers alone cannot tell a working per-type cache
+			// from no cache at all — the entry is therefore asserted at the cache.
+			var first = LogExtensionPoint.Log(new LoggerCacheProbe());
+			var second = LogExtensionPoint.Log(new LoggerCacheProbe());
+
+			Assert.IsNotNull(first, "Logging must return a logger.");
+			Assert.AreSame(first, second, "The same live type must keep resolving to the same logger.");
+
+			Assert.IsTrue(
+				TryGetCachedLogger(typeof(LoggerCacheProbe), out var cached),
+				"A logged type must have an entry in the logger cache while it is alive.");
+			Assert.AreSame(
+				first,
+				cached,
+				"The cached entry must be the logger handed to callers — the weak-keyed table must still memoize, not merely pass through to the factory.");
+		}
+
+		/// <summary>
+		/// Logs from a type of a collectible <see cref="AssemblyLoadContext"/>, unloads it, and
+		/// returns a weak reference to the context.
+		/// </summary>
+		/// <remarks>
+		/// Every strong reference to the context, its assembly and its types must stay in a
+		/// separate, non-inlined frame: locals in the frame that later runs the GC keep their
+		/// objects alive (especially under Debug codegen, which extends lifetimes to the end of the
+		/// method).
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static WeakReference LogFromCollectibleAlcAndUnload()
+		{
+			var alc = new AssemblyLoadContext("Given_LogExtensionPoint_Alc.probe", isCollectible: true);
+			var probeType = alc
+				.LoadFromAssemblyPath(typeof(Given_LogExtensionPoint_Alc).Assembly.Location)
+				.GetType(typeof(LoggerCacheProbe).FullName!, throwOnError: true)!;
+
+			Assert.IsTrue(probeType.IsCollectible, "Pre-condition: the probe type must belong to the collectible ALC.");
+
+			// The Type-as-instance path (`instance as Type`) caches `probeType` under exactly the
+			// same key an instance of it calling `this.Log()` would (`typeof(T)`), while keeping the
+			// probe a pure metadata load: nothing from the ALC's copy of this assembly is
+			// instantiated, so the context is pinned by the logger cache alone.
+			Assert.IsNotNull(LogExtensionPoint.Log<object>(probeType), "Pre-condition: logging the collectible type must return a logger.");
+
+			alc.Unload();
+
+			return new WeakReference(alc);
+		}
+
+		/// <summary>
+		/// Reads the per-type logger cache. Fails loudly if it is not weak-keyed — that is the
+		/// property this fixture exists for, and a strongly keyed cache would silently pin every
+		/// collectible context again.
+		/// </summary>
+		private static bool TryGetCachedLogger(Type type, out Logger? logger)
+		{
+			var field = typeof(LogExtensionPoint).GetField("_loggers", BindingFlags.Static | BindingFlags.NonPublic)
+				?? throw new InvalidOperationException("LogExtensionPoint._loggers field was not found.");
+			var cache = field.GetValue(null) as ConditionalWeakTable<Type, Logger>
+				?? throw new InvalidOperationException(
+					"LogExtensionPoint._loggers must be a ConditionalWeakTable<Type, Logger>: a strongly keyed cache pins collectible AssemblyLoadContexts.");
+
+			return cache.TryGetValue(type, out logger);
+		}
+
+		private static bool TryWaitUntilCollected(WeakReference reference)
+		{
+			// Unloading is asynchronous and takes several collections to walk the whole graph.
+			for (var i = 0; i < 10 && reference.IsAlive; i++)
+			{
+				GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+				GC.WaitForPendingFinalizers();
+			}
+
+			return !reference.IsAlive;
+		}
+	}
+
+	/// <summary>
+	/// Stand-in for a previewed app's type: logged both from the default ALC and from copies of this
+	/// assembly loaded into a collectible ALC.
+	/// </summary>
+	public class LoggerCacheProbe
+	{
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** closes #24077

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Uno.Foundation.Logging.LogExtensionPoint` memoized one `Logger` per `Type` in a process-lifetime, strongly keyed cache:

```csharp
private static ConcurrentDictionary<Type, Logger> _loggers = new();

public static Logger Log<T>(this T instance)
{
    var type = instance as Type ?? typeof(T);
    return _loggers.GetOrAdd(type, static t => _loggerFactory.CreateLogger(t));
}
```

### The pin

A `RuntimeType` key roots the `LoaderAllocator` of its `AssemblyLoadContext`. For a **collectible** ALC that means a single `.Log()` call from any of its types adds a permanent strong key, and the context — its assemblies, their metadata, and everything they reference — can never be collected. `Unload()` still reports success; the context simply never dies.

It was found by managed GC-root tracing in a host that loads previewed apps into collectible `AssemblyLoadContext`s and unloads them repeatedly: one uncollectable context accumulated per load/unload cycle. It is most damaging on WebAssembly, where `memory.grow` is irreversible, so every retained graph permanently inflates the heap.

```
LogExtensionPoint._loggers [Uno.Foundation.Logging] -> ._tables -> ._buckets -> [*] -> ._node -> ._key
  -> RuntimeType representing [<assembly in the collectible ALC>]
```

### The fix

`ConditionalWeakTable<Type, Logger>` instead of `ConcurrentDictionary<Type, Logger>`:

```csharp
private static readonly ConditionalWeakTable<Type, Logger> _loggers = new();

public static Logger Log<T>(this T instance)
{
    var type = instance as Type ?? typeof(T);
    return _loggers.GetValue(type, static t => _loggerFactory.CreateLogger(t));
}
```

The cache is a pure per-type memoization: nothing enumerates it, nothing else observes its contents, and an evicted entry is simply rebuilt on the next call. Weak keys therefore make it *inherently* collectible-safe — no `AssemblyLoadContext.Unloading` hook to register, no ALC-scoped sweep to keep in sync, and no way to regress by forgetting to purge.

Behavior is otherwise identical:

- same public surface; `Log(this Type forType)` still bypasses the cache exactly as before;
- `ConditionalWeakTable.GetValue(key, callback)` is thread-safe and preserves `GetOrAdd`'s semantics — both may run the callback more than once under contention while publishing a single value, and `LoggerFactory.CreateLogger` is itself an idempotent name-keyed lookup, so a redundant call returns the very same `Logger`;
- the same `Logger` instance is returned for a type for as long as that type is alive;
- reads stay lock-free (`ConditionalWeakTable` takes its lock only when adding), so the logging hot path is unaffected.

Note that `LoggerFactory`'s own cache is keyed by type *name* (`string`) and so never pinned anything — the `Type`-keyed table was the sole pin.

### The general rule

The same shape exists twice more in Mono's BCL — `System.Reflection.CustomAttribute.usage_cache` and `System.Dynamic.Utils.TypeExtensions.s_paramInfoCache`. CoreCLR made its equivalents collectible-safe; Mono has not, which is why this bites on WASM/Mono targets in practice. The general rule worth carrying forward: **a process-lifetime `Type`-keyed cache must be weak-keyed or purged on ALC unload.**

## Test evidence

New fixture `src/Uno.UI.UnitTests/Foundation/Given_LogExtensionPoint_Alc.cs` (the test project already has `InternalsVisibleTo` for `Uno.Foundation.Logging`, and it is where the other collectible-ALC pin fixtures live):

| Test | Asserts |
| --- | --- |
| `When_Collectible_Alc_Type_Logs_Then_Alc_Is_Collected` | Loads a copy of the test assembly into a collectible `AssemblyLoadContext`, logs with one of its types as the cache key, unloads, forces GC — and requires the `WeakReference` to the context to be dead. All strong references live in a separate `[MethodImpl(NoInlining)]` frame so the frame running the GC holds none. |
| `When_Live_Type_Logs_Twice_Then_Weak_Cache_Memoizes_Logger` | The memoization still works: the same live type resolves to the same `Logger`, and that instance is the one stored in the cache (asserted at the cache, because `LoggerFactory` also caches by type *name* — comparing only the two returned loggers cannot distinguish a working per-type cache from no cache at all). |

Red/green, on `Uno.UI.UnitTests` (`net10.0`, Debug):

- **Before the fix**: `When_Collectible_Alc_Type_Logs_Then_Alc_Is_Collected` fails — the strongly keyed dictionary holds the `Type` and the context stays alive; `When_Live_Type_Logs_Twice_Then_Weak_Cache_Memoizes_Logger` fails on the weak-keyed-cache requirement.
- **After the fix**: both pass.

```
dotnet build src/Uno.UI.UnitTests/Uno.UI.UnitTests.csproj -c Debug
dotnet test src/Uno.UI.UnitTests/Uno.UI.UnitTests.csproj -c Debug --no-build --filter "FullyQualifiedName~Given_LogExtensionPoint_Alc"
```

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, internal logging plumbing with no public API or behavior change
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no rendering change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
