### PR TITLE
fix(skia): Allow scrolling a touch-focused TextBox away

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6523,13 +6523,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
+		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/1164")]
+		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/537")]
 		public async Task When_Touch_Focused_Then_Scrolled_Away()
 		{
 			var SUT = new TextBox
 			{
 				Width = 400,
-				Text = "Some Text"
+				Text = "Some Text",
+				SelectionFlyout = null // avoid the selection toolbar's light-dismiss layer eating the scroll gesture
 			};
 
 			var sv = new ScrollViewer()
@@ -6572,6 +6574,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finger.Release();
 			await UITestHelper.WaitForIdle(true);
 
+			Assert.IsNotNull(SUT.VisibleGrippersForTesting, "the touch grippers should be showing after the taps");
+
 			// scroll
 			finger.Press(sv.GetAbsoluteBoundsRect().GetCenter());
 			await UITestHelper.WaitForIdle(true);
@@ -6581,8 +6585,125 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await UITestHelper.WaitForIdle(true);
 
 			await Task.Delay(TimeSpan.FromSeconds(2));
+			await UITestHelper.WaitForIdle(true);
 
-			SUT.GetAbsoluteBoundsRect().Bottom.Should().BeApproximately(sv.GetAbsoluteBoundsRect().Bottom, 5);
+			// The user must be able to scroll the focused TextBox away (native/WinUI parity): the TextBox
+			// stays out of the viewport instead of being scrolled back into view.
+			Assert.IsTrue(
+				SUT.GetAbsoluteBoundsRect().Top >= sv.GetAbsoluteBoundsRect().Bottom - 1,
+				$"the TextBox should remain scrolled out of view (tb top {SUT.GetAbsoluteBoundsRect().Top}, sv bottom {sv.GetAbsoluteBoundsRect().Bottom})");
+
+			// ...and its grippers must not float over unrelated content while it is out of view.
+			var grippers = SUT.VisibleGrippersForTesting;
+			Assert.IsNotNull(grippers, "the selection state (and thus the grippers pair) should still be active");
+			Assert.IsFalse(grippers.Value.end.IsPopupOpenForTesting, "grippers should be culled while the TextBox is scrolled out of view");
+
+			// Scrolling back must re-show the grippers at the selection.
+			SUT.StartBringIntoView(new BringIntoViewOptions { AnimationDesired = false });
+			await UITestHelper.WaitForIdle(true);
+			await WindowHelper.WaitFor(
+				() => SUT.VisibleGrippersForTesting is { end.IsPopupOpenForTesting: true },
+				timeoutMS: 5000,
+				message: "grippers should re-appear once the TextBox is scrolled back into view");
+		}
+
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/kahua-private/issues/537")]
+		[DataRow(true, DisplayName = "WithSelection")]
+		[DataRow(false, DisplayName = "CursorOnly")]
+		public async Task When_Touch_TextBox_In_ScrollViewer_Scroll_Away_Does_Not_Snap_Back(bool withSelection)
+		{
+			var SUT = new TextBox
+			{
+				Width = 300,
+				Text = "Hello world",
+				FontFamily = "Arial",
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android,
+				SelectionFlyout = null // avoid the selection toolbar's light-dismiss layer eating the scroll gesture
+			};
+
+			var panel = new StackPanel { Spacing = 8 };
+			panel.Children.Add(new Border { Height = 1200, Background = new SolidColorBrush(Microsoft.UI.Colors.LightGray) });
+			panel.Children.Add(SUT);
+			panel.Children.Add(new Border { Height = 150, Background = new SolidColorBrush(Microsoft.UI.Colors.LightBlue) });
+
+			var sv = new ScrollViewer
+			{
+				Height = 400,
+				Width = 340,
+				Content = panel,
+				IsScrollInertiaEnabled = false, // deterministic settling offset
+			};
+
+			await UITestHelper.Load(sv);
+
+			sv.ChangeView(null, sv.ScrollableHeight, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var tbBounds = SUT.GetAbsoluteBoundsRect();
+			var tapPoint = new Point(tbBounds.Left + 30, tbBounds.GetCenter().Y);
+
+			if (withSelection)
+			{
+				// Double-tap: select the word and show both grippers
+				finger.Press(tapPoint);
+				finger.Release();
+				finger.Press(tapPoint);
+				finger.Release();
+				await WindowHelper.WaitFor(
+					() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+					message: "double-tap should select the word and show both thumbs");
+			}
+			else
+			{
+				// Single tap: collapsed caret + single insertion handle
+				finger.Press(tapPoint);
+				finger.Release();
+				await WindowHelper.WaitFor(
+					() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+					message: "tap should place the single insertion handle");
+			}
+
+			await WindowHelper.WaitForIdle();
+
+			var offsetBefore = sv.VerticalOffset;
+
+			// Swipe: finger down over the filler above the TextBox, drag downward => scrolls the viewport up
+			var svBounds = sv.GetAbsoluteBoundsRect();
+			finger.Press(new Point(svBounds.GetCenter().X, svBounds.Top + 60));
+			finger.MoveBy(0, 250, steps: 25);
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			var offsetAfterRelease = sv.VerticalOffset;
+			Assert.IsTrue(
+				offsetAfterRelease < offsetBefore - 100,
+				$"the swipe should have scrolled the viewport up (before {offsetBefore}, after {offsetAfterRelease})");
+
+			// Let any (undesired) scroll-back animation run: the offset must stay where the user scrolled
+			// instead of snapping back to the focused TextBox (native/WinUI parity).
+			await Task.Delay(1500);
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(offsetAfterRelease, sv.VerticalOffset, 1.0,
+				"the viewport must not scroll back to the focused TextBox after the user scrolled away");
+
+			// The grippers must not float over unrelated content while the TextBox is out of view.
+			var grippers = SUT.VisibleGrippersForTesting;
+			Assert.IsNotNull(grippers, "the touch selection state (and thus the grippers pair) should still be active");
+			Assert.IsFalse(grippers.Value.end.IsPopupOpenForTesting,
+				"grippers should be culled while the TextBox is scrolled out of view");
+
+			// Scrolling back must re-show the grippers at the selection (on the next rendered frame,
+			// so allow a generous timeout for a frame to be produced).
+			sv.ChangeView(null, offsetBefore, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(
+				() => SUT.VisibleGrippersForTesting is { end.IsPopupOpenForTesting: true },
+				timeoutMS: 5000,
+				message: "grippers should re-appear once the TextBox is scrolled back into view");
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
@@ -22,7 +22,6 @@ internal sealed class CaretWithStemAndThumb : Grid
 	// change the thumb color on WinUI, only the selection color.
 	private static readonly Color ThumbFillColor = Colors.FromARGB("FF0078D7");
 
-	private readonly Action _repositionCallback;
 	private readonly Rectangle _stem;
 	private Popup _popup;
 
@@ -35,13 +34,8 @@ internal sealed class CaretWithStemAndThumb : Grid
 	/// </summary>
 	public double GrabOffsetY { get; set; }
 
-	/// <param name="repositionCallback">
-	/// Invoked once per rendered frame while the gripper is showing, so the owner
-	/// can keep the gripper glued to its anchor character as the text moves.
-	/// </param>
-	public CaretWithStemAndThumb(Action repositionCallback)
+	public CaretWithStemAndThumb()
 	{
-		_repositionCallback = repositionCallback;
 		// Numbers and colors below are partially measured by hand from WinUI and partially made up to be reasonable.
 
 		Background = new SolidColorBrush(Colors.Transparent); // to hit-test positively everywhere in the grid
@@ -87,6 +81,8 @@ internal sealed class CaretWithStemAndThumb : Grid
 
 	public void SetStemVisible(bool visible) => _stem.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
 
+	internal bool IsPopupOpenForTesting => _popup?.IsOpen == true;
+
 	public void ShowAt(XamlRoot xamlRoot, Matrix3x2 transform)
 	{
 		_popup ??= new Popup
@@ -103,24 +99,8 @@ internal sealed class CaretWithStemAndThumb : Grid
 			RenderTransform = matrixTransform;
 		}
 		matrixTransform.Matrix = new Matrix(transform);
-		if (!_popup.IsOpen)
-		{
-			_popup.IsOpen = true;
-			_popup.Closed += OnPopupClosed;
-			((CompositionTarget)Visual.CompositionTarget)!.FrameRendered += OnFrameRendered;
-		}
+		_popup.IsOpen = true;
 	}
-
-	private void OnPopupClosed(object sender, object e)
-	{
-		_popup.Closed -= OnPopupClosed;
-		if (Visual.CompositionTarget is CompositionTarget target)
-		{
-			target.FrameRendered -= OnFrameRendered;
-		}
-	}
-
-	private void OnFrameRendered() => _repositionCallback?.Invoke();
 
 	public void Hide()
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -96,12 +96,17 @@ internal sealed class TextSelectionGripperPresenter
 	private CaretWithStemAndThumb _startGripper;
 	private CaretWithStemAndThumb _endGripper;
 
+	// Subscribed while the grippers are active (GripperMode != Hidden) so they keep tracking their
+	// anchors every rendered frame (scrolling, text moves), even while culled out of view or after
+	// their popup was closed externally. Same pattern as SystemFocusVisual.
+	private CompositionTarget _frameRenderedTarget;
+
 	public TextSelectionGripperPresenter(ITextSelectionGripperHost host)
 	{
 		_host = host;
 
-		_startGripper = new CaretWithStemAndThumb(Update);
-		_endGripper = new CaretWithStemAndThumb(Update);
+		_startGripper = new CaretWithStemAndThumb();
+		_endGripper = new CaretWithStemAndThumb();
 
 		foreach (var gripper in (ReadOnlySpan<CaretWithStemAndThumb>)[_startGripper, _endGripper])
 		{
@@ -127,8 +132,33 @@ internal sealed class TextSelectionGripperPresenter
 
 	public void Hide()
 	{
+		UnsubscribeFrameRendered();
 		_startGripper.Hide();
 		_endGripper.Hide();
+	}
+
+	// While the grippers are active, reposition them on every rendered frame: scrolling an ancestor
+	// ScrollViewer produces frames without redrawing the text surface, so DrawingFinished alone would
+	// leave them (and their culling) stale. Subscribing at the content root (instead of on the gripper
+	// popups) keeps the tracking alive while a culled gripper's popup is closed, so it can re-show once
+	// its anchor scrolls back into view.
+	private void EnsureFrameRenderedSubscription()
+	{
+		if (_frameRenderedTarget is null
+			&& _host.GripperTextSurface.XamlRoot?.VisualTree.ContentRoot.CompositionTarget is { } target)
+		{
+			_frameRenderedTarget = target;
+			target.FrameRendered += Update;
+		}
+	}
+
+	private void UnsubscribeFrameRendered()
+	{
+		if (_frameRenderedTarget is { } target)
+		{
+			target.FrameRendered -= Update;
+			_frameRenderedTarget = null;
+		}
 	}
 
 	/// <summary>
@@ -143,6 +173,8 @@ internal sealed class TextSelectionGripperPresenter
 			Hide();
 			return;
 		}
+
+		EnsureFrameRenderedSubscription();
 
 		var surface = _host.GripperTextSurface;
 		var clip = _host.GripperClipBounds;
@@ -171,7 +203,7 @@ internal sealed class TextSelectionGripperPresenter
 			rect.Y += surface.Padding.Top;
 			gripper.Height = rect.Height + 16;
 			var transform = surface.TransformToVisual(null);
-			if (transform.TransformBounds(rect).IntersectWith(clip) is not null)
+			if (clip.Width > 0 && clip.Height > 0 && transform.TransformBounds(rect).IntersectWith(clip) is not null)
 			{
 				var matrixTransform = (MatrixTransform)transform;
 				var surfaceMatrix = matrixTransform.Matrix.ToMatrix3x2();
@@ -186,6 +218,8 @@ internal sealed class TextSelectionGripperPresenter
 			}
 			else
 			{
+				// Culled: its anchor is outside the visible clip (e.g. scrolled out of an ancestor
+				// ScrollViewer). The per-frame Update re-shows it once the anchor is back in view.
 				gripper.Hide();
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -747,8 +747,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// However, we determine the final value of the inertia to snap on the right snap-point.
 			var shouldSnapHorizontally = scrollable.Horizontally && sv is { HorizontalSnapPointsType: SnapPointsType.OptionalSingle or SnapPointsType.MandatorySingle };
 			var shouldSnapVertically = scrollable.Vertically && sv is { VerticalSnapPointsType: SnapPointsType.OptionalSingle or SnapPointsType.MandatorySingle };
-			var shouldSnapToTouchTextBox = sv.ShouldSnapToTouchTextBox();
-			if (shouldSnapHorizontally || shouldSnapVertically || shouldSnapToTouchTextBox)
+			if (shouldSnapHorizontally || shouldSnapVertically)
 			{
 				// Make clear that inertia is not allowed for the OnUpdated, but this is only for safety!
 				_touchInertia = null;
@@ -759,7 +758,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 				double? h = null, v = null;
 
-				if (shouldSnapHorizontally || shouldSnapToTouchTextBox)
+				if (shouldSnapHorizontally)
 				{
 					var v0 = args.Velocities.Linear.X;
 					var duration = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(v0, inertia.DesiredDisplacementDeceleration);
@@ -768,7 +767,7 @@ namespace Microsoft.UI.Xaml.Controls
 					h = HorizontalOffset - endValue;
 				}
 
-				if (shouldSnapVertically || shouldSnapToTouchTextBox)
+				if (shouldSnapVertically)
 				{
 					var v0 = args.Velocities.Linear.Y;
 					var duration = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(v0, inertia.DesiredDisplacementDeceleration);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.SnapPoints.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.SnapPoints.cs
@@ -48,10 +48,6 @@ namespace Microsoft.UI.Xaml.Controls
 					ref vOffset);
 				verticalOffset = vOffset;
 			}
-
-#if __SKIA__
-			(horizontalOffset, verticalOffset) = ClampOffsetsToFocusedTextBox(horizontalOffset, verticalOffset);
-#endif
 		}
 
 		private double AdjustPixelViewportDim(double pixelViewportDim)
@@ -62,11 +58,6 @@ namespace Microsoft.UI.Xaml.Controls
 			// +5.999 --> +5.0
 			return (double)(long)pixelViewportDim;
 		}
-
-		internal partial bool ShouldSnapToTouchTextBox();
-#if !__SKIA__
-		internal partial bool ShouldSnapToTouchTextBox() => false;
-#endif
 
 		private void AdjustOffsetWithMandatorySnapPoints(
 			bool isForHorizontalOffset,

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1298,8 +1298,7 @@ namespace Microsoft.UI.Xaml.Controls
 					)
 				{
 					if (HorizontalSnapPointsType != SnapPointsType.None
-						|| VerticalSnapPointsType != SnapPointsType.None
-						|| ShouldSnapToTouchTextBox())
+						|| VerticalSnapPointsType != SnapPointsType.None)
 					{
 						_horizontalOffsetForSnapPoints = horizontalOffset;
 						_verticalOffsetForSnapPoints = verticalOffset;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.skia.cs
@@ -1,49 +1,7 @@
-using Windows.Foundation;
-using Microsoft.UI.Xaml.Input;
-
 namespace Microsoft.UI.Xaml.Controls;
 
 public partial class ScrollViewer
 {
-	private (double? horizontal, double? vertical) ClampOffsetsToFocusedTextBox(double? horizontalOffset, double? verticalOffset)
-	{
-		if (Presenter is not null && ShouldSnapToTouchTextBox())
-		{
-			var textBox = (TextBox)FocusManager.GetFocusedElement(XamlRoot!)!;
-			var textBoxToPresenter = textBox.TransformToVisual(Presenter.FindFirstChild()).TransformBounds(new Rect(0, 0, textBox.ActualWidth, textBox.ActualHeight));
-			if (verticalOffset.HasValue)
-			{
-				if (verticalOffset + ViewportHeight < textBoxToPresenter.Top)
-				{
-					verticalOffset = textBoxToPresenter.Top - ViewportHeight + textBoxToPresenter.Height;
-				}
-				else if (verticalOffset > textBoxToPresenter.Bottom)
-				{
-					verticalOffset = textBoxToPresenter.Top;
-				}
-			}
-
-			if (horizontalOffset.HasValue)
-			{
-				if (horizontalOffset + ViewportWidth < textBoxToPresenter.Left)
-				{
-					horizontalOffset = textBoxToPresenter.Left - ViewportWidth + textBoxToPresenter.Width;
-				}
-				else if (horizontalOffset > textBoxToPresenter.Right)
-				{
-					horizontalOffset = textBoxToPresenter.Left;
-				}
-			}
-		}
-
-		return (horizontalOffset, verticalOffset);
-	}
-
-	internal partial bool ShouldSnapToTouchTextBox()
-	{
-		return XamlRoot is not null && FocusManager.GetFocusedElement(XamlRoot) is TextBox { CaretMode: TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing or TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing } textBox && textBox.FindFirstParent<ScrollViewer>() == this;
-	}
-
 	partial void OnZoomModeChangedPartial(ZoomMode zoomMode)
 	{
 		if (_presenter is ScrollContentPresenter scp)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -720,7 +720,10 @@ namespace Microsoft.UI.Xaml.Controls
 		#region ITextSelectionGripperHost
 		TextBlock ITextSelectionGripperHost.GripperTextSurface => this;
 
-		Rect ITextSelectionGripperHost.GripperClipBounds => this.GetAbsoluteBoundsRect();
+		// Effective visible bounds (ancestor clips applied), so grippers are culled when the TextBlock is
+		// scrolled out of a parent ScrollViewer's viewport rather than floating over unrelated content.
+		Rect ITextSelectionGripperHost.GripperClipBounds
+			=> GetGlobalBoundsWithOptions(ignoreClipping: false, ignoreClippingOnScrollContentPresenters: false, useTargetInformation: false);
 
 		GripperMode ITextSelectionGripperHost.GripperMode => _grippersShown ? GripperMode.Both : GripperMode.Hidden;
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1932,7 +1932,10 @@ public partial class TextBox : ITextSelectionGripperHost
 
 	TextBlock ITextSelectionGripperHost.GripperTextSurface => TextBoxView.DisplayBlock;
 
-	Rect ITextSelectionGripperHost.GripperClipBounds => this.GetAbsoluteBoundsRect();
+	// Effective visible bounds (ancestor clips applied), so grippers are culled when the TextBox is
+	// scrolled out of a parent ScrollViewer's viewport rather than floating over unrelated content.
+	Rect ITextSelectionGripperHost.GripperClipBounds
+		=> GetGlobalBoundsWithOptions(ignoreClipping: false, ignoreClippingOnScrollContentPresenters: false, useTargetInformation: false);
 
 	GripperMode ITextSelectionGripperHost.GripperMode => _caretMode switch
 	{


### PR DESCRIPTION
**GitHub Issue:** tracked internally (customer report)

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia targets, once a `TextBox` was focused via touch (insertion handle or selection grippers showing), the parent `ScrollViewer` refused to let the user scroll it out of view: any scroll away from the field stopped and animated back until the TextBox was in the viewport again. On a form with many fields (customer repro), selecting text in a field near the bottom made it impossible to scroll back up.

This "keep the touch TextBox in view" clamp (`ScrollViewer.ShouldSnapToTouchTextBox` / `ClampOffsetsToFocusedTextBox`, introduced in #20155) existed to work around the selection grippers floating over unrelated content (e.g. the OS navigation bar) when their anchor was scrolled out of view, since the gripper popups were only culled against the TextBox's own (unclipped) bounds.

This PR fixes the root cause of that original artifact and removes the clamp, restoring native/WinUI scrolling parity:

- `GripperClipBounds` (TextBox + selectable TextBlock) now returns the control's **effective visible bounds** (`GetGlobalBoundsWithOptions`, ancestor clips + window viewport applied) instead of its unclipped absolute bounds, so grippers are culled as soon as their anchor leaves a parent `ScrollViewer`'s viewport (or the window) — they no longer float over unrelated content.
- A culled gripper is now **soft-hidden** (child collapsed, popup kept open) so the per-frame reposition callback stays subscribed and the gripper **reappears** when the anchor is scrolled back into view — matching native Android/iOS handle behavior.
- Removed `ShouldSnapToTouchTextBox` / `ClampOffsetsToFocusedTextBox` and their call sites (snap-points adjustment, snap timer arming, direct-manipulation inertia handling). The user can now freely scroll a focused touch TextBox out of view.

`When_Touch_Focused_Then_Scrolled_Away` was updated to assert the new expectations (scroll offset preserved, grippers culled while out of view, grippers re-shown when brought back), and a new `When_Touch_TextBox_In_ScrollViewer_Scroll_Away_Does_Not_Snap_Back` test covers the customer scenario (Android touch convention, insertion-handle and selection variants).

Note: when the selection toolbar (`TextCommandBarFlyout`) is open, the first swipe is still consumed by its light-dismiss layer (dismisses the toolbar without scrolling); WinUI's transient flyouts pass that input through. That is a separate popup-infrastructure gap, out of scope here.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
