### PR TITLE
fix(input): Support absolute coordinates for mouse injection

### DIFF
--- a/src/Uno.UI.Extras/DevTools/Input/Mouse.cs
+++ b/src/Uno.UI.Extras/DevTools/Input/Mouse.cs
@@ -26,6 +26,10 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 	private readonly InputInjector _input;
 
 #if !HAS_UNO
+	// Below the observed real-InputInjector ceiling of ~16 items per InjectMouseInput call.
+	private const int MaxInjectBatchSize = 10;
+
+	// Window-relative, i.e. the same space callers pass to MoveTo.
 	private Point _currentPosition;
 	private bool _leftPressed;
 	private bool _rightPressed;
@@ -37,8 +41,7 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 	{
 		_input = input;
 #if !HAS_UNO
-		GetCursorPos(out var pt);
-		_currentPosition = new Point(pt.X, pt.Y);
+		_currentPosition = GetCursorWindowPosition();
 #endif
 	}
 
@@ -228,9 +231,7 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 		// On WinAppSDK, use absolute coordinates with screen-space conversion.
 		// The Absolute flag requires coordinates normalized to 0-65535 range.
 		var normalizedTarget = ToNormalizedScreenCoordinates(x, y);
-		var normalizedFrom = _currentPosition.X == 0 && _currentPosition.Y == 0
-			? normalizedTarget
-			: ToNormalizedScreenCoordinates(_currentPosition.X, _currentPosition.Y);
+		var normalizedFrom = ToNormalizedScreenCoordinates(_currentPosition.X, _currentPosition.Y);
 
 		steps ??= (uint)Math.Min(Math.Max(Math.Abs(normalizedTarget.X - normalizedFrom.X), Math.Abs(normalizedTarget.Y - normalizedFrom.Y)) / 100, 512);
 		stepOffsetInMilliseconds ??= 1;
@@ -253,7 +254,9 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 				DeltaX = posX,
 				DeltaY = posY,
 				TimeOffsetInMilliseconds = stepOffsetInMilliseconds.Value,
-				MouseOptions = InjectedInputMouseOptions.Move | InjectedInputMouseOptions.Absolute,
+				// VirtualDesk: normalized coordinates are mapped over SM_*VIRTUALSCREEN (the whole
+				// multi-monitor desktop), not just the primary monitor - see ToNormalizedScreenCoordinates.
+				MouseOptions = InjectedInputMouseOptions.Move | InjectedInputMouseOptions.Absolute | InjectedInputMouseOptions.VirtualDesk,
 			};
 		}
 
@@ -262,7 +265,19 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 	}
 
 	private void Inject(IEnumerable<InjectedInputMouseInfo> infos)
-		=> _input.InjectMouseInput(infos);
+	{
+#if !HAS_UNO
+		// The real WinAppSDK InputInjector rejects a single InjectMouseInput call with more than
+		// ~16 items (observed: E_INVALIDARG). MoveTo can interpolate hundreds of steps across a
+		// large screen distance, so batch defensively below that ceiling.
+		foreach (var chunk in infos.Chunk(MaxInjectBatchSize))
+		{
+			_input.InjectMouseInput(chunk);
+		}
+#else
+		_input.InjectMouseInput(infos);
+#endif
+	}
 
 #if HAS_UNO
 	private void Inject(IEnumerable<(InjectedInputMouseInfo, VirtualKeyModifiers)> infos)
@@ -387,25 +402,65 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 #if !HAS_UNO
 	internal static Microsoft.UI.Xaml.Window? TestServices_WindowHelper_CurrentTestWindow { get; set; }
 
-	private static Point ToNormalizedScreenCoordinates(double x, double y)
+	/// <summary>
+	/// Reads the OS cursor position, converting it from screen pixels into the window-relative
+	/// coordinates the rest of this type works in - the inverse of <see cref="ToScreenCoordinates"/>.
+	/// </summary>
+	private static Point GetCursorWindowPosition()
 	{
-		RECT rect = new();
-		GetWindowRect(WinRT.Interop.WindowNative.GetWindowHandle(TestServices_WindowHelper_CurrentTestWindow), ref rect);
-		var scale = TestServices_WindowHelper_CurrentTestWindow?.Content.XamlRoot.RasterizationScale ?? 1;
+		if (!GetCursorPos(out var cursor))
+		{
+			return default;
+		}
 
-		var screenX = (rect.Left + x) * scale;
-		var screenY = (rect.Top + y) * scale;
+		var (originX, originY, scale) = GetClientOrigin();
 
-		var screenWidth = GetSystemMetrics(SM_CXSCREEN);
-		var screenHeight = GetSystemMetrics(SM_CYSCREEN);
-
-		return new Point(
-			screenX / screenWidth * 65535.0,
-			screenY / screenHeight * 65535.0);
+		return new Point((cursor.X - originX) / scale, (cursor.Y - originY) / scale);
 	}
 
