### PR TITLE
fix(macos): Pace the Metal render thread so nextDrawable stops throttling it

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -333,6 +333,9 @@ internal static partial class NativeUno
 	internal static partial void uno_window_get_metal_handles(nint window, out nint device, out nint queue);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial double uno_window_get_refresh_rate(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	[return: MarshalAs(UnmanagedType.I1)]
 	internal static partial bool uno_window_acquire_next_frame(nint window, out nint texture, out double width, out double height);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Window/MacOSWindowHost.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -12,6 +14,7 @@ using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Uno.UI.Helpers;
 using Uno.UI.Hosting;
+using Uno.UI.Runtime.Skia.Hosting;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.Graphics;
@@ -94,8 +97,33 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			return;
 		}
 
-		_metalRenderThread = new MacOSRenderThread(_nativeWindow.Handle, _context, RenderThreadMetalDraw);
+		var screenFps = NativeUno.uno_window_get_refresh_rate(_nativeWindow.Handle);
+		var targetFps = ResolveTargetFps(screenFps);
+
+		// Logged unconditionally at Information: on a CI agent this is the only record of what the
+		// render clock is actually running at, and a screen reporting an unexpected rate (or none)
+		// is the first thing to check when frames stall.
+		if (this.Log().IsEnabled(LogLevel.Information))
+		{
+			this.Log().Info(
+				$"macOS render thread starting for window {_nativeWindow.Handle}: " +
+				$"surface={MacSkiaHost.Current.RenderSurfaceType}, " +
+				$"screen refresh rate={(screenFps > 0 ? screenFps.ToString("0.##", CultureInfo.InvariantCulture) + "Hz" : "unknown")}, " +
+				$"pacing at {targetFps.ToString("0.##", CultureInfo.InvariantCulture)} fps.");
+		}
+
+		_metalRenderThread = new MacOSRenderThread(_nativeWindow.Handle, _context, RenderThreadMetalDraw, targetFps);
 	}
+
+	/// <summary>
+	/// Frame rate the render thread should be paced at: the screen's refresh rate when it is known
+	/// and <see cref="FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate"/> is set,
+	/// otherwise the configured rate.
+	/// </summary>
+	private static double ResolveTargetFps(double screenFps)
+		=> FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate && screenFps > 0
+			? screenFps
+			: FeatureConfiguration.CompositionTarget.FrameRate;
 
 	/// <summary>
 	/// Called on the render thread. Draws the recorded SKPicture into the Metal texture
