### PR TITLE
fix(macos): Stop two native-peer use-after-free crashes in CI

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
@@ -42,7 +42,10 @@ internal class MacOSNativeElement : Microsoft.UI.Xaml.FrameworkElement
 		Disposed = true;
 		NativeHandle = 0;
 
-		NativeUno.uno_native_dispose(handle);
+		if (handle != 0)
+		{
+			NativeUno.uno_native_dispose(handle);
+		}
 	}
 }
 
@@ -79,9 +82,9 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 
 		if (nativeElement.Disposed || nativeElement.NativeHandle == 0)
 		{
-			if (this.Log().IsEnabled(LogLevel.Error))
+			if (this.Log().IsEnabled(LogLevel.Warning))
 			{
-				this.Log().Error($"Cannot {operation} a {content.GetType().FullName} whose native peer was already disposed.");
+				this.Log().Warn($"Cannot {operation} a {content.GetType().FullName} whose native peer was already disposed.");
 			}
 
 			element = null!;
@@ -179,6 +182,8 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 			NativeUno.uno_native_measure(element.NativeHandle, childMeasuredSize.Width, childMeasuredSize.Height, availableSize.Width, availableSize.Height, out var width, out var height);
 			return new Size(width, height);
 		}
+
+		// Not Size.Empty: that is (-∞, -∞), which ContentPresenter does not clamp and Layouter rejects.
 		return new Size(0, 0);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
@@ -13,15 +13,37 @@ internal class MacOSNativeElement : Microsoft.UI.Xaml.FrameworkElement
 {
 	public MacOSNativeElement()
 	{
-		Unloaded += (s, e) =>
-		{
-			NativeUno.uno_native_dispose(NativeHandle);
-		};
+		Unloaded += (s, e) => DisposeNativePeer();
 	}
 
 	public nint NativeHandle { get; internal set; }
 
 	internal bool Detached { get; set; }
+
+	/// <summary>
+	/// Set once the native peer has been released, at which point <see cref="NativeHandle"/> is zeroed.
+	/// </summary>
+	/// <remarks>
+	/// <c>uno_native_dispose</c> drops the last strong reference the native side holds on the NSView, so
+	/// the object is deallocated. Any later call handing the stale handle back to native code would make
+	/// ARC retain freed memory, which crashes the process rather than failing the current operation.
+	/// </remarks>
+	internal bool Disposed { get; private set; }
+
+	internal void DisposeNativePeer()
+	{
+		if (Disposed)
+		{
+			return;
+		}
+
+		var handle = NativeHandle;
+
+		Disposed = true;
+		NativeHandle = 0;
+
+		NativeUno.uno_native_dispose(handle);
+	}
 }
 
 internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElementHostingExtension
@@ -37,9 +59,42 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 
 	public static void Register() => ApiExtensibility.Register<ContentPresenter>(typeof(ContentPresenter.INativeElementHostingExtension), o => new MacOSNativeElementHostingExtension(o));
 
