### PR TITLE
fix(textbox): Use mobile touch selection in mobile browsers

### DIFF
--- a/src/Uno.UI.UnitTests/Helpers/Given_DeviceTargetHelper.cs
+++ b/src/Uno.UI.UnitTests/Helpers/Given_DeviceTargetHelper.cs
@@ -26,6 +26,8 @@ public class Given_DeviceTargetHelper
 	// iPadOS 13+ requests the desktop site by default, which reports the very same user agent and platform as a Mac.
 	[DataRow(IPadDesktopSiteUserAgent, "MacIntel", true, nameof(BrowserHostPlatform.iOS), DisplayName = "iPad requesting the desktop site")]
 	[DataRow(MacSafariUserAgent, "MacIntel", false, nameof(BrowserHostPlatform.Other), DisplayName = "Safari on macOS")]
+	// "Linux armv81" (with a digit one) is not a typo: it is the value Chrome 107+ and Firefox freeze on Android for
+	// UA reduction. "Linux armv8l" is what older browsers report, so both spellings are covered.
 	[DataRow(AndroidPhoneUserAgent, "Linux armv81", true, nameof(BrowserHostPlatform.Android), DisplayName = "Android phone")]
 	[DataRow(AndroidTabletUserAgent, "Linux armv8l", true, nameof(BrowserHostPlatform.Android), DisplayName = "Android tablet")]
 	// A touchscreen alone doesn't make a desktop OS follow mobile conventions - WinUI itself doesn't.

--- a/src/Uno.UI.UnitTests/Helpers/Given_DeviceTargetHelper.cs
+++ b/src/Uno.UI.UnitTests/Helpers/Given_DeviceTargetHelper.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Helpers;
+
+namespace Uno.UI.Tests.Helpers;
+
+[TestClass]
+public class Given_DeviceTargetHelper
+{
+	private const string IPadDesktopSiteUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+	private const string IPadMobileSiteUserAgent = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+	private const string IPadChromeUserAgent = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/118.0.5993.92 Mobile/15E148 Safari/604.1";
+	private const string IPhoneUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+	private const string AndroidPhoneUserAgent = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36";
+	private const string AndroidTabletUserAgent = "Mozilla/5.0 (Linux; Android 13; SM-X710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36";
+	private const string MacSafariUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+	private const string WindowsChromeUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36";
+	private const string LinuxFirefoxUserAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0";
+
+	// expected is passed by name because BrowserHostPlatform is internal and test methods must be public.
+	[TestMethod]
+	[DataRow(IPadMobileSiteUserAgent, "iPad", true, nameof(BrowserHostPlatform.iOS), DisplayName = "iPad requesting the mobile site")]
+	[DataRow(IPadChromeUserAgent, "iPad", true, nameof(BrowserHostPlatform.iOS), DisplayName = "Chrome on iPad")]
+	[DataRow(IPhoneUserAgent, "iPhone", true, nameof(BrowserHostPlatform.iOS), DisplayName = "iPhone")]
+	// iPadOS 13+ requests the desktop site by default, which reports the very same user agent and platform as a Mac.
+	[DataRow(IPadDesktopSiteUserAgent, "MacIntel", true, nameof(BrowserHostPlatform.iOS), DisplayName = "iPad requesting the desktop site")]
+	[DataRow(MacSafariUserAgent, "MacIntel", false, nameof(BrowserHostPlatform.Other), DisplayName = "Safari on macOS")]
+	[DataRow(AndroidPhoneUserAgent, "Linux armv81", true, nameof(BrowserHostPlatform.Android), DisplayName = "Android phone")]
+	[DataRow(AndroidTabletUserAgent, "Linux armv8l", true, nameof(BrowserHostPlatform.Android), DisplayName = "Android tablet")]
+	// A touchscreen alone doesn't make a desktop OS follow mobile conventions - WinUI itself doesn't.
+	[DataRow(WindowsChromeUserAgent, "Win32", true, nameof(BrowserHostPlatform.Other), DisplayName = "Windows touch device")]
+	[DataRow(WindowsChromeUserAgent, "Win32", false, nameof(BrowserHostPlatform.Other), DisplayName = "Windows desktop")]
+	[DataRow(LinuxFirefoxUserAgent, "Linux x86_64", false, nameof(BrowserHostPlatform.Other), DisplayName = "Linux desktop")]
+	[DataRow("", "", false, nameof(BrowserHostPlatform.Other), DisplayName = "Unavailable navigator values")]
+	public void When_GetBrowserHostPlatform(string userAgent, string platform, bool isTouchCapable, string expected)
+		=> Assert.AreEqual(
+			Enum.Parse<BrowserHostPlatform>(expected),
+			DeviceTargetHelper.GetBrowserHostPlatform(userAgent, platform, isTouchCapable));
+}

