### PR TITLE
perf(grid): Stop leaking the pooled span store on the empty path

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -354,12 +354,13 @@ namespace Microsoft.UI.Xaml.Controls
 			ref CellCacheStackVector cellCacheVector)
 		{
 
-			SpanStoreStackVector spanStore = new SpanStoreStackVector();
-
 			if (cellsHead >= cellCount)
 			{
 				return;
 			}
+
+			// Rented from the shared ArrayPool, so it must not be created before an exit that skips the Dispose below.
+			SpanStoreStackVector spanStore = new SpanStoreStackVector();
 
 			do
 			{


### PR DESCRIPTION
**GitHub Issue:** closes #24220

## PR Type:

🐞 Bugfix

## What changed? 🚀

`SpanStoreStackVector` rents from `ArrayPool<T>.Shared` in its constructor and returns the array in `Dispose()`. `MeasureCellsGroup` constructed it **before** the `cellsHead >= cellCount` early return, so that path never gave the array back. `Grid.MeasureOverride` calls `MeasureCellsGroup` up to seven times per measure and empty groups are the common case, so a typical grid leaked two to three rentals per measure while returning one: the pool bucket drains and every subsequent rent allocates.

Move the early return above the construction — nothing touches the vector before that point, so the change is inert other than not renting.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `grid.full-pass` | alloc / pass | 390,105 B | 79,113 B | **−79.7 %** |
| `grid.full-pass` | alloc / element | 285.8 B | 58.0 B | **−79.7 %** |
| `grid.full-pass` | time / pass | 3.67 ms | 3.11 ms | **−15.3 %** |

Isolated by reverting and re-applying this change alone on the current tree, both runs executing the workload alone. Allocation figures are byte-identical across runs. The saving is exactly the leaked rentals: ~3 per grid per pass × 341 grids × a 16-element `SpanStoreEntry[]`.

### Workaround 🛠️

None available from application code.

### Validation ✅

Runtime tests, Skia Desktop, `Given_Grid` + `Given_GridLayouting` + `Given_GridView_Items`: **85 run, 81 passed, 4 skipped, 4 failed**. All 4 failures reproduce on the baseline *and* on the tree before any of this work, verified by two separate rebuild-and-rerun cycles.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
