### PR TITLE
fix: Unblock master after the 7.0 merge (validation gate, AndroidX pins, Maui net11 split)

### DIFF
--- a/build/ci/scripts/validate-packages-json.ps1
+++ b/build/ci/scripts/validate-packages-json.ps1
@@ -18,6 +18,10 @@
 #>
 param(
     [string]$PackagesJsonPath,
+    # TFM of the base pin set - the framework a group applies to when it has no
+    # versionOverride. Resolved from $(NetPrevious) in Directory.Build.props when not
+    # supplied, so it cannot drift out of sync the way the previous hardcoded value did.
+    [string]$BaseTfm,
     [switch]$WarningOnly
 )
 
@@ -26,17 +30,32 @@ $ErrorActionPreference = 'Stop'
 # Auto-detect: only fail on master or PRs targeting master.
 # All other branches (release, feature, dev) use warning-only mode since they
 # may reference packages not yet published to NuGet.org.
+#
+# Build.SourceBranch always carries the refs/heads/ prefix, but ADO supplies
+# System.PullRequest.TargetBranch WITHOUT it for GitHub pull requests. Normalize both
+# before comparing, otherwise every PR to master silently falls through to warning-only
+# and the check only ever fails post-merge, on master, where it blocks everyone.
 if (-not $WarningOnly) {
-    $branch = $env:BUILD_SOURCEBRANCH
-    $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-    $isMaster = $branch -eq 'refs/heads/master'
-    $isPRToMaster = $targetBranch -eq 'refs/heads/master'
+    $branch = ($env:BUILD_SOURCEBRANCH -replace '^refs/heads/', '')
+    $targetBranch = ($env:SYSTEM_PULLREQUEST_TARGETBRANCH -replace '^refs/heads/', '')
+    $isMaster = $branch -eq 'master'
+    $isPRToMaster = $targetBranch -eq 'master'
 
     if (-not $isMaster -and -not $isPRToMaster) {
-        Write-Host "Non-master branch (source: $branch, target: $targetBranch) - running in warning-only mode." -ForegroundColor Yellow
+        Write-Host "Not master and not a PR to master (source: $branch, target: $targetBranch) - running in warning-only mode." -ForegroundColor Yellow
         $WarningOnly = $true
     }
 }
