### PR TITLE
feat(x11): Linux AT-SPI accessibility backend for the Skia.X11 head

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiNode.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiNode.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+/// <summary>
+/// Represents a node published through the AT-SPI accessibility tree.
+/// </summary>
+internal sealed class AtspiNode
+{
+	public required string Path { get; init; }
+	public nint Handle { get; set; }
+	public uint Role { get; set; }
+	public string RoleName { get; set; } = "";
+	public string Name { get; set; } = "";
+	public AtspiNode? Parent { get; set; }
+	public List<AtspiNode> Children { get; } = new();
+	public double X { get; set; }
+	public double Y { get; set; }
+	public double W { get; set; }
+	public double H { get; set; }
+	public bool Enabled { get; set; } = true;
+	public bool Focusable { get; set; }
+}

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiNode.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiNode.cs
@@ -22,4 +22,23 @@ internal sealed class AtspiNode
 	public double H { get; set; }
 	public bool Enabled { get; set; } = true;
 	public bool Focusable { get; set; }
+	public bool Checked;
+	public bool HasToggle;
+	public bool Editable;
+	public bool HasText;
+	public string Text = "";
+	public bool ReadOnly;
+	public bool Expandable;
+	public bool Expanded;
+	public bool Selectable;
+	public bool Selected;
+	public bool HasRange;
+	public double Min, Max, Val;
+	public int ItemIndex = -1;
+	public string? Description;
+	public int HeadingLevel;
+	public string? Landmark;
+	public bool Required;
+	public bool Offscreen;
+	public int PositionInSet, SizeOfSet;
 }

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiNode.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiNode.cs
@@ -22,23 +22,26 @@ internal sealed class AtspiNode
 	public double H { get; set; }
 	public bool Enabled { get; set; } = true;
 	public bool Focusable { get; set; }
-	public bool Checked;
-	public bool HasToggle;
-	public bool Editable;
-	public bool HasText;
-	public string Text = "";
-	public bool ReadOnly;
-	public bool Expandable;
-	public bool Expanded;
-	public bool Selectable;
-	public bool Selected;
-	public bool HasRange;
-	public double Min, Max, Val;
-	public int ItemIndex = -1;
-	public string? Description;
-	public int HeadingLevel;
-	public string? Landmark;
-	public bool Required;
-	public bool Offscreen;
-	public int PositionInSet, SizeOfSet;
+	public bool Checked { get; set; }
+	public bool HasToggle { get; set; }
+	public bool Editable { get; set; }
+	public bool HasText { get; set; }
+	public string Text { get; set; } = "";
+	public bool ReadOnly { get; set; }
+	public bool Expandable { get; set; }
+	public bool Expanded { get; set; }
+	public bool Selectable { get; set; }
+	public bool Selected { get; set; }
+	public bool HasRange { get; set; }
+	public double Min { get; set; }
+	public double Max { get; set; }
+	public double Val { get; set; }
+	public int ItemIndex { get; set; } = -1;
+	public string? Description { get; set; }
+	public int HeadingLevel { get; set; }
+	public string? Landmark { get; set; }
+	public bool Required { get; set; }
+	public bool Offscreen { get; set; }
+	public int PositionInSet { get; set; }
+	public int SizeOfSet { get; set; }
 }

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiRoleMap.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiRoleMap.cs
@@ -1,0 +1,38 @@
+#nullable enable
+
+using Microsoft.UI.Xaml.Automation.Peers;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+/// <summary>
+/// Maps WinUI <see cref="AutomationControlType"/> values to the numeric AT-SPI role
+/// ids defined by at-spi2-core's atspi-constants.h. libatspi derives the displayed
+/// role name from the numeric <c>GetRole</c> value, so the ids must match the real
+/// <c>AtspiRole</c> enum exactly. Unknown or unmapped control types fall back to
+/// <c>ATSPI_ROLE_PANEL</c>, which is a safe generic container role.
+/// </summary>
+internal static class AtspiRoleMap
+{
+	/// <summary>
+	/// Resolves the AT-SPI role id and name for a WinUI automation control type.
+	/// </summary>
+	public static (uint Id, string Name) GetRole(AutomationControlType controlType) => controlType switch
+	{
+		AutomationControlType.Button => (43u, "push button"),      // ATSPI_ROLE_PUSH_BUTTON
+		AutomationControlType.Edit => (79u, "entry"),              // ATSPI_ROLE_ENTRY
+		AutomationControlType.CheckBox => (7u, "check box"),       // ATSPI_ROLE_CHECK_BOX
+		AutomationControlType.RadioButton => (44u, "radio button"),// ATSPI_ROLE_RADIO_BUTTON
+		AutomationControlType.Slider => (51u, "slider"),           // ATSPI_ROLE_SLIDER
+		AutomationControlType.ComboBox => (11u, "combo box"),      // ATSPI_ROLE_COMBO_BOX
+		AutomationControlType.Text => (29u, "label"),              // ATSPI_ROLE_LABEL
+		AutomationControlType.List => (31u, "list"),               // ATSPI_ROLE_LIST
+		AutomationControlType.ListItem => (32u, "list item"),      // ATSPI_ROLE_LIST_ITEM
+		AutomationControlType.Image => (27u, "image"),             // ATSPI_ROLE_IMAGE
+		AutomationControlType.Hyperlink => (88u, "link"),          // ATSPI_ROLE_LINK
+		AutomationControlType.ScrollBar => (48u, "scroll bar"),    // ATSPI_ROLE_SCROLL_BAR
+		AutomationControlType.ProgressBar => (42u, "progress bar"),// ATSPI_ROLE_PROGRESS_BAR
+		AutomationControlType.TabItem => (37u, "page tab"),        // ATSPI_ROLE_PAGE_TAB
+		AutomationControlType.Tab => (38u, "page tab list"),       // ATSPI_ROLE_PAGE_TAB_LIST
+		_ => (39u, "panel"),                                       // ATSPI_ROLE_PANEL
+	};
+}

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiRoleMap.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiRoleMap.cs
@@ -13,6 +13,9 @@ namespace Uno.WinUI.Runtime.Skia.X11;
 /// </summary>
 internal static class AtspiRoleMap
 {
+	internal const uint ApplicationRoleId = 75; // ATSPI_ROLE_APPLICATION
+	internal const string ApplicationRoleName = "application";
+
 	/// <summary>
 	/// Resolves the AT-SPI role id and name for a WinUI automation control type.
 	/// </summary>

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
@@ -240,7 +240,7 @@ internal sealed class AtspiServer
 		}
 	}
 
-	public void EmitChildrenChanged(AtspiNode parent, bool added, int index, AtspiNode? child)
+	public void EmitChildrenChanged(AtspiNode parent, bool added, int index)
 	{
 		try
 		{
@@ -779,6 +779,8 @@ internal sealed class AtspiServer
 					writer.WriteVariantString(node.Name);
 					break;
 				case (AtspiDbus.AccessibleInterface, AtspiDbus.DescriptionProperty):
+					writer.WriteVariantString(node.Description ?? AtspiDbus.EmptyString);
+					break;
 				case (AtspiDbus.AccessibleInterface, AtspiDbus.AccessibleIdProperty):
 					writer.WriteVariantString(AtspiDbus.EmptyString);
 					break;
@@ -911,8 +913,11 @@ internal sealed class AtspiServer
 				SetState(AtspiDbus.SensitiveState);
 			}
 
-			SetState(AtspiDbus.ShowingState);
-			SetState(AtspiDbus.VisibleState);
+			if (!node.Offscreen)
+			{
+				SetState(AtspiDbus.ShowingState);
+				SetState(AtspiDbus.VisibleState);
+			}
 
 			if (node.Focusable)
 			{
@@ -952,10 +957,25 @@ internal sealed class AtspiServer
 				SetState(AtspiDbus.FocusedState);
 			}
 
+			// The AT-SPI state set is two 32-bit words; states with index >= 32 live in
+			// the second word.
+			uint state1 = 0;
+			void SetState1(int bit) => state1 |= 1u << (bit - 32);
+
+			if (node.Required)
+			{
+				SetState1(AtspiDbus.RequiredState);
+			}
+
+			if (node.ReadOnly)
+			{
+				SetState1(AtspiDbus.ReadOnlyState);
+			}
+
 			using var writer = context.CreateReplyWriter(AtspiDbus.UInt32ArraySignature);
 			var array = writer.WriteArrayStart(DBusType.UInt32);
 			writer.WriteUInt32(state0);
-			writer.WriteUInt32(0);
+			writer.WriteUInt32(state1);
 			writer.WriteArrayEnd(array);
 			context.Reply(writer.CreateMessage());
 		}
@@ -1062,14 +1082,6 @@ internal sealed class AtspiServer
 				writer.WriteString(key);
 				writer.WriteString(value);
 			}
-			writer.WriteDictionaryEnd(dictionary);
-			context.Reply(writer.CreateMessage());
-		}
-
-		private static void ReplyEmptyDictionary(MethodContext context, string signature)
-		{
-			using var writer = context.CreateReplyWriter(signature);
-			var dictionary = writer.WriteDictionaryStart();
 			writer.WriteDictionaryEnd(dictionary);
 			context.Reply(writer.CreateMessage());
 		}
@@ -1221,5 +1233,7 @@ internal sealed class AtspiServer
 		public const int FocusedState = 12;
 		public const int SelectableState = 22;
 		public const int SelectedState = 23;
