### PR TITLE
docs: Close the BC75 MRT Core follow-ups

### DIFF
--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -199,6 +199,46 @@ package together, so all of them were defined at once in a `netX.0-desktop` head
 `OperatingSystem.IsWindows()` / `IsLinux()` / `IsMacOS()`, which is the only check that can be correct for a
 target framework that runs on all three. `HAS_UNO_SKIA` and `__UNO_SKIA__` are unaffected.
 
+### MRT Core moves to the `Uno.WinRT` package
+
+The MRT Core surface — the `Microsoft.Windows.ApplicationModel.Resources` namespace — now lives in
+the assembly matching its Windows App SDK home:
+
+| | 6.x | 7.0 |
+|---|---|---|
+| Assembly | `Uno.UI` | `Uno.WinRT` |
+| Package | `Uno.WinUI` | `Uno.WinRT` |
+
+**Source code needs no change.** The namespace is unchanged, so
+`using Microsoft.Windows.ApplicationModel.Resources;` still resolves, and `Uno.WinUI` depends on
+`Uno.WinRT`, so both assemblies are already referenced. The types that moved are
+`ResourceLoader`, `ResourceManager`, `ResourceContext`, `ResourceMap`, `ResourceCandidate`,
+`ResourceCandidateKind`, `ResourceNotFoundEventArgs`, `KnownResourceQualifierName`,
+`MrtCoreContract`, `IResourceManager`, and `IResourceContext`.
+
+**Compiled binaries must be rebuilt.** Moving a type between assemblies is a binary break, and
+there is no forwarding shim: a library built against 6.x resolves these types from `Uno.UI` and
+fails at run time with
+
+```text
+Could not load type 'Microsoft.Windows.ApplicationModel.Resources.ResourceLoader'
+from assembly 'Uno.UI, Version=…'.
+```
+
+Rebuild every library that uses MRT Core against 7.0, and update anything that names the
+assembly explicitly — assembly-qualified type names, `TypeForwardedTo`, or an IL merge/repack
+configuration:
+
+```diff
+- Type.GetType("Microsoft.Windows.ApplicationModel.Resources.ResourceLoader, Uno.UI")
++ Type.GetType("Microsoft.Windows.ApplicationModel.Resources.ResourceLoader, Uno.WinRT")
+```
+
+The older WinRT loader — `Windows.ApplicationModel.Resources.ResourceLoader`, without the
+`Microsoft.` prefix — did **not** change assemblies; only the `Microsoft.Windows.*` MRT Core
+surface moved. It does still need the same assembly-qualified-name update, because the WinRT
+assembly it has always lived in is itself renamed `Uno` → `Uno.WinRT` in 7.0.
+
 ### Public API removed
 
 - **Native base classes / identity:** `BindableView` (and `Bindable*` widget wrappers),
@@ -590,7 +630,8 @@ New apps get Skia heads only. Existing apps should drop native `*.Mobile` / nati
 10. Convert the Android `Application` class to override `CreateHost()` instead of passing an
    `AppBuilder` delegate to the base constructor.
 11. Rename `Uno.UI.Toolkit` usings and `xmlns` declarations to their new `Uno.UI.*` namespaces.
