### PR TITLE
feat: Add opt-in press-to-stop-momentum for ManipulationMode panning

### DIFF
--- a/doc/articles/Uno.UI.Toolkit.md
+++ b/doc/articles/Uno.UI.Toolkit.md
@@ -167,7 +167,18 @@ xmlns:toolkit="using:Uno.UI.Toolkit"
 </Border>
 ```
 
-While enabled, the press which aborts the inertia raises no `Tapped`, `DoubleTapped`, `RightTapped` or `Holding` on the element, its ancestors or its descendants, so a second tap is needed to act on the pointed item. A tap while the content is at rest is unaffected. The property has no effect on Windows.
+While enabled, the press which aborts the inertia raises no `Tapped`, `DoubleTapped`, `RightTapped` or `Holding` on the element, its ancestors or its descendants, so a second tap is needed to act on the pointed item. A tap while the content is at rest is unaffected.
+
+### Platform reach
+
+| Target | Behavior |
+| --- | --- |
+| Skia (Desktop, and Skia on Android, iOS and WebAssembly) | Supported and validated. |
+| WebAssembly (native backend) | Supported — it uses the same managed pointer pipeline. |
+| Windows (WinAppSDK) | Inert. The property stores its value and nothing reads it, so cross-platform XAML stays valid. |
+| Android and iOS (native backends) | Not supported. Pointer events bubble natively there, so the order the gestures are muted in has not been validated. |
+
+The property is intentionally not gated per target: setting it where it does nothing is harmless — the default behavior is unchanged unless it is set — and a setter that silently refuses a value is harder to diagnose than one documented as inert.
 
 Panning elements which are template parts of a third-party control cannot be addressed directly. Reach them with an implicit `Style` in your application resources instead — for the CommunityToolkit `DataGrid`, whose rows are panned by its `DataGridRowsPresenter`:
 

--- a/doc/articles/Uno.UI.Toolkit.md
+++ b/doc/articles/Uno.UI.Toolkit.md
@@ -149,3 +149,22 @@ The bar of a `ScrollViewer` is a template part, so it cannot be addressed direct
 ```
 
 A known limitation: a finger pan which *starts* on a visible bar does not scroll the content, because hit-testing resolves into the `ScrollBar` and the content presenter is a sibling of it. Start the pan over the content instead.
+
+## ManipulationMode panning - press to stop the momentum
+
+An element which pans its own content through `ManipulationMode` (as the CommunityToolkit `DataGrid` does for its rows) keeps recognizing gestures while its content is coasting: the press which stops the momentum also activates the item under the finger, so a row gets selected by the very tap the user meant as "stop scrolling". This is the WinUI behavior — there, gesture recognition is per element and independent of the inertia of an ancestor — and it stays the default in Uno Platform.
+
+On a touch-only target such as a browser on a tablet, users expect the OS convention instead: the first press only stops the momentum. Opt into it with `ManipulationExtensions.IsTapToStopInertiaEnabled` on the panning element:
+
+```xml
+xmlns:toolkit="using:Uno.UI.Toolkit"
+```
+
+```xml
+<Border ManipulationMode="TranslateY,TranslateInertia"
+        toolkit:ManipulationExtensions.IsTapToStopInertiaEnabled="True">
+    <!-- content whose items act on Tapped -->
+</Border>
+```
+
+While enabled, the press which aborts the inertia raises no `Tapped`, `DoubleTapped`, `RightTapped` or `Holding` on the element, its ancestors or its descendants, so a second tap is needed to act on the pointed item. A tap while the content is at rest is unaffected. The property has no effect on Windows.