+		public const int RequiredState = 33;
+		public const int ReadOnlyState = 43;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
@@ -1,0 +1,680 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Tmds.DBus.Protocol;
+using Uno.Foundation.Logging;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+/// <summary>
+/// Serves an AT-SPI accessibility tree over the desktop accessibility D-Bus.
+/// </summary>
+internal sealed class AtspiServer
+{
+	private readonly DBusConnection _connection;
+	private readonly string _uniqueName;
+	private AtspiReference _rootParent;
+	private IReadOnlyDictionary<string, AtspiNode> _nodesByPath = new Dictionary<string, AtspiNode>();
+
+	private AtspiServer(DBusConnection connection, string uniqueName)
+	{
+		_connection = connection;
+		_uniqueName = uniqueName;
+		_rootParent = AtspiReference.Null;
+	}
+
+	public static async Task<AtspiServer?> TryStartAsync(string applicationName)
+	{
+		DBusConnection? connection = null;
+
+		try
+		{
+			var sessionBusAddress = DBusAddress.Session;
+			if (sessionBusAddress is null)
+			{
+				if (typeof(AtspiServer).Log().IsEnabled(LogLevel.Debug))
+				{
+					typeof(AtspiServer).Log().Debug("No D-Bus session bus available; AT-SPI bridge will be disabled.");
+				}
+
+				return null;
+			}
+
+			var a11yBusAddress = await GetA11yBusAddressAsync(sessionBusAddress);
+			if (string.IsNullOrEmpty(a11yBusAddress))
+			{
+				if (typeof(AtspiServer).Log().IsEnabled(LogLevel.Debug))
+				{
+					typeof(AtspiServer).Log().Debug("No AT-SPI accessibility bus address available; AT-SPI bridge will be disabled.");
+				}
+
+				return null;
+			}
+
+			connection = new DBusConnection(a11yBusAddress);
+			await connection.ConnectAsync();
+
+			var uniqueName = connection.UniqueName ?? "";
+			var server = new AtspiServer(connection, uniqueName);
+			server.SetRoot(new AtspiNode
+			{
+				Path = AtspiDbus.RootPath,
+				Name = applicationName,
+				Role = AtspiDbus.ApplicationRole,
+				RoleName = AtspiDbus.ApplicationRoleName
+			});
+			connection.AddMethodHandler(new NodeHandler(server));
+			server._rootParent = await server.EmbedAsync();
+
+			if (server.Log().IsEnabled(LogLevel.Debug))
+			{
+				server.Log().Debug($"AT-SPI bridge started for '{applicationName}' on {uniqueName}.");
+			}
+
+			return server;
+		}
+		catch (Exception ex)
+		{
+			connection?.Dispose();
+
+			if (typeof(AtspiServer).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(AtspiServer).Log().Debug($"Unable to start AT-SPI bridge: {ex.Message}");
+			}
+
+			return null;
+		}
+	}
+
+	public void SetRoot(AtspiNode root)
+	{
+		if (root.Path != AtspiDbus.RootPath)
+		{
+			throw new ArgumentException($"The AT-SPI root node path must be '{AtspiDbus.RootPath}'.", nameof(root));
+		}
+
+		var nodesByPath = new Dictionary<string, AtspiNode>(StringComparer.Ordinal);
+		AddNode(root, nodesByPath);
+		Volatile.Write(ref _nodesByPath, nodesByPath);
+	}
+
+	public ValueTask StopAsync()
+	{
+		_connection.Dispose();
+		return default;
+	}
+
+	private static async Task<string?> GetA11yBusAddressAsync(string sessionBusAddress)
+	{
+		using var sessionConnection = new DBusConnection(sessionBusAddress);
+		await sessionConnection.ConnectAsync();
+
+		MessageBuffer request;
+		using (var writer = sessionConnection.GetMessageWriter())
+		{
+			writer.WriteMethodCallHeader(
+				AtspiDbus.BusService,
+				AtspiDbus.BusPath,
+				AtspiDbus.BusInterface,
+				AtspiDbus.GetAddressMethod,
+				AtspiDbus.EmptySignature,
+				MessageFlags.None);
+			request = writer.CreateMessage();
+		}
+
+		return await sessionConnection.CallMethodAsync<string>(
+			request,
+			static (message, _) => message.GetBodyReader().ReadString(),
+			null);
+	}
+
+	private async Task<AtspiReference> EmbedAsync()
+	{
+		MessageBuffer request;
+		using (var writer = _connection.GetMessageWriter())
+		{
+			writer.WriteMethodCallHeader(
+				AtspiDbus.RegistryService,
+				AtspiDbus.RootPath,
+				AtspiDbus.SocketInterface,
+				AtspiDbus.EmbedMethod,
+				AtspiDbus.ReferenceSignature,
+				MessageFlags.None);
+			WriteReference(writer, new AtspiReference(_uniqueName, AtspiDbus.RootPath));
+			request = writer.CreateMessage();
+		}
+
+		return await _connection.CallMethodAsync<AtspiReference>(
+			request,
+			static (message, _) =>
+			{
+				var reader = message.GetBodyReader();
+				reader.AlignStruct();
+				return new AtspiReference(reader.ReadString(), reader.ReadObjectPathAsString());
+			},
+			null);
+	}
+
+	private AtspiNode? FindNode(string path)
+	{
+		var nodesByPath = Volatile.Read(ref _nodesByPath);
+		return nodesByPath.TryGetValue(path, out var node) ? node : null;
+	}
+
+	private AtspiReference GetReference(AtspiNode? node)
+		=> node is null
+			? new AtspiReference(_uniqueName, AtspiDbus.NullPath)
+			: new AtspiReference(_uniqueName, node.Path);
+
+	private AtspiReference GetParentReference(AtspiNode node)
+		=> node.Parent is null ? _rootParent : GetReference(node.Parent);
+
+	private static void AddNode(AtspiNode node, Dictionary<string, AtspiNode> nodesByPath)
+	{
+		nodesByPath[node.Path] = node;
+
+		foreach (var child in node.Children)
+		{
+			AddNode(child, nodesByPath);
+		}
+	}
+
+	private static int ToInt32(double value) => (int)Math.Round(value);
+
+	private static bool Contains(AtspiNode node, int x, int y)
+		=> x >= ToInt32(node.X)
+			&& y >= ToInt32(node.Y)
+			&& x < ToInt32(node.X + node.W)
+			&& y < ToInt32(node.Y + node.H);
+
+	private static AtspiNode? FindAccessibleAtPoint(AtspiNode node, int x, int y)
+	{
+		for (var i = node.Children.Count - 1; i >= 0; i--)
+		{
+			var child = node.Children[i];
+			if (Contains(child, x, y))
+			{
+				return FindAccessibleAtPoint(child, x, y) ?? child;
+			}
+		}
+
+		return Contains(node, x, y) ? node : null;
+	}
+
+	private static void WriteReference(MessageWriter writer, AtspiReference reference)
+	{
+		writer.WriteStructureStart();
+		writer.WriteString(reference.Service);
+		writer.WriteObjectPath(reference.Path);
+	}
+
+	private readonly record struct AtspiReference(string Service, string Path)
+	{
+		public static AtspiReference Null { get; } = new(AtspiDbus.RegistryService, AtspiDbus.NullPath);
+	}
+
+	/// <summary>
+	/// Dispatches AT-SPI method calls for the currently published node snapshot.
+	/// </summary>
+	private sealed class NodeHandler : IPathMethodHandler
+	{
+		private readonly AtspiServer _server;
+
+		public NodeHandler(AtspiServer server)
+		{
+			_server = server;
+		}
+
+		public string Path => AtspiDbus.AccessibleBasePath;
+
+		public bool HandlesChildPaths => true;
+
+		public ValueTask HandleMethodAsync(MethodContext context)
+		{
+			var node = context.Request.PathAsString is { } requestPath ? _server.FindNode(requestPath) : null;
+			if (node is null)
+			{
+				context.ReplyUnknownMethodError();
+				return default;
+			}
+
+			var iface = context.Request.InterfaceAsString ?? AtspiDbus.EmptyString;
+			var member = context.Request.MemberAsString ?? AtspiDbus.EmptyString;
+
+			switch (iface)
+			{
+				case AtspiDbus.AccessibleInterface:
+					Accessible(context, node, member);
+					break;
+				case AtspiDbus.ComponentInterface:
+					Component(context, node, member);
+					break;
+				case AtspiDbus.ApplicationInterface when node.Parent is null:
+					Application(context, member);
+					break;
+				case AtspiDbus.PropertiesInterface:
+					Properties(context, node, member);
+					break;
+				case AtspiDbus.IntrospectableInterface when member == AtspiDbus.IntrospectMethod:
+					ReplyString(context, AtspiDbus.StringSignature, AtspiDbus.IntrospectionXml);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+
+			return default;
+		}
+
+		private void Accessible(MethodContext context, AtspiNode node, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetRoleMethod:
+					ReplyUInt32(context, node.Role);
+					break;
+				case AtspiDbus.GetRoleNameMethod:
+				case AtspiDbus.GetLocalizedRoleNameMethod:
+					ReplyString(context, AtspiDbus.StringSignature, node.RoleName);
+					break;
+				case AtspiDbus.GetStateMethod:
+					ReplyStates(context, node);
+					break;
+				case AtspiDbus.GetInterfacesMethod:
+					ReplyInterfaces(context, node);
+					break;
+				case AtspiDbus.GetChildAtIndexMethod:
+					ReplyChildAtIndex(context, node);
+					break;
+				case AtspiDbus.GetChildrenMethod:
+					ReplyChildren(context, node);
+					break;
+				case AtspiDbus.GetIndexInParentMethod:
+					ReplyInt32(context, node.Parent?.Children.IndexOf(node) ?? -1);
+					break;
+				case AtspiDbus.GetApplicationMethod:
+					ReplyReference(context, new AtspiReference(_server._uniqueName, AtspiDbus.RootPath));
+					break;
+				case AtspiDbus.GetParentMethod:
+					ReplyReference(context, _server.GetParentReference(node));
+					break;
+				case AtspiDbus.GetAttributesMethod:
+					ReplyEmptyDictionary(context, AtspiDbus.StringDictionarySignature);
+					break;
+				case AtspiDbus.GetRelationSetMethod:
+					ReplyEmptyStructArray(context, AtspiDbus.RelationSetSignature);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private void Component(MethodContext context, AtspiNode node, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetExtentsMethod:
+					ReplyExtents(context, node);
+					break;
+				case AtspiDbus.GetPositionMethod:
+					ReplyPosition(context, node);
+					break;
+				case AtspiDbus.GetSizeMethod:
+					ReplySize(context, node);
+					break;
+				case AtspiDbus.GetLayerMethod:
+					ReplyUInt32(context, AtspiDbus.WindowLayer);
+					break;
+				case AtspiDbus.ContainsMethod:
+					ReplyContains(context, node);
+					break;
+				case AtspiDbus.GetAccessibleAtPointMethod:
+					ReplyAccessibleAtPoint(context, node);
+					break;
+				case AtspiDbus.GrabFocusMethod:
+					ReplyBool(context, false);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private static void Application(MethodContext context, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetLocaleMethod:
+					ReplyString(context, AtspiDbus.StringSignature, AtspiDbus.DefaultLocale);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private void Properties(MethodContext context, AtspiNode node, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetPropertyMethod:
+				{
+					var reader = context.Request.GetBodyReader();
+					var propertyInterface = reader.ReadString();
+					var property = reader.ReadString();
+					ReplyVariant(context, node, propertyInterface, property);
+					break;
+				}
+				case AtspiDbus.SetPropertyMethod:
+					ReplyVoid(context);
+					break;
+				case AtspiDbus.GetAllPropertiesMethod:
+					ReplyEmptyVariantDictionary(context);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private void ReplyVariant(MethodContext context, AtspiNode node, string propertyInterface, string property)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.VariantSignature);
+
+			switch (propertyInterface, property)
+			{
+				case (AtspiDbus.AccessibleInterface, AtspiDbus.NameProperty):
+					writer.WriteVariantString(node.Name);
+					break;
+				case (AtspiDbus.AccessibleInterface, AtspiDbus.DescriptionProperty):
+				case (AtspiDbus.AccessibleInterface, AtspiDbus.AccessibleIdProperty):
+					writer.WriteVariantString(AtspiDbus.EmptyString);
+					break;
+				case (AtspiDbus.AccessibleInterface, AtspiDbus.ChildCountProperty):
+					writer.WriteVariantInt32(node.Children.Count);
+					break;
+				case (AtspiDbus.AccessibleInterface, AtspiDbus.ParentProperty):
+					writer.WriteSignature(AtspiDbus.ReferenceSignature);
+					WriteReference(writer, _server.GetParentReference(node));
+					break;
+				case (AtspiDbus.ApplicationInterface, AtspiDbus.LocaleProperty):
+					writer.WriteVariantString(AtspiDbus.DefaultLocale);
+					break;
+				case (AtspiDbus.ApplicationInterface, AtspiDbus.ToolkitNameProperty):
+					writer.WriteVariantString(AtspiDbus.ToolkitName);
+					break;
+				case (AtspiDbus.ApplicationInterface, AtspiDbus.VersionProperty):
+					writer.WriteVariantString(AtspiDbus.ToolkitVersion);
+					break;
+				case (AtspiDbus.ApplicationInterface, AtspiDbus.AtspiVersionProperty):
+					writer.WriteVariantString(AtspiDbus.AtspiVersion);
+					break;
+				default:
+					writer.WriteVariantString(AtspiDbus.EmptyString);
+					break;
+			}
+
+			context.Reply(writer.CreateMessage());
+		}
+
+		private void ReplyChildAtIndex(MethodContext context, AtspiNode node)
+		{
+			var index = context.Request.GetBodyReader().ReadInt32();
+			var child = index >= 0 && index < node.Children.Count ? node.Children[index] : null;
+			ReplyReference(context, _server.GetReference(child));
+		}
+
+		private void ReplyChildren(MethodContext context, AtspiNode node)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.ReferenceArraySignature);
+			var array = writer.WriteArrayStart(DBusType.Struct);
+			foreach (var child in node.Children)
+			{
+				WriteReference(writer, _server.GetReference(child));
+			}
+			writer.WriteArrayEnd(array);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyExtents(MethodContext context, AtspiNode node)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.ExtentsSignature);
+			writer.WriteStructureStart();
+			writer.WriteInt32(ToInt32(node.X));
+			writer.WriteInt32(ToInt32(node.Y));
+			writer.WriteInt32(ToInt32(node.W));
+			writer.WriteInt32(ToInt32(node.H));
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyPosition(MethodContext context, AtspiNode node)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.PositionSignature);
+			writer.WriteStructureStart();
+			writer.WriteInt32(ToInt32(node.X));
+			writer.WriteInt32(ToInt32(node.Y));
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplySize(MethodContext context, AtspiNode node)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.PositionSignature);
+			writer.WriteStructureStart();
+			writer.WriteInt32(ToInt32(node.W));
+			writer.WriteInt32(ToInt32(node.H));
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyContains(MethodContext context, AtspiNode node)
+		{
+			var reader = context.Request.GetBodyReader();
+			var x = reader.ReadInt32();
+			var y = reader.ReadInt32();
+			_ = reader.ReadUInt32();
+			ReplyBool(context, Contains(node, x, y));
+		}
+
+		private void ReplyAccessibleAtPoint(MethodContext context, AtspiNode node)
+		{
+			var reader = context.Request.GetBodyReader();
+			var x = reader.ReadInt32();
+			var y = reader.ReadInt32();
+			_ = reader.ReadUInt32();
+			ReplyReference(context, _server.GetReference(FindAccessibleAtPoint(node, x, y)));
+		}
+
+		private static void ReplyStates(MethodContext context, AtspiNode node)
+		{
+			uint state0 = 0;
+			void SetState(int bit) => state0 |= 1u << bit;
+
+			if (node.Enabled)
+			{
+				SetState(AtspiDbus.EnabledState);
+				SetState(AtspiDbus.SensitiveState);
+			}
+
+			SetState(AtspiDbus.ShowingState);
+			SetState(AtspiDbus.VisibleState);
+
+			if (node.Focusable)
+			{
+				SetState(AtspiDbus.FocusableState);
+			}
+
+			using var writer = context.CreateReplyWriter(AtspiDbus.UInt32ArraySignature);
+			var array = writer.WriteArrayStart(DBusType.UInt32);
+			writer.WriteUInt32(state0);
+			writer.WriteUInt32(0);
+			writer.WriteArrayEnd(array);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyInterfaces(MethodContext context, AtspiNode node)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.StringArraySignature);
+			var array = writer.WriteArrayStart(DBusType.String);
+			writer.WriteString(AtspiDbus.AccessibleInterface);
+			writer.WriteString(AtspiDbus.ComponentInterface);
+			if (node.Parent is null)
+			{
+				writer.WriteString(AtspiDbus.ApplicationInterface);
+			}
+			writer.WriteArrayEnd(array);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyString(MethodContext context, string signature, string value)
+		{
+			using var writer = context.CreateReplyWriter(signature);
+			writer.WriteString(value);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyUInt32(MethodContext context, uint value)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.UInt32Signature);
+			writer.WriteUInt32(value);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyInt32(MethodContext context, int value)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.Int32Signature);
+			writer.WriteInt32(value);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyBool(MethodContext context, bool value)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.BoolSignature);
+			writer.WriteBool(value);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyVoid(MethodContext context)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.EmptySignature);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyReference(MethodContext context, AtspiReference reference)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.ReferenceSignature);
+			WriteReference(writer, reference);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyEmptyDictionary(MethodContext context, string signature)
+		{
+			using var writer = context.CreateReplyWriter(signature);
+			var dictionary = writer.WriteDictionaryStart();
+			writer.WriteDictionaryEnd(dictionary);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyEmptyVariantDictionary(MethodContext context)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.VariantDictionarySignature);
+			var dictionary = writer.WriteDictionaryStart();
+			writer.WriteDictionaryEnd(dictionary);
+			context.Reply(writer.CreateMessage());
+		}
+
+		private static void ReplyEmptyStructArray(MethodContext context, string signature)
+		{
+			using var writer = context.CreateReplyWriter(signature);
+			var array = writer.WriteArrayStart(DBusType.Struct);
+			writer.WriteArrayEnd(array);
+			context.Reply(writer.CreateMessage());
+		}
+	}
+
+	/// <summary>
+	/// Contains D-Bus names, signatures, and AT-SPI numeric constants used by the bridge.
+	/// </summary>
+	private static class AtspiDbus
+	{
+		public const string AccessibleBasePath = "/org/a11y/atspi/accessible";
+		public const string RootPath = "/org/a11y/atspi/accessible/root";
+		public const string NullPath = "/org/a11y/atspi/null";
+		public const string BusPath = "/org/a11y/bus";
+		public const string BusService = "org.a11y.Bus";
+		public const string BusInterface = "org.a11y.Bus";
+		public const string RegistryService = "org.a11y.atspi.Registry";
+		public const string AccessibleInterface = "org.a11y.atspi.Accessible";
+		public const string ComponentInterface = "org.a11y.atspi.Component";
+		public const string ApplicationInterface = "org.a11y.atspi.Application";
+		public const string SocketInterface = "org.a11y.atspi.Socket";
+		public const string PropertiesInterface = "org.freedesktop.DBus.Properties";
+		public const string IntrospectableInterface = "org.freedesktop.DBus.Introspectable";
+		public const string GetAddressMethod = "GetAddress";
+		public const string EmbedMethod = "Embed";
+		public const string GetRoleMethod = "GetRole";
+		public const string GetRoleNameMethod = "GetRoleName";
+		public const string GetLocalizedRoleNameMethod = "GetLocalizedRoleName";
+		public const string GetStateMethod = "GetState";
+		public const string GetInterfacesMethod = "GetInterfaces";
+		public const string GetChildAtIndexMethod = "GetChildAtIndex";
+		public const string GetChildrenMethod = "GetChildren";
+		public const string GetIndexInParentMethod = "GetIndexInParent";
+		public const string GetApplicationMethod = "GetApplication";
+		public const string GetParentMethod = "GetParent";
+		public const string GetAttributesMethod = "GetAttributes";
+		public const string GetRelationSetMethod = "GetRelationSet";
+		public const string GetExtentsMethod = "GetExtents";
+		public const string GetPositionMethod = "GetPosition";
+		public const string GetSizeMethod = "GetSize";
+		public const string GetLayerMethod = "GetLayer";
+		public const string ContainsMethod = "Contains";
+		public const string GetAccessibleAtPointMethod = "GetAccessibleAtPoint";
+		public const string GrabFocusMethod = "GrabFocus";
+		public const string GetLocaleMethod = "GetLocale";
+		public const string GetPropertyMethod = "Get";
+		public const string SetPropertyMethod = "Set";
+		public const string GetAllPropertiesMethod = "GetAll";
+		public const string IntrospectMethod = "Introspect";
+		public const string NameProperty = "Name";
+		public const string DescriptionProperty = "Description";
+		public const string AccessibleIdProperty = "AccessibleId";
+		public const string ChildCountProperty = "ChildCount";
+		public const string ParentProperty = "Parent";
+		public const string LocaleProperty = "Locale";
+		public const string ToolkitNameProperty = "ToolkitName";
+		public const string VersionProperty = "Version";
+		public const string AtspiVersionProperty = "AtspiVersion";
+		public const string DefaultLocale = "C";
+		public const string ToolkitName = "Uno";
+		public const string ToolkitVersion = "1.0";
+		public const string AtspiVersion = "2.1";
+		public const string EmptyString = "";
+		public const string EmptySignature = "";
+		public const string ReferenceSignature = "(so)";
+		public const string ReferenceArraySignature = "a(so)";
+		public const string StringSignature = "s";
+		public const string UInt32Signature = "u";
+		public const string Int32Signature = "i";
+		public const string BoolSignature = "b";
+		public const string VariantSignature = "v";
+		public const string ExtentsSignature = "(iiii)";
+		public const string PositionSignature = "(ii)";
+		public const string UInt32ArraySignature = "au";
+		public const string StringArraySignature = "as";
+		public const string StringDictionarySignature = "a{ss}";
+		public const string VariantDictionarySignature = "a{sv}";
+		public const string RelationSetSignature = "a(ua(so))";
+		public const string IntrospectionXml = "<node/>";
+		public const string ApplicationRoleName = "application";
+		public const uint WindowLayer = 3;
+		public const uint ApplicationRole = 75;
+		public const int EnabledState = 8;
+		public const int FocusableState = 11;
+		public const int SensitiveState = 24;
+		public const int ShowingState = 25;
+		public const int VisibleState = 30;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
@@ -166,7 +166,7 @@ internal sealed class AtspiServer
 
 	private AtspiReference GetReference(AtspiNode? node)
 		=> node is null
-			? new AtspiReference(_uniqueName, AtspiDbus.NullPath)
+			? AtspiReference.Null
 			: new AtspiReference(_uniqueName, node.Path);
 
 	private AtspiReference GetParentReference(AtspiNode node)
@@ -327,7 +327,7 @@ internal sealed class AtspiServer
 					ReplySize(context, node);
 					break;
 				case AtspiDbus.GetLayerMethod:
-					ReplyUInt32(context, AtspiDbus.WindowLayer);
+					ReplyUInt32(context, AtspiDbus.WidgetLayer);
 					break;
 				case AtspiDbus.ContainsMethod:
 					ReplyContains(context, node);
@@ -669,7 +669,7 @@ internal sealed class AtspiServer
 		public const string RelationSetSignature = "a(ua(so))";
 		public const string IntrospectionXml = "<node/>";
 		public const string ApplicationRoleName = "application";
-		public const uint WindowLayer = 3;
+		public const uint WidgetLayer = 3; // ATSPI_LAYER_WIDGET
 		public const uint ApplicationRole = 75;
 		public const int EnabledState = 8;
 		public const int FocusableState = 11;

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
@@ -67,7 +67,11 @@ internal sealed class AtspiServer
 				RoleName = AtspiDbus.ApplicationRoleName
 			});
 			connection.AddMethodHandler(new NodeHandler(server));
