### PR TITLE
fix: Cull text grippers instead of locking scroll

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -1526,6 +1526,68 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		}
 
+		// A selectable TextBlock is culled against the same ancestor-clipped GripperClipBounds as a TextBox, and it
+		// is the host the presenter's 1px anchor probe is written for (its flush last line must not flicker).
+		// Mirror of Given_TextBox.When_Scrolled_Out_Of_View_Grippers_Are_Hidden.
+		[TestMethod]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_IsTextSelectionEnabled_Scrolled_Out_Of_View_Then_Hides_Grippers()
+		{
+#if !__SKIA__
+			Assert.Inconclusive("Touch selection grippers are only implemented on Skia.");
+#else
+			using var _ = new DisposableAction(() =>
+				VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).ForEach((_, p) => p.IsOpen = false));
+
+			var sut = new TextBlock
+			{
+				Text = "hello uno",
+				IsTextSelectionEnabled = true,
+			};
+
+			var scrollViewer = new ScrollViewer
+			{
+				Width = 320,
+				Height = 150,
+				Content = new StackPanel
+				{
+					Children =
+					{
+						sut,
+						new Border { Height = 800 },
+					}
+				}
+			};
+
+			await UITestHelper.Load(scrollViewer);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var bounds = sut.GetAbsoluteBoundsRect();
+			finger.Press(new Point(bounds.X + bounds.Width / 4, bounds.GetCenter().Y));
+			finger.Release();
+			await WindowHelper.WaitFor(
+				() => sut.SelectionGrippersForTesting is { } g && g.start.IsShowing && g.end.IsShowing,
+				message: "the tap should select a word and show both grippers");
+
+			scrollViewer.ChangeView(null, 400, null, disableAnimation: true);
+			await WindowHelper.WaitFor(() => scrollViewer.VerticalOffset > 300, message: "the form should have scrolled");
+			await WindowHelper.WaitFor(
+				() => sut.SelectionGrippersForTesting is { } g && !g.start.IsShowing && !g.end.IsShowing,
+				timeoutMS: 5000,
+				message: "both grippers must be hidden once the TextBlock is scrolled out of view");
+
+			scrollViewer.ChangeView(null, 0, null, disableAnimation: true);
+			await WindowHelper.WaitFor(
+				() => sut.SelectionGrippersForTesting is { } g && g.start.IsShowing && g.end.IsShowing,
+				timeoutMS: 5000,
+				message: "both grippers must come back when the TextBlock is scrolled back into view");
+#endif
+		}
+
 		[TestMethod]
 #if !HAS_INPUT_INJECTOR
 		[Ignore("InputInjector is not supported on this platform.")]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -5762,6 +5762,92 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => !IsGripperShowing(SUT), timeoutMS: 5000, message: "the handle must be hidden once the point it hangs from leaves the viewport");
 		}
 
+		// The other half of the culling contract: a gripper the finger is holding must NOT be culled when its
+		// anchor crosses the clip edge. Cull() collapses the gripper, and collapsing an element releases its
+		// pointer captures, so culling mid-drag used to abort the gesture - the caret froze on the last line that
+		// was still inside the viewport and the remaining finger movement went nowhere.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public async Task When_Gripper_Dragged_Past_Viewport_Edge_Drag_Keeps_Tracking()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			// A multi-line box taller than its own text - so its inner ScrollViewer never scrolls and nothing
+			// chases the caret - inside a ScrollViewer far too short to show all of it: the lower lines are
+			// clipped away, and dragging the handle onto one of them crosses the clip edge.
+			var SUT = new TextBox
+			{
+				Width = 280,
+				Height = 400,
+				AcceptsReturn = true,
+				Text = string.Join("\r", Enumerable.Range(1, 10).Select(i => $"Line {i}")),
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android,
+			};
+
+			var scrollViewer = new ScrollViewer
+			{
+				Width = 320,
+				Height = 150,
+				Content = new StackPanel { Children = { SUT } }
+			};
+			await UITestHelper.Load(scrollViewer);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			// Tap the first line to place the Android insertion handle on it.
+			var boxBounds = SUT.GetAbsoluteBoundsRect();
+			finger.Press(new Point(boxBounds.Left + 20, boxBounds.Top + 8));
+			finger.Release();
+			await WindowHelper.WaitFor(() => IsGripperShowing(SUT), message: "the tap should show the insertion handle");
+
+			// The handle's popup is placed on a later frame, so wait until it is actually over the box before
+			// pressing it - otherwise the press misses and the drag is a no-op.
+			await WindowHelper.WaitFor(
+				() => SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect() is { Width: > 0 } g
+					&& g.Top < scrollViewer.GetAbsoluteBoundsRect().Bottom,
+				timeoutMS: 3000,
+				message: "the insertion handle should be positioned before dragging it");
+
+			// Past the multi-tap window, so the drag that follows is its own gesture.
+			await Task.Delay(600);
+
+			// Small steps on purpose: one of them lands the caret on the first line below the viewport, which is the
+			// step that used to cull the gripper and drop its capture. A single big move would sample the last line
+			// in one go (sampleY is clamped to the text's span) and pass either way.
+			// The real delay matters as much as the step size - culling only happens in the per-frame Update, and
+			// WaitForIdle pumps the dispatcher without necessarily producing a rendered frame, so back-to-back
+			// injected moves never give culling a chance to run at all.
+			finger.Press(SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect().GetCenter());
+			for (var i = 0; i < 8; i++)
+			{
+				finger.MoveBy(0, 30, stepOffsetInMilliseconds: 10);
+				await Task.Delay(60);
+				await WindowHelper.WaitForIdle();
+			}
+
+			Assert.IsTrue(IsGripperShowing(SUT), "the handle must stay up while the finger is still holding it");
+
+			var caretAtEndOfDrag = SUT.SelectionStart;
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			// The finger ended below every line, so the caret must have tracked all the way to the last one.
+			var lastLineStart = SUT.Text.LastIndexOf('\r') + 1;
+			Assert.IsGreaterThan(1, lastLineStart, "premise: the TextBox must hold several lines");
+			Assert.IsTrue(
+				caretAtEndOfDrag >= lastLineStart,
+				$"the drag must keep tracking the finger after the handle's anchor leaves the viewport (the caret ended at {caretAtEndOfDrag}, the last line starts at {lastLineStart})");
+
+			// The premise: nothing scrolled the form to follow the caret, so the anchor really did cross the clip.
+			Assert.AreEqual(0d, scrollViewer.VerticalOffset, "the form must not have scrolled to chase the caret");
+
+			// And once the finger is off, the handle is culled again - it now points below the viewport.
+			await WindowHelper.WaitFor(() => !IsGripperShowing(SUT), timeoutMS: 5000, message: "the handle must be culled again once the drag ends below the viewport");
+		}
+
 		#endregion
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6900,12 +6900,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// When_Scrolled_Out_Of_View_Grippers_Are_Hidden.
 		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mobile conventions: run on Desktop (dev) + real Android only
 		public async Task When_Touch_Focused_Then_Scrolled_Away_The_Scroll_Sticks()
 		{
 			var SUT = new TextBox
 			{
 				Width = 400,
-				Text = "Some Text"
+				Text = "Some Text",
+				// Pinned instead of left to the platform default, so every target reaches the same state: on the
+				// Android convention a single tap leaves the insertion handle up, where iOS leaves a thumbless caret
+				// and Desktop selects the tapped word. The handle is the state the removed scroll lock keyed on.
+				TouchSelectionConvention = TextBox.TouchTextSelectionConvention.Android
 			};
 
 			var sv = new ScrollViewer()
@@ -6937,25 +6942,41 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();
 
-			// Park the box in the viewport with an explicit offset rather than StartBringIntoView: on some targets
-			// that leaves the offset at 0, and the downward drag below then has nowhere left to scroll.
+			// Park the box in the viewport with an explicit offset instead of a bring-into-view, and bound it on both
+			// sides: past 500 the box would be pushed off the top of the viewport and the geometry below stops holding.
 			sv.ChangeView(null, 470, null, disableAnimation: true);
 			await WindowHelper.WaitFor(
-				() => sv.VerticalOffset > 400,
-				message: "the TextBox should be scrolled into view before it is tapped");
+				() => sv.VerticalOffset is > 400 and < 490,
+				message: "the TextBox should be parked inside the viewport before it is tapped");
 			await UITestHelper.WaitForIdle(true);
 
