### PR TITLE
fix(theming): focused NumberBox/ComboBox text is black in dark theme

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -4589,6 +4589,76 @@ public class Given_ElementTheme
 #endif
 
 	#endregion
+
+	#region Focused text input in dark theme (issue #24021)
+
+#if HAS_UNO
+	[TestMethod]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24021")]
+	public async Task When_NumberBox_Focused_In_Dark_Theme_Text_Is_Light()
+	{
+		// The NumberBox template's Focused state sets ContentElement.RequestedTheme = Light
+		// (as WinUI does). The theme boundary must not override the explicitly set focused
+		// Foreground that the text display block inherits.
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var numberBox = new NumberBox { Width = 150, Value = 888 };
+		WindowHelper.WindowContent = numberBox;
+		await WindowHelper.WaitForLoaded(numberBox);
+		await WindowHelper.WaitForIdle();
+
+		var inputBox = numberBox.FindFirstDescendant<TextBox>("InputBox");
+		Assert.IsNotNull(inputBox, "InputBox should exist in the NumberBox template");
+
+		inputBox.Focus(FocusState.Programmatic);
+		await WindowHelper.WaitForIdle();
+
+		var displayBlock = inputBox.FindFirstDescendant<TextBlock>(tb => tb.Text == "888");
+		Assert.IsNotNull(displayBlock, "The text display block should exist in the TextBox visual tree");
+
+		var foreground = displayBlock.Foreground as SolidColorBrush;
+		Assert.IsNotNull(foreground, "The display block Foreground should be a SolidColorBrush");
+		Assert.IsTrue((foreground.Color.R + foreground.Color.G + foreground.Color.B) / 3 > 200,
+			$"Focused NumberBox text should be light in dark theme, but was {foreground.Color}");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24021")]
+	public async Task When_Editable_ComboBox_Focused_In_Dark_Theme_Text_Is_Light()
+	{
+		// Same as the NumberBox scenario: the editable ComboBox's TextBox style sets
+		// ContentElement.RequestedTheme = Light in its Focused state.
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var comboBox = new ComboBox { Width = 150, IsEditable = true };
+		WindowHelper.WindowContent = comboBox;
+		await WindowHelper.WaitForLoaded(comboBox);
+		await WindowHelper.WaitForIdle();
+
+		var editableText = comboBox.FindFirstDescendant<TextBox>("EditableText");
+		Assert.IsNotNull(editableText, "EditableText should exist in the ComboBox template");
+
+		editableText.Focus(FocusState.Programmatic);
+		await WindowHelper.WaitForIdle();
+
+		editableText.Text = "888";
+		await WindowHelper.WaitForIdle();
+
+		var displayBlock = editableText.FindFirstDescendant<TextBlock>(tb => tb.Text == "888");
+		Assert.IsNotNull(displayBlock, "The text display block should exist in the TextBox visual tree");
+
+		var foreground = displayBlock.Foreground as SolidColorBrush;
+		Assert.IsNotNull(foreground, "The display block Foreground should be a SolidColorBrush");
+		Assert.IsTrue((foreground.Color.R + foreground.Color.G + foreground.Color.B) / 3 > 200,
+			$"Focused editable ComboBox text should be light in dark theme, but was {foreground.Color}");
+	}
+#endif
+
+	#endregion
 }
 
 public partial class Issue475ThemedDO : DependencyObject

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -4615,6 +4615,8 @@ public class Given_ElementTheme
 		inputBox.Focus(FocusState.Programmatic);
 		await WindowHelper.WaitForIdle();
 
+		AssertFocusedStateResolvedDark(inputBox);
+
 		var displayBlock = inputBox.FindFirstDescendant<TextBlock>(tb => tb.Text == "888");
 		Assert.IsNotNull(displayBlock, "The text display block should exist in the TextBox visual tree");
 