-			server._rootParent = await server.EmbedAsync();
+
+			// The app root's parent is the AT-SPI registry desktop; the Embed reply
+			// echoes it back but we do not depend on it.
+			server._rootParent = new AtspiReference(AtspiDbus.RegistryService, AtspiDbus.RootPath);
+			await server.EmbedAsync();
 
 			if (server.Log().IsEnabled(LogLevel.Debug))
 			{
@@ -82,7 +86,7 @@ internal sealed class AtspiServer
 
 			if (typeof(AtspiServer).Log().IsEnabled(LogLevel.Debug))
 			{
-				typeof(AtspiServer).Log().Debug($"Unable to start AT-SPI bridge: {ex.Message}");
+				typeof(AtspiServer).Log().Debug($"Unable to start AT-SPI bridge: {ex}");
 			}
 
 			return null;
@@ -112,18 +116,10 @@ internal sealed class AtspiServer
 		using var sessionConnection = new DBusConnection(sessionBusAddress);
 		await sessionConnection.ConnectAsync();
 
-		MessageBuffer request;
-		using (var writer = sessionConnection.GetMessageWriter())
-		{
-			writer.WriteMethodCallHeader(
-				AtspiDbus.BusService,
-				AtspiDbus.BusPath,
-				AtspiDbus.BusInterface,
-				AtspiDbus.GetAddressMethod,
-				AtspiDbus.EmptySignature,
-				MessageFlags.None);
-			request = writer.CreateMessage();
-		}
+		// MessageWriter is a ref struct in Tmds.DBus.Protocol 0.92 and must not be
+		// disposed before the call is sent, or the message's pooled buffer is
+		// reclaimed while still in flight.
+		var request = BuildGetAddressMessage(sessionConnection);
 
 		return await sessionConnection.CallMethodAsync<string>(
 			request,
@@ -131,31 +127,37 @@ internal sealed class AtspiServer
 			null);
 	}
 
-	private async Task<AtspiReference> EmbedAsync()
+	private static MessageBuffer BuildGetAddressMessage(DBusConnection sessionConnection)
 	{
-		MessageBuffer request;
-		using (var writer = _connection.GetMessageWriter())
-		{
-			writer.WriteMethodCallHeader(
-				AtspiDbus.RegistryService,
-				AtspiDbus.RootPath,
-				AtspiDbus.SocketInterface,
-				AtspiDbus.EmbedMethod,
-				AtspiDbus.ReferenceSignature,
-				MessageFlags.None);
-			WriteReference(writer, new AtspiReference(_uniqueName, AtspiDbus.RootPath));
-			request = writer.CreateMessage();
-		}
+		var writer = sessionConnection.GetMessageWriter();
+		writer.WriteMethodCallHeader(
+			AtspiDbus.BusService,
+			AtspiDbus.BusPath,
+			AtspiDbus.BusInterface,
+			AtspiDbus.GetAddressMethod,
+			AtspiDbus.EmptySignature,
+			MessageFlags.None);
+		return writer.CreateMessage();
+	}
 
-		return await _connection.CallMethodAsync<AtspiReference>(
-			request,
-			static (message, _) =>
-			{
-				var reader = message.GetBodyReader();
-				reader.AlignStruct();
-				return new AtspiReference(reader.ReadString(), reader.ReadObjectPathAsString());
-			},
-			null);
+	private async Task EmbedAsync()
+	{
+		var request = BuildEmbedMessage();
+		await _connection.CallMethodAsync(request);
+	}
+
+	private MessageBuffer BuildEmbedMessage()
+	{
+		var writer = _connection.GetMessageWriter();
+		writer.WriteMethodCallHeader(
+			AtspiDbus.RegistryService,
+			AtspiDbus.RootPath,
+			AtspiDbus.SocketInterface,
+			AtspiDbus.EmbedMethod,
+			AtspiDbus.ReferenceSignature,
+			MessageFlags.None);
+		WriteReference(ref writer, new AtspiReference(_uniqueName, AtspiDbus.RootPath));
+		return writer.CreateMessage();
 	}
 
 	private AtspiNode? FindNode(string path)
@@ -204,7 +206,7 @@ internal sealed class AtspiServer
 		return Contains(node, x, y) ? node : null;
 	}
 
-	private static void WriteReference(MessageWriter writer, AtspiReference reference)
+	private static void WriteReference(ref MessageWriter writer, AtspiReference reference)
 	{
 		writer.WriteStructureStart();
 		writer.WriteString(reference.Service);
@@ -228,21 +230,55 @@ internal sealed class AtspiServer
 			_server = server;
 		}
 
-		public string Path => AtspiDbus.AccessibleBasePath;
+		// Registered at the AT-SPI root so every incoming call under /org/a11y/atspi
+		// (accessible nodes, but also cache/registry callbacks the daemon makes after
+		// Embed) reaches this handler and gets a well-formed reply. Tmds.DBus.Protocol
+		// 0.92 tears down the whole connection if an incoming call hits no handler, so
+		// leaving sibling paths (e.g. .../cache) uncovered drops the a11y connection.
+		public string Path => AtspiDbus.RootObjectPath;
 
 		public bool HandlesChildPaths => true;
 
 		public ValueTask HandleMethodAsync(MethodContext context)
 		{
+			// A handler exception would tear down the whole AT-SPI connection with it,
+			// so a malformed or unexpected client request must never propagate.
+			try
+			{
+				HandleMethodCore(context);
+			}
+			catch (Exception ex)
+			{
+				if (_server.Log().IsEnabled(LogLevel.Debug))
+				{
+					_server.Log().Debug($"AT-SPI request {context.Request.InterfaceAsString}.{context.Request.MemberAsString} on '{context.Request.PathAsString}' failed: {ex}");
+				}
+
+				if (!context.ReplySent && !context.NoReplyExpected)
+				{
+					context.ReplyUnknownMethodError();
+				}
+			}
+
+			return default;
+		}
+
+		private void HandleMethodCore(MethodContext context)
+		{
+			var iface = context.Request.InterfaceAsString ?? AtspiDbus.EmptyString;
+			var member = context.Request.MemberAsString ?? AtspiDbus.EmptyString;
+
+			if (_server.Log().IsEnabled(LogLevel.Trace))
+			{
+				_server.Log().Trace($"AT-SPI request: {iface}.{member} on '{context.Request.PathAsString}'");
+			}
+
 			var node = context.Request.PathAsString is { } requestPath ? _server.FindNode(requestPath) : null;
 			if (node is null)
 			{
 				context.ReplyUnknownMethodError();
-				return default;
+				return;
 			}
-
-			var iface = context.Request.InterfaceAsString ?? AtspiDbus.EmptyString;
-			var member = context.Request.MemberAsString ?? AtspiDbus.EmptyString;
 
 			switch (iface)
 			{
@@ -265,8 +301,6 @@ internal sealed class AtspiServer
 					context.ReplyUnknownMethodError();
 					break;
 			}
-
-			return default;
 		}
 
 		private void Accessible(MethodContext context, AtspiNode node, string member)
@@ -399,7 +433,10 @@ internal sealed class AtspiServer
 					break;
 				case (AtspiDbus.AccessibleInterface, AtspiDbus.ParentProperty):
 					writer.WriteSignature(AtspiDbus.ReferenceSignature);
-					WriteReference(writer, _server.GetParentReference(node));
+					var parentRef = _server.GetParentReference(node);
+					writer.WriteStructureStart();
+					writer.WriteString(parentRef.Service);
+					writer.WriteObjectPath(parentRef.Path);
 					break;
 				case (AtspiDbus.ApplicationInterface, AtspiDbus.LocaleProperty):
 					writer.WriteVariantString(AtspiDbus.DefaultLocale);
@@ -434,7 +471,10 @@ internal sealed class AtspiServer
 			var array = writer.WriteArrayStart(DBusType.Struct);
 			foreach (var child in node.Children)
 			{
-				WriteReference(writer, _server.GetReference(child));
+				var childRef = _server.GetReference(child);
+				writer.WriteStructureStart();
+				writer.WriteString(childRef.Service);
+				writer.WriteObjectPath(childRef.Path);
 			}
 			writer.WriteArrayEnd(array);
 			context.Reply(writer.CreateMessage());
@@ -565,7 +605,9 @@ internal sealed class AtspiServer
 		private static void ReplyReference(MethodContext context, AtspiReference reference)
 		{
 			using var writer = context.CreateReplyWriter(AtspiDbus.ReferenceSignature);
-			WriteReference(writer, reference);
+			writer.WriteStructureStart();
+			writer.WriteString(reference.Service);
+			writer.WriteObjectPath(reference.Path);
 			context.Reply(writer.CreateMessage());
 		}
 
