### PR TITLE
fix(binding): Drop dead INotifyPropertyChanged subscriptions

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_BindingMemoryLeak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_BindingMemoryLeak.cs
@@ -1,7 +1,9 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -237,6 +239,81 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			Assert.IsFalse(viewRef.IsAlive, "View should have been garbage collected after removal from visual tree.");
 			Assert.IsFalse(vmRef.IsAlive, "ViewModel should have been garbage collected after View removal from visual tree.");
+		}
+
+		[TestMethod]
+		public async Task When_Source_Outlives_Targets_Then_Subscriptions_Are_Dropped()
+		{
+			// A long-lived source bound by many short-lived targets must not accumulate PropertyChanged
+			// subscriptions. Asserted on the source's own handler count rather than on a WeakReference, so
+			// the test does not depend on the GC actually collecting anything to be meaningful.
+			var source = new CountingSource();
+			var root = new ContentControl();
+			TestServices.WindowHelper.WindowContent = root;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			const int Cycles = 30;
+			var targets = new List<WeakReference>();
+			for (var i = 0; i < Cycles; i++)
+			{
+				// The helper is a non-inlined sync method so the target does not survive in this async
+				// method's state machine, which would keep every binding alive and defeat the test.
+				targets.Add(AddAndRemoveBoundChild(root, source));
+				await TestServices.WindowHelper.WaitForIdle();
+			}
+
+			GC.Collect(2);
+			GC.WaitForPendingFinalizers();
+			GC.Collect(2);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// A raise is what gives a self-purging weak event the chance to drop dead subscriptions.
+			source.Value = "changed";
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var aliveTargets = targets.Count(t => t.IsAlive);
+
+			// The precise invariant: the source must never hold more subscriptions than there are live
+			// targets. Comparing against aliveTargets rather than a fixed number keeps the test meaningful
+			// even if the GC declines to collect some of them on a given run.
+			Assert.IsTrue(
+				source.SubscriberCount <= aliveTargets,
+				$"The source kept {source.SubscriberCount} PropertyChanged subscriptions after {Cycles} "
+				+ $"bound-then-removed targets, of which only {aliveTargets} are still alive: dead "
+				+ "subscriptions are not being dropped.");
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static WeakReference AddAndRemoveBoundChild(ContentControl root, CountingSource source)
+		{
+			var child = new TextBlock { DataContext = source };
+			child.SetBinding(TextBlock.TextProperty, new Microsoft.UI.Xaml.Data.Binding { Path = new PropertyPath(nameof(CountingSource.Value)) });
+
+			root.Content = child;
+			root.UpdateLayout();
+			root.Content = null;
+			root.UpdateLayout();
+
+			return new WeakReference(child);
+		}
+
+		private sealed class CountingSource : System.ComponentModel.INotifyPropertyChanged
+		{
+			private string? _value;
+
+			public string? Value
+			{
+				get => _value;
+				set
+				{
+					_value = value;
+					PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(Value)));
+				}
+			}
+
+			public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+			internal int SubscriberCount => PropertyChanged?.GetInvocationList().Length ?? 0;
 		}
 	}
 }

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -495,8 +495,27 @@ namespace Uno.UI.DataBinding
 
 				var newValueActionWeak = Uno.UI.DataBinding.WeakReferencePool.RentWeakReference(null, propertyChangedValueHandler);
 
