### PR TITLE
feat(x11): Support OS accent color via the Settings portal

### DIFF
--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/ViewManagement/SystemAccentColorSample.xaml
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/ViewManagement/SystemAccentColorSample.xaml
@@ -11,7 +11,7 @@
         <StackPanel Spacing="16">
 
             <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="System accent color" />
-            <TextBlock Text="The swatches show the values returned by UISettings.GetColorValue. The controls below use the SystemAccentColor theme resources. On macOS, change the accent color in System Settings → Appearance and everything should update live." TextWrapping="Wrap" />
+            <TextBlock Text="The swatches show the values returned by UISettings.GetColorValue. The controls below use the SystemAccentColor theme resources. On macOS (System Settings → Appearance) or Linux (GNOME 47+ Settings → Appearance, KDE Plasma 6 System Settings → Colors &amp; Themes), change the accent color and everything should update live." TextWrapping="Wrap" />
             <Button Click="OnRefreshClick" Content="Refresh values" />
 
             <!--  Force a specific accent via FeatureConfiguration.AccentColor.OverrideAccentColor  -->

--- a/src/SamplesApp/SamplesApp.Samples/Windows/UI/ViewManagement/SystemAccentColorSample.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Samples/Windows/UI/ViewManagement/SystemAccentColorSample.xaml.cs
@@ -10,7 +10,8 @@ namespace UITests.Windows_UI_ViewManagement;
 [Sample("Windows.UI.ViewManagement",
 	Name = "SystemAccentColor",
 	Description = "Shows that SystemAccentColor and the accent brushes follow the OS accent color. "
-		+ "On macOS, open System Settings → Appearance and change the accent color while this "
+		+ "On macOS (System Settings → Appearance) or Linux (GNOME 47+ Settings → Appearance, KDE Plasma 6 System "
+		+ "Settings → Colors & Themes), change the accent color while this "
 		+ "sample is visible: the swatches and the controls below update live. The override buttons "
 		+ "force a specific accent color on any platform.",
 	IsManualTest = true,

--- a/src/Uno.UI.Runtime.Skia.X11/Helpers/Theming/LinuxAccentColorExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Helpers/Theming/LinuxAccentColorExtension.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Threading.Tasks;
+using Tmds.DBus.Protocol;
+using Uno.Foundation.Logging;
+using Uno.Helpers.Theming;
+using Uno.UI.Dispatching;
+using Uno.WinUI.Runtime.Skia.X11.DBus;
+using Windows.UI;
+
+namespace Uno.WinUI.Runtime.Skia.X11;
+
+// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html
+
+internal class LinuxAccentColorExtension : IAccentColorExtension
+{
+	private const string Service = "org.freedesktop.portal.Desktop";
+	private const string ObjectPath = "/org/freedesktop/portal/desktop";
+	private const string AppearanceNamespace = "org.freedesktop.appearance";
+	private const string AccentColorKey = "accent-color";
+	private const string NotFoundErrorName = "org.freedesktop.portal.Error.NotFound";
+
+	public static LinuxAccentColorExtension Instance { get; } = new();
+
+	public event EventHandler? AccentColorChanged;
+
+	private AccentColorPalette? _currentPalette;
+
+	private LinuxAccentColorExtension()
+	{
+		_ = Init();
+	}
+
+	// Null (default palette) until the asynchronous portal read completes; the OS value then arrives through
+	// AccentColorChanged. Init continues off the UI thread and the setter marshals to the dispatcher, so the
+	// first write always lands after the startup frame that created this instance has subscribed.
+	public AccentColorPalette? GetAccentColorPalette() => _currentPalette;
+
+	private AccentColorPalette? CurrentPalette
+	{
+		get => _currentPalette;
+		set
+		{
+			if (NativeDispatcher.Main.HasThreadAccess)
+			{
+				// The shades are derived from the accent, so comparing Accent is enough to detect a change.
+				if (_currentPalette?.Accent != value?.Accent)
+				{
+					_currentPalette = value;
+					AccentColorChanged?.Invoke(this, EventArgs.Empty);
+				}
+			}
+			else
+			{
+				NativeDispatcher.Main.Enqueue(() => CurrentPalette = value);
+			}
+		}
+	}
+
+	private async Task Init()
+	{
+		try
+		{
+			var sessionsAddressBus = DBusAddress.Session;
+			if (sessionsAddressBus is null)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn("Unable to observe the system accent color, the default accent will be used. (Unable to determine the DBus session bus address)");
+				}
+				return;
+			}
+
+			var connection = new DBusConnection(sessionsAddressBus);
+			await connection.ConnectAsync().ConfigureAwait(false);
+
+			var desktopService = new DBusService(connection, Service);
+			var settings = desktopService.CreateSettings(ObjectPath);
+
+			// ReadOne and the accent-color key are version 2 additions; later versions are additive.
+			var version = await settings.GetVersionAsync().ConfigureAwait(false);
+			if (version < 2)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn($"System accent color detection requires version 2 of the Settings portal, but version {version} was found. The default accent will be used.");
+				}
+				return;
+			}
+
+			// Watch before the initial read so that neither a change racing the read nor a failed read can leave
+			// the accent stale for the lifetime of the app. The IDisposable is ignored: the watch lives as long as the app.
+			await settings.WatchSettingChangedAsync((exception, tuple) =>
+			{
+				try
+				{
+					if (exception is not null)
+					{
+						if (this.Log().IsEnabled(LogLevel.Error))
+						{
+							this.Log().Error("Failed to observe desktop portal setting changes; the accent color will no longer follow the OS.", exception);
+						}
+						return;
+					}
+
+					if (tuple is { Namespace: AppearanceNamespace, Key: AccentColorKey })
+					{
+						CurrentPalette = ToPalette(tuple.Value);
+					}
+				}
+				catch (Exception e)
+				{
+					if (this.Log().IsEnabled(LogLevel.Error))
+					{
+						this.Log().Error("Unable to process a desktop portal accent color change.", e);
+					}
+				}
+			}).ConfigureAwait(false);
+
+			try
+			{
+				var result = await settings.ReadOneAsync(AppearanceNamespace, AccentColorKey).ConfigureAwait(false);
+				CurrentPalette = ToPalette(result);
+			}
+			catch (DBusErrorReplyException e) when (e.ErrorName == NotFoundErrorName)
+			{
+				// Portal backends may implement version 2 without the optional accent-color key.
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug("The desktop portal does not expose the optional accent-color setting.");
+				}
+			}
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn("Unable to read the initial accent color from the desktop portal; the default accent will be used until it changes.", e);
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			if (this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().Error("Unable to observe the system accent color. (DBus Settings error, see https://aka.platform.uno/x11-dbus-troubleshoot for troubleshooting information)", e);
+			}
+		}
+	}
+
+	// accent-color is a (ddd) struct of sRGB components in [0,1]; per the portal spec, out-of-range
+	// components mean that no accent color is set.
+	private AccentColorPalette? ToPalette(VariantValue value)
+	{
+		if (value.Type != VariantValueType.Struct || value.Count != 3 ||
+			value.GetItem(0).Type != VariantValueType.Double ||
+			value.GetItem(1).Type != VariantValueType.Double ||
+			value.GetItem(2).Type != VariantValueType.Double)
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn($"Unexpected accent-color value from the desktop portal ({value.Type} with {value.Count} item(s)); expected a (ddd) struct.");
+			}
+			return null;
+		}
+
+		var r = value.GetItem(0).GetDouble();
+		var g = value.GetItem(1).GetDouble();
+		var b = value.GetItem(2).GetDouble();
+
+		if (!IsInRange(r) || !IsInRange(g) || !IsInRange(b))
+		{
+			return null;
+		}
+
+		return AccentColorPalette.FromAccentColor(Color.FromArgb(0xFF, ToByte(r), ToByte(g), ToByte(b)));
+
+		static bool IsInRange(double component) => component is >= 0 and <= 1;
+
+		static byte ToByte(double component) => (byte)Math.Round(component * 255);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Hosting/X11ApplicationHost.cs
@@ -114,6 +114,7 @@ public partial class X11ApplicationHost : SkiaHost, ISkiaApplicationHost, IDispo
 		ApiExtensibility.Register<XamlRoot>(typeof(Uno.Graphics.INativeOpenGLWrapper), xamlRoot => new X11NativeOpenGLWrapper(xamlRoot));
 
 		ApiExtensibility.Register(typeof(ISystemThemeHelperExtension), _ => LinuxSystemThemeHelper.Instance);