@@ -4647,6 +4649,8 @@ public class Given_ElementTheme
 
 		editableText.Text = "888";
 		await WindowHelper.WaitForIdle();
+
+		AssertFocusedStateResolvedDark(editableText);
 
 		var displayBlock = editableText.FindFirstDescendant<TextBlock>(tb => tb.Text == "888");
 		Assert.IsNotNull(displayBlock, "The text display block should exist in the TextBox visual tree");
@@ -4685,6 +4689,8 @@ public class Given_ElementTheme
 		editableText.Text = "888";
 		await WindowHelper.WaitForIdle();
 
+		AssertFocusedStateResolvedDark(editableText);
+
 		var displayBlock = editableText.FindFirstDescendant<TextBlock>(tb => tb.Text == "888");
 		Assert.IsNotNull(displayBlock, "The text display block should exist in the TextBox visual tree");
 
@@ -4692,6 +4698,53 @@ public class Given_ElementTheme
 		Assert.IsNotNull(foreground, "The display block Foreground should be a SolidColorBrush");
 		Assert.IsTrue((foreground.Color.R + foreground.Color.G + foreground.Color.B) / 3 > 200,
 			$"Focused editable ComboBox text should be light in a dark app that never switched theme, but was {foreground.Color}");
+	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia | RuntimeTestPlatforms.NativeWasm)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24021")]
+	public async Task When_Editable_ComboBox_Focused_In_Dark_Theme_ContentElement_Foreground_Is_Light()
+	{
+		// Platform-agnostic variant: asserts the Focused setter's direct target
+		// (ContentElement.Foreground) instead of Skia's text display block, so it also runs
+		// on native WASM, where ResourceResolver.ApplyVisualStateSetter is not guarded.
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var comboBox = new ComboBox { Width = 150, IsEditable = true };
+		WindowHelper.WindowContent = comboBox;
+		await WindowHelper.WaitForLoaded(comboBox);
+		await WindowHelper.WaitForIdle();
+
+		var editableText = comboBox.FindFirstDescendant<TextBox>("EditableText");
+		Assert.IsNotNull(editableText, "EditableText should exist in the ComboBox template");
+
+		editableText.Focus(FocusState.Programmatic);
+		await WindowHelper.WaitForIdle();
+
+		AssertFocusedStateResolvedDark(editableText);
+
+		var contentElement = editableText.FindFirstDescendant<ScrollViewer>("ContentElement");
+		Assert.IsNotNull(contentElement, "ContentElement should exist in the TextBox template");
+
+		var foreground = contentElement.Foreground as SolidColorBrush;
+		Assert.IsNotNull(foreground, "ContentElement.Foreground should be a SolidColorBrush");
+		Assert.IsTrue((foreground.Color.R + foreground.Color.G + foreground.Color.B) / 3 > 200,
+			$"Focused ContentElement foreground should be light in dark theme, but was {foreground.Color}");
+	}
+
+	// Positive control: the Focused state's BorderElement background proves the state actually
+	// ran and resolved Dark — all Dark-theme text-control foregrounds alias the same light
+	// brush, so a foreground assert alone can't tell "resolved correctly" from "never applied".
+	private static void AssertFocusedStateResolvedDark(TextBox textBox)
+	{
+		var borderElement = textBox.FindFirstDescendant<Border>("BorderElement");
+		Assert.IsNotNull(borderElement, "BorderElement should exist in the TextBox template");
+
+		var background = borderElement.Background as SolidColorBrush;
+		Assert.IsNotNull(background, "BorderElement.Background should be a SolidColorBrush");
+		Assert.AreEqual(Windows.UI.Color.FromArgb(0xB3, 0x1E, 0x1E, 0x1E), background.Color,
+			"BorderElement should carry the dark TextControlBackgroundFocused value (#B31E1E1E)");
 	}
 
 	private static void ResetPersistedThemes(UIElement element)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ElementTheme.cs
