### PR TITLE
test(hotreload): record a wall-clock baseline for the reload cycle

### DIFF
--- a/specs/057-hotreload-end-to-end-instrumentation/spec.md
+++ b/specs/057-hotreload-end-to-end-instrumentation/spec.md
@@ -1,0 +1,317 @@
+# Hot-Reload: End-to-End Instrumentation — Make the Edit-to-Frame Cycle Measurable
+
+**Repo**: `uno` (Uno.HotReload, Uno.UI.RemoteControl, Uno.UI.RemoteControl.Server.Processors)
+**Created**: 2026-08-27
+**Status**: Proposed
+**Related**: [spec 050](../050-hotreload-updatefile-workspace-gate/spec.md) (R6 — the per-request
+info file that already carries the correlation id to the app),
+[spec 051](../051-hotreload-baseline-identity-handshake/spec.md) (baseline MVID mismatch — a
+silent drop this instrumentation would make visible),
+[spec 055](../055-hotreload-noop-pass-dedup/spec.md) (the `0.007 s` no-op emit measurement),
+[spec 044](../044-alc-memory-leak-fixes/spec.md) (per-reload memory accumulation),
+[spec 001](../001-fast-devserver-startup/) (`TIMELINE|` staged startup measurement — the model
+this spec follows for the edit cycle)
+
+> **Note**: this spec has no associated GitHub issue yet. One should be filed and linked here
+> before any PR, per the repository's contribution rules.
+
+## Overview & Objectives
+
+Uno's hot-reload pipeline **cannot measure itself end to end**, and the gap is structural
+rather than a matter of missing log lines.
+
+The pipeline already emits three durations. None of them is, or can become, an edit-to-frame
+figure:
+
+- `ServerHotReloadProcessor.cs:221-222` computes
+  `DurationMs = Current.CompletionTime - Current.StartTime` — a **server-side** operation
+  window.
+- `ServerHotReloadProcessor.cs:77` records `WaitDurationMs`, the workspace-gate queue time.
+- `RemoteControlClient.Status` records `_roundTrip`, a WebSocket ping RTT.
+
+The 250 ms watcher debounce (`FileSystemObserver.cs:242`,
+`bufferTimer.Change(250, Timeout.Infinite); // Wait for 250 ms without any file change`) is
+**inside** the server's window, not before it: `HotReloadManager.ProcessFileChanges` awaits
+`StartOrContinueHotReload()` *before* awaiting the file set, and says so in a comment —
+*"Notify the start of the hot-reload processing as soon as possible, even before the buffering
+of file change is completed"* (`HotReloadManager.cs:141-143`). `DurationMs` therefore already
+contains the debounce, which is why it cannot be compared across edits of different shapes.
+
+What `DurationMs` does exclude is everything after the server completes: the 100 ms
+`await Task.Delay(100, ct); // […] this is just for safety.`
+(`ClientHotReloadProcessor.ClientApi.cs:392`, reached on the fully-successful path only — six
+early returns bypass it) and **both visual-tree walks** land **entirely after**
+`CompletionTime`. So `DurationMs` covers a window that both starts too early to be a
+per-edit cost and ends too soon to be a developer-perceived latency, and no amount of careful
+reading turns it into one.
+
+**The blocking defect is narrower than "add instrumentation", but it is not a single field.**
+One field carries the id; a server-side frame handler is also required, because
+`ServerHotReloadProcessor.ProcessFrame` has no case for `HotReloadClientOperationEvent` and no
+`default`, so the client's outcome event is sent and silently dropped today. A
+correlation id already spans the server and reaches the app:
+`UpdateFileResponse.HotReloadCorrelationId` is the `HotReloadServerOperation.Id`
+(`HotReloadInfoHelper.cs:76` documents exactly this), and the client blocks on it in
+`WaitForServerHotReloadAsync` (`ClientApi.cs:350`). But when the client reports its own
+outcome it sends:
+
+```csharp
+// ClientHotReloadProcessor.Common.Status.cs:769-777
+_ = client.SendMessage(new Messages.HotReloadClientOperationEvent
+{
+    OperationSequenceId = Id,   // <- client-LOCAL sequential id, not the server correlation id
+    StartTime = StartTime,
+    …
+});
+```
+
+`Id` is the client's own counter. **The client half of every hot-reload operation therefore
+cannot be joined to the server half.** Two accurate timelines exist and there is no key
+between them.
+
+### Key objective
+
+Make one hot-reload cycle observable as a single correlated record spanning file-change
+observation to rendered frame, so that (a) a regression is detectable, (b) the stage that
+dominates is identifiable, and (c) Uno can state a latency figure at all.
+
+This is deliberately scoped as **measurement only**. No stage is optimised here; several
+obvious targets (the 250 ms trailing debounce, the 100 ms success-path delay) are left
+untouched precisely so that their cost is measured before it is argued about.
+
+### Why now
+
+Two independent motivations converge on the same plumbing.
+
+1. **Comparability.** Competing implementations publish to-frame numbers; Flutter measures
+   `hotReloadMillisecondsToFrame` at three edit tiers in CI, which is how a regression from
+   ~400 ms to ~670 ms was caught and escalated. Uno cannot currently detect an equivalent
+   regression in any stage.
+2. **Diagnosability.** The terminal verdict today is computed from what the *server* did.
+   Making `Success` conditional on a client acknowledgement that the delta reached the loaded
+   module requires exactly the correlation key R1 introduces. R1 is therefore a prerequisite
+   for the diagnosability fix as well as for measurement, and should be sequenced first.
+
+## Verified facts (investigation grounding)
+
+All confirmed by reading the source at the referenced lines on `master` (2026-08-27).
+
+| Fact | Location |
+|---|---|
+| Watcher debounce is a fixed 250 ms trailing quiet period | `Uno.HotReload/FileSystemObserver.cs:242` |
+| One `Stopwatch` covers solution-update **and** emit together | `Uno.HotReload/HotReloadManager.cs:178` (start) → `:309` (`Found {n} metadata updates after {sw.Elapsed}`) |
+| Server duration is StartTime→CompletionTime only | `Server.Processors/HotReload/ServerHotReloadProcessor.cs:219-222` |
+| Workspace-gate queue time is already measured | `ServerHotReloadProcessor.cs:77` (`WaitDurationMs`) |
+| Correlation id exists server→client and is documented as the server operation id | `Uno.UI.RemoteControl/HotReload/HotReloadInfoHelper.cs:76`; `IO/IUpdateFileResponse.cs:16` |
+| Client waits on that correlation id | `ClientHotReloadProcessor.ClientApi.cs:342-350` |
+| **Client outcome event is keyed by a client-local counter, not the correlation id** | `ClientHotReloadProcessor.Common.Status.cs:770` |
+| `EndTime` means "UI update completed", not "frame presented" | `Messages/HotReloadClientOperationEvent.cs:48-49` |
+| 100 ms trailing delay on the successful `UpdateFile` path (six early returns bypass it) | `ClientApi.cs:392` |
+| Client timeout budgets 10 s / 10 s / 5 s, ×10 or ×30 | `ClientApi.cs:81, 90, 96, 108-116` |
+| `TypeMappings` holds two static collections, cleared only by `ClearMappings()` | `Uno.UI/Helpers/TypeMappings.cs:32, 38, 119-122` |
+| `HotReloadAgent._deltas` accumulates per module | `HotReload/MetadataUpdater/HotReloadAgent.cs:28, 238` |
+| Telemetry can already be redirected to JSONL | `Uno.UI.RemoteControl.Server/Helpers/ServiceCollectionExtensions.cs:183` (`UNO_PLATFORM_TELEMETRY_FILE`) |
+| A no-op emit measured 0.007 s | spec 055 |
+
+## Design
+
+### The correlated record
+
+One hot-reload cycle becomes one record, keyed by the **existing**
+`HotReloadCorrelationId` (`HotReloadServerOperation.Id`). No new identifier is introduced;
+the id is propagated to the two ends that currently drop it.
+
+```
+ t0  first file-system event observed        ─┐ pre-server window
+ t1  debounce elapsed, batch closed           │ (today: unattributed)
+ t2  server operation created (StartTime)    ─┘
+ t3  workspace update complete                  ← split from t4 by R3
+ t4  EnC emit complete                          (today: t2→t4 is one stopwatch)
+ t5  delta serialized, payload size known       ← R4
+ t6  frame sent on the wire
+ t7  client received
+ t8  MetadataUpdater.ApplyUpdate returned
+ t9  UI update completed (today: EndTime)
+ t10 first frame presented containing the change ← R5
+```
+
+`t0→t10` is the figure a developer perceives. `t2→t9` is the most the pipeline can express
+today, and only if the two halves are joined.
+
+### Transport
+
+Reuse the existing telemetry channel rather than adding one. Stage timings ride the current
+`update-*` measurement events and the `HotReloadClientOperationEvent`, so
+`UNO_PLATFORM_TELEMETRY_FILE` continues to be the single collection point and the
+DevServer-test harness in `Uno.UI.RemoteControl.DevServer.Tests/Telemetry/` keeps working
+unchanged.
+
+## Requirements
+
+### R1 — join the client and server halves *(prerequisite for everything else)*
+
+`HotReloadClientOperationEvent` gains a nullable `ServerCorrelationId` (`long?`) carrying the
+`HotReloadCorrelationId` the client already received in `UpdateFileResponse` and already
+awaited in `WaitForServerHotReloadAsync`. `OperationSequenceId` is **retained unchanged** —
+it is a real client-local ordering key and existing consumers depend on it.
+
+Null is legal and meaningful: a client operation with no server correlation is one the client
+originated locally (a drain after a UI pause, an IDE-driven delta that never went through
+`UpdateFile`). Those must remain reportable.
+
+**Acceptance**: for a `UpdateFile`-originated edit, a consumer reading the telemetry stream can
+join the server's `update-*` events and the client's operation event on a single key without
+heuristics, timestamps, or file-path matching.
+
+### R2 — attribute the pre-server window
+
+`FileSystemObserver` stamps the timestamp of the **first** file-system event that opened the
+current buffer, and that stamp travels with the batch into `HotReloadManager.ProcessFileChanges`
+and onto the created server operation as `ObservedAtUtc`.
+
+The server then reports `DebounceDurationMs` = `BufferCompletedAtUtc - ObservedAtUtc`, which for
+a single quiet edit should approximate the 250 ms constant and for a burst should exceed it.
+
+Note the subtraction cannot use `StartTime`: the operation is started *before* the buffer
+completes (`HotReloadManager.cs:141-143`), so `StartTime - ObservedAtUtc` is approximately zero
+and would measure nothing. The batch therefore has to carry the moment the buffer closed —
+the completion of `filesAsync` — as a second stamp alongside `ObservedAtUtc`.
+
+**Rationale**: this window is currently invisible, is a fixed floor on every edit, and is one of
+the two cheapest optimisation targets in the pipeline. It must be measured before it is changed.
+
+### R3 — split the generator run from the EnC emit
+
+The single `Stopwatch` at `HotReloadManager.cs:178` is retained (its log line is load-bearing for
+existing diagnosis) and supplemented with two lap measurements reported as
+`SolutionUpdateMs` (through `SolutionUpdater.UpdateAsync`, which is where source generators
+re-run) and `EmitMs` (`WatchHotReloadService.EmitSolutionUpdateAsync`).
+
+**Rationale**: XAML-generator cost and Roslyn cost are currently indistinguishable from outside.
+Because Uno compiles XAML to C#, the generator share is the term most likely to differentiate a
+markup edit from a code edit, and it is the term a markup fast path would remove. Without this
+split, any argument about a markup fast path is unfalsifiable.
+
+### R4 — record delta payload size
+
+`AssemblyDeltaReload` records the byte length of the serialized payload, reported as
+`DeltaBytes`, along with `DeltaCount`.
+
+**Rationale**: deltas are base64 inside a JSON frame — roughly 1.33× inflation (4 characters per
+3 bytes), uncompressed — and
+nothing currently records how large they get. On WASM and on physical devices over Wi-Fi the
+transport term is plausibly significant, and it is currently pure speculation in both
+directions.
+
+### R5 — measure to the frame, not to the callback
+
+`HotReloadClientOperationEvent` gains a nullable `RenderedAtUtc`, stamped after the first
+rendering pass that follows the visual-tree update completing — not when `UpdateApplication`
+returns.
+
+`EndTime` keeps its current meaning; `RenderedAtUtc` is additive so no existing consumer breaks.
+Where a target cannot cheaply observe frame presentation, the field stays null rather than being
+approximated — a null is honest and a fabricated stamp would poison the only number this whole
+spec exists to produce.
+
+**Acceptance**: on Skia desktop, `RenderedAtUtc - ObservedAtUtc` is a defensible edit-to-frame
+figure for a single-file XAML edit.
+
+### R6 — memory counters on the known accumulators
+
+Report, per operation: `TypeMappingCount` (the two `TypeMapCollection` instances in
+`TypeMappings`), `RetainedDeltaCount` (`HotReloadAgent._deltas`, summed across modules), and
+managed heap size after the update settles.
+
+**Rationale**: spec 044 measured roughly +48 MB managed and +150 MB RSS per reload under ALC
+hosting, reaching OOM in 10–15 cycles. All three accumulators ship with no counter, so the
+condition is invisible until the process dies. These are cheap counters, not a profiler.
+
+### R7 — a staged CI benchmark
+
+A benchmark task in the DevServer test suite performs a scripted edit at three tiers and asserts
+the correlated record is complete, following the `TIMELINE|` precedent from spec 001:
+
+| Tier | Edit | Purpose |
+|---|---|---|
+| small | one attribute on one element in a leaf page | best case; dominated by fixed constants |
+| medium | a property on a `UserControl` instantiated in several places | exercises partial tree reload |
+| large | an app-level `ResourceDictionary` entry | exercises the every-content-root resource pass |
+
+The benchmark asserts **completeness and non-regression of the record**, not absolute wall-clock
+thresholds — the harness runs on shared CI hardware and absolute timings there would be noise.
+Absolute figures come from running the same task on controlled hardware.
+
+**Non-negotiable**: the benchmark must fail if any stage timestamp is missing. A silently
+incomplete record is precisely the failure this spec exists to eliminate.
+
+## Non-goals
+
+- **Optimising any stage.** The 250 ms debounce and the 100 ms trailing delay are both
+  measured here and both left in place. Removing them is a separate change that this spec makes
+  arguable with evidence.
+- **Changing the terminal verdict semantics.** Making `Success` conditional on client
+  acknowledgement is the natural follow-up and depends on R1, but it is a protocol change with
+  its own compatibility surface and belongs in its own spec.
+- **A cross-implementation benchmark.** Comparing Uno against other hot-reload stacks requires
+  one harness measuring all of them on the same metric and hardware; it cannot start until Uno
+  can measure itself.
+- **Instrumenting Hot Design's own write path.** It has its own debounce and coalescing
+  constants and deserves separate treatment.
+- **New transport or a new telemetry sink.**
+
+## Test plan
+
+1. **R1 join** — DevServer integration test: perform an `UpdateFile`, capture the JSONL
+   telemetry, assert exactly one server operation and one client event share a
+   `ServerCorrelationId`, and assert a locally-originated client operation still reports with a
+   null one.
+2. **R2 debounce** — assert `DebounceDurationMs` is present and ≥ 250 ms for a single edit;
+   assert a burst of edits inside the window produces **one** operation whose
+   `ObservedAtUtc` is that of the *first* event.
+3. **R3 split** — assert `SolutionUpdateMs + EmitMs` ≤ the existing stopwatch total, and that a
+   no-op pass reports a near-zero `EmitMs` (spec 055 measured 0.007 s).
+4. **R4 size** — assert `DeltaBytes > 0` for a real edit and that a no-op pass reports zero
+   deltas.
+5. **R5 frame** — Skia-desktop runtime test: assert `RenderedAtUtc` is set and ordered after
+   `EndTime`; assert the field is null rather than absent where unsupported.
+6. **R6 counters** — assert `TypeMappingCount` is monotonic across successive reloads of the
+   same type, which is the observable signature of the spec 044 leak.
+7. **R7 benchmark** — the three tiers run and produce complete records; the task fails on any
+   missing stage.
+
+Existing coverage that must not regress: `Given_HotReloadWorkspace`, `Given_HotReloadInfo`
+(pins the correlation id reaching the app, spec 050 R6), and the telemetry tests under
+`Uno.UI.RemoteControl.DevServer.Tests/Telemetry/`.
+
+## Resolved decisions
+
+- **Reuse `HotReloadCorrelationId`; do not mint a new trace id.** It already exists, is already
+  documented as the server operation id, and already reaches the app through the generated info
+  file. The defect is that one message drops it, not that the concept is missing.
+- **Keep `OperationSequenceId`.** It is a legitimate client-local ordering key with existing
+  consumers; `ServerCorrelationId` is additive.
+- **Null over approximation for `RenderedAtUtc`.** A fabricated frame stamp would corrupt the
+  one number this work exists to produce.
+- **Assert record completeness in CI, not wall-clock thresholds.** Shared CI hardware cannot
+  support absolute latency assertions; completeness is both checkable and the actual failure
+  mode being guarded against.
+- **Measure before optimising.** No stage cost is changed by this spec, so any later argument
+  about the debounce or the safety delay starts from evidence.
+
+## Residual risks / follow-ups
+
+- **Frame-presentation observability is uneven across targets.** Skia desktop is
+  straightforward; WASM, native Android and iOS may not offer a cheap present callback. R5
+  permits null, so the risk is reduced coverage rather than wrong data — but it does mean the
+  headline figure will initially exist only on Skia desktop, which is also the only target with
+  end-to-end hot-reload test coverage today.
+- **Telemetry volume.** Per-operation counters on every reload will increase the JSONL stream.
+  If this proves material, gate R6's heap measurement behind an opt-in switch rather than
+  dropping the counters.
+- **Observer effect.** Reading managed heap size after each update is not free. R6 should
+  measure the settled value only, and the benchmark should record whether enabling instrumentation
+  shifts the measured cycle.
+- **`DurationMs` becomes ambiguous.** Once richer stage timings exist, the existing server
+  `DurationMs` is a partial window that reads like a total. It should be documented as such at
+  its emission site, or renamed in a follow-up.

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadPerformance.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_HotReloadPerformance.cs
@@ -1,0 +1,172 @@
+﻿#nullable enable
+
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RemoteControl.HotReload;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+using _HR = Uno.UI.RuntimeTests.Tests.HotReload.HotReloadHelper;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+
+/// <summary>
+/// Establishes a wall-clock baseline for the hot-reload cycle across three edit tiers.
+/// </summary>
+/// <remarks>
+/// <para>These tests assert <b>completeness of the measurement record</b>, never a wall-clock
+/// threshold. The suite runs on shared CI hardware where absolute timings are noise; an absolute
+/// baseline comes from running the same tests on controlled hardware and reading the
+/// <c>HRPERF|</c> lines out of the captured output.</para>
+/// <para>The failure this guards against is the one that motivated the work: a measurement that
+/// silently stops being taken. If instrumentation regresses, these fail.</para>
+/// <para>Scope, stated plainly so the numbers are not over-read: this measures the
+/// dev-server-owned path only (the IDE-owned Visual Studio / VS Code / Rider paths never reach
+/// <see cref="HotReloadHelper"/>), and it ends when the local hot-reload operation completes
+/// rather than when a frame is presented. See <c>specs/057-hotreload-end-to-end-instrumentation</c>.</para>
+/// </remarks>
+[TestClass]
+[RunsOnUIThread]
+public class Given_HotReloadPerformance : BaseTestClass
+{
+	private const int WarmupIterations = 1;
+	private const int MeasuredIterations = 5;
+
+	private const string SmallTier = "small-leaf-page-attribute";
+	private const string MediumTier = "medium-shared-usercontrol";
+	private const string LargeTier = "large-app-resourcedictionary";
+	private const string RepeatScenario = "repeat-same-edit";
+
+	/// <summary>
+	/// Tier 1 — one attribute on one element in a leaf page. Best case: dominated by the fixed
+	/// constants (the 250 ms watcher buffer and the 100 ms trailing delay) rather than by the
+	/// size of the change.
+	/// </summary>
+	[TestMethod]
+	public Task When_Measure_SmallEdit()
+		=> MeasureTierAsync(
+			SmallTier,
+			XamlPathOf(new HR_Frame_Pages_Page1()),
+			"First page",
+			i => $"First page #{i:D2}");
+
+	/// <summary>
+	/// Tier 2 — a UserControl instantiated inside another page. Exercises partial tree reload:
+	/// the control should reload without its parents being torn down.
+	/// </summary>
+	[TestMethod]
+	public Task When_Measure_MediumEdit()
+		=> MeasureTierAsync(
+			MediumTier,
+			XamlPathOf(new HR_Frame_Pages_UC1()),
+			"Control 1",
+			i => $"Control 1 #{i:D2}");
+
+	/// <summary>
+	/// Tier 3 — an app-level ResourceDictionary entry. Exercises the resource pass, which walks
+	/// every content root rather than just the current window.
+	/// </summary>
+	[TestMethod]
+	public Task When_Measure_LargeEdit()
+		=> MeasureTierAsync(
+			LargeTier,
+			Path.Combine(_HR.ProjectPath, "AppResources.xaml"),
+			"** HR_Frame_Pages_AppResources Original String **",
+			i => $"** HR_Frame_Pages_AppResources Updated String#{i:D2} **");
+
+	/// <summary>
+	/// Repeats one edit many times to expose a degradation curve. Off by default: it is a
+	/// measurement run rather than a pass/fail gate, and it is far too slow for every CI build.
+	/// Enable it locally to check whether cycle cost grows with reload count — the observable
+	/// signature of the accumulators recorded in spec 044.
+	/// </summary>
+	[TestMethod]
+	[Ignore("Measurement run, not a gate. Enable locally to record the degradation curve.")]
+	public async Task When_Measure_RepeatedEdits()
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600));
+		var ct = cts.Token;
+		var path = XamlPathOf(new HR_Frame_Pages_Page1());
+
+		HotReloadTiming.BeginScenario(RepeatScenario);
+		try
+		{
+			for (var i = 0; i < 15; i++)
+			{
+				await EditAndRevertAsync(path, "First page", $"First page #{i:D2}", ct);
+			}
+		}
+		finally
+		{
+			HotReloadTiming.EndScenario();
+		}
+
+		Console.WriteLine(HotReloadTiming.Summarize(RepeatScenario));
+
+		var samples = HotReloadTiming.SamplesFor(RepeatScenario);
+		Assert.AreEqual(15, samples.Count, "Every cycle should have produced a sample.");
+	}
+
+	private static async Task MeasureTierAsync(
+		string scenario,
+		string filePath,
+		string originalText,
+		Func<int, string> replacement)
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+		var ct = cts.Token;
+		var total = WarmupIterations + MeasuredIterations;
+
+		Assert.IsTrue(File.Exists(filePath), $"Edit target not found: {filePath}");
+
+		HotReloadTiming.BeginScenario(scenario);
+		try
+		{
+			for (var i = 0; i < total; i++)
+			{
+				await EditAndRevertAsync(filePath, originalText, replacement(i), ct);
+			}
+		}
+		finally
+		{
+			HotReloadTiming.EndScenario();
+		}
+
+		Console.WriteLine(HotReloadTiming.Summarize(scenario));
+
+		// R7: fail on an incomplete record. A benchmark that silently stops measuring reads as
+		// a pass, which is the exact failure mode this exists to prevent.
+		var samples = HotReloadTiming.SamplesFor(scenario);
+		Assert.AreEqual(
+			total,
+			samples.Count,
+			$"Expected {total} timing samples for '{scenario}' but recorded {samples.Count}.");
+		// A positive duration is vacuous -- every path to Record has already awaited a round
+		// trip. The 250 ms watcher buffer plus the 100 ms trailing delay put a real floor under
+		// any cycle that genuinely reached the app, so assert against that instead.
+		Assert.IsTrue(
+			samples.All(s => s.ElapsedMs >= 300),
+			$"Every sample for '{scenario}' must clear the fixed constants; "
+			+ $"got [{string.Join(", ", samples.Select(s => s.ElapsedMs.ToString("F1")))}].");
+	}
+
+	/// <summary>
+	/// Applies an edit, waits for it to land, then reverts — so each iteration starts from the
+	/// same source state and the tier stays repeatable.
+	/// </summary>
+	/// <remarks>
+	/// Only the forward edit is timed. The revert runs through <c>FileUpdate.DisposeAsync</c>,
+	/// which calls <c>TryUpdateFilesAsync</c> on the processor directly rather than going back
+	/// through <see cref="HotReloadHelper.UpdateAsync(UpdateRequest, CancellationToken)"/> — so it
+	/// is never recorded as a sample. That is load-bearing, not incidental: if the revert were
+	/// timed it would double every tier's sample count.
+	/// </remarks>
+	private static async Task EditAndRevertAsync(string filePath, string oldText, string newText, CancellationToken ct)
+	{
+		await using var update = await _HR.UpdateAsync([new FileEdit(filePath, oldText, newText)], ct);
+	}
+
+	/// <summary>
+	/// Resolves the on-disk .xaml path of a page from its parse context, so no path is hard-coded.
+	/// </summary>
+	private static string XamlPathOf(FrameworkElement element)
+		=> FrameworkElementExtensions.GetDebugParseContext(element).FileName;
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadHelper.cs
@@ -24,9 +24,25 @@ internal static class HotReloadHelper
 
 		request = request.WithExtendedTimeouts(); // Required for CI
 
