### PR TITLE
fix(ci): Detect merge conflicts without a pipe

### DIFF
--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -231,12 +231,17 @@ jobs:
           conflict_files=""
           if git merge --no-ff --no-edit origin/master; then
             CONFLICT=0
-          elif git ls-files -u | grep -q .; then
+          # Test for unmerged entries via command substitution, never a pipe: under
+          # `pipefail` a reader that exits early (`grep -q`) can SIGPIPE the producer,
+          # and the 141 becomes the pipeline's status — reporting a conflicted merge
+          # as clean and dropping us into the "non-conflict failure" branch below.
+          elif [ -n "$(git ls-files -u)" ]; then
             CONFLICT=1
             conflict_files="$(git diff --name-only --diff-filter=U || true)"
             git add -A
             git commit --no-edit || { git merge --abort 2>/dev/null || true; note "❌ conflict commit failed"; exit 1; }
           else
+            git status --short || true
             git merge --abort 2>/dev/null || true
             note "❌ merge failed (non-conflict) — see logs"
             exit 1


### PR DESCRIPTION
**GitHub Issue:** closes #24114

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

The nightly `Sync master into feature branches` job has failed on `feature/breakingchanges` every night since 2026-08-03, and on most of those nights it died with **zero diagnostic output** — ~76 ms after `Automatic merge failed`, nothing in between.

The conflict-detection test in `master-sync.yml` runs under `set -euo pipefail`:

```bash
elif git ls-files -u | grep -q .; then
```

`grep -q` exits the moment it matches and closes the pipe, so `git ls-files -u` can be killed by `SIGPIPE` and exit **141** — which `pipefail` promotes to the pipeline's status. The `elif` then reads **false** on a genuinely conflicted merge, and control falls into the `else` branch, which runs `git merge --abort 2>/dev/null || true` (silent) and `exit 1`. That is the only fully-silent `exit 1` path in the step, which is exactly what the logs show.

This PR tests for unmerged entries via command substitution, which has no pipe and so cannot be affected, and prints `git status --short` on the genuine non-conflict path so that branch is no longer silent either.

It is a race, not a threshold — the same ~21 conflicts produced different outcomes on different nights (Aug 12 reached the merge commit; Aug 11/13/14/19 aborted silently).

Reproduced on Linux (git 2.43) against a real conflicted merge with 102 unmerged index entries:

```
OLD  git ls-files -u | grep -q .    rc=141 -> 1/1000,  rc=0 -> 999/1000
NEW  [ -n "$(git ls-files -u)" ]    rc=0   -> 1000/1000
```

1/1000 on an idle machine; the window is much wider on a loaded CI runner. Replaying the fixed decision block against the real `master` → `feature/breakingchanges` merge selects `CONFLICT=1` and lists all 34 conflicted paths.

`grep -rn "grep -q" .github/workflows/` shows this was the only instance of the pattern, and `master-sync.yml` is the only workflow that sets `pipefail`.

> [!NOTE]
> This fixes one of two independent defects. The sync will now correctly commit the conflicted merge and quarantine it as a draft PR — but the push itself is still rejected, because the merge updates `.github/workflows/**` and the default `GITHUB_TOKEN` may never do that. That is handled separately.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable to a workflow file; validated by the fails-before/passes-after reproduction above
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, the rationale is captured in an inline comment
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no rendering impact
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
