### PR TITLE
fix(ci): Add the dev feed to the add-in alignment gate

### DIFF
--- a/build/ci/tests/.azure-devops-tests-devserver-linux.yml
+++ b/build/ci/tests/.azure-devops-tests-devserver-linux.yml
@@ -25,6 +25,12 @@ jobs:
   # test only restores three NuGet packages and walks their static AssemblyRef tables.
   - template: ../templates/dotnet-install.yml
 
+  # The add-in packages this gate restores (Uno.Settings.DevServer, Uno.UI.HotDesign,
+  # Uno.UI.App.Mcp) publish their stable builds to the internal unoplatformdev feed, not
+  # nuget.org. Without this the restore only sees the public prerelease line and NU1103s
+  # on every pinned version in src/Uno.Sdk/packages.json.
+  - template: ../templates/uno-dev-feed.yml
+
   # Regression gate: Uno.Sdk.AddInVersionValidation.Tests scans every DevServer add-in
   # declared in src/Uno.Sdk/packages.json for cross-package AssemblyRef version mismatches.
   # The job is intentionally RED whenever the add-in maintainers ship a Uno.Sdk version


### PR DESCRIPTION
**GitHub Issue:** closes #24169

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

**Current behavior.** The `AddIn_Version_Alignment` job in `build/ci/tests/.azure-devops-tests-devserver-linux.yml` goes straight from `../templates/dotnet-install.yml` to `dotnet test`. It never adds the internal `unoplatformdev` NuGet feed, so restore sees only the two sources in the root `NuGet.Config` — `api.nuget.org` and the local `src/PackageCache` folder.

The add-in packages this gate restores publish their **stable** builds to `unoplatformdev`; only their prerelease line reaches nuget.org. So any stable pin in `src/Uno.Sdk/packages.json` fails the stage on `NU1103` before a single test runs (build `228518`):

```
error NU1103: Unable to find a stable package Uno.Settings.DevServer with version (>= 1.13.1)
  - Found 251 version(s) in NuGet official package source [ Nearest version: 1.14.0-dev.3 ]
  - Found 0 version(s) in Solution Packages
```

…and the same for `Uno.UI.HotDesign` (>= 1.20.338) and `Uno.UI.App.Mcp` (>= 1.3.2). The two sources NuGet lists are exactly the two in the root `NuGet.Config`, and the `-dev` "nearest version" is the tell: it was matching the public prerelease line because the feed holding the stable builds was absent.

All three versions **are** present on `unoplatformdev`, so the manifest pins were correct all along — restore just couldn't see them.

**This change.** Add the existing `../templates/uno-dev-feed.yml` template between the SDK install and the test step, with a comment explaining why the gate needs it. No new template, no new feed URL — the same template is already used by five jobs in `build/ci/tests/.azure-devops-tests-templates.yml`.

```yaml
  - template: ../templates/dotnet-install.yml

+ - template: ../templates/uno-dev-feed.yml

  - script: |
      dotnet test --project src/Uno.Sdk.AddInVersionValidation.Tests/…
```

**Impact.** The gate goes back to being red only for genuine `AssemblyRef` misalignments, which is its stated purpose, instead of for any stable pin not yet on nuget.org. This currently blocks #24108 (and its `master` original #23911), whose version pins are correct.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A: CI pipeline configuration. The change is validated by the `Tests - Add-in Version Alignment` stage on this PR.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A: no user-facing surface; rationale is captured in an inline YAML comment.
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A: no rendering change.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

### Note for reviewers

`uno-dev-feed.yml` adds the source with `dotnet nuget add source` and no explicit credentials. The five existing consumers in `.azure-devops-tests-templates.yml` do the same and pass, so the agent pools appear to resolve same-org Azure Artifacts feeds through the credential provider. If this job's pool differs, it may additionally need a `NuGetAuthenticate` task ahead of the template — the CI run on this PR will confirm either way.