-		if (await hr.TryUpdateFilesAsync(request, ct) is { Error: { } error })
+		// Timed only when a scenario is active (HotReloadTiming.BeginScenario); otherwise this is inert.
+		var watch = System.Diagnostics.Stopwatch.StartNew();
+		var result = await hr.TryUpdateFilesAsync(request, ct);
+		watch.Stop();
+
+		if (result is { Error: { } error })
 		{
 			throw error;
+		}
+
+		// A no-op pass returns WITHOUT an error: the server reports NoChanges and the client
+		// returns early (ClientHotReloadProcessor.ClientApi.cs:303 and :354). Recording
+		// unconditionally would therefore let a benchmark report a green baseline while
+		// measuring nothing but a round trip. Only a pass that actually reached the application
+		// is a sample -- a missing one then trips the completeness assertion in
+		// Given_HotReloadPerformance, which is exactly what that assertion is for.
+		if (result.ApplicationUpdated is true)
+		{
+			HotReloadTiming.Record(watch.Elapsed);
 		}
 
 		return new(hr, request);
@@ -252,6 +268,9 @@ internal static class HotReloadHelper
 				"The edit would have silently done nothing.");
 		}
 	}
+
+	/// <summary>Absolute path of the HRApp project directory.</summary>
+	internal static string ProjectPath => GetProjectPath();
 
 	/// <summary>
 	/// Gets the project path from the remotecontrol attributes

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadTiming.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/HotReloadTiming.cs
@@ -1,0 +1,140 @@
+﻿#nullable enable
+
+using System.Diagnostics;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload;
+
+/// <summary>
+/// Collects wall-clock samples for hot-reload cycles so a baseline can be established.
+/// </summary>
+/// <remarks>
+/// <para>What a sample actually measures: the span of <see cref="HotReloadHelper.UpdateAsync(UpdateRequest, CancellationToken)"/>,
+/// which brackets the request to the dev server, the server writing the file, the 250 ms
+/// <c>FileSystemObserver</c> buffer, the solution update (including source generators), the EnC emit,
+/// the WebSocket hop, <c>MetadataUpdater.ApplyUpdate</c>, the visual-tree pass, and the 100 ms trailing
+/// delay in <c>ClientHotReloadProcessor.ClientApi</c> &#8212; which is reached on the fully-successful
+/// path only, since six early returns bypass it.</para>
+/// <para>What it does NOT measure: frame presentation. The span ends when the local hot-reload
+/// operation completes, not when a frame containing the change is on screen. It is therefore an
+/// edit-to-tree-updated figure, not edit-to-pixel — see <c>specs/057-hotreload-end-to-end-instrumentation</c>
+/// R5. It also only covers the dev-server-owned path on the platform the suite runs on; the
+/// IDE-owned paths (Visual Studio, VS Code, Rider) never go through this helper.</para>
+/// <para>Samples are emitted as <c>HRPERF|{scenario}|{iteration}|{elapsedMs}</c>, following the
+/// <c>TIMELINE|</c> convention used by the dev-server startup work, so a run can be scraped from
+/// captured output without a debugger attached.</para>
+/// </remarks>
+internal static class HotReloadTiming
+{
+	private static readonly object _gate = new();
+	private static readonly List<Sample> _samples = new();
+
+	internal record Sample(string Scenario, int Iteration, double ElapsedMs);
+
+	/// <summary>
+	/// When set, <see cref="HotReloadHelper"/> records each update under this scenario name.
+	/// Null disables recording, so ordinary correctness tests contribute no samples.
+	/// </summary>
+	internal static string? CurrentScenario { get; private set; }
+
+	private static int _iteration;
+
+	/// <summary>Starts a scenario and resets its iteration counter.</summary>
+	internal static void BeginScenario(string scenario)
+	{
+		lock (_gate)
+		{
+			CurrentScenario = scenario;
+			_iteration = 0;
+		}
+	}
+
+	/// <summary>Stops recording. Always call this in a <c>finally</c>.</summary>
+	internal static void EndScenario()
+	{
+		lock (_gate)
+		{
+			CurrentScenario = null;
+		}
+	}
+
+	internal static void Record(TimeSpan elapsed)
+	{
+		string scenario;
+		int iteration;
+
+		lock (_gate)
+		{
+			if (CurrentScenario is not { } current)
+			{
+				return;
+			}
+
+			scenario = current;
+			iteration = _iteration++;
+			_samples.Add(new Sample(scenario, iteration, elapsed.TotalMilliseconds));
+		}
+
+		var line = $"HRPERF|{scenario}|{iteration}|{elapsed.TotalMilliseconds:F1}";
+		Console.WriteLine(line);
+		Debug.WriteLine(line);
+	}
+
+	internal static IReadOnlyList<Sample> SamplesFor(string scenario)
+	{
+		lock (_gate)
+		{
+			return _samples.Where(s => s.Scenario == scenario).ToList();
+		}
+	}
+
+	internal static void Clear()
+	{
+		lock (_gate)
+		{
+			_samples.Clear();
+		}
+	}
+
+	/// <summary>
+	/// Renders a fixed-width summary. The first iteration of a scenario is reported separately:
+	/// the first edit of a session pays warm-up costs (baseline capture, first generator run) that
+	/// no later edit repeats, so folding it into the median would misrepresent both.
+	/// </summary>
+	internal static string Summarize(params string[] scenarios)
+	{
+		var sb = new System.Text.StringBuilder();
+		sb.AppendLine();
+		sb.AppendLine("HRPERF SUMMARY (ms) — edit-to-tree-updated, dev-server-owned path");
+		sb.AppendLine("scenario                       n     first       min    median       max");
+		sb.AppendLine(new string('-', 78));
+
+		foreach (var scenario in scenarios)
+		{
+			var samples = SamplesFor(scenario);
+			if (samples.Count == 0)
+			{
+				sb.AppendLine($"{scenario,-28} {"—",3} {"(no samples recorded)",-40}");
+				continue;
+			}
+
+			var first = samples[0].ElapsedMs;
+			var steady = samples.Skip(1).Select(s => s.ElapsedMs).OrderBy(v => v).ToArray();
+
+			if (steady.Length == 0)
+			{
+				sb.AppendLine($"{scenario,-28} {samples.Count,3} {first,9:F1} {"—",9} {"—",9} {"—",9}");
+				continue;
+			}
+
+			var median = steady.Length % 2 == 1
+				? steady[steady.Length / 2]
+				: (steady[steady.Length / 2 - 1] + steady[steady.Length / 2]) / 2;
+
+			sb.AppendLine($"{scenario,-28} {samples.Count,3} {first,9:F1} {steady[0],9:F1} {median,9:F1} {steady[^1],9:F1}");
+		}
+
+		sb.AppendLine(new string('-', 78));
+		sb.AppendLine("'first' is the warm-up iteration and is excluded from min/median/max.");
+		return sb.ToString();
+	}
+}


