### PR TITLE
fix(ci): Report why a sync push was rejected

### DIFF
--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -17,13 +17,23 @@ name: Sync master into feature branches
 #
 # "Active" = a `feature/*` branch with a commit within ACTIVITY_DAYS (default 30).
 #
-# Token: uses the default GITHUB_TOKEN today. The gating CI is Azure Pipelines,
-# whose GitHub App receives PR webhooks regardless of the pusher, so CI runs and
-# auto-merge can complete. Swap-seam: drop a `SYNC_BOT_TOKEN` secret (PAT or App
-# token, ideally with read:org) later and it takes over with zero edits — needed
-# for (a) any *required* check that is itself a GitHub Actions workflow (those are
-# suppressed under the default token) and (b) reliable team-reviewer requests
-# (the repo-scoped default token cannot read org team membership).
+# Token: falls back to the default GITHUB_TOKEN, but that is NOT sufficient in
+# general. A sync merge that updates `.github/workflows/**` cannot be pushed by
+# GITHUB_TOKEN at all — GitHub rejects it with "refusing to allow a GitHub App to
+# create or update workflow ... without `workflows` permission", and `workflows`
+# is not a grantable `permissions:` key, so no job-level setting can unblock it.
+# Once master and a feature branch have both touched a workflow file, EVERY sync
+# of that branch is blocked until a `SYNC_BOT_TOKEN` secret exists.
+#
+# Provide `SYNC_BOT_TOKEN` as a PAT with `workflow` scope (fine-grained: Contents
+# + Pull requests + Workflows, all read/write) or a GitHub App token with the
+# equivalent. It takes over with zero edits, and additionally fixes (a) any
+# *required* check that is itself a GitHub Actions workflow (those are suppressed
+# under the default token) and (b) team-reviewer requests (the repo-scoped default
+# token cannot read org team membership).
+#
+# The gating CI is Azure Pipelines, whose GitHub App receives PR webhooks
+# regardless of the pusher, so CI runs and auto-merge complete either way.
 #
 # Repo prerequisite: Settings -> General -> "Allow auto-merge" must be ON, and
 # `feature/*` must have its required-review + required-CI protection. The
@@ -124,6 +134,8 @@ jobs:
     env:
       # Swap-seam: SYNC_BOT_TOKEN (PAT/App) wins if present, else the default token.
       SYNC_TOKEN: ${{ secrets.SYNC_BOT_TOKEN || github.token }}