+	/// <summary>
+	/// Resolves <paramref name="content"/> to a native element that is still safe to hand to native code.
+	/// A disposed element keeps its managed wrapper alive but its NSView is gone, and the framework can
+	/// still re-enter it into the visual tree (a reparent raises Unloaded then Loaded).
+	/// </summary>
+	private bool TryGetLiveElement(object content, string operation, out MacOSNativeElement element)
+	{
+		if (content is not MacOSNativeElement nativeElement)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"Object `content` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
+			}
+
+			element = null!;
+			return false;
+		}
+
+		if (nativeElement.Disposed || nativeElement.NativeHandle == 0)
+		{
+			if (this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"Cannot {operation} a {content.GetType().FullName} whose native peer was already disposed.");
+			}
+
+			element = null!;
+			return false;
+		}
+
+		element = nativeElement;
+		return true;
+	}
+
 	public void ArrangeNativeElement(object content, Rect arrangeRect)
 	{
-		if (content is MacOSNativeElement element)
+		if (TryGetLiveElement(content, "arrange", out var element))
 		{
 			if (element.Detached)
 			{
@@ -50,36 +105,24 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 				NativeUno.uno_native_arrange(element.NativeHandle, arrangeRect.Left, arrangeRect.Top, arrangeRect.Width, arrangeRect.Height);
 			}
 		}
-		else if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"Object `{nameof(content)}` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
-		}
 	}
 
 	public void AttachNativeElement(object content)
 	{
-		if (content is MacOSNativeElement element)
+		if (TryGetLiveElement(content, "attach", out var element))
 		{
 			NativeUno.uno_native_attach(element.NativeHandle);
 			element.Detached = false;
-		}
-		else if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"Object `{nameof(content)}` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
 		}
 	}
 
 	public void ChangeNativeElementOpacity(object content, double opacity)
 	{
-		if (content is MacOSNativeElement element)
+		if (TryGetLiveElement(content, "change the opacity of", out var element))
 		{
 			// https://developer.apple.com/documentation/appkit/nsview/1483560-alphavalue?language=objc
 			// note: no marshaling needed as CGFloat is double for 64bits apps
 			NativeUno.uno_native_set_opacity(element.NativeHandle, opacity);
-		}
-		else if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"Object `{nameof(content)}` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
 		}
 	}
 
@@ -104,7 +147,7 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 
 	public void DetachNativeElement(object content)
 	{
-		if (content is MacOSNativeElement element)
+		if (TryGetLiveElement(content, "detach", out var element))
 		{
 			if (element.Detached)
 			{
@@ -116,37 +159,25 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 				element.Detached = true;
 			}
 		}
-		else if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"Object `{nameof(content)}` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
-		}
 	}
 
 	public bool IsNativeElement(object content) => content is MacOSNativeElement;
 
 	public bool IsNativeElementAttached(object owner, object nativeElement)
 	{
-		if (nativeElement is MacOSNativeElement element)
+		if (TryGetLiveElement(nativeElement, "query the attached state of", out var element))
 		{
 			return NativeUno.uno_native_is_attached(element.NativeHandle);
-		}
-		else if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"Object `{nameof(owner)}` is a {owner.GetType().FullName} and not a MacOSNativeElement subclass.");
 		}
 		return false;
 	}
 
 	public Size MeasureNativeElement(object content, Size childMeasuredSize, Size availableSize)
 	{
-		if (content is MacOSNativeElement element)
+		if (TryGetLiveElement(content, "measure", out var element))
 		{
 			NativeUno.uno_native_measure(element.NativeHandle, childMeasuredSize.Width, childMeasuredSize.Height, availableSize.Width, availableSize.Height, out var width, out var height);
 			return new Size(width, height);
-		}
-		else if (this.Log().IsEnabled(LogLevel.Debug))
-		{
-			this.Log().Debug($"Object `{nameof(content)}` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
 		}
 		return Size.Empty;
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
@@ -6,15 +6,15 @@ using Microsoft.UI.Xaml.Controls;
 
 using Uno.Foundation.Extensibility;
 using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia.MacOS;
 
 internal class MacOSNativeElement : Microsoft.UI.Xaml.FrameworkElement
 {
-	public MacOSNativeElement()
-	{
-		Unloaded += (s, e) => DisposeNativePeer();
-	}
+	// The peer is tied to the managed wrapper, not to the visual tree: `Unloaded` also fires on a reparent,
+	// after which the framework re-enters the very same element through `AttachNativeElement`.
+	~MacOSNativeElement() => DisposeNativePeer();
 
 	public nint NativeHandle { get; internal set; }
 
@@ -44,7 +44,8 @@ internal class MacOSNativeElement : Microsoft.UI.Xaml.FrameworkElement
 
 		if (handle != 0)
 		{
-			NativeUno.uno_native_dispose(handle);
+			// AppKit is main-thread only and this runs on the finalizer thread.
+			MacOSDispatcher.DispatchNativeSingle(() => NativeUno.uno_native_dispose(handle), NativeDispatcherPriority.Normal);
 		}
 	}
 }
@@ -64,8 +65,8 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 
 	/// <summary>
 	/// Resolves <paramref name="content"/> to a native element that is still safe to hand to native code.
-	/// A disposed element keeps its managed wrapper alive but its NSView is gone, and the framework can
-	/// still re-enter it into the visual tree (a reparent raises Unloaded then Loaded).
+	/// A disposed element keeps its managed wrapper alive but its NSView is gone, so every operation has
+	/// to fail on its own rather than hand the stale handle back to ARC.
 	/// </summary>
 	private bool TryGetLiveElement(object content, string operation, out MacOSNativeElement element)
 	{

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/MacOSNativeElementHostingExtension.cs
@@ -70,7 +70,7 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 		{
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
-				this.Log().Debug($"Object `content` is a {content.GetType().FullName} and not a MacOSNativeElement subclass.");
+				this.Log().Debug($"Object `content` is a {content?.GetType().FullName ?? "null"} and not a MacOSNativeElement subclass.");
 			}
 
 			element = null!;
@@ -179,6 +179,6 @@ internal class MacOSNativeElementHostingExtension : ContentPresenter.INativeElem
 			NativeUno.uno_native_measure(element.NativeHandle, childMeasuredSize.Width, childMeasuredSize.Height, availableSize.Width, availableSize.Height, out var width, out var height);
 			return new Size(width, height);
 		}
-		return Size.Empty;
+		return new Size(0, 0);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -509,6 +509,9 @@ internal static partial class NativeUno
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_webview_register_message_handler(nint webview);
 
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_webview_unregister_message_handler(nint webview);
+
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]
 	internal static partial string uno_webview_get_title(nint webview);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