-			// make the textbox touch knob appear
+			// One tap, not two. A second tap selects the word and pops the selection flyout, and then the scroll
+			// gesture below has nowhere to land: the flyout's light-dismiss overlay fills the window, so a press on
+			// it is consumed dismissing the flyout instead of scrolling, and the toolbar itself is placed above the
+			// selection, overlapping the viewport - a press there goes to its buttons. Both are correct behaviour;
+			// they just cost the gesture this test needs.
 			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
 			finger.Release();
-			await UITestHelper.WaitForIdle(true);
-			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
-			finger.Release();
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				message: "the tap should leave the insertion handle up");
 			await UITestHelper.WaitForIdle(true);
 
-			// scroll
+			// Premises spelled out rather than left to a mute "the offset did not move": the touch conventions can
+			// only be observed on CI, so each half of the scenario has to say when it is the one that broke.
+			Assert.AreNotEqual(FocusState.Unfocused, SUT.FocusState, "the tap should have focused the TextBox");
+			Assert.AreEqual(0, SUT.SelectionLength, "the tap should leave a caret, not a selection");
+			Assert.IsFalse(
+				SUT.SelectionFlyout?.IsOpen is true,
+				"the selection flyout must not be up - the scroll gesture would go to it instead of the ScrollViewer");
+
+			// Drag the filler above the box rather than the box itself, so the gesture is unambiguously a scroll
+			// and not a text gesture on any target.
+			var viewport = sv.GetAbsoluteBoundsRect();
+			var dragStart = new Point(viewport.GetCenter().X, (viewport.Top + SUT.GetAbsoluteBoundsRect().Top) / 2);
+
 			var offsetBeforeScroll = sv.VerticalOffset;
-			finger.Press(sv.GetAbsoluteBoundsRect().GetCenter());
+			finger.Press(dragStart);
 			await UITestHelper.WaitForIdle(true);
 			finger.MoveBy(0, 300, stepOffsetInMilliseconds: 20);
 			await UITestHelper.WaitForIdle(true);
@@ -6965,12 +6986,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// Long enough to cover the scroll-end snap timer the old lock used to yank the offset back with.
 			await Task.Delay(TimeSpan.FromSeconds(2));
 
-			Assert.IsGreaterThan(200d, offsetBeforeScroll - sv.VerticalOffset, "the scroll the user performed must stick");
+			Assert.IsGreaterThan(
+				200d,
+				offsetBeforeScroll - sv.VerticalOffset,
+				$"the scroll the user performed must stick (offset {offsetBeforeScroll} -> {sv.VerticalOffset}, "
+				+ $"caret {SUT.CaretMode}, selection {SUT.SelectionStart}/{SUT.SelectionLength}, "
+				+ $"flyout {SUT.SelectionFlyout?.IsOpen}, dragged from {dragStart} in {viewport})");
 
 			// Spelled out rather than an IsGreaterThan whose argument order reads backwards: the box must have left
 			// the viewport entirely, which is exactly what the old pin prevented.
 			var boxBounds = SUT.GetAbsoluteBoundsRect();
-			var viewport = sv.GetAbsoluteBoundsRect();
 			Assert.IsTrue(
 				boxBounds.Top >= viewport.Bottom,
 				$"the focused TextBox must be allowed to leave the viewport (box {boxBounds}, viewport {viewport})");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6937,7 +6937,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();
 
-			SUT.StartBringIntoView();
+			// Park the box in the viewport with an explicit offset rather than StartBringIntoView: on some targets
+			// that leaves the offset at 0, and the downward drag below then has nowhere left to scroll.
+			sv.ChangeView(null, 470, null, disableAnimation: true);
+			await WindowHelper.WaitFor(
+				() => sv.VerticalOffset > 400,
+				message: "the TextBox should be scrolled into view before it is tapped");
 			await UITestHelper.WaitForIdle(true);
 
 			// make the textbox touch knob appear

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -5623,7 +5623,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Task.Delay(FeatureConfiguration.ScrollViewer.SnapDelay + TimeSpan.FromMilliseconds(750));
 			await WindowHelper.WaitForIdle();
 
-			Assert.IsGreaterThan(100d, scrollViewer.VerticalOffset, "the ScrollViewer must not scroll back to the focused TextBox");
+			// Asserting on where the box ended up rather than on an offset threshold: the clamp's target was the
+			// TextBox's own offset inside the content (CreateScrollableForm's fillerAbove), which clears any threshold
+			// low enough to be safe. What the lock did was put the box back against the viewport edge, so requiring it
+			// to be fully outside the viewport is what discriminates.
+			var boxBounds = SUT.GetAbsoluteBoundsRect();
+			var viewport = scrollViewer.GetAbsoluteBoundsRect();
+			Assert.IsTrue(
+				boxBounds.Bottom <= viewport.Top || boxBounds.Top >= viewport.Bottom,
+				$"the ScrollViewer must not scroll back to the focused TextBox (box {boxBounds}, viewport {viewport})");
 			Assert.AreEqual(expectedCaret, SUT.CaretMode, "scrolling away must not disturb the touch caret");
 		}
 
@@ -5751,15 +5759,43 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// Scrolling up by this much would put the anchor exactly on the viewport's bottom edge.
 			var offsetAtEdge = scrollViewer.VerticalOffset - (viewportBottom - thumbAnchorY);
 
-			// A few px short of the edge: the anchor is still inside, so the handle stays up.
+			// A few px short of the edge: the anchor is still inside, so the handle stays up. Waiting on the gripper's
+			// own reported position, not just on idle: WaitForIdle pumps the dispatcher without necessarily producing a
+			// rendered frame, and both the reposition and the culling only happen in the per-frame Update.
+			var gripperTopBefore = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect().Top;
 			scrollViewer.ChangeView(null, offsetAtEdge + 6, null, disableAnimation: true);
-			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(
+				() => SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect().Top != gripperTopBefore,
+				timeoutMS: 5000,
+				message: "the scroll should have repositioned the handle");
 			Assert.IsTrue(IsGripperShowing(SUT), "the handle should still show while the point it hangs from is inside the viewport");
+
+			// The band just below the viewport is where a thumb hanging from an anchor on the edge lands - the
+			// accepted sub-thumb-height overhang. Asserting on that ink is what makes the cull below meaningful:
+			// IsShowing alone is the very flag Cull sets, so it cannot tell us the thumb stopped painting.
+			var root = (FrameworkElement)WindowHelper.XamlRoot.VisualTree.RootElement;
+			var svBounds = scrollViewer.GetAbsoluteBoundsRect();
+			var bandBelowViewport = new Rectangle(
+				(int)svBounds.Left,
+				(int)svBounds.Bottom + 1,
+				(int)svBounds.Width,
+				(int)CaretWithStemAndThumb.ThumbSize);
+			ImageAssert.HasColorInRectangle(
+				await UITestHelper.ScreenShot(root),
+				bandBelowViewport,
+				CaretWithStemAndThumb.ThumbFillColor,
+				tolerance: 20);
 
 			// A few px past it and the thumb would hang entirely below the viewport, over whatever is painted there.
 			scrollViewer.ChangeView(null, offsetAtEdge - 6, null, disableAnimation: true);
 			await WindowHelper.WaitForIdle();
 			await WindowHelper.WaitFor(() => !IsGripperShowing(SUT), timeoutMS: 5000, message: "the handle must be hidden once the point it hangs from leaves the viewport");
+
+			ImageAssert.DoesNotHaveColorInRectangle(
+				await UITestHelper.ScreenShot(root),
+				bandBelowViewport,
+				CaretWithStemAndThumb.ThumbFillColor,
+				tolerance: 20);
 		}
 
 		// The other half of the culling contract: a gripper the finger is holding must NOT be culled when its
@@ -6925,7 +6961,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Task.Delay(TimeSpan.FromSeconds(2));
 
 			Assert.IsGreaterThan(200d, offsetBeforeScroll - sv.VerticalOffset, "the scroll the user performed must stick");
