### PR TITLE
fix(sdk): Keep Hot Design, App MCP and DevServer out of Release restores

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -11,19 +11,22 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Settings.DevServer" ProjectSystem="true" PrivateAssets="all" />
 	</ItemGroup>
 
+	<!--
+		The development-time packages below are absent from the Release graph, not merely asset-excluded.
+		IncludeAssets="None" still resolves, downloads and audits the whole closure, and does not stop the
+		package's analyzers from loading (dotnet/sdk#1212) - so re-adding an "excluded" Release entry here
+		puts them back in every shipped app's dependency closure.
+	-->
 	<ItemGroup Condition=" ('$(_ImplicitRestoreOutputType)' == 'WinExe' OR '$(_ImplicitRestoreOutputType)' == 'Exe') AND '$(UnoDisableHotDesign)' != 'true' ">
 		<_UnoProjectSystemPackageReference Include="Uno.UI.HotDesign" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
-		<_UnoProjectSystemPackageReference Include="Uno.UI.HotDesign" ProjectSystem="true" Exclude="all" IncludeAssets="None" Condition="$(Optimize) == 'true'" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" ('$(_ImplicitRestoreOutputType)' == 'WinExe' OR '$(_ImplicitRestoreOutputType)' == 'Exe') AND '$(UnoDisableMCPSupport)' != 'true' ">
 		<_UnoProjectSystemPackageReference Include="Uno.UI.App.Mcp" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
-		<_UnoProjectSystemPackageReference Include="Uno.UI.App.Mcp" ProjectSystem="true" Exclude="all" IncludeAssets="None" Condition="$(Optimize) == 'true'" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(_ImplicitRestoreOutputType)' == 'WinExe' OR '$(_ImplicitRestoreOutputType)' == 'Exe' ">
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
-		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Exclude="all" IncludeAssets="None" Condition="$(Optimize) == 'true'" />
 	</ItemGroup>
 
 	<Choose>


### PR DESCRIPTION
**GitHub Issue:** closes #24407

## PR Type:

🐞 Bugfix

## What changed? 🚀

Three lines deleted from `src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets`, plus a comment explaining why they must not come back.

```diff
  <_UnoProjectSystemPackageReference Include="Uno.UI.HotDesign" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
- <_UnoProjectSystemPackageReference Include="Uno.UI.HotDesign" ProjectSystem="true" Exclude="all" IncludeAssets="None" Condition="$(Optimize) == 'true'" />
```

### This is not a new divergence — it makes the existing intent actually work

**`Exclude="all"` has always been inert.** `Exclude` is one of MSBuild's reserved item *operation* attributes; every *other* attribute becomes metadata, but this one filters the `Include` set. Against a literal package id it matches nothing and produces no metadata — proven with a minimal probe: an item with `Exclude="all"` survives with `%(Exclude)` **empty**, while a sibling with `Exclude="Pkg.Two"` (matching its own Include) **vanishes**. NuGet has no `Exclude` concept anyway, and `"exclude"` never appears in the resulting assets file.

So only `IncludeAssets="None"` applied, and asset exclusion is not graph exclusion.

(The `Exclude="@(PackageReference)"` on the funnel at line 139 is the *legitimate* use — de-duplicating against explicit user references. That one stays.)

### Why `Uno.WinUI.DevServer` is included, though the issue names only the other two

It has the **strongest** case, not merely the same shape: its own shipped `buildTransitive/Uno.WinUI.DevServer.targets` raises `UNOB0019` when `$(Optimize)` is true. The package self-declares as development-only, so its presence in the Release graph is purely vestigial. It costs no build-time capability either — the only DevServer build task the SDK uses, `UnoNotifyAppLaunchToDevServer_v0`, comes from the SDK's own `Uno.Sdk_v0.dll`, not the package.

All three share one idiom from the same commits; fixing two of three guarantees drift and leaves a live template for the next package.

## Validation ✅

**Restore-graph measurement — ran locally**, twin scratch heads importing a patched vs unpatched copy of the cached `Uno.Sdk.Private/7.0.0-dev.645` by path, `net10.0-desktop`, zero `UnoFeatures`:

| | Debug | Release |
|---|---|---|
| Before | 68 | 68 |
| **After** | **68** | **54** |

**Debug is byte-for-byte unchanged** (library-set diff empty), which is the important half. Release drops 14 packages, adds none:

