### PR TITLE
test: Make the leak-counter failures diagnosable

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -224,22 +224,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		{
 			var controlType = GetControlType(controlTypeRaw);
 
-			var weakRefs = new HashSet<WeakReference<DependencyObject>>();
+			// The ordinal records which control instance a reference came from, so surviving objects can be
+			// attributed to the last instance (tolerated) or to an earlier one.
+			var weakRefs = new HashSet<(int Ordinal, WeakReference<DependencyObject> Reference)>();
 			var totalRefCount = 0;
 			void TrackDependencyObject(DependencyObject target)
 			{
-				totalRefCount++;
-				weakRefs.Add(new WeakReference<DependencyObject>(target));
+				weakRefs.Add((totalRefCount++, new WeakReference<DependencyObject>(target)));
 			}
 
-			IEnumerable<DependencyObject> RemoveDeadRefsAndGetAliveRefs()
+			IEnumerable<(int Ordinal, DependencyObject Target)> RemoveDeadRefsAndGetAliveRefs()
 			{
-				var toRemove = new List<WeakReference<DependencyObject>>();
+				var toRemove = new List<(int Ordinal, WeakReference<DependencyObject> Reference)>();
 				foreach (var weakRef in weakRefs)
 				{
-					if (weakRef.TryGetTarget(out var target))
+					if (weakRef.Reference.TryGetTarget(out var target))
 					{
-						yield return target;
+						yield return (weakRef.Ordinal, target);
 					}
 					else
 					{
@@ -278,10 +279,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			var totalRefCountExceptForLastControlInstance = totalRefCount;
 			await MaterializeControl(controlType, rootContainer);
 
+			// Some platforms have a problem with GC timing and / or the way things like async methods are compiled
+			// where the last created instance of the control will remain in memory, so we check that objects from
+			// all but the last instance of the control are collected
+			var expected = totalRefCount - totalRefCountExceptForLastControlInstance;
+
 			var sw = Stopwatch.StartNew();
 
 			var endTime = TimeSpan.FromSeconds(30);
-			while (sw.Elapsed < endTime && RemoveDeadRefsAndGetAliveRefs().Any())
+			// The alive count only decreases, so there is nothing left to wait for once it meets the bar.
+			// Count() also enumerates fully, which is what lets the iterator prune the dead refs.
+			while (sw.Elapsed < endTime && RemoveDeadRefsAndGetAliveRefs().Count() > expected)
 			{
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
@@ -316,16 +324,27 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			//var leaks = Uno.UI.DataBinding.BinderReferenceHolder.GetLeakedObjects();
 #endif
 
-			var retainedMessage = "";
+			// A single snapshot feeds both the diagnostics and the assertion, so the two cannot disagree.
+			var alive = RemoveDeadRefsAndGetAliveRefs().ToArray();
+			var refcount = alive.Length;
+			var aliveEarlier = alive.Count(x => x.Ordinal < totalRefCountExceptForLastControlInstance);
+			var aliveLast = refcount - aliveEarlier;
+			var retainedTypes = alive
+				.GroupBy(x => ExtractTargetName(x.Target))
+				.OrderByDescending(g => g.Count())
+				.Select(g => $"{g.Key} x{g.Count()}")
+				.ToArray();
 
-			if (OperatingSystem.IsIOS() || OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser())
+			var retainedMessage =
+				$"platform={RuntimeTestsPlatformHelper.CurrentPlatform}, settled in {sw.Elapsed.TotalSeconds:F1}s, " +
+				$"alive={refcount} (expected <= {expected}), from earlier instances={aliveEarlier}, from last instance={aliveLast}, " +
+				$"retained: {retainedTypes.JoinBy("; ")}";
+
+			if (refcount > 0 && (OperatingSystem.IsIOS() || OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser()))
 			{
-				var retainedTypes = RemoveDeadRefsAndGetAliveRefs().Select(ExtractTargetName).ToArray();
-				if (RemoveDeadRefsAndGetAliveRefs().Any())
-				{
-					Console.WriteLine($"\n --- Retained types ---\n{string.Join("\n", retainedTypes)}");
+				Console.WriteLine($"\n --- Retained types ---\n{string.Join("\n", retainedTypes)}");
 
-					Console.WriteLine($"\n ========== first run: tree-graph ============\n{forest.FirstOrDefault()}");
+				Console.WriteLine($"\n ========== first run: tree-graph ============\n{forest.FirstOrDefault()}");
 
 #if TRACK_REFS
 				Console.WriteLine($"\n ========== first run: total objects created ============");
@@ -342,17 +361,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				}
 				Console.WriteLine();
 #endif
-				}
-
-				retainedMessage = retainedTypes.JoinBy(";");
 			}
 
-			// Some platforms have a problem with GC timing and / or the way things like async methods are compiled
-			// where the last created instance of the control will remain in memory, so we check that objects from
-			// all but the last instance of the control are collected
-			var expected = totalRefCount - totalRefCountExceptForLastControlInstance;
-			var refcount = RemoveDeadRefsAndGetAliveRefs().Count();
-
+			// A failure on a single platform indicts that platform, not the bar: the survivors named in the
+			// message are the lead to follow, so don't raise `expected` or drop the row to make it pass.
 			refcount.Should().BeLessThanOrEqualTo(expected, retainedMessage);
 
 			[UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Use of [ActivatableDataRow] ensures that string fulfill TypeRequirements.")]


### PR DESCRIPTION
**GitHub Issue:** closes #24141

Part of #9080 ([Epic] Flaky tests roundup).

Split out of #24127 at review request — the CI-stabilization PR should not carry this.

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Given_FrameworkElement_And_Leak.When_Add_Remove` fails on Skia-WASM for `Microsoft.UI.Xaml.Controls.NavigationView` in **9 of the last 10 `master` builds**, and for `CommandBarFlyout_Leak` in **7 of 10**:

```
Expected value to be less than or equal to 67 because
Microsoft.UI.Xaml.Controls.NavigationView;Grid/RootGrid;Microsoft.UI.Xaml.Controls.Grid;…
```

Whether or not the underlying retention is real, three defects in the test *instrument* make that failure impossible to triage from CI output. This PR fixes the instrument only.

### 1. The settle loop ran past the pass bar

It looped until **nothing** was alive, rather than until the count met the assertion. `expected` is now hoisted above the loop and the condition is `.Count() > expected`, which is safe because the measurement is monotone.

### 2. …and never actually pruned

That loop polled through `.Any()` on `RemoveDeadRefsAndGetAliveRefs()` — a **lazy iterator** whose pruning `foreach` only runs on *full* enumeration. `Any()` short-circuits on the first element, so the pruning pass never executed. Switching to `.Count() > expected` fixes this as a side effect.

### 3. The failure message was gated off Linux, and disagreed with the assertion

`retainedMessage` was built under a platform condition that omits Linux Skia, so failures there asserted with an **empty** `because` string. It was also derived from an *earlier* visual-tree walk than the one the assertion samples, so the survivors it named could differ from the ones that actually failed the check.

It is now derived from a single post-settle snapshot — refcount, `aliveEarlier`, `aliveLast` and the type histogram all come from the same walk — and additionally carries `sw.Elapsed` and the platform. The elapsed time answers, for free on the next run, whether the settle loop really costs the ~30 s per style that has been assumed.

### What this deliberately does *not* do

- **No row is excluded** and **no threshold is raised.** Two siblings in this same file (`Expander`, `NavigationViewItem`) are already excluded on `SkiaWasm` citing #9080 — two *more* failing on the same platform under the same tracked issue points at the platform, not at the instrument. Masking them would destroy the only signal we have.
- **No assertion that `aliveEarlier == 0`.** Under conservative stack scanning an earlier instance can be pinned as easily as the last one, so that would be a new flake, not a tightening.

## Validation

**Compile** — `Uno.UI.RuntimeTests.Skia` builds with **0 errors, 0 warnings** on `net10.0`.

**Runtime** — not validated locally, and deliberately so: these are WASM flakes at 7/10 and 9/10, so a single green local run proves nothing either way. The value of this change is that the *next* CI failure is diagnosable; that has to be measured on CI over several runs.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — test-instrument change; no new test
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, test-only change
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfEBvJHHSSfsuqwsvtPPGe
