### PR TITLE
fix(clipboard): stop caching denied clipboard reads on Win32

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -191,3 +191,29 @@ accept this license. If you do not accept the license, do not use the software.
  (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
  (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
  (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+
+License notice for SDL (Simple DirectMedia Layer)
+-------------------------------------------------
+
+https://github.com/libsdl-org/SDL
+
+Parts of the Win32 Skia host (clipboard DIB/BMP conversion and window icon
+loading) are derived from SDL, translated to C# and modified.
+
+Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -200,6 +200,7 @@ GetCapture
 GetClientRect
 GetClipboardData
 GetClipboardFormatName
+GetClipboardSequenceNumber
 GetDC
 GetDeviceCaps
 GetDpiForWindow
@@ -232,6 +233,7 @@ GlobalUnlock
 InternetGetConnectedState
 InvalidateRect
 IsChild
+IsClipboardFormatAvailable
 IsZoomed
 LoadCursor
 LoadRegTypeLib

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.DragDrop.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.DragDrop.cs
@@ -14,7 +14,6 @@ using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.System.Ole;
 using Windows.Win32.UI.Shell;
-using Buffer = System.Buffer;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
@@ -73,36 +72,7 @@ internal partial class Win32ClipboardExtension
 				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {memSize}: {Win32Helper.GetErrorMessage()}"));
 			}
 
-			var srcBitmapInfo = (BITMAPINFO*)dib;
-
-			// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
-			int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
-			{
-				// BI_RGB
-				0 when srcBitmapInfo->bmiHeader.biBitCount <= 8 => Marshal.SizeOf<RGBQUAD>() * (srcBitmapInfo->bmiHeader.biClrUsed == 0 ? 1 << srcBitmapInfo->bmiHeader.biBitCount : (int)srcBitmapInfo->bmiHeader.biClrUsed),
-				0 => 0,
-				// BI_BITFIELDS
-				3 => 3 * Marshal.SizeOf<uint>(),
-				// FOURCC
-				_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
-			};
-
-			BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
-			{
-				bfType = /* BM */ 0x4d42,
-				bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
-				bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
-			};
-
-			var bmpSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize);
-			var arr = new byte[bmpSize];
-			fixed (byte* bmp = arr)
-			{
-				Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
-				Buffer.MemoryCopy(dib, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), bmpSize - Marshal.SizeOf<BITMAPFILEHEADER>(), bmpSize - Marshal.SizeOf<BITMAPFILEHEADER>());
-			}
-
-			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream()));
+			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(ConvertDibToBmp(dib, memSize)).AsRandomAccessStream()));
 		});
 	}
 	internal static unsafe List<IStorageItem>? GetFileDropList(HGLOBAL handle)

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.DragDrop.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.DragDrop.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Uno.Disposables;
+using Uno.Foundation.Logging;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.System.Ole;
+using Windows.Win32.UI.Shell;
+using Buffer = System.Buffer;
+
+namespace Uno.UI.Runtime.Skia.Win32;
+
+// Clipboard-format readers consumed by Win32DragDropExtension, which feeds them HGLOBALs
+// coming from an IDataObject instead of the clipboard.
+internal partial class Win32ClipboardExtension
+{
+	internal static void ReadContentIntoPackage(DataPackage package, IEnumerable<CLIPBOARD_FORMAT> formats, Func<CLIPBOARD_FORMAT, HGLOBAL?> dataGetter)
+	{
+		foreach (var format in formats)
+		{
+			if (Enum.IsDefined((CLIPBOARD_FORMAT)format) && dataGetter(format) is { } handle)
+			{
+				switch (format)
+				{
+					case CLIPBOARD_FORMAT.CF_UNICODETEXT:
+						GetText(handle, package);
+						break;
+					case CLIPBOARD_FORMAT.CF_HDROP:
+						var files = GetFileDropList(handle);
+						if (files is not null)
+						{
+							package.SetStorageItems(files);
+						}
+						break;
+					case CLIPBOARD_FORMAT.CF_DIB:
+						GetBitmap(handle, package);
+						break;
+				}
+			}
+		}
+	}
+	private static unsafe void GetText(HGLOBAL handle, DataPackage package)
+	{
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var bytes);
+		if (lockDisposable is null)
+		{
+			return;
+		}
+
+		package.SetText(Marshal.PtrToStringUni((IntPtr)bytes)!);
+	}
+	private static unsafe void GetBitmap(HGLOBAL handle, DataPackage package)
+	{
+		package.SetDataProvider(StandardDataFormats.Bitmap, _ =>
+		{
+			using var lockDisposable = Win32Helper.GlobalLock(handle, out var dib);
+			if (lockDisposable is null)
+			{
+				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}"));
+			}
+
+			var memSize = (uint)PInvoke.GlobalSize(handle);
+			if (memSize <= Marshal.SizeOf<BITMAPINFOHEADER>())
+			{
+				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {memSize}: {Win32Helper.GetErrorMessage()}"));
+			}
+
+			var srcBitmapInfo = (BITMAPINFO*)dib;
+
+			// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
+			int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
+			{
+				// BI_RGB
+				0 when srcBitmapInfo->bmiHeader.biBitCount <= 8 => Marshal.SizeOf<RGBQUAD>() * (srcBitmapInfo->bmiHeader.biClrUsed == 0 ? 1 << srcBitmapInfo->bmiHeader.biBitCount : (int)srcBitmapInfo->bmiHeader.biClrUsed),
+				0 => 0,
+				// BI_BITFIELDS
+				3 => 3 * Marshal.SizeOf<uint>(),
+				// FOURCC
+				_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
+			};
+
+			BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
+			{
+				bfType = /* BM */ 0x4d42,
+				bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
+				bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
+			};
+
+			var bmpSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize);
+			var arr = new byte[bmpSize];
+			fixed (byte* bmp = arr)
+			{
+				Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
+				Buffer.MemoryCopy(dib, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), bmpSize - Marshal.SizeOf<BITMAPFILEHEADER>(), bmpSize - Marshal.SizeOf<BITMAPFILEHEADER>());
+			}
+
+			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream()));
+		});
+	}
+	internal static unsafe List<IStorageItem>? GetFileDropList(HGLOBAL handle)
+	{
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var firstByte);
+		if (lockDisposable is null)
+		{
+			return null;
+		}
+
+		var hDrop = new HDROP((IntPtr)firstByte);
+
+		var filesDropped = PInvoke.DragQueryFile(hDrop, 0xFFFFFFFF, new PWSTR(), 0);
+		if (filesDropped == 0)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.DragQueryFile)} failed when querying total count: {Win32Helper.GetErrorMessage()}");
+			return null;
+		}
+
+		var files = new List<IStorageItem>((int)filesDropped);
+		for (uint i = 0; i < filesDropped; i++)
+		{
+			var charLength = PInvoke.DragQueryFile(hDrop, i, new PWSTR(), 0);
+			if (charLength == 0)
+			{
+				typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.DragQueryFile)} failed when querying buffer length: {Win32Helper.GetErrorMessage()}");
+				continue;
+			}
+			charLength++; // + 1 for \0
+
+			var buffer = Marshal.AllocHGlobal((IntPtr)(charLength * Unsafe.SizeOf<char>()));
+			using var bufferDisposable = new DisposableStruct<IntPtr>(Marshal.FreeHGlobal, buffer);
+			var charsWritten = PInvoke.DragQueryFile(hDrop, i, new PWSTR((char*)buffer), charLength);
+			if (charsWritten == 0)
+			{
+				typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.DragQueryFile)} failed when querying file path: {Win32Helper.GetErrorMessage()}");
+				break;
+			}
+			var filePath = Marshal.PtrToStringUni(buffer, (int)charsWritten);
+			if (Directory.Exists(filePath))
+			{
+				files.Add(new StorageFolder(filePath));
+			}
+			else if (File.Exists(filePath))
+			{
+				files.Add(StorageFile.GetFileFromPath(filePath));
+			}
+			else
+			{
+				typeof(Win32ClipboardExtension).LogError()?.Error($"HDROP Clipboard: file path '{filePath}' was not a valid file or directory.");
+			}
+		}
+
+		return files;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
@@ -23,14 +23,17 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using SkiaSharp;
 using Uno.ApplicationModel.DataTransfer;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.Storage;
@@ -82,7 +85,22 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 	private readonly HWND _hwnd;
 
 	private bool _observeContentChanged;
