### PR TITLE
feat!: Put WinAppSDK uniformly on 2.4.0

### DIFF
--- a/build/nuget/Uno.WinUI.Graphics2DSK.nuspec
+++ b/build/nuget/Uno.WinUI.Graphics2DSK.nuspec
@@ -17,7 +17,7 @@
 			</group>
 
 			<group targetFramework="net10.0-windows10.0.19041.0">
-				<dependency id="Microsoft.WindowsAppSDK" version="1.5.240227000" />
+				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
 				<dependency id="SkiaSharp" version="4.151.1" />
 			</group>
 

--- a/build/nuget/Uno.WinUI.nuspec
+++ b/build/nuget/Uno.WinUI.nuspec
@@ -19,11 +19,11 @@
 			<!-- References from Uno.UI.Extras -->
 			<!-- BEGIN UWP-excluded -->
 			<group targetFramework="net10.0-windows10.0.19041.0">
-				<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
+				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
 				<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
 			</group>
 			<group targetFramework="net11.0-windows10.0.19041.0">
-				<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
+				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
 				<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
 			</group>
 			<!-- END UWP-excluded -->

--- a/build/nuget/Uno.WinUI.nuspec
+++ b/build/nuget/Uno.WinUI.nuspec
@@ -20,11 +20,11 @@
 			<!-- BEGIN UWP-excluded -->
 			<group targetFramework="net10.0-windows10.0.19041.0">
 				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
-				<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
+				<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.28000.2526" />
 			</group>
 			<group targetFramework="net11.0-windows10.0.19041.0">
 				<dependency id="Microsoft.WindowsAppSDK" version="2.4.0" />
-				<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
+				<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.28000.2526" />
 			</group>
 			<!-- END UWP-excluded -->
 

--- a/src/AddIns/Uno.WinUI.Graphics2DSK/Uno.WinUI.Graphics2DSK.Windows.csproj
+++ b/src/AddIns/Uno.WinUI.Graphics2DSK/Uno.WinUI.Graphics2DSK.Windows.csproj
@@ -22,8 +22,9 @@
 		<WindowsPackageType>None</WindowsPackageType>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.6.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/Uno.WinUI.Graphics3DGL.csproj
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/Uno.WinUI.Graphics3DGL.csproj
@@ -55,8 +55,9 @@
 				<WindowsPackageType>None</WindowsPackageType>
 			</PropertyGroup>
 			<ItemGroup>
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
-				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" PrivateAssets="all" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" PrivateAssets="all" />
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.6.0" PrivateAssets="all" />
 				<PackageReference Include="Uno.Core.Extensions.Disposables" />
 
 				<Compile Include="Windows\WindowsRenderingNativeMethods.cs" />