-12. Re-baseline visual/snapshot tests and re-test text, lists/scroll, IME, pickers, and
+12. Update assembly-qualified type names that reach MRT Core (`Microsoft.Windows.ApplicationModel.Resources.*`) — the assembly is now `Uno.WinRT`, not `Uno.UI`.
+13. Re-baseline visual/snapshot tests and re-test text, lists/scroll, IME, pickers, and
    safe-area/notch handling on devices.
 
 See the [Uno 6.0 migration guide](xref:Uno.Development.MigratingToUno6#optional-use-of-skia-rendering-for-ios-android-and-webassembly)

--- a/specs/050-breaking-changes-rollup/spec.md
+++ b/specs/050-breaking-changes-rollup/spec.md
@@ -223,12 +223,21 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
 - [x] **BC52** — Reparent `RadioMenuFlyoutItem` -> `MenuFlyoutItem`  `d3·M`
   - Reparent to `MenuFlyoutItem`; re-implement the toggle behavior currently inherited from `ToggleMenuFlyoutItem`.
   - Files: `src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cs`, `src/Uno.UI/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.Properties.cs`, `src/Uno.WinAppSDKSyncGenerator/Generator.cs`
-- [ ] **#2138** — `PasswordBox` no longer inherits `TextBox`  `d3·L` · **[impact spec](bc2138-passwordbox-to-control.md)** · PR #24038
+- [x] **Reparent `PasswordBox` -> `Control`** — no longer inherits `TextBox`  `d3·L` · **[impact spec](bc2138-passwordbox-to-control.md)** · PR #24038
   - Both `TextBox` and `PasswordBox` derive from `Control` and share the editing implementation by composition — an `internal sealed TextBoxCore` reached through an `internal ITextBoxHost`. Stops the password being mirrored into the inherited `Text` and removes the leaked text-input API. An *internal shared base* is impossible (CS0060) and a public one would add Uno-only surface, so composition is used instead; WinUI's own `CTextBoxBase` accessor design carries over as the interface.
   - Files: `src/Uno.UI/UI/Xaml/Controls/TextBoxCore/*.cs` (new), `src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs`, `src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox*.cs`, `src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/TextCommandBarFlyout.mux.cs`, `src/Uno.UI/UI/Xaml/Internal/TextControlFlyoutHelper.cs`
+- [x] **Reparent `MediaPlayerPresenter` -> `FrameworkElement`**  `d3·M` · PR #23807
+  - Reparent to match WinUI, dropping the extra `Border` level; the video surface is hosted through an `internal UIElement Child` instead of the inherited `Border.Child`.
+  - Files: `src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs`
+- [x] **Reparent `ImageBrush` -> `TileBrush`**  `d3·M` · PR #23806
+  - Materialize the missing `TileBrush` base and move `AlignmentX`/`AlignmentY`/`Stretch` onto it, so the DPs are declared where WinUI declares them.
+  - Files: `src/Uno.UI/UI/Xaml/Media/TileBrush.cs` (new), `src/Uno.UI/UI/Xaml/Media/ImageBrush.cs`
+- [x] **Reparent `FadeIn`/`FadeOutThemeAnimation` -> `Timeline`**  `d3·M` · PR #23805
+  - Reparent off Uno's `DoubleAnimation`, which leaked `From`/`To`/`By`/`EasingFunction`/`EnableDependentAnimation`; each animation drives its fixed `Opacity` target. `RepositionThemeAnimation` already derived `Timeline`.
+  - Files: `src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs`, `src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs`
 - [ ] **BC74** — Android drawable extension in retarget keys  `d3·S` · PR #15891
-  - Adjust signature to match WinUI.
-  - Files: `src/Uno/Helpers/AndroidResourceNameEncoder.cs`, `src/Uno/Helpers/DrawableHelper.Android.cs`, `src/SourceGenerators/Uno.UI.Tasks/ResourceConverters/AndroidResourceConverter.cs`
+  - Adjust signature to match WinUI. **Deferred out of Phase 5:** draft PR #15891 still targets `master` and is blocked on the nine-patch (`.9.png`) regression it exposes. Not moot under Skia-only — Skia-on-Android still resolves drawables through this path.
+  - Files: `src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs`, `src/Uno.UWP/Helpers/DrawableHelper.Android.cs`, `src/SourceGenerators/Uno.UI.Tasks/ResourceConverters/AndroidResourceConverter.cs`
 - [x] **BC50** — Remove `UseLegacyPrimaryLanguageOverride`  `d3·S` · #13704
   - Hard-remove the flag and the legacy path; `PrimaryLanguageOverride` is always restart-to-apply (WinUI). **Behavior change** — the flag defaulted to `true`, so runtime language-switch apps must set the culture themselves; migration note added.
   - Files: `src/Uno.UWP/FeatureConfiguration/WinRTFeatureConfiguration.cs`, `src/Uno.UWP/Globalization/ApplicationLanguages.cs`, `src/Uno.UI/UI/Xaml/Application.cs`
@@ -243,12 +252,14 @@ _Danger 3. Wider but localized: visibility on more-derivable hooks, per-type bas
   - Expected values measured on native WinUI (WinAppSDK 1.7), application **and** library XAML. Known remaining divergence, pre-existing and out of scope: Uno resolves the `ms-appx` form against the assembly root, WinUI against the XAML file's folder.
   - **Public API rename shipped with it:** `Uno.Extensions.UriExtensions.IsLocalResource` → `IsMsAppx`. The old name said "local resource" but the predicate tests for `ms-appx`, three lines from the `ms-resource:///Files/` helpers this work introduced — the two are opposite ends of the mapping. No forwarding shim; registered in `build/PackageDiffIgnore.xml`.
   - Files: `src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs`, `src/Uno.UI/UI/Xaml/XamlFilePathHelper.shared.cs`, `src/Uno.UI/UI/Xaml/Media/ImageSource.cs`, `src/Uno.Foundation/Extensions/UriExtensions.cs`
-- [ ] **BC21** — Delete legacy `AutomationProperties` member ⚠️  `d3·S`
-  - **INVESTIGATE / likely drop.** The member at ~L44 (`AnnotationsProperty`) is valid WinUI and must NOT be deleted — the line ref drifted. Real target is probably the native `OnAutomationIdChanged` branches in `AutomationProperties.uno.cs`.
-  - Files: `src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs`, `src/Uno.UI/UI/Xaml/Automation/AutomationProperties.uno.cs`
-- [ ] **BC75** — Move MRT Core (`ApplicationModel.Resources`) -> `Uno.WinRT`  `d3·M`
-  - Move the MRT-Core types to the WinRT library at `src/Uno` (lower risk than a new assembly).
-  - Files: `src/Uno.UI/Windows/ApplicationModel/Resources/ResourceLoader.cs`, `src/Uno.UI/Windows/ApplicationModel/Resources/IResourceContext.cs`, `src/Uno.UI/Windows/ApplicationModel/Resources/IResourceManager.cs`
+- [x] **BC21** — Delete legacy `AutomationProperties` member ⚠️  `d3·S` · PR #19700
+  - **Resolved as a drifted line reference, not a deletion.** The member at ~L44 is `AnnotationsProperty`, which is valid WinUI and was correctly left in place. The real defect was the misspelled `AccessibilityView` registration, already fixed on `master`; nothing remains to remove.
+  - Files: `src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs`
+- [x] **BC75** — Move MRT Core (`Microsoft.Windows.ApplicationModel.Resources`) -> `Uno.WinRT`  `d3·M` · PR #23669
+  - Landed inside the four-namespace sync-generator relocation, not as its own PR: the back-compat redirect that forced this namespace into `Uno.UI` was removed, so it now generates into `src/Uno.WinRT` — assembly `Uno.WinRT`, package `Uno.WinRT` — matching its WinAppSDK metadata home. Relocating types across assemblies is binary-breaking, so the 11 types are registered in `build/PackageDiffIgnore.xml`. No `[assembly: TypeForwardedTo]` shim was added, though `Uno.UI` does reference the target assembly and could carry one — per ground rule 1 the break is taken now rather than shimmed.
+  - Follow-ups shipped separately from the relocation: the migration note in `doc/articles/migrating-to-uno-7.md`, and `Given_MrtCoreAssemblyIdentity`, which asserts each type resolves from assembly `Uno.WinRT` and that `Uno.UI` declares none of the namespace. The test is a **regression guard**, not fails-before/passes-after — the move had already landed.
+  - **Unowned follow-up — needs its own tracking item.** The same relocation moved three further namespace groups (`Microsoft.UI.System`, `Microsoft.Graphics.DirectX`/`.Display`, `Microsoft.UI.IClosableNotifier`) out of `Uno.UI`/`Uno.UI.Composition`, and BC41 moved `Microsoft.UI.Input.*` (`PointerPoint`, `PointerDeviceType`, …) the same way. All four are undocumented and unguarded, and `Microsoft.UI.Input.*` is far more widely consumed than any MRT Core type. Do not park this on BC41 — that item is closed.
+  - Files: `src/Uno.WinRT/Microsoft/Windows/ApplicationModel/Resources/*`, `src/Uno.WinAppSDKSyncGenerator/Generator.cs`, `build/PackageDiffIgnore.xml`
 
 ---
 
@@ -320,7 +331,7 @@ _Danger 4-5. Ship last, never batched — each lands as its own separately-stabi
 - **DataContext / DependencyObject (Phase 7):** do `BC58` (generator-wide DataContext->FE-only) **first**; it gates `BC54` (FlyoutBase symptom) and de-risks `BC26` (DependencyObject->class). All touch the same generated DO mixin.
 - **Background / UserControl (Phase 7):** `BC38` (Background -> Control) precedes `BC14` (UserControl -> Control) so the property relocation is not redone.
 - **Behaviour-drift items (validate at runtime):** `BC50` (culture no longer changes on setter), `BC45` (Center/Center default — source-breaking only; the flag defaulted to `false`, so default users are unaffected), `BC74` (drawable key collision), `BC42` (drop `clr-namespace:`), `BC51` (`ms-resource:///` rewrite) — most change runtime behaviour even for default users.
-- **Verify-first / open-decision items:** `BC16` (struct design maybe obsolete), `BC21` (line ref drifted; may drop), `BC53` (needs a new name), `BC55` (must preserve the prefs backing file).
+- **Verify-first / open-decision items:** `BC16` (struct design maybe obsolete), `BC53` (needs a new name), `BC55` (must preserve the prefs backing file).
 
 ---
 

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_Windows_ApplicationModel_Resources/Given_MrtCoreAssemblyIdentity.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_Windows_ApplicationModel_Resources/Given_MrtCoreAssemblyIdentity.cs
@@ -1,0 +1,71 @@
+﻿// Whole-file HAS_UNO guard rather than the [PlatformCondition] the runtime-test rules prescribe:
+// on the WinAppSDK head these types come from the platform projection, so neither the expected
+// assembly name nor the Uno.UI sweep has any meaning there - the test should not compile at all.
+#if HAS_UNO
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_Windows_ApplicationModel_Resources;
+
+[TestClass]
+public class Given_MrtCoreAssemblyIdentity
+{
+	private const string MrtCoreNamespace = "Microsoft.Windows.ApplicationModel.Resources";
+
+	// The assembly and the package id happen to match here; 7.0 renamed this assembly from "Uno".
+	private const string ExpectedAssemblyName = "Uno.WinRT";
+
+	private const string RepairHint = "Fix the namespace routing in src/Uno.WinAppSDKSyncGenerator/Generator.cs, "
+		+ "and the relocation entries in build/PackageDiffIgnore.xml.";
+
+	[TestMethod]
+	[DataRow(typeof(IResourceContext))]
+	[DataRow(typeof(IResourceManager))]
+	[DataRow(typeof(KnownResourceQualifierName))]
+	[DataRow(typeof(MrtCoreContract))]
+	[DataRow(typeof(ResourceCandidate))]
+	[DataRow(typeof(ResourceCandidateKind))]
+	[DataRow(typeof(ResourceContext))]
+	[DataRow(typeof(ResourceLoader))]
+	[DataRow(typeof(ResourceManager))]
+	[DataRow(typeof(ResourceMap))]
+	[DataRow(typeof(ResourceNotFoundEventArgs))]
+	public void When_MrtCoreType_Then_Declared_In_The_Uno_WinRT_Assembly(Type type)
+		=> Assert.AreEqual(
+			ExpectedAssemblyName,
+			type.Assembly.GetName().Name,
+			$"{type.FullName} must be declared in '{ExpectedAssemblyName}'. {RepairHint}");
+
+	[TestMethod]
+	public void When_Legacy_WinRT_ResourceLoader_Then_Also_In_The_Uno_WinRT_Assembly()
+		=> Assert.AreEqual(
+			ExpectedAssemblyName,
+			typeof(global::Windows.ApplicationModel.Resources.ResourceLoader).Assembly.GetName().Name,
+			"The pre-MRT loader has always lived in the WinRT assembly; the migration note says so explicitly.");
+
+	[TestMethod]
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Regarding Assembly.GetTypes(): the trimmer may remove types, which can only shrink the swept set. The anchor assertion below fails loudly if the assembly itself is not the expected one.")]
+	public void When_Uno_UI_Then_Declares_No_MrtCoreType()
+	{
+		var unoUI = typeof(Microsoft.UI.Xaml.UIElement).Assembly;
+
+		Assert.AreEqual("Uno.UI", unoUI.GetName().Name, "Sweep anchor moved out of Uno.UI - retarget this test.");
+
+		// The DataRows above only cover today's types; this catches a routing regression that
+		// declares a *new* MRT Core type back in Uno.UI.
+		var strays = unoUI.GetTypes()
+			.Where(type => type.Namespace?.StartsWith(MrtCoreNamespace, StringComparison.Ordinal) == true)
+			.Select(type => type.FullName)
+			.ToArray();
+
+		Assert.AreEqual(
+			string.Empty,
+			string.Join(", ", strays),
+			$"{MrtCoreNamespace} must not be declared in Uno.UI. {RepairHint}");
+	}
+}
+#endif


### PR DESCRIPTION
**GitHub Issue:** part of #8339

## PR Type:

📚 Documentation content changes

## What changed? 🚀

BC75 (move MRT Core to `Uno.UWP`) shipped inside the four-namespace sync-generator relocation in #23669, without the two artifacts that relocation still owed: a migration note and a test pinning the new assembly home. This adds both, and reconciles the rollup spec with what actually landed.

- **Migration note** — `doc/articles/migrating-to-uno-7.md` gains an *MRT Core moves to the `Uno.WinRT` package* section. The namespace is unchanged, so source needs no edit and `Uno.WinUI` already depends on `Uno.WinRT`; what breaks is binaries — a library built against 6.x resolves these types from `Uno.UI` — and assembly-qualified names. The section quotes the verbatim `Could not load type …` text so someone searching for the failure lands on it, and calls out that the older `Windows.ApplicationModel.Resources.ResourceLoader` is *not* affected: the two loaders are one namespace prefix apart, and only the `Microsoft.Windows.*` surface moved.

- **Runtime test** — `Given_MrtCoreAssemblyIdentity` asserts each of the 11 `Microsoft.Windows.ApplicationModel.Resources` types is declared in assembly `Uno`, that the pre-MRT loader is there too, and that `Uno.UI` declares none of that namespace. The sweep is the assertion that earns its keep: the `DataRow`s only cover today's types, while the sweep catches a routing regression that declares a *new* MRT Core type back in `Uno.UI`. It pins its anchor assembly first so it cannot silently start sweeping the wrong one, and both failure paths name the two repair sites (`Generator.cs` routing, `PackageDiffIgnore.xml`). Note the expected name is `Uno` — `Uno.WinRT` is the package id, and both the relocation commit message and the `PackageDiffIgnore` reasons say "Uno.WinRT", which is the trap here.

- **Spec reconciliation** — `specs/050-breaking-changes-rollup/spec.md`: BC75 checked, with its `Files:` list corrected (it pointed at the old `Windows.*` loader paths, not the `Microsoft.Windows.*` types that moved) and a note that no type-forwarder shim was taken; BC21 closed as a drifted line reference (the member it named is valid WinUI, and the real misspelling fix shipped in #19700); the `PasswordBox` reparenting checked off; the three reparenting items that were missing entirely added, labelled by subject and public PR. BC74 left open with its blocker recorded.

The spec also now records what this PR deliberately does **not** document: the same relocation moved `Microsoft.UI.System`, `Microsoft.Graphics.DirectX`/`.Display` and `Microsoft.UI.IClosableNotifier` out of `Uno.UI`/`Uno.UI.Composition`, and BC41 moved `Microsoft.UI.Input.*` the same way. Those four need their own tracking item — `Microsoft.UI.Input.PointerPoint` in particular is far more widely consumed than any MRT Core type.

### Validation

- **Runtime** — `Given_MrtCoreAssemblyIdentity`: 13/13 passed on Skia Desktop (Win32).
- **Negative control** — flipping the expected assembly to `Uno.UI` and the swept namespace to one `Uno.UI` declares fails every case, so the assertions bite rather than passing vacuously.
- **Compile** — `SamplesApp.Skia.Generic` Release/net10.0: 0 errors, 0 warnings.
- **Whitespace** — `dotnet format whitespace --verify-no-changes` clean on the new file, verified live by injecting a space indent and watching it fail.
- **Docs build** — DocFX 2.73.2 (the pinned CI version) renders the section, table and code blocks; warning/error counts are byte-identical to a pre-change run of the same tree (185/7, all `InvalidTocInclude` for locally-unimported external docs), so the change introduces none.

This is a **regression guard**, not a fails-before/passes-after test: the relocation already landed in #23669, so nothing fails on the parent commit. The negative control above stands in for the "fails-before" half.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — n/a, no visual change
- [x] ❗ Contains **NO** breaking changes — this PR adds a doc section and a test; the breaking change it documents shipped in #23669
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
