### PR TITLE
perf(uno-ui): Use the cached bool boxes in generated DP setters

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/DependencyObject/DependencyPropertyGenerator.cs
@@ -490,7 +490,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				}
 			}
 
-			builder.AppendLineIndented($"private static void Set{propertyName}Value({propertyTargetName} instance, {propertyTypeName} value) => instance.SetValue({propertyOwnerTypeName}.{propertyName}Property, value);");
+			builder.AppendLineIndented($"private static void Set{propertyName}Value({propertyTargetName} instance, {propertyTypeName} value) => instance.SetValue({propertyOwnerTypeName}.{propertyName}Property, {GetBoxedValueExpression(propertyTypeName)});");
 
 			GeneratePropertyStorage(builder, propertyName);
 
@@ -613,7 +613,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 
 			if (propertyData.PropertyHasSetter)
 			{
-				builder.AppendLineIndented($"private void Set{propertyName}Value({propertyTypeName} value) => SetValue({propertyName}Property, value);");
+				builder.AppendLineIndented($"private void Set{propertyName}Value({propertyTypeName} value) => SetValue({propertyName}Property, {GetBoxedValueExpression(propertyTypeName)});");
 			}
 
 			if (localCache)
@@ -716,6 +716,22 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				}
 			}
 		}
+
+		/// <summary>
+		/// The expression a generated setter passes to <c>SetValue</c>. <c>SetValue</c> takes an <c>object</c>,
+		/// so a <c>bool</c> would be boxed on every set — 24 bytes each time, for properties that are set
+		/// constantly (visual states, IsEnabled propagation, focus flags). Uno.UI already keeps the two
+		/// boxed instances, so use them.
+		/// </summary>
+		/// <remarks>
+		/// <c>Uno.UI.Helpers.Boxes</c> is internal to Uno.UI, which is the only assembly using
+		/// <c>[GeneratedDependencyProperty]</c>. Any other consumer would get a compile error here rather
+		/// than a silent behaviour change.
+		/// </remarks>
+		private static string GetBoxedValueExpression(string propertyTypeName)
+			=> propertyTypeName == "bool"
+				? "global::Uno.UI.Helpers.Boxes.Box(value)"
+				: "value";
 
 		private static void GeneratePropertyStorage(IndentedStringBuilder builder, string propertyName)
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/DependencyPropertyMixinGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/Mixins/DependencyPropertyMixinGenerator.cs
@@ -54,7 +54,11 @@ public sealed class DependencyPropertyMixinGenerator : IIncrementalGenerator
 					sb.AppendLine($"\t\t{dp.Modifier}public {dp.PropertyType} {dp.Name}");
 					sb.AppendLine("\t\t{");
 					sb.AppendLine($"\t\t\tget {{ return ({dp.PropertyType})this.GetValue({dp.Name}Property); }}");
-					sb.AppendLine($"\t\t\tset {{ this.SetValue({dp.Name}Property, value); }}");
+					// SetValue takes an object, so a bool would be boxed on every set. Uno.UI already keeps the
+					// two boxed instances, and these properties (IsTabStop, focus flags and the like) are set
+					// often enough for a 24-byte allocation each time to be worth avoiding.
+					var setterValue = dp.PropertyType == "bool" ? "global::Uno.UI.Helpers.Boxes.Box(value)" : "value";
+					sb.AppendLine($"\t\t\tset {{ this.SetValue({dp.Name}Property, {setterValue}); }}");
 					sb.AppendLine("\t\t}");
 					sb.AppendLine();
 


### PR DESCRIPTION
**GitHub Issue:** closes #24241

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

`DependencyObject.SetValue` takes an `object`, so a `bool` is boxed at the call site — 24 bytes on **every set**. Uno.UI already keeps the two boxed instances in `Uno.UI.Helpers.Boxes` and uses them by hand in a few places, but both DependencyProperty generators emitted the plain `SetValue(prop, value)`, so every generated `bool` setter allocated.

Both generators now emit `SetValue(XProperty, global::Uno.UI.Helpers.Boxes.Box(value))` when the property type is `bool`, and pass `value` through unchanged for every other type — so any `bool` DP added later gets this automatically.

- `DependencyPropertyGenerator` — both emission sites (attached and instance setters)
- `DependencyPropertyMixinGenerator` — its data model declares 13 `bool` properties

`Uno.UI.Helpers.Boxes` is internal to Uno.UI, which is the only assembly using `[GeneratedDependencyProperty]`; any other consumer would get a compile error here rather than a silent behaviour change.

### Measured impact 📊

1,000 × toggling `Control.IsEnabled` (a `[GeneratedDependencyProperty]` bool) on a `Button`, 3 runs, median:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| alloc / set | 72.0 B | 48.0 B | **−33.3 %** |

Byte-identical across every run in both configurations — exactly **24 B per set**, one box. The remaining 48 B is the change-notification path and is unrelated to this change.

Measured with a headless harness that project-references the real framework, rebuilt from the working tree; full methodology and raw runs in `specs/059-performance-improvements/evidence.md` (PR #24238).

### Why it cannot change behaviour ✅

`DependencyObject.AreDifferent` (`DependencyObject.Store.cs:2313`) takes the `newValue is ValueType` branch for a boxed `bool` and compares with `object.Equals` — a **value** comparison:

```csharp
if (newValue is ValueType || newValue is string)
{
    return !object.Equals(previousValue, newValue);
}
```

Change detection therefore never depended on box identity, so sharing the two boxed instances is invisible to it.

### Validation ✅

- **`DependencyPropertyGenerator` golden tests: 6 run, 6 passed.**
- **Runtime tests, Skia Desktop** — `Given_Control`, `Given_Button`, `Given_CheckBox`, `Given_ToggleSwitch`, `Given_RadioButton`, `Given_VisualStateManager`, `Given_UIElement`, `Given_FrameworkElement`: **684 run, 658 passed, 2 skipped, 26 failed**, compared as *sets of failing test names* against a baseline build — **0 new failures, 0 newly passing.**

> ⚠️ Note for reviewers: the wider `Uno.UI.SourceGenerators.Tests` suite is **not** a usable signal locally — it fails 340/482 on the **unmodified** tree and its pass count varies run to run (110, 128, 129 on identical inputs), because those tests load `src/*/bin/**` directly rather than through project references. The 6 DependencyProperty golden tests above were therefore checked individually. CI is the real check.

### Follow-up (not in this PR)

**151 hand-written `bool` DP setters** in `Uno.UI` still call `SetValue(XProperty, value)` directly and pay the same 24 B — including hot ones on the base types: `UIElement.IsHitTestVisible` (measured 72 B/set) and `UIElement.IsTabStop` (24 B/set) are hand-written, not generated. That is a 151-site mechanical sweep and is better done separately.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, allocation-only change with no behaviour difference; covered by the existing generator goldens and control suites above
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, no API or behaviour change for app authors
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results. — to check once CI has run
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
