### PR TITLE
fix(tests): Hot Reload runtime test correctness

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
@@ -78,7 +78,7 @@ public class Given_HotReloadResilience : BaseTestClass
 			// While the pause is held, the update is queued and the op is
 			// reported as Ignored ("UI update paused by UpdateFile").
 			await HotReloadHelper.UpdateServerFile<HR_Frame_Pages_Page1>(
-				"Hello", "PausedTest", ct);
+				"First page", "Paused page", ct);
 
 			// ReloadCompleted has not fired yet — it fires when the drain
 			// eventually applies the queued types after Dispose below.
@@ -97,7 +97,7 @@ public class Given_HotReloadResilience : BaseTestClass
 		{
 			// Undo the file change so subsequent tests start from a known state.
 			await HotReloadHelper.UpdateServerFile<HR_Frame_Pages_Page1>(
-				"PausedTest", "Hello", CancellationToken.None);
+				"Paused page", "First page", CancellationToken.None);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadResilience.cs
@@ -71,33 +71,40 @@ public class Given_HotReloadResilience : BaseTestClass
 
 		await UnitTestsUIContentHelper.WaitForIdle();
 
-		using (UIUpdate.Pause(HotReloadUIPhases.VisualTree))
-		{
-			var completed = TestingUpdateHandler.WaitForReloadCompleted();
-
-			// While the pause is held, the update is queued and the op is
-			// reported as Ignored ("UI update paused by UpdateFile").
-			await HotReloadHelper.UpdateServerFile<HR_Frame_Pages_Page1>(
-				"First page", "Paused page", ct);
-
-			// ReloadCompleted has not fired yet — it fires when the drain
-			// eventually applies the queued types after Dispose below.
-			Assert.IsFalse(completed.IsCompleted, "ReloadCompleted should not fire while VisualTree is paused.");
-		}
-
-		// After dispose, the pending visual-tree types are drained and the
-		// completion callback fires with uiUpdated=true.
+		var edited = false;
 		try
 		{
+			using (UIUpdate.Pause(HotReloadUIPhases.VisualTree))
+			{
+				var completed = TestingUpdateHandler.WaitForReloadCompleted();
+
+				// While the pause is held, the update is queued and the op is
+				// reported as Ignored ("UI update paused by UpdateFile").
+				await HotReloadHelper.UpdateServerFile<HR_Frame_Pages_Page1>(
+					"First page", "Paused page", ct);
+				edited = true;
+
+				// ReloadCompleted has not fired yet — it fires when the drain
+				// eventually applies the queued types after Dispose below.
+				Assert.IsFalse(completed.IsCompleted, "ReloadCompleted should not fire while VisualTree is paused.");
+			}
+
+			// After dispose, the pending visual-tree types are drained and the
+			// completion callback fires with uiUpdated=true.
 			var drained = TestingUpdateHandler.WaitForReloadCompleted();
 			var result = await drained.WaitAsync(ct);
 			Assert.IsTrue(result, "ReloadCompleted should report uiUpdated=true after pause is released and drain runs.");
 		}
 		finally
 		{
-			// Undo the file change so subsequent tests start from a known state.
-			await HotReloadHelper.UpdateServerFile<HR_Frame_Pages_Page1>(
-				"Paused page", "First page", CancellationToken.None);
+			// Undo the file change so subsequent tests start from a known state. The edit now also
+			// gets undone when the assertion inside the pause fails, and is skipped when it never
+			// landed — reverting an unmodified file trips the no-op guard and hides the real failure.
+			if (edited)
+			{
+				await HotReloadHelper.UpdateServerFile<HR_Frame_Pages_Page1>(
+					"Paused page", "First page", CancellationToken.None);
+			}
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadHelper.cs
@@ -69,6 +69,8 @@ internal static class HotReloadHelper
 			return;
 		}
 
+		EnsureOriginalTextIsPresent(message.FilePath, originalText, caller, line);
+
 		await Wait(RemoteControlClient.Instance.SendMessage(message), "send-msg");
 
 		if (Uno.HotReload.Client.UIUpdate.IsPaused(Uno.HotReload.Client.HotReloadUIPhases.VisualTree))
