### PR TITLE
ci: Build and publish from servicing/* branches

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
       - master
+      - servicing/*
       - release/beta/*
       - release/stable/*
       - feature/*
@@ -24,6 +25,7 @@ pr:
   branches:
     include:
       - master
+      - servicing/*
       - release/beta/*
       - release/stable/*
       - feature/*

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -169,6 +169,10 @@ stages:
 ##
 ## Publishing
 ##
+# A servicing/* branch continues a previous version line after master has moved on
+# to a newer one, so it publishes dev packages the same way master does. The same
+# pattern is added to the CI triggers, the dev-feed push step and version.json's
+# publicReleaseRefSpec.
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet'
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))

--- a/build/ci/.azure-devops-stages.yml
+++ b/build/ci/.azure-devops-stages.yml
@@ -171,7 +171,7 @@ stages:
 ##
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet'
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
   dependsOn: binaries_build_winui
   jobs:
   - template: publish/.azure-devops-publish-nuget-dev.yml

--- a/build/ci/templates/nuget-publish-dev.yml
+++ b/build/ci/templates/nuget-publish-dev.yml
@@ -1,4 +1,6 @@
 steps:
+  # A servicing/* branch continues a previous version line after master has moved on
+  # to a newer one, so its packages reach the dev feed the same way master's do.
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))

--- a/build/ci/templates/nuget-publish-dev.yml
+++ b/build/ci/templates/nuget-publish-dev.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/nuget-packages/**/*.nupkg'

--- a/version.json
+++ b/version.json
@@ -7,6 +7,7 @@
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/feature/.*$",
+    "^refs/heads/servicing/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {


### PR DESCRIPTION
**GitHub Issue:** No specific issue — internal maintenance, release-process plumbing

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Teaches this repo's pipeline about `servicing/*` branches.

A `servicing/*` branch continues a previous version line after `master` has moved on to a newer one, so that clients still on that line keep getting dev packages to validate fixes against before we backport them to a service release. Without CI support, such a branch builds nothing.

| Change | Why |
|---|---|
| `servicing/*` in `trigger.branches` and `pr.branches` (`.vsts-ci.yml`) | the branch builds at all, and PRs into it run |
| `servicing/` in the `Publish_Dev` stage condition (`build/ci/.azure-devops-stages.yml`) | the dev publish stage runs for it |
| `servicing/` in the dev-feed push step (`build/ci/templates/nuget-publish-dev.yml`) | packages also reach the internal dev feed, matching `master` |
| `^refs/heads/servicing/.*$` in `publicReleaseRefSpec` (`version.json`) | NBGV emits a clean `X.Y.0-dev.N` rather than appending a commit hash |

The nuget.org publish template needs no change — its condition is already "not a feature branch and not a PR", which `servicing/*` satisfies.

## Why this is inert on `master`

Every edit adds a branch pattern inside an existing `or(...)`, or appends an entry to a list. Nothing that `master` matches today changes, so `master` builds and publishes exactly as before. The only observable difference is for branches named `servicing/*`, of which there is currently one.

## Why it belongs on `master` rather than only on the servicing branch

This already exists on [`servicing/6.8`](https://github.com/unoplatform/uno/tree/servicing/6.8) — commit `18a7a9f6` — which is how it publishes `6.8.0-dev.*` today. But it lives *only* there, which leaves three problems:

- **The next servicing branch won't inherit it.** Cutting one from `master` later means rediscovering and redoing all four edits.
- **The branches conflict when they touch.** Any sync or cherry-pick across these four files hits a conflict that looks like a real disagreement but is only the missing plumbing.
- **It's undiscoverable.** Nothing on `master` indicates that `servicing/*` is a supported branch pattern.

Landing it here makes the pattern canonical. The equivalent change is going into the downstream repos alongside their version bumps — [`uno.toolkit.ui#1634`](https://github.com/unoplatform/uno.toolkit.ui/pull/1634) and `uno.csharpmarkup#904` — so all repos describe the pattern the same way.

## Validation

**Code review / static** — the four conditions were compared against the working copies on `servicing/6.8`; the resulting expressions are identical apart from `master` vs the servicing branch name. No pipeline behaviour on `master` is reachable by the added patterns.

**Runtime evidence from the servicing branch** — the same four edits on `servicing/6.8` produce `6.8.0-dev.142`, published to nuget.org, continuing unbroken from `master`'s last `6.8.0-dev.141`. `nbgv get-version` on a `servicing/*` branch returns a clean version with no hash suffix only once the `publicReleaseRefSpec` entry is present, which is what that entry is for.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) — n/a: pipeline YAML and version metadata only
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) — n/a
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a, no rendering change
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

> [!NOTE]
> `master` is currently red on the `packages.json` validation gate, which [#24360](https://github.com/unoplatform/uno/pull/24360) fixes. This PR will show the same failure until that one merges — it is unrelated to the changes here.
