### PR TITLE
fix(skia): Keep keyboard occlusion pad out of the content arrange

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -195,6 +195,135 @@ public class Given_InputPane
 		}
 	}
 
+	// The occlusion pad shrinks the viewport so BringIntoView can land the focused element above the
+	// keyboard. It must not re-arrange content that sizes itself to that viewport: a sign-in card
+	// centered in a Grid used to jump up by half the keyboard height even though it was never occluded.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_Focused_Element_Not_Occluded_Then_Centered_Content_Is_Not_Moved()
+	{
+		var (scrollViewer, card, textBox) = BuildCenteredCardPage();
+
+		var inputPane = InputPane.GetForCurrentView();
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+			Assert.IsTrue(textBox.Focus(FocusState.Programmatic), "TextBox failed to take focus.");
+			await WindowHelper.WaitForIdle();
+
+			var viewportHeight = scrollViewer.ActualHeight;
+			var scrollViewerTopLeft = scrollViewer.TransformToVisual(null).TransformPoint(default);
+			var occludedTop = scrollViewerTopLeft.Y + (viewportHeight * 0.6);
+			var occlusionHeight = viewportHeight * 0.4;
+
+			var cardTopBefore = GetTop(card);
+			Assert.IsTrue(GetBottom(textBox) < occludedTop, "Test setup: the focused TextBox must start above the keyboard top.");
+
+			inputPane.OccludedRect = new Rect(scrollViewerTopLeft.X, occludedTop, scrollViewer.ActualWidth, occlusionHeight);
+
+			// Guards against a vacuous pass: wait until the occlusion path actually padded the presenter.
+			await WindowHelper.WaitFor(
+				() => scrollViewer.Padding.Bottom > 0,
+				message: "The occlusion pad was never applied.");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(cardTopBefore, GetTop(card), 0.5, $"Centered card moved by {cardTopBefore - GetTop(card):F1}px although nothing was occluded.");
+
+			// The pad becomes scrollable extent, so the area behind the keyboard stays reachable.
+			Assert.AreEqual(viewportHeight, scrollViewer.ExtentHeight, 0.5, "The occluded area was squeezed out of the content instead of becoming scrollable extent.");
+			Assert.IsTrue(scrollViewer.ViewportHeight < viewportHeight, "The viewport must still shrink so BringIntoView stops above the keyboard.");
+
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+
+			await WindowHelper.WaitFor(
+				() => scrollViewer.Padding.Bottom == 0,
+				message: "The occlusion pad was not restored.");
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(cardTopBefore, GetTop(card), 0.5, "Centered card did not return to its original position.");
+		}
+		finally
+		{
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	// An app that handles InputPane.Showing and sets EnsuredFocusedElementInView owns the adjustment,
+	// so the framework must leave the layout alone entirely.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_App_Ensured_Focused_Element_In_View_Then_No_Pad_Is_Applied()
+	{
+		var (scrollViewer, card, textBox) = BuildCenteredCardPage();
+
+		var inputPane = InputPane.GetForCurrentView();
+		TypedEventHandler<InputPane, InputPaneVisibilityEventArgs> handler =
+			(_, args) => args.EnsuredFocusedElementInView = true;
+		inputPane.Showing += handler;
+		inputPane.Hiding += handler;
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+			Assert.IsTrue(textBox.Focus(FocusState.Programmatic), "TextBox failed to take focus.");
+			await WindowHelper.WaitForIdle();
+
+			var viewportHeight = scrollViewer.ActualHeight;
+			var scrollViewerTopLeft = scrollViewer.TransformToVisual(null).TransformPoint(default);
+			var cardTopBefore = GetTop(card);
+
+			inputPane.OccludedRect = new Rect(
+				scrollViewerTopLeft.X,
+				scrollViewerTopLeft.Y + (viewportHeight * 0.6),
+				scrollViewer.ActualWidth,
+				viewportHeight * 0.4);
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0d, scrollViewer.Padding.Bottom, 0.5, "No occlusion pad must be applied when the app handled the adjustment.");
+			Assert.AreEqual(cardTopBefore, GetTop(card), 0.5, "The layout must be left untouched when the app handled the adjustment.");
+		}
+		finally
+		{
+			inputPane.Showing -= handler;
+			inputPane.Hiding -= handler;
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+			WindowHelper.WindowContent = null;
+		}
+	}
+
+	// A sign-in card centered in a Grid that fills a full-window ScrollViewer, with the focused field
+	// nowhere near the keyboard.
+	private static (ScrollViewer ScrollViewer, Border Card, TextBox TextBox) BuildCenteredCardPage()
+	{
+		var textBox = new TextBox { Height = 40, PlaceholderText = "user" };
+		var card = new Border
+		{
+			Width = 300,
+			Height = 200,
+			HorizontalAlignment = HorizontalAlignment.Center,
+			VerticalAlignment = VerticalAlignment.Center,
+			Child = textBox,
+		};
+		var scrollViewer = new ScrollViewer
+		{
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Stretch,
+			Content = new Grid { Children = { card } },
+		};
+
+		return (scrollViewer, card, textBox);
+	}
+
+	private static double GetTop(FrameworkElement element)
+		=> element.TransformToVisual(null).TransformPoint(default).Y;
+
 	private static double GetBottom(FrameworkElement element)
 		=> element.TransformToVisual(null).TransformPoint(default).Y + element.ActualHeight;
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_InputPane.cs
@@ -298,6 +298,54 @@ public class Given_InputPane
 		}
 	}
 
