### PR TITLE
docs: Add 6.6 element-level theming migration note

### DIFF
--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -32,6 +32,21 @@ On the Linux Framebuffer target, the default mouse wheel scroll direction is now
 
 This change was introduced in [PR #22924](https://github.com/unoplatform/uno/pull/22924).
 
+### Element-level theming on Skia and WebAssembly
+
+Uno Platform 6.6 implements WinUI-compatible element-level theming on the Skia and WebAssembly targets. Setting `FrameworkElement.RequestedTheme` — including on the root element, which is what `Uno.Toolkit.UI.SystemThemeHelper.SetApplicationTheme`/`SetRootTheme` do — now themes that element's subtree only, exactly as it does on WinUI.
+
+Previously, setting the root element's `RequestedTheme` also switched the application-level theme (an Uno-specific behavior WinUI never had). After upgrading:
+
+- `Application.Current.RequestedTheme` no longer changes when a root element's theme is set. It keeps reporting the application-level theme, which follows the OS unless set in the `Application` constructor.
+- Programmatic resource lookups (`ResourceDictionary` indexer/`TryGetValue`, or helpers such as the Community Toolkit's `FindResource`) keep resolving `ThemeDictionaries` against the application-level theme, matching WinUI. The UI itself still updates: `{ThemeResource}` references inside the themed subtree re-resolve against the element theme.
+
+If your code — tests in particular — needs the theme-specific value of a resource, read the effective value from an element in the themed subtree (`element.ActualTheme`, or a theme-bound property such as a control's `Foreground`), or query the theme dictionary explicitly, for example `(ResourceDictionary)resources.ThemeDictionaries["Dark"]`.
+
+The native Android and native iOS UI targets retain the previous behavior.
+
+This change was introduced in [PR #22803](https://github.com/unoplatform/uno/pull/22803).
+
 ### Uno.Extensions MVUX bindable generation tool
 
 Uno.Extensions 7.2 (shipped with Uno Platform 6.6) changes the default MVUX bindable generation tool from version 2 to version 3, which improves Hot Reload support. Typical MVUX code is unaffected, because navigation and bindings reference your model type rather than the generated bindable. However, the *name* of the generated bindable view model changes: version 2 generated `Bindable{ModelName}` (for example, `BindableMainModel`), while version 3 generates `{Name}ViewModel` (for example, `MainModel` generates `MainViewModel`).


### PR DESCRIPTION
**GitHub Issue:** N/A — documentation-only change (upgrade issue reported privately; tracked internally)

## PR Type:

📚 Documentation content changes

## What changed? 🚀

Adds an **"Element-level theming on Skia and WebAssembly"** section under *Uno Platform 6.6* in `doc/articles/migrating-from-previous-releases.md`.

Since #22803, setting `FrameworkElement.RequestedTheme` (including on the root element via `Uno.Toolkit.UI.SystemThemeHelper.SetApplicationTheme`/`SetRootTheme`) themes that element's subtree only on Skia and WebAssembly, matching WinUI. Up to 6.5, it also switched the application-level theme, so code relying on that Uno-specific behavior — asserting `Application.Current.RequestedTheme`, or reading theme values through programmatic lookups such as the Community Toolkit's `FindResource` — silently gets Light-theme values after upgrading. There was no migration note covering this.

The new section explains the behavior change and the migration options (read effective values via `ActualTheme`/theme-bound properties, or query `ThemeDictionaries` explicitly).

The guidance was validated at runtime with a standalone sample (https://github.com/ajpinedam/uno-theme-migration-sample): the pre-6.6 test pattern passes on Uno.Sdk 6.5.36 and fails on 6.6.42, and the migrated pattern passes on both.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