@@ -17,11 +17,11 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 {
 	private readonly MacOSWindowNative _window;
 	private readonly CoreWebView2 _owner;
-	private readonly nint _webview;
 	private string _previousTitle;
 	private bool _isHistoryChangeQueued;
 	private bool _isCancelling;
 	private string? _lastHtmlContent;
+	private nint _registeredHandle;
 
 	private const string OkResourceKey = "WebView_Ok";
 	private const string CancelResourceKey = "WebView_Cancel";
@@ -55,26 +55,63 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 		OkString = !string.IsNullOrEmpty(ok) ? ok : "OK";
 		CancelString = !string.IsNullOrEmpty(cancel) ? cancel : "Cancel";
 
-		_webview = NativeUno.uno_webview_create(_window.Handle, OkString, CancelString);
-		NativeHandle = _webview;
+		NativeHandle = NativeUno.uno_webview_create(_window.Handle, OkString, CancelString);
 
-		NativeUno.uno_webview_set_inspectable(_webview, global::Uno.UI.FeatureConfiguration.WebView2.EnableDevTools);
+		NativeUno.uno_webview_set_inspectable(NativeHandle, global::Uno.UI.FeatureConfiguration.WebView2.EnableDevTools);
 
 		_previousTitle = "";
 	}
 
+	/// <summary>
+	/// Resolves the native <c>WKWebView</c> handle, refusing to hand a disposed peer to native code.
+	/// </summary>
+	/// <remarks>
+	/// The peer is destroyed when the element leaves the visual tree, which zeroes
+	/// <see cref="MacOSNativeElement.NativeHandle"/>. Messaging the freed <c>WKWebView</c> would make ARC
+	/// retain deallocated memory and take down the whole process, so each operation has to fail on its own.
+	/// </remarks>
+	private bool TryGetHandle(string operation, out nint handle)
+	{
+		handle = NativeHandle;
+
+		if (Disposed || handle == 0)
+		{
+			if (this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"Cannot {operation} a WebView2 whose native peer was already disposed.");
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
 	void ICleanableNativeWebView.OnLoaded()
 	{
-		_webViews[NativeHandle] = new WeakReference<MacOSNativeWebView>(this);
-		NativeUno.uno_webview_register_message_handler(NativeHandle);
+		// A zeroed handle would key the map at 0, which every disposed instance would then share.
+		if (TryGetHandle("register the message handler of", out var handle))
+		{
+			_registeredHandle = handle;
+			_webViews[handle] = new WeakReference<MacOSNativeWebView>(this);
+			NativeUno.uno_webview_register_message_handler(handle);
+		}
 	}
 
 	void ICleanableNativeWebView.OnUnloaded()
 	{
-		_webViews.Remove(NativeHandle);
+		// Removed by the remembered key, not by NativeHandle: the unload order between the WebView2 and
+		// its native element is undefined, so the peer may already be disposed and the handle zeroed.
+		if (_registeredHandle != 0)
+		{
+			_webViews.Remove(_registeredHandle);
+			_registeredHandle = 0;
+		}
 	}
 
-	public string DocumentTitle => NativeUno.uno_webview_get_title(_webview);
+	public string DocumentTitle => TryGetHandle("read the document title of", out var handle)
+		? NativeUno.uno_webview_get_title(handle)
+		: "";
 
 	public async Task<string?> ExecuteScriptAsync(string script, CancellationToken token)
 	{
@@ -85,11 +122,16 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 			this.Log().Debug($"ExecuteScriptAsync: {executedScript}");
 		}
 
+		if (!TryGetHandle("execute a script on", out var webview))
+		{
+			return null;
+		}
+
 		var tcs = new TaskCompletionSource<string>();
 		using (token.Register(() => tcs.TrySetCanceled()))
 		{
 			var handle = GCHandle.Alloc(tcs);
-			NativeUno.uno_webview_execute_script(_webview, GCHandle.ToIntPtr(handle), script);
+			NativeUno.uno_webview_execute_script(webview, GCHandle.ToIntPtr(handle), script);
 		}
 
 		return await tcs.Task;
@@ -116,9 +158,21 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 		gch.Free();
 	}
 
-	public void GoBack() => NativeUno.uno_webview_go_back(_webview);
+	public void GoBack()
+	{
+		if (TryGetHandle("navigate back", out var handle))
+		{
+			NativeUno.uno_webview_go_back(handle);
+		}
+	}
 
-	public void GoForward() => NativeUno.uno_webview_go_forward(_webview);
+	public void GoForward()
+	{
+		if (TryGetHandle("navigate forward", out var handle))
+		{
+			NativeUno.uno_webview_go_forward(handle);
+		}
+	}
 
 	public async Task<string?> InvokeScriptAsync(string script, string[]? arguments, CancellationToken token)
 	{
@@ -138,11 +192,16 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 			this.Log().Debug($"InvokeScriptAsync: {javascript}");
 		}
 
+		if (!TryGetHandle("invoke a script on", out var webview))
+		{
+			return null;
+		}
+
 		var tcs = new TaskCompletionSource<string?>();
 		using (token.Register(() => tcs.TrySetCanceled()))
 		{
 			var handle = GCHandle.Alloc(tcs);
-			NativeUno.uno_webview_invoke_script(_webview, GCHandle.ToIntPtr(handle), javascript);
+			NativeUno.uno_webview_invoke_script(webview, GCHandle.ToIntPtr(handle), javascript);
 			return await tcs.Task;
 		}
 	}