+	// The bring-into-view guarantee must survive arranging against the un-occluded height: content that
+	// sizes itself to the viewport now keeps a field behind the keyboard instead of being squeezed above
+	// it, so the scroll has to do the work. This is the geometry the taller-than-viewport tests never hit.
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	[PlatformCondition(ConditionMode.Include, RuntimeTestPlatforms.Skia)]
+	public async Task When_Occluded_Field_In_Viewport_Sized_Content_Then_Scrolled_Above_Occlusion()
+	{
+		var textBox = new TextBox { Height = 40, PlaceholderText = "bottom", VerticalAlignment = VerticalAlignment.Bottom };
+		var scrollViewer = new ScrollViewer
+		{
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Stretch,
+			Content = new Grid { Children = { textBox } },
+		};
+
+		var inputPane = InputPane.GetForCurrentView();
+		try
+		{
+			await UITestHelper.Load(scrollViewer);
+			Assert.IsTrue(textBox.Focus(FocusState.Programmatic), "TextBox failed to take focus.");
+			await WindowHelper.WaitForIdle();
+
+			var viewportHeight = scrollViewer.ActualHeight;
+			var scrollViewerTopLeft = scrollViewer.TransformToVisual(null).TransformPoint(default);
+			var occludedTop = scrollViewerTopLeft.Y + (viewportHeight * 0.6);
+
+			Assert.IsTrue(GetBottom(textBox) > occludedTop, "Test setup: the TextBox must start behind the keyboard.");
+
+			inputPane.OccludedRect = new Rect(scrollViewerTopLeft.X, occludedTop, scrollViewer.ActualWidth, viewportHeight * 0.4);
+
+			await WindowHelper.WaitFor(
+				() => GetBottom(textBox) <= occludedTop + 0.5,
+				message: $"Focused TextBox (bottom {GetBottom(textBox)}) was left below the keyboard top ({occludedTop}).");
+
+			// The scroll must stay minimal: flush with the keyboard top, not over-scrolled.
+			Assert.IsTrue(
+				GetBottom(textBox) > occludedTop - textBox.ActualHeight - 40,
+				$"Focused TextBox (bottom {GetBottom(textBox)}) was over-scrolled way above the keyboard top ({occludedTop}).");
+		}
+		finally
+		{
+			inputPane.OccludedRect = new Rect(0, 0, 0, 0);
+			WindowHelper.WindowContent = null;
+		}
+	}
+
 	// A sign-in card centered in a Grid that fills a full-window ScrollViewer, with the focused field
 	// nowhere near the keyboard.
 	private static (ScrollViewer ScrollViewer, Border Card, TextBox TextBox) BuildCenteredCardPage()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -215,7 +215,11 @@ namespace Microsoft.UI.Xaml.Controls
 				var desiredSize = child.DesiredSize;
 
 				childRect.Width = Math.Max(finalSize.Width, desiredSize.Width);
