### PR TITLE
perf(composition): Cache the rounded-clip paths

### DIFF
--- a/src/Uno.UI.Composition/Composition/BorderVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/BorderVisual.skia.cs
@@ -28,6 +28,9 @@ internal class BorderVisual(Compositor compositor) : ContainerVisual(compositor)
 	private CompositionSpriteShape? _borderShape; // Never null after _borderBrush is set
 	private CompositionClip? _backgroundClip;
 	private SKRoundRect? _borderPathOuterRect;
+	// The pre-painting round-rect path, keyed on the SKRoundRect instance it was built from.
+	// CreateBorderPath always assigns a brand new SKRoundRect, so reference identity is an exact key.
+	private (SKRoundRect rect, SKPath path)? _prePaintingRoundRect;
 	// state set here but affects children
 	private RectangleClip? _childClipCausedByCornerRadius;
 
@@ -150,7 +153,9 @@ internal class BorderVisual(Compositor compositor) : ContainerVisual(compositor)
 
 		if (_cornerRadius != CornerRadius.None && _borderPathOuterRect is { } rect)
 		{
-			using var roundRectPath = BuildRoundRectPath(rect);
+			// Not rebuilt per frame: this runs for every rounded border on every frame and Detach()
+			// hands out a new native path each time.
+			var roundRectPath = GetOrBuildPrePaintingRoundRectPath(rect);
 			if (base.GetPrePaintingClipping(dst))
 			{
 				dst.Op(roundRectPath, SKPathOp.Intersect, dst);
@@ -341,6 +346,20 @@ internal class BorderVisual(Compositor compositor) : ContainerVisual(compositor)
 		builder.Close();
 
 		return builder.Detach();
+	}
+
+	private SKPath GetOrBuildPrePaintingRoundRectPath(SKRoundRect rect)
+	{
+		if (_prePaintingRoundRect is { } cached && ReferenceEquals(cached.rect, rect))
+		{
+			return cached.path;
+		}
+
+		var path = BuildRoundRectPath(rect);
+		_prePaintingRoundRect?.path.Dispose();
+		_prePaintingRoundRect = (rect, path);
+
+		return path;
 	}
 
 	private static SKPath BuildRoundRectPath(SKRoundRect roundRect)

--- a/src/Uno.UI.Composition/Composition/RectangleClip.skia.cs
+++ b/src/Uno.UI.Composition/Composition/RectangleClip.skia.cs
@@ -12,6 +12,7 @@ partial class RectangleClip
 {
 	private SKRoundRect? _skRoundRect;
 	private static readonly SKPathBuilder _spareClipPathBuilder = new();
+	private SKPath? _clipPath;
 
 	private protected override Rect? GetBoundsCore(Visual visual)
 	{
@@ -25,11 +26,25 @@ partial class RectangleClip
 	// The path returned here is reused, do not cache
 	internal override SKPath GetClipPath(Visual visual)
 	{
+		// Detaching a builder hands out a brand new native SKPath, and this runs for every rounded visual
+		// on every frame. The path depends only on this clip's own properties -- GetBoundsCore ignores the
+		// visual -- so build it once and let OnPropertyChangedCore drop it when any of them changes.
+		if (_clipPath is { } cached)
+		{
+			return cached;
+		}
+
 		var builder = _spareClipPathBuilder;
 		builder.Reset();
 		builder.AddRoundRect(GetClipRoundedRect(visual), SKPathDirection.Clockwise);
 
-		return builder.Detach();
+		return _clipPath = builder.Detach();
+	}
+
+	private protected override void OnPropertyChangedCore(string? propertyName, bool isSubPropertyChange)
+	{
+		_clipPath = null;
+		base.OnPropertyChangedCore(propertyName, isSubPropertyChange);
 	}
 
 	private protected override SKRect? GetClipRect(Visual visual)


### PR DESCRIPTION
**GitHub Issue:** closes #24221

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

Two places handed out a brand-new native `SKPath` on every frame for every rounded visual, because `SKPathBuilder.Detach()` transfers ownership into a *new* path:

1. **`RectangleClip.GetClipPath`** — `Visual.Render` asks for the post-painting clip several times per visual per frame. The path depends only on the clip's own properties (`GetBoundsCore` ignores the `visual`, `GetBounds` applies the clip's own `TransformMatrix`), so it is now built once and dropped by `OnPropertyChangedCore`, making the hot path a single null check. Every mutation reaches that hook: the setters go through `SetProperty`, the `CreateRectangleClip` overloads use object initialisers, and `RectangleClip` does not override `SetAnimatableProperty`, so animations never touch these fields.
2. **`BorderVisual.GetPrePaintingClipping`** — allocated both an `SKPathBuilder` and an `SKPath` per rounded border per frame. Now cached and keyed on the `SKRoundRect` **instance** it was built from; `CreateBorderPath` assigns a brand-new instance whenever the geometry changes, so reference identity is an exact key. The superseded path is disposed, keeping the deterministic native cleanup the old `using` provided, and the path never escapes the call.

`RectangleClip` was the odd one out among the clips — `InsetClip` already caches its path and `CompositionGeometricClip` reuses a static spare.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `render.full-paint` | alloc / frame | 519,107 B | 119,747 B | **−76.9 %** |
| `render.full-paint` | alloc / element / frame | 332.5 B | 76.7 B | **−76.9 %** |
| `render.full-paint` | Gen0 collections / 40 frames | 1 | 0 | **−100 %** |
| `render.full-paint` | time / frame | — | — | unchanged (noise) |

780 rounded `Border`s + 625 rounded `Rectangle`s (1,561 elements), painted through
`RenderTargetBitmap` with **no layout invalidation**, so this is paint cost only. 5 runs each,
median; allocation figures vary by <11 B across runs.

**These numbers are for this PR alone**, measured by building this branch and the base and running
the same workload on each — not carried over from the combined sequence. (Two related fixes measured
in sequence during development reached −98 % on the same workload, but that figure includes the
separate `ShapeVisual` LINQ change, which is its own PR.)

**Honest scope note:** frame *time* is unchanged — the paint walk is bound by native rasterisation,
which also confirms the same rendering work still happens. This is a **GC-pressure** win: at 60 fps it
is ~24 MB/s of managed garbage a rounded-border UI no longer produces, plus roughly 1,560 fewer
finaliser-tracked native Skia objects per frame.

### Validation ✅

Runtime tests, Skia Desktop, `Given_Border` + `Given_ContainerVisual` + `Given_ShapeVisual` + `Given_Visual_Damage` + `Given_UIElement` + `Windows_UI_Xaml_Shapes.*`: **671 run, 654 passed, 1 skipped, 16 failed — before and after**, compared as *sets of failing test names* against a baseline build: **0 new failures, 0 newly fixed**. The 16 include the clip tests that would catch exactly this kind of bug (`When_Both_Layouting_Clip_And_Clip_DP`, `When_TranslateTransform_And_Clip`), and they fail identically on the baseline.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
