### PR TITLE
fix(theming): Cache theme lookups across a layout pass, as WinUI does

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObject.mux.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObject.mux.cs
@@ -277,7 +277,14 @@ public partial class DependencyObject
 		else
 		{
 			// Update theme references to account for new ancestor theme dictionaries.
-			UpdateAllThemeReferences(owner, cache: null, ThemeResolution.ResolveOwnerTheme(owner));
+			// The theme-walk cache is threaded in so the pinned-dictionary refresh can reuse lookups made by
+			// the other elements entering the tree in the same layout pass — WinUI reads the same cache off
+			// the core from CThemeResource::RefreshValue (ThemeResource.cpp:81, 96). It only caches while a
+			// session is open (CoreServices.OnTick), so this is inert outside one.
+			UpdateAllThemeReferences(
+				owner,
+				Uno.UI.Xaml.Core.CoreServices.Instance.ThemeWalkResourceCache,
+				ThemeResolution.ResolveOwnerTheme(owner));
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
@@ -73,6 +73,14 @@ namespace Uno.UI.Xaml.Core
 		{
 			_isAdditionalFrameRequested = 0;
 
+			// MUX Reference: xcpcore.cpp:6422-6426 — the layout pass is a synchronous callout to app code,
+			// and applying templates makes a great many elements enter the tree, each of which resolves its
+			// theme references. WinUI caches those lookups for the duration of the pass (its scenario 2,
+			// "spares ~69k ResourceDictionary lookups"). ResourceDictionary already evicts affected entries
+			// when a dictionary is mutated (ResourceDictionary.cs:249, :494 — MUX Resources.cpp:207, :335),
+			// which is what makes caching safe across the callout.
+			using var themeResourceCacheSession = Instance.ThemeWalkResourceCache.BeginCachingThemeResources();
+
 			// NOTE: The below code should really be replaced with just this:
 			// ----------------------------
 			//if (GetXamlRoot()?.VisualTree?.RootElement is { } root)


### PR DESCRIPTION
**GitHub Issue:** closes #24227

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

WinUI's `ThemeWalkResourceCache` header names three scenarios it exists for. Uno has a faithful port of the cache, including the eviction hook that makes it safe across a callout to app code, but only wired **scenario 1**, the theme-change walk. **Scenario 2** — *"during UpdateLayout … a lot of elements can enter the tree due to applying templates, and they will do a theme resource lookup as part of entering the tree"* — was not wired: `CoreServices.OnTick` opened no caching session and the tree-Enter path passed `cache: null`.

Port the two missing pieces: open a session around the per-frame layout pass (MUX `xcpcore.cpp`, which wraps `LayoutManager::UpdateLayout` for exactly this reason), and thread the core's cache through Enter so the pinned-dictionary refresh can consult it, as WinUI does from `CThemeResource::RefreshValue`.

⚠️ **This is an alignment fix, not a measured performance win**, and the numbers below say so plainly. It is worth landing because it closes a real gap against WinUI and becomes worth more as resolution moves through `RefreshValue`.

For reviewers: a hoist of the ancestor resource walk out of the per-property loop was tried first and measured −6.8 % allocations / −4.1 % time, then **reverted** — WinUI's `UpdateAllThemeReferences` deliberately re-resolves per property, so it observes a resource scope that changes *during* the loop where a hoisted snapshot would not. The allocation win was instead taken in a separate PR that changes only how the sequence is represented, not when it is resolved.

### Measured impact 📊

| Workload | Metric | Before | After | Δ |
|---|---|---:|---:|---:|
| `list.scroll-step` | time / step | 1.7219 ms | 1.6996 ms | −1.3 % (noise) |
| `list.scroll-step` | alloc / step | 152,744 B | 152,748 B | ±0 |

**This is an alignment fix, not a performance improvement — and the numbers say so.** 5 runs each, median.

Instrumenting the cache after wiring it confirms it *works*: **224 sessions, 1,353 hits, 37 misses, 37 stores** across a 200-step `ListView` scroll — a 97 % hit rate. But that is only ~7 avoided dictionary lookups per frame, nowhere near WinUI's 69k, so time and allocations are unchanged within noise.

The reason is structural: Uno resolves most theme references through the ancestor walk (which neither framework caches) and reaches the cached pinned-dictionary refresh comparatively rarely, because Uno pins the dictionary at parse time. It is worth doing as alignment, and becomes worth more as resolution moves through `RefreshValue`.

**Also worth recording for reviewers:** a hoist of the ancestor walk out of the per-property loop was tried first and measured −6.8 % allocations / −4.1 % time, then **reverted** — WinUI's `UpdateAllThemeReferences` deliberately re-resolves per property, so it observes a resource scope that changes *during* the loop where a hoisted snapshot would not.

### Validation ✅

Runtime tests, Skia Desktop — `Given_ThemeResource`, `Given_ElementTheme`, `Given_ElementTheme_Resolution_Regression`, `Given_FrameworkElement_ThemeResources`, `Given_MergedAppResources_ThemeResource`, `Given_CheckBox_ThemeResource_Regression`, `Given_Theme_Materialization`, `Given_ResourceDictionary`, `Given_ResourceResolver`, `Given_Style`, `Given_ListViewBase`, `Given_ListViewBase_Items`, `Given_AccessibleListView`: **327 run, 319 passed, 13 skipped, 7 failed**, set-compared against a baseline build — **0 new failures, 0 newly passing**.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