-			Assert.IsGreaterThan(sv.GetAbsoluteBoundsRect().Bottom, SUT.GetAbsoluteBoundsRect().Top, "the focused TextBox must be allowed to leave the viewport");
+
+			// Spelled out rather than an IsGreaterThan whose argument order reads backwards: the box must have left
+			// the viewport entirely, which is exactly what the old pin prevented.
+			var boxBounds = SUT.GetAbsoluteBoundsRect();
+			var viewport = sv.GetAbsoluteBoundsRect();
+			Assert.IsTrue(
+				boxBounds.Top >= viewport.Bottom,
+				$"the focused TextBox must be allowed to leave the viewport (box {boxBounds}, viewport {viewport})");
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -5515,6 +5515,255 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse((SUT.SelectionFlyout as TextCommandBarFlyout)?.IsOpen == true, "a single tap must not open the selection flyout");
 		}
 
+		#region A touch-selected TextBox must not lock its enclosing ScrollViewer
+
+		// A TextBox parked in the middle of a tall scrollable form. There is filler above it (so it can be scrolled
+		// down to the viewport's bottom edge) and much more below (so it can be scrolled entirely out of view), plus
+		// room below the box to start a drag without the finger ever touching the box itself.
+		private static (ScrollViewer scrollViewer, TextBox textBox) CreateScrollableForm(
+			string text,
+			TextBox.TouchTextSelectionConvention convention,
+			double fillerAbove = 120)
+		{
+			var textBox = new TextBox
+			{
+				Width = 280,
+				Height = 40,
+				Text = text,
+				TouchSelectionConvention = convention,
+			};
+
+			var scrollViewer = new ScrollViewer
+			{
+				Width = 320,
+				Height = 300,
+				Content = new StackPanel
+				{
+					Children =
+					{
+						// Transparent (not null) so the filler hit-tests: the scroll drags start on it.
+						new Border { Height = fillerAbove, Background = new SolidColorBrush(Colors.Transparent) },
+						textBox,
+						new Border { Height = 1200, Background = new SolidColorBrush(Colors.Transparent) },
+					}
+				}
+			};
+
+			return (scrollViewer, textBox);
+		}
+
+		private static bool IsGripperShowing(TextBox textBox)
+			=> textBox.VisibleGrippersForTesting is { } grippers && grippers.end.IsShowing;
+
+		// With a touch caret live in a TextBox (the Android insertion handle, or a full selection), an enclosing
+		// ScrollViewer used to refuse to scroll away from it: ScrollViewer.ClampOffsetsToFocusedTextBox rewrote the
+		// offset back onto the TextBox after every scroll and discarded touch inertia outright. The defect that
+		// clamp was working around - grippers still painting after the TextBox scrolled out of view - is now
+		// handled where it belongs, by culling them against the ancestor-clipped bounds
+		// (TextSelectionGripperPresenter.Update), so the scroll lock is gone.
+		private static async Task AssertTouchCaretDoesNotLockScrollViewer(
+			string text,
+			TextBox.TouchTextSelectionConvention convention,
+			TextBox.CaretDisplayMode expectedCaret,
+			bool doubleTap,
+			bool flick)
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var (scrollViewer, SUT) = CreateScrollableForm(text, convention);
+			await UITestHelper.Load(scrollViewer);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			var tapPoint = SUT.GetAbsoluteBoundsRect().GetCenter();
+			finger.Press(tapPoint);
+			finger.Release();
+			if (doubleTap)
+			{
+				finger.Press(tapPoint);
+				finger.Release();
+			}
+
+			await WindowHelper.WaitFor(
+				() => SUT.CaretMode == expectedCaret,
+				message: $"the {convention} touch gesture should leave the caret in {expectedCaret} - the mode that used to arm the scroll lock");
+
+			// Past the multi-tap window, so the drag that follows is not folded into the tap gesture.
+			await Task.Delay(600);
+
+			// A double-tap also pops the selection toolbar, and its light-dismiss overlay would swallow the drag
+			// below instead of letting it reach the ScrollViewer. On a device the first drag simply dismisses it;
+			// dismiss it here (after its dispatched open has run) so a single drag can be asserted on.
+			SUT.SelectionFlyout?.Hide();
+			await WindowHelper.WaitForIdle();
+
+			// Drag upwards on the filler below the box: the form scrolls down and the TextBox leaves the viewport.
+			var svBounds = scrollViewer.GetAbsoluteBoundsRect();
+			var from = new Point(svBounds.GetCenter().X, svBounds.Bottom - 30);
+			var to = new Point(svBounds.GetCenter().X, svBounds.Bottom - 230);
+			if (flick)
+			{
+				// A fast flick goes down the inertia path in ScrollContentPresenter, which the lock used to hijack
+				// (CompleteGesture + a clamped projected end offset) instead of letting inertia run.
+				finger.Drag(from, to, steps: 4, stepOffsetInMilliseconds: 1);
+			}
+			else
+			{
+				finger.Drag(from, to);
+			}
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsGreaterThan(100d, scrollViewer.VerticalOffset, "the drag should have scrolled the form down");
+
+			// The lock fired from a timer armed on scroll-end (FeatureConfiguration.ScrollViewer.SnapDelay, 250ms by
+			// default), so give it more than that to yank the offset back before asserting it stayed put.
+			await Task.Delay(FeatureConfiguration.ScrollViewer.SnapDelay + TimeSpan.FromMilliseconds(750));
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsGreaterThan(100d, scrollViewer.VerticalOffset, "the ScrollViewer must not scroll back to the focused TextBox");
+			Assert.AreEqual(expectedCaret, SUT.CaretMode, "scrolling away must not disturb the touch caret");
+		}
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mobile conventions: run on Desktop (dev) + real Android only
+		public Task When_Touch_Tap_Does_Not_Lock_ScrollViewer_Android()
+			=> AssertTouchCaretDoesNotLockScrollViewer(
+				"Some Text",
+				TextBox.TouchTextSelectionConvention.Android,
+				TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				doubleTap: false,
+				flick: false);
+
+		// The empty-field variant only started reaching the lock once an empty box stopped swallowing the tap: it
+		// now places the Android insertion handle like a filled one, which is what used to arm the clamp.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Tap_Empty_Does_Not_Lock_ScrollViewer_Android()
+			=> AssertTouchCaretDoesNotLockScrollViewer(
+				"",
+				TextBox.TouchTextSelectionConvention.Android,
+				TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing,
+				doubleTap: false,
+				flick: false);
+
+		// Both conventions reach the two-thumb mode through double-tap-to-select-word, so this is the iOS repro too.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Selection_Does_Not_Lock_ScrollViewer_Android()
+			=> AssertTouchCaretDoesNotLockScrollViewer(
+				"Some Text",
+				TextBox.TouchTextSelectionConvention.Android,
+				TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				doubleTap: true,
+				flick: false);
+
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Selection_Does_Not_Lock_ScrollViewer_iOS()
+			=> AssertTouchCaretDoesNotLockScrollViewer(
+				"Some Text",
+				TextBox.TouchTextSelectionConvention.iOS,
+				TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				doubleTap: true,
+				flick: false);
+
+		// Guards the ScrollContentPresenter half of the lock: the timer test alone would still pass if inertia
+		// stayed hijacked.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public Task When_Touch_Selection_Flick_Does_Not_Lock_ScrollViewer_Android()
+			=> AssertTouchCaretDoesNotLockScrollViewer(
+				"Some Text",
+				TextBox.TouchTextSelectionConvention.Android,
+				TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing,
+				doubleTap: true,
+				flick: true);
+
+		// The grippers live in a popup that no ScrollViewer clips, so they used to keep painting at their old screen
+		// position (over the app's status/nav bar) once the TextBox scrolled out of the viewport. They are now culled
+		// against the TextBox's ancestor-clipped bounds. This is what made removing the scroll lock safe, so it has
+		// to stay covered.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public async Task When_Scrolled_Out_Of_View_Grippers_Are_Hidden()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			var (scrollViewer, SUT) = CreateScrollableForm("Some Text", TextBox.TouchTextSelectionConvention.Android);
+			await UITestHelper.Load(scrollViewer);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitFor(() => IsGripperShowing(SUT), message: "the tap should show the insertion handle");
+
+			// Scroll the TextBox entirely above the viewport.
+			scrollViewer.ChangeView(null, 400, null, disableAnimation: true);
+			await WindowHelper.WaitFor(() => scrollViewer.VerticalOffset > 300, message: "the form should have scrolled");
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => !IsGripperShowing(SUT), timeoutMS: 5000, message: "the handle must be hidden once the TextBox is scrolled out of view");
+
+			scrollViewer.ChangeView(null, 0, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => IsGripperShowing(SUT), timeoutMS: 5000, message: "the handle must come back when the TextBox is scrolled back into view");
+		}
+
+		// The edge case that made handles paint over the system bars, and the reason culling tests the point the
+		// thumb hangs from rather than the caret line as a whole: a caret line straddling the viewport's edge is
+		// still (fractionally) visible, but its thumb - a full thumb-height below the line - paints entirely outside.
+		[TestMethod]
+		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)]
+		public async Task When_Caret_Line_Straddles_Viewport_Edge_Grippers_Are_Hidden()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+			using var __ = new DisposableAction(() =>
+				(VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot)).ForEach((_, p) => p.IsOpen = false));
+
+			// Enough filler above the box that it can be parked anywhere in the viewport, bottom edge included.
+			var (scrollViewer, SUT) = CreateScrollableForm("Some Text", TextBox.TouchTextSelectionConvention.Android, fillerAbove: 400);
+			await UITestHelper.Load(scrollViewer);
+
+			scrollViewer.ChangeView(null, 200, null, disableAnimation: true);
+			await WindowHelper.WaitFor(() => scrollViewer.VerticalOffset > 190, message: "the form should have scrolled the box into view");
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitFor(() => IsGripperShowing(SUT), message: "the tap should show the insertion handle");
+			await WindowHelper.WaitForIdle();
+
+			// The gripper spans the caret line plus the thumb below it, so it hangs from
+			// (gripper bottom - ThumbSize) - that is the point that has to stay inside the viewport.
+			var gripper = SUT.VisibleGrippersForTesting!.Value.end.GetAbsoluteBoundsRect();
+			var thumbAnchorY = gripper.Bottom - CaretWithStemAndThumb.ThumbSize;
+			var viewportBottom = scrollViewer.GetAbsoluteBoundsRect().Bottom;
+
+			// Scrolling up by this much would put the anchor exactly on the viewport's bottom edge.
+			var offsetAtEdge = scrollViewer.VerticalOffset - (viewportBottom - thumbAnchorY);
+
+			// A few px short of the edge: the anchor is still inside, so the handle stays up.
+			scrollViewer.ChangeView(null, offsetAtEdge + 6, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(IsGripperShowing(SUT), "the handle should still show while the point it hangs from is inside the viewport");
+
+			// A few px past it and the thumb would hang entirely below the viewport, over whatever is painted there.
+			scrollViewer.ChangeView(null, offsetAtEdge - 6, null, disableAnimation: true);
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => !IsGripperShowing(SUT), timeoutMS: 5000, message: "the handle must be hidden once the point it hangs from leaves the viewport");
+		}
+
+		#endregion
+
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.SkiaDesktop | RuntimeTestPlatforms.SkiaAndroid)] // mobile conventions: run on Desktop (dev) + real Android only
 		public Task When_Touch_DoubleTap_Empty_Opens_Flyout_Android()
