### PR TITLE
docs: clarify JavaScript inclusion for WebAssembly

### DIFF
--- a/doc/articles/interop/wasm-javascript-1.md
+++ b/doc/articles/interop/wasm-javascript-1.md
@@ -12,9 +12,17 @@ Uno Platform fully embraces HTML5 as its display backend when targeting WebAssem
 
 In the HTML world, everything running in the browser is assets that must be downloaded from a server. To integrate existing JavaScript frameworks, they can be either downloaded from another location on the Internet (usually from a CDN service) or embedded and deployed with the app.
 
-The Uno Bootstrapper can automatically embed any asset and deploy it with the app. Some of them (CSS & JavaScript) can also be loaded with the app. Here's how to declare them in a *Uno Wasm* project:
+The Uno Bootstrapper can automatically deploy embedded assets with the app. JavaScript and CSS files placed in the WebAssembly folders are also loaded or referenced by the bootstrapper. Here's how to declare them in a *Uno Wasm* project:
 
-1. **JavaScript files** should be in the `Platforms/WebAssembly/WasmScripts` folder. They will be copied to the output folder and loaded automatically by the bootstrapper when the page loads.
+1. **JavaScript files** should be in the `Platforms/WebAssembly/WasmScripts` folder. In a project using `Uno.Sdk`, `AppManifest.js` is included automatically. Other scripts must be added as embedded resources to the project file:
+
+   ```xml
+   <ItemGroup>
+     <EmbeddedResource Include="Platforms\WebAssembly\WasmScripts\my-script.js" />
+   </ItemGroup>
+   ```
+
+   They will then be copied to the output folder and loaded automatically by the bootstrapper when the page loads. If the script is an npm package, copy or bundle the required files from `node_modules` into `WasmScripts` first; the bootstrapper does not resolve npm dependencies.
 
 2. **CSS Style files** should be in the `Platforms/WebAssembly/WasmCSS` folder. They will be copied to the output folder and referenced in the *HTML head* of the application.
 
@@ -177,3 +185,5 @@ Then from your C# code, add the following:
 * [Continue with Part 2](xref:Uno.Interop.WasmJavaScript2) - an integration of a syntax highlighter component.
 * [Continue with Part 3](xref:Uno.Interop.WasmJavaScript3) - an integration of a more complex library with callbacks to application.
 * Read the [Uno Wasm Bootstrapper](xref:UnoWasmBootstrap.Overview) documentation.
+* For a CDN-based integration, see [Part 3](xref:Uno.Interop.WasmJavaScript3).
+* For platform checks, see [platform-specific C#](xref:Uno.Development.PlatformSpecificCSharp), and for package dependencies, see [Using the Uno.Sdk](xref:Uno.Features.Uno.Sdk#implicit-packages).

--- a/doc/articles/interop/wasm-javascript-2.md
+++ b/doc/articles/interop/wasm-javascript-2.md
@@ -152,14 +152,12 @@ Create a [new Uno Platform App project](xref:Uno.GetStarted) using one of the ge
 
    ```xml
    <ItemGroup>
-     <EmbeddedResource Include="WasmCSS\Fonts.css" />
-     <EmbeddedResource Include="WasmCSS\prism.css" /> <!-- This is new -->
-     <EmbeddedResource Include="WasmScripts\AppManifest.js" />
-     <EmbeddedResource Include="WasmScripts\prism.js" /> <!-- This one too -->
+     <EmbeddedResource Include="WasmCSS\prism.css" />
+     <EmbeddedResource Include="WasmScripts\prism.js" />
    </ItemGroup>
    ```
 
-   > For the Uno Wasm Bootstrapper to take those files automatically and load them with the application, they have to be put as embedded resources. A future version of Uno may remove this requirement.
+   > `AppManifest.js` and `Fonts.css` are included automatically by `Uno.Sdk`. Other JavaScript and CSS files must be embedded resources for the Uno Wasm Bootstrapper to load them with the application.
 7. Compile & run
 8. Once loaded, press F12 and go into the `Sources` tab. Both `prism.js` & `prism.css` files should be loaded this time.
 


### PR DESCRIPTION
**GitHub Issue:** closes #22268

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Clarified arbitrary JavaScript inclusion, current `EmbeddedResource` usage, npm dependency bundling, and links to existing CDN, runtime, and Uno.Sdk documentation. Removed stale automatic resource entries from the Prism example.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests, UI tests, or a manual test sample (not applicable to documentation)
- [x] 📚 Docs have been updated following the documentation conventions
- [ ] 🖼️ Validated PR Screenshots Compare Test Run results (not applicable)
- [x] ❗ Contains NO breaking changes

## Testing 🧪

- Markdownlint passed
- cSpell passed
- `git diff --check` passed
- Documentation-only; runtime and screenshot tests are not applicable

## Disclosure

No functional or breaking changes.