-	private DataPackage? _currentPackage;
+
+	/// <summary>A completed read, together with the clipboard generation it was read from.</summary>
+	/// <remarks>
+	/// Keyed on the sequence number rather than on WM_CLIPBOARDUPDATE alone because
+	/// <see cref="PInvoke.GetClipboardSequenceNumber"/> is lock-free and authoritative: it reports a
+	/// change even if we missed the message or have not processed it yet.
+	/// </remarks>
+	private sealed record CachedContent(DataPackage Package, uint Sequence);
+
+	// One reference field rather than a package/sequence pair, so that WndProc invalidating the cache
+	// cannot be seen half-applied by a reader on another thread. Only ever set to a COMPLETE read
+	// (see BuildPackage), and a reader revalidates the sequence anyway, so a lost update is benign.
+	private CachedContent? _cachedContent;
+
+	// Cancels the pending warm-up when the clipboard changes again before it ran.
+	private CancellationTokenSource? _warmUpCts;
 
 	private unsafe Win32ClipboardExtension()
 	{
@@ -134,7 +152,8 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 		{
 			if (msg is PInvoke.WM_CLIPBOARDUPDATE)
 			{
-				Instance._currentPackage = null;
+				Instance._cachedContent = null;
+				Instance.ScheduleWarmUp();
 				if (Instance._observeContentChanged)
 				{
 					Instance.ContentChanged?.Invoke(Instance, EventArgs.Empty);
@@ -157,7 +176,12 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 
 	public void Clear()
 	{
-		using var clipboardDisposable = new ClipboardDisposable(_hwnd, true);
+		using var clipboardDisposable = new ClipboardDisposable(_hwnd, true, ClipboardRetry.Blocking);
+		if (!clipboardDisposable.IsOpen)
+		{
+			// Previously this silently no-oped: EmptyClipboard was skipped and nothing reported it.
+			this.LogError()?.Error($"{nameof(Clear)} failed: could not take the clipboard, it is held by another application.");
+		}
 	}
 
 	public void Flush() { }
@@ -184,23 +208,90 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 		return Marshal.PtrToStringUni(buffer);
 	}
 
+	/// <summary>
+	/// How hard to try to take the clipboard.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="PInvoke.OpenClipboard"/> is a global exclusive lock with a single winner, so being
+	/// denied is a normal outcome under contention rather than an error. It fails quickly, which is
+	/// what makes retrying cheap; the right budget depends entirely on who is asking.
+	/// </remarks>
+	private enum ClipboardRetry
+	{
+		/// <summary>
+		/// A single attempt, never waiting. For callers on the UI hot path, where a denial is
+		/// recovered by the next call instead of by waiting.
+		/// </summary>
+		/// <remarks>
+		/// Blocking here would put <c>TextBox.CanPasteClipboardContent</c> — which is re-evaluated in
+		/// every process on every clipboard change — back onto a global exclusive lock.
+		/// </remarks>
+		Once,
+
+		/// <summary>
+		/// Up to <see cref="MaxOpenAttempts"/> attempts, sleeping in between. For user-initiated
+		/// writes, where losing the operation is worse than a delay and where the first attempt
+		/// almost always succeeds anyway.
+		/// </summary>
+		Blocking,
+	}
+
+	private const int MaxOpenAttempts = 10;
+	private const int OpenRetryDelayMs = 100;
+
+	/// <remarks>
+	/// Every listening process is woken by the same <see cref="PInvoke.WM_CLIPBOARDUPDATE"/> broadcast,
+	/// so a fixed backoff has them all retry in lockstep and collide again. The jitter is what breaks
+	/// up the herd, and is not decoration.
+	/// </remarks>
+	private static int NextRetryDelayMs(int baseDelayMs) =>
+		baseDelayMs + Random.Shared.Next(-baseDelayMs / 2, (baseDelayMs / 2) + 1);
+
+	private static bool TryOpenClipboard(HWND hwnd, ClipboardRetry retry)
+	{
+		var maxAttempts = retry is ClipboardRetry.Blocking ? MaxOpenAttempts : 1;
+		for (var attempt = 1; ; attempt++)
+		{
+			if (PInvoke.OpenClipboard(hwnd))
+			{
+				return true;
+			}
+
+			if (attempt >= maxAttempts)
+			{
+				// Deliberately not an error: under contention this is the expected outcome, and the
+				// callers that cannot proceed without the clipboard log it themselves.
+				typeof(Win32ClipboardExtension).LogDebug()?.Debug($"{nameof(PInvoke.OpenClipboard)} denied after {attempt} attempt(s): {Win32Helper.GetErrorMessage()}");
+				return false;
+			}
+
+			Thread.Sleep(NextRetryDelayMs(OpenRetryDelayMs));
+		}
+	}
+
 	private readonly ref struct ClipboardDisposable
 	{
-		private readonly bool _shouldClose;
-		public ClipboardDisposable(HWND hwnd, bool ownClipboard)
+		public ClipboardDisposable(HWND hwnd, bool ownClipboard, ClipboardRetry retry)
 		{
-			_shouldClose = PInvoke.OpenClipboard(hwnd);
-			if (!_shouldClose) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.OpenClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
-			if (ownClipboard && _shouldClose)
+			IsOpen = TryOpenClipboard(hwnd, retry);
+			if (ownClipboard && IsOpen)
 			{
 				var success = PInvoke.EmptyClipboard();
 				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.EmptyClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
 			}
 		}
 
+		/// <summary>
+		/// Whether the clipboard was actually opened. Callers MUST check this before calling anything
+		/// that needs the lock — <see cref="PInvoke.EnumClipboardFormats"/>,
+		/// <see cref="PInvoke.GetClipboardData"/>, <see cref="PInvoke.SetClipboardData"/> — all of
+		/// which fail with "Thread does not have a clipboard open" otherwise.
+		/// </summary>
+		public bool IsOpen { get; }
+
 		public void Dispose()
 		{
-			if (_shouldClose)
+			if (IsOpen)
 			{
 				var success = PInvoke.CloseClipboard();
 				if (!success) { typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.CloseClipboard)} failed: {Win32Helper.GetErrorMessage()}"); }
@@ -213,22 +304,106 @@ internal partial class Win32ClipboardExtension : IClipboardExtension
 
 partial class Win32ClipboardExtension // from clipboard
 {
+	/// <summary>
+	/// The standard formats this extension can decode. Anything else that happens to be on the
+	/// clipboard is surfaced by name via <see cref="DecodeUnknownData"/>, once
+	/// <see cref="PInvoke.EnumClipboardFormats"/> has told us it is there.
+	/// </summary>
+	private static readonly CLIPBOARD_FORMAT[] _knownStandardFormats =
+	[
+		CLIPBOARD_FORMAT.CF_UNICODETEXT,
+		CLIPBOARD_FORMAT.CF_OEMTEXT,
+		CLIPBOARD_FORMAT.CF_LOCALE,
+		CLIPBOARD_FORMAT.CF_DIB,
+	];
+
+	/// <summary>
+	/// The registered ids of <see cref="_knownTextBasedClipboardFormats"/>, so they can be probed
+	/// without the lock.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="PInvoke.RegisterClipboardFormat"/> returns the existing id when the name is already
+	/// registered, and ids are stable for the lifetime of the session, so this is safe to cache.
+	/// </remarks>
+	private static readonly Lazy<CLIPBOARD_FORMAT[]> _knownTextBasedFormatIds = new(() =>
+		_knownTextBasedClipboardFormats.Keys
+			.Select(name => (CLIPBOARD_FORMAT)PInvoke.RegisterClipboardFormat(name))
+			.Where(id => id != 0)
+			.Distinct()
+			.ToArray());
+
+	/// <summary>How long to wait before each warm-up attempt. See <see cref="ScheduleWarmUp"/>.</summary>
+	private static readonly int[] _warmUpDelaysMs = [60, 150, 400];
+
+	/// <summary>Decodes one clipboard format's payload from its handle, or null if it could not be read.</summary>
+	private delegate object? ClipboardDecoder(CLIPBOARD_FORMAT format, string name, HGLOBAL handle);
+
 	public DataPackageView GetContent()
 	{
-		if (_currentPackage is null)
+		// Lock-free, so this is trustworthy even while another process holds the clipboard, and it
+		// notices a change we haven't been told about yet.
+		var sequence = PInvoke.GetClipboardSequenceNumber();
+		if (_cachedContent is { } cached && cached.Sequence == sequence)
 		{
-			_currentPackage = GetContentPackage();
+			return cached.Package.GetView();
 		}
 
-		return _currentPackage.GetView();
+		var package = BuildPackage(sequence, out var complete);
+		if (complete)
+		{
+			// Only a complete read is worth remembering. Caching an incomplete one is what used to turn
+			// a single denied OpenClipboard into paste being dead until the next clipboard change.
+			_cachedContent = new CachedContent(package, sequence);
+		}
+
+		return package.GetView();
 	}
 
-	private static DataPackage GetContentPackage()
+	/// <summary>
+	/// Builds the package describing the current clipboard content, without materialising any payload.
+	/// </summary>
+	/// <param name="complete">
+	/// Whether the full format list could be enumerated. When false, the clipboard was held by someone
+	/// else and only the formats we can name by ourselves were probed - so the result is usable but
+	/// must not be cached.
+	/// </param>
+	private static DataPackage BuildPackage(uint sequence, out bool complete)
 	{
 		var package = new DataPackage();
+		var registered = new HashSet<string>();
 
-		using var clipboardDisposable = new ClipboardDisposable(Instance._hwnd, false);
+		// 1. What can be learned without the lock. IsClipboardFormatAvailable cannot be denied, and it
+		//    reports a delay-rendered format as available without forcing the (potentially very slow)
+		//    render. This alone covers every format this extension knows how to decode.
+		foreach (var format in _knownStandardFormats)
+		{
+			if (PInvoke.IsClipboardFormatAvailable((uint)format))
+			{
+				RegisterFormat(package, registered, format, sequence);
+			}
+		}
 
+		foreach (var format in _knownTextBasedFormatIds.Value)
+		{
+			if (PInvoke.IsClipboardFormatAvailable((uint)format))
+			{
+				RegisterFormat(package, registered, format, sequence);
+			}
+		}
+
+		// 2. Anything else needs EnumClipboardFormats, which needs the lock. Exactly one attempt: this
+		//    runs on the UI thread on every clipboard change in every process, so it must never wait.
+		//    Being denied only costs the app-specific formats we have no name for, and only until the
+		//    next call - or until the warm-up gets there first.
+		using var clipboardDisposable = new ClipboardDisposable(Instance._hwnd, false, ClipboardRetry.Once);
+		if (!clipboardDisposable.IsOpen)
+		{
+			complete = false;
+			return package;
+		}
+
+		// Collected before registering anything: GetClipboardFormatName, reached via ResolveFormat,
+		// overwrites the last Win32 error, which would make the check below meaningless.
 		var formats = new List<CLIPBOARD_FORMAT>();
 		for (uint lastFormat = 0; (lastFormat = PInvoke.EnumClipboardFormats(lastFormat)) != 0;)
 		{
@@ -238,78 +413,250 @@ partial class Win32ClipboardExtension // from clipboard
 		if (Marshal.GetLastWin32Error() != (int)WIN32_ERROR.ERROR_SUCCESS)
 		{
 			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.EnumClipboardFormats)} failed: {Win32Helper.GetErrorMessage()}");
+			complete = false;
 			return package;
 		}
 
 		foreach (var format in formats)
 		{
-			var loader = (Action<DataPackage, CLIPBOARD_FORMAT, HGLOBAL>?)(format switch
-			{
-				// https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats#constants
-				// https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#synthesized-clipboard-formats
-
-				// synthesized text formats
-				CLIPBOARD_FORMAT.CF_TEXT => null,
-				CLIPBOARD_FORMAT.CF_LOCALE => GetUnknownData, // 4 bytes CultureInfo.LCID
-				CLIPBOARD_FORMAT.CF_UNICODETEXT => GetText,
-				CLIPBOARD_FORMAT.CF_OEMTEXT => GetOemText,
-
-				// synthesized image formats
-				CLIPBOARD_FORMAT.CF_BITMAP => null, // Windows synthesizes CF_DIB from CF_BITMAP; handled below
-				CLIPBOARD_FORMAT.CF_DIB => GetDib,
-				CLIPBOARD_FORMAT.CF_DIBV5 => null,
-				CLIPBOARD_FORMAT.CF_PALETTE => null,
-
-				// synthesized meta-file formats
-				CLIPBOARD_FORMAT.CF_METAFILEPICT => null,
-				CLIPBOARD_FORMAT.CF_ENHMETAFILE => null,
-
-				CLIPBOARD_FORMAT.CF_HDROP => null,
-
-				CLIPBOARD_FORMAT.CF_SYLK => null,
-				CLIPBOARD_FORMAT.CF_DIF => null,
-				CLIPBOARD_FORMAT.CF_TIFF => null,
-				CLIPBOARD_FORMAT.CF_PENDATA => null,
-				CLIPBOARD_FORMAT.CF_RIFF => null,
-				CLIPBOARD_FORMAT.CF_WAVE => null,
-
-				_ => GetUnknownData,
-			});
-			if (loader is { })
-			{
-				// GetClipboardData must be called here, and not within async-func of SetDataProvider,
-				// or it will throw: Thread does not have a clipboard open
-				var handle = PInvoke.GetClipboardData((uint)format);
-				if (handle == default)
-				{
-					typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GetClipboardData)} failed: {Win32Helper.GetErrorMessage()}");
-					continue;
-				}
-
-				loader.Invoke(package, format, (HGLOBAL)(IntPtr)handle);
-			}
+			RegisterFormat(package, registered, format, sequence);
 		}
 
+		complete = true;
 		return package;
 	}
-	private static unsafe void GetText(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
-	{
-		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
-		if (lockDisposable is null) return;
 
-		package.SetText(Marshal.PtrToStringUni((IntPtr)ptr)!);
+	/// <summary>
+	/// Maps a clipboard format to the <see cref="DataPackage"/> key it is surfaced under and the
+	/// decoder for its payload, or null for the formats this extension does not surface.
+	/// </summary>
+	private static (string Name, ClipboardDecoder Decoder)? ResolveFormat(CLIPBOARD_FORMAT format) => format switch
+	{
+		// https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats#constants
+		// https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#synthesized-clipboard-formats
+
+		// synthesized text formats
+		CLIPBOARD_FORMAT.CF_TEXT => null,
+		CLIPBOARD_FORMAT.CF_LOCALE => (GetClipboardFormatName(format), DecodeUnknownData), // 4 bytes CultureInfo.LCID
+		CLIPBOARD_FORMAT.CF_UNICODETEXT => (StandardDataFormats.Text, DecodeText),
+		CLIPBOARD_FORMAT.CF_OEMTEXT => (GetClipboardFormatName(format), DecodeOemText),
+
+		// synthesized image formats
+		CLIPBOARD_FORMAT.CF_BITMAP => null, // Windows synthesizes CF_DIB from CF_BITMAP; handled below
+		CLIPBOARD_FORMAT.CF_DIB => (StandardDataFormats.Bitmap, DecodeDib),
+		CLIPBOARD_FORMAT.CF_DIBV5 => null,
+		CLIPBOARD_FORMAT.CF_PALETTE => null,
+
+		// synthesized meta-file formats
+		CLIPBOARD_FORMAT.CF_METAFILEPICT => null,
+		CLIPBOARD_FORMAT.CF_ENHMETAFILE => null,
+
+		CLIPBOARD_FORMAT.CF_HDROP => null,
+
+		CLIPBOARD_FORMAT.CF_SYLK => null,
+		CLIPBOARD_FORMAT.CF_DIF => null,
+		CLIPBOARD_FORMAT.CF_TIFF => null,
+		CLIPBOARD_FORMAT.CF_PENDATA => null,
+		CLIPBOARD_FORMAT.CF_RIFF => null,
+		CLIPBOARD_FORMAT.CF_WAVE => null,
+
+		_ => (GetClipboardFormatName(format), DecodeUnknownData),
+	};
+
+	/// <summary>
+	/// Registers a format key against a provider that will fetch the payload if anyone asks for it.
+	/// </summary>
+	/// <remarks>
+	/// Registering the key is all that <see cref="DataPackageView.Contains"/> and
+	/// <see cref="DataPackageView.AvailableFormats"/> need - they read only the keys - so "can I
+	/// paste?" is answered with no payload work and no clipboard lock at all.
+	/// </remarks>
+	private static void RegisterFormat(DataPackage package, HashSet<string> registered, CLIPBOARD_FORMAT format, uint sequence)
+	{
+		if (ResolveFormat(format) is not { } resolved || !registered.Add(resolved.Name))
+		{
+			return;
+		}
+
+		package.SetDataProvider(resolved.Name, ct => FetchPayloadAsync(format, resolved.Name, resolved.Decoder, sequence, ct));
 	}
-	private static unsafe void GetOemText(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+
+	/// <summary>
+	/// Fetches and decodes one format's payload, on demand.
+	/// </summary>
+	/// <remarks>
+	/// This is where the clipboard lock is actually needed, and where the full retry budget belongs: a
+	/// paste is user-initiated and infrequent, and a slow paste beats a failed one.
+	/// </remarks>
+	private static async Task<object> FetchPayloadAsync(CLIPBOARD_FORMAT format, string name, ClipboardDecoder decoder, uint sequence, CancellationToken ct)
+	{
+		for (var attempt = 1; ; attempt++)
+		{
+			// The open/read/close cycle must not span an await - CloseClipboard has to be called by the
+			// thread that opened - so the whole cycle runs as one unit on the dispatcher.
+			var (outcome, value) = await RunOnDispatcherAsync(() => TryFetchPayload(format, name, decoder, sequence));
+
+			switch (outcome)
+			{
+				case FetchOutcome.Success:
+					return value!;
+				case FetchOutcome.Stale:
+					throw new InvalidOperationException($"The clipboard content changed while reading format '{name}'.");
+				case FetchOutcome.Failed:
+					throw new InvalidOperationException($"Failed to read format '{name}' from the clipboard.");
+				case FetchOutcome.Denied when attempt >= MaxOpenAttempts:
+					throw new InvalidOperationException($"Could not take the clipboard to read format '{name}' after {attempt} attempts, it is held by another application.");
+			}
+
+			// Awaiting instead of sleeping: this can be running on the UI thread, and a paste must not
+			// freeze it for the length of the retry budget.
+			await Task.Delay(NextRetryDelayMs(OpenRetryDelayMs), ct);
+		}
+	}
+
+	private enum FetchOutcome
+	{
+		Success,
+
+		/// <summary>Another process held the clipboard. Worth retrying.</summary>
+		Denied,
+
+		/// <summary>The clipboard content changed since the package was built. Retrying cannot help.</summary>
+		Stale,
+
+		/// <summary>The data was there but could not be read or decoded. Retrying cannot help.</summary>
+		Failed,
+	}
+
+	private static (FetchOutcome Outcome, object? Value) TryFetchPayload(CLIPBOARD_FORMAT format, string name, ClipboardDecoder decoder, uint sequence)
+	{
+		if (PInvoke.GetClipboardSequenceNumber() != sequence)
+		{
+			// Serving content from a different clipboard generation would be worse than failing: the
+			// caller is asking about the formats it saw in this view.
+			return (FetchOutcome.Stale, null);
+		}
+
+		using var clipboardDisposable = new ClipboardDisposable(Instance._hwnd, false, ClipboardRetry.Once);
+		if (!clipboardDisposable.IsOpen)
+		{
+			return (FetchOutcome.Denied, null);
+		}
+
+		// Deliberately re-read from GetClipboardData rather than capturing a handle when the format was
+		// discovered: a clipboard data handle is owned by the clipboard and is only valid while it is
+		// open, so using a captured one later reads freed memory.
+		var handle = PInvoke.GetClipboardData((uint)format);
+		if (handle == default)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GetClipboardData)} failed (format={name}): {Win32Helper.GetErrorMessage()}");
+			return (FetchOutcome.Failed, null);
+		}
+
+		return decoder.Invoke(format, name, (HGLOBAL)(IntPtr)handle) is { } value
+			? (FetchOutcome.Success, value)
+			: (FetchOutcome.Failed, null);
+	}
+
+	private static async Task<T> RunOnDispatcherAsync<T>(Func<T> func)
+	{
+		if (NativeDispatcher.Main.HasThreadAccess)
+		{
+			return func();
+		}
+
+		var result = default(T)!;
+		await NativeDispatcher.Main.EnqueueAsync(() => result = func());
+		return result;
+	}
+
+	/// <summary>
+	/// Re-reads the clipboard shortly after it changed, off the message that announced the change.
+	/// </summary>
+	/// <remarks>
+	/// Every listening process handles WM_CLIPBOARDUPDATE at the same instant, which makes that the
+	/// worst possible moment to ask for the lock - all N of them collide. Waiting a jittered moment
+	/// and reading then means the complete format list is usually cached before anything asks for it.
+	/// This is fidelity only: <see cref="GetContent"/> is correct without it.
+	/// </remarks>
+	private void ScheduleWarmUp()
+	{
+		// Not disposed on purpose: the pending WarmUpAsync still holds the token, and a cancelled
+		// source with no registrations is cheap enough to leave to the GC.
+		_warmUpCts?.Cancel();
+
+		var cts = _warmUpCts = new CancellationTokenSource();
+		_ = WarmUpAsync(cts.Token);
+	}
+
+	private async Task WarmUpAsync(CancellationToken ct)
+	{
+		try
+		{
+			foreach (var baseDelayMs in _warmUpDelaysMs)
+			{
+				await Task.Delay(NextRetryDelayMs(baseDelayMs), ct);
+
+				var done = false;
+				await NativeDispatcher.Main.EnqueueAsync(() => done = TryWarmUp(ct));
+				if (done)
+				{
+					return;
+				}
+			}
+		}
+		catch (OperationCanceledException)
+		{
+			// The clipboard changed again; the newer warm-up supersedes this one.
+		}
+		catch (Exception e)
+		{
+			this.LogError()?.Error($"Exception while warming up the clipboard cache", e);
+		}
+	}
+
+	/// <returns>Whether the warm-up is finished, either because it succeeded or because it is moot.</returns>
+	private bool TryWarmUp(CancellationToken ct)
+	{
+		var sequence = PInvoke.GetClipboardSequenceNumber();
+		if (ct.IsCancellationRequested || _cachedContent?.Sequence == sequence)
+		{
+			return true;
+		}
+
+		var package = BuildPackage(sequence, out var complete);
+		if (!complete)
+		{
+			return false;
+		}
+
+		// The clipboard may have changed while we were reading it, in which case this package describes
+		// a generation nobody is asking about any more.
+		if (!ct.IsCancellationRequested && PInvoke.GetClipboardSequenceNumber() == sequence)
+		{
+			_cachedContent = new CachedContent(package, sequence);
+		}
+
+		return true;
+	}
+
+	private static unsafe object? DecodeText(CLIPBOARD_FORMAT format, string name, HGLOBAL handle)
 	{
 		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
-		if (lockDisposable is null) return;
+		if (lockDisposable is null) return null;
+
+		return Marshal.PtrToStringUni((IntPtr)ptr);
+	}
+	private static unsafe object? DecodeOemText(CLIPBOARD_FORMAT format, string name, HGLOBAL handle)
+	{
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr);
+		if (lockDisposable is null) return null;
 
 		var length = (int)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
-		var text = length > 1
+
+		return length > 1
 			? _oemEncoding.Value.GetString((byte*)ptr, length - 1)
 			: string.Empty;
-
-		package.SetData(GetClipboardFormatName(format), text);
 	}
 #if false // this would require System.Drawing.Common
 	private static void GetBitmap(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle) => package
@@ -330,95 +677,85 @@ partial class Win32ClipboardExtension // from clipboard
 			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(ras));
 		});
 #endif