@@ -6522,9 +6771,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(0, SUT.PointerCaptures?.Count ?? 0, "the caret-drag pointer capture must be released on release");
 		}
 
+		// Was When_Touch_Focused_Then_Scrolled_Away, which asserted that a touch-focused TextBox stayed pinned
+		// inside its ScrollViewer. That lock is gone - it left forms the user could not scroll away from - so the
+		// same scenario now asserts the opposite. What the lock was really working around, grippers left painting
+		// over whatever the TextBox scrolled onto, is handled by culling them instead; see
+		// When_Scrolled_Out_Of_View_Grippers_Are_Hidden.
 		[TestMethod]
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/753")]
-		public async Task When_Touch_Focused_Then_Scrolled_Away()
+		public async Task When_Touch_Focused_Then_Scrolled_Away_The_Scroll_Sticks()
 		{
 			var SUT = new TextBox
 			{
@@ -6573,6 +6827,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await UITestHelper.WaitForIdle(true);
 
 			// scroll
+			var offsetBeforeScroll = sv.VerticalOffset;
 			finger.Press(sv.GetAbsoluteBoundsRect().GetCenter());
 			await UITestHelper.WaitForIdle(true);
 			finger.MoveBy(0, 300, stepOffsetInMilliseconds: 20);
@@ -6580,9 +6835,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finger.Release();
 			await UITestHelper.WaitForIdle(true);
 
+			// Long enough to cover the scroll-end snap timer the old lock used to yank the offset back with.
 			await Task.Delay(TimeSpan.FromSeconds(2));
 
-			SUT.GetAbsoluteBoundsRect().Bottom.Should().BeApproximately(sv.GetAbsoluteBoundsRect().Bottom, 5);
+			Assert.IsGreaterThan(200d, offsetBeforeScroll - sv.VerticalOffset, "the scroll the user performed must stick");
+			Assert.IsGreaterThan(sv.GetAbsoluteBoundsRect().Bottom, SUT.GetAbsoluteBoundsRect().Top, "the focused TextBox must be allowed to leave the viewport");
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
@@ -84,9 +84,9 @@ internal sealed class CaretWithStemAndThumb : Grid
 		Children.Add(thumbRing);
 	}
 
-	// Test hook: whether the gripper is actually painted. A culled gripper keeps its popup open (see Cull),
-	// and its measured size survives either way, so neither alone is a reliable signal.
-	internal bool IsShowing => _popup?.IsOpen is true && Visibility == Visibility.Visible;
+	// Test hook: whether the gripper is actually painted. Its measured size survives a hide, so size alone
+	// is not a reliable signal.
+	internal bool IsShowing => _popup?.IsOpen is true;
 
 	public void SetStemVisible(bool visible) => _stem.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
 
@@ -106,19 +106,11 @@ internal sealed class CaretWithStemAndThumb : Grid
 			RenderTransform = matrixTransform;
 		}
 		matrixTransform.Matrix = new Matrix(transform);
-		Visibility = Visibility.Visible;
 		if (!_popup.IsOpen)
 		{
 			_popup.IsOpen = true;
 		}
 	}
-
-	/// <summary>
-	/// The character this gripper points at has scrolled out of the visible region: stop painting (and
-	/// hit-testing) it, but keep the popup open so the next <see cref="ShowAt"/> brings it straight back
-	/// when the anchor scrolls into view again.
-	/// </summary>
-	public void Cull() => Visibility = Visibility.Collapsed;
 
 	public void Hide()
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Windows.UI;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Media;
@@ -19,7 +19,7 @@ internal sealed class CaretWithStemAndThumb : Grid
 	// This is, however, a constant color that doesn't depend on the
 	// current system accent color. Changing the accent color does NOT
 	// change the thumb color on WinUI, only the selection color.
-	private static readonly Color ThumbFillColor = Colors.FromARGB("FF0078D7");
+	internal static readonly Color ThumbFillColor = Colors.FromARGB("FF0078D7");
 
 	/// <summary>
 	/// The side of the (square) thumb. The gripper is this wide, and hangs this far below the caret line
@@ -86,7 +86,7 @@ internal sealed class CaretWithStemAndThumb : Grid
 
 	// Test hook: whether the gripper is actually painted. A culled gripper keeps its popup open (see Cull),
 	// and its measured size survives either way, so neither alone is a reliable signal.
-	internal bool IsShowing => _popup?.IsOpen == true && Visibility == Visibility.Visible;
+	internal bool IsShowing => _popup?.IsOpen is true && Visibility == Visibility.Visible;
 
 	public void SetStemVisible(bool visible) => _stem.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Numerics;
 using Windows.UI;
 using Microsoft.UI.Input;
@@ -21,6 +21,12 @@ internal sealed class CaretWithStemAndThumb : Grid
 	// current system accent color. Changing the accent color does NOT
 	// change the thumb color on WinUI, only the selection color.
 	private static readonly Color ThumbFillColor = Colors.FromARGB("FF0078D7");
