### PR TITLE
fix(tests): Run the leak-test collection round on every platform

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -289,9 +289,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 				// This gets around some GC quirks where the objects from the last instance of the control
 				// stick around until this test method returns
-#if __SKIA__
-				if (OperatingSystem.IsBrowser() || OperatingSystem.IsLinux() || OperatingSystem.IsIOS() || OperatingSystem.IsAndroid())
-#endif
 				{
 					await Task.Yield();
 					GC.Collect();


### PR DESCRIPTION
**GitHub Issue:** closes #24181

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Given_FrameworkElement_And_Leak.When_Add_Remove` waits up to 30 s for the tracked weak references to
die. Inside that loop is a second collection round, added because "objects from the last instance of
the control stick around until this test method returns" — and on Skia it was gated to Browser,
Linux, iOS and Android.

macOS and Windows fall through it. Their references stay alive, the loop spins out the full 30 s
budget, and each case pays that twice because the body runs once for Fluent styles and once for UWP
styles. The test still passes, because the final assertion already tolerates the last instance's
references — so the wait was silent as well as wasted.

This removes the gate. **The gate only exists on Skia**: outside `__SKIA__` the `if` is not compiled
at all, so the native heads already run this block unconditionally. The Skia allowlist is the
anomaly, and `git log` shows it was grown one platform at a time (`Browser || Linux || iOS`, later
`|| Android`) rather than reasoned about — macOS and Windows were simply never added.

Median duration of the four `XamlEvent_Leak` cases, from `Running test` timestamps across 23 macOS
and 12 Linux CI logs, plus Windows and Linux-framebuffer from build 229709:

| case | Linux | Linux FB | macOS | Windows |
|---|---|---|---|---|
| `XamlEvent_Leak_UserControl` | 0.49 s | 0.81 s | **39.5 s** | **60.1 s** |
| `XamlEvent_Leak_TextBox` | 0.54 s | 0.72 s | 0.46 s | **13.7 s** |
| `XamlEvent_Leak_UserControl_xBind` | 0.48 s | 0.89 s | 0.54 s | 0.28 s |
| `XamlEvent_Leak_UserControl_xBind_Event` | 0.47 s | 0.86 s | 0.43 s | 0.39 s |

The two platforms the gate excludes are exactly the two that burn the budget. All ~40 other
`When_Add_Remove` variants are within 1x of Linux on macOS, so this is the gate and not a general
leak-test cost.

## Validation ✅

**Runtime** — Windows Skia (`SamplesApp.Skia.Generic`, `net10.0`, Debug), the four `XamlEvent_Leak`
cases, filter `UITEST_RUNTIME_TESTS_FILTER=WGFtbEV2ZW50X0xlYWs=`:

| | wall clock | NUnit result |
|---|---|---|
| unchanged | **252.2 s** | 4 total, 0 failures |
| this PR | **11.9 s** | 4 total, 0 failures |

21x faster with identical results — the tests exit the loop instead of timing out of it.

Windows is one of the two affected platforms, so this is a direct before/after on an affected head
rather than a proxy. **Not validated on a macOS agent locally** (no macOS hardware here); CI covers
that leg on this PR.

**Compile** — `SamplesApp.Skia.Generic`, `net10.0`, 0 warnings / 0 errors.

One measurement note for reviewers: the per-case `duration` in the NUnit output is useless for this —
the harness stops its stopwatch before awaiting an async body, so async tests report ~0 s. The
numbers above are wall clock and CI log timestamps.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, this *is* a runtime test; validated by running it, see above
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, no user-facing behaviour change
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGKr3vEBkqQJA6Su8NQMXq
