### PR TITLE
test: try building and running "Tests - WebAssembly Skia" for CoreCLR

### DIFF
--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -226,15 +226,14 @@
 		pre-unification head used) is the correct value.
 		-->
 		<WasmShellWebAppBasePath>./</WasmShellWebAppBasePath>
+		<UseMonoRuntime>false</UseMonoRuntime>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(_Platform)' == 'browserwasm' AND '$(Configuration)'=='Debug'">
-		<MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>
 		<DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(_Platform)' == 'browserwasm'">
-		<WasmShellMonoEnvironment Include="MONO_GC_PARAMS" Value="soft-heap-limit=1024m,nursery-size=64m,evacuation-threshold=66,major=marksweep" />
 		<LinkerDescriptor Include="Platforms\WebAssembly\LinkerConfig.xml" />
 		<EmbeddedResource Include="Platforms\WebAssembly\WasmScripts\AppManifest.js" />
 		<Content Include="..\LinkedFiles\WebContent\**\*.*">


### PR DESCRIPTION
Context: https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/runtime.md#browserwebassembly-coreclr-enablement
Context: https://devblogs.microsoft.com/dotnet/coreclr-progress-and-mono-timeline-dotnet-maui/

.NET 11 Preview 1 began introducing support for CoreCLR on WebAssembly, and .NET 11 Preview 5 mentioned how to use it:

> add the `UseMonoRuntime` property to the WebAssembly client project file:
>
>     <PropertyGroup>
>       <TargetFramework>net11.0</TargetFramework>
>       <UseMonoRuntime>false</UseMonoRuntime>
>     </PropertyGroup>

Which raises an obvious question: does *Uno* work with CoreCLR atop WebAssembly?

Let's find out!  Update `SamplesApp.csproj` to set `$(UseMonoRuntime)`=false for browserwasm platforms.

(We could plausibly set `$(UseMonoRuntime)`=false for *all* platforms, as Android and iOS use CoreCLR in .NET 11 Preview 6+, and desktop has always been CoreCLR, but let us minimize scope for now…)

Note: `SamplesApp.csproj` *fails to build* for @jonpryor on macOS:

	% dotnet publish -bl -f net11.0-browserwasm -p:UnoTargetFrameworkOverride=net11.0-browserwasm -p:PreBuildUnoUITasks=true -p:UNO_DISABLE_ANALYZERS_IN_SAMPLES=true src/SamplesApp/SamplesApp/SamplesApp.csproj
	…
	…/dotnet-sdk-11.0.100-preview.7.26381.103/packs/Microsoft.NET.Runtime.WebAssembly.Sdk/11.0.0-preview.7.26381.103/Sdk/BrowserWasmApp.CoreCLR.targets(216,11): error MSB4057:
	  The target "_WasmBuildAppCore" does not exist in the project.

This may be specific to macOS, while CI runs Linux, so…

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

🏗️ Build or CI related changes
<!--
Copy the label that applies to this PR and paste it above:

🐞 Bugfix
✨ Feature
🎨 Code style update (formatting)
🔄 Refactoring (no functional changes, no api changes)
📚 Documentation content changes
🤖 Project automation
💬 Other... (Please describe)

-->


## What changed? 🚀

<!-- Briefly describe the current behavior and what this PR changes. -->

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
