### PR TITLE
ci(ios): Pin the facebook/fb tap to the v1.1.8 formula

### DIFF
--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -19,8 +19,12 @@
 #   - `idb-companion` comes from Meta's Homebrew tap `facebook/fb`
 #     (github.com/facebook/homebrew-fb). The formula pins the binary artifact
 #     of facebook/idb release v1.1.8 together with its sha256, so what gets
-#     installed is reproducible byte-for-byte; the tap itself has been
-#     dormant since 2022.
+#     installed is reproducible byte-for-byte.
+#   - The tap is pinned to a specific revision: its tip now ships idb-companion
+#     1.5.0.b2, which declares `depends_on macos: :sequoia` and
+#     `depends_on xcode: "26.0"`. The UI test agents run macOS 14
+#     ($(macOSVMImage_UITests) in .vsts-ci.yml), so brew rejects that formula
+#     outright — see the install section below.
 #   - Newer Homebrew refuses formulas from third-party taps unless explicitly
 #     trusted (`brew trust`) — see the install section below.
 #   - `fb-idb` (the Python client) is installed from PyPI via pipx, pinned to
@@ -196,6 +200,24 @@ then
 	# 2) Install helpers
 	brew list --versions pipx >/dev/null 2>&1 || brew install pipx
 	brew tap facebook/fb >/dev/null 2>&1 || true
+	# Pin the tap to the v1.1.8 formula. Its tip (1.5.0.b2) requires macOS
+	# Sequoia and Xcode 26, which the macOS 14 UI test agents cannot satisfy,
+	# so `brew install idb-companion` aborts with "Unsatisfied requirements".
+	# Detaching the tap checkout is enough: brew reads the formula straight
+	# from the working tree. HOMEBREW_NO_AUTO_UPDATE keeps a later `brew
+	# install` from fast-forwarding the tap back to its default branch.
+	export HOMEBREW_NO_AUTO_UPDATE=1
+	IDB_TAP_REVISION=c0386793f59da10c619787f2aa18d938ef1d69c9
+	IDB_TAP_REPO="$(brew --repo facebook/fb)"
+	if [ ! -d "$IDB_TAP_REPO/.git" ]; then
+		echo "Tap facebook/fb is not checked out at $IDB_TAP_REPO — cannot pin idb-companion." >&2
+		exit 1
+	fi
+	git -C "$IDB_TAP_REPO" fetch --depth 1 origin "$IDB_TAP_REVISION" \
+		|| git -C "$IDB_TAP_REPO" fetch --unshallow origin \
+		|| git -C "$IDB_TAP_REPO" fetch origin
+	git -C "$IDB_TAP_REPO" checkout --detach --force "$IDB_TAP_REVISION"
+
 	# Newer Homebrew on the runner images gates third-party taps: installing
 	# idb-companion fails with "Refusing to load formula facebook/fb/idb-companion
 	# from untrusted tap facebook/fb" unless explicitly trusted. Trust only the


### PR DESCRIPTION
**GitHub Issue:** closes #24100

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Tests - iOS Skia` has been failing on **every** open PR since 2026-08-17 ~17:00 UTC, before a single test runs:

```
idb-companion: This formula does not run on macOS versions older than Sequoia.
idb-companion: A full installation of Xcode.app 26.0 is required to compile
Xcode 26.0 cannot be installed on macOS 14.
Error: Unsatisfied requirements failed this build.
##[error]Bash exited with code '1'.
```

`build/test-scripts/ios-uitest-run.sh` installs `idb-companion` from Meta's Homebrew tap [`facebook/fb`](https://github.com/facebook/homebrew-fb) and, as its own comments stated, relied on that tap being dormant since 2022 (idb v1.1.8). It was bumped twice this month; the [`idb 1.5.0.b2` commit](https://github.com/facebook/homebrew-fb/commit/7f764dad5bedcab7a257e72bf7367816c9551cdc) (2026-08-17 14:45 UTC) added:

```ruby
depends_on macos: :sequoia
depends_on xcode: "26.0"
```

Our UI test agents run macOS 14 (`macOSVMImage_UITests: 'macOS-14'`), so Homebrew refuses the formula and — under `set -euo pipefail` — the job dies immediately.

**This PR** detaches the tap checkout at the last v1.1.8 revision (`c0386793f59da10c619787f2aa18d938ef1d69c9`) before installing, and sets `HOMEBREW_NO_AUTO_UPDATE=1` so a later `brew install` cannot fast-forward the tap back to its default branch. Brew reads the formula straight from the tap working tree, so a detached checkout is all that is needed.

That revision declares only `depends_on :xcode => ["13.0", :build]`, which the macOS 14 agents satisfy, and it resolves to exactly the pinned artifact the script already documents.

Verified out-of-band:

- `https://github.com/facebook/idb/releases/download/v1.1.8/idb-companion.universal.tar.gz` → HTTP 200
- its sha256 is `3b72cc6a9a5b1a22a188205a84090d3a294347a846180efd755cf1a3c848e3e7`, byte-for-byte the value pinned in the v1.1.8 formula
- `bash -n build/test-scripts/ios-uitest-run.sh` passes; file stays LF, no BOM

### Alternative considered

Bumping `macOSVMImage_UITests` to a Sequoia-or-later image satisfies the new formula, but the pinned `iOS-17-5` simulator runtime would no longer be present, and a previous Xcode 26 bump was already reverted (e3bcb3a6b80). Pinning the tap is the smaller, reversible change; moving to a newer image + runtime is worth doing separately and deliberately.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, CI-only change; the iOS test stage going green *is* the validation
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A; the script's own supply-chain comment block is updated to explain the pin
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wRQ6PaGAKbEe2myWEQZS6