-	private const int SM_CXSCREEN = 0;
-	private const int SM_CYSCREEN = 1;
+	/// <summary>
+	/// Gets the screen position, in physical pixels, of the window's client area origin - which is
+	/// where the XamlRoot coordinates callers work in start - along with its rasterization scale.
+	/// </summary>
+	private static (int X, int Y, double Scale) GetClientOrigin()
+	{
+		POINT origin = new();
+		ClientToScreen(WinRT.Interop.WindowNative.GetWindowHandle(TestServices_WindowHelper_CurrentTestWindow), ref origin);
+		var scale = TestServices_WindowHelper_CurrentTestWindow?.Content.XamlRoot.RasterizationScale ?? 1;
+
+		return (origin.X, origin.Y, scale);
+	}
+
+	private static Point ToScreenCoordinates(double x, double y)
+	{
+		var (originX, originY, scale) = GetClientOrigin();
+
+		return new Point(originX + x * scale, originY + y * scale);
+	}
+
+	/// <summary>
+	/// Maps a window-relative position to the 0-65535 range expected by
+	/// <see cref="InjectedInputMouseOptions.Absolute"/>, over the whole virtual desktop so that
+	/// windows on a secondary monitor stay in range. Pair with <see cref="InjectedInputMouseOptions.VirtualDesk"/>.
+	/// </summary>
+	private static Point ToNormalizedScreenCoordinates(double x, double y)
+	{
+		var screen = ToScreenCoordinates(x, y);
+
+		var left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+		var top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+		var width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+		var height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+		return new Point(
+			(screen.X - left) / width * 65535.0,
+			(screen.Y - top) / height * 65535.0);
+	}
+
+	private const int SM_XVIRTUALSCREEN = 76;
+	private const int SM_YVIRTUALSCREEN = 77;
+	private const int SM_CXVIRTUALSCREEN = 78;
+	private const int SM_CYVIRTUALSCREEN = 79;
 
 	[LibraryImport("user32.dll")]
 	private static partial int GetSystemMetrics(int nIndex);