@@ -191,7 +250,10 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 			url = uri.AbsoluteUri;
 		}
 
-		NativeUno.uno_webview_navigate(_webview, url, null);
+		if (TryGetHandle("navigate", out var handle))
+		{
+			NativeUno.uno_webview_navigate(handle, url, null);
+		}
 	}
 
 	public void ProcessNavigation(string html)
@@ -202,7 +264,10 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 		}
 
 		_lastHtmlContent = html;
-		NativeUno.uno_webview_load_html(_webview, html);
+		if (TryGetHandle("load HTML into", out var handle))
+		{
+			NativeUno.uno_webview_load_html(handle, html);
+		}
 	}
 
 	public void ProcessNavigation(HttpRequestMessage httpRequestMessage)
@@ -218,32 +283,49 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 		if (url is not null)
 		{
 			var headers = JsonSerializer.Serialize(httpRequestMessage.Headers);
-			NativeUno.uno_webview_navigate(_webview, url, headers);
+			if (TryGetHandle("navigate", out var handle))
+			{
+				NativeUno.uno_webview_navigate(handle, url, headers);
+			}
 		}
 	}
 
 	public void Reload()
 	{
+		if (!TryGetHandle("reload", out var handle))
+		{
+			return;
+		}
+
 		if (_lastHtmlContent != null)
 		{
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
 				this.Log().Debug($"Reloading cached HTML content");
 			}
-			NativeUno.uno_webview_load_html(_webview, _lastHtmlContent);
+			NativeUno.uno_webview_load_html(handle, _lastHtmlContent);
 		}
 		else
 		{
-			NativeUno.uno_webview_reload(_webview);
+			NativeUno.uno_webview_reload(handle);
 		}
 	}
 
 	public void SetScrollingEnabled(bool isScrollingEnabled)
 	{
-		NativeUno.uno_webview_set_scrolling_enabled(_webview, isScrollingEnabled);
+		if (TryGetHandle("set the scrolling mode of", out var handle))
+		{
+			NativeUno.uno_webview_set_scrolling_enabled(handle, isScrollingEnabled);
+		}
 	}
 
