### PR TITLE
fix(ci): Let chrome navigate on its first launch

### DIFF
--- a/build/test-scripts/wasm-run-skia-runtime-tests.sh
+++ b/build/test-scripts/wasm-run-skia-runtime-tests.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -x #echo on
 set -euo pipefail
 IFS=$'\n\t'
@@ -75,8 +75,11 @@ while [ $TRY_COUNT -lt 5 ]; do
     # tests that wait on them time out (flaky WASM-Skia). Mirror linux-skia-runtime-tests.sh: define a
     # screen, run a window manager (fluxbox), keep a visible window size, and disable bg throttling.
     # (fluxbox degrades gracefully: if it is unavailable the backgrounded launch is a no-op and chrome
-    # still runs.) The URL is passed as a positional arg to avoid re-quoting its '&'/'='/'?' chars.
-    xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c '{ fluxbox >/dev/null 2>&1 & } ; google-chrome --enable-logging=stderr --no-sandbox --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --window-size=1920,1080 "$1"' _ "${RUNTIME_TESTS_URL}" &
+    # still runs.) --no-first-run/--no-default-browser-check/--disable-search-engine-choice-screen stop the
+    # first-run experience from swallowing the command-line URL on the agent's brand-new profile:
+    # without them chrome starts but never navigates, so the canary never appears.
+    # The URL is passed as a positional arg to avoid re-quoting its '&'/'='/'?' chars.
+    xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c '{ fluxbox >/dev/null 2>&1 & } ; google-chrome --enable-logging=stderr --no-sandbox --no-first-run --no-default-browser-check --disable-search-engine-choice-screen --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --window-size=1920,1080 "$1"' _ "${RUNTIME_TESTS_URL}" &
 
     # wait one minute for the canary file to be created, otherwise fail the script.
     # This may happen if xvfb-run of chrome fails to start


### PR DESCRIPTION
**GitHub Issue:** closes #24113

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The **Tests - WebAssembly Skia** stage has been failing across unrelated branches with:

```
Canary file not found. The app may not have started? Exiting.
```

and then `PublishTestResults` reporting `No test result files matching ...skia-browserwasm-runtime-tests-results.xml were found`. Re-queueing does not reliably clear it, because each retry re-rolls the same dice.

**Current behavior.** `wasm-run-skia-runtime-tests.sh` launched `google-chrome` against the agent's brand-new profile without `--no-first-run`, so Chrome ran its **first-run experience and discarded the URL given on the command line**. The job log shows Chrome starting (dbus/gpu warnings) but **zero HTTP requests** to the `http.server` serving the app — so the app never booted and never wrote the canary file.

That is why the *first* launch of every job never produced a request: across the WASM runs of build `228401`, every run that eventually passed shows exactly one `Canary file not found. retrying...` before succeeding, and the second launch — now reusing the initialised profile — navigated in ~0.1 s and wrote the canary ~6 s later. When the agent is slow enough that `killall -9` lands before the profile is persisted, all five retries repeat the first run and the stage fails for good.

**This change** adds `--no-first-run --no-default-browser-check --disable-search-engine-choice-screen` to the Chrome invocation, so it navigates on the first launch instead of spending one guaranteed retry (and sometimes all five) on the welcome screen. It also drops the UTF-8 BOM on line 1, which made bash report `line 1: ﻿#!/bin/bash: No such file or directory` on every single run.

**Validation.** Reproduced and verified locally under the same fresh-profile condition, pointing Chrome at a local `python -m http.server`:

| Flags | Result |
|---|---|
| none (current behavior) | **0 requests in 20 s** — Chrome never navigated |
| with the flags added here | **GET arrived in ~1 s** |

`bash -n` passes on the modified script. The end-to-end effect is only observable on the Linux CI agents, so the WASM Skia leg on this PR is the real proof.

Observed on builds from several unrelated branches — #24009, #24083, #24070, #24103, #24108, #24072 — so this is not specific to any one change. The same script exists on `master`, `feature/breakingchanges` and `release/stable/6.7`; this targets `master` so it propagates through the usual master→feature sync.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, CI script change; validated by the A/B reproduction above and by the WASM leg on this PR
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no user-facing surface
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
