### PR TITLE
fix(tests): Hot Reload runtime test correctness

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_ClientHotReloadProcessor.cs
@@ -16,7 +16,6 @@ namespace Uno.UI.RuntimeTests.Tests.HotReload;
 public class Given_ClientHotReloadProcessor
 {
 	[TestMethod]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaAndroid)] // Currently fails on Android .NET 11
 	public void When_GetRuntimeTargetFramework_Then_PlatformMatchesRuntimeIdentifier()
 	{
 		// Cross-check the reported platform against the runtime identifier rather than


### PR DESCRIPTION
**GitHub Issue:** closes #24124

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Four Hot Reload runtime-test defects, one commit each. **Split out of #24112** so the Hot Reload work can be reviewed on its own; #24112 keeps the macOS native-handle crash and the default test-body timeout.

### `test(hotreload)`: only cross-check the platform when a RID was stamped

The RID mapping fell through to `"skia"` for any unrecognised runtime identifier. The CoreCLR-on-Android host never sets `RUNTIME_IDENTIFIER`, so the test expected `skia` while the product correctly reported `android` — failing 100% of `android-skia-coreclr` runs since 2026-07-21. Only recognised RID families are mapped now; anything else means no independent oracle is available, and the desktop family is matched explicitly instead of by fallthrough. This also drops the `[PlatformCondition(Exclude, SkiaAndroid)]` workaround, which was over-broad — `SkiaAndroid` covers the Mono head too, where the test passes.

### `test(hotreload)`: stop the workspace scenario passing without running

On a CI retry the filter is rebuilt from the published failed-tests list, which carries fully qualified names, but the outer test stripped itself by comparing bare identifiers only. `…Given_HotReloadWorkspace.When_HotReloadScenario` was therefore forwarded to an HRApp that has no such test: it ran nothing, returned an empty result set, and the outer test reported success because there were no failures to collect. Now matches the fully qualified forms and fails explicitly when the HRApp returns no results, mirroring the `fail-empty` guard the CI scripts already apply to the outer run.

### `test(hotreload)`: assert on page content that exists

`Given_HotReloadResilience` drove `HR_Frame_Pages_Page1` by replacing `"Hello"` and then asserted on a TextBlock named `tb1`. The page contains neither — its TextBlocks are `FirstPageTextBlock` (`Text="First page"`) and a `{Binding TitleText}` one, and `grep -rn "tb1"` over the HotReload tree returns only the two lines of the assertion itself. The edit matched nothing and the assert then failed on an element that was never there.

This is the failure behind the red **Tests - Desktop Skia Windows** stage. Build 228363, test run 3886445:

```
Test When_HotReload_Succeeds_Then_ReloadCompleted_ReportsSuccess() failed with
Assert.IsNotNull failed. 'value' expression: 'tb'. TextBlock 'tb1' should exist in the page
```

Both tests now target the TextBlock the page actually declares.

### `test(hotreload)`: fail fast when a file edit matches nothing

The replacement is performed server-side, so a search string matching nothing is a silent no-op: no file change, no reload, and a test that asserts against content it never updated. That is how the stale `"Hello"`/`tb1` expectations survived for four months. `HotReloadHelper` now verifies the text is present before asking the server to replace it, naming the file and the caller when it is not. The check is skipped when the source is not readable from the test process, so the server stays the authority rather than a new failure mode appearing.

The `*AndRevert` helpers also undo only when an edit actually happened — reverting a file that was never modified trips the same guard from a `finally` block, which would replace the original failure with a confusing one.

## Validation

| Change | Evidence |
|---|---|
| RID oracle | **Runtime-validated** on Skia Desktop Win32 (RID `win-x64`), exercising the new explicit desktop branch: passes. |
| Workspace filter | Compile-validated, plus a table check that the predicate strips all four spellings of the outer test while leaving inner HRApp names untouched. |
| Resilience page content | **Verified against the page**: `HR_Frame_Pages_Page1.xaml` declares exactly one `"First page"` and `x:Name="FirstPageTextBlock"`; no `tb1`, no `"Hello"`. |
| No-op edit guard | Compile-validated. |

`Uno.UI.RuntimeTests.Skia.csproj` builds clean on net10.0 — **0 errors, 0 warnings**. The end-to-end hot-reload path needs a DevServer plus the HRApp child process, so the **Tests - Desktop Skia Windows** leg on this PR is the real validation.

⚠️ Expect that stage to stay red until all four land together: fixing the vacuous retry makes the HRApp actually run, which surfaces the `tb1` failure. That is correct behaviour, not a regression.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — these *are* test-correctness fixes
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no user-facing surface
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