-	public void Stop() => NativeUno.uno_webview_stop(_webview);
+	public void Stop()
+	{
+		if (TryGetHandle("stop", out var handle))
+		{
+			NativeUno.uno_webview_stop(handle);
+		}
+	}
 
 	private static readonly Dictionary<nint, WeakReference<MacOSNativeWebView>> _webViews = [];
 
@@ -264,9 +346,18 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 
 	private void SetHistoryProperties()
 	{
-		_owner.SetHistoryProperties(
-			NativeUno.uno_webview_can_go_back(_webview),
-			NativeUno.uno_webview_can_go_forward(_webview));
+		// A disposed peer reports no history rather than keeping the last known values: a stale `true`
+		// would invite a GoBack/GoForward call that can no longer do anything.
+		var canGoBack = false;
+		var canGoForward = false;
+
+		if (TryGetHandle("read the navigation history of", out var handle))
+		{
+			canGoBack = NativeUno.uno_webview_can_go_back(handle);
+			canGoForward = NativeUno.uno_webview_can_go_forward(handle);
+		}
+
+		_owner.SetHistoryProperties(canGoBack, canGoForward);
 	}
 
 	[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
@@ -66,9 +66,9 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 	/// Resolves the native <c>WKWebView</c> handle, refusing to hand a disposed peer to native code.
 	/// </summary>
 	/// <remarks>
-	/// The peer is destroyed when the element leaves the visual tree, which zeroes
-	/// <see cref="MacOSNativeElement.NativeHandle"/>. Messaging the freed <c>WKWebView</c> would make ARC
-	/// retain deallocated memory and take down the whole process, so each operation has to fail on its own.
+	/// Releasing the peer zeroes <see cref="MacOSNativeElement.NativeHandle"/>. Messaging the freed
+	/// <c>WKWebView</c> would make ARC retain deallocated memory and take down the whole process, so each
+	/// operation has to fail on its own.
 	/// </remarks>
 	private bool TryGetHandle(string operation, out nint handle)
 	{
@@ -105,6 +105,12 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 		if (_registeredHandle != 0)
 		{
 			_webViews.Remove(_registeredHandle);
+
+			if (!Disposed)
+			{
+				NativeUno.uno_webview_unregister_message_handler(_registeredHandle);
+			}
+
 			_registeredHandle = 0;
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
@@ -76,9 +76,9 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 
 		if (Disposed || handle == 0)
 		{
-			if (this.Log().IsEnabled(LogLevel.Error))
+			if (this.Log().IsEnabled(LogLevel.Warning))
 			{
-				this.Log().Error($"Cannot {operation} a WebView2 whose native peer was already disposed.");
+				this.Log().Warn($"Cannot {operation} a WebView2 whose native peer was already disposed.");
 			}
 
 			return false;
@@ -132,9 +132,8 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 		{
 			var handle = GCHandle.Alloc(tcs);
 			NativeUno.uno_webview_execute_script(webview, GCHandle.ToIntPtr(handle), script);
+			return await tcs.Task;
 		}
-
-		return await tcs.Task;
 	}
 
 	[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/WebView/MacOSNativeWebView.cs
@@ -127,7 +127,7 @@ internal partial class MacOSNativeWebView : MacOSNativeElement, ICleanableNative
 			return null;
 		}
 
-		var tcs = new TaskCompletionSource<string>();
+		var tcs = new TaskCompletionSource<string?>();
 		using (token.Register(() => tcs.TrySetCanceled()))
 		{
 			var handle = GCHandle.Alloc(tcs);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMediaPlayer.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMediaPlayer.m
@@ -284,6 +284,7 @@ UNOMediaPlayerView* uno_mediaplayer_create_view(void)
 #if DEBUG_MEDIAPLAYER
     NSLog(@"uno_mediaplayer_create_view #%p %@", view, view.layer);
 #endif
+    uno_native_track(view);
     return view;
 }
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -40,6 +40,15 @@
     id<CAMetalDrawable> drawable = view.currentDrawable;
     if (drawable == nil)
     {
+        // Returning without calling managed code would stop this window rendering for good: AppKit has
+        // already cleared needsDisplay to make this call, and the managed side latches its frame request
+        // (CompositionTarget.RenderRequested stays set), so every later RequestNewFrame coalesces into the
+        // invalidation that produced this dropped frame. Re-arm on a later turn -- setting it here would be
+        // cleared by the display pass we are inside of.
+        __weak MTKView *weakView = view;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NSEC_PER_SEC / 120)), dispatch_get_main_queue(), ^{
+            weakView.needsDisplay = YES;
+        });
         return;
     }
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.h
@@ -21,6 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/// Takes the native-side strong reference on a freshly created element.
+/// Creators hand back an autoreleased object, so without this the peer dies at the next pool drain and
+/// every later `uno_native_*` call retains freed memory.
+void uno_native_track(NSView<UNONativeElement>* element);
+
 NSView* uno_native_create_sample(NSWindow *window, const char* _Nullable text);
 
 void uno_native_arrange(NSView<UNONativeElement>* element, double arrangeLeft, double arrangeTop, double arrangeWidth, double arrangeHeight);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.m