### PR DESCRIPTION
## What this does

Uno's hot-reload pipeline cannot measure itself end to end. The server records a duration for its own slice, the client records a WebSocket ping RTT, and nothing correlates the two — so there is no edit-to-frame figure and no way to tell whether a change made the loop faster.

This PR adds the spec describing how to close that gap (`specs/057-hotreload-end-to-end-instrumentation/`) plus its R7 benchmark as an HRApp runtime test, so the cycle cost is at least **recorded** before anyone optimises it.

Test-project only: the diff touches `src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/**` and `specs/**`. No shipping code, no public API.

## Measured baseline

Three edit tiers, 6 iterations each (1 warm-up + 5 measured), 18/18 samples recorded. Times in ms, edit-to-tree-updated. Warm-up excluded from min/median/max.

| Tier | Edit target | n | Warm-up | Min | **Median** | Max |
|---|---|---|---|---|---|---|
| `small-leaf-page-attribute` | one attribute in a leaf page | 6 | 2050.6 | 728.4 | **731.6** | 744.0 |
| `medium-shared-usercontrol` | a `UserControl` instantiated elsewhere | 6 | 730.6 | 724.9 | **729.7** | 730.8 |
| `large-app-resourcedictionary` | an app-level `ResourceDictionary` entry | 6 | 905.0 | 737.1 | **743.3** | 747.4 |

