### PR TITLE
test: Disable four flaky tests on Skia macOS and Skia iOS

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests_InteractionTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests_InteractionTests.cs
@@ -35,6 +35,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 #if !HAS_INPUT_INJECTOR
 		[Ignore("InputInjector is not supported on this platform.")]
 #endif
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaIOS)] // Injected-pointer interaction is flaky on iOS Skia https://github.com/unoplatform/uno/issues/9080
 		public async Task BasicInteractionTest()
 		{
 			var splitButtonPage = new SplitButtonPage();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -320,7 +320,7 @@ public class Given_Window
 
 	[TestMethod]
 	[RunsOnUIThread]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI)]
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeWinUI | RuntimeTestPlatforms.SkiaIOS)] // Flaky on iOS Skia https://github.com/unoplatform/uno/issues/9080
 	public async Task When_Window_Closed_Is_Handled()
 	{
 		AssertSupportsMultipleWindows();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -749,8 +749,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		// reproducible on Skia-WASM (the flick never advances the page there). The matching native-Wasm head
 		// already documents that injection-driven scrolling is unsupported, and the deterministic
 		// When_TouchMoveMoreThanHalfItem_Then_FlipOneItem counterpart is likewise disabled on Skia.
+		// The same velocity-based snap is flaky on Skia macOS in CI, so it is excluded there too.
 		// See https://github.com/unoplatform/uno/issues/9080.
-		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm)]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaWasm | RuntimeTestPlatforms.SkiaMacOS)]
 		public async Task When_TouchFlick_Then_FlipOneItem()
 		{
 			var flipView = new FlipView()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1646,6 +1646,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #elif __WASM__
 		[Ignore("Flaky in CI.")]
 #endif
+		// The scrolls below are animated and are only awaited with fixed delays. Skia macOS steps through more
+		// animation frames than Win32, so those delays can elapse while the viewport is still moving and the
+		// layout-slot assertions observe an intermediate offset.
+		// See https://github.com/unoplatform/uno/issues/9080.
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaMacOS)]
 		public async Task When_Large_List_Scroll_To_End_Then_Back_Up_And_First_Item()
 		{
 			var materialized = 0;


### PR DESCRIPTION
**GitHub Issue:** #9080

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Four flaky runtime tests are excluded from CI legs where they cannot settle — two on **Skia macOS**, two on **Skia iOS**. One commit per test, so each can be re-enabled independently as it is fixed.

| Test | Excluded on | Existing condition |
| --- | --- | --- |
| `Given_FlipView.When_TouchFlick_Then_FlipOneItem` | Skia macOS | extended `SkiaWasm` mask |
| `Given_ListViewBase.When_Large_List_Scroll_To_End_Then_Back_Up_And_First_Item` | Skia macOS | none — attribute added |
| `SplitButtonTests.BasicInteractionTest` | Skia iOS | none — attribute added |
| `Given_Window.When_Window_Closed_Is_Handled` | Skia iOS | extended `NativeWinUI` mask |

Where a `PlatformCondition` already existed the mask is extended with `|` — the attribute is `AllowMultiple = false`, so a second one would not compile.

### Skia macOS — scroll animation timing

**`When_TouchFlick_Then_FlipOneItem`** injects a touch flick and relies on the `ScrollContentPresenter` velocity-based snap to advance the page. Timing-dependent, and not reproducible on the Skia macOS leg — the same reason it is already excluded on Skia-WASM, and why the deterministic `When_TouchMoveMoreThanHalfItem_Then_FlipOneItem` counterpart is disabled on Skia.

**`When_Large_List_Scroll_To_End_Then_Back_Up_And_First_Item`** scrolls to the end and back three times through `ScrollTo`, which calls `ChangeView(null, vOffset, null)` — i.e. **animated**, since `disableAnimation` defaults to `false` — and awaits it only with fixed `Task.Delay(200)` / `Task.Delay(600)` calls. Skia macOS steps through more animation frames than Win32, a difference already documented in the comment on the preceding test in the same file, so those delays can elapse mid-scroll and `GetLayoutSlot(...).Y` reads an intermediate offset.

### Skia iOS

**`BasicInteractionTest`** is injected-pointer driven (it is already `[Ignore]`d where `HAS_INPUT_INJECTOR` is undefined) and is flaky on the Skia iOS leg. Follows the exclusion style already used for iOS Skia in `MenuFlyoutIntegrationTests`.

**`When_Window_Closed_Is_Handled`** exercises a handled `Window.Closed` on a secondary window and is flaky on the Skia iOS leg.

### Class-level conditions are preserved

`Given_ListViewBase` carries a class-level `PlatformCondition(Exclude, NativeWinUI)`. Adding a method-level attribute does **not** replace it: the engine evaluates the method and its declaring type separately and OR's the two ignore verdicts (`UnitTestMethodInfo.IsIgnored`), so the two stack. `SplitButtonTests` and `Given_Window` have no class-level `PlatformCondition`.

### Not touched

`When_Large_List_Scroll_To_End_Then_Back_Up_And_First_Item2` is a separate test whose name is a prefix-match of the one disabled above. It is left enabled on macOS — if it fails in the same run it can be added.

## Validation

`Uno.UI.RuntimeTests.Skia` (net10.0): ✅ 0 warnings, 0 errors, after each commit.

Coverage on every other target — Skia Win32, X11, Islands, WebAssembly, Android, and the native heads — is unchanged.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, this narrows existing tests' platform reach
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gsfy1USDYeExNxsQGd3FQQ
