### PR TITLE
fix(android): refresh Skia text scale after configuration changes

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -399,12 +399,15 @@ namespace Microsoft.UI.Xaml
 			base.OnConfigurationChanged(newConfig);
 
 			RaiseConfigurationChanges();
+			// Read the settled configuration after Android has propagated it through the decor view.
+			Window?.DecorView?.Post(() =>
+				Uno.UI.Xaml.Core.CoreServices.Instance.UpdateFontScale(
+					global::Windows.UI.ViewManagement.UISettings.GetTextScaleFactorValue()));
 		}
 
 		private void RaiseConfigurationChanges()
 		{
 			NativeWindowWrapper.Instance.RaiseNativeSizeChanged();
-			//ViewHelper.RefreshFontScale();
 			DisplayInformation.GetForCurrentView().HandleConfigurationChange();
 			SystemThemeHelper.RefreshSystemTheme();
 		}


### PR DESCRIPTION
## Summary

Skia Android did not refresh Uno's font scale when Android delivered a live configuration change. The platform chrome changed, but already-rendered XAML text retained the previous scale.

This refreshes `CoreServices` from the shared `UISettings` text-scale source after Android has propagated the settled configuration through the decor view.

## Validation

- Strict Release build: `Uno.UI.Runtime.Skia.Android` (`net10.0-android`)
- Runtime validation is in progress against a generated MAUI Android host with live system font-scale changes.


### Live runtime acceptance

Validated on Android API 36 through a generated MAUI Gallery host. Changing system font scale from `1.0` to `1.3` updated live text bounds (`Gallery` from `[31,0][295,101]` to `[31,0][320,111]`) without recreating the process; the PID remained unchanged.
