### PR TITLE
fix(vs): Marshal dispose to the UI thread

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -890,21 +890,43 @@ public partial class EntryPoint : IDisposable
 
 		try
 		{
-			_ct.Cancel(false);
-			_dte.Events.BuildEvents.OnBuildBegin -= _onBuildBeginHandler;
-			_dte.Events.BuildEvents.OnBuildDone -= _onBuildDoneHandler;
-			_dte.Events.BuildEvents.OnBuildProjConfigBegin -= _onBuildProjConfigBeginHandler;
-			_globalJsonObserver?.Dispose();
-			_debuggerObserver?.Dispose();
-			_infoBarFactory?.Dispose();
-			_unoMenuCommand?.Dispose();
-			_appLaunchIdeBridge?.Dispose();
-			_appLaunchStateConsumer?.Dispose();
+			// DTE events, InfoBars and menu commands are UI-thread-affine COM objects, but Dispose
+			// can be invoked from any thread (e.g. the Studio VSIX disposes the entry point from a
+			// thread-pool task while the solution is closing).
+			if (ThreadHelper.CheckAccess())
+			{
+				DisposeCore();
+			}
+			else
+			{
+				ThreadHelper.JoinableTaskFactory.Run(async () =>
+				{
+					await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+					DisposeCore();
+				});
+			}
 		}
 		catch (Exception e)
 		{
 			_debugAction?.Invoke($"Failed to dispose Remote Control server: {e}");
 		}
+	}
+
+	private void DisposeCore()
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		_ct.Cancel(false);
+		_dte.Events.BuildEvents.OnBuildBegin -= _onBuildBeginHandler;
+		_dte.Events.BuildEvents.OnBuildDone -= _onBuildDoneHandler;
+		_dte.Events.BuildEvents.OnBuildProjConfigBegin -= _onBuildProjConfigBeginHandler;
+		_globalJsonObserver?.Dispose();
+		_debuggerObserver?.Dispose();
+		_infoBarFactory?.Dispose();
+		_unoMenuCommand?.Dispose();
+		_appLaunchIdeBridge?.Dispose();
+		_appLaunchStateConsumer?.Dispose();
 	}
 
 	protected IServiceProvider VisualStudioServiceProvider

--- a/src/Uno.UI.RemoteControl.VS/Notifications/InfoBar.cs
+++ b/src/Uno.UI.RemoteControl.VS/Notifications/InfoBar.cs
@@ -59,9 +59,19 @@ public class InfoBarFactory
 
 	internal void Dispose()
 	{
-		ThreadHelper.ThrowIfNotOnUIThread();
+		// IVsInfoBar* objects are UI-thread-affine, but Dispose can be invoked from any thread.
+		if (ThreadHelper.CheckAccess())
+		{
+			RemoveAllInfoBars();
+			return;
+		}
 
-		RemoveAllInfoBars();
+		ThreadHelper.JoinableTaskFactory.Run(async () =>
+		{
+			await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+			RemoveAllInfoBars();
+		});
 	}
 }
 


### PR DESCRIPTION
**GitHub Issue:** closes #24149

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Uno.UI.RemoteControl.VS.EntryPoint` can be disposed from any thread — for example, the Studio VSIX (`DevServerLauncher`) disposes the reflection-loaded entry point from a thread-pool task while the solution is closing. The teardown, however, touches UI-thread-affine COM objects (DTE `BuildEvents` unsubscription, `IVsInfoBar*` cleanup, menu command disposal), which throws `COMException` when invoked off the UI thread.

Because `Dispose` wraps the teardown in a `try/catch` and `_isDisposed` is set up-front, the exception was swallowed and the teardown was silently aborted partway through: `_unoMenuCommand`, `_appLaunchIdeBridge`, and `_appLaunchStateConsumer` leaked, and open InfoBars were never removed.

This PR marshals the teardown to the UI thread:

- `EntryPoint.Dispose` now takes a `ThreadHelper.CheckAccess()` fast path when already on the UI thread, and otherwise runs the teardown via `ThreadHelper.JoinableTaskFactory.Run` + `SwitchToMainThreadAsync`. The teardown body is extracted into `DisposeCore`, which keeps `ThrowIfNotOnUIThread` as a guard. Marshaling once at the `EntryPoint` level covers all child disposables.
- `InfoBarFactory.Dispose` gets the same treatment (it is also reachable independently), replacing its former `ThrowIfNotOnUIThread` hard requirement.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — not applicable: VS extension teardown path; validation requires a devenv + VSIX debugging session (manual verification with the reporter's scenario).
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — not applicable, no user-facing behavior change.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — not applicable, VS tooling only.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