@@ -599,6 +641,7 @@ internal sealed class AtspiServer
 	/// </summary>
 	private static class AtspiDbus
 	{
+		public const string RootObjectPath = "/org/a11y/atspi";
 		public const string AccessibleBasePath = "/org/a11y/atspi/accessible";
 		public const string RootPath = "/org/a11y/atspi/accessible/root";
 		public const string NullPath = "/org/a11y/atspi/null";

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/AtspiServer.cs
@@ -14,19 +14,35 @@ namespace Uno.WinUI.Runtime.Skia.X11;
 /// </summary>
 internal sealed class AtspiServer
 {
+	/// <summary>
+	/// Drives the real control behind an <see cref="AtspiNode"/>. Implemented by the
+	/// accessibility host, which marshals each call to the UI thread and drives the
+	/// control through its automation provider. Called from the D-Bus reader thread.
+	/// </summary>
+	public interface IWriteTarget
+	{
+		bool Invoke(AtspiNode node);
+		bool SetRangeValue(AtspiNode node, double value);
+		bool SetText(AtspiNode node, string text);
+		bool SelectChild(AtspiNode node, int index);
+	}
+
 	private readonly DBusConnection _connection;
 	private readonly string _uniqueName;
+	private readonly IWriteTarget _writeTarget;
 	private AtspiReference _rootParent;
 	private IReadOnlyDictionary<string, AtspiNode> _nodesByPath = new Dictionary<string, AtspiNode>();
+	private volatile AtspiNode? _focusedNode;
 
-	private AtspiServer(DBusConnection connection, string uniqueName)
+	private AtspiServer(DBusConnection connection, string uniqueName, IWriteTarget writeTarget)
 	{
 		_connection = connection;
 		_uniqueName = uniqueName;
+		_writeTarget = writeTarget;
 		_rootParent = AtspiReference.Null;
 	}
 
-	public static async Task<AtspiServer?> TryStartAsync(string applicationName)
+	public static async Task<AtspiServer?> TryStartAsync(string applicationName, IWriteTarget writeTarget)
 	{
 		DBusConnection? connection = null;
 
@@ -58,7 +74,7 @@ internal sealed class AtspiServer
 			await connection.ConnectAsync();
 
 			var uniqueName = connection.UniqueName ?? "";
-			var server = new AtspiServer(connection, uniqueName);
+			var server = new AtspiServer(connection, uniqueName, writeTarget);
 			server.SetRoot(new AtspiNode
 			{
 				Path = AtspiDbus.RootPath,
@@ -109,6 +125,146 @@ internal sealed class AtspiServer
 	{
 		_connection.Dispose();
 		return default;
+	}
+
+	/// <summary>
+	/// Records the currently focused node so <see cref="GetState"/> can report the
+	/// AT-SPI focused state and focus-change signals target the right node.
+	/// </summary>
+	public void SetFocus(AtspiNode? node)
+	{
+		// _focusedNode is declared volatile; a plain assignment is already a volatile write.
+		_focusedNode = node;
+	}
+
+	// ──────────────────────────────────────────────────────────────
+	//  Live event emission — org.a11y.atspi.Event.Object signals.
+	//  MessageWriter is a ref struct in Tmds.DBus.Protocol 0.92; the
+	//  (so) sender reference is always written inline here, never via a
+	//  helper that would receive the writer by value (struct copy ⇒ empty body).
+	// ──────────────────────────────────────────────────────────────
+
+	public void EmitStateChanged(AtspiNode node, string detail, int value)
+	{
+		try
+		{
+			var writer = _connection.GetMessageWriter();
+			writer.WriteSignalHeader(null, node.Path, AtspiDbus.EventObjectInterface, AtspiDbus.StateChangedMember, AtspiDbus.StateChangedSignature);
+			writer.WriteString(detail);
+			writer.WriteInt32(value);
+			writer.WriteInt32(0);
+			writer.WriteVariantInt32(0);
+			writer.WriteStructureStart();
+			writer.WriteString(_uniqueName);
+			writer.WriteObjectPath(AtspiDbus.RootPath);
+			_connection.TrySendMessage(writer.CreateMessage());
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"AT-SPI StateChanged emit failed on '{node.Path}': {ex}");
+			}
+		}
+	}
+
+	public void EmitPropertyChange(AtspiNode node, string prop, double value)
+	{
+		try
+		{
+			var writer = _connection.GetMessageWriter();
+			writer.WriteSignalHeader(null, node.Path, AtspiDbus.EventObjectInterface, AtspiDbus.PropertyChangeMember, AtspiDbus.StateChangedSignature);
+			writer.WriteString(prop);
+			writer.WriteInt32(0);
+			writer.WriteInt32(0);
+			writer.WriteVariantDouble(value);
+			writer.WriteStructureStart();
+			writer.WriteString(_uniqueName);
+			writer.WriteObjectPath(AtspiDbus.RootPath);
+			_connection.TrySendMessage(writer.CreateMessage());
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"AT-SPI PropertyChange emit failed on '{node.Path}': {ex}");
+			}
+		}
+	}
+
+	public void EmitPropertyChange(AtspiNode node, string prop, string value)
+	{
+		try
+		{
+			var writer = _connection.GetMessageWriter();
+			writer.WriteSignalHeader(null, node.Path, AtspiDbus.EventObjectInterface, AtspiDbus.PropertyChangeMember, AtspiDbus.StateChangedSignature);
+			writer.WriteString(prop);
+			writer.WriteInt32(0);
+			writer.WriteInt32(0);
+			writer.WriteVariantString(value);
+			writer.WriteStructureStart();
+			writer.WriteString(_uniqueName);
+			writer.WriteObjectPath(AtspiDbus.RootPath);
+			_connection.TrySendMessage(writer.CreateMessage());
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"AT-SPI PropertyChange emit failed on '{node.Path}': {ex}");
+			}
+		}
+	}
+
+	public void EmitSelectionChanged(AtspiNode node)
+	{
+		try
+		{
+			var writer = _connection.GetMessageWriter();
+			writer.WriteSignalHeader(null, node.Path, AtspiDbus.EventObjectInterface, AtspiDbus.SelectionChangedMember, AtspiDbus.StateChangedSignature);
+			writer.WriteString("");
+			writer.WriteInt32(0);
+			writer.WriteInt32(0);
+			writer.WriteVariantInt32(0);
+			writer.WriteStructureStart();
+			writer.WriteString(_uniqueName);
+			writer.WriteObjectPath(AtspiDbus.RootPath);
+			_connection.TrySendMessage(writer.CreateMessage());
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"AT-SPI SelectionChanged emit failed on '{node.Path}': {ex}");
+			}
+		}
+	}
+
+	public void EmitChildrenChanged(AtspiNode parent, bool added, int index, AtspiNode? child)
+	{
+		try
+		{
+			// The child reference would ideally ride as a variant of (so); expressing a
+			// variant-of-struct is awkward in Tmds.DBus.Protocol 0.92, so the variant is
+			// left empty — clients re-fetch children on this signal, which is sufficient.
+			var writer = _connection.GetMessageWriter();
+			writer.WriteSignalHeader(null, parent.Path, AtspiDbus.EventObjectInterface, AtspiDbus.ChildrenChangedMember, AtspiDbus.StateChangedSignature);
+			writer.WriteString(added ? "add" : "remove");
+			writer.WriteInt32(index);
+			writer.WriteInt32(0);
+			writer.WriteVariantInt32(0);
+			writer.WriteStructureStart();
+			writer.WriteString(_uniqueName);
+			writer.WriteObjectPath(AtspiDbus.RootPath);
+			_connection.TrySendMessage(writer.CreateMessage());
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"AT-SPI ChildrenChanged emit failed on '{parent.Path}': {ex}");
+			}
+		}
 	}
 
 	private static async Task<string?> GetA11yBusAddressAsync(string sessionBusAddress)
@@ -291,6 +447,18 @@ internal sealed class AtspiServer
 				case AtspiDbus.ApplicationInterface when node.Parent is null:
 					Application(context, member);
 					break;
+				case AtspiDbus.ActionInterface:
+					Action(context, node, member);
+					break;
+				case AtspiDbus.TextInterface:
+					Text(context, node, member);
+					break;
+				case AtspiDbus.EditableTextInterface:
+					EditableText(context, node, member);
+					break;
+				case AtspiDbus.SelectionInterface:
+					Selection(context, node, member);
+					break;
 				case AtspiDbus.PropertiesInterface:
 					Properties(context, node, member);
 					break;
@@ -336,7 +504,7 @@ internal sealed class AtspiServer
 					ReplyReference(context, _server.GetParentReference(node));
 					break;
 				case AtspiDbus.GetAttributesMethod:
-					ReplyEmptyDictionary(context, AtspiDbus.StringDictionarySignature);
+					ReplyAttributes(context, node);
 					break;
 				case AtspiDbus.GetRelationSetMethod:
 					ReplyEmptyStructArray(context, AtspiDbus.RelationSetSignature);
@@ -378,6 +546,181 @@ internal sealed class AtspiServer
 			}
 		}
 