-	private static unsafe void GetDib(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	private static unsafe object? DecodeDib(CLIPBOARD_FORMAT format, string name, HGLOBAL handle)
 	{
-		// we are remapping CF_DIB to bitmap, since there is no good way to load from CF_BITMAP which contains an HBITMAP
-		// normally, this would've been mapped to "DeviceIndependentBitmap"
-		var name = StandardDataFormats.Bitmap;
-
-		package.SetDataProvider(name, _ =>
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr, logLastError: false);
+		if (lockDisposable is null)
 		{
-			using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr, logLastError: false);
-			if (lockDisposable is null)
-			{
-				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}"));
-			}
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GlobalLock)} failed (format={name}): {Win32Helper.GetErrorMessage()}");
+			return null;
+		}
 
-			var memSize = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
-			if (memSize <= Marshal.SizeOf<BITMAPINFOHEADER>())
-			{
-				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {memSize}: {Win32Helper.GetErrorMessage()}"));
-			}
+		var memSize = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
+		if (memSize <= Marshal.SizeOf<BITMAPINFOHEADER>())
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GlobalSize)} returned {memSize} (format={name}): {Win32Helper.GetErrorMessage()}");
+			return null;
+		}
 
-			var srcBitmapInfo = (BITMAPINFO*)ptr;
+		var srcBitmapInfo = (BITMAPINFO*)ptr;
 