@@ -37,6 +37,14 @@ static NSMutableSet<NSView*> *transients;
 
 @end
 
+void uno_native_track(NSView<UNONativeElement>* element)
+{
+    if (!transients) {
+        transients = [[NSMutableSet alloc] initWithCapacity:10];
+    }
+    [transients addObject:element];
+}
+
 NSView* uno_native_create_sample(NSWindow *window, const char* _Nullable text)
 {
     // no NSLabel on macOS
@@ -54,6 +62,7 @@ NSView* uno_native_create_sample(NSWindow *window, const char* _Nullable text)
     NSLog(@"uno_native_create_sample #%p label: %@", sample, label.stringValue);
 #endif
     sample.originalSuperView = ((UNOWindow*)window).renderingView;
+    uno_native_track(sample);
     return sample;
 }
 
@@ -97,11 +106,8 @@ void uno_native_detach(NSView<UNONativeElement>* element)
 #endif
     element.layer.mask = nil;
 
-    if (!transients) {
-        transients = [[NSMutableSet alloc] initWithCapacity:10];
-    }
     // once removed from superview the instance can be freed by the runtime unless we keep another reference to it
-    [transients addObject:element];
+    uno_native_track(element);
     [elements removeObject:element];
     [element removeFromSuperview];
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.m
@@ -85,6 +85,8 @@ void uno_native_attach(NSView<UNONativeElement>* element)
         // note: it's too early to add a mask since the layer has not been set yet
         [elements addObject:element];
     }