`Uno.UI.HotDesign` · `Uno.WinUI.DevServer` · `Uno.WinUI.DevServer.Messaging` · `Uno.UI.App.Mcp` · `Uno.Themes.WinUI` · `Uno.Toolkit.WinUI` · `Uno.Toolkit` · `CommunityToolkit.Mvvm` · `Uno.Fonts.Roboto` · `SkiaSharp.Views.Uno.WinUI 3.119.2` · `SkiaSharp.NativeAssets.WebAssembly 3.119.2` · `Uno.Core.Extensions.{Collections,Disposables,Equality}`

**Download weight removed from every Release restore: 308.53 MB** — `Uno.UI.HotDesign` 193.43 MB, `SkiaSharp.NativeAssets.WebAssembly` 72.36 MB (a *WebAssembly* native pack on a *desktop* head), `Uno.WinUI.DevServer` 36.96 MB. Release analyzers drop 17 → 14.

**Compile.** `dotnet build src/Uno.Sdk/Uno.Sdk.csproj` → **Build succeeded**.

### ⚠️ One genuinely new failure mode, reproduced

**`packages.lock.json` with `RestoreLockedMode=true`.** A lock file written by a Debug restore, then met with `dotnet restore -p:Configuration=Release -p:RestoreLockedMode=true`, now fails:

```
error NU1004: The package references have changed for net10.0-desktop1.0.
```

The identical probe exits 0 against the current shape and 1 against the patched one, so this **is introduced by the change**. Root cause is structural: `packages.lock.json`, `project.assets.json` and `*.nuget.g.*` all live at `obj/` root and are not configuration-scoped, so one lock file must serve both graphs. Escape hatches: a per-configuration `$(NuGetLockFilePath)`, or `UnoDisableHotDesign`/`UnoDisableMCPSupport` to collapse back to one graph. No in-repo project uses lock files; external consumers and locked-mode CI do.

**Also expected:** every Debug↔Release switch is now a real re-restore, including re-materialising the 193 MB Hot Design package.

**One version divergence:** on a toolkit-less head, `Uno.Core.Extensions.Logging.Singleton` resolves 4.1.1 in Debug and 4.0.1 in Release — Hot Design was the only thing floating it up. Pinning it was considered and deliberately rejected: 4.0.1 is what the head's own dependencies request, and the guard needed would be untested.

**Not validated, and reviewers should weigh these:**

1. **Platform coverage** — only `net10.0-desktop` and `net10.0-browserwasm` scratch heads. Android, iOS, tvOS and WinAppSdk were not restored.
2. 🔴 **No IDE check.** Visual Studio and C# Dev Kit were never opened. This matters more than usual: the placeholder items exist precisely so the IDE can show package nodes before design-time targets run, and an equivalent Debug-only shape existed briefly in Nov 2024 and was replaced the same week. Someone should confirm the Release solution-explorer view is sane.
3. **Nothing was run.** Hot Design was not confirmed to still attach in Debug after the change. Evidence is restore graphs, MSBuild evaluation and compile inputs — never runtime.
4. **CPM not tested** — a user's `<PackageVersion Include="Uno.UI.HotDesign">` now survives in Release; harmless alone, but untested with `CentralPackageTransitivePinningEnabled`.

**Deliberately left alone:** `_RemoveHDAnalyzerRelease` (`build/nuget/uno.winui.targets:26`) **must stay** — it is still needed for anyone explicitly referencing Hot Design in Release, since `IncludeAssets`/`ExcludeAssets` do not filter analyzers.

**Follow-ups found, not fixed here:** `Uno.Wasm.Bootstrap.DevServer` (`…ProjectSystem.Wasm.targets:13`) has no `$(Optimize)` gate at all and sits in every WASM Release graph with full assets. And `$(Optimize)` is empty for any configuration not literally named `Debug`/`Release`, so `CustomRelease` takes the Debug branch — pre-existing, and **not** to be "fixed" by switching to `'$(Configuration)' == 'Release'`, which would desync this from the eight other `Optimize` gates in the SDK.

## PR Checklist ✅

- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) — n/a; validated by before/after restore-graph diff
- [ ] 📚 Docs have been added/updated
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)

**Breaking change: yes** — the `packages.lock.json` / `RestoreLockedMode` case above, plus the accepted Debug/Release graph divergence. Both belong in the 7.0 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8QhvftkoDBoNJN2iTLkUZ
