### PR TITLE
fix(wasm): Redispatch resize once viewport settles after rotation

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml
@@ -1,0 +1,65 @@
+﻿<Page
+    x:Class="UITests.Shared.Wasm.Wasm_ViewportOrientationTelemetry"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <ScrollViewer>
+        <StackPanel
+            MaxWidth="480"
+            Padding="16"
+            HorizontalAlignment="Center"
+            Spacing="12">
+            <TextBlock
+                FontSize="18"
+                FontWeight="Bold"
+                Text="Viewport orientation telemetry"
+                TextWrapping="Wrap" />
+            <TextBlock
+                Opacity="0.7"
+                Text="Rotate the device between portrait and landscape while watching the values below. Some mobile browsers fire resize before the layout viewport has reflowed, which can leave the app rendered at stale dimensions."
+                TextWrapping="Wrap" />
+
+            <Border
+                x:Name="StatusBorder"
+                Padding="10"
+                Background="MediumSeaGreen"
+                CornerRadius="6">
+                <TextBlock
+                    x:Name="StatusText"
+                    HorizontalAlignment="Center"
+                    FontSize="16"
+                    FontWeight="Bold"
+                    Foreground="White"
+                    Text="OK" />
+            </Border>
+
+            <StackPanel Spacing="4">
+                <TextBlock
+                    FontWeight="SemiBold"
+                    Text="XamlRoot.Size (Uno window size):"
+                    TextWrapping="Wrap" />
+                <TextBlock x:Name="UnoBoundsText" Text="-" />
+            </StackPanel>
+
+            <StackPanel Spacing="4">
+                <TextBlock
+                    FontWeight="SemiBold"
+                    Text="documentElement.getBoundingClientRect():"
+                    TextWrapping="Wrap" />
+                <TextBlock x:Name="DocRectText" Text="-" />
+            </StackPanel>
+
+            <StackPanel Spacing="4">
+                <TextBlock
+                    FontWeight="SemiBold"
+                    Text="Raw browser event counts (resize / orientationchange):"
+                    TextWrapping="Wrap" />
+                <TextBlock x:Name="EventCountsText" Text="-" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml
@@ -40,7 +40,7 @@
             <StackPanel Spacing="4">
                 <TextBlock
                     FontWeight="SemiBold"
-                    Text="XamlRoot.Size (Uno window size):"
+                    Text="XamlRoot.Size (Uno Platform window size):"
                     TextWrapping="Wrap" />
                 <TextBlock x:Name="UnoBoundsText" Text="-" />
             </StackPanel>

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -108,8 +108,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 					EventCountsText.Text = $"{parts[2]} resize / {parts[3]} orientationchange";
 
 					var stale = Math.Abs(unoSize.Width - docWidth) > 2 || Math.Abs(unoSize.Height - docHeight) > 2;
-					StatusText.Text = stale ? "STALE" : "OK";
-					StatusBorder.Background = new SolidColorBrush(stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
+					SetStatus(stale ? "STALE" : "OK", stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
 					return;
 				}
 
@@ -125,8 +124,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 		{
 			DocRectText.Text = $"Telemetry failed: {_telemetryError}";
 			EventCountsText.Text = "-";
-			StatusText.Text = "ERROR";
-			StatusBorder.Background = new SolidColorBrush(Microsoft.UI.Colors.IndianRed);
+			SetStatus("ERROR", Microsoft.UI.Colors.IndianRed);
 			return;
 		}
 #endif
@@ -144,6 +142,16 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 		_telemetryError = error;
 		_jsGateway?.Dispose();
 		_jsGateway = null;
+	}
+
+	// Allocate a brush only when the status actually transitions (the timer ticks at 10 Hz).
+	private void SetStatus(string status, Windows.UI.Color color)
+	{
+		if (StatusText.Text != status)
+		{
+			StatusText.Text = status;
+			StatusBorder.Background = new SolidColorBrush(color);
+		}
 	}
 #endif
 }

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -133,7 +133,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 
 		DocRectText.Text = "DOM telemetry is available only when running in a browser";
 		EventCountsText.Text = "-";
