### PR TITLE
feat: Add MarkupHelper.SetParent and CreateFrameworkTemplate for markup-library codegen

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
@@ -62,6 +62,21 @@ partial class Given_FrameworkTemplate // tests
 	}
 
 	[TestMethod]
+	public void When_CreatedThroughMarkupHelper_Then_BehavesLikeDirectConstruction()
+	{
+		// Arrange
+		FrameworkTemplateBuilder factory = (_, _) => new Border();
+		var viaCtor = new FrameworkTemplate(null, factory);
+
+		// Act
+		var viaMarkupHelper = Uno.UI.Helpers.MarkupHelper.CreateFrameworkTemplate(null, factory);
+
+		// Assert
+		Assert.AreEqual(viaCtor, viaMarkupHelper);
+		Assert.AreEqual(viaCtor.GetHashCode(), viaMarkupHelper.GetHashCode());
+	}
+
+	[TestMethod]
 	public async Task InstancedFactory_ShouldNotLeak()
 	{
 		// Arrange

--- a/src/Uno.UI.UnitTests/Helpers/Given_MarkupHelper.cs
+++ b/src/Uno.UI.UnitTests/Helpers/Given_MarkupHelper.cs
@@ -33,4 +33,17 @@ public class Given_MarkupHelper
 		MarkupHelper.SetParent(child, parent2);
 		Assert.AreEqual(42, child.DataContext);
 	}
+
+	[TestMethod]
+	public void When_SetParent_Null_Then_DataContextIsCleared()
+	{
+		var parent = new Border { DataContext = 42 };
+		var child = new Border();
+
+		MarkupHelper.SetParent(child, parent);
+		Assert.AreEqual(42, child.DataContext);
+
+		MarkupHelper.SetParent(child, null);
+		Assert.IsNull(child.DataContext);
+	}
 }

--- a/src/Uno.UI.UnitTests/Helpers/Given_MarkupHelper.cs
+++ b/src/Uno.UI.UnitTests/Helpers/Given_MarkupHelper.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Helpers;
+
+namespace Uno.UI.Tests.Helpers;
+
+[TestClass]
+public class Given_MarkupHelper
+{
+	[TestMethod]
+	public void When_SetParent_Then_DataContextIsInherited()
+	{
+		var parent = new Border { DataContext = 42 };
+		var child = new Border();
+
+		MarkupHelper.SetParent(child, parent);
+
+		Assert.AreEqual(42, child.DataContext);
+	}
+
+	[TestMethod]
+	public void When_SetParent_Called_Again_Then_DataContextFollowsNewParent()
+	{
+		var parent1 = new Border { DataContext = 10 };
+		var parent2 = new Border { DataContext = 42 };
+		var child = new Border();
+
+		MarkupHelper.SetParent(child, parent1);
+		Assert.AreEqual(10, child.DataContext);
+
+		MarkupHelper.SetParent(child, parent2);
+		Assert.AreEqual(42, child.DataContext);
+	}
+}

--- a/src/Uno.UI/Helpers/MarkupHelper.cs
+++ b/src/Uno.UI/Helpers/MarkupHelper.cs
@@ -156,6 +156,7 @@ namespace Uno.UI.Helpers
 		/// content-property assignment path -- for example, an item added by generated code to a collection
 		/// property -- so that it inherits DataContext and other ambient/inherited properties from
 		/// <paramref name="parent"/> as though it had been parsed as part of the declaration.
+		/// Passing <see langword="null"/> detaches the object, clearing the inherited values.
 		/// </summary>
 		/// <remarks>
 		/// <see cref="DependencyObject"/>'s Parent is internal -- WinUI has no equivalent public member, as its
@@ -163,7 +164,7 @@ namespace Uno.UI.Helpers
 		/// the consuming app's assembly, reaches it through this helper.
 		/// </remarks>
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static void SetParent(DependencyObject target, object parent)
+		public static void SetParent(DependencyObject target, object? parent)
 			=> target.SetParent(parent);
 
 		/// <summary>

--- a/src/Uno.UI/Helpers/MarkupHelper.cs
+++ b/src/Uno.UI/Helpers/MarkupHelper.cs
@@ -152,6 +152,21 @@ namespace Uno.UI.Helpers
 			=> settings?.OnMemberCreated(target);
 
 		/// <summary>
