### PR TITLE
chore: temp debug output for CI investigation (DO NOT MERGE)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -97,6 +97,7 @@ jobs:
           # token exchange entirely when github_token is provided).
           github_token: ${{ github.token }}
           track_progress: true
+          show_full_output: true
           prompt: ${{ steps.review_prompt.outputs.prompt }}
           claude_args: |
             --model claude-sonnet-4-6


### PR DESCRIPTION
Diagnostic-only PR to capture full Claude Code Review action output for investigating why the review workflow has been failing on every PR since 2026-08-26. Will be closed immediately after.