### PR TITLE
perf(grid): Index the definition collections

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinitionCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinitionCollection.cs
@@ -34,8 +34,6 @@ namespace Microsoft.UI.Xaml.Controls
 			_inner.RemoveAt(index);
 		}
 
-		IEnumerable<DefinitionBase> DefinitionCollectionBase.GetItems() => _inner;
-
 		DefinitionBase DefinitionCollectionBase.GetItem(int index) => _inner[index];
 
 		public ColumnDefinition this[int index]

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/DefinitionCollectionBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/DefinitionCollectionBase.cs
@@ -4,7 +4,6 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	internal interface DefinitionCollectionBase
 	{
-		IEnumerable<DefinitionBase> GetItems();
 		int Count { get; }
 		DefinitionBase GetItem(int index);
 		internal void Lock();

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -191,8 +191,11 @@ namespace Microsoft.UI.Xaml.Controls
 			DefinitionCollectionBase definitions,
 			bool treatStarAsAuto)
 		{
-			foreach (var def in definitions.GetItems())
+			// By index: GetItems() hands back the DependencyObjectCollection as an IEnumerable<T>, whose
+			// GetEnumerator boxes. This runs twice per Grid measure, once for rows and once for columns.
+			for (var defIndex = 0; defIndex < definitions.Count; defIndex++)
 			{
+				var def = definitions.GetItem(defIndex);
 
 				bool useLayoutRounding = GetUseLayoutRounding();
 				var userSize = double.PositiveInfinity;

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinitionCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinitionCollection.cs
@@ -34,8 +34,6 @@ namespace Microsoft.UI.Xaml.Controls
 			_inner.RemoveAt(index);
 		}
 
-		IEnumerable<DefinitionBase> DefinitionCollectionBase.GetItems() => _inner;
-
 		DefinitionBase DefinitionCollectionBase.GetItem(int index) => _inner[index];
 
 		public RowDefinition this[int index]


### PR DESCRIPTION
**GitHub Issue:** closes #24224

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`ValidateDefinitions` iterated `definitions.GetItems()`, which hands back the backing `DependencyObjectCollection` as `IEnumerable<DefinitionBase>`. Its `GetEnumerator` returns `IEnumerator<T>`, boxing the `List<T>.Enumerator` struct, and the method runs twice per `Grid` measure — once for rows, once for columns.

Loop by index instead. `DefinitionCollectionBase` already exposed `Count` and `GetItem(int)`, and `GetItem` is `_inner[index]` — the same sequence the enumerator walks — so no new API was needed. `GetItems()` then had no callers left and is removed rather than left dead.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `grid.full-pass` | alloc / pass | 79,113 B | 51,833 B | **−34.5 %** |
| `grid.full-pass` | alloc / element | 58.0 B | 38.0 B | **−34.5 %** |
| `grid.full-pass` | time / pass | 3.11 ms | 3.08 ms | ±0 (noise) |

Workload run **alone** in both configurations, change reverted and re-applied on the current tree, 5 runs each, median. Allocation figures byte-identical across runs.

27,280 B saved over 341 grids = **80 B per grid per pass** — two boxed `List<T>.Enumerator`s at 40 B each, one for rows and one for columns, matching the constant measured independently in `VisualTreeHelper`.

### Validation ✅

Runtime tests, Skia Desktop — same 937-test layout/rendering/framework suite as the visual-tree PR, set-compared against a baseline build: **0 new failures, 0 newly passing**.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
