### PR TITLE
perf(wasm): preload only common font variants

### DIFF
--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml_Media/Given_FontPreloadVariants.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml_Media/Given_FontPreloadVariants.cs
@@ -79,4 +79,52 @@ public class Given_FontPreloadVariants
 		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(350), Default));
 		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(350), FontPreloadVariants.Light));
 	}
+
+	[TestMethod]
+	public void When_Stretch_Is_Undefined_Then_Treated_As_Normal_Width()
+	{
+		// A manifest omitting font_stretch deserializes to Undefined, which describes a normal-width face.
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Normal.Weight, FontStretch.Undefined), Default));
+	}
+
+	[TestMethod]
+	public void When_All_Then_Manifest_Is_Not_Filtered()
+	{
+		var fonts = new[] { Font(FontWeights.Thin.Weight, FontStretch.Condensed, FontStyle.Italic) };
+
+		Assert.AreSame(fonts, FontFamilyHelper.SelectVariants(fonts, FontPreloadVariants.All));
+	}
+
+	[TestMethod]
+	public void When_Some_Variants_Match_Then_Only_Those_Are_Selected()
+	{
+		var regular = Font(FontWeights.Normal.Weight);
+		var fonts = new[] { regular, Font(FontWeights.Thin.Weight), Font(FontWeights.Normal.Weight, style: FontStyle.Italic) };
+
+		var selected = FontFamilyHelper.SelectVariants(fonts, Default);
+
+		Assert.AreEqual(1, selected.Count);
+		Assert.AreSame(regular, selected[0]);
+	}
+
+	[TestMethod]
+	public void When_No_Variant_Matches_Then_Whole_Manifest_Is_Selected()
+	{
+		var fonts = new[] { Font(FontWeights.Thin.Weight), Font(FontWeights.Light.Weight) };
+
+		// A family with no upright regular/semi-bold/bold face must not be left with nothing preloaded.
+		Assert.AreSame(fonts, FontFamilyHelper.SelectVariants(fonts, Default));
+	}
+
+	[TestMethod]
+	public void When_No_Weight_Requested_Then_Nothing_Is_Selected()
+	{
+		var fonts = new[] { Font(FontWeights.Normal.Weight), Font(FontWeights.Bold.Weight, style: FontStyle.Italic) };
+
+		// Italic and Condensed only widen a weight selection; on their own they must preload nothing
+		// rather than match no face and fall back to the whole manifest.
+		Assert.IsFalse(FontFamilyHelper.SelectsAnyFace(FontPreloadVariants.Italic | FontPreloadVariants.Condensed));
+		Assert.AreEqual(0, FontFamilyHelper.SelectVariants(fonts, FontPreloadVariants.Italic | FontPreloadVariants.Condensed).Count);
+		Assert.AreEqual(0, FontFamilyHelper.SelectVariants(fonts, FontPreloadVariants.None).Count);
+	}
 }

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml_Media/Given_FontPreloadVariants.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml_Media/Given_FontPreloadVariants.cs
@@ -1,0 +1,82 @@
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI;
+using Uno.UI.Xaml.Media;
+using Windows.UI.Text;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Media;
+
+[TestClass]
+public class Given_FontPreloadVariants
+{
+	private const FontPreloadVariants Default =
+		FontPreloadVariants.Normal | FontPreloadVariants.SemiBold | FontPreloadVariants.Bold;
+
+	private static FontInfo Font(ushort weight, FontStretch stretch = FontStretch.Normal, FontStyle style = FontStyle.Normal)
+		=> new() { FamilyName = "ms-appx:///test.ttf", FontWeight = weight, FontStretch = stretch, FontStyle = style };
+
+	[TestMethod]
+	public void When_Default_Then_Upright_Regular_Semibold_Bold_Selected()
+	{
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Normal.Weight), Default));
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(FontWeights.SemiBold.Weight), Default));
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Bold.Weight), Default));
+	}
+
+	[TestMethod]
+	public void When_Default_Then_Other_Weights_Excluded()
+	{
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Thin.Weight), Default));
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Light.Weight), Default));
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Medium.Weight), Default));
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(FontWeights.ExtraBold.Weight), Default));
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Black.Weight), Default));
+	}
+
+	[TestMethod]
+	public void When_Italic_Not_Requested_Then_Italic_Excluded()
+	{
+		var italicRegular = Font(FontWeights.Normal.Weight, style: FontStyle.Italic);
+
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(italicRegular, Default));
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(italicRegular, Default | FontPreloadVariants.Italic));
+	}
+
+	[TestMethod]
+	public void When_Condensed_Not_Requested_Then_Condensed_Excluded()
+	{
+		var condensedRegular = Font(FontWeights.Normal.Weight, stretch: FontStretch.Condensed);
+
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(condensedRegular, Default));
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(condensedRegular, Default | FontPreloadVariants.Condensed));
+	}
+
+	[TestMethod]
+	public void When_Condensed_Requested_Then_Weight_Still_Filtered()
+	{
+		var condensedLight = Font(FontWeights.Light.Weight, stretch: FontStretch.Condensed);
+
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(condensedLight, Default | FontPreloadVariants.Condensed));
+	}
+
+	[TestMethod]
+	public void When_None_Then_Nothing_Selected()
+		=> Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Normal.Weight), FontPreloadVariants.None));
+
+	[TestMethod]
+	public void When_All_Then_Every_Variant_Selected()
+	{
+		var variants = FontPreloadVariants.All;
+
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Thin.Weight), variants));
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(FontWeights.Black.Weight, FontStretch.Condensed, FontStyle.Italic), variants));
+	}
+
+	[TestMethod]
+	public void When_Weight_Is_Between_Named_Values_Then_Rounded_Up()
+	{
+		// OpenType allows arbitrary weights; 350 sits between Light (300) and Normal (400).
+		Assert.IsTrue(FontFamilyHelper.IsVariantSelected(Font(350), Default));
+		Assert.IsFalse(FontFamilyHelper.IsVariantSelected(Font(350), FontPreloadVariants.Light));
+	}
+}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -192,6 +192,8 @@ namespace Uno.UI
 			/// so only the upright regular, semi-bold and bold faces are preloaded by default and the rest
 			/// load on first use. Use <see cref="FontPreloadVariants.All"/> to preload the whole family, or
 			/// <see cref="FontPreloadVariants.None"/> to preload nothing.