**Edit size barely moves the number.** A ~14 ms spread across three tiers built to differ by an order of magnitude in scope. The cycle is dominated by fixed constants — the 250 ms `FileSystemObserver` buffer and the 100 ms trailing delay are ~350 ms, roughly half of every median — not by the size of the change. An earlier run of the same tiers on the same machine gave 742.2 / 739.0 / 751.0 ms, so the figures reproduce within ~12 ms across runs.

Scope, so the numbers are not over-read:

- **Hardware**: one macOS development machine (Apple M5 Pro, macOS 26.5.2, .NET 10.0.101, Debug). Not a controlled or uncontended environment, and not the platform CI measures.
- **Span**: **edit-to-tree-updated on the dev-server-owned path — NOT edit-to-frame.** It ends when the local hot-reload operation completes, not when a frame containing the change is presented. R5 is what would make it edit-to-frame. The IDE-owned paths (Visual Studio, VS Code, Rider) never reach `HotReloadHelper` and are not measured at all.

## Degradation

A separate 15-iteration run of the `[Ignore]`d degradation test passed: steady-state median **734.5 ms** (n=14), least-squares trend **−0.90 ms/reload**, 95% CI **[−1.62, −0.17]**.

**A positive slope is excluded at this sample size** — the cycle does not measurably slow down over 15 consecutive reloads. The interval sitting entirely below zero nominally reads as a slight speedup; that is far more likely a warming artifact than real, and no claim is made for it.