-			// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
-			int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
-			{
-				// BI_RGB
-				0 when srcBitmapInfo->bmiHeader.biBitCount <= 8 => Marshal.SizeOf<RGBQUAD>() * (srcBitmapInfo->bmiHeader.biClrUsed == 0 ? 1 << srcBitmapInfo->bmiHeader.biBitCount : (int)srcBitmapInfo->bmiHeader.biClrUsed),
-				0 => 0,
-				// BI_BITFIELDS
-				3 => 3 * Marshal.SizeOf<uint>(),
-				// FOURCC
-				_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
-			};
+		// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
+		int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
+		{
+			// BI_RGB
+			0 when srcBitmapInfo->bmiHeader.biBitCount <= 8 => Marshal.SizeOf<RGBQUAD>() * (srcBitmapInfo->bmiHeader.biClrUsed == 0 ? 1 << srcBitmapInfo->bmiHeader.biBitCount : (int)srcBitmapInfo->bmiHeader.biClrUsed),
+			0 => 0,
+			// BI_BITFIELDS
+			3 => 3 * Marshal.SizeOf<uint>(),
+			// FOURCC
+			_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
+		};
 
-			BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
-			{
-				bfType = /* BM */ 0x4d42,
-				bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
-				bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
-			};
+		BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
+		{
+			bfType = /* BM */ 0x4d42,
+			bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
+			bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
+		};
 
-			var bmpSize = Marshal.SizeOf<BITMAPFILEHEADER>() + (int)memSize;
-			var arr = new byte[bmpSize];
-			fixed (byte* bmp = arr)
-			{
-				Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
-				Buffer.MemoryCopy(ptr, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), memSize, memSize);
-			}
+		var bmpSize = Marshal.SizeOf<BITMAPFILEHEADER>() + (int)memSize;
+		var arr = new byte[bmpSize];
+		fixed (byte* bmp = arr)
+		{
+			Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
+			Buffer.MemoryCopy(ptr, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), memSize, memSize);
+		}
 
-			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream()));
-		});
+		return RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream());
 	}
-	private static unsafe void GetUnknownData(DataPackage package, CLIPBOARD_FORMAT format, HGLOBAL handle)
+	private static unsafe object? DecodeUnknownData(CLIPBOARD_FORMAT format, string name, HGLOBAL handle)
 	{
-		var name = GetClipboardFormatName(format);
-
-		package.SetDataProvider(name, _ =>
+		using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr, logLastError: false);
+		if (lockDisposable is null)
 		{
-			using var lockDisposable = Win32Helper.GlobalLock(handle, out var ptr, logLastError: false);
-			if (lockDisposable is null)
-			{
-				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}"));
-			}
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GlobalLock)} failed (format={name}): {Win32Helper.GetErrorMessage()}");
+			return null;
+		}
 
-			var size = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
-			if (size == 0 || size > int.MaxValue)
-			{
-				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {size}: {Win32Helper.GetErrorMessage()}"));
-			}
+		var size = (uint)PInvoke.GlobalSize((HGLOBAL)(IntPtr)handle);
+		if (size == 0 || size > int.MaxValue)
+		{
+			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.GlobalSize)} returned {size} (format={name}): {Win32Helper.GetErrorMessage()}");
+			return null;
+		}
 
-			var bufferLength = checked((int)size);
+		var bufferLength = checked((int)size);
 
-			// note: WinUI Clipboard seem to detect certain named format as string, it is unknown by which mechanism.
-			// since HGlobal itself doesnt carry any type metadata, presumably this is done with a white list.
-			if (_knownTextBasedClipboardFormats.TryGetValue(name, out var marshaler))
-			{
-				var text = marshaler.FromPointer.Invoke((IntPtr)ptr) ?? string.Empty;
+		// note: WinUI Clipboard seem to detect certain named format as string, it is unknown by which mechanism.
+		// since HGlobal itself doesnt carry any type metadata, presumably this is done with a white list.
+		if (_knownTextBasedClipboardFormats.TryGetValue(name, out var marshaler))
+		{
+			return marshaler.FromPointer.Invoke((IntPtr)ptr) ?? string.Empty;
+		}
 
-				return Task.FromResult<object>(text);
-			}
+		var buffer = new byte[bufferLength];
+		fixed (byte* pBuffer = buffer)
+		{
+			System.Buffer.MemoryCopy(ptr, pBuffer, bufferLength, bufferLength);
+		}
 
-			var buffer = new byte[bufferLength];
-			fixed (byte* pBuffer = buffer)
-			{
-				System.Buffer.MemoryCopy(ptr, pBuffer, bufferLength, bufferLength);
-			}
-
-			return Task.FromResult<object>(new MemoryStream(buffer).AsRandomAccessStream());
-		});
+		return new MemoryStream(buffer).AsRandomAccessStream();
 	}
 
 	internal static void ReadContentIntoPackage(DataPackage package, IEnumerable<CLIPBOARD_FORMAT> formats, Func<CLIPBOARD_FORMAT, HGLOBAL?> dataGetter)
@@ -561,23 +898,74 @@ partial class Win32ClipboardExtension // from clipboard
 
 partial class Win32ClipboardExtension // to clipboard
 {
+	/// <summary>A payload resolved outside the clipboard lock, ready to be handed straight to Windows.</summary>
+	/// <remarks>
+	/// Exactly one of <paramref name="Bytes"/> and <paramref name="CoTaskMem"/> carries the payload;
+	/// <paramref name="CoTaskMem"/> being non-zero selects it.
+	/// </remarks>
+	private readonly record struct PendingWrite(CLIPBOARD_FORMAT Format, ReadOnlyMemory<byte> Bytes, IntPtr CoTaskMem);
+
 	public void SetContent(DataPackage content)
 	{
-		using var clipboardDisposable = new ClipboardDisposable(_hwnd, true);
-
 		var view = content.GetView();
+
+		// Phase 1, OUTSIDE the lock. Resolving a payload pumps the message loop (see ResolveText), and
+		// pumping while holding the global clipboard lock dispatches arbitrary UI work - up to and
+		// including a re-entrant WM_CLIPBOARDUPDATE - while every other application is locked out.
+		var writes = new List<PendingWrite>();
 		foreach (var format in view.AvailableFormats)
 		{
-			var setter = (Action<DataPackageView, string>?)(format switch
+			var resolver = (Action<List<PendingWrite>, DataPackageView, string>?)(format switch
 			{
-				_ when format == StandardDataFormats.Text => SetText,
-				_ when format == StandardDataFormats.Bitmap => SetBitmap,
-				_ => SetUnknownData,
+				_ when format == StandardDataFormats.Text => ResolveText,
+				_ when format == StandardDataFormats.Bitmap => ResolveBitmap,
+				_ => ResolveUnknownData,
 			});
-			setter?.Invoke(view, format);
+			resolver?.Invoke(writes, view, format);
+		}
+
+		// Phase 2, INSIDE the lock. No pumping and no async work: just hand the payloads over.
+		// Entered even with nothing to write: an empty DataPackage still means "empty the clipboard".
+		using var clipboardDisposable = new ClipboardDisposable(_hwnd, true, ClipboardRetry.Blocking);
+		if (!clipboardDisposable.IsOpen)
+		{
+			// This used to be silent: EmptyClipboard was skipped, every SetClipboardData ran anyway and
+			// failed with "Thread does not have a clipboard open", and the copy was lost without a word.
+			this.LogError()?.Error($"{nameof(SetContent)} failed: could not take the clipboard, it is held by another application.");
+			FreePendingWrites(writes);
+			return;
+		}
+
+		foreach (var write in writes)
+		{
+			WritePending(write);
 		}
 	}
-	private static void SetText(DataPackageView view, string format)
+
+	private static void WritePending(PendingWrite write)
+	{
+		if (write.CoTaskMem != IntPtr.Zero)
+		{
+			SetClipboardCoTaskMemData(write.Format, write.CoTaskMem);
+		}
+		else
+		{
+			SetClipboardData(write.Format, write.Bytes.Span);
+		}
+	}
+
+	/// <summary>Releases payloads that were resolved but never handed over, so they don't leak.</summary>
+	private static void FreePendingWrites(List<PendingWrite> writes)
+	{
+		foreach (var write in writes)
+		{
+			if (write.CoTaskMem != IntPtr.Zero)
+			{
+				Marshal.FreeCoTaskMem(write.CoTaskMem);
+			}
+		}
+	}
+	private static void ResolveText(List<PendingWrite> writes, DataPackageView view, string format)
 	{
 		var task = view.GetTextAsync().AsTask();
 		while (!task.IsCompleted)
@@ -594,9 +982,9 @@ partial class Win32ClipboardExtension // to clipboard
 		var str = task.Result;
 		var bytes = new byte[(str.Length + 1) * sizeof(char)]; // +1 char: last 2 bytes remain 0 as null terminator
 		MemoryMarshal.Cast<char, byte>(str.AsSpan()).CopyTo(bytes);
-		SetClipboardData(CLIPBOARD_FORMAT.CF_UNICODETEXT, bytes);
+		writes.Add(new PendingWrite(CLIPBOARD_FORMAT.CF_UNICODETEXT, bytes, default));
 	}
-	private static unsafe void SetBitmap(DataPackageView view, string format)
+	private static unsafe void ResolveBitmap(List<PendingWrite> writes, DataPackageView view, string format)
 	{
 		var task = view.GetBitmapAsync().AsTask();
 		while (!task.IsCompleted)
@@ -651,7 +1039,7 @@ partial class Win32ClipboardExtension // to clipboard
 		if (bytes.Length > Marshal.SizeOf<BITMAPFILEHEADER>() &&
 			bytes[0] == 'B' && bytes[1] == 'M')
 		{
-			SetClipboardData(CLIPBOARD_FORMAT.CF_DIB, bytes.AsSpan(/* start after: */ Marshal.SizeOf<BITMAPFILEHEADER>()));
+			writes.Add(new PendingWrite(CLIPBOARD_FORMAT.CF_DIB, bytes.AsMemory(/* start after: */ Marshal.SizeOf<BITMAPFILEHEADER>()), default));
 		}
 		else
 		{
@@ -699,11 +1087,11 @@ partial class Win32ClipboardExtension // to clipboard
 				}
 			}
 
-			SetClipboardData(CLIPBOARD_FORMAT.CF_DIB, dib);
+			writes.Add(new PendingWrite(CLIPBOARD_FORMAT.CF_DIB, dib, default));
 		}
 #endif
 	}
