### PR TITLE
Trim on iOS

### DIFF
--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -359,6 +359,35 @@
 		<NoSymbolStrip>false</NoSymbolStrip>
 	</PropertyGroup>
 
+	<!--
+	Xamarin.Shared.Sdk.Trimming.props:58 turns linking off for CoreCLR on the simulator, so nothing is
+	trimmed and crossgen2 AOT-compiles every method of every assembly - Microsoft.Graph, Roslyn,
+	BenchmarkDotNet and Silk.NET included. That is the single largest cost in this build. The SDK's own
+	fallback default at :74 is SdkOnly, i.e. device builds - what users actually ship - are trimmed; the
+	untrimmed simulator build is the outlier, and it was the only configuration CI exercised.
+
+	Measured locally, cleared bin/obj between runs, R2R enabled throughout:
+	    none (previous)  ILLink+R2R 2.9 min   .app 551 MB   .r2r 384.3 MB
+	    SdkOnly          ILLink+R2R 1.5 min   .app 274 MB   .r2r 163.2 MB
+	    Full             ILLink+R2R 1.4 min   .app 243 MB   .r2r 142.5 MB
+
+	Full rather than SdkOnly, to match what Android already does: the android-nativeaot-skia stage
+	publishes this same project with PublishAot=true, and NativeAOT requires whole-program trimming
+	via ILC - strictly more aggressive than Full. The reflective sample discovery and runtime-test
+	discovery here already survive that on Android, so trimming app assemblies on iOS is not new
+	ground. Full also keeps the two Skia heads' trimming behaviour consistent.
+
+	Release-only, so local Debug iteration and Hot Reload are unaffected - see UHR001 in
+	Uno.WinUI.DevServer.targets, which warns Hot Reload misbehaves when linking is enabled.
+
+	Trimming is a runtime risk rather than a build risk: sample discovery and the runtime-test harness
+	both resolve types reflectively, and this project suppresses the IL2xxx trim warnings
+	(_UnoTrimmingNoWarn above), so a clean build proves little. The iOS runtime tests are the real gate.
+	-->
+	<PropertyGroup Condition="'$(_IsUIKit)' == 'true' AND '$(Configuration)' == 'Release' AND '$(RuntimeIdentifier)' != '' AND $(RuntimeIdentifier.Contains('simulator'))">
+		<MtouchLink>Full</MtouchLink>
+	</PropertyGroup>
+
 	<Import Condition="'$(_IsUIKit)' == 'true'" Project="..\..\Uno.UI.Runtime.Skia.AppleUIKit\build\*.Runtime.Skia.AppleUIKit.props" />
 	<Import Condition="'$(_IsUIKit)' == 'true'" Project="..\..\Uno.UI.Runtime.Skia.AppleUIKit\build\*.Runtime.Skia.AppleUIKit.targets" />
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_PasswordBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_PasswordBox.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -251,7 +252,11 @@ public partial class Given_PasswordBox
 		}
 	}
 
+	// This asserts PasswordBox's API surface by member name, which the trimmer cannot see: on trimmed
+	// targets the members would be removed and the lookups would return null. DynamicDependency tells
+	// ILLink to preserve them, so the test keeps validating parity instead of the trimmer's opinion.
 	[TestMethod]
+	[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(PasswordBox))]
 	public void When_WinUI_Surface_Is_Declared()
 	{
 		var type = typeof(PasswordBox);


### PR DESCRIPTION
**GitHub Issue:** closes #24160

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

**Current behavior.** On the 7.0 / net11 lane the iOS Skia SamplesApp simulator bundle is **2.18 GB**, of which **1.99 GB is one file** — `SamplesApp.app/Frameworks/SamplesApp.r2r.framework/SamplesApp.r2r`. The build step measures p50 33 min / p90 47 / max 76 and has both hit the 60-minute job cap and lost agents outright (`We stopped hearing from agent …`) — 12 timeouts across 10 PRs. On `master` / net10 the same step is a steady 14.5 min with a 0.24 GB app and has never timed out in 322 builds.

**Why.** ~80% of that image is crossgen2's diagnostic **local symbol names** — 5,376,911 symbols averaging 280 bytes, of which exactly **one** is external (the R2R header the runtime actually references):

| Region | Bytes | % |
|---|---:|---:|
| `__LINKEDIT` symbol string table | 1,508,951,480 | 75.8% |
| `__TEXT,__managedcode` (actual R2R code) | 247,417,445 | 12.4% |
| `__DATA,__data` (import/fixup cells) | 89,925,440 | 4.5% |
| `__LINKEDIT` nlist_64 (5,376,911 × 16 B) | 86,030,576 | 4.3% |
| everything else | 59,432,899 | 3.0% |

No DWARF segment, ~13 KB of embedded metadata — so this is neither debug info nor IL duplication. Composite R2R expansion itself is 2.13× (180 MB IL → 384 MB image), inside Microsoft's documented 2–3×; crossgen2 is not the problem.

The symbols survive because `Xamarin.Shared.props:125` in the iOS workload defaults `NoSymbolStrip=true` for **all** simulator builds — `Configuration` is not part of the condition — which filters the R2R framework back out of `_NativeStripFiles` even though `_CollectR2RFrameworksForPostProcessing` deliberately added it with the comment *"so they get stripped"*. Device builds strip; simulator builds don't. Filed upstream as [dotnet/macios#26455](https://github.com/dotnet/macios/issues/26455).

**This PR.**

1. `SamplesApp.csproj` — set `NoSymbolStrip=false` for UIKit **simulator** RIDs only. Device/TestFlight builds are unaffected (they already strip).
2. `.azure-devops-tests-ios-skia-build.yml` — raise the iOS build job timeout from 60. The 60 was calibrated in the net10 era; kept deliberately generous while post-fix numbers are gathered, with a follow-up to tighten once the smaller bundle's real distribution is known.

**Measured** (clean local build, .NET SDK 11.0.100-preview.7.26381.103, Microsoft.iOS.Sdk 26.5.11997-net11-p7, exit 0):

| | before | after |
|---|---:|---:|
| `SamplesApp.r2r` | 1,991,757,840 B | **384,315,040 B** (−80.7%) |
| `.app` total | 2.09 GB | **551 MB** (−74%) |
| build wall time | 2:55 | 2:55 (unchanged) |

**ReadyToRun stays enabled** — this was checked the hard way. Disabling R2R does cut the *build* to 17.5 min, but iOS runtime-test jobs then go from a 20.8 min median to 77.9 min for a single job (`master`, which has no R2R, runs a 51.8 min median). Trading a build-time problem for a worse test-time one is not a win, so the fix targets the symbol table rather than the feature.

**Not one branch.** Verified across 79 builds on 33 distinct branches — every one produces a 2.18–2.20 GB app, including `feature/breakingchanges` itself.

**Only cost:** managed-frame symbolication in *simulator* crash reports, which device builds already forgo.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a; build-configuration change, validated by full local iOS builds before/after and by the existing iOS runtime-test stage
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a; no public API or feature surface
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- Note: also cherry-picked onto #24009 and #24155 so whichever lands first carries the fix. -->
