### PR TITLE
test: Exclude When_MsAppData on Skia Android

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -87,12 +87,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 #if __SKIA__ // Not yet supported on the other platforms (https://github.com/unoplatform/uno/issues/8909)
 		[TestMethod]
 		// The ms-appdata load never completes on Skia Linux, and the awaited TCS has no timeout, so the job hangs to its limit (#23967).
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaFrameBuffer | RuntimeTestPlatforms.SkiaX11
-#if RUNTIME_NATIVE_AOT
-			// TODO: figure out why it's hanging on Android+NativeAOT: https://github.com/unoplatform/uno/issues/24271
-			| RuntimeTestPlatforms.SkiaAndroid
-#endif // RUNTIME_NATIVE_AOT
-		)]
+		// Android goes silent the same way: first seen under NativeAOT (#24271), then on plain Android Skia
+		// once #24003 fixed the shard partition and the test actually started running there.
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaFrameBuffer | RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaAndroid)]
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/23967")]
 		// Backstop for the storage calls below, which the inner WaitAsync does not cover.
 		[Timeout(60000)]


### PR DESCRIPTION
**GitHub Issue:** relates to #23967

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

`Given_BitmapSource.When_MsAppData` is now excluded on **Skia Android**, alongside the `SkiaFrameBuffer` and `SkiaX11` exclusions it already carried for #23967.

> **Note for @jonpryor** — #24215 already excluded `SkiaAndroid` for this test, but gated behind `#if RUNTIME_NATIVE_AOT` while investigating #24271. The evidence below shows the hang is **not** NativeAOT-specific: it reproduces on the plain Android Skia leg. So rather than duplicating the exclusion, this PR un-gates yours and keeps the #24271 reference in the comment. If you'd prefer to keep the two cases separate, happy to change it.

### The failure

On the Android Skia runtime-test host the ms-appdata load intermittently never completes. The device log shows the test start and then 30 seconds of complete silence — no `ImageOpened`, no `ImageFailed`, no exception — until the inner `WaitAsync` trips:

```
09-01 13:10:22.971 I DOTNET :       Running test When_MsAppData()
09-01 13:10:53.107 I DOTNET :       Retry 1/2 of When_MsAppData() after 36ms: TimeoutException: The operation has timed out.
```

That is the same signature already tracked in #23967 for the Linux hosts, where the root cause is still open.

### Why it appeared now

The test **never ran on Android at all** until #24003 aligned shard 0's `UITEST_RUNTIME_TEST_GROUP_COUNT` (`4` → `5`, `005db435370`, merged 2026-08-31). Test selection is a stable hash modulo that count, so before that fix `When_MsAppData` was one of the 14.7% of methods no shard selected — verified absent from every Android shard log in builds 231043, 231021 and 230963.

So this is not a new failure, just a newly *executed* one. `master` still carries the old count of `4` and therefore never runs it.

### Why it needs its own PR

Since that merge it has failed on three unrelated PR builds within hours of each other:

| Build | PR | Outcome |
|---|---|---|
| 231145 | #24186 | isolated retry passed → green |
| 231142 | #24194 | isolated retry failed 3× → **red** |
| 231152 | #19083 | isolated retry passed → green |

The retry only sometimes recovers, so the test reddens whichever PR happens to be unlucky rather than anything related to that PR's changes.

### Scope

Deliberately limited to this one test. `When_MsAppData_StreamDisposed_FileNotLocked` and `When_Exif_Rotated_MsAppData` exercise the same ms-appdata path but run green on Android in every post-fix build checked (231121, 231139, 231157), so they keep running.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — N/A, this is a test-gating change; the underlying bug stays tracked by #23967
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — N/A
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lk1RUZfAj6A7xGWzYaoBw