+			/// This value is read once during <see cref="Application"/> startup, before <see cref="Application.OnLaunched"/>
+			/// runs, so set it from a static initializer or from the <see cref="Application"/> constructor.
 			/// </remarks>
 			public static FontPreloadVariants PreloadedVariants { get; set; } =
 				FontPreloadVariants.Normal | FontPreloadVariants.SemiBold | FontPreloadVariants.Bold;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -184,6 +184,19 @@ namespace Uno.UI
 			public static string DefaultTextFontFamily { get; set; } = "Segoe UI";
 
 			/// <summary>
+			/// The variants of <see cref="DefaultTextFontFamily"/> preloaded at startup.
+			/// </summary>
+			/// <remarks>
+			/// Font families can declare dozens of weight/width/style combinations. On platforms that fetch
+			/// fonts individually (such as WebAssembly) each one is a separate request on the startup path,
+			/// so only the upright regular, semi-bold and bold faces are preloaded by default and the rest
+			/// load on first use. Use <see cref="FontPreloadVariants.All"/> to preload the whole family, or
+			/// <see cref="FontPreloadVariants.None"/> to preload nothing.
+			/// </remarks>
+			public static FontPreloadVariants PreloadedVariants { get; set; } =
+				FontPreloadVariants.Normal | FontPreloadVariants.SemiBold | FontPreloadVariants.Bold;
+
+			/// <summary>
 			/// Ignores text scale factor, resulting in a font size as dictated by the control.
 			/// </summary>
 			public static bool IgnoreTextScaleFactor { get; set; }

--- a/src/Uno.UI/FontPreloadVariants.cs
+++ b/src/Uno.UI/FontPreloadVariants.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System;
+
+namespace Uno.UI;
+
+/// <summary>
+/// Font variants preloaded at startup, used by <see cref="FeatureConfiguration.Font.PreloadedVariants"/>.
+/// </summary>
+/// <remarks>
+/// Weight flags select upright, normal-width faces. <see cref="Italic"/> and <see cref="Condensed"/>
+/// widen that selection to the italic and condensed forms of the selected weights.
+/// </remarks>
+[Flags]
+public enum FontPreloadVariants
+{
+	/// <summary>No font is preloaded; every face loads on first use.</summary>
+	None = 0,
+
+	Thin = 1 << 0,
+	ExtraLight = 1 << 1,
+	Light = 1 << 2,
+	Normal = 1 << 3,
+	Medium = 1 << 4,
+	SemiBold = 1 << 5,
+	Bold = 1 << 6,
+	ExtraBold = 1 << 7,
+	Black = 1 << 8,
+
+	/// <summary>Also preload the italic form of each selected weight.</summary>
+	Italic = 1 << 16,
+
+	/// <summary>Also preload the condensed and semi-condensed widths of each selected weight.</summary>
+	Condensed = 1 << 17,
+
+	/// <summary>Every variant declared by the font manifest.</summary>
+	All = ~0,
+}

