### PR TITLE
fix: Align Uno.Fonts pins with the shipped manifest

### DIFF
--- a/build/nuget/Uno.WinUI.nuspec
+++ b/build/nuget/Uno.WinUI.nuspec
@@ -46,7 +46,7 @@
 				<dependency id="System.Memory" version="4.5.2" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
 				<dependency id="System.Collections.Immutable" version="1.3.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.6.1" />
+				<dependency id="Uno.Fonts.Fluent" version="2.9.4" />
 				<dependency id="Uno.WinRT" version="2.4.5" />
 				<dependency id="SkiaSharp" version="4.151.1" />
 				<dependency id="HarfBuzzSharp" version="14.2.1.1" />
@@ -56,7 +56,7 @@
 			<group targetFramework="net11.0">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.6.1" />
+				<dependency id="Uno.Fonts.Fluent" version="2.9.4" />
 				<dependency id="Uno.WinRT" version="2.4.5" />
 				<dependency id="SkiaSharp" version="4.151.1" />
 				<dependency id="HarfBuzzSharp" version="14.2.1.1" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -143,7 +143,7 @@
 		<PackageReference Update="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
-		<PackageReference Update="Uno.Fonts.Fluent" version="2.6.1" />
+		<PackageReference Update="Uno.Fonts.Fluent" version="2.9.4" />
 		<PackageReference Update="Uno.Resizetizer" Version="1.11.0-dev.17" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 		<PackageReference Update="Xamarin.UITest" Version="4.3.5" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -143,7 +143,7 @@
 		<PackageReference Update="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
-		<PackageReference Update="Uno.Fonts.Fluent" version="2.9.4" />
+		<PackageReference Update="Uno.Fonts.Fluent" Version="2.9.4" />
 		<PackageReference Update="Uno.Resizetizer" Version="1.11.0-dev.17" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 		<PackageReference Update="Xamarin.UITest" Version="4.3.5" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -144,6 +144,7 @@
 		<PackageReference Update="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.Fonts.Fluent" Version="2.9.4" />
+		<PackageReference Update="Uno.Fonts.OpenSans" Version="2.9.4" />
 		<PackageReference Update="Uno.Resizetizer" Version="1.11.0-dev.17" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 		<PackageReference Update="Xamarin.UITest" Version="4.3.5" />

--- a/src/SamplesApp/Directory.Build.targets
+++ b/src/SamplesApp/Directory.Build.targets
@@ -11,6 +11,6 @@
 	</Target>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.4.5" Condition="'$(IsUnoHead)'=='true'" />
+		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" Condition="'$(IsUnoHead)'=='true'" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/Uno.UI.RuntimeTests.AlcApp.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/Uno.UI.RuntimeTests.AlcApp.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.7.1" />
+		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" />
 
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />

--- a/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/Uno.UI.RuntimeTests.AlcApp.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/AssemblyLoadContext/AlcApp/Uno.UI.RuntimeTests.AlcApp.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" />
+		<PackageReference Include="Uno.Fonts.OpenSans" />
 
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" />
+		<PackageReference Include="Uno.Fonts.OpenSans" />
 		<PackageReference Include="Uno.icu-win" />
 
 		<!--

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="HarfBuzzSharp" Version="14.2.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.36.0-dev.124" />
 		<PackageReference Include="Uno.Fonts.Fluent" />
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.7.1" />
+		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" />
 		<PackageReference Include="Uno.icu-win" />
 
 		<!--

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRUnoLib/Uno.UI.RuntimeTests.HRUnoLib.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRUnoLib/Uno.UI.RuntimeTests.HRUnoLib.csproj
@@ -40,7 +40,7 @@
 		<Reference Include="$(_UnoBaseReferenceBinPath)/*.dll" Exclude="@(UnoReferenceExclusion)" />
 
 		<PackageReference Include="Uno.Fonts.Fluent" />
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" />
+		<PackageReference Include="Uno.Fonts.OpenSans" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\..\..\Uno.UI.Runtime.Skia.X11\buildTransitive\*.Skia.X11.props" />

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRUnoLib/Uno.UI.RuntimeTests.HRUnoLib.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRUnoLib/Uno.UI.RuntimeTests.HRUnoLib.csproj
@@ -40,7 +40,7 @@
 		<Reference Include="$(_UnoBaseReferenceBinPath)/*.dll" Exclude="@(UnoReferenceExclusion)" />
 
 		<PackageReference Include="Uno.Fonts.Fluent" />
-		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.7.1" />
+		<PackageReference Include="Uno.Fonts.OpenSans" Version="2.9.4" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\..\..\Uno.UI.Runtime.Skia.X11\buildTransitive\*.Skia.X11.props" />


### PR DESCRIPTION
**GitHub Issue:** Relates to #24376 (that issue needs BOTH this PR and its sibling; using "Relates to" so whichever merges first does not auto-close it with the other half outstanding)

## PR Type:

🐞 Bugfix

## What changed? 🚀

`Uno.Fonts.Fluent` was pinned at **2.6.1** in three places while the `Uno.Sdk` manifest ships the `UnoFonts` group at **2.9.4**, and `SamplesApp` pinned `Uno.Fonts.OpenSans` at **2.4.5**.

| File | From | To |
|---|---|---|
| `src/Directory.Build.targets:146` | Fluent 2.6.1 | 2.9.4 |
| `build/nuget/Uno.WinUI.nuspec:49,:59` | Fluent 2.6.1 | 2.9.4 |
| `src/SamplesApp/Directory.Build.targets:14` | OpenSans 2.4.5 | 2.9.4 |

The stale value is **published**: `Uno.WinUI 7.0.0-dev.645`'s nuspec declares `<dependency id=Uno.Fonts.Fluent version=2.6.1 />`. It is not a hard break — the SDK injects 2.9.4 and that satisfies a 2.6.1 floor — but anyone consuming `Uno.WinUI` *without* the `Uno.Sdk` resolves the old font package, and the declared floor should state what we actually ship.

2.9.4 is the current stable for both packages.

## Validation

**Inspection only** — a version-pin change with no code effect. Not built locally; CI is the gate. The nuspec edit is the one worth a reviewer's eye, since it changes the published dependency floor.

Byte-level care: the three files differ in BOM (the nuspec has one, the two targets files do not), so edits were applied byte-exactly to avoid a spurious BOM change on line 1.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests (n/a — version pin)
- [ ] 📚 Docs
- [ ] 🖼️ Validated PR Screenshots Compare Test Run results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vRaBaNK2HnyWeg3TBzEu6

