### PR TITLE
fix(wasm): Chain BrowserHtmlElement scrolling to the enclosing ScrollViewer

### DIFF
--- a/doc/articles/features/using-skia-hosting-native-controls.md
+++ b/doc/articles/features/using-skia-hosting-native-controls.md
@@ -66,8 +66,10 @@ Chaining honors `ScrollViewer.IsHorizontalScrollChainingEnabled` and `IsVertical
 > [!NOTE]
 > Form controls (`input`, `textarea`, `select`) and `contenteditable` regions — and their descendants — always keep their full native touch behavior and never participate in chaining, so caret dragging and text selection are unaffected. Content hosted in an `iframe` also stays native-only, because pointer events do not cross the frame boundary and its scroll position cannot be observed from the hosting document.
 
+Because single-finger panning is driven by Uno in `Negotiated` mode, the negotiated subtree is set to `touch-action: pinch-zoom`.
+
 > [!IMPORTANT]
-> Because single-finger panning is driven by Uno in `Negotiated` mode, the negotiated subtree is set to `touch-action: pinch-zoom`. Pinch-zoom keeps working, but **double-tap-to-zoom is disabled** inside the negotiated element. Multi-touch gestures are not arbitrated: as soon as a second finger goes down, the whole interaction is handed back to the browser.
+> Pinch-zoom keeps working, but **double-tap-to-zoom is disabled** inside the negotiated element. Multi-touch gestures are not arbitrated: as soon as a second finger goes down, the whole interaction is handed back to the browser.
 
 ### Troubleshooting
 

--- a/doc/articles/features/using-skia-hosting-native-controls.md
+++ b/doc/articles/features/using-skia-hosting-native-controls.md
@@ -63,6 +63,8 @@ The default is `NativeOnly`, which preserves the behavior described above.
 
 Chaining honors `ScrollViewer.IsHorizontalScrollChainingEnabled` and `IsVerticalScrollChainingEnabled`: a `ScrollViewer` that opts out of chaining absorbs the remaining delta instead of passing it to its own ancestors.
 
+Inertia honors `ScrollViewer.IsScrollInertiaEnabled`: during the fling that follows a released touch drag, a `ScrollViewer` with inertia disabled neither scrolls nor lets the fling continue past it. The native element itself still decays its own momentum until it reaches its boundary.
+
 > [!NOTE]
 > Form controls (`input`, `textarea`, `select`) and `contenteditable` regions — and their descendants — always keep their full native touch behavior and never participate in chaining, so caret dragging and text selection are unaffected. Content hosted in an `iframe` also stays native-only, because pointer events do not cross the frame boundary and its scroll position cannot be observed from the hosting document.
 

--- a/doc/articles/features/using-skia-hosting-native-controls.md
+++ b/doc/articles/features/using-skia-hosting-native-controls.md
@@ -61,8 +61,21 @@ With this policy:
 
 The default is `NativeOnly`, which preserves the behavior described above.
 
+Chaining honors `ScrollViewer.IsHorizontalScrollChainingEnabled` and `IsVerticalScrollChainingEnabled`: a `ScrollViewer` that opts out of chaining absorbs the remaining delta instead of passing it to its own ancestors.
+
 > [!NOTE]
-> Form controls (`input`, `textarea`, `select`) and `contenteditable` regions always keep their full native touch behavior and never participate in chaining, so caret dragging and text selection are unaffected. Content hosted in an `iframe` also stays native-only, because pointer events do not cross the frame boundary and its scroll position cannot be observed from the hosting document.
+> Form controls (`input`, `textarea`, `select`) and `contenteditable` regions — and their descendants — always keep their full native touch behavior and never participate in chaining, so caret dragging and text selection are unaffected. Content hosted in an `iframe` also stays native-only, because pointer events do not cross the frame boundary and its scroll position cannot be observed from the hosting document.
+
+> [!IMPORTANT]
+> Because single-finger panning is driven by Uno in `Negotiated` mode, the negotiated subtree is set to `touch-action: pinch-zoom`. Pinch-zoom keeps working, but **double-tap-to-zoom is disabled** inside the negotiated element. Multi-touch gestures are not arbitrated: as soon as a second finger goes down, the whole interaction is handed back to the browser.
+
+### Troubleshooting
+
+If a drag over negotiated content does not scroll the enclosing `ScrollViewer`:
+
+- Confirm `InputPolicy` is set to `Negotiated` — it is `NativeOnly` by default, and it must be set on the element that is assigned as the `ContentPresenter`/`ContentControl` content, not on a nested element.
+- Confirm the target is not inside an `iframe`, a form control, or a `contenteditable` region.
+- Enable `Debug` logging on `Uno.UI.Runtime.Skia.BrowserNativeElementHostingExtension` — it logs when a delta arrives for an unknown element and when no `ScrollViewer` in the ancestry consumed one.
 
 ## Limitations
 

--- a/doc/articles/features/using-skia-hosting-native-controls.md
+++ b/doc/articles/features/using-skia-hosting-native-controls.md
@@ -42,6 +42,28 @@ Setting the `Opacity` of the wrapping `ContentControl` will also set the opacity
 > [!NOTE]
 > As of Uno Platform 6.0, setting the opacity of native elements is not supported on X11.
 
+## Scrolling a native HTML element inside a ScrollViewer (WebAssembly)
+
+On WebAssembly, an Uno Platform `ScrollViewer` is painted onto the canvas rather than being a DOM scroll container, so the browser has nothing to hand a scroll gesture over to when that gesture starts inside a `BrowserHtmlElement`. By default the native element keeps the whole gesture: a scrollable native child scrolls until its own boundary and then simply stops, and dragging over non-scrollable native content does not scroll the page at all.
+
+Set `BrowserHtmlElement.InputPolicy` to `Negotiated` to opt into scroll chaining:
+
+```csharp
+var element = BrowserHtmlElement.CreateHtmlElement("div");
+element.InputPolicy = BrowserHtmlElementInputPolicy.Negotiated;
+```
+
+With this policy:
+
+- A scrollable native element scrolls first, and only what it cannot consume at its boundary is transferred to the enclosing `ScrollViewer`, chaining outwards through nested `ScrollViewer`s.
+- A gesture over non-scrollable native content scrolls the enclosing `ScrollViewer` directly.
+- Taps, focus, text selection and keyboard input stay native.
+
+The default is `NativeOnly`, which preserves the behavior described above.
+
+> [!NOTE]
+> Form controls (`input`, `textarea`, `select`) and `contenteditable` regions always keep their full native touch behavior and never participate in chaining, so caret dragging and text selection are unaffected. Content hosted in an `iframe` also stays native-only, because pointer events do not cross the frame boundary and its scroll position cannot be observed from the hosting document.
+
 ## Limitations
 
 The native control is rendered by the native windowing system and cannot be styled by Uno Platform styles.

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml
@@ -1,0 +1,44 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.BrowserHtmlElementTests.BrowserHtmlElement_NativeScrollNegotiation"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <ScrollViewer x:Name="OuterScrollViewer">
+        <StackPanel Padding="24" Spacing="16">
+            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="BrowserHtmlElement native scroll negotiation" />
+            <TextBlock TextWrapping="Wrap">
+                This manual WebAssembly repro places a native HTML overlay inside an Uno Platform ScrollViewer. Dragging the native input or button should eventually allow the outer ScrollViewer to scroll; the inner native region should scroll first while it has content in the requested direction.
+            </TextBlock>
+            <Border
+                Height="280"
+                Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+                CornerRadius="4">
+                <TextBlock Margin="16" Text="Uno Platform content before the native element" />
+            </Border>
+            <CheckBox
+                x:Name="EnableInnerScroll"
+                Checked="OnInnerScrollToggled"
+                Content="Enable the inner native scroll region"
+                IsChecked="True"
+                Unchecked="OnInnerScrollToggled" />
+            <CheckBox
+                x:Name="EnableNegotiatedInput"
+                Checked="OnNegotiatedInputToggled"
+                Content="Enable negotiated native scroll handoff (experimental)"
+                IsChecked="False"
+                Unchecked="OnNegotiatedInputToggled" />
+            <TextBlock x:Name="NativeHostStatus" Text="Native host: awaiting setup." />
+            <ContentPresenter
+                x:Name="NativeHost"
+                Height="240"
+                HorizontalContentAlignment="Stretch"
+                VerticalContentAlignment="Stretch" />
+            <Border
+                Height="720"
+                Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+                CornerRadius="4">
+                <TextBlock Margin="16" Text="Uno Platform content after the native element" />
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="UITests.Shared.Windows_UI_Xaml_Controls.BrowserHtmlElementTests.BrowserHtmlElement_NativeScrollNegotiation"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,7 @@
         <StackPanel Padding="24" Spacing="16">
             <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="BrowserHtmlElement native scroll negotiation" />
             <TextBlock TextWrapping="Wrap">
-                This manual WebAssembly repro places a native HTML overlay inside an Uno Platform ScrollViewer. Dragging the native input or button should eventually allow the outer ScrollViewer to scroll; the inner native region should scroll first while it has content in the requested direction.
+                This manual WebAssembly repro places a native HTML overlay inside an Uno Platform ScrollViewer. With negotiation enabled, dragging over the paragraph or the button scrolls the outer ScrollViewer, and the inner native region scrolls first while it still has content in the drag direction, handing over only what is left at its boundary. The text input keeps its full native behavior and never scrolls the page.
             </TextBlock>
             <Border
                 Height="280"
@@ -24,7 +24,7 @@
             <CheckBox
                 x:Name="EnableNegotiatedInput"
                 Checked="OnNegotiatedInputToggled"
-                Content="Enable negotiated native scroll handoff (experimental)"
+                Content="Enable negotiated native scroll handoff"
                 IsChecked="False"
                 Unchecked="OnNegotiatedInputToggled" />
             <TextBlock x:Name="NativeHostStatus" Text="Native host: awaiting setup." />

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml.cs
@@ -3,7 +3,9 @@
 using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+#if HAS_UNO
 using Uno.UI.NativeElementHosting;
+#endif
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.BrowserHtmlElementTests;

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml.cs
@@ -1,0 +1,74 @@
+#nullable enable
+
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.NativeElementHosting;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.BrowserHtmlElementTests;
+
+[Sample("Native Element Hosting", Name = "BrowserHtmlElement native scroll negotiation", IsManualTest = true, IgnoreInSnapshotTests = true)]
+public sealed partial class BrowserHtmlElement_NativeScrollNegotiation : Page
+{
+#if __SKIA__
+	private BrowserHtmlElement? _nativeElement;
+#endif
+
+	public BrowserHtmlElement_NativeScrollNegotiation()
+	{
+		this.InitializeComponent();
+
+#if __SKIA__
+		if (OperatingSystem.IsBrowser())
+		{
+			try
+			{
+				_nativeElement = BrowserHtmlElement.CreateHtmlElement("div");
+				_nativeElement.InputPolicy = EnableNegotiatedInput.IsChecked is true
+					? BrowserHtmlElementInputPolicy.Negotiated
+					: BrowserHtmlElementInputPolicy.NativeOnly;
+				NativeHost.Content = _nativeElement;
+				_nativeElement.SetCssStyle(
+					("box-sizing", "border-box"),
+					("border", "2px solid #0078d4"),
+					("padding", "12px"),
+					("background", "white"),
+					("color", "black"));
+				_nativeElement.SetHtmlContent("""
+					<label>Native text input <input aria-label="Native text input" value="Tap to focus and edit" /></label>
+					<button type="button">Native button</button>
+					<p>Drag over the input or button: this native content cannot scroll.</p>
+					<div id="native-scroll-region" style="height: 120px; overflow-y: auto; border: 1px dashed #666;">
+						<div style="height: 480px; padding: 8px;">Drag here to scroll the native region. At its boundary, continue dragging to test scroll chaining to the Uno Platform parent.</div>
+					</div>
+					""");
+				NativeHostStatus.Text = "Native host: mounted.";
+			}
+			catch (Exception e)
+			{
+				NativeHostStatus.Text = $"Native host setup failed: {e.GetType().Name}";
+			}
+		}
+#endif
+	}
+
+	private void OnInnerScrollToggled(object sender, RoutedEventArgs e)
+	{
+#if __SKIA__
+		_nativeElement?.ExecuteJavascript($"element.querySelector('#native-scroll-region').style.overflowY = '{(EnableInnerScroll.IsChecked is true ? "auto" : "hidden")}';");
+#endif
+	}
+
+	private void OnNegotiatedInputToggled(object sender, RoutedEventArgs e)
+	{
+#if __SKIA__
+		if (_nativeElement is { } nativeElement)
+		{
+			nativeElement.InputPolicy = EnableNegotiatedInput.IsChecked is true
+				? BrowserHtmlElementInputPolicy.Negotiated
+				: BrowserHtmlElementInputPolicy.NativeOnly;
+		}
+#endif
+	}
+}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Xaml_Controls/BrowserHtmlElementTests/BrowserHtmlElement_NativeScrollNegotiation.xaml.cs
@@ -38,7 +38,7 @@ public sealed partial class BrowserHtmlElement_NativeScrollNegotiation : Page
 				_nativeElement.SetHtmlContent("""
 					<label>Native text input <input aria-label="Native text input" value="Tap to focus and edit" /></label>
 					<button type="button">Native button</button>
-					<p>Drag over the input or button: this native content cannot scroll.</p>
+					<p>Drag over this paragraph or the button: this native content cannot scroll, so the drag goes to the Uno Platform ScrollViewer.</p>
 					<div id="native-scroll-region" style="height: 120px; overflow-y: auto; border: 1px dashed #666;">
 						<div style="height: 480px; padding: 8px;">Drag here to scroll the native region. At its boundary, continue dragging to test scroll chaining to the Uno Platform parent.</div>
 					</div>
@@ -47,7 +47,7 @@ public sealed partial class BrowserHtmlElement_NativeScrollNegotiation : Page
 			}
 			catch (Exception e)
 			{
-				NativeHostStatus.Text = $"Native host setup failed: {e.GetType().Name}";
+				NativeHostStatus.Text = $"Native host setup failed: {e.GetType().Name}: {e.Message}";
 			}
 		}
 #endif

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.UI.Core;
@@ -166,11 +166,49 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 	[JSExport]
 	[return: JSMarshalAs<JSType.Number>]
 	private static int OnNativeScrollDelta(
-		[JSMarshalAs<JSType.Any>] object inputSource,
-		string elementId,
+		[JSMarshalAs<JSType.Number>] nint unoElementId,
 		double horizontalDelta,
-		double verticalDelta)
-		=> BrowserNativeElementHostingExtension.ApplyNegotiatedScroll(elementId, horizontalDelta, verticalDelta) ? 1 : 0;
+		double verticalDelta,
+		[JSMarshalAs<JSType.Boolean>] bool isIntermediate)
+	{
+		try
+		{
+			// Ensure that the async context is set properly, since we're scrolling (and therefore raising
+			// ViewChanged and running layout) from outside the dispatcher.
+			using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
+
+			return BrowserNativeElementHostingExtension.ApplyNegotiatedScroll(unoElementId, horizontalDelta, verticalDelta, isIntermediate)
+				? 1
+				: 0;
+		}
+		catch (Exception error)
+		{
+			if (_log.IsEnabled(LogLevel.Error))
+			{
+				_log.Error($"Failed to apply negotiated native scroll: {error}");
+			}
+
+			return 0;
+		}
+	}
+
+	[JSExport]
+	private static void OnNativeScrollCompleted([JSMarshalAs<JSType.Number>] nint unoElementId)
+	{
+		try
+		{
+			using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
+
+			BrowserNativeElementHostingExtension.CompleteNegotiatedScroll(unoElementId);
+		}
+		catch (Exception error)
+		{
+			if (_log.IsEnabled(LogLevel.Error))
+			{
+				_log.Error($"Failed to complete negotiated native scroll: {error}");
+			}
+		}
+	}
 
 	[NotImplemented] public bool HasCapture => false;
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
@@ -163,6 +163,15 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 		}
 	}
 
+	[JSExport]
+	[return: JSMarshalAs<JSType.Number>]
+	private static int OnNativeScrollDelta(
+		[JSMarshalAs<JSType.Any>] object inputSource,
+		string elementId,
+		double horizontalDelta,
+		double verticalDelta)
+		=> BrowserNativeElementHostingExtension.ApplyNegotiatedScroll(elementId, horizontalDelta, verticalDelta) ? 1 : 0;
+
 	[NotImplemented] public bool HasCapture => false;
 
 	private CoreCursor _pointerCursor = new(CoreCursorType.Arrow, 0);

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
@@ -169,7 +169,8 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 		[JSMarshalAs<JSType.Number>] nint unoElementId,
 		double horizontalDelta,
 		double verticalDelta,
-		[JSMarshalAs<JSType.Boolean>] bool isIntermediate)
+		[JSMarshalAs<JSType.Boolean>] bool isIntermediate,
+		[JSMarshalAs<JSType.Boolean>] bool isInertial)
 	{
 		try
 		{
@@ -177,7 +178,7 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 			// ViewChanged and running layout) from outside the dispatcher.
 			using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
 
-			return BrowserNativeElementHostingExtension.ApplyNegotiatedScroll(unoElementId, horizontalDelta, verticalDelta, isIntermediate)
+			return BrowserNativeElementHostingExtension.ApplyNegotiatedScroll(unoElementId, horizontalDelta, verticalDelta, isIntermediate, isInertial)
 				? 1
 				: 0;
 		}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -17,6 +17,9 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 	private static (string path, string fillType)? _lastSvgClipPath;
 	private static readonly Dictionary<string, WeakReference<BrowserNativeElementHostingExtension>> _hosts = new();
 
+	// Sub-pixel leftovers are not worth chaining to the next ScrollViewer.
+	private const double ScrollResidualEpsilon = 0.01;
+
 	public BrowserNativeElementHostingExtension(ContentPresenter contentPresenter)
 	{
 		_presenter = contentPresenter;
@@ -30,6 +33,10 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		Debug.Assert(content is BrowserHtmlElement);
 		var element = (BrowserHtmlElement)content;
 		NativeMethods.AttachNativeElement(element.ElementId);
+
+		// An element collected without a matching DetachNativeElement would leave its registration
+		// behind forever, so drop the dead ones whenever the map grows.
+		PruneCollectedHosts();
 		_hosts[element.ElementId] = new(this);
 	}
 
@@ -39,6 +46,26 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		var element = (BrowserHtmlElement)content;
 		_hosts.Remove(element.ElementId);
 		NativeMethods.DetachNativeElement(element.ElementId);
+	}
+
+	private static void PruneCollectedHosts()
+	{
+		List<string>? collected = null;
+		foreach (var (elementId, host) in _hosts)
+		{
+			if (!host.TryGetTarget(out _))
+			{
+				(collected ??= new()).Add(elementId);
+			}
+		}
+
+		if (collected is not null)
+		{
+			foreach (var elementId in collected)
+			{
+				_hosts.Remove(elementId);
+			}
+		}
 	}
 
 	internal static bool ApplyNegotiatedScroll(string elementId, double horizontalDelta, double verticalDelta)
@@ -53,6 +80,10 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		return extension.ApplyNegotiatedScroll(horizontalDelta, verticalDelta);
 	}
 
+	/// <summary>
+	/// Scrolls the <see cref="ScrollViewer"/> ancestry of the native element host by the residual delta a
+	/// native scroller could not consume, chaining outwards until the delta is exhausted.
+	/// </summary>
 	private bool ApplyNegotiatedScroll(double horizontalDelta, double verticalDelta)
 	{
 		var remainingHorizontalDelta = horizontalDelta;
@@ -61,24 +92,47 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 
 		foreach (var ancestor in _presenter.GetVisualAncestry())
 		{
-			if (ancestor is not ScrollViewer scrollViewer)
+			if (ancestor is not ScrollViewer { Presenter: { } presenter } scrollViewer)
 			{
 				continue;
 			}
 
-			var initialHorizontalOffset = scrollViewer.HorizontalOffset;
-			var initialVerticalOffset = scrollViewer.VerticalOffset;
-			scrollViewer.ChangeView(
-				horizontalOffset: initialHorizontalOffset + remainingHorizontalDelta,
-				verticalOffset: initialVerticalOffset + remainingVerticalDelta,
-				zoomFactor: null,
-				disableAnimation: true);
+			var horizontalOffset = presenter.CanHorizontallyScroll && remainingHorizontalDelta is not 0
+				? presenter.HorizontalOffset + remainingHorizontalDelta
+				: (double?)null;
+			var verticalOffset = presenter.CanVerticallyScroll && remainingVerticalDelta is not 0
+				? presenter.VerticalOffset + remainingVerticalDelta
+				: (double?)null;
 
-			remainingHorizontalDelta -= scrollViewer.HorizontalOffset - initialHorizontalOffset;
-			remainingVerticalDelta -= scrollViewer.VerticalOffset - initialVerticalOffset;
-			didScroll |= initialHorizontalOffset != scrollViewer.HorizontalOffset || initialVerticalOffset != scrollViewer.VerticalOffset;
+			if (horizontalOffset is null && verticalOffset is null)
+			{
+				continue;
+			}
 
-			if (remainingHorizontalDelta == 0 && remainingVerticalDelta == 0)
+			var initialHorizontalOffset = presenter.HorizontalOffset;
+			var initialVerticalOffset = presenter.VerticalOffset;
+
+			// This is user input, not a programmatic ChangeView. ChangeView arms the ScrollViewer's offset
+			// intent, which the post-layout recompute then keeps re-applying and would fight the drag - so
+			// clear it and go through the presenter exactly like PointerWheelScroll and
+			// TryEnableDirectManipulation do.
+			scrollViewer.ClearOffsetIntents();
+			presenter.Set(
+				horizontalOffset: horizontalOffset,
+				verticalOffset: verticalOffset,
+				disableAnimation: true,
+				isIntermediate: false);
+
+			// The presenter clamps and commits its offsets synchronously, unlike the ScrollViewer's own
+			// properties which are refreshed through a notification, so the residual is read back from it.
+			var consumedHorizontalDelta = presenter.HorizontalOffset - initialHorizontalOffset;
+			var consumedVerticalDelta = presenter.VerticalOffset - initialVerticalOffset;
+
+			remainingHorizontalDelta -= consumedHorizontalDelta;
+			remainingVerticalDelta -= consumedVerticalDelta;
+			didScroll |= consumedHorizontalDelta is not 0 || consumedVerticalDelta is not 0;
+
+			if (Math.Abs(remainingHorizontalDelta) < ScrollResidualEpsilon && Math.Abs(remainingVerticalDelta) < ScrollResidualEpsilon)
 			{
 				break;
 			}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -96,7 +96,7 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		return extension;
 	}
 
-	internal static bool ApplyNegotiatedScroll(nint unoElementId, double horizontalDelta, double verticalDelta, bool isIntermediate)
+	internal static bool ApplyNegotiatedScroll(nint unoElementId, double horizontalDelta, double verticalDelta, bool isIntermediate, bool isInertial)
 	{
 		if (TryGetHost(unoElementId) is not { } extension)
 		{
@@ -112,7 +112,8 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 			extension._presenter,
 			horizontalDelta,
 			verticalDelta,
-			isIntermediate);
+			isIntermediate,
+			isInertial);
 
 		if (!result.DidScroll && _log.IsEnabled(LogLevel.Debug))
 		{

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -49,14 +49,17 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		Debug.Assert(content is BrowserHtmlElement);
 		var element = (BrowserHtmlElement)content;
 
-		// Only drop the registration if it is still ours: when an element is recycled, the new host can
-		// attach before the old one detaches, and unregistering then would silently kill its chaining.
+		// Detach only if the element is still ours: when an element is recycled, the new host can attach
+		// before the old one detaches, and unregistering then would silently kill its chaining while the
+		// JS-side detach would hide the element the new host is actively presenting.
 		if (_hosts.TryGetValue(element.UnoElementId, out var registered)
-			&& (!registered.TryGetTarget(out var host) || ReferenceEquals(host, this)))
+			&& registered.TryGetTarget(out var host)
+			&& !ReferenceEquals(host, this))
 		{
-			_hosts.Remove(element.UnoElementId);
+			return;
 		}
 
+		_hosts.Remove(element.UnoElementId);
 		NativeMethods.DetachNativeElement(element.ElementId);
 	}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -17,9 +17,6 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 	private static (string path, string fillType)? _lastSvgClipPath;
 	private static readonly Dictionary<string, WeakReference<BrowserNativeElementHostingExtension>> _hosts = new();
 
-	// Sub-pixel leftovers are not worth chaining to the next ScrollViewer.
-	private const double ScrollResidualEpsilon = 0.01;
-
 	public BrowserNativeElementHostingExtension(ContentPresenter contentPresenter)
 	{
 		_presenter = contentPresenter;
@@ -80,66 +77,8 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		return extension.ApplyNegotiatedScroll(horizontalDelta, verticalDelta);
 	}
 
-	/// <summary>
-	/// Scrolls the <see cref="ScrollViewer"/> ancestry of the native element host by the residual delta a
-	/// native scroller could not consume, chaining outwards until the delta is exhausted.
-	/// </summary>
 	private bool ApplyNegotiatedScroll(double horizontalDelta, double verticalDelta)
-	{
-		var remainingHorizontalDelta = horizontalDelta;
-		var remainingVerticalDelta = verticalDelta;
-		var didScroll = false;
-
-		foreach (var ancestor in _presenter.GetVisualAncestry())
-		{
-			if (ancestor is not ScrollViewer { Presenter: { } presenter } scrollViewer)
-			{
-				continue;
-			}
-
-			var horizontalOffset = presenter.CanHorizontallyScroll && remainingHorizontalDelta is not 0
-				? presenter.HorizontalOffset + remainingHorizontalDelta
-				: (double?)null;
-			var verticalOffset = presenter.CanVerticallyScroll && remainingVerticalDelta is not 0
-				? presenter.VerticalOffset + remainingVerticalDelta
-				: (double?)null;
-
-			if (horizontalOffset is null && verticalOffset is null)
-			{
-				continue;
-			}
-
-			var initialHorizontalOffset = presenter.HorizontalOffset;
-			var initialVerticalOffset = presenter.VerticalOffset;
-
-			// This is user input, not a programmatic ChangeView. ChangeView arms the ScrollViewer's offset
-			// intent, which the post-layout recompute then keeps re-applying and would fight the drag - so
-			// clear it and go through the presenter exactly like PointerWheelScroll and
-			// TryEnableDirectManipulation do.
-			scrollViewer.ClearOffsetIntents();
-			presenter.Set(
-				horizontalOffset: horizontalOffset,
-				verticalOffset: verticalOffset,
-				disableAnimation: true,
-				isIntermediate: false);
-
-			// The presenter clamps and commits its offsets synchronously, unlike the ScrollViewer's own
-			// properties which are refreshed through a notification, so the residual is read back from it.
-			var consumedHorizontalDelta = presenter.HorizontalOffset - initialHorizontalOffset;
-			var consumedVerticalDelta = presenter.VerticalOffset - initialVerticalOffset;
-
-			remainingHorizontalDelta -= consumedHorizontalDelta;
-			remainingVerticalDelta -= consumedVerticalDelta;
-			didScroll |= consumedHorizontalDelta is not 0 || consumedVerticalDelta is not 0;
-
-			if (Math.Abs(remainingHorizontalDelta) < ScrollResidualEpsilon && Math.Abs(remainingVerticalDelta) < ScrollResidualEpsilon)
-			{
-				break;
-			}
-		}
-
-		return didScroll;
-	}
+		=> ScrollViewer.ChainScrollFromDescendant(_presenter, horizontalDelta, verticalDelta).DidScroll;
 
 	public void ArrangeNativeElement(object content, Windows.Foundation.Rect arrangeRect)
 	{

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Uno.Foundation.Logging;
 using System.Runtime.InteropServices.JavaScript;
 using Microsoft.UI.Xaml.Controls;
 using Uno.UI.NativeElementHosting;
@@ -13,9 +14,15 @@ namespace Uno.UI.Runtime.Skia;
 
 internal partial class BrowserNativeElementHostingExtension : ContentPresenter.INativeElementHostingExtension
 {
+	private static readonly Logger _log = typeof(BrowserNativeElementHostingExtension).Log();
+
 	private readonly ContentPresenter _presenter;
 	private static (string path, string fillType)? _lastSvgClipPath;
-	private static readonly Dictionary<string, WeakReference<BrowserNativeElementHostingExtension>> _hosts = new();
+
+	// Keyed by BrowserHtmlElement.UnoElementId (the GCHandle), never by the ElementId string: that string is
+	// settable by the caller (OwnHtmlElement) and observable from the hosted DOM, so it can collide or be
+	// spoofed by hosted content. The handle cannot.
+	private static readonly Dictionary<nint, WeakReference<BrowserNativeElementHostingExtension>> _hosts = new();
 
 	public BrowserNativeElementHostingExtension(ContentPresenter contentPresenter)
 	{
@@ -34,51 +41,94 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 		// An element collected without a matching DetachNativeElement would leave its registration
 		// behind forever, so drop the dead ones whenever the map grows.
 		PruneCollectedHosts();
-		_hosts[element.ElementId] = new(this);
+		_hosts[element.UnoElementId] = new(this);
 	}
 
 	public void DetachNativeElement(object content)
 	{
 		Debug.Assert(content is BrowserHtmlElement);
 		var element = (BrowserHtmlElement)content;
-		_hosts.Remove(element.ElementId);
+
+		// Only drop the registration if it is still ours: when an element is recycled, the new host can
+		// attach before the old one detaches, and unregistering then would silently kill its chaining.
+		if (_hosts.TryGetValue(element.UnoElementId, out var registered)
+			&& (!registered.TryGetTarget(out var host) || ReferenceEquals(host, this)))
+		{
+			_hosts.Remove(element.UnoElementId);
+		}
+
 		NativeMethods.DetachNativeElement(element.ElementId);
 	}
 
 	private static void PruneCollectedHosts()
 	{
-		List<string>? collected = null;
-		foreach (var (elementId, host) in _hosts)
+		List<nint>? collected = null;
+		foreach (var (unoElementId, host) in _hosts)
 		{
 			if (!host.TryGetTarget(out _))
 			{
-				(collected ??= new()).Add(elementId);
+				(collected ??= new()).Add(unoElementId);
 			}
 		}
 
 		if (collected is not null)
 		{
-			foreach (var elementId in collected)
+			foreach (var unoElementId in collected)
 			{
-				_hosts.Remove(elementId);
+				_hosts.Remove(unoElementId);
 			}
 		}
 	}
 
-	internal static bool ApplyNegotiatedScroll(string elementId, double horizontalDelta, double verticalDelta)
+	private static BrowserNativeElementHostingExtension? TryGetHost(nint unoElementId)
 	{
-		if (!_hosts.TryGetValue(elementId, out var weakExtension)
-			|| !weakExtension.TryGetTarget(out var extension))
+		if (!_hosts.TryGetValue(unoElementId, out var weakExtension))
 		{
-			_hosts.Remove(elementId);
+			return null;
+		}
+
+		if (!weakExtension.TryGetTarget(out var extension))
+		{
+			_hosts.Remove(unoElementId);
+			return null;
+		}
+
+		return extension;
+	}
+
+	internal static bool ApplyNegotiatedScroll(nint unoElementId, double horizontalDelta, double verticalDelta, bool isIntermediate)
+	{
+		if (TryGetHost(unoElementId) is not { } extension)
+		{
+			if (_log.IsEnabled(LogLevel.Warning))
+			{
+				_log.Warn($"Received a negotiated scroll for an unknown or collected native element ({unoElementId}).");
+			}
+
 			return false;
 		}
 
-		return extension.ApplyNegotiatedScroll(horizontalDelta, verticalDelta);
+		var result = ScrollViewer.ChainScrollFromDescendant(
+			extension._presenter,
+			horizontalDelta,
+			verticalDelta,
+			isIntermediate);
+
+		if (!result.DidScroll && _log.IsEnabled(LogLevel.Debug))
+		{
+			_log.Debug($"No ScrollViewer consumed the negotiated scroll for {unoElementId} (h={horizontalDelta}, v={verticalDelta}).");
+		}
+
+		return result.DidScroll;
 	}
 
-	private bool ApplyNegotiatedScroll(double horizontalDelta, double verticalDelta)
-		=> ScrollViewer.ChainScrollFromDescendant(_presenter, horizontalDelta, verticalDelta).DidScroll;
+	internal static void CompleteNegotiatedScroll(nint unoElementId)
+	{
+		if (TryGetHost(unoElementId) is { } extension)
+		{
+			ScrollViewer.CompleteChainedScrollFromDescendant(extension._presenter);
+		}
+	}
 
 	public void ArrangeNativeElement(object content, Windows.Foundation.Rect arrangeRect)
 	{

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Native/BrowserNativeElementHostingExtension.cs
@@ -1,9 +1,12 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices.JavaScript;
+using Microsoft.UI.Xaml.Controls;
 using Uno.UI.NativeElementHosting;
+using Uno.UI.Extensions;
 using ContentPresenter = Microsoft.UI.Xaml.Controls.ContentPresenter;
 
 namespace Uno.UI.Runtime.Skia;
@@ -12,6 +15,7 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 {
 	private readonly ContentPresenter _presenter;
 	private static (string path, string fillType)? _lastSvgClipPath;
+	private static readonly Dictionary<string, WeakReference<BrowserNativeElementHostingExtension>> _hosts = new();
 
 	public BrowserNativeElementHostingExtension(ContentPresenter contentPresenter)
 	{
@@ -24,13 +28,63 @@ internal partial class BrowserNativeElementHostingExtension : ContentPresenter.I
 	public void AttachNativeElement(object content)
 	{
 		Debug.Assert(content is BrowserHtmlElement);
-		NativeMethods.AttachNativeElement(((BrowserHtmlElement)content).ElementId);
+		var element = (BrowserHtmlElement)content;
+		NativeMethods.AttachNativeElement(element.ElementId);
+		_hosts[element.ElementId] = new(this);
 	}
 
 	public void DetachNativeElement(object content)
 	{
 		Debug.Assert(content is BrowserHtmlElement);
-		NativeMethods.DetachNativeElement(((BrowserHtmlElement)content).ElementId);
+		var element = (BrowserHtmlElement)content;
+		_hosts.Remove(element.ElementId);
+		NativeMethods.DetachNativeElement(element.ElementId);
+	}
+
+	internal static bool ApplyNegotiatedScroll(string elementId, double horizontalDelta, double verticalDelta)
+	{
+		if (!_hosts.TryGetValue(elementId, out var weakExtension)
+			|| !weakExtension.TryGetTarget(out var extension))
+		{
+			_hosts.Remove(elementId);
+			return false;
+		}
+
+		return extension.ApplyNegotiatedScroll(horizontalDelta, verticalDelta);
+	}
+
+	private bool ApplyNegotiatedScroll(double horizontalDelta, double verticalDelta)
+	{
+		var remainingHorizontalDelta = horizontalDelta;
+		var remainingVerticalDelta = verticalDelta;
+		var didScroll = false;
+
+		foreach (var ancestor in _presenter.GetVisualAncestry())
+		{
+			if (ancestor is not ScrollViewer scrollViewer)
+			{
+				continue;
+			}
+
+			var initialHorizontalOffset = scrollViewer.HorizontalOffset;
+			var initialVerticalOffset = scrollViewer.VerticalOffset;
+			scrollViewer.ChangeView(
+				horizontalOffset: initialHorizontalOffset + remainingHorizontalDelta,
+				verticalOffset: initialVerticalOffset + remainingVerticalDelta,
+				zoomFactor: null,
+				disableAnimation: true);
+
+			remainingHorizontalDelta -= scrollViewer.HorizontalOffset - initialHorizontalOffset;
+			remainingVerticalDelta -= scrollViewer.VerticalOffset - initialVerticalOffset;
+			didScroll |= initialHorizontalOffset != scrollViewer.HorizontalOffset || initialVerticalOffset != scrollViewer.VerticalOffset;
+
+			if (remainingHorizontalDelta == 0 && remainingVerticalDelta == 0)
+			{
+				break;
+			}
+		}
+
+		return didScroll;
 	}
 
 	public void ArrangeNativeElement(object content, Windows.Foundation.Rect arrangeRect)

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
@@ -86,18 +86,29 @@ input::-ms-clear {
 }
 
 /*
-  Negotiated native elements (BrowserHtmlElementInputPolicy.Negotiated) have their panning driven from
-  BrowserPointerInputSource so the residual can be chained to the enclosing Uno ScrollViewer.
+  Negotiated native elements (BrowserHtmlElementInputPolicy.Negotiated, value 1) have their panning driven
+  from BrowserPointerInputSource so the residual can be chained to the enclosing Uno ScrollViewer.
+
   `touch-action: none` on `html, body` above is not enough: the effective touch-action of a gesture is
   resolved only up to the nearest scroll container, so a scrollable element *inside* the native content
   resets the chain and would still be panned by the browser. Hence the descendant selector.
-  Form controls and contenteditable regions are deliberately excluded: they keep their full native touch
-  behavior (caret dragging, selection, nested scrolling) and simply do not participate in chaining.
+
+  `pinch-zoom` rather than `none`: it disables the single-finger panning we take over while leaving
+  multi-finger pinch-zoom to the browser. Double-tap-to-zoom is lost, which no touch-action value can
+  preserve alongside disabled panning.
+
+  Form controls and contenteditable regions - and their descendants, matching the `closest()` exclusion in
+  BrowserPointerInputSource.nativeInputSelector - are excluded: they keep full native touch behavior
+  (caret dragging, selection, nested scrolling) and do not participate in chaining. The two exclusion lists
+  must stay in sync or a gesture lands in a subtree that neither the browser nor Uno will pan.
+
+  The child combinator matters: only an element managed code registered as a negotiation root may carry
+  this policy. Hosted HTML is app- or third-party-supplied and could otherwise set the attribute itself.
   `!important` is needed to win over inline styles set by embedded third-party content.
 */
-#uno-native-element-host [data-uno-native-input-policy="1"],
-#uno-native-element-host [data-uno-native-input-policy="1"] *:not(input):not(textarea):not(select):not([contenteditable]) {
-	touch-action: none !important;
+#uno-native-element-host > [data-uno-native-input-policy="1"],
+#uno-native-element-host > [data-uno-native-input-policy="1"] *:not(:is(input, textarea, select, [contenteditable])):not(:is(input, textarea, select, [contenteditable]) *) {
+	touch-action: pinch-zoom !important;
 	overscroll-behavior: none !important;
 }
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
@@ -97,17 +97,22 @@ input::-ms-clear {
   multi-finger pinch-zoom to the browser. Double-tap-to-zoom is lost, which no touch-action value can
   preserve alongside disabled panning.
 
-  Form controls and contenteditable regions - and their descendants, matching the `closest()` exclusion in
-  BrowserPointerInputSource.nativeInputSelector - are excluded: they keep full native touch behavior
-  (caret dragging, selection, nested scrolling) and do not participate in chaining. The two exclusion lists
-  must stay in sync or a gesture lands in a subtree that neither the browser nor Uno will pan.
+  Form controls, contenteditable regions and iframes - and their descendants, matching the `closest()`
+  exclusion in BrowserPointerInputSource.nativeInputSelector - are excluded: they keep full native touch
+  behavior (caret dragging, selection, nested scrolling) and do not participate in chaining. The value this
+  rule puts on the negotiation root does not reach into them: a gesture's effective touch-action intersects
+  ancestor values only up to the nearest scroll container, so the chain stops at the excluded scroller
+  itself. Iframes need the CSS exclusion too, since the touch-action of the host document would otherwise
+  restrict panning inside the embedded document, whose events never reach our negotiation handler. The root
+  selector carries the same exclusion for when the negotiated element itself is such a control. The two
+  exclusion lists must stay in sync or a gesture lands in a subtree that neither the browser nor Uno will pan.
 
   The child combinator matters: only an element managed code registered as a negotiation root may carry
   this policy. Hosted HTML is app- or third-party-supplied and could otherwise set the attribute itself.
   `!important` is needed to win over inline styles set by embedded third-party content.
 */
-#uno-native-element-host > [data-uno-native-input-policy="1"],
-#uno-native-element-host > [data-uno-native-input-policy="1"] *:not(:is(input, textarea, select, [contenteditable])):not(:is(input, textarea, select, [contenteditable]) *) {
+#uno-native-element-host > [data-uno-native-input-policy="1"]:not(:is(input, textarea, select, iframe, [contenteditable])),
+#uno-native-element-host > [data-uno-native-input-policy="1"] *:not(:is(input, textarea, select, iframe, [contenteditable])):not(:is(input, textarea, select, iframe, [contenteditable]) *) {
 	touch-action: pinch-zoom !important;
 	overscroll-behavior: none !important;
 }

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
@@ -85,6 +85,14 @@ input::-ms-clear {
     height: 100%;
 }
 
+#uno-native-element-host [data-uno-native-input-policy="1"],
+#uno-native-element-host [data-uno-native-input-policy="1"] *,
+#uno-native-element-host [data-uno-native-input-policy="2"],
+#uno-native-element-host [data-uno-native-input-policy="2"] * {
+	touch-action: none !important;
+	overscroll-behavior: none !important;
+}
+
 /* Uno has its own HR indicator: hide default dotnet indicator. */
 #dotnet-hotreload-toast {
   visibility: collapse;

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
@@ -1,4 +1,4 @@
-﻿html,
+html,
 body {
   /**
       Disable root scrolling (bouncing effect on touch devices)
@@ -85,10 +85,18 @@ input::-ms-clear {
     height: 100%;
 }
 
+/*
+  Negotiated native elements (BrowserHtmlElementInputPolicy.Negotiated) have their panning driven from
+  BrowserPointerInputSource so the residual can be chained to the enclosing Uno ScrollViewer.
+  `touch-action: none` on `html, body` above is not enough: the effective touch-action of a gesture is
+  resolved only up to the nearest scroll container, so a scrollable element *inside* the native content
+  resets the chain and would still be panned by the browser. Hence the descendant selector.
+  Form controls and contenteditable regions are deliberately excluded: they keep their full native touch
+  behavior (caret dragging, selection, nested scrolling) and simply do not participate in chaining.
+  `!important` is needed to win over inline styles set by embedded third-party content.
+*/
 #uno-native-element-host [data-uno-native-input-policy="1"],
-#uno-native-element-host [data-uno-native-input-policy="1"] *,
-#uno-native-element-host [data-uno-native-input-policy="2"],
-#uno-native-element-host [data-uno-native-input-policy="2"] * {
+#uno-native-element-host [data-uno-native-input-policy="1"] *:not(input):not(textarea):not(select):not([contenteditable]) {
 	touch-action: none !important;
 	overscroll-behavior: none !important;
 }

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -176,6 +176,10 @@ namespace Uno.UI.NativeElementHosting {
 			element.innerHTML = html;
 		}
 
+		public static setInputPolicy(elementId: string, value: number) {
+			this.getElementOrThrow(elementId).dataset.unoNativeInputPolicy = value.toString();
+		}
+
 		public static registerNativeHtmlEvent(owner: any, elementId: string, eventName: string, managedHandler: string) {
 			const element = this.getElementOrThrow(elementId);
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -69,6 +69,10 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static detachNativeElement(content: string) {
+			// A fling still running against this element would keep scrolling a ScrollViewer it is no
+			// longer part of.
+			Uno.UI.Runtime.Skia.BrowserPointerInputSource.cancelNativeScrollInertiaFor(content);
+
 			let element = this.getElementOrThrow(content);
 			element.hidden = true;
 		}
@@ -176,8 +180,23 @@ namespace Uno.UI.NativeElementHosting {
 			element.innerHTML = html;
 		}
 
-		public static setInputPolicy(elementId: string, value: number) {
-			this.getElementOrThrow(elementId).dataset.unoNativeInputPolicy = value.toString();
+		/**
+		 * Input policies of the hosted elements, keyed by element reference.
+		 * The map - not the DOM attribute - is the source of truth: hosted HTML is app- or third-party-supplied
+		 * and could otherwise carry a data-uno-native-input-policy attribute of its own to opt itself in.
+		 * The attribute is still written because uno.css keys the touch-action override off it.
+		 */
+		private static inputPolicies = new WeakMap<HTMLElement, { policy: number, unoElementId: number }>();
+
+		public static setInputPolicy(elementId: string, unoElementId: number, value: number) {
+			const element = this.getElementOrThrow(elementId);
+			BrowserHtmlElement.inputPolicies.set(element, { policy: value, unoElementId: unoElementId });
+			element.dataset.unoNativeInputPolicy = value.toString();
+		}
+
+		/** Returns the policy registered by managed code for this exact element, or null if it has none. */
+		public static getInputPolicy(element: HTMLElement): { policy: number, unoElementId: number } | null {
+			return BrowserHtmlElement.inputPolicies.get(element) ?? null;
 		}
 
 		public static registerNativeHtmlEvent(owner: any, elementId: string, eventName: string, managedHandler: string) {

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -29,6 +29,29 @@
 		Mouse = 2,
 	}
 
+	export enum NativeElementInputPolicy {
+		NativeOnly = 0,
+		UnoOnly = 1,
+		Negotiated = 2,
+	}
+
+	interface NativeScrollGesture {
+		pointerId: number;
+		root: HTMLElement;
+		policy: NativeElementInputPolicy;
+		scrollTarget: HTMLElement | null;
+		startX: number;
+		startY: number;
+		lastX: number;
+		lastY: number;
+		lastTimestamp: number;
+		velocityX: number;
+		velocityY: number;
+		started: boolean;
+		primaryAxis: "horizontal" | "vertical" | null;
+		unoOwnsGesture: boolean;
+	}
+
 	export class BrowserPointerInputSource {
 
 		private static _exports: any;
@@ -57,6 +80,9 @@
 		private _bootTime: Number;
 		// Cached reference to #uno-native-element-host. Refreshed if detached/replaced.
 		private _nativeElementHost: HTMLElement | null = null;
+		private _nativeScrollGesture: NativeScrollGesture | null = null;
+		private _nativeScrollInertiaFrame: number | null = null;
+		private _nativeScrollInertiaSession = 0;
 
 		private constructor(manageSource: any) {
 			this._bootTime = Date.now() - performance.now();
@@ -75,7 +101,7 @@
 			element.addEventListener("pointerup", this.onPointerEventReceived.bind(this), { capture: true });
 			//element.addEventListener("lostpointercapture", this.onPointerEventReceived.bind(this), { capture: true });
 			element.addEventListener("pointercancel", this.onPointerEventReceived.bind(this), { capture: true });
-			element.addEventListener("pointermove", this.onPointerEventReceived.bind(this), { capture: true });
+			element.addEventListener("pointermove", this.onPointerEventReceived.bind(this), { capture: true, passive: false });
 			element.addEventListener("wheel", this.onPointerEventReceived.bind(this), { capture: true, passive: false });
 		}
 
@@ -130,7 +156,269 @@
 			return false;
 		}
 
-		private onPointerEventReceived(evt: PointerEvent): void {
+		private getNativeInputHost(eventTarget: EventTarget | null): HTMLElement | null {
+			let currentNode = eventTarget as Node | null;
+
+			while (currentNode !== null) {
+				if (currentNode instanceof HTMLElement && currentNode.dataset.unoNativeInputPolicy !== undefined) {
+					return currentNode;
+				}
+
+				const parent = currentNode.parentNode;
+				if (parent) {
+					currentNode = parent;
+					continue;
+				}
+
+				const root = currentNode.getRootNode();
+				if (root instanceof ShadowRoot && root.host) {
+					currentNode = root.host;
+					continue;
+				}
+
+				break;
+			}
+
+			return null;
+		}
+
+		private getInputPolicy(root: HTMLElement): NativeElementInputPolicy {
+			const value = Number(root.dataset.unoNativeInputPolicy);
+			return value === NativeElementInputPolicy.UnoOnly || value === NativeElementInputPolicy.Negotiated
+				? value
+				: NativeElementInputPolicy.NativeOnly;
+		}
+
+		private findScrollableElement(target: EventTarget | null, root: HTMLElement): HTMLElement | null {
+			let current = target instanceof HTMLElement ? target : null;
+			while (current !== null) {
+				if (current instanceof HTMLIFrameElement) {
+					return null;
+				}
+
+				const style = window.getComputedStyle(current);
+				if ((style.overflowX === "auto" || style.overflowX === "scroll" || style.overflowY === "auto" || style.overflowY === "scroll")
+					&& (current.scrollWidth > current.clientWidth || current.scrollHeight > current.clientHeight)) {
+					return current;
+				}
+
+				if (current === root) {
+					break;
+				}
+
+				current = current.parentElement;
+			}
+
+			return null;
+		}
+
+		private applyNativeScrollDelta(gesture: NativeScrollGesture, horizontalDelta: number, verticalDelta: number): boolean {
+			if (gesture.primaryAxis === "horizontal") {
+				verticalDelta = 0;
+			} else if (gesture.primaryAxis === "vertical") {
+				horizontalDelta = 0;
+			}
+
+			let remainingHorizontalDelta = horizontalDelta;
+			let remainingVerticalDelta = verticalDelta;
+
+			if (!gesture.unoOwnsGesture && (gesture.policy === NativeElementInputPolicy.UnoOnly || gesture.scrollTarget === null)) {
+				gesture.unoOwnsGesture = true;
+			}
+
+			if (!gesture.unoOwnsGesture && gesture.policy === NativeElementInputPolicy.Negotiated && gesture.scrollTarget !== null) {
+				const initialScrollLeft = gesture.scrollTarget.scrollLeft;
+				const initialScrollTop = gesture.scrollTarget.scrollTop;
+				const maximumScrollLeft = Math.max(gesture.scrollTarget.scrollWidth - gesture.scrollTarget.clientWidth, 0);
+				const maximumScrollTop = Math.max(gesture.scrollTarget.scrollHeight - gesture.scrollTarget.clientHeight, 0);
+				const requestedScrollLeft = initialScrollLeft + horizontalDelta;
+				const requestedScrollTop = initialScrollTop + verticalDelta;
+				const nextScrollLeft = Math.min(Math.max(requestedScrollLeft, 0), maximumScrollLeft);
+				const nextScrollTop = Math.min(Math.max(requestedScrollTop, 0), maximumScrollTop);
+
+				gesture.scrollTarget.scrollLeft = nextScrollLeft;
+				gesture.scrollTarget.scrollTop = nextScrollTop;
+
+				// Do not use the observed scroll offset to calculate residual input: browsers may
+				// round it. That would incorrectly hand a fractional drag to Uno before the
+				// native scroller reaches an actual boundary.
+				remainingHorizontalDelta = requestedScrollLeft - nextScrollLeft;
+				remainingVerticalDelta = requestedScrollTop - nextScrollTop;
+
+				if (Math.abs(remainingHorizontalDelta) > 0.01 || Math.abs(remainingVerticalDelta) > 0.01) {
+					gesture.unoOwnsGesture = true;
+				}
+			}
+
+			if (gesture.unoOwnsGesture || gesture.policy === NativeElementInputPolicy.UnoOnly) {
+				return BrowserPointerInputSource._exports.OnNativeScrollDelta(
+					this._source,
+					gesture.root.id,
+					remainingHorizontalDelta,
+					remainingVerticalDelta) !== 0;
+			}
+
+			return remainingHorizontalDelta !== horizontalDelta || remainingVerticalDelta !== verticalDelta;
+		}
+
+		private cancelNativeScrollInertia(): void {
+			this._nativeScrollInertiaSession++;
+			if (this._nativeScrollInertiaFrame !== null) {
+				cancelAnimationFrame(this._nativeScrollInertiaFrame);
+				this._nativeScrollInertiaFrame = null;
+			}
+		}
+
+		private startNativeScrollInertia(gesture: NativeScrollGesture): void {
+			const minimumVelocity = 0.01;
+			if (Math.abs(gesture.velocityX) < minimumVelocity && Math.abs(gesture.velocityY) < minimumVelocity) {
+				return;
+			}
+
+			this.cancelNativeScrollInertia();
+			const session = this._nativeScrollInertiaSession;
+			let lastTimestamp = performance.now();
+			const step = (timestamp: number) => {
+				if (session !== this._nativeScrollInertiaSession) {
+					return;
+				}
+
+				const elapsed = Math.min(timestamp - lastTimestamp, 64);
+				lastTimestamp = timestamp;
+				gesture.velocityX *= Math.pow(0.95, elapsed / (1000 / 60));
+				gesture.velocityY *= Math.pow(0.95, elapsed / (1000 / 60));
+
+				if (Math.abs(gesture.velocityX) < minimumVelocity && Math.abs(gesture.velocityY) < minimumVelocity) {
+					this._nativeScrollInertiaFrame = null;
+					return;
+				}
+
+				if (this.applyNativeScrollDelta(gesture, gesture.velocityX * elapsed, gesture.velocityY * elapsed)) {
+					this._nativeScrollInertiaFrame = requestAnimationFrame(step);
+				} else {
+					this._nativeScrollInertiaFrame = null;
+				}
+			};
+
+			this._nativeScrollInertiaFrame = requestAnimationFrame(step);
+		}
+
+		private tryHandleNegotiatedNativeInput(evt: PointerEvent | WheelEvent): boolean {
+			const root = this.getNativeInputHost(evt.target);
+			if (root === null) {
+				return false;
+			}
+
+			// Pointer events do not cross an iframe boundary. Keep the embedded document native-only
+			// until it explicitly registers a bridge capable of reporting its scroll residual.
+			if (evt.target instanceof HTMLIFrameElement) {
+				return false;
+			}
+
+			const policy = this.getInputPolicy(root);
+			if (policy === NativeElementInputPolicy.NativeOnly) {
+				return false;
+			}
+
+			if (evt instanceof WheelEvent) {
+				const gesture: NativeScrollGesture = {
+					pointerId: 0,
+					root,
+					policy,
+					scrollTarget: this.findScrollableElement(evt.target, root),
+					startX: evt.clientX,
+					startY: evt.clientY,
+					lastX: evt.clientX,
+					lastY: evt.clientY,
+					lastTimestamp: evt.timeStamp,
+					velocityX: 0,
+					velocityY: 0,
+					started: true,
+					primaryAxis: Math.abs(evt.deltaX) > Math.abs(evt.deltaY) ? "horizontal" : "vertical",
+					unoOwnsGesture: policy === NativeElementInputPolicy.UnoOnly,
+				};
+
+				const didScroll = this.applyNativeScrollDelta(gesture, evt.deltaX, evt.deltaY);
+				if (didScroll) {
+					evt.preventDefault();
+				}
+				return true;
+			}
+
+			if (evt.pointerType !== "touch" && evt.pointerType !== "pen") {
+				return false;
+			}
+
+			if (evt.type === "pointerdown") {
+				this.cancelNativeScrollInertia();
+				this._nativeScrollGesture = {
+					pointerId: evt.pointerId,
+					root,
+					policy,
+					scrollTarget: this.findScrollableElement(evt.target, root),
+					startX: evt.clientX,
+					startY: evt.clientY,
+					lastX: evt.clientX,
+					lastY: evt.clientY,
+					lastTimestamp: evt.timeStamp,
+					velocityX: 0,
+					velocityY: 0,
+					started: false,
+					primaryAxis: null,
+					unoOwnsGesture: policy === NativeElementInputPolicy.UnoOnly,
+				};
+				return true;
+			}
+
+			const gesture = this._nativeScrollGesture;
+			if (gesture === null || gesture.pointerId !== evt.pointerId) {
+				return true;
+			}
+
+			if (evt.type === "pointercancel") {
+				this._nativeScrollGesture = null;
+				return true;
+			}
+
+			if (evt.type === "pointermove") {
+				let horizontalDelta = gesture.lastX - evt.clientX;
+				let verticalDelta = gesture.lastY - evt.clientY;
+				if (!gesture.started) {
+					if (Math.hypot(evt.clientX - gesture.startX, evt.clientY - gesture.startY) < 8) {
+						gesture.lastX = evt.clientX;
+						gesture.lastY = evt.clientY;
+						gesture.lastTimestamp = evt.timeStamp;
+						return true;
+					}
+
+					gesture.started = true;
+					horizontalDelta = gesture.startX - evt.clientX;
+					verticalDelta = gesture.startY - evt.clientY;
+					gesture.primaryAxis = Math.abs(horizontalDelta) > Math.abs(verticalDelta) ? "horizontal" : "vertical";
+				}
+
+				const elapsed = Math.max(evt.timeStamp - gesture.lastTimestamp, 1);
+				gesture.velocityX = gesture.velocityX * 0.7 + horizontalDelta / elapsed * 0.3;
+				gesture.velocityY = gesture.velocityY * 0.7 + verticalDelta / elapsed * 0.3;
+				gesture.lastX = evt.clientX;
+				gesture.lastY = evt.clientY;
+				gesture.lastTimestamp = evt.timeStamp;
+				this.applyNativeScrollDelta(gesture, horizontalDelta, verticalDelta);
+				evt.preventDefault();
+				return true;
+			}
+
+			if (evt.type === "pointerup") {
+				this._nativeScrollGesture = null;
+				if (gesture.started) {
+					this.startNativeScrollInertia(gesture);
+				}
+			}
+
+			return true;
+		}
+
+		private onPointerEventReceived(evt: PointerEvent | WheelEvent): void {
 			let id = (evt.target as HTMLElement)?.id;
 			if (id === "uno-enable-accessibility") {
 				// We have a div to enable accessibility (see enableA11y in WebAssemblyWindowWrapper).
@@ -139,6 +427,10 @@
 			}
 
 			if (this.isEventFromNativeElementHost(evt.target)) {
+				if (this.tryHandleNegotiatedNativeInput(evt)) {
+					return;
+				}
+
 				// Events from the native host are handled by the native control directly.
 				// We don't want to interfere with them.
 				return;

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -207,8 +207,10 @@ namespace Uno.UI.Runtime.Skia {
 
 		// Mirrors the exclusions in uno.css: these keep their native touch-action, so the browser still pans
 		// and selects in them. A gesture anywhere inside one stays entirely native - negotiating it here as
-		// well would apply the browser's own panning a second time.
-		private static readonly nativeInputSelector = "input, textarea, select, [contenteditable]";
+		// well would apply the browser's own panning a second time. Iframes are in the list because pointer
+		// events do not cross the frame boundary: the embedded document stays native-only until it explicitly
+		// registers a bridge capable of reporting its scroll residual.
+		private static readonly nativeInputSelector = "input, textarea, select, iframe, [contenteditable]";
 
 		private findScrollableElement(target: EventTarget | null, root: HTMLElement): HTMLElement | null {
 			let current = target instanceof HTMLElement ? target : null;
@@ -390,12 +392,6 @@ namespace Uno.UI.Runtime.Skia {
 			}
 
 			const root = host.root;
-
-			// Pointer events do not cross an iframe boundary. Keep the embedded document native-only
-			// until it explicitly registers a bridge capable of reporting its scroll residual.
-			if (evt.target instanceof HTMLIFrameElement) {
-				return false;
-			}
 
 			if (evt.target instanceof Element && evt.target.closest(BrowserPointerInputSource.nativeInputSelector) !== null) {
 				return false;

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -235,7 +235,7 @@ namespace Uno.UI.Runtime.Skia {
 			return null;
 		}
 
-		private applyNativeScrollDelta(gesture: NativeScrollGesture, horizontalDelta: number, verticalDelta: number, isIntermediate: boolean = true): boolean {
+		private applyNativeScrollDelta(gesture: NativeScrollGesture, horizontalDelta: number, verticalDelta: number, isIntermediate: boolean = true, isInertial: boolean = false): boolean {
 			if (gesture.primaryAxis === "horizontal") {
 				verticalDelta = 0;
 			} else if (gesture.primaryAxis === "vertical") {
@@ -286,7 +286,8 @@ namespace Uno.UI.Runtime.Skia {
 					gesture.unoElementId,
 					remainingHorizontalDelta,
 					remainingVerticalDelta,
-					isIntermediate) !== 0;
+					isIntermediate,
+					isInertial) !== 0;
 			}
 
 			return remainingHorizontalDelta !== horizontalDelta || remainingVerticalDelta !== verticalDelta;
@@ -371,7 +372,9 @@ namespace Uno.UI.Runtime.Skia {
 				}
 
 				try {
-					if (this.applyNativeScrollDelta(gesture, gesture.velocityX * elapsed, gesture.velocityY * elapsed)) {
+					// isInertial lets the managed side honor ScrollViewer.IsScrollInertiaEnabled: a delta refused
+					// there stops the fling, while the native scrollTarget keeps its own momentum until then.
+					if (this.applyNativeScrollDelta(gesture, gesture.velocityX * elapsed, gesture.velocityY * elapsed, /* isIntermediate */ true, /* isInertial */ true)) {
 						this._nativeScrollInertiaFrame = requestAnimationFrame(step);
 					} else {
 						stop();

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -37,6 +37,7 @@ namespace Uno.UI.Runtime.Skia {
 	interface NativeScrollGesture {
 		pointerId: number;
 		root: HTMLElement;
+		unoElementId: number;
 		scrollTarget: HTMLElement | null;
 		startX: number;
 		startY: number;
@@ -53,6 +54,7 @@ namespace Uno.UI.Runtime.Skia {
 	export class BrowserPointerInputSource {
 
 		private static _exports: any;
+		private static _instance: BrowserPointerInputSource | null = null;
 		
 		public static async initialize(inputSource: any) {
 			if (BrowserPointerInputSource._exports == undefined) {
@@ -81,10 +83,12 @@ namespace Uno.UI.Runtime.Skia {
 		private _nativeScrollGesture: NativeScrollGesture | null = null;
 		private _nativeScrollInertiaFrame: number | null = null;
 		private _nativeScrollInertiaSession = 0;
+		private _nativeScrollInertiaGesture: NativeScrollGesture | null = null;
 
 		private constructor(manageSource: any) {
 			this._bootTime = Date.now() - performance.now();
 			this._source = manageSource;
+			BrowserPointerInputSource._instance = this;
 
 			BrowserPointerInputSource._exports.OnInitialized(manageSource, this._bootTime);
 			this.subscribePointerEvents(); // Subscribe only after the managed initialization is done
@@ -154,12 +158,33 @@ namespace Uno.UI.Runtime.Skia {
 			return false;
 		}
 
-		private getNativeInputHost(eventTarget: EventTarget | null): HTMLElement | null {
+		/**
+		 * Returns the hosted element the event originated from - the direct child of #uno-native-element-host -
+		 * together with the policy managed code registered for it. Resolution is by position in the tree and by
+		 * element identity, never by reading an attribute off the event target: hosted HTML can carry any
+		 * attribute it likes and must not be able to opt itself into a policy the app did not set.
+		 */
+		private getNativeInputHost(eventTarget: EventTarget | null): { root: HTMLElement, policy: NativeElementInputPolicy, unoElementId: number } | null {
+			const hostElement = this.getNativeElementHostCached();
+			if (hostElement === null) {
+				return null;
+			}
+
 			let currentNode = eventTarget as Node | null;
 
 			while (currentNode !== null) {
-				if (currentNode instanceof HTMLElement && currentNode.dataset.unoNativeInputPolicy !== undefined) {
-					return currentNode;
+				if (currentNode instanceof HTMLElement && currentNode.parentNode === hostElement) {
+					const registration = Uno.UI.NativeElementHosting.BrowserHtmlElement.getInputPolicy(currentNode);
+
+					return registration === null
+						? null
+						: {
+							root: currentNode,
+							policy: registration.policy === NativeElementInputPolicy.Negotiated
+								? NativeElementInputPolicy.Negotiated
+								: NativeElementInputPolicy.NativeOnly,
+							unoElementId: registration.unoElementId,
+						};
 				}
 
 				const parent = currentNode.parentNode;
@@ -178,12 +203,6 @@ namespace Uno.UI.Runtime.Skia {
 			}
 
 			return null;
-		}
-
-		private getInputPolicy(root: HTMLElement): NativeElementInputPolicy {
-			return Number(root.dataset.unoNativeInputPolicy) === NativeElementInputPolicy.Negotiated
-				? NativeElementInputPolicy.Negotiated
-				: NativeElementInputPolicy.NativeOnly;
 		}
 
 		// Mirrors the exclusions in uno.css: these keep their native touch-action, so the browser still pans
@@ -214,7 +233,7 @@ namespace Uno.UI.Runtime.Skia {
 			return null;
 		}
 
-		private applyNativeScrollDelta(gesture: NativeScrollGesture, horizontalDelta: number, verticalDelta: number): boolean {
+		private applyNativeScrollDelta(gesture: NativeScrollGesture, horizontalDelta: number, verticalDelta: number, isIntermediate: boolean = true): boolean {
 			if (gesture.primaryAxis === "horizontal") {
 				verticalDelta = 0;
 			} else if (gesture.primaryAxis === "vertical") {
@@ -232,11 +251,18 @@ namespace Uno.UI.Runtime.Skia {
 			if (!gesture.unoOwnsGesture && gesture.scrollTarget !== null) {
 				const initialScrollLeft = gesture.scrollTarget.scrollLeft;
 				const initialScrollTop = gesture.scrollTarget.scrollTop;
-				const maximumScrollLeft = Math.max(gesture.scrollTarget.scrollWidth - gesture.scrollTarget.clientWidth, 0);
+				const scrollRange = Math.max(gesture.scrollTarget.scrollWidth - gesture.scrollTarget.clientWidth, 0);
 				const maximumScrollTop = Math.max(gesture.scrollTarget.scrollHeight - gesture.scrollTarget.clientHeight, 0);
+
+				// In a right-to-left scroller scrollLeft runs from -scrollRange (fully scrolled) to 0, so the
+				// clamping bounds - not just the sign of the delta - depend on the direction.
+				const isRightToLeft = window.getComputedStyle(gesture.scrollTarget).direction === "rtl";
+				const minimumScrollLeft = isRightToLeft ? -scrollRange : 0;
+				const maximumScrollLeft = isRightToLeft ? 0 : scrollRange;
+
 				const requestedScrollLeft = initialScrollLeft + horizontalDelta;
 				const requestedScrollTop = initialScrollTop + verticalDelta;
-				const nextScrollLeft = Math.min(Math.max(requestedScrollLeft, 0), maximumScrollLeft);
+				const nextScrollLeft = Math.min(Math.max(requestedScrollLeft, minimumScrollLeft), maximumScrollLeft);
 				const nextScrollTop = Math.min(Math.max(requestedScrollTop, 0), maximumScrollTop);
 
 				gesture.scrollTarget.scrollLeft = nextScrollLeft;
@@ -255,10 +281,10 @@ namespace Uno.UI.Runtime.Skia {
 
 			if (gesture.unoOwnsGesture) {
 				return BrowserPointerInputSource._exports.OnNativeScrollDelta(
-					this._source,
-					gesture.root.id,
+					gesture.unoElementId,
 					remainingHorizontalDelta,
-					remainingVerticalDelta) !== 0;
+					remainingVerticalDelta,
+					isIntermediate) !== 0;
 			}
 
 			return remainingHorizontalDelta !== horizontalDelta || remainingVerticalDelta !== verticalDelta;
@@ -269,6 +295,37 @@ namespace Uno.UI.Runtime.Skia {
 			if (this._nativeScrollInertiaFrame !== null) {
 				cancelAnimationFrame(this._nativeScrollInertiaFrame);
 				this._nativeScrollInertiaFrame = null;
+
+				if (this._nativeScrollInertiaGesture !== null) {
+					this.completeNativeScroll(this._nativeScrollInertiaGesture);
+				}
+			}
+
+			this._nativeScrollInertiaGesture = null;
+		}
+
+		/** Public entry point so a detached element cannot leave a fling running against it. */
+		public static cancelNativeScrollInertiaFor(elementId: string): void {
+			const instance = BrowserPointerInputSource._instance;
+			if (instance !== null && instance._nativeScrollInertiaGesture?.root.id === elementId) {
+				instance.cancelNativeScrollInertia();
+			}
+		}
+
+		/**
+		 * Closes a chained scroll sequence so the ScrollViewers see a final non-intermediate view change.
+		 * Every delta during a drag or fling is reported as intermediate; without this, consumers that treat
+		 * IsIntermediate=false as "the scroll ended" would never observe the end.
+		 */
+		private completeNativeScroll(gesture: NativeScrollGesture): void {
+			if (!gesture.unoOwnsGesture) {
+				return;
+			}
+
+			try {
+				BrowserPointerInputSource._exports.OnNativeScrollCompleted(gesture.unoElementId);
+			} catch (e) {
+				console.warn(`Failed to complete negotiated native scroll: ${e}`);
 			}
 		}
 
@@ -280,9 +337,24 @@ namespace Uno.UI.Runtime.Skia {
 
 			this.cancelNativeScrollInertia();
 			const session = this._nativeScrollInertiaSession;
+			this._nativeScrollInertiaGesture = gesture;
 			let lastTimestamp = performance.now();
+
+			const stop = () => {
+				this._nativeScrollInertiaFrame = null;
+				this._nativeScrollInertiaGesture = null;
+				this.completeNativeScroll(gesture);
+			};
+
 			const step = (timestamp: number) => {
 				if (session !== this._nativeScrollInertiaSession) {
+					return;
+				}
+
+				// The element can be removed or the app torn down mid-fling; keep flinging only what is
+				// still on screen.
+				if (!gesture.root.isConnected) {
+					stop();
 					return;
 				}
 
@@ -292,14 +364,19 @@ namespace Uno.UI.Runtime.Skia {
 				gesture.velocityY *= Math.pow(0.95, elapsed / (1000 / 60));
 
 				if (Math.abs(gesture.velocityX) < minimumVelocity && Math.abs(gesture.velocityY) < minimumVelocity) {
-					this._nativeScrollInertiaFrame = null;
+					stop();
 					return;
 				}
 
-				if (this.applyNativeScrollDelta(gesture, gesture.velocityX * elapsed, gesture.velocityY * elapsed)) {
-					this._nativeScrollInertiaFrame = requestAnimationFrame(step);
-				} else {
-					this._nativeScrollInertiaFrame = null;
+				try {
+					if (this.applyNativeScrollDelta(gesture, gesture.velocityX * elapsed, gesture.velocityY * elapsed)) {
+						this._nativeScrollInertiaFrame = requestAnimationFrame(step);
+					} else {
+						stop();
+					}
+				} catch (e) {
+					console.warn(`Failed to apply negotiated native scroll inertia: ${e}`);
+					stop();
 				}
 			};
 
@@ -307,18 +384,16 @@ namespace Uno.UI.Runtime.Skia {
 		}
 
 		private tryHandleNegotiatedNativeInput(evt: PointerEvent | WheelEvent): boolean {
-			const root = this.getNativeInputHost(evt.target);
-			if (root === null) {
+			const host = this.getNativeInputHost(evt.target);
+			if (host === null || host.policy === NativeElementInputPolicy.NativeOnly) {
 				return false;
 			}
+
+			const root = host.root;
 
 			// Pointer events do not cross an iframe boundary. Keep the embedded document native-only
 			// until it explicitly registers a bridge capable of reporting its scroll residual.
 			if (evt.target instanceof HTMLIFrameElement) {
-				return false;
-			}
-
-			if (this.getInputPolicy(root) === NativeElementInputPolicy.NativeOnly) {
 				return false;
 			}
 
@@ -327,9 +402,19 @@ namespace Uno.UI.Runtime.Skia {
 			}
 
 			if (evt instanceof WheelEvent) {
+				// Ctrl+wheel is browser zoom, not scroll - leave it to the normal pipeline, which already
+				// carves it out when BrowserInputHelper.isBrowserZoomEnabled.
+				if (evt.ctrlKey && BrowserInputHelper.isBrowserZoomEnabled) {
+					return false;
+				}
+
+				// A wheel burst is not a touch gesture, but it still supersedes a fling that is still running.
+				this.cancelNativeScrollInertia();
+
 				const gesture: NativeScrollGesture = {
 					pointerId: 0,
 					root,
+					unoElementId: host.unoElementId,
 					scrollTarget: this.findScrollableElement(evt.target, root),
 					startX: evt.clientX,
 					startY: evt.clientY,
@@ -355,10 +440,20 @@ namespace Uno.UI.Runtime.Skia {
 			}
 
 			if (evt.type === "pointerdown") {
+				if (this._nativeScrollGesture !== null && this._nativeScrollGesture.pointerId !== evt.pointerId) {
+					// A second finger means a multi-touch gesture (pinch/zoom) which this negotiation does not
+					// arbitrate. Drop our single-pointer gesture and leave the whole interaction to the browser,
+					// which still has pinch-zoom available (see the touch-action rule in uno.css).
+					this.completeNativeScroll(this._nativeScrollGesture);
+					this._nativeScrollGesture = null;
+					return false;
+				}
+
 				this.cancelNativeScrollInertia();
 				this._nativeScrollGesture = {
 					pointerId: evt.pointerId,
 					root,
+					unoElementId: host.unoElementId,
 					scrollTarget: this.findScrollableElement(evt.target, root),
 					startX: evt.clientX,
 					startY: evt.clientY,
@@ -381,6 +476,7 @@ namespace Uno.UI.Runtime.Skia {
 
 			if (evt.type === "pointercancel") {
 				this._nativeScrollGesture = null;
+				this.completeNativeScroll(gesture);
 				return true;
 			}
 
@@ -414,8 +510,16 @@ namespace Uno.UI.Runtime.Skia {
 
 			if (evt.type === "pointerup") {
 				this._nativeScrollGesture = null;
+
+				// startNativeScrollInertia reports the completion itself once the fling decays, so only close
+				// the sequence here when no fling is taking over.
 				if (gesture.started) {
 					this.startNativeScrollInertia(gesture);
+					if (this._nativeScrollInertiaGesture === null) {
+						this.completeNativeScroll(gesture);
+					}
+				} else {
+					this.completeNativeScroll(gesture);
 				}
 			}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -1,4 +1,4 @@
-﻿namespace Uno.UI.Runtime.Skia {
+namespace Uno.UI.Runtime.Skia {
 	//import PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 
 	export enum HtmlPointerEvent {
@@ -31,14 +31,12 @@
 
 	export enum NativeElementInputPolicy {
 		NativeOnly = 0,
-		UnoOnly = 1,
-		Negotiated = 2,
+		Negotiated = 1,
 	}
 
 	interface NativeScrollGesture {
 		pointerId: number;
 		root: HTMLElement;
-		policy: NativeElementInputPolicy;
 		scrollTarget: HTMLElement | null;
 		startX: number;
 		startY: number;
@@ -183,11 +181,15 @@
 		}
 
 		private getInputPolicy(root: HTMLElement): NativeElementInputPolicy {
-			const value = Number(root.dataset.unoNativeInputPolicy);
-			return value === NativeElementInputPolicy.UnoOnly || value === NativeElementInputPolicy.Negotiated
-				? value
+			return Number(root.dataset.unoNativeInputPolicy) === NativeElementInputPolicy.Negotiated
+				? NativeElementInputPolicy.Negotiated
 				: NativeElementInputPolicy.NativeOnly;
 		}
+
+		// Mirrors the exclusions in uno.css: these keep their native touch-action, so the browser still pans
+		// and selects in them. A gesture anywhere inside one stays entirely native - negotiating it here as
+		// well would apply the browser's own panning a second time.
+		private static readonly nativeInputSelector = "input, textarea, select, [contenteditable]";
 
 		private findScrollableElement(target: EventTarget | null, root: HTMLElement): HTMLElement | null {
 			let current = target instanceof HTMLElement ? target : null;
@@ -222,11 +224,12 @@
 			let remainingHorizontalDelta = horizontalDelta;
 			let remainingVerticalDelta = verticalDelta;
 
-			if (!gesture.unoOwnsGesture && (gesture.policy === NativeElementInputPolicy.UnoOnly || gesture.scrollTarget === null)) {
+			// Non-scrollable native content has nothing to consume the gesture, so Uno takes it immediately.
+			if (!gesture.unoOwnsGesture && gesture.scrollTarget === null) {
 				gesture.unoOwnsGesture = true;
 			}
 
-			if (!gesture.unoOwnsGesture && gesture.policy === NativeElementInputPolicy.Negotiated && gesture.scrollTarget !== null) {
+			if (!gesture.unoOwnsGesture && gesture.scrollTarget !== null) {
 				const initialScrollLeft = gesture.scrollTarget.scrollLeft;
 				const initialScrollTop = gesture.scrollTarget.scrollTop;
 				const maximumScrollLeft = Math.max(gesture.scrollTarget.scrollWidth - gesture.scrollTarget.clientWidth, 0);
@@ -250,7 +253,7 @@
 				}
 			}
 
-			if (gesture.unoOwnsGesture || gesture.policy === NativeElementInputPolicy.UnoOnly) {
+			if (gesture.unoOwnsGesture) {
 				return BrowserPointerInputSource._exports.OnNativeScrollDelta(
 					this._source,
 					gesture.root.id,
@@ -315,8 +318,11 @@
 				return false;
 			}
 
-			const policy = this.getInputPolicy(root);
-			if (policy === NativeElementInputPolicy.NativeOnly) {
+			if (this.getInputPolicy(root) === NativeElementInputPolicy.NativeOnly) {
+				return false;
+			}
+
+			if (evt.target instanceof Element && evt.target.closest(BrowserPointerInputSource.nativeInputSelector) !== null) {
 				return false;
 			}
 
@@ -324,7 +330,6 @@
 				const gesture: NativeScrollGesture = {
 					pointerId: 0,
 					root,
-					policy,
 					scrollTarget: this.findScrollableElement(evt.target, root),
 					startX: evt.clientX,
 					startY: evt.clientY,
@@ -335,7 +340,7 @@
 					velocityY: 0,
 					started: true,
 					primaryAxis: Math.abs(evt.deltaX) > Math.abs(evt.deltaY) ? "horizontal" : "vertical",
-					unoOwnsGesture: policy === NativeElementInputPolicy.UnoOnly,
+					unoOwnsGesture: false,
 				};
 
 				const didScroll = this.applyNativeScrollDelta(gesture, evt.deltaX, evt.deltaY);
@@ -354,7 +359,6 @@
 				this._nativeScrollGesture = {
 					pointerId: evt.pointerId,
 					root,
-					policy,
 					scrollTarget: this.findScrollableElement(evt.target, root),
 					startX: evt.clientX,
 					startY: evt.clientY,
@@ -365,7 +369,7 @@
 					velocityY: 0,
 					started: false,
 					primaryAxis: null,
-					unoOwnsGesture: policy === NativeElementInputPolicy.UnoOnly,
+					unoOwnsGesture: false,
 				};
 				return true;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_BrowserHtmlElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_BrowserHtmlElement.cs
@@ -174,6 +174,48 @@ public class Given_BrowserHtmlElement
 		Assert.AreEqual("none", SUT.ExecuteJavascript($"return element.style.borderStyle"));
 	}
 
+#if __SKIA__
+	[TestMethod]
+	public async Task When_New_Host_Attaches_Before_Old_Host_Detaches()
+	{
+		if (!OperatingSystem.IsBrowser())
+		{
+			Assert.Inconclusive("This test is only supported on the browser.");
+		}
+
+		// When an element is recycled, the new host can attach before the old one detaches. The old
+		// host's detach must then leave the element alone: hiding it would blank the new host.
+		var SUT = BrowserHtmlElement.CreateHtmlElement("div");
+		var oldHost = new ContentControl { Width = 100, Height = 100, Content = SUT };
+		var newHost = new ContentControl { Width = 100, Height = 100, Content = "placeholder" };
+		var root = new StackPanel();
+		root.Children.Add(oldHost);
+		root.Children.Add(newHost);
+
+		try
+		{
+			WindowHelper.WindowContent = root;
+			await WindowHelper.WaitForLoaded(oldHost);
+			await WindowHelper.WaitForLoaded(newHost);
+			Assert.AreEqual("false", SUT.ExecuteJavascript("return element.hidden.toString()"));
+
+			newHost.Content = SUT;
+			await WindowHelper.WaitForIdle();
+			oldHost.Content = null;
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(
+				"false",
+				SUT.ExecuteJavascript("return element.hidden.toString()"),
+				"The old host's detach must not hide an element the new host already attached.");
+		}
+		finally
+		{
+			WindowHelper.WindowContent = null;
+		}
+	}
+#endif
+
 	[TestMethod]
 	public async Task Given_HtmlEvent()
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
@@ -1,0 +1,176 @@
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
+
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ScrollViewerTests;
+
+/// <summary>
+/// Covers <see cref="ScrollViewer.ChainScrollFromDescendant"/>, the entry point used to hand a scroll delta
+/// that Uno's pointer pipeline never saw (today: a native HTML element on Skia WebAssembly which exhausted
+/// its own scrolling) to the ScrollViewer ancestry of the element it originated from.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_ScrollViewer_ScrollChaining
+{
+#if HAS_UNO && UNO_HAS_MANAGED_SCROLL_PRESENTER
+	private const double ViewportSize = 200;
+	private const double InnerContentHeight = 500;
+	private const double OuterContentHeight = 2000;
+
+	private static (ScrollViewer outer, ScrollViewer inner, Border origin) BuildNested()
+	{
+		var origin = new Border
+		{
+			Height = InnerContentHeight,
+			Width = 100,
+			Background = new SolidColorBrush(Colors.LightCoral),
+		};
+
+		var inner = new ScrollViewer
+		{
+			Height = ViewportSize,
+			Width = 150,
+			Content = origin,
+		};
+
+		var outerContent = new StackPanel();
+		outerContent.Children.Add(inner);
+		outerContent.Children.Add(new Border
+		{
+			Height = OuterContentHeight,
+			Background = new SolidColorBrush(Colors.LightBlue),
+		});
+
+		var outer = new ScrollViewer
+		{
+			Height = ViewportSize,
+			Width = 200,
+			Content = outerContent,
+		};
+
+		return (outer, inner, origin);
+	}
+
+	[TestMethod]
+	public async Task When_Inner_Can_Scroll_Then_Outer_Is_Untouched()
+	{
+		var (outer, inner, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 50);
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01);
+		Assert.AreEqual(50, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(0, outer.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Inner_Reaches_Boundary_Then_Residual_Chains_To_Outer()
+	{
+		var (outer, inner, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		var scrollableHeight = inner.ScrollableHeight;
+		Assert.IsTrue(scrollableHeight > 0, "The inner ScrollViewer must be scrollable for this test to mean anything.");
+
+		// Ask for more than the inner one can possibly consume: it should take its full range and the
+		// leftover should end up on the outer one, in a single call.
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 80);
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01);
+		Assert.AreEqual(scrollableHeight, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(80, outer.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Chaining_Backwards_Then_Residual_Chains_To_Outer()
+	{
+		var (outer, inner, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		ScrollViewer.ChainScrollFromDescendant(origin, 0, inner.ScrollableHeight + 200);
+		Assert.AreEqual(200, outer.VerticalOffset, 0.01);
+
+		// Dragging the other way empties the inner one first, then pulls the outer one back up.
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, -(inner.ScrollableHeight + 150));
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01);
+		Assert.AreEqual(0, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(50, outer.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Inner_Scrolling_Is_Disabled_Then_Outer_Consumes_Everything()
+	{
+		var (outer, inner, origin) = BuildNested();
+		inner.VerticalScrollMode = ScrollMode.Disabled;
+		inner.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
+		await UITestHelper.Load(outer);
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 60);
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(0, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(60, outer.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Nothing_Can_Consume_Then_Delta_Is_Returned_As_Residual()
+	{
+		var (outer, inner, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		// Already at the top, so a backwards drag has nowhere to go on either ScrollViewer.
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, -40);
+
+		Assert.IsFalse(result.DidScroll);
+		Assert.AreEqual(-40, result.RemainingVerticalDelta, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Chained_Past_Boundary_Then_Growing_Extent_Does_Not_Jump()
+	{
+		// Regression guard: chaining used to drive the ancestry through ChangeView, which arms the
+		// ScrollViewer's offset intent with the *requested* offset. Overshooting at a boundary - which a
+		// chained drag or fling does constantly - therefore left an intent parked past the end of the
+		// content, and the next extent growth (virtualization realizing more items, an image loading, ...)
+		// made RecomputeOffsetsFromIntent re-apply it and jump the view away from where the user let go.
+		var origin = new Border { Height = 100, Background = new SolidColorBrush(Colors.LightCoral) };
+		var spacer = new Border { Height = 600, Background = new SolidColorBrush(Colors.LightBlue) };
+		var content = new StackPanel();
+		content.Children.Add(origin);
+		content.Children.Add(spacer);
+
+		var outer = new ScrollViewer { Height = ViewportSize, Width = 200, Content = content };
+		await UITestHelper.Load(outer);
+
+		var scrollableHeight = outer.ScrollableHeight;
+		Assert.IsTrue(scrollableHeight > 0, "The ScrollViewer must be scrollable for this test to mean anything.");
+
+		// Overshoot the bottom boundary by a wide margin, as a fling does.
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 300);
+		Assert.AreEqual(scrollableHeight, outer.VerticalOffset, 1);
+		Assert.AreEqual(300, result.RemainingVerticalDelta, 1, "The unconsumed overshoot must be reported back as residual.");
+
+		// Grow the content so the scrollable range now covers the offset that was overshot to.
+		spacer.Height = 1000;
+		outer.UpdateLayout();
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(outer.ScrollableHeight > scrollableHeight + 300, "The extent must grow past the overshoot for this test to mean anything.");
+		Assert.AreEqual(scrollableHeight, outer.VerticalOffset, 1, "The view must stay where the chained scroll left it, not jump to the overshot offset.");
+	}
+
+#endif
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
@@ -203,6 +203,53 @@ public class Given_ScrollViewer_ScrollChaining
 	}
 
 	[TestMethod]
+	public async Task When_Inertia_Is_Disabled_Then_Inertial_Delta_Is_Refused()
+	{
+		// IsScrollInertiaEnabled=false must stop the fling at that ScrollViewer, like
+		// IDirectManipulationHandler.OnInertiaStarting does for the managed recognizer: it neither
+		// scrolls nor lets the fling continue to the outer one.
+		var (outer, inner, origin) = BuildNested();
+		inner.IsScrollInertiaEnabled = false;
+		await UITestHelper.Load(outer);
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 50, isIntermediate: true, isInertial: true);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(result.DidScroll);
+		Assert.AreEqual(0, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(0, outer.VerticalOffset, 0.01, "The fling must not continue past the ScrollViewer that opted out of inertia.");
+		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01, "The opted-out ScrollViewer absorbs the inertial delta.");
+	}
+
+	[TestMethod]
+	public async Task When_Inertia_Is_Disabled_Then_Drag_Still_Scrolls()
+	{
+		// The opt-out only concerns the inertial phase; deltas from the finger itself are unaffected.
+		var (outer, inner, origin) = BuildNested();
+		inner.IsScrollInertiaEnabled = false;
+		await UITestHelper.Load(outer);
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 50, isIntermediate: true, isInertial: false);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(50, inner.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Inertia_Is_Enabled_Then_Inertial_Delta_Scrolls()
+	{
+		var (outer, inner, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 50, isIntermediate: true, isInertial: true);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(50, inner.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
 	public async Task When_Horizontal_Then_Residual_Chains_To_Outer()
 	{
 		var origin = new Border { Width = 500, Height = 100, Background = new SolidColorBrush(Colors.LightCoral) };

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ScrollViewerTests/Given_ScrollViewer_ScrollChaining.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -25,6 +26,9 @@ public class Given_ScrollViewer_ScrollChaining
 	private const double InnerContentHeight = 500;
 	private const double OuterContentHeight = 2000;
 
+	// A chained delta is reported as intermediate, so the presenter commits its own offsets synchronously
+	// while the ScrollViewer's public HorizontalOffset/VerticalOffset are refreshed through RequestUpdate.
+	// Every test therefore awaits idle before reading the ScrollViewer's offsets.
 	private static (ScrollViewer outer, ScrollViewer inner, Border origin) BuildNested()
 	{
 		var origin = new Border
@@ -65,7 +69,8 @@ public class Given_ScrollViewer_ScrollChaining
 		var (outer, inner, origin) = BuildNested();
 		await UITestHelper.Load(outer);
 
-		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 50);
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 50, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 
 		Assert.IsTrue(result.DidScroll);
 		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01);
@@ -84,7 +89,8 @@ public class Given_ScrollViewer_ScrollChaining
 
 		// Ask for more than the inner one can possibly consume: it should take its full range and the
 		// leftover should end up on the outer one, in a single call.
-		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 80);
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 80, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 
 		Assert.IsTrue(result.DidScroll);
 		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01);
@@ -98,11 +104,13 @@ public class Given_ScrollViewer_ScrollChaining
 		var (outer, inner, origin) = BuildNested();
 		await UITestHelper.Load(outer);
 
-		ScrollViewer.ChainScrollFromDescendant(origin, 0, inner.ScrollableHeight + 200);
+		ScrollViewer.ChainScrollFromDescendant(origin, 0, inner.ScrollableHeight + 200, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 		Assert.AreEqual(200, outer.VerticalOffset, 0.01);
 
 		// Dragging the other way empties the inner one first, then pulls the outer one back up.
-		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, -(inner.ScrollableHeight + 150));
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, -(inner.ScrollableHeight + 150), isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 
 		Assert.IsTrue(result.DidScroll);
 		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01);
@@ -118,7 +126,8 @@ public class Given_ScrollViewer_ScrollChaining
 		inner.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
 		await UITestHelper.Load(outer);
 
-		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 60);
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, 60, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 
 		Assert.IsTrue(result.DidScroll);
 		Assert.AreEqual(0, inner.VerticalOffset, 0.01);
@@ -132,7 +141,8 @@ public class Given_ScrollViewer_ScrollChaining
 		await UITestHelper.Load(outer);
 
 		// Already at the top, so a backwards drag has nowhere to go on either ScrollViewer.
-		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, -40);
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, -40, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 
 		Assert.IsFalse(result.DidScroll);
 		Assert.AreEqual(-40, result.RemainingVerticalDelta, 0.01);
@@ -159,7 +169,8 @@ public class Given_ScrollViewer_ScrollChaining
 		Assert.IsTrue(scrollableHeight > 0, "The ScrollViewer must be scrollable for this test to mean anything.");
 
 		// Overshoot the bottom boundary by a wide margin, as a fling does.
-		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 300);
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 300, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
 		Assert.AreEqual(scrollableHeight, outer.VerticalOffset, 1);
 		Assert.AreEqual(300, result.RemainingVerticalDelta, 1, "The unconsumed overshoot must be reported back as residual.");
 
@@ -172,5 +183,114 @@ public class Given_ScrollViewer_ScrollChaining
 		Assert.AreEqual(scrollableHeight, outer.VerticalOffset, 1, "The view must stay where the chained scroll left it, not jump to the overshot offset.");
 	}
 
+
+	[TestMethod]
+	public async Task When_Chaining_Is_Disabled_Then_Residual_Is_Absorbed()
+	{
+		// IsVerticalScrollChainingEnabled=false means this ScrollViewer is the end of the line: it takes what
+		// it can and the rest must not reach its ancestors. FlipView relies on this for the horizontal axis.
+		var (outer, inner, origin) = BuildNested();
+		inner.IsVerticalScrollChainingEnabled = false;
+		await UITestHelper.Load(outer);
+
+		var scrollableHeight = inner.ScrollableHeight;
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, 0, scrollableHeight + 120, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(scrollableHeight, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(0, outer.VerticalOffset, 0.01, "The outer ScrollViewer must not be chained into when the inner one opts out.");
+		Assert.AreEqual(0, result.RemainingVerticalDelta, 0.01, "The opted-out ScrollViewer absorbs the residual.");
+	}
+
+	[TestMethod]
+	public async Task When_Horizontal_Then_Residual_Chains_To_Outer()
+	{
+		var origin = new Border { Width = 500, Height = 100, Background = new SolidColorBrush(Colors.LightCoral) };
+		var inner = new ScrollViewer
+		{
+			Width = ViewportSize,
+			Height = 150,
+			HorizontalScrollMode = ScrollMode.Enabled,
+			HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+			VerticalScrollMode = ScrollMode.Disabled,
+			VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
+			Content = origin,
+		};
+
+		var outerContent = new StackPanel { Orientation = Orientation.Horizontal };
+		outerContent.Children.Add(inner);
+		outerContent.Children.Add(new Border { Width = 2000, Background = new SolidColorBrush(Colors.LightBlue) });
+
+		var outer = new ScrollViewer
+		{
+			Width = ViewportSize,
+			Height = 200,
+			HorizontalScrollMode = ScrollMode.Enabled,
+			HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+			Content = outerContent,
+		};
+
+		await UITestHelper.Load(outer);
+
+		var scrollableWidth = inner.ScrollableWidth;
+		Assert.IsTrue(scrollableWidth > 0, "The inner ScrollViewer must be horizontally scrollable for this test to mean anything.");
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, scrollableWidth + 70, 0, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(result.DidScroll);
+		Assert.AreEqual(scrollableWidth, inner.HorizontalOffset, 0.01);
+		Assert.AreEqual(70, outer.HorizontalOffset, 0.01);
+	}
+
+	[TestMethod]
+	[DataRow(double.NaN, 0d, DisplayName = "NaN horizontal")]
+	[DataRow(0d, double.NaN, DisplayName = "NaN vertical")]
+	[DataRow(double.PositiveInfinity, 0d, DisplayName = "Infinite horizontal")]
+	[DataRow(0d, double.NegativeInfinity, DisplayName = "Infinite vertical")]
+	public async Task When_Delta_Is_Not_Finite_Then_It_Is_Rejected(double horizontalDelta, double verticalDelta)
+	{
+		// The deltas come from JS, where nothing guarantees they are finite. A NaN reaching
+		// ScrollContentPresenter.ValidateInputOffset throws.
+		var (outer, inner, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		var result = ScrollViewer.ChainScrollFromDescendant(origin, horizontalDelta, verticalDelta, isIntermediate: true);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsFalse(result.DidScroll);
+		Assert.AreEqual(0, inner.VerticalOffset, 0.01);
+		Assert.AreEqual(0, outer.VerticalOffset, 0.01);
+	}
+
+	[TestMethod]
+	public async Task When_Gesture_Is_Intermediate_Then_Final_ViewChanged_Is_Not_Intermediate()
+	{
+		// Consumers treat ViewChanged(IsIntermediate: false) as "the scroll ended", so a drag must report
+		// intermediate deltas and exactly one terminal change when it completes.
+		var (outer, _, origin) = BuildNested();
+		await UITestHelper.Load(outer);
+
+		var intermediateStates = new List<bool>();
+		void OnViewChanged(object sender, ScrollViewerViewChangedEventArgs args) => intermediateStates.Add(args.IsIntermediate);
+
+		outer.ViewChanged += OnViewChanged;
+		try
+		{
+			ScrollViewer.ChainScrollFromDescendant(origin, 0, 4000, isIntermediate: true);
+			await WindowHelper.WaitForIdle();
+
+			CollectionAssert.DoesNotContain(intermediateStates, false, "Every in-flight delta must be reported as intermediate.");
+
+			ScrollViewer.CompleteChainedScrollFromDescendant(origin);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(intermediateStates.Contains(false), "Completing the gesture must raise a non-intermediate ViewChanged.");
+		}
+		finally
+		{
+			outer.ViewChanged -= OnViewChanged;
+		}
+	}
 #endif
 }

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
@@ -20,12 +20,17 @@ namespace Uno.UI.NativeElementHosting;
 /// Only scroll and pan gestures are affected; taps, focus, text selection and keyboard input always
 /// remain native.
 /// </summary>
+/// <remarks>
+/// The numeric values are a wire format: they are mirrored onto the hosted element as
+/// <c>data-uno-native-input-policy</c>, matched by <c>uno.css</c> and by the <c>NativeElementInputPolicy</c>
+/// enum in <c>BrowserPointerInputSource.ts</c>. Keep all four in sync.
+/// </remarks>
 public enum BrowserHtmlElementInputPolicy
 {
 	/// <summary>
 	/// Native HTML owns all input. This is the default behavior.
 	/// </summary>
-	NativeOnly,
+	NativeOnly = 0,
 
 	/// <summary>
 	/// A scrollable native element consumes the gesture first, then transfers whatever it could not
@@ -36,7 +41,7 @@ public enum BrowserHtmlElementInputPolicy
 	/// Content hosted in an <c>iframe</c> stays native-only: pointer events do not cross the frame
 	/// boundary, so its scroll residual cannot be observed.
 	/// </remarks>
-	Negotiated,
+	Negotiated = 1,
 }
 
 /// <summary>

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
@@ -16,7 +16,9 @@ using Uno.UI.Xaml;
 namespace Uno.UI.NativeElementHosting;
 
 /// <summary>
-/// Defines how scroll input originating from a <see cref="BrowserHtmlElement"/> is routed on Skia WebAssembly.
+/// Defines how input originating from a <see cref="BrowserHtmlElement"/> is routed on Skia WebAssembly.
+/// Only scroll and pan gestures are affected; taps, focus, text selection and keyboard input always
+/// remain native.
 /// </summary>
 public enum BrowserHtmlElementInputPolicy
 {
@@ -26,13 +28,14 @@ public enum BrowserHtmlElementInputPolicy
 	NativeOnly,
 
 	/// <summary>
-	/// Scroll gestures are routed to the enclosing Uno Platform ScrollViewer.
+	/// A scrollable native element consumes the gesture first, then transfers whatever it could not
+	/// consume at its boundary to the enclosing Uno Platform <see cref="Microsoft.UI.Xaml.Controls.ScrollViewer"/>.
+	/// A gesture over non-scrollable native content goes to the ScrollViewer directly.
 	/// </summary>
-	UnoOnly,
-
-	/// <summary>
-	/// Native HTML consumes scroll input first and transfers any boundary residual to the enclosing Uno Platform ScrollViewer.
-	/// </summary>
+	/// <remarks>
+	/// Content hosted in an <c>iframe</c> stays native-only: pointer events do not cross the frame
+	/// boundary, so its scroll residual cannot be observed.
+	/// </remarks>
 	Negotiated,
 }
 
@@ -56,6 +59,7 @@ public sealed partial class BrowserHtmlElement : IDisposable
 
 	/// <summary>
 	/// Gets or sets the input policy used when this element is hosted in the Skia WebAssembly renderer.
+	/// Defaults to <see cref="BrowserHtmlElementInputPolicy.NativeOnly"/>.
 	/// </summary>
 	public BrowserHtmlElementInputPolicy InputPolicy
 	{

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.cs
@@ -16,6 +16,27 @@ using Uno.UI.Xaml;
 namespace Uno.UI.NativeElementHosting;
 
 /// <summary>
+/// Defines how scroll input originating from a <see cref="BrowserHtmlElement"/> is routed on Skia WebAssembly.
+/// </summary>
+public enum BrowserHtmlElementInputPolicy
+{
+	/// <summary>
+	/// Native HTML owns all input. This is the default behavior.
+	/// </summary>
+	NativeOnly,
+
+	/// <summary>
+	/// Scroll gestures are routed to the enclosing Uno Platform ScrollViewer.
+	/// </summary>
+	UnoOnly,
+
+	/// <summary>
+	/// Native HTML consumes scroll input first and transfers any boundary residual to the enclosing Uno Platform ScrollViewer.
+	/// </summary>
+	Negotiated,
+}
+
+/// <summary>
 /// A managed handle to a DOM HTMLElement.
 /// </summary>
 public sealed partial class BrowserHtmlElement : IDisposable
@@ -30,6 +51,24 @@ public sealed partial class BrowserHtmlElement : IDisposable
 	public string ElementId { get; }
 
 	internal bool IsOwner { get; }
+
+	private BrowserHtmlElementInputPolicy _inputPolicy;
+
+	/// <summary>
+	/// Gets or sets the input policy used when this element is hosted in the Skia WebAssembly renderer.
+	/// </summary>
+	public BrowserHtmlElementInputPolicy InputPolicy
+	{
+		get => _inputPolicy;
+		set
+		{
+			if (_inputPolicy != value)
+			{
+				_inputPolicy = value;
+				OnInputPolicyChanged(value);
+			}
+		}
+	}
 
 	private BrowserHtmlElement(bool isOwner)
 	{
@@ -223,6 +262,8 @@ public sealed partial class BrowserHtmlElement : IDisposable
 
 	public void Dispose()
 		=> DisposeNative();
+
+	partial void OnInputPolicyChanged(BrowserHtmlElementInputPolicy value);
 
 	partial void DisposeNative();
 }

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.reference.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.reference.cs
@@ -77,6 +77,9 @@ public sealed partial class BrowserHtmlElement : IDisposable
 	private void UnregisterHtmlEventHandlerNative(string eventName, EventHandler<JSObject> handler)
 		=> throw new PlatformNotSupportedException();
 
+	partial void OnInputPolicyChanged(BrowserHtmlElementInputPolicy value)
+		=> throw new PlatformNotSupportedException();
+
 	partial void DisposeNative()
 		=> throw new PlatformNotSupportedException();
 

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.skia.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.skia.cs
@@ -113,6 +113,9 @@ public sealed partial class BrowserHtmlElement : IDisposable
 		NativeMethods.SetContentHtml(ElementId, html);
 	}
 
+	partial void OnInputPolicyChanged(BrowserHtmlElementInputPolicy value)
+		=> NativeMethods.SetInputPolicy(ElementId, (int)value);
+
 	[JSExport]
 	private static bool DispatchEventNativeElementMethod(
 		[JSMarshalAs<JSType.Any>] object owner,
@@ -191,6 +194,9 @@ public sealed partial class BrowserHtmlElement : IDisposable
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.setContentHtml")]
 		internal static partial void SetContentHtml(string elementId, string html);
+
+		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.setInputPolicy")]
+		internal static partial void SetInputPolicy(string elementId, int value);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.registerNativeHtmlEvent")]
 		internal static partial void RegisterNativeHtmlEvent(

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.skia.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.skia.cs
@@ -114,7 +114,7 @@ public sealed partial class BrowserHtmlElement : IDisposable
 	}
 
 	partial void OnInputPolicyChanged(BrowserHtmlElementInputPolicy value)
-		=> NativeMethods.SetInputPolicy(ElementId, (int)value);
+		=> NativeMethods.SetInputPolicy(ElementId, UnoElementId, (int)value);
 
 	[JSExport]
 	private static bool DispatchEventNativeElementMethod(
@@ -196,7 +196,7 @@ public sealed partial class BrowserHtmlElement : IDisposable
 		internal static partial void SetContentHtml(string elementId, string html);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.setInputPolicy")]
-		internal static partial void SetInputPolicy(string elementId, int value);
+		internal static partial void SetInputPolicy(string elementId, nint unoElementId, int value);
 
 		[JSImport($"globalThis.Uno.UI.NativeElementHosting.BrowserHtmlElement.registerNativeHtmlEvent")]
 		internal static partial void RegisterNativeHtmlEvent(

--- a/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.wasm.cs
+++ b/src/Uno.UI/NativeElementHosting/BrowserHtmlElement.wasm.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using Uno.Extensions;
 using Uno.Foundation;
+using Uno.Foundation.Logging;
 using Uno.UI.Xaml;
 using static Microsoft.UI.Xaml.Controls.CollectionChangedOperation;
 
@@ -153,6 +154,16 @@ partial class BrowserHtmlElement
 		{
 			_eventMap.Remove(handler);
 			NativeMethods.UnregisterNativeHtmlEvent(UnoElementId, eventName, wrapper);
+		}
+	}
+
+	// Scroll negotiation is implemented by the Skia renderer's pointer input source, which the native WASM
+	// target does not use: there the Uno ScrollViewer is a DOM scroller and the browser chains into it itself.
+	partial void OnInputPolicyChanged(BrowserHtmlElementInputPolicy value)
+	{
+		if (value != BrowserHtmlElementInputPolicy.NativeOnly && this.Log().IsEnabled(LogLevel.Warning))
+		{
+			this.Log().Warn($"{nameof(BrowserHtmlElement)}.{nameof(InputPolicy)} is only supported when using the Skia renderer, and is ignored here.");
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -1,4 +1,4 @@
-﻿#if UNO_HAS_MANAGED_SCROLL_PRESENTER
+#if UNO_HAS_MANAGED_SCROLL_PRESENTER
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -256,9 +256,10 @@ namespace Microsoft.UI.Xaml.Controls
 			float? zoomFactor = null,
 			bool disableAnimation = false,
 			bool isIntermediate = false,
+			bool isTouch = false,
 			[CallerMemberName] string callerName = "",
 			[CallerLineNumber] int callerLine = -1)
-			=> Set(horizontalOffset, verticalOffset, zoomFactor, options: new(disableAnimation, IsIntermediate: isIntermediate), callerName, callerLine);
+			=> Set(horizontalOffset, verticalOffset, zoomFactor, options: new(disableAnimation, IsTouch: isTouch, IsIntermediate: isIntermediate), callerName, callerLine);
 
 		private bool Set(
 			double? horizontalOffset = null,

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.ScrollChaining.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.ScrollChaining.cs
@@ -1,0 +1,87 @@
+#nullable enable
+
+#if UNO_HAS_MANAGED_SCROLL_PRESENTER
+using System;
+using Uno.UI.Extensions;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class ScrollViewer
+{
+	// Sub-pixel leftovers are not worth chaining to the next ScrollViewer.
+	private const double ScrollChainingResidualEpsilon = 0.01;
+
+	/// <summary>
+	/// Scrolls the <see cref="ScrollViewer"/> ancestry of <paramref name="origin"/> by the given delta,
+	/// chaining outwards: each ScrollViewer consumes what it can and passes the rest to the next one.
+	/// </summary>
+	/// <remarks>
+	/// This is the entry point for scroll deltas that originate outside of Uno's own pointer pipeline -
+	/// currently a native HTML element hosted on Skia WebAssembly which has exhausted its own scrolling.
+	/// The delta is treated as user input, not as a programmatic scroll.
+	/// </remarks>
+	/// <returns>
+	/// Whether any ScrollViewer moved, along with the delta that no ScrollViewer in the ancestry could consume.
+	/// </returns>
+	internal static (bool DidScroll, double RemainingHorizontalDelta, double RemainingVerticalDelta) ChainScrollFromDescendant(
+		UIElement origin,
+		double horizontalDelta,
+		double verticalDelta)
+	{
+		var remainingHorizontalDelta = horizontalDelta;
+		var remainingVerticalDelta = verticalDelta;
+		var didScroll = false;
+
+		foreach (var ancestor in origin.GetVisualAncestry())
+		{
+			if (ancestor is not ScrollViewer { Presenter: { } presenter } scrollViewer)
+			{
+				continue;
+			}
+
+			var horizontalOffset = presenter.CanHorizontallyScroll && remainingHorizontalDelta is not 0
+				? presenter.HorizontalOffset + remainingHorizontalDelta
+				: (double?)null;
+			var verticalOffset = presenter.CanVerticallyScroll && remainingVerticalDelta is not 0
+				? presenter.VerticalOffset + remainingVerticalDelta
+				: (double?)null;
+
+			if (horizontalOffset is null && verticalOffset is null)
+			{
+				continue;
+			}
+
+			var initialHorizontalOffset = presenter.HorizontalOffset;
+			var initialVerticalOffset = presenter.VerticalOffset;
+
+			// This is user input, not a programmatic ChangeView. ChangeView arms the ScrollViewer's offset
+			// intent, which the post-layout recompute then keeps re-applying and would fight the drag - so
+			// clear it and go through the presenter exactly like PointerWheelScroll and
+			// TryEnableDirectManipulation do.
+			scrollViewer.ClearOffsetIntents();
+			presenter.Set(
+				horizontalOffset: horizontalOffset,
+				verticalOffset: verticalOffset,
+				disableAnimation: true,
+				isIntermediate: false);
+
+			// The presenter clamps and commits its offsets synchronously, unlike the ScrollViewer's own
+			// properties which are refreshed through a notification, so the residual is read back from it.
+			var consumedHorizontalDelta = presenter.HorizontalOffset - initialHorizontalOffset;
+			var consumedVerticalDelta = presenter.VerticalOffset - initialVerticalOffset;
+
+			remainingHorizontalDelta -= consumedHorizontalDelta;
+			remainingVerticalDelta -= consumedVerticalDelta;
+			didScroll |= consumedHorizontalDelta is not 0 || consumedVerticalDelta is not 0;
+
+			if (Math.Abs(remainingHorizontalDelta) < ScrollChainingResidualEpsilon
+				&& Math.Abs(remainingVerticalDelta) < ScrollChainingResidualEpsilon)
+			{
+				break;
+			}
+		}
+
+		return (didScroll, remainingHorizontalDelta, remainingVerticalDelta);
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.ScrollChaining.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.ScrollChaining.cs
@@ -18,16 +18,28 @@ partial class ScrollViewer
 	/// <remarks>
 	/// This is the entry point for scroll deltas that originate outside of Uno's own pointer pipeline -
 	/// currently a native HTML element hosted on Skia WebAssembly which has exhausted its own scrolling.
-	/// The delta is treated as user input, not as a programmatic scroll.
+	/// The delta is treated as user touch input, not as a programmatic scroll.
 	/// </remarks>
+	/// <param name="isIntermediate">
+	/// False only for the last delta of a gesture. Callers that end a gesture without a final delta
+	/// should use <see cref="CompleteChainedScrollFromDescendant"/> instead.
+	/// </param>
 	/// <returns>
 	/// Whether any ScrollViewer moved, along with the delta that no ScrollViewer in the ancestry could consume.
 	/// </returns>
 	internal static (bool DidScroll, double RemainingHorizontalDelta, double RemainingVerticalDelta) ChainScrollFromDescendant(
 		UIElement origin,
 		double horizontalDelta,
-		double verticalDelta)
+		double verticalDelta,
+		bool isIntermediate)
 	{
+		// These deltas cross the JS boundary, where nothing guarantees they are finite. A NaN reaching
+		// ScrollContentPresenter.ValidateInputOffset throws, so reject it before it gets there.
+		if (!double.IsFinite(horizontalDelta) || !double.IsFinite(verticalDelta))
+		{
+			return (false, 0, 0);
+		}
+
 		var remainingHorizontalDelta = horizontalDelta;
 		var remainingVerticalDelta = verticalDelta;
 		var didScroll = false;
@@ -39,40 +51,50 @@ partial class ScrollViewer
 				continue;
 			}
 
-			var horizontalOffset = presenter.CanHorizontallyScroll && remainingHorizontalDelta is not 0
-				? presenter.HorizontalOffset + remainingHorizontalDelta
-				: (double?)null;
-			var verticalOffset = presenter.CanVerticallyScroll && remainingVerticalDelta is not 0
-				? presenter.VerticalOffset + remainingVerticalDelta
-				: (double?)null;
+			var scrollsHorizontally = presenter.CanHorizontallyScroll && Math.Abs(remainingHorizontalDelta) >= ScrollChainingResidualEpsilon;
+			var scrollsVertically = presenter.CanVerticallyScroll && Math.Abs(remainingVerticalDelta) >= ScrollChainingResidualEpsilon;
 
-			if (horizontalOffset is null && verticalOffset is null)
+			if (scrollsHorizontally || scrollsVertically)
 			{
-				continue;
+				var initialHorizontalOffset = presenter.HorizontalOffset;
+				var initialVerticalOffset = presenter.VerticalOffset;
+
+				// This is user input, not a programmatic ChangeView. ChangeView arms the ScrollViewer's offset
+				// intent, which the post-layout recompute then keeps re-applying and would fight the drag - so
+				// clear it and go through the presenter exactly like PointerWheelScroll and
+				// TryEnableDirectManipulation do.
+				scrollViewer.ClearOffsetIntents();
+				presenter.Set(
+					horizontalOffset: scrollsHorizontally ? initialHorizontalOffset + remainingHorizontalDelta : null,
+					verticalOffset: scrollsVertically ? initialVerticalOffset + remainingVerticalDelta : null,
+					disableAnimation: true,
+					isIntermediate: isIntermediate,
+					isTouch: true);
+
+				// The presenter clamps and commits its offsets synchronously, unlike the ScrollViewer's own
+				// properties which are refreshed through a notification, so the residual is read back from it.
+				var consumedHorizontalDelta = presenter.HorizontalOffset - initialHorizontalOffset;
+				var consumedVerticalDelta = presenter.VerticalOffset - initialVerticalOffset;
+
+				remainingHorizontalDelta -= consumedHorizontalDelta;
+				remainingVerticalDelta -= consumedVerticalDelta;
+				didScroll |= Math.Abs(consumedHorizontalDelta) >= ScrollChainingResidualEpsilon
+					|| Math.Abs(consumedVerticalDelta) >= ScrollChainingResidualEpsilon;
 			}
 
-			var initialHorizontalOffset = presenter.HorizontalOffset;
-			var initialVerticalOffset = presenter.VerticalOffset;
+			// A ScrollViewer that opts out of chaining absorbs the rest of the delta on that axis rather than
+			// letting it reach its own ancestors, mirroring IDirectManipulationHandler.OnUpdated. Only applied
+			// to an axis this ScrollViewer actually takes part in, so a horizontal-only scroller does not
+			// swallow the vertical delta of the scroller above it.
+			if (scrollsHorizontally && !scrollViewer.IsHorizontalScrollChainingEnabled)
+			{
+				remainingHorizontalDelta = 0;
+			}
 
-			// This is user input, not a programmatic ChangeView. ChangeView arms the ScrollViewer's offset
-			// intent, which the post-layout recompute then keeps re-applying and would fight the drag - so
-			// clear it and go through the presenter exactly like PointerWheelScroll and
-			// TryEnableDirectManipulation do.
-			scrollViewer.ClearOffsetIntents();
-			presenter.Set(
-				horizontalOffset: horizontalOffset,
-				verticalOffset: verticalOffset,
-				disableAnimation: true,
-				isIntermediate: false);
-
-			// The presenter clamps and commits its offsets synchronously, unlike the ScrollViewer's own
-			// properties which are refreshed through a notification, so the residual is read back from it.
-			var consumedHorizontalDelta = presenter.HorizontalOffset - initialHorizontalOffset;
-			var consumedVerticalDelta = presenter.VerticalOffset - initialVerticalOffset;
-
-			remainingHorizontalDelta -= consumedHorizontalDelta;
-			remainingVerticalDelta -= consumedVerticalDelta;
-			didScroll |= consumedHorizontalDelta is not 0 || consumedVerticalDelta is not 0;
+			if (scrollsVertically && !scrollViewer.IsVerticalScrollChainingEnabled)
+			{
+				remainingVerticalDelta = 0;
+			}
 
 			if (Math.Abs(remainingHorizontalDelta) < ScrollChainingResidualEpsilon
 				&& Math.Abs(remainingVerticalDelta) < ScrollChainingResidualEpsilon)
@@ -82,6 +104,23 @@ partial class ScrollViewer
 		}
 
 		return (didScroll, remainingHorizontalDelta, remainingVerticalDelta);
+	}
+
+	/// <summary>
+	/// Reports the end of a gesture previously driven through <see cref="ChainScrollFromDescendant"/>, so
+	/// consumers of <see cref="ViewChanged"/> observe a final non-intermediate view change.
+	/// </summary>
+	internal static void CompleteChainedScrollFromDescendant(UIElement origin)
+	{
+		foreach (var ancestor in origin.GetVisualAncestry())
+		{
+			if (ancestor is ScrollViewer { Presenter: { } presenter })
+			{
+				// No offset is passed: this only re-reports the offsets already in place, with
+				// IsIntermediate false to close the sequence of intermediate deltas.
+				presenter.Set(disableAnimation: true, isIntermediate: false, isTouch: true);
+			}
+		}
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.ScrollChaining.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.ScrollChaining.cs
@@ -24,6 +24,10 @@ partial class ScrollViewer
 	/// False only for the last delta of a gesture. Callers that end a gesture without a final delta
 	/// should use <see cref="CompleteChainedScrollFromDescendant"/> instead.
 	/// </param>
+	/// <param name="isInertial">
+	/// True when the delta comes from the inertia (fling) phase of a gesture rather than from the user's
+	/// finger. A ScrollViewer with <see cref="IsScrollInertiaEnabled"/> false then refuses the delta.
+	/// </param>
 	/// <returns>
 	/// Whether any ScrollViewer moved, along with the delta that no ScrollViewer in the ancestry could consume.
 	/// </returns>
@@ -31,7 +35,8 @@ partial class ScrollViewer
 		UIElement origin,
 		double horizontalDelta,
 		double verticalDelta,
-		bool isIntermediate)
+		bool isIntermediate,
+		bool isInertial = false)
 	{
 		// These deltas cross the JS boundary, where nothing guarantees they are finite. A NaN reaching
 		// ScrollContentPresenter.ValidateInputOffset throws, so reject it before it gets there.
@@ -54,7 +59,22 @@ partial class ScrollViewer
 			var scrollsHorizontally = presenter.CanHorizontallyScroll && Math.Abs(remainingHorizontalDelta) >= ScrollChainingResidualEpsilon;
 			var scrollsVertically = presenter.CanVerticallyScroll && Math.Abs(remainingVerticalDelta) >= ScrollChainingResidualEpsilon;
 
-			if (scrollsHorizontally || scrollsVertically)
+			if (isInertial && !scrollViewer.IsScrollInertiaEnabled)
+			{
+				// Mirrors IDirectManipulationHandler.OnInertiaStarting: with inertia opted out, this ScrollViewer
+				// neither moves during the inertial phase nor lets the fling continue past it on the axes it takes
+				// part in - an outer ScrollViewer flinging while this one stands still would look broken.
+				if (scrollsHorizontally)
+				{
+					remainingHorizontalDelta = 0;
+				}
+
+				if (scrollsVertically)
+				{
+					remainingVerticalDelta = 0;
+				}
+			}
+			else if (scrollsHorizontally || scrollsVertically)
 			{
 				var initialHorizontalOffset = presenter.HorizontalOffset;
 				var initialVerticalOffset = presenter.VerticalOffset;


### PR DESCRIPTION
**GitHub Issue:** related to #24134

<!-- This PR is the interim implementation referenced as "prior work" in #24134; it does not close it.
     #24134 tracks the follow-up design question of routing the residual through the existing
     direct-manipulation pipeline instead of a separate scroll implementation. -->

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior.** On Skia WebAssembly, a touch gesture that begins inside a `BrowserHtmlElement` does not participate in the enclosing Uno `ScrollViewer`. A scrollable native child consumes the whole gesture and dead-stops at its own boundary, and a drag that starts over non-scrollable native HTML does not scroll the enclosing `ScrollViewer` at all. This is most visible on tablets, where an embedded editor or grid can occupy most of the viewport and effectively traps the page.

There are two independent causes:

1. The Uno `ScrollViewer` is painted onto the canvas and is **not** a DOM scroll container, so `overscroll-behavior` and the browser's own scroll chaining have nothing to chain into.
2. `BrowserPointerInputSource.onPointerEventReceived` early-returns for any event targeting `#uno-native-element-host`, so Uno never observes the gesture.