+		private void Action(MethodContext context, AtspiNode node, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetNActionsMethod:
+					ReplyInt32(context, Actionable(node) ? 1 : 0);
+					break;
+				case AtspiDbus.GetActionNameMethod:
+				case AtspiDbus.GetLocalizedActionNameMethod:
+					_ = context.Request.GetBodyReader().ReadInt32();
+					ReplyString(context, AtspiDbus.StringSignature, ActionName(node));
+					break;
+				case AtspiDbus.GetActionDescriptionMethod:
+				case AtspiDbus.GetActionKeyBindingMethod:
+					_ = context.Request.GetBodyReader().ReadInt32();
+					ReplyString(context, AtspiDbus.StringSignature, AtspiDbus.EmptyString);
+					break;
+				case AtspiDbus.GetActionsMethod:
+					ReplyActions(context, node);
+					break;
+				case AtspiDbus.DoActionMethod:
+				{
+					_ = context.Request.GetBodyReader().ReadInt32();
+					ReplyBool(context, _server._writeTarget.Invoke(node));
+					break;
+				}
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private void Text(MethodContext context, AtspiNode node, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetTextMethod:
+				{
+					var reader = context.Request.GetBodyReader();
+					var start = reader.ReadInt32();
+					var end = reader.ReadInt32();
+					var text = node.Text;
+					start = Math.Max(0, Math.Min(start, text.Length));
+					end = end < 0 ? text.Length : Math.Max(start, Math.Min(end, text.Length));
+					ReplyString(context, AtspiDbus.StringSignature, text.Substring(start, end - start));
+					break;
+				}
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private void EditableText(MethodContext context, AtspiNode node, string member)
+		{
+			if (!node.Editable)
+			{
+				ReplyBool(context, false);
+				return;
+			}
+
+			var reader = context.Request.GetBodyReader();
+			switch (member)
+			{
+				case AtspiDbus.SetTextContentsMethod:
+					ReplyBool(context, _server._writeTarget.SetText(node, reader.ReadString()));
+					break;
+				case AtspiDbus.InsertTextMethod:
+				{
+					var pos = reader.ReadInt32();
+					var s = reader.ReadString();
+					var len = reader.ReadInt32();
+					var current = node.Text;
+					pos = Math.Max(0, Math.Min(pos, current.Length));
+					var insert = len >= 0 && len < s.Length ? s.Substring(0, len) : s;
+					ReplyBool(context, _server._writeTarget.SetText(node, current.Insert(pos, insert)));
+					break;
+				}
+				case AtspiDbus.DeleteTextMethod:
+				{
+					var start = reader.ReadInt32();
+					var end = reader.ReadInt32();
+					var current = node.Text;
+					start = Math.Max(0, Math.Min(start, current.Length));
+					end = Math.Max(start, Math.Min(end, current.Length));
+					if (start >= end)
+					{
+						ReplyBool(context, false);
+						break;
+					}
+					ReplyBool(context, _server._writeTarget.SetText(node, current.Remove(start, end - start)));
+					break;
+				}
+				case AtspiDbus.CopyTextMethod:
+					ReplyVoid(context);
+					break;
+				case AtspiDbus.CutTextMethod:
+				case AtspiDbus.PasteTextMethod:
+					ReplyBool(context, false);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private void Selection(MethodContext context, AtspiNode node, string member)
+		{
+			switch (member)
+			{
+				case AtspiDbus.GetSelectedChildMethod:
+				{
+					var index = context.Request.GetBodyReader().ReadInt32();
+					var selected = index == 0 ? node.Children.Find(c => c.Selected) : null;
+					ReplyReference(context, _server.GetReference(selected));
+					break;
+				}
+				case AtspiDbus.SelectChildMethod:
+				{
+					var index = context.Request.GetBodyReader().ReadInt32();
+					ReplyBool(context, _server._writeTarget.SelectChild(node, index));
+					break;
+				}
+				case AtspiDbus.IsChildSelectedMethod:
+				{
+					var index = context.Request.GetBodyReader().ReadInt32();
+					ReplyBool(context, index >= 0 && index < node.Children.Count && node.Children[index].Selected);
+					break;
+				}
+				case AtspiDbus.GetNSelectedChildrenMethod:
+					ReplyInt32(context, node.Children.Exists(c => c.Selected) ? 1 : 0);
+					break;
+				case AtspiDbus.DeselectSelectedChildMethod:
+				case AtspiDbus.DeselectChildMethod:
+				case AtspiDbus.SelectAllMethod:
+				case AtspiDbus.ClearSelectionMethod:
+					ReplyBool(context, false);
+					break;
+				default:
+					context.ReplyUnknownMethodError();
+					break;
+			}
+		}
+
+		private static bool Actionable(AtspiNode node)
+			=> node.HasToggle || node.Selectable || node.RoleName is "push button" or "combo box";
+
+		private static string ActionName(AtspiNode node)
+			=> node.Selectable ? "select" : node.RoleName switch
+			{
+				"push button" => "click",
+				"check box" => "toggle",
+				"radio button" => "toggle",
+				"combo box" => "expand or collapse",
+				_ => "activate",
+			};
+
+		private static bool HasSelectableChildren(AtspiNode node)
+			=> node.Children.Exists(c => c.Selectable);
+
+		private static void ReplyActions(MethodContext context, AtspiNode node)
+		{
+			using var writer = context.CreateReplyWriter(AtspiDbus.ActionsSignature);
+			var array = writer.WriteArrayStart(DBusType.Struct);
+			if (Actionable(node))
+			{
+				writer.WriteStructureStart();
+				writer.WriteString(ActionName(node));
+				writer.WriteString(AtspiDbus.EmptyString);
+				writer.WriteString(AtspiDbus.EmptyString);
+			}
+			writer.WriteArrayEnd(array);
+			context.Reply(writer.CreateMessage());
+		}
+
 		private static void Application(MethodContext context, string member)
 		{
 			switch (member)
@@ -404,8 +747,19 @@ internal sealed class AtspiServer
 					break;
 				}
 				case AtspiDbus.SetPropertyMethod:
+				{
+					var reader = context.Request.GetBodyReader();
+					var propertyInterface = reader.ReadString();
+					var property = reader.ReadString();
+					if (propertyInterface == AtspiDbus.ValueInterface &&
+						property == AtspiDbus.CurrentValueProperty &&
+						node.HasRange)
+					{
+						_server._writeTarget.SetRangeValue(node, reader.ReadVariantValue().GetDouble());
+					}
 					ReplyVoid(context);
 					break;
+				}
 				case AtspiDbus.GetAllPropertiesMethod:
 					ReplyEmptyVariantDictionary(context);
 					break;
@@ -449,6 +803,25 @@ internal sealed class AtspiServer
 					break;
 				case (AtspiDbus.ApplicationInterface, AtspiDbus.AtspiVersionProperty):
 					writer.WriteVariantString(AtspiDbus.AtspiVersion);
+					break;
+				case (AtspiDbus.ValueInterface, AtspiDbus.CurrentValueProperty) when node.HasRange:
+					writer.WriteVariantDouble(node.Val);
+					break;
+				case (AtspiDbus.ValueInterface, AtspiDbus.MinimumValueProperty) when node.HasRange:
+					writer.WriteVariantDouble(node.Min);
+					break;
+				case (AtspiDbus.ValueInterface, AtspiDbus.MaximumValueProperty) when node.HasRange:
+					writer.WriteVariantDouble(node.Max);
+					break;
+				case (AtspiDbus.ValueInterface, AtspiDbus.MinimumIncrementProperty) when node.HasRange:
+					writer.WriteVariantDouble(0);
+					break;
+				case (AtspiDbus.TextInterface, AtspiDbus.CharacterCountProperty) when node.HasText:
+					writer.WriteVariantInt32(node.Text.Length);
+					break;
+				case (AtspiDbus.ActionInterface, AtspiDbus.NActionsProperty):
+					// libatspi reads NActions as a property (int), not only via GetNActions.
+					writer.WriteVariantInt32(Actionable(node) ? 1 : 0);
 					break;
 				default:
 					writer.WriteVariantString(AtspiDbus.EmptyString);
@@ -527,7 +900,7 @@ internal sealed class AtspiServer
 			ReplyReference(context, _server.GetReference(FindAccessibleAtPoint(node, x, y)));
 		}
 
-		private static void ReplyStates(MethodContext context, AtspiNode node)
+		private void ReplyStates(MethodContext context, AtspiNode node)
 		{
 			uint state0 = 0;
 			void SetState(int bit) => state0 |= 1u << bit;
@@ -544,6 +917,39 @@ internal sealed class AtspiServer
 			if (node.Focusable)
 			{
 				SetState(AtspiDbus.FocusableState);
+			}
+
+			if (node.Checked)
+			{
+				SetState(AtspiDbus.CheckedState);
+			}
+
+			if (node.Editable)
+			{
+				SetState(AtspiDbus.EditableState);
+			}
+
+			if (node.Expandable)
+			{
+				SetState(AtspiDbus.ExpandableState);
+				if (node.Expanded)
+				{
+					SetState(AtspiDbus.ExpandedState);
+				}
+			}
+
+			if (node.Selectable)
+			{
+				SetState(AtspiDbus.SelectableState);
+				if (node.Selected)
+				{
+					SetState(AtspiDbus.SelectedState);
+				}
+			}
+
+			if (ReferenceEquals(_server._focusedNode, node))
+			{
+				SetState(AtspiDbus.FocusedState);
 			}
 
 			using var writer = context.CreateReplyWriter(AtspiDbus.UInt32ArraySignature);
@@ -563,6 +969,26 @@ internal sealed class AtspiServer
 			if (node.Parent is null)
 			{
 				writer.WriteString(AtspiDbus.ApplicationInterface);
+			}
+			if (Actionable(node))
+			{
+				writer.WriteString(AtspiDbus.ActionInterface);
+			}
+			if (node.HasRange)
+			{
+				writer.WriteString(AtspiDbus.ValueInterface);
+			}
+			if (node.HasText)
+			{
+				writer.WriteString(AtspiDbus.TextInterface);
+			}
+			if (node.Editable)
+			{
+				writer.WriteString(AtspiDbus.EditableTextInterface);
+			}
+			if (HasSelectableChildren(node))
+			{
+				writer.WriteString(AtspiDbus.SelectionInterface);
 			}
 			writer.WriteArrayEnd(array);
 			context.Reply(writer.CreateMessage());
@@ -611,6 +1037,35 @@ internal sealed class AtspiServer
 			context.Reply(writer.CreateMessage());
 		}
 
+		private static void ReplyAttributes(MethodContext context, AtspiNode node)
+		{
+			var attributes = new List<(string Key, string Value)>();
+			if (node.PositionInSet > 0)
+			{
+				attributes.Add(("posinset", node.PositionInSet.ToString()));
+				attributes.Add(("setsize", node.SizeOfSet.ToString()));
+			}
+			if (node.HeadingLevel > 0)
+			{
+				attributes.Add(("level", node.HeadingLevel.ToString()));
+			}
+			if (!string.IsNullOrEmpty(node.Landmark))
+			{
+				attributes.Add(("xml-roles", node.Landmark));
+			}
+
+			using var writer = context.CreateReplyWriter(AtspiDbus.StringDictionarySignature);
+			var dictionary = writer.WriteDictionaryStart();
+			foreach (var (key, value) in attributes)
+			{
+				writer.WriteDictionaryEntryStart();
+				writer.WriteString(key);
+				writer.WriteString(value);
+			}
+			writer.WriteDictionaryEnd(dictionary);
+			context.Reply(writer.CreateMessage());
+		}
+
 		private static void ReplyEmptyDictionary(MethodContext context, string signature)
 		{
 			using var writer = context.CreateReplyWriter(signature);
@@ -652,6 +1107,12 @@ internal sealed class AtspiServer
 		public const string AccessibleInterface = "org.a11y.atspi.Accessible";
 		public const string ComponentInterface = "org.a11y.atspi.Component";
 		public const string ApplicationInterface = "org.a11y.atspi.Application";
+		public const string ActionInterface = "org.a11y.atspi.Action";
+		public const string ValueInterface = "org.a11y.atspi.Value";
+		public const string TextInterface = "org.a11y.atspi.Text";
+		public const string EditableTextInterface = "org.a11y.atspi.EditableText";
+		public const string SelectionInterface = "org.a11y.atspi.Selection";
+		public const string EventObjectInterface = "org.a11y.atspi.Event.Object";
 		public const string SocketInterface = "org.a11y.atspi.Socket";
 		public const string PropertiesInterface = "org.freedesktop.DBus.Properties";
 		public const string IntrospectableInterface = "org.freedesktop.DBus.Introspectable";
@@ -676,6 +1137,28 @@ internal sealed class AtspiServer
 		public const string ContainsMethod = "Contains";
 		public const string GetAccessibleAtPointMethod = "GetAccessibleAtPoint";
 		public const string GrabFocusMethod = "GrabFocus";
+		public const string GetNActionsMethod = "GetNActions";
+		public const string GetActionNameMethod = "GetName";
+		public const string GetLocalizedActionNameMethod = "GetLocalizedName";
+		public const string GetActionDescriptionMethod = "GetDescription";
+		public const string GetActionKeyBindingMethod = "GetKeyBinding";
+		public const string GetActionsMethod = "GetActions";
+		public const string DoActionMethod = "DoAction";
+		public const string GetTextMethod = "GetText";
+		public const string SetTextContentsMethod = "SetTextContents";
+		public const string InsertTextMethod = "InsertText";
+		public const string DeleteTextMethod = "DeleteText";
+		public const string CopyTextMethod = "CopyText";
+		public const string CutTextMethod = "CutText";
+		public const string PasteTextMethod = "PasteText";
+		public const string GetSelectedChildMethod = "GetSelectedChild";
+		public const string SelectChildMethod = "SelectChild";
+		public const string IsChildSelectedMethod = "IsChildSelected";
+		public const string GetNSelectedChildrenMethod = "GetNSelectedChildren";
+		public const string DeselectSelectedChildMethod = "DeselectSelectedChild";
+		public const string DeselectChildMethod = "DeselectChild";
+		public const string SelectAllMethod = "SelectAll";
+		public const string ClearSelectionMethod = "ClearSelection";
 		public const string GetLocaleMethod = "GetLocale";
 		public const string GetPropertyMethod = "Get";
 		public const string SetPropertyMethod = "Set";
@@ -690,6 +1173,12 @@ internal sealed class AtspiServer
 		public const string ToolkitNameProperty = "ToolkitName";
 		public const string VersionProperty = "Version";
 		public const string AtspiVersionProperty = "AtspiVersion";
+		public const string CurrentValueProperty = "CurrentValue";
+		public const string MinimumValueProperty = "MinimumValue";
+		public const string MaximumValueProperty = "MaximumValue";
+		public const string MinimumIncrementProperty = "MinimumIncrement";
+		public const string CharacterCountProperty = "CharacterCount";
+		public const string NActionsProperty = "NActions";
 		public const string DefaultLocale = "C";
 		public const string ToolkitName = "Uno";
 		public const string ToolkitVersion = "1.0";
@@ -710,6 +1199,12 @@ internal sealed class AtspiServer
 		public const string StringDictionarySignature = "a{ss}";
 		public const string VariantDictionarySignature = "a{sv}";
 		public const string RelationSetSignature = "a(ua(so))";
+		public const string ActionsSignature = "a(sss)";
+		public const string StateChangedSignature = "siiv(so)";
+		public const string StateChangedMember = "StateChanged";
+		public const string PropertyChangeMember = "PropertyChange";
+		public const string SelectionChangedMember = "SelectionChanged";
+		public const string ChildrenChangedMember = "ChildrenChanged";
 		public const string IntrospectionXml = "<node/>";
 		public const string ApplicationRoleName = "application";
 		public const uint WidgetLayer = 3; // ATSPI_LAYER_WIDGET
@@ -719,5 +1214,12 @@ internal sealed class AtspiServer
 		public const int SensitiveState = 24;
 		public const int ShowingState = 25;
 		public const int VisibleState = 30;
+		public const int CheckedState = 4;
+		public const int EditableState = 7;
+		public const int ExpandableState = 9;
+		public const int ExpandedState = 10;
+		public const int FocusedState = 12;
+		public const int SelectableState = 22;
+		public const int SelectedState = 23;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
@@ -40,6 +40,10 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 	private bool _treeInitialized;
 	private bool _treeBuildQueued;
 	private int _nextPath = 1;
+	// Window top-left in screen space, captured per build; added to each node's
+	// client-space offset so AT-SPI extents are absolute screen coordinates.
+	private double _originX;
+	private double _originY;
 
 	internal X11Accessibility(X11XamlRootHost host, Window window)
 	{
@@ -173,6 +177,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			_nodesByHandle.Clear();
 			_elementsByHandle.Clear();
 			_nextPath = 1;
+			(_originX, _originY) = GetWindowOrigin();
 			_root = BuildRootNode(rootElement);
 			_treeInitialized = true;
 			// Publish an immutable element snapshot before the tree so the reader-thread
@@ -265,10 +270,9 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			? AtspiRoleMap.GetRole(peer.GetAutomationControlType())
 			: (39u, "panel");
 
-		// Absolute offset in client space (sum of GetTotalOffset up the Visual parent
-		// chain), matching MacOSAccessibility.GetAbsoluteOffset. The X11 window origin
-		// is not wired here, so coordinates remain window-relative; a follow-up adds
-		// the window position offset before publishing.
+		// Client-space offset (sum of GetTotalOffset up the Visual parent chain, like
+		// MacOSAccessibility.GetAbsoluteOffset) plus the window's screen origin, so the
+		// published extents are absolute screen coordinates.
 		var offset = GetAbsoluteOffset(element.Visual);
 		var size = element.Visual.Size;
 
@@ -280,8 +284,8 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			RoleName = roleName,
 			Name = ResolveName(peer),
 			Parent = parent,
-			X = offset.X,
-			Y = offset.Y,
+			X = offset.X + _originX,
+			Y = offset.Y + _originY,
 			W = size.X,
 			H = size.Y,
 			Enabled = peer?.IsEnabled() ?? true,
@@ -318,6 +322,21 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			current = current.Parent;
 		}
 		return (x, y);
+	}
+
+	private (double X, double Y) GetWindowOrigin()
+	{
+		try
+		{
+			var position = _window.AppWindow.Position;
+			return (position.X, position.Y);
+		}
+		catch (Exception)
+		{
+			// AppWindow position can be unavailable before the window is mapped; fall
+			// back to window-relative coordinates.
+			return (0, 0);
+		}
 	}
 
 	private static void PopulateNodeFromPeer(AtspiNode node, AutomationPeer peer)
@@ -499,8 +518,8 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 		}
 
 		var offset = GetAbsoluteOffset(containerVisual);
-		node.X = offset.X;
-		node.Y = offset.Y;
+		node.X = offset.X + _originX;
+		node.Y = offset.Y + _originY;
 		node.W = containerVisual.Size.X;
 		node.H = containerVisual.Size.Y;
 	}

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
@@ -1,0 +1,453 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Uno.Foundation.Logging;
+using Uno.UI.Runtime.Skia;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+/// <summary>
+/// Publishes the Skia-rendered X11 visual tree to the AT-SPI2 accessibility bus
+/// (<c>org.a11y.atspi</c>) as a tree of <see cref="AtspiNode"/> objects served by an
+/// <see cref="AtspiServer"/>. Mirrors <c>MacOSAccessibility</c>, but instead of a
+/// native per-window context it hands the whole tree to the process-scoped AT-SPI
+/// server (the a11y D-Bus exposes one application root per process).
+/// </summary>
+internal sealed class X11Accessibility : SkiaAccessibilityBase
+{
+	private const string RootPath = "/org/a11y/atspi/accessible/root";
+	private const string NodePathPrefix = "/org/a11y/atspi/accessible/";
+
+	private readonly X11XamlRootHost _host;
+	private readonly Window _window;
+
+	private AtspiServer? _server;
+	private AtspiNode? _root;
+	private readonly Dictionary<nint, AtspiNode> _nodesByHandle = new();
+	private bool _treeInitialized;
+	private bool _treeBuildQueued;
+	private int _nextPath = 1;
+
+	internal X11Accessibility(X11XamlRootHost host, Window window)
+	{
+		_host = host;
+		_window = window;
+	}
+
+	public override bool IsAccessibilityEnabled => !IsDisposed && _server is not null;
+
+	/// <summary>
+	/// Starts the AT-SPI server asynchronously and, once it resolves, builds and
+	/// publishes the accessibility tree on the UI thread. Called by the host after
+	/// the native X11 window exists.
+	/// </summary>
+	internal void Initialize()
+	{
+		if (_server is not null || IsDisposed)
+		{
+			return;
+		}
+
+		// Subscribe on the UI thread so a RootElement that only becomes available
+		// after the server starts still triggers the initial tree build.
+		_window.Activated += OnWindowActivated;
+
+		StartServerSafely();
+	}
+
+	private async void StartServerSafely()
+	{
+		try
+		{
+			var server = await AtspiServer.TryStartAsync(ResolveApplicationName());
+			if (IsDisposed || server is null)
+			{
+				return;
+			}
+
+			_server = server;
+
+			X11XamlRootHost.QueueAction(_host, () =>
+			{
+				if (IsDisposed || _server is null)
+				{
+					return;
+				}
+
+				if (_window.RootElement is { } rootElement)
+				{
+					QueueTreeBuild(rootElement);
+				}
+			});
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"[A11y] Failed to start AT-SPI server: {ex.Message}", ex);
+			}
+		}
+	}
+
+	private static string ResolveApplicationName()
+	{
+		try
+		{
+			var displayName = Windows.ApplicationModel.Package.Current.DisplayName;
+			if (!string.IsNullOrEmpty(displayName))
+			{
+				return displayName;
+			}
+		}
+		catch
+		{
+			// Package.Current throws outside of a packaged (MSIX) deployment.
+		}
+
+		return Process.GetCurrentProcess().ProcessName;
+	}
+
+	private void OnWindowActivated(object sender, WindowActivatedEventArgs args)
+	{
+		if (args.WindowActivationState == WindowActivationState.Deactivated)
+		{
+			return;
+		}
+
+		if (IsDisposed || _server is null || _treeInitialized)
+		{
+			return;
+		}
+
+		if (_window.RootElement is { } rootElement)
+		{
+			QueueTreeBuild(rootElement);
+		}
+	}
+
+	private void QueueTreeBuild(UIElement rootElement)
+	{
+		if (_treeBuildQueued)
+		{
+			return;
+		}
+		_treeBuildQueued = true;
+
+		X11XamlRootHost.QueueAction(_host, () =>
+		{
+			_treeBuildQueued = false;
+			if (IsDisposed || _server is null)
+			{
+				return;
+			}
+
+			BuildTree(rootElement);
+		});
+	}
+
+	private void BuildTree(UIElement rootElement)
+	{
+		try
+		{
+			_nodesByHandle.Clear();
+			_nextPath = 1;
+			_root = BuildRootNode(rootElement);
+			_treeInitialized = true;
+			_server!.SetRoot(_root);
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"[A11y] AT-SPI tree published with {_nodesByHandle.Count} node(s).");
+			}
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error($"[A11y] Failed to build AT-SPI tree: {ex.Message}", ex);
+			}
+		}
+	}
+
+	private AtspiNode BuildRootNode(UIElement rootElement)
+	{
+		var root = BuildNode(rootElement, null, RootPath);
+
+		// The AT-SPI application root must keep ATSPI_ROLE_APPLICATION regardless of
+		// the root element's own peer role, or clients mislabel the whole app.
+		root.Role = 75; // ATSPI_ROLE_APPLICATION
+		root.RoleName = "application";
+		if (string.IsNullOrEmpty(root.Name))
+		{
+			root.Name = ResolveApplicationName();
+		}
+
+		foreach (var child in rootElement.GetChildren())
+		{
+			BuildNodeRecursive(root, child);
+		}
+		return root;
+	}
+
+	private void BuildNodeRecursive(AtspiNode parent, UIElement child)
+	{
+		var accessibilityView = AutomationProperties.GetAccessibilityView(child);
+		if (accessibilityView == AccessibilityView.Raw)
+		{
+			foreach (var childChild in child.GetChildren())
+			{
+				BuildNodeRecursive(parent, childChild);
+			}
+			return;
+		}
+
+		var node = BuildNode(child, parent, NodePathPrefix + _nextPath++);
+		parent.Children.Add(node);
+
+		foreach (var childChild in child.GetChildren())
+		{
+			BuildNodeRecursive(node, childChild);
+		}
+	}
+
+	private AtspiNode BuildNode(UIElement element, AtspiNode? parent, string path)
+	{
+		var peer = element.GetOrCreateAutomationPeer();
+		var (role, roleName) = peer is not null
+			? AtspiRoleMap.GetRole(peer.GetAutomationControlType())
+			: (39u, "panel");
+
+		// GetBoundingRectangle returns client coordinates. The X11 window origin is not
+		// yet wired here, so boxes are window-relative; a follow-up PR adds the window
+		// position offset before publishing.
+		var bounds = peer?.GetBoundingRectangle() ?? default;
+
+		var node = new AtspiNode
+		{
+			Path = path,
+			Handle = element.Visual.Handle,
+			Role = role,
+			RoleName = roleName,
+			Name = ResolveName(peer),
+			Parent = parent,
+			X = bounds.X,
+			Y = bounds.Y,
+			W = bounds.Width,
+			H = bounds.Height,
+			Enabled = peer?.IsEnabled() ?? true,
+			Focusable = peer?.IsKeyboardFocusable() ?? false,
+		};
+
+		_nodesByHandle[node.Handle] = node;
+
+		return node;
+	}
+
+	private static string ResolveName(AutomationPeer? peer)
+	{
+		if (peer is null)
+		{
+			return string.Empty;
+		}
+
+		var label = ResolveLabel(peer);
+		if (!string.IsNullOrEmpty(label))
+		{
+			return label;
+		}
+
+		return peer.GetName() ?? string.Empty;
+	}
+
+	protected override void OnChildAdded(UIElement parent, UIElement child, int? index)
+		=> QueueRebuildIfNeeded();
+
+	protected override void OnChildRemoved(UIElement parent, UIElement child)
+		=> QueueRebuildIfNeeded();
+
+	public override void NotifyInvalidatePeer(AutomationPeer peer)
+	{
+		if (IsDisposed || !IsAccessibilityEnabled)
+		{
+			return;
+		}
+
+		QueueRebuildIfNeeded();
+	}
+
+	private void QueueRebuildIfNeeded()
+	{
+		if (!_treeInitialized)
+		{
+			return;
+		}
+
+		if (_window.RootElement is { } rootElement)
+		{
+			QueueTreeBuild(rootElement);
+		}
+	}
+
+	protected override void OnSizeOrOffsetChanged(Visual visual)
+	{
+		if (!IsAccessibilityEnabled || !_treeInitialized)
+		{
+			return;
+		}
+
+		if (visual is not ContainerVisual containerVisual ||
+			containerVisual.Owner?.Target is not UIElement owner ||
+			!_nodesByHandle.TryGetValue(containerVisual.Handle, out var node))
+		{
+			return;
+		}
+
+		var peer = owner.GetOrCreateAutomationPeer();
+		if (peer is null)
+		{
+			return;
+		}
+
+		var rect = peer.GetBoundingRectangle();
+		node.X = rect.X;
+		node.Y = rect.Y;
+		node.W = rect.Width;
+		node.H = rect.Height;
+	}
+
+	protected override void UpdateName(nint handle, AutomationPeer peer, string? label)
+	{
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Name = label ?? string.Empty;
+		}
+	}
+
+	protected override void UpdateEnabled(nint handle, bool enabled)
+	{
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Enabled = enabled;
+		}
+	}
+
+	protected override void UpdateFocusable(nint handle, bool focusable)
+	{
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Focusable = focusable;
+		}
+	}
+
+	protected override void UpdateToggleState(nint handle, AutomationPeer peer, ToggleState newState)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateRangeValue(nint handle, AutomationPeer peer, double value)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateRangeBounds(nint handle, double min, double max)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateTextValue(nint handle, string? value)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateExpandCollapseState(nint handle, bool isExpanded)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateSelected(nint handle, bool selected)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateHelpText(nint handle, string? helpText)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateHeadingLevel(nint handle, int level)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateLandmark(nint handle, string? landmarkRole)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateIsReadOnly(nint handle, bool isReadOnly)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void UpdateIsOffscreen(nint handle, bool isOffscreen)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void SetNativeFocus(nint handle)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void OnNativeStructureChanged()
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void AnnounceOnPlatform(string text, bool assertive)
+	{
+		// AT-SPI event emission lands in the live-events PR.
+	}
+
+	protected override void DisposeCore()
+	{
+		if (this.Log().IsEnabled(LogLevel.Debug))
+		{
+			this.Log().Debug("[A11y] Disposing X11Accessibility.");
+		}
+
+		_window.Activated -= OnWindowActivated;
+
+		var server = _server;
+		_server = null;
+		_root = null;
+		_nodesByHandle.Clear();
+		_treeInitialized = false;
+
+		if (server is not null)
+		{
+			StopServerSafely(server);
+		}
+	}
+
+	private async void StopServerSafely(AtspiServer server)
+	{
+		try
+		{
+			await server.StopAsync();
+		}
+		catch (Exception ex)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"[A11y] Failed to stop AT-SPI server: {ex.Message}");
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
@@ -29,6 +29,10 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 	private readonly X11XamlRootHost _host;
 	private readonly Window _window;
 
