### PR TITLE
test: cover VisualStateGroup transition selection with partial From/To matches

### DIFF
--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.Extensions;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
+{
+	[TestClass]
+	public class Given_VisualStateGroup_FindTransition
+	{
+		// Regression tests for https://github.com/unoplatform/uno/pull/17436:
+		// VisualStateGroup.FindTransition used to ignore VisualTransitions that
+		// didn't have both From and To set, even though only one of them is
+		// required to match.
+
+		private static VisualTransition GetAppliedTransition(VisualStateGroup group)
+		{
+			var currentField = typeof(VisualStateGroup).GetField("_current", BindingFlags.NonPublic | BindingFlags.Instance);
+			var current = currentField.GetValue(group);
+			// The tuple's element names (state, transition) are compiler sugar and are not
+			// preserved as actual reflection field names; the underlying ValueTuple<T1, T2>
+			// fields are Item1/Item2.
+			var transitionField = current.GetType().GetField("Item2");
+			return (VisualTransition)transitionField.GetValue(current);
+		}
+
+		private static Control CreateControlWithGroup(VisualStateGroup group)
+		{
+			var control = new TransitionsTestControl
+			{
+				Template = new ControlTemplate(() => new Border { Name = "root" }
+					.Apply(root => VisualStateManager.SetVisualStateGroups(root, new List<VisualStateGroup> { group })))
+			};
+
+			control.ApplyTemplate();
+
+			return control;
+		}
+
+		[TestMethod]
+		public void When_Perfect_Match_Exists_It_Takes_Priority_Over_Partial_Matches()
+		{
+			var group = new VisualStateGroup();
+			group.States.Add(new VisualState { Name = "A" });
+			group.States.Add(new VisualState { Name = "B" });
+
+			var fromOnly = new VisualTransition { From = "A" };
+			var toOnly = new VisualTransition { To = "B" };
+			var perfectMatch = new VisualTransition { From = "A", To = "B" };
+			group.Transitions.Add(fromOnly);
+			group.Transitions.Add(toOnly);
+			group.Transitions.Add(perfectMatch);
+
+			var control = CreateControlWithGroup(group);
+
+			VisualStateManager.GoToState(control, "A", false);
+			VisualStateManager.GoToState(control, "B", true);
+
+			Assert.AreSame(perfectMatch, GetAppliedTransition(group));
+		}
+
+		[TestMethod]
+		public void When_No_Perfect_Match_A_From_Only_Transition_Is_Used()
+		{
+			var group = new VisualStateGroup();
+			group.States.Add(new VisualState { Name = "A" });
+			group.States.Add(new VisualState { Name = "B" });
+
+			var fromOnly = new VisualTransition { From = "A" };
+			group.Transitions.Add(fromOnly);
+
+			var control = CreateControlWithGroup(group);
+
+			VisualStateManager.GoToState(control, "A", false);
+			VisualStateManager.GoToState(control, "B", true);
+
+			Assert.AreSame(fromOnly, GetAppliedTransition(group));
+		}
+
+		[TestMethod]
+		public void When_No_Perfect_Or_From_Only_Match_A_To_Only_Transition_Is_Used()
+		{
+			var group = new VisualStateGroup();
+			group.States.Add(new VisualState { Name = "A" });
+			group.States.Add(new VisualState { Name = "B" });
+
+			var toOnly = new VisualTransition { To = "B" };
+			group.Transitions.Add(toOnly);
+
+			var control = CreateControlWithGroup(group);
+
+			VisualStateManager.GoToState(control, "A", false);
+			VisualStateManager.GoToState(control, "B", true);
+
+			Assert.AreSame(toOnly, GetAppliedTransition(group));
+		}
+
+		[TestMethod]
+		public void When_No_Transition_Matches_None_Is_Applied()
+		{
+			var group = new VisualStateGroup();
+			group.States.Add(new VisualState { Name = "A" });
+			group.States.Add(new VisualState { Name = "B" });
+
+			group.Transitions.Add(new VisualTransition { From = "X", To = "Y" });
+
+			var control = CreateControlWithGroup(group);
+
+			VisualStateManager.GoToState(control, "A", false);
+			VisualStateManager.GoToState(control, "B", true);
+
+			Assert.IsNull(GetAppliedTransition(group));
+		}
+	}
+
+	public class TransitionsTestControl : ContentControl
+	{
+	}
+}

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
@@ -18,11 +18,13 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 		private static VisualTransition GetAppliedTransition(VisualStateGroup group)
 		{
 			var currentField = typeof(VisualStateGroup).GetField("_current", BindingFlags.NonPublic | BindingFlags.Instance);
+			Assert.IsNotNull(currentField, "Unable to find VisualStateGroup._current field (implementation changed).");
 			var current = currentField.GetValue(group);
 			// The tuple's element names (state, transition) are compiler sugar and are not
 			// preserved as actual reflection field names; the underlying ValueTuple<T1, T2>
 			// fields are Item1/Item2.
 			var transitionField = current.GetType().GetField("Item2");
+			Assert.IsNotNull(transitionField, "Unable to find ValueTuple.Item2 field (implementation changed).");
 			return (VisualTransition)transitionField.GetValue(current);
 		}
 