+
+# Base pin set TFM: read $(NetPrevious) from Directory.Build.props unless overridden.
+if (-not $BaseTfm) {
+    $propsPath = Join-Path $PSScriptRoot '../../../Directory.Build.props'
+    if (-not (Test-Path $propsPath)) { throw "Cannot resolve BaseTfm: $propsPath not found." }
+    $match = Select-String -Path $propsPath -Pattern '<NetPrevious>([^<]+)</NetPrevious>' | Select-Object -First 1
+    if (-not $match) { throw "Cannot resolve BaseTfm: <NetPrevious> not found in $propsPath." }
+    $BaseTfm = $match.Matches[0].Groups[1].Value
+}
+Write-Host "Base pin set TFM: $BaseTfm"
 
 # Resolve path
 if (-not $PackagesJsonPath) {
@@ -225,14 +244,14 @@ function Test-DependencyFloors($Pinned, [string]$SetLabel, [string]$TfmPrefix, [
     }
 }
 
-# Effective pin sets: base versions (net9.0 apps) plus one set per versionOverride TFM.
+# Effective pin sets: base versions ($BaseTfm apps) plus one set per versionOverride TFM.
 $overrideTfms = @()
 foreach ($group in $json) {
     if ($group.PSObject.Properties['versionOverride'] -and $null -ne $group.versionOverride) {
         $overrideTfms += $group.versionOverride.PSObject.Properties.Name
     }
 }
-$tfmSets = @(@{ Label = 'base/net9.0'; Tfm = 'net9.0'; OverrideKey = $null })
+$tfmSets = @(@{ Label = "base/$BaseTfm"; Tfm = $BaseTfm; OverrideKey = $null })
 foreach ($tfm in ($overrideTfms | Sort-Object -Unique)) {
     $tfmSets += @{ Label = $tfm; Tfm = $tfm; OverrideKey = $tfm }
 }
@@ -282,7 +301,7 @@ if ($errors.Count -gt 0) {
     }
     if ($WarningOnly) {
         Write-Host ""
-        Write-Host "Running in warning-only mode (stable branch) - not failing the build." -ForegroundColor Yellow
+        Write-Host "Running in warning-only mode (not master, not a PR to master) - not failing the build." -ForegroundColor Yellow
         exit 0
     }
     exit 1

--- a/src/Uno.Sdk/Services/PackageManifest.cs
+++ b/src/Uno.Sdk/Services/PackageManifest.cs
@@ -169,5 +169,16 @@ internal class PackageManifest
 		public const string AndroidXWear = nameof(AndroidXWear);
 		public const string AndroidXWearTiles = nameof(AndroidXWearTiles);
 		public const string Maui = nameof(Maui);
+
+		// Microsoft.Maui.Controls.Compatibility is kept in its own group because it is no
+		// longer built or shipped as of .NET 11 Preview 6, while Microsoft.Maui.Controls and
+		// Microsoft.Maui.Graphics continue to ship. Sharing the Maui group would apply that
+		// group's net11 override to a package that has no net11 version, which fails the
+		// packages.json validation. Splitting it lets the net11 override cover only the
+		// packages that still exist, while net10 and earlier keep a deterministic pin.
+		// MauiVersion updates both groups, so the public override still moves all of the
+		// MAUI packages together.
+		// https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview6/dotnetmaui.md
+		public const string MauiCompatibility = nameof(MauiCompatibility);
 	}
 }

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -284,7 +284,10 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 			.UpdateManifest(PackageManifest.Group.Extensions, UnoExtensionsVersion)
 			.UpdateManifest(PackageManifest.Group.Toolkit, UnoToolkitVersion)
 			.UpdateManifest(PackageManifest.Group.Themes, UnoThemesVersion)