+	// Guards _server assignment (on the D-Bus connect continuation thread) against
+	// DisposeCore (on the UI thread), so a server that starts as the window closes is
+	// never left running.
+	private readonly object _serverGate = new();
 	private AtspiServer? _server;
 	private AtspiNode? _root;
 	private readonly Dictionary<nint, AtspiNode> _nodesByHandle = new();
@@ -82,15 +86,18 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 				return;
 			}
 
-			if (IsDisposed)
+			lock (_serverGate)
 			{
-				// The window closed while the connection was being established;
-				// stop the server so the D-Bus connection is not leaked.
-				StopServerSafely(server);
-				return;
-			}
+				if (IsDisposed)
+				{
+					// The window closed while the connection was being established;
+					// stop the server so the D-Bus connection is not leaked.
+					StopServerSafely(server);
+					return;
+				}
 
-			_server = server;
+				_server = server;
+			}
 
 			X11XamlRootHost.QueueAction(_host, () =>
 			{
@@ -409,6 +416,20 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 	private void PopulateComboBoxItems(AtspiNode comboNode, ComboBox comboBox)
 	{
 		comboNode.Expandable = true;
+		comboNode.Expanded = comboBox.IsDropDownOpen;
+
+		// The combo's selected value is always exposed as text (like the macOS head),
+		// but the items themselves are only enumerated while the dropdown is open — an
+		// eager walk of comboBox.Items would materialize a large/virtualized ItemsSource
+		// on every rebuild. A rebuild is coalesced-triggered when the dropdown opens.
+		comboNode.Text = FrameworkElement.GetStringFromObject(comboBox.SelectionBoxItem) ?? "";
+		comboNode.HasText = true;
+
+		if (!comboBox.IsDropDownOpen)
+		{
+			return;
+		}
+
 		for (var index = 0; index < comboBox.Items.Count; index++)
 		{
 			var item = comboBox.Items[index];
@@ -437,10 +458,6 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			}
 			comboNode.Children.Add(itemNode);
 		}
-
-		// The combo also exposes its current selection as text.
-		comboNode.Text = comboNode.Children.Find(c => c.Selected)?.Name ?? "";
-		comboNode.HasText = true;
 	}
 
 	private static string ResolveName(AutomationPeer? peer)
@@ -812,11 +829,16 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 
 		_window.Activated -= OnWindowActivated;
 
-		var server = _server;
-		_server = null;
+		AtspiServer? server;
+		lock (_serverGate)
+		{
+			server = _server;
+			_server = null;
+		}
 		_root = null;
 		_nodesByHandle.Clear();
 		_elementsByHandle.Clear();
+		_elementsSnapshot = new Dictionary<nint, UIElement>();
 		_focusedNode = null;
 		_treeInitialized = false;
 

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
@@ -7,6 +7,8 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
 using Uno.Foundation.Logging;
 using Uno.UI.Runtime.Skia;
 
@@ -19,7 +21,7 @@ namespace Uno.WinUI.Runtime.Skia.X11;
 /// native per-window context it hands the whole tree to the process-scoped AT-SPI
 /// server (the a11y D-Bus exposes one application root per process).
 /// </summary>
-internal sealed class X11Accessibility : SkiaAccessibilityBase
+internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWriteTarget
 {
 	private const string RootPath = "/org/a11y/atspi/accessible/root";
 	private const string NodePathPrefix = "/org/a11y/atspi/accessible/";
@@ -30,6 +32,8 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 	private AtspiServer? _server;
 	private AtspiNode? _root;
 	private readonly Dictionary<nint, AtspiNode> _nodesByHandle = new();
+	private readonly Dictionary<nint, UIElement> _elementsByHandle = new();
+	private AtspiNode? _focusedNode;
 	private bool _treeInitialized;
 	private bool _treeBuildQueued;
 	private int _nextPath = 1;
@@ -65,7 +69,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 	{
 		try
 		{
-			var server = await AtspiServer.TryStartAsync(ResolveApplicationName());
+			var server = await AtspiServer.TryStartAsync(ResolveApplicationName(), this);
 			if (server is null)
 			{
 				return;
@@ -164,6 +168,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		try
 		{
 			_nodesByHandle.Clear();
+			_elementsByHandle.Clear();
 			_nextPath = 1;
 			_root = BuildRootNode(rootElement);
 			_treeInitialized = true;
@@ -221,6 +226,14 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		var node = BuildNode(child, parent, NodePathPrefix + _nextPath++);
 		parent.Children.Add(node);
 
+		// ComboBox items live in a popup outside the visual tree; BuildNode surfaces
+		// them as selectable child nodes, so do not descend into the combo's content
+		// presenter (which shows a copy of the selected item).
+		if (child is ComboBox)
+		{
+			return;
+		}
+
 		foreach (var childChild in child.GetChildren())
 		{
 			BuildNodeRecursive(node, childChild);
@@ -234,10 +247,12 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 			? AtspiRoleMap.GetRole(peer.GetAutomationControlType())
 			: (39u, "panel");
 
-		// GetBoundingRectangle returns client coordinates. The X11 window origin is not
-		// yet wired here, so boxes are window-relative; a follow-up PR adds the window
-		// position offset before publishing.
-		var bounds = peer?.GetBoundingRectangle() ?? default;
+		// Absolute offset in client space (sum of GetTotalOffset up the Visual parent
+		// chain), matching MacOSAccessibility.GetAbsoluteOffset. The X11 window origin
+		// is not wired here, so coordinates remain window-relative; a follow-up adds
+		// the window position offset before publishing.
+		var offset = GetAbsoluteOffset(element.Visual);
+		var size = element.Visual.Size;
 
 		var node = new AtspiNode
 		{
@@ -247,17 +262,137 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 			RoleName = roleName,
 			Name = ResolveName(peer),
 			Parent = parent,
-			X = bounds.X,
-			Y = bounds.Y,
-			W = bounds.Width,
-			H = bounds.Height,
+			X = offset.X,
+			Y = offset.Y,
+			W = size.X,
+			H = size.Y,
 			Enabled = peer?.IsEnabled() ?? true,
 			Focusable = peer?.IsKeyboardFocusable() ?? false,
+			ItemIndex = parent?.Children.Count ?? -1,
 		};
 
+		if (peer is not null)
+		{
+			PopulateNodeFromPeer(node, peer);
+		}
+
 		_nodesByHandle[node.Handle] = node;
+		_elementsByHandle[node.Handle] = element;
+
+		if (element is ComboBox comboBox)
+		{
+			PopulateComboBoxItems(node, comboBox);
+		}
 
 		return node;
+	}
+
+	private static (double X, double Y) GetAbsoluteOffset(Visual visual)
+	{
+		double x = 0;
+		double y = 0;
+		var current = visual;
+		while (current is not null)
+		{
+			var offset = current.GetTotalOffset();
+			x += offset.X;
+			y += offset.Y;
+			current = current.Parent;
+		}
+		return (x, y);
+	}
+
+	private static void PopulateNodeFromPeer(AtspiNode node, AutomationPeer peer)
+	{
+		var attributes = AriaMapper.GetAriaAttributes(peer);
+
+		node.Description = attributes.Description;
+		node.HeadingLevel = attributes.Level ?? 0;
+		node.Landmark = attributes.LandmarkRole;
+		node.Required = attributes.Required;
+		node.PositionInSet = attributes.PositionInSet ?? 0;
+		node.SizeOfSet = attributes.SizeOfSet ?? 0;
+
+		try
+		{
+			if (peer.GetPattern(PatternInterface.Toggle) is IToggleProvider toggleProvider)
+			{
+				node.HasToggle = true;
+				node.Checked = toggleProvider.ToggleState == ToggleState.On;
+			}
+
+			if (peer.GetPattern(PatternInterface.RangeValue) is IRangeValueProvider rangeProvider)
+			{
+				node.HasRange = true;
+				node.Min = rangeProvider.Minimum;
+				node.Max = rangeProvider.Maximum;
+				node.Val = rangeProvider.Value;
+			}
+
+			if (peer.GetPattern(PatternInterface.Value) is IValueProvider valueProvider)
+			{
+				node.HasText = true;
+				node.Text = valueProvider.Value ?? "";
+				node.ReadOnly = valueProvider.IsReadOnly;
+				node.Editable = !valueProvider.IsReadOnly;
+			}
+
+			if (peer.GetPattern(PatternInterface.ExpandCollapse) is IExpandCollapseProvider expandProvider)
+			{
+				node.Expandable = true;
+				node.Expanded = expandProvider.ExpandCollapseState is ExpandCollapseState.Expanded or ExpandCollapseState.PartiallyExpanded;
+			}
+
+			if (peer.GetPattern(PatternInterface.SelectionItem) is ISelectionItemProvider selectionItemProvider)
+			{
+				node.Selectable = true;
+				node.Selected = selectionItemProvider.IsSelected;
+			}
+
+			if (!node.HasToggle && attributes.Checked is not null)
+			{
+				node.HasToggle = true;
+				node.Checked = attributes.Checked == "true";
+			}
+		}
+		catch
+		{
+			// Some peers throw when queried before fully initialized; the attributes
+			// above were captured already and are refreshed on property changes.
+		}
+	}
+
+	private void PopulateComboBoxItems(AtspiNode comboNode, ComboBox comboBox)
+	{
+		comboNode.Expandable = true;
+		for (var index = 0; index < comboBox.Items.Count; index++)
+		{
+			var item = comboBox.Items[index];
+			var itemElement = item as ComboBoxItem;
+			var (itemRole, itemRoleName) = AtspiRoleMap.GetRole(AutomationControlType.ListItem);
+			var itemNode = new AtspiNode
+			{
+				Path = NodePathPrefix + _nextPath++,
+				Name = (itemElement?.Content ?? item)?.ToString() ?? $"item {index}",
+				Role = itemRole,
+				RoleName = itemRoleName,
+				Enabled = true,
+				Parent = comboNode,
+				Selectable = true,
+				Selected = index == comboBox.SelectedIndex,
+				ItemIndex = index,
+			};
+			if (itemElement is not null)
+			{
+				itemNode.Handle = itemElement.Visual.Handle;
+				_elementsByHandle[itemElement.Visual.Handle] = itemElement;
+			}
+			comboNode.Children.Add(itemNode);
+			_nodesByHandle[itemNode.Handle] = itemNode;
+		}
+
+		// The combo also exposes its current selection as text.
+		comboNode.Text = comboNode.Children.Find(c => c.Selected)?.Name ?? "";
 	}
 
 	private static string ResolveName(AutomationPeer? peer)
@@ -280,10 +415,22 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 	{
 		TrySubscribeScrollSource(child);
 		QueueRebuildIfNeeded();
+		if (_server is { } server && _nodesByHandle.TryGetValue(parent.Visual.Handle, out var parentNode))
+		{
+			server.EmitChildrenChanged(parentNode, added: true, index ?? -1, child: null);
+		}
 	}
 
 	protected override void OnChildRemoved(UIElement parent, UIElement child)
-		=> QueueRebuildIfNeeded();
+	{
+		if (_server is { } server && _nodesByHandle.TryGetValue(parent.Visual.Handle, out var parentNode))
+		{
+			var childNode = _nodesByHandle.TryGetValue(child.Visual.Handle, out var removed) ? removed : null;
+			var index = childNode is not null ? parentNode.Children.IndexOf(childNode) : -1;
+			server.EmitChildrenChanged(parentNode, added: false, index, childNode);
+		}
+		QueueRebuildIfNeeded();
+	}
 
 	public override void NotifyInvalidatePeer(AutomationPeer peer)
 	{
@@ -316,23 +463,17 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		}
 
 		if (visual is not ContainerVisual containerVisual ||
-			containerVisual.Owner?.Target is not UIElement owner ||
+			containerVisual.Owner?.Target is not UIElement ||
 			!_nodesByHandle.TryGetValue(containerVisual.Handle, out var node))
 		{
 			return;
 		}
 
-		var peer = owner.GetOrCreateAutomationPeer();
-		if (peer is null)
-		{
-			return;
-		}
-
-		var rect = peer.GetBoundingRectangle();
-		node.X = rect.X;
-		node.Y = rect.Y;
-		node.W = rect.Width;
-		node.H = rect.Height;
+		var offset = GetAbsoluteOffset(containerVisual);
+		node.X = offset.X;
+		node.Y = offset.Y;
+		node.W = containerVisual.Size.X;
+		node.H = containerVisual.Size.Y;
 	}
 
 	protected override void UpdateName(nint handle, AutomationPeer peer, string? label)
@@ -340,6 +481,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		if (_nodesByHandle.TryGetValue(handle, out var node))
 		{
 			node.Name = label ?? string.Empty;
+			_server?.EmitPropertyChange(node, "accessible-name", node.Name);
 		}
 	}
 
@@ -348,6 +490,8 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		if (_nodesByHandle.TryGetValue(handle, out var node))
 		{
 			node.Enabled = enabled;
+			_server?.EmitStateChanged(node, "enabled", enabled ? 1 : 0);
+			_server?.EmitStateChanged(node, "sensitive", enabled ? 1 : 0);
 		}
 	}
 
@@ -361,72 +505,254 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 
 	protected override void UpdateToggleState(nint handle, AutomationPeer peer, ToggleState newState)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Checked = newState == ToggleState.On;
+			_server?.EmitStateChanged(node, "checked", node.Checked ? 1 : 0);
+		}
 	}
 
 	protected override void UpdateRangeValue(nint handle, AutomationPeer peer, double value)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Val = value;
+			_server?.EmitPropertyChange(node, "accessible-value", value);
+		}
 	}
 
 	protected override void UpdateRangeBounds(nint handle, double min, double max)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Min = min;
