### PR TITLE
docs: clarify x:Bind literal argument scope

### DIFF
--- a/doc/articles/features/windows-ui-xaml-xbind.md
+++ b/doc/articles/features/windows-ui-xaml-xbind.md
@@ -57,6 +57,8 @@ Uno supports the [`x:Bind`](https://learn.microsoft.com/windows/uwp/xaml-platfor
     <TextBlock Text="{x:Bind TestString(x:Null)}" />
     ```
 
+    In this context, `x:True`, `x:False`, and `x:Null` are literal arguments scoped to `{x:Bind ...}` function calls; they are not general-purpose values that can be assigned to `FallbackValue`, `TargetNullValue`, or arbitrary XAML properties.
+
   - Quote escaping
 
     ```xml


### PR DESCRIPTION
**GitHub Issue:** closes #20928

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Clarifies that `x:True`, `x:False`, and `x:Null` are literal arguments supported in `{x:Bind ...}` function calls. They are not general-purpose values for `FallbackValue`, `TargetNullValue`, or arbitrary XAML properties.

## PR Checklist ✅

- [ ] 🧪 Runtime tests or a manual sample are not applicable to this documentation-only change.
- [x] 📚 Docs have been updated following the documentation template where applicable.
- [ ] 🖼️ Screenshots Compare Test Run is not applicable to documentation-only changes.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests.

## Validation

- `git diff --check`: passed.
- Markdownlint and cSpell: passed.
- DocFX: unavailable in the local environment.
