### PR TITLE
fix(devserver): close presumed-dead /rc connections via server-side keep-alive timeout

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_KeepAliveTimeout.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_KeepAliveTimeout.cs
@@ -1,0 +1,37 @@
+extern alias RemoteServerCore;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.UI.RemoteControl.Messaging;
+
+using RemoteServerCore::DevServerCore;
+using RemoteControlServer = RemoteServerCore::Uno.UI.RemoteControl.Server.RemoteControlServer;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+[TestClass]
+public sealed class Given_KeepAliveTimeout
+{
+	[TestMethod]
+	public async Task Silent_connection_is_closed_after_keep_alive_timeout()
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+		await using var devserver = InProcessDevServer.Create(options =>
+		{
+			// Shrink the production ~63s watchdog (KeepAliveMessage.Interval * 2.1) to a
+			// sub-second window so the test runs fast.
+			options.ConfigurationValues[RemoteControlServer.KeepAliveTimeoutConfigurationKey] = "300";
+		});
+
+		using var transport = devserver.ConnectApplication(ct: cts.Token);
+
+		// The client never sends a frame (a silent / half-open peer). With the shortened
+		// keep-alive timeout the server must reap the connection: once it closes its end,
+		// the client-side receive completes with null. See #24206.
+		var frame = await transport.ReceiveAsync(cts.Token);
+
+		frame.Should().BeNull("the server must close a connection that receives no frame within the keep-alive timeout");
+	}
+}

--- a/src/Uno.UI.RemoteControl.ServerCore/RemoteControlServer.cs
+++ b/src/Uno.UI.RemoteControl.ServerCore/RemoteControlServer.cs
@@ -41,6 +41,16 @@ public sealed class RemoteControlServer : IRemoteControlServer, IRemoteControlSe
 	private readonly IApplicationLaunchMonitor _launchMonitor;
 	private readonly IRemoteControlProcessorFactory _processorFactory;
 
+	// Multiplier applied to KeepAliveMessage.Interval to obtain the receive watchdog timeout.
+	private const double KeepAliveTimeoutFactor = 2.1;
+
+	/// <summary>
+	/// Optional configuration override (in milliseconds) for the keep-alive receive watchdog timeout.
+	/// Primarily for tests, so a regression test can assert the reaping behavior with a sub-second
+	/// window instead of the production default of <c>KeepAliveMessage.Interval * KeepAliveTimeoutFactor</c>.
+	/// </summary>
+	public const string KeepAliveTimeoutConfigurationKey = "uno-devserver:keep-alive-timeout-ms";
+
 	/// <summary>
 	/// Creates a per-connection server instance. The supplied <paramref name="serviceProvider"/> must be the scoped provider created by the host for that connection.
 	/// It is reused to resolve optional connection services (telemetry, launch monitor) and to materialize processors via dependency injection.
@@ -95,8 +105,41 @@ public sealed class RemoteControlServer : IRemoteControlServer, IRemoteControlSe
 
 		await _ideChannel.WaitForReady(ct);
 
-		while (await transport.ReceiveAsync(ct) is Frame frame)
+		// A connected client sends a KeepAliveMessage every KeepAliveMessage.Interval. If we do not
+		// receive ANY frame for more than 2.1x that interval, the peer is presumed dead (e.g. a
+		// half-open socket left by a crash, a network drop, or a client that reconnected on a new
+		// socket without closing this one). We tear the connection down so its scope — and the
+		// hot-reload workspace it owns — is disposed instead of lingering. See #24206.
+		var keepAliveTimeout = ResolveKeepAliveTimeout();
+		while (true)
 		{
+			Frame? frame;
+			using (var receiveCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
+			{
+				receiveCts.CancelAfter(keepAliveTimeout);
+				try
+				{
+					frame = await transport.ReceiveAsync(receiveCts.Token);
+				}
+				catch (OperationCanceledException) when (receiveCts.IsCancellationRequested && !ct.IsCancellationRequested)
+				{
+					if (this.Log().IsEnabled(LogLevel.Warning))
+					{
+						this.Log().LogWarning("No frame received within {Timeout} ({Factor}x the {Interval} keep-alive interval); closing the presumed-dead connection.", keepAliveTimeout, KeepAliveTimeoutFactor, KeepAliveMessage.Interval);
+					}
+
+					// Proactively close so the peer (and the in-process test harness) observes the teardown;
+					// exiting the loop then disposes the connection scope, workspace and EnC session.
+					await transport.CloseAsync().ConfigureAwait(false);
+					break;
+				}
+			}
+
+			if (frame is null)
+			{
+				break;
+			}
+
 			try
 			{
 				if (frame.Scope == WellKnownScopes.DevServerChannel)
@@ -160,6 +203,19 @@ public sealed class RemoteControlServer : IRemoteControlServer, IRemoteControlSe
 				}
 			}
 		}