+      # Secrets cannot be tested from bash, so surface presence as a plain boolean.
+      HAS_SYNC_BOT_TOKEN: ${{ secrets.SYNC_BOT_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -134,6 +146,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ env.SYNC_TOKEN }}
+          HAS_SYNC_BOT_TOKEN: ${{ env.HAS_SYNC_BOT_TOKEN }}
           FEATURE: ${{ matrix.branch }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           REVIEW_TEAM: unoplatform/uno-core-team
@@ -145,6 +158,7 @@ jobs:
           SYNC_BRANCH="automation/master-sync/${FEATURE}"
           TITLE="chore(automation): Sync master → ${FEATURE}"
           CMARKER="<!-- master-sync-bot:conflict -->"
+          PMARKER="<!-- master-sync-bot:push-failed -->"
 
           # Guarantee exactly ONE summary row per matrix leg, however we exit.
           STATUS=""
@@ -251,7 +265,35 @@ jobs:
             gh pr merge "$pr" --disable-auto >/dev/null 2>&1 || true
           fi
 
-          git push --force-with-lease origin "HEAD:refs/heads/${SYNC_BRANCH}"
+          # A rejected push used to end the run with a bare git error, leaving the PR
+          # quarantined (drafted, auto-merge off) but otherwise untouched — so it kept
+          # advertising a stale body while the feature branch drifted. Name the cause,
+          # mark the PR, and say so in the summary.
+          wf_changed="$(git diff --name-only "origin/${FEATURE}..HEAD" -- '.github/workflows' || true)"
+          if ! git push --force-with-lease origin "HEAD:refs/heads/${SYNC_BRANCH}"; then
+            if [ -n "$wf_changed" ] && [ "${HAS_SYNC_BOT_TOKEN:-false}" != "true" ]; then
+              why="the merge updates .github/workflows/** and the default GITHUB_TOKEN may not push workflow files — provision the SYNC_BOT_TOKEN secret (see this workflow's header)"
+            else
+              why="see the git output above"
+            fi
+            echo "::error title=master-sync push rejected::${FEATURE}: ${why}"
+            gh label create 'sync-failed' --color 'b60205' --description 'Automated master→feature sync could not complete' >/dev/null 2>&1 || true
+            if [ -n "$pr" ]; then
+              gh pr edit "$pr" --add-label 'sync-failed' >/dev/null 2>&1 || true
+              seen="$(gh pr view "$pr" --json comments --jq "[.comments[] | select(.body | contains(\"$PMARKER\"))] | length" 2>/dev/null || echo 0)"
+              if [ "${seen:-0}" = "0" ]; then
+                gh pr comment "$pr" --body "$(printf '%s\n' "$PMARKER" \
+                  "> [!CAUTION]" \
+                  "> **This sync PR is stale.** The nightly job could not push an update: ${why}." \
+                  "" \
+                  "Its description below describes an older sync and must not be trusted until this is resolved. [Failing run](${RUN_URL})")" \
+                  >/dev/null 2>&1 || true
+              fi
+            fi
+            note "❌ push rejected — ${why}"
+            exit 1
+          fi
+          [ -n "$pr" ] && gh pr edit "$pr" --remove-label 'sync-failed' >/dev/null 2>&1 || true
 
           # Ensure our labels exist (idempotent). '🤖 Project automation' is pre-existing;
           # create without --force so we never overwrite its established style.

--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -33,7 +33,7 @@ name: Sync master into feature branches
 # token cannot read org team membership).
 #
 # The gating CI is Azure Pipelines, whose GitHub App receives PR webhooks
-# regardless of the pusher, so CI runs and auto-merge complete either way.
+# regardless of the pusher, so CI still runs and auto-merge still completes either way.
 #
 # Repo prerequisite: Settings -> General -> "Allow auto-merge" must be ON, and
 # `feature/*` must have its required-review + required-CI protection. The
@@ -219,8 +219,13 @@ jobs:
             pr="$(open_pr)"
             if [ -n "$pr" ]; then
               is_draft="$(gh pr view "$pr" --json isDraft --jq '.isDraft' 2>/dev/null || echo '')"
-              if [ "$is_draft" != "true" ] && [ "$DRY_RUN" != "true" ]; then
-                gh pr merge "$pr" --auto --merge >/dev/null 2>&1 || true
+              if [ "$DRY_RUN" != "true" ]; then
+                # The branch is confirmed current, so a `sync-failed` from an earlier run is
+                # stale no matter who fixed it — this path never reaches the removal below.
+                gh pr edit "$pr" --remove-label 'sync-failed' >/dev/null 2>&1 || true
+                if [ "$is_draft" != "true" ]; then
+                  gh pr merge "$pr" --auto --merge >/dev/null 2>&1 || true
+                fi
               fi
               note "up to date — PR #$pr unchanged"
             else

--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -127,6 +127,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Labels are an Issues API operation: creating 'sync-failed' needs this.
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -146,7 +148,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ env.SYNC_TOKEN }}
-          HAS_SYNC_BOT_TOKEN: ${{ env.HAS_SYNC_BOT_TOKEN }}
           FEATURE: ${{ matrix.branch }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           REVIEW_TEAM: unoplatform/uno-core-team
@@ -269,7 +270,14 @@ jobs:
           # quarantined (drafted, auto-merge off) but otherwise untouched — so it kept
           # advertising a stale body while the feature branch drifted. Name the cause,
           # mark the PR, and say so in the summary.
-          wf_changed="$(git diff --name-only "origin/${FEATURE}..HEAD" -- '.github/workflows' || true)"
+          # Compare against the ref this push replaces: when the sync branch already exists
+          # HEAD can carry workflow files it already has, which are not new to this push.
+          if [ "$SYNC_EXISTS" = "1" ]; then
+            wf_base="origin/${SYNC_BRANCH}"
+          else
+            wf_base="origin/${FEATURE}"
+          fi
+          wf_changed="$(git diff --name-only "${wf_base}..HEAD" -- '.github/workflows' || true)"
           if ! git push --force-with-lease origin "HEAD:refs/heads/${SYNC_BRANCH}"; then
             if [ -n "$wf_changed" ] && [ "${HAS_SYNC_BOT_TOKEN:-false}" != "true" ]; then
               why="the merge updates .github/workflows/** and the default GITHUB_TOKEN may not push workflow files — provision the SYNC_BOT_TOKEN secret (see this workflow's header)"


### PR DESCRIPTION
**GitHub Issue:** closes #24117

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

When the sync merges `master` into `feature/breakingchanges`, the push is rejected:

```
! [remote rejected] HEAD -> automation/master-sync/feature/breakingchanges
  (refusing to allow a GitHub App to create or update workflow
   `.github/workflows/winappsdk-sync-apply.yml` without `workflows` permission)
```

`winappsdk-sync-apply.yml` was modified on **both** `master` and `feature/breakingchanges` after their merge base, so every sync merge rewrites it. `feature/wasm-mt` is unaffected only because its merge touches no workflow files.

No `permissions:` change can fix this — `workflows` is not a grantable key, so the default `GITHUB_TOKEN` can never push under `.github/workflows/`. The existing `SYNC_BOT_TOKEN` swap-seam is not an optional nicety here; it is required. **Provisioning that secret is an admin action and is not part of this PR.**

The worse half is that the failure was invisible. The quarantine step (`gh pr ready --undo`, `gh pr merge --disable-auto`) runs *before* the push, so on 2026-08-03 it drafted sync PR #23944 and disabled auto-merge, then the push died — before any label, comment, or body update could run. The result was a PR that looked maintained and wasn't: open, frozen at the 2026-08-02 merge, body still reading "Auto-merge: **enabled**", no `conflicts` label, while `feature/breakingchanges` drifted to 704 commits behind master.

This PR:

1. Surfaces `SYNC_BOT_TOKEN` presence to the script as a plain boolean (secrets can't be tested from bash), so a rejection can be attributed rather than guessed at.
2. Wraps the push — on rejection it emits a `::error::` naming the cause, adds a `sync-failed` label, posts a one-time sticky comment marking the PR stale, and records it in the step summary. The label is cleared once a push lands.
3. Rewrites the header comment so the token reads as **required**, not as an optional later swap.

### Provisioning `SYNC_BOT_TOKEN` (follow-up, not in this PR)

This PR makes the failure legible; it does not unblock the push. That needs the secret, which is an admin action.

**Fine-grained PAT** — no further code change, the workflow already prefers it over `github.token`:

1. **Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token**
2. Resource owner **unoplatform**; Repository access → Only select repositories → **unoplatform/uno**
3. Repository permissions:
   - **Contents: Read and write**
   - **Pull requests: Read and write**
   - **Workflows: Read and write** ← the one that unblocks this
4. Choose an expiry that will actually get renewed. Org policy may route the request to an owner for approval.
5. **unoplatform/uno → Settings → Secrets and variables → Actions → New repository secret**, named `SYNC_BOT_TOKEN`.

A classic PAT with the `repo` + `workflow` scopes works too.

> [!NOTE]
> A PAT is tied to one user account and expires, so the sync breaks again when it lapses or that person's access changes. An org-owned **GitHub App** (Contents / Pull requests / Workflows all read-write, minted per run with `actions/create-github-app-token`) has no expiry and no personal ownership — it needs one extra step in the workflow, which can be added on request.

Once the secret exists, the first successful run will update sync PR #23944 in place and leave it a **draft** labelled `conflicts`, with the conflicted paths listed for a human to resolve.

### Validation

The push wrapper was extracted from the workflow verbatim and exercised with stubbed `git`/`gh` across every branch:

| Case | Result |
|---|---|
| push fails, workflows touched, no token | `SYNC_BOT_TOKEN` advice, label + sticky comment, exit 1 |
| push fails, workflows touched, token present | generic reason (token correctly not blamed), exit 1 |
| push fails, no workflow files | generic reason, exit 1 |
| push succeeds | no error, clears `sync-failed`, continues (exit 0) |
| push fails, no open PR yet | error + summary, no `gh pr` calls, no crash |

YAML parses, and every `run:` block passes `bash -n`.

> [!NOTE]
> This is one of two independent defects. #24116 fixes the conflict-detection race that made the job die silently before it ever reached this push. Both are needed; neither depends on the other.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable to a workflow file; validated by the stubbed branch-coverage run above
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — the workflow header now documents the token requirement
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no rendering impact
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)