-	private static void SetUnknownData(DataPackageView view, string format)
+	private static void ResolveUnknownData(List<PendingWrite> writes, DataPackageView view, string format)
 	{
 		if (!WaitForAsyncOperation(view.GetDataAsync(format), out var task))
 		{
@@ -731,7 +1119,7 @@ partial class Win32ClipboardExtension // to clipboard
 			var bytes = new byte[checked((int)size)];
 			ras.AsStreamForRead().ReadExactly(bytes);
 
-			SetClipboardData(cfid, bytes);
+			writes.Add(new PendingWrite(cfid, bytes, default));
 		}
 		else if (task.Result is string str)
 		{
@@ -739,7 +1127,7 @@ partial class Win32ClipboardExtension // to clipboard
 				? marshaler.ToPointer(str)
 				: Marshal.StringToCoTaskMemUni(str);
 
-			SetClipboardCoTaskMemData(cfid, p);
+			writes.Add(new PendingWrite(cfid, default, p));
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
@@ -36,14 +36,12 @@ using Uno.Foundation.Logging;
 using Uno.UI.Dispatching;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
-using Windows.Storage;
 using Windows.Storage.Streams;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.System.Memory;
 using Windows.Win32.System.Ole;
-using Windows.Win32.UI.Shell;
 using Windows.Win32.UI.WindowsAndMessaging;
 using Buffer = System.Buffer;
 
@@ -756,143 +754,6 @@ partial class Win32ClipboardExtension // from clipboard
 		}
 
 		return new MemoryStream(buffer).AsRandomAccessStream();
-	}
-
-	internal static void ReadContentIntoPackage(DataPackage package, IEnumerable<CLIPBOARD_FORMAT> formats, Func<CLIPBOARD_FORMAT, HGLOBAL?> dataGetter)
-	{
-		foreach (var format in formats)
-		{
-			if (Enum.IsDefined((CLIPBOARD_FORMAT)format) && dataGetter(format) is { } handle)
-			{
-				switch (format)
-				{
-					case CLIPBOARD_FORMAT.CF_UNICODETEXT:
-						GetText(handle, package);
-						break;
-					case CLIPBOARD_FORMAT.CF_HDROP:
-						var files = GetFileDropList(handle);
-						if (files is not null)
-						{
-							package.SetStorageItems(files);
-						}
-						break;
-					case CLIPBOARD_FORMAT.CF_DIB:
-						GetBitmap(handle, package);
-						break;
-				}
-			}
-		}
-	}
-	private static unsafe void GetText(HGLOBAL handle, DataPackage package)
-	{
-		using var lockDisposable = Win32Helper.GlobalLock(handle, out var bytes);
-		if (lockDisposable is null)
-		{
-			return;
-		}
-
-		package.SetText(Marshal.PtrToStringUni((IntPtr)bytes)!);
-	}
-	private static unsafe void GetBitmap(HGLOBAL handle, DataPackage package)
-	{
-		package.SetDataProvider(StandardDataFormats.Bitmap, _ =>
-		{
-			using var lockDisposable = Win32Helper.GlobalLock(handle, out var dib);
-			if (lockDisposable is null)
-			{
-				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalLock)} failed: {Win32Helper.GetErrorMessage()}"));
-			}
-
-			var memSize = (uint)PInvoke.GlobalSize(handle);
-			if (memSize <= Marshal.SizeOf<BITMAPINFOHEADER>())
-			{
-				return Task.FromException<object>(new InvalidOperationException($"{nameof(PInvoke.GlobalSize)} returned {memSize}: {Win32Helper.GetErrorMessage()}"));
-			}
-
-			var srcBitmapInfo = (BITMAPINFO*)dib;
-
-			// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
-			int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
-			{
-				// BI_RGB
-				0 when srcBitmapInfo->bmiHeader.biBitCount <= 8 => Marshal.SizeOf<RGBQUAD>() * (srcBitmapInfo->bmiHeader.biClrUsed == 0 ? 1 << srcBitmapInfo->bmiHeader.biBitCount : (int)srcBitmapInfo->bmiHeader.biClrUsed),
-				0 => 0,
-				// BI_BITFIELDS
-				3 => 3 * Marshal.SizeOf<uint>(),
-				// FOURCC
-				_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
-			};
-
-			BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
-			{
-				bfType = /* BM */ 0x4d42,
-				bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
-				bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
-			};
-
-			var bmpSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize);
-			var arr = new byte[bmpSize];
-			fixed (byte* bmp = arr)
-			{
-				Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
-				Buffer.MemoryCopy(dib, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), bmpSize - Marshal.SizeOf<BITMAPFILEHEADER>(), bmpSize - Marshal.SizeOf<BITMAPFILEHEADER>());
-			}
-
-			return Task.FromResult<object>(RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream()));
-		});
-	}
-	internal static unsafe List<IStorageItem>? GetFileDropList(HGLOBAL handle)
-	{
-		using var lockDisposable = Win32Helper.GlobalLock(handle, out var firstByte);
-		if (lockDisposable is null)
-		{
-			return null;
-		}
-
-		var hDrop = new HDROP((IntPtr)firstByte);
-
-		var filesDropped = PInvoke.DragQueryFile(hDrop, 0xFFFFFFFF, new PWSTR(), 0);
-		if (filesDropped == 0)
-		{
-			typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.DragQueryFile)} failed when querying total count: {Win32Helper.GetErrorMessage()}");
-			return null;
-		}
-
-		var files = new List<IStorageItem>((int)filesDropped);
-		for (uint i = 0; i < filesDropped; i++)
-		{
-			var charLength = PInvoke.DragQueryFile(hDrop, i, new PWSTR(), 0);
-			if (charLength == 0)
-			{
-				typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.DragQueryFile)} failed when querying buffer length: {Win32Helper.GetErrorMessage()}");
-				continue;
-			}
-			charLength++; // + 1 for \0
-
-			var buffer = Marshal.AllocHGlobal((IntPtr)(charLength * Unsafe.SizeOf<char>()));
-			using var bufferDisposable = new DisposableStruct<IntPtr>(Marshal.FreeHGlobal, buffer);
-			var charsWritten = PInvoke.DragQueryFile(hDrop, i, new PWSTR((char*)buffer), charLength);
-			if (charsWritten == 0)
-			{
-				typeof(Win32ClipboardExtension).LogError()?.Error($"{nameof(PInvoke.DragQueryFile)} failed when querying file path: {Win32Helper.GetErrorMessage()}");
-				break;
-			}
-			var filePath = Marshal.PtrToStringUni(buffer, (int)charsWritten);
-			if (Directory.Exists(filePath))
-			{
-				files.Add(new StorageFolder(filePath));
-			}
-			else if (File.Exists(filePath))
-			{
-				files.Add(StorageFile.GetFileFromPath(filePath));
-			}
-			else
-			{
-				typeof(Win32ClipboardExtension).LogError()?.Error($"HDROP Clipboard: file path '{filePath}' was not a valid file or directory.");
-			}
-		}
-
-		return files;
 	}
 }
 

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/Win32ClipboardExtension.cs
@@ -1,24 +1,4 @@
-﻿// Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
-//
-// This software is provided 'as-is', without any express or implied
-// warranty.  In no event will the authors be held liable for any damages
-// arising from the use of this software.
-//
-// 	Permission is granted to anyone to use this software for any purpose,
-// 	including commercial applications, and to alter it and redistribute it
-// 	freely, subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented; you must not
-// 	claim that you wrote the original software. If you use this software
-// 	in a product, an acknowledgment in the product documentation would be
-// 	appreciated but is not required.
-// 2. Altered source versions must be plainly marked as such, and must not be
-// misrepresented as being the original software.
-// 3. This notice may not be removed or altered from any source distribution.
-
-// https://github.com/libsdl-org/SDL/blob/9f8157f42cc0351833c030febe8a559719c875bd/src/video/windows/SDL_windowsclipboard.c
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -691,7 +671,35 @@ partial class Win32ClipboardExtension // from clipboard
 			return null;
 		}
 
-		var srcBitmapInfo = (BITMAPINFO*)ptr;
+		return RandomAccessStreamReference.CreateFromStream(new MemoryStream(ConvertDibToBmp(ptr, memSize)).AsRandomAccessStream());
+	}
+
+	// Derived from SDL's WIN_ConvertDIBtoBMP, translated to C# and modified:
+	// https://github.com/libsdl-org/SDL/blob/9f8157f42cc0351833c030febe8a559719c875bd/src/video/windows/SDL_windowsclipboard.c
+	//
+	// Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+	//
+	// This software is provided 'as-is', without any express or implied
+	// warranty.  In no event will the authors be held liable for any damages
+	// arising from the use of this software.
+	//
+	// Permission is granted to anyone to use this software for any purpose,
+	// including commercial applications, and to alter it and redistribute it
+	// freely, subject to the following restrictions:
+	//
+	// 1. The origin of this software must not be misrepresented; you must not
+	//    claim that you wrote the original software. If you use this software
+	//    in a product, an acknowledgment in the product documentation would be
+	//    appreciated but is not required.
+	// 2. Altered source versions must be plainly marked as such, and must not be
+	//    misrepresented as being the original software.
+	// 3. This notice may not be removed or altered from any source distribution.
+	/// <summary>
+	/// Wraps a raw CF_DIB payload in a <see cref="BITMAPFILEHEADER"/>, yielding a self-contained BMP file.
+	/// </summary>
+	private static unsafe byte[] ConvertDibToBmp(void* dib, uint dibSize)
+	{
+		var srcBitmapInfo = (BITMAPINFO*)dib;
 
 		// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#color-tables
 		int colorTableSize = srcBitmapInfo->bmiHeader.biCompression switch
@@ -705,22 +713,22 @@ partial class Win32ClipboardExtension // from clipboard
 			_ => Marshal.SizeOf<RGBQUAD>() * (int)srcBitmapInfo->bmiHeader.biClrUsed
 		};
 
