### PR TITLE
docs(hotreload): restore guidance for waiting for Hot Reload

### DIFF
--- a/doc/articles/uno-development/uno-internals-hotreload.md
+++ b/doc/articles/uno-development/uno-internals-hotreload.md
@@ -73,6 +73,7 @@ When code needs to continue only after a file change has reached the running app
 ```csharp
 using System;
 using System.Linq;
+using System.Threading;
 using Uno.UI.RemoteControl;
 using Uno.UI.RemoteControl.HotReload;
 
@@ -87,9 +88,9 @@ var request = new ClientHotReloadProcessor.UpdateRequest(
     "New text",
     WaitForHotReload: true);
 
-await hotReload.UpdateFileAsync(request, cancellationToken);
+await hotReload.UpdateFileAsync(request, CancellationToken.None);
 ```
 
 `FilePath` is relative to the solution root. The Hot Reload processor must have published its initial status before the request is sent.
 
-Hot Reload normally triggers the UI update automatically. When the updated types are already available and the UI must be reapplied explicitly, call `UIUpdate.ForceRefresh(updatedTypes, cancellationToken)`. It returns after the UI-thread update pass completes and bypasses active `UIUpdate.Pause` handles.
+Hot Reload normally triggers the UI update automatically. When the updated types are already available and the UI must be reapplied explicitly, call `UIUpdate.ForceRefresh(updatedTypes, CancellationToken.None)`. It returns after the UI-thread update pass completes and bypasses active `UIUpdate.Pause` handles.

--- a/doc/articles/uno-development/uno-internals-hotreload.md
+++ b/doc/articles/uno-development/uno-internals-hotreload.md
@@ -66,8 +66,30 @@ Pausing and resuming UI Update is done by calling
 
 Note that pausing UI Updates doesn't stop the Hot Reload process. It only prevents the UI Update from running until UI Updates are resumed.
 
-<!---
 ## Waiting for Hot Reload to be applied
 
-// TODO: Give an example of how to await UI Updates (eg https://github.com/unoplatform/uno/blob/0340cc1394994cdbd525d61de611a0531c38bcc7/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs#L9-L37)
--->
+When code needs to continue only after a file change has reached the running application, use `ClientHotReloadProcessor.UpdateRequest` with `WaitForHotReload` set to `true` and await `UpdateFileAsync`. The task completes after server processing and local Hot Reload processing, including the UI update.
+
+```csharp
+using System;
+using System.Linq;
+using Uno.UI.RemoteControl;
+using Uno.UI.RemoteControl.HotReload;
+
+var hotReload = RemoteControlClient.Instance?.Processors
+    .OfType<ClientHotReloadProcessor>()
+    .SingleOrDefault()
+    ?? throw new InvalidOperationException("Hot Reload is unavailable.");
+
+var request = new ClientHotReloadProcessor.UpdateRequest(
+    "Pages/MainPage.xaml",
+    "Old text",
+    "New text",
+    WaitForHotReload: true);
+
+await hotReload.UpdateFileAsync(request, cancellationToken);
+```
+
+`FilePath` is relative to the solution root. The Hot Reload processor must have published its initial status before the request is sent.
+
+Hot Reload normally triggers the UI update automatically. When the updated types are already available and the UI must be reapplied explicitly, call `UIUpdate.ForceRefresh(updatedTypes, cancellationToken)`. It returns after the UI-thread update pass completes and bypasses active `UIUpdate.Pause` handles.


### PR DESCRIPTION
**GitHub Issue:** closes #18950

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Restores the `Waiting for Hot Reload to be applied` section with the current `UpdateRequest`, `UpdateFileAsync`, and `UIUpdate.ForceRefresh` APIs. The example also documents the initial-status requirement and uses a self-contained cancellation token.

## PR Checklist ✅

- [ ] 🧪 Runtime tests or a manual sample are not applicable to this documentation-only change.
- [x] 📚 Docs have been updated following the documentation template where applicable.
- [ ] 🖼️ Screenshots Compare Test Run is not applicable to documentation-only changes.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests.

## Validation

- `git diff --check`: passed.
- Markdownlint and cSpell: passed.
- DocFX: generated the changed page, but the shallow checkout lacks external/generated TOCs and exits with pre-existing diagnostics.