@@ -69,6 +71,26 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 			group.States.Add(new VisualState { Name = "B" });
 
 			var fromOnly = new VisualTransition { From = "A" };
+			group.Transitions.Add(fromOnly);
+
+			var control = CreateControlWithGroup(group);
+
+			VisualStateManager.GoToState(control, "A", false);
+			VisualStateManager.GoToState(control, "B", true);
+
+			Assert.AreSame(fromOnly, GetAppliedTransition(group));
+		}
+
+		[TestMethod]
+		public void When_No_Perfect_Match_A_From_Only_Transition_Takes_Priority_Over_A_To_Only_Transition()
+		{
+			var group = new VisualStateGroup();
+			group.States.Add(new VisualState { Name = "A" });
+			group.States.Add(new VisualState { Name = "B" });
+
+			var fromOnly = new VisualTransition { From = "A" };
+			var toOnly = new VisualTransition { To = "B" };
+			group.Transitions.Add(toOnly);
 			group.Transitions.Add(fromOnly);
 
 			var control = CreateControlWithGroup(group);

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
@@ -19,14 +19,8 @@ public class Given_VisualStateGroup_FindTransition
 	{
 		var currentField = typeof(VisualStateGroup).GetField("_current", BindingFlags.NonPublic | BindingFlags.Instance);
 		Assert.IsNotNull(currentField, "Unable to find VisualStateGroup._current field (implementation changed).");
-		var current = currentField.GetValue(group);
-		Assert.IsNotNull(current, "VisualStateGroup._current returned null unexpectedly.");
-		// The tuple's element names (state, transition) are compiler sugar and are not
-		// preserved as actual reflection field names; the underlying ValueTuple<T1, T2>
-		// fields are Item1/Item2.
-		var transitionField = current.GetType().GetField("Item2");
-		Assert.IsNotNull(transitionField, "Unable to find ValueTuple.Item2 field (implementation changed).");
-		return (VisualTransition)transitionField.GetValue(current);
+		var (_, transition) = ((VisualState, VisualTransition))currentField.GetValue(group);
+		return transition;
 	}
 
 	private static Control CreateControlWithGroup(VisualStateGroup group)

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateGroup_FindTransition.cs
@@ -5,139 +5,139 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Uno.Extensions;
 
-namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
+namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests;
+
+[TestClass]
+public class Given_VisualStateGroup_FindTransition
 {
-	[TestClass]
-	public class Given_VisualStateGroup_FindTransition
+	// Regression tests for https://github.com/unoplatform/uno/pull/17436:
+	// VisualStateGroup.FindTransition used to ignore VisualTransitions that
+	// didn't have both From and To set, even though only one of them is
+	// required to match.
+
+	private static VisualTransition GetAppliedTransition(VisualStateGroup group)
 	{
-		// Regression tests for https://github.com/unoplatform/uno/pull/17436:
-		// VisualStateGroup.FindTransition used to ignore VisualTransitions that
-		// didn't have both From and To set, even though only one of them is
-		// required to match.
-
-		private static VisualTransition GetAppliedTransition(VisualStateGroup group)
-		{
-			var currentField = typeof(VisualStateGroup).GetField("_current", BindingFlags.NonPublic | BindingFlags.Instance);
-			Assert.IsNotNull(currentField, "Unable to find VisualStateGroup._current field (implementation changed).");
-			var current = currentField.GetValue(group);
-			// The tuple's element names (state, transition) are compiler sugar and are not
-			// preserved as actual reflection field names; the underlying ValueTuple<T1, T2>
-			// fields are Item1/Item2.
-			var transitionField = current.GetType().GetField("Item2");
-			Assert.IsNotNull(transitionField, "Unable to find ValueTuple.Item2 field (implementation changed).");
-			return (VisualTransition)transitionField.GetValue(current);
-		}
-
-		private static Control CreateControlWithGroup(VisualStateGroup group)
-		{
-			var control = new TransitionsTestControl
-			{
-				Template = new ControlTemplate(() => new Border { Name = "root" }
-					.Apply(root => VisualStateManager.SetVisualStateGroups(root, new List<VisualStateGroup> { group })))
-			};
-
-			control.ApplyTemplate();
-
-			return control;
-		}
-
-		[TestMethod]
-		public void When_Perfect_Match_Exists_It_Takes_Priority_Over_Partial_Matches()
-		{
-			var group = new VisualStateGroup();
-			group.States.Add(new VisualState { Name = "A" });
-			group.States.Add(new VisualState { Name = "B" });
-
-			var fromOnly = new VisualTransition { From = "A" };
-			var toOnly = new VisualTransition { To = "B" };
-			var perfectMatch = new VisualTransition { From = "A", To = "B" };
-			group.Transitions.Add(fromOnly);
-			group.Transitions.Add(toOnly);
-			group.Transitions.Add(perfectMatch);
-
-			var control = CreateControlWithGroup(group);
-
-			VisualStateManager.GoToState(control, "A", false);
-			VisualStateManager.GoToState(control, "B", true);
-
-			Assert.AreSame(perfectMatch, GetAppliedTransition(group));
-		}
-
-		[TestMethod]
-		public void When_No_Perfect_Match_A_From_Only_Transition_Is_Used()
-		{
-			var group = new VisualStateGroup();
-			group.States.Add(new VisualState { Name = "A" });
-			group.States.Add(new VisualState { Name = "B" });
-
-			var fromOnly = new VisualTransition { From = "A" };
-			group.Transitions.Add(fromOnly);
-
-			var control = CreateControlWithGroup(group);
-
-			VisualStateManager.GoToState(control, "A", false);
-			VisualStateManager.GoToState(control, "B", true);
-
-			Assert.AreSame(fromOnly, GetAppliedTransition(group));
-		}
-
-		[TestMethod]
-		public void When_No_Perfect_Match_A_From_Only_Transition_Takes_Priority_Over_A_To_Only_Transition()
-		{
-			var group = new VisualStateGroup();
-			group.States.Add(new VisualState { Name = "A" });
-			group.States.Add(new VisualState { Name = "B" });
-
-			var fromOnly = new VisualTransition { From = "A" };
-			var toOnly = new VisualTransition { To = "B" };
-			group.Transitions.Add(toOnly);
-			group.Transitions.Add(fromOnly);
-
-			var control = CreateControlWithGroup(group);
-
-			VisualStateManager.GoToState(control, "A", false);
-			VisualStateManager.GoToState(control, "B", true);
-
-			Assert.AreSame(fromOnly, GetAppliedTransition(group));
-		}
-
-		[TestMethod]
-		public void When_No_Perfect_Or_From_Only_Match_A_To_Only_Transition_Is_Used()
-		{
-			var group = new VisualStateGroup();
-			group.States.Add(new VisualState { Name = "A" });
-			group.States.Add(new VisualState { Name = "B" });
-
-			var toOnly = new VisualTransition { To = "B" };
-			group.Transitions.Add(toOnly);
-
-			var control = CreateControlWithGroup(group);
-
-			VisualStateManager.GoToState(control, "A", false);
-			VisualStateManager.GoToState(control, "B", true);
-
-			Assert.AreSame(toOnly, GetAppliedTransition(group));
-		}
-
-		[TestMethod]
-		public void When_No_Transition_Matches_None_Is_Applied()
-		{
-			var group = new VisualStateGroup();
-			group.States.Add(new VisualState { Name = "A" });
-			group.States.Add(new VisualState { Name = "B" });
-
-			group.Transitions.Add(new VisualTransition { From = "X", To = "Y" });
-
-			var control = CreateControlWithGroup(group);
-
-			VisualStateManager.GoToState(control, "A", false);
-			VisualStateManager.GoToState(control, "B", true);
-
-			Assert.IsNull(GetAppliedTransition(group));
-		}
+		var currentField = typeof(VisualStateGroup).GetField("_current", BindingFlags.NonPublic | BindingFlags.Instance);
+		Assert.IsNotNull(currentField, "Unable to find VisualStateGroup._current field (implementation changed).");
+		var current = currentField.GetValue(group);
+		Assert.IsNotNull(current, "VisualStateGroup._current returned null unexpectedly.");
+		// The tuple's element names (state, transition) are compiler sugar and are not
+		// preserved as actual reflection field names; the underlying ValueTuple<T1, T2>
+		// fields are Item1/Item2.
+		var transitionField = current.GetType().GetField("Item2");
+		Assert.IsNotNull(transitionField, "Unable to find ValueTuple.Item2 field (implementation changed).");
+		return (VisualTransition)transitionField.GetValue(current);
 	}
 
-	public class TransitionsTestControl : ContentControl
+	private static Control CreateControlWithGroup(VisualStateGroup group)
 	{
+		var control = new TransitionsTestControl
+		{
+			Template = new ControlTemplate(() => new Border { Name = "root" }
+				.Apply(root => VisualStateManager.SetVisualStateGroups(root, new List<VisualStateGroup> { group })))
+		};
+
+		control.ApplyTemplate();
+
+		return control;
 	}
+
+	[TestMethod]
+	public void When_Perfect_Match_Exists_It_Takes_Priority_Over_Partial_Matches()
+	{
+		var group = new VisualStateGroup();
+		group.States.Add(new VisualState { Name = "A" });
+		group.States.Add(new VisualState { Name = "B" });
+
+		var fromOnly = new VisualTransition { From = "A" };
+		var toOnly = new VisualTransition { To = "B" };
+		var perfectMatch = new VisualTransition { From = "A", To = "B" };
+		group.Transitions.Add(fromOnly);
+		group.Transitions.Add(toOnly);
+		group.Transitions.Add(perfectMatch);
+
+		var control = CreateControlWithGroup(group);
+
+		Assert.IsTrue(VisualStateManager.GoToState(control, "A", false));
+		Assert.IsTrue(VisualStateManager.GoToState(control, "B", true));
+
+		Assert.AreSame(perfectMatch, GetAppliedTransition(group));
+	}
+
+	[TestMethod]
+	public void When_No_Perfect_Match_A_From_Only_Transition_Is_Used()
+	{
+		var group = new VisualStateGroup();
+		group.States.Add(new VisualState { Name = "A" });
+		group.States.Add(new VisualState { Name = "B" });
+
+		var fromOnly = new VisualTransition { From = "A" };
+		group.Transitions.Add(fromOnly);
+
+		var control = CreateControlWithGroup(group);
+
+		Assert.IsTrue(VisualStateManager.GoToState(control, "A", false));
+		Assert.IsTrue(VisualStateManager.GoToState(control, "B", true));
+
+		Assert.AreSame(fromOnly, GetAppliedTransition(group));
+	}
+
+	[TestMethod]
+	public void When_No_Perfect_Match_A_From_Only_Transition_Takes_Priority_Over_A_To_Only_Transition()
+	{
+		var group = new VisualStateGroup();
+		group.States.Add(new VisualState { Name = "A" });
+		group.States.Add(new VisualState { Name = "B" });
+
+		var fromOnly = new VisualTransition { From = "A" };
+		var toOnly = new VisualTransition { To = "B" };
+		group.Transitions.Add(toOnly);
+		group.Transitions.Add(fromOnly);
+
+		var control = CreateControlWithGroup(group);
+
+		Assert.IsTrue(VisualStateManager.GoToState(control, "A", false));
+		Assert.IsTrue(VisualStateManager.GoToState(control, "B", true));
+
+		Assert.AreSame(fromOnly, GetAppliedTransition(group));
+	}
+
+	[TestMethod]
+	public void When_No_Perfect_Or_From_Only_Match_A_To_Only_Transition_Is_Used()
+	{
+		var group = new VisualStateGroup();
+		group.States.Add(new VisualState { Name = "A" });
+		group.States.Add(new VisualState { Name = "B" });
+
+		var toOnly = new VisualTransition { To = "B" };
+		group.Transitions.Add(toOnly);
+
+		var control = CreateControlWithGroup(group);
+
+		Assert.IsTrue(VisualStateManager.GoToState(control, "A", false));
+		Assert.IsTrue(VisualStateManager.GoToState(control, "B", true));
+
+		Assert.AreSame(toOnly, GetAppliedTransition(group));
+	}
+
+	[TestMethod]
+	public void When_No_Transition_Matches_None_Is_Applied()
+	{
+		var group = new VisualStateGroup();
+		group.States.Add(new VisualState { Name = "A" });
+		group.States.Add(new VisualState { Name = "B" });
+
+		group.Transitions.Add(new VisualTransition { From = "X", To = "Y" });
+
+		var control = CreateControlWithGroup(group);
+
+		Assert.IsTrue(VisualStateManager.GoToState(control, "A", false));
+		Assert.IsTrue(VisualStateManager.GoToState(control, "B", true));
+
+		Assert.IsNull(GetAppliedTransition(group));
+	}
+}
+
+public class TransitionsTestControl : ContentControl
+{
 }


### PR DESCRIPTION
**GitHub Issue:** closes #17564

## PR Type:

🧪 Other... (Test coverage)

## What changed? 🚀

`VisualStateGroup.FindTransition` was fixed in #17436 to correctly select a `VisualTransition` when only `From` or only `To` is set (previously such transitions were effectively ignored), but no test coverage was added for that fix.

This PR adds unit tests covering `VisualStateGroup`'s transition-selection logic:
- A transition with both `From` and `To` set is preferred over partial matches.
- A `From`-only transition is used when no perfect match exists.
- A `To`-only transition is used when no perfect or `From`-only match exists.
- No transition is applied when nothing matches.

I confirmed these tests fail against the pre-#17436 code and pass against the current code.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
