### PR TITLE
fix(composition): Repaint RedirectVisual and stop Lottie clearing the frame

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.skia.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.skia.cs
@@ -143,8 +143,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 						return;
 					}
 
-					canvas.Clear(SKColors.Transparent);
-
+					// Deliberately no clear: this canvas is the frame being recorded, so clearing it (Src
+					// blend) would punch our own box straight through whatever is painted behind the player.
 					var progress = GetProgress();
 					var frameTime = TimeSpan.FromTicks((long)(Duration.Ticks * progress));
 					_animation.SeekFrameTime(frameTime, _invalidationController);

--- a/src/Uno.UI.Composition/Composition/RedirectVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/RedirectVisual.skia.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System.Numerics;
 using SkiaSharp;
 using Uno.UI.Composition;
 
@@ -19,7 +20,45 @@ namespace Microsoft.UI.Composition
 			return null;
 		}
 
-		internal override bool CanPaint() => Source?.CanPaint() ?? false;
+		// What gets painted here is the Source's whole subtree, and that subtree paints even when the Source
+		// visual itself doesn't (an element visual leaves the painting to its children).
+		internal override bool CanPaint() => Source is not null;
+
+		internal override bool TryGetLocalContentBounds(out SKRect localBounds)
+		{
+			localBounds = SKRect.Empty;
+
+			if (Source is not { } source)
+			{
+				return true;
+			}
+
+			if (!source.TryGetSubtreeContentBoundsInRoot(out var content))
+			{
+				return false;
+			}
+
+			// Paint undoes the source parent's transform (see Visual.RenderRootVisual), so what lands in
+			// this visual's local coordinates is the source subtree measured in its parent's space.
+			if (!content.IsEmpty && source.Parent is { } parent)
+			{
+				if (!Matrix4x4.Invert(parent.TotalMatrix, out var invertedParentTotalMatrix))
+				{
+					return false;
+				}
+
+				content = invertedParentTotalMatrix.ToSKMatrix().MapRect(content);
+			}
+
+			if (ShadowState is not null)
+			{
+				return TryGetShadowSilhouetteBounds(content, out localBounds);
+			}
+
+			localBounds = content;
+			return true;
+		}
+
 		internal override bool RequiresRepaintOnEveryFrame => true;
 	}
 }

--- a/src/Uno.UI.Composition/Composition/Visual.Damage.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.Damage.skia.cs
@@ -268,6 +268,28 @@ public partial class Visual
 		return true;
 	}
 
