### PR TITLE
docs: clarify Uno 6 platform and renderer names

### DIFF
--- a/doc/.feature-template-uno-only.md
+++ b/doc/.feature-template-uno-only.md
@@ -18,10 +18,10 @@
 
 <!-- If not feature is supported on every platform, fill in the matrix below to show which ones are supported. If there's no limitations to the feature on any platform, consider removing this whole section. -->
 
-| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) | 
-|---------------|-------|-------|-------|-------|-------|-------|-|
-| Feature1         | ✔ | ✔/✖ (choose appropriate) | ? (fill in) | ? | ? | ? | ? |
-| Feature2...     | ✔ | ? | ? | ? | ? | ? | ? |
+| Feature        | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------|-------|-------|-------|-------|-------|-------|-------|-------|
+| Feature1         | ✔ | ✔/✖ (choose appropriate) | ? (fill in) | ? | ? | ? | ? | ? |
+| Feature2...     | ✔ | ? | ? | ? | ? | ? | ? | ? |
 
 ## See YourFeature in action
 

--- a/doc/.feature-template.md
+++ b/doc/.feature-template.md
@@ -12,10 +12,10 @@
 
 ## Supported features
 
-| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) | 
-|---------------|-------|-------|-------|-------|-------|-------|-|
-| Feature1         | ✔ | ✔/✖ (choose appropriate) | ? (fill in) | ? | ? | ? | ? |
-| Feature2...     | ✔ | ? | ? | ? | ? | ? | ? |
+| Feature        | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------|-------|-------|-------|-------|-------|-------|-------|-------|
+| Feature1         | ✔ | ✔/✖ (choose appropriate) | ? (fill in) | ? | ? | ? | ? | ? |
+| Feature2...     | ✔ | ? | ? | ? | ? | ? | ? | ? |
 
 <!-- Add any additional information on platform-specific limitations and constraints -->
 

--- a/doc/articles/features/PasswordVault.md
+++ b/doc/articles/features/PasswordVault.md
@@ -12,10 +12,10 @@ uid: Uno.Features.PasswordVault
 
 ## Supported features
 
-| Feature              | Windows | Android | iOS     | Web (WASM)  Linux (Skia) | Win 7 (Skia) | Tizen |
-|----------------------|---------|---------|---------|--------------------------|--------------|-------|
-| `PasswordVault`      | ✔       | ✔       | ✔       | ✖           | ✖            | ✖            | ✖     |
-| `PasswordCredential` | ✔       | Partial | Partial | Partial   | ✖            | ✖            | ✖     |
+| Feature              | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|----------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `PasswordVault`      | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `PasswordCredential` | ✔               | Partial               | Partial           | Partial                    | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## `PasswordVault`
 

--- a/doc/articles/features/accelerometer.md
+++ b/doc/articles/features/accelerometer.md
@@ -11,12 +11,12 @@ uid: Uno.Features.Accelerometer
 
 ## Supported features
 
-| Feature          | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetDefault`     | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ReadingChanged` | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
-| `Shaken`         | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
-| `ReportInterval` | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
+| Feature          | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ReadingChanged` | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `Shaken`         | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReportInterval` | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Using Accelerometer with Uno
 

--- a/doc/articles/features/app-close-handler.md
+++ b/doc/articles/features/app-close-handler.md
@@ -11,9 +11,9 @@ The `AppWindow.Closing` API lets you respond to or prevent standard app window c
 
 ## Platform Support
 
-| Feature              | Windows App SDK | Android | iOS | Web (WASM) | Desktop (Windows) | Desktop (macOS) | Desktop (Linux) |
-|----------------------|------------------|---------|-----|------------|-------------------|------------------|------------------|
-| `AppWindow.Closing`  | ✔️               | ❌      | ❌  | ❌         | ✔️                | ✔️               | ✔️               |
+| Feature             | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `AppWindow.Closing` | ✔️              | ❌                    | ❌                | ❌                         | ✔️                    | ✔️                  | ✔️                                 | ✔️                      |
 
 > [!NOTE]
 > On platforms where this feature is not supported, the `Closing` event will still be raised, but setting `args.Cancel = true` has no effect.

--- a/doc/articles/features/applicationdata.md
+++ b/doc/articles/features/applicationdata.md
@@ -12,14 +12,14 @@ Legend
 
 - ✔  Supported
 