@@ -4656,6 +4656,56 @@ public class Given_ElementTheme
 		Assert.IsTrue((foreground.Color.R + foreground.Color.G + foreground.Color.B) / 3 > 200,
 			$"Focused editable ComboBox text should be light in dark theme, but was {foreground.Color}");
 	}
+
+	[TestMethod]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24021")]
+	public async Task When_Editable_ComboBox_Focused_In_Dark_Theme_Without_Theme_Walk_Text_Is_Light()
+	{
+		// An app that simply starts dark never runs a theme walk, so every per-object theme stays
+		// Theme.None — the state #24021 reports. Recreate it: switch the app theme to get a Dark
+		// base (the harness starts Light), then clear the per-object themes the switch persisted
+		// on the subtree, so the boundary escape cannot lean on an established parent theme.
+		using var _ = ThemeHelper.UseApplicationDarkTheme();
+
+		var comboBox = new ComboBox { Width = 150, IsEditable = true };
+		WindowHelper.WindowContent = comboBox;
+		await WindowHelper.WaitForLoaded(comboBox);
+		await WindowHelper.WaitForIdle();
+
+		ResetPersistedThemes(comboBox);
+
+		var editableText = comboBox.FindFirstDescendant<TextBox>("EditableText");
+		Assert.IsNotNull(editableText, "EditableText should exist in the ComboBox template");
+
+		editableText.Focus(FocusState.Programmatic);
+		await WindowHelper.WaitForIdle();
+
+		editableText.Text = "888";
+		await WindowHelper.WaitForIdle();
+
+		var displayBlock = editableText.FindFirstDescendant<TextBlock>(tb => tb.Text == "888");
+		Assert.IsNotNull(displayBlock, "The text display block should exist in the TextBox visual tree");
+
+		var foreground = displayBlock.Foreground as SolidColorBrush;
+		Assert.IsNotNull(foreground, "The display block Foreground should be a SolidColorBrush");
+		Assert.IsTrue((foreground.Color.R + foreground.Color.G + foreground.Color.B) / 3 > 200,
+			$"Focused editable ComboBox text should be light in a dark app that never switched theme, but was {foreground.Color}");
+	}
+
+	private static void ResetPersistedThemes(UIElement element)
+	{
+		element.SetTheme(Theme.None);
+		var count = VisualTreeHelper.GetChildrenCount(element);
+		for (var i = 0; i < count; i++)
+		{
+			if (VisualTreeHelper.GetChild(element, i) is UIElement child)
+			{
+				ResetPersistedThemes(child);
+			}
+		}
+	}
 #endif
 
 	#endregion

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Theming.cs
@@ -547,6 +547,15 @@ public partial class DependencyObject
 		{
 			return walkingParent.WalkTheme;
 		}
+
+		// An app that never switches theme at runtime has no established per-object themes (only
+		// a theme walk persists them), and ResolveOwnerTheme's owner-less fallback reads the
+		// requested-theme-for-subtree slot — mid-boundary already carrying the very theme being
+		// escaped. Use the application base theme instead (#24021).
+		if ((Parent as DependencyObject)?.GetTheme() is null or Theme.None)
+		{
+			return Uno.UI.Xaml.Core.CoreServices.Instance.Theming.GetBaseTheme();
+		}
 #endif
 
 		return ThemeResolution.ResolveOwnerTheme(Parent as DependencyObject);

--- a/src/Uno.UI/UI/Xaml/DependencyObject.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Theming.cs
@@ -392,12 +392,26 @@ public partial class DependencyObject
 			// owner's own inheritance chain.
 			var ownerTheme = ownerThemeOverride ?? ThemeResolution.ResolveOwnerTheme(owner);
 