--- a/src/Uno.UI/Helpers/BrowserHostPlatform.cs
+++ b/src/Uno.UI/Helpers/BrowserHostPlatform.cs
@@ -1,0 +1,19 @@
+namespace Uno.UI.Helpers;
+
+/// <summary>
+/// The mobile OS a browser is running on, as detected from the browser itself.
+/// </summary>
+internal enum BrowserHostPlatform
+{
+	/// <summary>
+	/// Not running in a browser, or running in a browser that is hosted neither by iOS/iPadOS nor by Android.
+	/// </summary>
+	Other,
+
+	/// <summary>
+	/// iOS or iPadOS, whichever browser engine is in use (they are all WebKit on those platforms).
+	/// </summary>
+	iOS,
+
+	Android,
+}

--- a/src/Uno.UI/Helpers/DeviceTargetHelper.cs
+++ b/src/Uno.UI/Helpers/DeviceTargetHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Uno.Foundation.Logging;
 using Windows.System;
 
 namespace Uno.UI.Helpers;
@@ -9,6 +10,8 @@ internal static class DeviceTargetHelper
 		OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsTvOS() ||
 		(OperatingSystem.IsBrowser() &&
 			Uno.Foundation.WebAssemblyImports.EvalBool("/Mac|iPhone|iPad|iPod/.test(navigator?.platform ?? '')")));
+
+	private static readonly Lazy<BrowserHostPlatform> _browserHost = new(GetBrowserHostPlatform);
 
 	internal static bool IsNonDesktop() =>
 		OperatingSystem.IsBrowser() ||
@@ -42,4 +45,64 @@ internal static class DeviceTargetHelper
 	/// </summary>
 	internal static VirtualKeyModifiers PlatformCommandModifier =>
 		UsesAppleKeyboardLayout ? VirtualKeyModifiers.Windows : VirtualKeyModifiers.Control;