-| Picker             | WinUI      | WebAssembly | Android | iOS/Mac Catalyst   | macOS | Skia Desktop |
-|--------------------|------------|-------------|---------|--------------------|-------|--------------|
-| `LocalFolder`      | ✔         | ✔          | ✔       | ✔                 | ✔     | ✔            |
-| `RoamingFolder`    | ✔         | ✔          | ✔       | ✔                 | ✔     | ✔            |
-| `LocalCacheFolder` | ✔         | ✔          | ✔       | ✔                 | ✔     | ✔            |
-| `TemporaryFolder`  | ✔         | ✔          | ✔       | ✔                 | ✔     | ✔            |
-| `LocalSettings`    | ✔         | ✔          | ✔       | ✔                 | ✔     | ✔            |
-| `RoamingSettings`  | ✔         | ✔          | ✔       | ✔                 | ✔     | ✔            |
+| Picker             | Windows App SDK | WebAssembly (Native/Skia) | Android (Native/Skia) | iOS (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|--------------------|-----------------|----------------------------|-----------------------|-------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `LocalFolder`      | ✔               | ✔                          | ✔                     | ✔                 | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `RoamingFolder`    | ✔               | ✔                          | ✔                     | ✔                 | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `LocalCacheFolder` | ✔               | ✔                          | ✔                     | ✔                 | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `TemporaryFolder`  | ✔               | ✔                          | ✔                     | ✔                 | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `LocalSettings`    | ✔               | ✔                          | ✔                     | ✔                 | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `RoamingSettings`  | ✔               | ✔                          | ✔                     | ✔                 | ✔                     | ✔                   | ✔                                  | ✔                       |
 
 Please note that `RoamingFolder` and `RoamingSettings` are not roamed automatically across devices, they only provide a logical separation between data that you intend to roam and that you intend to keep local.
 

--- a/doc/articles/features/auto-codebehind.md
+++ b/doc/articles/features/auto-codebehind.md
@@ -133,10 +133,10 @@ Per-file metadata always takes precedence over the project-level property.
 
 This feature works on all platforms supported by Uno Platform:
 
-| Feature | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) |
-|---|---|---|---|---|---|---|
-| Auto code-behind generation | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
-| Per-file configuration | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
-| Project-level configuration | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| Feature | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---|---|---|---|---|---|---|---|---|
+| Auto code-behind generation | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| Per-file configuration | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| Project-level configuration | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
 
 On Uno Platform targets, code-behind generation is handled by the integrated XAML source generation pipeline. On WinUI (Windows) targets, a standalone incremental source generator provides the same functionality.

--- a/doc/articles/features/barometer.md
+++ b/doc/articles/features/barometer.md
@@ -11,11 +11,11 @@ uid: Uno.Features.Barometer
 
 ## Supported features
 
-| Feature          | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetDefault`     | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ReadingChanged` | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
-| `ReportInterval` | ✔       | ✔       | ✖   | ✖          | ✖     | ✖            | ✖            |
+| Feature          | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ReadingChanged` | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReportInterval` | ✔               | ✔                     | ✖                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Using Barometer with Uno
 

--- a/doc/articles/features/clipboard.md
+++ b/doc/articles/features/clipboard.md
@@ -11,13 +11,13 @@ uid: Uno.Features.Clipboard
 
 ## Supported features
 
-| Feature          | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `SetContent`     | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `GetContent`     | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `Clear`          | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ContentChanged` | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `Flush`          | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
+| Feature          | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `SetContent`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `GetContent`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `Clear`          | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ContentChanged` | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `Flush`          | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
 
 <!-- Add any additional information on platform-specific limitations and constraints -->
 

--- a/doc/articles/features/compass.md
+++ b/doc/articles/features/compass.md
@@ -11,11 +11,11 @@ uid: Uno.Features.Compass
 
 ## Supported features
 
-| Feature          | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetDefault`     | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ReadingChanged` | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
-| `ReportInterval` | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
+| Feature          | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ReadingChanged` | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReportInterval` | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Using Compass with Uno
 

--- a/doc/articles/features/file-management.md
+++ b/doc/articles/features/file-management.md
@@ -11,12 +11,12 @@ File management allows shared reading and writing of files across all Uno Platfo
 
 ## Supported features
 
