### PR TITLE
fix(sdk): Mark MSAL as supported on the desktop target

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Common.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Desktop.targets
@@ -4,6 +4,8 @@
 		<UsingUnoCommonDesktopTargets>true</UsingUnoCommonDesktopTargets>
 		<UnoRuntimeIdentifier>Skia</UnoRuntimeIdentifier>
 
+		<IsMSALSupported>true</IsMSALSupported>
+
 		<!-- Enable the netx.0-desktop target -->
 		<TargetPlatformIdentifier>Desktop</TargetPlatformIdentifier>
 		<TargetFrameworkIdentifier>Desktop</TargetFrameworkIdentifier>


### PR DESCRIPTION
**GitHub Issue:** none — found while building the MSAL + Uno.Extensions sample for Uno.Samples; happy to file one if preferred.

## PR Type:

🐞 Bugfix

## What changed? 🚀

`IsMSALSupported` gates the `AuthenticationMsal` UnoFeature's implicit references to `Microsoft.Identity.Client`, `Microsoft.Identity.Client.Extensions.Msal` and `Uno.WinUI.MSAL`. It is set by the android, ios, wasm and winappsdk common targets — but not desktop, and it is the *only* consumer of the property (no error targets or linker configs key off it).

The gate doesn't actually keep MSAL off desktop: `Uno.Extensions.Authentication.MSAL.WinUI` is injected unconditionally, and its desktop TFM drags all three packages in transitively at their **nuspec floors**. The observable effect is silent version drift, e.g. on Uno.Sdk `6.8.0-dev.12`:

| TFM | Uno.WinUI.MSAL resolved |
| --- | --- |
| net10.0-android / -ios / -browserwasm | 6.8.0-dev.22 (implicit, SDK-pinned) |
| net10.0-desktop | **6.0.465** (transitive floor) |

MSAL has always worked on desktop — the loopback flow is pure MSAL.NET, and the skia flavour's no-op `WithUnoHelpers()` is the correct behaviour there. `Microsoft.Identity.Client.Extensions.Msal` is specifically the *desktop* token-cache helper (DPAPI / keychain / keyring), so desktop is the head that needs these pins most (mobile persists natively).

This sets `IsMSALSupported=true` in `Uno.Common.Desktop.targets`, mirroring the other heads, so `AuthenticationMsal` resolves the same SDK-pinned versions everywhere. MacCatalyst is intentionally not touched (dropped from the Uno.Sdk in f91aa26efe).

**Validation:** desktop-only `AuthenticationMsal` app on Uno.Sdk 6.8.0-dev.12 — `dotnet restore` as shipped resolves `Uno.WinUI.MSAL/6.0.465`; `dotnet restore -p:IsMSALSupported=true` (equivalent to this change) resolves `Uno.WinUI.MSAL/6.8.0-dev.22` and `Microsoft.Identity.Client(.Extensions.Msal)/4.87.0`.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample — validated via restore-graph comparison described above
- [ ] 📚 Docs have been added/updated — no doc states MSAL is unsupported on desktop; nothing to update
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BJKK7KeJ14DVxxW5UmJqo