### PR TITLE
perf(uno-ui): Walk the resource scope without an iterator

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.Store.cs
@@ -1581,39 +1581,147 @@ namespace Microsoft.UI.Xaml
 		/// <summary>
 		/// Returns all ResourceDictionaries in scope using the visual tree, from nearest to furthest.
 		/// </summary>
-		internal IEnumerable<ResourceDictionary> GetResourceDictionaries(
+		/// <remarks>
+		/// Returns a struct enumerable rather than a <c>yield return</c> iterator: this is walked once per
+		/// theme reference per element entering the tree, so the state-machine allocation showed up as the
+		/// single largest allocator while a virtualised list materialises containers during a scroll. The
+		/// walk itself is unchanged — still lazy and still short-circuiting at the first match, so callers
+		/// see exactly the sequence the iterator produced. WinUI's equivalent
+		/// (ScopedResources::TraverseVisualTreeResources) is likewise a plain loop that allocates nothing.
+		/// </remarks>
+		internal ResourceDictionaryScope GetResourceDictionaries(
 			bool includeAppResources,
 			FrameworkElement? resourceContextProvider = null,
 			ResourceDictionary? containingDictionary = null)
+			=> new(this, includeAppResources, resourceContextProvider, containingDictionary);
+
+		/// <summary>
+		/// The lazily-walked sequence of <see cref="ResourceDictionary"/> in scope for a
+		/// <see cref="DependencyObject"/>, nearest first. Implements <see cref="IEnumerable{T}"/> so LINQ
+		/// still works on the cold paths, but <c>foreach</c> binds to the struct enumerator and allocates
+		/// nothing.
+		/// </summary>
+		internal readonly struct ResourceDictionaryScope : IEnumerable<ResourceDictionary>
 		{
-			if (containingDictionary is not null)
+			private readonly DependencyObject _owner;
+			private readonly FrameworkElement? _resourceContextProvider;
+			private readonly ResourceDictionary? _containingDictionary;
+			private readonly bool _includeAppResources;
+
+			internal ResourceDictionaryScope(
+				DependencyObject owner,
+				bool includeAppResources,
+				FrameworkElement? resourceContextProvider,
+				ResourceDictionary? containingDictionary)
 			{
-				yield return containingDictionary;
+				_owner = owner;
+				_includeAppResources = includeAppResources;
+				_resourceContextProvider = resourceContextProvider;
+				_containingDictionary = containingDictionary;
 			}
 
-			// for non-FE, favor context provider over actual-instance
-			var candidate = ActualInstance as FrameworkElement ?? resourceContextProvider ?? ActualInstance;
-			while (candidate is not null)
+			public Enumerator GetEnumerator() => new(_owner, _includeAppResources, _resourceContextProvider, _containingDictionary);
+
+			IEnumerator<ResourceDictionary> IEnumerable<ResourceDictionary>.GetEnumerator() => GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+			public struct Enumerator : IEnumerator<ResourceDictionary>
 			{
-				if (candidate is FrameworkElement fe)
+				private const int StateContainingDictionary = 0;
+				private const int StateAncestors = 1;
+				private const int StateAppResources = 2;
+				private const int StateDone = 3;
+
+				private readonly DependencyObject _owner;
+				private readonly FrameworkElement? _resourceContextProvider;
+				private readonly ResourceDictionary? _containingDictionary;
+				private readonly bool _includeAppResources;
+
+				private int _state;
+				private object? _candidate;
+				private ResourceDictionary? _current;
+
+				internal Enumerator(
+					DependencyObject owner,
+					bool includeAppResources,
+					FrameworkElement? resourceContextProvider,
+					ResourceDictionary? containingDictionary)
 				{
-					if (fe.TryGetResources() is { IsEmpty: false }) // It's legal (if pointless) on UWP to set Resources to null from user code, so check
+					_owner = owner;
+					_includeAppResources = includeAppResources;
+					_resourceContextProvider = resourceContextProvider;
+					_containingDictionary = containingDictionary;
+					_state = StateContainingDictionary;
+					_candidate = null;
+					_current = null;
+				}
+
+				public readonly ResourceDictionary Current => _current!;
+
+				readonly object IEnumerator.Current => _current!;
+
+				public bool MoveNext()
+				{
+					if (_state == StateContainingDictionary)
 					{
-						yield return fe.Resources;
+						_state = StateAncestors;
+
+						// for non-FE, favor context provider over actual-instance
+						_candidate = _owner.ActualInstance as FrameworkElement ?? (object?)_resourceContextProvider ?? _owner.ActualInstance;
+
+						if (_containingDictionary is not null)
+						{
+							_current = _containingDictionary;
+							return true;
+						}
 					}
 
-					candidate = fe.Parent;
-				}
-				else
-				{
-					candidate = VisualTreeHelper.GetParent(candidate);
-				}
-			}
+					if (_state == StateAncestors)
+					{
+						while (_candidate is not null)
+						{
+							if (_candidate is FrameworkElement fe)
+							{
+								_candidate = fe.Parent;
 
-			if (includeAppResources && Application.Current != null)
-			{
-				// In the case of StaticResource resolution we skip Application.Resources because we assume these were already checked at initialize-time.
-				yield return Application.Current.Resources;
+								// It's legal (if pointless) on UWP to set Resources to null from user code, so check
+								if (fe.TryGetResources() is { IsEmpty: false })
+								{
+									_current = fe.Resources;
+									return true;
+								}
+							}
+							else
+							{
+								_candidate = VisualTreeHelper.GetParent((DependencyObject)_candidate);
+							}
+						}
+
+						_state = StateAppResources;
+					}
+
+					if (_state == StateAppResources)
+					{
+						_state = StateDone;
+
+						if (_includeAppResources && Application.Current is { } application)
+						{
+							// In the case of StaticResource resolution we skip Application.Resources because we assume these were already checked at initialize-time.
+							_current = application.Resources;
+							return true;
+						}
+					}
+
+					_current = null;
+					return false;
+				}
+
+				public void Reset() => throw new NotSupportedException();
+
+				public readonly void Dispose()
+				{
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -493,18 +493,14 @@ namespace Uno.UI
 		{
 			var scope = CurrentScope.Sources.FirstOrDefault();
 
-			if (scope != null)
+			if (scope?.Target is DependencyObject scopeOwner)
 			{
-				var dictionaries = (scope.Target as DependencyObject)?.GetResourceDictionaries(true);
-
-				if (dictionaries != null)
+				// Enumerated directly off the struct enumerable so the walk stays allocation-free.
+				foreach (var dict in scopeOwner.GetResourceDictionaries(true))
 				{
-					foreach (var dict in dictionaries)
+					if (dict.TryGetValue(resourceKey, out value, out providingDictionary, shouldCheckSystem: false))
 					{
-						if (dict.TryGetValue(resourceKey, out value, out providingDictionary, shouldCheckSystem: false))
-						{
-							return true;
-						}
+						return true;
 					}
 				}
 			}


### PR DESCRIPTION
**GitHub Issue:** closes #24225

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`GetResourceDictionaries` was a `yield return` iterator, so every call allocated a state machine — and it is called once per theme reference per element entering the tree, on top of every implicit-style lookup and every `{StaticResource}` visual-tree retrieval. It was the largest single allocator while a virtualised list materialises containers during a scroll.

Return a `readonly struct` enumerable with a struct enumerator instead. The walk is unchanged: still lazy, still containing-dictionary first, then non-empty ancestor `Resources` nearest-first, then `Application.Resources`, and still short-circuiting at the caller's first match — so consumers see exactly the sequence the iterator produced. It still implements `IEnumerable<ResourceDictionary>` for the two cold `.ToArray()` callers, while `foreach` binds to the struct enumerator and allocates nothing. WinUI's equivalent walk (`ScopedResources::TraverseVisualTreeResources`) is likewise an allocation-free loop.

`ResourceResolver.TryVisualTreeRetrieval` is rewritten from a `?.` + null-check to `if (scope?.Target is DependencyObject owner)`, so the struct is enumerated directly rather than through a nullable.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `list.scroll-step` | alloc / step | 154,522 B | 133,264 B | **−13.8 %** |
| `list.scroll-step` | alloc / realised container | 6,718.4 B | 5,794.1 B | **−13.8 %** |
| `list.scroll-step` | time / step | 1.6573 ms | 1.6444 ms | −0.8 % (noise) |
| *control* `layout.full-pass` | alloc | 4,096,383 B | 4,095,809 B | ±0 |
| *control* `grid.full-pass` | alloc | 51,833 B | 51,833 B | ±0 |
| *control* `tree.build` | alloc | 21,929,730 B | 21,976,875 B | ±0 |
| *control* `dp.set-get` | alloc | 48,001 B | 48,001 B | ±0 |

A `ListView` over 2,000 items with a two-`TextBlock` `DataTemplate` and 23 realised containers, scrolled 137 px per step (deliberately not a multiple of the item height, so every step straddles items and forces recycling), driven through the dispatcher tick. 3 runs of the full workload set in identical order, median.

The layout and grid workloads are unmoved because their trees are dirtied in place rather than re-entered — this cost is paid on **Enter**, which is what list virtualisation does constantly.

### Validation ✅

Two runtime-test suites on Skia Desktop, each set-compared against a baseline build: the **327-test** resources/theming/list suite (`Given_ThemeResource`, `Given_ElementTheme`, `Given_ResourceDictionary`, `Given_ResourceResolver`, `Given_Style`, `Given_ListViewBase`, …) and the **937-test** layout/rendering/framework suite. **1,264 tests, 0 new failures, 0 newly passing** in both.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