+    // `elements` owns it again, so drop the reference `uno_native_detach` took to survive the round trip.
+    [transients removeObject:element];
     [element.originalSuperView addSubview:element];
 }
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNONative.m
@@ -148,6 +148,14 @@ void uno_native_dispose(NSView<UNONativeElement>* element)
 #if DEBUG
     NSLog(@"uno_native_dispose #%p", element);
 #endif
+    if (!element) {
+        return;
+    }
     [element dispose];
+    // Disposal is terminal: drop BOTH strong references, so the view cannot be resurrected through
+    // `elements` by a later attach. `transients` alone is not enough — an element detached before it
+    // is disposed has already been moved out of `elements`, and one disposed while still attached
+    // would otherwise stay retained there forever.
     [transients removeObject:element];
+    [elements removeObject:element];
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWebView.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWebView.h
@@ -50,6 +50,7 @@ void uno_set_webview_new_window_requested_callback(uno_webview_new_window_reques
 const char* uno_webview_get_title(WKWebView *webview);
 
 void uno_webview_register_message_handler(WKWebView *webview);
+void uno_webview_unregister_message_handler(WKWebView *webview);
 
 bool uno_webview_can_go_back(WKWebView *webview);
 bool uno_webview_can_go_forward(WKWebView *webview);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWebView.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWebView.m
@@ -122,7 +122,18 @@ void uno_webview_register_message_handler(WKWebView *webview)
     NSLog(@"uno_webview_register_message_handler %p", webview);
 #endif
     __weak id weakSelf = webview;
+    // `addScriptMessageHandler:name:` raises on a name that is already taken, and the webview outlives
+    // every visual tree exit, so a re-entering element registers on the same WKWebView a second time.
+    [webview.configuration.userContentController removeScriptMessageHandlerForName:@"unoWebView"];
     [webview.configuration.userContentController addScriptMessageHandler:weakSelf name:@"unoWebView"];
+}
+
+void uno_webview_unregister_message_handler(WKWebView *webview)
+{
+#if DEBUG
+    NSLog(@"uno_webview_unregister_message_handler %p", webview);
+#endif
+    [webview.configuration.userContentController removeScriptMessageHandlerForName:@"unoWebView"];
 }
 
 const char* uno_webview_get_title(WKWebView *webview)

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWebView.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWebView.m
@@ -113,6 +113,7 @@ NSView* uno_webview_create(NSWindow *window, const char *ok, const char *cancel)
     webview.cancelString = [NSString stringWithUTF8String:cancel];
 
     webview.originalSuperView = ((UNOWindow*)window).renderingView;
+    uno_native_track(webview);
     return webview;
 }
 


### PR DESCRIPTION
**GitHub Issue:** closes #24111

## PR Type:

🐞 Bugfix

## What changed? 🚀

macOS native-peer lifetime defects that take down the whole `Tests - Desktop Skia macOS` job with a `SIGSEGV`, losing the results of every other test in the run.

> **Scope:** macOS only. The default test-body timeout moved to #24162 and the Hot Reload test fixes to #24125, so each change set stands on its own.

### Root cause: native peers were created unowned

`uno_webview_create`, `uno_mediaplayer_create_view` and `uno_native_create_sample` all end in `objc_autoreleaseReturnValue` — confirmed by disassembling the shipped dylib, not by reading the source. The handle they hand back to managed code is owned by nothing but the current autorelease pool. The native side only took a strong reference later, at `uno_native_attach`, which adds the view to the `elements` set.