+
+	/// <summary>
+	/// The mobile OS hosting the browser, for features that must follow the host device's interaction
+	/// conventions: on WebAssembly the OS APIs only ever report "browser", never the underlying device.
+	/// </summary>
+	internal static BrowserHostPlatform BrowserHost => _browserHost.Value;
+
+	private static BrowserHostPlatform GetBrowserHostPlatform()
+	{
+		if (!OperatingSystem.IsBrowser())
+		{
+			return BrowserHostPlatform.Other;
+		}
+
+		try
+		{
+			return GetBrowserHostPlatform(
+				Uno.Foundation.WebAssemblyImports.EvalString("navigator?.userAgent ?? ''"),
+				Uno.Foundation.WebAssemblyImports.EvalString("navigator?.platform ?? ''"),
+				Uno.Foundation.WebAssemblyImports.EvalBool("(navigator?.maxTouchPoints ?? 0) > 0"));
+		}
+		catch (Exception e)
+		{
+			// Probing navigator can fail (e.g. a Content-Security-Policy without 'unsafe-eval'). Falling back
+			// to desktop conventions is preferable to faulting every caller.
+			if (typeof(DeviceTargetHelper).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(DeviceTargetHelper).Log().Debug($"Unable to detect the browser host platform: {e}");
+			}
+
+			return BrowserHostPlatform.Other;
+		}
+	}
+
+	/// <remarks>
+	/// iPadOS 13+ browsers request the desktop site by default and report a Mac user agent and platform,
+	/// so touch capability is all that tells an iPad apart from a Mac.
+	/// </remarks>
+	internal static BrowserHostPlatform GetBrowserHostPlatform(string userAgent, string platform, bool isTouchCapable)
+	{
+		if (userAgent.Contains("Android", StringComparison.Ordinal))
+		{
+			return BrowserHostPlatform.Android;
+		}
+
+		if (userAgent.Contains("iPhone", StringComparison.Ordinal)
+			|| userAgent.Contains("iPad", StringComparison.Ordinal)
+			|| userAgent.Contains("iPod", StringComparison.Ordinal))
+		{
+			return BrowserHostPlatform.iOS;
+		}
+
+		if (isTouchCapable
+			&& (platform.Contains("Mac", StringComparison.Ordinal) || userAgent.Contains("Macintosh", StringComparison.Ordinal)))
+		{
+			return BrowserHostPlatform.iOS;
+		}
+
+		return BrowserHostPlatform.Other;
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -123,9 +123,11 @@ public partial class TextBox : ITextSelectionGripperHost
 	// OperatingSystem.IsAndroid()/IsIOS() are both false and the OS-derived default is Desktop.
 	internal TouchTextSelectionConvention TouchSelectionConvention { get; set; } = GetDefaultTouchTextSelectionConvention();
 
+	// A browser on a phone or tablet must follow that device's touch conventions too: on WebAssembly the
+	// OS APIs report "browser", so the host device comes from DeviceTargetHelper.BrowserHost.
 	private static TouchTextSelectionConvention GetDefaultTouchTextSelectionConvention()
-		=> OperatingSystem.IsAndroid() ? TouchTextSelectionConvention.Android
-			: Uno.UI.Helpers.DeviceTargetHelper.IsUIKit() ? TouchTextSelectionConvention.iOS
+		=> OperatingSystem.IsAndroid() || DeviceTargetHelper.BrowserHost is BrowserHostPlatform.Android ? TouchTextSelectionConvention.Android
+			: DeviceTargetHelper.IsUIKit() || DeviceTargetHelper.BrowserHost is BrowserHostPlatform.iOS ? TouchTextSelectionConvention.iOS
 			: TouchTextSelectionConvention.Desktop;
 
 	public static DependencyProperty CanUndoProperty { get; } = DependencyProperty.Register(
@@ -1877,11 +1879,11 @@ public partial class TextBox : ITextSelectionGripperHost
 	}
 
 	// Which platform's native touch text-selection conventions the Skia TextBox follows.
-	// Defaults to the running OS; runtime tests override it to exercise the mobile behavior on
-	// Skia Desktop, where OperatingSystem.IsAndroid()/IsIOS() are both false.
+	// Defaults to the running device (on WebAssembly, the device hosting the browser); runtime tests override
+	// it to exercise the mobile behavior on Skia Desktop, where OperatingSystem.IsAndroid()/IsIOS() are both false.
 	internal enum TouchTextSelectionConvention
 	{
-		// Desktop convention (Windows, macOS and Linux): the OS-derived default for every non-mobile target.
+		// Desktop convention (Windows, macOS, Linux and desktop browsers).
 		Desktop,
 		Android,
 		iOS


### PR DESCRIPTION
**GitHub Issue:** n/a — customer-reported, tracked internally.

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior:** in a WebAssembly app using the Skia renderer, editable text controls always used the **Desktop** touch-selection convention, even when the browser runs on a phone or a tablet. On an iPad that means a single tap *selects a word* instead of placing the caret, a double-tap does not select the word under the finger, and a long-press opens the context flyout instead of the iOS caret drag. It affects `TextBox`, multiline `TextBox`, `PasswordBox` and `NumberBox` alike.

The Skia `TextBox` already implements the native iOS/Android touch conventions (word select on double-tap, insertion/selection grippers, iOS caret drag on long-press, the copy/paste selection flyout). Only the default was wrong: `GetDefaultTouchTextSelectionConvention()` resolved it from `OperatingSystem.IsAndroid()` / `DeviceTargetHelper.IsUIKit()`, and both are false in a browser — the OS APIs only ever report "browser", never the device underneath.

**This PR** adds `DeviceTargetHelper.BrowserHost`, which detects the OS hosting the browser once per process from `navigator.userAgent`, `navigator.platform` and `navigator.maxTouchPoints`, and makes the touch-selection convention honor it: iOS/iPadOS browsers get the iOS convention, Android browsers the Android one, desktop browsers stay on Desktop as before.

The iPadOS 13+ wrinkle is worth calling out: iPad browsers request the desktop site by default and report a **Mac** user agent *and* `navigator.platform === "MacIntel"`, so touch capability is the only thing that tells an iPad apart from a Mac. A touchscreen alone does not switch a desktop OS to mobile conventions — WinUI itself doesn't. If probing `navigator` fails (e.g. a Content-Security-Policy without `unsafe-eval`), detection falls back to `Other`, i.e. exactly today's behavior.

Note that the browser's *own* selection UI (Safari's loupe, its handles and edit menu) is not what this restores, and cannot be: the Skia canvas sets `touch-action: none` so Uno receives every pointer event, and the text input backing it is invisible and `pointer-events: none`. Uno draws the platform-equivalent selection UI instead, which is what this PR makes appear on tablets and phones.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
  - `Given_DeviceTargetHelper.When_GetBrowserHostPlatform` covers the detection over real user agents: iPad requesting the desktop site, iPad requesting the mobile site, Chrome on iPad, iPhone, Android phone, Android tablet, Safari on macOS, a Windows touch device, Windows/Linux desktop, and an unavailable `navigator`.
  - The behavior each convention drives is already covered by the existing `Given_TextBox` touch tests (`When_Touch_DoubleTap_Selects_Word_iOS`, `When_Touch_SingleTap_Places_Caret_iOS`, `When_Touch_LongPress_*`, …). Those inject touch through `InputInjector` and are gated to `SkiaDesktop | SkiaAndroid`, so they cover the conventions themselves but not the browser; the browser side was validated manually: the published `SamplesApp.Skia.WebAssembly.Browser` served over LAN and opened on an **iPad in Safari** — single tap places the caret, double-tap selects the tapped word with grippers and the copy/paste bar, long-press drags the caret.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

Behavior change to be aware of: WebAssembly Skia apps opened on Android phones/tablets and on iPhones now follow those platforms' touch text-selection conventions too, matching the native Skia Android/iOS targets.
