### PR TITLE
fix(samplesapp): Root the head assembly for android trimming

### DIFF
--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -352,10 +352,16 @@
 	of Uno.UI through a LinkerConfig.xml and the samples assembly with RootMode=All, because both are
 	reached by reflection (XAML type resolution, the [Sample] scan) and neither is statically reachable
 	from the entry point. The samples now live in the head itself, so the root assembly is SamplesApp.
-	Android keeps its own copy of the descriptor under Platforms\Android; the SDK strips each
-	Platforms\<platform>\ folder from the other target frameworks, so it cannot be shared from there.
-	Note the generated descriptors in Uno.UI.Tasks (_UnoGenerateLinkerDescriptors) do not cover this —
-	they only run when PublishAot is true, and iOS/tvOS run interpreted here.
+	Each platform keeps its own copy of the descriptor under Platforms\<platform>; the SDK strips each
+	of those folders from the other target frameworks, so it cannot be shared from there.
+
+	The assembly root has to cover android as well as iOS/tvOS: android+NativeAOT publishes with
+	TrimMode=full and has no managed entry point to root the app assembly from, so without it the
+	samples and the runtime-test harness are trimmed out of the head. The generated descriptors in
+	Uno.UI.Tasks (_UnoGenerateLinkerDescriptors) are not a substitute — they only preserve properties
+	on [Bindable] types and attached-property accessors, and only run when PublishAot is true, which
+	iOS/tvOS (interpreted here) never sets. Kept on every Skia TFM, as the old samples-library root
+	was: desktop and wasm don't trim here, so it costs them nothing.
 	-->
 	<ItemGroup Condition="'$(_Platform)' == 'ios'">
 		<TrimmerRootDescriptor Include="Platforms\iOS\LinkerConfig.xml" />
@@ -363,7 +369,7 @@
 	<ItemGroup Condition="'$(_Platform)' == 'tvos'">
 		<TrimmerRootDescriptor Include="Platforms\tvOS\LinkerConfig.xml" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(_IsUIKit)' == 'true'">
+	<ItemGroup Condition="'$(_IsSkiaTfm)' == 'true'">
 		<TrimmerRootAssembly Include="SamplesApp" RootMode="All" />
 	</ItemGroup>
 


### PR DESCRIPTION
**GitHub Issue:** closes #24352

## PR Type:

🐞 Bugfix

## What changed? 🚀

Every Android + NativeAOT runtime-test group has been aborting since the SamplesApp head consolidation (#24046) — two NUnit results per group instead of ~1500, the second being the harness' synthetic `Runtime exception`:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'xamlRoot')
   at Microsoft.UI.Xaml.Media.VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot xamlRoot)
   at Uno.UI.Samples.Tests.UnitTestsControl.CloseRemainingPopups()
```

`UnitTestsControl.OnLoaded` is what publishes `TestServices.WindowHelper.XamlRoot`, and it never runs — the control never reaches the live visual tree — so the first test's general cleanup throws and the run is abandoned.

**Root cause.** The removed `SamplesApp.Skia.netcoremobile` head rooted the samples assembly with `TrimmerRootAssembly RootMode="All"` on every one of its targets. The consolidated head restored that only for iOS/tvOS (0cf84f8). Android + NativeAOT publishes with `PublishTrimmed=true` / `TrimMode=full` and has no managed entry point to root the app assembly from, so the samples and the runtime-test harness — both reached only by reflection — get trimmed out of the head. `Tests - Android Skia` (Mono, same head, same commit) passes with 1242–1475 results in the same CI run, which is what isolates it to the trimmed publish.

Confirmed by diffing the `TrimmerRootAssembly` items in the two CI build binlogs:

| | before (`0950717`) | after (`6dfcb8f`) |
|---|---|---|
| `Uno.UI.RuntimeTests` | `RootMode=All` | `RootMode=All` |
| `Uno.UI.Extras` | ✔ | ✔ |
| samples assembly | `SamplesApp.Skia` `RootMode=All` | **missing** |

The generated `Uno.UI.Tasks` descriptors are not a substitute: they only preserve properties on `[Bindable]` types and attached-property accessors.

**Fix.** Root `SamplesApp` with `RootMode="All"` on every Skia TFM, as the old samples-library root was — desktop and wasm don't trim here, so it costs them nothing.

**Validated on CI.** The `Tests - Android+NativeAOT Skia` stage is gated on `ne(variables['Build.Reason'], 'PullRequest')`, which is why no PR ever exercised it and the regression could only appear post-merge. That guard was temporarily dropped on this branch to run the stage against the fix — build 231546, group 0: **1472 results, 0 failed**, matching the pre-regression baseline exactly (2 results, 1 failed before the fix). The guard has since been restored, so the stage will not appear on this PR's checks.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — the existing Android+NativeAOT runtime-test stage is the test; see the CI validation above.
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a, build configuration only.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMa5PnRraRxZNYL61Grv9z