-		BITMAPFILEHEADER bitmapfileheader = new BITMAPFILEHEADER
+		var fileHeaderSize = Marshal.SizeOf<BITMAPFILEHEADER>();
+		var bitmapfileheader = new BITMAPFILEHEADER
 		{
 			bfType = /* BM */ 0x4d42,
-			bfSize = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + memSize),
-			bfOffBits = (uint)(Marshal.SizeOf<BITMAPFILEHEADER>() + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
+			bfSize = (uint)(fileHeaderSize + dibSize),
+			bfOffBits = (uint)(fileHeaderSize + Marshal.SizeOf<BITMAPINFOHEADER>() + colorTableSize)
 		};
 
-		var bmpSize = Marshal.SizeOf<BITMAPFILEHEADER>() + (int)memSize;
-		var arr = new byte[bmpSize];
+		var arr = new byte[fileHeaderSize + dibSize];
 		fixed (byte* bmp = arr)
 		{
-			Buffer.MemoryCopy(&bitmapfileheader, bmp, bmpSize, Marshal.SizeOf<BITMAPFILEHEADER>());
-			Buffer.MemoryCopy(ptr, bmp + Marshal.SizeOf<BITMAPFILEHEADER>(), memSize, memSize);
+			Buffer.MemoryCopy(&bitmapfileheader, bmp, arr.Length, fileHeaderSize);
+			Buffer.MemoryCopy(dib, bmp + fileHeaderSize, dibSize, dibSize);
 		}
 
-		return RandomAccessStreamReference.CreateFromStream(new MemoryStream(arr).AsRandomAccessStream());
+		return arr;
 	}
 	private static unsafe object? DecodeUnknownData(CLIPBOARD_FORMAT format, string name, HGLOBAL handle)
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
@@ -64,6 +64,13 @@ partial class Given_Clipboard // Win32 contention
 					release.Wait(TimeSpan.FromSeconds(30));
 					Win32.CloseClipboard();
 				}
+
+				// Destroying the owner keeps the content: it was set eagerly, not delay-rendered.
+				// This has to run on the thread that created the window, which is this one.
+				if (hwnd != IntPtr.Zero)
+				{
+					Win32.DestroyWindow(hwnd);
+				}
 			}
 		})
 		{
@@ -138,50 +145,16 @@ file static class Win32
 		return handle;
 	}
 
+	/// <summary>
+	/// A thread-owned window handle, which is what makes <c>OpenClipboard</c> exclusive.
+	/// </summary>
+	/// <remarks>
+	/// A built-in class already has a native window procedure, so nothing here has to outlive the
+	/// window: registering a class would mean handing user32 a pointer into a managed delegate that
+	/// the GC is free to collect the moment this returns, and a class that can never be unregistered.
+	/// </remarks>
 	public static IntPtr CreateMessageOnlyWindow()
