### PR TITLE
fix(devserver): cap concurrent hot-reload workspaces, disable oldest without closing the socket

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HotReloadWorkspaceRegistry.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Given_HotReloadWorkspaceRegistry.cs
@@ -1,0 +1,127 @@
+extern alias RemoteServerCore;
+
+using System;
+using System.Threading;
+using Microsoft.Extensions.Options;
+
+using RemoteServerCore::Uno.UI.RemoteControl.Server;
+
+namespace Uno.UI.RemoteControl.DevServer.Tests;
+
+[TestClass]
+public sealed class Given_HotReloadWorkspaceRegistry
+{
+	private sealed class FakeSlot : IHotReloadWorkspaceSlot
+	{
+		public int DisableCount;
+		public string? LastReason;
+
+		public void RequestDisable(string reason)
+		{
+			Interlocked.Increment(ref DisableCount);
+			LastReason = reason;
+		}
+	}
+
+	// Mutable IOptionsMonitor to exercise live capacity changes (IOptionsMonitor.OnChange).
+	private sealed class MutableOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+	{
+		private readonly List<Action<T, string?>> _listeners = new();
+		public T CurrentValue { get; private set; } = value;
+		public T Get(string? name) => CurrentValue;
+		public IDisposable? OnChange(Action<T, string?> listener)
+		{
+			_listeners.Add(listener);
+			return null;
+		}
+		public void Set(T value)
+		{
+			CurrentValue = value;
+			foreach (var l in _listeners.ToArray())
+			{
+				l(value, null);
+			}
+		}
+	}
+
+	private static HotReloadWorkspaceRegistry CreateRegistry(int capacity)
+		=> new(new MutableOptionsMonitor<HotReloadWorkspaceOptions>(new HotReloadWorkspaceOptions { MaxConcurrentWorkspaces = capacity }));
+
+	[TestMethod]
+	public void Registering_beyond_capacity_disables_oldest_first_and_keeps_the_newest()
+	{
+		var registry = CreateRegistry(2);
+		var s1 = new FakeSlot();
+		var s2 = new FakeSlot();
+		var s3 = new FakeSlot();
+
+		registry.Register(s1);
+		registry.Register(s2);
+
+		s1.DisableCount.Should().Be(0);
+		s2.DisableCount.Should().Be(0);
+		registry.Count.Should().Be(2);
+
+		registry.Register(s3); // over capacity -> oldest (s1) is disabled
+
+		s1.DisableCount.Should().Be(1, "the oldest workspace is disabled when capacity is exceeded");
+		s1.LastReason.Should().Contain("2", "the reason mentions the capacity that was reached");
+		s2.DisableCount.Should().Be(0);
+		s3.DisableCount.Should().Be(0);
+		registry.Count.Should().Be(2, "the registry keeps exactly Capacity active slots");
+	}
+
+	[TestMethod]
+	public void Unregister_frees_a_slot_so_a_later_registration_does_not_evict()
+	{
+		var registry = CreateRegistry(1);
+		var s1 = new FakeSlot();
+		var s2 = new FakeSlot();
+
+		registry.Register(s1);
+		registry.Unregister(s1); // e.g. the connection closed
+		registry.Register(s2);
+
+		s1.DisableCount.Should().Be(0, "s1 was already unregistered and must not be disabled");
+		s2.DisableCount.Should().Be(0, "the registry is under capacity after s1 left");
+		registry.Count.Should().Be(1);
+	}
+
+	[TestMethod]
+	public void Registering_the_same_slot_twice_is_idempotent()
+	{
+		var registry = CreateRegistry(2);
+		var s1 = new FakeSlot();
+
+		registry.Register(s1);
+		registry.Register(s1);
+
+		registry.Count.Should().Be(1);
+		s1.DisableCount.Should().Be(0);
+	}
+
+	[TestMethod]
+	public void Lowering_capacity_live_evicts_the_surplus_oldest_immediately()
+	{
+		var monitor = new MutableOptionsMonitor<HotReloadWorkspaceOptions>(new HotReloadWorkspaceOptions { MaxConcurrentWorkspaces = 3 });
+		var registry = new HotReloadWorkspaceRegistry(monitor);
+		var s1 = new FakeSlot();
+		var s2 = new FakeSlot();
+		var s3 = new FakeSlot();
+
+		registry.Register(s1);
+		registry.Register(s2);
+		registry.Register(s3);
+		registry.Count.Should().Be(3);
+		(s1.DisableCount + s2.DisableCount + s3.DisableCount).Should().Be(0);
+
+		// Live capacity drop 3 -> 1: the two oldest (s1, s2) must be evicted immediately,
+		// without waiting for the next registration. See PR review / #24205.
+		monitor.Set(new HotReloadWorkspaceOptions { MaxConcurrentWorkspaces = 1 });
+
+		s1.DisableCount.Should().Be(1, "the oldest is evicted on a live capacity drop");
+		s2.DisableCount.Should().Be(1, "the second oldest is evicted too");
+		s3.DisableCount.Should().Be(0, "the newest is kept");
+		registry.Count.Should().Be(1);
+	}
+}

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -177,6 +177,8 @@ namespace Uno.UI.RemoteControl.Host
 					{
 						services.AddRouting();
 						services.Configure<RemoteControlOptions>(builder.Configuration);
+						// Concurrent hot-reload workspace cap (see #24205): bind at startup.
+						services.Configure<Uno.UI.RemoteControl.Server.HotReloadWorkspaceOptions>(builder.Configuration.GetSection("HotReload"));
 					});
 
 				builder.Services.AddSingleton<IIdeChannel>(_ =>

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -21,6 +21,7 @@ using Uno.Roslyn.MSBuild;
 using Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates;
 using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.Messaging.HotReload;
+using Uno.UI.RemoteControl.Server;
 
 namespace Uno.UI.RemoteControl.Host.HotReload
 {
@@ -129,6 +130,13 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					// file-system observer is active, so a flushed edit can neither be folded into the
 					// baseline nor go unobserved.
 					_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Ready);
+
+					// Enforce the concurrent-workspace cap (see #24205): register this now-active app
+					// workspace. If the dev-server is already at capacity, the oldest workspace(s) get
+					// their hot reload disabled (workspace disposed, connection kept, app notified).
+					// IDE-driven connections never reach this path, so only app workspaces are counted.
+					// The capacity comes from HotReloadWorkspaceOptions via the injected registry.
+					_workspaceRegistry.Register(this);
 
 					return manager;
 				}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -30,6 +30,7 @@ using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.Messaging.HotReload;
 using Uno.UI.RemoteControl.Messaging.IdeChannel;
 using Uno.UI.RemoteControl.Server.Telemetry;
