### PR TITLE
perf(textblock): Skip the arrange-time text re-shape

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -1373,7 +1373,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool _grippersShown;
 		private Microsoft.UI.Input.PointerPoint? _lastPointerDownPoint;
 
-		private (Size availableSize, Size outSize, TextAlignment? alignment) _lastParsedTextCreationValues = (Size.Empty, Size.Empty, TextAlignment.Left);
+		private (Size availableSize, Size outSize, TextAlignment? alignment, bool heightTruncated) _lastParsedTextCreationValues = (Size.Empty, Size.Empty, TextAlignment.Left, false);
 		internal IParsedText ParsedText { get; private set; } = Microsoft.UI.Xaml.Documents.ParsedText.Empty;
 
 		internal event EventHandler? DrawingFinished;
@@ -1494,7 +1494,7 @@ namespace Microsoft.UI.Xaml.Controls
 				size.Width += CaretThickness;
 			}
 
-			_lastParsedTextCreationValues = (availableSizeWithoutPadding, size, adjustedTextAlignment);
+			_lastParsedTextCreationValues = (availableSizeWithoutPadding, size, adjustedTextAlignment, ret.IsHeightTruncated);
 			return ret;
 		}
 
@@ -1561,12 +1561,13 @@ namespace Microsoft.UI.Xaml.Controls
 			var padding = Padding;
 			var availableSizeWithoutPadding = finalSize.Subtract(padding);
 
-			// There's no reason to re-parse the text if the available size hasn't changed since the last measure/arrange.
-			// Note that MeasureOverride doesn't have these checks. If something in the text block has changed that would
-			// require a re-parse, the ParseText call during the measure pass will catch it. There are no changes that
-			// would require a re-parse that would invalidate arrange but not measure, except TextAlignment, which we explicitly check.
+			// There's no reason to re-parse the text if the constraint that shaped it hasn't changed since the last
+			// measure/arrange. Note that MeasureOverride doesn't have these checks. If something in the text block has
+			// changed that would require a re-parse, the ParseText call during the measure pass will catch it. There are
+			// no changes that would require a re-parse that would invalidate arrange but not measure, except
+			// TextAlignment, which we explicitly check.
 			var arrangedSize = _lastParsedTextCreationValues.outSize;
-			if (_lastParsedTextCreationValues.availableSize != availableSizeWithoutPadding || _lastParsedTextCreationValues.alignment != GetAdjustedTextAlignment())
+			if (NeedsReparseForArrange(availableSizeWithoutPadding))
 			{
 				ParsedText = ParseText(availableSizeWithoutPadding, out arrangedSize);
 			}
@@ -1577,6 +1578,27 @@ namespace Microsoft.UI.Xaml.Controls
 			UpdateIsTextTrimmed();
 
 			return result;
+		}
+
+		/// <summary>
+		/// The arrange-time counterpart of WinUI's <c>BlockNode::CanBypassMeasure</c>: the width must match, but the
+		/// height only has to match when the previous layout was actually cut short by it. Otherwise it is enough that
+		/// the text still fits, which is the common case — a panel measures with an unconstrained (or generous) height
+		/// and then arranges at the desired height, and re-shaping there would produce the exact same lines.
+		/// </summary>
+		private bool NeedsReparseForArrange(Size availableSizeWithoutPadding)
+		{
+			var last = _lastParsedTextCreationValues;
+
+			if (last.availableSize.Width != availableSizeWithoutPadding.Width
+				|| last.alignment != GetAdjustedTextAlignment())
+			{
+				return true;
+			}
+
+			return last.heightTruncated
+				? last.availableSize.Height != availableSizeWithoutPadding.Height
+				: last.outSize.Height > availableSizeWithoutPadding.Height;
 		}
 
 		internal bool RenderSelection

--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.cs
@@ -125,6 +125,7 @@ internal readonly partial struct UnicodeText : IParsedText
 	private readonly List<(int end, Brush? foreground, FlowDirection direction, TextDecorations decorations)> _runBreaks;
 	private readonly List<(int correctionStart, int correctionEnd)?>? _corrections;
 	private readonly Size _availableSize;
+	private readonly bool _isHeightTruncated;
 
 	internal unsafe UnicodeText(
 		Size availableSize,
@@ -224,6 +225,7 @@ internal readonly partial struct UnicodeText : IParsedText
 			var emptyHeight = GetLineHeightAndBaselineOffset(lineStackingStrategy, lineHeight, defaultFontDetails, false, true).lineHeight;
 			calculatedSize = new Size(0, emptyHeight);
 			_availableSize = availableSize;
+			_isHeightTruncated = false;
 			_xyTable = [];
 			_indexToCluster = [];
 			_clustersInLogicalOrder = [];
@@ -505,6 +507,7 @@ internal readonly partial struct UnicodeText : IParsedText
 		}
 
 		var textEndsInLineBreak = IsLineBreak(_text, _text.Length);
