### PR TITLE
fix(tests): Stop a hung test from consuming the whole CI job

### DIFF
--- a/.claude/rules/runtime-tests.md
+++ b/.claude/rules/runtime-tests.md
@@ -22,4 +22,6 @@ Build & run with the **`/runtime-tests`** skill. WinUI parity: `/winui-runtime-t
 - **Screenshots**: `var bmp = await UITestHelper.ScreenShot(el);` then `ImageAssert.HasColorAt(bmp, x, y, color, tolerance)` or `await ImageAssert.AreEqualAsync(a, b)`. A raw `RawBitmap` needs `await bmp.Populate()` before `GetPixel`. Use a small `tolerance` (1–5) for hardware rasterization variance. `[RequiresFullWindow]` for tests needing the real window size.
 - Don't reference Uno internals (`DirectUI`, `Uno.UI.Xaml.Input`) unguarded — gate with `#if HAS_UNO`. MSTest usings come from `GlobalUsings.cs`; don't re-import.
 
+- **Every async test body has a default time budget in Release builds** (10 minutes), so one hang can no longer take the whole CI job down with it and lose the shard's results. Raise it for a legitimately slow test with `[Timeout(<ms>)]`; the whole run can be re-budgeted with `UNO_TEST_DEFAULT_TIMEOUT_SECONDS` (non-positive opts out). DEBUG builds stay unbounded so a breakpoint doesn't trip it. Two limits worth knowing: a cut-off **abandons** the body rather than cancelling it, so a runaway test keeps touching the visual tree — reset shared state in `finally` as above; and only awaited work is bounded, so a synchronous body or a wedged UI thread still escapes it.
+
 Known flaky tests are tracked in GitHub issue #9080.

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -58,9 +58,13 @@ namespace Uno.UI.Samples.Tests
 		private double _lastTestResultsScrollableHeight;
 #if DEBUG
 		private readonly TimeSpan DefaultUnitTestTimeout = TimeSpan.FromSeconds(300);
+		private static readonly TimeSpan? DefaultTestBodyTimeoutFallback = null;
 #else
 		private readonly TimeSpan DefaultUnitTestTimeout = TimeSpan.FromSeconds(60);
+		private static readonly TimeSpan? DefaultTestBodyTimeoutFallback = TimeSpan.FromMinutes(5);
 #endif
+
+		private static readonly TimeSpan? DefaultTestBodyTimeout = GetDefaultTestBodyTimeout();
 
 #if !WINAPPSDK
 		private ApplicationView _applicationView;