--- a/src/Uno.UI/FontPreloadVariants.cs
+++ b/src/Uno.UI/FontPreloadVariants.cs
@@ -8,7 +8,8 @@ namespace Uno.UI;
 /// </summary>
 /// <remarks>
 /// Weight flags select upright, normal-width faces. <see cref="Italic"/> and <see cref="Condensed"/>
-/// widen that selection to the italic and condensed forms of the selected weights.
+/// widen that selection to the italic and non-normal-width forms of the selected weights. At least one
+/// weight flag is required: <see cref="Italic"/> or <see cref="Condensed"/> on their own preload nothing.
 /// </remarks>
 [Flags]
 public enum FontPreloadVariants
@@ -29,7 +30,7 @@ public enum FontPreloadVariants
 	/// <summary>Also preload the italic form of each selected weight.</summary>
 	Italic = 1 << 16,
 
-	/// <summary>Also preload the condensed and semi-condensed widths of each selected weight.</summary>
+	/// <summary>Also preload the non-normal widths (condensed and expanded) of each selected weight.</summary>
 	Condensed = 1 << 17,
 
 	/// <summary>Every variant declared by the font manifest.</summary>

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -898,7 +898,7 @@ namespace Microsoft.UI.Xaml
 				{
 					try
 					{
-						textFontManifestSuccess = await FontFamilyHelper.PreloadAllFontsInManifest(uri);
+						textFontManifestSuccess = await FontFamilyHelper.PreloadFontsInManifest(uri, FeatureConfiguration.Font.PreloadedVariants);
 						if (!textFontManifestSuccess)
 						{
 							typeof(Application).LogDebug()?.Debug($"Failed to load {nameof(FeatureConfiguration.Font.DefaultTextFontFamily)}=[{FeatureConfiguration.Font.DefaultTextFontFamily}] as a font manifest");

--- a/src/Uno.UI/UI/Xaml/FontFamilyHelper.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamilyHelper.cs
@@ -10,6 +10,7 @@ using Windows.Storage;
 using Windows.Storage.Helpers;
 using Windows.UI.Text;
 using Microsoft.UI.Xaml.Controls;
+using Uno.UI;
 using Uno.UI.Xaml.Media;
 
 namespace Microsoft.UI.Xaml;
@@ -47,8 +48,21 @@ internal static partial class FontFamilyHelper
 		=> PreloadAsync(new FontFamily(familyName), weight, stretch, style);
 
 	/// <param name="uri">The URI of the font (ending with.ttf without .manifest)</param>
-	public static async Task<bool> PreloadAllFontsInManifest(Uri uri)
+	public static Task<bool> PreloadAllFontsInManifest(Uri uri)
+		=> PreloadFontsInManifest(uri, FontPreloadVariants.All);
+
+	/// <param name="uri">The URI of the font (ending with.ttf without .manifest)</param>
+	/// <param name="variants">
+	/// The variants to preload. A full family can declare dozens of weight/width/style combinations,
+	/// and on platforms that fetch fonts individually each one is a separate request on the startup path.
+	/// </param>
+	internal static async Task<bool> PreloadFontsInManifest(Uri uri, FontPreloadVariants variants)
 	{
+		if (variants == FontPreloadVariants.None)
+		{
+			return true;
+		}
+
 		var manifestUri = new Uri(uri.OriginalString + ".manifest");
 		var path = Uri.UnescapeDataString(manifestUri.PathAndQuery).TrimStart('/');
 		if (!await StorageFileHelper.ExistsInPackage(path))
@@ -68,9 +82,45 @@ internal static partial class FontFamilyHelper
 			return false;
 		}
 
-		var tasks = manifest.Fonts
+		var fonts = (IEnumerable<FontInfo>)manifest.Fonts;
+		if (variants != FontPreloadVariants.All)
+		{
+			var selected = fonts.Where(font => IsVariantSelected(font, variants)).ToArray();
+			// A manifest declaring none of the selected variants would otherwise preload nothing at all.
+			fonts = selected.Length > 0 ? selected : fonts;
+		}
+
+		var tasks = fonts
 			.Select(fontInfo => PreloadAsync(fontInfo.FamilyName, new FontWeight(fontInfo.FontWeight), fontInfo.FontStretch, fontInfo.FontStyle));
 
 		return await Task.WhenAll(tasks).ContinueWith(combinedTask => combinedTask.Result.All(t => t));
 	}
+
+	internal static bool IsVariantSelected(FontInfo font, FontPreloadVariants variants)
+	{
+		if (font.FontStyle == FontStyle.Italic && !variants.HasFlag(FontPreloadVariants.Italic))
+		{
+			return false;
+		}
+
+		if (font.FontStretch != FontStretch.Normal && !variants.HasFlag(FontPreloadVariants.Condensed))
+		{
+			return false;
+		}
+
+		return variants.HasFlag(ToVariant(font.FontWeight));
+	}
+
+	private static FontPreloadVariants ToVariant(ushort weight) => weight switch
+	{
+		<= 100 => FontPreloadVariants.Thin,
+		<= 200 => FontPreloadVariants.ExtraLight,
+		<= 300 => FontPreloadVariants.Light,
+		<= 400 => FontPreloadVariants.Normal,
+		<= 500 => FontPreloadVariants.Medium,
+		<= 600 => FontPreloadVariants.SemiBold,
+		<= 700 => FontPreloadVariants.Bold,
+		<= 800 => FontPreloadVariants.ExtraBold,
+		_ => FontPreloadVariants.Black,
+	};
 }

--- a/src/Uno.UI/UI/Xaml/FontFamilyHelper.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamilyHelper.cs
@@ -17,6 +17,14 @@ namespace Microsoft.UI.Xaml;
 
 internal static partial class FontFamilyHelper
 {
+	/// <summary>
+	/// The weight flags, i.e. the ones that can select a face on their own. <see cref="FontPreloadVariants.Italic"/>
+	/// and <see cref="FontPreloadVariants.Condensed"/> only widen an existing weight selection.
+	/// </summary>
+	private const FontPreloadVariants AnyWeight =
+		FontPreloadVariants.Thin | FontPreloadVariants.ExtraLight | FontPreloadVariants.Light |
+		FontPreloadVariants.Normal | FontPreloadVariants.Medium | FontPreloadVariants.SemiBold |
+		FontPreloadVariants.Bold | FontPreloadVariants.ExtraBold | FontPreloadVariants.Black;
 
 	/// <summary>
 	/// Pre-loads a font to minimize loading time and prevent potential text re-layouts.
@@ -58,8 +66,9 @@ internal static partial class FontFamilyHelper
 	/// </param>
 	internal static async Task<bool> PreloadFontsInManifest(Uri uri, FontPreloadVariants variants)
 	{
-		if (variants == FontPreloadVariants.None)
+		if (!SelectsAnyFace(variants))
 		{
+			// Nothing can be selected, so don't even fetch the manifest.
 			return true;
 		}
 
@@ -82,18 +91,33 @@ internal static partial class FontFamilyHelper
 			return false;
 		}
 
-		var fonts = (IEnumerable<FontInfo>)manifest.Fonts;
-		if (variants != FontPreloadVariants.All)
-		{
-			var selected = fonts.Where(font => IsVariantSelected(font, variants)).ToArray();
-			// A manifest declaring none of the selected variants would otherwise preload nothing at all.
-			fonts = selected.Length > 0 ? selected : fonts;
-		}
-
-		var tasks = fonts
+		var tasks = SelectVariants(manifest.Fonts, variants)
 			.Select(fontInfo => PreloadAsync(fontInfo.FamilyName, new FontWeight(fontInfo.FontWeight), fontInfo.FontStretch, fontInfo.FontStyle));
 
 		return await Task.WhenAll(tasks).ContinueWith(combinedTask => combinedTask.Result.All(t => t));
+	}
+
+	/// <summary>
+	/// Whether <paramref name="variants"/> can match a face at all. Covers <see cref="FontPreloadVariants.None"/>
+	/// as well as a width/style-only selection, which would otherwise match nothing and trip the fallback below.
+	/// </summary>
+	internal static bool SelectsAnyFace(FontPreloadVariants variants) => (variants & AnyWeight) != 0;
+
+	internal static IReadOnlyList<FontInfo> SelectVariants(IReadOnlyList<FontInfo> fonts, FontPreloadVariants variants)
+	{
+		if (!SelectsAnyFace(variants))
+		{
+			return Array.Empty<FontInfo>();
+		}
+
+		if (variants == FontPreloadVariants.All)
+		{
+			return fonts;
+		}
+
+		var selected = fonts.Where(font => IsVariantSelected(font, variants)).ToArray();
+		// A manifest declaring none of the selected variants would otherwise preload nothing at all.
+		return selected.Length > 0 ? selected : fonts;
 	}
 
 	internal static bool IsVariantSelected(FontInfo font, FontPreloadVariants variants)
@@ -103,7 +127,8 @@ internal static partial class FontFamilyHelper
 			return false;
 		}
 