**This PR** adds an opt-in `BrowserHtmlElement.InputPolicy`:

```csharp
var element = BrowserHtmlElement.CreateHtmlElement("div");
element.InputPolicy = BrowserHtmlElementInputPolicy.Negotiated; // default is NativeOnly
```

With `Negotiated`, a scrollable native child scrolls first and transfers only what it could not consume at its boundary to the enclosing `ScrollViewer`, chaining outwards; a gesture over non-scrollable native content goes to the `ScrollViewer` directly. Taps, focus, text selection and native control interaction stay native. The default (`NativeOnly`) preserves today's behavior exactly.

### Managed side

`ScrollViewer.ChainScrollFromDescendant` walks the `ScrollViewer` ancestry and hands each one the residual the previous could not take. Two details matter:

- Deltas are applied through the **user-input** path (`ClearOffsetIntents()` + the presenter's `Set`), not `ScrollViewer.ChangeView`. `ChangeView` arms the ScrollViewer's offset intent, which the post-layout recompute re-applies — so overshooting at a boundary (as every fling does) parked an intent past the end of the content, and the next extent growth snapped the view to it. This is covered by a regression test that fails against the `ChangeView` implementation.
- In-flight deltas are reported as `IsTouch: true, IsIntermediate: true`, with a single non-intermediate change when the gesture ends. Reporting every frame as terminal fired `ViewChanged(IsIntermediate: false)` at 60–120 Hz and restarted the snap-points timer mid-fling.

Chaining honors `IsHorizontalScrollChainingEnabled` / `IsVerticalScrollChainingEnabled`, per-axis, matching `IDirectManipulationHandler.OnUpdated`.

### Browser side

Gesture detection, native-first scrolling and the residual bridge live in `BrowserPointerInputSource.ts`. Notable hardening over a naive implementation:

- The input policy and the negotiation root are resolved from a JS-side map keyed by **element reference**, and by position in the tree (direct child of `#uno-native-element-host`) — never by reading a `data-` attribute off the event target. Hosted HTML is app- or third-party-supplied and must not be able to opt itself into a policy the app did not set. The managed host registry is keyed on the `GCHandle`, not the caller-settable `ElementId` string.
- `OnNativeScrollDelta` is wrapped in try/catch with an `IsEnabled`-guarded error log and applies `NativeDispatcher.Main.SynchronizationContext`, matching the neighbouring `OnNativeEvent`. Non-finite deltas are rejected before reaching `ValidateInputOffset`, which throws on `NaN`.
- Form controls (`input`, `textarea`, `select`) and `contenteditable` regions — **and their descendants** — keep full native touch behavior and never participate in chaining. The CSS and TypeScript exclusion lists are deliberately kept in sync; a mismatch produces a subtree that neither the browser nor Uno will pan.
- `touch-action: pinch-zoom` rather than `none`, so multi-finger zoom survives. A second pointer abandons negotiation and hands the interaction back to the browser.
- ctrl+wheel is left to the normal pipeline so browser zoom keeps working when `isBrowserZoomEnabled`.
- Inertia is cancelled when the element is detached or leaves the document, and a wheel burst supersedes a running fling.

Iframes remain native-only: pointer events do not cross the frame boundary, so an embedded document's scroll residual cannot be observed.

The first commit is cherry-picked from an external contributor's branch with authorship preserved; the remainder is rework following an internal review.

## Validation

**Runtime tests (Skia Desktop)** — 13 tests in `Given_ScrollViewer_ScrollChaining`, all passing, covering forward/backward chaining, boundary residual, chaining-disabled absorption, horizontal, non-finite deltas, and the intermediate/terminal `ViewChanged` sequence. The offset-intent regression guard was verified to **fail** against the pre-fix implementation and pass after.

**Regression** — 241/243 passing across `Given_ScrollViewer`, `Given_ScrollViewer_Anchoring`, `Given_ScrollViewer_Zoom`, `Given_ListView*` and `Given_FlipView` (16 skipped). The one failure, `Given_ListViewBase.When_ThemeChange`, was verified to fail identically on clean `master` on the same machine and is unrelated.

**Manual, iPadOS Safari** — the core scenarios pass on device: drag over non-scrollable native content scrolls the page, the native scroller hands over residual at its boundary without stalling, reverse chaining works, and flick inertia carries across the handoff.

⚠️ **Not yet validated on device:** the native-interaction cases (text input focus and drag-selection, pinch-zoom, multi-touch handoff, button tap delivery). These exercise the exclusion lists and the `touch-action` change. Marked as draft until they are covered.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- New public API surface: BrowserHtmlElementInputPolicy and BrowserHtmlElement.InputPolicy. Additive,
     opt-in, and default-off, so no existing behavior changes. -->