--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -210,7 +210,7 @@
 
 	<!-- Windows / WinAppSDK packages (real WinUI) -->
 	<ItemGroup Condition="'$(_Platform)' == 'windows'">
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.6.0" PrivateAssets="all" />
 		<PackageReference Include="CommunityToolkit.WinUI.Lottie" Version="8.0.0-rc" />

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -117,7 +117,7 @@
 	},
 	{
 		"group": "WinAppSdk",
-		"version": "2.3.1",
+		"version": "2.4.0",
 		"packages": [
 			"Microsoft.WindowsAppSDK"
 		]

--- a/src/Uno.UI.Extras/Uno.UI.Extras.Windows.csproj
+++ b/src/Uno.UI.Extras/Uno.UI.Extras.Windows.csproj
@@ -69,7 +69,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
 
 		<PackageReference Include="PolySharp" Version="1.14.1">

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Windows.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Windows.csproj
@@ -62,7 +62,7 @@
 		<PackageReference Include="Uno.Core.Extensions.Disposables" />
 		<PackageReference Include="Uno.Core.Extensions.Compatibility" />
 		<PackageReference Include="Uno.Core.Extensions" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
 
 		<!-- We remove Unit tests imported from MUX on UAP as they are usualy heavily relying on internal classes.-->

--- a/src/Uno.WinAppSDKSyncGenerator.References/Uno.WinAppSDKSyncGenerator.References.csproj
+++ b/src/Uno.WinAppSDKSyncGenerator.References/Uno.WinAppSDKSyncGenerator.References.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
 		<!-- Explicit reference needed: WebView2 uses lib_manual/ with conditional MSBuild targets
 		     that may not resolve reliably as a transitive dependency of WindowsAppSDK. -->
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3856.49" />


### PR DESCRIPTION
**GitHub Issue:** Relates to #24376 (that issue needs BOTH this PR and its sibling; using "Relates to" so whichever merges first does not auto-close it with the other half outstanding)

## PR Type:

✨ Feature (dependency major)

## What changed? 🚀

Eight sites referenced **four different** WinAppSDK versions. They are now uniformly **2.4.0**.

| Location | Was | Now |
|---|---|---|
| `build/nuget/Uno.WinUI.nuspec:22,:26` | **1.0.0** | 2.4.0 |
| `build/nuget/Uno.WinUI.Graphics2DSK.nuspec:20` | 1.5.240227000 | 2.4.0 |
| `AddIns/Uno.WinUI.Graphics2DSK/…Windows.csproj:25` | 1.5.240227000 | 2.4.0 |
| `AddIns/Uno.WinUI.Graphics3DGL/….csproj:58` | 1.5.240227000 | 2.4.0 |
| `SamplesApp/SamplesApp.csproj:213` | 2.3.1 | 2.4.0 |
| `Uno.UI.Extras/Uno.UI.Extras.Windows.csproj:72` | 2.3.1 | 2.4.0 |
| `Uno.UI.RuntimeTests.Windows.csproj:65` | 2.3.1 | 2.4.0 |
| `Uno.WinAppSDKSyncGenerator.References.csproj:15` | 2.3.1 | 2.4.0 |

**The `1.0.0` in `Uno.WinUI.nuspec` is the important one.** It is published — `Uno.WinUI 7.0.0-dev.645` carries `<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />` — so Uno's own metadata claimed 7.0 works against a WinAppSDK from 2021. It has not caused visible breakage because apps resolve WinAppSDK from the `Uno.Sdk` manifest, not from this dependency; the floor only bites consumers referencing `Uno.WinUI` directly.

`Microsoft.Windows.SDK.BuildTools` moves with the two add-ins (10.0.22621.756 → 10.0.28000.2526, matching the other Windows projects) and gains the `BuildTools.WinApp 0.6.0` companion they already use.

`src/SolutionTemplate/**` stays on 1.3.230602002 — those are fixtures for validating old project shapes, so their pins are deliberate.

## Validation

**Compile — real MSBuild.exe (VS 18.9.1), Release, `net10.0-windows10.0.19041.0`, all exit 0 with assemblies emitted:**

- `Uno.WinUI.Graphics2DSK.Windows` → `Uno.WinUI.Graphics2DSK.dll`
- `Uno.WinUI.Graphics3DGL` → `Uno.WinUI.Graphics3DGL.dll`
- `Uno.UI.Extras.Windows` → `Uno.UI.Extras.dll`

**Not validated, and reviewers should weigh these:**

1. **The net11 leg was not built.** These projects multi-target `$(NetWinAppSDKPreviousAndCurrent)`, whose current leg is net11, and the installed SDK (10.0.400) cannot target .NET 11.
2. **Nothing was run.** The add-ins are rendering interop (SkiaSharp 2D, native OpenGL); a compile-clean major bump is not evidence the interop still behaves. Windows runtime tests are the real signal.
3. 🔴 **The sync generator's reference moved, so the generated stubs may be stale in this PR.** `Uno.WinAppSDKSyncGenerator.References` pins the WinAppSDK whose surface is mirrored into `Generated/`. Regenerating requires `dotnet workload install tvos` from an interactive terminal (a UAC prompt cancels in a non-interactive shell), so it was not run here. **If the *WinAppSDK Sync Generator Check* goes red, that is why** — and note the known failure shape when a bump makes public a DP that Uno registers privately: the generator emits a duplicate `DependencyProperty.Register` that throws at the type's static init and takes down every consumer.

## PR Checklist ✅

- [ ] 🧪 Added Runtime tests (n/a — dependency alignment)
- [ ] 📚 Docs
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

**Breaking change:** yes. The published `Uno.WinUI` WinAppSDK floor goes 1.0.0 → 2.4.0, which is a real constraint change for anyone referencing `Uno.WinUI` without the `Uno.Sdk`. Intentional for 7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vRaBaNK2HnyWeg3TBzEu6