@@ -365,8 +393,10 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	{
 		if (_metalRenderThread is not null)
 		{
-			// Metal path: wake the dedicated render thread so draw + present run off the UI thread.
-			_metalRenderThread.SignalNewFrame();
+			// Metal path: ask the dedicated render thread for a frame so draw + present run off the
+			// UI thread. The request is paced, so repeated invalidations inside one frame interval
+			// coalesce instead of each costing a drawable acquisition.
+			_metalRenderThread.RequestFrame();
 		}
 		else
 		{
@@ -860,6 +890,12 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			var window = GetWindowHost(handle);
 			window?.DisplayInformationExtension?.Update(width, height, scaleFactor);
 			window?.RasterizationScaleChanged?.Invoke(window, EventArgs.Empty);
+
+			if (window?._metalRenderThread is { } renderThread)
+			{
+				// Moving between screens can change the refresh rate (e.g. 120Hz laptop -> 60Hz external).
+				renderThread.UpdateTargetFps(ResolveTargetFps(NativeUno.uno_window_get_refresh_rate(handle)));
+			}
 		}
 		catch (Exception e)
 		{
@@ -895,41 +931,75 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	/// wait never blocks input or layout. Mirrors the Win32 render thread and the iOS
 	/// CADisplayLink render thread.
 	/// </summary>
+	/// <remarks>
+	/// Frame requests are paced by a <see cref="FramePacer"/>, exactly as X11 paces its render
+	/// thread. This is not an optimization: <c>nextDrawable</c> blocks for ~1s and then returns nil
+	/// once the layer's pool is exhausted, so an unpaced loop that acquires as fast as it is
+	/// signalled outruns the compositor and turns every frame into a one-second stall. Pacing keeps
+	/// acquisitions at most one per refresh interval, which is the rate the compositor recycles at.
+	/// A timer drives the pace rather than the display, so the render clock keeps ticking even when
+	/// the display does not (occluded window, headless CI agent).
+	/// </remarks>
 	private sealed class MacOSRenderThread : IDisposable
 	{
 		/// <summary>
-		/// Pause before retrying a frame the render loop could not present. nextDrawable already
-		/// blocks for up to ~1s before returning nil, so this only avoids a hot spin in the cases
-		/// where acquisition fails immediately (e.g. a zero-sized layer during window setup).
+		/// Consecutive unpresentable frames tolerated at the normal pace before retries start
+		/// backing off. Brief failures are expected (a zero-sized layer during window setup, a
+		/// drawable still held across a resize) and should recover within a frame or two.
 		/// </summary>
-		private const int FrameRetryDelayMs = 8;
+		private const int UnthrottledRetries = 3;
+
+		private const int InitialBackoffMs = 16;
+		private const int MaxBackoffMs = 1000;
+
+		/// <summary>Minimum interval between "still cannot present" warnings.</summary>
+		private const int FailureLogIntervalMs = 5000;
 
 		private readonly Thread _thread;
 		private readonly AutoResetEvent _frameSignal = new(false);
 		private readonly ManualResetEventSlim _presentedEvent = new(false);
+		private readonly ManualResetEventSlim _shutdown = new(false);
+		private readonly FramePacer _framePacer;
 		private readonly nint _windowHandle;
 		private readonly GRContext _context;
 		private readonly Action<double, double, nint> _drawFrame;
 		private volatile bool _disposed;
 
-		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame)
+		// Render-thread only.
+		private int _consecutiveFailures;
+		private long _firstFailureTimestamp;
+		private long _lastFailureLogTimestamp;
+
+		internal MacOSRenderThread(nint windowHandle, GRContext context, Action<double, double, nint> drawFrame, double targetFps)
 		{
 			_windowHandle = windowHandle;
 			_context = context;
 			_drawFrame = drawFrame;
+			_framePacer = new FramePacer(targetFps, () => _frameSignal.Set());
 			_thread = new Thread(RenderLoop) { Name = "Uno macOS Render Thread", IsBackground = true };
 			_thread.Start();
 		}
 
 		/// <summary>
-		/// Wakes the render thread to present a new frame. Calls made while it is busy
-		/// coalesce into a single wake-up. Resets the present-completion event first so a
-		/// <see cref="WaitForNextPresent"/> caller can never observe a previous present.
+		/// Asks for a frame. Requests made within the same frame interval coalesce into one
+		/// wake-up. Resets the present-completion event first so a <see cref="WaitForNextPresent"/>
+		/// caller can never observe a previous present.
 		/// </summary>
-		internal void SignalNewFrame()
+		internal void RequestFrame()
 		{
 			_presentedEvent.Reset();
-			_frameSignal.Set();
+			_framePacer.RequestFrame();
+		}
+
+		/// <summary>
+		/// Retargets the pace, e.g. when the window moves to a screen with a different refresh rate.
+		/// </summary>
+		internal void UpdateTargetFps(double fps)
+		{
+			if (fps > 0)
+			{
+				_framePacer.UpdateTargetFps(fps);
+			}
 		}
 
 		/// <summary>
@@ -951,6 +1021,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				{
 					break;
 				}
+
+				_framePacer.OnFrameStart();
 
 				var framePresented = false;
 				try
@@ -985,19 +1057,103 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 					NativeUno.uno_window_discard_frame(_windowHandle);
 				}
 
-				if (!framePresented && !_disposed)
+				if (framePresented)
 				{
-					// The frame request must not be lost. CompositionTarget.RequestNewFrame latches
-					// RenderRequested and only clears it once a frame is actually drawn, so it will not
-					// signal us again on its own: dropping this wake-up stops rendering for this window
-					// permanently, and anything awaiting a render (RenderTargetBitmap jobs, composition
-					// animations) would then never complete. AppKit gives the non-threaded path the same
-					// guarantee by re-invoking drawInMTKView: for as long as the view stays dirty, so
-					// re-arm to keep retrying until a frame gets through.
-					Thread.Sleep(FrameRetryDelayMs);
-					_frameSignal.Set();
+					OnFramePresented();
+				}
+				else if (!_disposed)
+				{
+					RetryFrame();
 				}
 			}