+
+	/// <summary>
+	/// The side of the (square) thumb. The gripper is this wide, and hangs this far below the caret line
+	/// it points at, which is what <see cref="TextSelectionGripperPresenter"/> culls against.
+	/// </summary>
+	internal const double ThumbSize = 16;
 
 	private readonly Action _repositionCallback;
 	private readonly Rectangle _stem;
@@ -46,16 +52,16 @@ internal sealed class CaretWithStemAndThumb : Grid
 
 		Background = new SolidColorBrush(Colors.Transparent); // to hit-test positively everywhere in the grid
 
-		Width = 16;
+		Width = ThumbSize;
 
 		RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
-		RowDefinitions.Add(new RowDefinition { Height = new GridLength(16, GridUnitType.Pixel) });
+		RowDefinitions.Add(new RowDefinition { Height = new GridLength(ThumbSize, GridUnitType.Pixel) });
 
 		var thumb = new Ellipse
 		{
 			Fill = new SolidColorBrush(Colors.White),
-			Width = 16,
-			Height = 16
+			Width = ThumbSize,
+			Height = ThumbSize
 		};
 
 		var thumbRing = new Ellipse
@@ -85,6 +91,10 @@ internal sealed class CaretWithStemAndThumb : Grid
 		Children.Add(thumbRing);
 	}
 
+	// Test hook: whether the gripper is actually painted. A culled gripper keeps its popup open (see Cull),
+	// and its measured size survives either way, so neither alone is a reliable signal.
+	internal bool IsShowing => _popup?.IsOpen == true && Visibility == Visibility.Visible;
+
 	public void SetStemVisible(bool visible) => _stem.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
 
 	public void ShowAt(XamlRoot xamlRoot, Matrix3x2 transform)
@@ -103,6 +113,7 @@ internal sealed class CaretWithStemAndThumb : Grid
 			RenderTransform = matrixTransform;
 		}
 		matrixTransform.Matrix = new Matrix(transform);
+		Visibility = Visibility.Visible;
 		if (!_popup.IsOpen)
 		{
 			_popup.IsOpen = true;
@@ -121,6 +132,13 @@ internal sealed class CaretWithStemAndThumb : Grid
 	}
 
 	private void OnFrameRendered() => _repositionCallback?.Invoke();
+
+	/// <summary>
+	/// The character this gripper points at has scrolled out of the visible region: stop painting (and
+	/// hit-testing) it, but keep the popup open. The popup is what drives the per-frame reposition, so
+	/// closing it here would leave nothing to notice the anchor scrolling back into view.
+	/// </summary>
+	public void Cull() => Visibility = Visibility.Collapsed;
 
 	public void Hide()
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CaretWithStemAndThumb.skia.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Numerics;
+﻿using System.Numerics;
 using Windows.UI;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Media;
@@ -28,7 +27,6 @@ internal sealed class CaretWithStemAndThumb : Grid
 	/// </summary>
 	internal const double ThumbSize = 16;
 
-	private readonly Action _repositionCallback;
 	private readonly Rectangle _stem;
 	private Popup _popup;
 
@@ -41,13 +39,8 @@ internal sealed class CaretWithStemAndThumb : Grid
 	/// </summary>
 	public double GrabOffsetY { get; set; }
 
-	/// <param name="repositionCallback">
-	/// Invoked once per rendered frame while the gripper is showing, so the owner
-	/// can keep the gripper glued to its anchor character as the text moves.
-	/// </param>
-	public CaretWithStemAndThumb(Action repositionCallback)
+	public CaretWithStemAndThumb()
 	{
-		_repositionCallback = repositionCallback;
 		// Numbers and colors below are partially measured by hand from WinUI and partially made up to be reasonable.
 
 		Background = new SolidColorBrush(Colors.Transparent); // to hit-test positively everywhere in the grid
@@ -117,26 +110,13 @@ internal sealed class CaretWithStemAndThumb : Grid
 		if (!_popup.IsOpen)
 		{
 			_popup.IsOpen = true;
-			_popup.Closed += OnPopupClosed;
-			((CompositionTarget)Visual.CompositionTarget)!.FrameRendered += OnFrameRendered;
 		}
 	}
-
-	private void OnPopupClosed(object sender, object e)
-	{
-		_popup.Closed -= OnPopupClosed;
-		if (Visual.CompositionTarget is CompositionTarget target)
-		{
-			target.FrameRendered -= OnFrameRendered;
-		}
-	}
-
-	private void OnFrameRendered() => _repositionCallback?.Invoke();
 
 	/// <summary>
 	/// The character this gripper points at has scrolled out of the visible region: stop painting (and
-	/// hit-testing) it, but keep the popup open. The popup is what drives the per-frame reposition, so
-	/// closing it here would leave nothing to notice the anchor scrolling back into view.
+	/// hit-testing) it, but keep the popup open so the next <see cref="ShowAt"/> brings it straight back
+	/// when the anchor scrolls into view again.
 	/// </summary>
 	public void Cull() => Visibility = Visibility.Collapsed;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Numerics;
 using Windows.Foundation;
@@ -6,6 +6,7 @@ using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI;
+using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 
 namespace Microsoft.UI.Xaml.Controls.Primitives;
@@ -96,10 +97,10 @@ internal sealed class TextSelectionGripperPresenter
 	private CaretWithStemAndThumb _startGripper;
 	private CaretWithStemAndThumb _endGripper;
 
-	// The per-frame reposition loop, owned here rather than by each gripper: both grippers used to subscribe
-	// individually and invoke this same Update, so a two-thumb selection did all of its work - the ancestor-clip
-	// walk behind GripperClipBounds included - twice per rendered frame.
+	// One frame-driven reposition pass for the pair: a per-gripper subscription runs Update - and the
+	// ancestor-clip walk behind GripperClipBounds - once per showing gripper per frame.
 	private CompositionTarget _frameLoop;
+	private bool _repositionFailureLogged;
 
 	public TextSelectionGripperPresenter(ITextSelectionGripperHost host)
 	{
@@ -137,15 +138,14 @@ internal sealed class TextSelectionGripperPresenter
 		_endGripper.Hide();
 	}
 
-	// Subscribed while the grippers are showing, so Update runs once per rendered frame however many of them
-	// are up. Unsubscribing from inside the callback is safe: FrameRendered is an Action event, so the in-flight
-	// invocation walks a snapshot of the handler list.
+	// Subscribed for as long as the grippers are showing. Unsubscribing from inside the callback is safe:
+	// FrameRendered is an Action event, so the in-flight invocation walks a snapshot of the handler list.
 	private void SubscribeToFrameLoop()
 	{
 		if (_frameLoop is null && _host.GripperTextSurface.XamlRoot is { } xamlRoot)
 		{
 			_frameLoop = xamlRoot.VisualTree.ContentRoot.CompositionTarget;
-			_frameLoop.FrameRendered += Update;
+			_frameLoop.FrameRendered += OnFrameRendered;
 		}
 	}
 
@@ -154,7 +154,29 @@ internal sealed class TextSelectionGripperPresenter
 		if (_frameLoop is { } frameLoop)
 		{
 			_frameLoop = null;
-			frameLoop.FrameRendered -= Update;
+			frameLoop.FrameRendered -= OnFrameRendered;
+		}
+	}
+
+	// The subscription outlives the grippers' visibility - a culled gripper still needs frames to notice its anchor
+	// scrolling back in - so an exception escaping Update would take the window's render loop with it.
+	private void OnFrameRendered()
+	{
+		try
+		{
+			Update();
+		}
+		catch (Exception e)
+		{
+			// First failure only: it would otherwise repeat every rendered frame.
+			if (!_repositionFailureLogged)
+			{
+				_repositionFailureLogged = true;
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().Error("Failed to reposition the text selection grippers.", e);
+				}
+			}
 		}
 	}
 
@@ -174,6 +196,8 @@ internal sealed class TextSelectionGripperPresenter
 		SubscribeToFrameLoop();
 
 		var surface = _host.GripperTextSurface;
+		// An axis-aligned bbox (GetGlobalBoundsWithOptions reduces the ancestor clip path to its Bounds), so a
+		// rotated ancestor over-approximates its clip and culls less than it could.
 		var clip = _host.GripperClipBounds;
 		var lower = _host.SelectionLowerIndex;
 		var upper = _host.SelectionUpperIndex;