+using Uno.UI.RemoteControl.Server;
 using Uno.HotReload.Info;
 using Uno.HotReload.IO;
 using static System.Runtime.InteropServices.JavaScript.JSType;
@@ -39,19 +40,23 @@ using static Uno.HotReload.Utils.RoslynExtensions;
 
 namespace Uno.UI.RemoteControl.Host.HotReload
 {
-	partial class ServerHotReloadProcessor : IServerProcessor, IDisposable
+	partial class ServerHotReloadProcessor : IServerProcessor, IDisposable, IHotReloadWorkspaceSlot
 	{
 		private static readonly TimeSpan _waitForIdeResultTimeout = TimeSpan.FromSeconds(25);
 		private readonly CancellationTokenSource _ct = new();
+		// 0 = active, 1 = hot reload disabled for this connection (workspace cap, see #24205).
+		private int _hotReloadDisabled;
 		private readonly IRemoteControlServer _remoteControlServer;
 		private readonly ITelemetry _telemetry;
 		private readonly HotReloadTracker _tracker;
 		private readonly WorkspaceGatedFileUpdater _fileUpdater;
+		private readonly HotReloadWorkspaceRegistry _workspaceRegistry;
 
-		public ServerHotReloadProcessor(IRemoteControlServer remoteControlServer, ITelemetry<ServerHotReloadProcessor> telemetry)
+		public ServerHotReloadProcessor(IRemoteControlServer remoteControlServer, ITelemetry<ServerHotReloadProcessor> telemetry, HotReloadWorkspaceRegistry workspaceRegistry)
 		{
 			_remoteControlServer = remoteControlServer;
 			_telemetry = telemetry;
+			_workspaceRegistry = workspaceRegistry;
 			_tracker = new(async (status, ct) => await _remoteControlServer.SendFrame(new HotReloadStatusMessage(status)), ct => RequestHotReloadToIde(), _reporter);
 
 			// Update requests are gated on the workspace lifecycle: queued while the baseline is being
@@ -476,9 +481,56 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		public void Dispose()
 		{
+			_workspaceRegistry.Unregister(this);
 			_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Disposed);
 			_ct.Cancel();
 			_workspace?.Ct.Cancel();
+		}
+
+		/// <summary>
+		/// Concurrent-workspace cap eviction (see #24205): another connection needed a hot-reload
+		/// workspace slot and this one is among the oldest, so disable hot reload here — dispose the
+		/// Roslyn workspace / EnC session to reclaim memory and report the end-of-life to the app —
+		/// WITHOUT closing the connection (closing it would trigger the client's auto-reconnect).
+		/// Fire-and-forget: the registry calls this from another connection's thread.
+		/// </summary>
+		void IHotReloadWorkspaceSlot.RequestDisable(string reason)
+			=> _ = DisableHotReloadAsync(reason);
+
+		private async Task DisableHotReloadAsync(string reason)
+		{
+			if (Interlocked.Exchange(ref _hotReloadDisabled, 1) == 1)
+			{
+				return; // already disabled/disposed
+			}
+
+			_workspaceRegistry.Unregister(this);
+
+			// Dispose the workspace (manager.Dispose -> EndSession + workspace.Dispose + file watcher),
+			// but keep the connection so the client does not reconnect.
+			var workspace = _workspace;
+			_workspace = null;
+			workspace?.Ct.Cancel();
+			// Terminal-but-NOT-closed: the /rc connection stays open (only hot reload is turned off),
+			// so report Failed rather than Disposed. Disposed makes WorkspaceGatedFileUpdater tell
+			// clients "the connection has been closed", which is misleading here (see #24205 review).
+			_fileUpdater.ReportWorkspaceState(HotReloadWorkspaceState.Failed);
+
+			if (this.Log().IsEnabled(LogLevel.Information))
+			{
+				this.Log().LogInformation("Hot reload disabled for this connection: {Reason}", reason);
+			}
+
+			try
+			{
+				// Report the end-of-life to the app over the hot-reload status channel.
+				await _tracker.SendUpdate(serverError: reason);
+				await Notify(HotReloadEvent.Disabled);
+			}
+			catch (Exception notifyError)
+			{
+				this.Log().LogWarning(notifyError, "Failed to notify hot-reload disabled state after workspace-cap eviction");
+			}
 		}
 
 		#region Helpers - IDE Channel SendAndWaitForResult

--- a/src/Uno.UI.RemoteControl.Server/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Uno.UI.RemoteControl.Server/Helpers/ServiceCollectionExtensions.cs
@@ -143,6 +143,10 @@ namespace Uno.UI.RemoteControl.Server.Helpers
 			services.AddScoped<RemoteControlServer>();
 			services.AddScoped<IRemoteControlServer>(static sp => sp.GetRequiredService<RemoteControlServer>());
 			services.AddScoped<IRemoteControlServerConnection>(static sp => sp.GetRequiredService<RemoteControlServer>());
+			// Concurrent hot-reload workspace cap (see #24205): a process-wide (singleton) registry,
+			// configured via IOptionsMonitor<HotReloadWorkspaceOptions> (bound by the host).
+			services.AddOptions<Uno.UI.RemoteControl.Server.HotReloadWorkspaceOptions>();
+			services.AddSingleton<Uno.UI.RemoteControl.Server.HotReloadWorkspaceRegistry>();
 			return services;
 		}
 

--- a/src/Uno.UI.RemoteControl.ServerCore/HotReloadWorkspaceRegistry.cs
+++ b/src/Uno.UI.RemoteControl.ServerCore/HotReloadWorkspaceRegistry.cs
@@ -1,0 +1,167 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Uno.UI.RemoteControl.Server;
+
+/// <summary>
+/// Options controlling the concurrent hot-reload workspace cap (see #24205). Bound from the
+/// dev-server configuration by the host and consumed by <see cref="HotReloadWorkspaceRegistry"/>
+/// via <see cref="IOptionsMonitor{TOptions}"/>.
+/// </summary>
+public sealed class HotReloadWorkspaceOptions
+{
+	/// <summary>Default maximum number of concurrent hot-reload workspaces.</summary>
+	public const int DefaultMaxConcurrentWorkspaces = 5;
+
+	/// <summary>
+	/// Maximum number of concurrent dev-server hot-reload workspaces. Beyond this, the oldest
+	/// workspaces have their hot reload disabled (workspace disposed, connection kept). Values
+	/// &lt; 1 are treated as the default.
+	/// </summary>
+	public int MaxConcurrentWorkspaces { get; set; } = DefaultMaxConcurrentWorkspaces;
+}
+
+/// <summary>
+/// A single dev-server hot-reload workspace slot: one per app connection that has an initialized
+/// (dev-server-driven) hot-reload workspace. Implemented by the connection's hot-reload processor
+/// so the registry can ask it to shut its workspace down when the concurrent-workspace cap is
+/// exceeded.
+/// </summary>
+public interface IHotReloadWorkspaceSlot
+{
+	/// <summary>
+	/// Requests that this slot disable hot reload: dispose its Roslyn workspace / EnC session to
+	/// reclaim memory and report the end-of-life to the connected app — WITHOUT closing the
+	/// underlying connection (so the client does not trigger an auto-reconnect / retry storm).
+	/// Implementations must be idempotent and non-blocking (fire-and-forget the actual teardown).
+	/// </summary>
+	void RequestDisable(string reason);
+}
+
+/// <summary>
+/// Process-wide (DI singleton) registry that bounds the number of concurrent dev-server
+/// hot-reload workspaces.
+/// <para>
+/// Each app connection that initializes a workspace registers a slot (IDE-driven connections,
+/// which never load a workspace, do not register). Once the number of active slots exceeds the
+/// configured capacity, the OLDEST slots have their hot reload disabled — their hundreds-of-MB
+/// Roslyn workspace / EnC session is disposed — while their connection stays open. This caps the
+/// memory a reused/long-lived dev-server accumulates across many app launches without provoking
+/// client reconnect storms. See https://github.com/unoplatform/uno/issues/24205.
+/// </para>
+/// </summary>
+public sealed class HotReloadWorkspaceRegistry : IDisposable
+{
+	private readonly object _gate = new();
+	// Insertion order == oldest first: eviction removes from the front.
+	private readonly List<IHotReloadWorkspaceSlot> _slots = new();
+	private readonly IOptionsMonitor<HotReloadWorkspaceOptions> _options;
+	private readonly IDisposable? _optionsChangeSubscription;
+
+	public HotReloadWorkspaceRegistry(IOptionsMonitor<HotReloadWorkspaceOptions> options)
+	{
+		_options = options ?? throw new ArgumentNullException(nameof(options));
+
+		// Apply a live capacity DROP immediately: if the configured limit is lowered while apps are
+		// connected, evict the surplus now instead of waiting for the next registration. See #24205.
+		_optionsChangeSubscription = _options.OnChange(_ => EnforceCapacity());
+	}
+
+	// Read on demand from IOptionsMonitor. A capacity change also takes effect immediately via the
+	// OnChange subscription (EnforceCapacity), not only on the next registration.
+	private int Capacity
+	{
+		get
+		{
+			var configured = _options.CurrentValue.MaxConcurrentWorkspaces;
+			return configured >= 1 ? configured : HotReloadWorkspaceOptions.DefaultMaxConcurrentWorkspaces;
+		}
+	}
+
+	/// <summary>Number of currently registered slots (diagnostics / tests).</summary>
+	public int Count { get { lock (_gate) { return _slots.Count; } } }
+
+	/// <summary>
+	/// Registers a newly-initialized workspace slot. If the capacity is now exceeded, the oldest
+	/// slot(s) are removed and asked to disable their hot reload (outside the lock). Idempotent for
+	/// an already-registered slot.
+	/// </summary>
+	public void Register(IHotReloadWorkspaceSlot slot)
+	{
+		if (slot is null)
+		{
+			throw new ArgumentNullException(nameof(slot));
+		}
+
+		lock (_gate)
+		{
+			if (!_slots.Contains(slot))
+			{
+				_slots.Add(slot);
+			}
+		}
+
+		EnforceCapacity();
+	}
+
+	/// <summary>
+	/// Evicts the oldest slot(s) while the registry is over capacity, disabling their hot reload
+	/// (outside the lock). Invoked after a registration AND from the options-change callback, so a
+	/// live capacity drop takes effect immediately.
+	/// </summary>
+	private void EnforceCapacity()
+	{
+		List<IHotReloadWorkspaceSlot>? toDisable = null;
+		int capacity;
+		lock (_gate)
+		{
+			capacity = Capacity;
+			while (_slots.Count > capacity)
+			{
+				(toDisable ??= new()).Add(_slots[0]);
+				_slots.RemoveAt(0);
+			}
+		}
+
+		if (toDisable is null)
+		{
+			return;
+		}
+
+		var reason =
+			$"Hot reload was disabled for this app because the dev-server reached its concurrent " +
+			$"hot-reload workspace limit ({capacity}). The connection is kept alive; restart the app " +
+			$"to get a fresh hot-reload session.";
+
+		foreach (var s in toDisable)
+		{
+			// Best effort: a faulty slot must not prevent evicting the others.
+			try { s.RequestDisable(reason); }
+			catch { }
+		}
+	}
+
+	/// <summary>Removes a slot (connection closed, or hot reload already disabled). Idempotent.</summary>
+	public void Unregister(IHotReloadWorkspaceSlot slot)
+	{
+		if (slot is null)
+		{
+			return;
+		}
+
+		lock (_gate)
+		{
+			_slots.Remove(slot);
+		}
+	}
+
+	/// <summary>
+	/// Disposes the <see cref="IOptionsMonitor{TOptions}"/> change subscription. The registry is a
+	/// DI singleton, so this runs when the root container is disposed.
+	/// </summary>
+	public void Dispose()
+		=> _optionsChangeSubscription?.Dispose();
+}

--- a/src/Uno.UI.RemoteControl.ServerCore/InProcess/InProcessDevServer.cs
+++ b/src/Uno.UI.RemoteControl.ServerCore/InProcess/InProcessDevServer.cs
@@ -84,6 +84,9 @@ public sealed class InProcessDevServer : IAsyncDisposable
 		services.AddScoped<RemoteControlServer>();
 		services.AddScoped<IRemoteControlServer>(static sp => sp.GetRequiredService<RemoteControlServer>());
 		services.AddScoped<IRemoteControlServerConnection>(static sp => sp.GetRequiredService<RemoteControlServer>());
+		// Concurrent hot-reload workspace cap (see #24205).
+		services.AddOptions<Uno.UI.RemoteControl.Server.HotReloadWorkspaceOptions>();
+		services.AddSingleton<Uno.UI.RemoteControl.Server.HotReloadWorkspaceRegistry>();
 
 		options.ConfigureServices?.Invoke(services);
 

--- a/src/Uno.UI.RemoteControl.ServerCore/Uno.UI.RemoteControl.ServerCore.csproj
+++ b/src/Uno.UI.RemoteControl.ServerCore/Uno.UI.RemoteControl.ServerCore.csproj
@@ -9,6 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
 	</ItemGroup>


### PR DESCRIPTION
**GitHub Issue:** closes #24205

## PR Type:

🐞 Bugfix

## What changed? 🚀

A reused / long-lived dev-server accumulates one Roslyn workspace + EnC session (~hundreds of MB) **per connected app**, with no upper bound: each `/rc` app connection owns its own workspace, and reconnect / restart loops (or a stale half-open socket) stack them — measured at ~+500 MB per extra connection (see #24205 / #24151).

This adds a **process-wide cap** on concurrent hot-reload workspaces:

- New `HotReloadWorkspaceRegistry` (in `Uno.UI.RemoteControl.ServerCore`), a **DI singleton** configured through the **Options pattern**: `HotReloadWorkspaceOptions.MaxConcurrentWorkspaces` (**default 5**), bound at startup from the `HotReload` configuration section and read via `IOptionsMonitor` (e.g. `HotReload:MaxConcurrentWorkspaces`, `UNO_DEVSERVER_HotReload__MaxConcurrentWorkspaces`, or `--HotReload:MaxConcurrentWorkspaces` through the existing config pipeline).
- Each app connection that initializes a hot-reload workspace registers a slot once it is **Ready**. IDE-driven connections never load a workspace, so **only app workspaces are counted**.
- When capacity is exceeded, the **oldest** slot(s) have hot reload **disabled**: their workspace / `DebuggingSession` is **disposed** to reclaim the memory, and the end-of-life is **reported to the app** over the existing hot-reload status channel (`HotReloadTracker.SendUpdate(serverError: …)` + `HotReloadEvent.Disabled`).
- Crucially, the `/rc` **connection is kept open** — only the HR processor's workspace is torn down — so the client does **not** trigger an auto-reconnect / retry storm. The file-update gate reports `Failed` (terminal-but-not-closed), never `Disposed`.
- A configuration change that **lowers** the capacity is applied **live** via `IOptionsMonitor.OnChange` (the surplus oldest workspaces are evicted immediately); the registry disposes that subscription (`IDisposable`).

This is terminal for the evicted connection (its app is told hot reload ended and why); the app gets a fresh HR session on its next launch.

## PR Checklist ✅

- [x] 🧪 Added `Given_HotReloadWorkspaceRegistry` (eviction: oldest-first, keeps `Capacity` slots; unregister; idempotent register; live capacity-drop).
- [ ] 📚 Docs — N/A.
- [ ] 🖼️ Screenshots — N/A (no UI change).
- [x] ❗ Contains **NO** breaking changes (apps within the cap are unaffected; the connection is never force-closed).
- [ ] 👀 Reviewed 2 other open pull requests.
