### PR TITLE
fix(remotecontrol): register HTTP transport for the DevServer Host's MCP server

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/Mcp/HostHealthTool.cs
+++ b/src/Uno.UI.RemoteControl.Host/Mcp/HostHealthTool.cs
@@ -81,6 +81,7 @@ internal sealed class HostHealthTool
 					Version = GetAssemblyVersion(),
 				};
 			})
+			.WithHttpTransport()
 			.WithTools<HostHealthTool>()
 			.WithListResourcesHandler((ctx, ct) =>
 			{


### PR DESCRIPTION
## Summary

Fixes #24195.

The DevServer host's `/mcp` HTTP endpoint (added in afa31547ff) never actually works: `HostHealthTool.Configure()` calls `AddMcpServer()` and registers tools/resources, but never calls `.WithHttpTransport()`. `Startup.cs` unconditionally calls `endpoints.MapMcp("/mcp")`, which throws `InvalidOperationException` on every request since no HTTP transport was registered — caught and only logged as a warning, so the host keeps running with `/mcp` silently 404ing.

This one-line fix adds `.WithHttpTransport()` to the `AddMcpServer()` chain.

## Test plan

- [x] Built `Uno.UI.RemoteControl.Host` from this branch (net10.0 slice) and ran it standalone.
- [x] `curl http://localhost:<port>/mcp` with a proper `initialize` request now returns `200` with a valid MCP handshake response, instead of `404`.
- [x] The host no longer logs the `Unable to find the MCP Tooling in the environment` warning on startup.
- [x] Verified end-to-end against a real MCP client (Claude Code's Uno App MCP bridge): `uno_health` now reports `status: Healthy`, `toolCount: 12` (once the `Uno.UI.App.Mcp.Server` add-in is also passed), `issues: []`, versus `toolCount: 0` / `HostMcpEndpointNotAvailable` before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hhqdwAeyzFqWJcy44Lyad