-	{
-		var className = $"UnoClipboardContentionTest{Environment.CurrentManagedThreadId}";
-		WndProcDelegate wndProc = DefWindowProc;
-		var windowClass = new WNDCLASSEX
-		{
-			cbSize = (uint)Marshal.SizeOf<WNDCLASSEX>(),
-			lpfnWndProc = Marshal.GetFunctionPointerForDelegate(wndProc),
-			hInstance = GetModuleHandle(null!),
-			lpszClassName = className,
-		};
-
-		try
-		{
-			return RegisterClassEx(ref windowClass) is 0
-				? IntPtr.Zero
-				: CreateWindowEx(0, className, className, 0, 0, 0, 0, 0, (IntPtr)HWND_MESSAGE, IntPtr.Zero, GetModuleHandle(null!), IntPtr.Zero);
-		}
-		finally
-		{
-			// The window only has to outlive the clipboard hold, but the delegate must not be collected
-			// while the class is registered.
-			GC.KeepAlive(wndProc);
-		}
-	}
-
-	private delegate IntPtr WndProcDelegate(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
-
-	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-	private struct WNDCLASSEX
-	{
-		public uint cbSize;
-		public uint style;
-		public IntPtr lpfnWndProc;
-		public int cbClsExtra;
-		public int cbWndExtra;
-		public IntPtr hInstance;
-		public IntPtr hIcon;
-		public IntPtr hCursor;
-		public IntPtr hbrBackground;
-		[MarshalAs(UnmanagedType.LPWStr)] public string? lpszMenuName;
-		[MarshalAs(UnmanagedType.LPWStr)] public string? lpszClassName;
-		public IntPtr hIconSm;
-	}
+		=> CreateWindowEx(0, "STATIC", null, 0, 0, 0, 0, 0, (IntPtr)HWND_MESSAGE, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 
 	[DllImport("user32.dll", SetLastError = true)]
 	public static extern bool OpenClipboard(IntPtr hWndNewOwner);
@@ -195,17 +168,11 @@ file static class Win32
 	[DllImport("user32.dll", SetLastError = true)]
 	public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
 
-	[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-	private static extern ushort RegisterClassEx(ref WNDCLASSEX windowClass);
+	[DllImport("user32.dll", SetLastError = true)]
+	public static extern bool DestroyWindow(IntPtr hwnd);
 
 	[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-	private static extern IntPtr CreateWindowEx(uint exStyle, string className, string windowName, uint style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr instance, IntPtr param);
-
-	[DllImport("user32.dll", CharSet = CharSet.Unicode)]
-	private static extern IntPtr DefWindowProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
-
-	[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-	private static extern IntPtr GetModuleHandle(string moduleName);
+	private static extern IntPtr CreateWindowEx(uint exStyle, string className, string? windowName, uint style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr instance, IntPtr param);
 
 	[DllImport("kernel32.dll")]
 	private static extern IntPtr GlobalAlloc(uint flags, UIntPtr bytes);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
@@ -14,11 +14,6 @@ namespace Uno.UI.RuntimeTests.Tests;
 
 partial class Given_Clipboard // Win32 contention
 {
-	private const uint CF_UNICODETEXT = 13;
-	private const uint GMEM_MOVEABLE = 0x0002;
-	private const int HWND_MESSAGE = -3;
-	private const int ERROR_ACCESS_DENIED = 5;
-
 	private const string ContendedText = "test-string-while-contended";
 
 	/// <summary>
@@ -47,18 +42,18 @@ partial class Given_Clipboard // Win32 contention
 
 		var holder = new Thread(() =>
 		{
-			var hwnd = CreateMessageOnlyWindow();
+			var hwnd = Win32.CreateMessageOnlyWindow();
 			try
 			{
 				// A NULL owner does NOT exclude other threads; a real window handle does.
-				holderTookClipboard = hwnd != IntPtr.Zero && OpenClipboard(hwnd);
+				holderTookClipboard = hwnd != IntPtr.Zero && Win32.OpenClipboard(hwnd);
 				if (!holderTookClipboard)
 				{
 					return;
 				}
 
-				EmptyClipboard();
-				SetClipboardData(CF_UNICODETEXT, AllocUnicodeText(ContendedText));
+				Win32.EmptyClipboard();
+				Win32.SetClipboardData(Win32.CF_UNICODETEXT, Win32.AllocUnicodeText(ContendedText));
 			}
 			finally
 			{
@@ -66,7 +61,7 @@ partial class Given_Clipboard // Win32 contention
 				if (holderTookClipboard)
 				{
 					release.Wait(TimeSpan.FromSeconds(30));
-					CloseClipboard();
+					Win32.CloseClipboard();
 				}
 			}
 		})
@@ -84,14 +79,14 @@ partial class Given_Clipboard // Win32 contention
 
 			// Confirm the contention is real rather than assuming it, so this cannot quietly become a
 			// test that passes because nothing was ever holding the clipboard.
-			if (OpenClipboard(IntPtr.Zero))
+			if (Win32.OpenClipboard(IntPtr.Zero))
 			{
-				CloseClipboard();
+				Win32.CloseClipboard();
 				Assert.Fail("expected the clipboard to be contended, but it could be opened");
 			}
 			else
 			{
-				Assert.AreEqual(ERROR_ACCESS_DENIED, Marshal.GetLastWin32Error(), "expected the clipboard to be denied while another thread holds it");
+				Assert.AreEqual(Win32.ERROR_ACCESS_DENIED, Marshal.GetLastWin32Error(), "expected the clipboard to be denied while another thread holds it");
 			}
 
 			var view = Clipboard.GetContent();
@@ -111,8 +106,23 @@ partial class Given_Clipboard // Win32 contention
 		await DelayForClipboard();
 		Assert.AreEqual(ContendedText, await Clipboard.GetContent()!.GetTextAsync());
 	}
+}
 
-	private static IntPtr AllocUnicodeText(string value)
+/// <summary>
+/// The interop is file-local: these entry points only exist on Windows, and the rest of
+/// <c>Given_Clipboard</c> is compiled for every Skia head (X11, macOS, wasm, mobile), where
+/// calling them would throw <see cref="DllNotFoundException"/>. Keeping them out of the
+/// partial class means they cannot be reached from a sibling file by accident.
+/// </summary>
+file static class Win32
+{
+	public const uint CF_UNICODETEXT = 13;
+	public const int ERROR_ACCESS_DENIED = 5;
+
+	private const uint GMEM_MOVEABLE = 0x0002;
+	private const int HWND_MESSAGE = -3;
+
+	public static IntPtr AllocUnicodeText(string value)
 	{
 		// SetClipboardData requires GMEM_MOVEABLE, and takes ownership on success.
 		var handle = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)((value.Length + 1) * sizeof(char)));
@@ -124,7 +134,7 @@ partial class Given_Clipboard // Win32 contention
 		return handle;
 	}
 
-	private static IntPtr CreateMessageOnlyWindow()
+	public static IntPtr CreateMessageOnlyWindow()
 	{
 		var className = $"UnoClipboardContentionTest{Environment.CurrentManagedThreadId}";
 		WndProcDelegate wndProc = DefWindowProc;
@@ -170,16 +180,16 @@ partial class Given_Clipboard // Win32 contention
 	}
 
 	[DllImport("user32.dll", SetLastError = true)]
-	private static extern bool OpenClipboard(IntPtr hWndNewOwner);
+	public static extern bool OpenClipboard(IntPtr hWndNewOwner);
 
 	[DllImport("user32.dll", SetLastError = true)]
-	private static extern bool CloseClipboard();
+	public static extern bool CloseClipboard();
 
 	[DllImport("user32.dll", SetLastError = true)]
-	private static extern bool EmptyClipboard();
+	public static extern bool EmptyClipboard();
 
 	[DllImport("user32.dll", SetLastError = true)]
-	private static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+	public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
 
 	[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
 	private static extern ushort RegisterClassEx(ref WNDCLASSEX windowClass);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
@@ -38,28 +38,43 @@ partial class Given_Clipboard // Win32 contention
 	{
 		using var held = new ManualResetEventSlim();
 		using var release = new ManualResetEventSlim();
-		var holderTookClipboard = false;
+		string? holderSetupFailure = null;
 		var holderExited = false;
 
 		var holder = new Thread(() =>
 		{
 			var hwnd = Win32.CreateMessageOnlyWindow();
+			var tookClipboard = false;
 			try
 			{
 				// A NULL owner does NOT exclude other threads; a real window handle does.
-				holderTookClipboard = hwnd != IntPtr.Zero && Win32.OpenClipboard(hwnd);
-				if (!holderTookClipboard)
+				tookClipboard = hwnd != IntPtr.Zero && Win32.OpenClipboard(hwnd);
+				if (!tookClipboard)
 				{
+					holderSetupFailure = hwnd == IntPtr.Zero
+						? "the owner window could not be created"
+						: $"OpenClipboard failed with error {Marshal.GetLastWin32Error()}";
 					return;
 				}
 
-				Win32.EmptyClipboard();
-				Win32.SetClipboardData(Win32.CF_UNICODETEXT, Win32.AllocUnicodeText(ContendedText));
+				if (!Win32.EmptyClipboard())
+				{
+					holderSetupFailure = $"EmptyClipboard failed with error {Marshal.GetLastWin32Error()}";
+					return;
+				}
+
+				if (!Win32.TrySetUnicodeText(ContendedText, out var error))
+				{
+					holderSetupFailure = $"SetClipboardData failed with error {error}";
+				}
 			}
 			finally
 			{
 				held.Set();
-				if (holderTookClipboard)
+
+				// Keyed on owning the lock, never on the setup having succeeded: a holder that took the
+				// clipboard and then failed still has to release it, or it poisons every later test.
+				if (tookClipboard)
 				{
 					release.Wait(TimeSpan.FromSeconds(30));
 					Win32.CloseClipboard();
@@ -83,7 +98,10 @@ partial class Given_Clipboard // Win32 contention
 		try
 		{
 			Assert.IsTrue(held.Wait(TimeSpan.FromSeconds(30)), "the holder thread never reported back");
-			Assert.IsTrue(holderTookClipboard, "the holder thread could not take the clipboard, so there is nothing to test");
+
+			// The contention is this test's premise, so a holder that never established it has to say so:
+			// letting it fall through would fail the assertions below and read as a product regression.
+			Assert.IsNull(holderSetupFailure, $"the holder thread never held the clipboard with text on it, so there is nothing to test: {holderSetupFailure}");
 
 			// Confirm the contention is real rather than assuming it, so this cannot quietly become a
 			// test that passes because nothing was ever holding the clipboard.
@@ -127,22 +145,39 @@ partial class Given_Clipboard // Win32 contention
 /// </summary>
 file static class Win32
 {
-	public const uint CF_UNICODETEXT = 13;
 	public const int ERROR_ACCESS_DENIED = 5;
 
+	private const uint CF_UNICODETEXT = 13;
 	private const uint GMEM_MOVEABLE = 0x0002;
 	private const int HWND_MESSAGE = -3;
 
-	public static IntPtr AllocUnicodeText(string value)
+	/// <summary>
+	/// Puts <paramref name="value"/> on the clipboard, which must already be open on this thread.
+	/// </summary>
+	/// <remarks>
+	/// The allocation is freed when the call fails, because <c>SetClipboardData</c> only takes
+	/// ownership of the handle on success. Keeping both halves here is the point: a caller that
+	/// allocated separately would have to know that rule to avoid leaking on the failure path.
+	/// </remarks>
+	public static bool TrySetUnicodeText(string value, out int error)
 	{
-		// SetClipboardData requires GMEM_MOVEABLE, and takes ownership on success.
+		// SetClipboardData requires GMEM_MOVEABLE.
 		var handle = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)((value.Length + 1) * sizeof(char)));
 		var pointer = GlobalLock(handle);
 		Marshal.Copy(value.ToCharArray(), 0, pointer, value.Length);
 		Marshal.WriteInt16(pointer, value.Length * sizeof(char), 0);
 		GlobalUnlock(handle);
 
-		return handle;
+		if (SetClipboardData(CF_UNICODETEXT, handle) != IntPtr.Zero)
+		{
+			error = 0;
+			return true;
+		}
+
+		error = Marshal.GetLastWin32Error();
+		GlobalFree(handle);
+
+		return false;
 	}
 
 	/// <summary>
@@ -166,7 +201,7 @@ file static class Win32
 	public static extern bool EmptyClipboard();
 
 	[DllImport("user32.dll", SetLastError = true)]
-	public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+	private static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
 
 	[DllImport("user32.dll", SetLastError = true)]
 	public static extern bool DestroyWindow(IntPtr hwnd);
@@ -176,6 +211,9 @@ file static class Win32
 
 	[DllImport("kernel32.dll")]
 	private static extern IntPtr GlobalAlloc(uint flags, UIntPtr bytes);
+
+	[DllImport("kernel32.dll")]
+	private static extern IntPtr GlobalFree(IntPtr handle);
 
 	[DllImport("kernel32.dll")]
 	private static extern IntPtr GlobalLock(IntPtr handle);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
@@ -1,0 +1,205 @@
+#if __SKIA__
+#nullable enable
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel.DataTransfer;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.ConditionMode;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.RuntimeTestPlatforms;
+
+namespace Uno.UI.RuntimeTests.Tests;
+
+partial class Given_Clipboard // Win32 contention
+{
+	private const uint CF_UNICODETEXT = 13;
+	private const uint GMEM_MOVEABLE = 0x0002;
+	private const int HWND_MESSAGE = -3;
+	private const int ERROR_ACCESS_DENIED = 5;
+
+	private const string ContendedText = "test-string-while-contended";
+
+	/// <summary>
+	/// Reading the clipboard must not require winning <c>OpenClipboard</c>.
+	/// </summary>
+	/// <remarks>
+	/// <para><c>OpenClipboard</c> is a global exclusive lock with a single winner. When several
+	/// applications are notified of a clipboard change they all read at the same instant, so all but
+	/// one are denied — and if a denied read is treated as "the clipboard is empty", paste silently
+	/// stops working in every one of them until the next copy.</para>
+	/// <para>The lock is owned by a <em>thread</em>, so a second thread of this same process holding it
+	/// through a real window handle denies the UI thread exactly as another process would: measured
+	/// to fail with <c>ERROR_ACCESS_DENIED</c>, identically to the cross-process case. The holder also
+	/// replaces the content while holding, which bumps the clipboard sequence number immediately and
+	/// visibly to other threads — so this cannot be satisfied by a cache populated before the
+	/// contention started.</para>
+	/// </remarks>
+	[TestMethod]
+	[RunsOnUIThread]
+	[PlatformCondition(Include, SkiaWin32)]
+	public async Task When_Clipboard_Contended_Then_Content_Is_Still_Visible()
+	{
+		using var held = new ManualResetEventSlim();
+		using var release = new ManualResetEventSlim();
+		var holderTookClipboard = false;
+
+		var holder = new Thread(() =>
+		{
+			var hwnd = CreateMessageOnlyWindow();
+			try
+			{
+				// A NULL owner does NOT exclude other threads; a real window handle does.
+				holderTookClipboard = hwnd != IntPtr.Zero && OpenClipboard(hwnd);
+				if (!holderTookClipboard)
+				{
+					return;
+				}
+
+				EmptyClipboard();
+				SetClipboardData(CF_UNICODETEXT, AllocUnicodeText(ContendedText));
+			}
+			finally
+			{
+				held.Set();
+				if (holderTookClipboard)
+				{
+					release.Wait(TimeSpan.FromSeconds(30));
+					CloseClipboard();
+				}
+			}
+		})
+		{
+			IsBackground = true,
+			Name = nameof(When_Clipboard_Contended_Then_Content_Is_Still_Visible),
+		};
+
+		holder.Start();
+
+		try
+		{
+			Assert.IsTrue(held.Wait(TimeSpan.FromSeconds(30)), "the holder thread never reported back");
+			Assert.IsTrue(holderTookClipboard, "the holder thread could not take the clipboard, so there is nothing to test");
+
+			// Confirm the contention is real rather than assuming it, so this cannot quietly become a
+			// test that passes because nothing was ever holding the clipboard.
+			if (OpenClipboard(IntPtr.Zero))
+			{
+				CloseClipboard();
+				Assert.Fail("expected the clipboard to be contended, but it could be opened");
+			}
+			else
+			{
+				Assert.AreEqual(ERROR_ACCESS_DENIED, Marshal.GetLastWin32Error(), "expected the clipboard to be denied while another thread holds it");
+			}
+
+			var view = Clipboard.GetContent();
+
+			Assert.IsNotNull(view, "GetContent returned null while the clipboard was contended");
+			Assert.IsTrue(
+				view.Contains(StandardDataFormats.Text),
+				"the clipboard holds text, so it must be reported as available even while another thread holds the clipboard");
+		}
+		finally
+		{
+			release.Set();
+			holder.Join(TimeSpan.FromSeconds(30));
+		}
+
+		// And the payload, which does need the lock, must be readable once the contention is over.
+		await DelayForClipboard();
+		Assert.AreEqual(ContendedText, await Clipboard.GetContent()!.GetTextAsync());
+	}
+
+	private static IntPtr AllocUnicodeText(string value)
+	{
+		// SetClipboardData requires GMEM_MOVEABLE, and takes ownership on success.
+		var handle = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)((value.Length + 1) * sizeof(char)));
+		var pointer = GlobalLock(handle);
+		Marshal.Copy(value.ToCharArray(), 0, pointer, value.Length);
+		Marshal.WriteInt16(pointer, value.Length * sizeof(char), 0);
+		GlobalUnlock(handle);
+
+		return handle;
+	}
+
+	private static IntPtr CreateMessageOnlyWindow()
+	{
+		var className = $"UnoClipboardContentionTest{Environment.CurrentManagedThreadId}";
+		WndProcDelegate wndProc = DefWindowProc;
+		var windowClass = new WNDCLASSEX
+		{
+			cbSize = (uint)Marshal.SizeOf<WNDCLASSEX>(),
+			lpfnWndProc = Marshal.GetFunctionPointerForDelegate(wndProc),
+			hInstance = GetModuleHandle(null!),
+			lpszClassName = className,
+		};
+
+		try
+		{
+			return RegisterClassEx(ref windowClass) is 0
+				? IntPtr.Zero
+				: CreateWindowEx(0, className, className, 0, 0, 0, 0, 0, (IntPtr)HWND_MESSAGE, IntPtr.Zero, GetModuleHandle(null!), IntPtr.Zero);
+		}
+		finally
+		{
+			// The window only has to outlive the clipboard hold, but the delegate must not be collected
+			// while the class is registered.
+			GC.KeepAlive(wndProc);
+		}
+	}
+
+	private delegate IntPtr WndProcDelegate(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+	[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+	private struct WNDCLASSEX
+	{
+		public uint cbSize;
+		public uint style;
+		public IntPtr lpfnWndProc;
+		public int cbClsExtra;
+		public int cbWndExtra;
+		public IntPtr hInstance;
+		public IntPtr hIcon;
+		public IntPtr hCursor;
+		public IntPtr hbrBackground;
+		[MarshalAs(UnmanagedType.LPWStr)] public string? lpszMenuName;
+		[MarshalAs(UnmanagedType.LPWStr)] public string? lpszClassName;
+		public IntPtr hIconSm;
+	}
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern bool CloseClipboard();
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern bool EmptyClipboard();
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+
+	[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+	private static extern ushort RegisterClassEx(ref WNDCLASSEX windowClass);
+
+	[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+	private static extern IntPtr CreateWindowEx(uint exStyle, string className, string windowName, uint style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr instance, IntPtr param);
+
+	[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+	private static extern IntPtr DefWindowProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+	private static extern IntPtr GetModuleHandle(string moduleName);
+
+	[DllImport("kernel32.dll")]
+	private static extern IntPtr GlobalAlloc(uint flags, UIntPtr bytes);
+
+	[DllImport("kernel32.dll")]
+	private static extern IntPtr GlobalLock(IntPtr handle);
+
+	[DllImport("kernel32.dll")]
+	private static extern bool GlobalUnlock(IntPtr handle);
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
@@ -155,15 +155,31 @@ file static class Win32
 	/// Puts <paramref name="value"/> on the clipboard, which must already be open on this thread.
 	/// </summary>
 	/// <remarks>
-	/// The allocation is freed when the call fails, because <c>SetClipboardData</c> only takes
+	/// <para>The allocation is freed on every failing path, because <c>SetClipboardData</c> only takes
 	/// ownership of the handle on success. Keeping both halves here is the point: a caller that
-	/// allocated separately would have to know that rule to avoid leaking on the failure path.
+	/// allocated separately would have to know that rule to avoid leaking.</para>
+	/// <para>Each step is checked so that a failure is reported to the test rather than thrown: this
+	/// runs on the holder thread, where an exception would take the whole test runner down with it.</para>
 	/// </remarks>
 	public static bool TrySetUnicodeText(string value, out int error)
 	{
 		// SetClipboardData requires GMEM_MOVEABLE.
 		var handle = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)((value.Length + 1) * sizeof(char)));
+		if (handle == IntPtr.Zero)
+		{
+			error = Marshal.GetLastWin32Error();
+			return false;
+		}
+
 		var pointer = GlobalLock(handle);
+		if (pointer == IntPtr.Zero)
+		{
+			error = Marshal.GetLastWin32Error();
+			GlobalFree(handle);
+
+			return false;
+		}
+
 		Marshal.Copy(value.ToCharArray(), 0, pointer, value.Length);
 		Marshal.WriteInt16(pointer, value.Length * sizeof(char), 0);
 		GlobalUnlock(handle);
@@ -209,13 +225,13 @@ file static class Win32
 	[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
 	private static extern IntPtr CreateWindowEx(uint exStyle, string className, string? windowName, uint style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr instance, IntPtr param);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", SetLastError = true)]
 	private static extern IntPtr GlobalAlloc(uint flags, UIntPtr bytes);
 
 	[DllImport("kernel32.dll")]
 	private static extern IntPtr GlobalFree(IntPtr handle);
 
-	[DllImport("kernel32.dll")]
+	[DllImport("kernel32.dll", SetLastError = true)]
 	private static extern IntPtr GlobalLock(IntPtr handle);
 
 	[DllImport("kernel32.dll")]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.Win32.cs
@@ -39,6 +39,7 @@ partial class Given_Clipboard // Win32 contention
 		using var held = new ManualResetEventSlim();
 		using var release = new ManualResetEventSlim();
 		var holderTookClipboard = false;
+		var holderExited = false;
 
 		var holder = new Thread(() =>
 		{
@@ -99,8 +100,11 @@ partial class Given_Clipboard // Win32 contention
 		finally
 		{
 			release.Set();
-			holder.Join(TimeSpan.FromSeconds(30));
+			holderExited = holder.Join(TimeSpan.FromSeconds(30));
 		}
+
+		// A holder that never exits is still owning the clipboard, which would poison every test after this one.
+		Assert.IsTrue(holderExited, "the holder thread did not exit, so it may still be holding the clipboard");
 
 		// And the payload, which does need the lock, must be readable once the contention is over.
 		await DelayForClipboard();


### PR DESCRIPTION
**GitHub Issue:** tracked internally — no public issue to link.

## PR Type:

🐞 Bugfix

## What changed? 🚀

**Current behavior.** Run N instances of a Skia Win32 app, copy text in any one of them, and only **one** instance can paste. In the other N−1, `Clipboard.GetContent().Contains(Text)` returns `false`, `TextBox.CanPasteClipboardContent` is `false`, and the Paste item vanishes from the context menu — until the clipboard changes again, when a *different* instance wins and a different set breaks.

**Cause.** `OpenClipboard` is a global exclusive lock with exactly one winner, and it is deniable. `Win32ClipboardExtension` took that lock with a **single attempt and no retry**, materialised **every** format under it, then cached the result — successes *and failures* alike — until the next `WM_CLIPBOARDUPDATE`.

Because `AddClipboardFormatListener` broadcasts `WM_CLIPBOARDUPDATE` to every listener at once, all N instances race for the lock on the same tick. One wins; the rest get `ERROR_ACCESS_DENIED`, which the old code could not distinguish from *an empty clipboard*, and then cached that empty `DataPackage`. Three compounding defects: a denied read looked like an empty one, the failure was cached, and the read ran synchronously from `WndProc`.

This is not only a multi-instance bug — with **no** competitor at all, a single un-retried `OpenClipboard` still failed **3–13 %** of the time on an idle desktop.

### Availability no longer takes the lock

- Probe the known formats with **`IsClipboardFormatAvailable`**, which is documented lock-free and measured **100 % correct while another process holds the lock** — including the Excel-style never-rendered delay-render case, where it answers without triggering a render.
- Then make **one** non-blocking `EnumClipboardFormats` attempt for full fidelity, so app-specific format names still surface. If that attempt is denied, the package is still correct for every format Uno can decode and is simply **not cached** — the next call retries. Retry *across* calls, never inside one, so nothing on the paste-enablement path can block.
- Key the cache on **`GetClipboardSequenceNumber`** (also lock-free) rather than on `WM_CLIPBOARDUPDATE`, so a cached package can never outlive the clipboard generation it was built from. Verified that the sequence number bumps on `EmptyClipboard`/`SetClipboardData` and is visible to other processes *while the clipboard is still held*.
- A **jittered** warm-up after `WM_CLIPBOARDUPDATE` (~60/150/400 ms) fills the complete list in the background. The jitter is not cosmetic: processes woken by one broadcast back off in lockstep and collide again without it.

### Payloads are fetched lazily, on demand

Via `SetDataProvider`, one format at a time, `await`ing the lock instead of sleeping on it. This also fixes a **pre-existing use-after-free**: the old deferred providers captured an `HGLOBAL` from `GetClipboardData` and `GlobalLock`ed it *inside* the callback — i.e. after `CloseClipboard`, when the clipboard-owned handle is no longer valid. Providers now re-fetch by format id and verify the sequence number first.

### Writes stop holding the lock across arbitrary work

`SetContent` resolves all payloads **before** opening the clipboard, so it no longer pumps the event loop — dispatching arbitrary UI work, and possibly a re-entrant `WM_CLIPBOARDUPDATE` — while holding the global lock. Eager materialisation of 21 delay-rendered formats measured **976 ms**, during which every *other* application's clipboard write fails.

`SetContent` and `Clear` retry the open **10 × 100 ms** (WPF's cadence, shared by its `OleRetryCount`/`OleRetryDelay`) and now check that they actually hold the lock. Previously `ClipboardDisposable` logged the denial and continued with `_shouldClose == false`, so `SetContent` issued every `SetClipboardData` against a clipboard it had never opened, and `Clear` silently no-oped.

The retry budget is deliberately **split**: one cheap attempt on the read hot path, the full budget only on payload fetch / write. A 10 × 100 ms loop inside `GetContent()` would block the dispatcher for up to 1 s per call, per TextBox, on every clipboard change — putting `CanPasteClipboardContent` back on a global exclusive lock.

### Measured

8 instances × 3 copies, then 12 × 5, driving a real Uno app and publishing from a third-party writer (PowerShell `Set-Clipboard`):

| | dead Ctrl+V | `Set-Clipboard` retries needed |
|---|---:|---:|
| before, 8 instances | **21/24 — 87.5 %** | 1 |
| after, 8 instances | **0/24 — 0.0 %** | 0 |
| after, 12 instances | **0/60 — 0.0 %** | 0 |

87.5 % is exactly (N−1)/N. Format fidelity is preserved, not just paste: after the fix every instance reports the complete list including `DataObject` and `Ole Private Data` — app-specific names with no table entry, learnable only from `EnumClipboardFormats`.

### Chose user32 over OLE, deliberately

`OleGetClipboard` does give lock-free *enumeration*, which user32 cannot. But measurement showed its `proxy.GetData` payload path is **0 %** against raw-published content, so an OLE rewrite would have needed the same retry logic and **would not have fixed this bug**.

### The drag/drop boundary, and what did get cleaned up

Drop's decode path is deliberately **not** merged into the clipboard's: `ReadContentIntoPackage` and drop's two decoder bypasses still use the old eager path, so a clipboard fix cannot regress drop. Those readers now live in their own partial, `Win32ClipboardExtension.DragDrop.cs`, so the boundary is visible in the file layout instead of only in a comment.

The one thing that *was* unified is the pure pixel work: a single `ConvertDibToBmp(void* dib, uint dibSize)` now serves both paths, since the DIB→BMP header rewrite has nothing to do with where the handle came from. That conversion is derived from SDL, so this also adds the corresponding zlib-license notice to `THIRD-PARTY-NOTICES.md`. The remaining duplication — `GetText` ×2 and drop's decoder dispatch — is left for a follow-up.

### Commits

| | |
|---|---|
| `fix(clipboard)` | the fix itself — everything described above |
| `refactor(clipboard)` | split the drag/drop-shared readers into a partial |
| `refactor(clipboard)` | dedupe the DIB→BMP conversion; SDL attribution |
| `test(clipboard)` | scope the test's P/Invokes to a `file static class` so a sibling partial cannot reach them |

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

`Given_Clipboard.Win32.cs` asserts the contention is *real* before asserting the fix: a background thread takes `OpenClipboard` from a message-only window and holds it, and the test fails unless `OpenClipboard` is genuinely denied with `ERROR_ACCESS_DENIED`. Confirmed to discriminate — reverting only the clipboard file makes it fail with the bug's exact log signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