-		if (font.FontStretch != FontStretch.Normal && !variants.HasFlag(FontPreloadVariants.Condensed))
+		// Undefined means the manifest omitted the width, which describes a normal-width face.
+		if (font.FontStretch is not (FontStretch.Normal or FontStretch.Undefined) && !variants.HasFlag(FontPreloadVariants.Condensed))
 		{
 			return false;
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #24079

## PR Type:

✨ Feature

## What changed? 🚀

**Current behavior.** `Application.PreloadFonts` awaits every entry in the default font's manifest before the first frame. `FontFamilyHelper.PreloadAllFontsInManifest` applies no weight/width/style filter, so a family such as `Uno.Fonts.OpenSans` (32 faces) is fetched in full. On WebAssembly each face is an individual HTTP request on the startup path, and because `WebAssemblyWindowWrapper.ShowCore` chains `RemoveSplashScreen()` off `FontPreloadTask`, those requests gate perceived startup.

Measured on a blank Skia WASM app (Release publish, brotli, cold context): **37 font requests, 2.62 MB brotli**. First GL draw at ~870 ms, last font at 1 026–1 215 ms, splash cleared at 1 141–1 306 ms.

**This PR.** Preloading is now driven by `FeatureConfiguration.Font.PreloadedVariants`, a new `[Flags] FontPreloadVariants` enum:

```csharp
// default
FontPreloadVariants.Normal | FontPreloadVariants.SemiBold | FontPreloadVariants.Bold

// opt into more
FeatureConfiguration.Font.PreloadedVariants |= FontPreloadVariants.Italic | FontPreloadVariants.Condensed;

// previous behaviour
FeatureConfiguration.Font.PreloadedVariants = FontPreloadVariants.All;

// no preloading at all
FeatureConfiguration.Font.PreloadedVariants = FontPreloadVariants.None;
```

Weight flags select upright, normal-width faces; `Italic` and `Condensed` widen the selection to those forms of the selected weights. Non-preloaded faces load on first use exactly as before.

`PreloadAllFontsInManifest` keeps its existing semantics and delegates to the new overload with `FontPreloadVariants.All`.

If a manifest declares none of the selected variants, the full set is preloaded, so a family without an upright regular face is not left with nothing preloaded.

This addresses the preload half of the cost. The 32 faces are still *deployed*; trimming what `Uno.Fonts.OpenSans` ships by default is separate follow-up work.

Context and full measurements: `specs/056-wasm-skia-startup-performance/spec.md` (R3), on branch `dev/mazi/wasm-startup-perf`.

## Validation

- **Code review**: selection logic is pure and side-effect free; the only behavioural change on the existing public entry point is that it now delegates with `All`, preserving semantics.
- **Compile**: `dotnet build src/Uno.UI/Uno.UI.csproj -p:UnoTargetFrameworkOverride=net10.0` — succeeded.
- **Runtime**: `dotnet test --project src/Uno.UI.UnitTests/Uno.UI.UnitTests.csproj --filter "FullyQualifiedName~Windows_UI_Xaml_Media"` — **63/63 passed**, comprising 8 new `Given_FontPreloadVariants` tests plus the 28 pre-existing `Given_FontManifest` tests and the rest of the namespace, confirming no regression.

Not yet measured end-to-end in a published WASM app — the expected effect is that the 37 startup font requests drop to the small number of faces actually selected.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- Behavioural note: apps relying on every manifest variant being resident before first render will now load the remaining faces on first use instead. Set FeatureConfiguration.Font.PreloadedVariants = FontPreloadVariants.All to restore the previous behaviour. -->