@@ -1016,9 +1020,13 @@ namespace Uno.UI.Samples.Tests
 									var timeout = GetTestTimeout(test);
 									if (timeout.HasValue)
 									{
-										var timeoutTask = Task.Delay(timeout.Value);
+										// Cancel the delay as soon as the test finishes, otherwise every test
+										// leaves a pending timer alive for the whole timeout window.
+										using var timeoutCts = new CancellationTokenSource();
+										var timeoutTask = Task.Delay(timeout.Value, timeoutCts.Token);
 
 										var resultingTask = await Task.WhenAny(task, timeoutTask);
+										timeoutCts.Cancel();
 
 										if (resultingTask == timeoutTask)
 										{
@@ -1338,7 +1346,31 @@ namespace Uno.UI.Samples.Tests
 		private TimeSpan? GetTestTimeout(UnitTestMethodInfo test)
 			=> test.Method.GetCustomAttribute(typeof(TimeoutAttribute)) is TimeoutAttribute methodAttribute
 					? TimeSpan.FromMilliseconds(methodAttribute.Timeout)
-					: null;
+					: DefaultTestBodyTimeout;
+
+		/// <summary>
+		/// Fallback timeout applied to every async test body that carries no <see cref="TimeoutAttribute"/>.
+		/// Without it a single hung test consumes the whole CI job budget and the run ends with no results
+		/// file at all, losing the outcome of every other test in the shard.
+		/// </summary>
+		private static TimeSpan? GetDefaultTestBodyTimeout()
+		{
+			var configured = Environment.GetEnvironmentVariable("UNO_TEST_DEFAULT_TIMEOUT_SECONDS");
+
+			if (configured is not null)
+			{
+				if (!int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+				{
+					return DefaultTestBodyTimeoutFallback;
+				}
+
+				// An explicit non-positive value opts out entirely, which is the only way to get the
+				// pre-existing unbounded behaviour back when debugging a test under a breakpoint.
+				return seconds <= 0 ? null : TimeSpan.FromSeconds(seconds);
+			}
+
+			return DefaultTestBodyTimeoutFallback;
+		}
 
 		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Appears to work on CI!")]
 		private IEnumerable<UnitTestClassInfo> InitializeTests()

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -1030,7 +1030,7 @@ namespace Uno.UI.Samples.Tests
 
 										if (resultingTask == timeoutTask)
 										{
-											throw new TimeoutException(
+											throw new TestBodyTimeoutException(
 												$"Test execution timed out after {timeout.Value}");
 										}
 
@@ -1077,7 +1077,11 @@ namespace Uno.UI.Samples.Tests
 								}
 								else
 								{
-									if (_currentRun.CurrentRepeatCount < config.Attempts - 1)
+									// A test the harness had to cut off will not do better on a second run, and
+									// each attempt costs the shard the same wait again: three attempts of a stuck
+									// test still add up to most of the job budget. A TimeoutException a test raises
+									// from one of its own waits is an ordinary failure and stays retryable.
+									if (e is not TestBodyTimeoutException && _currentRun.CurrentRepeatCount < config.Attempts - 1)
 									{
 										// Count only the first time we retry this test.
 										if (_currentRun.CurrentRepeatCount == 0)
@@ -1347,6 +1351,18 @@ namespace Uno.UI.Samples.Tests
 			=> test.Method.GetCustomAttribute(typeof(TimeoutAttribute)) is TimeoutAttribute methodAttribute
 					? TimeSpan.FromMilliseconds(methodAttribute.Timeout)
 					: DefaultTestBodyTimeout;
+
+		/// <summary>
+		/// Raised when the harness cuts off a test body that outlived its budget. Distinct from the
+		/// <see cref="TimeoutException"/> a test raises from one of its own waits, so only the former
+		/// skips the retries.
+		/// </summary>
+		private sealed class TestBodyTimeoutException : TimeoutException
+		{
+			public TestBodyTimeoutException(string message) : base(message)
+			{
+			}
+		}
 
 		/// <summary>
 		/// Fallback timeout applied to every async test body that carries no <see cref="TimeoutAttribute"/>.

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -69,6 +69,7 @@ namespace Uno.UI.Samples.Tests
 		private const string DefaultTestBodyTimeoutVariable = "UNO_TEST_DEFAULT_TIMEOUT_SECONDS";
 		private const int MaxTestBodyTimeoutSeconds = 24 * 60 * 60;
 
+		private static string _rejectedTestBodyTimeout;
 		private static readonly TimeSpan? DefaultTestBodyTimeout = GetDefaultTestBodyTimeout();
 
 #if !WINAPPSDK
@@ -772,6 +773,11 @@ namespace Uno.UI.Samples.Tests
 					? $"Default test body budget: {defaultBudget} (override with {DefaultTestBodyTimeoutVariable})"
 					: $"Default test body budget: none ({DefaultTestBodyTimeoutVariable} opted out, or DEBUG build)");
 
+				if (_rejectedTestBodyTimeout is { } rejected)
+				{
+					_log?.Error($"Ignored {DefaultTestBodyTimeoutVariable}='{rejected}': expected a whole number of seconds.");
+				}
+
 				foreach (var type in testTypes)
 				{
 					if (ct.IsCancellationRequested)
@@ -1406,8 +1412,9 @@ namespace Uno.UI.Samples.Tests
 
 			if (!int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
 			{
-				typeof(UnitTestsControl).Log().Warn(
-					$"Ignoring {DefaultTestBodyTimeoutVariable}='{configured}': expected a whole number of seconds.");
+				// Reported from the run header rather than here: this runs at type init, before there is
+				// anywhere to report to.
+				_rejectedTestBodyTimeout = configured;
 
 				return DefaultTestBodyTimeoutFallback;
 			}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -61,8 +61,13 @@ namespace Uno.UI.Samples.Tests
 		private static readonly TimeSpan? DefaultTestBodyTimeoutFallback = null;
 #else
 		private readonly TimeSpan DefaultUnitTestTimeout = TimeSpan.FromSeconds(60);
-		private static readonly TimeSpan? DefaultTestBodyTimeoutFallback = TimeSpan.FromMinutes(5);
+		// Must stay above the longest wait a test can legitimately perform, or the harness cuts off a healthy
+		// test and hides its own diagnostic: SynchronouslyTickUIThread alone waits five minutes per tick.
+		private static readonly TimeSpan? DefaultTestBodyTimeoutFallback = TimeSpan.FromMinutes(10);
 #endif
+
+		private const string DefaultTestBodyTimeoutVariable = "UNO_TEST_DEFAULT_TIMEOUT_SECONDS";
+		private const int MaxTestBodyTimeoutSeconds = 24 * 60 * 60;
 
 		private static readonly TimeSpan? DefaultTestBodyTimeout = GetDefaultTestBodyTimeout();
 
@@ -761,6 +766,12 @@ namespace Uno.UI.Samples.Tests
 
 				_ = ReportMessage($"Running tests ({testTypes.Count()} fixtures)...");
 
+				// Say the budget out loud once: a cut-off five minutes into a shard is otherwise
+				// unattributable, and there is no other way to tell an override from the default.
+				_log?.Info(DefaultTestBodyTimeout is { } defaultBudget
+					? $"Default test body budget: {defaultBudget} (override with {DefaultTestBodyTimeoutVariable})"
+					: $"Default test body budget: none ({DefaultTestBodyTimeoutVariable} opted out, or DEBUG build)");
+
 				foreach (var type in testTypes)
 				{
 					if (ct.IsCancellationRequested)
@@ -973,7 +984,7 @@ namespace Uno.UI.Samples.Tests
 											var initializeReturn = testClassInfo.Initialize?.Invoke(instance, Array.Empty<object>());
 											if (initializeReturn is Task initializeReturnTask)
 											{
-												await initializeReturnTask;
+												await AwaitWithBudget(initializeReturnTask, GetTestTimeout(test), $"[TestInitialize] of {test.Method.Name}");
 											}
 
 											returnValue = InvokeMethod(test.Method, instance, methodArguments);
@@ -1007,7 +1018,7 @@ namespace Uno.UI.Samples.Tests
 									var initializeReturn = testClassInfo.Initialize?.Invoke(instance, Array.Empty<object>());
 									if (initializeReturn is Task initializeReturnTask)
 									{
-										await initializeReturnTask;
+										await AwaitWithBudget(initializeReturnTask, GetTestTimeout(test), $"[TestInitialize] of {test.Method.Name}");
 									}
 
 									returnValue = InvokeMethod(test.Method, instance, methodArguments);
@@ -1016,32 +1027,7 @@ namespace Uno.UI.Samples.Tests
 
 								if (test.Method.ReturnType == typeof(Task))
 								{
-									var task = (Task)returnValue;
-									var timeout = GetTestTimeout(test);
-									if (timeout.HasValue)
-									{
-										// Cancel the delay as soon as the test finishes, otherwise every test
-										// leaves a pending timer alive for the whole timeout window.
-										using var timeoutCts = new CancellationTokenSource();
-										var timeoutTask = Task.Delay(timeout.Value, timeoutCts.Token);
-
-										var resultingTask = await Task.WhenAny(task, timeoutTask);
-										timeoutCts.Cancel();
-
-										if (resultingTask == timeoutTask)
-										{
-											throw new TestBodyTimeoutException(
-												$"Test execution timed out after {timeout.Value}");
-										}
-
-										// Rethrow exception if failed OR task cancelled if task **internally** raised
-										// a TaskCancelledException (we don't provide any cancellation token).
-										await resultingTask;
-									}
-									else
-									{
-										await task;
-									}
+									await AwaitWithBudget((Task)returnValue, GetTestTimeout(test), $"Test {test.Method.Name}");
 								}
 
 								var console = consoleRecorder?.GetContentAndReset();
@@ -1077,10 +1063,8 @@ namespace Uno.UI.Samples.Tests
 								}
 								else
 								{
-									// A test the harness had to cut off will not do better on a second run, and
-									// each attempt costs the shard the same wait again: three attempts of a stuck
-									// test still add up to most of the job budget. A TimeoutException a test raises
-									// from one of its own waits is an ordinary failure and stays retryable.
+									// A cut-off test costs the same wait on every attempt. A TimeoutException a test
+									// raises from one of its own waits is an ordinary failure and stays retryable.
 									if (e is not TestBodyTimeoutException && _currentRun.CurrentRepeatCount < config.Attempts - 1)
 									{
 										// Count only the first time we retry this test.
@@ -1353,7 +1337,7 @@ namespace Uno.UI.Samples.Tests
 					: DefaultTestBodyTimeout;
 
 		/// <summary>
-		/// Raised when the harness cuts off a test body that outlived its budget. Distinct from the
+		/// Raised when the harness cuts off work that outlived its budget. Distinct from the
 		/// <see cref="TimeoutException"/> a test raises from one of its own waits, so only the former
 		/// skips the retries.
 		/// </summary>
@@ -1365,27 +1349,78 @@ namespace Uno.UI.Samples.Tests
 		}
 
 		/// <summary>
+		/// Awaits <paramref name="task"/>, giving up on it once <paramref name="budget"/> elapses.
+		/// </summary>
+		/// <remarks>
+		/// The cut-off abandons the task, it does not cancel it — nothing here can stop a body that is not
+		/// cooperating. The run continues with that task still in flight, so it is named again if it ever
+		/// finishes; an unrelated test failing right after a cut-off is the expected shape of that damage.
+		/// </remarks>
+		private async Task AwaitWithBudget(Task task, TimeSpan? budget, string what)
+		{
+			if (budget is not { } timeout)
+			{
+				await task;
+				return;
+			}
+
+			// Cancelling the delay is what releases the timer: disposing the source alone would leave one
+			// armed per test for the whole window.
+			using var timeoutCts = new CancellationTokenSource();
+			var timeoutTask = Task.Delay(timeout, timeoutCts.Token);
+
+			var completed = await Task.WhenAny(task, timeoutTask);
+			timeoutCts.Cancel();
+
+			if (completed == timeoutTask)
+			{
+				_ = task.ContinueWith(
+					t => _log?.Info($"{what} completed after the harness cut it off ({t.Status}). Any failure reported between the cut-off and now may come from it."),
+					TaskScheduler.Default);
+
+				throw new TestBodyTimeoutException($"{what} timed out after {timeout}");
+			}
+
+			// Rethrow if faulted, or surface a cancellation the task raised internally.
+			await completed;
+		}
+
+		/// <summary>
 		/// Fallback timeout applied to every async test body that carries no <see cref="TimeoutAttribute"/>.
 		/// Without it a single hung test consumes the whole CI job budget and the run ends with no results
 		/// file at all, losing the outcome of every other test in the shard.
 		/// </summary>
+		/// <remarks>
+		/// Async work only. The harness can cut off an awaited <see cref="Task"/>; a synchronous body runs to
+		/// completion inside the invoke and cannot be interrupted portably. A wedged UI thread escapes it too,
+		/// because the timer itself needs the loop to run.
+		/// </remarks>
 		private static TimeSpan? GetDefaultTestBodyTimeout()
 		{
-			var configured = Environment.GetEnvironmentVariable("UNO_TEST_DEFAULT_TIMEOUT_SECONDS");
+			var configured = Environment.GetEnvironmentVariable(DefaultTestBodyTimeoutVariable);
 
-			if (configured is not null)
+			if (configured is null)
 			{
-				if (!int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
-				{
-					return DefaultTestBodyTimeoutFallback;
-				}
-
-				// An explicit non-positive value opts out entirely, which is the only way to get the
-				// pre-existing unbounded behaviour back when debugging a test under a breakpoint.
-				return seconds <= 0 ? null : TimeSpan.FromSeconds(seconds);
+				return DefaultTestBodyTimeoutFallback;
 			}
 
-			return DefaultTestBodyTimeoutFallback;
+			if (!int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+			{
+				typeof(UnitTestsControl).Log().Warn(
+					$"Ignoring {DefaultTestBodyTimeoutVariable}='{configured}': expected a whole number of seconds.");
+
+				return DefaultTestBodyTimeoutFallback;
+			}
+
+			// A non-positive value opts out entirely. DEBUG builds are unbounded already; this is how a
+			// Release build gets the same behaviour back, e.g. when debugging a test under a breakpoint.
+			if (seconds <= 0)
+			{
+				return null;
+			}
+
+			// Task.Delay rejects anything past Timer.MaxSupportedTimeout, which would throw on every test.
+			return TimeSpan.FromSeconds(Math.Min(seconds, MaxTestBodyTimeoutSeconds));
 		}
 
 		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Appears to work on CI!")]

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
@@ -33,6 +33,16 @@ public partial class Given_HotReloadWorkspace
 	private static int _remoteControlPort;
 	private static Process? _testAppProcess;
 
+	/// <summary>
+	/// Budget for a single run of the hot-reload app.
+	/// </summary>
+	/// <remarks>
+	/// A healthy run of the whole HRApp suite takes about ninety seconds. When a hot-reload session
+	/// breaks server-side, every remaining test in the app instead burns its own five-minute budget,
+	/// which turns this single test into a multi-hour one and used to consume the entire CI job.
+	/// </remarks>
+	private static readonly TimeSpan TestAppTimeout = TimeSpan.FromMinutes(6);
+
 	/// <remarks>
 	/// This test is running C# hot reload tests in a separate app, located 
 	/// in the HRApp folder. These tests are run as "runtime tests" in the HRApp, and the
@@ -55,11 +65,28 @@ public partial class Given_HotReloadWorkspace
 	// Hot reload tests are only available on Skia desktop targets
 	[Filters]
 	[TestMethod]
+	// Backstop for the whole test: TestAppTimeout bounds the app run itself, this also covers the
+	// build and the result parsing around it.
+	[Timeout(8 * 60 * 1000, CooperativeCancellation = false)]
 	public async Task When_HotReloadScenario(string filters)
 	{
 		// Remove this class and this method from the filters
 		filters = string.Join(";", (filters?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()).ToImmutableArray().RemoveAll(IsOuterTestFilter));
-		var resultFile = await RunTestApp(filters, CancellationToken.None);
+
+		using var cts = new CancellationTokenSource(TestAppTimeout);
+
+		string resultFile;
+		try
+		{
+			resultFile = await RunTestApp(filters, cts.Token);
+		}
+		catch (OperationCanceledException) when (cts.IsCancellationRequested)
+		{
+			throw new TimeoutException(
+				$"The hot reload test app did not complete within {TestAppTimeout} and was killed. " +
+				"This usually means a hot-reload never completed: look for an internal error in the " +
+				"dev-server output above.");
+		}
 
 		// Parse the nunit XML results file and extract all failed tests
 		var tests = NUnitXmlParser.GetTests(resultFile);
@@ -119,8 +146,8 @@ public partial class Given_HotReloadWorkspace
 	[TestCleanup]
 	public void TestCleanupWrapper()
 	{
-		_testAppProcess?.Kill();
-		_testAppProcess?.WaitForExit();
+		ProcessHelpers.KillProcessTree(_testAppProcess);
+		_testAppProcess = null;
 	}
 
 	public static async Task InitializeServer()
@@ -140,8 +167,7 @@ public partial class Given_HotReloadWorkspace
 		var hrAppPath = GetHotReloadAppPath();
 
 		typeof(Given_HotReloadWorkspace).Log().Debug($"Starting test app (path{hrAppPath})");
-		var p = await ProcessHelpers.RunProcess(
-			ct,
+		var p = ProcessHelpers.StartProcess(
 			"dotnet",
 			new() {
 				"run",
@@ -160,13 +186,16 @@ public partial class Given_HotReloadWorkspace
 			},
 			hrAppPath,
 			"HRApp",
-			true,
 
 			// Required when running in CI, as VS sets it automatically in debug
 			new() { ["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug" }
 		);
 
+		// Track the app before waiting on it: a run that never completes leaves this method waiting,
+		// and the cleanup can only kill the app once it has been recorded here.
 		_testAppProcess = p;
+
+		await ProcessHelpers.WaitForExitAsync(p, "HRApp", ct);
 
 		if (p.ExitCode != 0)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Given_HotReloadWorkspace.cs
@@ -34,14 +34,16 @@ public partial class Given_HotReloadWorkspace
 	private static Process? _testAppProcess;
 
 	/// <summary>
-	/// Budget for a single run of the hot-reload app.
+	/// Budget for a single run of the hot-reload app. A healthy run takes about ninety seconds; a session
+	/// that breaks server-side leaves every remaining test in the app burning its own budget instead.
 	/// </summary>
-	/// <remarks>
-	/// A healthy run of the whole HRApp suite takes about ninety seconds. When a hot-reload session
-	/// breaks server-side, every remaining test in the app instead burns its own five-minute budget,
-	/// which turns this single test into a multi-hour one and used to consume the entire CI job.
-	/// </remarks>
 	private static readonly TimeSpan TestAppTimeout = TimeSpan.FromMinutes(6);
+
+	/// <summary>
+	/// Budget for building the app. This runs from <c>[TestInitialize]</c>, so a hang here is only bounded
+	/// by whatever the harness applies to initialize — never leave it unbounded.
+	/// </summary>
+	private static readonly TimeSpan BuildTimeout = TimeSpan.FromMinutes(10);
 
 	/// <remarks>
 	/// This test is running C# hot reload tests in a separate app, located 
@@ -65,9 +67,9 @@ public partial class Given_HotReloadWorkspace
 	// Hot reload tests are only available on Skia desktop targets
 	[Filters]
 	[TestMethod]
-	// Backstop for the whole test: TestAppTimeout bounds the app run itself, this also covers the
-	// build and the result parsing around it.
-	[Timeout(8 * 60 * 1000, CooperativeCancellation = false)]
+	// Raises the harness default for this test, which builds an app before it runs one. A cut-off here is
+	// the harness's, so it is reported once and not retried; TestAppTimeout below only reaps the app.
+	[Timeout(8 * 60 * 1000)]
 	public async Task When_HotReloadScenario(string filters)
 	{
 		// Remove this class and this method from the filters
@@ -82,10 +84,14 @@ public partial class Given_HotReloadWorkspace
 		}
 		catch (OperationCanceledException) when (cts.IsCancellationRequested)
 		{
-			throw new TimeoutException(
+			// Assert.Fail rather than TimeoutException: the harness retries a TimeoutException, and three
+			// attempts at a wedged session cost the shard the same wait over again.
+			Assert.Fail(
 				$"The hot reload test app did not complete within {TestAppTimeout} and was killed. " +
 				"This usually means a hot-reload never completed: look for an internal error in the " +
 				"dev-server output above.");
+
+			throw; // unreachable, Assert.Fail always throws
 		}
 
 		// Parse the nunit XML results file and extract all failed tests
@@ -146,8 +152,19 @@ public partial class Given_HotReloadWorkspace
 	[TestCleanup]
 	public void TestCleanupWrapper()
 	{
-		ProcessHelpers.KillProcessTree(_testAppProcess);
+		// StartProcess redirects both streams, so the Process owns OS pipe handles that only a Dispose
+		// releases before the finalizer runs.
+		var process = _testAppProcess;
 		_testAppProcess = null;
+
+		if (process is { HasExited: false })
+		{
+			typeof(Given_HotReloadWorkspace).Log().Warn(
+				"The hot reload app was still running at cleanup and had to be killed — the run above did not complete on its own.");
+		}
+
+		ProcessHelpers.KillProcessTree(process);
+		process?.Dispose();
 	}
 
 	public static async Task InitializeServer()
@@ -228,11 +245,24 @@ public partial class Given_HotReloadWorkspace
 			output: builder
 		);
 
-		await process.WaitForExitAsync();
-
-		if (process.ExitCode != 0)
+		try
 		{
-			throw new InvalidOperationException($"Failed to build app{Environment.NewLine}{builder}");
+			using var cts = new CancellationTokenSource(BuildTimeout);
+			await ProcessHelpers.WaitForExitAsync(process, "HRAppBuild", cts.Token);
+
+			if (process.ExitCode != 0)
+			{
+				throw new InvalidOperationException($"Failed to build app{Environment.NewLine}{builder}");
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			throw new InvalidOperationException(
+				$"Building the hot reload app did not complete within {BuildTimeout}.{Environment.NewLine}{builder}");
+		}
+		finally
+		{
+			process.Dispose();
 		}
 	}
 

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/ProcessHelpers.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/ProcessHelpers.cs
@@ -59,27 +59,62 @@ internal class ProcessHelpers
 		}
 	}
 
-	public static async Task<Process> RunProcess(
-		CancellationToken ct,
-		string executable,
-		List<string> parameters,
-		string workingDirectory,
-		string logPrefix,
-		bool waitForExit,
-		Dictionary<string, string>? environmentVariables = null)
+	/// <summary>
+	/// Waits for <paramref name="process"/> to exit, killing it and everything it spawned when
+	/// <paramref name="ct"/> fires first.
+	/// </summary>
+	/// <remarks>
+	/// Merely abandoning the wait is not enough: the orphaned app keeps holding its dev-server
+	/// connection and goes on competing with the attempt that follows.
+	/// </remarks>
+	public static async Task WaitForExitAsync(Process process, string logPrefix, CancellationToken ct)
 	{
-		var process = StartProcess(executable, parameters, workingDirectory, logPrefix, environmentVariables);
-
 #if HAS_UNO
 		typeof(ProcessHelpers).Log().Debug(logPrefix + $" waiting for process exit");
 #endif
 
-		if (waitForExit)
+		try
 		{
-			await process.WaitForExitAsync();
+			await process.WaitForExitAsync(ct);
+		}
+		catch (OperationCanceledException)
+		{
+#if HAS_UNO
+			typeof(ProcessHelpers).Log().Error(logPrefix + $" did not exit in time, killing it");
+#endif
+			KillProcessTree(process);
+
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// Kills <paramref name="process"/> and its children, tolerating a process that already exited.
+	/// </summary>
+	public static void KillProcessTree(Process? process)
+	{
+		if (process is null)
+		{
+			return;
 		}
 
-		return process;
+		try
+		{
+			if (!process.HasExited)
+			{
+				// The app is started through "dotnet run", so killing the launcher alone would
+				// leave the app itself running.
+				process.Kill(entireProcessTree: true);
+				process.WaitForExit(10_000);
+			}
+		}
+		catch (Exception e)
+		{
+			// The process may exit on its own between the check and the kill.
+#if HAS_UNO
+			typeof(ProcessHelpers).Log().Debug($"Failed to kill process ({e.Message})");
+#endif
+		}
 	}
 
 	public static Process StartProcess(

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/ProcessHelpers.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/ProcessHelpers.cs
@@ -80,7 +80,7 @@ internal class ProcessHelpers
 		catch (OperationCanceledException)
 		{
 #if HAS_UNO
-			typeof(ProcessHelpers).Log().Error(logPrefix + $" did not exit in time, killing it");
+			typeof(Given_HotReloadWorkspace).Log().Error(logPrefix + " wait was cancelled before the process exited, killing it");
 #endif
 			KillProcessTree(process);
 
@@ -105,14 +105,21 @@ internal class ProcessHelpers
 				// The app is started through "dotnet run", so killing the launcher alone would
 				// leave the app itself running.
 				process.Kill(entireProcessTree: true);
-				process.WaitForExit(10_000);
+
+				// Synchronous on purpose: this also runs from the synchronous [TestCleanup], and the next
+				// attempt must not start while the old app still holds its dev-server connection.
+				if (!process.WaitForExit(10_000))
+				{
+					typeof(Given_HotReloadWorkspace).Log().Error(
+						"A killed process tree was still alive after 10s; the next attempt may fight it for the dev-server port.");
+				}
 			}
 		}
 		catch (Exception e)
 		{
 			// The process may exit on its own between the check and the kill.
 #if HAS_UNO
-			typeof(ProcessHelpers).Log().Debug($"Failed to kill process ({e.Message})");
+			typeof(Given_HotReloadWorkspace).Log().Warn($"Failed to kill process ({e.Message})");
 #endif
 		}
 	}
@@ -155,13 +162,13 @@ internal class ProcessHelpers
 		// hookup the event handlers to capture the data that is received
 		process.OutputDataReceived += (sender, args) =>
 		{
-			var logMessage = $"[{DateTime.Now}] " + logPrefix + ": " + args.Data ?? "<Empty>";
+			var logMessage = $"[{DateTime.UtcNow:O}] {logPrefix}: {args.Data ?? "<Empty>"}";
 			output?.AppendLine(logMessage);
 			typeof(Given_HotReloadWorkspace).Log().Debug(logMessage);
 		};
 		process.ErrorDataReceived += (sender, args) =>
 		{
-			var logMessage = $"[{DateTime.Now}] " + logPrefix + ": " + args.Data ?? "<Empty>";
+			var logMessage = $"[{DateTime.UtcNow:O}] {logPrefix}: {args.Data ?? "<Empty>"}";
 			output?.AppendLine(logMessage);
 			typeof(Given_HotReloadWorkspace).Log().Error(logMessage);
 		};


### PR DESCRIPTION
**GitHub Issue:** #24111 (addresses item 2 only — the macOS native-peer defects of item 1 are #24112, so this deliberately does not auto-close the issue)

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Addresses item 2 of #24111 — *"Test bodies have no timeout, so one hang costs the entire shard"* — after it took down `Tests - Desktop Skia Windows` on build `7.0-dev.445` (job cancelled at its 60-minute limit, no results published).

### What happened on that build

1. A hot-reload session broke server-side: the dev-server's Roslyn `EmitDifference` started throwing `NullReferenceException` in `DefinitionMap.GetPreviousMethodHandle`, and every update in that session then failed the same way. Three tests in `Given_FileAddUpdateRemove` are already `[Ignore]`d with exactly this message, so it is a known-bad area of Edit-and-Continue rather than anything the PR under test changed.
2. Every remaining test inside the HRApp waited out its own budget, so a run that takes **~90 seconds** when healthy took **14–21 minutes**.
3. Nothing bounded that: `RunTestApp` waited on the app with a token that was `CancellationToken.None` at the call site and dropped inside `ProcessHelpers.RunProcess`.
4. The harness retried the test three times → **48 minutes** in one test.
5. The job hit its 60-minute limit and was cancelled, so `PublishTestResults` found nothing — *every other test in the shard reported nothing*.

### The changes

**A default bound on every awaited test step.** The harness only bounded Initialize/Cleanup *steps*; the body was awaited bare unless it carried an explicit `[Timeout]`, which one of ~4,600 `[TestMethod]`s does. Release builds now apply a default per-step budget, overridable with `UNO_TEST_DEFAULT_TIMEOUT_SECONDS` (non-positive opts out); DEBUG stays unbounded so local debugging under a breakpoint is unaffected.

The budget covers **`[TestInitialize]` as well as the body** — both go through one `AwaitWithBudget` helper. That matters here specifically: this PR's own motivating hang lives in initialize, which builds an app.

The default is **10 minutes**, not 5. Five collides with the harness's own waits — `SynchronouslyTickUIThread` allows five minutes *per tick*, so a healthy multi-tick test could be cut off and its own, more useful, diagnostic lost. The default has to exceed the longest wait a test can legitimately perform.

**Not retrying a test the harness cut off.** A bounded body still cost the shard three times over. Cut-off tests now skip the retries. The signal is a harness-private exception type rather than `TimeoutException` itself, so a `TimeoutException` a test raises from one of its own waits — `EventTester`, `Event`, the `cts.Token.Register` helpers — stays an ordinary, retryable failure.

**Bounding the hot-reload app.** A six-minute budget on a single HRApp run (4× the healthy ~90s), and a separate budget on the **build**, which runs from `[TestInitialize]` and previously awaited `WaitForExitAsync()` with no token at all. Cancellation kills the **process tree**, because the app is started through `dotnet run` and abandoning the wait leaves an orphan still holding its dev-server connection; the app process is recorded *before* being waited on, so a hang leaves `TestCleanup` something to kill. A wedged run fails through `Assert.Fail`, leaving the harness `[Timeout]` as the single deciding bound — throwing `TimeoutException` there would have been retried three times, contradicting the point above.

**Diagnostics the CI log could not show.** The kill-failure path logged at `Debug` under a category filtered to `Warning`, so the one line explaining "the next attempt fought a surviving app" was invisible. A process tree still alive after the grace period was silent. Cleanup now says when it had to kill an app that never exited. The resolved budget is reported once per run, so a cut-off five minutes into a shard is attributable, and an unreadable `UNO_TEST_DEFAULT_TIMEOUT_SECONDS` says so rather than falling back silently.

### Known limits, deliberately not fixed here

- A cut-off **abandons** the body rather than cancelling it — nothing can stop a body that is not cooperating. A runaway test keeps touching the visual tree, so it is logged again if it ever finishes. Whether the harness should instead poison the run and flush results is a design decision worth its own discussion.
- Only awaited work is bounded. A synchronous body, or a UI thread wedged before the first `await`, still escapes — the timer itself needs the loop to run. This is most acute on WASM, which is single-threaded.
- A guarantee that survives *every* hang cause would be writing the NUnit file incrementally as tests complete, rather than after the loop. That is strictly stronger than any timeout and is worth a follow-up.

### Effect

The same wedged session costs one bounded attempt instead of 48 minutes of retries — and, the part that actually matters, the shard still publishes results for everything else, with the failing test naming its own cause.

Not addressed: the underlying Roslyn Edit-and-Continue `NullReferenceException`, an upstream compiler defect.

## Validation

Skia desktop, **Release** (what CI builds and runs):

- Healthy path unchanged: `Given_ContentPresenter` 269/270 (one pre-existing inconclusive), and the run header reports `Default test body budget: 00:10:00`.
- **Negative control** with `UNO_TEST_DEFAULT_TIMEOUT_SECONDS=1` over `Given_ListViewBase`: 6 tests cut off, each naming itself and its budget; **0 retries**; app exit 0 — and **the results XML is still written** (146 total, 138 passed, 7 failed). That last property is the one that was missing when the job was cancelled.
- Earlier, on Windows: `Given_HotReloadWorkspace.When_HotReloadScenario` passes in 82 s against a ~90 s CI baseline, and a negative control with the app budget cut to 20 s showed 3 bounded attempts, `HRApp did not exit in time, killing it` on each, and no orphaned processes.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, this *is* the test harness; validated by running it, see above.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
   - The cap is documented for test authors in `.claude/rules/runtime-tests.md`, including both limits it carries.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LKUHFiW2J8nNFy7FmuCsd
