### PR TITLE
docs: clarify UnoAsset build action semantics

### DIFF
--- a/doc/articles/features/file-management.md
+++ b/doc/articles/features/file-management.md
@@ -70,6 +70,9 @@ Ensure that a declaration exists in your project file like the following:
 </ItemGroup>
 ```
 
+> [!NOTE]
+> `UnoAsset` is an available Uno.Sdk build action, but it is not a storage-assets feature. It does not by itself process or package a file. In WinAppSDK projects, items marked `UnoAsset` are excluded from the default content glob for the Windows platform folder. Use `Content` to include a file in the application package, as shown above.
+
 A URI with the `ms-appx:///` scheme can then be used to read a file's content:
 
 ```csharp

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -357,6 +357,9 @@
 		}
 	],
 	"items": {
+		"UnoAsset": {
+			"description": "An available item name for an Uno asset. This item type does not by itself process or package a file; use Content to include a file in the application package. In WinAppSDK projects, UnoAsset items are excluded from the default content glob for the Windows platform folder."
+		},
 		"UnoDspImportColors": {
 			"description": "Imports a theme file with color definitions.",
 			"metadata": {


### PR DESCRIPTION
**GitHub Issue:** closes #21616

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Adds `UnoAsset` to the Uno.Sdk build schema and documents its current behavior. `UnoAsset` does not itself process or package files; package files should use `Content`. The existing WinAppSDK exclusion from the default Windows-platform content glob is also documented.

## PR Checklist ✅

- [ ] 🧪 Runtime tests or a manual sample are not applicable to this documentation and schema metadata change.
- [x] 📚 Docs have been updated following the documentation template where applicable.
- [ ] 🖼️ Screenshots Compare Test Run is not applicable to documentation-only changes.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests.

## Validation

- `git diff --check`: passed.
- `jq empty src/Uno.Sdk/Sdk/Sdk.props.buildschema.json`: passed.
- Markdownlint: passed.
- DocFX: unavailable in the local environment.
