### PR TITLE
fix(ci): Unbreak the iOS TestFlight stages on master

### DIFF
--- a/build/ci/publish/.azure-devops-publish-ios-testflight.yml
+++ b/build/ci/publish/.azure-devops-publish-ios-testflight.yml
@@ -39,6 +39,9 @@ jobs:
       certSecureFile: UnoPlatform-Apple-Distribution.p12
       certPwd: $(appleappstorecertificatepassword)
       keychain: temp
+      # The .p12 is encrypted with RC2-40-CBC, which OpenSSL 3 (macOS-26 image) only offers
+      # through the legacy provider. Without this the task cannot read the certificate at all.
+      opensslPkcsArgs: '-legacy'
 
   - task: InstallAppleProvisioningProfile@1
     displayName: Install Provisioning Profile

--- a/src/SamplesApp/SamplesApp/SamplesApp.csproj
+++ b/src/SamplesApp/SamplesApp/SamplesApp.csproj
@@ -396,6 +396,12 @@
 		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">iossimulator-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(_Platform)' == 'ios' AND '$(BuildForTestFlight)' == 'true'">
+		<CodesignKey>iPhone Distribution</CodesignKey>
+		<RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+		<DefineConstants>$(DefineConstants);TESTFLIGHT</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup Condition="'$(_Platform)' == 'tvos'">
 		<PackageReference Include="SkiaSharp.NativeAssets.TvOS" />
 


### PR DESCRIPTION
**GitHub Issue:** closes #24387

## PR Type:

🏗️ Build or CI related changes

## What changed? 🚀

Both iOS TestFlight stages have failed on every `master` build since the 7.0 merge. Two independent regressions, the second hidden behind the first.

**1. `Install Certificate` fails on the macOS-26 image** — this is the failure you actually see.

```
error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:
  Algorithm (RC2-40-CBC : 0)
##[error]Error: /usr/local/bin/openssl failed with return code: 1
```

`.vsts-ci.yml` moved `macOSVMImage` from `macOS-14` to `macOS-26` with the .NET 11 Preview 5 bump. macOS-26 ships OpenSSL 3, which only offers the distribution `.p12`'s RC2-40-CBC encryption through the legacy provider. Fixed by passing `opensslPkcsArgs: '-legacy'`, as the task's own warning recommends.

`InstallAppleCertificate` is a **pre-job** task, so its failure skips `checkout` and every later step fails against an empty working copy — the `rm: global.json: No such file or directory` and `Failed to find global.json at and inside path: /Users/runner/work/1/s` errors further down the job are symptoms, not causes.

**2. iOS lost its `BuildForTestFlight` properties in the SamplesApp head consolidation** — latent, and would have failed the build step next.

The removed `SamplesApp.Skia.netcoremobile` head carried a `BuildForTestFlight` property group per platform; the consolidated head kept only the tvOS one. On iOS the pipeline's `-p:BuildForTestFlight=true` was therefore inert: `RuntimeIdentifier` stayed `iossimulator-x64`, no distribution `CodesignKey` was applied, and `TESTFLIGHT` was not defined (it gates `LaunchiOSWatchDog()` in `App.xaml.cs`). The publish would have landed in `iossimulator-x64/` while the pipeline's `CopyFiles` step reads `.../ios-arm64/publish`. Fixed by mirroring the tvOS block for iOS.

Both jobs are gated on `refs/heads/master`, which is why the branch that introduced them could not surface either one before the merge.

### Validation

**Code review** — the certificate change matches the task's documented `opensslPkcsArgs` input and the remediation named in its own warning message.

**Evaluation** — `dotnet msbuild -getProperty` on the head with the net11 preview SDK, with a negative control:

| property | `BuildForTestFlight=true` | without (control) |
|---|---|---|
| `RuntimeIdentifier` | `ios-arm64` | `iossimulator-x64` |
| `CodesignKey` | `iPhone Distribution` | *(empty)* |
| `DefineConstants` | includes `TESTFLIGHT` | no `TESTFLIGHT` |
| `OutputPath` | `bin\Release\net11.0-ios\ios-arm64\` — matches the pipeline's `CopyFiles` source | — |
| `MtouchLink` | *(SDK default)* | `Full` (the simulator-only rule still applies) |

The control column is unchanged throughout, so the iOS simulator build and test stages are untouched.

**Not validated at runtime**: the device publish, the codesign against `Uno_Dev_Samples_Skia.mobileprovision` and the `.ipa` production need macOS CI on `master` to confirm. Since the stages are `master`-gated, this PR's own CI run will not exercise them.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — n/a, CI-only change; validated by MSBuild property evaluation with a negative control
- [x] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — n/a
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGbrNUJc6dpNehRCkmewFq