+			// A VisualState setter value comes from outside its target's subtree, so when the same
+			// state applied a RequestedTheme boundary onto the target, resolve the setter's
+			// {ThemeResource} under the surrounding ambient theme instead — even mid-walk, where
+			// the slot carries the boundary theme (#24021).
+			if (themeRef.SetterBindingPath is not null
+				&& GetVisualStateSetterResolutionTheme() is { } setterAmbientTheme)
+			{
+				prevSlotTheme = core.GetRequestedThemeForSubTree();
+				if (prevSlotTheme != Theming.GetBaseValue(setterAmbientTheme))
+				{
+					core.SetRequestedThemeForSubTree(setterAmbientTheme);
+					popSlotTheme = true;
+				}
+			}
 			// MUX: Theming.cpp:368-376 — "Push theme that resource lookup should use to get the
 			// property value": only OUTSIDE a theme walk (`!IsProcessingThemeWalk()`) and when the
 			// owner's base theme differs from the slot. During a walk the slot already carries the
 			// walk's theme (set in NotifyThemeChanged, Theming.cpp:137-149) while the owner's
 			// per-object theme is not yet persisted — pushing here would re-scope to the stale theme.
-			if (!IsProcessingThemeWalk)
+			else if (!IsProcessingThemeWalk)
 			{
 				prevSlotTheme = core.GetRequestedThemeForSubTree();
 				if (prevSlotTheme != Theming.GetBaseValue(ownerTheme))
@@ -501,6 +515,41 @@ public partial class DependencyObject
 				core.SetRequestedThemeForSubTree(prevSlotTheme);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Gets the theme a VisualState setter's {ThemeResource} value must resolve under when the
+	/// visual state itself applied a RequestedTheme boundary onto the setter's target, or null
+	/// to resolve under the target's own theme as usual.
+	/// </summary>
+	/// <remarks>
+	/// The setter lives outside its target's subtree (in the template's VisualStateGroups), so in
+	/// WinUI its resource reference never resolves under the target's RequestedTheme — e.g.
+	/// ComboBoxTextBoxStyle's Focused state sets both ContentElement.Foreground and
+	/// ContentElement.RequestedTheme=Light (#24021). Scoped to state-applied (Animations
+	/// precedence) boundaries only, so a XAML-authored RequestedTheme keeps Uno's element-level
+	/// theming semantics for setter targets.
+	/// </remarks>
+	internal Theme? GetVisualStateSetterResolutionTheme()
+	{
+		if (ActualInstance is not FrameworkElement fe
+			|| fe.RequestedTheme == ElementTheme.Default
+			|| GetCurrentHighestValuePrecedence(FrameworkElement.RequestedThemeProperty)
+				!= DependencyPropertyValuePrecedences.Animations)
+		{
+			return null;
+		}
+
+#if UNO_HAS_ENHANCED_LIFECYCLE
+		// The ambient theme surrounding the target: mid-walk the parent's persisted theme is
+		// stale (persisted only after its subtree completes) but its walk theme is current.
+		if (Parent is DependencyObject { IsProcessingThemeWalk: true } walkingParent)
+		{
+			return walkingParent.WalkTheme;
+		}
+#endif
+
+		return ThemeResolution.ResolveOwnerTheme(Parent as DependencyObject);
 	}
 
 	#endregion
@@ -873,6 +922,13 @@ public partial class DependencyObject
 		// The Light/Dark sub-dictionary is selected at the dictionary leaf by the ambient active theme —
 		// the owner's effective theme scoped onto the core requested-theme-for-subtree slot by
 		// UpdateResourceBindings (EnsureActiveThemeDictionary, Resources.cpp:764-768).
+
+		// Same VisualState-setter ambient rule as UpdateThemeReference (#24021): a state-applied
+		// value resolves outside the state-applied RequestedTheme boundary of its target.
+		using var setterAmbientScope = binding.SetterBindingPath is not null
+			&& GetVisualStateSetterResolutionTheme() is { } setterAmbientTheme
+				? Uno.UI.Xaml.Core.CoreServices.Instance.ScopeRequestedThemeForSubTree(setterAmbientTheme)
+				: default;
 
 		// Note: we intentionally do NOT skip theme resource bindings here even though
 		// Phase 1 (UpdateAllThemeReferences) may have already resolved them. The Phase 2

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
@@ -465,9 +465,11 @@ public partial class FrameworkElement
 				if (precedence != DependencyPropertyValuePrecedences.DefaultValue
 					&& precedence != DependencyPropertyValuePrecedences.Inheritance)
 				{
-					// Clear a freeze from an earlier walk (when Foreground was still default)
-					// so the explicit value isn't blocked from cascading to children.
-					_isForegroundFrozen = false;
+					// Clear only the brush an earlier walk (when Foreground was still default) may
+					// have stored, so children don't re-pull it — Uno keeps it in a separate field
+					// while WinUI shares the local Foreground slot. The freeze flag stays, as
+					// WinUI's bail writes no freeze state and the boundary keeps blocking
+					// cross-boundary Foreground inheritance.
 					_themeForeground = null;
 					return;
 				}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Theming.cs
@@ -454,20 +454,22 @@ public partial class FrameworkElement
 			DependencyProperty? foregroundProperty = GetForegroundProperty();
 
 			// MUX Reference framework.cpp line 3423-3429:
-			// WinUI skips the entire freeze when Foreground is set locally or by style,
-			// relying on PullInheritedTextFormatting to propagate the styled value.
-			// In Uno, Foreground is an inherited DP, so children auto-cascade from
-			// the parent. We still need _themeForeground for children that don't
-			// inherit via DP (e.g., popup/template content), but we skip the SetValue
-			// to avoid overriding the styled value on THIS element.
-			bool skipSetValue = false;
+			// "If this element has a Foreground property and it is set locally, by style or
+			//  animated, there is nothing to do, because that value will be used."
+			// The explicit value cascades to children through DP inheritance, so the boundary
+			// must not freeze the theme's default foreground over it (e.g. the focused TextBox
+			// ContentElement with RequestedTheme=Light in NumberBox/ComboBox templates, #24021).
 			if (foregroundProperty is not null)
 			{
 				var precedence = this.GetCurrentHighestValuePrecedence(foregroundProperty);
 				if (precedence != DependencyPropertyValuePrecedences.DefaultValue
 					&& precedence != DependencyPropertyValuePrecedences.Inheritance)
 				{
-					skipSetValue = true;
+					// Clear a freeze from an earlier walk (when Foreground was still default)
+					// so the explicit value isn't blocked from cascading to children.
+					_isForegroundFrozen = false;
+					_themeForeground = null;
+					return;
 				}
 			}
 
@@ -496,14 +498,11 @@ public partial class FrameworkElement
 					"DefaultTextForegroundThemeBrush");
 				if (brush is not null)
 				{
-					// Always store for child inheritance (popup content, template children)
+					// Store for child inheritance (popup content, template children)
 					_themeForeground = brush;
 					_isForegroundFrozen = true;
 
-					// Only set the DP when Foreground isn't already set by a higher
-					// precedence (local/style). This matches WinUI's skip behavior
-					// while preserving _themeForeground for child propagation.
-					if (foregroundProperty is not null && !skipSetValue)
+					if (foregroundProperty is not null)
 					{
 						this.SetValue(
 							foregroundProperty, brush,

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -451,7 +451,12 @@ namespace Uno.UI
 			// (bindingPath.DataContext is the setter target), scoped onto the core
 			// requested-theme-for-subtree slot like WinUI's LookupThemeResource(theme, key); the
 			// resolution leaf reads the slot (EnsureActiveThemeDictionary, Resources.cpp:764-768).
-			var ownerTheme = ThemeResolution.ResolveOwnerTheme(bindingPath.DataContext as DependencyObject);
+			// When a previous state entry applied a RequestedTheme boundary onto the target that is
+			// still active (state re-entry), resolve outside that boundary instead (#24021).
+			var target = bindingPath.DataContext as DependencyObject;
+			var ownerTheme =
+				target?.GetVisualStateSetterResolutionTheme()
+				?? ThemeResolution.ResolveOwnerTheme(target);
 			using var themeScope = Uno.UI.Xaml.Core.CoreServices.Instance.ScopeRequestedThemeForSubTree(ownerTheme);
 			if (TryVisualTreeRetrieval(resourceKey, context, out var value, out var providingDictionary)
 				&& bindingPath.DataContext != null)


### PR DESCRIPTION
**GitHub Issue:** closes #24021

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia, text typed into a focused `NumberBox` or editable `ComboBox` rendered black while the app was in dark theme, making it nearly unreadable.

Both templates carry (verbatim from current WinUI) a `Focused` visual state that sets `ContentElement.RequestedTheme="Light"` on the inner `TextBox`. In WinUI that is harmless; in Uno it exposed two distinct defects — though **not** one per control: the foreground-freeze defect affects **both** controls, while the setter-resolution defect affects **only the editable `ComboBox`**. `NumberBox` applies its focused foreground through `ObjectAnimationUsingKeyFrames`, whose keyframe value resolves under its own templated-parent theme and was already correct — so the freeze fix alone makes `NumberBox` pass, while `ComboBox` needs both fixes (confirmed by ablation of the hunks; thanks @MartinZikmund for measuring this).

### 1. Foreground freeze overrode an explicitly-set `Foreground` (both controls)

`FrameworkElement.NotifyThemeChangedForInheritedProperties(freeze: true)` froze the Light-theme `DefaultTextForegroundThemeBrush` (black) onto the boundary element and its children, even when that element already had a `Foreground` set locally, by style, or by animation.

WinUI (`framework.cpp`, `NotifyThemeChangedForInheritedProperties`) skips the *entire* freeze in that case — *"there is nothing to do, because that value will be used"*. Uno only skipped the `SetValue` while still recording `_themeForeground` / `_isForegroundFrozen`, which then blocked the explicit value from cascading to children through DP inheritance. On Skia the typed text is the `TextBoxView` `DisplayBlock`, which inherits `Foreground` from `ContentElement` — so it picked up the frozen black brush. This corrupts the child display block regardless of how the focused foreground was applied, which is why it hits both controls.

Fix: early-return when the foreground precedence is above `Inheritance`. The bail clears only the stored `_themeForeground` brush an earlier walk may have left (Uno keeps it in a separate field, while WinUI shares the local `Foreground` slot, so only Uno can leak it to children) and leaves `_isForegroundFrozen` untouched — WinUI's bail is a pure cleanup jump that writes no freeze state, so the boundary keeps blocking cross-boundary `Foreground` inheritance.

### 2. VisualState setter `{ThemeResource}` re-resolved under its target's own theme (editable ComboBox only)

A `{ThemeResource}` inside a `VisualState` `Setter` is registered on the **target** element in Uno. When the same state also applied `RequestedTheme="Light"` to that target, the resulting theme walk re-resolved `TextControlForegroundFocused` under Light and produced a black brush.

In WinUI the resource reference lives on the `Setter` DO, which sits in the template's `VisualStateGroups` — outside the target's subtree — so it never resolves under the target's `RequestedTheme`.

Fix: `DependencyObjectStore.GetVisualStateSetterResolutionTheme()` returns the ambient theme surrounding the target, applied at the three resolution sites (`UpdateThemeReference`, `InnerUpdateResourceBindingsUnsafe`, `ResourceResolver.ApplyVisualStateSetter`). It is deliberately scoped to boundaries applied by the state itself (`RequestedTheme` at `Animations` precedence); a XAML-authored `RequestedTheme` keeps Uno's existing element-level theming semantics for setter targets.

Mid-walk, an ancestor's persisted theme is stale (it is persisted only after its subtree completes), so the ambient is read from the parent's in-flight walk theme when the parent is still processing a theme walk.

When the parent has **no established per-object theme** — the state of every element in an app that never switches theme at runtime, since only a theme walk persists per-object themes — the ambient now falls back to the application base theme (`FrameworkTheming.GetBaseTheme()`). `ResolveOwnerTheme`'s owner-less fallback instead reads the requested-theme-for-subtree slot, which mid-boundary already carries the very Light theme being escaped, silently turning the escape into a no-op — so the fix did nothing in exactly the cold-start-dark scenario #24021 reports. Caught in review by @MartinZikmund. The fallback is `UNO_HAS_ENHANCED_LIFECYCLE`-only; native targets keep their existing behavior.

## Behavior change

Theme resolution changes in two observable ways, both toward WinUI parity:

- An element with an explicitly-set `Foreground` (local / style / animation) no longer has the theme's default foreground frozen over it — and no longer propagates that frozen default to its children — when it acts as a theme boundary.
- A `{ThemeResource}` in a `VisualState` `Setter` now resolves under the ambient theme rather than the target's own `RequestedTheme`, **only** when that `RequestedTheme` was applied by a visual state.

Existing app code that (intentionally or not) relied on the frozen-default behaviour could see a different foreground on such elements. No public API changed.

## Validation

- **Build:** `SamplesApp.Skia.Generic` (Release, net10.0) — 0 warnings, 0 errors.
- **Runtime tests (Skia Desktop):** `Given_ElementTheme` — 115 tests, 114 passed. The regression tests fail before their respective fixes and pass after:
  - `When_NumberBox_Focused_In_Dark_Theme_Text_Is_Light` (freeze fix)
  - `When_Editable_ComboBox_Focused_In_Dark_Theme_Text_Is_Light` (freeze + setter-resolution fixes)
  - `When_Editable_ComboBox_Focused_In_Dark_Theme_Without_Theme_Walk_Text_Is_Light` (base-theme fallback) — stages the never-theme-switched cold start (the exact #24021 scenario) by clearing the per-object themes the harness's theme switch persists; on a build without the fallback it fails with the focused text at `#E4000000` (black).
  - `When_Editable_ComboBox_Focused_In_Dark_Theme_ContentElement_Foreground_Is_Light` — platform-agnostic variant asserting the setter's direct target (`ContentElement.Foreground`, no Skia display-block dependency); it is also enabled for **native WASM** to cover the unguarded `ApplyVisualStateSetter` path there. Native runtime tests are excluded from PR CI by design, so it first executes there on the post-merge `master` branch build; `Uno.UI.RuntimeTests.Wasm` (and the changed `Uno.UI` sources under `__WASM__`) were compile-validated locally.
  - Every test carries a positive control asserting `BorderElement.Background` is the dark `TextControlBackgroundFocused` value (`#B31E1E1E`), proving the Focused state actually ran and resolved Dark — the Dark dictionary aliases all text-control foregrounds to the same light brush, so the foreground assert alone can't distinguish "resolved correctly" from "state never applied".
  - The single failure, `When_Flyout_Closed_Target_Does_Not_Hold_Flyout`, is a pre-existing GC/leak-sensitive test that fails identically on the unmodified branch — unrelated to this change.

### Not yet measured

- Native Android/iOS were not exercised beyond compilation (the class-level `PlatformCondition` already excludes them). Native WASM has direct coverage through the `ContentElement` test above, but native runtime tests only run on branch builds — first execution is master's post-merge build; `Screenshots Compare Test Run` results remain the broader check.
- No performance measurement was taken. The added work is an extra precedence check on the setter path and an early return on the freeze path, so no regression is expected, but it has not been benchmarked.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — no documented behaviour changes; the fix aligns with existing WinUI-documented semantics
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to be validated once the CI run completes
- [ ] ❗ Contains **NO** breaking changes — see the *Behavior change* section above; theme resolution is observably different in two cases, both toward WinUI parity
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