So any element that is never attached, or whose attach lands in a later run-loop turn than its creation, is already deallocated. Both `uno_native_attach` and `uno_native_dispose` begin with an ARC `objc_retain` of their parameter, so the next call takes the process down at `+0x1f`.

Three CI core dumps from this branch all fault at the same image offset, which symbolizes to `uno_native_dispose` retaining a freed `NSView`.

**Fix:** `uno_native_track` takes the strong reference at creation. Ownership is now continuous — `transients` from birth, `elements` while attached, back to `transients` on detach — until `uno_native_dispose` drops both and deallocates.

### Peers no longer die on a reparent

`MacOSNativeElement` destroyed its `NSView` from `Unloaded`, but `Unloaded` also fires on a reparent and the framework re-enters the very same element through `AttachNativeElement`. A `WebView2` removed from and re-added to the tree came back dead — which is what failed `When_WebMessageReceived_After_RemoveAdd`. Neither the X11 nor the Win32 hosting extension destroys its peer on unload.

The peer's lifetime now follows the managed wrapper: the finalizer releases it, dispatched to the main thread since AppKit is main-thread only. The disposed-handle guards stay as hardening — they can no longer be reached through a reparent.

`addScriptMessageHandler:name:` raises on a name that is already registered, and the `WKWebView` now survives the round trip, so registration removes the previous handler first and `OnUnloaded` unregisters symmetrically with `OnLoaded`. The stale private `_webview` shadow copy of the handle is gone; every call resolves through `TryGetHandle`.

### A dropped frame no longer stops rendering permanently

`drawInMTKView:` returned without calling managed code when `currentDrawable` was nil. The view runs with `enableSetNeedsDisplay`, so AppKit had already cleared `needsDisplay` to make that call, and the managed side latches its own request: `CompositionTarget.RequestNewFrame` sets `RenderRequested` and only clears it from `OnNativePlatformFrameRequested`, which the dropped frame never reaches. Every later `RequestNewFrame` then coalesced into an invalidation that had already been consumed, so a single nil drawable stopped that window rendering for good. It now re-arms `needsDisplay` on a later main-queue turn. The software path never had the defect — it calls the managed callback before its own early return.

## Validation

| Change | Evidence |
|---|---|
| Unowned native peer | **Runtime.** Reproduced against the exact dylib CI built, using `uno_mediaplayer_create_view` (no arguments): create → drain the pool → `uno_native_dispose` gives `Segmentation fault: 11`, exit 139 — the same exit code CI reported. The fixed dylib survives, exit 0. |
| Reparent survival | **Runtime.** `When_WebMessageReceived_After_RemoveAdd` passes on macOS Skia; `Given_WebView2` 9/9. |
| No regression | **Runtime.** `Given_WebView2` + `Given_MediaPlayerElement` + `Given_ContentPresenter`: 278 passed, 0 failed, clean exit. |
| Nil-drawable re-arm | **Code review only.** A nil drawable cannot be forced on a healthy Mac, so the latch is established by inspection of both sides rather than by a repro. `Given_ListViewBase` shows no regression (144/146; the one failure, `When_ThemeChange`, fails identically without this change). |

**One claim to correct from an earlier revision of this description:** the nil-drawable fix was described as the cause of the macOS 60-minute job hangs. That is not established. `UITestHelper.WaitForRender` does have a 1000 ms bound, and `NativeDispatcher.TryGetRenderAction` consumes a render action one-shot, so a dead render loop makes a test fail in about a second rather than hang. The latch is a genuine defect worth fixing on its own terms; it is not the hang's explanation. The hang reproduces on `feature/breakingchanges` without any of this PR's code and is tracked separately.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
   - `When_WebMessageReceived_After_RemoveAdd` already existed and is the fail-before/pass-after case for the reparent fix. The ownership defect is covered by a native repro described above; there is no managed harness that can reach it.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
   - Not applicable: no public API or user-facing behaviour change.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LKUHFiW2J8nNFy7FmuCsd