**This says nothing about the multi-app / ALC memory accumulation** recorded in `specs/044-alc-memory-leak-fixes` (~+48 MB managed and +150 MB RSS per reload, OOM in 10–15 cycles). That is a different scenario, measured in megabytes; this test never loads a second app. A flat wall-clock curve is not evidence against it. Per-operation memory counters are R6.

Measured on the tree before the review fixes below. The only behavioural change since is the recording gate, and all 15 samples were recorded, so it does not affect these figures.

## Verification status

Labelled precisely, with nothing implied beyond each level:

- **Code review — done.** Four independent passes: correctness/test-fidelity, repository conventions, spec factual accuracy, CI cost. They found real defects; those are disclosed below rather than left to be rediscovered.
- **Compile-verified — yes, but not on this branch's base.** The code builds clean in a space-free copy. **This checkout cannot build at all**: `src/Directory.Build.targets:188` hard-errors on a space in the repository path, and this clone lives under one. A symlink does not help — MSBuild resolves back to the real path.
- **Tests executed and passing — yes, on macOS.** 3 passed / 1 skipped / 0 failed, 18/18 samples, producing the table above. The skip is the `[Ignore]`d degradation test, run separately.
- **NOT verified on this branch's base.** The verified tree is 66 commits behind `origin/master` @ `84b5571e68b7`. Exactly one of those 66 touches the hot-reload area: `6f057b77ddce` (devserver `/rc` keep-alive). Its watchdog is `KeepAliveMessage.Interval` (30 s) × `KeepAliveTimeoutFactor` (2.1) ≈ **63 s without a received frame**; the benchmark drives an edit every ~750 ms, so it stays well inside. That is reasoning from source, not a measurement.
- **NOT verified on Windows** — the only CI leg that runs these tests. No pipeline run attached yet.