@@ -416,22 +471,13 @@ internal partial class Mouse : IInjectedPointer, IDisposable
 
 	[LibraryImport("user32.dll", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
-	private static partial bool GetWindowRect(IntPtr hWnd, ref RECT lpRect);
+	private static partial bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
 
 	[StructLayout(LayoutKind.Sequential)]
 	private struct POINT
 	{
 		public int X;
 		public int Y;
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	private struct RECT
-	{
-		public int Left;
-		public int Top;
-		public int Right;
-		public int Bottom;
 	}
 #endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
@@ -201,6 +201,131 @@ public class Given_InputInjector
 		Assert.AreNotEqual(0, movedCount, "PointerMoved should have been raised");
 	}
 
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid | RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.NativeWasm)]
+	public async Task When_MouseMoveAbsolute_PointerLandsAtExpectedPosition()
+	{
+		if (TestServices.WindowHelper.IsXamlIsland)
+		{
+			return;
+		}
+
+		var border = new Border
+		{
+			Background = new SolidColorBrush(Colors.DeepPink),
+			Width = 200,
+			Height = 200,
+		};
+
+		Point? capturedPosition = null;
+		border.PointerMoved += (s, e) => capturedPosition = e.GetCurrentPoint(border).Position;
+
+		WindowContent = border;
+		await WaitForLoaded(border);
+		await WaitForIdle();
+
+		var injector = InputInjector.TryCreate();
+		Assert.IsNotNull(injector);
+
+		var root = TestServices.WindowHelper.XamlRoot;
+		var target = new Point(border.ActualWidth / 2, border.ActualHeight / 2);
+		var rootTarget = border.TransformToVisual(root.Content).TransformPoint(target);
+
+#if HAS_UNO
+		// Exercise InjectedInputMouseOptions.Absolute directly: DeltaX/DeltaY are normalized
+		// 0-65535 coordinates (mirroring Win32 SendInput's MOUSEEVENTF_ABSOLUTE), mapped by Uno
+		// onto the current root visual's bounds.
+		var bounds = root.Size;
+		injector.InjectMouseInput(new[]
+		{
+			new InjectedInputMouseInfo
+			{
+				MouseOptions = InjectedInputMouseOptions.Move | InjectedInputMouseOptions.Absolute,
+				DeltaX = (int)Math.Round(rootTarget.X / bounds.Width * 65535.0),
+				DeltaY = (int)Math.Round(rootTarget.Y / bounds.Height * 65535.0),
+			}
+		});
+#else
+		// On WinAppSDK, Mouse.MoveTo already injects using real, screen-normalized absolute
+		// coordinates - this is the real OS behavior InjectedInputMouseOptions.Absolute mirrors.
+		var mouse = injector.GetMouse();
+		mouse.MoveTo(rootTarget);
+#endif
+
+		await WaitForIdle();
+
+		Assert.IsNotNull(capturedPosition, "PointerMoved should have been raised");
+		Assert.AreEqual(target.X, capturedPosition!.Value.X, 2.0, "Unexpected X");
+		Assert.AreEqual(target.Y, capturedPosition!.Value.Y, 2.0, "Unexpected Y");
+	}
+
+#if HAS_UNO
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeAndroid | RuntimeTestPlatforms.NativeIOS | RuntimeTestPlatforms.NativeWasm)]
+	public async Task When_MouseMoveAbsolute_NormalizedCoordinatesMapLinearlyToRootBounds()
+	{
+		if (TestServices.WindowHelper.IsXamlIsland)
+		{
+			return;
+		}
+
+		var border = new Border
+		{
+			Background = new SolidColorBrush(Colors.DeepPink),
+			Width = 200,
+			Height = 200,
+		};
+
+		Point? capturedPosition = null;
+		border.PointerMoved += (s, e) => capturedPosition = e.GetCurrentPoint(border).Position;
+
+		WindowContent = border;
+		await WaitForLoaded(border);
+		await WaitForIdle();
+
+		var injector = InputInjector.TryCreate();
+		Assert.IsNotNull(injector);
+
+		var root = TestServices.WindowHelper.XamlRoot;
+		var bounds = root.Size;
+		var borderOrigin = border.TransformToVisual(root.Content).TransformPoint(default);
+
+		foreach (var (normalized, useVirtualDesk) in new[] { (0.25, false), (0.75, true) })
+		{
+			capturedPosition = null;
+
+			var localTarget = new Point(border.ActualWidth * normalized, border.ActualHeight * normalized);
+			var rootTarget = new Point(borderOrigin.X + localTarget.X, borderOrigin.Y + localTarget.Y);
+
+			var options = InjectedInputMouseOptions.Move | InjectedInputMouseOptions.Absolute;
+			if (useVirtualDesk)
+			{
+				// Uno has no cross-platform notion of a multi-monitor virtual desktop, so VirtualDesk
+				// is expected to be a no-op: the normalized space always maps onto the root's bounds.
+				options |= InjectedInputMouseOptions.VirtualDesk;
+			}
+
+			injector.InjectMouseInput(new[]
+			{
+				new InjectedInputMouseInfo
+				{
+					MouseOptions = options,
+					DeltaX = (int)Math.Round(rootTarget.X / bounds.Width * 65535.0),
+					DeltaY = (int)Math.Round(rootTarget.Y / bounds.Height * 65535.0),
+				}
+			});
+
+			await WaitForIdle();
+
+			Assert.IsNotNull(capturedPosition, $"PointerMoved should have been raised for normalized={normalized}");
+			Assert.AreEqual(localTarget.X, capturedPosition!.Value.X, 2.0);
+			Assert.AreEqual(localTarget.Y, capturedPosition!.Value.Y, 2.0);
+		}
+	}
+#endif
+
 #if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
