### PR TITLE
docs: document localized application name

### DIFF
--- a/doc/articles/guides/localization.md
+++ b/doc/articles/guides/localization.md
@@ -116,6 +116,24 @@ This guide will walk you through the necessary steps to localize an Uno Platform
     </Resources>
     ```
 
+## Localize the application name
+
+For Windows and Skia Desktop targets, the application name in `Package.appxmanifest` can reference a localized string with `ms-resource:`:
+
+```xml
+<Properties>
+    <DisplayName>ms-resource:ApplicationName</DisplayName>
+</Properties>
+```
+
+Add an `ApplicationName` entry to each language's `Strings/[language]/Resources.resw` file:
+
+|Name|Value in `en/Resources.resw`|Value in `fr/Resources.resw`|
+|-|-|-|
+|ApplicationName|`My application`|`Mon application`|
+
+On Skia Desktop, the manifest is embedded in the app and `Package.Current.DisplayName` resolves the resource using the current UI language. Android, iOS, Mac Catalyst, and WebAssembly use platform-specific application metadata instead.
+
 ## Get the complete code
 
 See the completed sample on GitHub: [LocalizationSamples/Localization](https://github.com/unoplatform/Uno.Samples/tree/master/UI/LocalizationSamples/Localization)

--- a/doc/articles/guides/localization.md
+++ b/doc/articles/guides/localization.md
@@ -118,7 +118,7 @@ This guide will walk you through the necessary steps to localize an Uno Platform
 
 ## Localize the application name
 
-For Windows and Skia Desktop targets, the application name in `Package.appxmanifest` can reference a localized string with `ms-resource:`:
+For Windows packaged apps and Skia Desktop targets, the application name in `Package.appxmanifest` can reference a localized string with `ms-resource:`:
 
 ```xml
 <Properties>


### PR DESCRIPTION
**GitHub Issue:** closes #17909

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Documents how to localize an application name by referencing `ApplicationName` from `Package.appxmanifest` with `ms-resource:`. The documented behavior is scoped to Windows packaged apps and Skia Desktop targets; other targets continue to use their platform-specific application metadata.

## PR Checklist ✅

- [ ] 🧪 Runtime tests or a manual sample are not applicable to this documentation-only change.
- [x] 📚 Docs have been updated following the documentation template where applicable.
- [ ] 🖼️ Screenshots Compare Test Run is not applicable to documentation-only changes.
- [x] ❗ Contains **NO** breaking changes.
- [ ] 👀 Reviewed 2 other open pull requests.

## Validation

- `git diff --check`: passed.
- Markdownlint: passed for the changed documentation file.
- cSpell: passed for the changed documentation file.
- DocFX: not run; DocFX is unavailable in the local environment.
