### PR TITLE
chore(ios): drop dead conditionals from web auth broker and Geolocator

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.iOS.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.iOS.cs
@@ -153,16 +153,12 @@ public sealed partial class Geolocator
 				var accessStatus = default(GeolocationAccessStatus);
 				var tsc = new TaskCompletionSource<CLAuthorizationStatus>();
 
-#if __IOS__ || __TVOS__
 				// Workaround for a bug in Xamarin.iOS https://github.com/unoplatform/uno/issues/4853
 				var @delegate = new CLLocationManagerDelegate();
 
 				mgr.Delegate = @delegate;
 
 				@delegate.AuthorizationChanged += (s, e) =>
-#else
-				mgr.AuthorizationChanged += (s, e) =>
-#endif
 				{
 					if (e.Status != CLAuthorizationStatus.NotDetermined)
 					{
@@ -170,9 +166,7 @@ public sealed partial class Geolocator
 					}
 				};
 
-#if __IOS__ || __TVOS__ //required only for iOS
 				mgr.RequestWhenInUseAuthorization();
-#endif
 
 				if (CLLocationManager.Status != CLAuthorizationStatus.NotDetermined)
 				{
@@ -229,7 +223,6 @@ public sealed partial class Geolocator
 		}
 	}
 
-#if __IOS__ || __TVOS__
 	private class CLLocationManagerDelegate : NSObject, ICLLocationManagerDelegate
 	{
 		public event EventHandler<CLAuthorizationChangedEventArgs> AuthorizationChanged;
@@ -240,5 +233,4 @@ public sealed partial class Geolocator
 			AuthorizationChanged?.Invoke(manager, new CLAuthorizationChangedEventArgs(status));
 		}
 	}
-#endif
 }

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOS.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOS.cs
@@ -18,10 +18,9 @@ namespace Uno.AuthenticationBroker
 	{
 		private const string asWebAuthenticationSessionErrorDomain = "com.apple.AuthenticationServices.WebAuthenticationSession";
 		private const int asWebAuthenticationSessionErrorCodeCanceledLogin = 1;
-#if __IOS__
 		private const string sfAuthenticationErrorDomain = "com.apple.SafariServices.Authentication";
 		private const int sfAuthenticationErrorCanceledLogin = 1;
-#endif
+
 		protected virtual async Task<WebAuthenticationResult> AuthenticateAsyncCore(
 			WebAuthenticationOptions options,
 			Uri requestUri,
@@ -48,12 +47,10 @@ namespace Uno.AuthenticationBroker
 				{
 					aswas.Cancel();
 				}
-#if __IOS__
 				else if (w is SFAuthenticationSession sfwas)
 				{
 					sfwas.Cancel();
 				}
-#endif
 
 				w?.Dispose();
 				was = null;
@@ -78,19 +75,12 @@ namespace Uno.AuthenticationBroker
 			// is a fully defined url
 			var scheme = callbackUri.Scheme;
 
-#if __IOS__
 			if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
-#else
-			var osVersion = NSProcessInfo.ProcessInfo.OperatingSystemVersion;
-			if (new Version((int)osVersion.Major, (int)osVersion.Minor) >= new Version(10, 15))
-#endif
 			{
 				var aswas = new ASWebAuthenticationSession(startUrl, callbackUrlScheme: scheme, AuthSessionCallback);
 				was = aswas;
 
-#if __IOS__
 				if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
-#endif
 				{
 					aswas.PresentationContextProvider = new PresentationContextProviderToSharedKeyWindow();
 					aswas.PrefersEphemeralWebBrowserSession =
@@ -115,7 +105,6 @@ namespace Uno.AuthenticationBroker
 					}
 				}
 			}
-#if __IOS__
 			else
 			{
 				if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
@@ -134,7 +123,6 @@ namespace Uno.AuthenticationBroker
 					throw new InvalidOperationException("iOS v11+ is required for this implementation of WebAuthenticationBroker.");
 				}
 			}
-#endif
 
 			try
 			{
@@ -173,19 +161,12 @@ namespace Uno.AuthenticationBroker
 		private static bool IsUserCanceledLogin(NSError error)
 			=> (error.Domain == asWebAuthenticationSessionErrorDomain &&
 				error.Code == asWebAuthenticationSessionErrorCodeCanceledLogin)
-#if __IOS__
 				|| (error.Domain == sfAuthenticationErrorDomain &&
-					error.Code == sfAuthenticationErrorCanceledLogin)
-#endif
-				;
+					error.Code == sfAuthenticationErrorCanceledLogin);
 
 		private class PresentationContextProviderToSharedKeyWindow : NSObject, IASWebAuthenticationPresentationContextProviding
 		{
-#if __IOS__
 			public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session) => UIApplication.SharedApplication.KeyWindow!;
-#else
-			public NSWindow GetPresentationAnchor(ASWebAuthenticationSession session) => NSApplication.SharedApplication.KeyWindow!;
-#endif
 		}
 
 		protected virtual IEnumerable<string> GetApplicationCustomSchemes()


### PR DESCRIPTION
**GitHub Issue:** follow-up to #24057 (no separate issue — cleanup surfaced while fixing that one)

## PR Type:

🔄 Refactoring (no functional changes, no api changes)

## What changed? 🚀

While fixing the web auth cancel crash in #24057, the surrounding file turned out to be full of `#if __IOS__` / `#if __IOS__ || __TVOS__` branches that can never be taken. Both files use the `.iOS.cs` suffix, and `src/Uno.CrossTargetting.targets` removes `**\*.iOS.cs` from compilation unless `IsIOSOrCatalyst` — so the `#else` sides (tvOS, AppKit/macOS) are dead code that only obscures what actually runs.

This PR deletes those conditionals and keeps the branch that was already being compiled. No behavior change.

`WebAuthenticationBrokerProvider.iOS.cs`:

- Unconditionally keeps the `SFAuthenticationSession` constants, `Cancel()` case, `IsUserCanceledLogin` clause, and the pre-iOS-12 fallback path.
- Drops the `#else` version check that read `NSProcessInfo.ProcessInfo.OperatingSystemVersion >= 10.15` — the `UIDevice.CurrentDevice.CheckSystemVersion(12, 0)` branch is the one that compiles.
- `PresentationContextProviderToSharedKeyWindow.GetPresentationAnchor` keeps the `UIWindow` overload and drops the `NSWindow`/`NSApplication` one.

`Geolocator.iOS.cs`:

- Keeps the `CLLocationManagerDelegate` workaround for unoplatform/uno#4853 and `RequestWhenInUseAuthorization()`, dropping the `mgr.AuthorizationChanged` `#else` branch and the `#if` around the nested delegate class.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

No new tests: this is a pure dead-code removal, and the behavior of the web auth broker is already pinned by `Given_WebAuthenticationBrokerProvider` plus the `AuthenticationBroker_Cancel` manual sample added in #24057.