+	/// <summary>
+	/// The bounds of everything this visual and its subtree paint, in root coordinates. False when some
+	/// part of it can't be bounded analytically, in which case the caller has to fall back to its clip.
+	/// </summary>
+	internal bool TryGetSubtreeContentBoundsInRoot(out SKRect boundsInRoot)
+	{
+		boundsInRoot = SKRect.Empty;
+
+		if (!TryGetLocalContentBounds(out var own))
+		{
+			return false;
+		}
+
+		if (!own.IsEmpty)
+		{
+			boundsInRoot = TotalMatrix.ToSKMatrix().MapRect(own);
+		}
+
+		// A shadow's silhouette already covers the descendants, see TryGetShadowSilhouetteBounds.
+		return ShadowState is not null || TryAccumulateDescendantContentBoundsInRoot(ref boundsInRoot);
+	}
+
 	private bool TryAccumulateDescendantContentBoundsInRoot(ref SKRect acc)
 	{
 		foreach (var child in GetChildrenInRenderOrder())

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_AnimatedVisualPlayer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_AnimatedVisualPlayer.cs
@@ -749,6 +749,7 @@ public class Given_AnimatedVisualPlayer
 	// anything it does to the whole canvas (such as clearing it) is applied to the pixels already painted
 	// underneath it, turning an opaque background behind the player into a hole.
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24193")]
 	public async Task When_Production_Lottie_Source_Renders_Then_Content_Behind_It_Is_Preserved()
 	{
 		var player = new AnimatedVisualPlayer

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_AnimatedVisualPlayer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_AnimatedVisualPlayer.cs
@@ -745,6 +745,39 @@ public class Given_AnimatedVisualPlayer
 		Assert.IsTrue(CountDifferentPixels(firstFrame, secondFrame, (int)host.ActualWidth, (int)host.ActualHeight) > 0, "Two known progress frames should produce different output.");
 	}
 
+	// The Lottie visual draws through an SKCanvasElement, i.e. straight into the frame being recorded, so
+	// anything it does to the whole canvas (such as clearing it) is applied to the pixels already painted
+	// underneath it, turning an opaque background behind the player into a hole.
+	[TestMethod]
+	public async Task When_Production_Lottie_Source_Renders_Then_Content_Behind_It_Is_Preserved()
+	{
+		var player = new AnimatedVisualPlayer
+		{
+			Width = 48,
+			Height = 48,
+			AutoPlay = false,
+			Source = new LottieVisualSource
+			{
+				UriSource = FeatureConfiguration.ProgressRing.DeterminateProgressRingAsset
+			}
+		};
+		var host = CreateHost(player);
+		host.Background = new SolidColorBrush(Microsoft.UI.Colors.Red);
+
+		await UITestHelper.Load(host);
+		await TestServices.WindowHelper.WaitFor(() => player.IsAnimatedVisualLoaded, timeoutMS: 5000, "The production Lottie source should load asynchronously.");
+
+		player.SetProgress(0.15);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var frame = await UITestHelper.ScreenShot(host);
+		await frame.Populate();
+
+		Assert.IsFalse(
+			ContainsTransparentPixel(frame, (int)host.ActualWidth, (int)host.ActualHeight),
+			"The Lottie visual cleared its own box, punching a hole through the opaque background behind it.");
+	}
+
 	private static AnimatedVisualPlayer CreatePlayer(bool autoPlay = false, TimeSpan? duration = null)
 	{
 		return new AnimatedVisualPlayer
@@ -830,6 +863,23 @@ public class Given_AnimatedVisualPlayer
 		}
 
 		return differentPixels;
+	}
+
+	// Inset by a pixel so the host's own antialiased edge isn't mistaken for a hole punched in its middle.
+	private static bool ContainsTransparentPixel(RawBitmap screenshot, int width, int height)
+	{
+		for (var x = 1; x < width - 1; x++)
+		{
+			for (var y = 1; y < height - 1; y++)
+			{
+				if (screenshot.GetPixel(x, y).A < 250)
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private static bool ContainsNonWhitePixel(RawBitmap screenshot, int startX, int startY, int width, int height)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -23,9 +23,7 @@ public class Given_Visual_Damage
 	// height) hit this whenever the clip grows.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Ancestor_Clip_Grows_Then_Revealed_Region_Is_Damaged()
 	{
 #if __SKIA__
@@ -77,9 +75,7 @@ public class Given_Visual_Damage
 	// nothing would get the chance to report the damage.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Clip_Shape_Changes_Within_Same_Bounds_Then_It_Is_Damaged()
 	{
 #if __SKIA__
@@ -141,9 +137,7 @@ public class Given_Visual_Damage
 	// vacated pixels stale.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Visual_Stops_Moving_Then_Damage_Falls_Silent()
 	{
 #if __SKIA__
@@ -207,9 +201,7 @@ public class Given_Visual_Damage
 	// only on a full repaint (a window resize) and never follows the source afterwards.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_RedirectVisual_Repaints_Then_Its_Own_Region_Is_Damaged()
 	{
 #if __SKIA__
@@ -265,9 +257,7 @@ public class Given_Visual_Damage
 	// cheap branch is allowed to answer for it). Moving it must still damage both positions in full.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Visual_With_Content_Path_Moves_Then_Both_Positions_Are_Damaged()
 	{
 #if __SKIA__
@@ -318,9 +308,7 @@ public class Given_Visual_Damage
 	// progress ring, a caret — must not have the two merged, or everything between them repaints as well.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Damage_Is_Far_Apart_Then_It_Is_Not_Merged()
 	{
 #if __SKIA__
@@ -352,9 +340,7 @@ public class Given_Visual_Damage
 	// reported region has to cover what is painted without being widened to the whole visual or to the clip.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Shape_Visual_Moves_Then_Damage_Covers_Its_Shapes()
 	{
 #if __SKIA__
@@ -407,9 +393,7 @@ public class Given_Visual_Damage
 	// survive it.
 	[TestMethod]
 	[RunsOnUIThread]
-#if !__SKIA__
-	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
-#endif
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
 	public async Task When_Many_Visuals_Move_Then_Collapsed_Damage_Is_A_Superset()
 	{
 #if __SKIA__

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -201,6 +201,65 @@ public class Given_Visual_Damage
 #endif
 	}
 
+	// A RedirectVisual paints its Source's whole subtree at its own location, but the Source visual itself is
+	// typically a non-painting container (an element visual leaves the painting to its children). If the
+	// redirect reports that it paints nothing, its region is never damaged: the mirrored content shows up
+	// only on a full repaint (a window resize) and never follows the source afterwards.
+	[TestMethod]
+	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("Damage-region rendering is specific to the Skia compositor.")]
+#endif
+	public async Task When_RedirectVisual_Repaints_Then_Its_Own_Region_Is_Damaged()
+	{
+#if __SKIA__
+		var compositor = Compositor.GetSharedCompositor();
+
+		var root = compositor.CreateContainerVisual();
+		root.Size = new Vector2(200, 200);
+
+		var source = compositor.CreateContainerVisual();
+		source.Size = new Vector2(50, 50);
+		root.Children.InsertAtTop(source);
+
+		var sourceContent = compositor.CreateSpriteVisual();
+		sourceContent.Brush = compositor.CreateColorBrush(Colors.Magenta);
+		sourceContent.Size = new Vector2(50, 50);
+		source.Children.InsertAtTop(sourceContent);
+
+		var redirect = compositor.CreateRedirectVisual(source);
+		redirect.Size = new Vector2(50, 50);
+		redirect.Offset = new Vector3(100, 0, 0);
+		root.Children.InsertAtTop(redirect);
+
+		using var damage = new DamageRegion();
+		RenderFrame(root, damage);
+
+		// Nothing in the scene changed, but a RedirectVisual repaints on every frame, so the region it
+		// mirrors into must be reported every frame too.
+		damage.Reset();
+		RenderFrame(root, damage);
+
+		using var reported = SnapshotDamage(damage);
+
+		Assert.IsFalse(
+			reported.IsEmpty,
+			"A RedirectVisual reported no damage, so the region it mirrors into would keep the previous frame's pixels.");
+
+		Assert.IsTrue(
+			reported.Bounds.Left >= 90 && reported.Bounds.Right >= 148,
+			$"Damage does not cover the redirect's own region at x=100..150 (damage bounds: {reported.Bounds}).");
+
+		// Falling back to the whole surface would satisfy the assertion above while defeating partial
+		// repaint, so bound the reported region to the mirrored content plus antialiasing slack.
+		Assert.IsTrue(
+			reported.Bounds.Right <= 160,
+			$"Damage is far wider than the mirrored content, partial repaint is being defeated (damage bounds: {reported.Bounds}).");
+#else
+		await Task.CompletedTask;
+#endif
+	}
+
 	// BorderVisual is the visual that the moved-visual fast path actually applies to: it has an exact content
 	// path (so it would otherwise take the expensive branch) and guarantees it paints within its Size (so the
 	// cheap branch is allowed to answer for it). Moving it must still damage both positions in full.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -202,6 +202,7 @@ public class Given_Visual_Damage
 	[TestMethod]
 	[RunsOnUIThread]
 	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/24193")]
 	public async Task When_RedirectVisual_Repaints_Then_Its_Own_Region_Is_Damaged()
 	{
 #if __SKIA__

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_Visual_Damage.cs
@@ -247,13 +247,13 @@ public class Given_Visual_Damage
 			"A RedirectVisual reported no damage, so the region it mirrors into would keep the previous frame's pixels.");
 
 		Assert.IsTrue(
-			reported.Bounds.Left >= 90 && reported.Bounds.Right >= 148,
+			reported.Bounds.Left <= 102 && reported.Bounds.Right >= 148,
 			$"Damage does not cover the redirect's own region at x=100..150 (damage bounds: {reported.Bounds}).");
 
 		// Falling back to the whole surface would satisfy the assertion above while defeating partial
 		// repaint, so bound the reported region to the mirrored content plus antialiasing slack.
 		Assert.IsTrue(
-			reported.Bounds.Right <= 160,
+			reported.Bounds.Left >= 90 && reported.Bounds.Right <= 160,
 			$"Damage is far wider than the mirrored content, partial repaint is being defeated (damage bounds: {reported.Bounds}).");
 #else
 		await Task.CompletedTask;


### PR DESCRIPTION
**GitHub Issue:** closes #24193

## PR Type:

🐞 Bugfix

## What changed? 🚀

The `Microsoft.UI.Composition / RedirectVisual` sample regressed on this branch: the redirected column stayed blank (and, once a window resize forced it to appear, froze on a single frame), and the Lottie animation next to it painted on an opaque rectangle instead of the app background. Two independent defects, both on the Skia compositor.

### 1. A `RedirectVisual` never damaged the region it paints

`RedirectVisual.CanPaint()` delegated to its `Source`. An element's visual is normally a plain `ContainerVisual` that leaves the painting to its children, so the redirect answered "I paint nothing". `Visual.TryGetLocalContentBounds` then sized its content to an empty rect, `TryGetPaintDamageRegion` bailed out, and the region the redirect actually draws into was never reported as damaged — it only ever showed up on a full repaint, and never followed its source afterwards.

This is latent on `master` as well. There, the Lottie render surface was an unclipped child element whose own damage covered the whole frame, which incidentally repainted the redirect every frame. The ported `AnimatedVisualPlayer` now clips its animated visual (`m_rootVisual.Clip = compositor.CreateInsetClip()`), so the frame is no longer over-damaged and the defect surfaced.

- `RedirectVisual.CanPaint()` now reports painting whenever there is a `Source`.
- `RedirectVisual.TryGetLocalContentBounds` reports the source subtree's bounds measured in the source parent's coordinate space — exactly what `Visual.RenderRootVisual` maps into the redirect's local space — so the damage stays tight instead of falling back to the whole clip.
- New `Visual.TryGetSubtreeContentBoundsInRoot` helper, factored from the existing own-plus-descendants bounds logic used by the drop-shadow silhouette walk.

### 2. The Skia Lottie visual cleared the frame behind the player

`LottieVisualSource`'s Skia path called `canvas.Clear(SKColors.Transparent)` inside `SKCanvasElement.RenderOverride`. That canvas is the frame being recorded, not a private surface, so the clear blended with `Src` over everything already painted underneath and punched the animation's box through the app background — black on Win32, and the white page behind the canvas in a browser. The renderer already clears the frame before the visual tree is drawn, and `master`'s Skia Lottie path never cleared here either.

### Validation

- **Runtime tests** (Skia Desktop / Win32): both new tests fail before the change and pass after; `Given_Visual_Damage`, `Given_RedirectVisual` and `Given_AnimatedVisualPlayer` are green (32/32).
- **Manual** (Skia Desktop / Win32): the sample now renders and animates both columns with a transparent animation background, matching a `master` build of the same sample side by side.
- **Regression sweep** (Skia Desktop / Win32): 2984 tests across `Windows_UI_Composition`, `Microsoft_UI_Xaml_Controls`, `Windows_UI_Xaml_Controls`, `Windows_UI_Xaml_Media` and `Windows_UI_Xaml_Shapes` — 2754 passed, 67 failed, 73 skipped. The same test classes on a baseline build of `55f41a366e` (this branch's tip before the change) fail 68. The two failure sets differ only in clipboard- and context-menu-dependent `Given_TextBox` cases, whose membership shuffles on every local run; the remaining failures are identical on both sides and are DPI-scaling layout assertions specific to this machine (`Expected:<193>. Actual:<192.8>`). No Composition, rendering or Lottie failures on either side.
- WebAssembly was not re-verified locally (`wasm-tools` workload is not installed on this machine); both root causes are in shared Skia code and the browser symptoms are the same defects with a white page behind the canvas instead of a black window.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMoHqSCNVaS4na2bEk1DCJ