+		/// Sets the parent of a <see cref="DependencyObject"/> that was created outside its owner's normal
+		/// content-property assignment path -- for example, an item added by generated code to a collection
+		/// property -- so that it inherits DataContext and other ambient/inherited properties from
+		/// <paramref name="parent"/> as though it had been parsed as part of the declaration.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="DependencyObject"/>'s Parent is internal -- WinUI has no equivalent public member, as its
+		/// Parent is computed by the engine from the live visual tree -- so generated code, which compiles into
+		/// the consuming app's assembly, reaches it through this helper.
+		/// </remarks>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetParent(DependencyObject target, object parent)
+			=> target.SetParent(parent);
+
+		/// <summary>
 		/// Creates a <see cref="DataTemplate"/> from a factory.
 		/// </summary>
 		/// <remarks>
@@ -172,6 +187,12 @@ namespace Uno.UI.Helpers
 		/// </summary>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static ItemsPanelTemplate CreateItemsPanelTemplate(object? owner, FrameworkTemplateBuilder? factory) => new(owner, factory);
+
+		/// <summary>
+		/// Creates a <see cref="FrameworkTemplate"/> from a factory. See <see cref="CreateDataTemplate"/>.
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static FrameworkTemplate CreateFrameworkTemplate(object? owner, FrameworkTemplateBuilder? factory) => new(owner, factory);
 
 		/// <summary>
 		/// Helper for XAML code generation. Not intended to be used in apps outside of XAML generator.


### PR DESCRIPTION
**GitHub Issue:** relates to unoplatform/uno-private#2075, unblocks [unoplatform/uno.csharpmarkup#906](https://github.com/unoplatform/uno.csharpmarkup/pull/906)

## PR Type:

✨ Feature

## What changed? 🚀

Adds two small, purely-additive public members to `MarkupHelper`, matching its existing `[EditorBrowsable(Never)]` "bridge for markup-library codegen" convention (`CreateDataTemplate`/`CreateControlTemplate`/`CreateItemsPanelTemplate`, `OnTemplateMemberCreated`):

- **`MarkupHelper.SetParent(DependencyObject target, object parent)`** — a public way to parent a `DependencyObject` created outside its owner's normal content-property assignment path (e.g. an item added by generated code to a collection property), so it inherits `DataContext` as though it had been parsed as part of the declaration. This is the capability `IDependencyObjectStoreProvider` used to provide before `d8cd44b77a6`/`b5722b7eab0` (BC26) folded `DependencyObjectStore` into `DependencyObject` and made `Parent` internal, with no public replacement.
- **`MarkupHelper.CreateFrameworkTemplate(object? owner, FrameworkTemplateBuilder? factory)`** — completes the `CreateXxxTemplate` set. `DataTemplate`/`ControlTemplate`/`ItemsPanelTemplate` all got a `MarkupHelper` factory when their constructors were narrowed to internal (`ab549229406`); the base `FrameworkTemplate` class did not.

Both were Uno-only public surface to begin with (WinUI has no builder constructor for any of these four types, and no public `DependencyObject.Parent`) — this isn't restoring WinUI parity, it's completing the existing Uno-only bridge that external codegen consumers (like C# Markup) need and generated XAML code already gets for free via same-assembly internal access.

Concretely, this unblocks the last two compile errors in [uno.csharpmarkup#906](https://github.com/unoplatform/uno.csharpmarkup/pull/906) (retargeting C# Markup to Uno 7.0) — see that PR's "Known-red" section for the full analysis.

## PR Checklist ✅

- [x] 🧪 Added Runtime tests / UI tests (`Given_MarkupHelper` unit test; `Given_FrameworkTemplate.When_CreatedThroughMarkupHelper_Then_BehavesLikeDirectConstruction` runtime test)
- [ ] 📚 Docs — n/a, both members are `[EditorBrowsable(Never)]` internal-facing codegen helpers, matching the undocumented `CreateDataTemplate`/`CreateControlTemplate`/`CreateItemsPanelTemplate`/`OnTemplateMemberCreated` siblings
- [ ] 🖼️ Screenshots Compare Test Run — n/a, no rendering/UI changes
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NieLLgaAvny2Uxdt5xxK1M