+		var heightTruncated = false;
 		float totalHeight = 0;
 		int nextTrimPointLookupStart = 0;
 		for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
@@ -517,7 +520,9 @@ internal readonly partial struct UnicodeText : IParsedText
 					? GetLineHeightAndBaselineOffset(lineStackingStrategy, lineHeight, defaultFontDetails, false, true).lineHeight
 					: 0;
 			var actualLineCount = lines.Count + (textEndsInLineBreak ? 1 : 0);
-			var isEarlyLastLine = (maxLines > 0 && maxLines < actualLineCount && lineIndex == maxLines - 1) || (lineIndex < actualLineCount - 1 && nextLineHeight + totalHeight > availableSize.Height);
+			var droppedByHeight = lineIndex < actualLineCount - 1 && nextLineHeight + totalHeight > availableSize.Height;
+			heightTruncated |= droppedByHeight;
+			var isEarlyLastLine = (maxLines > 0 && maxLines < actualLineCount && lineIndex == maxLines - 1) || droppedByHeight;
 
 			var lineWidth = line.width;
 			LinkedListNode<Cluster> lastClusterIncludedInLine = line.clusterLast;
@@ -736,7 +741,15 @@ internal readonly partial struct UnicodeText : IParsedText
 		_corrections = isSpellCheckEnabled ? _spellCheckingService.Value?.SpellCheck(_wordBoundaries, _text) : null;
 		calculatedSize = new Size(maxLineWidth, totalHeight);
 		_availableSize = availableSize;
+		_isHeightTruncated = heightTruncated;
 	}
+
+	/// <summary>
+	/// True when at least one line was dropped because it did not fit in the available height.
+	/// Mirrors WinUI's <c>m_pBreak != nullptr</c> test in <c>BlockNode::CanBypassMeasure</c>: a layout
+	/// that was cut short by the height constraint can only be reused at the very same height.
+	/// </summary>
+	internal bool IsHeightTruncated => _isHeightTruncated;
 
 	private static IEnumerable<LinkedListNode<Cluster>> EnumeratePossibleCharacterTrimmingBreaks(Line line)
 	{


### PR DESCRIPTION
**GitHub Issue:** closes #24219

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`TextBlock.ArrangeOverride` re-parsed and re-shaped its whole text whenever the arrange constraint differed from the measure constraint by **full `Size` equality**. A panel measures a child with an unconstrained height and arranges it at its desired height, so the height differs on nearly every pass — and the text was shaped twice per layout pass, through ICU boundary analysis, HarfBuzz shaping and line breaking.

Height only matters when it actually dropped a line, so `UnicodeText` now records that (`IsHeightTruncated`) and `TextBlock` applies WinUI's rule from `BlockNode::CanBypassMeasure`: the width and adjusted alignment must match, but the height only has to match when the previous layout was truncated by it — otherwise it is enough that the text still fits.

The bypass condition is exact rather than approximate: for every line *i*, `totalHeight_i + nextLineHeight_i` is the prefix sum through *i+1*, which is `<= outSize.Height`, so `arrangeHeight >= outSize.Height` implies no line can be dropped that was not dropped before. The boundary case — a panel arranging at exactly the desired height — lands on the `<=` side.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `layout.full-pass` | time / pass | 32.41 ms | 19.03 ms | **−41.3 %** |
| `layout.full-pass` | alloc / pass | 8,194,446 B | 4,143,044 B | **−49.4 %** |
| `layout.full-pass` | alloc / element | 2,635.7 B | 1,332.6 B | **−49.4 %** |
| `layout.resize-pass` | time / pass | 32.93 ms | 18.57 ms | **−43.6 %** |
| `layout.resize-pass` | alloc / pass | 8,191,210 B | 4,137,379 B | **−49.5 %** |
| *control* `tree.build` | time | 33.00 ms | 33.32 ms | +1.0 % (noise) |
| *control* `dp.set-get` | time | 0.2413 ms | 0.2434 ms | +0.9 % (noise) |

A 3,109-element tree (nested `Grid`/`StackPanel`, `Border` at every level, `TextBlock` leaves), every element dirtied per pass. 3 runs each, median. Raw `layout.full-pass` time runs: 32.41 / 33.45 / 31.45 → 19.42 / 19.03 / 18.86 ms. Measured against the branch base, with no other fix applied.

### Validation ✅

Runtime tests, Skia Desktop, `Given_TextBlock*` + `Given_TextBox*`: **363 run, 358 passed, 7 skipped, 5 failed**. All 5 failures reproduce **unchanged on the baseline** with the change reverted and the app rebuilt, so none is caused by this PR (`When_Inlines_Transitively_Change`, `When_IsTextSelectionEnabled_CRLF`, `When_Caret_Line_Straddles_Viewport_Edge_Grippers_Are_Hidden`, `When_Copy_Paste` — clipboard, flaky in both directions — and `When_Multiline_Pointer_TripleTap_With_Wrapping`).

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
