### PR TITLE
fix(databinding): reject bindable metadata resolved across ALC boundaries

### DIFF
--- a/src/Uno.UI.UnitTests/BinderTests/Given_Binder.MetadataProviderIdentity.cs
+++ b/src/Uno.UI.UnitTests/BinderTests/Given_Binder.MetadataProviderIdentity.cs
@@ -14,7 +14,10 @@ namespace Uno.UI.Tests.BinderTests
 	/// named type from the other context. Its typed getters then throw InvalidCastException. The
 	/// binder must treat such a type-identity mismatch as a miss and fall back to reflection.
 	/// </summary>
+	// RunWithProvider swaps the static BindingPropertyHelper.BindableMetadataProvider and clears the
+	// binder caches; running concurrently with any other test that touches that shared state would flake.
 	[TestClass]
+	[DoNotParallelize]
 	public partial class Given_Binder_MetadataProviderIdentity
 	{
 		[TestMethod]

--- a/src/Uno.UI.UnitTests/BinderTests/Given_Binder.MetadataProviderIdentity.cs
+++ b/src/Uno.UI.UnitTests/BinderTests/Given_Binder.MetadataProviderIdentity.cs
@@ -1,0 +1,126 @@
+#nullable enable
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Uno.UI.DataBinding;
+
+namespace Uno.UI.Tests.BinderTests
+{
+	/// <summary>
+	/// Bindable metadata providers match types by full name, so when the same assembly is loaded
+	/// in a second AssemblyLoadContext a lookup can return metadata generated for the identically
+	/// named type from the other context. Its typed getters then throw InvalidCastException. The
+	/// binder must treat such a type-identity mismatch as a miss and fall back to reflection.
+	/// </summary>
+	[TestClass]
+	public partial class Given_Binder_MetadataProviderIdentity
+	{
+		[TestMethod]
+		public void When_Provider_Returns_Matching_Type_Then_Metadata_Is_Used()
+		{
+			var matching = new BindableType(0, typeof(MetadataIdentitySource));
+
+			IBindableType? result = null;
+			RunWithProvider(
+				new StubMetadataProvider(matching),
+				() => result = BindingPropertyHelper.GetValidatedBindableType(typeof(MetadataIdentitySource)));
+
+			Assert.AreSame(matching, result);
+		}
+
+		[TestMethod]
+		public void When_Provider_Returns_Mismatched_Type_Then_Lookup_Is_A_Miss()
+		{
+			// Metadata whose Type is NOT the requested type — the shape a cross-ALC full-name match produces.
+			var mismatched = new BindableType(0, typeof(MetadataIdentityOther));
+
+			IBindableType? result = null;
+			RunWithProvider(
+				new StubMetadataProvider(mismatched),
+				() => result = BindingPropertyHelper.GetValidatedBindableType(typeof(MetadataIdentitySource)));
+
+			Assert.IsNull(result);
+		}
+
+		[TestMethod]
+		public void When_Provider_Returns_Mismatched_Type_Then_Binding_Falls_Back_To_Reflection()
+		{
+			// The mismatched metadata carries a poisoned getter; a binding must ignore it and
+			// resolve the real value through reflection.
+			var poisoned = new BindableType(1, typeof(MetadataIdentityOther));
+			poisoned.AddProperty(
+				"Value",
+				typeof(string),
+				(instance, precedence) => throw new InvalidCastException("poisoned cross-context getter"));
+
+			var target = new MetadataIdentityControl();
+			RunWithProvider(new StubMetadataProvider(poisoned), () =>
+			{
+				target.SetBinding(
+					MetadataIdentityControl.MyPropertyProperty,
+					new Binding { Path = new PropertyPath("Value") });
+
+				target.DataContext = new MetadataIdentitySource { Value = "reflected" };
+			});
+
+			Assert.AreEqual("reflected", target.MyProperty);
+		}
+
+		private static void RunWithProvider(IBindableMetadataProvider provider, Action action)
+		{
+			var previous = BindingPropertyHelper.BindableMetadataProvider;
+			BindingPropertyHelper.BindableMetadataProvider = provider;
+			BindingPropertyHelper.ClearCaches();
+
+			try
+			{
+				action();
+			}
+			finally
+			{
+				BindingPropertyHelper.BindableMetadataProvider = previous;
+				BindingPropertyHelper.ClearCaches();
+			}
+		}
+
+		private class StubMetadataProvider : IBindableMetadataProvider
+		{
+			private readonly IBindableType _result;
+
+			public StubMetadataProvider(IBindableType result)
+			{
+				_result = result;
+			}
+
+			public IBindableType GetBindableTypeByType(Type type) => _result;
+
+			public IBindableType GetBindableTypeByFullName(string fullName) => _result;
+		}
+
+		public partial class MetadataIdentityControl : DependencyObject
+		{
+			public string MyProperty
+			{
+				get => (string)GetValue(MyPropertyProperty);
+				set => SetValue(MyPropertyProperty, value);
+			}
+
+			public static readonly DependencyProperty MyPropertyProperty =
+				DependencyProperty.Register(nameof(MyProperty), typeof(string), typeof(MetadataIdentityControl), new PropertyMetadata(null));
+		}
+	}
+
+	// Top-level public on purpose: IsValidMetadataProviderType rejects nested types (Type.IsPublic is
+	// false for them), so a nested source would bypass the provider path this fixture exercises.
+	public partial class MetadataIdentitySource
+	{
+		public string? Value { get; set; }
+	}
+
+	public partial class MetadataIdentityOther
+	{
+		public string? Value { get; set; }
+	}
+}

--- a/src/Uno.UI/DataBinding/BindablePropertyDescriptor.cs
+++ b/src/Uno.UI/DataBinding/BindablePropertyDescriptor.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.DataBinding
 		/// <returns>A bindable type descriptor.</returns>
 		internal static BindablePropertyDescriptor GetPropertByBindableMetadataProvider(Type originalType, string property)
 		{
-			var bindableType = BindingPropertyHelper.BindableMetadataProvider.GetBindableTypeByType(originalType);
+			var bindableType = BindingPropertyHelper.GetValidatedBindableType(originalType);
 
 			if (bindableType != null)
 			{
@@ -44,7 +44,7 @@ namespace Uno.UI.DataBinding
 
 					if (dpDescriptor != null)
 					{
-						bindableType = BindingPropertyHelper.BindableMetadataProvider.GetBindableTypeByType(dpDescriptor.OwnerType);
+						bindableType = BindingPropertyHelper.GetValidatedBindableType(dpDescriptor.OwnerType);
 
 						if (bindableType != null)
 						{

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -141,6 +141,40 @@ namespace Uno.UI.DataBinding
 		/// </summary>
 		public static IBindableMetadataProvider? BindableMetadataProvider { get; set; }
 
+		/// <summary>
+		/// Resolves bindable metadata for <paramref name="type"/>, rejecting a result whose
+		/// <see cref="IBindableType.Type"/> is not <paramref name="type"/> itself. Generated providers
+		/// match by full name, so when the same assembly is loaded in a second AssemblyLoadContext the
+		/// provider can return metadata for the identically-named type from the other context; its
+		/// typed getters then fail with <see cref="InvalidCastException"/>. On mismatch this returns
+		/// null and callers fall back to reflection.
+		/// </summary>
+		internal static IBindableType? GetValidatedBindableType(Type type)
+		{
+			var bindableType = BindableMetadataProvider?.GetBindableTypeByType(type);
+
+			if (bindableType is null)
+			{
+				return null;
+			}
+
+			if (bindableType.Type != type)
+			{
+				if (_log.IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+				{
+					_log.DebugFormat(
+						"Bindable metadata for [{0}] resolved to another type instance (context [{1}] vs [{2}]); using reflection instead.",
+						type.FullName,
+						System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(type.Assembly)?.Name,
+						System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(bindableType.Type.Assembly)?.Name);
+				}
+
+				return null;
+			}
+
+			return bindableType;
+		}
+
 		public static Type? GetPropertyType(Type type, string property, bool allowPrivateMembers)
 		{
 			// Capture the pooled key into a local: ClearCaches() swaps the static field, and a
@@ -643,7 +677,7 @@ namespace Uno.UI.DataBinding
 					using (Performance.Measure("GetValueGetter.BindableMetadataProvider"))
 #endif
 					{
-						var bindableType = BindableMetadataProvider.GetBindableTypeByType(type);
+						var bindableType = GetValidatedBindableType(type);
 
 						if (bindableType != null)
 						{
@@ -972,7 +1006,7 @@ namespace Uno.UI.DataBinding
 					using (Performance.Measure("GetValueSetter.BindableMetadataProvider"))
 #endif
 					{
-						var bindableType = BindableMetadataProvider.GetBindableTypeByType(type);
+						var bindableType = GetValidatedBindableType(type);
 
 						if (bindableType != null)
 						{

--- a/src/Uno.UI/Helpers/TypeActivator.cs
+++ b/src/Uno.UI/Helpers/TypeActivator.cs
@@ -20,7 +20,9 @@ internal static class TypeActivator
 	{
 		var replacementType = type.GetReplacementType();
 
-		if (Uno.UI.DataBinding.BindingPropertyHelper.BindableMetadataProvider?.GetBindableTypeByType(replacementType)?.CreateInstance() is { } factory)
+		// Validated lookup: a full-name match from another AssemblyLoadContext would otherwise
+		// instantiate the other context's identically-named type.
+		if (Uno.UI.DataBinding.BindingPropertyHelper.GetValidatedBindableType(replacementType)?.CreateInstance() is { } factory)
 		{
 			return factory();
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #24095 and  https://github.com/unoplatform/studio.live/issues/3640

## PR Type:

🐞 Bugfix

## What changed? 🚀

Generated bindable metadata providers match types **by full name** (`GetBindableTypeByType(type)` delegates to `GetBindableTypeByFullName(type.FullName)`). When the same assembly is loaded in a second `AssemblyLoadContext` (a host application previewing a secondary app, per the `Uno.UI.RuntimeTests` hosting pattern), a lookup for the secondary context's type returns the *host* context's `IBindableType` — whose typed getters then throw `InvalidCastException`, and controls binding such types (e.g. `FeedView`'s `FeedViewState` as a template DataContext) silently render blank.

`IBindableType` already carries its `Type`, so the binder now validates the lookup result against the requested type identity (`BindingPropertyHelper.GetValidatedBindableType`): a mismatch is treated as a miss and falls back to the reflection path — which is where non-colliding secondary-context types already resolved. A rejected mismatch is logged at Debug with both load-context names.

Covered call sites: `BindablePropertyDescriptor.GetPropertByBindableMetadataProvider` (named + attached properties), both indexer lookups in `BindingPropertyHelper`, and `TypeActivator.CreateInstance` (where a cross-context match would silently instantiate the other context's identically-named type). Known remaining raw provider sites, deliberately out of scope for a minimal fix: `DirectUI/PropertyAccess.cs` (`HAS_UNO` branch) and the name-based lookup in `DependencyPropertyDescriptor` (no `Type` input exists to validate against).

Behavior notes:
- Single-ALC apps are unaffected: generated providers construct every entry with `typeof(X)`, so the identity check never fires for them; hot-reload replacement types carry `#N`-suffixed names and never matched the name-keyed tables in the first place.
- A custom `IBindableMetadataProvider` that deliberately returns metadata whose `Type` differs from the queried type would now be treated as a miss; generated providers never do this.

Tests: `Given_Binder.MetadataProviderIdentity` — matching-type pass-through, mismatched-type miss, and an end-to-end binding assertion that a poisoned cross-context getter is ignored in favor of the reflected value (fails with `InvalidCastException` on the previous code).

## Verification (secondary-ALC host, FeedView repro)

Three variants were run against the same repro: a host app loading a prebuilt secondary app (using MVUX `FeedView`) into a collectible ALC.

| Variant | `InvalidCastException` | Page creation / rendering | Verdict |
|---|---|---|---|
| **A - baseline** (unpatched 6.7.16) | Thrown in `FeedViewState` typed getters via the host's bindable metadata provider | Pages create, but every `FeedView` renders blank | Bug reproduced |
| **B - host-side workaround**: load `Uno.Extensions.Reactive(.UI/.Messaging)` from the host ALC (shared identity) | Gone | Page creation fails outright - navigation errors and XAML instantiation returning null (Reactive.UI registers its XAML resources per load context) | Rejected - strictly worse |
| **C - this fix**: identity-validated metadata lookup + reflection fallback | Gone | All pages render fully, 0 navigation failures, transient converter noise gone | Shipped |

B also only works at all when host and secondary app carry byte-identical `Uno.Extensions` versions, which a host cannot guarantee; C fixes the lookup for any same-named type across contexts with no host cooperation.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, internal fix
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