-		StatusText.Text = "N/A";
+		SetStatus("N/A");
 	}
 
 #if __CROSSRUNTIME__

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -102,12 +102,12 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 			try
 			{
 				var parts = _jsGateway.ExecuteJavascript(PollScript).Split(',');
-				if (parts.Length >= 4
-					&& double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var docWidth)
-					&& double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var docHeight))
+				if (parts is [var width, var height, var resize, var orientation]
+					&& double.TryParse(width, NumberStyles.Float, CultureInfo.InvariantCulture, out var docWidth)
+					&& double.TryParse(height, NumberStyles.Float, CultureInfo.InvariantCulture, out var docHeight))
 				{
 					DocRectText.Text = $"{docWidth:0} x {docHeight:0}";
-					EventCountsText.Text = $"{parts[2]} resize / {parts[3]} orientationchange";
+					EventCountsText.Text = $"{resize} resize / {orientation} orientationchange";
 
 					var stale = Math.Abs(unoSize.Width - docWidth) > 2 || Math.Abs(unoSize.Height - docHeight) > 2;
 					SetStatus(stale ? "STALE" : "OK", stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -1,0 +1,110 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+#if __CROSSRUNTIME__
+using Uno.UI.NativeElementHosting;
+#endif
+
+namespace UITests.Shared.Wasm;
+
+[Sample("Wasm",
+	Name = nameof(Wasm_ViewportOrientationTelemetry),
+	Description = "Compares the Uno window size against the browser's documentElement size after device rotation. The banner turns STALE if the Uno-measured size lags the settled viewport size.",
+	IsManualTest = true,
+	IgnoreInSnapshotTests = true)]
+public sealed partial class Wasm_ViewportOrientationTelemetry : Page
+{
+	private const string InstallCountersScript = @"
+(function() {
+	let t = globalThis.__unoViewportTelemetry;
+	if (!t) {
+		t = { resize: 0, orientation: 0 };
+		globalThis.__unoViewportTelemetry = t;
+		window.addEventListener(""resize"", function() { t.resize++; });
+		window.addEventListener(""orientationchange"", function() { t.orientation++; });
+	}
+	return ""ok"";
+})();";
+
+	private const string PollScript = @"
+(function() {
+	const r = document.documentElement.getBoundingClientRect();
+	const t = globalThis.__unoViewportTelemetry || { resize: 0, orientation: 0 };
+	return Math.round(r.width) + "","" + Math.round(r.height) + "","" + t.resize + "","" + t.orientation;
+})();";
+
+	private readonly DispatcherTimer _pollTimer;
+
+#if __CROSSRUNTIME__
+	private BrowserHtmlElement? _jsGateway;
+#endif
+
+	public Wasm_ViewportOrientationTelemetry()
+	{
+		this.InitializeComponent();
+
+		// Poll on an interval rather than only on SizeChanged so a stuck stale
+		// size is visibly stuck instead of sampled once right after rotation.
+		_pollTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
+		_pollTimer.Tick += (_, _) => UpdateTelemetry();
+
+		Loaded += OnPageLoaded;
+		Unloaded += OnPageUnloaded;
+	}
+
+	private void OnPageLoaded(object sender, RoutedEventArgs e)
+	{
+#if __CROSSRUNTIME__
+		if (OperatingSystem.IsBrowser())
+		{
+			_jsGateway = BrowserHtmlElement.CreateHtmlElement("div");
+			_jsGateway.ExecuteJavascript(InstallCountersScript);
+		}
+#endif
+
+		_pollTimer.Start();
+		UpdateTelemetry();
+	}
+
+	private void OnPageUnloaded(object sender, RoutedEventArgs e)
+	{
+		_pollTimer.Stop();
+
+#if __CROSSRUNTIME__
+		_jsGateway?.Dispose();
+		_jsGateway = null;
+#endif
+	}
+
+	private void UpdateTelemetry()
+	{
+		var unoSize = XamlRoot?.Size ?? default;
+		UnoBoundsText.Text = $"{unoSize.Width:0} x {unoSize.Height:0}";
+
+#if __CROSSRUNTIME__
+		if (_jsGateway is not null)
+		{
+			var parts = _jsGateway.ExecuteJavascript(PollScript).Split(',');
+			var docWidth = double.Parse(parts[0], CultureInfo.InvariantCulture);
+			var docHeight = double.Parse(parts[1], CultureInfo.InvariantCulture);
+
+			DocRectText.Text = $"{docWidth:0} x {docHeight:0}";
+			EventCountsText.Text = $"{parts[2]} resize / {parts[3]} orientationchange";
+
+			var stale = Math.Abs(unoSize.Width - docWidth) > 2 || Math.Abs(unoSize.Height - docHeight) > 2;
+			StatusText.Text = stale ? "STALE" : "OK";
+			StatusBorder.Background = new SolidColorBrush(stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
+			return;
+		}
+#endif
+
+		DocRectText.Text = "DOM telemetry is available only when running in a browser";
+		EventCountsText.Text = "-";
+		StatusText.Text = "N/A";
+	}
+}

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -110,7 +110,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 					EventCountsText.Text = $"{resize} resize / {orientation} orientationchange";
 
 					var stale = Math.Abs(unoSize.Width - docWidth) > 2 || Math.Abs(unoSize.Height - docHeight) > 2;
-					SetStatus(stale ? "STALE" : "OK", stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
+					SetStatus(stale ? "STALE" : "OK", isError: stale);
 					return;
 				}
 
@@ -126,7 +126,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 		{
 			DocRectText.Text = $"Telemetry failed: {_telemetryError}";
 			EventCountsText.Text = "-";
-			SetStatus("ERROR", Microsoft.UI.Colors.IndianRed);
+			SetStatus("ERROR", isError: true);
 			return;
 		}
 #endif
@@ -145,15 +145,15 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 		_jsGateway?.Dispose();
 		_jsGateway = null;
 	}
+#endif
 
 	// Allocate a brush only when the status actually transitions (the timer ticks at 10 Hz).
-	private void SetStatus(string status, Windows.UI.Color color)
+	private void SetStatus(string status, bool isError = false)
 	{
 		if (StatusText.Text != status)
 		{
 			StatusText.Text = status;
-			StatusBorder.Background = new SolidColorBrush(color);
+			StatusBorder.Background = new SolidColorBrush(isError ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
 		}
 	}
-#endif
 }

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -12,11 +12,15 @@ using Uno.UI.NativeElementHosting;
 
 namespace UITests.Shared.Wasm;
 
+// Not __WASM__: the Skia browser head compiles with __SKIA__/__CROSSRUNTIME__ only,
+// and browser-vs-desktop is a runtime distinction there (OperatingSystem.IsBrowser()).
+#if __CROSSRUNTIME__
 [Sample("Wasm",
 	Name = nameof(Wasm_ViewportOrientationTelemetry),
 	Description = "Compares the Uno Platform window size against the browser's documentElement size after device rotation. The banner turns STALE if the app-measured size lags the settled viewport size.",
 	IsManualTest = true,
 	IgnoreInSnapshotTests = true)]
+#endif
 public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 {
 	private const string InstallCountersScript = """

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -101,8 +101,8 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 		{
 			try
 			{
-				var parts = _jsGateway.ExecuteJavascript(PollScript).Split(',');
-				if (parts is [var width, var height, var resize, var orientation]
+				var result = _jsGateway.ExecuteJavascript(PollScript);
+				if (result.Split(',') is [var width, var height, var resize, var orientation]
 					&& double.TryParse(width, NumberStyles.Float, CultureInfo.InvariantCulture, out var docWidth)
 					&& double.TryParse(height, NumberStyles.Float, CultureInfo.InvariantCulture, out var docHeight))
 				{
@@ -114,7 +114,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 					return;
 				}
 
-				DropGateway("unexpected telemetry format");
+				DropGateway($"unexpected telemetry format: {result}");
 			}
 			catch (Exception ex)
 			{

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -14,7 +14,7 @@ namespace UITests.Shared.Wasm;
 
 [Sample("Wasm",
 	Name = nameof(Wasm_ViewportOrientationTelemetry),
-	Description = "Compares the Uno window size against the browser's documentElement size after device rotation. The banner turns STALE if the Uno-measured size lags the settled viewport size.",
+	Description = "Compares the Uno Platform window size against the browser's documentElement size after device rotation. The banner turns STALE if the app-measured size lags the settled viewport size.",
 	IsManualTest = true,
 	IgnoreInSnapshotTests = true)]
 public sealed partial class Wasm_ViewportOrientationTelemetry : Page
@@ -42,6 +42,7 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 
 #if __CROSSRUNTIME__
 	private BrowserHtmlElement? _jsGateway;
+	private string? _telemetryError;
 #endif
 
 	public Wasm_ViewportOrientationTelemetry()
@@ -62,8 +63,15 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 #if __CROSSRUNTIME__
 		if (OperatingSystem.IsBrowser())
 		{
-			_jsGateway = BrowserHtmlElement.CreateHtmlElement("div");
-			_jsGateway.ExecuteJavascript(InstallCountersScript);
+			try
+			{
+				_jsGateway = BrowserHtmlElement.CreateHtmlElement("div");
+				_jsGateway.ExecuteJavascript(InstallCountersScript);
+			}
+			catch (Exception ex)
+			{
+				DropGateway(ex.Message);
+			}
 		}
 #endif
 
@@ -89,16 +97,36 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 #if __CROSSRUNTIME__
 		if (_jsGateway is not null)
 		{
-			var parts = _jsGateway.ExecuteJavascript(PollScript).Split(',');
-			var docWidth = double.Parse(parts[0], CultureInfo.InvariantCulture);
-			var docHeight = double.Parse(parts[1], CultureInfo.InvariantCulture);
+			try
+			{
+				var parts = _jsGateway.ExecuteJavascript(PollScript).Split(',');
+				if (parts.Length >= 4
+					&& double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var docWidth)
+					&& double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var docHeight))
+				{
+					DocRectText.Text = $"{docWidth:0} x {docHeight:0}";
+					EventCountsText.Text = $"{parts[2]} resize / {parts[3]} orientationchange";
 
-			DocRectText.Text = $"{docWidth:0} x {docHeight:0}";
-			EventCountsText.Text = $"{parts[2]} resize / {parts[3]} orientationchange";
+					var stale = Math.Abs(unoSize.Width - docWidth) > 2 || Math.Abs(unoSize.Height - docHeight) > 2;
+					StatusText.Text = stale ? "STALE" : "OK";
+					StatusBorder.Background = new SolidColorBrush(stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
+					return;
+				}
 
-			var stale = Math.Abs(unoSize.Width - docWidth) > 2 || Math.Abs(unoSize.Height - docHeight) > 2;
-			StatusText.Text = stale ? "STALE" : "OK";
-			StatusBorder.Background = new SolidColorBrush(stale ? Microsoft.UI.Colors.IndianRed : Microsoft.UI.Colors.MediumSeaGreen);
+				DropGateway("unexpected telemetry format");
+			}
+			catch (Exception ex)
+			{
+				DropGateway(ex.Message);
+			}
+		}
+
+		if (_telemetryError is not null)
+		{
+			DocRectText.Text = $"Telemetry failed: {_telemetryError}";
+			EventCountsText.Text = "-";
+			StatusText.Text = "ERROR";
+			StatusBorder.Background = new SolidColorBrush(Microsoft.UI.Colors.IndianRed);
 			return;
 		}
 #endif
@@ -107,4 +135,15 @@ public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 		EventCountsText.Text = "-";
 		StatusText.Text = "N/A";
 	}
+
+#if __CROSSRUNTIME__
+	// Surface the failure on the page instead of throwing every timer tick — the
+	// diagnostic must diagnose itself.
+	private void DropGateway(string error)
+	{
+		_telemetryError = error;
+		_jsGateway?.Dispose();
+		_jsGateway = null;
+	}
+#endif
 }

--- a/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Wasm/Wasm_ViewportOrientationTelemetry.xaml.cs
@@ -19,24 +19,26 @@ namespace UITests.Shared.Wasm;
 	IgnoreInSnapshotTests = true)]
 public sealed partial class Wasm_ViewportOrientationTelemetry : Page
 {
-	private const string InstallCountersScript = @"
-(function() {
-	let t = globalThis.__unoViewportTelemetry;
-	if (!t) {
-		t = { resize: 0, orientation: 0 };
-		globalThis.__unoViewportTelemetry = t;
-		window.addEventListener(""resize"", function() { t.resize++; });
-		window.addEventListener(""orientationchange"", function() { t.orientation++; });
-	}
-	return ""ok"";
-})();";
+	private const string InstallCountersScript = """
+		(function() {
+			let t = globalThis.__unoViewportTelemetry;
+			if (!t) {
+				t = { resize: 0, orientation: 0 };
+				globalThis.__unoViewportTelemetry = t;
+				window.addEventListener("resize", function() { t.resize++; });
+				window.addEventListener("orientationchange", function() { t.orientation++; });
+			}
+			return "ok";
+		})();
+		""";
 
-	private const string PollScript = @"
-(function() {
-	const r = document.documentElement.getBoundingClientRect();
-	const t = globalThis.__unoViewportTelemetry || { resize: 0, orientation: 0 };
-	return Math.round(r.width) + "","" + Math.round(r.height) + "","" + t.resize + "","" + t.orientation;
-})();";
+	private const string PollScript = """
+		(function() {
+			const r = document.documentElement.getBoundingClientRect();
+			const t = globalThis.__unoViewportTelemetry || { resize: 0, orientation: 0 };
+			return Math.round(r.width) + "," + Math.round(r.height) + "," + t.resize + "," + t.orientation;
+		})();
+		""";
 
 	private readonly DispatcherTimer _pollTimer;
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
@@ -86,14 +86,22 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 	[JSExport]
 	private static void OnResize([JSMarshalAs<JSType.Any>] object instance, double width, double height, float scale)
 	{
-		if (instance is WebAssemblyWindowWrapper windowWrapper)
+		try
 		{
-			windowWrapper.RasterizationScale = scale;
-			windowWrapper.RaiseNativeSizeChanged(new(width, height));
+			if (instance is WebAssemblyWindowWrapper windowWrapper)
+			{
+				windowWrapper.RasterizationScale = scale;
+				windowWrapper.RaiseNativeSizeChanged(new(width, height));
+			}
+			else
+			{
+				Console.WriteLine($"RaiseNativeSizeChanged target for {instance} does not exist");
+			}
 		}
-		else
+		catch (Exception e)
 		{
-			Console.WriteLine($"RaiseNativeSizeChanged target for {instance} does not exist");
+			// A managed exception must not cross back into the JS DOM-event callback.
+			Application.Current.RaiseRecoverableUnhandledException(e);
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Window/WebAssemblyWindowWrapper.cs
@@ -15,6 +15,7 @@ using FontFamilyHelper = Microsoft.UI.Xaml.FontFamilyHelper;
 using Windows.Graphics;
 using Microsoft.UI.Xaml;
 using Uno.Disposables;
+using Uno.Extensions;
 using Uno.UI.Dispatching;
 using Uno.UI.Hosting;
 using Uno.UI.Runtime.Skia.WebAssembly.Browser;
@@ -101,7 +102,8 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 		catch (Exception e)
 		{
 			// A managed exception must not cross back into the JS DOM-event callback.
-			Application.Current.RaiseRecoverableUnhandledException(e);
+			// Null-safe: the initial resize runs before Application.Start.
+			Application.Current.RaiseRecoverableUnhandledExceptionOrLog(e, typeof(WebAssemblyWindowWrapper));
 		}
 	}
 
@@ -130,7 +132,8 @@ internal partial class WebAssemblyWindowWrapper : NativeWindowWrapperBase
 		catch (Exception e)
 		{
 			// A managed exception must not cross back into the JS DOM-event callback.
-			Application.Current.RaiseRecoverableUnhandledException(e);
+			// Null-safe: visualViewport events can fire before Application.Start.
+			Application.Current.RaiseRecoverableUnhandledExceptionOrLog(e, typeof(WebAssemblyWindowWrapper));
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/WebAssemblyWindowWrapper.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/WebAssemblyWindowWrapper.ts
@@ -85,6 +85,7 @@ namespace Uno.UI.Runtime.Skia {
 		// its settled dimensions (ResizeObserver fires post-layout, so no polling is needed).
 		private observeViewportSize() {
 			if (typeof ResizeObserver === "undefined") {
+				console.debug("ResizeObserver is not available; the viewport settle correction is disabled.");
 				return;
 			}
 
@@ -101,6 +102,9 @@ namespace Uno.UI.Runtime.Skia {
 
 				this.lastObservedViewportSize = { width: rect.width, height: rect.height };
 
+				// Dispatch globally rather than calling this.resize(): other listeners size from
+				// this event too (BrowserRenderer sizes the canvas), and app code is owed the
+				// corrective resize the browser never fired.
 				window.dispatchEvent(new Event("resize"));
 			});
 			this.viewportResizeObserver.observe(rootElement);
@@ -168,6 +172,7 @@ namespace Uno.UI.Runtime.Skia {
 		}
 
 		private resize() {
+			// Measures the same element observeViewportSize() watches — keep the two in sync.
 			var rect = document.documentElement.getBoundingClientRect();
 			this.lastObservedViewportSize = { width: rect.width, height: rect.height };
 			this.onResize(this.owner, rect.width, rect.height, globalThis.devicePixelRatio);

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/WebAssemblyWindowWrapper.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/WebAssemblyWindowWrapper.ts
@@ -7,6 +7,8 @@ namespace Uno.UI.Runtime.Skia {
 		private onViewportOcclusionChanged: any;
 		private owner: any;
 		private lastReportedOcclusion: number = -1;
+		private viewportResizeObserver: ResizeObserver | undefined;
+		private lastObservedViewportSize: { width: number, height: number } | undefined;
 		private static readonly unoPersistentLoaderClassName = "uno-persistent-loader";
 		private static readonly loadingElementId = "uno-loading";
 		private static readonly unoKeepLoaderClassName = "uno-keep-loader";
@@ -60,6 +62,7 @@ namespace Uno.UI.Runtime.Skia {
 			Accessibility.setup();
 
 			window.addEventListener("resize", x => this.resize());
+			this.observeViewportSize();
 
 			window.addEventListener("contextmenu", x => {
 				x.preventDefault();
@@ -73,6 +76,34 @@ namespace Uno.UI.Runtime.Skia {
 			}
 
 			this.resize();
+		}
+
+		// Some mobile browsers (Chrome on iPad) can raise window "resize" before the layout
+		// viewport has reflowed to the new orientation size, without raising a corrective
+		// event afterward — leaving the Skia surface sized from a stale documentElement rect.
+		// Observe the element resize() measures from and re-dispatch "resize" once it reports
+		// its settled dimensions (ResizeObserver fires post-layout, so no polling is needed).
+		private observeViewportSize() {
+			if (typeof ResizeObserver === "undefined") {
+				return;
+			}
+
+			const rootElement = document.documentElement;
+			const initialRect = rootElement.getBoundingClientRect();
+			this.lastObservedViewportSize = { width: initialRect.width, height: initialRect.height };
+			this.viewportResizeObserver = new ResizeObserver(() => {
+				const rect = rootElement.getBoundingClientRect();
+				const lastSize = this.lastObservedViewportSize;
+
+				if (lastSize && rect.width === lastSize.width && rect.height === lastSize.height) {
+					return;
+				}
+
+				this.lastObservedViewportSize = { width: rect.width, height: rect.height };
+
+				window.dispatchEvent(new Event("resize"));
+			});
+			this.viewportResizeObserver.observe(rootElement);
 		}
 
 		// Reports how much of the viewport the on-screen keyboard occludes, in the same CSS pixels
@@ -138,6 +169,7 @@ namespace Uno.UI.Runtime.Skia {
 
 		private resize() {
 			var rect = document.documentElement.getBoundingClientRect();
+			this.lastObservedViewportSize = { width: rect.width, height: rect.height };
 			this.onResize(this.owner, rect.width, rect.height, globalThis.devicePixelRatio);
 		}
 


### PR DESCRIPTION
**GitHub Issue:** n/a — customer-reported, tracked internally.

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior:** in a WebAssembly app using the Skia renderer, rotating the device between portrait and landscape can leave the app rendered at the wrong dimensions (controls squished / at the wrong scale). Some mobile browsers — observed with Chrome on iPad, while Safari is fine — fire `resize` / `orientationchange` **before** the layout viewport (`document.documentElement`) has actually reflowed to the new size, and never fire a corrective `resize` afterward. Since `WebAssemblyWindowWrapper` sizes the window (and thus the Skia surface) from `documentElement.getBoundingClientRect()` inside that early `resize` handler, it keeps the stale pre-rotation dimensions until some other event forces a re-measure. Because rendering and input mapping both use the stale size, taps also land offset from the visuals.

**This PR** installs a `ResizeObserver` on `document.documentElement` — the exact element `resize()` measures from — in the Skia WASM host. `ResizeObserver` fires after layout, i.e. precisely when the element has actually settled to its post-rotation size. When the observed size differs from the last size the host measured, it re-dispatches a synthetic `window.resize`, restoring the corrective event the browser should have fired; the existing resize path then re-measures against the settled dimensions. The host records the last measured size on every `resize()`, so when a native resize already handled the change the observer callback no-ops — no redundant dispatches, no loops (the observer only fires on actual size changes). Browsers without `ResizeObserver` keep the previous behavior.

The fix is host-level and benefits app code too: application-level `window.resize` listeners were equally stale, and now receive the corrective event. Dispatching the global event (rather than re-measuring internally) is deliberate — `BrowserRenderer` sizes the canvas from its own `window.resize` listener, so an internal-only re-measure would fix the window bounds but leave the canvas stale.

Design notes / scope:
- The `window.resize` listener stays the primary size source; the observer is only the corrective for the mis-ordered case. The native listener uniquely covers DPR-only resizes (browser zoom fires `resize` without changing `documentElement`'s CSS size, which a `ResizeObserver` cannot see).
- No feedback-loop risk: `uno.css` pins `html`/`body` and the canvas to `position: fixed; width/height: 100%; overflow: hidden`, so the viewport drives `documentElement` — never the canvas — and `resize()` records the last measured size, making the observer a no-op whenever a native resize already handled the change.
- The native (non-Skia) WebAssembly target has the same measure-on-resize pattern in `WindowManager.ts` and may exhibit the same staleness, but per the Skia-first policy it is maintenance-only and intentionally out of scope here.
- DPR-only staleness (`RasterizationScale` on zoom/monitor moves) is a pre-existing, unrelated behavior and is unchanged.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
  - The race requires physically rotating a device and a browser that mis-orders the events, so it is not runtime-testable. Added the manual sample `Wasm_ViewportOrientationTelemetry` (Wasm category), which live-compares `XamlRoot.Size` against `documentElement.getBoundingClientRect()` with a STALE/OK banner and raw `resize`/`orientationchange` counters, so the symptom and the fix are directly observable on a device.
  - Manual validation on a physical iPad in Chrome (the affected combination): without the fix the stale size reproduces after rotation and sticks; with the fix (validated both as the patched host in the published `SamplesApp.Skia.WebAssembly.Browser` served over LAN, and as the equivalent logic A/B-toggled in a telemetry repro app) every rotation converges to the settled viewport size. Safari behavior is unchanged.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

Credit: the root-cause analysis and the proposed `ResizeObserver` approach come from the reporting customer's investigation.