+			node.Max = max;
+		}
 	}
 
 	protected override void UpdateTextValue(nint handle, string? value)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Text = value ?? string.Empty;
+			_server?.EmitPropertyChange(node, "accessible-value", node.Text);
+		}
 	}
 
 	protected override void UpdateExpandCollapseState(nint handle, bool isExpanded)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Expanded = isExpanded;
+			_server?.EmitStateChanged(node, "expanded", isExpanded ? 1 : 0);
+		}
 	}
 
 	protected override void UpdateSelected(nint handle, bool selected)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Selected = selected;
+			_server?.EmitStateChanged(node, "selected", selected ? 1 : 0);
+			if (node.Parent is { } parentNode)
+			{
+				_server?.EmitSelectionChanged(parentNode);
+			}
+		}
 	}
 
 	protected override void UpdateHelpText(nint handle, string? helpText)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Description = helpText;
+		}
 	}
 
 	protected override void UpdateHeadingLevel(nint handle, int level)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.HeadingLevel = level;
+		}
 	}
 
 	protected override void UpdateLandmark(nint handle, string? landmarkRole)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Landmark = landmarkRole;
+		}
 	}
 
 	protected override void UpdateIsReadOnly(nint handle, bool isReadOnly)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.ReadOnly = isReadOnly;
+			_server?.EmitStateChanged(node, "read-only", isReadOnly ? 1 : 0);
+		}
 	}
 
 	protected override void UpdateIsOffscreen(nint handle, bool isOffscreen)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			node.Offscreen = isOffscreen;
+			_server?.EmitStateChanged(node, "showing", isOffscreen ? 0 : 1);
+			_server?.EmitStateChanged(node, "visible", isOffscreen ? 0 : 1);
+		}
 	}
 
 	protected override void SetNativeFocus(nint handle)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		if (!_nodesByHandle.TryGetValue(handle, out var node))
+		{
+			return;
+		}
+
+		if (_focusedNode is { } previous && previous != node)
+		{
+			_server?.EmitStateChanged(previous, "focused", 0);
+		}
+
+		_focusedNode = node;
+		_server?.SetFocus(node);
+		_server?.EmitStateChanged(node, "focused", 1);
 	}
 
 	protected override void OnNativeStructureChanged()
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		QueueRebuildIfNeeded();
 	}
 
 	protected override void AnnounceOnPlatform(string text, bool assertive)
 	{
-		// AT-SPI event emission lands in the live-events PR.
+		// AT-SPI has no simple bus-level announce; live regions are surfaced via
+		// StateChanged/PropertyChange signals rather than a native speech API.
+	}
+
+	// ──────────────────────────────────────────────────────────────
+	//  AtspiServer.IWriteTarget — drive the real control from the
+	//  D-Bus thread. Each method dispatches to the UI thread and
+	//  returns once the action is enqueued; the state-changed signal
+	//  emitted by the Update* overrides is the confirmation.
+	// ──────────────────────────────────────────────────────────────
+
+	bool AtspiServer.IWriteTarget.Invoke(AtspiNode node)
+	{
+		if (node.Selectable && node.Parent is { } parentNode && parentNode.RoleName == "combo box")
+		{
+			return ((AtspiServer.IWriteTarget)this).SelectChild(parentNode, node.ItemIndex);
+		}
+
+		if (!_elementsByHandle.TryGetValue(node.Handle, out var element))
+		{
+			return false;
+		}
+
+		return element.DispatcherQueue.TryEnqueue(() => InvokeOnUiThread(element));
+	}
+
+	bool AtspiServer.IWriteTarget.SetRangeValue(AtspiNode node, double value)
+	{
+		if (!_elementsByHandle.TryGetValue(node.Handle, out var element))
+		{
+			return false;
+		}
+
+		return element.DispatcherQueue.TryEnqueue(() => SetRangeValueOnUiThread(element, value));
+	}
+
+	bool AtspiServer.IWriteTarget.SetText(AtspiNode node, string text)
+	{
+		if (!_elementsByHandle.TryGetValue(node.Handle, out var element))
+		{
+			return false;
+		}
+
+		return element.DispatcherQueue.TryEnqueue(() => SetTextOnUiThread(element, text));
+	}
+
+	bool AtspiServer.IWriteTarget.SelectChild(AtspiNode node, int index)
+	{
+		if (!_elementsByHandle.TryGetValue(node.Handle, out var element) || element is not ComboBox comboBox)
+		{
+			return false;
+		}
+
+		return comboBox.DispatcherQueue.TryEnqueue(() => SelectChildOnUiThread(comboBox, index));
+	}
+
+	private static void InvokeOnUiThread(UIElement element)
+	{
+		var peer = element.GetOrCreateAutomationPeer();
+		if (peer is null)
+		{
+			return;
+		}
+
+		if (peer.GetPattern(PatternInterface.Invoke) is IInvokeProvider invokeProvider)
+		{
+			invokeProvider.Invoke();
+		}
+		else if (peer.GetPattern(PatternInterface.Toggle) is IToggleProvider toggleProvider)
+		{
+			toggleProvider.Toggle();
+		}
+		else if (peer.GetPattern(PatternInterface.ExpandCollapse) is IExpandCollapseProvider expandCollapseProvider)
+		{
+			if (expandCollapseProvider.ExpandCollapseState == ExpandCollapseState.Expanded)
+			{
+				expandCollapseProvider.Collapse();
+			}
+			else
+			{
+				expandCollapseProvider.Expand();
+			}
+		}
+		else if (peer.GetPattern(PatternInterface.SelectionItem) is ISelectionItemProvider selectionItemProvider)
+		{
+			selectionItemProvider.Select();
+		}
+	}
+
+	private static void SetRangeValueOnUiThread(UIElement element, double value)
+	{
+		var peer = element.GetOrCreateAutomationPeer();
+		if (peer?.GetPattern(PatternInterface.RangeValue) is IRangeValueProvider rangeValueProvider)
+		{
+			var clamped = Math.Max(rangeValueProvider.Minimum, Math.Min(rangeValueProvider.Maximum, value));
+			rangeValueProvider.SetValue(clamped);
+		}
+	}
+
+	private static void SetTextOnUiThread(UIElement element, string text)
+	{
+		var peer = element.GetOrCreateAutomationPeer();
+		if (peer?.GetPattern(PatternInterface.Value) is IValueProvider { IsReadOnly: false } valueProvider)
+		{
+			valueProvider.SetValue(text);
+		}
+	}
+
+	private static void SelectChildOnUiThread(ComboBox comboBox, int index)
+	{
+		if (index < 0 || index >= comboBox.Items.Count)
+		{
+			return;
+		}
+
+		var itemElement = comboBox.Items[index] as ComboBoxItem;
+		var peer = itemElement?.GetOrCreateAutomationPeer();
+		if (peer?.GetPattern(PatternInterface.SelectionItem) is ISelectionItemProvider selectionItemProvider)
+		{
+			selectionItemProvider.AddToSelection();
+		}
+		else
+		{
+			comboBox.SelectedIndex = index;
+		}
 	}
 
 	protected override void DisposeCore()
@@ -442,6 +768,8 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		_server = null;
 		_root = null;
 		_nodesByHandle.Clear();
+		_elementsByHandle.Clear();
+		_focusedNode = null;
 		_treeInitialized = false;
 
 		if (server is not null)

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
@@ -33,6 +33,9 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 	private AtspiNode? _root;
 	private readonly Dictionary<nint, AtspiNode> _nodesByHandle = new();
 	private readonly Dictionary<nint, UIElement> _elementsByHandle = new();
