### PR TITLE
refactor!: Give the legacy toolkit types their natural namespaces

### DIFF
--- a/doc/articles/additional-features.md
+++ b/doc/articles/additional-features.md
@@ -1,10 +1,10 @@
----
+﻿---
 uid: Uno.Development.AdditionalFeatures
 ---
 
-# Other Uno.UI Features
+# Additional Uno Platform Features
 
-Uno.UI.Extras is a set of extension methods or behaviors used to enhance WinUI and activate device/OS specific features.
+Uno Platform ships a set of extension methods, attached properties and behaviors that enhance WinUI and activate device/OS specific features. They are available on every target, including WinAppSDK.
 
 Those methods are built to have no effect on a platform that does not support the enhanced feature: no need to wrap them into conditional code.
 

--- a/doc/articles/additional-features.md
+++ b/doc/articles/additional-features.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Uno.Development.AdditionalFeatures
 ---
 

--- a/doc/articles/controls/CommandBar.md
+++ b/doc/articles/controls/CommandBar.md
@@ -1,4 +1,4 @@
----
+﻿---
 uid: Uno.Controls.CommandBar
 ---
 
@@ -175,7 +175,7 @@ The height is fixed and cannot be changed.
 
 Extensions are attached properties that extend the **WinUI** APIs to provide platform-specific features.
 
-They can be found in the `Uno.UI.Extras` namespace.
+They can be found in the `Uno.UI.Xaml.Controls` namespace.
 
 Extensions to extend the functionality of `CommandBar` can be found in the `CommandBarExtensions` class.
 
@@ -431,10 +431,10 @@ Gets or sets a value indicating whether the user can interact with the control.
   You must use `VisibleBoundsPadding.PaddingMask="Top"` on `CommandBar` to properly support the notch or punch-holes on iOS and Android.
 
   ```xml
-  xmlns:extras="using:Uno.UI.Extras"
+  xmlns:uno="using:Uno.UI.Behaviors"
   ...
   <Style Target="CommandBar">
-      <Setter Property="extras:VisibleBoundsPadding.PaddingMask"
+      <Setter Property="uno:VisibleBoundsPadding.PaddingMask"
               Value="Top" />
   </Style>
   ```
@@ -442,10 +442,10 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I remove the back button title from all pages on iOS?
 
   ```xml
-  xmlns:extras="using:Uno.UI.Extras"
+  xmlns:uno="using:Uno.UI.Xaml.Controls"
   ...
   <Style Target="CommandBar">
-      <Setter Property="extras:CommandBarExtensions.BackButtonTitle"
+      <Setter Property="uno:CommandBarExtensions.BackButtonTitle"
               Value="" />
   </Style>
   ```
@@ -453,10 +453,10 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I change the back button icon/arrow/chevron in my app?
 
   ```xml
-  xmlns:extras="using:Uno.UI.Extras"
+  xmlns:uno="using:Uno.UI.Xaml.Controls"
   ...
   <Style Target="CommandBar">
-      <Setter Property="extras:CommandBarExtensions.BackButtonIcon">
+      <Setter Property="uno:CommandBarExtensions.BackButtonIcon">
           <Setter.Value>
               <BitmapIcon UriSource="ms-appx://Assets/back.png" />
           </Setter.Value>
@@ -467,9 +467,9 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I change the color of the back button?
 
   ```xml
-  xmlns:extras="using:Uno.UI.Extras"
+  xmlns:uno="using:Uno.UI.Xaml.Controls"
   ...
-  <CommandBar extras:CommandBarExtensions.BackButtonForeground="Red" />
+  <CommandBar uno:CommandBarExtensions.BackButtonForeground="Red" />
   ```
 
 - > Why does my back button display "Back" on iOS?
@@ -490,9 +490,9 @@ Gets or sets a value indicating whether the user can interact with the control.
   You must use `VisibleBoundsPadding.PaddingMask="Top"` on the parent control of `CommandBar` to properly support the notch or punch-holes on iOS and Android.
 
   ```xml
-  xmlns:extras="using:Uno.UI.Extras"
+  xmlns:uno="using:Uno.UI.Behaviors"
   ...
-  <Grid extras:VisibleBoundsPadding.PaddingMask="Top">
+  <Grid uno:VisibleBoundsPadding.PaddingMask="Top">
       <CommandBar>
         ...
       </CommandBar>
@@ -597,9 +597,9 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I add an elevation shadow to the CommandBar on Android?
 
   ```xml
-  xmlns:extras="using:Uno.UI.Extras"
+  xmlns:uno="using:Uno.UI.Xaml"
   ...
-  <CommandBar extras:UIElementExtensions.Elevation="4" />
+  <CommandBar uno:UIElementExtensions.Elevation="4" />
   ```
 
 - > How can I use a Path for the AppBarButton Icon?
@@ -623,12 +623,12 @@ Gets or sets a value indicating whether the user can interact with the control.
   ```xml
 
   <CommandBar x:Uid="MyCommandBar"
-              extras:CommandBarExtensions.BackButtonTitle="My Page Title">
+              uno:CommandBarExtensions.BackButtonTitle="My Page Title">
           ...
   </CommandBar>
   ```
 
-  And in the `.resw` file, the name would be: `MyCommandBar.[using:Uno.UI.Extras]CommandBarExtensions.BackButtonTitle`
+  And in the `.resw` file, the name would be: `MyCommandBar.[using:Uno.UI.Xaml.Controls]CommandBarExtensions.BackButtonTitle`
 
 - > How can I put a ComboBox in my CommandBar?
 
@@ -654,13 +654,13 @@ Gets or sets a value indicating whether the user can interact with the control.
 
   ```xml
   <CommandBar>
-      <extras:CommandBarExtensions.NavigationCommand>
+      <uno:CommandBarExtensions.NavigationCommand>
           <AppBarButton Command="{Binding GoBack}">
               <AppBarButton.Icon>
                   <BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
               </AppBarButton.Icon>
           </AppBarButton>
-      </extras:CommandBarExtensions.NavigationCommand>
+      </uno:CommandBarExtensions.NavigationCommand>
   </CommandBar>
   ```
 
@@ -672,13 +672,13 @@ Gets or sets a value indicating whether the user can interact with the control.
 
   ```xml
   <CommandBar>
-      <extras:CommandBarExtensions.NavigationCommand>
+      <uno:CommandBarExtensions.NavigationCommand>
           <AppBarButton Command="{Binding ToggleMenu}">
               <AppBarButton.Icon>
                   <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
               </AppBarButton.Icon>
           </AppBarButton>
-      </extras:CommandBarExtensions.NavigationCommand>
+      </uno:CommandBarExtensions.NavigationCommand>
   </CommandBar>
   ```
 
@@ -805,7 +805,7 @@ Gets or sets a value indicating whether the user can interact with the control.
 
   ```xml
   <Style Target="CommandBar">
-      <Setter Property="extras:CommandBarExtensions.BackButtonIcon">
+      <Setter Property="uno:CommandBarExtensions.BackButtonIcon">
           <Setter.Value>
               <BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
           </Setter.Value>

--- a/doc/articles/controls/CommandBar.md
+++ b/doc/articles/controls/CommandBar.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Uno.Controls.CommandBar
 ---
 
@@ -431,10 +431,10 @@ Gets or sets a value indicating whether the user can interact with the control.
   You must use `VisibleBoundsPadding.PaddingMask="Top"` on `CommandBar` to properly support the notch or punch-holes on iOS and Android.
 
   ```xml
-  xmlns:uno="using:Uno.UI.Behaviors"
+  xmlns:uub="using:Uno.UI.Behaviors"
   ...
   <Style Target="CommandBar">
-      <Setter Property="uno:VisibleBoundsPadding.PaddingMask"
+      <Setter Property="uub:VisibleBoundsPadding.PaddingMask"
               Value="Top" />
   </Style>
   ```
@@ -442,10 +442,10 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I remove the back button title from all pages on iOS?
 
   ```xml
-  xmlns:uno="using:Uno.UI.Xaml.Controls"
+  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
   ...
   <Style Target="CommandBar">
-      <Setter Property="uno:CommandBarExtensions.BackButtonTitle"
+      <Setter Property="uuxc:CommandBarExtensions.BackButtonTitle"
               Value="" />
   </Style>
   ```
@@ -453,10 +453,10 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I change the back button icon/arrow/chevron in my app?
 
   ```xml
-  xmlns:uno="using:Uno.UI.Xaml.Controls"
+  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
   ...
   <Style Target="CommandBar">
-      <Setter Property="uno:CommandBarExtensions.BackButtonIcon">
+      <Setter Property="uuxc:CommandBarExtensions.BackButtonIcon">
           <Setter.Value>
               <BitmapIcon UriSource="ms-appx://Assets/back.png" />
           </Setter.Value>
@@ -467,9 +467,9 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I change the color of the back button?
 
   ```xml
-  xmlns:uno="using:Uno.UI.Xaml.Controls"
+  xmlns:uuxc="using:Uno.UI.Xaml.Controls"
   ...
-  <CommandBar uno:CommandBarExtensions.BackButtonForeground="Red" />
+  <CommandBar uuxc:CommandBarExtensions.BackButtonForeground="Red" />
   ```
 
 - > Why does my back button display "Back" on iOS?
@@ -490,9 +490,9 @@ Gets or sets a value indicating whether the user can interact with the control.
   You must use `VisibleBoundsPadding.PaddingMask="Top"` on the parent control of `CommandBar` to properly support the notch or punch-holes on iOS and Android.
 
   ```xml
-  xmlns:uno="using:Uno.UI.Behaviors"
+  xmlns:uub="using:Uno.UI.Behaviors"
   ...
-  <Grid uno:VisibleBoundsPadding.PaddingMask="Top">
+  <Grid uub:VisibleBoundsPadding.PaddingMask="Top">
       <CommandBar>
         ...
       </CommandBar>
@@ -597,9 +597,9 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I add an elevation shadow to the CommandBar on Android?
 
   ```xml
-  xmlns:uno="using:Uno.UI.Xaml"
+  xmlns:uux="using:Uno.UI.Xaml"
   ...
-  <CommandBar uno:UIElementExtensions.Elevation="4" />
+  <CommandBar uux:UIElementExtensions.Elevation="4" />
   ```
 
 - > How can I use a Path for the AppBarButton Icon?
@@ -623,7 +623,7 @@ Gets or sets a value indicating whether the user can interact with the control.
   ```xml
 
   <CommandBar x:Uid="MyCommandBar"
-              uno:CommandBarExtensions.BackButtonTitle="My Page Title">
+              uuxc:CommandBarExtensions.BackButtonTitle="My Page Title">
           ...
   </CommandBar>
   ```
@@ -654,13 +654,13 @@ Gets or sets a value indicating whether the user can interact with the control.
 
   ```xml
   <CommandBar>
-      <uno:CommandBarExtensions.NavigationCommand>
+      <uuxc:CommandBarExtensions.NavigationCommand>
           <AppBarButton Command="{Binding GoBack}">
               <AppBarButton.Icon>
                   <BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
               </AppBarButton.Icon>
           </AppBarButton>
-      </uno:CommandBarExtensions.NavigationCommand>
+      </uuxc:CommandBarExtensions.NavigationCommand>
   </CommandBar>
   ```
 
@@ -672,13 +672,13 @@ Gets or sets a value indicating whether the user can interact with the control.
 
   ```xml
   <CommandBar>
-      <uno:CommandBarExtensions.NavigationCommand>
+      <uuxc:CommandBarExtensions.NavigationCommand>
           <AppBarButton Command="{Binding ToggleMenu}">
               <AppBarButton.Icon>
                   <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
               </AppBarButton.Icon>
           </AppBarButton>
-      </uno:CommandBarExtensions.NavigationCommand>
+      </uuxc:CommandBarExtensions.NavigationCommand>
   </CommandBar>
   ```
 
@@ -805,7 +805,7 @@ Gets or sets a value indicating whether the user can interact with the control.
 
   ```xml
   <Style Target="CommandBar">
-      <Setter Property="uno:CommandBarExtensions.BackButtonIcon">
+      <Setter Property="uuxc:CommandBarExtensions.BackButtonIcon">
           <Setter.Value>
               <BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
           </Setter.Value>

--- a/doc/articles/features/ElevatedView.md
+++ b/doc/articles/features/ElevatedView.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Uno.Features.ElevatedView
 ---
 
@@ -12,10 +12,10 @@ This control is very useful for creating cards with both rounded corners and an 
 
 ## How to use the `ElevatedView`
 
-First you need to add the `extras` namespace in your XAML file:
+First you need to add the Uno controls namespace to your XAML file:
 
 ```xml
-xmlns:uno="using:Uno.UI.Xaml.Controls"
+xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 ```
 
 After that, use the `ElevatedView` to host the content you need to be elevated:
@@ -25,9 +25,9 @@ After that, use the `ElevatedView` to host the content you need to be elevated:
 
     <Button>Non-Elevated Button</Button>
 
-    <uno:ElevatedView Elevation="10" Background="Gray" ShadowColor="Black">
+    <uuxc:ElevatedView Elevation="10" Background="Gray" ShadowColor="Black">
         <Button>Elevated Button</Button>
-    </uno:ElevatedView>
+    </uuxc:ElevatedView>
 
 </StackPanel>
 ```
@@ -36,7 +36,7 @@ Will produce the following result:
 
 ![ElevatedView sample](../Assets/features/elevatedview/elevatedview-sample.png)
 
-> **ATTENTION FOR WinUI**: When there is an error resolving the `<uno:ElevatedView>` on WinUI, the common mistake is to forget to include the `Uno.WinUI` package for all platforms, including WinUI. On WinUI, the `Uno.WinUI` package contributes only these Uno Platform additions on top of WinUI.
+> **ATTENTION FOR WinUI**: When there is an error resolving the `<uuxc:ElevatedView>` on WinUI, the common mistake is to forget to include the `Uno.WinUI` package for all platforms, including WinUI. On WinUI, the `Uno.WinUI` package contributes only these Uno Platform additions on top of WinUI.
 
 ## Settings
 
@@ -49,4 +49,4 @@ You can set the following properties:
 
 ## Particularities
 
-* Make sure to _give room_ for the shadow in the layout (eg. by setting a `Margin` on the `ElevatedView`).  Some platforms like macOS may clip the shadow otherwise. For the same reason, avoid wrapping the `<uno:ElevatedView>` directly in a `<ScrollViewer>` because it's designed to clip its content.
+* Make sure to _give room_ for the shadow in the layout (eg. by setting a `Margin` on the `ElevatedView`).  Some platforms like macOS may clip the shadow otherwise. For the same reason, avoid wrapping the `<uuxc:ElevatedView>` directly in a `<ScrollViewer>` because it's designed to clip its content.

--- a/doc/articles/features/ElevatedView.md
+++ b/doc/articles/features/ElevatedView.md
@@ -1,4 +1,4 @@
----
+﻿---
 uid: Uno.Features.ElevatedView
 ---
 
@@ -15,7 +15,7 @@ This control is very useful for creating cards with both rounded corners and an 
 First you need to add the `extras` namespace in your XAML file:
 
 ```xml
-xmlns:extras="using:Uno.UI.Extras"
+xmlns:uno="using:Uno.UI.Xaml.Controls"
 ```
 
 After that, use the `ElevatedView` to host the content you need to be elevated:
@@ -25,9 +25,9 @@ After that, use the `ElevatedView` to host the content you need to be elevated:
 
     <Button>Non-Elevated Button</Button>
 
-    <extras:ElevatedView Elevation="10" Background="Gray" ShadowColor="Black">
+    <uno:ElevatedView Elevation="10" Background="Gray" ShadowColor="Black">
         <Button>Elevated Button</Button>
-    </extras:ElevatedView>
+    </uno:ElevatedView>
 
 </StackPanel>
 ```
@@ -36,7 +36,7 @@ Will produce the following result:
 
 ![ElevatedView sample](../Assets/features/elevatedview/elevatedview-sample.png)
 
-> **ATTENTION FOR WinUI**: When there is an error resolving the `<extras:ElevatedView>` on WinUI, the common mistake is to forget to include the `Uno.WinUI` package for all platforms, including WinUI. On WinUI, the only component that the `Uno.WinUI` package adds is `Uno.UI.Extras`.
+> **ATTENTION FOR WinUI**: When there is an error resolving the `<uno:ElevatedView>` on WinUI, the common mistake is to forget to include the `Uno.WinUI` package for all platforms, including WinUI. On WinUI, the `Uno.WinUI` package contributes only these Uno Platform additions on top of WinUI.
 
 ## Settings
 
@@ -49,4 +49,4 @@ You can set the following properties:
 
 ## Particularities
 
-* Make sure to _give room_ for the shadow in the layout (eg. by setting a `Margin` on the `ElevatedView`).  Some platforms like macOS may clip the shadow otherwise. For the same reason, avoid wrapping the `<extras:ElevatedView>` directly in a `<ScrollViewer>` because it's designed to clip its content.
+* Make sure to _give room_ for the shadow in the layout (eg. by setting a `Margin` on the `ElevatedView`).  Some platforms like macOS may clip the shadow otherwise. For the same reason, avoid wrapping the `<uno:ElevatedView>` directly in a `<ScrollViewer>` because it's designed to clip its content.

--- a/doc/articles/features/VisibleBoundsPadding.md
+++ b/doc/articles/features/VisibleBoundsPadding.md
@@ -7,7 +7,7 @@ uid: Uno.Features.VisibleBoundsPadding
 > [!IMPORTANT]
 > The [`SafeArea`](xref:Toolkit.Controls.SafeArea) control is now preferred to `VisibleBoundsPadding`.
 
-The `Uno.UI.Extras.VisibleBoundsPadding` is a behavior that overrides the `Padding` property of a control to ensure that its inner content is always inside the `ApplicationView.VisibleBounds` rectangle.
+The `Uno.UI.Behaviors.VisibleBoundsPadding` is a behavior that overrides the `Padding` property of a control to ensure that its inner content is always inside the `ApplicationView.VisibleBounds` rectangle.
 
 The `ApplicationView.VisibleBounds` is the rectangular area of the screen which is completely unobscured by any window decoration, such as the status bar, rounded screen corners or some screen notch (e.g. the iPhone X or Essential Phone top sensors notch).
 