@@ -251,6 +251,9 @@ public class Given_InputInjector
 		// coordinates - this is the real OS behavior InjectedInputMouseOptions.Absolute mirrors.
 		var mouse = injector.GetMouse();
 		mouse.MoveTo(rootTarget);
+		// Real OS input injection propagates through the system input stack asynchronously;
+		// WaitForIdle only flushes the XAML dispatcher, not that hardware-level delivery.
+		await Task.Delay(100);
 #endif
 
 		await WaitForIdle();

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using Windows.Devices.Input;
+using Windows.Foundation;
 using Windows.UI.Core;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml;
@@ -45,6 +46,8 @@ partial class InputManager
 
 	void IInputInjectorTarget.InjectPointerRemoved(PointerEventArgs args) => InjectPointerRemoved(args);
 	partial void InjectPointerRemoved(PointerEventArgs args);
+
+	Size IInputInjectorTarget.GetInjectionBounds() => ContentRoot.XamlRoot?.Size ?? default;
 
 	#endregion
 

--- a/src/Uno.WinRT/UI/Input/Preview.Injection/IInputInjectorTarget.cs
+++ b/src/Uno.WinRT/UI/Input/Preview.Injection/IInputInjectorTarget.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Linq;
+using Windows.Foundation;
 using Windows.UI.Core;
 
 namespace Windows.UI.Input.Preview.Injection;
@@ -12,4 +13,10 @@ internal interface IInputInjectorTarget
 	void InjectPointerUpdated(PointerEventArgs args);
 
 	void InjectPointerRemoved(PointerEventArgs args);
+
+	/// <summary>
+	/// Gets the bounds, in the same coordinate space as injected <see cref="PointerEventArgs"/> positions,
+	/// used to resolve <see cref="InjectedInputMouseOptions.Absolute"/> normalized coordinates.
+	/// </summary>
+	Size GetInjectionBounds();
 }

--- a/src/Uno.WinRT/UI/Input/Preview.Injection/InjectedInputMouseInfo.cs
+++ b/src/Uno.WinRT/UI/Input/Preview.Injection/InjectedInputMouseInfo.cs
@@ -25,7 +25,7 @@ public partial class InjectedInputMouseInfo
 
 	public int DeltaX { get; set; }
 
-	internal PointerEventArgs ToEventArgs(InjectedInputState state, VirtualKeyModifiers modifiers)
+	internal PointerEventArgs ToEventArgs(InjectedInputState state, VirtualKeyModifiers modifiers, Size bounds)
 	{
 		var update = default(PointerUpdateKind);
 		var position = state.Position;
@@ -94,9 +94,24 @@ public partial class InjectedInputMouseInfo
 			properties.MouseWheelDelta = default;
 			properties.IsHorizontalMouseWheel = false;
 
-			// Should we use MouseData ??? But How to discriminate between X and Y moves?
-			position.X += DeltaX;
-			position.Y += DeltaY;
+			if (MouseOptions.HasFlag(InjectedInputMouseOptions.Absolute))
+			{
+				// DeltaX/DeltaY are normalized coordinates in the 0-65535 range, mirroring Win32 SendInput's
+				// MOUSEEVENTF_ABSOLUTE convention: (0,0) is the top-left corner of the display surface and
+				// (65535,65535) is the bottom-right corner. Uno has no portable notion of monitors/virtual
+				// desktop wired into pointer injection, so - unlike real Windows, where VirtualDesk switches
+				// between the primary monitor and the full virtual desktop - the normalized space always maps
+				// onto the current root visual's bounds.
+				if (bounds.Width > 0 && bounds.Height > 0)
+				{
+					position = new Point(DeltaX / 65535.0 * bounds.Width, DeltaY / 65535.0 * bounds.Height);
+				}
+			}
+			else
+			{
+				position.X += DeltaX;
+				position.Y += DeltaY;
+			}
 		}
 		else
 		{

--- a/src/Uno.WinRT/UI/Input/Preview.Injection/InjectedInputMouseOptions.cs
+++ b/src/Uno.WinRT/UI/Input/Preview.Injection/InjectedInputMouseOptions.cs
@@ -33,7 +33,17 @@ public enum InjectedInputMouseOptions : uint
 
 	MoveNoCoalesce = 8192,
 
+	/// <remarks>
+	/// Uno has no cross-platform notion of a multi-monitor virtual desktop, so this flag has no effect:
+	/// normalized coordinates set via <see cref="Absolute"/> always map onto the current XamlRoot's bounds,
+	/// with or without this flag.
+	/// </remarks>
 	VirtualDesk = 16384,
 
+	/// <remarks>
+	/// On Uno, the "display surface" normalized coordinates map onto is the current XamlRoot's bounds -
+	/// there is no cross-platform notion of screen/monitor resolution independent of the app window - and
+	/// this mapping is unaffected by <see cref="VirtualDesk"/>.
+	/// </remarks>
 	Absolute = 32768,
 }