@@ -115,6 +117,8 @@ internal static class HotReloadHelper
 			return;
 		}
 
+		EnsureOriginalTextIsPresent(message.FilePath, originalText, caller, line);
+
 		await Wait(RemoteControlClient.Instance.SendMessage(message), "send-msg");
 
 		if (Uno.HotReload.Client.UIUpdate.IsPaused(Uno.HotReload.Client.HotReloadUIPhases.VisualTree))
@@ -155,15 +159,22 @@ internal static class HotReloadHelper
 
 		await RemoteControlClient.Instance.WaitForConnection();
 
+		var edited = false;
 		try
 		{
 			await UpdateServerFile(filePathInProject, originalText, replacementText, ct, caller, line);
+			edited = true;
 
 			await callback();
 		}
 		finally
 		{
-			await UpdateServerFile(filePathInProject, replacementText, originalText, CancellationToken.None, caller + "<undo>", line);
+			// Only undo an edit that actually happened: reverting a file that was never modified
+			// throws from the same guard and would replace the original failure.
+			if (edited)
+			{
+				await UpdateServerFile(filePathInProject, replacementText, originalText, CancellationToken.None, caller + "<undo>", line);
+			}
 		}
 	}
 
@@ -186,15 +197,47 @@ internal static class HotReloadHelper
 
 		await RemoteControlClient.Instance.WaitForConnection();
 