+		}
+
+		private void OnFramePresented()
+		{
+			if (_consecutiveFailures == 0)
+			{
+				return;
+			}
+
+			if (this.Log().IsEnabled(LogLevel.Information))
+			{
+				this.Log().Info(
+					$"macOS render thread presented a frame again after {_consecutiveFailures} failed " +
+					$"attempt(s) over {ElapsedMsSince(_firstFailureTimestamp)}ms.");
+			}
+
+			_consecutiveFailures = 0;
+			_lastFailureLogTimestamp = 0;
+		}
+
+		/// <summary>
+		/// Re-arms a frame that could not be presented. The request must not be dropped:
+		/// <see cref="CompositionTarget.RequestNewFrame"/> latches its render-requested flag and only
+		/// clears it once a frame is actually drawn, so it will not signal us again on its own, and
+		/// anything awaiting a render (RenderTargetBitmap jobs, composition animations) would hang.
+		/// Retries are paced, and back off once failures persist so a window that can never present
+		/// (minimized, or a compositor that stopped recycling drawables) does not spin the GPU.
+		/// </summary>
+		private void RetryFrame()
+		{
+			if (_consecutiveFailures == 0)
+			{
+				_firstFailureTimestamp = Stopwatch.GetTimestamp();
+			}
+
+			_consecutiveFailures++;
+			ReportPersistentFailure();
+
+			var backoff = BackoffDelayMs(_consecutiveFailures);
+			if (backoff > 0 && _shutdown.Wait(backoff))
+			{
+				// Disposed while backing off.
+				return;
+			}
+
+			_framePacer.RequestFrame();
+		}
+
+		private void ReportPersistentFailure()
+		{
+			if (!this.Log().IsEnabled(LogLevel.Warning))
+			{
+				return;
+			}
+
+			if (_consecutiveFailures <= UnthrottledRetries)
+			{
+				// Still inside the tolerated window — a frame or two of failure is routine.
+				return;
+			}
+
+			if (_consecutiveFailures > UnthrottledRetries + 1
+				&& ElapsedMsSince(_lastFailureLogTimestamp) < FailureLogIntervalMs)
+			{
+				return;
+			}
+
+			_lastFailureLogTimestamp = Stopwatch.GetTimestamp();
+			this.Log().Warn(
+				$"macOS render thread could not present {_consecutiveFailures} consecutive frame(s) over " +
+				$"{ElapsedMsSince(_firstFailureTimestamp)}ms for window {_windowHandle}: the layer vended no " +
+				$"drawable. Retrying with backoff; rendering for this window is stalled until one is available.");
+		}
+
+		private static long ElapsedMsSince(long timestamp)
+			=> timestamp == 0 ? 0 : (long)Stopwatch.GetElapsedTime(timestamp).TotalMilliseconds;
+
+		private static int BackoffDelayMs(int consecutiveFailures)
+		{
+			if (consecutiveFailures <= UnthrottledRetries)
+			{
+				// Still within the tolerated window: retry at the normal pace.
+				return 0;
+			}
+
+			// Double from InitialBackoffMs, capped — the shift is bounded so it cannot overflow.
+			var steps = Math.Min(consecutiveFailures - UnthrottledRetries - 1, 8);
+			return Math.Min(MaxBackoffMs, InitialBackoffMs << steps);
 		}
 
 		/// <summary>
@@ -1005,18 +1161,22 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		/// primitives. The join is intentionally unbounded, matching the Win32 render thread: the
 		/// loop only delays observing <see cref="_disposed"/> while a frame is in flight, and both
 		/// <c>nextDrawable</c> and the present complete in bounded time (a vsync wait, or ~1s and a