--- a/doc/articles/Uno.UI.Toolkit.md
+++ b/doc/articles/Uno.UI.Toolkit.md
@@ -168,3 +168,15 @@ xmlns:toolkit="using:Uno.UI.Toolkit"
 ```
 
 While enabled, the press which aborts the inertia raises no `Tapped`, `DoubleTapped`, `RightTapped` or `Holding` on the element, its ancestors or its descendants, so a second tap is needed to act on the pointed item. A tap while the content is at rest is unaffected. The property has no effect on Windows.
+
+Panning elements which are template parts of a third-party control cannot be addressed directly. Reach them with an implicit `Style` in your application resources instead — for the CommunityToolkit `DataGrid`, whose rows are panned by its `DataGridRowsPresenter`:
+
+```xml
+xmlns:primitives="using:CommunityToolkit.WinUI.UI.Controls.Primitives"
+```
+
+```xml
+<Style TargetType="primitives:DataGridRowsPresenter">
+    <Setter Property="toolkit:ManipulationExtensions.IsTapToStopInertiaEnabled" Value="True" />
+</Style>
+```

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml
@@ -1,0 +1,80 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Input.GestureRecognizerTests.Manipulation_TapStopsInertia"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid Padding="16" RowSpacing="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Row="0"
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            Text="Tap to stop the momentum" />
+
+        <TextBlock
+            Grid.Row="1"
+            Text="Flick the list with a finger, then tap a row while it is still coasting. By default - which is the WinUI behavior - that tap both stops the momentum and selects the row. With the opt-in below it only stops the momentum, and a second tap selects."
+            TextWrapping="WrapWholeWords" />
+
+        <CheckBox
+            x:Name="OptIn"
+            Grid.Row="2"
+            Checked="OptIn_Changed"
+            Content="ManipulationExtensions.IsTapToStopInertiaEnabled"
+            Unchecked="OptIn_Changed" />
+
+        <TextBlock x:Name="Status" Grid.Row="3" />
+
+        <!--
+            The viewport translates its content itself through ManipulationMode, like the CommunityToolkit
+            DataGrid does: the momentum is then run by the GestureRecognizer of this very element, and not by
+            the direct-manipulation of a ScrollViewer.
+        -->
+        <Border
+            x:Name="Viewport"
+            Grid.Row="4"
+            Background="{ThemeResource SystemControlBackgroundAltMediumLowBrush}"
+            ManipulationDelta="Viewport_ManipulationDelta"
+            ManipulationInertiaStarting="Viewport_ManipulationInertiaStarting"
+            ManipulationMode="TranslateY,TranslateInertia">
+            <Border.Clip>
+                <RectangleGeometry x:Name="ViewportClip" />
+            </Border.Clip>
+
+            <ItemsControl x:Name="Rows" VerticalAlignment="Top">
+                <ItemsControl.RenderTransform>
+                    <TranslateTransform x:Name="RowsTransform" />
+                </ItemsControl.RenderTransform>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border
+                            Height="44"
+                            Margin="0,0,0,1"
+                            Padding="12,0"
+                            Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
+                            BorderBrush="{ThemeResource SystemControlHighlightAccentBrush}"
+                            BorderThickness="0"
+                            Tapped="Row_Tapped">
+                            <TextBlock VerticalAlignment="Center" Text="{Binding}" />
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Border>
+    </Grid>
+</Page>

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml
@@ -44,6 +44,7 @@
             x:Name="Viewport"
             Grid.Row="4"
             Background="{ThemeResource SystemControlBackgroundAltMediumLowBrush}"
+            ManipulationCompleted="Viewport_ManipulationCompleted"
             ManipulationDelta="Viewport_ManipulationDelta"
             ManipulationInertiaStarting="Viewport_ManipulationInertiaStarting"
             ManipulationMode="TranslateY,TranslateInertia">

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Toolkit;
+using Windows.Foundation;
+
+namespace UITests.Windows_UI_Input.GestureRecognizerTests
+{
+	[Sample(
+		"Gesture Recognizer",
+		Description = "ManipulationExtensions.IsTapToStopInertiaEnabled: the tap which stops the momentum of a ManipulationMode element does not select the pointed row.",
+		IsManualTest = true)]
+	public sealed partial class Manipulation_TapStopsInertia : Page
+	{
+		private const int RowCount = 40;
+		private const double RowHeight = 45; // Including the 1px margin between the rows.
+
+		private Border _selectedRow;
+		private int _selectionCount;
+
+		public Manipulation_TapStopsInertia()
+		{
+			this.InitializeComponent();
+
+			Rows.ItemsSource = Enumerable.Range(1, RowCount).Select(i => $"Row {i}").ToArray();
+			Viewport.SizeChanged += (_, e) => ViewportClip.Rect = new Rect(new Point(), e.NewSize);
+
+			UpdateStatus("ready");
+		}
+
+		private void OptIn_Changed(object sender, RoutedEventArgs e)
+			=> Viewport.SetIsTapToStopInertiaEnabled(OptIn.IsChecked is true);
+
+		private void Row_Tapped(object sender, TappedRoutedEventArgs e)
+		{
+			if (_selectedRow is { } previous)
+			{
+				previous.BorderThickness = default;
+			}
+
+			var row = (Border)sender;
+			row.BorderThickness = new Thickness(3);
+			_selectedRow = row;
+			_selectionCount++;
+
+			UpdateStatus($"selected {((TextBlock)row.Child).Text}");
+		}
+
+		private void Viewport_ManipulationInertiaStarting(object sender, ManipulationInertiaStartingRoutedEventArgs e)
+			=> UpdateStatus("coasting");
+
+		private void Viewport_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
+		{
+			var minOffset = Math.Min(0, Viewport.ActualHeight - RowCount * RowHeight);
+			RowsTransform.Y = Math.Clamp(RowsTransform.Y + e.Delta.Translation.Y, minOffset, 0);
+
+			if (!e.IsInertial)
+			{
+				UpdateStatus("dragging");
+			}
+		}
+
+		private void UpdateStatus(string state)
+			=> Status.Text = $"{state} — selections: {_selectionCount}";
+	}
+}

--- a/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows_UI_Input/GestureRecognizerTests/Manipulation_TapStopsInertia.xaml.cs
@@ -52,6 +52,9 @@ namespace UITests.Windows_UI_Input.GestureRecognizerTests
 		private void Viewport_ManipulationInertiaStarting(object sender, ManipulationInertiaStartingRoutedEventArgs e)
 			=> UpdateStatus("coasting");
 
+		private void Viewport_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+			=> UpdateStatus("completed");
+
 		private void Viewport_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
 		{
 			var minOffset = Math.Min(0, Viewport.ActualHeight - RowCount * RowHeight);

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_ManipulationExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_ManipulationExtensions.cs
@@ -1,0 +1,132 @@
+#if HAS_INPUT_INJECTOR && !WINAPPSDK
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.Toolkit;
+using Uno.UI.Toolkit.DevTools.Input;
+using Windows.UI;
+using Windows.UI.Input.Preview.Injection;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Toolkit;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_ManipulationExtensions
+{
+	[TestMethod]
+	public async Task When_PressStopsInertia_Without_OptIn_Then_TapIsRaised()
+	{
+		// Pins the default behavior, which is the WinUI one: gesture recognition is per element and unrelated to
+		// the inertia of an ancestor, so the very press which stops the momentum still activates the pointed item.
+		var taps = await PressWhileCoasting(isTapToStopInertiaEnabled: false);
+
+		taps.Cell.Should().Be(1, because: "without the opt-in the press which stops the inertia still taps");
+	}
+
+	[TestMethod]
+	public async Task When_PressStopsInertia_With_OptIn_Then_NoTapIsRaisedOnThePath()
+	{
+		var taps = await PressWhileCoasting(isTapToStopInertiaEnabled: true);
+
+		taps.Cell.Should().Be(0, because: "the press which stopped the inertia must not tap the original source");
+		taps.Row.Should().Be(0, because: "the press which stopped the inertia must not tap the intermediate element");
+		taps.Scroller.Should().Be(0, because: "the press which stopped the inertia must not tap the coasting element");
+		taps.Ancestor.Should().Be(0, because: "the press which stopped the inertia must not tap the ancestor");
+	}
+
+	[TestMethod]
+	public async Task When_TapAtRest_With_OptIn_Then_TapIsRaisedOnThePath()
+	{
+		var taps = BuildTree(isTapToStopInertiaEnabled: true, out var ancestor, out _, out _);
+
+		var bounds = await UITestHelper.Load(ancestor);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		finger.Tap(bounds.GetCenter());
+
+		taps.Cell.Should().Be(1, because: "the opt-in must not affect a tap while the content is at rest");
+		taps.Row.Should().Be(1, because: "the tap of the original source must bubble to the intermediate element");
+		taps.Scroller.Should().Be(1, because: "the tap of the original source must bubble to the coasting element");
+		taps.Ancestor.Should().Be(1, because: "the tap of the original source must bubble to the ancestor");
+	}
+
+	private static async Task<TapCounts> PressWhileCoasting(bool isTapToStopInertiaEnabled)
+	{
+		var taps = BuildTree(isTapToStopInertiaEnabled, out var ancestor, out var scroller, out _);
+
+		var inertiaStarted = false;
+		scroller.ManipulationInertiaStarting += (_, _) => inertiaStarted = true;
+
+		var bounds = await UITestHelper.Load(ancestor);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+
+		// Flick fast enough to start the inertia. Do NOT await WaitForIdle: the inertia must still be running
+		// when the next press is injected.
+		using var flickFinger = injector.GetFinger();
+		flickFinger.Drag(from: bounds.GetCenter(), to: bounds.GetCenter().Offset(y: -200), steps: 1, stepOffsetInMilliseconds: 50);
+
+		inertiaStarted.Should().BeTrue(because: "the fast flick should have started the manipulation inertia");
+
+		using var tapFinger = injector.GetFinger(id: 43);
+		tapFinger.Tap(bounds.GetCenter());
+
+		return taps;
+	}
+
+	/// <summary>
+	/// Builds the shape of a CommunityToolkit DataGrid: a panning element (the rows presenter) whose descendants
+	/// (the row and its cell) act on tap.
+	/// </summary>
+	private static TapCounts BuildTree(bool isTapToStopInertiaEnabled, out Border ancestor, out Border scroller, out Border cell)
+	{
+		Border row;
+		ancestor = new Border
+		{
+			Width = 200,
+			Height = 600,
+			Background = new SolidColorBrush(Colors.DarkSlateGray),
+			Child = (scroller = new Border
+			{
+				Background = new SolidColorBrush(Colors.DeepSkyBlue),
+				ManipulationMode = ManipulationModes.TranslateY | ManipulationModes.TranslateInertia,
+				Child = (row = new Border
+				{
+					Background = new SolidColorBrush(Colors.BlueViolet),
+					Padding = new Thickness(10),
+					Child = (cell = new Border
+					{
+						Background = new SolidColorBrush(Colors.DeepPink),
+					}),
+				}),
+			}),
+		};
+
+		scroller.SetIsTapToStopInertiaEnabled(isTapToStopInertiaEnabled);
+
+		var taps = new TapCounts();
+		ancestor.Tapped += (_, _) => taps.Ancestor++;
+		scroller.Tapped += (_, _) => taps.Scroller++;
+		row.Tapped += (_, _) => taps.Row++;
+		cell.Tapped += (_, _) => taps.Cell++;
+
+		return taps;
+	}
+
+	private sealed class TapCounts
+	{
+		public int Ancestor;
+		public int Scroller;
+		public int Row;
+		public int Cell;
+	}
+}
+#endif

--- a/src/Uno.UI.Toolkit/ManipulationExtensions.cs
+++ b/src/Uno.UI.Toolkit/ManipulationExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Microsoft.UI.Xaml;
 
 #if HAS_UNO
@@ -139,7 +141,7 @@ namespace Uno.UI.Toolkit
 				}
 			}
 
-			private static void MutePath(PointerRoutedEventArgs args, PointerIdentifier pointer, UIElement upTo)
+			private static void MutePath(PointerRoutedEventArgs args, PointerIdentifier pointer, UIElement? upTo)
 			{
 				if (args.OriginalSource is not UIElement originalSource || Mute(originalSource))
 				{

--- a/src/Uno.UI.Toolkit/ManipulationExtensions.cs
+++ b/src/Uno.UI.Toolkit/ManipulationExtensions.cs
@@ -1,0 +1,161 @@
+using Microsoft.UI.Xaml;
+
+#if HAS_UNO
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml.Input;
+using Uno.Disposables;
+using Windows.Devices.Input;
+
+#if HAS_UNO_WINUI
+using GestureSettings = Microsoft.UI.Input.GestureSettings;
+#else
+using GestureSettings = Windows.UI.Input.GestureSettings;
+#endif
+#endif
+
+namespace Uno.UI.Toolkit
+{
+	/// <summary>
+	/// Opt-in behaviors for elements which pan their own content through <see cref="UIElement.ManipulationMode"/>.
+	/// </summary>
+	public static class ManipulationExtensions
+	{
+		/// <summary>
+		/// When set on an element which pans its content with <see cref="Microsoft.UI.Xaml.Input.ManipulationModes.TranslateInertia"/>, the
+		/// press which stops the inertia is consumed as a "stop the momentum" gesture: it raises no
+		/// Tapped/DoubleTapped/RightTapped on the element, its ancestors nor its descendants, so a first tap only
+		/// stops the coasting content and a second one acts on the pointed item.
+		/// </summary>
+		/// <remarks>
+		/// This is not the WinUI behavior: there, gesture recognition is per-element and independent of the inertia
+		/// of an ancestor, so the pointed item is activated by the very press which stops the momentum. It matches
+		/// what the OS does for its own scrollable surfaces though, which is what touch users expect on a
+		/// touch-only target - hence an opt-in. No-op on WinAppSDK.
+		/// </remarks>
+		public static DependencyProperty IsTapToStopInertiaEnabledProperty { get; } =
+			DependencyProperty.RegisterAttached(
+				"IsTapToStopInertiaEnabled",
+				typeof(bool),
+				typeof(ManipulationExtensions),
+				new PropertyMetadata(false, OnIsTapToStopInertiaEnabledChanged));
+
+		public static void SetIsTapToStopInertiaEnabled(this UIElement element, bool isTapToStopInertiaEnabled)
+			=> element.SetValue(IsTapToStopInertiaEnabledProperty, isTapToStopInertiaEnabled);
+
+		public static bool GetIsTapToStopInertiaEnabled(this UIElement element)
+			=> (bool)element.GetValue(IsTapToStopInertiaEnabledProperty);
+
+#if !HAS_UNO
+		private static void OnIsTapToStopInertiaEnabledChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+		{
+		}
+#else
+		private const GestureSettings Taps = GestureSettings.Tap
+			| GestureSettings.DoubleTap
+			| GestureSettings.RightTap
+			| GestureSettings.Hold
+			| GestureSettings.HoldWithMouse;
+
+		private static readonly DependencyProperty SubscriptionProperty = DependencyProperty.RegisterAttached(
+			"Subscription",
+			typeof(IDisposable),
+			typeof(ManipulationExtensions),
+			new PropertyMetadata(default(IDisposable)));
+
+		private static void OnIsTapToStopInertiaEnabledChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
+		{
+			if (sender is not UIElement element)
+			{
+				return;
+			}
+
+			(element.GetValue(SubscriptionProperty) as IDisposable)?.Dispose();
+			element.SetValue(SubscriptionProperty, args.NewValue is true ? new InertiaStopTracker(element) : null);
+		}
+
+		/// <summary>
+		/// Mutes the tap gestures of the whole pointer path of the press which stops the inertia of its element.
+		/// </summary>
+		/// <remarks>
+		/// The muting has to be done in two steps because of the order in which the pointer events reach the
+		/// gesture recognizers: the ancestors of the original source are visited from the closest to the root, each
+		/// updating its own gestures before invoking its handlers, and the original source updates its own gestures
+		/// last of all. So on the press only the elements from the original source up to the tracked one have a
+		/// gesture to mute, and the rest - the ancestors and the original source - is muted on the release, which
+		/// still runs before their own gestures are recognized.
+		/// </remarks>
+		private sealed class InertiaStopTracker : IDisposable
+		{
+			private readonly UIElement _element;
+			private readonly SerialDisposable _subscriptions = new();
+			private readonly HashSet<PointerIdentifier> _pendingPointers = new();
+
+			public InertiaStopTracker(UIElement element)
+			{
+				_element = element;
+
+				var pressed = new PointerEventHandler(OnPointerPressed);
+				var released = new PointerEventHandler(OnPointerReleased);
+
+				element.AddHandler(UIElement.PointerPressedEvent, pressed, handledEventsToo: true);
+				element.AddHandler(UIElement.PointerReleasedEvent, released, handledEventsToo: true);
+				element.AddHandler(UIElement.PointerCanceledEvent, released, handledEventsToo: true);
+
+				_subscriptions.Disposable = Disposable.Create(() =>
+				{
+					element.RemoveHandler(UIElement.PointerPressedEvent, pressed);
+					element.RemoveHandler(UIElement.PointerReleasedEvent, released);
+					element.RemoveHandler(UIElement.PointerCanceledEvent, released);
+				});
+			}
+
+			private void OnPointerPressed(object sender, PointerRoutedEventArgs args)
+			{
+				// An element updates its own gestures before invoking its handlers, so the recognizer has already
+				// told us whether this press is what aborted the coasting manipulation.
+				if (!_element.LastPointerDownStoppedInertia)
+				{
+					return;
+				}
+
+				var pointer = args.Pointer.UniqueId;
+				_pendingPointers.Add(pointer);
+
+				// Only the elements from the original source up to this one have a gesture at this point.
+				MutePath(args, pointer, upTo: _element);
+			}
+
+			private void OnPointerReleased(object sender, PointerRoutedEventArgs args)
+			{
+				var pointer = args.Pointer.UniqueId;
+				if (_pendingPointers.Remove(pointer))
+				{
+					MutePath(args, pointer, upTo: null);
+				}
+			}
+
+			private static void MutePath(PointerRoutedEventArgs args, PointerIdentifier pointer, UIElement upTo)
+			{
+				DependencyObject current = args.OriginalSource as UIElement;
+				while (current is not null)
+				{
+					if (current is UIElement element)
+					{
+						element.PreventGestures(pointer, Taps);
+
+						if (element == upTo)
+						{
+							return;
+						}
+					}
+
+					current = (current as FrameworkElement)?.Parent ?? Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(current);
+				}
+			}
+
+			public void Dispose() => _subscriptions.Dispose();
+		}
+#endif
+	}
+}

--- a/src/Uno.UI.Toolkit/ManipulationExtensions.cs
+++ b/src/Uno.UI.Toolkit/ManipulationExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Input;
 using Uno.Disposables;
+using Uno.UI.Extensions;
 using Windows.Devices.Input;
 
 #if HAS_UNO_WINUI
@@ -31,7 +32,10 @@ namespace Uno.UI.Toolkit
 		/// This is not the WinUI behavior: there, gesture recognition is per-element and independent of the inertia
 		/// of an ancestor, so the pointed item is activated by the very press which stops the momentum. It matches
 		/// what the OS does for its own scrollable surfaces though, which is what touch users expect on a
-		/// touch-only target - hence an opt-in. No-op on WinAppSDK.
+		/// touch-only target - hence an opt-in.
+		/// Honored on the targets which use the managed pointer pipeline (every Skia target and WebAssembly).
+		/// Inert on WinAppSDK, and unsupported on the native Android and iOS backends where pointer events bubble
+		/// natively. See the Uno.UI.Toolkit documentation for the full platform reach.
 		/// </remarks>
 		public static DependencyProperty IsTapToStopInertiaEnabledProperty { get; } =
 			DependencyProperty.RegisterAttached(
@@ -137,20 +141,24 @@ namespace Uno.UI.Toolkit
 
 			private static void MutePath(PointerRoutedEventArgs args, PointerIdentifier pointer, UIElement upTo)
 			{
-				DependencyObject current = args.OriginalSource as UIElement;
-				while (current is not null)
+				if (args.OriginalSource is not UIElement originalSource || Mute(originalSource))
 				{
-					if (current is UIElement element)
+					return;
+				}
+
+				foreach (var ancestor in originalSource.EnumerateAncestors())
+				{
+					if (ancestor is UIElement element && Mute(element))
 					{
-						element.PreventGestures(pointer, Taps);
-
-						if (element == upTo)
-						{
-							return;
-						}
+						return;
 					}
+				}
 
-					current = (current as FrameworkElement)?.Parent ?? Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(current);
+				bool Mute(UIElement element)
+				{
+					element.PreventGestures(pointer, Taps);
+
+					return element == upTo;
 				}
 			}
 

--- a/src/Uno.UI.UnitTests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -1164,6 +1164,53 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		}
 
 		[TestMethod]
+#if RUNTIME_NATIVE_AOT
+		[Ignore(".BeEquivalentTo() unsupported under NativeAOT; see: https://github.com/AwesomeAssertions/AwesomeAssertions/issues/290")]
+#endif  // RUNTIME_NATIVE_AOT
+		public void Manipulation_Inertia_Aborted_By_Press_Then_Tap_Is_Still_Raised()
+		{
+			using var _ = Touch();
+			var sut = new GestureRecognizer
+			{
+				GestureSettings = GestureSettings.Tap
+					| GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateInertia
+			};
+			var taps = new List<TappedEventArgs>();
+			sut.Tapped += (snd, e) => taps.Add(e);
+
+			// Flick at 2 px/ms so the manipulation goes to inertia on the up.
+			sut.ProcessDownEvent(10, 10, ts: 0);
+			sut.ProcessMoveEvent(10, 100, ts: 100 * MicrosecondsPerMillisecond);
+			sut.ProcessUpEvent(10, 104, ts: 102 * MicrosecondsPerMillisecond);
+			sut.PendingManipulation!.IsCoasting.Should().BeTrue();
+
+			// The press aborts the coasting manipulation and the recognizer reports it, but the gestures of that
+			// press are still recognized: this is the WinUI behavior, muting them is opt-in
+			// (cf. Uno.UI.Toolkit ManipulationExtensions.IsTapToStopInertiaEnabled).
+			sut.ProcessDownEvent(50, 50, ts: 110 * MicrosecondsPerMillisecond);
+			sut.LastDownStoppedInertia.Should().BeTrue();
+			sut.PendingManipulation!.IsCoasting.Should().BeFalse();
+
+			sut.ProcessUpEvent(51, 51, ts: 112 * MicrosecondsPerMillisecond);
+			taps.Should().BeEquivalentTo([Tap(50, 50)]);
+		}
+
+		[TestMethod]
+		public void Manipulation_Press_Without_Inertia_Then_No_Inertia_Reported_As_Stopped()
+		{
+			using var _ = Touch();
+			var sut = new GestureRecognizer
+			{
+				GestureSettings = GestureSettings.Tap
+					| GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateInertia
+			};
+
+			sut.ProcessDownEvent(50, 50, ts: 0);
+
+			sut.LastDownStoppedInertia.Should().BeFalse();
+		}
+
+		[TestMethod]
 		public void Manipulation_Inertia_Translate_Negative()
 		{
 			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };

--- a/src/Uno.UI.UnitTests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -1164,9 +1164,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		}
 
 		[TestMethod]
-#if RUNTIME_NATIVE_AOT
-		[Ignore(".BeEquivalentTo() unsupported under NativeAOT; see: https://github.com/AwesomeAssertions/AwesomeAssertions/issues/290")]
-#endif  // RUNTIME_NATIVE_AOT
 		public void Manipulation_Inertia_Aborted_By_Press_Then_Tap_Is_Still_Raised()
 		{
 			using var _ = Touch();
@@ -1192,7 +1189,10 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			sut.PendingManipulation!.IsCoasting.Should().BeFalse();
 
 			sut.ProcessUpEvent(51, 51, ts: 112 * MicrosecondsPerMillisecond);
-			taps.Should().BeEquivalentTo([Tap(50, 50)]);
+			taps.Should().HaveCount(1);
+			taps[0].Position.Should().Be(new Point(50, 50));
+			taps[0].TapCount.Should().Be(1u);
+			taps[0].PointerDeviceType.Should().Be(PointerDeviceType.Touch);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.Manipulation.cs
@@ -99,6 +99,12 @@ namespace Windows.UI.Input
 			public bool IsScaleEnabled => _isScaleEnabled;
 			public bool IsDraggingEnabled => _isDraggingEnable;
 
+			/// <summary>
+			/// Indicates that this manipulation is coasting, i.e. it no longer has any active pointer and is only
+			/// running its inertia. Any new pointer press will abort it (cf. <see cref="TryAdd"/>).
+			/// </summary>
+			public bool IsCoasting => _status is ManipulationStatus.Inertia;
+
 			internal static void AddPointer(GestureRecognizer recognizer, PointerPoint pointer)
 			{
 				var current = recognizer._manipulation;

--- a/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.cs
+++ b/src/Uno.UI/UI/Input/WinRT/GestureRecognizer.cs
@@ -51,6 +51,16 @@ namespace Windows.UI.Input
 
 		public bool IsActive => _gestures.Count > 0 || _manipulation != null;
 
+		/// <summary>
+		/// Indicates that the pointer of the last processed down event landed while a manipulation was coasting,
+		/// i.e. that press is what aborted the inertia.
+		/// This is informative only: the gestures of that press are still recognized as usual, like on WinUI where
+		/// gesture recognition is independent of the inertia of another element. Owners which want the OS-like
+		/// "the first press only stops the momentum" behavior opt into it explicitly
+		/// (cf. Uno.UI.Toolkit ManipulationExtensions.IsTapToStopInertiaEnabled).
+		/// </summary>
+		internal bool LastDownStoppedInertia { get; private set; }
+
 		internal bool IsTracking(PointerIdentifier pointer)
 			=> _gestures.ContainsKey(pointer) || _manipulation?.IsActive(pointer) is true;
 
@@ -82,6 +92,10 @@ namespace Windows.UI.Input
 
 		public void ProcessDownEvent(PointerPoint value)
 		{
+			// Must be evaluated before the manipulation is updated below, as a press which lands while the
+			// manipulation is coasting aborts it.
+			LastDownStoppedInertia = _isManipulationOrDragEnabled && _manipulation?.IsCoasting is true;
+
 			// Sanity validation. This is pretty important as the Gesture now has an internal state for the Holding state.
 			if (_gestures.TryGetValue(value.Pointer, out var previousGesture))
 			{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -794,6 +794,25 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
+		/// <summary>
+		/// Indicates that the last pointer down processed by this element's gesture recognizer is what aborted a
+		/// coasting manipulation of this element (cf. GestureRecognizer.LastDownStoppedInertia).
+		/// </summary>
+		internal bool LastPointerDownStoppedInertia
+			=> IsGestureRecognizerCreated && GestureRecognizer.LastDownStoppedInertia;
+
+		/// <summary>
+		/// Prevents this element from recognizing the given gestures for the given pointer.
+		/// Does nothing if this element has no gesture recognizer, or none for that pointer.
+		/// </summary>
+		internal void PreventGestures(global::Windows.Devices.Input.PointerIdentifier pointer, GestureSettings gestures)
+		{
+			if (IsGestureRecognizerCreated)
+			{
+				GestureRecognizer.PreventEvents(pointer, gestures);
+			}
+		}
+
 		private void UpdateRaisedGestureEventsFlag(PointerRoutedEventArgs args)
 		{
 			if (!IsGestureRecognizerCreated)


### PR DESCRIPTION
**GitHub Issue:** Tracked internally (customer-reported). No public issue.

## PR Type:

✨ Feature

## What changed? 🚀

A customer reported that on a tablet, tapping a CommunityToolkit `DataGrid` while it is still decelerating after a fling both stops the momentum **and** selects the row under the finger, instead of the first tap only halting the scroll.

**This turned out to be intended WinUI behaviour, not a bug.** The `DataGrid` pans its rows through the `ManipulationMode` of its `DataGridRowsPresenter` (runtime-confirmed: `TranslateX, TranslateY, TranslateRailsX, TranslateRailsY, TranslateInertia, System`), and in WinUI gesture recognition for that path is per-element and independent of an ancestor's inertia:

- interaction contexts are keyed per `CUIElement` (`CInteractionManager::m_mapInteractions`), so a descendant's tap recognition knows nothing about the panning ancestor's inertia;
- `CInteractionManager::IsManipulationInertiaProcessing()` has **zero callers**, so nothing gates press dispatch while an inertia is running;
- the tap-suppression guard that does exist — `GestureOutputMapper::OnTapped`/`OnSecondaryTapped`/`OnHolding` dropping the message when `IsInteractionStopping() && IsInteractionStopped()` — is armed only by `ElementGestureTracker::Stop()`, whose callers are DirectManipulation-steals-the-pointer, capture-changed and focus. Not "a press landed during my own inertia".

So WinUI activates the pointed item on that press, and Uno Platform now keeps doing the same by default.

Worth noting the corollary: Uno Platform's own `ScrollViewer` is **not** diverging. Its touch panning goes through the direct-manipulation pipeline, which swallows the press that stops an inertia before it reaches the visual tree — the same thing DirectManipulation does on WinUI. Only the `UIElement.ManipulationMode` path is affected, which is why the two behave differently today.

The gap is nonetheless real on touch-only targets: a browser on a tablet has no mouse, and users expect the OS convention that the first press only stops the momentum. That makes this an **enhancement**, which must not change default behaviour on any target.

So it ships as an opt-in Toolkit extension:

```xml
<Border ManipulationMode="TranslateY,TranslateInertia"
        toolkit:ManipulationExtensions.IsTapToStopInertiaEnabled="True">