## Review findings — fixed before opening

The review found a defect that would have defeated the test's own purpose, plus several smaller ones. All fixed in this branch, and the suite re-run green afterwards:

1. **A green pass was possible with zero hot reloads.** `HotReloadHelper.UpdateAsync` had no old-text guard, and a no-op returns *without* an error — the server reports `NoChanges` and the client returns early (`ClientApi.cs:303`, `:354`). Six no-op samples satisfied both assertions, so the suite could report a green "baseline" measuring nothing but a round trip. Now only a pass with `ApplicationUpdated is true` is recorded, so a no-op trips the completeness assertion instead. That all 18 samples still record is positive evidence the edits genuinely apply.
2. **The duration assertion was vacuous.** `ElapsedMs > 0` is satisfied by any round trip; it now asserts against the ~350 ms of fixed constants.
3. **Spec premise was inverted.** It claimed the 250 ms debounce lands *before* the server's `StartTime`. It does not: `HotReloadManager.cs:141-143` starts the operation before the buffer closes, by design and by comment. The debounce is *inside* `DurationMs`. R2's formula depended on this and was corrected — `StartTime - ObservedAtUtc` would read ≈0.
4. **R1 was described as "one field".** It is not: `ServerHotReloadProcessor.ProcessFrame` has no case for `HotReloadClientOperationEvent` and no `default`, so the client's outcome event is dropped server-side today. R1 also needs a frame handler.
5. Smaller: the 100 ms delay is not "unconditional" (six early returns bypass it — the word had propagated into a code comment); base64 inflation is ~1.33×, not ~4×; const naming corrected to PascalCase per `.editorconfig`; the tier `CancellationTokenSource` instances are now disposed; a displaced `<summary>` restored.