-		/// nil drawable when the window is occluded), so the thread always exits. The caller tears
-		/// down the native window and the <see cref="GRContext"/> right after this returns, and the
-		/// render thread is their sole other user, so it must be guaranteed stopped first.
+		/// nil drawable when the window is occluded), so the thread always exits. A retry backoff
+		/// waits on <see cref="_shutdown"/> rather than sleeping, so it is cut short here. The caller
+		/// tears down the native window and the <see cref="GRContext"/> right after this returns, and
+		/// the render thread is their sole other user, so it must be guaranteed stopped first.
 		/// </summary>
 		public void Dispose()
 		{
 			_disposed = true;
+			_shutdown.Set();
 			_frameSignal.Set();
 			_thread.Join();
 
+			_framePacer.Dispose();
 			_frameSignal.Dispose();
 			_presentedEvent.Dispose();
+			_shutdown.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -141,9 +141,9 @@ bool uno_window_acquire_next_frame(NSWindow* window, void** texture, double* wid
         UNOMetalViewDelegate* delegate = unoWindow.metalViewDelegate;
         if (delegate == nil) return false;
 
-        // nextDrawable is thread-safe (unlike MTKView.currentDrawable). It blocks up to ~1s
-        // if all drawables are in use (occluded/minimized window); with maximumDrawableCount=2
-        // set in uno_window_create that is rare, and a nil return is handled by the caller.
+        // nextDrawable is thread-safe (unlike MTKView.currentDrawable). It blocks for up to ~1s
+        // and then returns nil when every drawable in the layer's pool is still held by the
+        // compositor, so the caller must pace its acquisitions rather than retry in a tight loop.
         CAMetalLayer* metalLayer = (CAMetalLayer*)view.layer;
 
         id<CAMetalDrawable> drawable = [metalLayer nextDrawable];

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -345,6 +345,10 @@ void uno_set_window_close_callbacks(window_should_close_fn_ptr shouldClose, wind
 
 void uno_window_get_metal_handles(UNOWindow* window, void*_Nonnull* _Nonnull device, void*_Nonnull* _Nonnull queue);
 
+/// Refresh rate, in frames per second, of the screen currently showing the window.
+/// Returns 0 when it cannot be determined, in which case the caller keeps its configured rate.
+double uno_window_get_refresh_rate(NSWindow* window);
+
 /// Acquires the next drawable from the window's CAMetalLayer (texture handle + size).
 /// Called from the managed render thread.
 bool uno_window_acquire_next_frame(NSWindow* window, void* _Nullable * _Nonnull texture, double* width, double* height);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -1026,6 +1026,30 @@ void uno_set_ime_active(UNOWindow* window, bool active)
     }
 }
 
+double uno_window_get_refresh_rate(NSWindow* window)
+{
+    NSScreen* screen = window.screen;
+    if (screen == nil)
+    {
+        // An off-screen window (never ordered front, or on a headless agent) has no screen;
+        // fall back to the main screen so the render loop still gets a sane pace.
+        screen = NSScreen.mainScreen;
+    }
+    if (screen == nil)
+    {
+        return 0;
+    }
+    if (@available(macOS 12.0, *))
+    {
+        NSInteger fps = screen.maximumFramesPerSecond;
+        if (fps > 0)
+        {
+            return (double)fps;
+        }
+    }
+    return 0;
+}
+
 void uno_window_get_metal_handles(UNOWindow* window, void** device, void** queue)
 {
     *device = (__bridge void *)(uno_application_get_metal_device());


### PR DESCRIPTION
**GitHub Issue:** closes #24005

Stacked on #23594 — this PR targets `dev/mazi/render-macos-renderthread`, not `master`. Review it as the
follow-up that makes that branch mergeable. Also gives #24006 (undiagnosable stalls) its first real signal.

## PR Type:

🐞 Bugfix

## What changed? 🚀

**macOS is the only Skia host whose render thread has no pace.** X11 and Win32 both got one in #21299;
macOS was left driving frames straight off `InvalidateRender`, relying on `nextDrawable` to block until
the compositor was ready.

That works only while the compositor keeps up. Once the layer's drawable pool is exhausted `nextDrawable`
does not block-and-succeed — it blocks for **~1 s and returns nil**. So an unpaced loop that acquires as
fast as it is signalled outruns the compositor, converts every frame into a one-second stall, and retries
straight back into the same wall.

On the hosted CI agents that is exactly what happens. On #23594's own macOS runs, **738 of 1069 mid-range
inter-test gaps land in a hard 3.0–3.1 s spike, consuming 2911 s ≈ 87 % of the run**; the job reaches only
~2510 of ~8000 tests before the 60-minute cap, against master's 8006. The 3 s is ~3 × `nextDrawable`'s
1 s timeout plus the branch's 8 ms retry.

### The change

- **Pace frame requests through `FramePacer`, exactly as X11 does.** Acquisitions now happen at most once
  per refresh interval — the rate the compositor actually recycles at. A timer drives the pace rather than
  the display, so the render clock keeps ticking when the display does not (occluded window, headless agent).
- **New native export `uno_window_get_refresh_rate`** (`NSScreen.maximumFramesPerSecond`), honouring
  `FeatureConfiguration.CompositionTarget.SetFrameRateAsScreenRefreshRate`, and re-resolved when the window
  changes screen. Returns 0 when unknown, in which case the configured `FrameRate` is kept.
- **Retries back off.** Dropping a failed frame permanently latches `CompositionTarget`'s render-requested
  flag and hangs anything awaiting a frame, so retries must stay — but they are now paced and back off
  16 ms → 1 s, so a window that can never present (minimized, or a compositor that stopped recycling)
  no longer spins the GPU. The backoff waits on the shutdown event, so `Dispose` still joins promptly.
- **Diagnostics.** Logs the render surface, screen refresh rate and resolved pace once per window, and warns
  when consecutive frames cannot be presented (count + elapsed), with a recovery line. Nothing in the stack
  currently records whether a drawable was ever vended — which is why this failure mode stayed invisible.

### Why this shape, and not Win32's

Win32 paces **after** the present, inside each renderer's `CopyPixels`, and only for renderers whose present
returns without blocking (`Win32WindowWrapper.Rendering.Software.cs:102`, `.Vulkan.cs:131`; the GL path
passes `null` because `SwapBuffers` self-throttles). That is right for Win32, where the throttled step is
the present and over-requesting merely blocks.

macOS is the opposite: the cost and the failure are at the **acquire**, before anything is drawn, and a
failed acquire is not free — it costs a full second and yields no frame. Pacing after the present would
never run, because the frame that needed throttling never got that far. So the throttle has to sit on the
request, which is X11's shape (`X11XamlRootHost.Rendering.cs:53`).

Using the timer as the only clock also gives, by construction, what Win32 gets from its DwmFlush →
`FramePacer` degradation path: a render clock that survives a display that stops ticking. There is no
non-deprecated, thread-safe macOS equivalent of `DwmFlush` (`CVDisplayLink` is deprecated in macOS 15;
`NSView.displayLink(target:selector:)` is main-thread-bound), so a timer clock is also the pragmatic choice.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — see *Validation*; the runtime-test suite on the macOS leg **is** the test for this change, and the new logging is what makes it verifiable.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no public API or user-facing behaviour change.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — **not yet**, needs the CI run.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

## Validation

**Runtime** — local A/B on the same machine (Apple M2 Max, Darwin 25.2, 120 Hz), same test slice
(`UITEST_RUNTIME_TEST_GROUP=0`, `COUNT=20`, 479 tests), builds differing only in the macOS host:

| build | wall clock | passed / failed |
|---|---|---|
| #23594 merge-base (draw on the UI thread) | 70.7 s | 477 / 1 |
| #23594 head (unpaced render thread) | 67.0 s | 477 / 1 |
| **this PR (paced render thread)** | **68.6 s** | **477 / 1** |

Identical outcomes; the one failure (`Given_ResourceLoader.When_MissingLocalizedResource_FallbackOnDefault`)
is pre-existing and present in all three. The pacer costs nothing measurable on a healthy machine — as
expected, since it caps at the display rate the host was already achieving.

New diagnostics on that run: `macOS render thread starting for window …: surface=Metal, screen refresh
rate=120Hz, pacing at 120 fps.` — zero drawable-acquisition failures, zero render-thread errors.

**Compile** — `Uno.UI.Runtime.Skia.MacOS` and `SamplesApp.Skia.Generic` build clean (0 errors), including
the `UnoNativeMac` Xcode step that produces the new export.

**Not validated locally** — the failure this fixes only reproduces on the hosted CI agents, where drawable
acquisition fails; it does not reproduce on a Mac with a real display. The macOS CI leg on this PR is the
real test, and the new warnings will say directly whether acquisition is failing there and how often. Please
check that leg before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K297hJpRGEufnFFqS7pZh9
