### PR TITLE
ci: Make Claude Code Review check advisory

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,10 +55,8 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Keeps the workflow run itself green. This alone does NOT green the PR's
-    # `review` check — a job's own check run still reports its real conclusion,
-    # so the per-step continue-on-error flags below are what keep the PR out of
-    # the red.
+    # Advisory check: a flaky agent run must not turn the PR red. This flag
+    # greens the run, the step flags below green the PR check.
     continue-on-error: true
     steps:
       - name: Checkout repository
@@ -87,11 +85,7 @@ jobs:
 
       - name: Claude Code Review
         id: review
-        # Don't review against a truncated prompt if the fetch above failed.
         if: steps.review_prompt.outcome == 'success'
-        # The review is advisory: a failed or flaky agent run — transient API
-        # errors, rate limits, timeouts — must not turn the PR red. The failure
-        # stays in the job log and in the warning step below.
         continue-on-error: true
         # SECURITY: pinned to a full commit SHA (not the mutable `@v1` tag) so a
         # repointed/compromised tag can't pull unexpected action code — the

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,9 +55,10 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # The review is advisory, so a failed or flaky agent run must never turn the
-    # PR red. Failures stay visible in the job log and as a warning annotation,
-    # but the check itself reports green.
+    # Keeps the workflow run itself green. This alone does NOT green the PR's
+    # `review` check — a job's own check run still reports its real conclusion,
+    # so the per-step continue-on-error flags below are what keep the PR out of
+    # the red.
     continue-on-error: true
     steps:
       - name: Checkout repository
@@ -70,6 +71,7 @@ jobs:
 
       - name: Load review prompt
         id: review_prompt
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -84,6 +86,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Claude Code Review
+        id: review
+        # Don't review against a truncated prompt if the fetch above failed.
+        if: steps.review_prompt.outcome == 'success'
+        # The review is advisory: a failed or flaky agent run — transient API
+        # errors, rate limits, timeouts — must not turn the PR red. The failure
+        # stays in the job log and in the warning step below.
+        continue-on-error: true
         # SECURITY: pinned to a full commit SHA (not the mutable `@v1` tag) so a
         # repointed/compromised tag can't pull unexpected action code — the
         # supply-chain risk the RyotaK disclosure centers on. Dependabot
@@ -107,6 +116,6 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       - name: Report failure as a warning
-        if: failure()
+        if: always() && steps.review.outcome != 'success'
         run: |
-          echo "::warning title=Claude Code Review did not complete::The review job failed - see the job log. This check is advisory and does not block the PR."
+          echo "::warning title=Claude Code Review did not complete::The review step reported '${{ steps.review.outcome }}' - see the job log. This check is advisory and does not block the PR."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,6 +55,10 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # The review is advisory, so a failed or flaky agent run must never turn the
+    # PR red. Failures stay visible in the job log and as a warning annotation,
+    # but the check itself reports green.
+    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -101,3 +105,8 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      - name: Report failure as a warning
+        if: failure()
+        run: |
+          echo "::warning title=Claude Code Review did not complete::The review job failed - see the job log. This check is advisory and does not block the PR."


### PR DESCRIPTION
**GitHub Issue:** closes #24305

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

**Current behavior:** when the `Claude Code Review` job fails, the pull request's check rollup turns red — even when every Azure Pipelines build and test job passed. The job fails for reasons unrelated to the PR's content: transient API errors, rate limiting, or timeouts. PR #24194 is a recent example — fully green CI, but the `review` job died after 213 ms with `is_error: true`, `num_turns: 1`, `total_cost_usd: 0`, before the agent looked at a single line of the diff.

**This PR** makes the review advisory:

- `continue-on-error: true` on the **steps**, so a failed agent run doesn't fail the job — and therefore doesn't fail the `review` check that the PR renders.
- `continue-on-error: true` on the **job** as well, which keeps the workflow run itself green in the Actions tab. Worth being explicit about the difference, because it is not obvious: the job-level flag alone does *not* green the PR check — a job's check run still reports its real conclusion, and only the run's rollup is affected. The first commit here got that wrong; the second fixes it.
- The agent step is skipped when the `REVIEW.md` fetch failed, rather than reviewing against a truncated prompt.
- A final step emits a `::warning::` annotation whenever the review step didn't succeed, so a genuinely broken workflow (bad action pin, missing `REVIEW.md`, expired key) still surfaces in the run summary rather than failing silently. It keys off `steps.review.outcome` because `failure()` no longer trips once the step is marked continue-on-error.

The review comments the agent posts on the PR are unaffected — only the check status changes.

**Tradeoff:** the check can no longer block a merge, even for a real configuration error. The warning annotation and the job log are the remaining signal. One deliberate hole is left: a failure of the `Checkout repository` step is still red, since that means the runner itself is broken rather than the review being flaky.

**Security posture unchanged:** none of the five defenses documented in the workflow header are touched — the trigger gate, tool allowlist, absence of `id-token: write`, the pinned action SHA, and the base-branch prompt all stay exactly as they were.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, CI configuration only. Verified on this PR's own workflow runs, which exercise the changed file directly.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A, no user-facing change; the rationale is inline in the workflow comments.
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
