### PR TITLE
fix(devserver): memory-conscious GC profile for the Hot Reload host

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -8,6 +8,12 @@
 		<Nullable>enable</Nullable>
 		<NoWarn>$(NoWarn);VSTHRD200</NoWarn>
 		<DefineConstants>$(DefineConstants);IS_DEVSERVER</DefineConstants>
+
+		<!-- The dev-server is a long-running background daemon on the developer's machine.
+		     The default Web SDK profile (Server GC) is throughput-oriented and retains committed
+		     memory; switch to a memory-conscious Workstation profile instead. See #24203. -->
+		<ServerGarbageCollection>false</ServerGarbageCollection>
+		<ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
 	</PropertyGroup>
 
 	<Import Project="../targetframework-override-noplatform.props" />
@@ -98,5 +104,13 @@
 
 	<Target Name="GetTargetPath" />
 	<Target Name="GetCopyToPublishDirectoryItems" />
+
+
+	<ItemGroup>
+		<!-- runtimeconfig.template.json is a build-time input merged into the generated
+		     Uno.UI.RemoteControl.Host.runtimeconfig.json; it must not be copied to output
+		     nor packed. See #24203. -->
+		<Content Remove="runtimeconfig.template.json" />
+	</ItemGroup>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.Host/runtimeconfig.template.json
+++ b/src/Uno.UI.RemoteControl.Host/runtimeconfig.template.json
@@ -1,0 +1,7 @@
+{
+  "configProperties": {
+    "System.GC.ConserveMemory": 5,
+    "System.GC.HeapHardLimitPercent": 66,
+    "System.GC.HighMemoryPercent": 70
+  }
+}


### PR DESCRIPTION
**GitHub Issue:** closes #24203

## PR Type:

🐞 Bugfix

## What changed? 🚀

The Hot Reload dev-server host (`Uno.UI.RemoteControl.Host`) is a long-running background daemon on the developer's machine, but it inherited the `Microsoft.NET.Sdk.Web` default GC profile (**Server GC**), which is throughput-oriented and holds onto committed memory. Under Hot Reload each emit allocates a large amount of *transient* garbage (tens of MB on a real app, for a ~150 KB delta); with Server GC the runtime feels no pressure to collect it, so the host's working set climbs monotonically into the multi-GB range over a working session (see #24203 / #24151).

This aligns the host's GC profile with a **memory-conscious background daemon**:

- `ServerGarbageCollection=false` + `ConcurrentGarbageCollection=true` → Workstation background GC: pressure is applied early, so the transient garbage is actually collected and the working set stays bounded.
- New `runtimeconfig.template.json`:
  - `System.GC.ConserveMemory=5` → keeps the heap compact and **decommits freed memory back to the OS** (so RSS actually goes down, not just the managed heap).
  - `System.GC.HeapHardLimitPercent=66` → relative last-resort ceiling (no absolute, machine-dependent value to pick).
  - `System.GC.HighMemoryPercent=70` → the GC becomes aggressive earlier when the **machine** is under memory pressure — a good citizen on a shared dev box.

Measured (synthetic LOH churn, 40 iterations, ~27 MB live heap in all three cases) — peak / final process working set:

| GC profile | RSS peak | RSS final |
|---|---|---|
| Server GC (previous default) | 670 MB | 534 MB |
| Workstation GC | 387 MB | 387 MB |
| Workstation + ConserveMemory | 317 MB | 317 MB (flat) |

The emitted `runtimeconfig.json` was verified to contain the five expected `System.GC.*` values.

This is the fast, low-risk mitigation track. The root-cause tracks (non-incremental generators, connection/workspace lifetime, per-solution/baseline/target workspace sharing) are tracked separately in #24204, #24205, #24206 and #24207.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample] — N/A: runtime GC configuration only; validated by measured working-set behavior and the emitted `runtimeconfig.json`.
- [ ] 📚 Docs have been added/updated following the documentation template — N/A.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A (no UI change).
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests (optional but appreciated!)