```

While enabled, the press that aborts the inertia raises no `Tapped`, `DoubleTapped`, `RightTapped` or `Holding` on the element, its ancestors or its descendants; a tap at rest is unaffected. It is a no-op on Windows.

Applied through an implicit `Style` it also reaches panning elements an app cannot address directly — including `DataGrid`'s `DataGridRowsPresenter`, which is the customer's actual case:

```xml
<Style TargetType="primitives:DataGridRowsPresenter">
    <Setter Property="toolkit:ManipulationExtensions.IsTapToStopInertiaEnabled" Value="True" />
</Style>
```

### This does change core code, and the default is unchanged

The Toolkit cannot observe what it needs on its own, so `Uno.UI` gains four internals. All of them are **purely additive and behaviour-neutral** — nothing in core reads them, so no code path changes unless the opt-in is set. Core reports the fact, the opt-in decides what to do with it:

- `GestureRecognizer.Manipulation.IsCoasting`
- `GestureRecognizer.LastDownStoppedInertia` — informative only; the gestures of that press are still recognized exactly as before
- `UIElement.LastPointerDownStoppedInertia`
- `UIElement.PreventGestures(pointer, gestures)`

`GestureRecognizer.ProcessDownEvent` gains one assignment to compute the flag; every other line is a new member. The unchanged default is pinned by `When_PressStopsInertia_Without_OptIn_Then_TapIsRaised`.

### Platform reach

The opt-in is honoured on the targets which use the managed pointer pipeline — every Skia target (Desktop, and Skia on Android, iOS and WebAssembly) and the WebAssembly backend. It is inert on WinAppSDK, where the callback body is `#if HAS_UNO` so the property just stores its value and cross-platform XAML stays valid. On the native Android and iOS backends pointer events bubble natively, so the order the gestures are muted in has not been validated and those backends are documented as unsupported for this opt-in.