+	}
+
+	private TimeSpan ResolveKeepAliveTimeout()
+	{
+		// Overridable via configuration (primarily for tests); production uses the 2.1x default.
+		if (_configuration.GetValue(KeepAliveTimeoutConfigurationKey) is { Length: > 0 } raw
+			&& int.TryParse(raw, out var milliseconds)
+			&& milliseconds > 0)
+		{
+			return TimeSpan.FromMilliseconds(milliseconds);
+		}
+
+		return KeepAliveMessage.Interval * KeepAliveTimeoutFactor;
 	}
 
 	private static bool IsTransportClosure(Exception error)

--- a/src/Uno.UI.RemoteControl/Messages/KeepAliveMessage.cs
+++ b/src/Uno.UI.RemoteControl/Messages/KeepAliveMessage.cs
@@ -9,6 +9,14 @@ public record KeepAliveMessage : IMessage
 
 	public const string Name = nameof(KeepAliveMessage);
 
+	/// <summary>
+	/// Interval at which a connected client sends keep-alive pings. This file is linked into
+	/// Uno.UI.RemoteControl.ServerCore, so client and server share the exact same cadence: the
+	/// server tears down a connection that stays silent for more than 2.1x this interval
+	/// (a presumed-dead/half-open socket). See https://github.com/unoplatform/uno/issues/24206.
+	/// </summary>
+	public static readonly TimeSpan Interval = TimeSpan.FromSeconds(30);
+
 	public string Scope => WellKnownScopes.DevServerChannel;
 
 	string IMessage.Name => Name;

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -381,7 +381,7 @@ public partial class RemoteControlClient : IRemoteControlClient, IAsyncDisposabl
 	private const int _connectionRetryInterval = 5_000;
 
 	private readonly StatusSink _status;
-	private static readonly TimeSpan _keepAliveInterval = TimeSpan.FromSeconds(30);
+	private static readonly TimeSpan _keepAliveInterval = KeepAliveMessage.Interval;
 	private static RemoteControlClient? _instance;
 	private readonly (string endpoint, int port)[]? _serverAddresses;
 	private readonly Dictionary<string, IClientProcessor> _processors = new();


### PR DESCRIPTION
**GitHub Issue:** closes #24206

## PR Type:

🐞 Bugfix

## What changed? 🚀

Every connected client already sends a `KeepAliveMessage` every 30 s, but the **server** only ever *answered* pings — it never used their **absence** to notice a dead peer. A half-open `/rc` socket (a client crash, a network drop, or a client that reconnected on a new socket without closing the old one) therefore kept its connection scope — and the hot-reload workspace / EnC session it owns (~hundreds of MB) — alive **indefinitely** (see #24206 / #24151).

`RemoteControlServer.HandleConnectionAsync` now bounds each receive with a watchdog: if **no frame** arrives for more than **2.1× the keep-alive interval**, the peer is presumed dead and the connection is torn down, so its scope (and the workspace it owns) is disposed instead of lingering. A healthy client pings every 30 s — well within the ~63 s window — so only silent / half-open connections are reaped.

The interval is now defined **once** and shared, so the two ends can't drift:

- `KeepAliveMessage.Interval = TimeSpan.FromSeconds(30)` — single source of truth. `Messages/KeepAliveMessage.cs` is already `<Compile Link>`-ed into `Uno.UI.RemoteControl.ServerCore`, so client and server compile the exact same value (no new csproj plumbing).
- `RemoteControlClient`'s keep-alive timer now reads `KeepAliveMessage.Interval`.
- `RemoteControlServer.HandleConnectionAsync`: per-receive timeout of `KeepAliveMessage.Interval * 2.1`; on timeout it logs a warning and closes the connection (→ scope dispose → `EndSession` + workspace dispose).

## PR Checklist ✅

- [ ] 🧪 Automated test — a fast test would require the interval to be injectable (it is a shared compile-time constant today). The change is small and validated by build + review; happy to add a configurable timeout + regression test if preferred.
- [ ] 📚 Docs — N/A.
- [ ] 🖼️ Screenshots — N/A (no UI change).
- [x] ❗ Contains **NO** breaking changes (healthy clients are unaffected).
- [ ] 👀 Reviewed 2 other open pull requests.

