### PR TITLE
test: Disable three Skia-WASM flakes behind tracked issues

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -3872,7 +3872,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native)] // Destabilized by changes in https://github.com/unoplatform/uno/pull/23269
+		// Skia-WASM: the materialized index regresses during the settle that follows a successful poll, see https://github.com/unoplatform/uno/issues/24147
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.Native | RuntimeTestPlatforms.SkiaWasm)] // Destabilized by changes in https://github.com/unoplatform/uno/pull/23269
 		public async Task When_Incremental_Load_ShouldStop()
 		{
 			const int BatchSize = 25;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -3817,6 +3817,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		// Skia-WASM: the second scroll samples mid-recycle, so the materialized index moves backwards, see https://github.com/unoplatform/uno/issues/24156
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
 		public async Task When_Incremental_Load_Default()
 		{
 			const int BatchSize = 25;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -6998,6 +6998,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		// Skia-WASM: the TextBox grows but the outer ScrollViewer never scrolls further in time, see https://github.com/unoplatform/uno/issues/24157
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
 		public async Task When_OuterScrollViewer_BringIntoView_Scrolls_To_Caret()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();


### PR DESCRIPTION
**GitHub Issue:** #24156, #24157, #24147

<!-- These stay OPEN on purpose: this PR only stops the three tests from blocking CI.
     Each issue is closed by fixing the underlying settle race and removing the exclusion. -->

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Three runtime tests are excluded on Skia-WASM only, each citing the issue that must re-enable it.

Two of them were caught failing WebAssembly Skia Runtime Tests 0 and 2 (one failure per job) in CI build 229119. In that **same** build both ran green on every other runtime-test target — Desktop Skia Windows/Linux/macOS, Skia-Android (5 shards) and Skia-iOS (4 shards) — so this is a slow-runtime settle race on the WASM runtime, not a product regression. The third is a long-tracked flake that happened to pass in that build.

**`Given_ListViewBase.When_Incremental_Load_Default`** (#24156)

```
Assert.IsLessThan failed. Actual value <27> is not less than expected value <11>.
No extra item materialized after second scroll: index1=27, index2=11
```

The last materialized index moved *backwards* between two identical scroll-to-bottom operations, so the second sample lands mid-recycle. The test samples after a fixed `Task.Delay(500)` rather than polling for a settled state.

**`Given_TextBox.When_OuterScrollViewer_BringIntoView_Scrolls_To_Caret`** (#24157)

```
Timed out waiting for condition to be met.
TextBox grew but the outer ScrollViewer did not scroll further:
offset 267 (was 466), extent 814, scrollable 514
```

The waits here were split by failure mode in `b085d50c87b` precisely because this test was measured failing **6 times in 10 master builds**, always as a timeout. That instrumentation now pays off: the extent wait passes, so the `TextBox` does grow and it is the scroll that never settles.

**`Given_ListViewBase.When_Incremental_Load_ShouldStop`** (#24147)

Measured failing **5 times in 10 master builds** in the same commit that instrumented it, and tracked as #24147 since, but never actually excluded — only the Native exclusion from #23269 was in place. It passed in build 229119 by luck while its weaker sibling `When_Incremental_Load_Default` failed, leaving it one unlucky rerun from reddening CI. Polling is not the fix: the test already waits for the condition, then waits for composition animations, then samples with nothing awaited in between, and the index regresses during that settle. Its exclusion joins the existing Native one rather than replacing it.

Same changes are going into `feature/breakingchanges` via the master-sync PR #24155, where the first two failures were surfaced.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — test-only change; no new coverage needed
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no product change
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
