### PR TITLE
fix(build): Add missing 6.7 PackageDiffIgnore set

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3487,6 +3487,1383 @@
 		  <Member fullName="Windows\.Foundation\.TypedEventHandler.+(::|\.)DataContextChanged" reason="DataContext restricted to FrameworkElement" isRegex="true" />
 	  </Events>
 	</IgnoreSet>
+
+	<!-- 6.7.65 is now the published stable baseline generatepkgdiff resolves to (CompareVersion matches on
+	     Major.Minor), so the 6.6 set above stopped being consulted and every entry in it silently went dark.
+	     None of the pending 7.0 breaking changes have shipped yet, so the same ignore set still applies. -->
+	<IgnoreSet baseVersion="6.7">
+	  <Assemblies>
+		  <!-- The whole assembly is renamed for 7.0, so every type in it reads as removed against the stable baseline. -->
+		  <Member fullName="Uno.UI.Toolkit" reason="Assembly renamed Uno.UI.Toolkit -> Uno.UI.Extras (7.0 assembly renames)" />
+		  <Member fullName="Uno" reason="Assembly renamed Uno -> Uno.WinRT (7.0 assembly renames)" />
+		  <!-- Fluent V1 shipped an assembly whose style content had already been deleted: themeresources_v1.xaml was an empty ResourceDictionary and XamlControlsResources forced version 2 regardless (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.FluentTheme.v1" reason="Removed the Uno.UI.FluentTheme.v1 assembly along with the Fluent V1 scaffolding (BC71, breaking changes for 7.0)" />
+		  <!-- With V1 gone the "v2" suffix had no meaning, so the assembly was merged into Uno.UI.FluentTheme (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.FluentTheme.v2" reason="Merged the Uno.UI.FluentTheme.v2 assembly into Uno.UI.FluentTheme; the v2 suffix was an artifact of the removed Fluent V1/V2 split (BC71, breaking changes for 7.0)" />
+	  </Assemblies>
+	  <Types>
+		  <!-- Fluent V1 public surface, removed with the Uno.UI.FluentTheme.v1 assembly (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.XamlControlsResourcesV1" reason="Removed XamlControlsResourcesV1; it sourced an empty V1 dictionary and had no consumers (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FluentTheme.v1.GlobalStaticResources" reason="Generated with the removed Uno.UI.FluentTheme.v1 assembly (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FluentTheme.v1.Resource" reason="Generated with the removed Uno.UI.FluentTheme.v1 assembly (BC71, breaking changes for 7.0)" />
+		  <!-- Fluent V2 public surface, removed with the merge of Uno.UI.FluentTheme.v2 into Uno.UI.FluentTheme (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.XamlControlsResourcesV2" reason="Removed XamlControlsResourcesV2; WinAppSDK has no such type and with V1 gone it duplicated XamlControlsResources (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FluentTheme.v2.GlobalStaticResources" reason="Generated with the merged-away Uno.UI.FluentTheme.v2 assembly (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FluentTheme.v2.Resource" reason="Generated with the merged-away Uno.UI.FluentTheme.v2 assembly (BC71, breaking changes for 7.0)" />
+		  <!-- Uno-only resources-version selector with no WinUI counterpart; version 2 was already forced unconditionally (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ControlsResourcesVersion" reason="Removed the Uno-only ControlsResourcesVersion enum; WinAppSDK has no such type and only version 2 exists (BC71, breaking changes for 7.0)" />
+		  <!-- Legacy cross-target FeatureConfiguration holder class removed with its sole flag (#2053, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.FeatureConfiguration/Binding" reason="Removed empty FeatureConfiguration.Binding holder after deleting IgnoreINPCSameReferences (#2053, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/Timeline" reason="Removed empty FeatureConfiguration.Timeline holder after deleting DefaultsStartingValueFromAnimatedValue (#2053, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/VisualState" reason="Removed empty FeatureConfiguration.VisualState holder after deleting ApplySettersBeforeTransition (#2053, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/DataTemplateSelector" reason="Removed empty FeatureConfiguration.DataTemplateSelector holder after deleting UseLegacyTemplateSelectorOverload (#2053, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/ManipulationRoutedEventArgs" reason="Removed empty FeatureConfiguration.ManipulationRoutedEventArgs holder after deleting IsAbsolutePositionEnabled (#2053, breaking changes for 7.0)" />
+		  <!-- Holder classes emptied by the residual dead native-renderer flag removals (#2125/#2052, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.FeatureConfiguration/Interop" reason="Removed empty FeatureConfiguration.Interop holder after deleting ForceJavascriptInterop (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/UIElement" reason="Removed empty FeatureConfiguration.UIElement holder after deleting its last WASM DOM flags (#2125/#2052, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/Shape" reason="Removed empty FeatureConfiguration.Shape holder after deleting its WASM getBBox/svg flags (#2052, breaking changes for 7.0)" />
+		  <!-- Native default-styles system removed: the styles templated native views that no longer exist (#2052, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.FeatureConfiguration/Style" reason="Removed FeatureConfiguration.Style holder along with the native default-styles system it gated (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Converters.UnoNativeDefaultProgressBarReverseBoolConverter" reason="Removed Uno-internal converter used only by the deleted NativeDefaultProgressBar style (#2052, breaking changes for 7.0)" />
+		  <!-- Toolkit attached properties whose only consumer was the native iOS MenuFlyout presentation (#2052, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.Toolkit.MenuFlyoutItemExtensions" reason="Removed MenuFlyoutItemExtensions; its IsDestructive attached property was read only by the native iOS MenuFlyout presentation (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Toolkit.MenuFlyoutExtensions" reason="Removed MenuFlyoutExtensions; its CancelTextIosOverride attached property was read only by the native iOS MenuFlyout presentation (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.FeatureConfiguration/Control" reason="Removed empty FeatureConfiguration.Control holder after deleting UseLegacyContentAlignment (BC45, breaking changes for 7.0)" />
+		  <!-- Xaml-compat stub of the native-only Uno.UI.Maps addin, removed along with the addin itself (#2049, breaking changes for 7.0). -->
+		  <Member fullName="Uno.UI.Maps.MapResources" reason="Removed the Uno.UI.Toolkit Xaml-compat ResourceDictionary stub together with the native-only Uno.UI.Maps addin (#2049, breaking changes for 7.0)" />
+		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.DropDownButtonAutomationPeer" reason="Moved to correct namespace Microsoft.UI.Xaml.Automation.Peers" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ExpanderAutomationPeer" reason="Moved to correct namespace Microsoft.UI.Xaml.Automation.Peers" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.NumberBoxAutomationPeer" reason="Moved to correct namespace Microsoft.UI.Xaml.Automation.Peers" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ProgressRingAutomationPeer" reason="Moved to correct namespace Microsoft.UI.Xaml.Automation.Peers" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.Primitives.ColorSpectrumAutomationPeer" reason="Moved to correct namespace Microsoft.UI.Xaml.Automation.Peers" />
+		  <!-- BEGIN WinUI sync: WinRT interop projections replaced by BCL equivalents -->
+		  <Member fullName="Microsoft.UI.Xaml.Interop.IBindableIterable" reason="WinUI sync: replaced by System.Collections.IEnumerable" />
+		  <Member fullName="Microsoft.UI.Xaml.Interop.IBindableVector" reason="WinUI sync: replaced by System.Collections.IList" />
+		  <Member fullName="Microsoft.UI.Xaml.Interop.INotifyCollectionChanged" reason="WinUI sync: replaced by System.Collections.Specialized.INotifyCollectionChanged" />
+		  <Member fullName="Microsoft.UI.Xaml.Interop.NotifyCollectionChangedAction" reason="WinUI sync: replaced by System.Collections.Specialized.NotifyCollectionChangedAction" />
+		  <Member fullName="Microsoft.UI.Xaml.Interop.NotifyCollectionChangedEventArgs" reason="WinUI sync: replaced by System.Collections.Specialized.NotifyCollectionChangedEventArgs" />
+		  <Member fullName="Microsoft.UI.Xaml.Interop.NotifyCollectionChangedEventHandler" reason="WinUI sync: replaced by System.Collections.Specialized.NotifyCollectionChangedEventHandler" />
+		  <Member fullName="Microsoft.UI.Xaml.Data.DataErrorsChangedEventArgs" reason="WinUI sync: replaced by System.ComponentModel.DataErrorsChangedEventArgs" />
+		  <Member fullName="Microsoft.UI.Xaml.Data.INotifyDataErrorInfo" reason="WinUI sync: replaced by System.ComponentModel.INotifyDataErrorInfo" />
+		  <!-- END WinUI sync: WinRT interop projections replaced by BCL equivalents -->
+		  <!-- BEGIN WinUI sync: NotImplemented helper stubs not present in WinAppSDK 1.8 -->
+		  <Member fullName="Microsoft.UI.Xaml.Media.MatrixHelper" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <Member fullName="Microsoft.UI.Xaml.Media.Media3D.Matrix3DHelper" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <Member fullName="Microsoft.UI.Xaml.Media.Animation.KeyTimeHelper" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <Member fullName="Microsoft.UI.Xaml.Media.Animation.RepeatBehaviorHelper" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.Primitives.GeneratorPositionHelper" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <!-- END WinUI sync: NotImplemented helper stubs -->
+
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync: Windows.* legacy / preview namespaces removed         -->
+		  <!--                                                                        -->
+		  <!-- All entries below were [NotImplemented] generated stubs only on Uno.   -->
+		  <!-- Verified: zero non-Generated implementations on master, zero usage     -->
+		  <!-- references outside generator/test infrastructure. Removed types match  -->
+		  <!-- WinAppSDK 1.8 surface trim. Where Uno had a real impl in a different  -->
+		  <!-- namespace (Microsoft.UI.Composition, Windows.Devices.Power, etc.) the  -->
+		  <!-- impl is preserved by the branch.                                       -->
+		  <!-- ====================================================================== -->
+
+		  <!-- Group 1: Windows.Phone.* — entire WP8 namespace tree retired by Microsoft.
+		       Includes ApplicationModel, Devices.Power, Management.Deployment,
+		       Media.Devices, Notification.Management, PersonalInformation (incl. Provisioning),
+		       PhoneContract, Speech.Recognition, System.*, UI.Input.
+		       Windows.Phone.Devices.Notification.VibrationDevice is the only real Uno impl
+		       under Windows.Phone.* and is preserved (commit 81670705f0). -->
+		  <Member fullName="Windows\.Phone\.(?!Devices\.Notification\.).+" reason="WinUI sync: Windows.Phone.* retired by WinAppSDK 1.8 (legacy WP8 surface; Windows.Phone.Devices.Notification.VibrationDevice preserved)" isRegex="true" />
+
+		  <!-- Group 2: Windows.ApplicationModel.Calls.* — legacy active-call control APIs.
+		       Modern PhoneCallManager / PhoneCallHistory* surface is preserved (Uno has real
+		       Android/iOS/wasm impls); only the call-state/DTMF/audio-routing stubs go. -->
+		  <Member fullName="Windows\.ApplicationModel\.Calls\.(Dtmf(Key|ToneAudioPlayback)|PhoneCall(AudioDevice|Direction|Info|OperationStatus|Status|sResult)?|PhoneLine(DialResult|OperationStatus)|TransportDeviceAudioRoutingStatus)" reason="WinUI sync: legacy active-call control APIs removed by WinAppSDK 1.8 (PhoneCallManager / PhoneCallHistory* preserved)" isRegex="true" />
+
+		  <!-- Group 3: Windows.ApplicationModel.ConversationalAgent.* — Cortana voice
+		       activation result/configuration types. Cortana retired by Microsoft. -->
+		  <Member fullName="Windows\.ApplicationModel\.ConversationalAgent\.(ActivationSignalDetectionConfiguration(CreationResult|CreationStatus|RemovalResult|SetModelDataResult|StateChangeResult)|ConversationalAgent(ActivationKind|ActivationResult|VoiceActivationPrerequisiteKind)|SignalDetectorResourceKind)" reason="WinUI sync: Cortana ConversationalAgent preview types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 4: Windows.ApplicationModel.* miscellaneous preview/phone-related types -->
+		  <Member fullName="Windows.ApplicationModel.Activation.IPhoneCallActivatedEventArgs" reason="WinUI sync: phone-call activation contract removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.Activation.PhoneCallActivatedEventArgs" reason="WinUI sync: phone-call activation args removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.AppExecutionContext" reason="WinUI sync: preview app-execution-context API removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.AppInstallerPolicySource" reason="WinUI sync: preview installer-policy enum removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.CameraApplicationManager" reason="WinUI sync: legacy camera-app launcher removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.Holographic.HolographicKeyboard" reason="WinUI sync: HoloLens preview API removed by WinAppSDK 1.8" />
+
+		  <!-- Group 5a: Windows.Devices.Bluetooth.BluetoothLE PHY / preferred-connection
+		       preview parameters. Core BLE surface unchanged. -->
+		  <Member fullName="Windows\.Devices\.Bluetooth\.BluetoothLE(ConnectionParameters|ConnectionPhy(Info)?|PreferredConnectionParameters(Request(Status)?)?)" reason="WinUI sync: BLE PHY / preferred-connection-parameters preview types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 5b: Windows.Devices.Display.Core preview status enums -->
+		  <Member fullName="Windows\.Devices\.Display\.Core\.Display(PresentStatus|ScanoutOptions|SourceStatus|TaskResult)" reason="WinUI sync: DisplayCore preview status enums removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 5c: Windows.Devices.Printers.Ipp* preview IPP printer surface -->
+		  <Member fullName="Windows\.Devices\.Printers\.Ipp(AttributeError(Reason)?|AttributeValue(Kind)?|IntegerRange|PrintDevice|Resolution(Unit)?|SetAttributesResult|TextWithLanguage)" reason="WinUI sync: IPP printer preview API removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 6a: Windows.Graphics.Capture preview access-gating types -->
+		  <Member fullName="Windows\.Graphics\.Capture\.GraphicsCaptureAccess(Kind)?" reason="WinUI sync: preview capture-access API removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 6b/c: Single-type preview removals in Windows.Graphics.* -->
+		  <Member fullName="Windows.Graphics.Display.DisplayServices" reason="WinUI sync: preview API removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Graphics.Holographic.HolographicDepthReprojectionMethod" reason="WinUI sync: preview enum removed by WinAppSDK 1.8" />
+
+		  <!-- Group 6d: Windows.Graphics.Printing.PrintSupport.* — entire sub-namespace
+		       retired (preview print extension API never stabilized). -->
+		  <Member fullName="Windows\.Graphics\.Printing\.PrintSupport\..+" reason="WinUI sync: PrintSupport preview namespace removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 6e: Windows.Graphics.Printing.Workflow.* — entire sub-namespace
+		       retired (preview print-workflow API never stabilized). -->
+		  <Member fullName="Windows\.Graphics\.Printing\.Workflow\..+" reason="WinUI sync: PrintWorkflow preview namespace removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 7: Windows.Management.Deployment.* preview deployment types -->
+		  <Member fullName="Windows.Management.Deployment.AppInstallerManager" reason="WinUI sync: preview installer manager removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Management.Deployment.AutoUpdateSettingsOptions" reason="WinUI sync: preview auto-update settings removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Management.Deployment.PackageAllUserProvisioningOptions" reason="WinUI sync: preview provisioning options removed by WinAppSDK 1.8" />
+
+		  <!-- Group 8a: Windows.Media.Capture preview types -->
+		  <Member fullName="Windows.Media.Capture.ScreenCapture" reason="WinUI sync: preview screen-capture API removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Media.Capture.SourceSuspensionChangedEventArgs" reason="WinUI sync: preview event args removed by WinAppSDK 1.8" />
+
+		  <!-- Group 8b: Windows.Media.Core.TimedText{Bouten,Ruby}* — Japanese subtitle
+		       (Bouten emphasis marks and CSS Ruby) types removed by WinAppSDK 1.8. -->
+		  <Member fullName="Windows\.Media\.Core\.TimedText(Bouten(Position|Type)?|Ruby(Align|Position|Reserve)?)" reason="WinUI sync: Japanese subtitle (Bouten/Ruby) types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 8c: Windows.Media.Devices preview camera APIs (CameraOcclusion*, DigitalWindow*) -->
+		  <Member fullName="Windows\.Media\.Devices\.(CameraOcclusion(Info|Kind|State|StateChangedEventArgs)?|DigitalWindow(Bounds|Capability|Control|Mode))" reason="WinUI sync: preview camera occlusion / digital-window APIs removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 8d: Windows.Media.Effects single removal -->
+		  <Member fullName="Windows.Media.Effects.SlowMotionEffectDefinition" reason="WinUI sync: preview slow-motion effect removed by WinAppSDK 1.8" />
+
+		  <!-- Group 8e: Cortana voice command APIs (real SpeechRecognition surface preserved) -->
+		  <Member fullName="Windows\.Media\.SpeechRecognition\.VoiceCommand(Manager|Set)" reason="WinUI sync: Cortana voice-command APIs removed by WinAppSDK 1.8 (core SpeechRecognition preserved)" isRegex="true" />
+
+		  <!-- Group 9a: Windows.Networking.NetworkOperators.MobileBroadband* — cellular SIM
+		       slot management preview API. -->
+		  <Member fullName="Windows\.Networking\.NetworkOperators\.MobileBroadband(CellNR|CurrentSlotIndexChangedEventArgs|SlotInfo(ChangedEventArgs)?|SlotManager|SlotState)" reason="WinUI sync: cellular slot-management preview removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 9b: Windows.Networking.Vpn preview foreground-activation -->
+		  <Member fullName="Windows\.Networking\.Vpn\.VpnForeground(ActivatedEventArgs|ActivationOperation)" reason="WinUI sync: VPN foreground-activation preview removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 10a: Windows.Storage.* preview -->
+		  <Member fullName="Windows.Storage.StorageLibraryChangeTrackerOptions" reason="WinUI sync: preview change-tracker options removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Storage.StorageLibraryLastChangeId" reason="WinUI sync: preview change-id type removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Storage.Streams.IPropertySetSerializer" reason="WinUI sync: preview property-set serializer removed by WinAppSDK 1.8" />
+
+		  <!-- Group 10b: Windows.System.* preview -->
+		  <Member fullName="Windows.System.RemoteDesktop.Input.RemoteTextConnection" reason="WinUI sync: preview remote-desktop text connection removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.RemoteDesktop.Input.RemoteTextConnectionDataHandler" reason="WinUI sync: preview remote-desktop text data handler removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.UserAgeConsentGroup" reason="WinUI sync: preview age-consent enum removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.UserAgeConsentResult" reason="WinUI sync: preview age-consent result removed by WinAppSDK 1.8" />
+
+		  <!-- Group 11a: Windows.UI.Composition.* — legacy WinRT projections superseded
+		       by the unified Microsoft.UI.Composition namespace. Real Uno impls live in
+		       Microsoft.UI.Composition (RectangleClip, DelegatedInkTrailVisual,
+		       *EasingFunction, IVisualElement2) and are preserved on the branch. -->
+		  <Member fullName="Windows\.UI\.Composition\.((Back|Bounce|Circle|Elastic|Exponential|Power|Sine)EasingFunction|CompositionEasingFunctionMode|DelegatedInkTrailVisual|ICompositionSupportsSystemBackdrop|ICompositionSurfaceFacade|IVisualElement2|InkTrailPoint|RectangleClip)" reason="WinUI sync: legacy Windows.UI.Composition projections removed (Microsoft.UI.Composition equivalents preserved)" isRegex="true" />
+
+		  <!-- Uno-native dead stub (Visual subclass, private ctor only, no factory, zero consumers) removed. -->
+		  <Member fullName="Microsoft.UI.Composition.DelegatedInkTrailVisual" reason="Removed dead DelegatedInkTrailVisual stub (BC32, breaking changes for 7.0)" />
+
+		  <!-- Group 11b: Windows.UI.Core preview independent-input controllers -->
+		  <Member fullName="Windows\.UI\.Core\.CoreIndependentInput(Filters|SourceController)" reason="WinUI sync: preview independent-input controller types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 11c: Windows.UI.Notifications single removal -->
+		  <Member fullName="Windows.UI.Notifications.ToastNotificationMode" reason="WinUI sync: preview toast notification mode removed by WinAppSDK 1.8" />
+
+		  <!-- Group 11d: Windows.UI.Shell.ShareWindowCommand* — preview share-window cmds -->
+		  <Member fullName="Windows\.UI\.Shell\.ShareWindowCommand(EventArgs|Source)?" reason="WinUI sync: preview share-window command types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 11e: Windows.UI.ViewManagement.Core preview framework-input view types -->
+		  <Member fullName="Windows\.UI\.ViewManagement\.Core\.Core(FrameworkInputView(AnimationStartingEventArgs|OcclusionsChangedEventArgs)?|InputViewAnimationStartingEventArgs)" reason="WinUI sync: preview core framework-input view types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Group 11f/g: single-type Windows.UI.* removals -->
+		  <Member fullName="Windows.UI.WebUI.WebUIPhoneCallActivatedEventArgs" reason="WinUI sync: phone-call activation event args removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.UI.WindowManagement.WindowServices" reason="WinUI sync: preview window-services type removed by WinAppSDK 1.8" />
+
+		  <!-- END WinUI sync: Windows.* legacy / preview namespaces removed -->
+
+		  <!-- ItemsRepeater animator surface removed by WinAppSDK 1.8 (replaced by TransitionManager / ItemCollectionTransitionProvider). No references remain in WinUI microsoft-ui-xaml sources. -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.AnimationContext" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimationCompleted" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator" reason="WinUI sync: ElementAnimator surface removed by WinAppSDK 1.8 (replaced by ItemCollectionTransitionProvider)" />
+
+		  <!-- Uno-only generic setter (not part of the WinUI surface); removed with its non-DP Style codegen fallback. -->
+		  <Member fullName="Microsoft.UI.Xaml.Setter`1" reason="Removed Uno-only generic Setter&lt;T&gt; (BC44, breaking changes for 7.0)" />
+
+		  <!-- Legacy WASM IJSObject DOM-interop mechanism (Uno-only, no WinUI counterpart); hard-removed. -->
+		  <Member fullName="Uno.Foundation.Interop.IJSObject" reason="Removed legacy WASM IJSObject DOM-interop API (BC02, breaking changes for 7.0)" />
+		  <Member fullName="Uno.Foundation.Interop.IJSObjectMetadata" reason="Removed legacy WASM IJSObject DOM-interop API (BC02, breaking changes for 7.0)" />
+		  <Member fullName="Uno.Foundation.Interop.JSObjectHandle" reason="Removed legacy WASM IJSObject DOM-interop API (BC02, breaking changes for 7.0)" />
+		  <Member fullName="Uno.Foundation.Interop.JSObject" reason="Removed legacy WASM IJSObject DOM-interop API (BC02, breaking changes for 7.0)" />
+
+		  <!-- Uno-only duplicate of System.Numerics.VectorExtensions; removed in favor of the WinAppSDK-ref counterpart. -->
+		  <Member fullName="Uno.Extensions.Vector2Extensions" reason="Removed redundant Uno.Extensions.Vector2Extensions (BC72, breaking changes for 7.0)" />
+
+		  <!-- DependencyObject as class (BC26): DependencyObjectStore folded into DependencyObject and IDependencyObjectStoreProvider removed. Both were Uno-only, not part of the WinUI surface. -->
+		  <Member fullName="^Microsoft\.UI\.Xaml\.DependencyObjectStore([/+].+)?$" reason="DependencyObject as class: store dissolved into DependencyObject" isRegex="true" />
+		  <Member fullName="Microsoft.UI.Xaml.IDependencyObjectStoreProvider" reason="DependencyObject as class: provider indirection removed" />
+
+		  <!-- Microsoft.UI.Input.PointerPoint family relocated from Uno.UI to Uno.WinRT (BC41, breaking changes for 7.0); the types read as removed from their former assembly. -->
+		  <Member fullName="Microsoft.UI.Input.PointerPoint" reason="Relocated Microsoft.UI.Input.PointerPoint to Uno.WinRT (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Input.PointerPointProperties" reason="Relocated Microsoft.UI.Input.PointerPointProperties to Uno.WinRT (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Input.PointerUpdateKind" reason="Relocated Microsoft.UI.Input.PointerUpdateKind to Uno.WinRT (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Input.IPointerPointTransform" reason="Relocated Microsoft.UI.Input.IPointerPointTransform to Uno.WinRT (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Input.PointerDeviceType" reason="Relocated Microsoft.UI.Input.PointerDeviceType to Uno.WinRT alongside PointerPoint (BC41, breaking changes for 7.0)" />
+
+		  <!-- Sync-generator assembly-home correction: these WinUI-parity types now generate into their WinAppSDK-correct assembly (Uno.WinRT) instead of Uno.WinUI. Relocation across assemblies is a binary break, intentional for 7.0 (#2065). -->
+		  <Member fullName="Microsoft.UI.System.ThemeSettings" reason="Relocated Microsoft.UI.System.ThemeSettings from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.InteractiveExperiences.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.DirectX.DirectXAlphaMode" reason="Relocated Microsoft.Graphics.DirectX.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.DirectX.DirectXColorSpace" reason="Relocated Microsoft.Graphics.DirectX.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.DirectX.DirectXPixelFormat" reason="Relocated Microsoft.Graphics.DirectX.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.DirectX.DirectXPrimitiveTopology" reason="Relocated Microsoft.Graphics.DirectX.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.Display.DisplayAdvancedColorInfo" reason="Relocated Microsoft.Graphics.Display.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.Display.DisplayAdvancedColorKind" reason="Relocated Microsoft.Graphics.Display.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.Display.DisplayHdrMetadataFormat" reason="Relocated Microsoft.Graphics.Display.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Graphics.Display.DisplayInformation" reason="Relocated Microsoft.Graphics.Display.* from Uno.UI.Composition to Uno.WinRT to match WinAppSDK (Microsoft.Windows.SDK.NET) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.IClosableNotifier" reason="Relocated Microsoft.UI.IClosableNotifier from Uno.UI.Composition to Uno.WinRT to match WinAppSDK Microsoft.UI root namespace (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.ClosableNotifierHandler" reason="Relocated Microsoft.UI.ClosableNotifierHandler from Uno.UI.Composition to Uno.WinRT to match WinAppSDK Microsoft.UI root namespace (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.IResourceContext" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.IResourceManager" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.KnownResourceQualifierName" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.MrtCoreContract" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceCandidate" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceCandidateKind" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceContext" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceLoader" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceManager" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceMap" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.Windows.ApplicationModel.Resources.ResourceNotFoundEventArgs" reason="Relocated Microsoft.Windows.ApplicationModel.Resources.* (MRT-Core) from Uno.UI to Uno.WinRT to match WinAppSDK (Microsoft.Windows.ApplicationModel.Resources.Projection) (#2065, breaking changes for 7.0)" />
+
+		  <!-- Uno-only menu-plumbing interfaces reduced to internal; WinUI has no public counterparts. -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.IMenu" reason="Reduced Uno-only IMenu to internal (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.IMenuPresenter" reason="Reduced Uno-only IMenuPresenter to internal (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ISubMenuOwner" reason="Reduced Uno-only ISubMenuOwner to internal (breaking changes for 7.0, uno#8339)" />
+
+		  <!-- Uno-only MaterializableList<T> reduced to internal (BC48); WinUI has no counterpart. -->
+		  <Member fullName="Uno.Collections.MaterializableList`1" reason="Reduced Uno-only MaterializableList&lt;T&gt; to internal (BC48, breaking changes for 7.0)" />
+
+		  <!-- Android head aligned on UnoPlatformHostBuilder: NativeApplication is now abstract with a CreateHost() override, replacing the AppBuilder delegate ctor. AndroidHost is now internal and built via UseAndroid(). -->
+		  <Member fullName="Microsoft.UI.Xaml.NativeApplication/AppBuilder" reason="Android head now overrides CreateHost() instead of passing an AppBuilder delegate (breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Runtime.Skia.Android.AndroidHost" reason="AndroidHost reduced to internal; use UseAndroid() on the host builder (breaking changes for 7.0)" />
+		  <!-- Legacy WinRTFeatureConfiguration holder removed with its sole flag (accessors paired in <Properties>/<Methods> below). -->
+		  <Member fullName="Uno.WinRTFeatureConfiguration/ApplicationLanguages" reason="Removed empty WinRTFeatureConfiguration.ApplicationLanguages holder after deleting UseLegacyPrimaryLanguageOverride (BC50, breaking changes for 7.0)" />
+		  <!-- BC01: legacy templated-parent mechanism removed; the template factory is now a plain System.Func (uno#18672, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.FrameworkTemplateBuilder" reason="BC01: legacy template builder delegate removed with the ambient TemplatedParentScope (uno#18672, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.NewFrameworkTemplateBuilder" reason="BC01: replaced by Uno.UI.FrameworkTemplateBuilder, declared next to TemplateManager instead of in the WinUI namespace (uno#18672, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.TemplateMaterializationSettings" reason="BC01: moved to the Uno.UI namespace, alongside FrameworkTemplateBuilder and TemplateManager -- it is Uno plumbing with no WinUI counterpart (uno#18672, breaking changes for 7.0)" />
+	  </Types>
+	  <Fields>
+		  <!-- Members of the removed ControlsResourcesVersion enum (see the <Types> entry above), listed in case the diff reports them independently of their declaring type (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ControlsResourcesVersion Microsoft.UI.Xaml.Controls.ControlsResourcesVersion::Version1" reason="Removed with the ControlsResourcesVersion enum; V1 styles no longer exist (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ControlsResourcesVersion Microsoft.UI.Xaml.Controls.ControlsResourcesVersion::Version2" reason="Removed with the ControlsResourcesVersion enum; version 2 is the only behavior and needs no selector (BC71, breaking changes for 7.0)" />
+		  <Member fullName="System.Int32 Microsoft.UI.Xaml.Controls.ControlsResourcesVersion::value__" reason="Removed with the ControlsResourcesVersion enum (BC71, breaking changes for 7.0)" />
+		  <!-- ControlsResourcesVersionProperty is declared as a get-only property today, but the 6.6.x base may expose it as a DP field; cover both shapes (paired with the <Properties>/<Methods> entries). -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.XamlControlsResources::ControlsResourcesVersionProperty" reason="Removed the ControlsResourcesVersionProperty DP with its property (BC71, breaking changes for 7.0)" />
+		  <!-- Any remaining member of the deleted Uno.UI.FluentTheme.v1 assembly or of XamlControlsResourcesV1 (see the <Assemblies>/<Types> entries above). Regex because the generated GlobalStaticResources member set is not reproducible locally. -->
+		  <Member fullName=".+ Uno\.UI\.FluentTheme\.v1\..+" reason="Member of the removed Uno.UI.FluentTheme.v1 assembly (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.XamlControlsResourcesV1(::|\.).+" reason="Member of the removed XamlControlsResourcesV1 type (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Uno\.UI\.FluentTheme\.v2\..+" reason="Member of the merged-away Uno.UI.FluentTheme.v2 assembly (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.XamlControlsResourcesV2(::|\.).+" reason="Member of the removed XamlControlsResourcesV2 type (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->
+		  <!-- DependencyPropertyValuePrecedences enum cleanup: obsolete/misused members removed and style levels renamed to match WinUI's BaseValueSource (#16356, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::TemplatedParent" reason="Removed unused TemplatedParent precedence (#16356, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::ExplicitStyle" reason="Renamed ExplicitStyle to Style to match WinUI BaseValueSourceStyle (#16356, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::ImplicitStyle" reason="Removed misused ImplicitStyle precedence; default styles now use BuiltInStyle (#16356, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyPropertyValuePrecedences Microsoft.UI.Xaml.DependencyPropertyValuePrecedences::DefaultStyle" reason="Renamed DefaultStyle to BuiltInStyle to match WinUI BaseValueSourceBuiltInStyle (#16356, breaking changes for 7.0)" />
+		  <Member fullName="System.Int32 Microsoft.UI.Xaml.Controls.ScrollingInputKinds::value__" reason="WinUI sync: type restructured in WinAppSDK 1.8" />
+
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync (Category D): enum constant removals.                 -->
+		  <!--                                                                        -->
+		  <!-- 31 enum members removed by Microsoft from WinAppSDK 1.8 across 19      -->
+		  <!-- preserved enum types. All verified stub-only on master (the enums       -->
+		  <!-- exist as generated stubs; the specific members have zero references in -->
+		  <!-- non-Generated Uno code). User impact: an app that switched on these    -->
+		  <!-- specific enum members in a `case X.Y` arm gets a compile error;        -->
+		  <!-- functional behavior was already broken since Uno never returned these  -->
+		  <!-- values from any API.                                                   -->
+		  <!-- ====================================================================== -->
+
+		  <!-- ConversationalAgent (Cortana retired) -->
+		  <Member fullName="Windows\.ApplicationModel\.ConversationalAgent\.DetectionConfigurationTrainingStatus Windows\.ApplicationModel\.ConversationalAgent\.DetectionConfigurationTrainingStatus::(ConfigurationNotFound|TrainingTimedOut)" reason="WinUI sync: Cortana training-status enum members removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- DisplayCore preview enum members -->
+		  <Member fullName="Windows.Devices.Display.Core.DisplayManagerOptions Windows.Devices.Display.Core.DisplayManagerOptions::VirtualRefreshRateAware" reason="WinUI sync: preview DisplayManagerOptions.VirtualRefreshRateAware removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Devices.Display.Core.DisplayTaskSignalKind Windows.Devices.Display.Core.DisplayTaskSignalKind::OnPresentFlipTo" reason="WinUI sync: preview DisplayTaskSignalKind.OnPresentFlipTo removed by WinAppSDK 1.8" />
+
+		  <!-- PrintWorkflow preview enum member -->
+		  <Member fullName="Windows.Graphics.Printing.Workflow.PrintWorkflowSessionStatus Windows.Graphics.Printing.Workflow.PrintWorkflowSessionStatus::PdlDataAvailableForModification" reason="WinUI sync: preview PrintWorkflowSessionStatus.PdlDataAvailableForModification removed by WinAppSDK 1.8" />
+
+		  <!-- Media.Capture preview enum members (metadata stream / preview audio profiles / preview video profiles) -->
+		  <Member fullName="Windows.Media.Capture.Frames.MediaFrameSourceKind Windows.Media.Capture.Frames.MediaFrameSourceKind::Metadata" reason="WinUI sync: preview metadata frame-source kind removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Media.Capture.MediaStreamType Windows.Media.Capture.MediaStreamType::Metadata" reason="WinUI sync: preview metadata media-stream type removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Media.Capture.KnownVideoProfile Windows.Media.Capture.KnownVideoProfile::CompressedCamera" reason="WinUI sync: preview CompressedCamera video profile removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows\.Media\.Capture\.MediaCategory Windows\.Media\.Capture\.MediaCategory::(FarFieldSpeech|UniformSpeech|VoiceTyping)" reason="WinUI sync: preview audio media categories removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Media.Effects preview audio effects -->
+		  <Member fullName="Windows\.Media\.Effects\.AudioEffectType Windows\.Media\.Effects\.AudioEffectType::(DeepNoiseSuppression|FarFieldBeamForming)" reason="WinUI sync: preview audio effect types removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Networking.Connectivity preview WPA3 / GCMP enum members -->
+		  <Member fullName="Windows\.Networking\.Connectivity\.NetworkAuthenticationType Windows\.Networking\.Connectivity\.NetworkAuthenticationType::Wpa3Enterprise(192Bits)?" reason="WinUI sync: preview WPA3 Enterprise auth type variants removed by WinAppSDK 1.8" isRegex="true" />
+		  <Member fullName="Windows\.Networking\.Connectivity\.NetworkEncryptionType Windows\.Networking\.Connectivity\.NetworkEncryptionType::Gcmp(256)?" reason="WinUI sync: preview GCMP encryption variants removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Networking.NetworkOperators preview 5G NR / eSIM error enum members -->
+		  <Member fullName="Windows\.Networking\.NetworkOperators\.DataClasses Windows\.Networking\.NetworkOperators\.DataClasses::NewRadio(NonStandalone|Standalone)" reason="WinUI sync: preview 5G New Radio data-class members removed by WinAppSDK 1.8" isRegex="true" />
+		  <Member fullName="Windows\.Networking\.NetworkOperators\.ESimOperationStatus Windows\.Networking\.NetworkOperators\.ESimOperationStatus::(IccidAlreadyExists|ProfileDownloadMaxRetriesExceeded|ProfileProcessingError|ServerNotTrusted|TimeoutWaitingForResponse)" reason="WinUI sync: preview eSIM operation-status error members removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Storage preview enum members (see chat: SharedLocal app-data area, DownloadsFolder
+		       known-folder id, AllowedPerAppFolder partial-access status — all preview/Phone-era) -->
+		  <Member fullName="Windows.Storage.ApplicationDataLocality Windows.Storage.ApplicationDataLocality::SharedLocal" reason="WinUI sync: legacy shared-local app-data area removed by WinAppSDK 1.8 (Phone-era publisher sharing)" />
+		  <Member fullName="Windows.Storage.KnownFolderId Windows.Storage.KnownFolderId::DownloadsFolder" reason="WinUI sync: KnownFolderId.DownloadsFolder removed (use KnownFolders.Downloads / FolderPicker)" />
+		  <Member fullName="Windows.Storage.KnownFoldersAccessStatus Windows.Storage.KnownFoldersAccessStatus::AllowedPerAppFolder" reason="WinUI sync: partial per-app-folder access status removed by WinAppSDK 1.8 (binary granted/denied model)" />
+
+		  <!-- System preview enum members -->
+		  <Member fullName="Windows.System.Diagnostics.DiagnosticActionState Windows.System.Diagnostics.DiagnosticActionState::Executing" reason="WinUI sync: preview DiagnosticActionState.Executing removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.UserType Windows.System.UserType::SystemManaged" reason="WinUI sync: preview UserType.SystemManaged removed by WinAppSDK 1.8" />
+
+		  <!-- ViewManagement.Core preview input-view kinds -->
+		  <Member fullName="Windows\.UI\.ViewManagement\.Core\.CoreInputViewKind Windows\.UI\.ViewManagement\.Core\.CoreInputViewKind::(Clipboard|Dictation)" reason="WinUI sync: preview CoreInputViewKind members removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- END WinUI sync (Category D): enum constant removals -->
+
+		  <!-- DependencyObject as class (BC26): fields of the removed DependencyObjectStore (incl. its nested TraceProvider). -->
+		  <Member fullName="^.+ Microsoft\.UI\.Xaml\.DependencyObjectStore(::|\.|/).+$" reason="DependencyObject as class: DependencyObjectStore removed" isRegex="true" />
+
+		  <!-- Duration.TimeSpan public field removed; WinUI exposes TimeSpan as a get-only property (paired accessor is emitted by the property, not a field). -->
+		  <Member fullName="System.TimeSpan Microsoft.UI.Xaml.Duration::TimeSpan" reason="Made Duration.TimeSpan read-only to match WinUI (breaking changes for 7.0, uno#8339)" />
+
+		  <!-- Reference flavor folded into Skia: lib/ now carries the Skia build, so members that only the -->
+		  <!-- Reference compilation produced are gone. _fullyInitialized sat under !UNO_HAS_ENHANCED_LIFECYCLE, -->
+		  <!-- which Skia defines, so it never existed in the build lib/ now ships.                            -->
+		  <Member fullName="System.Boolean Microsoft.UI.Xaml.Controls.NavigationViewItemBase::_fullyInitialized" reason="Reference flavor folded into Skia; field was compiled only under !UNO_HAS_ENHANCED_LIFECYCLE (breaking changes for 7.0, uno#8339)" />
+	  </Fields>
+	  <Properties>
+		  <!-- Fluent resources-version selector removed: only version 2 exists and WinAppSDK has no equivalent surface. Accessors paired in the <Methods> block below (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ControlsResourcesVersion Microsoft.UI.Xaml.Controls.XamlControlsResources::ControlsResourcesVersion()" reason="Removed the Uno-only XamlControlsResources.ControlsResourcesVersion property; version 2 was already forced unconditionally (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.XamlControlsResources::ControlsResourcesVersionProperty()" reason="Removed the ControlsResourcesVersionProperty DP with its property (BC71, breaking changes for 7.0)" />
+		  <Member fullName="System.Object Microsoft.UI.Xaml.Controls.XamlControlsResourcesV2::ControlsResourcesVersion()" reason="Removed the inert object-typed ControlsResourcesVersion stub on XamlControlsResourcesV2; it was never a DP and never read (BC71, breaking changes for 7.0)" />
+		  <Member fullName=".+ Uno\.UI\.FluentTheme\.v1\..+" reason="Member of the removed Uno.UI.FluentTheme.v1 assembly (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.XamlControlsResourcesV1(::|\.).+" reason="Member of the removed XamlControlsResourcesV1 type (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Uno\.UI\.FluentTheme\.v2\..+" reason="Member of the merged-away Uno.UI.FluentTheme.v2 assembly (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.XamlControlsResourcesV2(::|\.).+" reason="Member of the removed XamlControlsResourcesV2 type (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <!-- StackLayout.DisableVirtualization is a plain CLR property in WinUI (backed by internal IsVirtualizationEnabledProperty); the DisableVirtualizationProperty DP is not part of the WinUI surface. -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout::DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
+		  <!-- Native-only FeatureConfiguration knobs removed with the native renderers (#2052, breaking changes for 7.0). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors::UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/WebView2::IsInspectable()" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/AndroidSettings::IsEdgeToEdgeEnabled()" reason="Removed AndroidSettings.IsEdgeToEdgeEnabled flag; edge-to-edge is now unconditional on Skia-Android (#2052, breaking changes for 7.0)" />
+		  <!-- Legacy cross-target FeatureConfiguration flags removed (#2053, breaking changes for 7.0). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Binding::IgnoreINPCSameReferences()" reason="Removed Binding.IgnoreINPCSameReferences legacy flag; binding engine always uses the correct INPC path (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/FrameworkElement::UseLegacyHitTest()" reason="Removed FrameworkElement.UseLegacyHitTest legacy flag; hit-testing locked to the WinUI-aligned default behavior (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::ShowClippingBounds()" reason="Removed orphaned UIElement.ShowClippingBounds diagnostic flag (no consumers) (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Timeline::DefaultsStartingValueFromAnimatedValue()" reason="Removed Timeline.DefaultsStartingValueFromAnimatedValue legacy flag; animations always default the starting value from the animated value (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/VisualState::ApplySettersBeforeTransition()" reason="Removed VisualState.ApplySettersBeforeTransition legacy flag; setters always applied at the WinUI-correct time (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Control::UseLegacyLazyApplyTemplate()" reason="Removed Control.UseLegacyLazyApplyTemplate legacy flag; templates always materialize eagerly (WinUI-aligned) (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Control::UseLegacyContentAlignment()" reason="Removed Control.UseLegacyContentAlignment legacy flag; content alignment always defaults to the WinUI-correct Center/Center (BC45, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/DataTemplateSelector::UseLegacyTemplateSelectorOverload()" reason="Removed DataTemplateSelector.UseLegacyTemplateSelectorOverload legacy flag; the two-arg SelectTemplate fallback always runs (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/ManipulationRoutedEventArgs::IsAbsolutePositionEnabled()" reason="Removed ManipulationRoutedEventArgs.IsAbsolutePositionEnabled legacy flag; manipulation Position is always container-relative (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::DisablePointersSpecificEventPrevention()" reason="Removed UIElement.DisablePointersSpecificEventPrevention legacy flag; specific-event prevention always used (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::UseInvalidateMeasurePath()" reason="Removed UIElement.UseInvalidateMeasurePath legacy flag; measure dirty-path is always on globally (per-element opt-out via FrameworkElementHelper remains) (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::UseInvalidateArrangePath()" reason="Removed UIElement.UseInvalidateArrangePath legacy flag; arrange dirty-path is always on globally (per-element opt-out via FrameworkElementHelper remains) (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Control::UseDeferredOnApplyTemplate()" reason="Removed Control.UseDeferredOnApplyTemplate legacy flag; OnApplyTemplate deferral is now a compile-time platform decision (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Popup::EnableLightDismissByDefault()" reason="Removed Popup.EnableLightDismissByDefault legacy flag; Popup.IsLightDismissEnabled always defaults to false (WinUI-aligned) (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/TextBox::UseOverlayOnSkia()" reason="Removed TextBox.UseOverlayOnSkia legacy flag; the Skia-based TextBox is always used (#2053, breaking changes for 7.0)" />
+		  <!-- Residual dead native-renderer FeatureConfiguration flags removed (#2125/#2052, breaking changes for 7.0). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::AssignDOMXamlName()" reason="Removed UIElement.AssignDOMXamlName flag; the WASM DOM annotation it gated no longer exists (#2125/#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::FailOnNSObjectExtensionsValidateDispose()" reason="Removed UIElement.FailOnNSObjectExtensionsValidateDispose flag; NSObjectExtensions.ValidateDispose it gated is gone (BC47) (#2125, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::AssignDOMXamlProperties()" reason="Removed UIElement.AssignDOMXamlProperties flag; the WASM DOM attribute annotation it gated no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Interop::ForceJavascriptInterop()" reason="Removed Interop.ForceJavascriptInterop flag; the WASM eval-mode interop switch it gated no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement::RenderToStringWithId()" reason="Removed UIElement.RenderToStringWithId flag; the WASM UIElement.ToString() override it gated no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/TextBlock::IsMeasureCacheEnabled()" reason="Removed TextBlock.IsMeasureCacheEnabled flag along with the orphaned TextBlockMeasureCache it gated (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/TextBlock::IsJavaStringCachedEnabled()" reason="Removed TextBlock.IsJavaStringCachedEnabled flag; the Android Java string-cache it gated no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Int32 Uno.UI.FeatureConfiguration/TextBlock::JavaStringCachedCapacity()" reason="Removed TextBlock.JavaStringCachedCapacity flag; the Android Java string-cache it sized no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Image::LegacyIosAlignment()" reason="Removed Image.LegacyIosAlignment flag; the UIKit ContentMode alignment path it selected no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Shape::WasmDelayUpdateUntilFirstArrange()" reason="Removed Shape.WasmDelayUpdateUntilFirstArrange flag; the WASM svg attribute assignment path it gated no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Shape::WasmCacheBBoxCalculationResult()" reason="Removed Shape.WasmCacheBBoxCalculationResult flag; the WASM getBBox cache it gated no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Int32 Uno.UI.FeatureConfiguration/Shape::WasmBBoxCacheSize()" reason="Removed Shape.WasmBBoxCacheSize flag; the WASM getBBox cache it sized no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Microsoft.UI.Xaml.Controls.Primitives.FlyoutBase::UseNativePopup()" reason="Removed FlyoutBase.UseNativePopup; the native popup presentation it selected no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Style::UseUWPDefaultStyles()" reason="Removed Style.UseUWPDefaultStyles flag; the native default styles it opted out of no longer exist (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Collections.Generic.IDictionary`2&lt;System.Type,System.Boolean&gt; Uno.UI.FeatureConfiguration/Style::UseUWPDefaultStylesOverride()" reason="Removed Style.UseUWPDefaultStylesOverride; the per-type native style opt-in it carried no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Uno.UI.Toolkit.MenuFlyoutItemExtensions::IsDestructiveProperty()" reason="Removed MenuFlyoutItemExtensions.IsDestructive; only the native iOS MenuFlyout presentation read it (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Uno.UI.Toolkit.MenuFlyoutExtensions::CancelTextIosOverrideProperty()" reason="Removed MenuFlyoutExtensions.CancelTextIosOverride; only the native iOS MenuFlyout presentation read it (#2052, breaking changes for 7.0)" />
+		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->
+		  <!-- BEGIN WinUI sync: WinRT IVector.Size replaced by ICollection.Count -->
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.CompositionColorGradientStopCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.CompositionShapeCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.ImplicitAnimationCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.InitialValueExpressionCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.Scenes.SceneComponentCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.Scenes.SceneMeshMaterialAttributeMap::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.Scenes.SceneNodeCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.ResourceDictionary::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="Microsoft.UI.Xaml.Documents.Block Microsoft.UI.Xaml.Documents.BlockCollection::Item(System.Int32)" reason="WinUI sync: indexer provided by base class" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Documents.InlineCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.BrushCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.DoubleCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.PointCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.TransformCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.Animation.PointKeyFrameCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.Animation.TransitionCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Controls.HubSectionCollection::Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <!-- END WinUI sync: WinRT IVector.Size -->
+
+		  <!-- BEGIN WinUI sync (Category A): WinRT IVector.Size projection removed across Windows.* collections.
+		       Same migration as the Microsoft.UI.* block above, extended to all 49 Windows.*
+		       collection types whose WinRT-projected uint Size getter is gone in WinAppSDK 1.8.
+		       Verified all 49 owners: 45 stub-only, 3 with real impls in Microsoft.UI.* namespace
+		       (their non-Generated impl uses ICollection.Count, not Size), 1
+		       (CompositionStrokeDashArray) has a real Size impl but only on the Microsoft.UI.Composition
+		       version which is preserved by this branch. The Windows.* stubs all threw
+		       NotImplementedException at runtime, so converting to a compile error is strictly
+		       an improvement for callers. The Windows\. prefix in the regex prevents matching
+		       any Microsoft.UI.* real impls. -->
+		  <Member fullName="System\.UInt32 Windows\..+::Size\(\)" reason="WinUI sync: WinRT IVector.Size projection removed across Windows.* collections (replaced by ICollection.Count)" isRegex="true" />
+		  <!-- END WinUI sync (Category A): Windows.* IVector.Size -->
+
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync (Category B): shadow property removals.               -->
+		  <!--                                                                        -->
+		  <!-- Properties on KEPT types whose getter/setter type is itself a removed  -->
+		  <!-- type (see Group X entries in <Types> above). Each entry is paired with -->
+		  <!-- a get_/set_ accessor in the <Methods> Category B block below.          -->
+		  <!-- All verified stub-only on master.                                      -->
+		  <!-- ====================================================================== -->
+
+		  <!-- Refs Group 4: Windows.ApplicationModel.AppExecutionContext -->
+		  <Member fullName="Windows.ApplicationModel.AppExecutionContext Windows.ApplicationModel.AppInfo::ExecutionContext()" reason="WinUI sync: returns removed type AppExecutionContext (Group 4)" />
+
+		  <!-- Refs Group 4: Windows.ApplicationModel.AppInstallerPolicySource -->
+		  <Member fullName="Windows.ApplicationModel.AppInstallerPolicySource Windows.ApplicationModel.AppInstallerInfo::PolicySource()" reason="WinUI sync: returns removed type AppInstallerPolicySource (Group 4)" />
+
+		  <!-- Refs Group 2: Windows.ApplicationModel.Calls.TransportDeviceAudioRoutingStatus -->
+		  <Member fullName="Windows.ApplicationModel.Calls.TransportDeviceAudioRoutingStatus Windows.ApplicationModel.Calls.PhoneLineTransportDevice::AudioRoutingStatus()" reason="WinUI sync: returns removed type TransportDeviceAudioRoutingStatus (Group 2)" />
+
+		  <!-- Refs Group 3: Windows.ApplicationModel.ConversationalAgent.SignalDetectorResourceKind -->
+		  <Member fullName="System\.Collections\.Generic\.IReadOnlyList`1&lt;Windows\.ApplicationModel\.ConversationalAgent\.SignalDetectorResourceKind&gt; Windows\.ApplicationModel\.ConversationalAgent\.DetectionConfigurationAvailabilityInfo::UnavailableSystemResources\(\)" reason="WinUI sync: returns list of removed enum SignalDetectorResourceKind (Group 3)" isRegex="true" />
+
+		  <!-- Refs Group 5b: Windows.Devices.Display.Core.DisplaySourceStatus -->
+		  <Member fullName="Windows.Devices.Display.Core.DisplaySourceStatus Windows.Devices.Display.Core.DisplaySource::Status()" reason="WinUI sync: returns removed enum DisplaySourceStatus (Group 5b)" />
+
+		  <!-- Refs Group 6: Windows.Graphics.Holographic.HolographicDepthReprojectionMethod -->
+		  <Member fullName="Windows.Graphics.Holographic.HolographicDepthReprojectionMethod Windows.Graphics.Holographic.HolographicCameraRenderingParameters::DepthReprojectionMethod()" reason="WinUI sync: returns removed enum HolographicDepthReprojectionMethod (Group 6)" />
+		  <Member fullName="System\.Collections\.Generic\.IReadOnlyList`1&lt;Windows\.Graphics\.Holographic\.HolographicDepthReprojectionMethod&gt; Windows\.Graphics\.Holographic\.HolographicViewConfiguration::SupportedDepthReprojectionMethods\(\)" reason="WinUI sync: returns list of removed enum HolographicDepthReprojectionMethod (Group 6)" isRegex="true" />
+
+		  <!-- Refs Group 8b: Windows.Media.Core.TimedTextBouten / TimedTextRuby -->
+		  <Member fullName="Windows.Media.Core.TimedTextBouten Windows.Media.Core.TimedTextStyle::Bouten()" reason="WinUI sync: returns removed type TimedTextBouten (Group 8b)" />
+		  <Member fullName="Windows.Media.Core.TimedTextRuby Windows.Media.Core.TimedTextStyle::Ruby()" reason="WinUI sync: returns removed type TimedTextRuby (Group 8b)" />
+
+		  <!-- Refs Group 8c: Windows.Media.Devices.CameraOcclusionInfo / DigitalWindowControl -->
+		  <Member fullName="Windows.Media.Devices.CameraOcclusionInfo Windows.Media.Devices.VideoDeviceController::CameraOcclusionInfo()" reason="WinUI sync: returns removed type CameraOcclusionInfo (Group 8c)" />
+		  <Member fullName="Windows.Media.Devices.DigitalWindowControl Windows.Media.Devices.VideoDeviceController::DigitalWindowControl()" reason="WinUI sync: returns removed type DigitalWindowControl (Group 8c)" />
+
+		  <!-- Refs Group 9a: Windows.Networking.NetworkOperators.MobileBroadbandCellNR / SlotManager -->
+		  <Member fullName="System\.Collections\.Generic\.IReadOnlyList`1&lt;Windows\.Networking\.NetworkOperators\.MobileBroadbandCellNR&gt; Windows\.Networking\.NetworkOperators\.MobileBroadbandCellsInfo::(Neighboring|Serving)CellsNR\(\)" reason="WinUI sync: returns list of removed type MobileBroadbandCellNR (Group 9a)" isRegex="true" />
+		  <Member fullName="Windows.Networking.NetworkOperators.MobileBroadbandSlotManager Windows.Networking.NetworkOperators.MobileBroadbandDeviceInformation::SlotManager()" reason="WinUI sync: returns removed type MobileBroadbandSlotManager (Group 9a)" />
+
+		  <!-- Refs Group 11c: Windows.UI.Notifications.ToastNotificationMode -->
+		  <Member fullName="Windows.UI.Notifications.ToastNotificationMode Windows.UI.Notifications.ToastNotificationManagerForUser::NotificationMode()" reason="WinUI sync: returns removed enum ToastNotificationMode (Group 11c)" />
+
+		  <!-- END WinUI sync (Category B): shadow property removals -->
+
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync (Category C): independent property removals.          -->
+		  <!--                                                                        -->
+		  <!-- Properties trimmed from kept types that DON'T reference a removed type -->
+		  <!-- in their signature. Microsoft restructured/removed these in WinAppSDK  -->
+		  <!-- 1.8 directly. Each property is paired with its get_/set_ accessor in   -->
+		  <!-- the <Methods> Category C block below.                                  -->
+		  <!--                                                                        -->
+		  <!-- Verified all stub-only on master (zero non-Generated impls of the      -->
+		  <!-- specific members, even where the owner type has a real Uno impl).     -->
+		  <!-- ====================================================================== -->
+
+		  <!-- AppExtensions / AppInfo / AppListEntry / AppInstallerInfo: heavy preview restructure -->
+		  <Member fullName="System.String Windows.ApplicationModel.AppExtensions.AppExtension::AppUserModelId()" reason="WinUI sync: AppExtension.AppUserModelId removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String[] Windows.ApplicationModel.AppInfo::SupportedFileExtensions()" reason="WinUI sync: AppInfo.SupportedFileExtensions removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.AppInfo Windows.ApplicationModel.Core.AppListEntry::AppInfo()" reason="WinUI sync: AppListEntry.AppInfo removed by WinAppSDK 1.8 (use Package.Current.Id)" />
+		  <!-- AppInstallerInfo: 15 properties trimmed in WinAppSDK 1.8 (preview install-policy/auto-update surface restructured). -->
+		  <Member fullName="System.Boolean Windows.ApplicationModel.AppInstallerInfo::AutomaticBackgroundTask()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.AppInstallerInfo::ForceUpdateFromAnyVersion()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.AppInstallerInfo::IsAutoRepairEnabled()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.AppInstallerInfo::OnLaunch()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.AppInstallerInfo::ShowPrompt()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.AppInstallerInfo::UpdateBlocksActivation()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System\.Collections\.Generic\.IReadOnlyList`1&lt;System\.Uri&gt; Windows\.ApplicationModel\.AppInstallerInfo::(DependencyPackage|OptionalPackage|Repair|Update)Uris\(\)" reason="WinUI sync: AppInstallerInfo URI list properties removed (preview)" isRegex="true" />
+		  <Member fullName="System.DateTimeOffset Windows.ApplicationModel.AppInstallerInfo::LastChecked()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Nullable`1&lt;System.DateTimeOffset&gt; Windows.ApplicationModel.AppInstallerInfo::PausedUntil()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.UInt32 Windows.ApplicationModel.AppInstallerInfo::HoursBetweenUpdateChecks()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="Windows.ApplicationModel.PackageVersion Windows.ApplicationModel.AppInstallerInfo::Version()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+
+		  <!-- PhoneLineTransportDevice: paired with Cat B InBandRingingEnabledChanged event -->
+		  <Member fullName="System.Boolean Windows.ApplicationModel.Calls.PhoneLineTransportDevice::InBandRingingEnabled()" reason="WinUI sync: paired with removed InBandRingingEnabledChanged event (Group 2)" />
+
+		  <!-- ConversationalAgent: ActivationSignalDetector / ConversationalAgentSignal preview surface -->
+		  <Member fullName="System.String Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector::DetectorId()" reason="WinUI sync: ConversationalAgent preview restructured" />
+		  <Member fullName="System.UInt32 Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration::TrainingStepCompletionMaxAllowedTime()" reason="WinUI sync: ConversationalAgent preview restructured" />
+		  <Member fullName="System.String Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSignal::DetectorId()" reason="WinUI sync: ConversationalAgent preview restructured" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectorKind Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSignal::DetectorKind()" reason="WinUI sync: ConversationalAgent preview restructured" />
+
+		  <!-- ResourceMapIterator / MapViewIterator: WinRT IIterator pattern dropped -->
+		  <Member fullName="System.Boolean Windows.ApplicationModel.Resources.Core.ResourceMapIterator::HasCurrent()" reason="WinUI sync: WinRT IIterator pattern removed (use IEnumerator)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.Resources.Core.ResourceMapMapViewIterator::HasCurrent()" reason="WinUI sync: WinRT IIterator pattern removed (use IEnumerator)" />
+
+		  <!-- Bluetooth/Display preview properties on kept types -->
+		  <Member fullName="System.Boolean Windows.Devices.Geolocation.Geocoordinate::IsRemoteSource()" reason="WinUI sync: preview Geocoordinate.IsRemoteSource removed by WinAppSDK 1.8" />
+		  <Member fullName="System\.Nullable`1&lt;System\.Double&gt; Windows\.Devices\.Geolocation\.GeocoordinateSatelliteData::(GeometricDilutionOfPrecision|TimeDilutionOfPrecision)\(\)" reason="WinUI sync: preview GNSS DOP properties removed by WinAppSDK 1.8" isRegex="true" />
+		  <Member fullName="System.Nullable`1&lt;Windows.Devices.Display.Core.DisplayPresentationRate&gt; Windows.Devices.Display.Core.DisplayPath::PhysicalPresentationRate()" reason="WinUI sync: preview DisplayPath.PhysicalPresentationRate removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Devices.Display.Core.DisplayPresentationRate Windows.Devices.Display.Core.DisplayModeInfo::PhysicalPresentationRate()" reason="WinUI sync: preview DisplayModeInfo.PhysicalPresentationRate removed by WinAppSDK 1.8" />
+
+		  <!-- KnownSimpleHapticsControllerWaveforms: 10 preview waveform constants removed.
+		       Uno only ships 4 waveforms (BuzzContinuous, Click, Press, Release). -->
+		  <Member fullName="System\.UInt16 Windows\.Devices\.Haptics\.KnownSimpleHapticsControllerWaveforms::(BrushContinuous|ChiselMarkerContinuous|EraserContinuous|Error|GalaxyPenContinuous|Hover|InkContinuous|MarkerContinuous|PencilContinuous|Success)\(\)" reason="WinUI sync: preview KnownSimpleHapticsControllerWaveforms constants removed by WinAppSDK 1.8 (Uno keeps BuzzContinuous/Click/Press/Release)" isRegex="true" />
+
+		  <!-- PenDevice / Inking preview -->
+		  <Member fullName="Windows.Devices.Haptics.SimpleHapticsController Windows.Devices.Input.PenDevice::SimpleHapticsController()" reason="WinUI sync: preview PenDevice.SimpleHapticsController removed by WinAppSDK 1.8" />
+		  <Member fullName="System.UInt32 Windows.UI.Input.Inking.InkStroke::PointerId()" reason="WinUI sync: preview InkStroke.PointerId removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Boolean Windows.UI.Input.Inking.InkInputConfiguration::IsPenHapticFeedbackEnabled()" reason="WinUI sync: preview pen-haptic-feedback removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.UI.Core.CoreCursor Windows.UI.Input.Inking.Core.CoreInkIndependentInputSource::PointerCursor()" reason="WinUI sync: preview CoreInkIndependentInputSource.PointerCursor removed by WinAppSDK 1.8" />
+
+		  <!-- Capture session border-required preview -->
+		  <Member fullName="System.Boolean Windows.Graphics.Capture.GraphicsCaptureSession::IsBorderRequired()" reason="WinUI sync: preview GraphicsCaptureSession.IsBorderRequired removed by WinAppSDK 1.8" />
+
+		  <!-- TimedTextStyle: properties associated with removed Bouten/Ruby (Group 8b) but
+		       not directly returning those types -->
+		  <Member fullName="System.Boolean Windows.Media.Core.TimedTextStyle::IsTextCombined()" reason="WinUI sync: TimedTextStyle preview property removed alongside Bouten/Ruby surface (Group 8b)" />
+		  <Member fullName="System.Double Windows.Media.Core.TimedTextStyle::FontAngleInDegrees()" reason="WinUI sync: TimedTextStyle preview property removed alongside Bouten/Ruby surface (Group 8b)" />
+
+		  <!-- PlayReady iterator HasCurrent: WinRT IIterator pattern dropped -->
+		  <Member fullName="System\.Boolean Windows\.Media\.Protection\.PlayReady\.PlayReady(Domain|License|SecureStop)Iterator::HasCurrent\(\)" reason="WinUI sync: WinRT IIterator pattern removed (use IEnumerator)" isRegex="true" />
+
+		  <!-- AppUriHandlerHost / Registration / RegistrationManager preview -->
+		  <Member fullName="System.Boolean Windows.System.AppUriHandlerHost::IsEnabled()" reason="WinUI sync: AppUriHandlerHost preview property removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String Windows.System.AppUriHandlerRegistration::PackageFamilyName()" reason="WinUI sync: AppUriHandlerRegistration preview property removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String Windows.System.AppUriHandlerRegistrationManager::PackageFamilyName()" reason="WinUI sync: AppUriHandlerRegistrationManager preview property removed by WinAppSDK 1.8" />
+
+		  <!-- KnownUserProperties / AnalyticsVersionInfo / SystemDiagnosticInfo preview -->
+		  <Member fullName="System.String Windows.System.KnownUserProperties::AgeEnforcementRegion()" reason="WinUI sync: preview AgeEnforcementRegion known-user-property removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String Windows.System.Profile.AnalyticsVersionInfo::ProductName()" reason="WinUI sync: preview AnalyticsVersionInfo.ProductName removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.ProcessorArchitecture Windows.System.Diagnostics.SystemDiagnosticInfo::PreferredArchitecture()" reason="WinUI sync: preview SystemDiagnosticInfo.PreferredArchitecture removed by WinAppSDK 1.8" />
+
+		  <!-- SpatialAudioFormatSubtype.DTSXForHomeTheater preview -->
+		  <Member fullName="System.String Windows.Media.Audio.SpatialAudioFormatSubtype::DTSXForHomeTheater()" reason="WinUI sync: preview DTSXForHomeTheater spatial-audio constant removed by WinAppSDK 1.8" />
+
+		  <!-- Windows.UI.Composition.Compositor.DispatcherQueue (legacy WinRT projection;
+		       Microsoft.UI.Composition.Compositor real impl uses Dispatching.DispatcherQueue.Main separately) -->
+		  <Member fullName="Windows.System.DispatcherQueue Windows.UI.Composition.Compositor::DispatcherQueue()" reason="WinUI sync: legacy Compositor.DispatcherQueue projection removed; Microsoft.UI.Composition.Compositor preserved" />
+
+		  <!-- Windows.UI.Composition.Visual: hit-test / pixel-snap properties.
+		       Verified zero impls in Uno's real Visual.cs across all platforms. -->
+		  <Member fullName="System.Boolean Windows.UI.Composition.Visual::IsHitTestVisible()" reason="WinUI sync: preview Visual.IsHitTestVisible removed by WinAppSDK 1.8 (no Uno impl)" />
+		  <Member fullName="System.Boolean Windows.UI.Composition.Visual::IsPixelSnappingEnabled()" reason="WinUI sync: preview Visual.IsPixelSnappingEnabled removed by WinAppSDK 1.8 (no Uno impl)" />
+
+		  <!-- StatusBar.ProgressIndicator: returns kept StatusBarProgressIndicator type
+		       but the getter itself was removed by the WinAppSDK 1.8 trim. -->
+		  <Member fullName="Windows.UI.ViewManagement.StatusBarProgressIndicator Windows.UI.ViewManagement.StatusBar::ProgressIndicator()" reason="WinUI sync: StatusBar.ProgressIndicator getter removed by WinAppSDK 1.8" />
+
+		  <!-- END WinUI sync (Category C): independent property removals -->
+
+
+		  <!-- ItemsRepeater.Animator property: paired with removed ElementAnimator type (see <Types> above). -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ItemsRepeater::AnimatorProperty()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator Microsoft.UI.Xaml.Controls.ItemsRepeater::Animator()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+
+		  <!-- DataContext restricted to FrameworkElement. DataContext / DataContextProperty are
+		       removed from UIElement and every non-FrameworkElement DependencyObject (Brush, Transform, Setter,
+		       GradientStop, Timeline, FlyoutBase, DependencyObjectCollection, ResourceDictionary, VisualState, ElementFactory, ...).
+		       FrameworkElement keeps them, so its members are never reported as removed and are unaffected by these patterns. -->
+		  <Member fullName="System\.Object .+(::|\.)DataContext\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)DataContextProperty\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+
+		  <!-- Uno-only native-bubbling knob (no WinUI counterpart); meaningless once native bubbling is gone on Skia. -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.UIElement::EventsBubblingInManagedCodeProperty()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Xaml.RoutedEventFlag Microsoft.UI.Xaml.UIElement::EventsBubblingInManagedCode()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+
+		  <!-- DependencyObject as class (BC26): property-backed store/TemplatedParent members now inherited from the base. -->
+		  <Member fullName="Windows\.UI\.Core\.CoreDispatcher .+(::|\.)Dispatcher\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Dispatching\.DispatcherQueue .+(::|\.)DispatcherQueue\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Boolean .+(::|\.)IsStoreInitialized\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyObject .+(::|\.)TemplatedParent\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)TemplatedParentProperty\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <!-- ColorKeyFrameCollection carried a binary-compat 'new'-shadow block (Size/Count/IsReadOnly/indexer) that its zero-shadow siblings Double/ObjectKeyFrameCollection never had; the get-only base DependencyObjectCollection<T> members show through with identical behavior. Accessor methods are paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.ColorKeyFrameCollection(::|\.)(Size|Count|IsReadOnly|Item)\(.*\)" reason="Removed ColorKeyFrameCollection binary-compat shadow members; provided by base DependencyObjectCollection&lt;T&gt; (BC67, breaking changes for 7.0)" isRegex="true" />
+
+		  <!-- DependencyObject as class (BC26): Uno-only members demoted to internal. Recorded explicitly rather than
+		       relying on the declaring-type wildcards above, so the demotion stays documented if those are tightened. -->
+		  <Member fullName="System.Boolean Microsoft.UI.Xaml.DependencyObject::IsStoreInitialized()" reason="DependencyObject as class: removed, was a constant with no consumer (BC26, breaking changes for 7.0)" />
+
+		  <!-- DependencyObject as class (BC26): properties of the removed DependencyObjectStore / IDependencyObjectStoreProvider. -->
+		  <Member fullName="^.+ Microsoft\.UI\.Xaml\.DependencyObjectStore(::|\.|/).+$" reason="DependencyObject as class: DependencyObjectStore removed" isRegex="true" />
+		  <Member fullName="^.+ Microsoft\.UI\.Xaml\.IDependencyObjectStoreProvider(::|\.).+$" reason="DependencyObject as class: IDependencyObjectStoreProvider removed" isRegex="true" />
+
+		  <!-- WindowActivatedEventArgs.WindowActivationState retyped from the Uno-only Windows.UI.Core.CoreWindowActivationState to the WinUI Microsoft.UI.Xaml.WindowActivationState; the old-typed property reads as removed (getter accessor paired in <Methods> below). -->
+		  <Member fullName="Windows.UI.Core.CoreWindowActivationState Microsoft.UI.Xaml.WindowActivatedEventArgs::WindowActivationState()" reason="Retyped WindowActivationState to Microsoft.UI.Xaml.WindowActivationState (BC13, breaking changes for 7.0)" />
+
+		  <!-- MediaPlayerPresenter reparented from Border to FrameworkElement (WinUI parity); the Border-only Child/BorderBrush/BorderThickness/CornerRadius/Padding/BackgroundSizing/ChildTransitions surface (and DP fields) reads as removed. Background goes with the old base too, but needs no entry here: it was declared on FrameworkElement, whose removal is ignored just below (BC38). Accessor methods paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.MediaPlayerPresenter(::|\.)(Child|ChildProperty|BorderBrush|BorderBrushProperty|BorderThickness|BorderThicknessProperty|CornerRadius|CornerRadiusProperty|Padding|PaddingProperty|BackgroundSizing|BackgroundSizingProperty|ChildTransitions|ChildTransitionsProperty|BackgroundTransition|BackgroundTransitionProperty)\(\)" reason="Reparented MediaPlayerPresenter from Border to FrameworkElement for WinUI parity; Border-only members removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
+		  <!-- FrameworkElement.Background removed: declared per-type to match WinUI (BC38, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Media.Brush Microsoft.UI.Xaml.FrameworkElement::Background()" reason="WinUI sync (BC38): Background declared per-type, not on FrameworkElement" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement::BackgroundProperty()" reason="WinUI sync (BC38): BackgroundProperty declared per-type, not on FrameworkElement" />
+
+		  <!-- Uno-only public ContentPresenter.ContentTemplateRoot reduced to internal (WinUI's ContentPresenter has no such member; the real WinUI ContentTemplateRoot lives on ContentControl). Accessors paired in <Methods> below. -->
+		  <Member fullName="Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Controls.ContentPresenter::ContentTemplateRoot()" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
+
+		  <!-- ImageBrush reparented to derive from a materialized TileBrush (Brush -> TileBrush -> ImageBrush, WinUI parity); AlignmentX/AlignmentY/Stretch and their DP fields are now declared on TileBrush and read as removed from ImageBrush (still resolve via inheritance at runtime). Accessor methods paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.ImageBrush(::|\.)(AlignmentX|AlignmentY|Stretch|AlignmentXProperty|AlignmentYProperty|StretchProperty)\(\)" reason="Moved AlignmentX/AlignmentY/Stretch owner from ImageBrush to TileBrush base for WinUI parity (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
+		  <!-- Uno-only public members removed/hidden to match WinUI (accessors paired in <Methods> below). -->
+		  <Member fullName="Microsoft.UI.Xaml.Data.UpdateSourceTrigger Microsoft.UI.Xaml.FrameworkPropertyMetadata::DefaultUpdateSourceTrigger()" reason="Removed Uno-only FrameworkPropertyMetadata.DefaultUpdateSourceTrigger (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.Border::ChildProperty()" reason="Removed Border.ChildProperty DP; Child is a plain CLR property in WinUI (breaking changes for 7.0, uno#8339)" />
+		  <!-- ScrollControllerPanRequestedEventArgs.PointerPoint retyped from Windows.UI.Input.PointerPoint to Microsoft.UI.Input.PointerPoint (getter/ctor paired in <Methods> below). -->
+		  <Member fullName="Windows.UI.Input.PointerPoint Microsoft.UI.Xaml.Controls.Primitives.ScrollControllerPanRequestedEventArgs::PointerPoint()" reason="Retyped ScrollControllerPanRequestedEventArgs.PointerPoint to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+
+		  <!-- BC41: legacy Windows.UI.Input.PointerPoint variant dropped and Windows.UI.Core.PointerEventArgs.CurrentPoint retyped to Microsoft.UI.Input.PointerPoint (getters paired in <Methods> below). -->
+		  <Member fullName="Windows.Devices.Input.PointerDeviceType Windows.UI.Input.PointerPoint::PointerDeviceType()" reason="Dropped legacy Windows.UI.Input.PointerPoint variant (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Windows.UI.Input.PointerPoint Windows.UI.Core.PointerEventArgs::CurrentPoint()" reason="Retyped Windows.UI.Core.PointerEventArgs.CurrentPoint to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+
+		  <!-- PrimaryLanguageOverride no longer applies the culture in its setter (restart-to-apply, as on WinUI), so the opt-out flag is gone. Accessors paired in <Methods> below. -->
+		  <Member fullName="System.Boolean Uno.WinRTFeatureConfiguration/ApplicationLanguages::UseLegacyPrimaryLanguageOverride()" reason="Removed ApplicationLanguages.UseLegacyPrimaryLanguageOverride legacy flag; PrimaryLanguageOverride is always restart-to-apply (BC50, breaking changes for 7.0)" />
+
+		  <!-- FadeIn/FadeOutThemeAnimation reparented from DoubleAnimation to Timeline (WinUI parity); the DoubleAnimation-only From/To/By/EasingFunction/EnableDependentAnimation properties (and their DP fields) read as removed. Accessor methods paired in <Methods> below. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.(FadeIn|FadeOut)ThemeAnimation(::|\.)(From|To|By|EasingFunction|EnableDependentAnimation|FromProperty|ToProperty|ByProperty|EasingFunctionProperty|EnableDependentAnimationProperty)\(\)" reason="Reparented *ThemeAnimation from DoubleAnimation to Timeline for WinUI parity; DoubleAnimation-only members removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
+		  <!-- BC01: vestigial DependencyObject.TemplatedParent storage removed; it was never written and every reader saw null (accessors paired in <Methods> below). -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyObject Microsoft.UI.Xaml.DependencyObject::TemplatedParent()" reason="BC01: vestigial TemplatedParent DP removed, disjoint from the storage the framework uses (uno#18672, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.DependencyObject::TemplatedParentProperty()" reason="BC01: vestigial TemplatedParentProperty removed (uno#18672, breaking changes for 7.0)" />
+
+		  <!-- BC01: TemplateMaterializationSettings moved to the Uno.UI namespace, and its per-member callback gave way to the OnMemberCreated instance method so the templated parent cannot be captured strongly (accessors paired in <Methods> below). -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.TemplateMaterializationSettings::(TemplatedParent|TemplateMemberCreatedCallback)\(\)" reason="BC01: type moved to Uno.UI; TemplateMemberCreatedCallback replaced by OnMemberCreated (uno#18672, breaking changes for 7.0)" isRegex="true" />
+	  </Properties>
+	  <Methods>
+		  <!-- Fluent resources-version accessors, paired with the <Properties> entries above (BC71, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ControlsResourcesVersion Microsoft.UI.Xaml.Controls.XamlControlsResources.get_ControlsResourcesVersion()" reason="Removed with the XamlControlsResources.ControlsResourcesVersion property (BC71, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.XamlControlsResources.set_ControlsResourcesVersion(Microsoft.UI.Xaml.Controls.ControlsResourcesVersion value)" reason="Removed with the XamlControlsResources.ControlsResourcesVersion property (BC71, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.XamlControlsResources.get_ControlsResourcesVersionProperty()" reason="Removed with the ControlsResourcesVersionProperty DP (BC71, breaking changes for 7.0)" />
+		  <Member fullName="System.Object Microsoft.UI.Xaml.Controls.XamlControlsResourcesV2.get_ControlsResourcesVersion()" reason="Removed with the inert XamlControlsResourcesV2.ControlsResourcesVersion stub (BC71, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.XamlControlsResourcesV2.set_ControlsResourcesVersion(System.Object value)" reason="Removed with the inert XamlControlsResourcesV2.ControlsResourcesVersion stub (BC71, breaking changes for 7.0)" />
+		  <!-- Any remaining member of the deleted Uno.UI.FluentTheme.v1 assembly (its generated GlobalStaticResources member set is not reproducible locally) or of XamlControlsResourcesV1. -->
+		  <Member fullName=".+ Uno\.UI\.FluentTheme\.v1\..+" reason="Member of the removed Uno.UI.FluentTheme.v1 assembly (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.XamlControlsResourcesV1(::|\.).+" reason="Member of the removed XamlControlsResourcesV1 type (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Uno\.UI\.FluentTheme\.v2\..+" reason="Member of the merged-away Uno.UI.FluentTheme.v2 assembly (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.XamlControlsResourcesV2(::|\.).+" reason="Member of the removed XamlControlsResourcesV2 type (BC71, breaking changes for 7.0)" isRegex="true" />
+		  <!-- Uno's legacy source-driven AnimatedVisualPlayer contract was removed in favor of WinUI's composition visual source contract. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Update(Microsoft.UI.Xaml.Controls.AnimatedVisualPlayer player)" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Load()" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Unload()" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Play(System.Double fromProgress, System.Double toProgress, System.Boolean looped)" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Stop()" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Pause()" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Resume()" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.SetProgress(System.Double progress)" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+		  <Member fullName="Windows.Foundation.Size Microsoft.UI.Xaml.Controls.IAnimatedVisualSource.Measure(Windows.Foundation.Size availableSize)" reason="Removed Uno-only IAnimatedVisualSource member to match WinUI (breaking changes for 7.0)" />
+
+		  <!-- Legacy source-driven Lottie methods were removed with the AnimatedVisualPlayer WinUI port. -->
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Play(System.Double fromProgress, System.Double toProgress, System.Boolean looped)" reason="Removed legacy source-driven Lottie playback API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Stop()" reason="Removed legacy source-driven Lottie playback API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Pause()" reason="Removed legacy source-driven Lottie playback API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Resume()" reason="Removed legacy source-driven Lottie playback API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.SetProgress(System.Double progress)" reason="Removed legacy source-driven Lottie playback API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Load()" reason="Removed legacy source-driven Lottie lifecycle API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Unload()" reason="Removed legacy source-driven Lottie lifecycle API (breaking changes for 7.0)" />
+		  <Member fullName="Windows.Foundation.Size CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Measure(Windows.Foundation.Size availableSize)" reason="Removed legacy source-driven Lottie measure API (breaking changes for 7.0)" />
+		  <Member fullName="System.Void CommunityToolkit.WinUI.Lottie.LottieVisualSourceBase.Update(Microsoft.UI.Xaml.Controls.AnimatedVisualPlayer player)" reason="Removed legacy source-driven Lottie update API (breaking changes for 7.0)" />
+
+		  <!-- Android head aligned on UnoPlatformHostBuilder (paired with the removed types above). -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.NativeApplication..ctor(Microsoft.UI.Xaml.NativeApplication/AppBuilder appBuilder, System.IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer)" reason="Replaced by the (IntPtr, JniHandleOwnership) ctor plus a CreateHost() override (breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.Runtime.Skia.Android.AndroidHost..ctor(System.Func`1&lt;Microsoft.UI.Xaml.Application&gt; appBuilder)" reason="AndroidHost reduced to internal; use UseAndroid() on the host builder (breaking changes for 7.0)" />
+		  <Member fullName="System.Threading.Tasks.Task Uno.UI.Runtime.Skia.Android.AndroidHost.Run()" reason="AndroidHost reduced to internal and now derives SkiaHost/UnoPlatformHost (breaking changes for 7.0)" />
+		  <!-- StackLayout.DisableVirtualizationProperty DP getter: paired with the removed property (see <Properties> above). DisableVirtualization is a plain CLR property in WinUI. -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.StackLayout.get_DisableVirtualizationProperty()" reason="WinUI sync: DisableVirtualization is a plain property in WinUI; DisableVirtualizationProperty DP removed (backed by internal IsVirtualizationEnabledProperty)" />
+		  <!-- Cursors.UseHandForInteraction / WebView2.IsInspectable accessors: paired with the removed properties (see <Properties> above). Native-only knobs removed with the native renderers (#2052). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Cursors.get_UseHandForInteraction()" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Cursors.set_UseHandForInteraction(System.Boolean value)" reason="Removed Cursors.UseHandForInteraction flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/WebView2.get_IsInspectable()" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/WebView2.set_IsInspectable(System.Boolean value)" reason="Removed WebView2.IsInspectable flag, superseded by EnableDevTools (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/AndroidSettings.get_IsEdgeToEdgeEnabled()" reason="Removed AndroidSettings.IsEdgeToEdgeEnabled flag; edge-to-edge is now unconditional on Skia-Android (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/AndroidSettings.set_IsEdgeToEdgeEnabled(System.Boolean value)" reason="Removed AndroidSettings.IsEdgeToEdgeEnabled flag; edge-to-edge is now unconditional on Skia-Android (#2052, breaking changes for 7.0)" />
+		  <!-- Binding.IgnoreINPCSameReferences accessors: paired with the removed property and holder class (#2053). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Binding.get_IgnoreINPCSameReferences()" reason="Removed Binding.IgnoreINPCSameReferences legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Binding.set_IgnoreINPCSameReferences(System.Boolean value)" reason="Removed Binding.IgnoreINPCSameReferences legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/FrameworkElement.get_UseLegacyHitTest()" reason="Removed FrameworkElement.UseLegacyHitTest legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/FrameworkElement.set_UseLegacyHitTest(System.Boolean value)" reason="Removed FrameworkElement.UseLegacyHitTest legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_ShowClippingBounds()" reason="Removed orphaned UIElement.ShowClippingBounds diagnostic flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_ShowClippingBounds(System.Boolean value)" reason="Removed orphaned UIElement.ShowClippingBounds diagnostic flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Timeline.get_DefaultsStartingValueFromAnimatedValue()" reason="Removed Timeline.DefaultsStartingValueFromAnimatedValue legacy flag (get-only) (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/VisualState.get_ApplySettersBeforeTransition()" reason="Removed VisualState.ApplySettersBeforeTransition legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/VisualState.set_ApplySettersBeforeTransition(System.Boolean value)" reason="Removed VisualState.ApplySettersBeforeTransition legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Control.get_UseLegacyLazyApplyTemplate()" reason="Removed Control.UseLegacyLazyApplyTemplate legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Control.set_UseLegacyLazyApplyTemplate(System.Boolean value)" reason="Removed Control.UseLegacyLazyApplyTemplate legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Control.get_UseLegacyContentAlignment()" reason="Removed Control.UseLegacyContentAlignment legacy flag (BC45, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Control.set_UseLegacyContentAlignment(System.Boolean value)" reason="Removed Control.UseLegacyContentAlignment legacy flag (BC45, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/DataTemplateSelector.get_UseLegacyTemplateSelectorOverload()" reason="Removed DataTemplateSelector.UseLegacyTemplateSelectorOverload legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/DataTemplateSelector.set_UseLegacyTemplateSelectorOverload(System.Boolean value)" reason="Removed DataTemplateSelector.UseLegacyTemplateSelectorOverload legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/ManipulationRoutedEventArgs.get_IsAbsolutePositionEnabled()" reason="Removed ManipulationRoutedEventArgs.IsAbsolutePositionEnabled legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/ManipulationRoutedEventArgs.set_IsAbsolutePositionEnabled(System.Boolean value)" reason="Removed ManipulationRoutedEventArgs.IsAbsolutePositionEnabled legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_DisablePointersSpecificEventPrevention()" reason="Removed UIElement.DisablePointersSpecificEventPrevention legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_DisablePointersSpecificEventPrevention(System.Boolean value)" reason="Removed UIElement.DisablePointersSpecificEventPrevention legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_UseInvalidateMeasurePath()" reason="Removed UIElement.UseInvalidateMeasurePath legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_UseInvalidateMeasurePath(System.Boolean value)" reason="Removed UIElement.UseInvalidateMeasurePath legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_UseInvalidateArrangePath()" reason="Removed UIElement.UseInvalidateArrangePath legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_UseInvalidateArrangePath(System.Boolean value)" reason="Removed UIElement.UseInvalidateArrangePath legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Control.get_UseDeferredOnApplyTemplate()" reason="Removed Control.UseDeferredOnApplyTemplate legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Control.set_UseDeferredOnApplyTemplate(System.Boolean value)" reason="Removed Control.UseDeferredOnApplyTemplate legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Popup.get_EnableLightDismissByDefault()" reason="Removed Popup.EnableLightDismissByDefault legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Popup.set_EnableLightDismissByDefault(System.Boolean value)" reason="Removed Popup.EnableLightDismissByDefault legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/TextBox.get_UseOverlayOnSkia()" reason="Removed TextBox.UseOverlayOnSkia legacy flag (#2053, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/TextBox.set_UseOverlayOnSkia(System.Boolean value)" reason="Removed TextBox.UseOverlayOnSkia legacy flag (#2053, breaking changes for 7.0)" />
+		  <!-- Residual dead native-renderer flag accessors: paired with the removed properties (see <Properties> above) (#2125/#2052). -->
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_AssignDOMXamlName()" reason="Removed UIElement.AssignDOMXamlName flag (#2125/#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_AssignDOMXamlName(System.Boolean value)" reason="Removed UIElement.AssignDOMXamlName flag (#2125/#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_FailOnNSObjectExtensionsValidateDispose()" reason="Removed UIElement.FailOnNSObjectExtensionsValidateDispose flag (#2125, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_FailOnNSObjectExtensionsValidateDispose(System.Boolean value)" reason="Removed UIElement.FailOnNSObjectExtensionsValidateDispose flag (#2125, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_AssignDOMXamlProperties()" reason="Removed UIElement.AssignDOMXamlProperties flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_AssignDOMXamlProperties(System.Boolean value)" reason="Removed UIElement.AssignDOMXamlProperties flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Interop.get_ForceJavascriptInterop()" reason="Removed Interop.ForceJavascriptInterop flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Interop.set_ForceJavascriptInterop(System.Boolean value)" reason="Removed Interop.ForceJavascriptInterop flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/UIElement.get_RenderToStringWithId()" reason="Removed UIElement.RenderToStringWithId flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/UIElement.set_RenderToStringWithId(System.Boolean value)" reason="Removed UIElement.RenderToStringWithId flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/TextBlock.get_IsMeasureCacheEnabled()" reason="Removed TextBlock.IsMeasureCacheEnabled flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/TextBlock.set_IsMeasureCacheEnabled(System.Boolean value)" reason="Removed TextBlock.IsMeasureCacheEnabled flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/TextBlock.get_IsJavaStringCachedEnabled()" reason="Removed TextBlock.IsJavaStringCachedEnabled flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/TextBlock.set_IsJavaStringCachedEnabled(System.Boolean value)" reason="Removed TextBlock.IsJavaStringCachedEnabled flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Int32 Uno.UI.FeatureConfiguration/TextBlock.get_JavaStringCachedCapacity()" reason="Removed TextBlock.JavaStringCachedCapacity flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/TextBlock.set_JavaStringCachedCapacity(System.Int32 value)" reason="Removed TextBlock.JavaStringCachedCapacity flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Image.get_LegacyIosAlignment()" reason="Removed Image.LegacyIosAlignment flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Image.set_LegacyIosAlignment(System.Boolean value)" reason="Removed Image.LegacyIosAlignment flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Shape.get_WasmDelayUpdateUntilFirstArrange()" reason="Removed Shape.WasmDelayUpdateUntilFirstArrange flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Shape.set_WasmDelayUpdateUntilFirstArrange(System.Boolean value)" reason="Removed Shape.WasmDelayUpdateUntilFirstArrange flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Shape.get_WasmCacheBBoxCalculationResult()" reason="Removed Shape.WasmCacheBBoxCalculationResult flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Shape.set_WasmCacheBBoxCalculationResult(System.Boolean value)" reason="Removed Shape.WasmCacheBBoxCalculationResult flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Int32 Uno.UI.FeatureConfiguration/Shape.get_WasmBBoxCacheSize()" reason="Removed Shape.WasmBBoxCacheSize flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Shape.set_WasmBBoxCacheSize(System.Int32 value)" reason="Removed Shape.WasmBBoxCacheSize flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Microsoft.UI.Xaml.Controls.Primitives.FlyoutBase.get_UseNativePopup()" reason="Removed FlyoutBase.UseNativePopup (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Primitives.FlyoutBase.set_UseNativePopup(System.Boolean value)" reason="Removed FlyoutBase.UseNativePopup (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.FeatureConfiguration/Style.get_UseUWPDefaultStyles()" reason="Removed Style.UseUWPDefaultStyles flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Style.set_UseUWPDefaultStyles(System.Boolean value)" reason="Removed Style.UseUWPDefaultStyles flag (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Collections.Generic.IDictionary`2&lt;System.Type,System.Boolean&gt; Uno.UI.FeatureConfiguration/Style.get_UseUWPDefaultStylesOverride()" reason="Removed Style.UseUWPDefaultStylesOverride (get-only) (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Style.ConfigureNativeFrameNavigation()" reason="Removed Style.ConfigureNativeFrameNavigation(); native frame navigation no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.FeatureConfiguration/Style.SetUWPDefaultStylesOverride(System.Boolean useUWPDefaultStyle)" reason="Removed Style.SetUWPDefaultStylesOverride&lt;TControl&gt;(); the per-type native style opt-in it wrote no longer exists (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Style.RegisterDefaultStyleForType(System.Type type, Uno.UI.IXamlResourceDictionaryProvider dictionaryProvider, System.Boolean isNative)" reason="RegisterDefaultStyleForType lost its isNative parameter with the native default styles; the 2-parameter overload replaces it (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.Converters.UnoNativeDefaultProgressBarReverseBoolConverter..ctor()" reason="Removed Uno-internal converter used only by the deleted NativeDefaultProgressBar style (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Object Uno.UI.Converters.UnoNativeDefaultProgressBarReverseBoolConverter.Convert(System.Object value, System.Type targetType, System.Object parameter)" reason="Removed Uno-internal converter used only by the deleted NativeDefaultProgressBar style (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Object Uno.UI.Converters.UnoNativeDefaultProgressBarReverseBoolConverter.ConvertBack(System.Object value, System.Type targetType, System.Object parameter)" reason="Removed Uno-internal converter used only by the deleted NativeDefaultProgressBar style (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Uno.UI.Toolkit.MenuFlyoutItemExtensions.get_IsDestructiveProperty()" reason="Removed MenuFlyoutItemExtensions.IsDestructive (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.Toolkit.MenuFlyoutItemExtensions.SetIsDestructive(Microsoft.UI.Xaml.Controls.MenuFlyoutItem menuFlyoutItem, System.Boolean isDestructive)" reason="Removed MenuFlyoutItemExtensions.IsDestructive (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Uno.UI.Toolkit.MenuFlyoutItemExtensions.GetIsDestructive(Microsoft.UI.Xaml.Controls.MenuFlyoutItem menuFlyoutItem)" reason="Removed MenuFlyoutItemExtensions.IsDestructive (#2052, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Uno.UI.Toolkit.MenuFlyoutExtensions.get_CancelTextIosOverrideProperty()" reason="Removed MenuFlyoutExtensions.CancelTextIosOverride (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.String Uno.UI.Toolkit.MenuFlyoutExtensions.GetCancelTextIosOverride(Microsoft.UI.Xaml.Controls.MenuFlyout obj)" reason="Removed MenuFlyoutExtensions.CancelTextIosOverride (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.Toolkit.MenuFlyoutExtensions.SetCancelTextIosOverride(Microsoft.UI.Xaml.Controls.MenuFlyout obj, System.String value)" reason="Removed MenuFlyoutExtensions.CancelTextIosOverride (#2052, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Uno.UI.Toolkit.MenuFlyoutExtensions..ctor()" reason="Removed MenuFlyoutExtensions (non-static class, implicit public constructor) (#2052, breaking changes for 7.0)" />
+		  <!-- NavigationView API surface aligned to the WinUI IDL: get-only properties and a non-activatable args type. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationView.set_SettingsItem(System.Object value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_CompactPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewItem.set_MenuItems(System.Collections.Generic.IList`1&lt;System.Object&gt; value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings.set_OpenPaneLength(System.Double value)" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs..ctor()" reason="Aligned to WinUI IDL (get-only / non-activatable)" />
+
+		  <!-- #8339 (sync-generator alignment): method/constructor parameter names aligned to the WinAppSDK/CsWinRT
+		       metadata for 7.0 (removed the SymbolMatchingHelpers.IgnoreParameterName workaround). Only public members
+		       appear in the diff; the internal PointInt32/RectInt32/SizeInt32 ctors are excluded. Source-only break
+		       (parameter names are not part of the binary signature); affects named-argument callers. -->
+		  <Member fullName="System.Void Windows.UI.Text.FontWeight..ctor(System.UInt16 weight)" reason="WinUI sync #8339: FontWeight ctor param weight-&gt;_Weight (matches WinAppSDK metadata)" />
+		  <Member fullName="System.Void Windows.Foundation.Rect..ctor(Windows.Foundation.Point point, Windows.Foundation.Size size)" reason="WinUI sync #8339: Rect(Point,Size) ctor param point-&gt;location (matches WinAppSDK metadata)" />
+		  <Member fullName="System.Int32 Microsoft.UI.Xaml.Duration.Compare(Microsoft.UI.Xaml.Duration first, Microsoft.UI.Xaml.Duration second)" reason="WinUI sync #8339: Duration.Compare params first/second-&gt;t1/t2 (matches WinAppSDK metadata)" />
+		  <Member fullName="System.IO.Stream System.IO.WindowsRuntimeStreamExtensions.AsStream(Windows.Storage.Streams.IRandomAccessStream windowsRuntimeStream)" reason="WinUI sync #8339: windowsRuntimeStream-&gt;windowsruntimeStream (matches WinAppSDK metadata)" />
+		  <Member fullName="System.IO.Stream System.IO.WindowsRuntimeStreamExtensions.AsStream(Windows.Storage.Streams.IRandomAccessStream windowsRuntimeStream, System.Int32 bufferSize)" reason="WinUI sync #8339: windowsRuntimeStream-&gt;windowsruntimeStream (matches WinAppSDK metadata)" />
+		  <Member fullName="System.IO.Stream System.IO.WindowsRuntimeStreamExtensions.AsStreamForRead(Windows.Storage.Streams.IInputStream windowsRuntimeStream)" reason="WinUI sync #8339: windowsRuntimeStream-&gt;windowsruntimeStream (matches WinAppSDK metadata)" />
+		  <Member fullName="System.IO.Stream System.IO.WindowsRuntimeStreamExtensions.AsStreamForRead(Windows.Storage.Streams.IInputStream windowsRuntimeStream, System.Int32 bufferSize)" reason="WinUI sync #8339: windowsRuntimeStream-&gt;windowsruntimeStream (matches WinAppSDK metadata)" />
+		  <Member fullName="System.IO.Stream System.IO.WindowsRuntimeStreamExtensions.AsStreamForWrite(Windows.Storage.Streams.IOutputStream windowsRuntimeStream)" reason="WinUI sync #8339: windowsRuntimeStream-&gt;windowsruntimeStream (matches WinAppSDK metadata)" />
+		  <Member fullName="System.IO.Stream System.IO.WindowsRuntimeStreamExtensions.AsStreamForWrite(Windows.Storage.Streams.IOutputStream windowsRuntimeStream, System.Int32 bufferSize)" reason="WinUI sync #8339: windowsRuntimeStream-&gt;windowsruntimeStream (matches WinAppSDK metadata)" />
+		  <!-- ==== Relocated from the retired 6.5 set when the diff base advanced to 6.6.166: still breaking against 6.6.x (none of these removals shipped in a 6.6 stable). ==== -->
+		  <!-- BEGIN AutomationPeer API alignment -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.AutomationPeer.RaiseTextEditTextChangedEvent(Microsoft.UI.Xaml.Automation.AutomationTextEditChangeType automationTextEditChangeType, System.Collections.Generic.IReadOnlyList`1&lt;System.String&gt; changedData)" reason="AP reorganization - API alignment" />
+		  <Member fullName="Microsoft.UI.Xaml.Automation.Peers.RawElementProviderRuntimeId Microsoft.UI.Xaml.Automation.Peers.AutomationPeer.GenerateRawElementProviderRuntimeId()" reason="AP reorganization - API alignment" />
+		  <Member fullName="System.Object Microsoft.UI.Xaml.Automation.Peers.AutomationPeer.GetElementFromPointCore(Windows.Foundation.Point pointInWindowCoordinates)" reason="AP reorganization - API alignment" />
+		  <Member fullName="Microsoft.UI.Xaml.Automation.Provider.IRawElementProviderSimple Microsoft.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer.FindItemByProperty(Microsoft.UI.Xaml.Automation.Provider.IRawElementProviderSimple startAfter, Microsoft.UI.Xaml.Automation.AutomationProperty automationProperty, System.Object value)" reason="AP reorganization - API alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer..ctor(Microsoft.UI.Xaml.FrameworkElement e)" reason="AP reorganization - constructor signature alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer..ctor(System.Object e)" reason="AP reorganization - constructor signature alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.ListViewBaseAutomationPeer..ctor(System.Object e)" reason="AP reorganization - constructor signature alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.ListViewBaseHeaderItemAutomationPeer..ctor(System.Object owner)" reason="AP reorganization - constructor signature alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.SelectorAutomationPeer..ctor(System.Object o)" reason="AP reorganization - constructor signature alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.TreeViewItemDataAutomationPeer..ctor(System.Object item, Microsoft.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent)" reason="AP reorganization - constructor signature alignment" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Automation.Peers.DatePickerFlyoutPresenterAutomationPeer..ctor()" reason="AP reorganization - constructor signature alignment (now requires owner)" />
+		  <!-- END AutomationPeer API alignment -->
+
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Layout.InvalidateMeasure()" reason="protected to protected internal" />
+
+		  <!-- Replaced generic App<TApplication>(Func<TApplication>) with non-generic App(Func<Application>)
+		       to prevent CoreCLR shared-generic policy from placing Func<TApp> instantiations in the default
+		       ALC's LoaderAllocator, which otherwise creates a permanent cross-LA reference into the inner
+		       app's MethodTable and prevents collectible AssemblyLoadContext unload.
+		       Callers using .App<App>(...) need to drop the explicit type argument to resolve to the new
+		       non-generic overload. UnoPlatformHostBuilderExtensions is source-rebuilt per consuming app. -->
+		  <Member fullName="Uno.UI.Hosting.IUnoPlatformHostBuilder Uno.UI.Hosting.UnoPlatformHostBuilderExtensions.App(Uno.UI.Hosting.IUnoPlatformHostBuilder builder, System.Func`1&lt;TApplication&gt; appBuilder)" reason="Replaced by non-generic App(Func&lt;Application&gt;) to allow collectible ALC collection on CoreCLR" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.MenuFlyoutSubItem.SetSubMenuDirection(System.Boolean isSubMenuDirectionUp)" reason="Moved to explicit ISubMenuOwner interface implementation" />
+
+		  <!-- BEGIN WinUI sync: WinRT IVector.get_Size replaced by ICollection.Count -->
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.CompositionColorGradientStopCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.CompositionShapeCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.ImplicitAnimationCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.InitialValueExpressionCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.Scenes.SceneComponentCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.Scenes.SceneMeshMaterialAttributeMap.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Composition.Scenes.SceneNodeCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.ResourceDictionary.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Documents.InlineCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.BrushCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.DoubleCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.PointCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.TransformCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.Animation.PointKeyFrameCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Media.Animation.TransitionCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <Member fullName="System.UInt32 Microsoft.UI.Xaml.Controls.HubSectionCollection.get_Size()" reason="WinUI sync: WinRT Size replaced by Count" />
+		  <!-- END WinUI sync: WinRT IVector.get_Size -->
+
+		  <!-- BEGIN WinUI sync (Category A): WinRT IVector.get_Size projection removed across Windows.* collections.
+		       Companion to the Properties-section regex above. Covers ~49 owner types across:
+		       Windows.ApplicationModel.Resources.Core.* (7), Windows.Web.Http(.Headers).* (17),
+		       Windows.UI.Composition.* incl. Scenes.* (8), Windows.Media.Playback.* (3),
+		       Windows.Data.Json (2), plus 12 misc (WwwFormUrlDecoder, BitmapPropertySet,
+		       DnssdServiceInstanceCollection, ApplicationDataContainerSettings, etc.).
+		       Verified all 49 stub-only on master (would throw NotImplementedException at runtime).
+		       Windows\. prefix prevents matching preserved Microsoft.UI.* real impls. -->
+		  <Member fullName="System\.UInt32 Windows\..+\.get_Size\(\)" reason="WinUI sync: WinRT IVector.get_Size projection removed across Windows.* collections (replaced by ICollection.Count)" isRegex="true" />
+		  <!-- END WinUI sync (Category A): Windows.* IVector.get_Size -->
+		  <!-- BEGIN WinUI sync: other removed methods -->
+		  <Member fullName="System.Boolean Microsoft.UI.Xaml.SizeHelper.Equals(Windows.Foundation.Size target, Windows.Foundation.Size value)" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <Member fullName="Microsoft.UI.Xaml.Documents.Block Microsoft.UI.Xaml.Documents.BlockCollection.get_Item(System.Int32 index)" reason="WinUI sync: indexer provided by base class" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Documents.BlockCollection.set_Item(System.Int32 index, Microsoft.UI.Xaml.Documents.Block value)" reason="WinUI sync: indexer provided by base class" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.VirtualizingStackPanel.OnCleanUpVirtualizedItem(Microsoft.UI.Xaml.Controls.CleanUpVirtualizedItemEventArgs e)" reason="WinUI sync: not in WinAppSDK 1.8" />
+		  <!-- END WinUI sync: other removed methods -->
+
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync (Category B): shadow method removals.                 -->
+		  <!--                                                                        -->
+		  <!-- Methods on KEPT types whose signature references a removed type        -->
+		  <!-- (Group X entries in <Types>). These had to go from the kept type's     -->
+		  <!-- surface because the parameter or return type is gone.                  -->
+		  <!--                                                                        -->
+		  <!-- Includes: property accessors (get_/set_), event accessors (add_/      -->
+		  <!-- remove_), and regular methods. Each block is annotated with the Group  -->
+		  <!-- number from the <Types> section it depends on.                         -->
+		  <!--                                                                        -->
+		  <!-- All verified stub-only on master. Spot-checked owner types with real   -->
+		  <!-- Uno impls (Compositor, Visual, BluetoothLEDevice, etc.): the specific  -->
+		  <!-- removed members were never implemented.                                -->
+		  <!-- ====================================================================== -->
+
+		  <!-- Refs Group 4: Windows.ApplicationModel.AppExecutionContext -->
+		  <Member fullName="Windows.ApplicationModel.AppExecutionContext Windows.ApplicationModel.AppInfo.get_ExecutionContext()" reason="WinUI sync: returns removed type AppExecutionContext (Group 4)" />
+
+		  <!-- Refs Group 4: Windows.ApplicationModel.AppInstallerPolicySource -->
+		  <Member fullName="Windows.ApplicationModel.AppInstallerPolicySource Windows.ApplicationModel.AppInstallerInfo.get_PolicySource()" reason="WinUI sync: returns removed type AppInstallerPolicySource (Group 4)" />
+
+		  <!-- Refs Group 2: Windows.ApplicationModel.Calls.* legacy phone-call types.
+		       PhoneLine factory/dial methods returning removed result types, and
+		       PhoneLineTransportDevice members exposing the removed audio-routing-status enum. -->
+		  <Member fullName="Windows.ApplicationModel.Calls.PhoneCallsResult Windows.ApplicationModel.Calls.PhoneLine.GetAllActivePhoneCalls()" reason="WinUI sync: returns removed type PhoneCallsResult (Group 2)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.Calls.PhoneCallsResult&gt; Windows.ApplicationModel.Calls.PhoneLine.GetAllActivePhoneCallsAsync()" reason="WinUI sync: async returns removed type PhoneCallsResult (Group 2)" />
+		  <Member fullName="Windows.ApplicationModel.Calls.PhoneLineDialResult Windows.ApplicationModel.Calls.PhoneLine.DialWithResult(System.String number, System.String displayName)" reason="WinUI sync: returns removed type PhoneLineDialResult (Group 2)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.Calls.PhoneLineDialResult&gt; Windows.ApplicationModel.Calls.PhoneLine.DialWithResultAsync(System.String number, System.String displayName)" reason="WinUI sync: async returns removed type PhoneLineDialResult (Group 2)" />
+		  <Member fullName="Windows.ApplicationModel.Calls.TransportDeviceAudioRoutingStatus Windows.ApplicationModel.Calls.PhoneLineTransportDevice.get_AudioRoutingStatus()" reason="WinUI sync: returns removed enum TransportDeviceAudioRoutingStatus (Group 2)" />
+		  <!-- PhoneLineTransportDevice: the InBandRingingEnabled property and AudioRoutingStatusChanged/InBandRingingEnabledChanged event accessors below are paired with removed events (see <Events> Category B block). -->
+		  <Member fullName="System.Boolean Windows.ApplicationModel.Calls.PhoneLineTransportDevice.get_InBandRingingEnabled()" reason="WinUI sync: removed alongside InBandRingingEnabledChanged event (Group 2)" />
+		  <Member fullName="System\.Void Windows\.ApplicationModel\.Calls\.PhoneLineTransportDevice\.(add|remove)_(AudioRoutingStatusChanged|InBandRingingEnabledChanged)\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.ApplicationModel\.Calls\.PhoneLineTransportDevice,System\.Object&gt; value\)" reason="WinUI sync: event accessors for removed PhoneLineTransportDevice events (Group 2)" isRegex="true" />
+
+		  <!-- Refs Group 3: ConversationalAgent result/configuration types -->
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationCreationResult Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.CreateConfigurationWithResult(System.String signalId, System.String modelId, System.String displayName)" reason="WinUI sync: returns removed type ActivationSignalDetectionConfigurationCreationResult (Group 3)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationCreationResult&gt; Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.CreateConfigurationWithResultAsync(System.String signalId, System.String modelId, System.String displayName)" reason="WinUI sync: async returns removed type ActivationSignalDetectionConfigurationCreationResult (Group 3)" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationRemovalResult Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.RemoveConfigurationWithResult(System.String signalId, System.String modelId)" reason="WinUI sync: returns removed type ActivationSignalDetectionConfigurationRemovalResult (Group 3)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationRemovalResult&gt; Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.RemoveConfigurationWithResultAsync(System.String signalId, System.String modelId)" reason="WinUI sync: async returns removed type ActivationSignalDetectionConfigurationRemovalResult (Group 3)" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationSetModelDataResult Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration.SetModelDataWithResult(System.String dataType, Windows.Storage.Streams.IInputStream data)" reason="WinUI sync: returns removed type ActivationSignalDetectionConfigurationSetModelDataResult (Group 3)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationSetModelDataResult&gt; Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration.SetModelDataWithResultAsync(System.String dataType, Windows.Storage.Streams.IInputStream data)" reason="WinUI sync: async returns removed type (Group 3)" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationStateChangeResult Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration.SetEnabledWithResult(System.Boolean value)" reason="WinUI sync: returns removed type ActivationSignalDetectionConfigurationStateChangeResult (Group 3)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfigurationStateChangeResult&gt; Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration.SetEnabledWithResultAsync(System.Boolean value)" reason="WinUI sync: async returns removed type (Group 3)" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ConversationalAgentActivationResult Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession.RequestActivation(Windows.ApplicationModel.ConversationalAgent.ConversationalAgentActivationKind activationKind)" reason="WinUI sync: takes removed enum ConversationalAgentActivationKind / returns removed type (Group 3)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.ConversationalAgent.ConversationalAgentActivationResult&gt; Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession.RequestActivationAsync(Windows.ApplicationModel.ConversationalAgent.ConversationalAgentActivationKind activationKind)" reason="WinUI sync: async takes/returns removed types (Group 3)" />
+		  <Member fullName="System.Collections.Generic.IReadOnlyList`1&lt;Windows.ApplicationModel.ConversationalAgent.ConversationalAgentVoiceActivationPrerequisiteKind&gt; Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession.GetMissingPrerequisites()" reason="WinUI sync: returns list of removed enum ConversationalAgentVoiceActivationPrerequisiteKind (Group 3)" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;System.Collections.Generic.IReadOnlyList`1&lt;Windows.ApplicationModel.ConversationalAgent.ConversationalAgentVoiceActivationPrerequisiteKind&gt;&gt; Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession.GetMissingPrerequisitesAsync()" reason="WinUI sync: async returns list of removed enum (Group 3)" />
+		  <Member fullName="System.Collections.Generic.IReadOnlyList`1&lt;Windows.ApplicationModel.ConversationalAgent.SignalDetectorResourceKind&gt; Windows.ApplicationModel.ConversationalAgent.DetectionConfigurationAvailabilityInfo.get_UnavailableSystemResources()" reason="WinUI sync: returns list of removed enum SignalDetectorResourceKind (Group 3)" />
+
+		  <!-- Refs Group 5a: Windows.Devices.Bluetooth.BluetoothLE PHY/preferred-connection types -->
+		  <Member fullName="Windows.Devices.Bluetooth.BluetoothLEConnectionParameters Windows.Devices.Bluetooth.BluetoothLEDevice.GetConnectionParameters()" reason="WinUI sync: returns removed BLE PHY type (Group 5a)" />
+		  <Member fullName="Windows.Devices.Bluetooth.BluetoothLEConnectionPhy Windows.Devices.Bluetooth.BluetoothLEDevice.GetConnectionPhy()" reason="WinUI sync: returns removed BLE PHY type (Group 5a)" />
+		  <Member fullName="Windows.Devices.Bluetooth.BluetoothLEPreferredConnectionParametersRequest Windows.Devices.Bluetooth.BluetoothLEDevice.RequestPreferredConnectionParameters(Windows.Devices.Bluetooth.BluetoothLEPreferredConnectionParameters preferredConnectionParameters)" reason="WinUI sync: takes/returns removed BLE PHY types (Group 5a)" />
+		  <Member fullName="System\.Void Windows\.Devices\.Bluetooth\.BluetoothLEDevice\.(add|remove)_(ConnectionParametersChanged|ConnectionPhyChanged)\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.Devices\.Bluetooth\.BluetoothLEDevice,System\.Object&gt; value\)" reason="WinUI sync: event accessors for removed BLE PHY events (Group 5a)" isRegex="true" />
+
+		  <!-- Refs Group 5b: Windows.Devices.Display.Core.* preview status enums -->
+		  <Member fullName="Windows.Devices.Display.Core.DisplayScanout Windows.Devices.Display.Core.DisplayDevice.CreateSimpleScanoutWithDirtyRectsAndOptions(Windows.Devices.Display.Core.DisplaySource source, Windows.Devices.Display.Core.DisplaySurface surface, System.UInt32 subresourceIndex, System.UInt32 syncInterval, System.Collections.Generic.IEnumerable`1&lt;Windows.Graphics.RectInt32&gt; dirtyRects, Windows.Devices.Display.Core.DisplayScanoutOptions options)" reason="WinUI sync: takes removed enum DisplayScanoutOptions (Group 5b)" />
+		  <Member fullName="Windows.Devices.Display.Core.DisplaySourceStatus Windows.Devices.Display.Core.DisplaySource.get_Status()" reason="WinUI sync: returns removed enum DisplaySourceStatus (Group 5b)" />
+		  <Member fullName="Windows.Devices.Display.Core.DisplayTaskResult Windows.Devices.Display.Core.DisplayTaskPool.TryExecuteTask(Windows.Devices.Display.Core.DisplayTask task)" reason="WinUI sync: returns removed enum DisplayTaskResult (Group 5b)" />
+		  <Member fullName="System\.Void Windows\.Devices\.Display\.Core\.DisplaySource\.(add|remove)_StatusChanged\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.Devices\.Display\.Core\.DisplaySource,System\.Object&gt; value\)" reason="WinUI sync: event accessors for removed StatusChanged event (Group 5b)" isRegex="true" />
+
+		  <!-- Refs Group 6: Windows.Graphics.Holographic.HolographicDepthReprojectionMethod -->
+		  <Member fullName="System.Collections.Generic.IReadOnlyList`1&lt;Windows.Graphics.Holographic.HolographicDepthReprojectionMethod&gt; Windows.Graphics.Holographic.HolographicViewConfiguration.get_SupportedDepthReprojectionMethods()" reason="WinUI sync: returns list of removed enum HolographicDepthReprojectionMethod (Group 6)" />
+		  <Member fullName="System.Void Windows.Graphics.Holographic.HolographicCameraRenderingParameters.set_DepthReprojectionMethod(Windows.Graphics.Holographic.HolographicDepthReprojectionMethod value)" reason="WinUI sync: takes removed enum HolographicDepthReprojectionMethod (Group 6)" />
+		  <Member fullName="Windows.Graphics.Holographic.HolographicDepthReprojectionMethod Windows.Graphics.Holographic.HolographicCameraRenderingParameters.get_DepthReprojectionMethod()" reason="WinUI sync: returns removed enum HolographicDepthReprojectionMethod (Group 6)" />
+
+		  <!-- Refs Group 6e: Windows.Graphics.Printing.Workflow types -->
+		  <Member fullName="System.Void Windows.Graphics.Printing.Workflow.PrintWorkflowConfiguration.AbortPrintFlow(Windows.Graphics.Printing.Workflow.PrintWorkflowJobAbortReason reason)" reason="WinUI sync: takes removed enum PrintWorkflowJobAbortReason (Group 6e)" />
+		  <Member fullName="System.Void Windows.Graphics.Printing.Workflow.PrintWorkflowObjectModelSourceFileContent..ctor(Windows.Storage.Streams.IInputStream xpsStream)" reason="WinUI sync: ctor on type from removed PrintWorkflow namespace (Group 6e)" />
+
+		  <!-- Refs Group 7: Windows.Management.Deployment.PackageAllUserProvisioningOptions -->
+		  <Member fullName="Windows.Foundation.IAsyncOperationWithProgress`2&lt;Windows.Management.Deployment.DeploymentResult,Windows.Management.Deployment.DeploymentProgress&gt; Windows.Management.Deployment.PackageManager.ProvisionPackageForAllUsersAsync(System.String mainPackageFamilyName, Windows.Management.Deployment.PackageAllUserProvisioningOptions options)" reason="WinUI sync: takes removed type PackageAllUserProvisioningOptions (Group 7)" />
+
+		  <!-- Refs Group 8b: Windows.Media.Core.TimedTextBouten / TimedTextRuby -->
+		  <Member fullName="Windows.Media.Core.TimedTextBouten Windows.Media.Core.TimedTextStyle.get_Bouten()" reason="WinUI sync: returns removed type TimedTextBouten (Group 8b)" />
+		  <Member fullName="Windows.Media.Core.TimedTextRuby Windows.Media.Core.TimedTextStyle.get_Ruby()" reason="WinUI sync: returns removed type TimedTextRuby (Group 8b)" />
+
+		  <!-- Refs Group 8c: Windows.Media.Devices.CameraOcclusionInfo / DigitalWindowControl -->
+		  <Member fullName="Windows.Media.Devices.CameraOcclusionInfo Windows.Media.Devices.VideoDeviceController.get_CameraOcclusionInfo()" reason="WinUI sync: returns removed type CameraOcclusionInfo (Group 8c)" />
+		  <Member fullName="Windows.Media.Devices.DigitalWindowControl Windows.Media.Devices.VideoDeviceController.get_DigitalWindowControl()" reason="WinUI sync: returns removed type DigitalWindowControl (Group 8c)" />
+
+		  <!-- Refs Group 9a: Windows.Networking.NetworkOperators.MobileBroadbandCellNR / SlotManager -->
+		  <Member fullName="System\.Collections\.Generic\.IReadOnlyList`1&lt;Windows\.Networking\.NetworkOperators\.MobileBroadbandCellNR&gt; Windows\.Networking\.NetworkOperators\.MobileBroadbandCellsInfo\.get_(Neighboring|Serving)CellsNR\(\)" reason="WinUI sync: returns list of removed type MobileBroadbandCellNR (Group 9a)" isRegex="true" />
+		  <Member fullName="Windows.Networking.NetworkOperators.MobileBroadbandSlotManager Windows.Networking.NetworkOperators.MobileBroadbandDeviceInformation.get_SlotManager()" reason="WinUI sync: returns removed type MobileBroadbandSlotManager (Group 9a)" />
+
+		  <!-- Refs Group 10a: Windows.Storage.StorageLibraryChangeTrackerOptions -->
+		  <Member fullName="System.Void Windows.Storage.StorageLibraryChangeTracker.Enable(Windows.Storage.StorageLibraryChangeTrackerOptions options)" reason="WinUI sync: takes removed type StorageLibraryChangeTrackerOptions (Group 10a)" />
+
+		  <!-- Refs Group 10b: Windows.System.UserAge* -->
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.System.UserAgeConsentResult&gt; Windows.System.User.CheckUserAgeConsentGroupAsync(Windows.System.UserAgeConsentGroup consentGroup)" reason="WinUI sync: takes removed enum UserAgeConsentGroup, returns removed UserAgeConsentResult (Group 10b)" />
+
+		  <!-- Refs Group 11a: Windows.UI.Composition easing-function factories.
+		       All Create*EasingFunction overloads on the legacy Windows.UI.Composition.CompositionEasingFunction
+		       static class return removed *EasingFunction types. The Microsoft.UI.Composition.CompositionEasingFunction
+		       equivalents are preserved on the branch (Uno's real impl). -->
+		  <Member fullName="Windows\.UI\.Composition\.(Back|Bounce|Circle|Elastic|Exponential|Power|Sine)EasingFunction Windows\.UI\.Composition\.CompositionEasingFunction\.Create(Back|Bounce|Circle|Elastic|Exponential|Power|Sine)EasingFunction\(Windows\.UI\.Composition\.Compositor owner(.+)?\)" reason="WinUI sync: factory returning removed Windows.UI.Composition.*EasingFunction (Group 11a; Microsoft.UI.Composition equivalents preserved)" isRegex="true" />
+
+		  <!-- Refs Group 11a: Windows.UI.Composition.RectangleClip factories on legacy Compositor.
+		       Microsoft.UI.Composition.Compositor.CreateRectangleClip(...) is the real implemented API
+		       (Uno: src/Uno.UI.Composition/Composition/Compositor.cs lines 123/126/135) and is preserved. -->
+		  <Member fullName="Windows\.UI\.Composition\.RectangleClip Windows\.UI\.Composition\.Compositor\.CreateRectangleClip(\(\)|\(System\.Single .+\))" reason="WinUI sync: legacy Compositor factory returning removed Windows.UI.Composition.RectangleClip (Group 11a; Microsoft.UI.Composition.Compositor.CreateRectangleClip preserved)" isRegex="true" />
+
+		  <!-- Refs Group 11c: Windows.UI.Notifications.ToastNotificationMode -->
+		  <Member fullName="Windows.UI.Notifications.ToastNotificationMode Windows.UI.Notifications.ToastNotificationManagerForUser.get_NotificationMode()" reason="WinUI sync: returns removed enum ToastNotificationMode (Group 11c)" />
+		  <Member fullName="System\.Void Windows\.UI\.Notifications\.ToastNotificationManagerForUser\.(add|remove)_NotificationModeChanged\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.UI\.Notifications\.ToastNotificationManagerForUser,System\.Object&gt; value\)" reason="WinUI sync: event accessors for NotificationModeChanged paired with removed ToastNotificationMode (Group 11c)" isRegex="true" />
+
+		  <!-- Refs Group 11e: Windows.UI.ViewManagement.Core.CoreInputViewAnimationStartingEventArgs -->
+		  <Member fullName="System\.Void Windows\.UI\.ViewManagement\.Core\.CoreInputView\.(add|remove)_PrimaryViewAnimationStarting\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.UI\.ViewManagement\.Core\.CoreInputView,Windows\.UI\.ViewManagement\.Core\.CoreInputViewAnimationStartingEventArgs&gt; value\)" reason="WinUI sync: event accessors using removed CoreInputViewAnimationStartingEventArgs (Group 11e)" isRegex="true" />
+
+		  <!-- END WinUI sync (Category B): shadow method removals -->
+
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync (Category C): independent method removals.            -->
+		  <!--                                                                        -->
+		  <!-- Methods/accessors trimmed from kept types whose signatures DON'T       -->
+		  <!-- reference a removed type. Includes property accessors paired with the  -->
+		  <!-- Cat C properties above, plus standalone methods (Dispose, GetDefault,  -->
+		  <!-- factory methods restructured by Microsoft, etc.).                      -->
+		  <!--                                                                        -->
+		  <!-- Verified all stub-only on master.                                      -->
+		  <!-- ====================================================================== -->
+
+		  <!-- AppExtension / AppListEntry / AppInstallerInfo accessors (paired with Cat C properties) -->
+		  <Member fullName="System.String Windows.ApplicationModel.AppExtensions.AppExtension.get_AppUserModelId()" reason="WinUI sync: AppExtension.AppUserModelId removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String[] Windows.ApplicationModel.AppInfo.get_SupportedFileExtensions()" reason="WinUI sync: AppInfo.SupportedFileExtensions removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.AppInfo Windows.ApplicationModel.Core.AppListEntry.get_AppInfo()" reason="WinUI sync: AppListEntry.AppInfo removed by WinAppSDK 1.8" />
+		  <Member fullName="System\.Boolean Windows\.ApplicationModel\.AppInstallerInfo\.get_(AutomaticBackgroundTask|ForceUpdateFromAnyVersion|IsAutoRepairEnabled|OnLaunch|ShowPrompt|UpdateBlocksActivation)\(\)" reason="WinUI sync: AppInstallerInfo bool getter trim (preview)" isRegex="true" />
+		  <Member fullName="System\.Collections\.Generic\.IReadOnlyList`1&lt;System\.Uri&gt; Windows\.ApplicationModel\.AppInstallerInfo\.get_(DependencyPackage|OptionalPackage|Repair|Update)Uris\(\)" reason="WinUI sync: AppInstallerInfo URI list getter trim (preview)" isRegex="true" />
+		  <Member fullName="System.DateTimeOffset Windows.ApplicationModel.AppInstallerInfo.get_LastChecked()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.Nullable`1&lt;System.DateTimeOffset&gt; Windows.ApplicationModel.AppInstallerInfo.get_PausedUntil()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="System.UInt32 Windows.ApplicationModel.AppInstallerInfo.get_HoursBetweenUpdateChecks()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+		  <Member fullName="Windows.ApplicationModel.PackageVersion Windows.ApplicationModel.AppInstallerInfo.get_Version()" reason="WinUI sync: AppInstallerInfo trim (preview)" />
+
+		  <!-- BackgroundExecutionManager: preview modern-standby surface -->
+		  <Member fullName="Windows.ApplicationModel.Background.BackgroundAccessStatus Windows.ApplicationModel.Background.BackgroundExecutionManager.GetAccessStatusForModernStandby()" reason="WinUI sync: preview modern-standby API removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.ApplicationModel.Background.BackgroundAccessStatus Windows.ApplicationModel.Background.BackgroundExecutionManager.GetAccessStatusForModernStandby(System.String applicationId)" reason="WinUI sync: preview modern-standby API removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;System.Boolean&gt; Windows.ApplicationModel.Background.BackgroundExecutionManager.RequestAccessKindForModernStandbyAsync(Windows.ApplicationModel.Background.BackgroundAccessRequestKind requestedAccess, System.String reason)" reason="WinUI sync: preview modern-standby API removed by WinAppSDK 1.8" />
+
+		  <!-- ConversationalAgent preview accessors / methods -->
+		  <Member fullName="System.String Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.get_DetectorId()" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="System.Collections.Generic.IList`1&lt;System.String&gt; Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.GetAvailableModelIdsForSignalId(System.String signalId)" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;System.Collections.Generic.IList`1&lt;System.String&gt;&gt; Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector.GetAvailableModelIdsForSignalIdAsync(System.String signalId)" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="System.UInt32 Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration.get_TrainingStepCompletionMaxAllowedTime()" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="System.Void Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectionConfiguration.Dispose()" reason="WinUI sync: Dispose removed (no IDisposable in WinAppSDK 1.8 surface)" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector Windows.ApplicationModel.ConversationalAgent.ConversationalAgentDetectorManager.GetActivationSignalDetectorFromId(System.String detectorId)" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetector&gt; Windows.ApplicationModel.ConversationalAgent.ConversationalAgentDetectorManager.GetActivationSignalDetectorFromIdAsync(System.String detectorId)" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="System.Void Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession.SetSupportLockScreenActivation(System.Boolean lockScreenActivationSupported)" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="Windows.Foundation.IAsyncAction Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSession.SetSupportLockScreenActivationAsync(System.Boolean lockScreenActivationSupported)" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="System.String Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSignal.get_DetectorId()" reason="WinUI sync: ConversationalAgent preview" />
+		  <Member fullName="Windows.ApplicationModel.ConversationalAgent.ActivationSignalDetectorKind Windows.ApplicationModel.ConversationalAgent.ConversationalAgentSignal.get_DetectorKind()" reason="WinUI sync: ConversationalAgent preview" />
+
+		  <!-- ResourceMapIterator / MapViewIterator: WinRT IIterator (HasCurrent + GetMany) dropped -->
+		  <Member fullName="System.Boolean Windows.ApplicationModel.Resources.Core.ResourceMapIterator.get_HasCurrent()" reason="WinUI sync: WinRT IIterator pattern removed (use IEnumerator)" />
+		  <Member fullName="System.Boolean Windows.ApplicationModel.Resources.Core.ResourceMapMapViewIterator.get_HasCurrent()" reason="WinUI sync: WinRT IIterator pattern removed (use IEnumerator)" />
+		  <Member fullName="System\.UInt32 Windows\.ApplicationModel\.Resources\.Core\.(ResourceMap|ResourceMapMapView)Iterator\.GetMany\(System\.Collections\.Generic\.KeyValuePair`2&lt;System\.String,Windows\.ApplicationModel\.Resources\.Core\.(NamedResource|ResourceMap)&gt;.*" reason="WinUI sync: WinRT IIterator GetMany dropped" isRegex="true" />
+		  <Member fullName="System.String Windows.ApplicationModel.Resources.ResourceLoader.GetDefaultPriPath(System.String packageFullName)" reason="WinUI sync: preview ResourceLoader.GetDefaultPriPath removed by WinAppSDK 1.8" />
+
+		  <!-- Geocoordinate / GeocoordinateSatelliteData preview -->
+		  <Member fullName="System.Boolean Windows.Devices.Geolocation.Geocoordinate.get_IsRemoteSource()" reason="WinUI sync: preview Geocoordinate.IsRemoteSource removed by WinAppSDK 1.8" />
+		  <Member fullName="System\.Nullable`1&lt;System\.Double&gt; Windows\.Devices\.Geolocation\.GeocoordinateSatelliteData\.get_(GeometricDilutionOfPrecision|TimeDilutionOfPrecision)\(\)" reason="WinUI sync: preview GNSS DOP getters removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- KnownSimpleHapticsControllerWaveforms: 10 preview waveform getters removed.
+		       Uno only ships 4 waveforms. -->
+		  <Member fullName="System\.UInt16 Windows\.Devices\.Haptics\.KnownSimpleHapticsControllerWaveforms\.get_(BrushContinuous|ChiselMarkerContinuous|EraserContinuous|Error|GalaxyPenContinuous|Hover|InkContinuous|MarkerContinuous|PencilContinuous|Success)\(\)" reason="WinUI sync: preview KnownSimpleHapticsControllerWaveforms getters removed (Uno keeps BuzzContinuous/Click/Press/Release)" isRegex="true" />
+
+		  <!-- PenDevice preview -->
+		  <Member fullName="Windows.Devices.Haptics.SimpleHapticsController Windows.Devices.Input.PenDevice.get_SimpleHapticsController()" reason="WinUI sync: preview PenDevice.SimpleHapticsController removed by WinAppSDK 1.8" />
+
+		  <!-- DisplayPath / DisplayModeInfo preview -->
+		  <Member fullName="System.Nullable`1&lt;Windows.Devices.Display.Core.DisplayPresentationRate&gt; Windows.Devices.Display.Core.DisplayPath.get_PhysicalPresentationRate()" reason="WinUI sync: preview DisplayPath.PhysicalPresentationRate removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Void Windows.Devices.Display.Core.DisplayPath.set_PhysicalPresentationRate(System.Nullable`1&lt;Windows.Devices.Display.Core.DisplayPresentationRate&gt; value)" reason="WinUI sync: preview DisplayPath.PhysicalPresentationRate removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.Devices.Display.Core.DisplayPresentationRate Windows.Devices.Display.Core.DisplayModeInfo.get_PhysicalPresentationRate()" reason="WinUI sync: preview DisplayModeInfo.PhysicalPresentationRate removed by WinAppSDK 1.8" />
+
+		  <!-- DisplayTask.SetSignal: takes preview DisplayTaskSignalKind / DisplayFence -->
+		  <Member fullName="System.Void Windows.Devices.Display.Core.DisplayTask.SetSignal(Windows.Devices.Display.Core.DisplayTaskSignalKind signalKind, Windows.Devices.Display.Core.DisplayFence fence)" reason="WinUI sync: preview DisplayTask.SetSignal removed by WinAppSDK 1.8" />
+
+		  <!-- Capture session border-required preview accessors -->
+		  <Member fullName="System.Boolean Windows.Graphics.Capture.GraphicsCaptureSession.get_IsBorderRequired()" reason="WinUI sync: preview GraphicsCaptureSession.IsBorderRequired removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Void Windows.Graphics.Capture.GraphicsCaptureSession.set_IsBorderRequired(System.Boolean value)" reason="WinUI sync: preview GraphicsCaptureSession.IsBorderRequired removed by WinAppSDK 1.8" />
+
+		  <!-- GraphicsCaptureItem.TryCreateFromDisplayId/WindowId: factory overloads restructured -->
+		  <Member fullName="Windows.Graphics.Capture.GraphicsCaptureItem Windows.Graphics.Capture.GraphicsCaptureItem.TryCreateFromDisplayId(Windows.Graphics.DisplayId displayId)" reason="WinUI sync: GraphicsCaptureItem factory restructured (Microsoft.UI.DisplayId is the modern surface)" />
+		  <Member fullName="Windows.Graphics.Capture.GraphicsCaptureItem Windows.Graphics.Capture.GraphicsCaptureItem.TryCreateFromWindowId(Windows.UI.WindowId windowId)" reason="WinUI sync: GraphicsCaptureItem factory restructured (Microsoft.UI.WindowId is the modern surface)" />
+
+		  <!-- TimedTextStyle preview accessors (paired with Cat C properties / Group 8b cleanup) -->
+		  <Member fullName="System.Boolean Windows.Media.Core.TimedTextStyle.get_IsTextCombined()" reason="WinUI sync: TimedTextStyle preview accessor removed (Group 8b cleanup)" />
+		  <Member fullName="System.Double Windows.Media.Core.TimedTextStyle.get_FontAngleInDegrees()" reason="WinUI sync: TimedTextStyle preview accessor removed (Group 8b cleanup)" />
+		  <Member fullName="System.Void Windows.Media.Core.TimedTextStyle.set_FontAngleInDegrees(System.Double value)" reason="WinUI sync: TimedTextStyle preview accessor removed (Group 8b cleanup)" />
+		  <Member fullName="System.Void Windows.Media.Core.TimedTextStyle.set_IsTextCombined(System.Boolean value)" reason="WinUI sync: TimedTextStyle preview accessor removed (Group 8b cleanup)" />
+
+		  <!-- SpatialAudioFormatSubtype preview -->
+		  <Member fullName="System.String Windows.Media.Audio.SpatialAudioFormatSubtype.get_DTSXForHomeTheater()" reason="WinUI sync: preview DTSXForHomeTheater removed by WinAppSDK 1.8" />
+
+		  <!-- PlayReady iterator pattern (HasCurrent + GetMany) -->
+		  <Member fullName="System\.Boolean Windows\.Media\.Protection\.PlayReady\.PlayReady(Domain|License|SecureStop)Iterator\.get_HasCurrent\(\)" reason="WinUI sync: WinRT IIterator pattern removed (use IEnumerator)" isRegex="true" />
+		  <Member fullName="System\.UInt32 Windows\.Media\.Protection\.PlayReady\.PlayReady(Domain|License|SecureStop)Iterator\.GetMany\(Windows\.Media\.Protection\.PlayReady\.IPlayReady(Domain|License|SecureStopServiceRequest).*" reason="WinUI sync: WinRT IIterator GetMany dropped" isRegex="true" />
+
+		  <!-- VpnChannel preview packet-buffer surface -->
+		  <Member fullName="Windows.Foundation.Collections.ValueSet Windows.Networking.Vpn.VpnChannel.ActivateForeground(System.String packageRelativeAppId, Windows.Foundation.Collections.ValueSet sharedContext)" reason="WinUI sync: preview VpnChannel.ActivateForeground removed by WinAppSDK 1.8" />
+		  <Member fullName="System\.Void Windows\.Networking\.Vpn\.VpnChannel\.(Append|Flush)Vpn(Receive|Send)PacketBuffer(s)?\(.*" reason="WinUI sync: preview VpnChannel packet-buffer methods removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- VibrationDevice.Cancel: legacy phone-vibration method removed (the VibrationDevice
+		       type itself is preserved by the branch via commit 81670705f0). -->
+		  <Member fullName="System.Void Windows.Phone.Devices.Notification.VibrationDevice.Cancel()" reason="WinUI sync: legacy VibrationDevice.Cancel removed by WinAppSDK 1.8 (type preserved)" />
+
+		  <!-- ApplicationData / ApplicationDataContainer / StorageLibraryChangeReader/Tracker: Dispose / change-id removals -->
+		  <Member fullName="System.Void Windows.Storage.ApplicationData.Dispose()" reason="WinUI sync: ApplicationData.Dispose removed (no IDisposable in WinAppSDK 1.8 surface)" />
+		  <Member fullName="System.Void Windows.Storage.ApplicationDataContainer.Dispose()" reason="WinUI sync: ApplicationDataContainer.Dispose removed (no IDisposable)" />
+		  <Member fullName="System.UInt64 Windows.Storage.StorageLibraryChangeReader.GetLastChangeId()" reason="WinUI sync: paired with removed StorageLibraryLastChangeId (Group 10a)" />
+		  <Member fullName="System.Void Windows.Storage.StorageLibraryChangeTracker.Disable()" reason="WinUI sync: preview StorageLibraryChangeTracker.Disable removed by WinAppSDK 1.8" />
+
+		  <!-- AppUriHandler{Host,Registration,RegistrationManager} preview -->
+		  <Member fullName="System.Boolean Windows.System.AppUriHandlerHost.get_IsEnabled()" reason="WinUI sync: AppUriHandlerHost preview accessor removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Void Windows.System.AppUriHandlerHost.set_IsEnabled(System.Boolean value)" reason="WinUI sync: AppUriHandlerHost preview accessor removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Collections.Generic.IList`1&lt;Windows.System.AppUriHandlerHost&gt; Windows.System.AppUriHandlerRegistration.GetAllHosts()" reason="WinUI sync: preview AppUriHandlerRegistration method removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String Windows.System.AppUriHandlerRegistration.get_PackageFamilyName()" reason="WinUI sync: AppUriHandlerRegistration preview accessor removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Void Windows.System.AppUriHandlerRegistration.UpdateHosts(System.Collections.Generic.IEnumerable`1&lt;Windows.System.AppUriHandlerHost&gt; hosts)" reason="WinUI sync: preview AppUriHandlerRegistration.UpdateHosts removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String Windows.System.AppUriHandlerRegistrationManager.get_PackageFamilyName()" reason="WinUI sync: AppUriHandlerRegistrationManager preview accessor removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.AppUriHandlerRegistrationManager Windows.System.AppUriHandlerRegistrationManager.GetForPackage(System.String packageFamilyName)" reason="WinUI sync: AppUriHandlerRegistrationManager.GetForPackage factory removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.AppUriHandlerRegistrationManager Windows.System.AppUriHandlerRegistrationManager.GetForPackageForUser(System.String packageFamilyName, Windows.System.User user)" reason="WinUI sync: AppUriHandlerRegistrationManager.GetForPackageForUser factory removed by WinAppSDK 1.8" />
+
+		  <!-- KnownUserProperties / AnalyticsVersionInfo / SystemDiagnosticInfo / User accessors -->
+		  <Member fullName="System.String Windows.System.KnownUserProperties.get_AgeEnforcementRegion()" reason="WinUI sync: preview AgeEnforcementRegion removed by WinAppSDK 1.8" />
+		  <Member fullName="System.String Windows.System.Profile.AnalyticsVersionInfo.get_ProductName()" reason="WinUI sync: preview AnalyticsVersionInfo.ProductName removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.ProcessorArchitecture Windows.System.Diagnostics.SystemDiagnosticInfo.get_PreferredArchitecture()" reason="WinUI sync: preview SystemDiagnosticInfo.PreferredArchitecture removed by WinAppSDK 1.8" />
+		  <Member fullName="System.Boolean Windows.System.Diagnostics.SystemDiagnosticInfo.IsArchitectureSupported(Windows.System.ProcessorArchitecture type)" reason="WinUI sync: preview IsArchitectureSupported removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.System.User Windows.System.User.GetDefault()" reason="WinUI sync: preview User.GetDefault removed by WinAppSDK 1.8 (use User.FindAllAsync)" />
+
+		  <!-- Compositor: legacy Windows.UI.Composition projection accessors / factory methods.
+		       Microsoft.UI.Composition.Compositor.CreateRectangleClip(...) is the real implemented API
+		       and is preserved (src/Uno.UI.Composition/Composition/Compositor.cs:123/126/135).
+		       DispatcherQueue/CreateAnimationPropertyInfo/TryCreateBlurredWallpaperBackdropBrush are
+		       all stub-only on master across both Windows.* and Microsoft.* namespaces. -->
+		  <Member fullName="Windows.System.DispatcherQueue Windows.UI.Composition.Compositor.get_DispatcherQueue()" reason="WinUI sync: legacy Compositor.DispatcherQueue projection accessor removed" />
+		  <Member fullName="Windows.UI.Composition.AnimationPropertyInfo Windows.UI.Composition.Compositor.CreateAnimationPropertyInfo()" reason="WinUI sync: legacy Compositor.CreateAnimationPropertyInfo removed" />
+		  <Member fullName="Windows.UI.Composition.CompositionBackdropBrush Windows.UI.Composition.Compositor.TryCreateBlurredWallpaperBackdropBrush()" reason="WinUI sync: legacy Compositor.TryCreateBlurredWallpaperBackdropBrush removed" />
+
+		  <!-- Compositor preview Visual.IsHitTestVisible / IsPixelSnappingEnabled accessors -->
+		  <Member fullName="System.Boolean Windows.UI.Composition.Visual.get_IsHitTestVisible()" reason="WinUI sync: preview Visual.IsHitTestVisible accessor removed (no Uno impl)" />
+		  <Member fullName="System.Boolean Windows.UI.Composition.Visual.get_IsPixelSnappingEnabled()" reason="WinUI sync: preview Visual.IsPixelSnappingEnabled accessor removed (no Uno impl)" />
+		  <Member fullName="System.Void Windows.UI.Composition.Visual.set_IsHitTestVisible(System.Boolean value)" reason="WinUI sync: preview Visual.IsHitTestVisible accessor removed (no Uno impl)" />
+		  <Member fullName="System.Void Windows.UI.Composition.Visual.set_IsPixelSnappingEnabled(System.Boolean value)" reason="WinUI sync: preview Visual.IsPixelSnappingEnabled accessor removed (no Uno impl)" />
+
+		  <!-- AnimationPropertyInfo preview helpers -->
+		  <Member fullName="System.String Windows.UI.Composition.AnimationPropertyInfo.GetResolvedCompositionObjectProperty()" reason="WinUI sync: preview AnimationPropertyInfo helper removed by WinAppSDK 1.8" />
+		  <Member fullName="Windows.UI.Composition.CompositionObject Windows.UI.Composition.AnimationPropertyInfo.GetResolvedCompositionObject()" reason="WinUI sync: preview AnimationPropertyInfo helper removed by WinAppSDK 1.8" />
+
+		  <!-- CompositionGraphicsDevice.CaptureAsync(... sdrBoost): preview HDR overload removed -->
+		  <Member fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.UI.Composition.ICompositionSurface&gt; Windows.UI.Composition.CompositionGraphicsDevice.CaptureAsync(Windows.UI.Composition.Visual captureVisual, Windows.Graphics.SizeInt32 size, Windows.Graphics.DirectX.DirectXPixelFormat pixelFormat, Windows.Graphics.DirectX.DirectXAlphaMode alphaMode, System.Single sdrBoost)" reason="WinUI sync: preview CaptureAsync sdrBoost overload removed by WinAppSDK 1.8" />
+
+		  <!-- CompositionEasingFunction: factories returning kept easing types (CubicBezier/Linear/Step)
+		       on the legacy Windows.UI.Composition surface. Microsoft.UI.Composition equivalents preserved. -->
+		  <Member fullName="Windows.UI.Composition.CubicBezierEasingFunction Windows.UI.Composition.CompositionEasingFunction.CreateCubicBezierEasingFunction(Windows.UI.Composition.Compositor owner, System.Numerics.Vector2 controlPoint1, System.Numerics.Vector2 controlPoint2)" reason="WinUI sync: legacy Windows.UI.Composition factory removed (Microsoft.UI.Composition preserved)" />
+		  <Member fullName="Windows.UI.Composition.LinearEasingFunction Windows.UI.Composition.CompositionEasingFunction.CreateLinearEasingFunction(Windows.UI.Composition.Compositor owner)" reason="WinUI sync: legacy Windows.UI.Composition factory removed (Microsoft.UI.Composition preserved)" />
+		  <Member fullName="Windows\.UI\.Composition\.StepEasingFunction Windows\.UI\.Composition\.CompositionEasingFunction\.CreateStepEasingFunction\(Windows\.UI\.Composition\.Compositor owner(, System\.Int32 stepCount)?\)" reason="WinUI sync: legacy Windows.UI.Composition factory removed (Microsoft.UI.Composition preserved)" isRegex="true" />
+
+		  <!-- CoreIndependentInputSource pointer-redirect events: paired with Cat B Events.
+		       These are the add_/remove_ method accessors orphaned when the events were trimmed. -->
+		  <Member fullName="System\.Void Windows\.UI\.Core\.CoreIndependentInputSource\.(add|remove)_PointerRouted(Away|Released|To)\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.UI\.Core\.ICorePointerRedirector,Windows\.UI\.Core\.PointerEventArgs&gt; value\)" reason="WinUI sync: event accessors for preview pointer-redirect events (paired with Cat B events)" isRegex="true" />
+
+		  <!-- CoreInkIndependentInputSource pointer-cursor accessors -->
+		  <Member fullName="Windows.UI.Core.CoreCursor Windows.UI.Input.Inking.Core.CoreInkIndependentInputSource.get_PointerCursor()" reason="WinUI sync: preview CoreInkIndependentInputSource.PointerCursor accessor removed" />
+		  <Member fullName="System.Void Windows.UI.Input.Inking.Core.CoreInkIndependentInputSource.set_PointerCursor(Windows.UI.Core.CoreCursor value)" reason="WinUI sync: preview CoreInkIndependentInputSource.PointerCursor accessor removed" />
+
+		  <!-- InkInputConfiguration / InkStroke / PenAndInkSettings preview -->
+		  <Member fullName="System.Boolean Windows.UI.Input.Inking.InkInputConfiguration.get_IsPenHapticFeedbackEnabled()" reason="WinUI sync: preview pen-haptic-feedback accessor removed" />
+		  <Member fullName="System.Void Windows.UI.Input.Inking.InkInputConfiguration.set_IsPenHapticFeedbackEnabled(System.Boolean value)" reason="WinUI sync: preview pen-haptic-feedback accessor removed" />
+		  <Member fullName="System.UInt32 Windows.UI.Input.Inking.InkStroke.get_PointerId()" reason="WinUI sync: preview InkStroke.PointerId accessor removed" />
+		  <Member fullName="System.Void Windows.UI.Input.Inking.PenAndInkSettings.SetPenHandedness(Windows.UI.Input.Inking.PenHandedness value)" reason="WinUI sync: preview PenAndInkSettings.SetPenHandedness removed" />
+
+		  <!-- CoreInputView.SupportedKindsChanged event accessors (paired with Cat B event) and IsKindSupported -->
+		  <Member fullName="System\.Void Windows\.UI\.ViewManagement\.Core\.CoreInputView\.(add|remove)_SupportedKindsChanged\(Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.UI\.ViewManagement\.Core\.CoreInputView,System\.Object&gt; value\)" reason="WinUI sync: event accessors for SupportedKindsChanged (paired with Cat B event)" isRegex="true" />
+		  <Member fullName="System.Boolean Windows.UI.ViewManagement.Core.CoreInputView.IsKindSupported(Windows.UI.ViewManagement.Core.CoreInputViewKind type)" reason="WinUI sync: paired with removed CoreInputViewKind enum members (Cat D)" />
+
+		  <!-- StatusBar.ProgressIndicator getter (paired with Cat C property) -->
+		  <Member fullName="Windows.UI.ViewManagement.StatusBarProgressIndicator Windows.UI.ViewManagement.StatusBar.get_ProgressIndicator()" reason="WinUI sync: StatusBar.ProgressIndicator getter removed by WinAppSDK 1.8" />
+
+		  <!-- END WinUI sync (Category C): independent method removals -->
+
+
+
+		  <!-- ItemsRepeater.Animator accessors: paired with removed ElementAnimator type (see <Types>) and ItemsRepeater::Animator property (see <Properties>). -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ItemsRepeater.get_AnimatorProperty()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ElementAnimator Microsoft.UI.Xaml.Controls.ItemsRepeater.get_Animator()" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ItemsRepeater.set_Animator(Microsoft.UI.Xaml.Controls.ElementAnimator value)" reason="WinUI sync: ItemsRepeater.Animator property removed by WinAppSDK 1.8 (paired with removed ElementAnimator)" />
+
+		  <!-- Layout.CreateDefaultItemTransitionProvider narrowed from public to protected internal virtual to match WinUI's protected virtual (docs: learn.microsoft.com/.../layout.createdefaultitemtransitionprovider). Uno adds 'internal' so ItemsRepeater (same assembly) can invoke the protected-for-external method. -->
+		  <Member fullName="Microsoft.UI.Xaml.Controls.ItemCollectionTransitionProvider Microsoft.UI.Xaml.Controls.Layout.CreateDefaultItemTransitionProvider()" reason="WinUI sync: Layout.CreateDefaultItemTransitionProvider is protected virtual in WinAppSDK 1.8 (was public in baseline); narrowed to protected internal virtual in Uno for WinUI parity" />
+
+		  <!-- AnimatedIcon rework: the Uno-specific legacy IAnimatedVisualSource hooks
+		       (Load/Unload/Update/Play/Pause/Resume/Stop/SetProgress/Measure) are no-ops
+		       that never existed in WinUI. They are now explicit interface implementations
+		       on the generated Animated*VisualSource sources, so they drop off the concrete
+		       type's public surface; they remain callable via the public IAnimatedVisualSource. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.AnimatedVisuals\.Animated.+VisualSource\.(Load|Unload|Pause|Resume|Stop|Play|SetProgress|Update|Measure)\(.*\)" reason="AnimatedIcon rework: Uno-specific legacy IAnimatedVisualSource no-op hooks moved to explicit interface implementations (not in WinUI; still callable via the interface)" isRegex="true" />
+
+		  <!-- DataContext restricted to FrameworkElement — accessor methods removed from UIElement and every non-FE DependencyObject. -->
+		  <Member fullName="System\.Object .+(::|\.)get_DataContext\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)set_DataContext\(System\.Object value\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)get_DataContextProperty\(\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)add_DataContextChanged\(.+\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)remove_DataContextChanged\(.+\)" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+
+		  <!-- EventsBubblingInManagedCode accessors: paired with the removed DP (see <Properties> above). Uno-only native-bubbling knob with no WinUI counterpart. -->
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.UIElement.get_EventsBubblingInManagedCodeProperty()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <Member fullName="Uno.UI.Xaml.RoutedEventFlag Microsoft.UI.Xaml.UIElement.get_EventsBubblingInManagedCode()" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.UIElement.set_EventsBubblingInManagedCode(Uno.UI.Xaml.RoutedEventFlag value)" reason="Removed EventsBubblingInManagedCode DP (BC04, breaking changes for 7.0)" />
+		  <!-- Binary-compat shim for the removed Setter<T> (see <Types> above); no source callers. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.SetterBase.set_Property(System.String name)" reason="Removed SetterBase.set_Property shim (BC63, breaking changes for 7.0)" />
+
+		  <!-- DependencyObject is now a base class (BC26). The dependency-property store, binder and TemplatedParent
+		       members it used to surface on every type (via the DependencyObjectGenerator per-type mixin) are now
+		       inherited from the DependencyObject base, so the diff reports them "removed" on each previously-declaring
+		       type. They remain available (inherited), so these accessor/method removals are ignored across all types. -->
+		  <Member fullName="Windows\.UI\.Core\.CoreDispatcher .+(::|\.)get_Dispatcher\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Dispatching\.DispatcherQueue .+(::|\.)get_DispatcherQueue\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Boolean .+(::|\.)get_IsStoreInitialized\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Object .+(::|\.)GetValue\(Microsoft\.UI\.Xaml\.DependencyProperty dp\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)SetValue\(Microsoft\.UI\.Xaml\.DependencyProperty dp, System\.Object value\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)ClearValue\(Microsoft\.UI\.Xaml\.DependencyProperty dp\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Object .+(::|\.)ReadLocalValue\(Microsoft\.UI\.Xaml\.DependencyProperty dp\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Object .+(::|\.)GetAnimationBaseValue\(Microsoft\.UI\.Xaml\.DependencyProperty dp\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Int64 .+(::|\.)RegisterPropertyChangedCallback\(Microsoft\.UI\.Xaml\.DependencyProperty dp, Microsoft\.UI\.Xaml\.DependencyPropertyChangedCallback callback\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)UnregisterPropertyChangedCallback\(Microsoft\.UI\.Xaml\.DependencyProperty dp, System\.Int64 token\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyObject .+(::|\.)get_TemplatedParent\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)set_TemplatedParent\(Microsoft\.UI\.Xaml\.DependencyObject value\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.DependencyProperty .+(::|\.)get_TemplatedParentProperty\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)SetBinding\(System\.Object target, System\.String dependencyProperty, Microsoft\.UI\.Xaml\.Data\.BindingBase binding\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)SetBinding\(System\.String dependencyProperty, Microsoft\.UI\.Xaml\.Data\.BindingBase binding\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)SetBinding\(Microsoft\.UI\.Xaml\.DependencyProperty dependencyProperty, Microsoft\.UI\.Xaml\.Data\.BindingBase binding\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)SetBindingValue\(System\.Object value, System\.String propertyName\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="Microsoft\.UI\.Xaml\.Data\.BindingExpression .+(::|\.)GetBindingExpression\(Microsoft\.UI\.Xaml\.DependencyProperty dependencyProperty\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)ClearBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)RestoreBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)ResumeBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+		  <Member fullName="System\.Void .+(::|\.)SuspendBindings\(\)" reason="DependencyObject as class: member inherited from base" isRegex="true" />
+
+		  <!-- op_Explicit binary-compat shim on PointerPoint; hand-emitted only to keep old binaries linking after the explicit-to-implicit conversion change. The implicit operators remain. -->
+		  <Member fullName="Windows.UI.Input.PointerPoint Microsoft.UI.Input.PointerPoint.op_Explicit(Microsoft.UI.Input.PointerPoint muxPointerPoint)" reason="Removed op_Explicit binary-compat shim on Microsoft.UI.Input.PointerPoint (BC43, breaking changes for 7.0)" />
+
+		  <!-- Interop helper whose only purpose was marshalling IJSObject arguments; removed with the IJSObject mechanism. -->
+		  <Member fullName="System.String Uno.Foundation.WebAssemblyRuntime.InvokeJSWithInterop(System.FormattableString formattable)" reason="Removed legacy WASM IJSObject DOM-interop API (BC02, breaking changes for 7.0)" />
+
+		  <!-- ColorKeyFrameCollection shadow-block accessors/methods (paired with the <Properties> entry above); base DependencyObjectCollection<T> still satisfies IList<ColorKeyFrame>. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.ColorKeyFrameCollection(::|\.)(get_Size|GetEnumerator|Add|Clear|Contains|CopyTo|Remove|get_Count|set_Count|get_IsReadOnly|set_IsReadOnly|IndexOf|Insert|RemoveAt|get_Item|set_Item)\(.*\)" reason="Removed ColorKeyFrameCollection binary-compat shadow members; provided by base DependencyObjectCollection&lt;T&gt; (BC67, breaking changes for 7.0)" isRegex="true" />
+
+		  <!-- No-op AdjustArrange(Size) (always returned its input) declared on the internal IFrameworkElement; publicly surfaced only as this implicit implementation on FrameworkElement. The lone caller in the legacy Layouter path is inlined. -->
+		  <Member fullName="Windows.Foundation.Size Microsoft.UI.Xaml.FrameworkElement.AdjustArrange(Windows.Foundation.Size finalSize)" reason="Removed no-op AdjustArrange (BC70, breaking changes for 7.0)" />
+
+		  <!-- DependencyObject as class (BC26): Uno-only members demoted to internal. Recorded explicitly rather than
+		       relying on the declaring-type wildcards above, so the demotion stays documented if those are tightened.
+		       The two SetBinding overloads the XAML generator emits into consuming assemblies stay public. -->
+		  <Member fullName="System.Boolean Microsoft.UI.Xaml.DependencyObject.get_IsStoreInitialized()" reason="DependencyObject as class: removed, was a constant with no consumer (BC26, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.DependencyObject.SetBinding(System.Object target, System.String dependencyProperty, Microsoft.UI.Xaml.Data.BindingBase binding)" reason="DependencyObject as class: demoted to internal, not emitted by the XAML generator and no consumer (BC26, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.DependencyObject.SetBindingValue(System.Object value, System.String propertyName)" reason="DependencyObject as class: demoted to internal, Uno-only binder plumbing (BC26, breaking changes for 7.0)" />
+		  <Member fullName="Microsoft.UI.Xaml.Data.BindingExpression Microsoft.UI.Xaml.DependencyObject.GetBindingExpression(Microsoft.UI.Xaml.DependencyProperty dependencyProperty)" reason="DependencyObject as class: demoted to internal, Uno-only and absent from WinUI (BC26, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.DependencyObject.SuspendBindings()" reason="DependencyObject as class: demoted to internal, Uno-only binder plumbing (BC26, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.DependencyObject.ResumeBindings()" reason="DependencyObject as class: demoted to internal, Uno-only binder plumbing (BC26, breaking changes for 7.0)" />
+
+		  <!-- DependencyObject as class (BC26): methods of the removed DependencyObjectStore / IDependencyObjectStoreProvider. -->
+		  <Member fullName="^.+ Microsoft\.UI\.Xaml\.DependencyObjectStore(::|\.|/).+$" reason="DependencyObject as class: DependencyObjectStore removed" isRegex="true" />
+		  <Member fullName="^.+ Microsoft\.UI\.Xaml\.IDependencyObjectStoreProvider(::|\.).+$" reason="DependencyObject as class: IDependencyObjectStoreProvider removed" isRegex="true" />
+
+		  <!-- WindowActivatedEventArgs.WindowActivationState getter accessor retyped from the Uno-only Windows.UI.Core.CoreWindowActivationState to the WinUI Microsoft.UI.Xaml.WindowActivationState; the old-typed getter reads as removed (property paired in <Properties> above). -->
+		  <Member fullName="Windows.UI.Core.CoreWindowActivationState Microsoft.UI.Xaml.WindowActivatedEventArgs.get_WindowActivationState()" reason="Retyped WindowActivationState to Microsoft.UI.Xaml.WindowActivationState (BC13, breaking changes for 7.0)" />
+
+		  <!-- MediaPlayerPresenter->FrameworkElement reparent accessors (paired with the <Properties> entry above): get_/set_ and DP-field get_ accessors for the removed Border-only members. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.MediaPlayerPresenter(::|\.)(get_Child|set_Child|get_ChildProperty|get_BorderBrush|set_BorderBrush|get_BorderBrushProperty|get_BorderThickness|set_BorderThickness|get_BorderThicknessProperty|get_CornerRadius|set_CornerRadius|get_CornerRadiusProperty|get_Padding|set_Padding|get_PaddingProperty|get_BackgroundSizing|set_BackgroundSizing|get_BackgroundSizingProperty|get_ChildTransitions|set_ChildTransitions|get_ChildTransitionsProperty|get_BackgroundTransition|set_BackgroundTransition|Add)\(.*\)" reason="Reparented MediaPlayerPresenter from Border to FrameworkElement for WinUI parity; Border-only member accessors removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
+		  <!-- FrameworkElement.Background accessors + OnBackgroundChanged relocated to the declaring types (BC38, breaking changes for 7.0). -->
+		  <Member fullName="Microsoft.UI.Xaml.Media.Brush Microsoft.UI.Xaml.FrameworkElement.get_Background()" reason="WinUI sync (BC38): Background declared per-type, not on FrameworkElement" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.FrameworkElement.set_Background(Microsoft.UI.Xaml.Media.Brush value)" reason="WinUI sync (BC38): Background declared per-type, not on FrameworkElement" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement.get_BackgroundProperty()" reason="WinUI sync (BC38): BackgroundProperty declared per-type, not on FrameworkElement" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.FrameworkElement.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged moved to the declaring types" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Shapes.Shape.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): Shape has no Background in WinUI (uses Fill)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Control.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Panel.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Border.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Page.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.CalendarViewBaseItem.OnBackgroundChanged(Microsoft.UI.Xaml.DependencyPropertyChangedEventArgs e)" reason="WinUI sync (BC38): OnBackgroundChanged is Uno-only plumbing, narrowed to private protected" />
+
+		  <!-- ContentPresenter.ContentTemplateRoot accessors (paired with the <Properties> entry above); getter public->internal, setter protected->private. -->
+		  <Member fullName="Microsoft.UI.Xaml.UIElement Microsoft.UI.Xaml.Controls.ContentPresenter.get_ContentTemplateRoot()" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.set_ContentTemplateRoot(Microsoft.UI.Xaml.UIElement value)" reason="Reduced ContentPresenter.ContentTemplateRoot to internal (BC36, breaking changes for 7.0)" />
+
+		  <!-- ContentPresenter bypass removal (#2163): the bypass materialized ContentTemplate itself when no ControlTemplate was present, so ContentControl carried a parallel copy of the ContentPresenter logic. With the bypass gone, UpdateContentTemplateRoot/SyncDataContext and the visibility, data-context and measure overrides that only drove it are removed, and ContentTemplateRoot is now reported by the template ContentPresenter (setter protected to internal, matching WinUI where the property is get-only). -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.ContentControl(::|\.)(set_ContentTemplateRoot|UpdateContentTemplateRoot|SyncDataContext|MeasureOverride|OnVisibilityChanged|OnDataContextChanged)\(.*\)" reason="Removed the ContentPresenter bypass from ContentControl (#2163, breaking changes for 7.0, uno#8339)" isRegex="true" />
+
+		  <!-- ImageBrush->TileBrush reparent accessors (paired with the <Properties> entry above): get_/set_ for AlignmentX/AlignmentY/Stretch and the get_ DP-field accessors, now inherited from TileBrush. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.ImageBrush(::|\.)(get_AlignmentX|set_AlignmentX|get_AlignmentY|set_AlignmentY|get_Stretch|set_Stretch|get_AlignmentXProperty|get_AlignmentYProperty|get_StretchProperty)\(.*\)" reason="Moved AlignmentX/AlignmentY/Stretch owner from ImageBrush to TileBrush base for WinUI parity (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
+		  <!-- On[Vertical|Horizontal]ContentAlignmentChanged removed: the empty TextBox override and the ContentPresenter base virtuals. All no-ops (the ...Partial hooks were never implemented); layout is still driven by the AffectsArrange metadata option. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnVerticalContentAlignmentChanged(Microsoft.UI.Xaml.VerticalAlignment oldVerticalContentAlignment, Microsoft.UI.Xaml.VerticalAlignment newVerticalContentAlignment)" reason="Removed ContentPresenter.OnVerticalContentAlignmentChanged virtual (BC34, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ContentPresenter.OnHorizontalContentAlignmentChanged(Microsoft.UI.Xaml.HorizontalAlignment oldHorizontalContentAlignment, Microsoft.UI.Xaml.HorizontalAlignment newHorizontalContentAlignment)" reason="Removed ContentPresenter.OnHorizontalContentAlignmentChanged virtual (BC34, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.TextBox.OnVerticalContentAlignmentChanged(Microsoft.UI.Xaml.VerticalAlignment oldVerticalContentAlignment, Microsoft.UI.Xaml.VerticalAlignment newVerticalContentAlignment)" reason="Removed empty TextBox.OnVerticalContentAlignmentChanged override (BC34, breaking changes for 7.0)" />
+
+		  <!-- Uno-only IEnumerable.GetEnumerator on FrameworkElement (enumerated the visual children); WinUI's FrameworkElement is not IEnumerable. ContentControl inherited it and re-declared the interface only. -->
+		  <Member fullName="System.Collections.IEnumerator Microsoft.UI.Xaml.FrameworkElement.GetEnumerator()" reason="Removed Uno-only IEnumerable/GetEnumerator (BC65, breaking changes for 7.0)" />
+
+		  <!-- Uno-only collection-initializer Add(UIElement) on Border/Panel/ScrollViewer, paired with the removed FrameworkElement IEnumerable to enable 'new Panel { child }' markup; WinUI has neither. -->
+		  <Member fullName="System\.Void Microsoft\.UI\.Xaml\.Controls\.(Border|Panel|ScrollViewer)(::|\.)Add\(.+\)" reason="Removed Uno-only collection-initializer Add(UIElement) (BC65, breaking changes for 7.0)" isRegex="true" />
+
+		  <!-- CompositionSpriteShape.StrokeDashArray setter reduced to internal (BC28, breaking changes for 7.0). -->
+		  <Member fullName="System.Void Microsoft.UI.Composition.CompositionSpriteShape.set_StrokeDashArray(Microsoft.UI.Composition.CompositionStrokeDashArray value)" reason="Reduced CompositionSpriteShape.StrokeDashArray setter to internal (BC28, breaking changes for 7.0)" />
+
+		  <!-- VisualInteractionSource.TryRedirectForManipulation param retyped from Windows.UI.Input.PointerPoint to Microsoft.UI.Input.PointerPoint (BC41); the old-typed overload reads as removed. -->
+		  <Member fullName="System.Void Microsoft.UI.Composition.Interactions.VisualInteractionSource.TryRedirectForManipulation(Windows.UI.Input.PointerPoint pointerPoint)" reason="Retyped TryRedirectForManipulation param to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+
+		  <!-- ScrollControllerPanRequestedEventArgs.PointerPoint retyped to Microsoft.UI.Input.PointerPoint (BC41): old-typed getter and ctor read as removed (property paired in <Properties> above). -->
+		  <Member fullName="Windows.UI.Input.PointerPoint Microsoft.UI.Xaml.Controls.Primitives.ScrollControllerPanRequestedEventArgs.get_PointerPoint()" reason="Retyped ScrollControllerPanRequestedEventArgs.PointerPoint to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Primitives.ScrollControllerPanRequestedEventArgs..ctor(Windows.UI.Input.PointerPoint pointerPoint)" reason="Retyped ScrollControllerPanRequestedEventArgs ctor param to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+
+		  <!-- BC41: GestureRecognizer processing methods retyped to take Microsoft.UI.Input.PointerPoint; PointerEventArgs.CurrentPoint/GetIntermediatePoints retyped; legacy Windows.UI.Input.PointerPoint.PointerDeviceType getter dropped. Old-typed signatures read as removed. -->
+		  <Member fullName="System.Void Windows.UI.Input.GestureRecognizer.ProcessDownEvent(Windows.UI.Input.PointerPoint value)" reason="Retyped GestureRecognizer.ProcessDownEvent to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Windows.UI.Input.GestureRecognizer.ProcessMoveEvents(System.Collections.Generic.IList`1&lt;Windows.UI.Input.PointerPoint&gt; value)" reason="Retyped GestureRecognizer.ProcessMoveEvents to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="System.Void Windows.UI.Input.GestureRecognizer.ProcessUpEvent(Windows.UI.Input.PointerPoint value)" reason="Retyped GestureRecognizer.ProcessUpEvent to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="System.Boolean Windows.UI.Input.GestureRecognizer.CanBeDoubleTap(Windows.UI.Input.PointerPoint value)" reason="Retyped GestureRecognizer.CanBeDoubleTap to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Windows.UI.Input.PointerPoint Windows.UI.Core.PointerEventArgs.get_CurrentPoint()" reason="Retyped Windows.UI.Core.PointerEventArgs.CurrentPoint to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="System.Collections.Generic.IList`1&lt;Windows.UI.Input.PointerPoint&gt; Windows.UI.Core.PointerEventArgs.GetIntermediatePoints()" reason="Retyped Windows.UI.Core.PointerEventArgs.GetIntermediatePoints to Microsoft.UI.Input.PointerPoint (BC41, breaking changes for 7.0)" />
+		  <Member fullName="Windows.Devices.Input.PointerDeviceType Windows.UI.Input.PointerPoint.get_PointerDeviceType()" reason="Dropped legacy Windows.UI.Input.PointerPoint variant (BC41, breaking changes for 7.0)" />
+
+		  <!-- Uno-only public members removed/hidden to match WinUI. get_ accessors paired with the <Properties> entries above. -->
+		  <Member fullName="Microsoft.UI.Xaml.Data.UpdateSourceTrigger Microsoft.UI.Xaml.FrameworkPropertyMetadata.get_DefaultUpdateSourceTrigger()" reason="Removed Uno-only FrameworkPropertyMetadata.DefaultUpdateSourceTrigger (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.Border.get_ChildProperty()" reason="Removed Border.ChildProperty DP; Child is a plain CLR property in WinUI (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ComboBox.OnIsDropDownOpenChanged(System.Boolean oldIsDropDownOpen, System.Boolean newIsDropDownOpen)" reason="Hid Uno-only ComboBox.OnIsDropDownOpenChanged (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Frame.set_BackStack(System.Collections.Generic.IList`1&lt;Microsoft.UI.Xaml.Navigation.PageStackEntry&gt; value)" reason="Removed Frame.BackStack setter to match WinUI get-only property (breaking changes for 7.0, uno#8339)" />
+
+		  <!-- OnTemplateRecycled made an explicit interface implementation (BC), so the public methods read as removed. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.TextBox.OnTemplateRecycled()" reason="Made OnTemplateRecycled an explicit interface implementation (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.ToggleSwitch.OnTemplateRecycled()" reason="Made OnTemplateRecycled an explicit interface implementation (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Controls.Primitives.ToggleButton.OnTemplateRecycled()" reason="Made OnTemplateRecycled an explicit interface implementation (breaking changes for 7.0, uno#8339)" />
+
+		  <!-- Navigation ctor/setters hidden to match WinUI. -->
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Navigation.NavigatingCancelEventArgs..ctor(Microsoft.UI.Xaml.Navigation.NavigationMode navigationMode, Microsoft.UI.Xaml.Media.Animation.NavigationTransitionInfo navigationTransitionInfo, System.Object parameter, System.Type sourcePageType)" reason="Hid NavigatingCancelEventArgs ctor to match WinUI (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Microsoft.UI.Xaml.Navigation.PageStackEntry.set_SourcePageType(System.Type value)" reason="Removed PageStackEntry.SourcePageType setter to match WinUI (breaking changes for 7.0, uno#8339)" />
+
+		  <!-- WinRTFeatureConfiguration.ApplicationLanguages.UseLegacyPrimaryLanguageOverride accessors (paired with the <Properties> entry above). -->
+		  <Member fullName="System.Boolean Uno.WinRTFeatureConfiguration/ApplicationLanguages.get_UseLegacyPrimaryLanguageOverride()" reason="Removed ApplicationLanguages.UseLegacyPrimaryLanguageOverride legacy flag (BC50, breaking changes for 7.0)" />
+
+		  <!-- FadeIn/FadeOutThemeAnimation reparent accessors (paired with the <Properties> entry above): get_/set_ for the removed From/To/By/EasingFunction/EnableDependentAnimation and the get_ DP-field accessors. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Media\.Animation\.(FadeIn|FadeOut)ThemeAnimation(::|\.)(get_From|set_From|get_To|set_To|get_By|set_By|get_EasingFunction|set_EasingFunction|get_EnableDependentAnimation|set_EnableDependentAnimation|get_FromProperty|get_ToProperty|get_ByProperty|get_EasingFunctionProperty|get_EnableDependentAnimationProperty)\(.*\)" reason="Reparented *ThemeAnimation from DoubleAnimation to Timeline for WinUI parity; DoubleAnimation-only member accessors removed (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
+		  <!-- ====================================================================== -->
+		  <!-- Reference flavor folded into Skia (breaking changes for 7.0, uno#8339). -->
+		  <!--                                                                        -->
+		  <!-- lib/ used to carry the Reference build and now carries the Skia one.   -->
+		  <!-- These members exist in both, with the same signature, but differ in    -->
+		  <!-- their vtable slot: the Skia compilation implements the internal        -->
+		  <!-- interfaces these types declare, so the accessors become newslot        -->
+		  <!-- virtual final, while GetVisualInternal goes the other way (Skia        -->
+		  <!-- provides an explicit IVisualElement2 implementation, leaving the       -->
+		  <!-- generated stub non-virtual). PackageDiff keys on the exact slot, so    -->
+		  <!-- the flip reads as a removal even though the API surface is unchanged.  -->
+		  <!-- ====================================================================== -->
+		  <Member fullName="Microsoft.UI.Xaml.FlowDirection Microsoft.UI.Xaml.FrameworkElement.get_FlowDirection()" reason="Reference flavor folded into Skia; accessor changed vtable slot, member still present (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="Microsoft.UI.Composition.Visual Microsoft.UI.Xaml.UIElement.GetVisualInternal()" reason="Reference flavor folded into Skia; accessor changed vtable slot, member still present (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.Controls\.TextBlock(::|\.)(get_TextWrapping|get_MaxLines|get_TextTrimming|get_TextAlignment|get_LineHeight|get_LineStackingStrategy)\(\)" reason="Reference flavor folded into Skia; accessors changed vtable slot, members still present (breaking changes for 7.0, uno#8339)" isRegex="true" />
+
+		  <!-- ====================================================================== -->
+		  <!-- SpeechRecognitionResult construction and mutation made internal        -->
+		  <!-- (breaking changes for 7.0, uno#8339).                                  -->
+		  <!--                                                                        -->
+		  <!-- Unlike the vtable-slot entries above, these are real removals from the -->
+		  <!-- public surface: the parameterless constructor and the Text /           -->
+		  <!-- RawConfidence setters were public only under #if __WASM__, a TODO      -->
+		  <!-- deferral explicitly labelled "make a breaking change". Every caller is -->
+		  <!-- internal to Uno.WinRT, so nothing inside the assembly breaks, but      -->
+		  <!-- external code that constructed or mutated a result needs a migration   -->
+		  <!-- note.                                                                  -->
+		  <!-- ====================================================================== -->
+		  <Member fullName="System.Void Windows.Media.SpeechRecognition.SpeechRecognitionResult..ctor()" reason="SpeechRecognitionResult constructor made internal; results are produced by the recognizer (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Windows.Media.SpeechRecognition.SpeechRecognitionResult.set_Text(System.String value)" reason="SpeechRecognitionResult.Text setter made internal (breaking changes for 7.0, uno#8339)" />
+		  <Member fullName="System.Void Windows.Media.SpeechRecognition.SpeechRecognitionResult.set_RawConfidence(System.Double value)" reason="SpeechRecognitionResult.RawConfidence setter made internal (breaking changes for 7.0, uno#8339)" />
+
+		  <!-- UriExtensions.IsLocalResource renamed: the name said "local resource" but the check is ms-appx, three lines from the ms-resource helpers it was confused with. -->
+		  <Member fullName="System.Boolean Uno.Extensions.UriExtensions.IsLocalResource(System.Uri uri)" reason="Renamed to IsMsAppx (BC51, breaking changes for 7.0)" />
+		  <!-- BC01: all template builder ctors removed from the public surface. WinUI exposes only the parameterless ctor; the builder overload is now internal and re-exposed via Uno.UI.Helpers.MarkupHelper.Create*. Regex covers FrameworkTemplate/DataTemplate/ControlTemplate/ItemsPanelTemplate across the legacy FrameworkTemplateBuilder, the NewFrameworkTemplateBuilder and the Func<View> shapes. -->
+		  <Member fullName="System\.Void Microsoft\.UI\.Xaml\.(Controls\.)?(FrameworkTemplate|DataTemplate|ControlTemplate|ItemsPanelTemplate)\.\.ctor\(.*(FrameworkTemplateBuilder|System\.Func).*\)" reason="BC01: template builder ctors removed/internalized; use Uno.UI.Helpers.MarkupHelper.Create* (uno#18672, breaking changes for 7.0)" isRegex="true" />
+		  <!-- BC01: TemplateManager dynamic-update overloads retyped/removed with the delegate change. -->
+		  <Member fullName="System\.Boolean Uno\.UI\.TemplateManager\.UpdateDataTemplate\(.*\)" reason="BC01: UpdateDataTemplate overloads retyped to Uno.UI.FrameworkTemplateBuilder; the Func&lt;View&gt; overload is removed (uno#18672, breaking changes for 7.0)" isRegex="true" />
+		  <!-- BC01: vestigial TemplatedParent DP accessors (paired with the <Properties> entries above). The removed no-op SetTemplatedParent and the ignored-argument ctor sat on DependencyObjectStore, already covered by the BC26 DependencyObjectStore regexes. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.DependencyObject(::|\.)(get_TemplatedParent|set_TemplatedParent|get_TemplatedParentProperty|OnTemplatedParentChanged)\(.*\)" reason="BC01: vestigial TemplatedParent DP and its accessors removed (uno#18672, breaking changes for 7.0)" isRegex="true" />
+		  <!-- BC01: only the framework materializes a template, so the settings ctor is internal. TemplatedParent stays public — an app-authored builder still reads the settings handed to it — but the member callback became an instance method (paired with the <Properties> entry above). -->
+		  <!-- BC01: nothing survives under the old name — the type moved to Uno.UI, its ctor is internal, and TemplateMemberCreatedCallback gave way to the OnMemberCreated instance method. -->
+		  <Member fullName=".+ Microsoft\.UI\.Xaml\.TemplateMaterializationSettings(::|\.|/).+" reason="BC01: TemplateMaterializationSettings moved to Uno.UI and is framework-constructed (uno#18672, breaking changes for 7.0)" isRegex="true" />
+	  </Methods>
+	  <Events>
+		  <!-- ====================================================================== -->
+		  <!-- BEGIN WinUI sync (Category B): shadow event removals.                  -->
+		  <!--                                                                        -->
+		  <!-- Events on KEPT types removed because they expose removed types in the  -->
+		  <!-- handler signature, OR are paired with already-removed siblings (e.g.   -->
+		  <!-- the BLE PHY events, the ToastNotificationMode change event).           -->
+		  <!--                                                                        -->
+		  <!-- The corresponding add_/remove_ method accessors are in the <Methods>   -->
+		  <!-- Category B block above.                                                -->
+		  <!-- ====================================================================== -->
+
+		  <!-- Refs Group 2: PhoneLineTransportDevice events. AudioRoutingStatusChanged
+		       fires alongside the removed AudioRoutingStatus enum getter; InBandRingingEnabledChanged
+		       fires alongside the removed InBandRingingEnabled property. -->
+		  <Member fullName="Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.ApplicationModel\.Calls\.PhoneLineTransportDevice,System\.Object&gt; Windows\.ApplicationModel\.Calls\.PhoneLineTransportDevice::(AudioRoutingStatusChanged|InBandRingingEnabledChanged)" reason="WinUI sync: removed alongside legacy phone-call control surface (Group 2)" isRegex="true" />
+
+		  <!-- Refs Group 5a: BLE PHY events expose removed BluetoothLEConnection{Parameters,Phy} types -->
+		  <Member fullName="Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.Devices\.Bluetooth\.BluetoothLEDevice,System\.Object&gt; Windows\.Devices\.Bluetooth\.BluetoothLEDevice::Connection(Parameters|Phy)Changed" reason="WinUI sync: BLE PHY-change events removed alongside their data types (Group 5a)" isRegex="true" />
+
+		  <!-- Refs Group 5b: DisplaySource.StatusChanged exposes removed DisplaySourceStatus -->
+		  <Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Windows.Devices.Display.Core.DisplaySource,System.Object&gt; Windows.Devices.Display.Core.DisplaySource::StatusChanged" reason="WinUI sync: paired with removed DisplaySource.Status / DisplaySourceStatus (Group 5b)" />
+
+		  <!-- Preview pointer-redirect API: events on CoreIndependentInputSource using ICorePointerRedirector
+		       (preview interface dropped from WinAppSDK 1.8). -->
+		  <Member fullName="Windows\.Foundation\.TypedEventHandler`2&lt;Windows\.UI\.Core\.ICorePointerRedirector,Windows\.UI\.Core\.PointerEventArgs&gt; Windows\.UI\.Core\.CoreIndependentInputSource::PointerRouted(Away|Released|To)" reason="WinUI sync: preview pointer-redirect events removed by WinAppSDK 1.8" isRegex="true" />
+
+		  <!-- Refs Group 11c: ToastNotificationManagerForUser.NotificationModeChanged uses removed ToastNotificationMode -->
+		  <Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Windows.UI.Notifications.ToastNotificationManagerForUser,System.Object&gt; Windows.UI.Notifications.ToastNotificationManagerForUser::NotificationModeChanged" reason="WinUI sync: paired with removed ToastNotificationMode (Group 11c)" />
+
+		  <!-- Refs Group 11e: CoreInputView events on view-management surface that's restructured.
+		       SupportedKindsChanged tracks removed CoreInputViewKind enum members; PrimaryViewAnimationStarting
+		       uses removed CoreInputViewAnimationStartingEventArgs. -->
+		  <Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Windows.UI.ViewManagement.Core.CoreInputView,System.Object&gt; Windows.UI.ViewManagement.Core.CoreInputView::SupportedKindsChanged" reason="WinUI sync: paired with removed CoreInputViewKind enum members (Group 11e / Cat D)" />
+		  <Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Windows.UI.ViewManagement.Core.CoreInputView,Windows.UI.ViewManagement.Core.CoreInputViewAnimationStartingEventArgs&gt; Windows.UI.ViewManagement.Core.CoreInputView::PrimaryViewAnimationStarting" reason="WinUI sync: uses removed CoreInputViewAnimationStartingEventArgs (Group 11e)" />
+
+		  <!-- END WinUI sync (Category B): shadow event removals -->
+
+		  <!-- DataContext restricted to FrameworkElement — DataContextChanged removed from UIElement and every non-FE DependencyObject. -->
+		  <Member fullName="Windows\.Foundation\.TypedEventHandler.+(::|\.)DataContextChanged" reason="DataContext restricted to FrameworkElement" isRegex="true" />
+	  </Events>
+	</IgnoreSet>
 	<![CDATA[
 		The 'baseVersion' should be the current latest stable version published on nuget, 
 		NOT what will be published by the PR in progress.


### PR DESCRIPTION
**GitHub Issue:** closes #24262

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Uno.WinUI` `6.7.65` is now the published stable baseline that `generatepkgdiff --base=Uno.WinUI` resolves to, but `build/PackageDiffIgnore.xml`'s most complete `IgnoreSet` was still pinned to `baseVersion="6.6"`.

`Uno.PackageDiff`'s `CompareVersion` matches an `IgnoreSet` only when the diff base's `Major.Minor` equals the set's (for a two-part `baseVersion` like `6.6`) — see [`DiffIgnore.cs`](https://github.com/unoplatform/Uno.PackageDiff/blob/main/src/Uno.PackageDiff/DiffIgnore.cs). Since the diff base moved to `6.7`, no set matched and the tool silently fell back to an **empty** ignore set, so every one of the ~1,300 entries accumulated in the `6.6` block (mostly the pending 7.0 breaking-change surface) stopped being consulted. That's why `Uno.UI - CI`'s `Generate NuGet Packages` step has been failing with hundreds of `Removed ... not found in ignore set.` errors on almost every PR into `feature/breakingchanges`, regardless of what the PR itself changes — confirmed across five unrelated PRs (#24061, #24186, #23655, #24185, #23703), all failing on the same step with the same class of error.

Adds a new `<IgnoreSet baseVersion="6.7">`, duplicating the `6.6` set's content verbatim, since none of the breaking changes it covers have actually shipped yet — they're still only on `feature/breakingchanges`. The historical `6.6` set is left in place.

### Why it cannot change behaviour ✅

Purely additive to `build/PackageDiffIgnore.xml` (a CI-only diagnostic input, not shipped code); no source changes. Confirmed the new set is well-formed XML and that `CompareVersion`'s `Major.Minor` matching now resolves `6.7.65` to the new set instead of falling through to an empty one.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
