### PR TITLE
fix(skia-x11): Fix X11 clipboard segfault on TIMESTAMP selection requests

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
@@ -245,7 +245,7 @@ internal class X11ClipboardExtension : IClipboardExtension
 				X11Helper.GetAtom(_x11Window.Display, X11Helper.XA_INTEGER),
 				32,
 				PropertyMode.Replace,
-				_ownershipTimestamp,
+				[_ownershipTimestamp],
 				1);
 		}
 		else if (target == X11Helper.GetAtom(_x11Window.Display, X11Helper.TARGETS))


### PR DESCRIPTION
**GitHub Issue:** n/a

## PR Type:

🐞 Bugfix

## What changed? 🚀

Fixed X11 clipboard TIMESTAMP selection replies: ownership timestamp is now passed via IntPtr[] instead of a bare IntPtr, so XChangeProperty receives a pointer to the value rather than treating the timestamp as a memory address. Fixes intermittent segfaults when paste is triggered repeatedly while the app owns the clipboard.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
