### PR TITLE
perf(composition): Walk shapes by index on the frame path

### DIFF
--- a/src/Uno.UI.Composition/Composition/ShapeVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ShapeVisual.skia.cs
@@ -51,18 +51,81 @@ public partial class ShapeVisual
 		return BuildOwnContentPath();
 	}
 
-	internal override bool RequiresRepaintOnEveryFrame => _shapes
-		?.OfType<CompositionSpriteShape>()
-		.Any(s => s.FillBrush?.RequiresRepaintOnEveryFrame ?? false)
-		?? false;
+	// Queried once per shape element per frame, so these walk the collection by index: the LINQ chains
+	// they replace allocated an OfType iterator, a Select iterator and a closure on every frame.
+	internal override bool RequiresRepaintOnEveryFrame
+	{
+		get
+		{
+			if (_shapes is not { Count: not 0 } shapes)
+			{
+				return false;
+			}
 
-	internal override float DamageRegionSamplingMargin => _shapes
-		?.OfType<CompositionSpriteShape>()
-		.Select(s => s.FillBrush?.DamageRegionSamplingMargin ?? 0)
-		.DefaultIfEmpty(0f)
-		.Max() ?? 0;
+			for (var i = 0; i < shapes.Count; i++)
+			{
+				if (shapes[i] is CompositionSpriteShape { FillBrush: { } fill } && fill.RequiresRepaintOnEveryFrame)
+				{
+					return true;
+				}
+			}
 
-	internal override bool CanPaint() => base.CanPaint() || (_shapes?.Any(s => s.CanPaint()) ?? false);
+			return false;
+		}
+	}
+
+	internal override float DamageRegionSamplingMargin
+	{
+		get
+		{
+			if (_shapes is not { Count: not 0 } shapes)
+			{
+				return 0;
+			}
+
+			// `seen` keeps the DefaultIfEmpty(0f) semantics: 0 only when there is no sprite shape at all,
+			// rather than clamping a set of margins up to 0.
+			var max = 0f;
+			var seen = false;
+			for (var i = 0; i < shapes.Count; i++)
+			{
+				if (shapes[i] is not CompositionSpriteShape sprite)
+				{
+					continue;
+				}
+
+				var margin = sprite.FillBrush?.DamageRegionSamplingMargin ?? 0;
+				if (!seen || margin > max)
+				{
+					max = margin;
+					seen = true;
+				}
+			}
+
+			return seen ? max : 0;
+		}
+	}
+
+	internal override bool CanPaint()
+	{
+		if (base.CanPaint())
+		{
+			return true;
+		}
+
+		if (_shapes is { Count: not 0 } shapes)
+		{
+			for (var i = 0; i < shapes.Count; i++)
+			{
+				if (shapes[i].CanPaint())
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 
 	internal override bool TryGetLocalContentBounds(out SKRect localBounds)
 	{


### PR DESCRIPTION
**GitHub Issue:** closes #24222

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`RequiresRepaintOnEveryFrame`, `DamageRegionSamplingMargin` and `CanPaint()` are queried once per shape element per frame, and each was a LINQ chain — so every frame allocated a collection enumerator, one or two iterators and a closure per shape visual. `BorderVisual` already implements the equivalent members as plain expressions.

Walk the collection by index instead. `DamageRegionSamplingMargin` keeps a `seen` flag so `DefaultIfEmpty(0f)` semantics are preserved exactly: 0 is returned when there is no sprite shape at all, rather than clamping a set of margins up to 0, which a naive `Max` starting from 0 would do.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `render.full-paint` | alloc / frame | 381,830 B | 271,826 B | **−28.8 %** |
| `render.full-paint` | alloc / element / frame | 244.6 B | 174.1 B | **−28.8 %** |
| `render.full-paint` | time / frame | 70.08 ms | 69.28 ms | −1.1 % (noise) |

Same 1,561-element rounded tree, paint only, 5 runs each, median. Allocation figures vary by <5 B across runs. Measured on a tree that already has the `RectangleClip` cache applied.

### Validation ✅

Same suite as the clip-path PR (`Given_Border`, `Given_ContainerVisual`, `Given_ShapeVisual`, `Given_Visual_Damage`, `Given_UIElement`, `Windows_UI_Xaml_Shapes.*`): **671 run, 654 passed, 16 failed**, set-compared against a baseline build — **0 new failures, 0 newly passing**.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