-				System.ComponentModel.PropertyChangedEventHandler handler = (s, args) =>
+				System.ComponentModel.PropertyChangedEventHandler? handler = null;
+				handler = (s, args) =>
 				{
+					// The subscription is only detached by the disposable returned below, and nothing disposes it
+					// when the binding target is simply collected — so without this the source would hold a dead
+					// handler for the rest of its life, and every raise would walk all of them. Detaching here on
+					// the first raise after the value handler has gone is the self-purging weak-event pattern
+					// (the same thing WPF's PropertyChangedEventManager does when it finds a dead listener).
+					if (newValueActionWeak.IsDisposed
+						|| newValueActionWeak.Target is not IPropertyChangedValueHandler valueHandler)
+					{
+						// Detached through the same weak reference the disposable uses, so a source that raises
+						// with a different sender is still handled correctly.
+						if (dataContextReference.Target is System.ComponentModel.INotifyPropertyChanged deadSource)
+						{
+							deadSource.PropertyChanged -= handler;
+						}
+
+						return;
+					}
+
 					if (args.PropertyName == propertyName || string.IsNullOrEmpty(args.PropertyName))
 					{
 						if (typeof(BindingPath).Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
@@ -504,11 +523,7 @@ namespace Uno.UI.DataBinding
 							typeof(BindingPath).Log().Debug($"Property changed for {propertyName} on [{dataContextReference.Target?.GetType()}]");
 						}
 
-						if (!newValueActionWeak.IsDisposed
-						&& newValueActionWeak.Target is IPropertyChangedValueHandler handler)
-						{
-							handler.NewValue();
-						}
+						valueHandler.NewValue();
 					}
 				};
 


### PR DESCRIPTION
**GitHub Issue:** closes #24214

## PR Type:

🐞 Bugfix

## What changed? 🚀

A long-lived binding source accumulated `PropertyChanged` subscriptions forever: one per element ever bound to it, never removed. The bound elements themselves **are** collected — what leaked is the subscription, the delegate plus its captured weak-reference wrapper.

`SubscribeToNotifyPropertyChanged` attaches a closure holding only a weak reference to the value handler, which is why the target stays collectable, but the subscription is removed only by the returned `IDisposable` — and nothing disposes it when the target is simply garbage-collected.

Make it self-purging: when raised and the value handler has gone, detach from the source, the way WPF's `PropertyChangedEventManager` does with a dead listener. The dead-check sits above the property-name filter so a raise for *any* property purges, and detaching goes through the same weak data-context reference the disposable uses, so a source raising with a different `sender` still works. Unsubscribing during a raise is safe: invocation lists are immutable, so the in-flight raise completes over the list it started with.

Purging happens on the source's next raise, which is the standard limitation of self-purging weak events (WPF shares it): a source that never raises keeps its subscriptions, but it also never pays the raise cost.

### Measured impact 📊

| Metric | Before | After |
|---|---:|---:|
| subscriptions held after 135 bound-then-removed elements | **135** (unbounded) | **1** (bounded) |
| subscriptions between raises | 35 → 60 → 85 → 110 → 135 | 26, flat |
| subscriptions after each raise | unchanged | **1** |
| cost per `PropertyChanged` raise | 2.873 µs | **0.455 µs** (**−84 %**) |

The raise cost is the second-order effect: every raise walks the whole invocation list, dead entries included. −84 % is the figure *after only 135 cycles* — the gap grows without bound, because the before-case list never stops growing while the after-case stays at the number of live bindings.

Measured on the source's own invocation-list length, so the evidence is **deterministic** and does not depend on the GC actually collecting anything.

### Validation ✅

**A regression test is included**, and was verified red before the fix and green after:

- without the fix: **30 subscriptions held, 0 targets alive** → fails
- with the fix: **0 held** → passes

It asserts the precise invariant — the source must never hold more subscriptions than there are live targets — rather than a fixed number, so it stays meaningful even if the GC declines to collect some targets on a given run. `Given_BindingMemoryLeak`: **7 run, 7 passed**.

Wider: `Given_BindingExpression`, `Given_xBind`, `Given_XBind_NavigatedTo`, `Given_BindableFoundationStructs`, `Given_BindableNullableValueType`, `Given_NonFE_DataContextBinding`, `Given_Frame_DataContext`, `Given_ResourceDictionary_DataContext`, `Given_FrameworkElement_And_Leak`, `Given_ListViewBase`: **278 run, 270 passed, 11 skipped, 7 failed**, set-compared against a baseline build — **0 new failures**.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — `Given_BindingMemoryLeak.When_Source_Outlives_Targets_Then_Subscriptions_Are_Dropped`, verified red→green
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