-			.UpdateManifest(PackageManifest.Group.Maui, MauiVersion);
+			.UpdateManifest(PackageManifest.Group.Maui, MauiVersion)
+			// MauiCompatibility is a separate group only so the net11 override does not apply
+			// to it - MauiVersion must still move all of the MAUI packages together.
+			.UpdateManifest(PackageManifest.Group.MauiCompatibility, MauiVersion);
 	}
 
 	private UnoFeature[] GetFeatures()

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -231,7 +231,7 @@
 	},
 	{
 		"group": "AndroidXRecyclerView",
-		"version": "1.4.0.3",
+		"version": "1.4.0.5",
 		"packages": [
 			"Xamarin.AndroidX.RecyclerView"
 		],
@@ -241,7 +241,7 @@
 	},
 	{
 		"group": "AndroidXActivity",
-		"version": "1.10.1.3",
+		"version": "1.12.4.1",
 		"packages": [
 			"Xamarin.AndroidX.Activity"
 		],
@@ -261,7 +261,7 @@
 	},
 	{
 		"group": "AndroidXSwipeRefreshLayout",
-		"version": "1.1.0.29",
+		"version": "1.2.0.2",
 		"packages": [
 			"Xamarin.AndroidX.SwipeRefreshLayout"
 		],
@@ -324,7 +324,7 @@
 	},
 	{
 		"group": "AndroidXCollection",
-		"version": "1.5.0.3",
+		"version": "1.5.0.5",
 		"packages": [
 			"Xamarin.AndroidX.Collection",
 			"Xamarin.AndroidX.Collection.Ktx"

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -338,12 +338,18 @@
 		"version": "10.0.90",
 		"packages": [
 			"Microsoft.Maui.Controls",
-			"Microsoft.Maui.Controls.Compatibility",
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
 			"net11.0": "11.0.0-preview.7.26406.9"
 		}
+	},
+	{
+		"group": "MauiCompatibility",
+		"version": "10.0.90",
+		"packages": [
+			"Microsoft.Maui.Controls.Compatibility"
+		]
 	},
 	{
 		"group": "CSharpMarkup",

--- a/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
@@ -61,7 +61,14 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Markup" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';csharpmarkup;'))" />
 		<_UnoProjectSystemPackageReference Include="Microsoft.Maui.Controls" ProjectSystem="true" />
-		<_UnoProjectSystemPackageReference Include="Microsoft.Maui.Controls.Compatibility" ProjectSystem="true" />
+		<!-- Microsoft.Maui.Controls.Compatibility is no longer built or shipped as of .NET 11
+		     Preview 6 (https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview6/dotnetmaui.md).
+		     The compatibility-named handler and layout base types it exposed are compiled into
+		     Microsoft.Maui.Controls.Core, so net11+ needs no reference. -->
+		<_UnoProjectSystemPackageReference Include="Microsoft.Maui.Controls.Compatibility" ProjectSystem="true"
+			Condition=" '$(TargetFramework)' != ''
+				AND $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) != ''
+				AND $([MSBuild]::VersionLessThan($([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')), '11.0')) " />
 		<_UnoProjectSystemPackageReference Include="Microsoft.Maui.Graphics" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Microsoft.Maui.Controls.Build.Tasks" ProjectSystem="true" Condition="$(SingleProject) == 'true'"/>
 


### PR DESCRIPTION
**GitHub Issue:** No specific issue — internal maintenance, follow-up of #23471

## PR Type:

🐞 Bugfix

## What changed? 🚀

`master` has been red since the 7.0 merge (#23471). Build [231628](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=231628&view=results) fails in **Setup → Validations → "Validate packages.json (NuGet existence check)"** with 5 errors, blocking every build on `master`.

Three independent problems, one per commit.

---

### 1. The validation gate has been inert on every PR since May

`Build.SourceBranch` carries the `refs/heads/` prefix; ADO supplies `System.PullRequest.TargetBranch` **without** it for GitHub PRs. So `$targetBranch -eq 'refs/heads/master'` never matched, and every PR to `master` fell through to warning-only mode. #23471's own build ([231590](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=231590&view=results)) logged it:

```
Non-master branch (source: refs/pull/23471/merge, target: master)
  - running in warning-only mode.
VALIDATION WARNINGS - 5 package(s) not found on NuGet.org (non-fatal):
```

**It found these same 5 errors two hours before the merge and downgraded them to warnings.**

This is a regression, not the original design: the pre-refactor logic matched both forms (`'feature/*'` *and* `'refs/heads/feature/*'`), and that tolerance was dropped in 0ad9e5f (2026-05-08) while simplifying branch detection. Both values are now normalized. The message describing a PR-to-master as a *"stable branch"* is corrected too.

> [!IMPORTANT]
> Once this lands, PRs enforce again — **any in-flight PR with a manifest problem will start failing** where it previously passed with warnings. That is the intent, but it may surface issues accumulated since May.

### 2. The validation base TFM was hardcoded to `net9.0`

7.0 moved to net10/net11 (`NetPrevious` = `net10.0`), so the base pin set was being validated against a framework the SDK no longer supports. It is now read from `$(NetPrevious)` in `Directory.Build.props` — the same value the build itself uses — so it cannot drift on the next TFM shift. A `-BaseTfm` parameter allows overriding it.

### 3. The net10 base pin set was internally incoherent

The 7.0 restructuring moved each group's base version down a slot (base is now net10, overrides are net11) and raised `Xamarin.AndroidX.Wear` from `1.3.0.15` to `1.4.0.1` **without raising its companion packages**:

| Package | Was | Now | Required via |
|---|---|---|---|
| `Xamarin.AndroidX.Collection` | 1.5.0.3 | **1.5.0.5** | Wear to Core.Core.Ktx to Core |
| `Xamarin.AndroidX.Activity` | 1.10.1.3 | **1.12.4.1** | Wear to Fragment |
| `Xamarin.AndroidX.RecyclerView` | 1.4.0.3 | **1.4.0.5** | Wear |
| `Xamarin.AndroidX.SwipeRefreshLayout` | 1.1.0.29 | **1.2.0.2** | Wear |

Pre-merge the set was coherent because the base was Wear `1.3.0.14`, whose floors were exactly `RecyclerView 1.4.0.2` / `SwipeRefreshLayout 1.1.0.28`. The net11 override set already satisfied Wear `1.4.0.2` and validated clean throughout.

### 4. `Microsoft.Maui.Controls.Compatibility` no longer exists for net11

Per the [.NET 11 Preview 6 release notes](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview6/dotnetmaui.md) and [What's new in .NET MAUI for .NET 11](https://learn.microsoft.com/en-us/dotnet/maui/whats-new/dotnet-11?view=net-maui-10.0):

> *"Starting in .NET 11 Preview 6, the optional `Microsoft.Maui.Controls.Compatibility` NuGet package is no longer built or shipped."*

Deprecated in MAUI 9, removed to shed Xamarin.Forms-era infrastructure. It publishes `11.0.0-preview.1` through `preview.5` and then stops, so the `Maui` group's net11 override pointed at a version that does not exist. `Microsoft.Maui.Controls` and `Microsoft.Maui.Graphics` **do** publish at `preview.7.26406.9`.

**What this does**

- Moves `Microsoft.Maui.Controls.Compatibility` into its own **`MauiCompatibility`** group pinned at `10.0.90`, with **no net11 override** — so the override covers only the packages that still exist. `Controls` and `Graphics` stay on preview.7.
- Keeps **`MauiVersion` wired to both groups**, so the documented public override still moves all of the MAUI packages together.
- **Conditions the implicit reference off for net11 and later.** The compatibility-named handler and layout base types it exposed are compiled into `Microsoft.Maui.Controls.Core`, so net11 needs no reference. net10 and earlier are unchanged.

The rationale is recorded in-code on the `PackageManifest.Group.MauiCompatibility` constant and at the `UpdateManifest` call site — `packages.json` is read with `JsonSerializerDefaults.Web`, which does not enable comment handling, so the manifest itself cannot carry it.

**Three alternatives were rejected**

| Alternative | Why not |
|---|---|
| Pin the whole `Maui` group back to `preview.5` | The net11 band is aligned on preview.7 across the repo — `DotNetSdkVersion`, `Microsoft.Win32.SystemEvents`, `Microsoft.Android.Ref.37`, and a runtime-pack workaround in `Uno.CrossTargetting.targets` keyed on `11.0.0-preview.7.26381.103`. MAUI would sit two bands behind, and it would need undoing at preview.8 |
| Drop the package from the manifest entirely | `PackageManifest.GetPackageVersion` returns `null` when no group lists the id, and `ImplicitPackagesResolver.AddPackage` then **warns and resolves live from NuGet.org** — non-deterministic version plus a build-time network dependency on every net9/net10 `mauiembedding` build |
| Split the group but leave `MauiVersion` on `Maui` only | Would silently desynchronise a lockstep-versioned package set. The templates bind `.Compatibility` to `$(MauiVersion)` directly (`unoapp` and `unomauilib` `Directory.Packages.props`), so `Controls` would move while `.Compatibility` stayed at `10.0.90` |

The group deliberately has **no MSBuild override property of its own**. 42 of the 43 existing groups do, but adding one would extend the SDK's public surface — `MauiCompatibilityVersion`, its `Sdk.props.buildschema.json` entry and the `uno.templates` ReadMe table — to manage a package Microsoft has retired. The ReadMe generator only substitutes `$GroupName$` placeholders already present in its template, so no row is added or broken.

The condition reuses the SDK's existing idiom, including the parsed-value guard from `Uno.SingleProject.Wasm.targets:36`:

```xml
Condition=" '$(TargetFramework)' != ''
  AND $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) != ''
  AND $([MSBuild]::VersionLessThan($([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')), '11.0')) "
```

---

## Validation

**Validator run**, simulating a PR to `master` — the case that was silently passing:

```
BUILD_SOURCEBRANCH=refs/pull/99999/merge SYSTEM_PULLREQUEST_TARGETBRANCH=master
  pwsh -File build/ci/scripts/validate-packages-json.ps1
       -PackagesJsonPath src/Uno.Sdk/packages.json

Base pin set TFM: net10.0
Checked 122 package/version combinations.
Validating dependency coherence for pin set 'base/net10.0'...
Validating dependency coherence for pin set 'net11.0'...
Checked dependency coherence for 36 pinned package/set combinations.
All packages validated successfully.
```

**`Uno.Sdk` builds clean** with the C# changes: `Build succeeded. 0 Warning(s) 0 Error(s)`.

**MSBuild condition**, evaluated directly per TFM:

| TargetFramework | reference emitted |
|---|---|
| `net9.0`, `net10.0`, `net10.0-android36.0` | yes |
| `net11.0`, `net11.0-ios26.5`, `net12.0` | no |
| *(empty)* | no — guard holds |

`netstandard2.0` also evaluates true, which is inert: the whole `ItemGroup` is gated on `$(UnoFeatures.Contains(';mauiembedding;'))`.

**Not backported to `servicing/6.8`** — deliberately. That branch still supports net9, so its base pin set genuinely *is* `net9.0`, its AndroidX base pins are the coherent net9-era set, and its `Maui` group has no net11 override. Build [231641](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=231641&view=results) passes this task there unchanged.

## Follow-ups (not in this PR)

> [!WARNING]
> **`uno.templates` must drop `Microsoft.Maui.Controls.Compatibility` from its own `Maui` group before it bumps `SdkVersion` to a private SDK containing this change.** This is an ordering requirement, not a nicety.
>
> The public `Uno.Sdk` package is assembled in `uno.templates`: `src/Uno.Sdk/Uno.Sdk.csproj` downloads `Uno.Sdk.Private` (this repo, `PackageId` at `src/Uno.Sdk/Uno.Sdk.csproj:8`), and `BundleSdkAssets` packs its `.dll`/`.props`/`.targets`/`.buildschema.json` — **but not its `packages.json`**. The manifest that ships to users comes from `uno.templates`' own `src/Uno.Sdk/packages.json`, packed to `targets/netstandard2.0/packages.json` via `Uno.Sdk.Updater.props`. So the resolver assembly and the manifest it reads ship from **two different repos**.
>
> `Uno.Sdk.Updater` keys its merge on group *name* only and never reconciles a group's `packages` array (`MergeLocalOverridesOnly` / `MergeLocalManifest` in `tools/Uno.Sdk.Updater/Program.cs`). It would add `MauiCompatibility` as a brand-new group while leaving `Microsoft.Maui.Controls.Compatibility` in the local `Maui` group — putting the id in **two** groups. `PackageManifest.GetPackageVersion` resolves with `SingleOrDefault`, which **throws** `Sequence contains more than one matching element` on a duplicate — a hard build failure for every `mauiembedding` consumer on net9/net10, not a warning or a fallback.
>
> `servicing/6.8` is unaffected: it pulls 6.8 private SDKs, which do not carry this change. The exposure is the 7.0 templates branch only.
>
> Two things are worth doing there: remove the id from the local `Maui` group in the same change as the `SdkVersion` bump, and — durably — teach the updater to treat the SDK manifest as authoritative for group membership, or at least fail on a duplicate id, so the next group split can't reintroduce this. Its templates also bind `Microsoft.Maui.Controls.Compatibility` to `$(MauiVersion)` unconditionally in `unoapp` and `unomauilib` `Directory.Packages.props`, which needs conditioning for net11 there.

- **`uno.extensions`** declares `<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />` in `Uno.Extensions.Maui.WinUI` and `Uno.Extensions.Maui.WinUI.Markup`. That resolves against whatever SDK manifest *its own* build uses, so it does not affect `master` here, but it will need removing on that repo's 7.0 branch — and someone should confirm MAUI embedding behaves on net11 without the compatibility renderers. Worth its own issue with the MAUI-embedding owner.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) — n/a: CI script, package manifest, SDK targets and the SDK task. Validated by running the validator, building `Uno.Sdk`, and evaluating the MSBuild condition (output above)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) — n/a
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a, no rendering change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

On the "no breaking changes" box: dropping the `Microsoft.Maui.Controls.Compatibility` implicit reference on net11 is not a breaking change — the package does not exist for net11, so no net11 project can be consuming it today. net10 and earlier keep both the reference and the existing `MauiVersion` override behaviour.

