### PR TITLE
fix(flyout): forward the placement target's FlowDirection to the popup and presenter

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Private.Infrastructure;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
@@ -693,5 +694,128 @@ public class Given_FlowDirection
 
 		var redTransformToRoot = (MatrixTransform)red.TransformToVisual(null);
 		Assert.AreEqual($"-0.5,0,0,0.5,{m31},{m32}", redTransformToRoot.Matrix.ToString());
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Flyout_Opened_From_RTL_Target()
+	{
+		// The flow direction of the placement target is forwarded to the popup and presenter (WinUI: ForwardPopupFlowDirection /
+		// ForwardTargetPropertiesToPresenter), so flyout content is laid out right-to-left when the target is.
+		var first = new Border { Width = 40, Height = 20, Background = new SolidColorBrush(Colors.Red) };
+		var second = new Border { Width = 40, Height = 20, Background = new SolidColorBrush(Colors.Green) };
+		var content = new StackPanel { Orientation = Orientation.Horizontal, Children = { first, second } };
+		var flyout = new Flyout { Content = content };
+		var button = new Button
+		{
+			Content = "Open",
+			FlowDirection = FlowDirection.RightToLeft,
+			Flyout = flyout,
+			HorizontalAlignment = HorizontalAlignment.Center,
+			VerticalAlignment = VerticalAlignment.Center,
+		};
+		var root = new Grid { Children = { button } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(button);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(content);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = content.FindFirstParent<FlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			Assert.AreEqual(FlowDirection.RightToLeft, presenter.FlowDirection);
+			Assert.AreEqual(FlowDirection.RightToLeft, content.FlowDirection);
+
+#if SUPPORTS_RTL
+			// The presenter is the element whose direction differs from its (popup panel) parent, so it is the one being mirrored.
+			Assert.IsFalse(presenter.GetFlowDirectionTransform().IsIdentity);
+#endif
+
+			// Mirrored layout: the first child ends up to the right of the second one.
+			var firstX = first.TransformToVisual(null).TransformPoint(new Point(0, 0)).X;
+			var secondX = second.TransformToVisual(null).TransformPoint(new Point(0, 0)).X;
+			Assert.IsTrue(firstX > secondX, $"Expected the first child ({firstX}) to be laid out to the right of the second one ({secondX}).");
+		}
+		finally
+		{
+			flyout.Hide();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_MenuFlyout_Opened_From_RTL_Target()
+	{
+		var item = new MenuFlyoutItem { Text = "Item" };
+		var flyout = new MenuFlyout { Items = { item } };
+		var button = new Button
+		{
+			Content = "Open",
+			FlowDirection = FlowDirection.RightToLeft,
+			Flyout = flyout,
+			HorizontalAlignment = HorizontalAlignment.Center,
+			VerticalAlignment = VerticalAlignment.Center,
+		};
+		var root = new Grid { Children = { button } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(button);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(item);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = item.FindFirstParent<MenuFlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			Assert.AreEqual(FlowDirection.RightToLeft, presenter.FlowDirection);
+			Assert.AreEqual(FlowDirection.RightToLeft, item.FlowDirection);
+		}
+		finally
+		{
+			flyout.Hide();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task When_Flyout_Opened_From_LTR_Target()
+	{
+		var content = new Border { Width = 40, Height = 20 };
+		var flyout = new Flyout { Content = content };
+		var button = new Button { Content = "Open", Flyout = flyout, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center };
+		var root = new Grid { Children = { button } };
+
+		TestServices.WindowHelper.WindowContent = root;
+		await TestServices.WindowHelper.WaitForLoaded(root);
+
+		flyout.ShowAt(button);
+
+		try
+		{
+			await TestServices.WindowHelper.WaitForLoaded(content);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = content.FindFirstParent<FlyoutPresenter>();
+			Assert.IsNotNull(presenter);
+			Assert.AreEqual(FlowDirection.LeftToRight, presenter.FlowDirection);
+#if SUPPORTS_RTL
+			Assert.IsTrue(presenter.GetFlowDirectionTransform().IsIdentity);
+#endif
+		}
+		finally
+		{
+			flyout.Hide();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -537,6 +537,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			}
 
 			ForwardTargetPropertiesToPresenter();
+			ForwardPopupFlowDirection();
 
 			// Capture the input device that triggered this flyout (mirrors WinUI ValidateAndSetParameters)
 			var contentRoot = VisualTree.GetContentRootForElement(placementTarget);
@@ -724,14 +725,33 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		}
 
 		/// <summary>
-		/// Forwards DataContext and theme from the placement target to the presenter.
+		/// Forwards the placement target's flow direction to the popup so that the flyout content is laid out (and mirrored) like the target.
+		/// Ported from WinUI: FlyoutBase_partial.cpp ForwardPopupFlowDirection.
+		/// </summary>
+		private void ForwardPopupFlowDirection()
+		{
+			if (_popup is not null)
+			{
+				// The popup is reused across openings, so a missing target resets the direction rather than keeping the previous target's.
+				_popup.FlowDirection = Target?.FlowDirection ?? FlowDirection.LeftToRight;
+			}
+		}
+
+		/// <summary>
+		/// Forwards DataContext, flow direction and theme from the placement target to the presenter.
 		/// Ported from WinUI: FlyoutBase_partial.cpp ForwardTargetPropertiesToPresenter.
 		/// </summary>
 		private void ForwardTargetPropertiesToPresenter()
 		{
-			if (_popup?.Child is FrameworkElement presenter && Target is { } target)
+			if (_popup?.Child is FrameworkElement presenter)
 			{
-				presenter.DataContext = target.DataContext;
+				if (Target is { } target)
+				{
+					presenter.DataContext = target.DataContext;
+				}
+
+				// The presenter is reused across openings, so a missing target resets the direction rather than keeping the previous target's.
+				presenter.FlowDirection = Target?.FlowDirection ?? FlowDirection.LeftToRight;
 			}
 
 			ForwardThemeToPresenter();

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -127,7 +127,9 @@ namespace Microsoft.UI.Xaml
 			{
 				if (parent is FrameworkElement feParent)
 				{
-					return feParent is not PopupPanel && fe.FlowDirection != feParent.FlowDirection;
+					// The popup panel covers the whole window and positions its child in absolute coordinates, so it never mirrors itself;
+					// popup content (whose flow direction is forwarded from the flyout's placement target) mirrors relative to the panel.
+					return fe is not PopupPanel && fe.FlowDirection != feParent.FlowDirection;
 				}
 
 				parent = VisualTreeHelper.GetParent(parent);


### PR DESCRIPTION
**GitHub Issue:** closes #24422

## PR Type:

🐞 Bugfix

## What changed? 🚀

On Skia, flyout content was always laid out left-to-right, even when the placement target (and the whole window content) was `RightToLeft`: the popup and its presenter never received the target's `FlowDirection`, so menu items showed their icon on the left and text left-aligned in an otherwise mirrored UI.

Two things were needed:

- `FlyoutBase` now forwards the placement target's `FlowDirection` to the popup and to the presenter when the flyout is shown, porting WinUI's `ForwardPopupFlowDirection` and the `FlowDirection` part of `ForwardTargetPropertiesToPresenter` (`FlyoutBase_partial.cpp`).
- `UIElement.ShouldMirrorVisual` had its popup exclusion inverted by the allocation refactor in eb007cadb1: it excluded children of a `PopupPanel` from mirroring instead of excluding the `PopupPanel` itself. Since popup content is a child of the popup panel, nothing inside a popup could ever mirror. The original rule is restored: the panel (which covers the window and positions its child in absolute coordinates) never mirrors itself, and popup content whose direction differs from the panel does.

With both, a `Flyout` or `MenuFlyout` opened from a `RightToLeft` target gets a `RightToLeft` presenter that is mirrored like the rest of the UI. The placement math in `UpdateTargetPosition` still positions popups in left-to-right coordinates (e.g. a `MenuFlyout` shown at a point still opens towards the right in RTL); that is addressed separately.

## PR Checklist ✅

- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) (for bug fixes / features, if applicable)
- [ ] 📚 Docs have been added/updated following the [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
- [ ] 👀 Reviewed 2 other [open pull requests](https://github.com/unoplatform/uno/pulls) (optional but appreciated!)