## Open — worth a reviewer's opinion

1. **The measurement runs against an inherited visual tree.** The tests never set `UnitTestsUIContentHelper.Content`, and the engine does not reset content between classes, so whatever ran previously is still mounted. The medium tier's stated purpose (partial tree reload) may therefore not be exercised, and the same test can yield different costs under `--filters` than in a full-suite run. This is a design question, not a typo, so it is left for discussion rather than patched blind.
2. **Spec number 057 is taken** by `specs/057-resourcedictionary-source-location/`. Kept as-is because the directory names are distinct and the repo already carries two `055-` specs; renumbering also means updating references elsewhere. Happy to renumber if preferred.
3. **CI cost.** Nothing gates these out: the Skia Windows runtime-test stage is unconditional, `UnoEnableHRuntimeTests` is set on that job, and no filter excludes the new class. 3 tiers × 6 iterations = 36 additional round trips, roughly **+36 s to +108 s per attempt**, and the outer test retries up to 3×.
4. **`Given_AppDictionary.When_Change_AppResource_LotOfTimes`** already performs 15 edit+revert cycles on the same file with the same strings, and carries a commented-out `//[Ignore("Failing ramdomly on CI")]`. "Why a new test rather than instrumenting that one?" is a fair question this diff does not answer. The shared strings are also a dirty-file risk if a forward edit lands and then cancels.
5. **`HRPERF|` output does not reach the Tests tab.** HRApp sets `IsConsoleOutputEnabled = false` and its results collapse into one outer test, so the summary survives only in the raw step log.
6. **`HotReloadTiming._samples` is process-lifetime** and never cleared (`Clear()` has no callers). Running a scenario twice in one process would fail the count assertion spuriously; not reachable today only because HRApp sets `Attempts = 1`.