@@ -21,8 +21,8 @@ The behavior can be placed on any control that provides a Padding property (e.g.
 <UserControl x:Class="Uno.UI.Samples.Controls.SampleChooserControl"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:extras="using:Uno.UI.Extras">
-    <Grid extras:VisibleBoundsPadding.PaddingMask="All">
+            xmlns:uno="using:Uno.UI.Behaviors">
+    <Grid uno:VisibleBoundsPadding.PaddingMask="All">
     </Grid>
 </UserControl>
 ```
@@ -31,7 +31,7 @@ This grid will automatically be assigned a padding, and will be refreshed every 
 
 ### Specifying a target
 
-The `Uno.UI.Extras.VisibleBoundsPadding` behavior defines a `PaddingMask` property that specifies if you want to set the padding to a specific bound of the UI. The values are:
+The `Uno.UI.Behaviors.VisibleBoundsPadding` behavior defines a `PaddingMask` property that specifies if you want to set the padding to a specific bound of the UI. The values are:
 
 - `None` (*default value*)
 - `All`
@@ -46,8 +46,8 @@ Usage is as follows:
 <UserControl x:Class="Uno.UI.Samples.Controls.SampleChooserControl"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:extras="using:Uno.UI.Extras">
-    <Grid extras:VisibleBoundsPadding.PaddingMask="Bottom" />
+            xmlns:uno="using:Uno.UI.Behaviors">
+    <Grid uno:VisibleBoundsPadding.PaddingMask="Bottom" />
 </UserControl>
 ```
 

--- a/doc/articles/features/VisibleBoundsPadding.md
+++ b/doc/articles/features/VisibleBoundsPadding.md
@@ -21,8 +21,8 @@ The behavior can be placed on any control that provides a Padding property (e.g.
 <UserControl x:Class="Uno.UI.Samples.Controls.SampleChooserControl"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:uno="using:Uno.UI.Behaviors">
-    <Grid uno:VisibleBoundsPadding.PaddingMask="All">
+            xmlns:uub="using:Uno.UI.Behaviors">
+    <Grid uub:VisibleBoundsPadding.PaddingMask="All">
     </Grid>
 </UserControl>
 ```
@@ -46,8 +46,8 @@ Usage is as follows:
 <UserControl x:Class="Uno.UI.Samples.Controls.SampleChooserControl"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-            xmlns:uno="using:Uno.UI.Behaviors">
-    <Grid uno:VisibleBoundsPadding.PaddingMask="Bottom" />
+            xmlns:uub="using:Uno.UI.Behaviors">
+    <Grid uub:VisibleBoundsPadding.PaddingMask="Bottom" />
 </UserControl>
 ```
 

--- a/doc/articles/features/accessibility/role-override.md
+++ b/doc/articles/features/accessibility/role-override.md
@@ -14,16 +14,16 @@ This Uno-specific attached property lets you explicitly override the accessibili
 Add the `Uno.UI.Xaml.Automation` namespace to your XAML, then set the `AutomationPropertiesExtensions.Role` attached property on any element:
 
 ```xml
-<Page xmlns:uno="using:Uno.UI.Xaml.Automation">
+<Page xmlns:uuxa="using:Uno.UI.Xaml.Automation">
 
     <!-- Declare a navigation landmark -->
-    <StackPanel uno:AutomationPropertiesExtensions.Role="navigation">
+    <StackPanel uuxa:AutomationPropertiesExtensions.Role="navigation">
         <Button Content="Home" />
         <Button Content="Settings" />
     </StackPanel>
 
     <!-- Force a specific role on a control -->
-    <Button uno:AutomationPropertiesExtensions.Role="tab"
+    <Button uuxa:AutomationPropertiesExtensions.Role="tab"
             Content="Overview" />
 </Page>
 ```
@@ -36,7 +36,7 @@ Setting the value to an empty string or `null` removes the override, reverting t
 
 ```xml
 <!-- Remove a previously set role override -->
-<Button uno:AutomationPropertiesExtensions.Role="" Content="Regular button" />
+<Button uuxa:AutomationPropertiesExtensions.Role="" Content="Regular button" />
 ```
 
 Or in code-behind:
@@ -70,7 +70,7 @@ For standard landmark regions, prefer `AutomationProperties.LandmarkType` — it
 <StackPanel AutomationProperties.LandmarkType="Navigation" />
 
 <!-- Use Role override for non-standard or specific ARIA roles -->
-<StackPanel uno:AutomationPropertiesExtensions.Role="complementary" />
+<StackPanel uuxa:AutomationPropertiesExtensions.Role="complementary" />
 ```
 
 Use `AutomationPropertiesExtensions.Role` when:

--- a/doc/articles/features/accessibility/role-override.md
+++ b/doc/articles/features/accessibility/role-override.md
@@ -7,23 +7,23 @@ uid: Uno.Features.Accessibility.RoleOverride
 This Uno-specific attached property lets you explicitly override the accessibility role of any XAML element. It is useful for declaring landmarks, custom regions, or forcing a specific ARIA role when the default mapping from the control's `AutomationPeer` is not sufficient.
 
 > [!NOTE]
-> This is an Uno Platform extension with no WinUI equivalent. It is defined in the `Uno.UI.Extras` namespace.
+> This is an Uno Platform extension with no WinUI equivalent. It is defined in the `Uno.UI.Xaml.Automation` namespace.
 
 ## How to use
 
-Add the `Uno.UI.Extras` namespace to your XAML, then set the `AutomationPropertiesExtensions.Role` attached property on any element:
+Add the `Uno.UI.Xaml.Automation` namespace to your XAML, then set the `AutomationPropertiesExtensions.Role` attached property on any element:
 
 ```xml
-<Page xmlns:uut="using:Uno.UI.Extras">
+<Page xmlns:uno="using:Uno.UI.Xaml.Automation">
 
     <!-- Declare a navigation landmark -->
-    <StackPanel uut:AutomationPropertiesExtensions.Role="navigation">
+    <StackPanel uno:AutomationPropertiesExtensions.Role="navigation">
         <Button Content="Home" />
         <Button Content="Settings" />
     </StackPanel>
 
     <!-- Force a specific role on a control -->
-    <Button uut:AutomationPropertiesExtensions.Role="tab"
+    <Button uno:AutomationPropertiesExtensions.Role="tab"
             Content="Overview" />
 </Page>
 ```
@@ -36,7 +36,7 @@ Setting the value to an empty string or `null` removes the override, reverting t
 
 ```xml
 <!-- Remove a previously set role override -->
-<Button uut:AutomationPropertiesExtensions.Role="" Content="Regular button" />
+<Button uno:AutomationPropertiesExtensions.Role="" Content="Regular button" />
 ```
 
 Or in code-behind:
@@ -70,7 +70,7 @@ For standard landmark regions, prefer `AutomationProperties.LandmarkType` — it
 <StackPanel AutomationProperties.LandmarkType="Navigation" />
 
 <!-- Use Role override for non-standard or specific ARIA roles -->
-<StackPanel uut:AutomationPropertiesExtensions.Role="complementary" />
+<StackPanel uno:AutomationPropertiesExtensions.Role="complementary" />
 ```
 
 Use `AutomationPropertiesExtensions.Role` when:

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -1,4 +1,4 @@
----
+﻿---
 uid: Uno.Features.Uno.Sdk
 ---
 
@@ -301,7 +301,7 @@ Enable this with:
 
 When set, `Uno.Sdk` stops adding the following implicit package references on the `net*-windows10*` target framework:
 
-- `Uno.WinUI` (also removes the bundled `Uno.UI.Extras.dll` it ships under `lib/net*-windows10.0.19041.0/`)
+- `Uno.WinUI` (also removes the Uno Platform extension APIs it bundles under `lib/net*-windows10.0.19041.0/`)
 - `Uno.Resizetizer`
 - `Uno.Sdk.Extras`
 - `Uno.Settings.DevServer`

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Uno.Features.Uno.Sdk
 ---
 

--- a/doc/articles/guides/hotswap-app-language.md
+++ b/doc/articles/guides/hotswap-app-language.md
@@ -30,9 +30,9 @@ Make sure to setup your environment first by [following our instructions](xref:U
         <Page x:Class="UnoLocalization.Page1"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-              xmlns:extras="using:Uno.UI.Extras">
+              xmlns:uno="using:Uno.UI.Behaviors">
 
-            <StackPanel extras:VisibleBoundsPadding.PaddingMask="Top">
+            <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
                 <TextBlock x:Uid="Page1_Title" Text="Page one" FontSize="30" />
 
                 <Button x:Uid="Page1_GoBack" Content="Go back" Click="GoBack" />
@@ -52,9 +52,9 @@ Make sure to setup your environment first by [following our instructions](xref:U
         <Page x:Class="UnoLocalization.LanguageSettings"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-              xmlns:extras="using:Uno.UI.Extras">
+              xmlns:uno="using:Uno.UI.Behaviors">
 
-            <StackPanel extras:VisibleBoundsPadding.PaddingMask="Top">
+            <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
                 <TextBlock x:Uid="LanguageSettings_Title" Text="Language Settings" FontSize="30" />
 
                 <Button Content="English" Click="SetAppLanguage" Tag="en" />
@@ -107,7 +107,7 @@ Make sure to setup your environment first by [following our instructions](xref:U
     * `MainPage.xaml`:
 
         ```xml
-        <StackPanel extras:VisibleBoundsPadding.PaddingMask="Top">
+        <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
             <TextBlock x:Uid="MainPage_IntroText" Text="Hello, world!" Margin="20" FontSize="30" />
             <TextBlock x:Name="CodeBehindText" Text="This text will be replaced" />
 

--- a/doc/articles/guides/hotswap-app-language.md
+++ b/doc/articles/guides/hotswap-app-language.md
@@ -30,9 +30,9 @@ Make sure to setup your environment first by [following our instructions](xref:U
         <Page x:Class="UnoLocalization.Page1"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-              xmlns:uno="using:Uno.UI.Behaviors">
+              xmlns:uub="using:Uno.UI.Behaviors">
 
-            <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
+            <StackPanel uub:VisibleBoundsPadding.PaddingMask="Top">
                 <TextBlock x:Uid="Page1_Title" Text="Page one" FontSize="30" />
 
                 <Button x:Uid="Page1_GoBack" Content="Go back" Click="GoBack" />
@@ -52,9 +52,9 @@ Make sure to setup your environment first by [following our instructions](xref:U
         <Page x:Class="UnoLocalization.LanguageSettings"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-              xmlns:uno="using:Uno.UI.Behaviors">
+              xmlns:uub="using:Uno.UI.Behaviors">
 
-            <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
+            <StackPanel uub:VisibleBoundsPadding.PaddingMask="Top">
                 <TextBlock x:Uid="LanguageSettings_Title" Text="Language Settings" FontSize="30" />
 
                 <Button Content="English" Click="SetAppLanguage" Tag="en" />
@@ -107,7 +107,7 @@ Make sure to setup your environment first by [following our instructions](xref:U
     * `MainPage.xaml`:
 
         ```xml
-        <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
+        <StackPanel uub:VisibleBoundsPadding.PaddingMask="Top">
             <TextBlock x:Uid="MainPage_IntroText" Text="Hello, world!" Margin="20" FontSize="30" />
             <TextBlock x:Name="CodeBehindText" Text="This text will be replaced" />
 

--- a/doc/articles/guides/localization.md
+++ b/doc/articles/guides/localization.md
@@ -23,9 +23,9 @@ This guide will walk you through the necessary steps to localize an Uno Platform
         <Page x:Class="UnoLocalization.MainPage"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-              xmlns:uno="using:Uno.UI.Behaviors">
+              xmlns:uub="using:Uno.UI.Behaviors">
 
-            <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
+            <StackPanel uub:VisibleBoundsPadding.PaddingMask="Top">
                 <TextBlock x:Uid="MainPage_IntroText" Text="Hello, world!" Margin="20" FontSize="30" />
                 <TextBlock x:Name="CodeBehindText" Text="This text will be replaced" />
             </StackPanel>

--- a/doc/articles/guides/localization.md
+++ b/doc/articles/guides/localization.md
@@ -23,9 +23,9 @@ This guide will walk you through the necessary steps to localize an Uno Platform
         <Page x:Class="UnoLocalization.MainPage"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-              xmlns:extras="using:Uno.UI.Extras">
+              xmlns:uno="using:Uno.UI.Behaviors">
 
-            <StackPanel extras:VisibleBoundsPadding.PaddingMask="Top">
+            <StackPanel uno:VisibleBoundsPadding.PaddingMask="Top">
                 <TextBlock x:Uid="MainPage_IntroText" Text="Hello, world!" Margin="20" FontSize="30" />
                 <TextBlock x:Name="CodeBehindText" Text="This text will be replaced" />
             </StackPanel>

--- a/doc/articles/guides/open-id-connect.md
+++ b/doc/articles/guides/open-id-connect.md
@@ -99,10 +99,10 @@ Add the following lines in your application, in `[Project-name]/MainPage.xaml`:
 ```xml
 
 <!--Add this line with the other dependencies-->
-xmlns:extras="using:Uno.UI.Extras"
+xmlns:uno="using:Uno.UI.Behaviors"
 
 <!--This will replace the initial Grid-->
-<Border extras:VisibleBoundsPadding.PaddingMask="All">
+<Border uno:VisibleBoundsPadding.PaddingMask="All">
     <StackPanel Spacing="10" Margin="10">
         <StackPanel Orientation="Horizontal" Spacing="5">
             <Button Click="SignIn_Clicked" x:Name="btnSignin" IsEnabled="False">Sign In</Button>

--- a/doc/articles/guides/open-id-connect.md
+++ b/doc/articles/guides/open-id-connect.md
@@ -99,10 +99,10 @@ Add the following lines in your application, in `[Project-name]/MainPage.xaml`:
 ```xml
 
 <!--Add this line with the other dependencies-->
-xmlns:uno="using:Uno.UI.Behaviors"
+xmlns:uub="using:Uno.UI.Behaviors"
 
 <!--This will replace the initial Grid-->
-<Border uno:VisibleBoundsPadding.PaddingMask="All">
+<Border uub:VisibleBoundsPadding.PaddingMask="All">
     <StackPanel Spacing="10" Margin="10">
         <StackPanel Orientation="Horizontal" Spacing="5">
             <Button Click="SignIn_Clicked" x:Name="btnSignin" IsEnabled="False">Sign In</Button>

--- a/doc/articles/howto-consume-webservices.md
+++ b/doc/articles/howto-consume-webservices.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Uno.Development.ConsumeWebApi
 ---
 
@@ -890,7 +890,7 @@ In this task you will create the XAML for the UI and implement the bindings for 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:viewmodels="using:TheCatApiClient.Models.ViewModels"
         xmlns:datamodels="using:TheCatApiClient.Models.DataModels"
-        xmlns:uno="using:Uno.UI.Behaviors"
+        xmlns:uub="using:Uno.UI.Behaviors"
         mc:Ignorable="d"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -898,7 +898,7 @@ In this task you will create the XAML for the UI and implement the bindings for 
             <viewmodels:MainViewModel x:Name="ViewModel" />
         </Page.DataContext>
 
-        <Grid uno:VisibleBoundsPadding.PaddingMask="All">
+        <Grid uub:VisibleBoundsPadding.PaddingMask="All">
             <Grid Padding="12">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -935,12 +935,12 @@ In this task you will create the XAML for the UI and implement the bindings for 
         ...
         xmlns:viewmodels="using:TheCatApiClient.Models.ViewModels"
         xmlns:datamodels="using:TheCatApiClient.Models.DataModels"
-        xmlns:uno="using:Uno.UI.Behaviors"
+        xmlns:uub="using:Uno.UI.Behaviors"
         ...
     >
     ```
 
-    `Uno.UI.Behaviors` is added so that **uno:VisibleBoundsPadding** can be added - this ensures that the UI will adapt appropriately when the app is running on a device that has a "notch", etc.
+    `Uno.UI.Behaviors` is added so that **uub:VisibleBoundsPadding** can be added - this ensures that the UI will adapt appropriately when the app is running on a device that has a "notch", etc.
 
     Also note how the view-model **MainViewModel** is instantiated and assigned as the **DataContext**. The view-model can then be referred to as **ViewModel** in the `x:Bind` expressions you will add shortly.
 
@@ -1017,7 +1017,7 @@ In this task you will create the XAML for the UI and implement the bindings for 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:viewmodels="using:TheCatApiClient.Models.ViewModels"
         xmlns:datamodels="using:TheCatApiClient.Models.DataModels"
-        xmlns:uno="using:Uno.UI.Behaviors"
+        xmlns:uub="using:Uno.UI.Behaviors"
         mc:Ignorable="d"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/doc/articles/howto-consume-webservices.md
+++ b/doc/articles/howto-consume-webservices.md
@@ -1,4 +1,4 @@
----
+﻿---
 uid: Uno.Development.ConsumeWebApi
 ---
 
@@ -890,7 +890,7 @@ In this task you will create the XAML for the UI and implement the bindings for 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:viewmodels="using:TheCatApiClient.Models.ViewModels"
         xmlns:datamodels="using:TheCatApiClient.Models.DataModels"
-        xmlns:extras="using:Uno.UI.Extras"
+        xmlns:uno="using:Uno.UI.Behaviors"
         mc:Ignorable="d"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -898,7 +898,7 @@ In this task you will create the XAML for the UI and implement the bindings for 
             <viewmodels:MainViewModel x:Name="ViewModel" />
         </Page.DataContext>
 
-        <Grid extras:VisibleBoundsPadding.PaddingMask="All">
+        <Grid uno:VisibleBoundsPadding.PaddingMask="All">
             <Grid Padding="12">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -928,19 +928,19 @@ In this task you will create the XAML for the UI and implement the bindings for 
 
     This page utilizes a simple grid layout with 6 rows to separate the various areas of the UI and will define an overlay that will appear when the app is busy retrieving data from the service.
 
-    Notice that the XAML includes namespace definitions for the **ViewModels** and **DataModels**, as well as the **Uno.UI.Extras**:
+    Notice that the XAML includes namespace definitions for the **ViewModels** and **DataModels**, as well as **Uno.UI.Behaviors**:
 
     ```xml
     <Page
         ...
         xmlns:viewmodels="using:TheCatApiClient.Models.ViewModels"
         xmlns:datamodels="using:TheCatApiClient.Models.DataModels"
-        xmlns:extras="using:Uno.UI.Extras"
+        xmlns:uno="using:Uno.UI.Behaviors"
         ...
     >
     ```
 
-    `Uno.UI.Extras` is added so that **extras:VisibleBoundsPadding** can be added - this ensures that the UI will adapt appropriately when the app is running on a device that has a "notch", etc.
+    `Uno.UI.Behaviors` is added so that **uno:VisibleBoundsPadding** can be added - this ensures that the UI will adapt appropriately when the app is running on a device that has a "notch", etc.
 
     Also note how the view-model **MainViewModel** is instantiated and assigned as the **DataContext**. The view-model can then be referred to as **ViewModel** in the `x:Bind` expressions you will add shortly.
 
@@ -1017,7 +1017,7 @@ In this task you will create the XAML for the UI and implement the bindings for 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:viewmodels="using:TheCatApiClient.Models.ViewModels"
         xmlns:datamodels="using:TheCatApiClient.Models.DataModels"
-        xmlns:extras="using:Uno.UI.Extras"
+        xmlns:uno="using:Uno.UI.Behaviors"
         mc:Ignorable="d"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -1,4 +1,4 @@
-﻿---
+---
 uid: Uno.Development.MigratingToUno7
 ---
 
@@ -87,7 +87,7 @@ on macOS with Skia rendering. To migrate:
 | `Xamarin.AndroidX.*` transitive deps removed (AppCompat, RecyclerView, Activity, Browser, SwipeRefreshLayout) | If *your own* code uses AndroidX, add explicit `PackageReference`s. |
 | `SkiaSharp.Views.Uno.WinUI` no longer referenced implicitly | The `Uno.Sdk` used to add it to every Uno Platform target, and to WebAssembly heads using the `lottie`, `svg`, `material`, `cupertino`, or `simpletheme` features. Nothing in Uno Platform needs it anymore — SVG draws through `Uno.WinUI.Graphics2DSK` and Lottie through `SkiaSharp.Skottie`. If *your own* code uses `SKXamlCanvas` or `SKSwapChainPanel`, switch to [`SKCanvasElement`](xref:Uno.Controls.SKCanvasElement), which is hardware-accelerated and referenced implicitly; otherwise add an explicit `PackageReference`. |
 | Windows App SDK default moved from 1.7 to 2.3.1 | Windows heads now build against Windows App SDK 2.x, so packaged apps take a framework dependency on `Microsoft.WindowsAppRuntime.2` and end users need the matching [Windows App Runtime](https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads) — 2.3.1 or later from the **Stable release** section — installed. To stay on 1.x, set `<WinAppSdkVersion>` (and `<WinAppSdkBuildToolsVersion>`) explicitly in your Windows head. |
-| `Uno.UI.Toolkit.dll` renamed to `Uno.UI.Extras.dll` | The old name was routinely confused with the separate Uno Toolkit (`Uno.Toolkit.UI`). Update `using Uno.UI.Toolkit;` to `using Uno.UI.Extras;` and `xmlns:toolkit="using:Uno.UI.Toolkit"` to `using:Uno.UI.Extras`. Types keep their names. `Uno.Diagnostics.UI`, `Uno.UI.Markup`, `Uno.Helpers` and `Uno.UI.Maps` are unaffected — only the `Uno.UI.Toolkit*` namespaces moved. |
+| `Uno.UI.Toolkit` types moved to the `Uno.UI.*` namespaces | The old name was routinely confused with the separate Uno Toolkit (`Uno.Toolkit.UI`). Each type now sits in the namespace it belongs to — see [the mapping table below](#unouitoolkit-types-move-to-the-unoui-namespaces). Type names and behavior are unchanged. `Uno.Diagnostics.UI`, `Uno.UI.Markup`, `Uno.Helpers` and `Uno.UI.Maps` are unaffected — only the `Uno.UI.Toolkit*` namespaces moved. |
 
 > [!IMPORTANT]
 > This is a hard rename — there is no type-forwarder and no `xmlns` alias. `Uno.UI.Toolkit.dll`
@@ -121,9 +121,9 @@ are unchanged, and there is **no** forwarding shim: the old namespaces stop reso
 | input injection dev helpers | `Uno.UI.Toolkit.DevTools.Input` (and `.DevTools.Xaml`) | `Uno.UI.DevTools.Input` (and `.DevTools.Xaml`) |
 
 XAML declarations follow the same mapping, for example
-`xmlns:toolkit="using:Uno.UI.Toolkit"` becomes `xmlns:uno="using:Uno.UI.Xaml.Controls"` for
+`xmlns:toolkit="using:Uno.UI.Toolkit"` becomes `xmlns:uuxc="using:Uno.UI.Xaml.Controls"` for
 `ElevatedView` and the `CommandBar`/`SplitView` extensions, or
-`xmlns:uno="using:Uno.UI.Behaviors"` for `VisibleBoundsPadding`.
+`xmlns:uub="using:Uno.UI.Behaviors"` for `VisibleBoundsPadding`.
 
 The other namespaces carried by that assembly keep their names, so code using
 `DiagnosticsOverlay` (`Uno.Diagnostics.UI`), `FromJsonExtension` (`Uno.UI.Markup`) or

--- a/doc/articles/migrating-to-uno-7.md
+++ b/doc/articles/migrating-to-uno-7.md
@@ -1,4 +1,4 @@
----
+﻿---
 uid: Uno.Development.MigratingToUno7
 ---
 
@@ -103,20 +103,27 @@ on macOS with Skia rendering. To migrate:
 > alongside the Skia browser head raises the `UNOB0017` build diagnostic. Removing the
 > explicit reference resolves it.
 
-### `Uno.UI.Toolkit` is renamed to `Uno.UI.Extras`
+### `Uno.UI.Toolkit` types move to the `Uno.UI.*` namespaces
 
-The `Uno.UI.Toolkit` assembly — which ships inside the `Uno.WinUI` package — was routinely
+The `Uno.UI.Toolkit` namespace — which ships inside the `Uno.WinUI` package — was routinely
 mistaken for the separate [Uno Toolkit](xref:Toolkit.GettingStarted) product
-(`Uno.Toolkit.UI`); the two names are a word-order swap apart. It is now
-`Uno.UI.Extras`. Type names and behavior are unchanged, and there is **no** forwarding
-shim: the old namespaces stop resolving.
+(`Uno.Toolkit.UI`); the two names are a word-order swap apart. Its types now sit in the
+namespace each one belongs to, alongside the rest of the framework. Type names and behavior
+are unchanged, and there is **no** forwarding shim: the old namespaces stop resolving.
 
-| Before | After |
-|---|---|
-| `using Uno.UI.Toolkit;` | `using Uno.UI.Extras;` |
-| `using Uno.UI.Toolkit.Extensions;` | `using Uno.UI.Extras.Extensions;` |
-| `using Uno.UI.Toolkit.DevTools.Input;` (and `.DevTools.Xaml`) | `using Uno.UI.Extras.DevTools.Input;` |
-| `xmlns:toolkit="using:Uno.UI.Toolkit"` | `xmlns:extras="using:Uno.UI.Extras"` |
+| Type | Before | After |
+|---|---|---|
+| `ElevatedView`, `CommandBarExtensions`, `SplitViewExtensions` | `Uno.UI.Toolkit` | `Uno.UI.Xaml.Controls` |
+| `UIElementExtensions` | `Uno.UI.Toolkit` | `Uno.UI.Xaml` |
+| `AutomationPropertiesExtensions` | `Uno.UI.Toolkit` | `Uno.UI.Xaml.Automation` |
+| `VisibleBoundsPadding` | `Uno.UI.Toolkit` | `Uno.UI.Behaviors` |
+| `StorageFileHelper` | `Uno.UI.Toolkit` | `Uno.Storage` |
+| input injection dev helpers | `Uno.UI.Toolkit.DevTools.Input` (and `.DevTools.Xaml`) | `Uno.UI.DevTools.Input` (and `.DevTools.Xaml`) |
+
+XAML declarations follow the same mapping, for example
+`xmlns:toolkit="using:Uno.UI.Toolkit"` becomes `xmlns:uno="using:Uno.UI.Xaml.Controls"` for
+`ElevatedView` and the `CommandBar`/`SplitView` extensions, or
+`xmlns:uno="using:Uno.UI.Behaviors"` for `VisibleBoundsPadding`.
 
 The other namespaces carried by that assembly keep their names, so code using
 `DiagnosticsOverlay` (`Uno.Diagnostics.UI`), `FromJsonExtension` (`Uno.UI.Markup`) or
@@ -218,7 +225,7 @@ target framework that runs on all three. `HAS_UNO_SKIA` and `__UNO_SKIA__` are u
   `MenuFlyoutExtensions.CancelTextIosOverride` (custom cancel-button caption). Remove the
   attributes; style the `MenuFlyoutItem` directly for a destructive look.
   `UICommand.IsDestructive` is **not** removed — it still drives the native iOS
-  `MessageDialog` — but its `Uno.UI.Extras` wrapper is (see below); set the property directly.
+  `MessageDialog` — but its Uno Platform wrapper is (see below); set the property directly.
 - **Native default styles:** the whole `Generic.Native.xaml` dictionary is gone, so the
   `NativeDefaultButton`, `NativeDefaultCheckBox`, `NativeDefaultCommandBar`,
   `NativeDefaultAppBarButton`, `NativeDefaultFrame`, `NativeDefaultPivot`,
@@ -238,8 +245,8 @@ target framework that runs on all three. `HAS_UNO_SKIA` and `__UNO_SKIA__` are u
   `Style.RegisterDefaultStyleForType(Type, IXamlResourceDictionaryProvider, bool)` also loses its
   `isNative` parameter; it is `[EditorBrowsable(Never)]` and normally only called from
   XAML-generated code, so rebuilding regenerates the correct call.
-- **`Uno.UI.Extras` members that only ever ran on native targets:**
-  `Uno.UI.ViewHelper` (the `Uno.UI.Extras` one, whose only member `Architecture` always
+- **`Uno.UI.Toolkit` members that only ever ran on native targets:**
+  `Uno.UI.ViewHelper` (the `Uno.UI.Toolkit` one, whose only member `Architecture` always
   returned `null` — the unrelated `Uno.UI.ViewHelper` in `Uno.UI` stays) and
   `UICommandExtensions.SetDestructive`. To flag a destructive `UICommand`, set
   `UICommand.IsDestructive` directly from an iOS-targeted head.
@@ -582,7 +589,7 @@ New apps get Skia heads only. Existing apps should drop native `*.Mobile` / nati
 9. Convert every `xmlns:…="clr-namespace:…"` declaration in your XAML to the `using:` form.
 10. Convert the Android `Application` class to override `CreateHost()` instead of passing an
    `AppBuilder` delegate to the base constructor.
-11. Rename `Uno.UI.Toolkit` usings and `xmlns` declarations to `Uno.UI.Extras`.
+11. Rename `Uno.UI.Toolkit` usings and `xmlns` declarations to their new `Uno.UI.*` namespaces.
 12. Re-baseline visual/snapshot tests and re-test text, lists/scroll, IME, pickers, and
    safe-area/notch handling on devices.
 

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedViewTests.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedViewTests.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -46,12 +46,12 @@
                     ElevatedView With Default Color
                 </TextBlock>
                 <Grid Padding="16">
-                    <extras:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
+                    <uno:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
                         <Rectangle
                             Width="60"
                             Height="60"
                             Fill="Red" />
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <StackPanel Orientation="Horizontal" Spacing="10">
                     <Button
@@ -89,21 +89,21 @@
                     ElevatedView, some with rounded corners...
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <extras:ElevatedView
+                    <uno:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}" />
-                    <extras:ElevatedView
+                    <uno:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Rectangle Fill="Red" />
-                    </extras:ElevatedView>
-                    <extras:ElevatedView
+                    </uno:ElevatedView>
+                    <uno:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
@@ -114,8 +114,8 @@
                             Fill="Red"
                             Stroke="Blue"
                             StrokeThickness="6" />
-                    </extras:ElevatedView>
-                    <extras:ElevatedView
+                    </uno:ElevatedView>
+                    <uno:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
@@ -126,58 +126,58 @@
                             Fill="Red"
                             Stroke="Blue"
                             StrokeThickness="6" />
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </StackPanel>
                 <TextBlock FontSize="15">
                     ElevatedView with Button in them...
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <extras:ElevatedView
+                    <uno:ElevatedView
                         VerticalAlignment="Top"
                         Background="Orange"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button>Nice Elevated Button</Button>
-                    </extras:ElevatedView>
-                    <extras:ElevatedView
+                    </uno:ElevatedView>
+                    <uno:ElevatedView
                         Background="White"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button Width="120" Height="120">
                             BIG BUTTON
                         </Button>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </StackPanel>
                 <TextBlock FontSize="15">
                     ElevatedView Without background (shouldn't be elevated)
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <extras:ElevatedView
+                    <uno:ElevatedView
                         Width="60"
                         Height="60"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Rectangle Fill="Red" />
-                    </extras:ElevatedView>
-                    <extras:ElevatedView
+                    </uno:ElevatedView>
+                    <uno:ElevatedView
                         Width="60"
                         Height="60"
                         CornerRadius="10,5,10,35"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Rectangle Fill="Red" />
-                    </extras:ElevatedView>
-                    <extras:ElevatedView
+                    </uno:ElevatedView>
+                    <uno:ElevatedView
                         VerticalAlignment="Top"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button>Nice Elevated Button</Button>
-                    </extras:ElevatedView>
-                    <extras:ElevatedView Elevation="{Binding Value, ElementName=elevation1}" ShadowColor="{Binding Tag, ElementName=elevation1}">
+                    </uno:ElevatedView>
+                    <uno:ElevatedView Elevation="{Binding Value, ElementName=elevation1}" ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button Width="120" Height="120">
                             BIG BUTTON
                         </Button>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedViewTests.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedViewTests.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -46,12 +46,12 @@
                     ElevatedView With Default Color
                 </TextBlock>
                 <Grid Padding="16">
-                    <uno:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
+                    <uuxc:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
                         <Rectangle
                             Width="60"
                             Height="60"
                             Fill="Red" />
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <StackPanel Orientation="Horizontal" Spacing="10">
                     <Button
@@ -89,21 +89,21 @@
                     ElevatedView, some with rounded corners...
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <uno:ElevatedView
+                    <uuxc:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}" />
-                    <uno:ElevatedView
+                    <uuxc:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Rectangle Fill="Red" />
-                    </uno:ElevatedView>
-                    <uno:ElevatedView
+                    </uuxc:ElevatedView>
+                    <uuxc:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
@@ -114,8 +114,8 @@
                             Fill="Red"
                             Stroke="Blue"
                             StrokeThickness="6" />
-                    </uno:ElevatedView>
-                    <uno:ElevatedView
+                    </uuxc:ElevatedView>
+                    <uuxc:ElevatedView
                         Width="60"
                         Height="60"
                         Background="Orange"
@@ -126,58 +126,58 @@
                             Fill="Red"
                             Stroke="Blue"
                             StrokeThickness="6" />
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </StackPanel>
                 <TextBlock FontSize="15">
                     ElevatedView with Button in them...
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <uno:ElevatedView
+                    <uuxc:ElevatedView
                         VerticalAlignment="Top"
                         Background="Orange"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button>Nice Elevated Button</Button>
-                    </uno:ElevatedView>
-                    <uno:ElevatedView
+                    </uuxc:ElevatedView>
+                    <uuxc:ElevatedView
                         Background="White"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button Width="120" Height="120">
                             BIG BUTTON
                         </Button>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </StackPanel>
                 <TextBlock FontSize="15">
                     ElevatedView Without background (shouldn't be elevated)
                 </TextBlock>
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <uno:ElevatedView
+                    <uuxc:ElevatedView
                         Width="60"
                         Height="60"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Rectangle Fill="Red" />
-                    </uno:ElevatedView>
-                    <uno:ElevatedView
+                    </uuxc:ElevatedView>
+                    <uuxc:ElevatedView
                         Width="60"
                         Height="60"
                         CornerRadius="10,5,10,35"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Rectangle Fill="Red" />
-                    </uno:ElevatedView>
-                    <uno:ElevatedView
+                    </uuxc:ElevatedView>
+                    <uuxc:ElevatedView
                         VerticalAlignment="Top"
                         Elevation="{Binding Value, ElementName=elevation1}"
                         ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button>Nice Elevated Button</Button>
-                    </uno:ElevatedView>
-                    <uno:ElevatedView Elevation="{Binding Value, ElementName=elevation1}" ShadowColor="{Binding Tag, ElementName=elevation1}">
+                    </uuxc:ElevatedView>
+                    <uuxc:ElevatedView Elevation="{Binding Value, ElementName=elevation1}" ShadowColor="{Binding Tag, ElementName=elevation1}">
                         <Button Width="120" Height="120">
                             BIG BUTTON
                         </Button>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_BorderThickness.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_BorderThickness.xaml
@@ -3,13 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <StackPanel Margin="12" Spacing="10">
-        <extras:ElevatedView
+        <uno:ElevatedView
             Width="120"
             Height="120"
             Margin="0,30"
@@ -22,6 +22,6 @@
                 Width="120"
                 Height="120"
                 Fill="Orange" />
-        </extras:ElevatedView>
+        </uno:ElevatedView>
     </StackPanel>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_BorderThickness.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_BorderThickness.xaml
@@ -4,12 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <StackPanel Margin="12" Spacing="10">
-        <uno:ElevatedView
+        <uuxc:ElevatedView
             Width="120"
             Height="120"
             Margin="0,30"
@@ -22,6 +22,6 @@
                 Width="120"
                 Height="120"
                 Fill="Orange" />
-        </uno:ElevatedView>
+        </uuxc:ElevatedView>
     </StackPanel>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_CornerRadius.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_CornerRadius.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -22,7 +22,7 @@
         <TextBlock FontSize="15">Those elevated views should all be identical</TextBlock>
 
         <StackPanel Orientation="Horizontal" Spacing="15">
-            <uno:ElevatedView
+            <uuxc:ElevatedView
                 Width="120"
                 Height="120"
                 Margin="0,30"
@@ -33,8 +33,8 @@
                     Width="120"
                     Height="120"
                     Fill="Orange" />
-            </uno:ElevatedView>
-            <uno:ElevatedView
+            </uuxc:ElevatedView>
+            <uuxc:ElevatedView
                 Width="120"
                 Height="120"
                 Margin="0,30"
@@ -42,7 +42,7 @@
                 CornerRadius="{Binding Value, ElementName=radius}"
                 Elevation="{Binding Value, ElementName=elevation}" />
             <StackPanel Margin="0,30">
-                <uno:ElevatedView
+                <uuxc:ElevatedView
                     Width="120"
                     Height="120"
                     Background="Orange"
@@ -50,7 +50,7 @@
                     Elevation="{Binding Value, ElementName=elevation}" />
             </StackPanel>
             <ScrollViewer Padding="30">
-                <uno:ElevatedView
+                <uuxc:ElevatedView
                     Width="120"
                     Height="120"
                     Background="Orange"
@@ -58,7 +58,7 @@
                     Elevation="{Binding Value, ElementName=elevation}" />
             </ScrollViewer>
             <ScrollViewer>
-                <uno:ElevatedView
+                <uuxc:ElevatedView
                     Width="120"
                     Height="120"
                     Margin="0,30"

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_CornerRadius.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_CornerRadius.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -22,7 +22,7 @@
         <TextBlock FontSize="15">Those elevated views should all be identical</TextBlock>
 
         <StackPanel Orientation="Horizontal" Spacing="15">
-            <extras:ElevatedView
+            <uno:ElevatedView
                 Width="120"
                 Height="120"
                 Margin="0,30"
@@ -33,8 +33,8 @@
                     Width="120"
                     Height="120"
                     Fill="Orange" />
-            </extras:ElevatedView>
-            <extras:ElevatedView
+            </uno:ElevatedView>
+            <uno:ElevatedView
                 Width="120"
                 Height="120"
                 Margin="0,30"
@@ -42,7 +42,7 @@
                 CornerRadius="{Binding Value, ElementName=radius}"
                 Elevation="{Binding Value, ElementName=elevation}" />
             <StackPanel Margin="0,30">
-                <extras:ElevatedView
+                <uno:ElevatedView
                     Width="120"
                     Height="120"
                     Background="Orange"
@@ -50,7 +50,7 @@
                     Elevation="{Binding Value, ElementName=elevation}" />
             </StackPanel>
             <ScrollViewer Padding="30">
-                <extras:ElevatedView
+                <uno:ElevatedView
                     Width="120"
                     Height="120"
                     Background="Orange"
@@ -58,7 +58,7 @@
                     Elevation="{Binding Value, ElementName=elevation}" />
             </ScrollViewer>
             <ScrollViewer>
-                <extras:ElevatedView
+                <uno:ElevatedView
                     Width="120"
                     Height="120"
                     Margin="0,30"

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Corners.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Corners.xaml
@@ -3,14 +3,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:UITests.Toolkit"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <Grid Background="White">
-        <extras:ElevatedView
+        <uno:ElevatedView
             x:Name="Elevation"
             Width="300"
             Height="300"
@@ -28,6 +28,6 @@
                 This sample is used by automated unit tests to ensure the
                 elevation's drop shadow is drawn properly on all platforms.
             </TextBlock>
-        </extras:ElevatedView>
+        </uno:ElevatedView>
     </Grid>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Corners.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Corners.xaml
@@ -5,12 +5,12 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Toolkit"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <Grid Background="White">
-        <uno:ElevatedView
+        <uuxc:ElevatedView
             x:Name="Elevation"
             Width="300"
             Height="300"
@@ -28,6 +28,6 @@
                 This sample is used by automated unit tests to ensure the
                 elevation's drop shadow is drawn properly on all platforms.
             </TextBlock>
-        </uno:ElevatedView>
+        </uuxc:ElevatedView>
     </Grid>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Dimensions.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Dimensions.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -13,7 +13,7 @@
         Padding="32,32"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-        <extras:ElevatedView
+        <uno:ElevatedView
             x:Name="elevatedView"
             Width="200"
             Height="160"
@@ -28,6 +28,6 @@
                 Margin="20"
                 FontSize="30"
                 Text="Hello, world!" />
-        </extras:ElevatedView>
+        </uno:ElevatedView>
     </Grid>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Dimensions.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Dimensions.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -13,7 +13,7 @@
         Padding="32,32"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-        <uno:ElevatedView
+        <uuxc:ElevatedView
             x:Name="elevatedView"
             Width="200"
             Height="160"
@@ -28,6 +28,6 @@
                 Margin="20"
                 FontSize="30"
                 Text="Hello, world!" />
-        </uno:ElevatedView>
+        </uuxc:ElevatedView>
     </Grid>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Levels.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Levels.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
     <Page.Resources>
@@ -23,67 +23,67 @@
             RowSpacing="8">
             <StackPanel Spacing="0">
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="1">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="1">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="01 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="2">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="2">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="02 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="3">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="3">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="03 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="4">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="4">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="04 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="6">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="6">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="06 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="8">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="8">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="08 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="9">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="9">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="09 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="12">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="12">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="12 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <extras:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="16">
+                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="16">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="16 dp" />
                         </Grid>
-                    </extras:ElevatedView>
+                    </uno:ElevatedView>
                 </Grid>
             </StackPanel>
         </Grid>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Levels.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Levels.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
     <Page.Resources>
@@ -23,67 +23,67 @@
             RowSpacing="8">
             <StackPanel Spacing="0">
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="1">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="1">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="01 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="2">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="2">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="02 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="3">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="3">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="03 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="4">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="4">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="04 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="6">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="6">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="06 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="8">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="8">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="08 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="9">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="9">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="09 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="12">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="12">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="12 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
                 <Grid Padding="20">
-                    <uno:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="16">
+                    <uuxc:ElevatedView Background="{StaticResource SurfaceBrush}" Elevation="16">
                         <Grid Height="50">
                             <TextBlock Style="{StaticResource DescriptionTextStyle}" Text="16 dp" />
                         </Grid>
-                    </uno:ElevatedView>
+                    </uuxc:ElevatedView>
                 </Grid>
             </StackPanel>
         </Grid>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Tester.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Tester.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -46,13 +46,13 @@
             Text="{x:Bind ColorString, Mode=TwoWay}" />
 
         <Grid Grid.Row="3">
-            <extras:ElevatedView
+            <uno:ElevatedView
                 x:Name="ElevatedElement"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Background="Blue">
                 <Grid Width="100" Height="100" />
-            </extras:ElevatedView>
+            </uno:ElevatedView>
         </Grid>
     </Grid>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Tester.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevatedView_Tester.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -46,13 +46,13 @@
             Text="{x:Bind ColorString, Mode=TwoWay}" />
 
         <Grid Grid.Row="3">
-            <uno:ElevatedView
+            <uuxc:ElevatedView
                 x:Name="ElevatedElement"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Background="Blue">
                 <Grid Width="100" Height="100" />
-            </uno:ElevatedView>
+            </uuxc:ElevatedView>
         </Grid>
     </Grid>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/Elevation.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/Elevation.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.Elevation"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml"
+    xmlns:uux="using:Uno.UI.Xaml"
     mc:Ignorable="">
 
     <Grid>
@@ -31,7 +31,7 @@
                     Width="300"
                     Height="125"
                     Margin="10"
-                    uno:UIElementExtensions.Elevation="24"
+                    uux:UIElementExtensions.Elevation="24"
                     Background="White"
                     Visibility="Collapsed" />
 
@@ -50,7 +50,7 @@
                     Width="56"
                     Height="56"
                     Margin="10"
-                    uno:UIElementExtensions.Elevation="6"
+                    uux:UIElementExtensions.Elevation="6"
                     Background="Red"
                     CornerRadius="28"
                     Visibility="Collapsed" />
@@ -70,7 +70,7 @@
                     Width="56"
                     Height="56"
                     Margin="10"
-                    uno:UIElementExtensions.Elevation="6"
+                    uux:UIElementExtensions.Elevation="6"
                     Background="Orange"
                     CornerRadius="4,8,12,16"
                     Visibility="Collapsed" />
@@ -89,7 +89,7 @@
                     x:Name="MyAppBar_WithElevation"
                     Width="200"
                     Margin="10"
-                    uno:UIElementExtensions.Elevation="4"
+                    uux:UIElementExtensions.Elevation="4"
                     Background="RoyalBlue"
                     Content="Title"
                     Foreground="White"
@@ -109,7 +109,7 @@
                     Width="75"
                     Height="100"
                     Margin="10"
-                    uno:UIElementExtensions.Elevation="2"
+                    uux:UIElementExtensions.Elevation="2"
                     Background="White"
                     Visibility="Collapsed" />
             </StackPanel>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/Elevation.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/Elevation.xaml
@@ -2,9 +2,9 @@
     x:Class="UITests.Shared.Toolkit.Elevation"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.Elevation"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml"
     mc:Ignorable="">
 
     <Grid>
@@ -31,7 +31,7 @@
                     Width="300"
                     Height="125"
                     Margin="10"
-                    extras:UIElementExtensions.Elevation="24"
+                    uno:UIElementExtensions.Elevation="24"
                     Background="White"
                     Visibility="Collapsed" />
 
@@ -50,7 +50,7 @@
                     Width="56"
                     Height="56"
                     Margin="10"
-                    extras:UIElementExtensions.Elevation="6"
+                    uno:UIElementExtensions.Elevation="6"
                     Background="Red"
                     CornerRadius="28"
                     Visibility="Collapsed" />
@@ -70,7 +70,7 @@
                     Width="56"
                     Height="56"
                     Margin="10"
-                    extras:UIElementExtensions.Elevation="6"
+                    uno:UIElementExtensions.Elevation="6"
                     Background="Orange"
                     CornerRadius="4,8,12,16"
                     Visibility="Collapsed" />
@@ -89,7 +89,7 @@
                     x:Name="MyAppBar_WithElevation"
                     Width="200"
                     Margin="10"
-                    extras:UIElementExtensions.Elevation="4"
+                    uno:UIElementExtensions.Elevation="4"
                     Background="RoyalBlue"
                     Content="Title"
                     Foreground="White"
@@ -109,7 +109,7 @@
                     Width="75"
                     Height="100"
                     Margin="10"
-                    extras:UIElementExtensions.Elevation="2"
+                    uno:UIElementExtensions.Elevation="2"
                     Background="White"
                     Visibility="Collapsed" />
             </StackPanel>

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevationView_Clipping.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevationView_Clipping.xaml
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:UITests.Toolkit"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -15,7 +15,7 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ContentControl">
-                        <extras:ElevatedView
+                        <uno:ElevatedView
                             Background="{TemplateBinding Background}"
                             Elevation="15"
                             ShadowColor="Chartreuse">
@@ -26,7 +26,7 @@
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-                        </extras:ElevatedView>
+                        </uno:ElevatedView>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
@@ -37,7 +37,7 @@
         <TextBlock>The following rectangles should have the same drop shadow...</TextBlock>
 
         <StackPanel Orientation="Horizontal" Spacing="15">
-            <extras:ElevatedView
+            <uno:ElevatedView
                 Background="Blue"
                 Elevation="15"
                 ShadowColor="Chartreuse">
@@ -45,24 +45,24 @@
                     Width="40"
                     Height="40"
                     Background="Red" />
-            </extras:ElevatedView>
+            </uno:ElevatedView>
 
             <ContentControl>
-                <extras:ElevatedView Elevation="15" ShadowColor="Chartreuse">
+                <uno:ElevatedView Elevation="15" ShadowColor="Chartreuse">
                     <Border
                         Width="40"
                         Height="40"
                         Background="Red" />
-                </extras:ElevatedView>
+                </uno:ElevatedView>
             </ContentControl>
 
             <Border>
-                <extras:ElevatedView Elevation="15" ShadowColor="Chartreuse">
+                <uno:ElevatedView Elevation="15" ShadowColor="Chartreuse">
                     <Border
                         Width="40"
                         Height="40"
                         Background="Red" />
-                </extras:ElevatedView>
+                </uno:ElevatedView>
             </Border>
 
             <ContentControl Style="{StaticResource style1}">

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevationView_Clipping.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/ElevationView_Clipping.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Toolkit"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -15,7 +15,7 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ContentControl">
-                        <uno:ElevatedView
+                        <uuxc:ElevatedView
                             Background="{TemplateBinding Background}"
                             Elevation="15"
                             ShadowColor="Chartreuse">
@@ -26,7 +26,7 @@
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
-                        </uno:ElevatedView>
+                        </uuxc:ElevatedView>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
@@ -37,7 +37,7 @@
         <TextBlock>The following rectangles should have the same drop shadow...</TextBlock>
 
         <StackPanel Orientation="Horizontal" Spacing="15">
-            <uno:ElevatedView
+            <uuxc:ElevatedView
                 Background="Blue"
                 Elevation="15"
                 ShadowColor="Chartreuse">
@@ -45,24 +45,24 @@
                     Width="40"
                     Height="40"
                     Background="Red" />
-            </uno:ElevatedView>
+            </uuxc:ElevatedView>
 
             <ContentControl>
-                <uno:ElevatedView Elevation="15" ShadowColor="Chartreuse">
+                <uuxc:ElevatedView Elevation="15" ShadowColor="Chartreuse">
                     <Border
                         Width="40"
                         Height="40"
                         Background="Red" />
-                </uno:ElevatedView>
+                </uuxc:ElevatedView>
             </ContentControl>
 
             <Border>
-                <uno:ElevatedView Elevation="15" ShadowColor="Chartreuse">
+                <uuxc:ElevatedView Elevation="15" ShadowColor="Chartreuse">
                     <Border
                         Width="40"
                         Height="40"
                         Background="Red" />
-                </uno:ElevatedView>
+                </uuxc:ElevatedView>
             </Border>
 
             <ContentControl Style="{StaticResource style1}">

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/VisibleBoundsPadding_Modal.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/VisibleBoundsPadding_Modal.xaml
@@ -5,12 +5,12 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Toolkit"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Behaviors"
+    xmlns:uub="using:Uno.UI.Behaviors"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <Grid
-        uno:VisibleBoundsPadding.PaddingMask="All"
+        uub:VisibleBoundsPadding.PaddingMask="All"
         AutomationProperties.AutomationId="ContainerGrid"
         Background="Blue">
         <Rectangle AutomationProperties.AutomationId="TestRectangle" Fill="Red" />

--- a/src/SamplesApp/SamplesApp.Samples/Toolkit/VisibleBoundsPadding_Modal.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Toolkit/VisibleBoundsPadding_Modal.xaml
@@ -3,14 +3,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:UITests.Toolkit"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Behaviors"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <Grid
-        extras:VisibleBoundsPadding.PaddingMask="All"
+        uno:VisibleBoundsPadding.PaddingMask="All"
         AutomationProperties.AutomationId="ContainerGrid"
         Background="Blue">
         <Rectangle AutomationProperties.AutomationId="TestRectangle" Fill="Red" />

--- a/src/SamplesApp/SamplesApp.Samples/Windows/Data/Pdf/PdfDocumentRenderTest.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/Data/Pdf/PdfDocumentRenderTest.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml"
+    xmlns:uux="using:Uno.UI.Xaml"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -83,7 +83,7 @@
                 Margin="10"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
-                uno:UIElementExtensions.Elevation="2"
+                uux:UIElementExtensions.Elevation="2"
                 Background="White">
                 <Image
                     x:Name="Output"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/Data/Pdf/PdfDocumentRenderTest.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/Data/Pdf/PdfDocumentRenderTest.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -83,7 +83,7 @@
                 Margin="10"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
-                extras:UIElementExtensions.Elevation="2"
+                uno:UIElementExtensions.Elevation="2"
                 Background="White">
                 <Image
                     x:Name="Output"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_Shadow.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_Shadow.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -15,7 +15,7 @@
             Canvas.Top="100"
             Width="60"
             Height="60"
-            extras:UIElementExtensions.Elevation="24"
+            uno:UIElementExtensions.Elevation="24"
             Background="{ThemeResource SystemControlBackgroundAccentBrush}" />
     </Canvas>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_Shadow.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_Shadow.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml"
+    xmlns:uux="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -15,7 +15,7 @@
             Canvas.Top="100"
             Width="60"
             Height="60"
-            uno:UIElementExtensions.Elevation="24"
+            uux:UIElementExtensions.Elevation="24"
             Background="{ThemeResource SystemControlBackgroundAccentBrush}" />
     </Canvas>
 </Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChild.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChild.xaml
@@ -2,7 +2,7 @@
     x:Class="UITests.Shared.Windows_UI_Composition.DamageRegion.DamageRegion_ShadowChild"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:extras="using:Uno.UI.Extras"
+    xmlns:uno="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Canvas>
         <Border
@@ -11,7 +11,7 @@
             Canvas.Top="100"
             Width="300"
             Height="200"
-            extras:UIElementExtensions.Elevation="24">
+            uno:UIElementExtensions.Elevation="24">
             <Canvas>
                 <Border
                     x:Name="Child"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChild.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChild.xaml
@@ -2,7 +2,7 @@
     x:Class="UITests.Shared.Windows_UI_Composition.DamageRegion.DamageRegion_ShadowChild"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:uno="using:Uno.UI.Xaml"
+    xmlns:uux="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Canvas>
         <Border
@@ -11,7 +11,7 @@
             Canvas.Top="100"
             Width="300"
             Height="200"
-            uno:UIElementExtensions.Elevation="24">
+            uux:UIElementExtensions.Elevation="24">
             <Canvas>
                 <Border
                     x:Name="Child"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildPaintingCaster.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildPaintingCaster.xaml
@@ -2,7 +2,7 @@
     x:Class="UITests.Shared.Windows_UI_Composition.DamageRegion.DamageRegion_ShadowChildPaintingCaster"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:uno="using:Uno.UI.Xaml"
+    xmlns:uux="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Canvas>
         <Border
@@ -11,7 +11,7 @@
             Canvas.Top="120"
             Width="320"
             Height="160"
-            uno:UIElementExtensions.Elevation="24"
+            uux:UIElementExtensions.Elevation="24"
             Background="#40808080">
             <Canvas>
                 <Border

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildPaintingCaster.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildPaintingCaster.xaml
@@ -2,7 +2,7 @@
     x:Class="UITests.Shared.Windows_UI_Composition.DamageRegion.DamageRegion_ShadowChildPaintingCaster"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:extras="using:Uno.UI.Extras"
+    xmlns:uno="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Canvas>
         <Border
@@ -11,7 +11,7 @@
             Canvas.Top="120"
             Width="320"
             Height="160"
-            extras:UIElementExtensions.Elevation="24"
+            uno:UIElementExtensions.Elevation="24"
             Background="#40808080">
             <Canvas>
                 <Border

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildShape.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildShape.xaml
@@ -2,7 +2,7 @@
     x:Class="UITests.Shared.Windows_UI_Composition.DamageRegion.DamageRegion_ShadowChildShape"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:uno="using:Uno.UI.Xaml"
+    xmlns:uux="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Canvas>
         <Border
@@ -11,7 +11,7 @@
             Canvas.Top="120"
             Width="120"
             Height="120"
-            uno:UIElementExtensions.Elevation="24">
+            uux:UIElementExtensions.Elevation="24">
             <Canvas>
                 <Ellipse
                     x:Name="Child"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildShape.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Composition/DamageRegion/DamageRegion_ShadowChildShape.xaml
@@ -2,7 +2,7 @@
     x:Class="UITests.Shared.Windows_UI_Composition.DamageRegion.DamageRegion_ShadowChildShape"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:extras="using:Uno.UI.Extras"
+    xmlns:uno="using:Uno.UI.Xaml"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
     <Canvas>
         <Border
@@ -11,7 +11,7 @@
             Canvas.Top="120"
             Width="120"
             Height="120"
-            extras:UIElementExtensions.Elevation="24">
+            uno:UIElementExtensions.Elevation="24">
             <Canvas>
                 <Ellipse
                     x:Name="Child"

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Automation/AutomationPropertiesExtensions_Role.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Automation/AutomationPropertiesExtensions_Role.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:Uno.UI.Samples.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uut="using:Uno.UI.Extras"
+    xmlns:uno="using:Uno.UI.Xaml.Automation"
     d:DesignHeight="400"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -22,21 +22,21 @@
             <!--  Landmark roles  -->
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="main"
+                uno:AutomationPropertiesExtensions.Role="main"
                 Background="CornflowerBlue">
                 <TextBlock Foreground="White" Text="Border with role='main'" />
             </Border>
 
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="navigation"
+                uno:AutomationPropertiesExtensions.Role="navigation"
                 Background="SteelBlue">
                 <TextBlock Foreground="White" Text="Border with role='navigation'" />
             </Border>
 
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="region"
+                uno:AutomationPropertiesExtensions.Role="region"
                 Background="MediumSlateBlue">
                 <TextBlock Foreground="White" Text="Border with role='region'" />
             </Border>
@@ -44,14 +44,14 @@
             <!--  Non-landmark overrides  -->
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="application"
+                uno:AutomationPropertiesExtensions.Role="application"
                 Background="DarkSlateBlue">
                 <TextBlock Foreground="White" Text="Border with role='application'" />
             </Border>
 
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="presentation"
+                uno:AutomationPropertiesExtensions.Role="presentation"
                 Background="SlateGray">
                 <TextBlock Foreground="White" Text="Border with role='presentation'" />
             </Border>
@@ -59,29 +59,29 @@
             <!--  Widget-level overrides  -->
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="tablist"
+                uno:AutomationPropertiesExtensions.Role="tablist"
                 Background="Teal">
                 <TextBlock Foreground="White" Text="Border with role='tablist'" />
             </Border>
 
             <Border
                 Padding="8"
-                uut:AutomationPropertiesExtensions.Role="tab"
+                uno:AutomationPropertiesExtensions.Role="tab"
                 Background="CadetBlue">
                 <TextBlock Foreground="White" Text="Border with role='tab'" />
             </Border>
 
             <!--  Button – role clears back to default (null/empty)  -->
-            <Button uut:AutomationPropertiesExtensions.Role="" Content="Button with role cleared (default)" />
+            <Button uno:AutomationPropertiesExtensions.Role="" Content="Button with role cleared (default)" />
 
-            <ComboBox uut:AutomationPropertiesExtensions.Role="listbox">
+            <ComboBox uno:AutomationPropertiesExtensions.Role="listbox">
                 <ComboBoxItem Content="ComboBox with role='listbox'" />
                 <ComboBoxItem Content="Item 2" />
                 <ComboBoxItem Content="Item 3" />
                 <ComboBoxItem Content="Item 4" />
             </ComboBox>
 
-            <CheckBox uut:AutomationPropertiesExtensions.Role="application" Content="CheckBox with role='application'" />
+            <CheckBox uno:AutomationPropertiesExtensions.Role="application" Content="CheckBox with role='application'" />
         </StackPanel>
     </ScrollViewer>
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Automation/AutomationPropertiesExtensions_Role.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Automation/AutomationPropertiesExtensions_Role.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:Uno.UI.Samples.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Automation"
+    xmlns:uuxa="using:Uno.UI.Xaml.Automation"
     d:DesignHeight="400"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -22,21 +22,21 @@
             <!--  Landmark roles  -->
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="main"
+                uuxa:AutomationPropertiesExtensions.Role="main"
                 Background="CornflowerBlue">
                 <TextBlock Foreground="White" Text="Border with role='main'" />
             </Border>
 
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="navigation"
+                uuxa:AutomationPropertiesExtensions.Role="navigation"
                 Background="SteelBlue">
                 <TextBlock Foreground="White" Text="Border with role='navigation'" />
             </Border>
 
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="region"
+                uuxa:AutomationPropertiesExtensions.Role="region"
                 Background="MediumSlateBlue">
                 <TextBlock Foreground="White" Text="Border with role='region'" />
             </Border>
@@ -44,14 +44,14 @@
             <!--  Non-landmark overrides  -->
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="application"
+                uuxa:AutomationPropertiesExtensions.Role="application"
                 Background="DarkSlateBlue">
                 <TextBlock Foreground="White" Text="Border with role='application'" />
             </Border>
 
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="presentation"
+                uuxa:AutomationPropertiesExtensions.Role="presentation"
                 Background="SlateGray">
                 <TextBlock Foreground="White" Text="Border with role='presentation'" />
             </Border>
@@ -59,29 +59,29 @@
             <!--  Widget-level overrides  -->
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="tablist"
+                uuxa:AutomationPropertiesExtensions.Role="tablist"
                 Background="Teal">
                 <TextBlock Foreground="White" Text="Border with role='tablist'" />
             </Border>
 
             <Border
                 Padding="8"
-                uno:AutomationPropertiesExtensions.Role="tab"
+                uuxa:AutomationPropertiesExtensions.Role="tab"
                 Background="CadetBlue">
                 <TextBlock Foreground="White" Text="Border with role='tab'" />
             </Border>
 
             <!--  Button – role clears back to default (null/empty)  -->
-            <Button uno:AutomationPropertiesExtensions.Role="" Content="Button with role cleared (default)" />
+            <Button uuxa:AutomationPropertiesExtensions.Role="" Content="Button with role cleared (default)" />
 
-            <ComboBox uno:AutomationPropertiesExtensions.Role="listbox">
+            <ComboBox uuxa:AutomationPropertiesExtensions.Role="listbox">
                 <ComboBoxItem Content="ComboBox with role='listbox'" />
                 <ComboBoxItem Content="Item 2" />
                 <ComboBoxItem Content="Item 3" />
                 <ComboBoxItem Content="Item 4" />
             </ComboBox>
 
-            <CheckBox uno:AutomationPropertiesExtensions.Role="application" Content="CheckBox with role='application'" />
+            <CheckBox uuxa:AutomationPropertiesExtensions.Role="application" Content="CheckBox with role='application'" />
         </StackPanel>
     </ScrollViewer>
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/ComboBox/ComboBox_VisibleBounds.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/ComboBox/ComboBox_VisibleBounds.xaml
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ComboBox"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Behaviors"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -277,7 +277,7 @@
 
         <Border
             Padding="0,28,0,0"
-            extras:VisibleBoundsPadding.PaddingMask="Top"
+            uno:VisibleBoundsPadding.PaddingMask="Top"
             Background="Black" />
 
         <!--  HEADER  -->

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/ComboBox/ComboBox_VisibleBounds.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/ComboBox/ComboBox_VisibleBounds.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ComboBox"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Behaviors"
+    xmlns:uub="using:Uno.UI.Behaviors"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -277,7 +277,7 @@
 
         <Border
             Padding="0,28,0,0"
-            uno:VisibleBoundsPadding.PaddingMask="Top"
+            uub:VisibleBoundsPadding.PaddingMask="Top"
             Background="Black" />
 
         <!--  HEADER  -->

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_CollapsedNavigationCommand.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_CollapsedNavigationCommand.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     mc:Ignorable="d">
 
     <Grid Background="Purple">
@@ -15,13 +15,13 @@
         </Grid.RowDefinitions>
 
         <CommandBar Content="Collapsed NavigationCommand" Visibility="Collapsed">
-            <uno:CommandBarExtensions.NavigationCommand>
+            <uuxc:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Command="{Binding Command}" Label="MyLabel">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </uno:CommandBarExtensions.NavigationCommand>
+            </uuxc:CommandBarExtensions.NavigationCommand>
         </CommandBar>
 
         <TextBlock

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_CollapsedNavigationCommand.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_CollapsedNavigationCommand.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     mc:Ignorable="d">
 
     <Grid Background="Purple">
@@ -15,13 +15,13 @@
         </Grid.RowDefinitions>
 
         <CommandBar Content="Collapsed NavigationCommand" Visibility="Collapsed">
-            <extras:CommandBarExtensions.NavigationCommand>
+            <uno:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Command="{Binding Command}" Label="MyLabel">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </extras:CommandBarExtensions.NavigationCommand>
+            </uno:CommandBarExtensions.NavigationCommand>
         </CommandBar>
 
         <TextBlock

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_NavigationCommand.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_NavigationCommand.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     mc:Ignorable="d">
 
     <Grid Background="Orange">
@@ -15,13 +15,13 @@
         </Grid.RowDefinitions>
 
         <CommandBar Content="NavigationCommand" Foreground="DarkGray">
-            <uno:CommandBarExtensions.NavigationCommand>
+            <uuxc:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Command="{Binding Command}" Label="MyLabel">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </uno:CommandBarExtensions.NavigationCommand>
+            </uuxc:CommandBarExtensions.NavigationCommand>
         </CommandBar>
 
         <TextBlock

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_NavigationCommand.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/BackGesture/BackGesture_NavigationCommand.xaml
@@ -3,8 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     mc:Ignorable="d">
 
     <Grid Background="Orange">
@@ -15,13 +15,13 @@
         </Grid.RowDefinitions>
 
         <CommandBar Content="NavigationCommand" Foreground="DarkGray">
-            <extras:CommandBarExtensions.NavigationCommand>
+            <uno:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Command="{Binding Command}" Label="MyLabel">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </extras:CommandBarExtensions.NavigationCommand>
+            </uno:CommandBarExtensions.NavigationCommand>
         </CommandBar>
 
         <TextBlock

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Content.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Content.xaml
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -58,13 +58,13 @@
 
             <TextBlock Text="Empty" />
             <CommandBar Background="Orange">
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -80,13 +80,13 @@
                 Background="LightGreen"
                 Content="String"
                 Foreground="DarkGray">
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -102,13 +102,13 @@
                 <CommandBar.Content>
                     <Border Background="Red" />
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton>
                         <AppBarButton.Icon>
@@ -131,13 +131,13 @@
                         VerticalAlignment="Center"
                         Background="Red" />
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -153,13 +153,13 @@
                 <CommandBar.Content>
                     <TextBlock VerticalAlignment="Center" Text="TextBlock" />
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.SecondaryCommands>
                     <AppBarButton Foreground="DarkBlue" Label="SecondaryCommand1" />
                     <AppBarButton Foreground="DarkBlue">
@@ -178,13 +178,13 @@
                         <TextBlock Text="TextBlock" />
                     </StackPanel>
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -200,13 +200,13 @@
                 <CommandBar.Content>
                     <TextBox PlaceholderText="TextBox" Style="{StaticResource XamlDefaultTextBox}" />
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton>
                         <AppBarButton.Icon>
@@ -222,13 +222,13 @@
                 <CommandBar.Content>
                     <TextBlock Text="TextBlock" />
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton Label="Icon">
@@ -244,13 +244,13 @@
                 <CommandBar.Content>
                     <TextBlock Text="{Binding}" />
                 </CommandBar.Content>
-                <extras:CommandBarExtensions.NavigationCommand>
+                <uno:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </extras:CommandBarExtensions.NavigationCommand>
+                </uno:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Content.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Content.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -58,13 +58,13 @@
 
             <TextBlock Text="Empty" />
             <CommandBar Background="Orange">
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -80,13 +80,13 @@
                 Background="LightGreen"
                 Content="String"
                 Foreground="DarkGray">
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -102,13 +102,13 @@
                 <CommandBar.Content>
                     <Border Background="Red" />
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton>
                         <AppBarButton.Icon>
@@ -131,13 +131,13 @@
                         VerticalAlignment="Center"
                         Background="Red" />
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -153,13 +153,13 @@
                 <CommandBar.Content>
                     <TextBlock VerticalAlignment="Center" Text="TextBlock" />
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.SecondaryCommands>
                     <AppBarButton Foreground="DarkBlue" Label="SecondaryCommand1" />
                     <AppBarButton Foreground="DarkBlue">
@@ -178,13 +178,13 @@
                         <TextBlock Text="TextBlock" />
                     </StackPanel>
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>
@@ -200,13 +200,13 @@
                 <CommandBar.Content>
                     <TextBox PlaceholderText="TextBox" Style="{StaticResource XamlDefaultTextBox}" />
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton>
                         <AppBarButton.Icon>
@@ -222,13 +222,13 @@
                 <CommandBar.Content>
                     <TextBlock Text="TextBlock" />
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton Label="Icon">
@@ -244,13 +244,13 @@
                 <CommandBar.Content>
                     <TextBlock Text="{Binding}" />
                 </CommandBar.Content>
-                <uno:CommandBarExtensions.NavigationCommand>
+                <uuxc:CommandBarExtensions.NavigationCommand>
                     <AppBarButton Command="{Binding Command}" Label="Label">
                         <AppBarButton.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                         </AppBarButton.Icon>
                     </AppBarButton>
-                </uno:CommandBarExtensions.NavigationCommand>
+                </uuxc:CommandBarExtensions.NavigationCommand>
                 <CommandBar.PrimaryCommands>
                     <AppBarButton Content="Button" />
                     <AppBarButton>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Extensions.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Extensions.xaml
@@ -6,7 +6,7 @@
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:not_win="http://uno.ui/not_win"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -27,13 +27,13 @@
 
             <not_win:Grid>
                 <CommandBar Content="Title">
-                    <uno:CommandBarExtensions.NavigationCommand>
+                    <uuxc:CommandBarExtensions.NavigationCommand>
                         <AppBarButton Command="{Binding Command}" Label="Label">
                             <AppBarButton.Icon>
                                 <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                             </AppBarButton.Icon>
                         </AppBarButton>
-                    </uno:CommandBarExtensions.NavigationCommand>
+                    </uuxc:CommandBarExtensions.NavigationCommand>
                 </CommandBar>
             </not_win:Grid>
 
@@ -42,7 +42,7 @@
                     Background="Tomato"
                     Content="Title"
                     Foreground="White">
-                    <uno:CommandBarExtensions.NavigationCommand>
+                    <uuxc:CommandBarExtensions.NavigationCommand>
                         <AppBarButton
                             Command="{Binding Command}"
                             Foreground="White"
@@ -51,7 +51,7 @@
                                 <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                             </AppBarButton.Icon>
                         </AppBarButton>
-                    </uno:CommandBarExtensions.NavigationCommand>
+                    </uuxc:CommandBarExtensions.NavigationCommand>
                 </CommandBar>
             </not_win:Grid>
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Extensions.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_Extensions.xaml
@@ -3,11 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:not_win="http://uno.ui/not_win"
-    xmlns:uno="using:Uno.UI.Controls"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -28,13 +27,13 @@
 
             <not_win:Grid>
                 <CommandBar Content="Title">
-                    <extras:CommandBarExtensions.NavigationCommand>
+                    <uno:CommandBarExtensions.NavigationCommand>
                         <AppBarButton Command="{Binding Command}" Label="Label">
                             <AppBarButton.Icon>
                                 <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                             </AppBarButton.Icon>
                         </AppBarButton>
-                    </extras:CommandBarExtensions.NavigationCommand>
+                    </uno:CommandBarExtensions.NavigationCommand>
                 </CommandBar>
             </not_win:Grid>
 
@@ -43,7 +42,7 @@
                     Background="Tomato"
                     Content="Title"
                     Foreground="White">
-                    <extras:CommandBarExtensions.NavigationCommand>
+                    <uno:CommandBarExtensions.NavigationCommand>
                         <AppBarButton
                             Command="{Binding Command}"
                             Foreground="White"
@@ -52,7 +51,7 @@
                                 <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                             </AppBarButton.Icon>
                         </AppBarButton>
-                    </extras:CommandBarExtensions.NavigationCommand>
+                    </uno:CommandBarExtensions.NavigationCommand>
                 </CommandBar>
             </not_win:Grid>
 

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_LongTitle.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_LongTitle.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     x:Name="ThePage">
 
     <StackPanel VerticalAlignment="Top">
@@ -70,13 +70,13 @@
             Foreground="Red">
 
             <!--  Burger Menu  -->
-            <uno:CommandBarExtensions.NavigationCommand>
+            <uuxc:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Label="Label">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </uno:CommandBarExtensions.NavigationCommand>
+            </uuxc:CommandBarExtensions.NavigationCommand>
 
             <CommandBar.PrimaryCommands>
                 <AppBarButton Content="Button" />

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_LongTitle.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_LongTitle.xaml
@@ -2,9 +2,9 @@
     x:Class="Uno.UI.Samples.Content.UITests.CommandBar.CommandBar_LongTitle"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     x:Name="ThePage">
 
     <StackPanel VerticalAlignment="Top">
@@ -70,13 +70,13 @@
             Foreground="Red">
 
             <!--  Burger Menu  -->
-            <extras:CommandBarExtensions.NavigationCommand>
+            <uno:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Label="Label">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </extras:CommandBarExtensions.NavigationCommand>
+            </uno:CommandBarExtensions.NavigationCommand>
 
             <CommandBar.PrimaryCommands>
                 <AppBarButton Content="Button" />

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_With_Long_Sentences.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_With_Long_Sentences.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -79,13 +79,13 @@
                     Text="Ceci est une longue phrase pour tester la commandBar sur Android et iOS"
                     TextTrimming="CharacterEllipsis" />
             </CommandBar.Content>
-            <uno:CommandBarExtensions.NavigationCommand>
+            <uuxc:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Label="Label">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </uno:CommandBarExtensions.NavigationCommand>
+            </uuxc:CommandBarExtensions.NavigationCommand>
             <CommandBar.PrimaryCommands>
                 <AppBarButton Content="Button" />
                 <AppBarButton Label="Icon">

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_With_Long_Sentences.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/Controls/CommandBar/CommandBar_With_Long_Sentences.xaml
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
@@ -79,13 +79,13 @@
                     Text="Ceci est une longue phrase pour tester la commandBar sur Android et iOS"
                     TextTrimming="CharacterEllipsis" />
             </CommandBar.Content>
-            <extras:CommandBarExtensions.NavigationCommand>
+            <uno:CommandBarExtensions.NavigationCommand>
                 <AppBarButton Label="Label">
                     <AppBarButton.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/Icons/menu.png" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-            </extras:CommandBarExtensions.NavigationCommand>
+            </uno:CommandBarExtensions.NavigationCommand>
             <CommandBar.PrimaryCommands>
                 <AppBarButton Content="Button" />
                 <AppBarButton Label="Icon">

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/DragAndDrop/DragDrop_ListView_Custom_States.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/DragAndDrop/DragDrop_ListView_Custom_States.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Windows_UI_Xaml.DragAndDrop"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Xaml.Controls"
+    xmlns:uuxc="using:Uno.UI.Xaml.Controls"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -40,7 +40,7 @@
                                     <TranslateTransform x:Name="ContentPresenterTranslateTransform" />
                                 </Grid.RenderTransform>
                                 <!--  Uno workaround: template-bind ContentTemplateSelector because it's not automatically propagated from the ContentControl  -->
-                                <uno:ElevatedView
+                                <uuxc:ElevatedView
                                     x:Name="ElevatedView"
                                     Margin="3"
                                     Background="Beige"
@@ -54,7 +54,7 @@
                                         ContentTemplate="{TemplateBinding ContentTemplate}"
                                         ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
                                         ContentTransitions="{TemplateBinding ContentTransitions}" />
-                                </uno:ElevatedView>
+                                </uuxc:ElevatedView>
                             </Grid>
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/DragAndDrop/DragDrop_ListView_Custom_States.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/DragAndDrop/DragDrop_ListView_Custom_States.xaml
@@ -3,9 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:local="using:UITests.Windows_UI_Xaml.DragAndDrop"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Xaml.Controls"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -40,7 +40,7 @@
                                     <TranslateTransform x:Name="ContentPresenterTranslateTransform" />
                                 </Grid.RenderTransform>
                                 <!--  Uno workaround: template-bind ContentTemplateSelector because it's not automatically propagated from the ContentControl  -->
-                                <extras:ElevatedView
+                                <uno:ElevatedView
                                     x:Name="ElevatedView"
                                     Margin="3"
                                     Background="Beige"
@@ -54,7 +54,7 @@
                                         ContentTemplate="{TemplateBinding ContentTemplate}"
                                         ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
                                         ContentTransitions="{TemplateBinding ContentTransitions}" />
-                                </extras:ElevatedView>
+                                </uno:ElevatedView>
                             </Grid>
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/UIElementTests/TransformToVisual_Transform.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/UIElementTests/TransformToVisual_Transform.xaml.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Uno.Extensions;
 using Uno.UI.Samples.Controls;
 using Uno.UI.Samples.UITests.Helpers;
-using Uno.UI.Extras;
+using Uno.UI.Behaviors;
 using Windows.Foundation;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/UIElementTests/UIElement_Layout_Constrains.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/UIElementTests/UIElement_Layout_Constrains.xaml
@@ -3,13 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Behaviors"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel extras:VisibleBoundsPadding.PaddingMask="All" Spacing="8">
+        <StackPanel uno:VisibleBoundsPadding.PaddingMask="All" Spacing="8">
             <TextBlock FontSize="18">Following 6 buttons should be of same look &amp; size:</TextBlock>
 
             <Border Height="40" Background="Aquamarine">

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/UIElementTests/UIElement_Layout_Constrains.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/UIElementTests/UIElement_Layout_Constrains.xaml
@@ -4,12 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Behaviors"
+    xmlns:uub="using:Uno.UI.Behaviors"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel uno:VisibleBoundsPadding.PaddingMask="All" Spacing="8">
+        <StackPanel uub:VisibleBoundsPadding.PaddingMask="All" Spacing="8">
             <TextBlock FontSize="18">Following 6 buttons should be of same look &amp; size:</TextBlock>
 
             <Border Height="40" Background="Aquamarine">

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/WindowTests/Window_Metrics.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/WindowTests/Window_Metrics.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Windows_UI_Xaml.WindowTests"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:Uno.UI.Extras"
+    xmlns:uno="using:Uno.UI.Behaviors"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -47,6 +47,6 @@
             <Run x:Name="VisibleBoundsPaddingValue" />
         </TextBlock>
 
-        <Grid x:Name="PaddedGrid" ui:VisibleBoundsPadding.PaddingMask="All" />
+        <Grid x:Name="PaddedGrid" uno:VisibleBoundsPadding.PaddingMask="All" />
     </StackPanel>
 </UserControl>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/WindowTests/Window_Metrics.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/WindowTests/Window_Metrics.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Windows_UI_Xaml.WindowTests"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:uno="using:Uno.UI.Behaviors"
+    xmlns:uub="using:Uno.UI.Behaviors"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -47,6 +47,6 @@
             <Run x:Name="VisibleBoundsPaddingValue" />
         </TextBlock>
 
-        <Grid x:Name="PaddedGrid" uno:VisibleBoundsPadding.PaddingMask="All" />
+        <Grid x:Name="PaddedGrid" uub:VisibleBoundsPadding.PaddingMask="All" />
     </StackPanel>
 </UserControl>

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/WindowTests/Window_Metrics.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/Xaml/WindowTests/Window_Metrics.xaml.cs
@@ -2,7 +2,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
-using Uno.UI.Extras;
+using Uno.UI.Behaviors;
 
 namespace UITests.Windows_UI_Xaml.WindowTests
 {

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -7,7 +7,6 @@
     xmlns:converters="using:Uno.UI.Samples.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:entities="using:SampleControl.Entities"
-    xmlns:extras="using:Uno.UI.Extras"
     xmlns:helper="using:Uno.UI.Samples.Behaviors"
     xmlns:ios="http://umbrella/ios"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -15,6 +14,7 @@
     xmlns:u="using:Uno.UI.Samples.Controls"
     xmlns:ub="using:Uno.UI.Samples.Behaviors"
     xmlns:uc="using:Uno.UI.Samples.Converters"
+    xmlns:uno="using:Uno.UI.Behaviors"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -226,7 +226,7 @@
             IsPaneOpen="{Binding IsSplitVisible, Mode=TwoWay}"
             OpenPaneLength="280">
             <SplitView.Pane>
-                <Grid extras:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource SystemControlBackgroundAltMediumLowBrush}">
+                <Grid uno:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource SystemControlBackgroundAltMediumLowBrush}">
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -487,7 +487,7 @@
                 </Grid>
             </SplitView.Pane>
             <SplitView.Content>
-                <Grid extras:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource NavigationViewContentBackground}">
+                <Grid uno:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource NavigationViewContentBackground}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -14,7 +14,7 @@
     xmlns:u="using:Uno.UI.Samples.Controls"
     xmlns:ub="using:Uno.UI.Samples.Behaviors"
     xmlns:uc="using:Uno.UI.Samples.Converters"
-    xmlns:uno="using:Uno.UI.Behaviors"
+    xmlns:uub="using:Uno.UI.Behaviors"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="300"
     d:DesignWidth="400"
@@ -226,7 +226,7 @@
             IsPaneOpen="{Binding IsSplitVisible, Mode=TwoWay}"
             OpenPaneLength="280">
             <SplitView.Pane>
-                <Grid uno:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource SystemControlBackgroundAltMediumLowBrush}">
+                <Grid uub:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource SystemControlBackgroundAltMediumLowBrush}">
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -487,7 +487,7 @@
                 </Grid>
             </SplitView.Pane>
             <SplitView.Content>
-                <Grid uno:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource NavigationViewContentBackground}">
+                <Grid uub:VisibleBoundsPadding.PaddingMask="All" Background="{ThemeResource NavigationViewContentBackground}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedProperty.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedProperty.xaml
@@ -1,7 +1,7 @@
 <UserControl
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:utk="using:Uno.UI.Extras">
+	xmlns:utk="using:Uno.UI.Xaml.Controls">
 
 	<Grid utk:MyAttachedProperty.IsEnabled="True">
 	</Grid>

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedProperty.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedProperty.xaml
@@ -1,9 +1,9 @@
 <UserControl
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:utk="using:Uno.UI.Xaml.Controls">
+	xmlns:uuxc="using:Uno.UI.Xaml.Controls">
 
-	<Grid utk:MyAttachedProperty.IsEnabled="True">
+	<Grid uuxc:MyAttachedProperty.IsEnabled="True">
 	</Grid>
 	
 </UserControl>

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/Generic.Native.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/Generic.Native.xaml
@@ -12,7 +12,7 @@
 					xmlns:android="http://uno.ui/android#using:Uno.UI.Controls"
 					xmlns:native_ios="using:UIKit"
 					xmlns:native_android="using:Android.Widget"
-					xmlns:toolkit="using:Uno.UI.Extras"
+					xmlns:uno="using:Uno.UI.Xaml.Controls"
 					mc:Ignorable="d win not_win android">
 
     <!-- Default native Button styles -->
@@ -381,7 +381,7 @@
 										  LeftPane="{TemplateBinding Pane}"
 										  LeftPaneBackground="{TemplateBinding PaneBackground}"
 										  IsLeftPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsLeftPaneEnabled="{Binding (toolkit:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsLeftPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -401,7 +401,7 @@
 										  RightPane="{TemplateBinding Pane}"
 										  RightPaneBackground="{TemplateBinding PaneBackground}"
 										  IsRightPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsRightPaneEnabled="{Binding (toolkit:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsRightPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/Generic.Native.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/Generic.Native.xaml
@@ -12,7 +12,7 @@
 					xmlns:android="http://uno.ui/android#using:Uno.UI.Controls"
 					xmlns:native_ios="using:UIKit"
 					xmlns:native_android="using:Android.Widget"
-					xmlns:uno="using:Uno.UI.Xaml.Controls"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					mc:Ignorable="d win not_win android">
 
     <!-- Default native Button styles -->
@@ -381,7 +381,7 @@
 										  LeftPane="{TemplateBinding Pane}"
 										  LeftPaneBackground="{TemplateBinding PaneBackground}"
 										  IsLeftPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsLeftPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsLeftPaneEnabled="{Binding (uuxc:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -401,7 +401,7 @@
 										  RightPane="{TemplateBinding Pane}"
 										  RightPaneBackground="{TemplateBinding PaneBackground}"
 										  IsRightPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsRightPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsRightPaneEnabled="{Binding (uuxc:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/SourceGenerators/System.Xaml.Tests/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1395,7 +1395,7 @@ namespace MonoTests.Uno.Xaml
 
 				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{http://schemas.microsoft.com/winfx/2006/xaml}_UnknownContent", },
 				new SequenceItem { NodeType = XamlNodeType.StartObject, TypeName = "{http://schemas.microsoft.com/winfx/2006/xaml/presentation}Grid"},
-				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{using:Uno.UI.Extras}MyAttachedProperty.IsEnabled", },
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{using:Uno.UI.Xaml.Controls}MyAttachedProperty.IsEnabled", },
 				new SequenceItem { NodeType = XamlNodeType.Value, Value = "True", },
 				new SequenceItem { NodeType = XamlNodeType.EndMember, },
 				new SequenceItem { NodeType = XamlNodeType.EndObject, },

--- a/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/CustomAttachedProperty.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/CustomAttachedProperty.xaml
@@ -1,7 +1,7 @@
 <UserControl
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:utk="using:Uno.UI.Extras">
+	xmlns:utk="using:Uno.UI.Xaml.Controls">
 
 	<Grid utk:MyAttachedProperty.IsEnabled="True">
 	</Grid>

--- a/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/CustomAttachedProperty.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/CustomAttachedProperty.xaml
@@ -1,9 +1,9 @@
 <UserControl
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:utk="using:Uno.UI.Xaml.Controls">
+	xmlns:uuxc="using:Uno.UI.Xaml.Controls">
 
-	<Grid utk:MyAttachedProperty.IsEnabled="True">
+	<Grid uuxc:MyAttachedProperty.IsEnabled="True">
 	</Grid>
 	
 </UserControl>

--- a/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/Generic.Native.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/Generic.Native.xaml
@@ -12,7 +12,7 @@
 					xmlns:android="http://uno.ui/android#using:Uno.UI.Controls"
 					xmlns:native_ios="using:UIKit"
 					xmlns:native_android="using:Android.Widget"
-					xmlns:toolkit="using:Uno.UI.Extras"
+					xmlns:uno="using:Uno.UI.Xaml.Controls"
 					mc:Ignorable="d android">
 
     <!-- Default native Button styles -->
@@ -381,7 +381,7 @@
 										  LeftPane="{TemplateBinding Pane}"
 										  LeftPaneBackground="{TemplateBinding PaneBackground}"
 										  IsLeftPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsLeftPaneEnabled="{Binding (toolkit:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsLeftPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -401,7 +401,7 @@
 										  RightPane="{TemplateBinding Pane}"
 										  RightPaneBackground="{TemplateBinding PaneBackground}"
 										  IsRightPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsRightPaneEnabled="{Binding (toolkit:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsRightPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/Generic.Native.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/Generic.Native.xaml
@@ -12,7 +12,7 @@
 					xmlns:android="http://uno.ui/android#using:Uno.UI.Controls"
 					xmlns:native_ios="using:UIKit"
 					xmlns:native_android="using:Android.Widget"
-					xmlns:uno="using:Uno.UI.Xaml.Controls"
+					xmlns:uuxc="using:Uno.UI.Xaml.Controls"
 					mc:Ignorable="d android">
 
     <!-- Default native Button styles -->
@@ -381,7 +381,7 @@
 										  LeftPane="{TemplateBinding Pane}"
 										  LeftPaneBackground="{TemplateBinding PaneBackground}"
 										  IsLeftPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsLeftPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsLeftPaneEnabled="{Binding (uuxc:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>
@@ -401,7 +401,7 @@
 										  RightPane="{TemplateBinding Pane}"
 										  RightPaneBackground="{TemplateBinding PaneBackground}"
 										  IsRightPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
-										  IsRightPaneEnabled="{Binding (uno:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  IsRightPaneEnabled="{Binding (uuxc:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
 										  Content="{TemplateBinding Content}" />
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/UnoAssemblyHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/UnoAssemblyHelper.cs
@@ -59,8 +59,8 @@ internal static partial class UnoAssemblyHelper
 
 	/// <summary>
 	/// Replacement for the Uno.UI.Toolkit assembly shipped by pre-7.0 Uno.WinUI packages, whose
-	/// types now live in Uno.UI.Extras. Loaded only where that package assembly was referenced,
-	/// so tests that never saw the Toolkit keep their existing reference set.
+	/// types now live in the Uno.UI.* namespaces. Loaded only where that package assembly was
+	/// referenced, so tests that never saw the Toolkit keep their existing reference set.
 	/// </summary>
 	public static PortableExecutableReference[] LoadExtrasAssemblies() =>
 		LoadAssemblies(GetBinDirectory(

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_HotReloadEnabledInBuild.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_HotReloadEnabledInBuild.cs
@@ -17,10 +17,10 @@ public class Given_HotReloadEnabledInBuild
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Extras"
+					xmlns:uno="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 
-				<Grid toolkit:VisibleBoundsPadding.PaddingMask="Top">
+				<Grid uno:VisibleBoundsPadding.PaddingMask="Top">
 					<TextBlock Text="Hello, world!"
 							   Margin="20"
 							   FontSize="30" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_HotReloadEnabledInBuild.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_HotReloadEnabledInBuild.cs
@@ -17,10 +17,10 @@ public class Given_HotReloadEnabledInBuild
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:uno="using:Uno.UI.Behaviors"
+					xmlns:uub="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 
-				<Grid uno:VisibleBoundsPadding.PaddingMask="Top">
+				<Grid uub:VisibleBoundsPadding.PaddingMask="Top">
 					<TextBlock Text="Hello, world!"
 							   Margin="20"
 							   FontSize="30" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_NoFuzzyMatching.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_NoFuzzyMatching.cs
@@ -17,10 +17,10 @@ public class Given_NoFuzzyMatching
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:uno="using:Uno.UI.Behaviors"
+					xmlns:uub="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 
-				<Grid uno:VisibleBoundsPadding.PaddingMask="Top">
+				<Grid uub:VisibleBoundsPadding.PaddingMask="Top">
 					<TextBlock Text="Hello, world!"
 							   Margin="20"
 							   FontSize="30" />
@@ -67,7 +67,7 @@ public class Given_NoFuzzyMatching
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:local="using:TestRepro"
-					xmlns:uno="using:Uno.UI.Behaviors"
+					xmlns:uub="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 
 				<local:MyButton MyProperty="x:String" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_NoFuzzyMatching.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_NoFuzzyMatching.cs
@@ -17,10 +17,10 @@ public class Given_NoFuzzyMatching
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Extras"
+					xmlns:uno="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 
-				<Grid toolkit:VisibleBoundsPadding.PaddingMask="Top">
+				<Grid uno:VisibleBoundsPadding.PaddingMask="Top">
 					<TextBlock Text="Hello, world!"
 							   Margin="20"
 							   FontSize="30" />
@@ -67,7 +67,7 @@ public class Given_NoFuzzyMatching
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					xmlns:local="using:TestRepro"
-					xmlns:toolkit="using:Uno.UI.Extras"
+					xmlns:uno="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 
 				<local:MyButton MyProperty="x:String" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_HotReloadEnabledInBuild/SeBaUrInInOuFoFrEl/XamlCodeGenerator_EmbeddedXamlSources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_HotReloadEnabledInBuild/SeBaUrInInOuFoFrEl/XamlCodeGenerator_EmbeddedXamlSources.cs
@@ -97,16 +97,16 @@ internal static class EmbeddedXamlSourcesProvider
 	private static (string hash, string payload) GetSources_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a()
 	{
 		return (
-			"f66d9a6fdc7ebb90b2fb92d0afb8eb75f6d6c36b", // hash
+			"4326d7b6e8ac04c7c6a3b887c16a738cf921fe85", // hash
 			_utf8.GetString("""
 			<Page x:Class="TestRepro.MainPage"
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:uno="using:Uno.UI.Behaviors"
+					xmlns:uub="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 			
-				<Grid uno:VisibleBoundsPadding.PaddingMask="Top">
+				<Grid uub:VisibleBoundsPadding.PaddingMask="Top">
 					<TextBlock Text="Hello, world!"
 							   Margin="20"
 							   FontSize="30" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_HotReloadEnabledInBuild/SeBaUrInInOuFoFrEl/XamlCodeGenerator_EmbeddedXamlSources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_HotReloadEnabledInBuild/SeBaUrInInOuFoFrEl/XamlCodeGenerator_EmbeddedXamlSources.cs
@@ -97,16 +97,16 @@ internal static class EmbeddedXamlSourcesProvider
 	private static (string hash, string payload) GetSources_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a()
 	{
 		return (
-			"fbb299ad859e1f762c93ba333c8a3b50a2ac65ea", // hash
+			"f66d9a6fdc7ebb90b2fb92d0afb8eb75f6d6c36b", // hash
 			_utf8.GetString("""
 			<Page x:Class="TestRepro.MainPage"
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-					xmlns:toolkit="using:Uno.UI.Extras"
+					xmlns:uno="using:Uno.UI.Behaviors"
 					mc:Ignorable="android ios">
 			
-				<Grid toolkit:VisibleBoundsPadding.PaddingMask="Top">
+				<Grid uno:VisibleBoundsPadding.PaddingMask="Top">
 					<TextBlock Text="Hello, world!"
 							   Margin="20"
 							   FontSize="30" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_HotReloadEnabledInBuild/SeBaUrInInOuFoFrEl/XamlCodeGenerator_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_HotReloadEnabledInBuild/SeBaUrInInOuFoFrEl/XamlCodeGenerator_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a.cs
@@ -98,7 +98,7 @@ namespace TestRepro
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "Generated code")]
 		private void ApplyTo_PagΞ0_Gri(global::Microsoft.UI.Xaml.Controls.Grid __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 		{
-			global::Uno.UI.Extras.VisibleBoundsPadding.SetPaddingMask(__p1, global::Uno.UI.Extras.VisibleBoundsPadding.PaddingMask.Top);
+			global::Uno.UI.Behaviors.VisibleBoundsPadding.SetPaddingMask(__p1, global::Uno.UI.Behaviors.VisibleBoundsPadding.PaddingMask.Top);
 			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a, "file://///Project/0/MainPage.xaml", 8, 3);
 			__p1.CreationComplete();
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_NoFuzzyMatching/TeViBoPa/XamlCodeGenerator_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/Given_NoFuzzyMatching/TeViBoPa/XamlCodeGenerator_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a.cs
@@ -78,7 +78,7 @@ namespace TestRepro
 				}
 				.MainPage_0e3f323f9a22a3699cbcd4f0217eee4a_XamlApply((MainPage_0e3f323f9a22a3699cbcd4f0217eee4aXamlApplyExtensions.XamlApplyHandler1)(__p1 => 
 				{
-				global::Uno.UI.Extras.VisibleBoundsPadding.SetPaddingMask(__p1, global::Uno.UI.Extras.VisibleBoundsPadding.PaddingMask.Top);
+				global::Uno.UI.Behaviors.VisibleBoundsPadding.SetPaddingMask(__p1, global::Uno.UI.Behaviors.VisibleBoundsPadding.PaddingMask.Top);
 				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_0e3f323f9a22a3699cbcd4f0217eee4a);
 				__p1.CreationComplete();
 				}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
@@ -265,7 +265,7 @@ build_metadata.AdditionalFiles.Link = 0/Strings/{resourceFile.Locale}/{resourceF
 			protected override Project ApplyCompilationOptions(Project project)
 			{
 				// Tests using WithUnoPackage() pull a pre-7.0 Uno.WinUI package, which still ships
-				// Uno.UI.Toolkit.dll. Its types were renamed to Uno.UI.Extras, so the package copy no
+				// Uno.UI.Toolkit.dll. Its types moved to the Uno.UI.* namespaces, so the package copy no
 				// longer matches the local build and would resolve the old namespace instead. The local
 				// build is authoritative.
 				var supersededByLocalBuild = project.MetadataReferences

--- a/src/SourceGenerators/XamlGenerationTests/TypeResolutionTests.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/TypeResolutionTests.xaml
@@ -11,7 +11,7 @@
     xmlns:android="http://uno.ui/android"
 	xmlns:not_win="http://uno.ui/not_win"
 	xmlns:test="http://uno.ui/test"
-	xmlns:uno="using:Uno.UI.Xaml"
+	xmlns:uux="using:Uno.UI.Xaml"
     mc:Ignorable="d not_win android test ios"
     d:DesignHeight="300"
     d:DesignWidth="400">
@@ -54,10 +54,10 @@
 		<Grid not_win:Background="Green" />
 
 		<!-- UWP Control with external project property -->
-		<Border uno:UIElementExtensions.Elevation="5" />
+		<Border uux:UIElementExtensions.Elevation="5" />
 		
 		<!-- Control with external project property -->
-		<u:ControlWithContent uno:UIElementExtensions.Elevation="10" />
+		<u:ControlWithContent uux:UIElementExtensions.Elevation="10" />
 		
 		<!-- Control with phase -->
 		<not_win:Border x:Phase="3" Background="{x:Bind}" />

--- a/src/SourceGenerators/XamlGenerationTests/TypeResolutionTests.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/TypeResolutionTests.xaml
@@ -11,7 +11,7 @@
     xmlns:android="http://uno.ui/android"
 	xmlns:not_win="http://uno.ui/not_win"
 	xmlns:test="http://uno.ui/test"
-	xmlns:toolkit="using:Uno.UI.Extras"
+	xmlns:uno="using:Uno.UI.Xaml"
     mc:Ignorable="d not_win android test ios"
     d:DesignHeight="300"
     d:DesignWidth="400">
@@ -54,10 +54,10 @@
 		<Grid not_win:Background="Green" />
 
 		<!-- UWP Control with external project property -->
-		<Border toolkit:UIElementExtensions.Elevation="5" />
+		<Border uno:UIElementExtensions.Elevation="5" />
 		
 		<!-- Control with external project property -->
-		<u:ControlWithContent toolkit:UIElementExtensions.Elevation="10" />
+		<u:ControlWithContent uno:UIElementExtensions.Elevation="10" />
 		
 		<!-- Control with phase -->
 		<not_win:Border x:Phase="3" Background="{x:Bind}" />

--- a/src/Uno.UI.Extras/AutomationPropertiesExtensions.cs
+++ b/src/Uno.UI.Extras/AutomationPropertiesExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.UI.Xaml.Automation;
 using Uno;
 #endif
 
-namespace Uno.UI.Extras;
+namespace Uno.UI.Xaml.Automation;
 
 /// <summary>
 /// Provides attached properties that extend the standard
@@ -21,8 +21,8 @@ namespace Uno.UI.Extras;
 ///
 /// XAML usage:
 /// <code>
-/// xmlns:uut="using:Uno.UI.Extras"
-/// &lt;Button uut:AutomationPropertiesExtensions.Role="tab" /&gt;
+/// xmlns:uno="using:Uno.UI.Xaml.Automation"
+/// &lt;Button uno:AutomationPropertiesExtensions.Role="tab" /&gt;
 /// </code>
 /// </remarks>
 public static class AutomationPropertiesExtensions

--- a/src/Uno.UI.Extras/AutomationPropertiesExtensions.cs
+++ b/src/Uno.UI.Extras/AutomationPropertiesExtensions.cs
@@ -21,8 +21,8 @@ namespace Uno.UI.Xaml.Automation;
 ///
 /// XAML usage:
 /// <code>
-/// xmlns:uno="using:Uno.UI.Xaml.Automation"
-/// &lt;Button uno:AutomationPropertiesExtensions.Role="tab" /&gt;
+/// xmlns:uuxa="using:Uno.UI.Xaml.Automation"
+/// &lt;Button uuxa:AutomationPropertiesExtensions.Role="tab" /&gt;
 /// </code>
 /// </remarks>
 public static class AutomationPropertiesExtensions

--- a/src/Uno.UI.Extras/CommandBarExtensions.cs
+++ b/src/Uno.UI.Extras/CommandBarExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
-namespace Uno.UI.Extras
+namespace Uno.UI.Xaml.Controls
 {
 	public static class CommandBarExtensions
 	{

--- a/src/Uno.UI.Extras/DevTools/Input/Finger.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/Finger.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 internal partial class Finger : IInjectedPointer, IDisposable
 {

--- a/src/Uno.UI.Extras/DevTools/Input/IInjectedPointer.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/IInjectedPointer.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 internal interface IInjectedPointer
 {

--- a/src/Uno.UI.Extras/DevTools/Input/InjectedPointerExtensions.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/InjectedPointerExtensions.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 internal static class InjectedPointerExtensions
 {

--- a/src/Uno.UI.Extras/DevTools/Input/InputInjectorExtensions.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/InputInjectorExtensions.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 internal static class InputInjectorExtensions
 {

--- a/src/Uno.UI.Extras/DevTools/Input/Mouse.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/Mouse.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 internal partial class Mouse : IInjectedPointer, IDisposable
 {

--- a/src/Uno.UI.Extras/DevTools/Input/Pen.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/Pen.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 #if HAS_UNO
 internal class Pen : IInjectedPointer, IDisposable

--- a/src/Uno.UI.Extras/DevTools/Input/PointExtensions.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/PointExtensions.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
-namespace Uno.UI.Extras.DevTools.Input;
+namespace Uno.UI.DevTools.Input;
 
 internal static class PointExtensions
 {

--- a/src/Uno.UI.Extras/DevTools/Xaml/UIElementHelper.cs
+++ b/src/Uno.UI.Extras/DevTools/Xaml/UIElementHelper.cs
@@ -2,7 +2,7 @@
 using Microsoft.UI.Xaml.Input;
 using Windows.System;
 
-namespace Uno.UI.Extras.DevTools.Xaml;
+namespace Uno.UI.DevTools.Xaml;
 
 internal static class UIElementHelper
 {

--- a/src/Uno.UI.Extras/Diagnostics/DiagnosticsOverlay.Placement.cs
+++ b/src/Uno.UI.Extras/Diagnostics/DiagnosticsOverlay.Placement.cs
@@ -12,7 +12,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI;
-using Uno.UI.Extras.Extensions;
+using Uno.UI.Extensions;
 
 namespace Uno.Diagnostics.UI;
 

--- a/src/Uno.UI.Extras/ElevatedView.cs
+++ b/src/Uno.UI.Extras/ElevatedView.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 
-namespace Uno.UI.Extras
+namespace Uno.UI.Xaml.Controls
 {
 	[ContentProperty(Name = "ElevatedContent")]
 	[TemplatePart(Name = "PART_Border", Type = typeof(Border))]

--- a/src/Uno.UI.Extras/Extensions/RectExtensions.cs
+++ b/src/Uno.UI.Extras/Extensions/RectExtensions.cs
@@ -7,7 +7,7 @@ using Windows.Foundation;
 using Windows.Graphics.Display;
 using Microsoft.UI.Xaml;
 
-namespace Uno.UI.Extras.Extensions
+namespace Uno.UI.Extensions
 {
 	internal static class RectExtensions
 	{

--- a/src/Uno.UI.Extras/Extensions/RectExtensions.cs
+++ b/src/Uno.UI.Extras/Extensions/RectExtensions.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Graphics.Display;
 using Microsoft.UI.Xaml;
@@ -17,7 +13,7 @@ namespace Uno.UI.Extensions
 		/// </summary>
 		/// <param name="rect">A rectangle.</param>
 		/// <returns>The center of the rectangle.</returns>
-		public static Point GetCenter(this Rect rect)
+		internal static Point GetCenter(this Rect rect)
 			=> new(rect.Left + rect.Width / 2, rect.Top + rect.Height / 2);
 
 		/// <summary>
@@ -25,7 +21,7 @@ namespace Uno.UI.Extensions
 		/// </summary>
 		/// <param name="rect">A rectangle.</param>
 		/// <returns>The center of the rectangle.</returns>
-		public static Point GetLocation(this Rect rect)
+		internal static Point GetLocation(this Rect rect)
 			=> new(rect.X, rect.Y);
 
 		/// <summary>
@@ -33,7 +29,7 @@ namespace Uno.UI.Extensions
 		/// </summary>
 		/// <param name="rect">A rectangle.</param>
 		/// <returns>Portrait, Landscape, or None (if the rectangle has an exact 1:1 ratio)</returns>
-		public static DisplayOrientations GetOrientation(this Rect rect)
+		internal static DisplayOrientations GetOrientation(this Rect rect)
 		{
 			if (rect.Height > rect.Width)
 			{

--- a/src/Uno.UI.Extras/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI.Extras/Extensions/UIElementExtensions.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+﻿#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ internal static partial class UIElementExtensions
 			return padding;
 		}
 
-		var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+		var property = uiElement.FindDependencyPropertyUsingReflection("PaddingProperty");
 		return property != null && uiElement.GetValue(property) is Thickness t ? t : default;
 	}
 
@@ -31,7 +31,7 @@ internal static partial class UIElementExtensions
 			return true;
 		}
 
-		var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+		var property = uiElement.FindDependencyPropertyUsingReflection("PaddingProperty");
 		if (property != null)
 		{
 			uiElement.SetValue(property, padding);
@@ -98,14 +98,14 @@ internal static partial class UIElementExtensions
 		return false;
 	}
 
-	private static Dictionary<(Type type, string property), DependencyProperty> _dependencyPropertyReflectionCache;
+	private static Dictionary<(Type type, string property), DependencyProperty?>? _dependencyPropertyReflectionCache;
 
-	internal static DependencyProperty FindDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
+	internal static DependencyProperty? FindDependencyPropertyUsingReflection(this UIElement uiElement, string propertyName)
 	{
 		var type = GetType(uiElement);
 		var key = (ownerType: type, propertyName);
 
-		_dependencyPropertyReflectionCache ??= new Dictionary<(Type, string), DependencyProperty>(2);
+		_dependencyPropertyReflectionCache ??= new Dictionary<(Type, string), DependencyProperty?>(2);
 
 		if (_dependencyPropertyReflectionCache.TryGetValue(key, out var property))
 		{

--- a/src/Uno.UI.Extras/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI.Extras/Extensions/UIElementExtensions.cs
@@ -1,0 +1,134 @@
+﻿#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+// On Uno targets these helpers come from Uno.UI itself; this copy only serves the WinAppSDK build.
+#if !HAS_UNO
+namespace Uno.UI.Extensions;
+
+internal static partial class UIElementExtensions
+{
+	internal static Thickness GetPadding(this UIElement uiElement)
+	{
+		if (uiElement is FrameworkElement fe && fe.TryGetPadding(out var padding))
+		{
+			return padding;
+		}
+
+		var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+		return property != null && uiElement.GetValue(property) is Thickness t ? t : default;
+	}
+
+	internal static bool SetPadding(this UIElement uiElement, Thickness padding)
+	{
+		if (uiElement is FrameworkElement fe && fe.TrySetPadding(padding))
+		{
+			return true;
+		}
+
+		var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+		if (property != null)
+		{
+			uiElement.SetValue(property, padding);
+			return true;
+		}
+
+		return false;
+	}
+
+	internal static bool TryGetPadding(this FrameworkElement frameworkElement, out Thickness padding)
+	{
+		switch (frameworkElement)
+		{
+			case Grid g:
+				padding = g.Padding;
+				return true;
+
+			case StackPanel sp:
+				padding = sp.Padding;
+				return true;
+
+			case Control c:
+				padding = c.Padding;
+				return true;
+
+			case ContentPresenter cp:
+				padding = cp.Padding;
+				return true;
+
+			case Border b:
+				padding = b.Padding;
+				return true;
+		}
+
+		padding = default;
+		return false;
+	}
+
+	internal static bool TrySetPadding(this FrameworkElement frameworkElement, Thickness padding)
+	{
+		switch (frameworkElement)
+		{
+			case Grid g:
+				g.Padding = padding;
+				return true;
+
+			case StackPanel sp:
+				sp.Padding = padding;
+				return true;
+
+			case Control c:
+				c.Padding = padding;
+				return true;
+
+			case ContentPresenter cp:
+				cp.Padding = padding;
+				return true;
+
+			case Border b:
+				b.Padding = padding;
+				return true;
+		}
+
+		return false;
+	}
+
+	private static Dictionary<(Type type, string property), DependencyProperty> _dependencyPropertyReflectionCache;
+
+	internal static DependencyProperty FindDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
+	{
+		var type = GetType(uiElement);
+		var key = (ownerType: type, propertyName);
+
+		_dependencyPropertyReflectionCache ??= new Dictionary<(Type, string), DependencyProperty>(2);
+
+		if (_dependencyPropertyReflectionCache.TryGetValue(key, out var property))
+		{
+			return property;
+		}
+
+		property =
+			type
+				.GetTypeInfo()
+				.GetDeclaredProperty(propertyName)
+				?.GetValue(null) as DependencyProperty
+			?? type
+				.GetTypeInfo()
+				.GetDeclaredField(propertyName)
+				?.GetValue(null) as DependencyProperty;
+
+		_dependencyPropertyReflectionCache[key] = property;
+
+		return property;
+
+		[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "🤷‍♂️")]
+		[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+		static Type GetType(object value) => value.GetType();
+	}
+}
+#endif

--- a/src/Uno.UI.Extras/LinkerDefinition.net6.0.xml
+++ b/src/Uno.UI.Extras/LinkerDefinition.net6.0.xml
@@ -1,8 +1,8 @@
-﻿<linker>
+<linker>
   <assembly fullname="Uno.UI.Extras">
-	<type fullname="Uno.UI.Extras.CommandBarExtensions"/>
-	<type fullname="Uno.UI.Extras.UIElementExtensions"/>
-	<type fullname="Uno.UI.Extras.SplitViewExtensions"/>
+	<type fullname="Uno.UI.Xaml.Controls.CommandBarExtensions"/>
+	<type fullname="Uno.UI.Xaml.UIElementExtensions"/>
+	<type fullname="Uno.UI.Xaml.Controls.SplitViewExtensions"/>
 	<type fullname="Uno.UI.Markup.FromJsonExtension"/>
   </assembly>
 </linker>

--- a/src/Uno.UI.Extras/SplitViewExtensions.cs
+++ b/src/Uno.UI.Extras/SplitViewExtensions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
-namespace Uno.UI.Extras
+namespace Uno.UI.Xaml.Controls
 {
 	public static class SplitViewExtensions
 	{

--- a/src/Uno.UI.Extras/Storage/StorageFileHelper.cs
+++ b/src/Uno.UI.Extras/Storage/StorageFileHelper.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Uno;
 
-namespace Uno.UI.Extras;
+namespace Uno.Storage;
 
 public partial class StorageFileHelper
 {

--- a/src/Uno.UI.Extras/Storage/StorageFileHelper.cs
+++ b/src/Uno.UI.Extras/Storage/StorageFileHelper.cs
@@ -9,7 +9,7 @@ using Uno;
 
 namespace Uno.Storage;
 
-public partial class StorageFileHelper
+public static partial class StorageFileHelper
 {
 	/// <summary>
 	/// Determines if an asset or resource exists within application package

--- a/src/Uno.UI.Extras/Themes/Generic.xaml
+++ b/src/Uno.UI.Extras/Themes/Generic.xaml
@@ -1,12 +1,12 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-					xmlns:extras="using:Uno.UI.Extras">
+					xmlns:controls="using:Uno.UI.Xaml.Controls">
 
-	<Style TargetType="extras:ElevatedView">
+	<Style TargetType="controls:ElevatedView">
 		<Setter Property="IsTabStop" Value="False" />
 		<Setter Property="Template">
 			<Setter.Value>
-				<ControlTemplate TargetType="extras:ElevatedView">
+				<ControlTemplate TargetType="controls:ElevatedView">
 					<Grid>
 						<Canvas x:Name="PART_ShadowHost" />
 						

--- a/src/Uno.UI.Extras/UIElementExtensions.cs
+++ b/src/Uno.UI.Extras/UIElementExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
-using System.Reflection;
 using Windows.UI;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
@@ -10,10 +7,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
-
-#if HAS_UNO
-using Uno.Foundation.Logging;
-#endif
 
 #if NETCOREAPP && !HAS_UNO
 using Microsoft.UI;
@@ -23,7 +16,7 @@ using Microsoft.UI;
 using Uno.UI.Composition.Composition;
 #endif
 
-namespace Uno.UI.Extras
+namespace Uno.UI.Xaml
 {
 	public static class UIElementExtensions
 	{
@@ -151,138 +144,5 @@ namespace Uno.UI.Extras
 		}
 
 		#endregion
-
-		internal static Thickness GetPadding(this UIElement uiElement)
-		{
-			if (uiElement is FrameworkElement fe && fe.TryGetPadding(out var padding))
-			{
-				return padding;
-			}
-
-			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
-			return property != null && uiElement.GetValue(property) is Thickness t ? t : default;
-		}
-
-		internal static bool SetPadding(this UIElement uiElement, Thickness padding)
-		{
-			if (uiElement is FrameworkElement fe && fe.TrySetPadding(padding))
-			{
-				return true;
-			}
-
-			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
-			if (property != null)
-			{
-				uiElement.SetValue(property, padding);
-				return true;
-			}
-
-			return false;
-		}
-
-		internal static bool TryGetPadding(this FrameworkElement frameworkElement, out Thickness padding)
-		{
-			switch (frameworkElement)
-			{
-				case Grid g:
-					padding = g.Padding;
-					return true;
-
-				case StackPanel sp:
-					padding = sp.Padding;
-					return true;
-
-				case Control c:
-					padding = c.Padding;
-					return true;
-
-				case ContentPresenter cp:
-					padding = cp.Padding;
-					return true;
-
-				case Border b:
-					padding = b.Padding;
-					return true;
-			}
-
-			padding = default;
-			return false;
-		}
-
-		internal static bool TrySetPadding(this FrameworkElement frameworkElement, Thickness padding)
-		{
-			switch (frameworkElement)
-			{
-				case Grid g:
-					g.Padding = padding;
-					return true;
-
-				case StackPanel sp:
-					sp.Padding = padding;
-					return true;
-
-				case Control c:
-					c.Padding = padding;
-					return true;
-
-				case ContentPresenter cp:
-					cp.Padding = padding;
-					return true;
-
-				case Border b:
-					b.Padding = padding;
-					return true;
-			}
-
-			return false;
-		}
-
-		private static Dictionary<(Type type, string property), DependencyProperty> _dependencyPropertyReflectionCache;
-
-		internal static DependencyProperty FindDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
-		{
-			var type = GetType(uiElement);
-			var propertyType = typeof(TProperty);
-			var key = (ownerType: type, propertyName);
-
-			_dependencyPropertyReflectionCache ??= new Dictionary<(Type, string), DependencyProperty>(2);
-
-			if (_dependencyPropertyReflectionCache.TryGetValue(key, out var property))
-			{
-				return property;
-			}
-
-			property =
-				type
-					.GetTypeInfo()
-					.GetDeclaredProperty(propertyName)
-					?.GetValue(null) as DependencyProperty
-				?? type
-					.GetTypeInfo()
-					.GetDeclaredField(propertyName)
-					?.GetValue(null) as DependencyProperty;
-
-			if (property == null)
-			{
-#if HAS_UNO
-				uiElement.Log().Warn($"The {propertyName} dependency property does not exist on {type}");
-#endif
-			}
-#if HAS_UNO
-			else if (property.Type != propertyType)
-			{
-				uiElement.Log().Warn($"The {propertyName} dependency property {type} is not of the {propertyType} Type.");
-				property = null;
-			}
-#endif
-
-			_dependencyPropertyReflectionCache[key] = property;
-
-			return property;
-
-			[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "🤷‍♂️")]
-			[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
-			static Type GetType(object value) => value.GetType();
-		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
@@ -10,7 +10,7 @@ using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 using System.Threading;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if HAS_UNO
 using Uno.UI.Xaml.Input;

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -52,8 +52,8 @@ namespace Private.Infrastructure
 #if !HAS_UNO
 					// Inject the current test window in the input injection services to avoid a
 					// dependency on TestServices in the Uno.UI.Extras project
-					Uno.UI.Extras.DevTools.Input.Finger.TestServices_WindowHelper_CurrentTestWindow = value;
-					Uno.UI.Extras.DevTools.Input.Mouse.TestServices_WindowHelper_CurrentTestWindow = value;
+					Uno.UI.DevTools.Input.Finger.TestServices_WindowHelper_CurrentTestWindow = value;
+					Uno.UI.DevTools.Input.Mouse.TestServices_WindowHelper_CurrentTestWindow = value;
 #endif
 				}
 			}

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.uno.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.uno.cs
@@ -10,7 +10,7 @@ using static Private.Infrastructure.TestServices;
 using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
 using NavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
 using Private.Infrastructure;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests;
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SelectorBar/SelectorBarTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SelectorBar/SelectorBarTests.cs
@@ -14,7 +14,7 @@ using Private.Infrastructure;
 using System.Threading.Tasks;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.MUX.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Uno.UI;

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests_InteractionTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests_InteractionTests.cs
@@ -23,7 +23,7 @@ using Uno.UI.RuntimeTests.Helpers;
 using static Private.Infrastructure.TestServices;
 using SplitButton = Microsoft.UI.Xaml.Controls.SplitButton;
 using ToggleSplitButton = Microsoft.UI.Xaml.Controls.ToggleSplitButton;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ItemContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ItemContainer.cs
@@ -11,7 +11,7 @@ using Uno.UI;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using ItemContainer = Microsoft.UI.Xaml.Controls.ItemContainer;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -23,8 +23,7 @@ using Color = Windows.UI.Color;
 using Point = Windows.Foundation.Point;
 #if HAS_INPUT_INJECTOR
 using Windows.UI.Input.Preview.Injection;
-using Uno.UI.Extras.DevTools.Input;
-using Uno.UI.Extras.Extensions;
+using Uno.UI.DevTools.Input;
 #endif
 #if __APPLE_UIKIT__
 using UIKit;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
@@ -6,7 +6,7 @@ using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml.Controls;
 using RatingControl = Microsoft.UI.Xaml.Controls.RatingControl;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if HAS_UNO && !HAS_UNO_WINUI
 using Windows.UI.Xaml.Controls;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -14,7 +14,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Uno.Extensions;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Controls;
 using Private.Infrastructure;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 using TabView = Microsoft.UI.Xaml.Controls.TabView;
 using TabViewItem = Microsoft.UI.Xaml.Controls.TabViewItem;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TreeView.cs
@@ -23,7 +23,7 @@ using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.ListViewPages;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if __APPLE_UIKIT__
 using UIKit;

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_VisibleBoundsPadding.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_VisibleBoundsPadding.cs
@@ -7,7 +7,7 @@ using Private.Infrastructure;
 using Uno.Disposables;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras;
+using Uno.UI.Behaviors;
 using Windows.UI;
 using Windows.UI.ViewManagement;
 using Microsoft.UI.Xaml;

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputInjector_RelativeRoot.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputInjector_RelativeRoot.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
@@ -21,7 +21,7 @@ using Private.Infrastructure;
 using Uno.Extensions;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using MUXControlsTestApp.Utilities;
 
 #if HAS_UNO_WINUI

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
@@ -11,7 +11,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_FileDoesNotExistsInPackage()
 		{
-			var fileExists = await Uno.UI.Extras.StorageFileHelper.ExistsInPackage("Asset_InvalidFile.xml");
+			var fileExists = await Uno.Storage.StorageFileHelper.ExistsInPackage("Asset_InvalidFile.xml");
 
 			Assert.IsFalse(fileExists);
 		}
@@ -19,7 +19,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_FileExistsInPackage_Nested()
 		{
-			var fileExists = await Uno.UI.Extras.StorageFileHelper.ExistsInPackage("Assets/Fonts/RoteFlora.ttf");
+			var fileExists = await Uno.Storage.StorageFileHelper.ExistsInPackage("Assets/Fonts/RoteFlora.ttf");
 
 			Assert.IsTrue(fileExists);
 		}
@@ -27,7 +27,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_FileExistsInPackage_RootPath()
 		{
-			var fileExists = await Uno.UI.Extras.StorageFileHelper.ExistsInPackage("Asset_GetFileFromApplicationUriAsync.xml");
+			var fileExists = await Uno.Storage.StorageFileHelper.ExistsInPackage("Asset_GetFileFromApplicationUriAsync.xml");
 
 			Assert.IsTrue(fileExists);
 		}
@@ -35,7 +35,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_ResourceFileExistsInPackage_Nested()
 		{
-			var fileExists = await Uno.UI.Extras.StorageFileHelper.ExistsInPackage("Assets/Icons/menu.png");
+			var fileExists = await Uno.Storage.StorageFileHelper.ExistsInPackage("Assets/Icons/menu.png");
 
 			Assert.IsTrue(fileExists);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
@@ -16,7 +16,7 @@ using Uno.Disposables;
 using Uno.Extensions.Specialized;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.WinUI.Graphics2DSK;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using CollectionExtensions = Uno.Extensions.CollectionExtensions;
 using RectExtensions = Uno.Extensions.RectExtensions;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI.Input.Preview.Injection;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if HAS_UNO_WINUI || WINAPPSDK
 using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
@@ -19,7 +19,7 @@ using Private.Infrastructure;
 using Windows.Foundation;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if HAS_UNO_WINUI
 using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
@@ -34,7 +34,7 @@ public class Given_StatusBar
 
 			var outerGrid = XamlHelper.LoadXaml<Grid>("""
 				<Grid BorderBrush="Red" BorderThickness="5">
-					<Grid behaviors:VisibleBoundsPadding.PaddingMask="All">
+					<Grid uub:VisibleBoundsPadding.PaddingMask="All">
 						<Border Background="SkyBlue" />
 					</Grid>
 				</Grid>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
@@ -34,7 +34,7 @@ public class Given_StatusBar
 
 			var outerGrid = XamlHelper.LoadXaml<Grid>("""
 				<Grid BorderBrush="Red" BorderThickness="5">
-					<Grid extras:VisibleBoundsPadding.PaddingMask="All">
+					<Grid behaviors:VisibleBoundsPadding.PaddingMask="All">
 						<Border Background="SkyBlue" />
 					</Grid>
 				</Grid>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -13,7 +13,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
@@ -12,8 +12,7 @@ using Private.Infrastructure;
 using Uno.Extensions;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.Extensions;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -33,10 +33,10 @@ using Windows.UI;
 using Windows.ApplicationModel.Appointments;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Hosting;
-using Uno.UI.Extras.Extensions;
+using Uno.UI.Extensions;
 using KeyEventArgs = Windows.UI.Core.KeyEventArgs;
 using Combinatorial.MSTest;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if !HAS_UNO_WINUI
 using Windows.UI.Input;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -24,7 +24,7 @@ using Uno.Extensions;
 using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 using System.Numerics;
 using Combinatorial.MSTest;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -18,7 +18,7 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Color = Windows.UI.Color;
 using Microsoft.UI.Xaml.Data;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 
 #if HAS_UNO_WINUI || WINAPPSDK || WINUI

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -26,7 +26,7 @@ using static Private.Infrastructure.TestServices;
 using ComboBoxHelper = Microsoft.UI.Xaml.Tests.Common.ComboBoxHelper;
 using Uno.UI.Extensions;
 using Combinatorial.MSTest;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if __APPLE_UIKIT__
 using _UIViewController = UIKit.UIViewController;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CommandBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CommandBar.cs
@@ -7,7 +7,7 @@ using Uno.UI.RuntimeTests.Helpers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.CommandBarPages;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -25,7 +25,7 @@ using Combinatorial.MSTest;
 using Microsoft.UI.Windowing;
 using Private.Infrastructure;
 using Uno.UI.Extensions;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -19,7 +19,7 @@ using static Private.Infrastructure.TestServices;
 using Windows.UI.Input.Preview.Injection;
 using Uno.Extensions;
 using Windows.Foundation;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -11,7 +11,6 @@ using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.FlyoutPages;
 using Uno.UI.RuntimeTests.FramePages;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.Extensions;
 using Windows.Foundation;
 using Windows.UI;
 using Windows.UI.Core;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
@@ -94,7 +94,7 @@ public class Given_FrameworkTemplatePool
 		using (FeatureConfigurationHelper.UseTemplatePooling())
 		{
 			var scrollViewer = new ScrollViewer();
-			var elevatedViewChild = new Uno.UI.Extras.ElevatedView();
+			var elevatedViewChild = new Uno.UI.Xaml.Controls.ElevatedView();
 			scrollViewer.Content = elevatedViewChild;
 
 			var c = new CheckBox();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -21,7 +21,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
 using Uno.Extensions;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if HAS_UNO
 using DirectUI;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -24,7 +24,7 @@ using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.ListViewPages;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if !WINAPPSDK
 using Uno.UI;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -13,7 +13,7 @@ using Private.Infrastructure;
 using Uno.UI.Extensions;
 using SamplesApp.UITests;
 using Uno.UI.RuntimeTests.ListViewPages;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 #if __APPLE_UIKIT__
 using UIKit;
 #else
@@ -37,7 +37,6 @@ using Uno.Extensions;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
-using Uno.UI.Extras.Extensions;
 using Microsoft.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -22,9 +22,9 @@ using Windows.UI.ViewManagement;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.Extensions;
+using Uno.UI.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 using static Private.Infrastructure.TestServices;
 using Disposable = Uno.Disposables.Disposable;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Slider.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Slider.cs
@@ -9,7 +9,7 @@ using MUXControlsTestApp.Utilities;
 using Uno.Extensions;
 using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Windows.UI.Input.Preview.Injection;
 using static Private.Infrastructure.TestServices;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SwipeControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SwipeControl.cs
@@ -11,7 +11,7 @@ using SamplesApp.UITests;
 using Uno.Extensions;
 using Uno.Testing;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -24,7 +24,7 @@ using Uno.UI.Extensions;
 using Combinatorial.MSTest;
 using Uno.UI.Helpers;
 using Microsoft.UI.Xaml.Markup;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if __SKIA__
 using Microsoft.UI.Xaml.Data;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -13,7 +13,7 @@ using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.UI;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Color = Windows.UI.Color;
 using static Private.Infrastructure.TestServices;
 using SamplesApp.UITests;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -18,7 +18,7 @@ using Uno.Disposables;
 using Uno.Extensions;
 using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Uno.UI.Xaml.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -11,7 +11,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Markup;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Uno.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater_FastScroll.cs
@@ -16,7 +16,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if HAS_UNO && !HAS_UNO_WINUI
 using Windows.UI.Xaml.Controls;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Documents/Given_Hyperlink.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Documents/Given_Hyperlink.cs
@@ -13,7 +13,7 @@ using Microsoft.UI.Xaml.Media;
 using Uno.Extensions;
 using static Private.Infrastructure.TestServices;
 using Uno.Disposables;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Documents;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.Bubbling.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.Bubbling.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI.Input.Preview.Injection;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_ContextRequested.Injection.cs
@@ -13,8 +13,8 @@ using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI.Input.Preview.Injection;
 using SamplesApp.UITests;
 using Uno.Extensions;
-using Uno.UI.Extras.DevTools.Input;
-using Uno.UI.Extras.Extensions;
+using Uno.UI.DevTools.Input;
+using Uno.UI.Extensions;
 using Windows.ApplicationModel.Background;
 using MUXControlsTestApp.Utilities;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
@@ -6,10 +6,10 @@ using Windows.UI.Input.Preview.Injection;
 using RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 
 #if WINAPPSDK
-using Uno.UI.Extras.Extensions;
+using Uno.UI.Extensions;
 #endif
 
 #if HAS_UNO_WINUI

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
@@ -16,7 +16,7 @@ using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Data;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.VisualTreeHelperPages;
-using Uno.UI.Extras.DevTools.Input;
+using Uno.UI.DevTools.Input;
 using Windows.Foundation;
 using Windows.UI;
 using static Private.Infrastructure.TestServices;

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -155,7 +155,8 @@ namespace Uno.UI.Behaviors
 		}
 
 #if !WINUI
-		public class VisibleBoundsDetails
+		// Every member is internal: the type is an implementation detail of the attached property.
+		internal class VisibleBoundsDetails
 		{
 			private static readonly ConditionalWeakTable<FrameworkElement, VisibleBoundsDetails> _instances =
 				new ConditionalWeakTable<FrameworkElement, VisibleBoundsDetails>();

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -22,26 +22,21 @@ using Uno.Foundation.Logging;
 #if IS_UNO // Is inside the Uno.UI project
 using _VisibleBoundsPadding = Uno.UI.Behaviors.InternalVisibleBoundsPadding;
 #else
-using Uno.UI.Extras.Extensions;
-using _VisibleBoundsPadding = Uno.UI.Extras.VisibleBoundsPadding;
+using _VisibleBoundsPadding = Uno.UI.Behaviors.VisibleBoundsPadding;
 #endif
 
-#if IS_UNO
 namespace Uno.UI.Behaviors
 {
+#if IS_UNO
 	/// <summary>
 	/// Internal Uno behavior, use VisibleBoundsPadding instead.
 	/// </summary>
 	/// <remarks>
-	/// This class is located in the same source file as the VisibleBoundsPadding class to avoid code duplication.
-	/// This is required to ensure that both Uno.UI styles and UWP (through Uno.UI.Extras) can use this behavior
-	/// and not have to synchronize two code files. The internal implementation is not supposed to be used outside
-	/// of the Uno.UI assembly, Uno.UI.Extras.VisibleBoundsPadding should be used by dependents.
+	/// This class shares its source file with the public VisibleBoundsPadding so that the Uno.UI styles and the
+	/// WinAppSDK build use the same implementation. The internal one is not meant to be used outside of Uno.UI.
 	/// </remarks>
 	internal static class InternalVisibleBoundsPadding
 #else
-namespace Uno.UI.Extras
-{
 	/// <summary>
 	/// A behavior which automatically adds padding to a control that ensures its content will always be inside
 	/// the <see cref="ApplicationView.VisibleBounds"/> of the application. Set PaddingMask to 'All' to enable this behavior,

--- a/src/Uno.UI/Helpers/XamlHelper.cs
+++ b/src/Uno.UI/Helpers/XamlHelper.cs
@@ -26,7 +26,9 @@ internal static partial class XamlHelper
 	{
 		[string.Empty] = "http://schemas.microsoft.com/winfx/2006/xaml/presentation",
 		["x"] = "http://schemas.microsoft.com/winfx/2006/xaml",
-		["extras"] = "using:Uno.UI.Extras", // uno utilities
+		["uno"] = "using:Uno.UI.Xaml.Controls", // uno controls and control extensions
+		["unoxaml"] = "using:Uno.UI.Xaml", // uno UIElement extensions
+		["behaviors"] = "using:Uno.UI.Behaviors", // uno behaviors
 		["muxc"] = "using:Microsoft.UI.Xaml.Controls",
 	};
 

--- a/src/Uno.UI/Helpers/XamlHelper.cs
+++ b/src/Uno.UI/Helpers/XamlHelper.cs
@@ -26,10 +26,11 @@ internal static partial class XamlHelper
 	{
 		[string.Empty] = "http://schemas.microsoft.com/winfx/2006/xaml/presentation",
 		["x"] = "http://schemas.microsoft.com/winfx/2006/xaml",
-		["uno"] = "using:Uno.UI.Xaml.Controls", // uno controls and control extensions
-		["unoxaml"] = "using:Uno.UI.Xaml", // uno UIElement extensions
-		["behaviors"] = "using:Uno.UI.Behaviors", // uno behaviors
 		["muxc"] = "using:Microsoft.UI.Xaml.Controls",
+		// uno utilities
+		["uub"] = "using:Uno.UI.Behaviors",
+		["uux"] = "using:Uno.UI.Xaml",
+		["uuxc"] = "using:Uno.UI.Xaml.Controls",
 	};
 
 	/// <summary>

--- a/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.uno.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.uno.cs
@@ -61,7 +61,7 @@ public sealed partial class AutomationProperties
 	internal static string? FindHtmlRole(UIElement uIElement)
 	{
 		// Uno-specific: allow explicit role override via AutomationPropertiesExtensions.Role
-		// (defined in Uno.UI.Extras). The provider is registered via RoleOverrideProvider.
+		// (defined in Uno.UI.Xaml.Automation). The provider is registered via RoleOverrideProvider.
 		var roleOverride = GetRoleOverride(uIElement);
 		if (!string.IsNullOrEmpty(roleOverride))
 		{
@@ -230,7 +230,8 @@ public sealed partial class AutomationProperties
 #endif
 
 	/// <summary>
-	/// Attached property allowing role override to be supplied by external assemblies (e.g. Uno.UI.Extras).
+	/// Attached property allowing role override to be supplied by external assemblies
+	/// (e.g. Uno.UI.Xaml.Automation.AutomationPropertiesExtensions).
 	/// This avoids the need for a delegate/provider and simplifies lookups.
 	/// </summary>
 	public static DependencyProperty RoleOverrideProperty { get; } =

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.Visuals.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.Visuals.cs
@@ -192,7 +192,7 @@ namespace Microsoft.UI.Xaml.Controls
 					SizeAndPositionContentInPopup();
 				}
 
-				// Uno TODO (for now this would have to be applied in-app using ElevatedView from Uno.UI.Extras)
+				// Uno TODO (for now this would have to be applied in-app using Uno.UI.Xaml.Controls.ElevatedView)
 				//// Cast a shadow
 				//(ApplyElevationEffect(m_tpBackgroundElementPart.AsOrNull<UIElement>()));
 


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno-private#2131, closes #12322

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

**In one line:** after this PR, a developer using Uno Platform never types, reads or sees the word `Extras` - the types sit in namespaces that read like the rest of the framework, and the assembly name becomes an invisible build detail.

`Uno.UI` has always shipped a small companion assembly next to it, so that a handful of Uno-specific helpers (`ElevatedView`, `VisibleBoundsPadding`, the `CommandBar` extensions…) can also compile against the Windows App SDK. Its name has leaked into the API for years: first as `Uno.UI.Toolkit` — routinely confused with the separate **Uno Toolkit** product — and, after #24010 renamed the artifact, as `Uno.UI.Extras`. Either way, consumers were forced to know the name of a build artifact in order to use a control.

This PR removes that coupling. Each type moves to the namespace it would have had if it had simply been written inside `Uno.UI`:

| What a developer writes | Before | After |
|---|---|---|
| `ElevatedView`, the `CommandBar` / `SplitView` extensions | `using:Uno.UI.Toolkit` | `using:Uno.UI.Xaml.Controls` |
| `UIElementExtensions.Elevation` | `using:Uno.UI.Toolkit` | `using:Uno.UI.Xaml` |
| `AutomationPropertiesExtensions.Role` | `using:Uno.UI.Toolkit` | `using:Uno.UI.Xaml.Automation` |
| `VisibleBoundsPadding` | `using:Uno.UI.Toolkit` | `using:Uno.UI.Behaviors` |
| `StorageFileHelper` | `Uno.UI.Toolkit` | `Uno.Storage` |

`Uno.Diagnostics.UI`, `Uno.Helpers` and `Uno.UI.Markup` were already named for what they do and are untouched. Two internal-only namespaces move alongside (`Uno.UI.Extensions`, `Uno.UI.DevTools.*`).

### Why this is a low-risk change

- **Nothing behaves differently.** No logic changed. Type names, member names, signatures and runtime behaviour are identical — only the namespace each type is declared in.
- **Customers migrate once, not twice.** #24010 has not shipped in a released package. An app coming from 6.x changes its `using` / `xmlns` lines exactly one time, straight to the final 7.0 names. Nobody has to learn `Uno.UI.Extras` and then unlearn it.
- **The change is mechanical and fully documented.** It is a find-and-replace on `using` and `xmlns` declarations, with a per-type mapping table in the 7.0 migration guide.
- **This is the one release where it can land.** Renaming a namespace is inherently breaking, so a major version is the only correct place for it; doing it now is what keeps 7.x stable afterwards.
- **The API surface gets smaller, not bigger.** Two types that were public by accident are now correctly hidden (below). Nothing new is exposed.
- **Every affected first-party repo is identified**, with the exact edit each one needs (listed at the bottom). Each is a one-line change.

### Why the type names themselves were left alone

The repo already has a precedent for naming Uno-specific attached properties after the control they extend — `Uno.UI.Xaml.Controls.ComboBox`, `Uno.UI.Xaml.Controls.ScrollViewer`. Following it here would have meant renaming `CommandBarExtensions` → `CommandBar` and `AutomationPropertiesExtensions` → `AutomationProperties`.

That was deliberately **not** done. A static `CommandBar` in `Uno.UI.Xaml.Controls` becomes an ambiguous name for every consumer that also imports `Microsoft.UI.Xaml.Controls`, and the same applies to `AutomationProperties`. The `*Extensions` suffix is exactly what keeps these collision-free, so keeping the names both reduces churn for consumers *and* is the technically correct choice. (Folding `UIElementExtensions.Elevation` into `ElevatedView` is not possible either — `ElevatedView.Elevation` is already an instance property.)

### Beyond the find-and-replace

- **`VisibleBoundsPadding.cs` no longer forks its namespace.** The file is compiled by both `Uno.UI` and the companion assembly, and each leg used to open a *different* `namespace` block inside the same `#if`. Both now declare `namespace Uno.UI.Behaviors` once, and the `#if` only switches the class name. This retires a long-standing piece of awkwardness flagged as a prerequisite for the eventual assembly fold.
- **A duplicated helper is gone.** Five padding/reflection helpers existed byte-identically in `Uno.UI` and in the companion assembly, with the duplicate silently winning by namespace-resolution order. The copy is now gated to the Windows App SDK leg only, so the Uno targets use the `Uno.UI` implementation.
- **Golden files are regenerated, not hand-edited** — via the test harness's `WRITE_EXPECTED` path, then re-verified with it switched back off, so the generator is genuinely proven rather than the expectations being bent to match. (One of them carries a content checksum, so hand-editing was not even possible.)
- **Docs**: eleven articles updated, and `Uno.UI.Extras` no longer appears anywhere under `doc/`. `doc/articles/Uno.UI.Extras.md` → `additional-features.md`; the TOC references it by `xref` uid, so no published link breaks.

### Public surface narrowed (2 items)

Every public type was audited against all 13 first-party repositories. Everything else earns its place — `ElevatedView` 235 XAML usages, `VisibleBoundsPadding` 53, `CommandBarExtensions.NavigationCommand` 27, `UIElementExtensions.Elevation` 10, `SplitViewExtensions.IsPaneEnabled` 1 (uno.themes), `StorageFileHelper` (uno.extensions), `DiagnosticsOverlay` and `FromJsonExtension` (uno.hotdesign). Two did not:

- **`VisibleBoundsPadding.VisibleBoundsDetails` → `internal`.** It was public, but its constructor *and* its factory were internal — no consumer could ever construct or call it. It also did not exist at all on the Windows App SDK leg, so the public surface differed per target for no benefit.
- **`StorageFileHelper` → `static`.** All members were already static; the implicit public constructor only offered consumers a meaningless instance.

### Known residue, deliberately deferred

The XAML generator derives one generated type name from the project's `RootNamespace`, so `Uno.UI.Extras.GlobalStaticResources` still appears in generated code. It is machine-written and never typed by a developer, but it is the last trace of the name. Changing it is a two-line project edit plus a golden regeneration, and it belongs with the assembly rename itself rather than here.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
  - No new tests: a namespace move with no behavioural change. The existing suites are the regression proof, and the narrowed public surface is verified by a metadata dump of the built assembly.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
  - Eleven articles plus a per-type mapping table in the 7.0 migration guide.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

> **This PR contains a breaking change**, and it is the intended kind for a major release. Consumers update their `using` and `xmlns` declarations per the table above. Type names, members and behaviour are unchanged, except that `VisibleBoundsDetails` is no longer public and `StorageFileHelper` is no longer instantiable — neither was usable in practice. No transitional alias is provided, per the hard-remove policy. Because #24010 has not shipped, an app upgrading from 6.x makes this change once.

## Validation

| Check | Result |
|---|---|
| **Compile** — `Uno.UI.Extras.Skia`, **with analyzers and code-style enforced** | ✅ clean |
| **Compile** — `Uno.UI` (`VisibleBoundsPadding`, `XamlHelper`), **with analyzers and code-style enforced** | ✅ clean |
| **Compile** — `Uno.UI.Extras.Windows` (real WinUI markup compiler; resolves `uno:ElevatedView` in `Themes/Generic.xaml`) | ✅ clean |
| **Compile** — `Uno.UI.RuntimeTests.Skia`, `Uno.UI.RuntimeTests.Windows` | ✅ clean |
| **Compile** — `SamplesApp.Skia`, `Uno.UI.UnitTests` | ✅ clean |
| **Test** — `Uno.UI.SourceGenerators.Tests` | ✅ **232 / 232**, with `WRITE_EXPECTED` off so the regenerated goldens are genuinely verified |
| **Test** — `Uno.Xaml.Tests` | ✅ 554 passed / 237 skipped / **0 failed** |
| **Format** — `dotnet xstyler -d src/SamplesApp -r -p` | ✅ 1523 / 1523 |

The Windows App SDK leg matters here: it compiles these sources *without* `Uno.UI`, so it is a compiler-enforced check that the new namespaces resolve correctly on both legs rather than only on Skia.

**Not validated locally, left to CI:** `SamplesApp.Windows` — it is pinned to `$(NetCurrentWinAppSDK)` (net11) and the locally installed .NET 11 preview SDK has no `android` workload, so restore fails on a referenced project. The only extras usage it adds beyond what is already covered is `uno:CommandBarExtensions.*` in `App.xaml`, which goes through the same attached-property resolution as the `ElevatedView` case that *is* proven above. Packaging/PackageDiff and runtime-test execution are also left to CI.

**Pre-existing and unrelated:** `XamlGenerationTests` reports 3 `UXAML0001` errors (`Style.PartialOverride`, `VSM.Test.xaml`). Confirmed identical on a stashed clean tree, so they are not caused by this PR.

## Downstream

Consumers owe **one** combined edit rather than two, because they never adopted #24010's names:

- `uno.extensions/src/Uno.Extensions.Storage.UI/FileStorage.cs` — `Uno.UI.Toolkit.StorageFileHelper` → `Uno.Storage.StorageFileHelper`
- `uno.app-mcp` — `using Uno.UI.Toolkit.DevTools.{Input,Xaml}` → `Uno.UI.DevTools.*`
- `uno.themes`, `uno.toolkit.ui`, `uno.hotdesign`, `Uno.Gallery`, `uno.chefs`, `uno.samples`, `uno.playground`, `uno.studio` — `xmlns` declarations, mapped per type in the table above

Each is a declaration-line change, tracked by the existing 7.0 update items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2BKcDZXJgiec1nHY1ZwMf