The property is deliberately not gated per target: the default is unchanged unless it is set, and a setter that silently refuses a value is harder to diagnose than one documented as inert.

### Implementation note

The muting needs two passes because of the order in which a press reaches the gesture recognizers: each element updates its own gestures **before** invoking its handlers, ancestors are visited from the closest to the root, and the original source updates its own gestures **last of all**. So the extension mutes the original-source→tracked-element path on the press (retroactively, those gestures already exist) and the remainder — the ancestors and the original source — on the release, which still runs before their gestures are recognized.

### Validation

- **Runtime** — Skia Desktop (`SamplesApp.Skia.Generic`), `Given_ManipulationExtensions`: 3 passed.
  - `When_PressStopsInertia_Without_OptIn_Then_TapIsRaised` pins the **default**, i.e. the WinUI behaviour, so parity cannot regress silently.
  - `When_PressStopsInertia_With_OptIn_Then_NoTapIsRaisedOnThePath` asserts no tap on the original source, an intermediate element, the coasting element and an ancestor — the four positions the two passes have to cover.
  - `When_TapAtRest_With_OptIn_Then_TapIsRaisedOnThePath` asserts the opt-in leaves a normal tap alone.
  - Both halves of the muting are load-bearing: removing the retroactive pass fails on the intermediate element, removing the forward flag fails on the original source.
- **Runtime (regression)** — 92 passed / 13 skipped across `Given_InputManager`, `Given_GestureRecognizer`, `Given_ScrollViewer`, `Given_SwipeControl`, `Given_FlipView`, `Given_RefreshContainer` and `Uno_UI_Toolkit`.
- **Unit** — `Given_GestureRecognizer`: the recognizer reports `LastDownStoppedInertia` for the aborting press **and still raises the tap**, plus a no-false-positive case.
- **Against the customer's repro** — a rebuilt copy of the reported project (real `DataGrid` 7.1.205) on Skia macOS confirmed the implicit `Style` does deliver an attached property to `DataGridRowsPresenter`, and that its `ManipulationMode` is the inertia-enabled one above.
- **Compile** — `Uno.UI` and `Uno.UI.Toolkit` for Skia, Reference, WebAssembly and iOS, and an analyzer-enabled build (no `UnoFastDevBuild`) of `Uno.UI.Toolkit` and `Uno.UI.RuntimeTests`: 0 errors, no new warnings.
- **Device** — confirmed on iPadOS against a LAN-served WebAssembly Skia SamplesApp build of this branch, through the `Manipulation_TapStopsInertia` sample (its in-app toggle flips between the default and the opt-in on the same screen).

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
