### PR TITLE
ci: Use Claude Sonnet 5 for the code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,14 +98,6 @@ jobs:
           github_token: ${{ github.token }}
           track_progress: true
           prompt: ${{ steps.review_prompt.outputs.prompt }}
-          # The model is not a security control — the allowlist above is.
-          # `claude-sonnet-4-6` runs a 200K context window, and PRs past roughly
-          # 4k added lines died on it: `num_turns: 2`, ~$0.8 billed, no review
-          # posted, while smaller PRs on the same day passed with `num_turns: 9`.
-          # Sonnet 5 supports a 1M window, and the `[1m]` selector is what
-          # actually resolves it — a run using `claude-opus-5[1m]` reports
-          # `contextWindow: 1000000` under `modelUsage`, which is how this is
-          # verified from the run log without turning on `show_full_output`.
           claude_args: |
-            --model "claude-sonnet-5[1m]"
+            --model "claude-sonnet-5"
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,6 +98,17 @@ jobs:
           github_token: ${{ github.token }}
           track_progress: true
           prompt: ${{ steps.review_prompt.outputs.prompt }}
+          # The model is not a security control — the allowlist above is. Two
+          # separate failure modes drove this choice, both visible in the run logs:
+          #   - `claude-sonnet-4-6` stopped being served. Every run since
+          #     2026-08-26 ends with `is_error: true`, `num_turns: 1`,
+          #     `total_cost_usd: 0` and `modelUsage: {}` — the first request is
+          #     rejected before a token is billed, so no review happens.
+          #   - Before that, PRs over ~4k added lines died at `num_turns: 2` with
+          #     ~$0.8 billed: the review does not fit in a 200K context window.
+          # Sonnet 5 is current and has a native 1M context window, which covers
+          # both. The action logs the resolved `contextWindow` under `modelUsage`,
+          # so a regression here is visible without `show_full_output`.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,17 +98,14 @@ jobs:
           github_token: ${{ github.token }}
           track_progress: true
           prompt: ${{ steps.review_prompt.outputs.prompt }}
-          # The model is not a security control — the allowlist above is. Two
-          # separate failure modes drove this choice, both visible in the run logs:
-          #   - `claude-sonnet-4-6` stopped being served. Every run since
-          #     2026-08-26 ends with `is_error: true`, `num_turns: 1`,
-          #     `total_cost_usd: 0` and `modelUsage: {}` — the first request is
-          #     rejected before a token is billed, so no review happens.
-          #   - Before that, PRs over ~4k added lines died at `num_turns: 2` with
-          #     ~$0.8 billed: the review does not fit in a 200K context window.
-          # Sonnet 5 is current and has a native 1M context window, which covers
-          # both. The action logs the resolved `contextWindow` under `modelUsage`,
-          # so a regression here is visible without `show_full_output`.
+          # The model is not a security control — the allowlist above is.
+          # `claude-sonnet-4-6` runs a 200K context window, and PRs past roughly
+          # 4k added lines died on it: `num_turns: 2`, ~$0.8 billed, no review
+          # posted, while smaller PRs on the same day passed with `num_turns: 9`.
+          # Sonnet 5 supports a 1M window, and the `[1m]` selector is what
+          # actually resolves it — a run using `claude-opus-5[1m]` reports
+          # `contextWindow: 1000000` under `modelUsage`, which is how this is
+          # verified from the run log without turning on `show_full_output`.
           claude_args: |
-            --model claude-sonnet-5
+            --model "claude-sonnet-5[1m]"
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
> **Draft — do not merge yet.** The premise this PR was opened on is disproven; see "Correction". The change it now carries is real but cannot be validated while the review agent cannot reach the provider at all.

## GitHub Issue

Related to #24305.

## Correction ⚠️

This PR was opened on the theory that `claude-sonnet-4-6` had stopped being served. **That is wrong**, and this PR's own `review` check is the disproof: run [33400806514](https://github.com/unoplatform/uno/actions/runs/33400806514) ran `--model claude-sonnet-5` and failed **identically** to `claude-sonnet-4-6`:

```json
{ "type": "result", "subtype": "success", "is_error": true,
  "duration_ms": 230, "num_turns": 1, "total_cost_usd": 0,
  "permission_denials_count": 0, "modelUsage": {} }
```

Same ~230 ms, same zero cost, same empty `modelUsage`, on two different models and on both action v1.0.194 and v1.0.210. Meanwhile the upstream action's own `Claude Issue Triage` job ran green on 2026-08-30 23:15 UTC ([33341326738](https://github.com/anthropics/claude-code-action/actions/runs/33341326738), `is_error: false`, `num_turns: 8`), so the provider and the action are both healthy. **The current outage is specific to this repository's credential/account, and nothing in this repo can fix it.** Exact maintainer action is in #24305.

## What this PR is for 🚀

One line: `--model claude-sonnet-4-6` -> `--model "claude-sonnet-5[1m]"`, for the **other**, older failure mode — the one that was happening while the provider was still answering.

Between 2026-08-25 and 2026-08-26, large PRs failed with a distinct signature: `num_turns: 2`, ~\.77-0.94 billed, no review output, 15-30 s — real tokens spent, then the request rejected. It tracks size rather than luck: #23756 passed at a smaller size ([32830925303](https://github.com/unoplatform/uno/actions/runs/32830925303), `num_turns: 9`, \.13) and has failed on every attempt since its diff grew, and the same signature hits #23935, #23755 and #24174 — all 90+ file PRs. That is a 200K context ceiling.

**Why the `[1m]` suffix and not a bare `claude-sonnet-5`:** the selector is what actually resolves the wider window. The upstream run above uses `claude-opus-5[1m]` and reports `"contextWindow": 1000000` under `modelUsage`; the action's own docs list Claude Opus 5 and Claude Sonnet 5 as the models the `[1m]` selector applies to, and the selector is resolved by Claude Code before the request is sent. Because the action surfaces the resolved `contextWindow` in the sanitized result (upstream anthropics/claude-code-action#1608, shipped in v1.0.199), a regression back to 200K is visible straight from the run log — no `show_full_output` needed.

Five of the seven PRs blocked on this check are over 15k added lines, so this matters again the moment the credential side is restored — but **it is untestable until then**, hence draft.

## Security posture unchanged 🔒

None of the five defenses in the workflow header are touched. The member-only trigger gate, the `--allowedTools` allowlist, the absence of `id-token: write`, the full-SHA action pin (`a874e9ec` / v1.0.210) and the base-branch `REVIEW.md` prompt are byte-for-byte identical — the whole diff is the `--model` value plus comments. The model is not a security control; the allowlist is, and a hijacked agent still has no tool that can read env/files/`/proc` or reach the network. Nothing here makes the check pass artificially: the job still fails if the review does not run.

Cost note: 1M-context requests are billed at a higher rate above the 200K mark, so this trades some spend for large PRs actually getting reviewed instead of erroring out.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) — N/A, CI configuration only.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) — N/A; rationale is inline in the workflow.
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — N/A.
- [x] ❗ Contains **NO** breaking changes