-				childRect.Height = Math.Max(finalSize.Height, desiredSize.Height);
+				// The keyboard-occlusion pad shrinks the viewport so the BringIntoView that follows lands the
+				// focused element right above the input pane. It must not re-arrange content that sizes itself
+				// to the viewport: arranging against the un-occluded height turns the pad into scrollable
+				// extent instead, so a centered or stretched layout stays where it was.
+				childRect.Height = Math.Max(finalSize.Height + _occludedRectPadding.Bottom, desiredSize.Height);
 
 				child.Arrange(childRect);
 


### PR DESCRIPTION
**GitHub Issue:** closes #24409

## PR Type:

🐞 Bugfix

## What changed? 🚀

When the soft keyboard opens, `InputPane` pads the nearest constrained `ScrollContentPresenter` by the full keyboard overlap, so that the minimal `BringIntoView` which follows lands the focused element flush above the input pane. That padding shrinks the **layout** viewport, so content that sizes itself to the viewport gets re-arranged into the smaller box: a sign-in card centered in a `Grid` inside a full-window `ScrollViewer` jumps up by *half* the keyboard height even when the focused field was never occluded, and the area behind the keyboard is squeezed out of the content instead of becoming scrollable.

The presenter now arranges its content against the **un-occluded** height:

```csharp
childRect.Height = Math.Max(finalSize.Height + _occludedRectPadding.Bottom, desiredSize.Height);
```

The viewport still shrinks — that is what makes `BringIntoView` stop above the keyboard — but the pad turns into scrollable extent rather than moving viewport-sized content. It is a strict no-op whenever no occlusion pad is applied (`_occludedRectPadding.Bottom == 0`), i.e. whenever the keyboard is down.

This is the regression half of 6f6bd62a667 (`fix(skia): Fix keyboard occlusion scroll padding`, in 6.7.103). That commit correctly replaced a pad that was never large enough to move a genuinely occluded field; this PR keeps that behavior and removes the layout side effect it introduced.

Measured on Skia Desktop (viewport 768, occlusion 307.2):

| | pad bottom | viewport | extent | card top |
|---|---|---|---|---|
| before this PR | 307.2 | 461 | 461 | 284 → **130.5** |
| after this PR | 307.2 | 461 | **768** | 284 → **284** |

### Validation

- New runtime test `Given_InputPane.When_Focused_Element_Not_Occluded_Then_Centered_Content_Is_Not_Moved`, verified **fail-before / pass-after** on `master` (fails with "Centered card moved by 153.5px although nothing was occluded", passes with the fix). It waits for the pad to actually be applied before asserting, so it cannot pass vacuously, and it also asserts that the extent grows by the occlusion and that the viewport still shrinks.
- New runtime test `Given_InputPane.When_App_Ensured_Focused_Element_In_View_Then_No_Pad_Is_Applied`, covering the WinUI opt-out (`InputPaneVisibilityEventArgs.EnsuredFocusedElementInView`) on the same code path.
- New runtime test `Given_InputPane.When_Occluded_Field_In_Viewport_Sized_Content_Then_Scrolled_Above_Occlusion`, guarding the bring-into-view contract in the geometry this change actually alters: content that sizes itself to the viewport with the focused field behind the keyboard. It passes both before and after by design — before, the field was squeezed above the keyboard by the shrunken arrange; after, the scroll does the work — which is the point: the guarantee holds either way. The two pre-existing occlusion tests use content ~2040px tall, where this change is a mathematical no-op (`desired` already exceeds `viewport + pad`), so they could not have shown this.
- The three existing `Given_InputPane` tests (the 6f6bd62a667 coverage) still pass — the occluded-field bring-into-view behavior is unchanged.
- Regression sweep: all 55 `Given_ScrollViewer` / `Given_ScrollViewer_Zoom` runtime tests pass (4 skipped), plus 33 `ScrollViewerTests.Given_ScrollViewer_Anchoring` / `_ScrollChaining`.
- All runs on the Skia Desktop head (macOS) against `master`.

Reported by a customer on 6.7.103; a backport to `release/stable/6.7` should follow once this merges, where the same change was validated on the branch directly.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [x] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
