### PR TITLE
fix(skia): Scope the native-element clip cache to its composition target

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.cs
@@ -55,11 +55,15 @@ public partial class CompositionTarget
 	private readonly Lock _frameGate = new();
 	private readonly Lock _xamlRootBoundsGate = new();
 
-	// Only read and set from the native rendering thread in OnNativePlatformFrameRequested
+	// Only read and set from the native rendering thread in OnNativePlatformFrameRequested.
+	// All four cache per-composition-target (i.e. per-window) state and must not be static: the
+	// scaled clip path is invalidated by a per-target canvas recreation and keyed on this target's
+	// own frame, so sharing it lets one window discard and overwrite another's. On the hosts that
+	// render each window on its own thread that is also a data race on the SKPath itself.
 	private Size _lastCanvasSize = Size.Empty;
-	private static SKPath? _lastNativeClipPath;
+	private SKPath? _lastNativeClipPath;
 	private float _lastRasterizationScale = 1;
-	private static SKPath? _lastScaledNativeClipPath;
+	private SKPath? _lastScaledNativeClipPath;
 
 	private readonly DamageRegion _pendingDamage = new();
 


### PR DESCRIPTION
**GitHub Issue:** closes #24122

## PR Type:

🐞 Bugfix

## What changed? 🚀

`_lastNativeClipPath` and `_lastScaledNativeClipPath` in `CompositionTarget.Rendering.skia.cs` are `static`, but everything about them is per-composition-target — i.e. per window:

- they are invalidated by a **per-target** event: a canvas recreation nulls the scaled path (`:304`);
- they are keyed on **this target's** frame: `_lastNativeClipPath != lastRenderedFrame.nativeElementClipPath` (`:348`);
- their immediate neighbours under the same comment, `_lastCanvasSize` and `_lastRasterizationScale`, are already instance fields.

So with more than one window open the two targets discard and overwrite each other's cache every frame, and the scaled path handed to the native clipping layer at `:359` can belong to the wrong window. On the hosts that render each window on its own thread (Win32, X11, and macOS once #23594 lands) it is additionally a plain data race on the `SKPath`: one thread can be at `_lastScaledNativeClipPath = new()` (`:350`) while another transforms into it (`:354`) or returns it (`:359`).

This change makes both fields instance fields. Three lines, plus a comment recording why they must not be static.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — **no**, see *Testing* below.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, private field scope, no API or documented behaviour change.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — pending CI.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

## Testing

**Why there is no automated test.** The defect is only observable with two windows *each hosting native elements with different clip geometry*, and the corrupted value is a private `SKPath` consumed by platform-native clipping (`uno_window_clip_svg` on macOS). There is no managed surface to assert against, and the race is timing-dependent. A test here would be an expensive approximation that does not actually pin the invariant; the field scope itself is the invariant.

**What was verified.** Local A/B on the same machine, same 480-test slice (`UITEST_RUNTIME_TEST_GROUP=0`, `COUNT=20`), macOS Skia:

| build | wall clock | passed / failed |
|---|---|---|
| master (`static`) | 72.6 s | 479 / 1 |
| this PR (instance) | 74.4 s | 479 / 1 |

Identical outcomes; the difference is run-to-run noise. That is the expected result and is itself the safety argument: **with a single window there is one composition target, so instance and `static` are behaviourally identical.** The change can only differ where the bug is — two or more windows.

The single failure (`Given_ResourceLoader.When_MissingLocalizedResource_FallbackOnDefault`) is pre-existing and present on both sides.

Compiles clean for Skia desktop (`SamplesApp.Skia.Generic`, net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K297hJpRGEufnFFqS7pZh9