-| Feature             | WinUI     | Android | iOS     | Web (WASM) | macOS   | Linux (Skia) | WPF (Skia) |
-|---------------------|-----------|---------|---------|------------|---------|--------------|------------|
-| `StorageFile`       | ✔         | ✔       | ✔       | ✔          | ✔       | ✔            | ✔          |
-| `StorageFolder`     | ✔         | ✔       | ✔       | ✔          | ✔       | ✔            | ✔          |
-| `CachedFileManager` | ✔         | partial | partial | partial    | partial | partial      | partial    |
-| `StorageFileHelper` | ✔         | ✔       | ✔       | ✔          | ✔       | ✔            | ✔          |
+| Feature             | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `StorageFile`       | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `StorageFolder`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `CachedFileManager` | ✔               | partial               | partial           | partial                    | partial               | partial             | partial                            | partial                 |
+| `StorageFileHelper` | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
 
 ## Overview
 

--- a/doc/articles/features/flashlight.md
+++ b/doc/articles/features/flashlight.md
@@ -11,11 +11,11 @@ uid: Uno.Features.Flashlight
 
 ## Supported features
 
-| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) |
-|---------------|-------|-------|-------|-------|-------|-------|-|
-| `GetDefaultAsync` | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
-| `IsEnabled`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
-| `BrightnessLevel`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
+| Feature        | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefaultAsync` | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| `IsEnabled`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ | ✖ |
+| `BrightnessLevel`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ | ✖ |
 
 <!-- Add any additional information on platform-specific limitations and constraints -->
 

--- a/doc/articles/features/gamepad.md
+++ b/doc/articles/features/gamepad.md
@@ -11,12 +11,12 @@ uid: Uno.Features.Gamepad
 
 ## Supported features
 
-| Feature             | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-| ------------------- | ------- | ------- | --- | ---------- | ----- | ------------ | ------------ |
-| `GetCurrentReading` | ✔       | ✔       | ✔   | ✔          | ✔     | ✖            | ✖            |
-| `GamepadAdded`      | ✔       | ✔       | ✔   | ✔          | ✔     | ✖            | ✖            |
-| `GamepadRemoved`    | ✔       | ✔       | ✔   | ✔          | ✔     | ✖            | ✖            |
-| `Gamepads`          | ✔       | ✔       | ✔   | ✔          | ✔     | ✖            | ✖            |
+| Feature             | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+| ------------------- | ----------------| ----------------------| ------------------| --------------------------| ----------------------| --------------------| -----------------------------------| ------------------------|
+| `GetCurrentReading` | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✖                   | ✖                                  | ✖                       |
+| `GamepadAdded`      | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✖                   | ✖                                  | ✖                       |
+| `GamepadRemoved`    | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✖                   | ✖                                  | ✖                       |
+| `Gamepads`          | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✖                   | ✖                                  | ✖                       |
 
 ## Example
 

--- a/doc/articles/features/gyrometer.md
+++ b/doc/articles/features/gyrometer.md
@@ -11,11 +11,11 @@ uid: Uno.Features.Gyrometer
 
 ## Supported features
 
-| Feature          | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetDefault`     | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ReadingChanged` | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
-| `ReportInterval` | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
+| Feature          | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`     | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ReadingChanged` | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReportInterval` | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Using Gyrometer with Uno
 

--- a/doc/articles/features/lightsensor.md
+++ b/doc/articles/features/lightsensor.md
@@ -11,11 +11,11 @@ uid: Uno.Features.LightSensor
 
 ## Supported features
 
-| Feature          |Windows|Android|iOS|Wasm|macOS|Skia|
-|------------------|-------|-------|---|----|-----|----|
-| `GetDefault`     |   ✔   |   ✔   | ✖ | ✔ | ✖ | ✖ |
-| `ReadingChanged` |   ✔   |   ✔   | ✖ | ✔ | ✖ | ✖ |
-| `ReportInterval` |   ✔   |   ✔   | ✖ | ✖ | ✖ | ✖ |
+| Feature          | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`     | ✔               | ✔                     | ✖                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReadingChanged` | ✔               | ✔                     | ✖                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReportInterval` | ✔               | ✔                     | ✖                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Using LightSensor with Uno
 

--- a/doc/articles/features/magnetometer.md
+++ b/doc/articles/features/magnetometer.md
@@ -11,11 +11,11 @@ uid: Uno.Features.Magnetometer
 
 ## Supported features
 
-| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) |
-|---------------|-------|-------|-------|-------|-------|-------|-|
-| `GetDefault`         | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
-| `ReadingChanged` | ✔ | ✔ | ✔ | ✔ | ✖ | ✖| ✖ |
-| `ReportInterval`     | ✔ | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ |
+| Feature        | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`         | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| `ReadingChanged` | ✔ | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
+| `ReportInterval`     | ✔ | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
 
 ## Using Magnetometer with Uno
 

