### PR TITLE
fix(resources): resolve localized strings by culture script

### DIFF
--- a/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader.cs
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader.cs
@@ -23,6 +23,9 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 		private const string ScriptNamedResources = "Uno.UI.UnitTests/ZhScriptFolders";
 		private const string RegionNamedResources = "Uno.UI.UnitTests/ZhRegionFolders";
 
+		// A bare zh folder (Simplified) alongside two Traditional ones, zh-HK and zh-Hant-TW.
+		private const string MixedResources = "Uno.UI.UnitTests/ZhMixedFolders";
+
 		[TestInitialize]
 		public void Init()
 		{
@@ -152,6 +155,24 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 
 			ApplicationLanguages.PrimaryLanguageOverride = language;
 			Assert.AreEqual("Traditional", SUT.GetString("Given_ResourceLoader/When_ChineseScript"));
+		}
+
+		[TestMethod]
+		[DataRow("zh-CN", "Simplified")]
+		[DataRow("zh-Hans", "Simplified")]
+		[DataRow("zh", "Simplified")]
+		[DataRow("zh-TW", "Taiwan")] // zh is a nearer ancestor, but it is Simplified
+		[DataRow("zh-Hant", "Taiwan")] // both siblings are Traditional, ordinal order picks TW
+		[DataRow("zh-MO", "Taiwan")]
+		[DataRow("zh-Hant-HK", "Hong Kong")] // same script, and HK is the matching region
+		[DataRow("zh-HK", "Hong Kong")]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24024")]
+		public void When_Chinese_And_MixedFolders(string language, string expected)
+		{
+			var SUT = _ResourceLoader.GetForCurrentView(MixedResources);
+
+			ApplicationLanguages.PrimaryLanguageOverride = language;
+			Assert.AreEqual(expected, SUT.GetString("Given_ResourceLoader/When_ChineseMixedFolders"));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader.cs
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Given_ResourceLoader.cs
@@ -18,6 +18,11 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 		private const string DefaultLanguage = "en-US";
 		private const string UITestResources = "Uno.UI.UnitTests/Resources";
 
+		// The same strings, localized once under script-named folders (zh-Hans/zh-Hant, the WinUI
+		// convention) and once under region-named ones (zh-CN/zh-TW). Both must resolve identically.
+		private const string ScriptNamedResources = "Uno.UI.UnitTests/ZhScriptFolders";
+		private const string RegionNamedResources = "Uno.UI.UnitTests/ZhRegionFolders";
+
 		[TestInitialize]
 		public void Init()
 		{
@@ -87,6 +92,66 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 
 			ApplicationLanguages.PrimaryLanguageOverride = "de-DE";
 			Assert.AreEqual(@"Text in 'en'", SUT.GetString("Given_ResourceLoader/When_LocalizedResource"));
+		}
+
+		[TestMethod]
+		[DataRow("zh-CN")]
+		[DataRow("zh-Hans")]
+		[DataRow("zh-Hans-CN")]
+		[DataRow("zh-SG")]
+		[DataRow("zh")]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24024")]
+		public void When_SimplifiedChinese_And_ScriptNamedFolders(string language)
+		{
+			var SUT = _ResourceLoader.GetForCurrentView(ScriptNamedResources);
+
+			ApplicationLanguages.PrimaryLanguageOverride = language;
+			Assert.AreEqual("Simplified", SUT.GetString("Given_ResourceLoader/When_ChineseScript"));
+		}
+
+		[TestMethod]
+		[DataRow("zh-TW")]
+		[DataRow("zh-Hant")]
+		[DataRow("zh-Hant-TW")]
+		[DataRow("zh-HK")]
+		[DataRow("zh-MO")]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24024")]
+		public void When_TraditionalChinese_And_ScriptNamedFolders(string language)
+		{
+			var SUT = _ResourceLoader.GetForCurrentView(ScriptNamedResources);
+
+			ApplicationLanguages.PrimaryLanguageOverride = language;
+			Assert.AreEqual("Traditional", SUT.GetString("Given_ResourceLoader/When_ChineseScript"));
+		}
+
+		[TestMethod]
+		[DataRow("zh-CN")]
+		[DataRow("zh-Hans")]
+		[DataRow("zh-Hans-CN")]
+		[DataRow("zh-SG")]
+		[DataRow("zh")]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24024")]
+		public void When_SimplifiedChinese_And_RegionNamedFolders(string language)
+		{
+			var SUT = _ResourceLoader.GetForCurrentView(RegionNamedResources);
+
+			ApplicationLanguages.PrimaryLanguageOverride = language;
+			Assert.AreEqual("Simplified", SUT.GetString("Given_ResourceLoader/When_ChineseScript"));
+		}
+
+		[TestMethod]
+		[DataRow("zh-TW")]
+		[DataRow("zh-Hant")]
+		[DataRow("zh-Hant-TW")]
+		[DataRow("zh-HK")]
+		[DataRow("zh-MO")]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24024")]
+		public void When_TraditionalChinese_And_RegionNamedFolders(string language)
+		{
+			var SUT = _ResourceLoader.GetForCurrentView(RegionNamedResources);
+
+			ApplicationLanguages.PrimaryLanguageOverride = language;
+			Assert.AreEqual("Traditional", SUT.GetString("Given_ResourceLoader/When_ChineseScript"));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-CN/ZhRegionFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-CN/ZhRegionFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseScript" xml:space="preserve">
+    <value>Simplified</value>
+  </data>
+</root>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-HK/ZhMixedFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-HK/ZhMixedFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseMixedFolders" xml:space="preserve">
+    <value>Hong Kong</value>
+  </data>
+</root>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-Hans/ZhScriptFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-Hans/ZhScriptFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseScript" xml:space="preserve">
+    <value>Simplified</value>
+  </data>
+</root>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-Hant-TW/ZhMixedFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-Hant-TW/ZhMixedFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseMixedFolders" xml:space="preserve">
+    <value>Taiwan</value>
+  </data>
+</root>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-Hant/ZhScriptFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-Hant/ZhScriptFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseScript" xml:space="preserve">
+    <value>Traditional</value>
+  </data>
+</root>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-TW/ZhRegionFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh-TW/ZhRegionFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseScript" xml:space="preserve">
+    <value>Traditional</value>
+  </data>
+</root>

--- a/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh/ZhMixedFolders.resw
+++ b/src/Uno.UI.UnitTests/ResourceLoader/Strings/zh/ZhMixedFolders.resw
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Given_ResourceLoader.When_ChineseMixedFolders" xml:space="preserve">
+    <value>Simplified</value>
+  </data>
+</root>

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
@@ -26,9 +26,11 @@ partial class ResourceLoader
 {
 	private readonly Dictionary<string, Dictionary<string, string>> _resources = new(StringComparer.OrdinalIgnoreCase); // _resources[CULTURE][RES_KEY] => RES_VALUE
 
-	// Concurrent because, unlike the per-loader state, this is shared process-wide and GetString
-	// carries no thread affinity.
-	private static readonly ConcurrentDictionary<string, string?> _scripts = new(StringComparer.OrdinalIgnoreCase); // _scripts[CULTURE] => ISO 15924 script
+	// Keyed only by resource cultures, which are fixed at build time — never by the requested
+	// culture, which comes from PrimaryLanguageOverride and is caller-controlled. Concurrent
+	// because, unlike the per-loader state, this is shared process-wide and GetString carries no
+	// thread affinity.
+	private static readonly ConcurrentDictionary<string, string?> _resourceScripts = new(StringComparer.OrdinalIgnoreCase); // _resourceScripts[CULTURE] => ISO 15924 script
 
 	internal string LoaderName { get; }
 
@@ -126,10 +128,12 @@ partial class ResourceLoader
 		// for a Simplified Chinese culture just because both are written "zh-".
 		if (culture.Split('-', 2)[0] is { Length: > 0 } baseCulture)
 		{
-			var script = GetScript(culture);
+			// Resolved rather than cached: the requested culture is caller-controlled, so caching it
+			// would let a process-wide dictionary grow without bound.
+			var script = ResolveScript(culture);
 			var relatedCultures = _resources.Keys
 				.Where(x => x.StartsWith(baseCulture, StringComparison.OrdinalIgnoreCase))
-				.OrderByDescending(x => script is not null && GetScript(x) == script) // same script first
+				.OrderByDescending(x => script is not null && GetResourceScript(x) == script) // same script first
 				.ThenByDescending(x => string.Equals(x, baseCulture, StringComparison.OrdinalIgnoreCase)) // then base culture
 				.ThenByDescending(x => x, StringComparer.Ordinal); // and then, sibling cultures in reverse order (from ex-ZZ to ex-AA)
 			foreach (var related in relatedCultures)
@@ -181,11 +185,12 @@ partial class ResourceLoader
 	}
 
 	/// <summary>
-	/// Gets the ISO 15924 script of a culture (Hans, Hant, Latn, Cyrl, ...), or null when the
-	/// platform doesn't associate one with it.
+	/// Gets the ISO 15924 script of a culture holding resources (Hans, Hant, Latn, Cyrl, ...), or
+	/// null when the platform doesn't associate one with it. Cached: the resource cultures are
+	/// fixed at build time, and each is scored repeatedly while ordering the fallback candidates.
 	/// </summary>
-	private static string? GetScript(string culture)
-		=> _scripts.GetOrAdd(culture, static x => ResolveScript(x));
+	private static string? GetResourceScript(string culture)
+		=> _resourceScripts.GetOrAdd(culture, static x => ResolveScript(x));
 
 	private static string? ResolveScript(string culture)
 	{

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
@@ -26,11 +26,17 @@ partial class ResourceLoader
 {
 	private readonly Dictionary<string, Dictionary<string, string>> _resources = new(StringComparer.OrdinalIgnoreCase); // _resources[CULTURE][RES_KEY] => RES_VALUE
 
-	// Keyed only by resource cultures, which are fixed at build time — never by the requested
-	// culture, which comes from PrimaryLanguageOverride and is caller-controlled. Concurrent
-	// because, unlike the per-loader state, this is shared process-wide and GetString carries no
-	// thread affinity.
-	private static readonly ConcurrentDictionary<string, string?> _resourceScripts = new(StringComparer.OrdinalIgnoreCase); // _resourceScripts[CULTURE] => ISO 15924 script
+	// Keyed only by resource cultures, which are fixed at build time. Concurrent because, unlike the
+	// per-loader state, this is shared process-wide and GetString carries no thread affinity.
+	private static readonly ConcurrentDictionary<string, (string? Script, string? Region)> _resourceSubtags = new(StringComparer.OrdinalIgnoreCase);
+
+	// The requested culture comes from PrimaryLanguageOverride and is caller-controlled, so it gets a
+	// separate memo that is dropped wholesale instead of growing. Entries can never go stale: a name's
+	// script and region are pure functions of the name.
+	private static readonly ConcurrentDictionary<string, (string? Script, string? Region)> _requestedSubtags = new(StringComparer.OrdinalIgnoreCase);
+
+	// Comfortably above the handful of language preferences a lookup cycles through.
+	private const int MaxRequestedSubtags = 32;
 
 	internal string LoaderName { get; }
 
@@ -132,28 +138,79 @@ partial class ResourceLoader
 	/// the closest match down. Script comes first, so that zh-Hant never answers a Simplified Chinese
 	/// request, whether it is reached as a sibling or as a bare zh folder holding Traditional content.
 	/// </summary>
-	private IEnumerable<string> GetFallbackCultures(string culture)
+	private List<string> GetFallbackCultures(string culture)
 	{
 		var baseCulture = culture.Split('-', 2)[0];
+		var ancestors = GetAncestors(culture).ToArray();
+		var (script, region) = GetRequestedSubtags(culture);
 
-		var ancestors = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-		foreach (var ancestor in GetAncestors(culture))
+		var candidates = new List<string>();
+		foreach (var resourceCulture in _resources.Keys)
 		{
-			ancestors.TryAdd(ancestor, ancestors.Count);
+			if (AncestorDepth(resourceCulture) >= 0 ||
+				(baseCulture.Length > 0 && resourceCulture.StartsWith(baseCulture, StringComparison.OrdinalIgnoreCase)))
+			{
+				candidates.Add(resourceCulture);
+			}
 		}
 
-		// Resolved rather than cached: the requested culture is caller-controlled, so caching it
-		// would let a process-wide dictionary grow without bound.
-		var script = ResolveScript(culture);
-		var region = GetRegionSubtag(culture);
+		candidates.Sort(CompareCandidates);
 
-		return _resources.Keys
-			.Where(x => ancestors.ContainsKey(x) || (baseCulture.Length > 0 && x.StartsWith(baseCulture, StringComparison.OrdinalIgnoreCase)))
-			.OrderByDescending(x => script is not null && string.Equals(GetResourceScript(x), script, StringComparison.OrdinalIgnoreCase)) // same script first
-			.ThenByDescending(x => region is not null && string.Equals(GetRegionSubtag(x), region, StringComparison.OrdinalIgnoreCase)) // then same region (Windows matches language+region ahead of language+script)
-			.ThenBy(x => ancestors.TryGetValue(x, out var depth) ? depth : int.MaxValue) // then the closest ancestor
-			.ThenByDescending(x => string.Equals(x, baseCulture, StringComparison.OrdinalIgnoreCase)) // then the base culture, the only ancestor an unresolvable culture still reaches
-			.ThenByDescending(x => x, StringComparer.Ordinal); // and finally the remaining siblings, from ex-ZZ to ex-AA
+		return candidates;
+
+		int CompareCandidates(string left, string right)
+		{
+			var byScript = SameScript(right).CompareTo(SameScript(left)); // same script first
+			if (byScript != 0)
+			{
+				return byScript;
+			}
+
+			var byRegion = SameRegion(right).CompareTo(SameRegion(left)); // then same region
+			if (byRegion != 0)
+			{
+				return byRegion;
+			}
+
+			var byAncestor = Proximity(left).CompareTo(Proximity(right)); // then the closest ancestor
+			if (byAncestor != 0)
+			{
+				return byAncestor;
+			}
+
+			var byBaseCulture = IsBaseCulture(right).CompareTo(IsBaseCulture(left)); // then the base culture
+			if (byBaseCulture != 0)
+			{
+				return byBaseCulture;
+			}
+
+			return StringComparer.Ordinal.Compare(right, left); // and finally from ex-ZZ to ex-AA
+		}
+
+		bool SameScript(string candidate)
+			=> script is not null && string.Equals(GetResourceSubtags(candidate).Script, script, StringComparison.OrdinalIgnoreCase);
+
+		bool SameRegion(string candidate)
+			=> region is not null && string.Equals(GetResourceSubtags(candidate).Region, region, StringComparison.OrdinalIgnoreCase);
+
+		int Proximity(string candidate)
+			=> AncestorDepth(candidate) is var depth && depth >= 0 ? depth : int.MaxValue;
+
+		int AncestorDepth(string candidate)
+		{
+			for (var i = 0; i < ancestors.Length; i++)
+			{
+				if (string.Equals(ancestors[i], candidate, StringComparison.OrdinalIgnoreCase))
+				{
+					return i;
+				}
+			}
+
+			return -1;
+		}
+
+		bool IsBaseCulture(string candidate)
+			=> string.Equals(candidate, baseCulture, StringComparison.OrdinalIgnoreCase);
 	}
 
 	private bool TryGetForCulture(string culture, string resource, out string? resourceValue)
@@ -194,12 +251,35 @@ partial class ResourceLoader
 	}
 
 	/// <summary>
-	/// Gets the ISO 15924 script of a culture holding resources (Hans, Hant, Latn, Cyrl, ...), or
-	/// null when the platform doesn't associate one with it. Cached: the resource cultures are
+	/// Gets the ISO 15924 script (Hans, Hant, Latn, Cyrl, ...) and the region of a culture holding
+	/// resources, either being null when the culture carries none. Cached: the resource cultures are
 	/// fixed at build time, and each is scored repeatedly while ordering the fallback candidates.
 	/// </summary>
-	private static string? GetResourceScript(string culture)
-		=> _resourceScripts.GetOrAdd(culture, static x => ResolveScript(x));
+	private static (string? Script, string? Region) GetResourceSubtags(string culture)
+		=> _resourceSubtags.GetOrAdd(culture, static x => (ResolveScript(x), GetRegionSubtag(x)));
+
+	/// <summary>
+	/// Same for the requested culture, memoized under <see cref="MaxRequestedSubtags"/> entries
+	/// because its name is caller-controlled.
+	/// </summary>
+	private static (string? Script, string? Region) GetRequestedSubtags(string culture)
+	{
+		if (_requestedSubtags.TryGetValue(culture, out var subtags))
+		{
+			return subtags;
+		}
+
+		subtags = (ResolveScript(culture), GetRegionSubtag(culture));
+
+		if (_requestedSubtags.Count >= MaxRequestedSubtags)
+		{
+			_requestedSubtags.Clear();
+		}
+
+		_requestedSubtags[culture] = subtags;
+
+		return subtags;
+	}
 
 	private static string? ResolveScript(string culture)
 	{

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
@@ -114,39 +114,46 @@ partial class ResourceLoader
 			return true;
 		}
 
-		// Then the culture's ancestors (zh-CN -> zh-Hans -> zh). The script tag only ever appears
-		// there, so a region-named culture can reach its script-named resources and vice versa.
-		foreach (var ancestor in GetAncestors(culture))
+		foreach (var candidate in GetFallbackCultures(culture))
 		{
-			if (TryGetForCulture(ancestor, resource, out resourceValue))
+			if (TryGetForCulture(candidate, resource, out resourceValue))
 			{
 				return true;
 			}
 		}
 
-		// Finally sibling cultures, same-script ones first: zh-Hant must never answer a request
-		// for a Simplified Chinese culture just because both are written "zh-".
-		if (culture.Split('-', 2)[0] is { Length: > 0 } baseCulture)
-		{
-			// Resolved rather than cached: the requested culture is caller-controlled, so caching it
-			// would let a process-wide dictionary grow without bound.
-			var script = ResolveScript(culture);
-			var relatedCultures = _resources.Keys
-				.Where(x => x.StartsWith(baseCulture, StringComparison.OrdinalIgnoreCase))
-				.OrderByDescending(x => script is not null && GetResourceScript(x) == script) // same script first
-				.ThenByDescending(x => string.Equals(x, baseCulture, StringComparison.OrdinalIgnoreCase)) // then base culture
-				.ThenByDescending(x => x, StringComparer.Ordinal); // and then, sibling cultures in reverse order (from ex-ZZ to ex-AA)
-			foreach (var related in relatedCultures)
-			{
-				if (TryGetForCulture(related, resource, out resourceValue))
-				{
-					return true;
-				}
-			}
-		}
-
 		resourceValue = null;
 		return false;
+	}
+
+	/// <summary>
+	/// Orders the resource cultures that may stand in for <paramref name="culture"/> — its ancestors
+	/// (zh-CN -> zh-Hans -> zh) and the siblings sharing its language (zh-Hant-TW for zh-TW) — from
+	/// the closest match down. Script comes first, so that zh-Hant never answers a Simplified Chinese
+	/// request, whether it is reached as a sibling or as a bare zh folder holding Traditional content.
+	/// </summary>
+	private IEnumerable<string> GetFallbackCultures(string culture)
+	{
+		var baseCulture = culture.Split('-', 2)[0];
+
+		var ancestors = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+		foreach (var ancestor in GetAncestors(culture))
+		{
+			ancestors.TryAdd(ancestor, ancestors.Count);
+		}
+
+		// Resolved rather than cached: the requested culture is caller-controlled, so caching it
+		// would let a process-wide dictionary grow without bound.
+		var script = ResolveScript(culture);
+		var region = GetRegionSubtag(culture);
+
+		return _resources.Keys
+			.Where(x => ancestors.ContainsKey(x) || (baseCulture.Length > 0 && x.StartsWith(baseCulture, StringComparison.OrdinalIgnoreCase)))
+			.OrderByDescending(x => script is not null && string.Equals(GetResourceScript(x), script, StringComparison.OrdinalIgnoreCase)) // same script first
+			.ThenByDescending(x => region is not null && string.Equals(GetRegionSubtag(x), region, StringComparison.OrdinalIgnoreCase)) // then same region (Windows matches language+region ahead of language+script)
+			.ThenBy(x => ancestors.TryGetValue(x, out var depth) ? depth : int.MaxValue) // then the closest ancestor
+			.ThenByDescending(x => string.Equals(x, baseCulture, StringComparison.OrdinalIgnoreCase)) // then the base culture, the only ancestor an unresolvable culture still reaches
+			.ThenByDescending(x => x, StringComparer.Ordinal); // and finally the remaining siblings, from ex-ZZ to ex-AA
 	}
 
 	private bool TryGetForCulture(string culture, string resource, out string? resourceValue)
@@ -166,17 +173,19 @@ partial class ResourceLoader
 	/// and the invariant culture.
 	/// </summary>
 	private static IEnumerable<string> GetAncestors(string culture)
-	{
-		if (TryGetCulture(culture) is not { } info)
-		{
-			yield break;
-		}
+		=> TryGetCulture(culture) is { } info ? GetSelfAndAncestors(info).Skip(1) : [];
 
-		for (var parent = info.Parent; parent.Name is { Length: > 0 } name; parent = parent.Parent)
+	/// <summary>
+	/// Enumerates <paramref name="culture"/> and its parents, closest first, excluding the invariant
+	/// culture.
+	/// </summary>
+	private static IEnumerable<string> GetSelfAndAncestors(CultureInfo culture)
+	{
+		for (var current = culture; current.Name is { Length: > 0 } name; current = current.Parent)
 		{
 			yield return name;
 
-			if (string.Equals(parent.Parent.Name, name, StringComparison.Ordinal))
+			if (string.Equals(current.Parent.Name, name, StringComparison.Ordinal))
 			{
 				// A culture whose parent is itself would loop forever.
 				yield break;
@@ -206,16 +215,11 @@ partial class ResourceLoader
 			info = TryGetSpecificCulture(info.Name) ?? info;
 		}
 
-		for (var current = info; current.Name is { Length: > 0 } name; current = current.Parent)
+		foreach (var name in GetSelfAndAncestors(info))
 		{
 			if (GetScriptSubtag(name) is { } script)
 			{
 				return script;
-			}
-
-			if (string.Equals(current.Parent.Name, name, StringComparison.Ordinal))
-			{
-				break;
 			}
 		}
 
@@ -227,51 +231,20 @@ partial class ResourceLoader
 	/// language itself (zh-Hant-TW -> Hant, ca-ES-VALENCIA -> null).
 	/// </summary>
 	private static string? GetScriptSubtag(string cultureName)
-	{
-		var remaining = cultureName.AsSpan();
+		=> cultureName.Split('-')
+			.Skip(1) // index 0 is never a script: a four-letter subtag there is a (reserved) language
+			.FirstOrDefault(subtag => subtag.Length is 4 && subtag.All(char.IsLetter));
 
-		// Skip the language subtag, a script can never be in first position.
-		var separator = remaining.IndexOf('-');
-		if (separator < 0)
-		{
-			return null;
-		}
-
-		remaining = remaining.Slice(separator + 1);
-
-		while (!remaining.IsEmpty)
-		{
-			separator = remaining.IndexOf('-');
-			var subtag = separator < 0 ? remaining : remaining.Slice(0, separator);
-
-			if (subtag.Length == 4 && IsAllLetters(subtag))
-			{
-				return subtag.ToString();
-			}
-
-			if (separator < 0)
-			{
-				break;
-			}
-
-			remaining = remaining.Slice(separator + 1);
-		}
-
-		return null;
-
-		static bool IsAllLetters(ReadOnlySpan<char> value)
-		{
-			foreach (var c in value)
-			{
-				if (!char.IsLetter(c))
-				{
-					return false;
-				}
-			}
-
-			return true;
-		}
-	}
+	/// <summary>
+	/// Extracts the region subtag of a culture name, i.e. the two-letter or three-digit subtag that
+	/// follows the language and the optional script (zh-Hant-HK -> HK, es-419 -> 419, zh-Hant -> null).
+	/// </summary>
+	private static string? GetRegionSubtag(string cultureName)
+		=> cultureName.Split('-')
+			.Skip(1) // index 0 is the language
+			.FirstOrDefault(subtag =>
+				(subtag.Length is 2 && subtag.All(char.IsLetter)) ||
+				(subtag.Length is 3 && subtag.All(char.IsDigit)));
 
 	private static CultureInfo? TryGetCulture(string name)
 	{

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.instanced.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -24,6 +25,10 @@ namespace Windows.ApplicationModel.Resources;
 partial class ResourceLoader
 {
 	private readonly Dictionary<string, Dictionary<string, string>> _resources = new(StringComparer.OrdinalIgnoreCase); // _resources[CULTURE][RES_KEY] => RES_VALUE
+
+	// Concurrent because, unlike the per-loader state, this is shared process-wide and GetString
+	// carries no thread affinity.
+	private static readonly ConcurrentDictionary<string, string?> _scripts = new(StringComparer.OrdinalIgnoreCase); // _scripts[CULTURE] => ISO 15924 script
 
 	internal string LoaderName { get; }
 
@@ -102,23 +107,34 @@ partial class ResourceLoader
 			_log.LogDebug($"[{LoaderName}] FindForCulture {culture}, {resource}");
 		}
 
-		if (_resources.TryGetValue(culture, out var map1) &&
-			map1.TryGetValue(resource, out resourceValue))
+		if (TryGetForCulture(culture, resource, out resourceValue))
 		{
 			return true;
 		}
 
-		// if we cant find using the specific culture, fallback on base culture, and then sibling cultures
+		// Then the culture's ancestors (zh-CN -> zh-Hans -> zh). The script tag only ever appears
+		// there, so a region-named culture can reach its script-named resources and vice versa.
+		foreach (var ancestor in GetAncestors(culture))
+		{
+			if (TryGetForCulture(ancestor, resource, out resourceValue))
+			{
+				return true;
+			}
+		}
+
+		// Finally sibling cultures, same-script ones first: zh-Hant must never answer a request
+		// for a Simplified Chinese culture just because both are written "zh-".
 		if (culture.Split('-', 2)[0] is { Length: > 0 } baseCulture)
 		{
+			var script = GetScript(culture);
 			var relatedCultures = _resources.Keys
 				.Where(x => x.StartsWith(baseCulture, StringComparison.OrdinalIgnoreCase))
-				.OrderByDescending(x => x == baseCulture) // base culture first
-				.ThenByDescending(x => x); // and then, sibling cultures in reverse order (from ex-ZZ to ex-AA)
+				.OrderByDescending(x => script is not null && GetScript(x) == script) // same script first
+				.ThenByDescending(x => string.Equals(x, baseCulture, StringComparison.OrdinalIgnoreCase)) // then base culture
+				.ThenByDescending(x => x, StringComparer.Ordinal); // and then, sibling cultures in reverse order (from ex-ZZ to ex-AA)
 			foreach (var related in relatedCultures)
 			{
-				if (_resources.TryGetValue(related, out var map2) &&
-					map2.TryGetValue(resource, out resourceValue))
+				if (TryGetForCulture(related, resource, out resourceValue))
 				{
 					return true;
 				}
@@ -127,5 +143,152 @@ partial class ResourceLoader
 
 		resourceValue = null;
 		return false;
+	}
+
+	private bool TryGetForCulture(string culture, string resource, out string? resourceValue)
+	{
+		if (_resources.TryGetValue(culture, out var map) &&
+			map.TryGetValue(resource, out resourceValue))
+		{
+			return true;
+		}
+
+		resourceValue = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Enumerates the parent cultures of <paramref name="culture"/>, closest first, excluding itself
+	/// and the invariant culture.
+	/// </summary>
+	private static IEnumerable<string> GetAncestors(string culture)
+	{
+		if (TryGetCulture(culture) is not { } info)
+		{
+			yield break;
+		}
+
+		for (var parent = info.Parent; parent.Name is { Length: > 0 } name; parent = parent.Parent)
+		{
+			yield return name;
+
+			if (string.Equals(parent.Parent.Name, name, StringComparison.Ordinal))
+			{
+				// A culture whose parent is itself would loop forever.
+				yield break;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets the ISO 15924 script of a culture (Hans, Hant, Latn, Cyrl, ...), or null when the
+	/// platform doesn't associate one with it.
+	/// </summary>
+	private static string? GetScript(string culture)
+		=> _scripts.GetOrAdd(culture, static x => ResolveScript(x));
+
+	private static string? ResolveScript(string culture)
+	{
+		if (TryGetCulture(culture) is not { } info)
+		{
+			return null;
+		}
+
+		// A neutral culture carrying no script of its own (zh) only reveals its default one through
+		// the specific culture the platform considers likely for it (zh -> zh-CN -> zh-Hans).
+		if (info.IsNeutralCulture && GetScriptSubtag(info.Name) is null)
+		{
+			info = TryGetSpecificCulture(info.Name) ?? info;
+		}
+
+		for (var current = info; current.Name is { Length: > 0 } name; current = current.Parent)
+		{
+			if (GetScriptSubtag(name) is { } script)
+			{
+				return script;
+			}
+
+			if (string.Equals(current.Parent.Name, name, StringComparison.Ordinal))
+			{
+				break;
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Extracts the script subtag of a culture name, i.e. a four-letter subtag that is not the
+	/// language itself (zh-Hant-TW -> Hant, ca-ES-VALENCIA -> null).
+	/// </summary>
+	private static string? GetScriptSubtag(string cultureName)
+	{
+		var remaining = cultureName.AsSpan();
+
+		// Skip the language subtag, a script can never be in first position.
+		var separator = remaining.IndexOf('-');
+		if (separator < 0)
+		{
+			return null;
+		}
+
+		remaining = remaining.Slice(separator + 1);
+
+		while (!remaining.IsEmpty)
+		{
+			separator = remaining.IndexOf('-');
+			var subtag = separator < 0 ? remaining : remaining.Slice(0, separator);
+
+			if (subtag.Length == 4 && IsAllLetters(subtag))
+			{
+				return subtag.ToString();
+			}
+
+			if (separator < 0)
+			{
+				break;
+			}
+
+			remaining = remaining.Slice(separator + 1);
+		}
+
+		return null;
+
+		static bool IsAllLetters(ReadOnlySpan<char> value)
+		{
+			foreach (var c in value)
+			{
+				if (!char.IsLetter(c))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+
+	private static CultureInfo? TryGetCulture(string name)
+	{
+		try
+		{
+			return CultureInfo.GetCultureInfo(name);
+		}
+		catch (CultureNotFoundException)
+		{
+			return null;
+		}
+	}
+
+	private static CultureInfo? TryGetSpecificCulture(string name)
+	{
+		try
+		{
+			return CultureInfo.CreateSpecificCulture(name);
+		}
+		catch (CultureNotFoundException)
+		{
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** closes #24024

## PR Type:

🐞 Bugfix

## What changed? 🚀

Setting `ApplicationLanguages.PrimaryLanguageOverride = "zh-CN"` produced **Traditional** Chinese strings in built-in controls (`TabView`, `NavigationView`, ...).

### Current behavior

`ResourceLoader.FindForCulture` resolved in two steps: exact culture match, then — on a miss — sibling cultures sharing the base language, ordered **reverse-alphabetically**. Script (`Hans`/`Hant`) was never part of the decision, so among `zh-*` siblings the reverse-alphabetical winner was always the Traditional one.

On the version in the report (Uno.Sdk 6.5.31 → Uno.WinUI 6.5.153) the control strings ship under `zh-Hans` / `zh-Hant` folders. A request for `zh-CN` therefore had no exact match and fell through to `zh-Hant`:

```
cultureKeys = [en, en-GB, en-us, zh-Hans, zh-Hant]     <- no zh-CN
TabViewCloseButtonTooltipWithKA = '關閉索引標籤 (Ctrl+F4)'
SettingsButtonName              = '設定'
```

`1ff113c647` later renamed those folders to `zh-CN` / `zh-TW` (present in `release/stable/6.6`, `6.7` and `master`, not in `6.5`). That makes the reported `zh-CN` case work by accident while moving the same defect onto `zh-Hans`, `zh-Hans-CN`, `zh`, and `zh-SG` — so the rename is not a fix, and the fallback itself needs correcting. This is also why the report does not reproduce on `master` as written.

### New behavior

`FindForCulture` now resolves in two steps:

1. **Exact culture** — unchanged.
2. **One ranked candidate list.** The candidates are the culture's ancestors (`zh-CN` → `zh-Hans` → `zh`) **union** its siblings under the same base language — the script subtag only ever appears on the ancestor chain, which is what lets a region-named culture reach script-named resources and vice versa. They are ordered:

   > **same script → same region → closest ancestor → base culture → ordinal**

   Script first means `zh-Hant` can never answer a Simplified Chinese request, whether it is reached as a *sibling* or as a bare `zh` folder holding Traditional content. Region next follows the Windows matching order (language+script+region → language+region → language+script → language). Below that, closest-ancestor-then-base-culture-then-reverse-alphabetical preserves the previous behavior, so script-less languages are unaffected.

   A wrong-script candidate is **demoted, never dropped**: with `zh` as the only resource culture, a `zh-TW` request still resolves to `zh`.

Supporting changes: script detection from the four-letter subtag, resolving a script-less neutral culture (`zh`) through `CultureInfo.CreateSpecificCulture` rather than a hardcoded language table, cached in a `ConcurrentDictionary`; the final sibling tiebreak now uses `StringComparer.Ordinal` (it previously used the culture-sensitive default comparer, so fallback order shifted with `CurrentCulture`); unresolvable culture names are guarded and degrade to the previous behavior.

### Impact

Old loader vs new loader swept over the same resources, 111 culture tags × 4 resource keys = 444 lookups:

| | |
|---|---|
| identical | 425 |
| changed | 19 |
| resolved value → empty | **0** |

Every change is wrong-script → right-script:

- `zh`, `zh-Hans`, `zh-Hans-CN`, `zh-SG` — Traditional → Simplified
- `sr-Cyrl` — Latin → Cyrillic (same defect, surfaced by the sweep: `Zatvori karticu` → `Затвори картицу`)

The candidate set is unchanged — it is exactly the union of the two tiers the previous code walked, so the ranking only decides which of them answers first. The change can therefore only affect *which* sibling wins; it cannot make a resolvable string unresolvable, and apps shipping only one Chinese script are unaffected (verified: every `zh-TW` / `zh-Hant` / `zh-HK` / `zh-MO` lookup is unchanged).

Two notes for reviewers:

- A nearer ancestor now beats the bare base culture. An app shipping both `zh` and `zh-Hans` of its own will see `zh-CN` resolve to `zh-Hans` where it previously resolved to `zh` (more specific wins, matching .NET/MRT).
- This also changes *which* sibling wins when an app ships both region- and script-named Traditional folders. Ordinal ordering alone lets every `zh-Hant*` key outrank `zh-HK`, which loses the exact region match for a `zh-Hant-HK` request; the region tiebreak restores it. `zh-MO` against a `zh-HK` + `zh-Hant-TW` set still resolves to `zh-Hant-TW` by the ordinal tiebreak — both are Traditional, and which fallback Macau should prefer is unaudited, so it is left as-is. Uno ships no `zh-HK` folder, so none of this touches the built-in resources.
- Globalization-invariant mode is unaffected: it already fails earlier in `ApplicationLanguages.CreateCulture` when a non-invariant `PrimaryLanguageOverride` is set, identically before and after this change; the new code guards every `CultureInfo` call and is not reached.

### Validation

- **Unit tests** — 28 new `[DataRow]` cases in `Given_ResourceLoader`. 20 cover both folder conventions (`zh-Hans`/`zh-Hant` and `zh-CN`/`zh-TW`) so a future rename cannot silently reintroduce this — against the un-fixed build 8 fail, including `zh-CN` on script-named folders (the reported case). The other 8 are `When_Chinese_And_MixedFolders`, pinning the ranking against a mixed set (a bare `zh` holding Simplified, next to `zh-HK` and `zh-Hant-TW`); 4 of them fail before the ranking change. All 28 pass after.
- **Fallback sweep** — old vs new resolution over all 889 installed culture names against Uno's own 86 resource folders: **0 diffs**. The ranking only bites on layouts Uno itself doesn't ship (a bare `zh` folder, or `zh-HK` alongside `zh-Hant-*`).
- **Full `Uno.UI.UnitTests` suite** — 4082 passing. The 13 failures are timezone-sensitive `Given_Calendar` / `DateTimeOffset` tests, identical on a clean baseline run of the same commit range.
- **Ordering equivalence** — the ranking is applied by an explicit sort rather than a chain of `OrderBy`/`ThenBy` (see Allocations below). Verified by comparing the *whole ordered candidate list*, not just the winner, across 13 resource-culture layouts × 893 requested cultures = 11,609 lists: 0 differences.
- **Allocations** — bytes per `GetString`, measured with `GC.GetAllocatedBytesForCurrentThread()` over 200k calls:

  | path | master | this PR |
  |---|---|---|
  | exact hit (`zh-Hans` → `zh-Hans`) | 480 | 456 |
  | script miss (`zh-CN` → `zh-Hans`) | 1328 | 1040 |
  | mixed set (`zh-Hant-HK` → `zh-HK`) | 1366 | 1077 |
  | typical app (`en-US` → `en`) | 1272 | 936 |

  The fallback path is the default path for an app — the templates ship `Strings/en/Resources.resw`, so an `en-US` run misses the exact key on every `x:Uid` lookup. Subtags are cached per resource culture (build-time-fixed keys) and memoized for the requested culture under a 32-entry cap, safe to cache because a name's script and region are pure functions of the name.
- **Analyzers** — `Uno.UWP/Uno.Skia.csproj` rebuilt with `UnoFastDevBuild=false`: 0 warnings, 0 errors.
- **End-to-end against the reported version** — the fixed loader driven against the actual shipped `Uno.WinUI 6.5.153` `Uno.UI.dll` returns `关闭选项卡(Ctrl+F4)` and `设置` for `zh-CN`.

This should be backported to `release/stable/6.5`, `6.6` and `6.7` — 6.5 is where the issue was reported, and on 6.6/6.7 the folder rename hides that case while the same defect still affects `zh-Hans`.

Separate pre-existing issue, not addressed here: strings are resolved once when a control materializes and are never re-resolved if `PrimaryLanguageOverride` changes afterwards.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- No API or binary breaking change: every added/modified member is private. Behavior changes only
     for the locales that were resolving to the wrong script; see the Impact section above. -->