+	// Immutable snapshot published for the D-Bus reader thread (write-path lookups).
+	// The mutable _elementsByHandle above is only touched on the UI thread during a build.
+	private volatile IReadOnlyDictionary<nint, UIElement> _elementsSnapshot = new Dictionary<nint, UIElement>();
 	private AtspiNode? _focusedNode;
 	private bool _treeInitialized;
 	private bool _treeBuildQueued;
@@ -172,7 +175,22 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			_nextPath = 1;
 			_root = BuildRootNode(rootElement);
 			_treeInitialized = true;
+			// Publish an immutable element snapshot before the tree so the reader-thread
+			// write path never observes the dictionary mid-rebuild.
+			_elementsSnapshot = new Dictionary<nint, UIElement>(_elementsByHandle);
 			_server!.SetRoot(_root);
+
+			// A rebuild replaces every node instance; re-point focus at the fresh node
+			// for the same handle so the focused state survives structure changes.
+			if (_focusedNode is { } prevFocus && _nodesByHandle.TryGetValue(prevFocus.Handle, out var refocused))
+			{
+				_focusedNode = refocused;
+			}
+			else
+			{
+				_focusedNode = null;
+			}
+			_server.SetFocus(_focusedNode);
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
@@ -348,6 +366,13 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 				node.Selectable = true;
 				node.Selected = selectionItemProvider.IsSelected;
 			}
+			else if (attributes.Selected is { } ariaSelected)
+			{
+				// ListViewItem/ListBoxItem peers are container peers without the
+				// SelectionItem pattern; AriaMapper still resolves their selected state.
+				node.Selectable = true;
+				node.Selected = ariaSelected;
+			}
 
 			if (!node.HasToggle && attributes.Checked is not null)
 			{
@@ -382,17 +407,21 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 				Selected = index == comboBox.SelectedIndex,
 				ItemIndex = index,
 			};
+			// Data-only items have no ComboBoxItem container (Handle stays 0); they are
+			// reached by path via the combo's children and driven through the parent's
+			// SelectChild(ItemIndex), so only handle-backed items go in the handle maps.
 			if (itemElement is not null)
 			{
 				itemNode.Handle = itemElement.Visual.Handle;
 				_elementsByHandle[itemElement.Visual.Handle] = itemElement;
+				_nodesByHandle[itemNode.Handle] = itemNode;
 			}
 			comboNode.Children.Add(itemNode);
-			_nodesByHandle[itemNode.Handle] = itemNode;
 		}
 
 		// The combo also exposes its current selection as text.
 		comboNode.Text = comboNode.Children.Find(c => c.Selected)?.Name ?? "";
+		comboNode.HasText = true;
 	}
 
 	private static string ResolveName(AutomationPeer? peer)
@@ -417,7 +446,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 		QueueRebuildIfNeeded();
 		if (_server is { } server && _nodesByHandle.TryGetValue(parent.Visual.Handle, out var parentNode))
 		{
-			server.EmitChildrenChanged(parentNode, added: true, index ?? -1, child: null);
+			server.EmitChildrenChanged(parentNode, added: true, index ?? -1);
 		}
 	}
 
@@ -427,7 +456,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 		{
 			var childNode = _nodesByHandle.TryGetValue(child.Visual.Handle, out var removed) ? removed : null;
 			var index = childNode is not null ? parentNode.Children.IndexOf(childNode) : -1;
-			server.EmitChildrenChanged(parentNode, added: false, index, childNode);
+			server.EmitChildrenChanged(parentNode, added: false, index);
 		}
 		QueueRebuildIfNeeded();
 	}
@@ -646,7 +675,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 			return ((AtspiServer.IWriteTarget)this).SelectChild(parentNode, node.ItemIndex);
 		}
 
-		if (!_elementsByHandle.TryGetValue(node.Handle, out var element))
+		if (!_elementsSnapshot.TryGetValue(node.Handle, out var element))
 		{
 			return false;
 		}
@@ -656,7 +685,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 
 	bool AtspiServer.IWriteTarget.SetRangeValue(AtspiNode node, double value)
 	{
-		if (!_elementsByHandle.TryGetValue(node.Handle, out var element))
+		if (!_elementsSnapshot.TryGetValue(node.Handle, out var element))
 		{
 			return false;
 		}
@@ -666,7 +695,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 
 	bool AtspiServer.IWriteTarget.SetText(AtspiNode node, string text)
 	{
-		if (!_elementsByHandle.TryGetValue(node.Handle, out var element))
+		if (!_elementsSnapshot.TryGetValue(node.Handle, out var element))
 		{
 			return false;
 		}
@@ -676,7 +705,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase, AtspiServer.IWri
 
 	bool AtspiServer.IWriteTarget.SelectChild(AtspiNode node, int index)
 	{
-		if (!_elementsByHandle.TryGetValue(node.Handle, out var element) || element is not ComboBox comboBox)
+		if (!_elementsSnapshot.TryGetValue(node.Handle, out var element) || element is not ComboBox comboBox)
 		{
 			return false;
 		}

--- a/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Accessibility/X11Accessibility.cs
@@ -66,8 +66,16 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 		try
 		{
 			var server = await AtspiServer.TryStartAsync(ResolveApplicationName());
-			if (IsDisposed || server is null)
+			if (server is null)
 			{
+				return;
+			}
+
+			if (IsDisposed)
+			{
+				// The window closed while the connection was being established;
+				// stop the server so the D-Bus connection is not leaked.
+				StopServerSafely(server);
 				return;
 			}
 
@@ -105,7 +113,7 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 				return displayName;
 			}
 		}
-		catch
+		catch (Exception)
 		{
 			// Package.Current throws outside of a packaged (MSIX) deployment.
 		}
@@ -177,12 +185,13 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 
 	private AtspiNode BuildRootNode(UIElement rootElement)
 	{
+		TrySubscribeScrollSource(rootElement);
 		var root = BuildNode(rootElement, null, RootPath);
 
 		// The AT-SPI application root must keep ATSPI_ROLE_APPLICATION regardless of
 		// the root element's own peer role, or clients mislabel the whole app.
-		root.Role = 75; // ATSPI_ROLE_APPLICATION
-		root.RoleName = "application";
+		root.Role = AtspiRoleMap.ApplicationRoleId;
+		root.RoleName = AtspiRoleMap.ApplicationRoleName;
 		if (string.IsNullOrEmpty(root.Name))
 		{
 			root.Name = ResolveApplicationName();
@@ -197,6 +206,8 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 
 	private void BuildNodeRecursive(AtspiNode parent, UIElement child)
 	{
+		TrySubscribeScrollSource(child);
+
 		var accessibilityView = AutomationProperties.GetAccessibilityView(child);
 		if (accessibilityView == AccessibilityView.Raw)
 		{
@@ -266,7 +277,10 @@ internal sealed class X11Accessibility : SkiaAccessibilityBase
 	}
 
 	protected override void OnChildAdded(UIElement parent, UIElement child, int? index)
-		=> QueueRebuildIfNeeded();
+	{
+		TrySubscribeScrollSource(child);
+		QueueRebuildIfNeeded();
+	}
 
 	protected override void OnChildRemoved(UIElement parent, UIElement child)
 		=> QueueRebuildIfNeeded();

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
@@ -135,6 +135,8 @@ public partial class X11ApplicationHost : SkiaHost, ISkiaApplicationHost, IDispo
 			}
 		}
 
+		AccessibilityRouter.EnsureInitialized();
+
 		CompositionTarget.FrameRenderingOptions = (true, true);
 	}
 

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.cs
@@ -14,6 +14,7 @@ using Windows.Foundation;
 using Windows.UI.ViewManagement;
 using Uno.Foundation.Logging;
 using Uno.UI.Hosting;
+using Uno.UI.Runtime.Skia;
 using Microsoft.UI.Xaml;
 using SkiaSharp;
 using Uno.Disposables;
@@ -22,7 +23,7 @@ using Uno.UI.Xaml.Controls;
 
 namespace Uno.WinUI.Runtime.Skia.X11;
 
-internal partial class X11XamlRootHost : IXamlRootHost
+internal partial class X11XamlRootHost : IXamlRootHost, IAccessibilityOwner
 {
 	private const int DefaultColorDepth = 32;
 	private const int FallbackColorDepth = 24;
@@ -83,6 +84,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 	private X11Window? _x11Window;
 	private X11Window? _x11TopWindow;
 	private X11Renderer? _renderer;
+	private X11Accessibility? _accessibility;
 
 	private static readonly Stopwatch _stopwatch = Stopwatch.StartNew();
 
@@ -143,6 +145,7 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		{
 			using (X11Helper.XLock(RootX11Window.Display))
 			{
+				DisposeAccessibility();
 				XamlRootMap.Unregister(xamlRoot);
 				_windowToHost.Remove(winUIWindow, out var _);
 				CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBarChanged -= UpdateWindowPropertiesFromCoreApplication;
@@ -554,6 +557,8 @@ internal partial class X11XamlRootHost : IXamlRootHost
 		}
 
 		_ = X11Helper.XClearWindow(RootX11Window.Display, RootX11Window.Window); // the root window is never drawn, just always blank
+
+		InitializeAccessibility();
 	}
 
 	// https://github.com/gamedevtech/X11OpenGLWindow/blob/4a3d55bb7aafd135670947f71bd2a3ee691d3fb3/README.md
@@ -660,6 +665,31 @@ internal partial class X11XamlRootHost : IXamlRootHost
 	}
 
 	UIElement? IXamlRootHost.RootElement => _window.RootElement;
+
+	SkiaAccessibilityBase? IAccessibilityOwner.Accessibility => _accessibility;
+
+	internal void InitializeAccessibility()
+	{
+		if (_accessibility is not null)
+		{
+			return;
+		}
+
+		_accessibility = new X11Accessibility(this, _window);
+		_accessibility.Initialize();
+	}
+
+	internal void DisposeAccessibility()
+	{
+		if (_accessibility is not { } accessibility)
+		{
+			return;
+		}
+
+		_accessibility = null;
+		accessibility.Dispose();
+		AccessibilityRouter.NotifyDisposed(this);
+	}
 
 	private void RaiseConfigureCallback()
 	{

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.x11events.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.x11events.cs
@@ -7,6 +7,7 @@ using Windows.UI.Core;
 using Microsoft.UI.Windowing;
 using Uno.Foundation.Logging;
 using Uno.UI.Hosting;
+using Uno.UI.Runtime.Skia;
 
 namespace Uno.WinUI.Runtime.Skia.X11;
 
@@ -200,7 +201,14 @@ internal partial class X11XamlRootHost
 							RaiseConfigureCallback();
 							break;
 						case XEventName.FocusIn:
-							QueueAction(this, () => _focusCallback(true));
+							QueueAction(this, () =>
+							{
+								_focusCallback(true);
+								if (_accessibility is not null)
+								{
+									AccessibilityRouter.SetActive(this);
+								}
+							});
 							break;
 						case XEventName.FocusOut:
 							QueueAction(this, () => _focusCallback(false));

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.x11events.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11XamlRootHost.x11events.cs
@@ -203,11 +203,11 @@ internal partial class X11XamlRootHost
 						case XEventName.FocusIn:
 							QueueAction(this, () =>
 							{
-								_focusCallback(true);
 								if (_accessibility is not null)
 								{
 									AccessibilityRouter.SetActive(this);
 								}
+								_focusCallback(true);
 							});
 							break;
 						case XEventName.FocusOut:


### PR DESCRIPTION
**GitHub Issue:** closes #24380

Discussed in https://github.com/unoplatform/uno/discussions/24256 — maintainers confirmed a Linux AT-SPI backend is in scope and suggested mirroring the macOS seam.

## PR Type:

✨ Feature

## What changed? 🚀

Adds a Linux / X11 **AT-SPI2 accessibility backend** to `Uno.UI.Runtime.Skia.X11`. Previously the X11 head rendered to the screen but published no accessibility tree, so Uno apps were invisible to Orca and to AT-SPI-based automation. This brings the X11 head to behavioral parity with the macOS and WASM Skia heads.

New `src/Uno.UI.Runtime.Skia.X11/Accessibility/`:
- **`AtspiServer`** — discovers the a11y bus (`org.a11y.Bus.GetAddress`), registers via `org.a11y.atspi.Socket.Embed`, and serves each node over D-Bus (`Tmds.DBus.Protocol`, already referenced by the head's `DBus/` layer). Serves `Accessible`, `Component`, `Application` (root), `Action`, `Value`, `Text`, `EditableText`, `Selection`, plus `Properties`/`Introspectable`.
- **`X11Accessibility : SkiaAccessibilityBase`** — builds an `AtspiNode` tree from the automation peers (skipping `AccessibilityView.Raw`), enriched from `AriaMapper.GetAriaAttributes` + the automation providers; implements the base `Update*` / `SetNativeFocus` / child hooks to emit AT-SPI `state-changed` / `property-change` / `selection-changed` / `children-changed` signals; and implements the write path (`IWriteTarget`) that drives the real control through its provider on the UI thread.
- **`AtspiRoleMap`** — `AutomationControlType` → numeric `AtspiRole` id (ids match `at-spi2-core/atspi-constants.h`; unmapped types fall back to `panel`).

Host wiring mirrors the macOS head: `X11XamlRootHost` implements `IAccessibilityOwner`, `AccessibilityRouter` is initialized in `X11ApplicationHost` and activated on `FocusIn`.

**Verification.** Built from source and run headless in a container (Xvfb + dbus + at-spi2-core). An external AT-SPI client:
- reads the published tree (roles, states, bounding boxes);
- writes over the bus and reads back — `EditableText.SetTextContents` → `Text.GetText`, `Value.SetCurrentValue` → read back, checkbox toggle via `Action.DoAction` flips the `checked` state;
- observes live `state-changed` / `property-change` signals during those writes.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample] — verified headless against at-spi2-core with an external AT-SPI client (read + write + live events); happy to add runtime tests under `Windows_UI_Xaml_Automation` if the team prefers a specific harness for the Linux head.
- [ ] 📚 Docs have been added/updated
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a (no visual change).
- [x] ❗ Contains **NO** breaking changes — additive; no other head or TFM is touched.
- [ ] 👀 Reviewed 2 other open pull requests

## Notes for reviewers

- Suggested split if you'd rather review in chunks: (1) read path + registration, (2) live events + write path. Happy to break it up.
- Coordinates are currently window-relative (`GetExtents` returns client-space); wiring the X11 window origin for true screen coordinates is a small follow-up, noted in code.
- `Tmds.DBus.Protocol` is pinned at the head's existing `0.92.0`; a subtlety worth knowing is that `MessageWriter` is a `ref struct` (writing the message body through a by-value helper silently drops it), and 0.92 tears the connection down on an unhandled incoming call — both are handled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