--- a/doc/articles/features/orientation-sensor.md
+++ b/doc/articles/features/orientation-sensor.md
@@ -11,10 +11,10 @@ uid: Uno.Features.OrientationSensor
 
 ## Supported features
 
-| Feature              | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|----------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetDefault`         | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `OrientationChanged` | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
+| Feature              | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|----------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefault`         | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `OrientationChanged` | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 > [!IMPORTANT]
 > The `OrientationChanged` event is not supported by iOS simulators.

--- a/doc/articles/features/settings.md
+++ b/doc/articles/features/settings.md
@@ -11,10 +11,10 @@ uid: Uno.Features.Settings
 
 ## Supported features
 
-| Feature                                   | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|-------------------------------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `ApplicationData.Current.LocalSettings`   | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ApplicationData.Current.RoamingSettings` | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
+| Feature                                   | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|-------------------------------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `ApplicationData.Current.LocalSettings`   | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ApplicationData.Current.RoamingSettings` | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
 
 ## Using Settings with Uno
 

--- a/doc/articles/features/step-counter.md
+++ b/doc/articles/features/step-counter.md
@@ -11,11 +11,11 @@ uid: Uno.Features.StepCounter
 
 ## Supported features
 
-| Feature           | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|-------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetDefaultAsync` | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `ReadingChanged`  | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
-| `ReportInterval`  | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
+| Feature           | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|-------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetDefaultAsync` | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `ReadingChanged`  | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ReportInterval`  | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Using Pedometer with Uno
 

--- a/doc/articles/features/windows-applicationmodel-calls.md
+++ b/doc/articles/features/windows-applicationmodel-calls.md
@@ -13,13 +13,13 @@ uid: Uno.Features.WAMCalls
 
 ## Supported features
 
-| Feature                   | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|---------------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `ShowPhoneCallUI`         | ✔       | ✔       | ✔   | ✔          | ✖     | ✖            | ✖            |
-| `ShowPhoneCallSettingsUI` | ✔       | ✔       | ✖   | ✖          | ✖     | ✖            | ✖            |
-| `CallStateChanged`        | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
-| `IsCallActive`            | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
-| `IsCallActive`            | ✔       | ✔       | ✔   | ✖          | ✖     | ✖            | ✖            |
+| Feature                   | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|---------------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `ShowPhoneCallUI`         | ✔               | ✔                     | ✔                 | ✔                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `ShowPhoneCallSettingsUI` | ✔               | ✔                     | ✖                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `CallStateChanged`        | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `IsCallActive`            | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `IsCallActive`            | ✔               | ✔                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ## Examples
 

--- a/doc/articles/features/windows-networking.md
+++ b/doc/articles/features/windows-networking.md
@@ -15,10 +15,10 @@ The `Windows.Networking.Connectivity.NetworkInformation` class provides access t
 
 ### Supported features
 
-| Feature                        | Windows | Android | iOS | Web (WASM) | macOS | Linux (Skia) | Win 7 (Skia) |
-|--------------------------------|---------|---------|-----|------------|-------|--------------|--------------|
-| `GetInternetConnectionProfile` | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
-| `NetworkStatusChanged`         | ✔       | ✔       | ✔   | ✔          | ✔     | ✔            | ✔            |
+| Feature                        | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|--------------------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `GetInternetConnectionProfile` | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| `NetworkStatusChanged`         | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
 
 ### Checking Network Connectivity in Uno
 

--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -19,23 +19,23 @@ Legend
 * 💬 Partially supported (see below for more details)
 * ✖ Not supported
 
-| Picker         | Windows App SDK   | WebAssembly | Android | iOS    | Desktop |
-|----------------|-------|-------------|---------|--------|-------|
-| FileOpenPicker | ✔    | ✔ (1)       | ✔      | ✔      | ✔    |
-| FileSavePicker | ✔    | ✔ (1)       | ✔      | 💬 (2) | ✔    |
-| FolderPicker   | ✔    | ✔           | ✔      | ✔      | ✔    |
+| Picker         | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|----------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| FileOpenPicker | ✔               | ✔                     | ✔                 | ✔ (1)                      | ✔                     | ✔                   | ✔                                  | ✔                       |
+| FileSavePicker | ✔               | ✔                     | 💬 (2)            | ✔ (1)                      | ✔                     | ✔                   | ✔                                  | ✔                       |
+| FolderPicker   | ✔               | ✔                     | ✔                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
 
 *(1) - Multiple implementations supported - see WebAssembly section below*\
 *(2) - See iOS section below*
 
 On some platforms, you can further customize the file-picking experience by utilizing additional properties:
 
-| Feature                 | Windows App SDK  | WebAssembly | Android | iOS   | Desktop |
-|-------------------------|------|-------------|---------|-------|-----|
-| SuggestedFileName       | ✔   | ✔           | ✖      | ✖     | ✔ |
-| SuggestedStartLocation  | ✔   | ✔ (1)       | 💬 (4) | ✔ (3) | ✔ |
-| SettingsIdentifier      | ✔   | ✔ (1)       | ✔      | ✖     | ✔ |
-| SetMultipleFilesLimit   | ✖   | ✖           | ✖      | ✔     | ✖ |
+| Feature                | Windows App SDK | Android (Native/Skia) | iOS (Native/Skia) | WebAssembly (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|------------------------|-----------------|-----------------------|-------------------|----------------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| SuggestedFileName      | ✔               | ✖                     | ✖                 | ✔                          | ✔                     | ✔                   | ✔                                  | ✔                       |
+| SuggestedStartLocation | ✔               | 💬 (4)                | ✔ (3)             | ✔ (1)                      | ✔                     | ✔                   | ✔                                  | ✔                       |
+| SettingsIdentifier     | ✔               | ✔                     | ✖                 | ✔ (1)                      | ✔                     | ✔                   | ✔                                  | ✔                       |
+| SetMultipleFilesLimit  | ✖               | ✖                     | ✔                 | ✖                          | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 *(1) - Only for the native file pickers - see WebAssembly section below*\
 *(2) - For FileOpenPicker, VideosLibrary and PicturesLibrary are used to apply `image/*` and `video/*` filters*\

--- a/doc/articles/features/windows-system-power.md
+++ b/doc/articles/features/windows-system-power.md
@@ -16,18 +16,18 @@ uid: Uno.Features.WSPower
 * ✔  Supported
 * ✖ Not supported
 
-| Picker         | WinUI   | WebAssembly | Android | iOS   | macOS | Skia Desktop |
-|----------------|-------|-------------|---------|-------|-------|-----|
-| `BatteryStatus` | ✔   | ✔  | ✔     | ✔    |✖ ️   | ✖ |
-| `EnergySaverStatus` | ✔   |  ✖ | ✔     | ✔    |✖ ️   | ✖ |
-| `PowerSupplyStatus` | ✔   | ✔  | ✔     | ✔   |✖ ️   | ✖ |
-| `RemainingChargePercent` | ✔   | ✔ | ✔     | ✔   |✖ ️   | ✖ |
-| `RemainingDischargeTime` | ✔   | ✔ |  ✖    | ✖ |✖ ️   | ✖ |
-| `BatteryStatusChanged` | ✔   | ✔  | ✔     | ✔   |✖ ️   | ✖ |
-| `EnergySaverStatusChanged` | ✔   |  ✖ | ✔     | ✔    |✖ ️   | ✖ |
-| `PowerSupplyStatusChanged` | ✔   | ✔  | ✔     | ✔   |✖ ️   | ✖ |
-| `RemainingChargePercentChanged` | ✔   | ✔| ✔     | ✔   |✖ ️   | ✖ |
-| `RemainingDischargeTimeChanged` | ✔   | ✔     |  ✖     |  ✖  |✖ ️   | ✖ |
+| Picker         | Windows App SDK | WebAssembly (Native/Skia) | Android (Native/Skia) | iOS (Native/Skia) | Desktop (macOS, Skia) | Desktop (X11, Skia) | Desktop (Linux Framebuffer, Skia) | Desktop (Windows, Skia) |
+|----------------|-----------------|----------------------------|-----------------------|-------------------|-----------------------|---------------------|------------------------------------|-------------------------|
+| `BatteryStatus` | ✔               | ✔                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `EnergySaverStatus` | ✔           | ✖                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `PowerSupplyStatus` | ✔           | ✔                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `RemainingChargePercent` | ✔    | ✔                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `RemainingDischargeTime` | ✔    | ✔                          | ✖                     | ✖                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `BatteryStatusChanged` | ✔      | ✔                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `EnergySaverStatusChanged` | ✔  | ✖                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `PowerSupplyStatusChanged` | ✔  | ✔                          | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `RemainingChargePercentChanged` | ✔ | ✔                       | ✔                     | ✔                 | ✖                     | ✖                   | ✖                                  | ✖                       |
+| `RemainingDischargeTimeChanged` | ✔ | ✔                      | ✖                     | ✖                 | ✖                     | ✖                   | ✖                                  | ✖                       |
 
 ### Usage
 

--- a/doc/articles/features/working-with-assets.md
+++ b/doc/articles/features/working-with-assets.md
@@ -16,12 +16,14 @@ At the moment, the following image file types are supported as `Content` assets:
 
 |             | `.bmp` (Win BMP) | `.gif`‡ | `.heic` (Apple) | `.jpg` & `.jpeg` (JFIF) | `.png` | `.webp` | `.pdf` | `.svg` |
 | ----------- | :-------------: | :---: | :-----------: | :-----------------: | :--: | :---: | :--: | :--: |
-| WinUI       |       ✔️        |   ✔️   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
-| Android 10  |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ✔️   |  ✔️   |  ✔️   |
-| iOS 13      |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ❌   |  ✔️   |
-| macOS       |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ✔️   |  ❌   |
-| WebAssembly†       |       ✔️        |  ✔️‡   |      ❌†       |          ✔️          |  ✔️   |  ❌†   |  ❌†  |  ✔️   |
-| Skia Desktop |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Windows App SDK       |       ✔️        |   ✔️   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Android (Native/Skia)  |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ✔️   |  ✔️   |  ✔️   |
+| iOS (Native/Skia)      |       ✔️        |  ✔️‡   |       ✔️       |          ✔️          |  ✔️   |   ❌   |  ❌   |  ✔️   |
+| WebAssembly (Native/Skia)†       |       ✔️        |  ✔️‡   |      ❌†       |          ✔️          |  ✔️   |  ❌†   |  ❌†  |  ✔️   |
+| Desktop (Windows, Skia) |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Desktop (macOS, Skia) |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Desktop (X11, Skia) |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
+| Desktop (Linux Framebuffer, Skia) |       ✔️        |  ✔️‡   |       ❌       |          ✔️          |  ✔️   |   ✔️   |  ❌   |  ✔️   |
 
 * † Actual WebAssembly image format support is browser dependent. For example, `.webp` is not working on Safari on macOS, but works on Chromium-based browsers. Check-marks (✔️) indicate a format that can safely be expected to work on all browsers able to run Wasm applications.
 * ‡ **Gif animation support**:


### PR DESCRIPTION
**GitHub Issue:** closes #21735

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Updates 24 supported-feature tables and templates to use Uno 6 target and renderer names: Windows App SDK, Native/Skia mobile and WebAssembly, and the four Skia Desktop hosts (Windows, macOS, X11, and Linux Framebuffer). Existing support marks are preserved.

## PR Checklist ✅

- [ ] 🧪 Runtime tests or a manual sample are not applicable to this documentation-only change.
- [x] 📚 Docs have been updated following the documentation template where applicable.
- [ ] 🖼️ Screenshots Compare Test Run is not applicable to documentation-only changes.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests.

## Validation

- `git diff --check`: passed.
- Markdownlint: passed for all 24 changed documentation files.
- `npm run strict`: reached DocFX, which is unavailable in the local environment.

The specialized renderer/implementation tables were intentionally left unchanged because their columns describe different dimensions and need independent support verification.
