### PR TITLE
perf(vsm): Stop materialising empty state-trigger collections

### DIFF
--- a/src/Uno.UI/UI/Xaml/VisualState.cs
+++ b/src/Uno.UI/UI/Xaml/VisualState.cs
@@ -119,6 +119,18 @@ namespace Microsoft.UI.Xaml
 			internal set => SetValue(StateTriggersProperty, value);
 		}
 
+		/// <summary>
+		/// The trigger collection if one has already been created, without materialising an empty one.
+		/// </summary>
+		/// <remarks>
+		/// Reading <see cref="StateTriggers"/> lazily creates the collection, subscribes to it and writes it
+		/// back through <c>SetValue</c>. That is pure overhead for the common case of a state with no
+		/// triggers at all, and it is paid for every state of every templated control as it is loaded.
+		/// Callers that only read should use this instead.
+		/// </remarks>
+		internal IList<StateTriggerBase> StateTriggersOrDefault
+			=> GetValue(StateTriggersProperty) as IList<StateTriggerBase>;
+
 		internal static DependencyProperty StateTriggersProperty { get; } =
 			DependencyProperty.Register(
 				name: "StateTriggers",

--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -181,9 +181,14 @@ namespace Microsoft.UI.Xaml
 			for (var stateIndex = 0; stateIndex < States.Count; stateIndex++)
 			{
 				var state = States[stateIndex];
-				for (var triggerIndex = 0; triggerIndex < state.StateTriggers.Count; triggerIndex++)
+				if (state.StateTriggersOrDefault is not { } triggers)
 				{
-					var trigger = state.StateTriggers[triggerIndex];
+					continue;
+				}
+
+				for (var triggerIndex = 0; triggerIndex < triggers.Count; triggerIndex++)
+				{
+					var trigger = triggers[triggerIndex];
 
 					action(trigger);
 				}
@@ -564,7 +569,7 @@ namespace Microsoft.UI.Xaml
 			for (var stateIndex = 0; stateIndex < States.Count; stateIndex++)
 			{
 				var state = States[stateIndex];
-				if (state.StateTriggers.Count > 0)
+				if (state.StateTriggersOrDefault is { Count: > 0 })
 				{
 					return true;
 				}
@@ -596,9 +601,14 @@ namespace Microsoft.UI.Xaml
 			for (var stateIndex = 0; stateIndex < States.Count; stateIndex++)
 			{
 				var state = States[stateIndex];
-				for (var triggerIndex = 0; triggerIndex < state.StateTriggers.Count; triggerIndex++)
+				if (state.StateTriggersOrDefault is not { } triggers)
 				{
-					var trigger = state.StateTriggers[triggerIndex];
+					continue;
+				}
+
+				for (var triggerIndex = 0; triggerIndex < triggers.Count; triggerIndex++)
+				{
+					var trigger = triggers[triggerIndex];
 
 					// the first active CustomTrigger is an automatic winner.
 					if (trigger.CurrentPrecedence == StateTriggerPrecedence.CustomTrigger)


### PR DESCRIPTION
**GitHub Issue:** closes #24226

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`VisualState.StateTriggers` is a lazily-materialising getter: with no list on the DP it creates a `DependencyObjectCollection`, subscribes to its `VectorChanged` and writes it back through `SetValue`. That is right for a caller intending to *add* a trigger, but all four consumers in `VisualStateGroup` only read — `ExecuteOnTriggers` (three call sites), `HasStateTriggers`, and `GetActiveTrigger` twice. So every visual state of every templated control materialised a collection, a subscription, a `DependencyPropertyDetails` entry and a pooled-array rent to represent **no triggers at all**, which is what almost every state has.

Add `StateTriggersOrDefault`, which reads the DP without materialising, and use it at the four read sites. Behaviour is identical: with no collection there are no triggers, so each loop body ran zero times anyway and `HasStateTriggers` returned false. A caller that actually adds a trigger still goes through `StateTriggers` and creates it lazily as before.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `list.scroll-step` | alloc / step | 133,277 B | 121,814 B | **−8.6 %** |
| `list.scroll-step` | time / step | 1.6278 ms | 1.5791 ms | **−3.0 %** |
| *control* `layout.full-pass` | alloc | 4,096,259 B | 4,096,127 B | ±0 |
| *control* `grid.full-pass` | alloc | 51,833 B | 51,833 B | ±0 |
| *control* `tree.build` | alloc | 21,946,936 B | 21,942,484 B | ±0 |

Same 2,000-item virtualised `ListView` workload, 3 runs of the full set in identical order, median. Measured on a tree that already has the resource-scope enumerator fix applied.

### Validation ✅

Runtime tests, Skia Desktop — `Given_VisualStateManager`, `Given_EventTrigger`, `Given_Button`, `Given_CheckBox`, `Given_RadioButton`, `Given_ToggleSwitch`, `Given_HyperlinkButton`, `Given_AppBarButton`, `Given_Style`, `Given_ListViewBase`: **221 run, 214 passed, 11 skipped, 7 failed**. Every visual-state and control test passes; the only failures are the `Given_ListViewBase` set already established as pre-existing against baseline builds in the other PRs of this series.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