--- a/src/Uno.WinRT/UI/Input/Preview.Injection/InputInjector.cs
+++ b/src/Uno.WinRT/UI/Input/Preview.Injection/InputInjector.cs
@@ -255,7 +255,7 @@ public partial class InputInjector
 				_mouse.StartNewSequence();
 			}
 
-			var args = info.ToEventArgs(_mouse!, VirtualKeyModifiers.None);
+			var args = info.ToEventArgs(_mouse!, VirtualKeyModifiers.None, _target.GetInjectionBounds());
 			_mouse!.Update(args);
 
 			DispatchPointerUpdated(args);
@@ -272,7 +272,7 @@ public partial class InputInjector
 				_mouse.StartNewSequence();
 			}
 
-			var args = info.ToEventArgs(_mouse!, VirtualKeyModifiers.None);
+			var args = info.ToEventArgs(_mouse!, VirtualKeyModifiers.None, _target.GetInjectionBounds());
 			_mouse!.Update(args);
 
 			DispatchPointerUpdated(args);
@@ -285,7 +285,7 @@ public partial class InputInjector
 	{
 		foreach (var (info, modifiers) in input)
 		{
-			var args = info.ToEventArgs(_mouse!, modifiers);
+			var args = info.ToEventArgs(_mouse!, modifiers, _target.GetInjectionBounds());
 			_mouse!.Update(args);
 
 			DispatchPointerUpdated(args);
@@ -302,7 +302,7 @@ public partial class InputInjector
 				_mouse.StartNewSequence();
 			}
 
-			var args = info.ToEventArgs(_mouse!, modifiers);
+			var args = info.ToEventArgs(_mouse!, modifiers, _target.GetInjectionBounds());
 			_mouse!.Update(args);
 
 			DispatchPointerUpdated(args);


### PR DESCRIPTION
**GitHub Issue:** closes #24277

## PR Type:

🐞 Bugfix

## What changed? 🚀

`InputInjector.InjectMouseInput` previously ignored `InjectedInputMouseOptions.Absolute`: `DeltaX`/`DeltaY` were always applied as a relative delta from the pointer's last position, even when a caller followed the documented WinRT contract and set `Absolute` (normalized 0-65,535 coordinates, mirroring Win32 `SendInput`'s `MOUSEEVENTF_ABSOLUTE`). This produced wildly wrong (typically off-screen) pointer positions for any absolute-coordinate mouse injection.

This PR resolves `Absolute` coordinates against the current window's bounds:
- `IInputInjectorTarget` gains `GetInjectionBounds()`, implemented by `InputManager` as the current `XamlRoot.Size`.
- `InjectedInputMouseInfo.ToEventArgs` now maps normalized coordinates onto those bounds instead of accumulating them as a delta.
- Since Uno's injector is an in-process synthetic-pointer model with no cross-platform notion of monitors/virtual desktop, `VirtualDesk` is documented (via XML doc on the public enum members) as a no-op - the normalized space always maps onto the current root visual's bounds.

The fix lives entirely in shared `Uno.UI`/`Uno.WinRT` code with no per-platform branches, so it applies uniformly across every Skia target (Desktop Win32/macOS/X11, WebAssembly, Android, iOS).

Two new runtime tests were added to `Given_InputInjector.cs`: one exercises the fix directly on Uno and cross-checks against real WinAppSDK (which already injects real absolute-coordinate input) for parity; the other validates the normalized-to-bounds mapping at two points and confirms `VirtualDesk` doesn't change the result. All 12 tests in the file pass on Skia Desktop, with no regressions to the pre-existing touch/pen/mouse coverage.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