+		var edited = false;
 		try
 		{
 			await UpdateServerFile<T>(originalText, replacementText, ct, caller, line);
+			edited = true;
 
 			await callback();
 		}
 		finally
 		{
-			await UpdateServerFile<T>(replacementText, originalText, CancellationToken.None, caller + "<undo>", line);
+			// Only undo an edit that actually happened: reverting a file that was never modified
+			// throws from the same guard and would replace the original failure.
+			if (edited)
+			{
+				await UpdateServerFile<T>(replacementText, originalText, CancellationToken.None, caller + "<undo>", line);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Fails fast when <paramref name="originalText"/> is absent from the file the server is about to edit.
+	/// </summary>
+	/// <remarks>
+	/// The replacement is performed server-side and a search string that matches nothing is applied as a
+	/// silent no-op: no file change, no hot reload, and a test that then asserts against content which was
+	/// never updated. Checking here turns that into an explicit failure naming the file and the caller.
+	/// The check is skipped when the source is not readable from this process, leaving the server as the
+	/// authority rather than introducing a new failure mode.
+	/// </remarks>
+	private static void EnsureOriginalTextIsPresent(string filePath, string originalText, string caller, int line)
+	{
+		if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+		{
+			return;
+		}
+
+		if (!File.ReadAllText(filePath).Contains(originalText, StringComparison.Ordinal))
+		{
+			throw new InvalidOperationException(
+				$"'{originalText}' was not found in '{filePath}' (requested by {caller}@{line}). " +
+				"The edit would have silently done nothing.");
 		}
 	}
 

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadHelper.cs
@@ -228,12 +228,24 @@ internal static class HotReloadHelper
 	/// </remarks>
 	private static void EnsureOriginalTextIsPresent(string filePath, string originalText, string caller, int line)
 	{
-		if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+		if (string.IsNullOrEmpty(filePath))
 		{
 			return;
 		}
 
-		if (!File.ReadAllText(filePath).Contains(originalText, StringComparison.Ordinal))
+		string content;
+		try
+		{
+			content = File.ReadAllText(filePath);
+		}
+		catch (Exception e) when (e is IOException or UnauthorizedAccessException or NotSupportedException)
+		{
+			// Missing, locked or otherwise unreadable from this process: the server remains the
+			// authority, rather than an unreadable path becoming a failure mode of its own.
+			return;
+		}
+
+		if (!content.Contains(originalText, StringComparison.Ordinal))
 		{
 			throw new InvalidOperationException(
 				$"'{originalText}' was not found in '{filePath}' (requested by {caller}@{line}). " +

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_ClientHotReloadProcessor.cs
@@ -30,7 +30,15 @@ public class Given_ClientHotReloadProcessor
 			: rid.StartsWith("tvos", StringComparison.OrdinalIgnoreCase) ? "tvos" // incl. tvossimulator
 			: rid.StartsWith("ios", StringComparison.OrdinalIgnoreCase) ? "ios" // incl. iossimulator
 			: rid.StartsWith("browser", StringComparison.OrdinalIgnoreCase) ? "browserwasm"
-			: "skia"; // win-*, linux-*, osx-*: the desktop family reports the `skia` pseudo-platform
+			// win-*, linux-*, osx-*, freebsd-*: the desktop family reports the `skia` pseudo-platform
+			: rid.StartsWith("win", StringComparison.OrdinalIgnoreCase)
+				|| rid.StartsWith("linux", StringComparison.OrdinalIgnoreCase)
+				|| rid.StartsWith("osx", StringComparison.OrdinalIgnoreCase)
+				|| rid.StartsWith("freebsd", StringComparison.OrdinalIgnoreCase) ? "skia"
+			// Anything else means the host never stamped a RID — RuntimeInformation then reports
+			// "unknown", which is no oracle at all. The CoreCLR-on-Android host does exactly that,
+			// and mapping it onto the desktop family made this test assert `skia` on Android.
+			: null;
 
 		var reported = ClientHotReloadProcessor.GetRuntimeTargetFramework(Microsoft.UI.Xaml.Application.Current.GetType().Assembly);
 
@@ -44,7 +52,17 @@ public class Given_ClientHotReloadProcessor
 		Assert.IsTrue(
 			Version.TryParse(frameworkVersion.Substring(3), out var version) && version.Major >= 9,
 			$"Unexpected framework version in '{reported}'.");
-		Assert.AreEqual(expectedPlatform, platform, $"Reported '{reported}' for runtime identifier '{rid}'.");
+
+		if (expectedPlatform is null)
+		{
+			Assert.IsFalse(
+				string.IsNullOrEmpty(platform),
+				$"Reported '{reported}' carries no platform (runtime identifier '{rid}' provides no cross-check).");
+		}
+		else
+		{
+			Assert.AreEqual(expectedPlatform, platform, $"Reported '{reported}' for runtime identifier '{rid}'.");
+		}
 	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
@@ -58,11 +58,17 @@ public partial class Given_HotReloadWorkspace
 	public async Task When_HotReloadScenario(string filters)
 	{
 		// Remove this class and this method from the filters
-		filters = string.Join(";", (filters?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()).ToImmutableArray().RemoveAll(x => x == nameof(Given_HotReloadWorkspace) || x == nameof(When_HotReloadScenario)));
+		filters = string.Join(";", (filters?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()).ToImmutableArray().RemoveAll(IsOuterTestFilter));
 		var resultFile = await RunTestApp(filters, CancellationToken.None);
 
 		// Parse the nunit XML results file and extract all failed tests
 		var tests = NUnitXmlParser.GetTests(resultFile);
+
+		// An empty result set means the HRApp never ran anything, which would otherwise be reported
+		// as success because there are no failures to collect.
+		Assert.IsTrue(
+			tests.Length > 0,
+			$"The hot reload test app reported no test results at all (filters: '{filters}').");
 
 		StringBuilder sb = new();
 
@@ -81,6 +87,20 @@ public partial class Given_HotReloadWorkspace
 			Assert.Fail($"Tests failed:\n{resultMessage}");
 		}
 	}
+
+	/// <summary>
+	/// Identifies a filter entry that names the outer test rather than one of the HRApp's own tests.
+	/// </summary>
+	/// <remarks>
+	/// A CI retry rebuilds the filter from the published failed-tests list, which carries fully
+	/// qualified names. Matching only the bare identifiers let the outer name through to the HRApp,
+	/// which has no such test and consequently ran nothing.
+	/// </remarks>
+	private static bool IsOuterTestFilter(string filter)
+		=> filter == nameof(Given_HotReloadWorkspace)
+			|| filter == nameof(When_HotReloadScenario)
+			|| filter.EndsWith("." + nameof(Given_HotReloadWorkspace), StringComparison.Ordinal)
+			|| filter.EndsWith("." + nameof(When_HotReloadScenario), StringComparison.Ordinal);
 
 	[TestInitialize]
 	public async Task Initialize()


### PR DESCRIPTION
**GitHub Issue:** closes #24124

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Four Hot Reload runtime-test defects, one commit each. Originally raised against `feature/breakingchanges` in #24125; retargeted here because three of the four are missing from `master` entirely, and the fourth is a latent break that `master` still carries. `feature/breakingchanges` picks these up through the normal master sync.

### `test(hotreload)`: only cross-check the platform when a RID was stamped

The RID mapping fell through to `"skia"` for any unrecognised runtime identifier. The CoreCLR-on-Android host never sets `RUNTIME_IDENTIFIER`, so the test expected `skia` while the product correctly reported `android` — failing 100% of `android-skia-coreclr` runs since 2026-07-21. Only recognised RID families are mapped now; anything else means no independent oracle is available, and the desktop family is matched explicitly instead of by fallthrough. This also drops the `[PlatformCondition(Exclude, SkiaAndroid)]` workaround, which was over-broad — `SkiaAndroid` covers the Mono head too, where the test passes.

### `test(hotreload)`: stop the workspace scenario passing without running

On a CI retry the filter is rebuilt from the published failed-tests list, which carries fully qualified names, but the outer test stripped itself by comparing bare identifiers only. `…Given_HotReloadWorkspace.When_HotReloadScenario` was therefore forwarded to an HRApp that has no such test: it ran nothing, returned an empty result set, and the outer test reported success because there were no failures to collect. Now matches the fully qualified forms and fails explicitly when the HRApp returns no results, mirroring the `fail-empty` guard the CI scripts already apply to the outer run.

### `test(hotreload)`: fail fast when a file edit matches nothing

The replacement is performed server-side, so a search string matching nothing is a silent no-op: no file change, no reload, and a test that asserts against content it never updated. `HotReloadHelper` now verifies the text is present before asking the server to replace it, naming the file and the caller when it is not. The check is skipped when the source is not readable from the test process, so the server stays the authority rather than a new failure mode appearing.

The `*AndRevert` helpers also undo only when an edit actually happened — reverting a file that was never modified trips the same guard from a `finally` block, which would replace the original failure with a confusing one.

### `test(hotreload)`: drive the pause test with text the page contains

`When_VisualTree_Paused_Then_ReloadCompleted_StillFires` replaced `"Hello"` with `"PausedTest"`, and `HR_Frame_Pages_Page1.xaml` contains neither — its TextBlocks are `FirstPageTextBlock` (`Text="First page"`) and a `{Binding TitleText}` one. The edit matched nothing, so no reload was requested and the drain had nothing to apply.

**This one has to land with the guard above.** Once a no-op edit is a hard error, the stale `"Hello"` search stops being invisible and starts failing the stage. Verified by reverting just this commit and re-running:

```
Test When_VisualTree_Paused_Then_ReloadCompleted_StillFires() failed with
System.InvalidOperationException: 'Hello' was not found in
'…/HR_Frame_Pages_Page1.xaml' (requested by
When_VisualTree_Paused_Then_ReloadCompleted_StillFires@80).
The edit would have silently done nothing.
```

`When_HotReload_Succeeds_Then_ReloadCompleted_ReportsSuccess` needs no change here — it was already corrected on `master` (Frame host, element re-resolved from the live tree, because a reloadable-type update replaces the page instance rather than mutating it).

## Validation

**Runtime-validated** on Skia Desktop Win32, running the real harness — DevServer host plus the spawned HRApp child process — via `Given_HotReloadWorkspace`:

| Run | Inner HRApp result |
|---|---|
| This branch | **35 passed / 11 skipped / 0 failed** |
| Negative control (pause-test commit reverted) | 1 failed, with the guard message quoted above |

Both `Given_HotReloadResilience` tests are among the 35 that ran and passed — confirmed against the HRApp's own NUnit result file, so the outer pass is not the vacuous one described above.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — these *are* test-correctness fixes
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no user-facing surface
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