@@ -207,12 +231,10 @@ internal sealed class TextSelectionGripperPresenter
 			// A 1px probe rather than a bare point: both sides of the test come from float matrices, and a caret
 			// line that ends flush with the clip (a selectable TextBlock's last line) must not flicker on rounding.
 			var anchor = new Rect(rect.GetMidX() - 0.5, rect.Bottom - 0.5, 1, 1);
-			// Never cull the gripper the finger is holding. Cull() collapses it, and collapsing an element releases
-			// its pointer captures (UIElement.Pointers.ClearPointersStateIfNeeded), which aborts the drag mid-gesture:
-			// the remaining moves are dropped and the release never reaches the gripper, so the selection toolbar
-			// never comes back either. The trade is that a dragged gripper may paint outside the clip for the duration
-			// of the gesture - transient, and under the finger. Native avoids even that by auto-scrolling the container
-			// when a handle reaches the edge, which we don't do yet.
+			// Never cull the gripper the finger is holding: Cull() collapses it, and collapsing an element releases
+			// its pointer captures (UIElement.Pointers.ClearPointersStateIfNeeded), which would end the drag. The cost
+			// is a dragged gripper painting outside the clip until the finger lifts; native instead auto-scrolls the
+			// container when a handle reaches the edge, which we don't do.
 			if (gripper.HasPointerCapture || transform.TransformBounds(anchor).IntersectWith(clip) is not null)
 			{
 				var matrixTransform = (MatrixTransform)transform;
@@ -228,6 +250,13 @@ internal sealed class TextSelectionGripperPresenter
 			}
 			else
 			{
+				// On the transition only. An empty clip here means GripperClipBounds computed nothing (host out of
+				// the live tree, or zero-sized) rather than the anchor genuinely being scrolled away.
+				if (gripper.Visibility != Visibility.Collapsed && this.Log().IsEnabled(LogLevel.Trace))
+				{
+					this.Log().Trace($"Culling a text selection gripper: anchor {transform.TransformBounds(anchor)} is outside the clip {clip}.");
+				}
+
 				gripper.Cull();
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -178,7 +178,13 @@ internal sealed class TextSelectionGripperPresenter
 			// A 1px probe rather than a bare point: both sides of the test come from float matrices, and a caret
 			// line that ends flush with the clip (a selectable TextBlock's last line) must not flicker on rounding.
 			var anchor = new Rect(rect.GetMidX() - 0.5, rect.Bottom - 0.5, 1, 1);
-			if (transform.TransformBounds(anchor).IntersectWith(clip) is not null)
+			// Never cull the gripper the finger is holding. Cull() collapses it, and collapsing an element releases
+			// its pointer captures (UIElement.Pointers.ClearPointersStateIfNeeded), which aborts the drag mid-gesture:
+			// the remaining moves are dropped and the release never reaches the gripper, so the selection toolbar
+			// never comes back either. The trade is that a dragged gripper may paint outside the clip for the duration
+			// of the gesture - transient, and under the finger. Native avoids even that by auto-scrolling the container
+			// when a handle reaches the edge, which we don't do yet.
+			if (gripper.HasPointerCapture || transform.TransformBounds(anchor).IntersectWith(clip) is not null)
 			{
 				var matrixTransform = (MatrixTransform)transform;
 				var surfaceMatrix = matrixTransform.Matrix.ToMatrix3x2();

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -231,10 +231,10 @@ internal sealed class TextSelectionGripperPresenter
 			// A 1px probe rather than a bare point: both sides of the test come from float matrices, and a caret
 			// line that ends flush with the clip (a selectable TextBlock's last line) must not flicker on rounding.
 			var anchor = new Rect(rect.GetMidX() - 0.5, rect.Bottom - 0.5, 1, 1);
-			// Never cull the gripper the finger is holding: Cull() collapses it, and collapsing an element releases
-			// its pointer captures (UIElement.Pointers.ClearPointersStateIfNeeded), which would end the drag. The cost
-			// is a dragged gripper painting outside the clip until the finger lifts; native instead auto-scrolls the
-			// container when a handle reaches the edge, which we don't do.
+			// Never cull the gripper the finger is holding: hiding it closes its popup, and unloading an element
+			// releases its pointer captures (UIElement.Pointers.ClearPointersStateOnUnload), which would end the drag.
+			// The cost is a dragged gripper painting outside the clip until the finger lifts; native instead
+			// auto-scrolls the container when a handle reaches the edge, which we don't do.
 			if (gripper.HasPointerCapture || transform.TransformBounds(anchor).IntersectWith(clip) is not null)
 			{
 				var matrixTransform = (MatrixTransform)transform;
@@ -252,12 +252,15 @@ internal sealed class TextSelectionGripperPresenter
 			{
 				// On the transition only. An empty clip here means GripperClipBounds computed nothing (host out of
 				// the live tree, or zero-sized) rather than the anchor genuinely being scrolled away.
-				if (gripper.Visibility != Visibility.Collapsed && this.Log().IsEnabled(LogLevel.Trace))
+				if (gripper.IsShowing && this.Log().IsEnabled(LogLevel.Trace))
 				{
 					this.Log().Trace($"Culling a text selection gripper: anchor {transform.TransformBounds(anchor)} is outside the clip {clip}.");
 				}
 
-				gripper.Cull();
+				// Closed rather than collapsed: the reposition loop is driven by the presenter, not by the popups, so
+				// nothing depends on a culled gripper's popup staying open - and an open one shows up in the public
+				// VisualTreeHelper.GetOpenPopupsForXamlRoot.
+				gripper.Hide();
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -96,12 +96,17 @@ internal sealed class TextSelectionGripperPresenter
 	private CaretWithStemAndThumb _startGripper;
 	private CaretWithStemAndThumb _endGripper;
 
+	// The per-frame reposition loop, owned here rather than by each gripper: both grippers used to subscribe
+	// individually and invoke this same Update, so a two-thumb selection did all of its work - the ancestor-clip
+	// walk behind GripperClipBounds included - twice per rendered frame.
+	private CompositionTarget _frameLoop;
+
 	public TextSelectionGripperPresenter(ITextSelectionGripperHost host)
 	{
 		_host = host;
 
-		_startGripper = new CaretWithStemAndThumb(Update);
-		_endGripper = new CaretWithStemAndThumb(Update);
+		_startGripper = new CaretWithStemAndThumb();
+		_endGripper = new CaretWithStemAndThumb();
 
 		foreach (var gripper in (ReadOnlySpan<CaretWithStemAndThumb>)[_startGripper, _endGripper])
 		{
@@ -127,8 +132,30 @@ internal sealed class TextSelectionGripperPresenter
 
 	public void Hide()
 	{
+		UnsubscribeFromFrameLoop();
 		_startGripper.Hide();
 		_endGripper.Hide();
+	}
+
+	// Subscribed while the grippers are showing, so Update runs once per rendered frame however many of them
+	// are up. Unsubscribing from inside the callback is safe: FrameRendered is an Action event, so the in-flight
+	// invocation walks a snapshot of the handler list.
+	private void SubscribeToFrameLoop()
+	{
+		if (_frameLoop is null && _host.GripperTextSurface.XamlRoot is { } xamlRoot)
+		{
+			_frameLoop = xamlRoot.VisualTree.ContentRoot.CompositionTarget;
+			_frameLoop.FrameRendered += Update;
+		}
+	}
+
+	private void UnsubscribeFromFrameLoop()
+	{
+		if (_frameLoop is { } frameLoop)
+		{
+			_frameLoop = null;
+			frameLoop.FrameRendered -= Update;
+		}
 	}
 
 	/// <summary>
@@ -143,6 +170,8 @@ internal sealed class TextSelectionGripperPresenter
 			Hide();
 			return;
 		}
+
+		SubscribeToFrameLoop();
 
 		var surface = _host.GripperTextSurface;
 		var clip = _host.GripperClipBounds;

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/TextSelectionGripperPresenter.skia.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Numerics;
 using Windows.Foundation;
@@ -169,9 +169,16 @@ internal sealed class TextSelectionGripperPresenter
 			// ParsedText rects are relative to the text origin; the surface draws translated by its Padding.
 			rect.X += surface.Padding.Left;
 			rect.Y += surface.Padding.Top;
-			gripper.Height = rect.Height + 16;
+			gripper.Height = rect.Height + CaretWithStemAndThumb.ThumbSize;
 			var transform = surface.TransformToVisual(null);
-			if (transform.TransformBounds(rect).IntersectWith(clip) is not null)
+			// Cull on the point the thumb hangs from - the bottom-center of the caret line - rather than on the
+			// caret line as a whole. The grippers are drawn in an unclipped popup above the tree, so a line that is
+			// only fractionally visible at the edge of the clip would still paint a whole thumb past it. This is
+			// what native Android checks too (Editor.HandleView.isPositionVisible).
+			// A 1px probe rather than a bare point: both sides of the test come from float matrices, and a caret
+			// line that ends flush with the clip (a selectable TextBlock's last line) must not flicker on rounding.
+			var anchor = new Rect(rect.GetMidX() - 0.5, rect.Bottom - 0.5, 1, 1);
+			if (transform.TransformBounds(anchor).IntersectWith(clip) is not null)
 			{
 				var matrixTransform = (MatrixTransform)transform;
 				var surfaceMatrix = matrixTransform.Matrix.ToMatrix3x2();
@@ -186,7 +193,7 @@ internal sealed class TextSelectionGripperPresenter
 			}
 			else
 			{
-				gripper.Hide();
+				gripper.Cull();
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -747,8 +747,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// However, we determine the final value of the inertia to snap on the right snap-point.
 			var shouldSnapHorizontally = scrollable.Horizontally && sv is { HorizontalSnapPointsType: SnapPointsType.OptionalSingle or SnapPointsType.MandatorySingle };
 			var shouldSnapVertically = scrollable.Vertically && sv is { VerticalSnapPointsType: SnapPointsType.OptionalSingle or SnapPointsType.MandatorySingle };
-			var shouldSnapToTouchTextBox = sv.ShouldSnapToTouchTextBox();
-			if (shouldSnapHorizontally || shouldSnapVertically || shouldSnapToTouchTextBox)
+			if (shouldSnapHorizontally || shouldSnapVertically)
 			{
 				// Make clear that inertia is not allowed for the OnUpdated, but this is only for safety!
 				_touchInertia = null;
@@ -759,7 +758,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 				double? h = null, v = null;
 
-				if (shouldSnapHorizontally || shouldSnapToTouchTextBox)
+				if (shouldSnapHorizontally)
 				{
 					var v0 = args.Velocities.Linear.X;
 					var duration = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(v0, inertia.DesiredDisplacementDeceleration);
@@ -768,7 +767,7 @@ namespace Microsoft.UI.Xaml.Controls
 					h = HorizontalOffset - endValue;
 				}
 
-				if (shouldSnapVertically || shouldSnapToTouchTextBox)
+				if (shouldSnapVertically)
 				{
 					var v0 = args.Velocities.Linear.Y;
 					var duration = GestureRecognizer.Manipulation.InertiaProcessor.GetCompletionTime(v0, inertia.DesiredDisplacementDeceleration);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.SnapPoints.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.SnapPoints.cs
@@ -48,10 +48,6 @@ namespace Microsoft.UI.Xaml.Controls
 					ref vOffset);
 				verticalOffset = vOffset;
 			}
-
-#if __SKIA__
-			(horizontalOffset, verticalOffset) = ClampOffsetsToFocusedTextBox(horizontalOffset, verticalOffset);
-#endif
 		}
 
 		private double AdjustPixelViewportDim(double pixelViewportDim)
@@ -62,11 +58,6 @@ namespace Microsoft.UI.Xaml.Controls
 			// +5.999 --> +5.0
 			return (double)(long)pixelViewportDim;
 		}
-
-		internal partial bool ShouldSnapToTouchTextBox();
-#if !__SKIA__
-		internal partial bool ShouldSnapToTouchTextBox() => false;
-#endif
 
 		private void AdjustOffsetWithMandatorySnapPoints(
 			bool isForHorizontalOffset,

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1298,8 +1298,7 @@ namespace Microsoft.UI.Xaml.Controls
 					)
 				{
 					if (HorizontalSnapPointsType != SnapPointsType.None
-						|| VerticalSnapPointsType != SnapPointsType.None
-						|| ShouldSnapToTouchTextBox())
+						|| VerticalSnapPointsType != SnapPointsType.None)
 					{
 						_horizontalOffsetForSnapPoints = horizontalOffset;
 						_verticalOffsetForSnapPoints = verticalOffset;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.skia.cs
@@ -1,49 +1,7 @@
-using Windows.Foundation;
-using Microsoft.UI.Xaml.Input;
-
 namespace Microsoft.UI.Xaml.Controls;
 
 public partial class ScrollViewer
 {
-	private (double? horizontal, double? vertical) ClampOffsetsToFocusedTextBox(double? horizontalOffset, double? verticalOffset)
-	{
-		if (Presenter is not null && ShouldSnapToTouchTextBox())
-		{
-			var textBox = (TextBox)FocusManager.GetFocusedElement(XamlRoot!)!;
-			var textBoxToPresenter = textBox.TransformToVisual(Presenter.FindFirstChild()).TransformBounds(new Rect(0, 0, textBox.ActualWidth, textBox.ActualHeight));
-			if (verticalOffset.HasValue)
-			{
-				if (verticalOffset + ViewportHeight < textBoxToPresenter.Top)
-				{
-					verticalOffset = textBoxToPresenter.Top - ViewportHeight + textBoxToPresenter.Height;
-				}
-				else if (verticalOffset > textBoxToPresenter.Bottom)
-				{
-					verticalOffset = textBoxToPresenter.Top;
-				}
-			}
-
-			if (horizontalOffset.HasValue)
-			{
-				if (horizontalOffset + ViewportWidth < textBoxToPresenter.Left)
-				{
-					horizontalOffset = textBoxToPresenter.Left - ViewportWidth + textBoxToPresenter.Width;
-				}
-				else if (horizontalOffset > textBoxToPresenter.Right)
-				{
-					horizontalOffset = textBoxToPresenter.Left;
-				}
-			}
-		}
-
-		return (horizontalOffset, verticalOffset);
-	}
-
-	internal partial bool ShouldSnapToTouchTextBox()
-	{
-		return XamlRoot is not null && FocusManager.GetFocusedElement(XamlRoot) is TextBox { CaretMode: TextBox.CaretDisplayMode.CaretWithThumbsBothEndsShowing or TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing } textBox && textBox.FindFirstParent<ScrollViewer>() == this;
-	}
-
 	partial void OnZoomModeChangedPartial(ZoomMode zoomMode)
 	{
 		if (_presenter is ScrollContentPresenter scp)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -720,7 +720,11 @@ namespace Microsoft.UI.Xaml.Controls
 		#region ITextSelectionGripperHost
 		TextBlock ITextSelectionGripperHost.GripperTextSurface => this;
 
-		Rect ITextSelectionGripperHost.GripperClipBounds => this.GetAbsoluteBoundsRect();
+		// Ancestor-clipped, not the raw bounds: see the matching comment on TextBox.
+		Rect ITextSelectionGripperHost.GripperClipBounds => this.GetGlobalBoundsWithOptions(
+			ignoreClipping: false,
+			ignoreClippingOnScrollContentPresenters: false,
+			useTargetInformation: false);
 
 		GripperMode ITextSelectionGripperHost.GripperMode => _grippersShown ? GripperMode.Both : GripperMode.Hidden;
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1932,7 +1932,13 @@ public partial class TextBox : ITextSelectionGripperHost
 
 	TextBlock ITextSelectionGripperHost.GripperTextSurface => TextBoxView.DisplayBlock;
 
-	Rect ITextSelectionGripperHost.GripperClipBounds => this.GetAbsoluteBoundsRect();
+	// Ancestor-clipped, not the raw bounds: a TextBox scrolled out of an enclosing ScrollViewer still has
+	// valid bounds, and the grippers live in an unclipped popup above the tree - so culling against the raw
+	// bounds leaves them painted over whatever the ScrollViewer scrolled them onto.
+	Rect ITextSelectionGripperHost.GripperClipBounds => this.GetGlobalBoundsWithOptions(
+		ignoreClipping: false,
+		ignoreClippingOnScrollContentPresenters: false,
+		useTargetInformation: false);
 
 	GripperMode ITextSelectionGripperHost.GripperMode => _caretMode switch
 	{


### PR DESCRIPTION
**GitHub Issue:** Tracked internally — no public issue for this one.

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior.** While a TextBox held a live touch caret — the Android insertion handle, or a full touch selection — an enclosing `ScrollViewer` refused to scroll away from it. `ScrollViewer.ClampOffsetsToFocusedTextBox` rewrote the offset back onto the TextBox after every scroll, and `ScrollContentPresenter` discarded touch inertia outright to make the clamp land. The user-visible result was a form that could not be scrolled past the field they had just tapped.

That clamp existed to hide a different defect: the selection grippers are drawn in a popup that no `ScrollViewer` clips, so once the TextBox scrolled out of view they kept painting at their old screen position — over the app's status/nav bar, or over whatever the scroll had moved under them. Pinning the scroll meant the TextBox could never leave the viewport, so the grippers never got the chance to strand.

**This PR** removes the scroll lock and fixes the gripper problem where it belongs:

- `TextSelectionGripperPresenter.Update` now culls each gripper against the host's **ancestor-clipped** bounds (`GetGlobalBoundsWithOptions(ignoreClipping: false, …)`) rather than its raw bounds. A TextBox scrolled out of an enclosing `ScrollViewer` still has valid raw bounds, which is why the old test passed while the grippers stranded.
- Culling probes **the point the thumb hangs from** — the bottom-center of the caret line — not the caret line as a whole. A line only fractionally visible at the clip edge would otherwise still paint a full thumb past it. This matches what native Android checks (`Editor.HandleView.isPositionVisible`). The probe is a 1px rect rather than a bare point, because both sides of the test come from float matrices and a caret line ending flush with the clip (a selectable `TextBlock`'s last line) must not flicker on rounding.
- A culled gripper's **popup is closed**, and the next `ShowAt` reopens it when the anchor scrolls back into view. That is only safe because the per-frame reposition is driven by a single presenter-level `CompositionTarget.FrameRendered` subscription keyed on the gripper mode — not by the popups, and not once per showing gripper — so the loop keeps ticking with every popup closed. Leaving them open would report a popup through the public `VisualTreeHelper.GetOpenPopupsForXamlRoot` that WinUI never exposes.
- **A gripper holding the pointer capture is never culled.** Closing the popup unloads its child, and unloading an element releases its pointer captures (`UIElement.Pointers.ClearPointersStateOnUnload`), so culling mid-drag ends the gesture: the remaining moves are dropped and the release never reaches the gripper, leaving the selection toolbar closed too. The accepted cost is a dragged gripper painting outside the clip until the finger lifts; native avoids even that by auto-scrolling the container when a handle reaches the edge, which we don't do.
- A throw escaping `Update` is contained and reported once — the subscription outlives gripper visibility, so it would otherwise take the window's render loop with it. The cull *transition* logs the anchor and the clip at `Trace`, so an empty clip (`GripperClipBounds` computing nothing for an out-of-tree or zero-sized host) is distinguishable from the anchor genuinely having scrolled away.
- `ScrollViewer.ShouldSnapToTouchTextBox` / `ClampOffsetsToFocusedTextBox` and the matching inertia special-case in `ScrollContentPresenter.Managed` are gone. The thumb side length is now a named constant (`CaretWithStemAndThumb.ThumbSize`) shared by the gripper layout and the culling math, instead of a `16` repeated in both.

⚠️ **Behavior change worth a reviewer's eye** (no API surface changes — everything removed was `internal`/`private`): a focused TextBox with a touch caret no longer pins its `ScrollViewer`. That is the point of the fix, but it does reverse a previously-asserted behavior. `When_Touch_Focused_Then_Scrolled_Away` asserted the TextBox stayed pinned inside its `ScrollViewer`; it is renamed to `When_Touch_Focused_Then_Scrolled_Away_The_Scroll_Sticks` and now asserts the opposite — the user's scroll sticks and the box is allowed to leave the viewport. The gripper stranding that the old assertion was really protecting against is covered directly instead (see below).

**Intended behavior, for the record:** a focused element is scrolled *into view on focus* — it is not permanently locked there. A user scroll expresses intent and must always override it. Focus-driven bring-into-view is untouched by this PR and still covered by `When_GotFocus_BringIntoView` and `When_OuterScrollViewer_BringIntoView_Scrolls_To_Caret`.

### Test coverage

Eight runtime tests in `Given_TextBox.skia.cs` (Skia Desktop + Skia Android, for the mobile touch conventions) and one in `Given_TextBlock.cs`:

| Test | Guards |
|---|---|
| `When_Touch_Tap_Does_Not_Lock_ScrollViewer_Android` | Android insertion handle doesn't pin the scroll |
| `When_Touch_Tap_Empty_Does_Not_Lock_ScrollViewer_Android` | …same for an empty field, which now places the handle like a filled one |
| `When_Touch_Selection_Does_Not_Lock_ScrollViewer_Android` / `_iOS` | Two-thumb selection, both conventions |
| `When_Touch_Selection_Flick_Does_Not_Lock_ScrollViewer_Android` | The `ScrollContentPresenter` inertia half — the timer tests alone would still pass if inertia stayed hijacked |
| `When_Scrolled_Out_Of_View_Grippers_Are_Hidden` | Handle hides when the box scrolls out, **and comes back** when it scrolls in |
| `When_Caret_Line_Straddles_Viewport_Edge_Grippers_Are_Hidden` | The anchor-point culling rule a few px either side of the edge, plus the **thumb ink** in the band below the viewport — present while the anchor is inside (the accepted sub-thumb-height overhang), gone once culled |
| `When_Gripper_Dragged_Past_Viewport_Edge_Drag_Keeps_Tracking` | A gripper drag survives its anchor crossing the clip edge |
| `Given_TextBlock.When_IsTextSelectionEnabled_Scrolled_Out_Of_View_Then_Hides_Grippers` | The selectable-`TextBlock` host, which takes the same clip change |

The five `*_Does_Not_Lock_*` tests assert the box ended up **outside the viewport** rather than that the offset cleared a threshold: the old clamp's target was the box's own offset inside the content, which clears any threshold low enough to be safe. Verified by injecting the clamp's exact result (`ChangeView(null, 120, …)`) immediately before the assert — all five fail, and pass again once it is removed.

**Two notes for reviewers on test timing.** Several tests wait on the scroll-end snap timer (`FeatureConfiguration.ScrollViewer.SnapDelay`) plus a margin, since that timer is what the old lock fired from — if any prove flaky on slower CI agents, the waits are the place to look. And `WindowHelper.WaitForIdle` pumps the dispatcher without necessarily producing a **rendered frame**, while culling and repositioning only happen in the per-frame `Update`: tests that depend on either wait on the gripper's own reported position, or put a real delay between injected pointer moves. Back-to-back injected moves never yield to the renderer at all, which silently passed two of these tests before it was caught.

### Known gaps, tracked separately

Accepted in this PR, so a reviewer doesn't have to re-derive them:

- A thumb whose anchor sits just inside the clip edge still overhangs it by up to `ThumbSize` (16px). That is the deliberate rule — native Android probes the same anchor point — and `When_Caret_Line_Straddles_Viewport_Edge_Grippers_Are_Hidden` asserts that ink is there.
- A gripper drag is not auto-scrolled when the handle reaches the container edge, so a drag past the clip keeps painting outside it until the finger lifts. Native scrolls the container instead; we don't, and cutting the drag short is the worse of the two.
- The ancestor clip walk behind `GetGlobalBoundsWithOptions` builds an `SKPath` only to read its `Bounds`, which costs native Skia ops per clipping ancestor on a per-frame path and loses rotation. It makes this PR cull *less*, never more, so it is a follow-up rather than a prerequisite — #24163.
- The `SelectionFlyout` gets none of this treatment: it is positioned once at show time, so a scroll that doesn't press on the text leaves it parked over unrelated content — #24164. Pre-existing, and out of scope here.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no public API or documented behavior surface
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — pending first CI run
- [x] ❗ Contains **NO** breaking changes — no API changes; see the behavior-change note above
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