## Known gaps this PR does not fix

- **These tests cannot run on macOS as committed.** `Uno.UI.RuntimeTests.HRApp.Skia.csproj:48` references only `Uno.icu-win` (a macOS run needs `Uno.icu-macos`), and HRApp inherits no native assets, so `libUnoNativeMac.dylib` is unresolvable at launch. The baseline above was obtained with both patched locally; the patches are deliberately not in this branch, since HRApp's cross-platform asset story is its own change.
- **HR runtime tests are enabled on one CI leg only.** `UnoEnableHRuntimeTests` occurs exactly once: `build/ci/tests/.azure-devops-tests-windows-skia.yml:69`. Every other leg reports without exercising hot reload — which is why the two gaps above went unnoticed.
- **R1–R6 are unimplemented.** Only R7 lands here, so the correlated stage record this benchmark is ultimately meant to guard does not exist yet.

## Checklist

- [x] Test-project only — no shipping code or public API touched
- [x] Tests executed and passing (macOS): 3 passed / 1 skipped / 0 failed, 18/18 samples
- [x] Conventional Commits (`docs(hotreload):`, `test(hotreload):`)
- [x] Spec added, with every `file:line` citation re-verified against master
- [x] Confirmed review defects fixed and the suite re-run green
- [ ] **Linked GitHub issue — MISSING.** The spec flags this itself (`spec.md:15-16`); an issue must be filed and linked in both the spec header and this description before merge.
- [ ] Release build with zero warnings — not verified; this checkout cannot build
- [ ] Verified on this branch's base (66 commits newer than the verified tree)
- [ ] Verified on the Windows CI leg that actually runs these tests; no pipeline run attached
- [ ] Open items above triaged (inherited visual tree; spec number; CI cost; overlap with `When_Change_AppResource_LotOfTimes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
