### PR TITLE
ci: Run the docs pipeline for servicing/* branches

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
       - master
+      - servicing/*
       - release/beta/*
       - release/stable/*
       - feature/*
@@ -15,6 +16,7 @@ pr:
   branches:
     include:
       - master
+      - servicing/*
       - release/beta/*
       - release/stable/*
       - feature/*


### PR DESCRIPTION
**GitHub Issue:** No specific issue — internal maintenance, release-process plumbing

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Adds `servicing/*` to the `trigger` and `pr` branch lists in `.vsts-ci-docs.yml` — the pipeline that reports the **`Uno.UI - docs`** status check.

## Why

`Uno.UI - docs` is one of the two required status checks on `master` (with `Uno.UI - CI`). We are about to give `servicing/*` branches the same branch protection as the default branch, and **a required check that never reports leaves a PR stuck at "Expected — waiting for status"**, unmergeable short of an admin override.

`.vsts-ci-docs.yml` currently triggers on `master`, `release/beta/*`, `release/stable/*`, `feature/*` and `legacy/*` — every long-lived branch pattern except the new one. This closes that gap so the protection can be applied safely.

`Uno.UI - CI` already covers `servicing/*` via [#24361](https://github.com/unoplatform/uno/pull/24361).

## Scope

Two added lines. The pipeline keeps its existing path filters (`doc/**`, `**/*.md`), so it still only runs when documentation changes — this just makes `servicing/*` eligible in the first place.

The same prerequisite exists in three sibling repos, where the `Conventional Commits` workflow is a required check that does not list `servicing/*`: `uno.csharpmarkup`, `uno.app-mcp` and `Uno.Themes`. Those are being handled in parallel.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) — n/a: pipeline trigger configuration only
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) — n/a
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results — n/a, no rendering change
- [x] ❗ Contains **NO** breaking changes