+		ApiExtensibility.Register(typeof(IAccentColorExtension), _ => LinuxAccentColorExtension.Instance);
 		ApiExtensibility.Register(typeof(ITextScaleFactorExtension), _ => X11TextScaleFactorExtension.Instance);
 
 		if (Type.GetType("Uno.UI.MediaPlayer.Skia.X11.X11MediaPlayerPresenterExtension, Uno.UI.MediaPlayer.Skia.X11") is { } mediaPresenterExtensionType

--- a/src/Uno.WinRT/Helpers/Theming/AccentColorPalette.cs
+++ b/src/Uno.WinRT/Helpers/Theming/AccentColorPalette.cs
@@ -50,7 +50,7 @@ internal readonly struct AccentColorPalette
 	/// Factors were reverse-engineered from Windows default blue (#0078D7) and its palette.
 	/// This is a linear-RGB approximation and diverges from the Windows HSL-based palette
 	/// (most visibly for warm hues). It is only used where the OS exposes a single accent color
-	/// (macOS, Android); the Win32 host reads the real OS palette from the registry.
+	/// (macOS, Linux, Android); the Win32 host reads the real OS palette from the registry.
 	/// </remarks>
 	public static AccentColorPalette FromAccentColor(Color accent)
 	{


### PR DESCRIPTION
**GitHub Issue:** related to #4444 (Linux part; closed by the parent PR #22851)

> **Stacked on #22851** (`dev/mazi/accentcolor`). Only the commits on top of that branch belong to this PR; it should be rebased onto `master` (or the base switched) once #22851 merges.

## PR Type:

✨ Feature

## What changed? 🚀

#22851 introduces `IAccentColorExtension` for Skia hosts and implements it for Win32 (registry) and macOS (`NSColor.controlAccentColor`). On Linux the X11 host had no implementation, so `UISettings.GetColorValue(UIColorType.Accent*)` and the `SystemAccentColor*` resources stayed on the default blue palette.

This PR adds `LinuxAccentColorExtension` to `Uno.UI.Runtime.Skia.X11`, reading the accent from the XDG Settings portal (`org.freedesktop.portal.Settings`, version 2, `org.freedesktop.appearance` / `accent-color`), the same portal the existing `LinuxSystemThemeHelper` already uses for `color-scheme` and `contrast`:

- **Initial read** via `ReadOne`; the value is a `(ddd)` struct of sRGB components in `[0,1]`, converted to a `Color` and expanded with `AccentColorPalette.FromAccentColor` (Linux exposes a single accent color, like macOS).
- **Live updates** via the `SettingChanged` signal; the change is marshalled to the UI thread and raised through `AccentColorChanged`, so the shared `AccentColorHelper` → `Application.OnAccentColorChanged` path refreshes the resources and raises `UISettings.ColorValuesChanged`.
- **Graceful fallbacks** (default palette, no crash): no session bus, portal older than version 2, backend without the optional `accent-color` key (`DBusErrorReplyException`), and out-of-range components, which the portal spec defines as "no accent color set".
- Registered in `X11ApplicationHost` next to `ISystemThemeHelperExtension`. The framebuffer host is not covered (no session bus / portal in that scenario).
- `SystemAccentColorSample` description now mentions Linux (GNOME Settings → Appearance, KDE System Settings → Colors & Themes).

Supported desktops are those whose portal backend implements `accent-color`: GNOME 47+ (`xdg-desktop-portal-gnome`), KDE Plasma 6 (`xdg-desktop-portal-kde`), and others following the version 2 spec. Older backends fall back to the default palette.

## Validation

- **Compile**: `Uno.UI.Runtime.Skia.X11` and `SamplesApp.Skia.Generic` (net10.0, Release) build clean on Windows.
- **Runtime** (WSL2 Ubuntu 24.04 / WSLg, .NET 10): `SamplesApp.Skia.Generic` run against a mock `org.freedesktop.portal.Settings` v2 service on a private session bus, with a temporary runtime test (not committed) asserting `UISettings.GetColorValue(Accent)`, the resolved `SystemColorControlAccentBrush`, and `UISettings.ColorValuesChanged`:
  - initial `(1, 0, 0)` → `GetColorValue(Accent)` = `#FFFF0000`, brush red
  - live `SettingChanged` → green on both, `ColorValuesChanged` raised
  - `(-1, -1, -1)` (out of range) → default `#FF0078D7`, brush follows
  - `(0.5, 0.25, 0.75)` → `(128, 64, 191)` rounding
  - a `color-scheme` change leaves the accent untouched
  - portal without the `accent-color` key → debug log, default palette, no crash

  Not verified on a real GNOME/KDE portal backend or under Wayland: I do not have a Linux desktop at hand, so a manual pass with `SystemAccentColorSample` on GNOME 47+ / Plasma 6 would be welcome.


### Behaviour worth knowing

- The portal is read **asynchronously**: the first frames use the default palette and the OS accent arrives through `AccentColorChanged` a few dispatcher turns later, exactly like the system theme on X11 today. `{ThemeResource}` consumers update; `{StaticResource SystemAccentColor}` consumers resolved during `OnLaunched` keep the default (WinUI parity: static resources never re-resolve). A bounded synchronous first read (`Task.Run` + short `Wait`) would remove the flash at the cost of blocking startup on DBus; I kept the async design to match the theme helper and avoid a UI-thread wait. Happy to switch if reviewers prefer no flash.
- The watch is installed **before** the initial read, so a change racing the read, or a malformed initial value, can never leave the accent stale for the app's lifetime.
- Degraded environments log at **Warning** (no session bus, Settings portal older than v2) and Debug (backend without the `accent-color` key); only unexpected exceptions log at Error.

### Follow-ups (not in this PR)

- The X11 host now opens three independent portal connections (`LinuxSystemThemeHelper`, `X11TextScaleFactorExtension`, this one). A shared Settings-portal client fanning out one `SettingChanged` watch would remove the duplication and the duplicated "no session bus" logs; also align the siblings' `version != 2` gate with the forward-compatible `version < 2` used here.
- The `(ddd)` → palette conversion is pure and could be exposed `internal static` with an `InternalsVisibleTo` for a unit test; today the X11 runtime has no test project reference.
## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable) — covered by the existing manual `SystemAccentColorSample`; the portal cannot be driven from CI, see Validation above.
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features) — to follow the parent PR's documentation.
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
